### PR TITLE
Generate/validate a PIN for our virtual smartcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,9 +825,21 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -837,7 +849,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -850,12 +872,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.4",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -892,7 +932,7 @@ dependencies = [
  "native-tls",
  "num-bigint",
  "num_enum",
- "rand",
+ "rand 0.7.3",
  "x509-parser",
  "yasna",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,8 @@ dependencies = [
  "num-derive",
  "num-traits",
  "openssl",
+ "rand 0.8.4",
+ "rand_chacha 0.3.1",
  "rdp-rs",
  "uuid",
 ]

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -21,5 +21,7 @@ num-traits = "0.2.14"
 # RustCrypto doesn't expose the low-level primitives we need for the smartcard
 # challenge signing (see src/piv.rs for details).
 openssl = { version = "0.10.38", features = ["vendored"] }
+rand = { version = "0.8.4", features = ["getrandom"] }
+rand_chacha = "0.3.1"
 rdp-rs = { git = "https://github.com/gravitational/rdp-rs", rev = "cb61119d2803f647b60e6c9b2ef05ab587cc1966" }
 uuid = { version = "0.8.2", features = ["v4"] }

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -246,6 +246,12 @@ func (c *Client) start() {
 		// calls handle_bitmap repeatedly with the incoming bitmaps.
 		if err := cgoError(C.read_rdp_output(c.rustClient)); err != nil {
 			c.cfg.Log.Warningf("Failed reading RDP output frame: %v", err)
+
+			// close the TDP connection to the browser
+			// (without this the input streaming goroutine will hang
+			// waiting for user input)
+			c.cfg.Conn.SendError("There was an error reading data from the Windows Desktop")
+			c.cfg.Conn.Close()
 		}
 	}()
 

--- a/lib/srv/desktop/rdp/rdpclient/src/piv.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/piv.rs
@@ -142,10 +142,7 @@ impl<const S: usize> Card<S> {
             Ok(Response::new(Status::Success))
         } else {
             warn!("PIN mismatch, want {}, got {:?}", self.pin, cmd.data());
-            Err(rdp::model::error::Error::RdpError(RdpError::new(
-                RdpErrorKind::Unknown,
-                "Invalid PIN",
-            )))
+            Ok(Response::new(Status::VerificationFailed))
         };
     }
 

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -35,9 +35,9 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new(cert_der: Vec<u8>, key_der: Vec<u8>) -> Self {
+    pub fn new(cert_der: Vec<u8>, key_der: Vec<u8>, pin: String) -> Self {
         Client {
-            scard: scard::Client::new(cert_der, key_der),
+            scard: scard::Client::new(cert_der, key_der, pin),
         }
     }
     pub fn read<S: Read + Write>(

--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -19,16 +19,20 @@ package tdp
 import (
 	"bufio"
 	"io"
+	"net"
+	"sync"
 
+	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/trace"
 )
 
 // Conn is a desktop protocol connection.
 // It converts between a stream of bytes (io.ReadWriter) and a stream of
-// Teleport Desktop Protofol (TDP) messages.
+// Teleport Desktop Protocol (TDP) messages.
 type Conn struct {
-	rw   io.ReadWriter
-	bufr *bufio.Reader
+	rw        io.ReadWriter
+	bufr      *bufio.Reader
+	closeOnce sync.Once
 
 	// OnSend is an optional callback that is invoked when a TDP message
 	// is sent on the wire. It is passed both the raw bytes and the encoded
@@ -38,15 +42,39 @@ type Conn struct {
 	// OnRecv is an optional callback that is invoked when a TDP message
 	// is received on the wire.
 	OnRecv func(m Message)
+
+	// localAddr and remoteAddr will be set if rw is
+	// a conn that provides these fields
+	localAddr  net.Addr
+	remoteAddr net.Addr
 }
 
 // NewConn creates a new Conn on top of a ReadWriter, for example a TCP
-// connection.
+// connection. If the provided ReadWriter also implements srv.TrackingConn,
+// then its LocalAddr() and RemoteAddr() will apply to this Conn.
 func NewConn(rw io.ReadWriter) *Conn {
-	return &Conn{
+	c := &Conn{
 		rw:   rw,
 		bufr: bufio.NewReader(rw),
 	}
+
+	if tc, ok := rw.(srv.TrackingConn); ok {
+		c.localAddr = tc.LocalAddr()
+		c.remoteAddr = tc.RemoteAddr()
+	}
+
+	return c
+}
+
+// Close closes the connection if the underlying reader can be closed.
+func (c *Conn) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		if closer, ok := c.rw.(io.Closer); ok {
+			err = closer.Close()
+		}
+	})
+	return err
 }
 
 // InputMessage reads the next incoming message from the connection.
@@ -70,4 +98,19 @@ func (c *Conn) OutputMessage(m Message) error {
 		c.OnSend(m, buf)
 	}
 	return trace.Wrap(err)
+}
+
+// SendError is a convenience function for sending an error message.
+func (c *Conn) SendError(message string) error {
+	return c.OutputMessage(Error{Message: message})
+}
+
+// LocalAddr returns local address
+func (c *Conn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+// RemoteAddr returns remote address
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.remoteAddr
 }

--- a/lib/srv/desktop/tdp/conn_test.go
+++ b/lib/srv/desktop/tdp/conn_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tdp
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTDPConnTracksLocalRemoteAddrs verifies that a TDP connection
+// uses the underlying local/remote addrs when available.
+func TestTDPConnTracksLocalRemoteAddrs(t *testing.T) {
+	local := &net.IPAddr{IP: net.ParseIP("192.168.1.2")}
+	remote := &net.IPAddr{IP: net.ParseIP("192.168.1.3")}
+
+	for _, test := range []struct {
+		desc   string
+		conn   io.ReadWriter
+		local  net.Addr
+		remote net.Addr
+	}{
+		{
+			desc: "implements srv.TrackingConn",
+			conn: fakeTrackingConn{
+				local:  local,
+				remote: remote,
+			},
+			local:  local,
+			remote: remote,
+		},
+		{
+			desc:   "does not implement srv.TrackingConn",
+			conn:   &bytes.Buffer{},
+			local:  nil,
+			remote: nil,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			tc := NewConn(test.conn)
+			l := tc.LocalAddr()
+			r := tc.RemoteAddr()
+			require.Equal(t, test.local, l)
+			require.Equal(t, test.remote, r)
+		})
+	}
+}
+
+type fakeTrackingConn struct {
+	*bytes.Buffer
+	local  net.Addr
+	remote net.Addr
+}
+
+func (f fakeTrackingConn) LocalAddr() net.Addr {
+	return f.local
+}
+
+func (f fakeTrackingConn) RemoteAddr() net.Addr {
+	return f.remote
+}
+
+func (f fakeTrackingConn) Close() error { return nil }

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -665,22 +665,24 @@ func (s *WindowsService) ldapReady() bool {
 // It authenticates and authorizes the connection, and then begins
 // translating the TDP messages from the proxy into native RDP.
 func (s *WindowsService) handleConnection(proxyConn *tls.Conn) {
-	defer proxyConn.Close()
 	log := s.cfg.Log
+
 	tdpConn := tdp.NewConn(proxyConn)
+	defer tdpConn.Close()
 
 	// Inline function to enforce that we are centralizing TDP Error sending in this function.
 	sendTDPError := func(message string) {
-		if err := tdpConn.OutputMessage(tdp.Error{Message: message}); err != nil {
-			log.Errorf("Failed to send TDP error message %v: %v", tdp.Error{Message: message}, err)
+		if err := tdpConn.SendError(message); err != nil {
+			s.cfg.Log.Errorf("Failed to send TDP error message %v", err)
 		}
 	}
 
 	// don't handle connections until the LDAP initialization retry loop has succeeded
 	// (it would fail anyway, but this presents a better error to the user)
 	if !s.ldapReady() {
-		// TODO(zmb3): send TDP error message
-		log.Error("This service cannot accept connections until LDAP initialization has completed.")
+		const msg = "This service cannot accept connections until LDAP initialization has completed."
+		log.Error(msg)
+		sendTDPError(msg)
 		return
 	}
 
@@ -730,14 +732,14 @@ func (s *WindowsService) handleConnection(proxyConn *tls.Conn) {
 	log.Debug("Connecting to Windows desktop")
 	defer log.Debug("Windows desktop disconnected")
 
-	if err := s.connectRDP(ctx, log, proxyConn, desktop, authContext); err != nil {
+	if err := s.connectRDP(ctx, log, tdpConn, desktop, authContext); err != nil {
 		log.Errorf("RDP connection failed: %v", err)
 		sendTDPError("RDP connection failed.")
 		return
 	}
 }
 
-func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger, proxyConn *tls.Conn, desktop types.WindowsDesktop, authCtx *auth.Context) error {
+func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger, tdpConn *tdp.Conn, desktop types.WindowsDesktop, authCtx *auth.Context) error {
 	identity := authCtx.Identity.GetIdentity()
 
 	netConfig, err := s.cfg.AccessPoint.GetClusterNetworkingConfig(ctx)
@@ -821,7 +823,7 @@ func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger,
 
 	monitorCfg := srv.MonitorConfig{
 		Context:           ctx,
-		Conn:              proxyConn,
+		Conn:              tdpConn,
 		Clock:             s.cfg.Clock,
 		ClientIdleTimeout: authCtx.Checker.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout()),
 		Entry:             log,

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -800,7 +800,6 @@ func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger,
 	defer cancel()
 
 	delay := timer()
-	tdpConn := tdp.NewConn(proxyConn)
 	tdpConn.OnSend = s.makeTDPSendHandler(ctx, sw, delay)
 	tdpConn.OnRecv = s.makeTDPRecieveHandler(ctx, sw, delay)
 


### PR DESCRIPTION
Instead of using a shared static PIN for all sessions, use a
cryptographically secure random number generator to generate
a random 8-digit PIN that is unique per session.

Additionally, implement the verify command by checking that the
PIN that Windows sends back matches the one we randomly generated.

Since the PIN is only-known to Teleport, this prevents users from
using the virtual smartcard for anything besides the initial
Windows login.