### PR TITLE
[v8] backport #9501 (access requests in TLS certs)

### DIFF
--- a/api/types/session.go
+++ b/api/types/session.go
@@ -510,6 +510,8 @@ type NewWebSessionRequest struct {
 	SessionTTL time.Duration
 	// LoginTime is the time that this user recently logged in.
 	LoginTime time.Time
+	// AccessRequests contains the UUIDs of the access requests currently in use.
+	AccessRequests []string
 }
 
 // Check validates the request.

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -985,11 +985,12 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 			Username:    req.dbUser,
 			Database:    req.dbName,
 		},
-		DatabaseNames: dbNames,
-		DatabaseUsers: dbUsers,
-		MFAVerified:   req.mfaVerified,
-		ClientIP:      req.clientIP,
-		AWSRoleARNs:   roleARNs,
+		DatabaseNames:  dbNames,
+		DatabaseUsers:  dbUsers,
+		MFAVerified:    req.mfaVerified,
+		ClientIP:       req.clientIP,
+		AWSRoleARNs:    roleARNs,
+		ActiveRequests: req.activeRequests.AccessRequests,
 	}
 	subject, err := identity.Subject()
 	if err != nil {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1733,6 +1733,7 @@ func (a *Server) ExtendWebSession(req WebSessionReq, identity tlsca.Identity) (t
 		return nil, trace.Wrap(err)
 	}
 
+	accessRequests := identity.ActiveRequests
 	if req.AccessRequestID != "" {
 		newRoles, requestExpiry, err := a.getRolesAndExpiryFromAccessRequest(req.User, req.AccessRequestID)
 		if err != nil {
@@ -1741,6 +1742,7 @@ func (a *Server) ExtendWebSession(req WebSessionReq, identity tlsca.Identity) (t
 
 		roles = append(roles, newRoles...)
 		roles = apiutils.Deduplicate(roles)
+		accessRequests = apiutils.Deduplicate(append(accessRequests, req.AccessRequestID))
 
 		// Let session expire with the shortest expiry time.
 		if expiresAt.After(requestExpiry) {
@@ -1770,14 +1772,16 @@ func (a *Server) ExtendWebSession(req WebSessionReq, identity tlsca.Identity) (t
 		// Set default roles and expiration.
 		expiresAt = prevSession.GetLoginTime().UTC().Add(sessionTTL)
 		roles = user.GetRoles()
+		accessRequests = nil
 	}
 
 	sessionTTL := utils.ToTTL(a.clock, expiresAt)
 	sess, err := a.NewWebSession(types.NewWebSessionRequest{
-		User:       req.User,
-		Roles:      roles,
-		Traits:     traits,
-		SessionTTL: sessionTTL,
+		User:           req.User,
+		Roles:          roles,
+		Traits:         traits,
+		SessionTTL:     sessionTTL,
+		AccessRequests: accessRequests,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2353,11 +2357,12 @@ func (a *Server) NewWebSession(req types.NewWebSessionRequest) (types.WebSession
 		sessionTTL = checker.AdjustSessionTTL(apidefaults.CertDuration)
 	}
 	certs, err := a.generateUserCert(certRequest{
-		user:      user,
-		ttl:       sessionTTL,
-		publicKey: pub,
-		checker:   checker,
-		traits:    req.Traits,
+		user:           user,
+		ttl:            sessionTTL,
+		publicKey:      pub,
+		checker:        checker,
+		traits:         req.Traits,
+		activeRequests: services.RequestIDs{AccessRequests: req.AccessRequests},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1104,9 +1104,10 @@ func (a *Server) PreAuthenticatedSignIn(user string, identity tlsca.Identity) (t
 		return nil, trace.Wrap(err)
 	}
 	sess, err := a.NewWebSession(types.NewWebSessionRequest{
-		User:   user,
-		Roles:  roles,
-		Traits: traits,
+		User:           user,
+		Roles:          roles,
+		Traits:         traits,
+		AccessRequests: identity.ActiveRequests,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1560,6 +1560,10 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	// If the user is generating a certificate, the roles and traits come from the logged in identity.
 	if req.Username == a.context.User.GetName() {
 		roles, traits, err = services.ExtractFromIdentity(a.authServer, a.context.Identity.GetIdentity())
+		// we're going to extend the roles list based on the access requests, so
+		// we ensure that all the current requests are added to the new
+		// certificate (and are checked again)
+		req.AccessRequests = append(req.AccessRequests, a.context.Identity.GetIdentity().ActiveRequests...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -66,11 +66,12 @@ func (s *Server) CreateAppSession(ctx context.Context, req types.CreateAppSessio
 		return nil, trace.Wrap(err)
 	}
 	certs, err := s.generateUserCert(certRequest{
-		user:      user,
-		publicKey: publicKey,
-		checker:   checker,
-		ttl:       ttl,
-		traits:    traits,
+		user:           user,
+		publicKey:      publicKey,
+		checker:        checker,
+		ttl:            ttl,
+		traits:         traits,
+		activeRequests: services.RequestIDs{AccessRequests: identity.ActiveRequests},
 		// Only allow this certificate to be used for applications.
 		usage: []string{teleport.UsageAppsOnly},
 		// Add in the application routing information.

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1547,6 +1547,19 @@ func (s *TLSSuite) TestWebSessionWithApprovedAccessRequestAndSwitchback(c *check
 	_, hasRole = mappedRole["test-request-role"]
 	c.Assert(hasRole, check.Equals, true)
 
+	// certRequests extracts the active requests from a PEM encoded TLS cert.
+	certRequests := func(tlsCert []byte) []string {
+		cert, err := tlsca.ParseCertificatePEM(tlsCert)
+		c.Assert(err, check.IsNil)
+
+		identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+		c.Assert(err, check.IsNil)
+
+		return identity.ActiveRequests
+	}
+
+	c.Assert(certRequests(sess1.GetTLSCert()), check.DeepEquals, []string{accessReq.GetName()})
+
 	// Test switch back to default role and expiry.
 	sess2, err := web.ExtendWebSession(WebSessionReq{
 		User:          user,
@@ -1563,6 +1576,8 @@ func (s *TLSSuite) TestWebSessionWithApprovedAccessRequestAndSwitchback(c *check
 	roles, _, err = services.ExtractFromCertificate(sshcert)
 	c.Assert(err, check.IsNil)
 	c.Assert(roles, check.DeepEquals, []string{initialRole})
+
+	c.Assert(certRequests(sess2.GetTLSCert()), check.HasLen, 0)
 }
 
 // TestGetCertAuthority tests certificate authority permissions
@@ -1709,6 +1724,17 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 		return apiutils.SliceContainsStr(identity.Groups, role)
 	}
 
+	// certRequests extracts the active requests from a PEM encoded TLS cert.
+	certRequests := func(tlsCert []byte) []string {
+		cert, err := tlsca.ParseCertificatePEM(tlsCert)
+		c.Assert(err, check.IsNil)
+
+		identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+		c.Assert(err, check.IsNil)
+
+		return identity.ActiveRequests
+	}
+
 	// certLogins extracts the logins from an ssh certificate
 	certLogins := func(sshCert []byte) []string {
 		cert, err := sshutils.ParseCertificate(sshCert)
@@ -1722,6 +1748,8 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 	if certContainsRole(userCerts.TLS, role) {
 		c.Errorf("unexpected role %s", role)
 	}
+	// ensure that the default identity doesn't have any active requests
+	c.Assert(certRequests(userCerts.TLS), check.HasLen, 0)
 
 	// verify that cert for user with no static logins is generated with
 	// exactly one login and that it is an invalid unix login (indicated
@@ -1748,12 +1776,35 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 	if !certContainsRole(userCerts.TLS, role) {
 		c.Errorf("missing requested role %s", role)
 	}
+	// ensure that the request is stored in the certs
+	c.Assert(certRequests(userCerts.TLS), check.DeepEquals, []string{req.GetName()})
 
 	// verify that dynamically applied role granted a login,
 	// which is is valid and has replaced the dummy login.
 	logins = certLogins(userCerts.SSH)
 	c.Assert(len(logins), check.Equals, 1)
 	c.Assert(rune(logins[0][0]), check.Not(check.Equals), '-')
+
+	elevatedCert, err := tls.X509KeyPair(userCerts.TLS, priv)
+	c.Assert(err, check.IsNil)
+	elevatedClient := s.server.NewClientWithCert(elevatedCert)
+
+	newCerts, err := elevatedClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
+		PublicKey: pub,
+		Username:  user,
+		Expires:   time.Now().Add(time.Hour).UTC(),
+		Format:    constants.CertificateFormatStandard,
+		// no new access requests
+		AccessRequests: nil,
+	})
+	c.Assert(err, check.IsNil)
+
+	// in spite of having no access requests, we still have elevated roles...
+	if !certContainsRole(newCerts.TLS, role) {
+		c.Errorf("missing requested role %s", role)
+	}
+	// ...and the certificate shows the access request
+	c.Assert(certRequests(newCerts.TLS), check.DeepEquals, []string{req.GetName()})
 
 	// attempt to apply request in DENIED state (should fail)
 	c.Assert(s.server.Auth().SetAccessRequestState(ctx, types.AccessRequestUpdate{RequestID: req.GetName(), State: types.RequestState_DENIED}), check.IsNil)
@@ -1765,6 +1816,17 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 
 	// ensure that once in the DENIED state, a request cannot be set back to APPROVED state.
 	c.Assert(s.server.Auth().SetAccessRequestState(ctx, types.AccessRequestUpdate{RequestID: req.GetName(), State: types.RequestState_APPROVED}), check.NotNil)
+
+	// ensure that identities with requests in the DENIED state can't reissue new certs.
+	_, err = elevatedClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
+		PublicKey: pub,
+		Username:  user,
+		Expires:   time.Now().Add(time.Hour).UTC(),
+		Format:    constants.CertificateFormatStandard,
+		// no new access requests
+		AccessRequests: nil,
+	})
+	c.Assert(err, check.NotNil)
 }
 
 func (s *TLSSuite) TestPluginData(c *check.C) {


### PR DESCRIPTION
Backport of
* #9501

as a dependency for the backports of
* #9758
* #9478