### PR TITLE
Ignore artifact failures in remaining pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1143,6 +1143,7 @@ steps:
       from_secret: RELEASES_CERT_STAGING
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
+  failure: ignore
 services:
 - name: Start Docker
   image: docker:dind
@@ -1282,6 +1283,7 @@ steps:
       from_secret: RELEASES_CERT_STAGING
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
+  failure: ignore
 services:
 - name: Start Docker
   image: docker:dind
@@ -1419,6 +1421,7 @@ steps:
       from_secret: RELEASES_CERT_STAGING
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
+  failure: ignore
 services:
 - name: Start Docker
   image: docker:dind
@@ -1556,6 +1559,7 @@ steps:
       from_secret: RELEASES_CERT_STAGING
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
+  failure: ignore
 services:
 - name: Start Docker
   image: docker:dind
@@ -1696,6 +1700,7 @@ steps:
       from_secret: RELEASES_CERT_STAGING
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
+  failure: ignore
 services:
 - name: Start Docker
   image: docker:dind
@@ -1711,7 +1716,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:418
+# Generated at dronegen/tag.go:419
 ################################################
 
 kind: pipeline
@@ -1877,7 +1882,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:418
+# Generated at dronegen/tag.go:419
 ################################################
 
 kind: pipeline
@@ -2040,7 +2045,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:418
+# Generated at dronegen/tag.go:419
 ################################################
 
 kind: pipeline
@@ -2192,7 +2197,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:418
+# Generated at dronegen/tag.go:419
 ################################################
 
 kind: pipeline
@@ -2463,6 +2468,7 @@ steps:
       from_secret: RELEASES_CERT_STAGING
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
+  failure: ignore
 services:
 - name: Start Docker
   image: docker:dind
@@ -2478,7 +2484,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:418
+# Generated at dronegen/tag.go:419
 ################################################
 
 kind: pipeline
@@ -2644,7 +2650,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:418
+# Generated at dronegen/tag.go:419
 ################################################
 
 kind: pipeline
@@ -3138,6 +3144,7 @@ steps:
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
     WORKSPACE_DIR: /tmp/build-darwin-amd64-pkg
+  failure: ignore
 - name: Clean up exec runner storage (post)
   commands:
   - set -u
@@ -3308,6 +3315,7 @@ steps:
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
     WORKSPACE_DIR: /tmp/build-darwin-amd64-pkg-tsh
+  failure: ignore
 - name: Clean up exec runner storage (post)
   commands:
   - set -u
@@ -3442,6 +3450,7 @@ steps:
       from_secret: RELEASES_CERT_STAGING
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
+  failure: ignore
 services:
 - name: Start Docker
   image: docker:dind
@@ -3579,6 +3588,7 @@ steps:
       from_secret: RELEASES_CERT_STAGING
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
+  failure: ignore
 services:
 - name: Start Docker
   image: docker:dind
@@ -3594,7 +3604,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:418
+# Generated at dronegen/tag.go:419
 ################################################
 
 kind: pipeline
@@ -3746,7 +3756,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:418
+# Generated at dronegen/tag.go:419
 ################################################
 
 kind: pipeline
@@ -3898,7 +3908,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:418
+# Generated at dronegen/tag.go:419
 ################################################
 
 kind: pipeline
@@ -4064,7 +4074,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:418
+# Generated at dronegen/tag.go:419
 ################################################
 
 kind: pipeline
@@ -4355,6 +4365,7 @@ steps:
       from_secret: RELEASES_CERT_STAGING
     RELEASES_KEY:
       from_secret: RELEASES_KEY_STAGING
+  failure: ignore
 services:
 - name: Start Docker
   image: docker:dind
@@ -5181,6 +5192,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: b7d5c32e345aacbe70ff7436f757ebde787732bf1ae54f7b743507794415602a
+hmac: 99a2fb84d52277bf71a7c325b55b3a7ff9e61a820a11603a7a741ba83b100e98
 
 ...

--- a/dronegen/mac_pkg.go
+++ b/dronegen/mac_pkg.go
@@ -88,6 +88,7 @@ func darwinPkgPipeline(name, makeTarget string, pkgGlobs []string) pipeline {
 		{
 			Name:     "Register artifacts",
 			Commands: tagCreateReleaseAssetCommands(b),
+			Failure:  "ignore",
 			Environment: map[string]value{
 				"WORKSPACE_DIR": {raw: p.Workspace.Path},
 				"RELEASES_CERT": value{fromSecret: "RELEASES_CERT_STAGING"},

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -273,6 +273,7 @@ func tagPipeline(b buildType) pipeline {
 		{
 			Name:     "Register artifacts",
 			Image:    "docker",
+			Failure:  "ignore",
 			Commands: tagCreateReleaseAssetCommands(b),
 			Environment: map[string]value{
 				"RELEASES_CERT": value{fromSecret: "RELEASES_CERT_STAGING"},


### PR DESCRIPTION
I overlooked a couple of build pipeline types in #9921 (sorry!). This fixes the build for remaining pipelines.

Quick verification that all of the steps are covered now:
```console
$ rg --count 'Register artifacts' .drone.yml && rg --count 'failure: ignore' .drone.yml
22
22
```