### PR TITLE
Revert "[backport v8] force http2 kubernetes #9294"

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -60,7 +60,6 @@ import (
 	"github.com/julienschmidt/httprouter"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/net/http2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/httpstream"
@@ -1441,11 +1440,7 @@ func (f *Forwarder) newClusterSessionRemoteCluster(ctx authContext) (*clusterSes
 		tlsConfig:            tlsConfig,
 	}
 
-	transport, err := f.newTransport(sess.Dial, sess.tlsConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+	transport := f.newTransport(sess.Dial, sess.tlsConfig)
 	sess.forwarder, err = forward.New(
 		forward.FlushInterval(100*time.Millisecond),
 		forward.RoundTripper(transport),
@@ -1517,18 +1512,13 @@ func (f *Forwarder) newClusterSessionLocal(ctx authContext) (*clusterSession, er
 		tlsConfig:            creds.tlsConfig,
 	}
 
-	t, err := f.newTransport(sess.Dial, sess.tlsConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// When running inside Kubernetes cluster or using auth/exec providers,
 	// kubeconfig provides a transport wrapper that adds a bearer token to
 	// requests
 	//
 	// When forwarding request to a remote cluster, this is not needed
 	// as the proxy uses client cert auth to reach out to remote proxy.
-	transport, err := creds.wrapTransport(t)
+	transport, err := creds.wrapTransport(f.newTransport(sess.Dial, sess.tlsConfig))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1568,11 +1558,7 @@ func (f *Forwarder) newClusterSessionDirect(ctx authContext, endpoints []kubeClu
 		noAuditEvents: true,
 	}
 
-	transport, err := f.newTransport(sess.Dial, sess.tlsConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+	transport := f.newTransport(sess.Dial, sess.tlsConfig)
 	sess.forwarder, err = forward.New(
 		forward.FlushInterval(100*time.Millisecond),
 		forward.RoundTripper(transport),
@@ -1589,8 +1575,8 @@ func (f *Forwarder) newClusterSessionDirect(ctx authContext, endpoints []kubeClu
 // DialFunc is a network dialer function that returns a network connection
 type DialFunc func(string, string) (net.Conn, error)
 
-func (f *Forwarder) newTransport(dial DialFunc, tlsConfig *tls.Config) (*http.Transport, error) {
-	t := &http.Transport{
+func (f *Forwarder) newTransport(dial DialFunc, tlsConfig *tls.Config) *http.Transport {
+	return &http.Transport{
 		Dial:            dial,
 		TLSClientConfig: tlsConfig,
 		// Increase the size of the connection pool. This substantially improves the
@@ -1601,16 +1587,8 @@ func (f *Forwarder) newTransport(dial DialFunc, tlsConfig *tls.Config) (*http.Tr
 		// IdleConnTimeout defines the maximum amount of time before idle connections
 		// are closed. Leaving this unset will lead to connections open forever and
 		// will cause memory leaks in a long running process.
-		IdleConnTimeout:   defaults.HTTPIdleTimeout,
-		ForceAttemptHTTP2: true,
+		IdleConnTimeout: defaults.HTTPIdleTimeout,
 	}
-
-	err := http2.ConfigureTransport(t)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return t, nil
 }
 
 // getOrCreateRequestContext creates a new certificate request for a given context,

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/http2"
 )
 
 // TLSServerConfig is a configuration for TLS server
@@ -125,7 +124,6 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		Server: &http.Server{
 			Handler:           limiter,
 			ReadHeaderTimeout: apidefaults.DefaultDialTimeout * 2,
-			TLSConfig:         cfg.TLS,
 		},
 	}
 	server.TLS.GetConfigForClient = server.GetConfigForClient
@@ -175,15 +173,11 @@ func (t *TLSServer) Serve(listener net.Listener) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
 	go mux.Serve()
 	defer mux.Close()
 
 	t.mu.Lock()
 	t.listener = mux.TLS()
-	if err = http2.ConfigureServer(t.Server, &http2.Server{}); err != nil {
-		return trace.Wrap(err)
-	}
 	t.mu.Unlock()
 
 	if t.heartbeat != nil {


### PR DESCRIPTION
Reverts gravitational/teleport#9796

Issue reported today about not being able to use with the http2 change I introduced `kubectl exec`

It turns out spdy doesn't play well with http2 and I naively thought the connection would downgrade to http1.
I also thought I tested this case.

There has been works to deprecate spdy in kubernetes but nothing concrete at the moment.
https://github.com/kubernetes/kubernetes/issues/7452
https://github.com/kubernetes/kubernetes/issues/89163

I won't revert the change to master as of right now as I would like to try a couple more things.