### PR TITLE
Desktop Access: clipboard support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,7 +451,7 @@ $(RENDER_TESTS): $(wildcard ./build.assets/tooling/cmd/render-tests/*.go)
 # Runs all Go/shell tests, called by CI/CD.
 #
 .PHONY: test
-test: test-sh test-api test-go
+test: test-sh test-api test-go test-rust
 
 # Runs bot Go tests.
 #
@@ -487,7 +487,8 @@ test-go-root: PACKAGES = $(shell go list $(ADDFLAGS) ./... | grep -v integration
 test-go-root: $(VERSRC)
 	$(CGOFLAG) go test -run "$(UNIT_ROOT_REGEX)" -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(ROLETESTER_TAG) $(RDPCLIENT_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)
 
-# Runs API Go tests. These have to be run separately as the package name is different.
+#
+# Runs Go tests on the api module. These have to be run separately as the package name is different.
 #
 .PHONY: test-api
 test-api:
@@ -495,6 +496,21 @@ test-api: FLAGS ?= '-race'
 test-api: PACKAGES = $(shell cd api && go list ./...)
 test-api: $(VERSRC)
 	$(CGOFLAG) go test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(ROLETESTER_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)
+
+#
+# Runs cargo test on our Rust modules.
+# (a no-op if cargo and rustc are not installed)
+#
+ifneq ($(CHECK_RUST),)
+ifneq ($(CHECK_CARGO),)
+.PHONY: test-rust
+test-rust:
+	cargo test
+else
+.PHONY: test-rust
+test-rust:
+endif
+endif
 
 # Find and run all shell script unit tests (using https://github.com/bats-core/bats-core)
 .PHONY: test-sh
@@ -540,16 +556,26 @@ integration-root: $(RENDER_TESTS)
 # changes (or last commit).
 #
 .PHONY: lint
-lint: lint-sh lint-helm lint-api lint-go lint-license lint-rdp lint-tools
+lint: lint-sh lint-helm lint-api lint-go lint-license lint-rust lint-tools
 
 .PHONY: lint-tools
 lint-tools: lint-version-check lint-bot lint-ci-scripts lint-backport
 
-.PHONY: lint-rdp
-lint-rdp:
-	cd lib/srv/desktop/rdp/rdpclient \
-		&& cargo clippy --locked --all-targets -- -D warnings \
+#
+# Runs the clippy linter on our rust modules
+# (a no-op if cargo and rustc are not installed)
+#
+ifneq ($(CHECK_RUST),)
+ifneq ($(CHECK_CARGO),)
+.PHONY: lint-rust
+lint-rust:
+	cargo clippy --locked --all-targets -- -D warnings \
 		&& cargo fmt -- --check
+else
+.PHONY: lint-rust
+lint-rust:
+endif
+endif
 
 .PHONY: lint-go
 lint-go: GO_LINT_FLAGS ?=
@@ -990,4 +1016,4 @@ dronegen:
 # installed locally. To backport, type "make backport PR=1234 TO=branch/1,branch/2".
 .PHONY: backport
 backport:
-	(cd ./assets/backport && go run main.go -pr=$(PR) -to=$(TO)) 
+	(cd ./assets/backport && go run main.go -pr=$(PR) -to=$(TO))

--- a/lib/datalog/roletester/src/role_tester.rs
+++ b/lib/datalog/roletester/src/role_tester.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// the crepe! macro expands to code that triggers a linter warning.
+// supressing the warning on the offending line breaks the macro,
+// so we just disable it for the entire file
 #![allow(clippy::collapsible_if)]
+
 use bytes::BytesMut;
 use crepe::crepe;
 use libc::{c_uchar, size_t};

--- a/lib/datalog/roletester/src/role_tester.rs
+++ b/lib/datalog/roletester/src/role_tester.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::collapsible_if)]
 use bytes::BytesMut;
 use crepe::crepe;
 use libc::{c_uchar, size_t};

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -115,6 +115,9 @@ type Client struct {
 	clientWidth, clientHeight uint16
 	username                  string
 
+	// handle allows the rust code to call back into the client
+	handle cgo.Handle
+
 	// RDP client on the Rust side.
 	rustClient *C.Client
 
@@ -141,6 +144,7 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 		cfg:           cfg,
 		readyForInput: 0,
 	}
+	c.handle = cgo.NewHandle(c)
 
 	if err := c.readClientUsername(); err != nil {
 		return nil, trace.Wrap(err)
@@ -207,6 +211,7 @@ func (c *Client) connect(ctx context.Context) error {
 	defer C.free(unsafe.Pointer(username))
 
 	res := C.connect_rdp(
+		C.uintptr_t(c.handle),
 		addr,
 		username,
 		// cert length and bytes.
@@ -236,12 +241,9 @@ func (c *Client) start() {
 		defer c.Close()
 		defer c.cfg.Log.Info("RDP output streaming finished")
 
-		h := cgo.NewHandle(c)
-		defer h.Delete()
-
 		// C.read_rdp_output blocks for the duration of the RDP connection and
 		// calls handle_bitmap repeatedly with the incoming bitmaps.
-		if err := cgoError(C.read_rdp_output(c.rustClient, C.uintptr_t(h))); err != nil {
+		if err := cgoError(C.read_rdp_output(c.rustClient)); err != nil {
 			c.cfg.Log.Warningf("Failed reading RDP output frame: %v", err)
 		}
 	}()
@@ -257,7 +259,7 @@ func (c *Client) start() {
 		for {
 			msg, err := c.cfg.Conn.InputMessage()
 			if err != nil {
-				c.cfg.Log.Warningf("Failed reading RDP input message: %v", err)
+				c.cfg.Log.Warningf("Failed reading TDP input message: %v", err)
 				return
 			}
 
@@ -280,7 +282,7 @@ func (c *Client) start() {
 						wheel:  C.PointerWheelNone,
 					},
 				)); err != nil {
-					c.cfg.Log.Warningf("Failed forwarding RDP input message: %v", err)
+					c.cfg.Log.Warningf("Failed forwarding RDP mouse pointer: %v", err)
 					return
 				}
 			case tdp.MouseButton:
@@ -306,7 +308,7 @@ func (c *Client) start() {
 						wheel:  C.PointerWheelNone,
 					},
 				)); err != nil {
-					c.cfg.Log.Warningf("Failed forwarding RDP input message: %v", err)
+					c.cfg.Log.Warningf("Failed forwarding RDP mouse button: %v", err)
 					return
 				}
 			case tdp.MouseWheel:
@@ -335,7 +337,7 @@ func (c *Client) start() {
 						wheel_delta: C.int16_t(m.Delta),
 					},
 				)); err != nil {
-					c.cfg.Log.Warningf("Failed forwarding RDP input message: %v", err)
+					c.cfg.Log.Warningf("Failed forwarding RDP mouse wheel: %v", err)
 					return
 				}
 			case tdp.KeyboardButton:
@@ -346,11 +348,20 @@ func (c *Client) start() {
 						down: m.State == tdp.ButtonPressed,
 					},
 				)); err != nil {
-					c.cfg.Log.Warningf("Failed forwarding RDP input message: %v", err)
+					c.cfg.Log.Warningf("Failed forwarding RDP key press: %v", err)
+					return
+				}
+			case tdp.ClipboardData:
+				if err := cgoError(C.update_clipboard(
+					c.rustClient,
+					(*C.uint8_t)(unsafe.Pointer(&m[0])),
+					C.uint32_t(len(m)),
+				)); err != nil {
+					c.cfg.Log.Warningf("Failed forwarding RDP clipboard data: %v", err)
 					return
 				}
 			default:
-				c.cfg.Log.Warningf("Skipping unimplemented desktop protocol message type %T", msg)
+				c.cfg.Log.Warningf("Skipping unimplemented TDP message type %T", msg)
 			}
 		}
 	}()
@@ -389,6 +400,23 @@ func (c *Client) handleBitmap(cb C.CGOBitmap) C.CGOError {
 	return nil
 }
 
+//export handle_remote_copy
+func handle_remote_copy(handle C.uintptr_t, data *C.uint8_t, length C.uint32_t) C.CGOError {
+	goData := C.GoBytes(unsafe.Pointer(data), C.int(length))
+	return cgo.Handle(handle).Value().(*Client).handleRemoteCopy(goData)
+}
+
+// handleRemoteCopy is called from Rust when data is copied
+// on the remote desktop
+func (c *Client) handleRemoteCopy(data []byte) C.CGOError {
+	c.cfg.Log.Debugf("Received %d bytes of clipboard data from Windows desktop", len(data))
+
+	if err := c.cfg.Conn.OutputMessage(tdp.ClipboardData(data)); err != nil {
+		return C.CString(fmt.Sprintf("failed to send clipboard data: %v", err))
+	}
+	return nil
+}
+
 // Wait blocks until the client disconnects and runs the cleanup.
 func (c *Client) Wait() error {
 	c.wg.Wait()
@@ -402,6 +430,8 @@ func (c *Client) Wait() error {
 // Calls other than the first one are no-ops.
 func (c *Client) Close() {
 	c.closeOnce.Do(func() {
+		c.handle.Delete()
+
 		if err := cgoError(C.close_rdp(c.rustClient)); err != nil {
 			c.cfg.Log.Warningf("Error closing RDP connection: %v", err)
 		}

--- a/lib/srv/desktop/rdp/rdpclient/librdprs.h
+++ b/lib/srv/desktop/rdp/rdpclient/librdprs.h
@@ -94,7 +94,8 @@ void init(void);
  * The caller mmust ensure that go_addr, go_username, cert_der, key_der point to valid buffers in respect
  * to their corresponding parameters.
  */
-struct ClientOrError connect_rdp(char *go_addr,
+struct ClientOrError connect_rdp(uintptr_t go_ref,
+                                 char *go_addr,
                                  char *go_username,
                                  uint32_t cert_der_len,
                                  uint8_t *cert_der,
@@ -104,15 +105,25 @@ struct ClientOrError connect_rdp(char *go_addr,
                                  uint16_t screen_height);
 
 /**
+ * `update_clipboard` is called from Go, and caches data that was copied
+ * client-side while notifying the RDP server that new clipboard data is available.
+ *
+ * # Safety
+ *
+ * `client_ptr` must be a valid pointer to a Client.
+ */
+CGOError update_clipboard(struct Client *client_ptr, uint8_t *data, uint32_t len);
+
+/**
  * `read_rdp_output` reads incoming RDP bitmap frames from client at client_ref and forwards them to
  * handle_bitmap.
  *
  * # Safety
  *
- * client_ptr must be a valid pointer to a Client.
- * handle_bitmap *must not* free the memory of CGOBitmap.
+ * `client_ptr` must be a valid pointer to a Client.
+ * `handle_bitmap` *must not* free the memory of CGOBitmap.
  */
-CGOError read_rdp_output(struct Client *client_ptr, uintptr_t client_ref);
+CGOError read_rdp_output(struct Client *client_ptr);
 
 /**
  * # Safety
@@ -154,3 +165,5 @@ void free_rust_string(char *s);
 extern void free_go_string(char *s);
 
 extern CGOError handle_bitmap(uintptr_t client_ref, struct CGOBitmap b);
+
+extern CGOError handle_remote_copy(uintptr_t client_ref, uint8_t *data, uint32_t len);

--- a/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
@@ -1,0 +1,186 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::errors::invalid_data_error;
+use crate::Payload;
+use bitflags::bitflags;
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use rdp::core::{mcs, tpkt};
+use rdp::model::error::*;
+use std::io::{Read, Write};
+
+const CHANNEL_NAME: &str = "cliprdr";
+
+/// Client implements a client for the clipboard virtual channel
+/// (CLIPRDR) extension, as defined in:
+/// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeclip/fb9b7e0b-6db4-41c2-b83c-f889c1ee7688
+pub struct Client {}
+
+impl Client {
+    pub fn new() -> Self {
+        Client {}
+    }
+
+    pub fn read<S: Read + Write>(
+        &mut self,
+        payload: tpkt::Payload,
+        mcs: &mut mcs::Client<S>,
+    ) -> RdpResult<()> {
+        Ok(())
+    }
+}
+
+bitflags! {
+    struct ClipboardHeaderFlags: u16 {
+        /// Indicates that the assocated request was processed successfully.
+        const CB_RESPONSE_OK = 0x0001;
+
+        /// Indicates that the associated request was not procesed successfully.
+        const CB_RESPONSE_FAIL = 0x0002;
+
+        /// Used by the short format name variant to indicate that the format
+        /// names are in ASCII 8.
+        const CB_ASCII_NAMES = 0x0004;
+    }
+}
+
+/// This header (CLIPRDR_HEADER) is present in all clipboard PDUs.
+#[derive(Debug)]
+struct ClipboardPDUHeader {
+    /// Specifies the type of clipboard PDU that follows the dataLen field.
+    msg_type: ClipboardPDUType,
+    msg_flags: ClipboardHeaderFlags,
+    /// Specifies the size, in bytes, of the data which follows this header.
+    data_len: u32,
+}
+
+#[derive(Debug, FromPrimitive, ToPrimitive)]
+#[allow(non_camel_case_types)]
+enum ClipboardPDUType {
+    CB_MONITOR_READY = 0x0001,
+    CB_FORMAT_LIST = 0x0002,
+    CB_FORMAT_LIST_RESPONSE = 0x0003,
+    CB_FORMAT_DATA_REQUEST = 0x0004,
+    CB_FORMAT_DATA_RESPONSE = 0x0005,
+    CB_TEMP_DIRECTORY = 0x0006,
+    CB_CLIP_CAPS = 0x0007,
+    CB_FILECONTENTS_REQUEST = 0x0008,
+    CB_FILECONTENTS_RESPONSE = 0x0009,
+    CB_LOCK_CLIPDATA = 0x000A,
+    CB_UNLOCK_CLIPDATA = 0x000B,
+}
+
+/// An optional PDU (CLIPRDR_CAPS) used to exchange capability information.
+/// If this PDU is not sent, it is assumed that the endpoint which did not
+/// send capabilities is using the default values for each field.
+#[derive(Debug)]
+struct ClipboardCapabilitiesPDU {
+    // The protocol is written in such a way that there can be
+    // a variable number of capability sets in this PDU. However,
+    // the spec only defines one type of capability set (general),
+    // so we'll just use an Option.
+    general: Option<GeneralClipboardCapabilitySet>,
+}
+
+const CB_CAPS_VERSION_2: u32 = 0x0002;
+
+impl ClipboardCapabilitiesPDU {
+    fn encode(&self) -> RdpResult<Vec<u8>> {
+        let mut w = vec![];
+        // there's either 0 or 1 capability sets included here
+        w.write_u16::<LittleEndian>(self.general.as_ref().map_or(0, |_| 1))?;
+        w.write_u16::<LittleEndian>(0)?; // pad
+
+        if let Some(set) = &self.general {
+            w.write_u16::<LittleEndian>(ClipboardCapabilitySetType::General as u16)?;
+            w.write_u16::<LittleEndian>(12)?; // length
+            w.write_u32::<LittleEndian>(CB_CAPS_VERSION_2)?;
+            w.write_u32::<LittleEndian>(set.flags.bits)?;
+        }
+
+        Ok(w)
+    }
+
+    fn decode(payload: &mut Payload) -> RdpResult<Self> {
+        let count = payload.read_u16::<LittleEndian>()?;
+        payload.read_u16::<LittleEndian>()?; // pad
+
+        return match count {
+            0 => Ok(Self { general: None }),
+            1 => Ok(Self {
+                general: Some(GeneralClipboardCapabilitySet::decode(payload)?),
+            }),
+            _ => Err(invalid_data_error("expected 0 or 1 capabilities")),
+        };
+    }
+}
+
+impl GeneralClipboardCapabilitySet {
+    fn decode(payload: &mut Payload) -> RdpResult<Self> {
+        let set_type = payload.read_u16::<LittleEndian>()?;
+        if set_type != ClipboardCapabilitySetType::General as u16 {
+            return Err(invalid_data_error("expected general capability set"));
+        }
+
+        let length = payload.read_u16::<LittleEndian>()?;
+        if length != 12u16 {
+            return Err(invalid_data_error(
+                "expected 12 bytes for the general capability set",
+            ));
+        }
+
+        Ok(Self {
+            version: payload.read_u32::<LittleEndian>()?,
+            flags: ClipboardGeneralCapabilityFlags::from_bits(payload.read_u32::<LittleEndian>()?)
+                .ok_or_else(|| invalid_data_error("invalid flags in general capability set"))?,
+        })
+    }
+}
+
+enum ClipboardCapabilitySetType {
+    General = 0x0001,
+}
+
+/// The general capability set (CLIPRDR_GENERAL_CAPABILITY) is used to
+/// advertise general clipboard settings.
+#[derive(Debug)]
+struct GeneralClipboardCapabilitySet {
+    /// Specifies the RDP Clipboard Virtual Extension version number.
+    /// Used for informational purposes only, and MUST NOT be used to
+    /// make protocol capability decisions.
+    version: u32,
+    flags: ClipboardGeneralCapabilityFlags,
+}
+
+bitflags! {
+    struct ClipboardGeneralCapabilityFlags: u32 {
+        /// Indicates that long format names will be used in the format list PDU.
+        /// If this flag is not set, then the short format names MUST be used.
+        const CB_USE_LONG_FORMAT_NAMES = 0x0002;
+
+        /// File copy and paste using stream-based operations are supported.
+        const CB_STREAM_FILECLIP_ENABLED = 0x0004;
+
+        /// Indicates that any description of files to copy and paste MUST NOT
+        /// include the source path of the files.
+        const CB_FILECLIP_NO_FILE_PATHS = 0x0008;
+
+        /// Indicates that locking and unlocking of file stream data
+        /// on the clipboard is supported.
+        const CB_CAN_LOCK_CLIPDATA = 0x0010;
+
+        /// Indicates support for transferring files greater than 4GB.
+        const CB_HUGE_FILE_SUPPORT_ENABLED = 0x0020;
+    }
+}

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod cliprdr;
 pub mod errors;
 pub mod piv;
 pub mod rdpdr;

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -27,10 +27,10 @@ use std::io::{Read, Write};
 
 const CHANNEL_NAME: &str = "rdpdr";
 
-// Client implements a device redirection (RDPDR) client, as defined in
-// https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-RDPEFS/%5bMS-RDPEFS%5d.pdf
-//
-// This client only supports a single smartcard device.
+/// Client implements a device redirection (RDPDR) client, as defined in
+/// https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-RDPEFS/%5bMS-RDPEFS%5d.pdf
+///
+/// This client only supports a single smartcard device.
 pub struct Client {
     scard: scard::Client,
 }

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -168,7 +168,11 @@ impl Client {
 fn encode_message(packet_id: PacketId, payload: Vec<u8>) -> RdpResult<Vec<u8>> {
     let mut inner = Header::new(Component::RDPDR_CTYP_CORE, packet_id).encode()?;
     inner.extend_from_slice(&payload);
-    let mut outer = vchan::ChannelPDUHeader::new(inner.length() as u32).encode()?;
+    let mut outer = vchan::ChannelPDUHeader::new(
+        inner.length() as u32,
+        vchan::ChannelPDUFlags::CHANNEL_FLAG_ONLY,
+    )
+    .encode()?;
     outer.extend_from_slice(&inner);
     Ok(outer)
 }

--- a/lib/srv/desktop/rdp/rdpclient/src/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/scard.rs
@@ -510,13 +510,13 @@ impl RPCETypeHeader {
 #[derive(Debug)]
 #[allow(non_camel_case_types, dead_code)]
 struct ScardAccessStartedEvent_Call {
-    unused: u32,
+    _unused: u32,
 }
 
 impl ScardAccessStartedEvent_Call {
     fn decode(payload: &mut Payload) -> RdpResult<Self> {
         Ok(Self {
-            unused: payload.read_u32::<LittleEndian>()?,
+            _unused: payload.read_u32::<LittleEndian>()?,
         })
     }
 }
@@ -612,7 +612,7 @@ impl Long_Return {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct EstablishContext_Call {
     scope: Scope,
 }
@@ -731,7 +731,7 @@ fn decode_ptr(payload: &mut Payload, index: &mut u32) -> RdpResult<u32> {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct ListReaders_Call {
     context: Context,
     groups_length: u32,
@@ -903,7 +903,7 @@ impl Context_Call {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct GetStatusChange_Call {
     context: Context,
     timeout: u32,
@@ -1110,7 +1110,7 @@ impl GetStatusChange_Return {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct Connect_Call {
     reader: String,
     common: Connect_Common,
@@ -1143,7 +1143,7 @@ bitflags! {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct Connect_Common {
     context: Context,
     share_mode: u32,
@@ -1251,7 +1251,7 @@ impl Handle {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct HCardAndDisposition_Call {
     handle: Handle,
     disposition: u32,
@@ -1274,7 +1274,7 @@ impl HCardAndDisposition_Call {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct Status_Call {
     handle: Handle,
     reader_names_is_null: bool,
@@ -1373,7 +1373,7 @@ impl Status_Return {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct Transmit_Call {
     handle: Handle,
     send_pci: SCardIO_Request,
@@ -1427,7 +1427,7 @@ impl Transmit_Call {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct SCardIO_Request {
     protocol: CardProtocol,
     extra_bytes_length: u32,
@@ -1486,7 +1486,7 @@ impl Transmit_Return {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct GetDeviceTypeId_Call {
     context: Context,
     reader_name: String,
@@ -1565,7 +1565,7 @@ impl ReadCache_Call {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct ReadCache_Common {
     context: Context,
     card_uuid: Vec<u8>,
@@ -1696,7 +1696,7 @@ impl WriteCache_Common {
 }
 
 #[derive(Debug)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 struct GetReaderIcon_Call {
     context: Context,
     reader_name: String,

--- a/lib/srv/desktop/rdp/rdpclient/src/vchan.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/vchan.rs
@@ -1,0 +1,59 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::errors::invalid_data_error;
+use crate::Payload;
+use bitflags::bitflags;
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use rdp::model::error::*;
+
+bitflags! {
+    pub struct ChannelPDUFlags: u32 {
+        const CHANNEL_FLAG_FIRST = 0x00000001;
+        const CHANNEL_FLAG_LAST = 0x00000002;
+        const CHANNEL_FLAG_ONLY = Self::CHANNEL_FLAG_FIRST.bits | Self::CHANNEL_FLAG_LAST.bits;
+    }
+}
+
+/// Channel PDU header precedes all static virtual channel traffic
+/// transmitted between an RDP client and server.
+///
+/// It is specified in section 2.2.6.1.1 of MS-RDPBCGR.
+#[derive(Debug)]
+pub struct ChannelPDUHeader {
+    length: u32,
+    flags: ChannelPDUFlags,
+}
+
+impl ChannelPDUHeader {
+    pub fn new(length: u32) -> Self {
+        Self {
+            length,
+            flags: ChannelPDUFlags::CHANNEL_FLAG_ONLY,
+        }
+    }
+    pub fn decode(payload: &mut Payload) -> RdpResult<Self> {
+        Ok(Self {
+            length: payload.read_u32::<LittleEndian>()?,
+            flags: ChannelPDUFlags::from_bits(payload.read_u32::<LittleEndian>()?)
+                .ok_or_else(|| invalid_data_error("invalid flags in ChannelPDUHeader"))?,
+        })
+    }
+    pub fn encode(&self) -> RdpResult<Vec<u8>> {
+        let mut w = vec![];
+        w.write_u32::<LittleEndian>(self.length)?;
+        w.write_u32::<LittleEndian>(self.flags.bits())?;
+        Ok(w)
+    }
+}

--- a/lib/srv/desktop/rdp/rdpclient/src/vchan.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/vchan.rs
@@ -19,9 +19,20 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use rdp::model::error::*;
 
 bitflags! {
+    /// Channel control flags, as specified in section 2.2.6.1.1 of MS-RDPBCGR.
+    ///
+    /// See: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/f125c65e-6901-43c3-8071-d7d5aaee7ae4
     pub struct ChannelPDUFlags: u32 {
         const CHANNEL_FLAG_FIRST = 0x00000001;
         const CHANNEL_FLAG_LAST = 0x00000002;
+        const CHANNEL_FLAG_SHOW_PROTOCOL = 0x00000010;
+        const CHANNEL_FLAG_SUSPEND = 0x00000020;
+        const CHANNEL_FLAG_RESUME = 0x00000040;
+        const CHANNEL_FLAG_SHADOW_PERSISTENT = 0x00000080;
+        const CHANNEL_PACKET_COMPRESSED = 0x00200000;
+        const CHANNEL_PACKET_AT_FRONT = 0x00400000;
+        const CHANNEL_PACKET_FLUSHED = 0x00800000;
+
         const CHANNEL_FLAG_ONLY = Self::CHANNEL_FLAG_FIRST.bits | Self::CHANNEL_FLAG_LAST.bits;
     }
 }
@@ -37,11 +48,8 @@ pub struct ChannelPDUHeader {
 }
 
 impl ChannelPDUHeader {
-    pub fn new(length: u32) -> Self {
-        Self {
-            length,
-            flags: ChannelPDUFlags::CHANNEL_FLAG_ONLY,
-        }
+    pub fn new(length: u32, flags: ChannelPDUFlags) -> Self {
+        Self { length, flags }
     }
     pub fn decode(payload: &mut Payload) -> RdpResult<Self> {
         Ok(Self {

--- a/rfd/0049-desktop-clipboard.md
+++ b/rfd/0049-desktop-clipboard.md
@@ -1,6 +1,6 @@
 ---
 authors: Zac Bergquist (zac@goteleport.com)
-state: draft
+state: implemented
 ---
 
 # RFD 0049 - Desktop Access: Clipboard Support


### PR DESCRIPTION
This PR implements the `CLIPRDR` virtual channel for clipboard redirection over RDP.

For sending clipboard data from the local workstation to the remote desktop:

- Go decodes the clipboard data TDP message
- Go calls into Rust's `update_clipboard` function via CGo
- The Rust cliprdr client implements the exchange between Teleport and the RDP server.

For receiving data that was copied on the remote desktop:

- The RDP server sends a notification to our Rust client.
- The Rust client requests the clipboard data.
- On receipt of the data, Rust calls into Go's `handle_remote_copy` func
- The Go code packages the data up and sends it to the browser

Note: at this point, no support in the browser has been implemented. That will come in a follow up PR. I did verify via the browser's dev tools that the websocket message received in the browser is properly encoded.

Updates #9980