### PR TITLE
Client Certificate Authentication for GCP Cloud SQL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -216,6 +216,6 @@ replace (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 	github.com/gravitational/teleport/api => ./api
-	github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77
+	github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-teleport.1
 	github.com/sirupsen/logrus => github.com/gravitational/logrus v1.4.4-0.20210817004754-047e20245621
 )

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23 h1:havbccu
 github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23/go.mod h1:XL9nebvlfNVvRzRPWdDcWootcyA0l7THiH/A+W1233g=
 github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70 h1:To76nCJtM3DI0mdq3nGLzXqTV1wNOJByxv01+u9/BxM=
 github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70/go.mod h1:88hFR45MpUd23d2vNWE/dYtesU50jKsbz0I9kH7UaBY=
-github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77 h1:ivambM2XeST8qfxeSm+0Y8CP/DlNbS3o/9tSF2KtGFk=
-github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77/go.mod h1:re0JQZ1Cy5dVlIDGq0YksfDIla/GRZlxqOoC0XPSSGE=
+github.com/gravitational/go-mysql v1.1.1-teleport.1 h1:062V8u0juCyUvpYMdkYch8JDDw7wf5rdhKaIfhnojDg=
+github.com/gravitational/go-mysql v1.1.1-teleport.1/go.mod h1:re0JQZ1Cy5dVlIDGq0YksfDIla/GRZlxqOoC0XPSSGE=
 github.com/gravitational/go-oidc v0.0.5 h1:kxsCknoOZ+KqIAoYLLdHuQcvcc+SrQlnT7xxIM8oo6o=
 github.com/gravitational/go-oidc v0.0.5/go.mod h1:SevmOUNdOB0aD9BAIgjptZ6oHkKxMZZgA70nwPfgU/w=
 github.com/gravitational/kingpin v2.1.11-0.20190130013101-742f2714c145+incompatible h1:CfyZl3nyo9K5lLqOmqvl9/IElY1UCnOWKZiQxJ8HKdA=

--- a/lib/srv/db/cloud/gcp.go
+++ b/lib/srv/db/cloud/gcp.go
@@ -27,8 +27,10 @@ import (
 )
 
 // GetGCPRequireSSL requests settings for the project/instance in session from GCP
-// and returns true when the instance requires SSL. An error is returned when the
-// API call fails or the returned settings are incomplete.
+// and returns true when the instance requires SSL. Unauthorized requests will fallback
+// to returning false for requireSSL with a nil error so callers can attempt to connect
+// without SSL. An error is returned for all other API call errors or the returned settings
+// are incomplete.
 func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient common.GCPSQLAdminClient) (requireSSL bool, err error) {
 	dbi, err := gcpClient.GetDatabaseInstance(ctx, sessionCtx)
 	if err != nil {
@@ -44,7 +46,8 @@ func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient
 }
 
 // AppendGCPClientCert calls the GCP API to generate an ephemeral certificate
-// and adds it to the TLS config.
+// and adds it to the TLS config. Access denied error is returned when the
+// generate call fails.
 func AppendGCPClientCert(ctx context.Context, sessionCtx *common.Session, gcpClient common.GCPSQLAdminClient, tlsConfig *tls.Config) error {
 	cert, err := gcpClient.GenerateEphemeralCert(ctx, sessionCtx)
 	if err == nil {

--- a/lib/srv/db/cloud/gcp.go
+++ b/lib/srv/db/cloud/gcp.go
@@ -19,9 +19,11 @@ package cloud
 import (
 	"context"
 	"crypto/tls"
+	"net/http"
 
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/trace"
+	"google.golang.org/api/googleapi"
 )
 
 // GetGCPRequireSSL requests settings for the project/instance in session from GCP
@@ -30,9 +32,13 @@ import (
 func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient common.GCPSQLAdminClient) (requireSSL bool, err error) {
 	dbi, err := gcpClient.GetDatabaseInstance(ctx, sessionCtx)
 	if err != nil {
-		return false, trace.Wrap(err, "failed to get Cloud SQL instance information for %q", sessionCtx.GCPServerName())
+		// Fallback: don't require SSL when not authorized.
+		if e, ok := trace.Unwrap(err).(*googleapi.Error); ok && e.Code == http.StatusForbidden {
+			return false, nil
+		}
+		return false, trace.Wrap(err, "Failed to get Cloud SQL instance information for %q.", sessionCtx.GCPServerName())
 	} else if dbi.Settings == nil || dbi.Settings.IpConfiguration == nil {
-		return false, trace.BadParameter("failed to find Cloud SQL settings for %q. GCP returned %+v", sessionCtx.GCPServerName(), dbi)
+		return false, trace.BadParameter("Failed to find Cloud SQL settings for %q. GCP returned %+v.", sessionCtx.GCPServerName(), dbi)
 	}
 	return dbi.Settings.IpConfiguration.RequireSsl, nil
 }
@@ -41,9 +47,15 @@ func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient
 // and adds it to the TLS config.
 func AppendGCPClientCert(ctx context.Context, sessionCtx *common.Session, gcpClient common.GCPSQLAdminClient, tlsConfig *tls.Config) error {
 	cert, err := gcpClient.GenerateEphemeralCert(ctx, sessionCtx)
-	if err != nil {
-		return trace.Wrap(err, "failed to generate Cloud SQL ephemeral client certificate for %q", tlsConfig.ServerName)
+	if err == nil {
+		tlsConfig.Certificates = []tls.Certificate{*cert}
+		return nil
 	}
-	tlsConfig.Certificates = []tls.Certificate{*cert}
-	return nil
+	return trace.AccessDenied(`Could not generate GCP ephemeral client certificate:
+
+  %v
+
+Make sure Teleport db service has "Cloud SQL Admin" GCP IAM role,
+or "cloudsql.sslCerts.createEphemeral" IAM permission.
+`, err)
 }

--- a/lib/srv/db/cloud/gcp.go
+++ b/lib/srv/db/cloud/gcp.go
@@ -32,8 +32,8 @@ import (
 func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient common.GCPSQLAdminClient) (requireSSL bool, err error) {
 	dbi, err := gcpClient.GetDatabaseInstance(ctx, sessionCtx)
 	if err != nil {
-		if IsGCPUnauthorizedErr(err) {
-			return false, GCPAccessDeniedErr(err, "Could not get GCP database instance settings",
+		if IsGCPUnauthorizedError(err) {
+			return false, GCPAccessDeniedError(err, "Could not get GCP database instance settings",
 				GCPCloudSQLAdminRole, GCPInstancesGetPermission)
 		}
 		return false, trace.Wrap(err, "Failed to get Cloud SQL instance information for %q.", common.GCPServerName(sessionCtx))
@@ -49,8 +49,8 @@ func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient
 func AppendGCPClientCert(ctx context.Context, sessionCtx *common.Session, gcpClient common.GCPSQLAdminClient, tlsConfig *tls.Config) error {
 	cert, err := gcpClient.GenerateEphemeralCert(ctx, sessionCtx)
 	if err != nil {
-		if IsGCPUnauthorizedErr(err) {
-			return GCPAccessDeniedErr(err, "Cloud not generate GCP ephemeral client certificate",
+		if IsGCPUnauthorizedError(err) {
+			return GCPAccessDeniedError(err, "Cloud not generate GCP ephemeral client certificate",
 				GCPCloudSQLAdminRole, GCPCreateEphemeralPermission)
 		}
 		return trace.Wrap(err, "Failed to generate GCP ephemeral client certificate for %q.", common.GCPServerName(sessionCtx))
@@ -59,17 +59,17 @@ func AppendGCPClientCert(ctx context.Context, sessionCtx *common.Session, gcpCli
 	return nil
 }
 
-// IsGCPUnauthorizedErr returns true when the error is a googleapi.Error
+// IsGCPUnauthorizedError returns true when the error is a googleapi.Error
 // and its error code is StatusForbidden. The error is unwrapped before
 // comparing.
-func IsGCPUnauthorizedErr(err error) bool {
+func IsGCPUnauthorizedError(err error) bool {
 	e, ok := trace.Unwrap(err).(*googleapi.Error)
 	return ok && e.Code == http.StatusForbidden
 }
 
-// GCPAccessDeniedErr returns an access denied error with details for the user
+// GCPAccessDeniedError returns an access denied error with details for the user
 // to help them configure IAM roles.
-func GCPAccessDeniedErr(err error, failure, needRole, needPermission string) error {
+func GCPAccessDeniedError(err error, failure, needRole, needPermission string) error {
 	return trace.AccessDenied(`%s:
 
   %v

--- a/lib/srv/db/cloud/gcp.go
+++ b/lib/srv/db/cloud/gcp.go
@@ -36,9 +36,9 @@ func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient
 			return false, GCPAccessDeniedErr(err, "Could not get GCP database instance settings",
 				GCPCloudSQLAdminRole, GCPInstancesGetPermission)
 		}
-		return false, trace.Wrap(err, "Failed to get Cloud SQL instance information for %q.", sessionCtx.GCPServerName())
+		return false, trace.Wrap(err, "Failed to get Cloud SQL instance information for %q.", common.GCPServerName(sessionCtx))
 	} else if dbi.Settings == nil || dbi.Settings.IpConfiguration == nil {
-		return false, trace.BadParameter("Failed to find Cloud SQL settings for %q. GCP returned %+v.", sessionCtx.GCPServerName(), dbi)
+		return false, trace.BadParameter("Failed to find Cloud SQL settings for %q. GCP returned %+v.", common.GCPServerName(sessionCtx), dbi)
 	}
 	return dbi.Settings.IpConfiguration.RequireSsl, nil
 }
@@ -53,7 +53,7 @@ func AppendGCPClientCert(ctx context.Context, sessionCtx *common.Session, gcpCli
 			return GCPAccessDeniedErr(err, "Cloud not generate GCP ephemeral client certificate",
 				GCPCloudSQLAdminRole, GCPCreateEphemeralPermission)
 		}
-		return trace.Wrap(err, "Failed to generate GCP ephemeral client certificate for %q.", sessionCtx.GCPServerName())
+		return trace.Wrap(err, "Failed to generate GCP ephemeral client certificate for %q.", common.GCPServerName(sessionCtx))
 	}
 	tlsConfig.Certificates = []tls.Certificate{*cert}
 	return nil

--- a/lib/srv/db/cloud/gcp.go
+++ b/lib/srv/db/cloud/gcp.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+	"crypto/tls"
+
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/trace"
+)
+
+// GetGCPRequireSSL requests settings for the project/instance in session from GCP
+// and returns true when the instance requires SSL. An error is returned when the
+// API call fails or the returned settings are incomplete.
+func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient common.GCPSQLAdminClient) (requireSSL bool, err error) {
+	dbi, err := gcpClient.GetDatabaseInstance(ctx, sessionCtx)
+	if err != nil {
+		return false, trace.Wrap(err, "failed to get Cloud SQL instance information for %q", sessionCtx.GCPServerName())
+	} else if dbi.Settings == nil || dbi.Settings.IpConfiguration == nil {
+		return false, trace.BadParameter("failed to find Cloud SQL settings for %q. GCP returned %+v", sessionCtx.GCPServerName(), dbi)
+	}
+	return dbi.Settings.IpConfiguration.RequireSsl, nil
+}
+
+// AppendGCPClientCert calls the GCP API to generate an ephemeral certificate
+// and adds it to the TLS config.
+func AppendGCPClientCert(ctx context.Context, sessionCtx *common.Session, gcpClient common.GCPSQLAdminClient, tlsConfig *tls.Config) error {
+	cert, err := gcpClient.GenerateEphemeralCert(ctx, sessionCtx)
+	if err != nil {
+		return trace.Wrap(err, "failed to generate Cloud SQL ephemeral client certificate for %q", tlsConfig.ServerName)
+	}
+	tlsConfig.Certificates = []tls.Certificate{*cert}
+	return nil
+}

--- a/lib/srv/db/cloud/mocks.go
+++ b/lib/srv/db/cloud/mocks.go
@@ -17,6 +17,9 @@ limitations under the License.
 package cloud
 
 import (
+	"context"
+	"crypto/tls"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -27,7 +30,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/redshift/redshiftiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/trace"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 // STSMock mocks AWS STS API.
@@ -313,4 +318,24 @@ func (m *IAMMockUnauth) GetUserPolicyWithContext(ctx aws.Context, input *iam.Get
 
 func (m *IAMMockUnauth) PutUserPolicyWithContext(ctx aws.Context, input *iam.PutUserPolicyInput, options ...request.Option) (*iam.PutUserPolicyOutput, error) {
 	return nil, trace.AccessDenied("unauthorized")
+}
+
+// GCPSQLAdminClientMock implements the common.GCPSQLAdminClient interface for tests.
+type GCPSQLAdminClientMock struct {
+	// DatabaseInstance is returned from GetDatabaseInstance.
+	DatabaseInstance *sqladmin.DatabaseInstance
+	// EphemeralCert is returned from GenerateEphemeralCert.
+	EphemeralCert *tls.Certificate
+}
+
+func (g *GCPSQLAdminClientMock) UpdateUser(ctx context.Context, sessionCtx *common.Session, user *sqladmin.User) error {
+	return nil
+}
+
+func (g *GCPSQLAdminClientMock) GetDatabaseInstance(ctx context.Context, sessionCtx *common.Session) (*sqladmin.DatabaseInstance, error) {
+	return g.DatabaseInstance, nil
+}
+
+func (g *GCPSQLAdminClientMock) GenerateEphemeralCert(ctx context.Context, sessionCtx *common.Session) (*tls.Certificate, error) {
+	return g.EphemeralCert, nil
 }

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -251,11 +251,8 @@ func (a *dbAuth) GetCloudSQLPassword(ctx context.Context, sessionCtx *Session) (
 }
 
 // updateCloudSQLUser makes a request to Cloud SQL API to update the provided user.
-func (a *dbAuth) updateCloudSQLUser(ctx context.Context, sessionCtx *Session, gcpCloudSQL *sqladmin.Service, user *sqladmin.User) error {
-	_, err := gcpCloudSQL.Users.Update(
-		sessionCtx.Database.GetGCP().ProjectID,
-		sessionCtx.Database.GetGCP().InstanceID,
-		user).Name(sessionCtx.DatabaseUser).Host("%").Context(ctx).Do()
+func (a *dbAuth) updateCloudSQLUser(ctx context.Context, sessionCtx *Session, gcpCloudSQL GCPSQLAdminClient, user *sqladmin.User) error {
+	err := gcpCloudSQL.UpdateUser(ctx, sessionCtx, user)
 	if err != nil {
 		return trace.AccessDenied(`Could not update Cloud SQL user %q password:
 

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -351,7 +351,7 @@ func (a *dbAuth) getTLSConfigVerifyFull(ctx context.Context, sessionCtx *Session
 		// Cloud SQL server presented certificates encode instance names as
 		// "<project-id>:<instance-id>" in CommonName. This is verified against
 		// the ServerName in a custom connection verification step (see below).
-		tlsConfig.ServerName = fmt.Sprintf("%v:%v", sessionCtx.Database.GetGCP().ProjectID, sessionCtx.Database.GetGCP().InstanceID)
+		tlsConfig.ServerName = sessionCtx.GCPServerName()
 		// This just disables default verification.
 		tlsConfig.InsecureSkipVerify = true
 		// This will verify CN and cert chain on each connection.

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -351,7 +351,7 @@ func (a *dbAuth) getTLSConfigVerifyFull(ctx context.Context, sessionCtx *Session
 		// Cloud SQL server presented certificates encode instance names as
 		// "<project-id>:<instance-id>" in CommonName. This is verified against
 		// the ServerName in a custom connection verification step (see below).
-		tlsConfig.ServerName = sessionCtx.GCPServerName()
+		tlsConfig.ServerName = GCPServerName(sessionCtx)
 		// This just disables default verification.
 		tlsConfig.InsecureSkipVerify = true
 		// This will verify CN and cert chain on each connection.

--- a/lib/srv/db/common/gcp.go
+++ b/lib/srv/db/common/gcp.go
@@ -32,6 +32,12 @@ import (
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
+// GCPServerName returns the GCP database project and instance as "<project-id>:<instance-id>".
+func GCPServerName(sessionCtx *Session) string {
+	gcp := sessionCtx.Database.GetGCP()
+	return fmt.Sprintf("%s:%s", gcp.ProjectID, gcp.InstanceID)
+}
+
 // GCPSQLAdminClient defines an interface providing access to the GCP Cloud SQL API.
 type GCPSQLAdminClient interface {
 	// UpdateUser updates an existing user for the project/instance configured in a session.

--- a/lib/srv/db/common/gcp.go
+++ b/lib/srv/db/common/gcp.go
@@ -105,7 +105,7 @@ func (g *gcpSQLAdminClient) GenerateEphemeralCert(ctx context.Context, sessionCt
 	gcp := sessionCtx.Database.GetGCP()
 	req := g.service.Connect.GenerateEphemeralCert(gcp.ProjectID, gcp.InstanceID, &sqladmin.GenerateEphemeralCertRequest{
 		PublicKey:     string(pem.EncodeToMemory(&pem.Block{Bytes: pkix, Type: "RSA PUBLIC KEY"})),
-		ValidDuration: fmt.Sprintf("%ds", int(sessionCtx.Identity.Expires.Sub(time.Now()).Seconds())),
+		ValidDuration: fmt.Sprintf("%ds", int(time.Until(sessionCtx.Identity.Expires).Seconds())),
 	})
 	resp, err := req.Context(ctx).Do()
 	if err != nil {

--- a/lib/srv/db/common/gcp.go
+++ b/lib/srv/db/common/gcp.go
@@ -22,6 +22,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
+	"time"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -102,7 +104,8 @@ func (g *gcpSQLAdminClient) GenerateEphemeralCert(ctx context.Context, sessionCt
 	// Make API call.
 	gcp := sessionCtx.Database.GetGCP()
 	req := g.service.Connect.GenerateEphemeralCert(gcp.ProjectID, gcp.InstanceID, &sqladmin.GenerateEphemeralCertRequest{
-		PublicKey: string(pem.EncodeToMemory(&pem.Block{Bytes: pkix, Type: "RSA PUBLIC KEY"})),
+		PublicKey:     string(pem.EncodeToMemory(&pem.Block{Bytes: pkix, Type: "RSA PUBLIC KEY"})),
+		ValidDuration: fmt.Sprintf("%ds", int(sessionCtx.Identity.Expires.Sub(time.Now()).Seconds())),
 	})
 	resp, err := req.Context(ctx).Do()
 	if err != nil {

--- a/lib/srv/db/common/gcp.go
+++ b/lib/srv/db/common/gcp.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/trace"
+
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+)
+
+// GCPSQLAdminClient defines an interface providing access to the GCP Cloud SQL API.
+type GCPSQLAdminClient interface {
+	// UpdateUser updates an existing user for the project/instance configured in a session.
+	UpdateUser(ctx context.Context, sessionCtx *Session, user *sqladmin.User) error
+	// GetDatabaseInstance returns database instance details for the project/instance
+	// configured in a session.
+	GetDatabaseInstance(ctx context.Context, sessionCtx *Session) (*sqladmin.DatabaseInstance, error)
+	// GenerateEphemeralCert returns a new client certificate with RSA key for the
+	// project/instance configured in a session.
+	GenerateEphemeralCert(ctx context.Context, sessionCtx *Session) (*tls.Certificate, error)
+}
+
+// NewGCPSQLAdminClient returns a GCPSQLAdminClient interface wrapping sqladmin.Service.
+func NewGCPSQLAdminClient(ctx context.Context) (GCPSQLAdminClient, error) {
+	service, err := sqladmin.NewService(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &gcpSQLAdminClient{service: service}, nil
+}
+
+// gcpSQLAdminClient implements the GCPSQLAdminClient interface by wrapping
+// sqladmin.Service.
+type gcpSQLAdminClient struct {
+	service *sqladmin.Service
+}
+
+// UpdateUser updates an existing user in a Cloud SQL for the project/instance
+// configured in a session.
+func (g *gcpSQLAdminClient) UpdateUser(ctx context.Context, sessionCtx *Session, user *sqladmin.User) error {
+	_, err := g.service.Users.Update(
+		sessionCtx.Database.GetGCP().ProjectID,
+		sessionCtx.Database.GetGCP().InstanceID,
+		user).Name(sessionCtx.DatabaseUser).Host("%").Context(ctx).Do()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// GetDatabaseInstance returns database instance details from Cloud SQL for the
+// project/instance configured in a session.
+func (g *gcpSQLAdminClient) GetDatabaseInstance(ctx context.Context, sessionCtx *Session) (*sqladmin.DatabaseInstance, error) {
+	gcp := sessionCtx.Database.GetGCP()
+	dbi, err := g.service.Instances.Get(gcp.ProjectID, gcp.InstanceID).Context(ctx).Do()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return dbi, nil
+
+}
+
+// GenerateEphemeralCert returns a new client certificate with RSA key created
+// using the GenerateEphemeralCertRequest Cloud SQL API. Client certificates are
+// required when enabling SSL in Cloud SQL.
+func (g *gcpSQLAdminClient) GenerateEphemeralCert(ctx context.Context, sessionCtx *Session) (*tls.Certificate, error) {
+	// TODO(jimbishopp): cache database certificates to avoid expensive generate
+	// operation on each connection.
+
+	// Generate RSA private key, x509 encoded public key, and append to certificate request.
+	pkey, err := rsa.GenerateKey(rand.Reader, constants.RSAKeySize)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	pkix, err := x509.MarshalPKIXPublicKey(pkey.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Make API call.
+	gcp := sessionCtx.Database.GetGCP()
+	req := g.service.Connect.GenerateEphemeralCert(gcp.ProjectID, gcp.InstanceID, &sqladmin.GenerateEphemeralCertRequest{
+		PublicKey: string(pem.EncodeToMemory(&pem.Block{Bytes: pkix, Type: "RSA PUBLIC KEY"})),
+	})
+	resp, err := req.Context(ctx).Do()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Create TLS certificate from returned ephemeral certificate and private key.
+	cert, err := tls.X509KeyPair([]byte(resp.EphemeralCert.Cert), tlsca.MarshalPrivateKeyPEM(pkey))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &cert, nil
+}

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -52,12 +52,6 @@ type Session struct {
 	LockTargets []types.LockTarget
 }
 
-// GCPServerName returns the GCP database project and instance as "<project-id>:<instance-id>".
-func (c *Session) GCPServerName() string {
-	gcp := c.Database.GetGCP()
-	return fmt.Sprintf("%v:%v", gcp.ProjectID, gcp.InstanceID)
-}
-
 // String returns string representation of the session parameters.
 func (c *Session) String() string {
 	return fmt.Sprintf("db[%v] identity[%v] dbUser[%v] dbName[%v]",

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -52,6 +52,12 @@ type Session struct {
 	LockTargets []types.LockTarget
 }
 
+// GCPServerName returns the GCP database project and instance as "<project-id>:<instance-id>".
+func (c *Session) GCPServerName() string {
+	gcp := c.Database.GetGCP()
+	return fmt.Sprintf("%v:%v", gcp.ProjectID, gcp.InstanceID)
+}
+
 // String returns string representation of the session parameters.
 func (c *Session) String() string {
 	return fmt.Sprintf("db[%v] identity[%v] dbUser[%v] dbName[%v]",

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -206,8 +206,9 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
 			return nil, trace.Wrap(err)
 		}
 		// Detect whether the instance is set to require SSL.
+		// Fallback to not requiring SSL for access denied errors.
 		requireSSL, err := cloud.GetGCPRequireSSL(ctx, sessionCtx, gcpClient)
-		if err != nil {
+		if err != nil && !trace.IsAccessDenied(err) {
 			return nil, trace.Wrap(err)
 		}
 		// Create ephemeral certificate and append to TLS config when

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -451,8 +451,9 @@ func (e *Engine) getConnectConfig(ctx context.Context, sessionCtx *common.Sessio
 			return nil, trace.Wrap(err)
 		}
 		// Detect whether the instance is set to require SSL.
+		// Fallback to not requiring SSL for access denied errors.
 		requireSSL, err := cloud.GetGCPRequireSSL(ctx, sessionCtx, gcpClient)
-		if err != nil {
+		if err != nil && !trace.IsAccessDenied(err) {
 			return nil, trace.Wrap(err)
 		}
 		// Create ephemeral certificate and append to TLS config when

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -18,6 +18,7 @@ package postgres
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -50,6 +51,8 @@ type Engine struct {
 	Context context.Context
 	// Clock is the clock interface.
 	Clock clockwork.Clock
+	// CloudClients provides access to cloud API clients.
+	CloudClients common.CloudClients
 	// Log is used for logging.
 	Log logrus.FieldLogger
 	// client is a client connection.
@@ -410,6 +413,12 @@ func (e *Engine) getConnectConfig(ctx context.Context, sessionCtx *common.Sessio
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// TLS config will use client certificate for an onprem database or
+	// will contain RDS root certificate for RDS/Aurora.
+	config.TLSConfig, err = e.Auth.GetTLSConfig(ctx, sessionCtx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	config.User = sessionCtx.DatabaseUser
 	config.Database = sessionCtx.DatabaseName
 	// Pgconn adds fallbacks to retry connection without TLS if the TLS
@@ -436,6 +445,12 @@ func (e *Engine) getConnectConfig(ctx context.Context, sessionCtx *common.Sessio
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+		// Create ephemeral certificate and append to TLS config when
+		// instance's RequireSsl setting is true.
+		err = e.appendGCPClientCert(ctx, sessionCtx, config.TLSConfig)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	case types.DatabaseTypeAzure:
 		config.Password, err = e.Auth.GetAzureAccessToken(ctx, sessionCtx)
 		if err != nil {
@@ -445,13 +460,33 @@ func (e *Engine) getConnectConfig(ctx context.Context, sessionCtx *common.Sessio
 		// alice@postgres-server-name.
 		config.User = fmt.Sprintf("%v@%v", config.User, sessionCtx.Database.GetAzure().Name)
 	}
-	// TLS config will use client certificate for an onprem database or
-	// will contain RDS root certificate for RDS/Aurora.
-	config.TLSConfig, err = e.Auth.GetTLSConfig(ctx, sessionCtx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	return config, nil
+}
+
+// appendGCPClientCert calls the GCP API to generate an ephemeral certificate
+// when the instance's RequireSsl setting is true.
+func (e *Engine) appendGCPClientCert(ctx context.Context, sessionCtx *common.Session, tlsConfig *tls.Config) error {
+	svc, err := e.CloudClients.GetGCPSQLAdminClient(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	dbi, err := svc.GetDatabaseInstance(ctx, sessionCtx)
+	if err != nil {
+		return trace.Wrap(err, "failed to get Cloud SQL instance information for %q", tlsConfig.ServerName)
+	} else if dbi.Settings == nil || dbi.Settings.IpConfiguration == nil {
+		return trace.BadParameter("failed to find Cloud SQL settings for %q. GCP returned %+v", tlsConfig.ServerName, dbi)
+	}
+
+	if dbi.Settings.IpConfiguration.RequireSsl {
+		cert, err := svc.GenerateEphemeralCert(ctx, sessionCtx)
+		if err != nil {
+			return trace.Wrap(err, "failed to generate Cloud SQL ephemeral client certificate for %q", tlsConfig.ServerName)
+		}
+		tlsConfig.Certificates = []tls.Certificate{*cert}
+	}
+
+	return nil
 }
 
 // formatParameters converts parameters from the Postgres wire message into

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -758,20 +758,22 @@ func (s *Server) createEngine(sessionCtx *common.Session, audit common.Audit) (c
 	switch sessionCtx.Database.GetProtocol() {
 	case defaults.ProtocolPostgres, defaults.ProtocolCockroachDB:
 		return &postgres.Engine{
-			Auth:    s.cfg.Auth,
-			Audit:   audit,
-			Context: s.closeContext,
-			Clock:   s.cfg.Clock,
-			Log:     sessionCtx.Log,
+			Auth:         s.cfg.Auth,
+			Audit:        audit,
+			Context:      s.closeContext,
+			Clock:        s.cfg.Clock,
+			CloudClients: s.cfg.CloudClients,
+			Log:          sessionCtx.Log,
 		}, nil
 	case defaults.ProtocolMySQL:
 		return &mysql.Engine{
-			Auth:       s.cfg.Auth,
-			Audit:      audit,
-			AuthClient: s.cfg.AuthClient,
-			Context:    s.closeContext,
-			Clock:      s.cfg.Clock,
-			Log:        sessionCtx.Log,
+			Auth:         s.cfg.Auth,
+			Audit:        audit,
+			AuthClient:   s.cfg.AuthClient,
+			Context:      s.closeContext,
+			Clock:        s.cfg.Clock,
+			CloudClients: s.cfg.CloudClients,
+			Log:          sessionCtx.Log,
 		}, nil
 	case defaults.ProtocolMongoDB:
 		return &mongodb.Engine{


### PR DESCRIPTION
Closes #8217

Allow users to secure GCP Cloud SQL instances by setting "Allow only SSL connections",  which enforces client certificate authentication.

This implementation does not require any configuration changes for Teleport users. Teleport will detect whether client certificate authentication is required and handle either case automatically.

Client certificates are ephemeral. They are created for every connection by calling the GCP Cloud SQL API's `GenerateEphemeralCert` function. Certificates are only created when the destination Cloud SQL instance is configured to require client certificate authentication. The configuration is detected by requesting instance settings from the GCP Cloud SQL API on every connection attempt.

A special case was implemented for MySQL. MySQL servers in GCP Cloud SQL do not trust the ephemeral certificate's CA but GCP Cloud Proxy does. To work around this issue, the implementation will connect to the MySQL Cloud _Proxy_ port using a TLS dialer instead of the default MySQL port when client certificate authentication is required.

The `common.CloudClients` interface and implementation now return an interface (`GCPSQLAdminClient`) from the `GetGCPSQLAdminClient` function instead of the GCP client's `sqladmin.Service`. Returning an interface simplified calling code and allowed for the client to be mocked for testing.

Existing GCP Cloud SQL tests are configured to not require client certificate authentication by default. A new test named `TestGCPRequireSSL` was created to simulate client certificate authentication for both Postgres and MySQL. This required some minor changes to the test server code.

A new `ConnectWithDialer` function was added to the `github.com/gravitational/go-mysql` fork. This function is available upstream in `v1.4.0` but other changes upstream resulted in a number of errors and a panic processing network packets. So instead of upgrading, the dialer function was copied to the Teleport fork and a custom version was created instead: `v1.1.1-teleport.1`. The errors found will be documented in another issue.

Teleport documentation will be updated in another PR.