### PR TITLE
quote command args with & for printing

### DIFF
--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -251,7 +251,7 @@ func onDatabaseConfig(cf *CLIConf) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Println(cmd.Path, strings.Join(cmd.Args[1:], " "))
+		printCommand(cf.Stdout(), cmd)
 	default:
 		fmt.Printf(`Name:      %v
 Host:      %v

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path"
 	"path/filepath"
@@ -2468,4 +2469,16 @@ func handleUnimplementedError(ctx context.Context, perr error, cf CLIConf) error
 		return trace.WrapWithMessage(perr, errMsgFormat, unknownServerVersion, teleport.Version)
 	}
 	return trace.WrapWithMessage(perr, errMsgFormat, pr.ServerVersion, teleport.Version)
+}
+
+// printCommand prints command to standard output.
+func printCommand(output io.Writer, cmd *exec.Cmd) {
+	// Add quotes for arguments with '&' to prevent sending the command to
+	// background in terminal.
+	for i, arg := range cmd.Args {
+		if strings.ContainsRune(arg, '&') {
+			cmd.Args[i] = fmt.Sprintf("%q", arg)
+		}
+	}
+	fmt.Fprintln(output, cmd.Path, strings.Join(cmd.Args[1:], " "))
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -2476,7 +2476,7 @@ func printCommand(output io.Writer, cmd *exec.Cmd) {
 	// Add quotes for arguments with '&' to prevent sending the command to
 	// background in terminal.
 	for i, arg := range cmd.Args {
-		if strings.ContainsRune(arg, '&') {
+		if strings.ContainsRune(arg, '&') && !strings.ContainsRune(arg, '"') {
 			cmd.Args[i] = fmt.Sprintf("%q", arg)
 		}
 	}

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1141,6 +1143,14 @@ func TestMakeTableWithTruncatedColumn(t *testing.T) {
 			require.Equal(t, testCase.expectedOutput, rows)
 		})
 	}
+}
+
+func TestPrintCommand(t *testing.T) {
+	var buff bytes.Buffer
+	cmd := exec.Command("path-to-binary", "arg1", "arg2&need&quote", "arg3")
+
+	printCommand(&buff, cmd)
+	require.Equal(t, "path-to-binary arg1 \"arg2&need&quote\" arg3\n", buff.String())
 }
 
 type testServersOpts struct {

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -1147,10 +1147,10 @@ func TestMakeTableWithTruncatedColumn(t *testing.T) {
 
 func TestPrintCommand(t *testing.T) {
 	var buff bytes.Buffer
-	cmd := exec.Command("path-to-binary", "arg1", "arg2&need&quote", "arg3")
+	cmd := exec.Command("path-to-binary", "arg1", "arg2&need&quote", "\"arg3\"")
 
 	printCommand(&buff, cmd)
-	require.Equal(t, "path-to-binary arg1 \"arg2&need&quote\" arg3\n", buff.String())
+	require.Equal(t, "path-to-binary arg1 \"arg2&need&quote\" \"arg3\"\n", buff.String())
 }
 
 type testServersOpts struct {


### PR DESCRIPTION
Fixes:
* #9256

closes #9256

## testing
quoted for psql command
```
$ ./tsh db config --format cmd steve-postgres
/opt/homebrew/bin/psql "postgres://alice@teleport.dev.aws.stevexin.me:443/test?sslrootcert=/Users/stevehuang/.tsh/keys/teleport.dev.aws.stevexin.me/certs.pem&sslcert=/Users/stevehuang/.tsh/keys/teleport.dev.aws.stevexin.me/STeve-db/teleport.dev.aws.stevexin.me/steve-postgres-x509.pem&sslkey=/Users/stevehuang/.tsh/keys/teleport.dev.aws.stevexin.me/STeve&sslmode=verify-full"
```

no change for mysql
```
$ ./tsh db config --format cmd steve-rds
/opt/homebrew/opt/mysql-client/bin/mysql --defaults-group-suffix=_teleport.dev.aws.stevexin.me-steve-rds --user alice --database test
```