### PR TITLE
RFD0053: Passwordless for FIDO2 clients (hold RFD number)

### DIFF
--- a/rfd/0053-passwordless-fido2.md
+++ b/rfd/0053-passwordless-fido2.md
@@ -1,0 +1,1 @@
+Hold for Passwordless / https://github.com/gravitational/teleport/pull/9296.


### PR DESCRIPTION
See https://github.com/gravitational/teleport/pull/9296.