### PR TITLE
RFD0054: Passwordless for macOS CLI (hold RFD number)

### DIFF
--- a/rfd/0054-passwordless-macos.md
+++ b/rfd/0054-passwordless-macos.md
@@ -1,0 +1,1 @@
+Hold for Passwordless / https://github.com/gravitational/teleport/pull/9296.


### PR DESCRIPTION
See https://github.com/gravitational/teleport/pull/9296.