### PR TITLE
Provide error information on starting as non-root or not as sudo

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -498,6 +498,11 @@ func Run(ctx context.Context, cfg Config, newTeleport NewProcess) error {
 	copyCfg := cfg
 	srv, err := newTeleport(&copyCfg)
 	if err != nil {
+		//look to see if the typical issue of running teleport start to a data dir it doesn't have permission to access
+		// typical error is lstat /var/lib/teleport/host_uuid: permission denied
+		if strings.Contains(err.Error(), "permission denied") {
+			cfg.Log.Error("Teleport was unable to access a resource it needed. Make sure the Teleport process is running with enough permissions, typically as root or with sudo (sudo teleport start ...).")
+		}
 		return trace.Wrap(err, "initialization failed")
 	}
 	if srv == nil {


### PR DESCRIPTION
Addresses #10032
Provide more information on a `teleport start` error.  Typically when a user starts teleport as non-root or not as sudo.  Teleport defaults using `/var/lib/teleport` as the data dir that will fail if started with a user w/o permission for that dir.

So if a person runs as a non-root user they could get the following output now.
```bash
$ teleport start
ERRO             Teleport was unable to access a resource it needed. Make sure the Teleport process is running with enough permissions, typically as root or with sudo (sudo teleport start ...). service/service.go:504
ERROR: initialization failed
lstat /private/var/lib/teleport/host_uuid: permission denied
```