### PR TITLE
Allow 'tsh proxy ssh' to use --user flag (#10035)

### DIFF
--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -118,11 +118,14 @@ func sshProxy(cf *CLIConf, tc *libclient.TeleportClient, targetHost, targetPort 
 	knownHostsPath := keypaths.KnownHostsPath(keysDir)
 
 	sshHost, sshPort := tc.SSHProxyHostPort()
+	if cf.Username == "" {
+		cf.Username = tc.Username
+	}
 	args := []string{
 		"-A",
 		"-o", fmt.Sprintf("UserKnownHostsFile=%s", knownHostsPath),
 		"-p", strconv.Itoa(sshPort),
-		sshHost,
+		fmt.Sprintf("%s@%s", cf.Username, sshHost),
 		"-s",
 		fmt.Sprintf("proxy:%s:%s@%s", targetHost, targetPort, tc.SiteName),
 	}


### PR DESCRIPTION
Allow tsh proxy ssh to use the properly principal (with the --user flag) to generate the ssh proxy command https://github.com/gravitational/teleport/issues/10035
