### PR TITLE
Log when App Service fails due to empty `proxy_service.public_addr`

### DIFF
--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -65,6 +65,11 @@ func (h *Handler) withAuth(handler handlerAuthFunc) http.HandlerFunc {
 // address of the proxy is set.
 func (h *Handler) redirectToLauncher(w http.ResponseWriter, r *http.Request, p launcherURLParams) error {
 	if h.c.WebPublicAddr == "" {
+		// The error below tends to be swallowed by the Web UI, so log a warning for
+		// admins as well.
+		h.log.Error("" +
+			"Application Service needs the Proxy's public_addr to be explicitly set, otherwise it won't work. " +
+			"Please refer to https://goteleport.com/docs/application-access/guides/connecting-apps/#start-authproxy-service.")
 		return trace.BadParameter("public address of the proxy is not set")
 	}
 	addr, err := utils.ParseAddr(r.Host)

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -68,8 +68,9 @@ func (h *Handler) redirectToLauncher(w http.ResponseWriter, r *http.Request, p l
 		// The error below tends to be swallowed by the Web UI, so log a warning for
 		// admins as well.
 		h.log.Error("" +
-			"Application Service needs the Proxy's public_addr to be explicitly set, otherwise it won't work. " +
-			"Please refer to https://goteleport.com/docs/application-access/guides/connecting-apps/#start-authproxy-service.")
+			"Application Service requires public_addr to be set in the Teleport Proxy Service configuration. " +
+			"Please contact your Teleport cluster administrator or refer to " +
+			"https://goteleport.com/docs/application-access/guides/connecting-apps/#start-authproxy-service.")
 		return trace.BadParameter("public address of the proxy is not set")
 	}
 	addr, err := utils.ParseAddr(r.Host)


### PR DESCRIPTION
Log a warning for admins when App Service fails due to an empty Proxy `public_addr`.

The warning is useful because the handler error tends to get swallowed by the Web UI, plus it is a more useful for an admin.