### PR TITLE
Omit Reviewers On Leave

### DIFF
--- a/.github/workflows/robot/internal/leave/leave.go
+++ b/.github/workflows/robot/internal/leave/leave.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leave
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+)
+
+type Config struct {
+	Ctx context.Context
+	// RipplingToken is the Rippling authentication token.
+	RipplingToken string
+	// Usernames is a JSON string of employees' Github
+	// usernames mapped to their full name.
+	Usernames string
+}
+
+type leave struct {
+	// onLeave is a map of employees who are on leave.
+	onLeave map[string]bool
+	// usernames is employees' GitHub usernames mapped to their
+	// full name.
+	usernames map[string]string
+}
+
+func New(c *Config) (Leave, error) {
+	if err := c.CheckAndSetDefaults(); err != nil {
+		return leave{}, trace.Wrap(err)
+	}
+	omit, err := getEmployeesOnLeave(c.Ctx, c.RipplingToken)
+	if err != nil {
+		return leave{}, trace.Wrap(err)
+	}
+	var employeeUsernames map[string]string
+	if err := json.Unmarshal([]byte(c.Usernames), &employeeUsernames); err != nil {
+		return leave{}, trace.Wrap(err)
+	}
+	return leave{onLeave: omit, usernames: employeeUsernames}, nil
+}
+
+func (c *Config) CheckAndSetDefaults() error {
+	if c.RipplingToken == "" {
+		return trace.BadParameter("missing parameter RipplingToken")
+	}
+	if c.Ctx == nil {
+		c.Ctx = context.Background()
+	}
+	if c.Usernames == "" {
+		return trace.BadParameter("missing parameter Usernames")
+	}
+	return nil
+}
+
+type Leave interface {
+	ShouldOmit(name string) bool
+}
+
+func (l leave) ShouldOmit(username string) bool {
+	fullname, ok := l.usernames[username]
+	if !ok {
+		return false
+	}
+	if _, ok := l.onLeave[fullname]; ok {
+		return true
+	}
+	return false
+}
+
+// getEmployeesOnLeave gets a map of employees who are on leave.
+func getEmployeesOnLeave(ctx context.Context, token string) (map[string]bool, error) {
+	now := time.Now()
+
+	leaveRequests, err := getLeaveRequests(ctx, now, token)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	omit := map[string]bool{}
+	for _, req := range leaveRequests {
+		// Skip over requests that have any zero-equivalent fields.
+		if req.StartDate.IsZero() || req.EndDate.IsZero() || req.FullName == "" {
+			log.Printf("Skipping over leave request: %+v.\n", req)
+			continue
+		}
+		if req.shouldOmitEmployee(now) {
+			omit[req.FullName] = true
+		}
+	}
+	return omit, nil
+}
+
+func (r *employeeLeaveRequest) shouldOmitEmployee(date time.Time) bool {
+	// Leave is defined as being out for more than
+	// two business days.
+	if r.businessDayCount() <= 2 {
+		return false
+	}
+
+	// Pre-leave omit period to be added to the leave range.
+	startOmitPeriod := -2
+
+	// Post-leave omit period to be added to the leave range.
+	endOmitPeriod := 1
+
+	// If the request starts on a Monday or Tuesday, subtract two
+	// more days to account for non-business days.
+	if r.StartDate.Weekday() == time.Monday || r.StartDate.Weekday() == time.Tuesday {
+		startOmitPeriod -= 2
+	}
+
+	// If the leave request end date is a Friday, add two more days
+	// to account for non-business days.
+	if r.EndDate.Weekday() == time.Friday {
+		endOmitPeriod += 2
+	}
+
+	// Subtract and add 1 day to the range so the last return statement
+	// returns true if today lands on the start or end date of the
+	// leave request omit period.
+	start := r.StartDate.Time.AddDate(0, 0, startOmitPeriod-1)
+	end := r.EndDate.AddDate(0, 0, endOmitPeriod+1)
+
+	return date.After(start) && date.Before(end)
+}
+
+// businessDayCount gets the number of business days
+// during the leave request.
+func (r *employeeLeaveRequest) businessDayCount() int {
+	start, end, businessDays := r.StartDate, r.EndDate, 0
+	for !start.After(end.Time) {
+		if start.Weekday() != time.Saturday && start.Weekday() != time.Sunday {
+			businessDays++
+		}
+		start.Time = start.AddDate(0, 0, 1)
+	}
+	return businessDays
+}
+
+const (
+	// layout is the Time format layout
+	layout = "2006-01-02"
+
+	// approvedLeaveRequestStatus is the status of an
+	// approved leave request.
+	approvedLeaveRequestStatus = "APPROVED"
+)
+
+// UnmarshalJSON unmarshals a []byte into Time.
+// A custom method is necessary because the UnmarshalJSON method
+// for time.Time cannot parse the date returned in the Rippling
+// response.
+func (t *Time) UnmarshalJSON(b []byte) error {
+	timeToParse := strings.Trim(string(b), "\"")
+	date, err := time.Parse(layout, timeToParse)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	*t = Time{date}
+	return nil
+}
+
+func (t Time) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Time(t.Time))
+}
+
+// Time is a wrapper around time.Time.
+type Time struct {
+	time.Time
+}
+
+type employeeLeaveRequest struct {
+	// FullName is the employee's full name.
+	FullName string `json:"roleName"`
+	// StartDate is the start date of the leave request.
+	StartDate Time `json:"startDate"`
+	// EndDate is the end date of the leave request.
+	EndDate Time `json:"endDate"`
+}
+
+// getLeaveRequests gets leave requests from the Rippling API and unmarshals the response
+// into []*EmployeeLeaveRequest.
+func getLeaveRequests(ctx context.Context, now time.Time, token string) ([]*employeeLeaveRequest, error) {
+	ripplingUrl := url.URL{
+		Scheme: "https",
+		Host:   "api.rippling.com",
+		Path:   path.Join("platform", "api", "leave_requests"),
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ripplingUrl.String(), nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	req.URL.RawQuery = getQueryValuesForGetLeaveRequests(now).Encode()
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var leaveRequests []*employeeLeaveRequest
+	err = json.Unmarshal([]byte(body), &leaveRequests)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return leaveRequests, nil
+}
+
+// getQueryValuesForGetLeaveRequests sets and returns query values.
+// This is used in conjunction with getLeaveRequests().
+func getQueryValuesForGetLeaveRequests(now time.Time) url.Values {
+	// Start query 3 days in the past to get leave requests that may
+	// have already ended, but still need to omit the employee from
+	// reviews.
+	// 3 days is needed to account for non-business days plus the 1
+	// day post-leave omit period.
+	startQuery := now.AddDate(0, 0, -3)
+	formattedStart := fmt.Sprintf("%d-%02d-%02d",
+		startQuery.Year(), startQuery.Month(), startQuery.Day())
+
+	// End query 4 days in the future to get future leave requests of
+	// the reviewers that need to be omitted.
+	// 4 days is needed to account for non-business days plus the 2
+	// days pre-leave omit period.
+	endQuery := now.AddDate(0, 0, 4)
+	formattedEnd := fmt.Sprintf("%d-%02d-%02d",
+		endQuery.Year(), endQuery.Month(), endQuery.Day())
+
+	// Set query values.
+	q := url.Values{}
+	q.Add(from, formattedStart)
+	q.Add(to, formattedEnd)
+	q.Add(status, approvedLeaveRequestStatus)
+	return q
+}
+
+// Query parameter constants.
+const (
+	// to is a parameter name to get leave requests until a specified date.
+	to = "to"
+	// from is a parameter name to get leave requests from a specified date.
+	from = "from"
+	// status is a parameter name to filter leave requests by status.
+	status = "status"
+)

--- a/.github/workflows/robot/internal/leave/leave_test.go
+++ b/.github/workflows/robot/internal/leave/leave_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leave
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldOmitRangeOverNonBusinessDays(t *testing.T) {
+	// Leave is 3 days long over a weekend.
+	req := employeeLeaveRequest{
+		StartDate: Time{time.Date(2021, time.Month(1), 1, 0, 0, 0, 0, time.UTC)},
+		EndDate:   Time{time.Date(2021, time.Month(1), 5, 0, 0, 0, 0, time.UTC)},
+	}
+
+	tests := []struct {
+		currentDay time.Time
+		expected   bool
+		desc       string
+	}{
+		{
+			currentDay: time.Date(2020, time.Month(12), 29, 0, 0, 0, 0, time.UTC),
+			expected:   false,
+			desc:       "three-business-days-before-leave--don't-omit",
+		},
+		{
+			currentDay: time.Date(2020, time.Month(12), 30, 0, 0, 0, 0, time.UTC),
+			expected:   true,
+			desc:       "two-business-days-before-leave--omit",
+		},
+		{
+			currentDay: time.Date(2020, time.Month(12), 31, 0, 0, 0, 0, time.UTC),
+			expected:   true,
+			desc:       "one-business-day before-leave--omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 1, 0, 0, 0, 0, time.UTC),
+			expected:   true,
+			desc:       "first-day-of-leave--omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 4, 0, 0, 0, 0, time.UTC),
+			expected:   true,
+			desc:       "during-leave--omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 5, 0, 0, 0, 0, time.UTC),
+			expected:   true,
+			desc:       "last-day-of-leave--omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 6, 0, 0, 0, 0, time.UTC),
+			expected:   true,
+			desc:       "one-business-day-after-leave--omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 7, 0, 0, 0, 0, time.UTC),
+			expected:   false,
+			desc:       "two-business-days-after-leave--don't-omit",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			res := req.shouldOmitEmployee(test.currentDay)
+			require.Equal(t, test.expected, res)
+
+		})
+	}
+}
+
+func TestShouldOmitRangeOverOnlyBusinessDays(t *testing.T) {
+	// Leave is a business week.
+	req := employeeLeaveRequest{
+		StartDate: Time{time.Date(2021, time.Month(1), 18, 0, 0, 0, 0, time.UTC)},
+		EndDate:   Time{time.Date(2021, time.Month(1), 22, 0, 0, 0, 0, time.UTC)},
+	}
+
+	tests := []struct {
+		currentDay time.Time
+		expected   bool
+		desc       string
+	}{
+		{
+			currentDay: time.Date(2021, time.Month(1), 13, 0, 0, 0, 0, time.UTC),
+			expected:   false,
+			desc:       "three-business-days-before-leave--don't-omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 14, 0, 0, 0, 0, time.UTC),
+			expected:   true,
+			desc:       "two-business-days-before-leave--omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 15, 0, 0, 0, 0, time.UTC),
+			expected:   true,
+			desc:       "one-business-day-before-leave-before-weekend--omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 25, 0, 0, 0, 0, time.UTC),
+			expected:   true,
+			desc:       "one-business-day-after-leave-after-weekend--omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 26, 0, 0, 0, 0, time.UTC),
+			expected:   false,
+			desc:       "two-business-days-after-leave--don't-omit",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			res := req.shouldOmitEmployee(test.currentDay)
+			require.Equal(t, test.expected, res)
+		})
+	}
+}
+
+func TestShouldOmitTwoDaysOfLeave(t *testing.T) {
+	// Leave is not more than two business days.
+	req := employeeLeaveRequest{
+		StartDate: Time{time.Date(2021, time.Month(1), 18, 0, 0, 0, 0, time.UTC)},
+		EndDate:   Time{time.Date(2021, time.Month(1), 19, 0, 0, 0, 0, time.UTC)},
+	}
+
+	tests := []struct {
+		currentDay time.Time
+		expected   bool
+		desc       string
+	}{
+		{
+			currentDay: time.Date(2021, time.Month(1), 15, 0, 0, 0, 0, time.UTC),
+			expected:   false,
+			desc:       "one-business-day-before-two-day-leave--don't-omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 18, 0, 0, 0, 0, time.UTC),
+			expected:   false,
+			desc:       "first-day-of-two-day-leave--don't-omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 19, 0, 0, 0, 0, time.UTC),
+			expected:   false,
+			desc:       "last-day-of-two-day-leave--don't-omit",
+		},
+		{
+			currentDay: time.Date(2021, time.Month(1), 20, 0, 0, 0, 0, time.UTC),
+			expected:   false,
+			desc:       "day-after-two-day-leave--don't-omit",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			res := req.shouldOmitEmployee(test.currentDay)
+			require.Equal(t, test.expected, res)
+
+		})
+	}
+}
+
+func TestBusinessDaysCount(t *testing.T) {
+	tests := []struct {
+		leave    employeeLeaveRequest
+		expected int
+		desc     string
+	}{
+		{
+			leave: employeeLeaveRequest{
+				StartDate: Time{time.Date(2021, time.Month(1), 1, 0, 0, 0, 0, time.UTC)},
+				EndDate:   Time{time.Date(2021, time.Month(1), 5, 0, 0, 0, 0, time.UTC)},
+			},
+			expected: 3,
+			desc:     "5-day-range-over-a-weekend",
+		},
+		{
+			leave: employeeLeaveRequest{
+				StartDate: Time{time.Date(2021, time.Month(1), 15, 0, 0, 0, 0, time.UTC)},
+				EndDate:   Time{time.Date(2021, time.Month(1), 28, 0, 0, 0, 0, time.UTC)},
+			},
+			expected: 10,
+			desc:     "14-day-range-over-two-weekends",
+		},
+		{
+			leave: employeeLeaveRequest{
+				StartDate: Time{time.Date(2021, time.Month(1), 1, 0, 0, 0, 0, time.UTC)},
+				EndDate:   Time{time.Date(2021, time.Month(1), 1, 0, 0, 0, 0, time.UTC)},
+			},
+			expected: 1,
+			desc:     "1-day-range",
+		},
+		{
+			leave: employeeLeaveRequest{
+				StartDate: Time{time.Date(2021, time.Month(1), 1, 0, 0, 0, 0, time.UTC)},
+				EndDate:   Time{time.Date(2021, time.Month(1), 4, 0, 0, 0, 0, time.UTC)},
+			},
+			expected: 2,
+			desc:     "4-day-range-over-a-weekend",
+		},
+		{
+			leave: employeeLeaveRequest{
+				StartDate: Time{time.Date(2021, time.Month(1), 18, 0, 0, 0, 0, time.UTC)},
+				EndDate:   Time{time.Date(2021, time.Month(1), 22, 0, 0, 0, 0, time.UTC)},
+			},
+			expected: 5,
+			desc:     "5-day-range",
+		},
+		{
+			leave: employeeLeaveRequest{
+				StartDate: Time{time.Date(2021, time.Month(1), 27, 0, 0, 0, 0, time.UTC)},
+				EndDate:   Time{time.Date(2021, time.Month(2), 17, 0, 0, 0, 0, time.UTC)},
+			},
+			expected: 16,
+			desc:     "22-day-range-over-three-weekends",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			result := test.leave.businessDayCount()
+			require.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestShouldOmit(t *testing.T) {
+	employeeUsernames := map[string]string{"username-a": "1", "username-b": "2"}
+	omit := map[string]bool{
+		"1": true,
+	}
+	l := leave{usernames: employeeUsernames, onLeave: omit}
+
+	result := l.ShouldOmit("username-a")
+	require.True(t, result)
+
+	result = l.ShouldOmit("username-b")
+	require.False(t, result)
+}

--- a/.github/workflows/robot/internal/review/review_test.go
+++ b/.github/workflows/robot/internal/review/review_test.go
@@ -35,24 +35,27 @@ func TestIsInternal(t *testing.T) {
 			desc: "code-is-internal",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Code.
-					CodeReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-						"3": Reviewer{Team: "Core", Owner: false},
-						"4": Reviewer{Team: "Core", Owner: false},
-					},
-					CodeReviewersOmit: map[string]bool{},
-					// Docs.
-					DocsReviewers: map[string]Reviewer{
-						"5": Reviewer{Team: "Core", Owner: true},
-						"6": Reviewer{Team: "Core", Owner: true},
-					},
-					DocsReviewersOmit: map[string]bool{},
-					// Admins.
-					Admins: []string{
-						"1",
-						"2",
+					r: reviewers{
+						CodeReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+							"3": Reviewer{Team: "Core", Owner: false},
+							"4": Reviewer{Team: "Core", Owner: false},
+						},
+						CodeReviewersOmit: map[string]bool{},
+						// Docs.
+						DocsReviewers: map[string]Reviewer{
+							"5": Reviewer{Team: "Core", Owner: true},
+							"6": Reviewer{Team: "Core", Owner: true},
+						},
+						DocsReviewersOmit: map[string]bool{},
+						// Admins.
+						Admins: []string{
+							"1",
+							"2",
+						},
 					},
 				},
 			},
@@ -63,24 +66,27 @@ func TestIsInternal(t *testing.T) {
 			desc: "docs-is-internal",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Code.
-					CodeReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-						"3": Reviewer{Team: "Core", Owner: false},
-						"4": Reviewer{Team: "Core", Owner: false},
-					},
-					CodeReviewersOmit: map[string]bool{},
-					// Docs.
-					DocsReviewers: map[string]Reviewer{
-						"5": Reviewer{Team: "Core", Owner: true},
-						"6": Reviewer{Team: "Core", Owner: true},
-					},
-					DocsReviewersOmit: map[string]bool{},
-					// Admins.
-					Admins: []string{
-						"1",
-						"2",
+					r: reviewers{
+						CodeReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+							"3": Reviewer{Team: "Core", Owner: false},
+							"4": Reviewer{Team: "Core", Owner: false},
+						},
+						CodeReviewersOmit: map[string]bool{},
+						// Docs.
+						DocsReviewers: map[string]Reviewer{
+							"5": Reviewer{Team: "Core", Owner: true},
+							"6": Reviewer{Team: "Core", Owner: true},
+						},
+						DocsReviewersOmit: map[string]bool{},
+						// Admins.
+						Admins: []string{
+							"1",
+							"2",
+						},
 					},
 				},
 			},
@@ -91,24 +97,27 @@ func TestIsInternal(t *testing.T) {
 			desc: "other-is-not-internal",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Code.
-					CodeReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-						"3": Reviewer{Team: "Core", Owner: false},
-						"4": Reviewer{Team: "Core", Owner: false},
-					},
-					CodeReviewersOmit: map[string]bool{},
-					// Docs.
-					DocsReviewers: map[string]Reviewer{
-						"5": Reviewer{Team: "Core", Owner: true},
-						"6": Reviewer{Team: "Core", Owner: true},
-					},
-					DocsReviewersOmit: map[string]bool{},
-					// Admins.
-					Admins: []string{
-						"1",
-						"2",
+					r: reviewers{
+						CodeReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+							"3": Reviewer{Team: "Core", Owner: false},
+							"4": Reviewer{Team: "Core", Owner: false},
+						},
+						CodeReviewersOmit: map[string]bool{},
+						// Docs.
+						DocsReviewers: map[string]Reviewer{
+							"5": Reviewer{Team: "Core", Owner: true},
+							"6": Reviewer{Team: "Core", Owner: true},
+						},
+						DocsReviewersOmit: map[string]bool{},
+						// Admins.
+						Admins: []string{
+							"1",
+							"2",
+						},
 					},
 				},
 			},
@@ -137,18 +146,21 @@ func TestGetCodeReviewers(t *testing.T) {
 			desc: "skip-self-assign",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Code.
-					CodeReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-						"3": Reviewer{Team: "Core", Owner: false},
-						"4": Reviewer{Team: "Core", Owner: false},
-					},
-					CodeReviewersOmit: map[string]bool{},
-					// Admins.
-					Admins: []string{
-						"1",
-						"2",
+					r: reviewers{
+						CodeReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+							"3": Reviewer{Team: "Core", Owner: false},
+							"4": Reviewer{Team: "Core", Owner: false},
+						},
+						CodeReviewersOmit: map[string]bool{},
+						// Admins.
+						Admins: []string{
+							"1",
+							"2",
+						},
 					},
 				},
 			},
@@ -160,21 +172,24 @@ func TestGetCodeReviewers(t *testing.T) {
 			desc: "skip-omitted-user",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Code.
-					CodeReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-						"3": Reviewer{Team: "Core", Owner: false},
-						"4": Reviewer{Team: "Core", Owner: false},
-						"5": Reviewer{Team: "Core", Owner: false},
-					},
-					CodeReviewersOmit: map[string]bool{
-						"3": true,
-					},
-					// Admins.
-					Admins: []string{
-						"1",
-						"2",
+					r: reviewers{
+						CodeReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+							"3": Reviewer{Team: "Core", Owner: false},
+							"4": Reviewer{Team: "Core", Owner: false},
+							"5": Reviewer{Team: "Core", Owner: false},
+						},
+						CodeReviewersOmit: map[string]bool{
+							"3": true,
+						},
+						// Admins.
+						Admins: []string{
+							"1",
+							"2",
+						},
 					},
 				},
 			},
@@ -186,19 +201,22 @@ func TestGetCodeReviewers(t *testing.T) {
 			desc: "internal-gets-defaults",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Code.
-					CodeReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-						"3": Reviewer{Team: "Core", Owner: false},
-						"4": Reviewer{Team: "Core", Owner: false},
-						"5": Reviewer{Team: "Internal"},
-					},
-					CodeReviewersOmit: map[string]bool{},
-					// Admins.
-					Admins: []string{
-						"1",
-						"2",
+					r: reviewers{
+						CodeReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+							"3": Reviewer{Team: "Core", Owner: false},
+							"4": Reviewer{Team: "Core", Owner: false},
+							"5": Reviewer{Team: "Internal"},
+						},
+						CodeReviewersOmit: map[string]bool{},
+						// Admins.
+						Admins: []string{
+							"1",
+							"2",
+						},
 					},
 				},
 			},
@@ -210,28 +228,31 @@ func TestGetCodeReviewers(t *testing.T) {
 			desc: "cloud-gets-core-reviewers",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Code.
-					CodeReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-						"3": Reviewer{Team: "Core", Owner: true},
-						"4": Reviewer{Team: "Core", Owner: false},
-						"5": Reviewer{Team: "Core", Owner: false},
-						"6": Reviewer{Team: "Core", Owner: false},
-						"7": Reviewer{Team: "Internal", Owner: false},
-						"8": Reviewer{Team: "Cloud", Owner: false},
-						"9": Reviewer{Team: "Cloud", Owner: false},
-					},
-					CodeReviewersOmit: map[string]bool{
-						"6": true,
-					},
-					// Docs.
-					DocsReviewers:     map[string]Reviewer{},
-					DocsReviewersOmit: map[string]bool{},
-					// Admins.
-					Admins: []string{
-						"1",
-						"2",
+					r: reviewers{
+						CodeReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+							"3": Reviewer{Team: "Core", Owner: true},
+							"4": Reviewer{Team: "Core", Owner: false},
+							"5": Reviewer{Team: "Core", Owner: false},
+							"6": Reviewer{Team: "Core", Owner: false},
+							"7": Reviewer{Team: "Internal", Owner: false},
+							"8": Reviewer{Team: "Cloud", Owner: false},
+							"9": Reviewer{Team: "Cloud", Owner: false},
+						},
+						CodeReviewersOmit: map[string]bool{
+							"6": true,
+						},
+						// Docs.
+						DocsReviewers:     map[string]Reviewer{},
+						DocsReviewersOmit: map[string]bool{},
+						// Admins.
+						Admins: []string{
+							"1",
+							"2",
+						},
 					},
 				},
 			},
@@ -243,26 +264,29 @@ func TestGetCodeReviewers(t *testing.T) {
 			desc: "normal",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Code.
-					CodeReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-						"3": Reviewer{Team: "Core", Owner: true},
-						"4": Reviewer{Team: "Core", Owner: false},
-						"5": Reviewer{Team: "Core", Owner: false},
-						"6": Reviewer{Team: "Core", Owner: false},
-						"7": Reviewer{Team: "Internal", Owner: false},
-					},
-					CodeReviewersOmit: map[string]bool{
-						"6": true,
-					},
-					// Docs.
-					DocsReviewers:     map[string]Reviewer{},
-					DocsReviewersOmit: map[string]bool{},
-					// Admins.
-					Admins: []string{
-						"1",
-						"2",
+					r: reviewers{
+						CodeReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+							"3": Reviewer{Team: "Core", Owner: true},
+							"4": Reviewer{Team: "Core", Owner: false},
+							"5": Reviewer{Team: "Core", Owner: false},
+							"6": Reviewer{Team: "Core", Owner: false},
+							"7": Reviewer{Team: "Internal", Owner: false},
+						},
+						CodeReviewersOmit: map[string]bool{
+							"6": true,
+						},
+						// Docs.
+						DocsReviewers:     map[string]Reviewer{},
+						DocsReviewersOmit: map[string]bool{},
+						// Admins.
+						Admins: []string{
+							"1",
+							"2",
+						},
 					},
 				},
 			},
@@ -292,16 +316,19 @@ func TestGetDocsReviewers(t *testing.T) {
 			desc: "skip-self-assign",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Docs.
-					DocsReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-					},
-					DocsReviewersOmit: map[string]bool{},
-					// Admins.
-					Admins: []string{
-						"3",
-						"4",
+					r: reviewers{
+						DocsReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+						},
+						DocsReviewersOmit: map[string]bool{},
+						// Admins.
+						Admins: []string{
+							"3",
+							"4",
+						},
 					},
 				},
 			},
@@ -312,18 +339,21 @@ func TestGetDocsReviewers(t *testing.T) {
 			desc: "skip-self-assign-with-omit",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Docs.
-					DocsReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-					},
-					DocsReviewersOmit: map[string]bool{
-						"2": true,
-					},
-					// Admins.
-					Admins: []string{
-						"3",
-						"4",
+					r: reviewers{
+						DocsReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+						},
+						DocsReviewersOmit: map[string]bool{
+							"2": true,
+						},
+						// Admins.
+						Admins: []string{
+							"3",
+							"4",
+						},
 					},
 				},
 			},
@@ -334,16 +364,19 @@ func TestGetDocsReviewers(t *testing.T) {
 			desc: "normal",
 			assignments: &Assignments{
 				c: &Config{
+					Leave: &test{},
 					// Docs.
-					DocsReviewers: map[string]Reviewer{
-						"1": Reviewer{Team: "Core", Owner: true},
-						"2": Reviewer{Team: "Core", Owner: true},
-					},
-					DocsReviewersOmit: map[string]bool{},
-					// Admins.
-					Admins: []string{
-						"3",
-						"4",
+					r: reviewers{
+						DocsReviewers: map[string]Reviewer{
+							"1": Reviewer{Team: "Core", Owner: true},
+							"2": Reviewer{Team: "Core", Owner: true},
+						},
+						DocsReviewersOmit: map[string]bool{},
+						// Admins.
+						Admins: []string{
+							"3",
+							"4",
+						},
 					},
 				},
 			},
@@ -363,20 +396,23 @@ func TestGetDocsReviewers(t *testing.T) {
 func TestCheckExternal(t *testing.T) {
 	r := &Assignments{
 		c: &Config{
+			Leave: &test{},
 			// Code.
-			CodeReviewers: map[string]Reviewer{
-				"1": Reviewer{Team: "Core", Owner: true},
-				"2": Reviewer{Team: "Core", Owner: true},
-				"3": Reviewer{Team: "Core", Owner: true},
-				"4": Reviewer{Team: "Core", Owner: false},
-				"5": Reviewer{Team: "Core", Owner: false},
-				"6": Reviewer{Team: "Core", Owner: false},
-			},
-			CodeReviewersOmit: map[string]bool{},
-			// Default.
-			Admins: []string{
-				"1",
-				"2",
+			r: reviewers{
+				CodeReviewers: map[string]Reviewer{
+					"1": Reviewer{Team: "Core", Owner: true},
+					"2": Reviewer{Team: "Core", Owner: true},
+					"3": Reviewer{Team: "Core", Owner: true},
+					"4": Reviewer{Team: "Core", Owner: false},
+					"5": Reviewer{Team: "Core", Owner: false},
+					"6": Reviewer{Team: "Core", Owner: false},
+				},
+				CodeReviewersOmit: map[string]bool{},
+				// Default.
+				Admins: []string{
+					"1",
+					"2",
+				},
 			},
 		},
 	}
@@ -470,29 +506,32 @@ func TestCheckInternal(t *testing.T) {
 	r := &Assignments{
 		c: &Config{
 			// Code.
-			CodeReviewers: map[string]Reviewer{
-				"1":  Reviewer{Team: "Core", Owner: true},
-				"2":  Reviewer{Team: "Core", Owner: true},
-				"3":  Reviewer{Team: "Core", Owner: true},
-				"9":  Reviewer{Team: "Core", Owner: true},
-				"4":  Reviewer{Team: "Core", Owner: false},
-				"5":  Reviewer{Team: "Core", Owner: false},
-				"6":  Reviewer{Team: "Core", Owner: false},
-				"8":  Reviewer{Team: "Internal", Owner: false},
-				"10": Reviewer{Team: "Cloud", Owner: false},
-				"11": Reviewer{Team: "Cloud", Owner: false},
-				"12": Reviewer{Team: "Cloud", Owner: false},
-			},
-			// Docs.
-			DocsReviewers: map[string]Reviewer{
-				"7": Reviewer{Team: "Core", Owner: true},
-			},
-			DocsReviewersOmit: map[string]bool{},
-			CodeReviewersOmit: map[string]bool{},
-			// Default.
-			Admins: []string{
-				"1",
-				"2",
+			Leave: &test{},
+			r: reviewers{
+				CodeReviewers: map[string]Reviewer{
+					"1":  Reviewer{Team: "Core", Owner: true},
+					"2":  Reviewer{Team: "Core", Owner: true},
+					"3":  Reviewer{Team: "Core", Owner: true},
+					"9":  Reviewer{Team: "Core", Owner: true},
+					"4":  Reviewer{Team: "Core", Owner: false},
+					"5":  Reviewer{Team: "Core", Owner: false},
+					"6":  Reviewer{Team: "Core", Owner: false},
+					"8":  Reviewer{Team: "Internal", Owner: false},
+					"10": Reviewer{Team: "Cloud", Owner: false},
+					"11": Reviewer{Team: "Cloud", Owner: false},
+					"12": Reviewer{Team: "Cloud", Owner: false},
+				},
+				// Docs.
+				DocsReviewers: map[string]Reviewer{
+					"7": Reviewer{Team: "Core", Owner: true},
+				},
+				DocsReviewersOmit: map[string]bool{},
+				CodeReviewersOmit: map[string]bool{},
+				// Default.
+				Admins: []string{
+					"1",
+					"2",
+				},
 			},
 		},
 	}
@@ -689,12 +728,15 @@ func TestCheckInternal(t *testing.T) {
 	}
 }
 
-// TestFromString tests if configuration is correctly read in from a string.
-func TestFromString(t *testing.T) {
-	r, err := FromString(reviewers)
+// TestNew tests New.
+func TestNew(t *testing.T) {
+	r, err := New(&Config{
+		Reviewers: reviewersJSON,
+		Leave:     &test{},
+	})
 	require.NoError(t, err)
 
-	require.EqualValues(t, r.c.CodeReviewers, map[string]Reviewer{
+	require.EqualValues(t, r.c.r.CodeReviewers, map[string]Reviewer{
 		"1": Reviewer{
 			Team:  "Core",
 			Owner: true,
@@ -704,10 +746,10 @@ func TestFromString(t *testing.T) {
 			Owner: false,
 		},
 	})
-	require.EqualValues(t, r.c.CodeReviewersOmit, map[string]bool{
+	require.EqualValues(t, r.c.r.CodeReviewersOmit, map[string]bool{
 		"3": true,
 	})
-	require.EqualValues(t, r.c.DocsReviewers, map[string]Reviewer{
+	require.EqualValues(t, r.c.r.DocsReviewers, map[string]Reviewer{
 		"4": Reviewer{
 			Team:  "Core",
 			Owner: true,
@@ -717,16 +759,16 @@ func TestFromString(t *testing.T) {
 			Owner: false,
 		},
 	})
-	require.EqualValues(t, r.c.DocsReviewersOmit, map[string]bool{
+	require.EqualValues(t, r.c.r.DocsReviewersOmit, map[string]bool{
 		"6": true,
 	})
-	require.EqualValues(t, r.c.Admins, []string{
+	require.EqualValues(t, r.c.r.Admins, []string{
 		"7",
 		"8",
 	})
 }
 
-const reviewers = `
+const reviewersJSON = `
 {
 	"codeReviewers": {
 		"1": {
@@ -760,3 +802,9 @@ const reviewers = `
 	]
 }
 `
+
+type test struct{}
+
+func (t *test) ShouldOmit(name string) bool {
+	return false
+}

--- a/.github/workflows/robot/main.go
+++ b/.github/workflows/robot/main.go
@@ -26,13 +26,14 @@ import (
 	"github.com/gravitational/teleport/.github/workflows/robot/internal/bot"
 	"github.com/gravitational/teleport/.github/workflows/robot/internal/env"
 	"github.com/gravitational/teleport/.github/workflows/robot/internal/github"
+	"github.com/gravitational/teleport/.github/workflows/robot/internal/leave"
 	"github.com/gravitational/teleport/.github/workflows/robot/internal/review"
 
 	"github.com/gravitational/trace"
 )
 
 func main() {
-	workflow, token, reviewers, err := parseFlags()
+	workflow, token, reviewers, ripplingToken, usernames, err := parseFlags()
 	if err != nil {
 		log.Fatalf("Failed to parse flags: %v.", err)
 	}
@@ -44,7 +45,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	b, err := createBot(ctx, token, reviewers)
+	b, err := createBot(ctx, token, reviewers, ripplingToken, usernames)
 	if err != nil {
 		log.Fatalf("Failed to create bot: %v.", err)
 	}
@@ -70,33 +71,40 @@ func main() {
 	log.Printf("Workflow %v complete.", workflow)
 }
 
-func parseFlags() (string, string, string, error) {
+func parseFlags() (string, string, string, string, string, error) {
 	var (
-		workflow  = flag.String("workflow", "", "specific workflow to run [assign, check, dismiss]")
-		token     = flag.String("token", "", "GitHub authentication token")
-		reviewers = flag.String("reviewers", "", "reviewer assignments")
+		workflow      = flag.String("workflow", "", "specific workflow to run [assign, check, dismiss]")
+		token         = flag.String("token", "", "GitHub authentication token")
+		reviewers     = flag.String("reviewers", "", "reviewer assignments")
+		usernames     = flag.String("usernames", "", "employee GitHub usernames")
+		ripplingToken = flag.String("rippling-token", "", "Rippling authentication token")
 	)
 	flag.Parse()
 
 	if *workflow == "" {
-		return "", "", "", trace.BadParameter("workflow missing")
+		return "", "", "", "", "", trace.BadParameter("workflow missing")
 	}
 	if *token == "" {
-		return "", "", "", trace.BadParameter("token missing")
+		return "", "", "", "", "", trace.BadParameter("token missing")
 	}
 	if *reviewers == "" {
-		return "", "", "", trace.BadParameter("reviewers required for assign and check")
+		return "", "", "", "", "", trace.BadParameter("reviewers required for assign and check")
 	}
-
+	if *ripplingToken == "" {
+		return "", "", "", "", "", trace.BadParameter("rippling token missing")
+	}
+	if *usernames == "" {
+		return "", "", "", "", "", trace.BadParameter("rippling token missing")
+	}
 	data, err := base64.StdEncoding.DecodeString(*reviewers)
 	if err != nil {
-		return "", "", "", trace.Wrap(err)
+		return "", "", "", "", "", trace.Wrap(err)
 	}
 
-	return *workflow, *token, string(data), nil
+	return *workflow, *token, string(data), *ripplingToken, *usernames, nil
 }
 
-func createBot(ctx context.Context, token string, reviewers string) (*bot.Bot, error) {
+func createBot(ctx context.Context, token string, reviewers string, ripplingToken string, usernames string) (*bot.Bot, error) {
 	gh, err := github.New(ctx, token)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -105,7 +113,17 @@ func createBot(ctx context.Context, token string, reviewers string) (*bot.Bot, e
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	reviewer, err := review.FromString(reviewers)
+	leave, err := leave.New(&leave.Config{
+		RipplingToken: ripplingToken,
+		Ctx:           ctx,
+		Usernames:     usernames /* GitHub usernames */})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	reviewer, err := review.New(&review.Config{
+		Reviewers: reviewers,
+		Leave:     leave,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
**Purpose**

This change omits reviewers who are on vacation/sick leave. The leave requests are obtained via the Rippling API for now, though the way we will ultimately end up getting leave request information is still up in the air because the Rippling API returns the reason for requesting the leave request and may expose some sensitive employee information. 

**Determining Omission** 

Leave is defined as being out for more than 2 business days. If an employee requests less than 2 business days off, they will continue to be assigned to PRs, even during the time they are OOO. Additionally, there is a 2-day pre-leave and 1-day post-leave omit period for employees on leave for more than 2 business days. During the pre-leave, post-leave, and the duration of their actual leave, they will not be assigned to review PRs. 

**Timezones** 

This addition doesn't take timezones into account, it was decided that the complexity of adding timezones wasn't worth it. Employees in different time zones may have different windows for the pre and post omission period. For example, someone in Melbourne will have ~1-day pre-omit and ~2-day post-omit period if the runner is running on a machine where the local time is PST. So there is a possibility for some variation. 

Notes: 
The start and end dates for leave requests returned by the Rippling API are the local dates to the requester. So if someone in Melbourne requested 01/31/22-02/05/22 off, the response would be exactly those dates, even if the dates differ in other time zones. 

It is also assumed that leave requests will never start/end on a non-business day because Rippling simply doesn't allow you to use PTO on non-business days. 

**Permissions**
If we decide to use the [Rippling API to get leave requests](https://developer.rippling.com/docs/rippling-api/b3A6OTgxMjM0-get-leave-requests), the authentication token will need the following scopes: 

> `company` - The parent company scope. This is a prequisite to additional company:* scopes, but does not serve as a scope superset.
> `company:leave_requests` - Permission to access the company's leave request information.

**TODO** 
- Pass the rippling token into the bot. 
- Add an additional secret that is a JSON string representing a map of employees' GH usernames with their full name as the value. 