### PR TITLE
[v7] Update S3 Canned ACL Docs

### DIFF
--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -207,7 +207,7 @@ teleport:
 The AWS authentication settings above can be omitted if the machine itself is
 running on an EC2 instance with an IAM role.
 
-These optional `GET` parameters control how Teleport interacts with an S3 endpoint, including S3-compatible endpoints.
+The optional `GET` parameters shown below control how Teleport interacts with an S3 endpoint, including S3-compatible endpoints.
 
 `s3://bucket/path?region=us-east-1&endpoint=mys3.example.com&insecure=false&disablesse=false&acl=private`
 
@@ -215,17 +215,17 @@ These optional `GET` parameters control how Teleport interacts with an S3 endpoi
 - `endpoint=mys3.example.com` - connect to a custom S3 endpoint.
 - `insecure=true` - set to `true` or `false`. If `true`, TLS will be disabled.
 - `disablesse=true` - set to `true` or `false`. If `true`, S3 server-side encryption will be disabled. If `false`, aws:kms (Key Management Service) will be used for server-side encryption. Other SSE types are not supported at this time.
-- `acl=private` - set the [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) to use.
+- `acl=private` - set the [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) to use. Must be one of the predefined ACL values.
 
-### ACL Example: Transferring Object Ownership
+### ACL example: transferring object ownership
 
-If you are uploading from account `A` to a bucket owned by account `B` and want `A` to retain ownership of the objects, you can take one of two approaches.
+If you are uploading from AWS account `A` to a bucket owned by AWS account `B` and want `A` to retain ownership of the objects, you can take one of two approaches.
 
-#### Without ACL
+#### Without ACLs
 
-If ACLs are disabled, object ownership will be set to `Bucket owner enforced` and no action is needed.
+If ACLs are disabled, object ownership will be set to `Bucket owner enforced` and no action will be needed.
 
-#### With ACL
+#### With ACLs
 
 - Set object ownership to `Bucket owner preferred` (under Permissions in the management console).
 - Add `acl=bucket-owner-full-control` to `audit_sessions_uri`.
@@ -256,7 +256,7 @@ To enforce the ownership transfer, set `B`'s bucket's policy to only allow uploa
 
 ```
 
-For more information, see the [AWS Docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html).
+For more information, see the [AWS Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html).
 
 ## DynamoDB
 


### PR DESCRIPTION
This is a follow-up to #9042. The docs for canned ACLs were updated as part of the review of #10005, and this PR ports those changes to v7.