### PR TITLE
Use an apt-key alternative in install instructions

### DIFF
--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -22,54 +22,7 @@ If you would like to try out Teleport on your local machine—e.g., you do not h
 
 Run the following commands to install the Teleport binary on your system:
 
-<Tabs>
-  <TabItem label="Amazon Linux 2/RHEL (RPM)">
-    ```code
-    $ sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-    $ sudo yum install teleport
-
-    # Optional:  Using DNF on newer distributions
-    # $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-    # $ sudo dnf install teleport
-    ```
-  </TabItem>
-
-  <TabItem label="Debian/Ubuntu (DEB)">
-    ```code
-    $ curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-    $ sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    $ sudo apt-get update
-    $ sudo apt-get install teleport
-    ```
-  </TabItem>
-
-  <TabItem label="Linux">
-    ```code
-    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    $ tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    $ cd teleport
-    $ sudo ./install
-    ```
-  </TabItem>
-
-  <TabItem label="ARMv7 (32-bit)">
-    ```code
-    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-    $ tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-    $ cd teleport
-    $ sudo ./install
-    ```
-  </TabItem>
-
-  <TabItem label="ARMv8 (64-bit)">
-    ```code
-    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-    $ tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-    $ cd teleport
-    $ sudo ./install
-    ```
-  </TabItem>
-</Tabs>
+(!docs/pages/includes/install-linux.mdx!)
 
 Take a look at the [Installation Guide](../installation.mdx) for more options.
 

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,0 +1,65 @@
+<Tabs>
+    <TabItem label="Debian/Ubuntu (DEB)">
+        ```code
+        # Download Teleport's PGP public key
+        $ sudo curl https://deb.releases.teleport.dev/teleport-pubkey.asc \
+          -o /usr/share/keyrings/teleport-archive-keyring.asc
+        # Add the Teleport APT repository
+        $ cat<<EOF>/etc/apt/sources.list.d/teleport.list
+        deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://deb.releases.teleport.dev/ stable main
+        EOF
+        $ sudo apt-get update
+        $ sudo apt-get install teleport
+        ```
+    </TabItem>
+    <TabItem label="Amazon Linux 2/RHEL (RPM)">
+        ```code
+        $ sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+        $ sudo yum install teleport
+
+        # Optional:  Using DNF on newer distributions
+        # $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+        # $ sudo dnf install teleport
+        ```
+    </TabItem>
+
+    <TabItem label="Tarball">
+        ```code
+        curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
+        # <checksum> <filename>
+        curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+        shasum -a 256 teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+        # Verify that the checksums match
+        tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+        cd teleport
+        ./install
+        ```
+    </TabItem>
+
+    <TabItem label="ARMv7 (32-bit)">
+        ```code
+        $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz.sha256
+        # <checksum> <filename>
+        $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
+        $ shasum -a 256 teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
+        # Verify that the checksums match
+        $ tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
+        $ cd teleport
+        $ ./install
+        ```
+  </TabItem>
+
+  <TabItem label="ARM64/ARMv8 (64-bit)">
+        ```code
+        $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz.sha256
+        # <checksum> <filename>
+        $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+        $ shasum -a 256 teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+        # Verify that the checksums match
+        $ tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+        $ cd teleport
+        $ ./install
+        ```
+  </TabItem>
+
+</Tabs>

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -25,14 +25,14 @@
 
     <TabItem label="Tarball">
         ```code
-        curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
+        $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
         # <checksum> <filename>
-        curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-        shasum -a 256 teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+        $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+        $ shasum -a 256 teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
         # Verify that the checksums match
-        tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-        cd teleport
-        ./install
+        $ tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+        $ cd teleport
+        $ sudo ./install
         ```
     </TabItem>
 
@@ -45,7 +45,7 @@
         # Verify that the checksums match
         $ tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
         $ cd teleport
-        $ ./install
+        $ sudo ./install
         ```
   </TabItem>
 
@@ -58,7 +58,7 @@
         # Verify that the checksums match
         $ tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
         $ cd teleport
-        $ ./install
+        $ sudo ./install
         ```
   </TabItem>
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -15,66 +15,7 @@ up-to-date information.
 
 (!docs/pages/includes/permission-warning.mdx!)
 
-<Tabs>
-  <TabItem label="Debian/Ubuntu (DEB)">
-    ```code
-    # Install our public key.
-    $ curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-    # Add repo to APT
-    $ add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    # Update APT Cache
-    $ apt-get update
-    # Install Teleport
-    $ apt install teleport
-    ```
-  </TabItem>
-
-  <TabItem label="Amazon Linux 2/RHEL/Fedora (RPM)">
-    ```code
-    $ yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-    $ yum install teleport
-    ```
-  </TabItem>
-
-  <TabItem label="ARMv7 (32-bit)">
-    ```code
-    $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz.sha256
-    # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-    $ shasum -a 256 teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-    # Verify that the checksums match
-    $ tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-    $ cd teleport
-    $ ./install
-    ```
-  </TabItem>
-
-  <TabItem label="ARM64/ARMv8 (64-bit)">
-    ```code
-    $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz.sha256
-    # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-    $ shasum -a 256 teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-    # Verify that the checksums match
-    $ tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-    $ cd teleport
-    $ ./install
-    ```
-  </TabItem>
-
-  <TabItem label="Tarball">
-    ```code
-    curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
-    # <checksum> <filename>
-    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    shasum -a 256 teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    # Verify that the checksums match
-    tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    cd teleport
-    ./install
-    ```
-  </TabItem>
-</Tabs>
+(!docs/pages/includes/install-linux.mdx!)
 
 ## Docker
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -66,54 +66,7 @@ This guide introduces some of these common scenarios and how to interact with Te
 
 2. Install Teleport on each instance.
 
-   <Tabs>
-     <TabItem label="Amazon Linux 2/RHEL (RPM)">
-      ```code
-      $ sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-      $ sudo yum install teleport
-
-      # Optional:  Using DNF on newer distributions
-      # $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-      # $ sudo dnf install teleport
-      ```
-     </TabItem>
-
-     <TabItem label="Debian/Ubuntu (DEB)">
-      ```code
-      $ curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-      $ sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-      $ sudo apt-get update
-      $ sudo apt-get install teleport
-      ```
-     </TabItem>
-
-     <TabItem label="Linux">
-      ```code
-      $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-      $ tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-      $ cd teleport
-      $ sudo ./install
-      ```
-     </TabItem>
-
-     <TabItem label="ARMv7 (32-bit)">
-      ```code
-      $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-      $ tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-      $ cd teleport
-      $ sudo ./install
-      ```
-     </TabItem>
-
-     <TabItem label="ARMv8 (64-bit)">
-      ```code
-      $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-      $ tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-      $ cd teleport
-      $ sudo ./install
-      ```
-     </TabItem>
-   </Tabs>
+   (!docs/pages/includes/install-linux.mdx!)
 
 3. Configure Teleport on the *Bastion Host*.
 


### PR DESCRIPTION
Current installation instructions for Debian/Ubuntu advise using
apt-key, which is deprecated. This change uses the recommended
method of appending a "signed-by" argument to the APT sources
list along with the rest of a repo's information.

Also creates a partial with Linux installation info to avoid
having to repeat changes in our different Linux installation
instructions.

Fixes #9611