### PR TITLE
playback end event

### DIFF
--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -170,10 +170,16 @@ func (pp *playbackPlayer) streamSessionEvents(ctx context.Context, cancel contex
 			if !errors.Is(err, context.Canceled) {
 				pp.log.WithError(err).Errorf("streaming session %v", pp.sID)
 			}
+
 			return
 		case evt := <-eventsC:
 			if evt == nil {
 				pp.log.Debug("reached end of playback")
+
+				if _, err := pp.ws.Write([]byte("end")); err != nil {
+					pp.log.WithError(err).Error("failed to write \"end\" message over websocket")
+				}
+
 				// deferred ps.Close() will set ps.playState = playStateFinished for us
 				return
 			}

--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -176,7 +176,13 @@ func (pp *playbackPlayer) streamSessionEvents(ctx context.Context, cancel contex
 			if evt == nil {
 				pp.log.Debug("reached end of playback")
 
-				if _, err := pp.ws.Write([]byte("end")); err != nil {
+				msg, err := utils.FastMarshal(struct {
+					Message string `json:"message"`
+				}{Message: "end"})
+				if err != nil {
+					pp.log.WithError(err).Errorf("failed to marshal end message into JSON: %v", msg)
+				}
+				if _, err := pp.ws.Write(msg); err != nil {
 					pp.log.WithError(err).Error("failed to write \"end\" message over websocket")
 				}
 
@@ -191,7 +197,7 @@ func (pp *playbackPlayer) streamSessionEvents(ctx context.Context, cancel contex
 				}
 				msg, err := utils.FastMarshal(e)
 				if err != nil {
-					pp.log.WithError(err).Errorf("failed to marshal DesktopRecording event into JSON: %v", msg)
+					pp.log.WithError(err).Errorf("failed to marshal DesktopRecording event into JSON: %v", e)
 				}
 				if _, err := pp.ws.Write(msg); err != nil {
 					// We expect net.ErrClosed to arise when another goroutine returns before

--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -176,15 +176,8 @@ func (pp *playbackPlayer) streamSessionEvents(ctx context.Context, cancel contex
 			if evt == nil {
 				pp.log.Debug("reached end of playback")
 
-				msg, err := utils.FastMarshal(struct {
-					Message string `json:"message"`
-				}{Message: "end"})
-				if err != nil {
-					pp.log.WithError(err).Errorf("failed to marshal end message into JSON: %v", msg)
-				} else {
-					if _, err := pp.ws.Write(msg); err != nil {
-						pp.log.WithError(err).Error("failed to write \"end\" message over websocket")
-					}
+				if _, err := pp.ws.Write([]byte(`{"message":"end"}`)); err != nil {
+					pp.log.WithError(err).Error("failed to write \"end\" message over websocket")
 				}
 
 				// deferred ps.Close() will set ps.playState = playStateFinished for us

--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -181,9 +181,10 @@ func (pp *playbackPlayer) streamSessionEvents(ctx context.Context, cancel contex
 				}{Message: "end"})
 				if err != nil {
 					pp.log.WithError(err).Errorf("failed to marshal end message into JSON: %v", msg)
-				}
-				if _, err := pp.ws.Write(msg); err != nil {
-					pp.log.WithError(err).Error("failed to write \"end\" message over websocket")
+				} else {
+					if _, err := pp.ws.Write(msg); err != nil {
+						pp.log.WithError(err).Error("failed to write \"end\" message over websocket")
+					}
 				}
 
 				// deferred ps.Close() will set ps.playState = playStateFinished for us


### PR DESCRIPTION
Adds an "end" message to the playback handler so that the frontend player knows to set its progress bar to its end state. 

Without this the progress bar would just hang at the last DesktopSession event's time, even though the overall recording was longer (i.e. if the user waited on the same screen for 10 seconds at the very end of their session, the progress bar would hang at 10 seconds before the true end of the recording).