### PR TITLE
[v8] Update version-check paths

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5010,7 +5010,7 @@ steps:
   - name: Check if tag is prerelease
     image: golang:1.17-alpine
     commands:
-      - cd build.assets/version-check
+      - cd /go/src/github.com/gravitational/teleport/build.assets/version-check
       - go run . -tag ${DRONE_TAG} -check prerelease || (echo '---> Not publishing ${DRONE_REPO} packages to RPM and DEB repos' && exit 78)
 
   - name: "RPM: Download RPM repository"
@@ -5100,7 +5100,7 @@ steps:
   - name: Check if tag is latest
     image: golang:1.17-alpine
     commands:
-      - cd build.assets/version-check
+      - cd /go/src/github.com/gravitational/teleport/build.assets/version-check
       - go run . -tag ${DRONE_TAG} -check latest || (echo '---> Not publishing ${DRONE_REPO} packages to DEB repo' && exit 78)
 
   - name: Download DEB repo contents
@@ -5213,6 +5213,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 4c16db480cb739be3baf97dff0bf444ae18e6d29080a27e5ef777b99a7b80542
+hmac: 35b04926a6bf74eb9cffaeb16471d924f28b8768770a5c3715527a304278c6f2
 
 ...


### PR DESCRIPTION
This is the v8 backport of https://github.com/gravitational/teleport/pull/10118

## Summary

This fixes a release error seen in https://drone.platform.teleport.sh/gravitational/teleport/10050/1/6

Particularly, teleport source code is not checked out in `/drone/src`, it is checked out in `/go/src/github.com/gravitational/teleport`  by an earlier step. As such, we need to use `/go/src/github.com/gravitational/teleport` as our base.

Needs backport to branch/v8

## Testing Done

No additional testing beyond what was done for https://github.com/gravitational/teleport/pull/10118.