### PR TITLE
Align TestKube/Deny integration tests

### DIFF
--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/events"
@@ -350,13 +351,15 @@ func testKubeDeny(t *testing.T, suite *KubeSuite) {
 	kubeUsers := []string{"alice@example.com"}
 	role, err := types.NewRole("kubemaster", types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins:     []string{username},
-			KubeGroups: kubeGroups,
-			KubeUsers:  kubeUsers,
+			Logins:           []string{username},
+			KubeGroups:       kubeGroups,
+			KubeUsers:        kubeUsers,
+			KubernetesLabels: map[string]apiutils.Strings{types.Wildcard: []string{types.Wildcard}},
 		},
 		Deny: types.RoleConditions{
-			KubeGroups: kubeGroups,
-			KubeUsers:  kubeUsers,
+			KubeGroups:       kubeGroups,
+			KubeUsers:        kubeUsers,
+			KubernetesLabels: map[string]apiutils.Strings{types.Wildcard: []string{types.Wildcard}},
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
## What 
Fix `TestKube/Deny` integration test after introducing: https://github.com/gravitational/teleport/pull/9759

## Why
By default, if a new role is created and the role spec version field is empty the code will fallback to V3 resource version https://github.com/gravitational/teleport/blob/master/api/types/role.go#L563 where the default Wildcard rule is applied to `r.Spec.Allow.KubernetesLabels` https://github.com/gravitational/teleport/blob/master/api/types/role.go#L607

The `TestKube/Deny` tests  creates the `kubemaster`  role without specifying any resource version:
```go
	role, err := types.NewRole("kubemaster", types.RoleSpecV4{
		Allow: types.RoleConditions{
			Logins:     []string{username},
			KubeGroups: kubeGroups,
			KubeUsers:  kubeUsers,
		},
		Deny: types.RoleConditions{
			KubeGroups: kubeGroups,
			KubeUsers:  kubeUsers,
		},
	})
```
this will produce the following role where Wildcard is added to `allow.kubernetes_labels`
```json
{
  "kind": "role",
  "version": "v3",
  "metadata": {
   "name": "kubemaster"
  },
  "spec": {
   "allow": {
    "kubernetes_groups": [
     "teleport-ci-test-group"
    ],
    "kubernetes_users": [
     "alice@example.com"
    ],
    "kubernetes_labels": {
     "*": "*"
    },
   },
   "deny": {
    "kubernetes_groups": [
     "teleport-ci-test-group"
    ],
    "kubernetes_users": [
     "alice@example.com"
    ]
   }
  }
 }
```
After https://github.com/gravitational/teleport/pull/9759/files#diff-9b3fca74b2b2d4ce46a466de333f6c3e7640c21da8bd587e1837aa7a113eb7e7R1058 PR the `kubernetes_labels` labels are respected during evaluation k8 access . Thus `deny.kubernetes_labels` is empty in `kubemaster` TC  the `teleport-ci-test-group` group is not filtered out. 

## How
Add `KubernetesLabels`   explicitly in Deny role struct. 

## Risk: 
This change seems to be not backward compatible and will change the result of v3 Kube roles evaluated based on the empty `deny.kubernetes_labels` rule but logic is compatible with how rules are evaluated in other resources. 

Alternative solutions: 
* For V3 role resources if `deny.kubernetes_labels` is empty add default `Wildcard` rule to `deny.kubernetes_labels` so the allow rule will be always evaluated. 

* Skip `deny.kubernetes_labels` check added in "Fix k8 access - respect kube service labels" PR  for v3 resources if deny.kubernetes_labels list is empty:  https://github.com/gravitational/teleport/pull/9759/files#diff-9b3fca74b2b2d4ce46a466de333f6c3e7640c21da8bd587e1837aa7a113eb7e7R1058 