### PR TITLE
docs: fix audit_retention_period

### DIFF
--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -428,7 +428,7 @@ teleport:
     # This setting configures Teleport to save the recorded sessions in an S3 bucket:
     audit_sessions_uri: s3://Example_TELEPORT_S3_BUCKET/records
 
-    # Teleport by default stores stores audit events with an AWS TTL of 1 year.
+    # By default, Teleport stores stores audit events with an AWS TTL of 1 year.
     # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
     audit_retention_period: 365d
 ```

--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -430,7 +430,7 @@ teleport:
 
     # Teleport by default stores stores audit events with an AWS TTL of 1 year.
     # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
-    audit_retention_period: 1y
+    audit_retention_period: 365d
 ```
 
 - Replace `us-east-1` and `Example_TELEPORT_DYNAMO_TABLE_NAME`

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -51,7 +51,7 @@ By default, it is stored in `/etc/teleport.yaml`.
   ```yaml
   auth_service:
     enabled: no
-  
+
   proxy_service:
     enabled: no
   ```
@@ -176,15 +176,20 @@ teleport:
         # (https://goteleport.com/docs/admin-guide/#using-amazon-s3).
         audit_sessions_uri: 's3://example.com/path/to/bucket?region=us-east-1'
 
-        # DynamoDB Specific Section
+        # DynamoDB Specific Section:
+
         # continuous_backups is used to enable continuous backups.
         continuous_backups: [true|false]
 
-        # DynamoDB Specific Section
         # auto_scaling is used to enable (and define settings for) auto
         # scaling.
         # default: false
         auto_scaling:  [true|false]
+
+        # By default, Teleport stores stores audit events with an AWS TTL of 1 year.
+        # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
+        audit_retention_period: 365d
+
         # minimum/maximum read capacity in units
         read_min_capacity: int
         read_max_capacity: int


### PR DESCRIPTION
Corrected the example TTL specified to 365d from 1y which is incorrect