### PR TITLE
docs: add note about user CA rotation + desktop access

### DIFF
--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -148,11 +148,14 @@ certificate-based smart card authentication, and ensuring RDP is enabled.
 
 ### Export the Teleport CA
 
-<Admonition type="note" title="Requires Existing Cluster">
-  The following step requires an existing cluster. If you don't already have a
-  Teleport cluster up and running, see our general [Getting
-  Started](../getting-started.mdx) guide.
+The following step requires an existing cluster. If you don't already have a
+Teleport cluster up and running, see our general [Getting
+Started](../getting-started.mdx) guide.
+
+<Admonition type="note" title="User CA Rotation">
+These steps will need to be repeated if Teleport's user certificate authority is rotated.
 </Admonition>
+
 
 1. Get the Teleport user CA certificate by running:
 

--- a/docs/pages/setup/operations/ca-rotation.mdx
+++ b/docs/pages/setup/operations/ca-rotation.mdx
@@ -61,11 +61,16 @@ the [customer portal](https://dashboard.gravitational.com/web/login).
 
 This section will show you how to implement certificate rotation in practice.
 
-<Admonition type="warning" title="CA Pinning Warning">
-  If you are using [CA
-  Pinning](../admin/adding-nodes.mdx#untrusted-auth-servers) when adding new
-  nodes, the CA pin will change after the rotation. Make sure you use the *new*
-  CA pin when adding nodes after rotation.
+If you are using [CA Pinning](../admin/adding-nodes.mdx#untrusted-auth-servers)
+when adding new nodes, the CA pin will change after the rotation. Make sure you
+use the *new* CA pin when adding nodes after rotation.
+
+<Admonition type="warning" title="Desktop Access">
+Teleport signs Windows Desktop certificates with the user certificate authority.
+If the user CA is rotated, the new CA certificate will need to be exported and
+configured in group policy.
+
+[Read more about exporting the Teleport CA](../../desktop-access/getting-started.mdx#export-the-teleport-ca)
 </Admonition>
 
 ### Rotation phases


### PR DESCRIPTION
In the future we'll move desktop access to a separate CA, but for
now Windows certs are generated with the user CA, so Active Directory
will need to be updated to trust the new certificate when a rotation
takes place.