### PR TITLE
Fix ineffective timeout break in integration test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5232,6 +5232,9 @@ func testBPFSessionDifferentiation(t *testing.T, suite *integrationTestSuite) {
 
 	// It's possible to run this test sequentially but it should
 	// be run in parallel to amortize the time since the two tasks can be run in parallel.
+	//
+	// This is also important because it ensures the tests faults if some part of the SSH code
+	// hangs unexpectedly instead of timing out silently.
 	go writeTerm(termA)
 	go writeTerm(termB)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5211,7 +5211,9 @@ func testBPFSessionDifferentiation(t *testing.T, suite *integrationTestSuite) {
 			Host:    Host,
 			Port:    main.GetPortSSHInt(),
 		})
-		require.NoError(t, err)
+		if err != nil {
+			t.Errorf("Failed to create client: %v.", err)
+		}
 
 		// Connect terminal to std{in,out} of client.
 		client.Stdout = term
@@ -5220,11 +5222,16 @@ func testBPFSessionDifferentiation(t *testing.T, suite *integrationTestSuite) {
 		// "Type" a command into the terminal.
 		term.Type(fmt.Sprintf("\a%v\n\r\aexit\n\r\a", lsPath))
 		err = client.SSH(context.Background(), []string{}, false)
-		require.NoError(t, err)
+		if err != nil {
+			t.Errorf("Failed to start SSH session: %v.", err)
+		}
 
 		// Signal that the client has finished the interactive session.
 		doneCh <- true
 	}
+
+	// It's possible to run this test sequentially but it should
+	// be run in parallel to amortize the time since the two tasks can be run in parallel.
 	go writeTerm(termA)
 	go writeTerm(termB)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5230,11 +5230,12 @@ func testBPFSessionDifferentiation(t *testing.T, suite *integrationTestSuite) {
 
 	// Wait 10 seconds for both events to arrive, otherwise timeout.
 	timeout := time.After(10 * time.Second)
+outer:
 	for i := 0; i < 2; i++ {
 		select {
 		case <-doneCh:
 			if i == 1 {
-				break
+				break outer
 			}
 		case <-timeout:
 			dumpGoroutineProfile()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5225,21 +5225,21 @@ func testBPFSessionDifferentiation(t *testing.T, suite *integrationTestSuite) {
 		// Signal that the client has finished the interactive session.
 		doneCh <- true
 	}
-	writeTerm(termA)
-	writeTerm(termB)
+	go writeTerm(termA)
+	go writeTerm(termB)
 
 	// Wait 10 seconds for both events to arrive, otherwise timeout.
 	timeout := time.After(10 * time.Second)
-outer:
-	for i := 0; i < 2; i++ {
+	gotEvents := 0
+	for {
 		select {
 		case <-doneCh:
-			if i == 1 {
-				break outer
-			}
+			gotEvents++
 		case <-timeout:
-			dumpGoroutineProfile()
 			require.FailNow(t, "Timed out waiting for client to finish interactive session.")
+		}
+		if gotEvents == 2 {
+			break
 		}
 	}
 


### PR DESCRIPTION
This PR fixes an ineffective (it does nothing, usually unintended) cancel break in an integration test causing us to fall back onto a timeout.