### PR TITLE
[v8] Backport Add teleport_build_info Prometheus metric to Teleport (#9595)

### DIFF
--- a/docs/pages/setup/reference/metrics.mdx
+++ b/docs/pages/setup/reference/metrics.mdx
@@ -108,6 +108,7 @@ Now you can see the monitoring information by visiting several endpoints:
 | `reversetunnel_connected_proxies` | gauge | Teleport | Number of known proxies being sought. |
 | `rx` | counter | Teleport | Number of bytes received. |
 | `server_interactive_sessions_total` | gauge | Teleport | Number of active sessions. |
+| `teleport_build_info` | gauge | Teleport | Provides build information of Teleport including gitref (git describe --long --tags), Go version, and Teleport version. The value of this gauge will always be 1. |
 | `trusted_clusters` | gauge | Teleport | Number of tunnels per state. |
 | `tx` | counter | Teleport | Number of bytes transmitted. |
 | `user_login_total` | counter | Teleport Auth | Number of user logins. |

--- a/lib/utils/prometheus.go
+++ b/lib/utils/prometheus.go
@@ -17,6 +17,9 @@ limitations under the License.
 package utils
 
 import (
+	"runtime"
+
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,4 +39,21 @@ func RegisterPrometheusCollectors(collectors ...prometheus.Collector) error {
 		}
 	}
 	return nil
+}
+
+// BuildCollector provides a Collector that contains build information gauge
+func BuildCollector() prometheus.Collector {
+	return prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricBuildInfo,
+			Help:      "Provides build information of Teleport including gitref (git describe --long --tags), Go version, and Teleport version. The value of this gauge will always be 1.",
+			ConstLabels: prometheus.Labels{
+				teleport.TagVersion:   teleport.Version,
+				teleport.TagGitref:    teleport.Gitref,
+				teleport.TagGoVersion: runtime.Version(),
+			},
+		},
+		func() float64 { return 1 },
+	)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -177,6 +177,12 @@ const (
 	// MetricState tracks the state of the teleport process.
 	MetricState = "process_state"
 
+	// MetricNamespace defines the teleport prometheus namespace
+	MetricNamespace = "teleport"
+
+	// MetricBuildInfo tracks build information
+	MetricBuildInfo = "build_info"
+
 	// TagRange is a tag specifying backend requests
 	TagRange = "range"
 
@@ -191,4 +197,13 @@ const (
 
 	// TagResource is a tag specifying the resource for an event
 	TagResource = "resource"
+
+	// TagVersion is a prometheus label for version of Teleport built
+	TagVersion = "version"
+
+	// TagGitref is a prometheus label for the gitref of Teleport built
+	TagGitref = "gitref"
+
+	// TagGoVersion is a prometheus label for version of Go used to build Teleport
+	TagGoVersion = "goversion"
 )

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -21,10 +21,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/teleport/common"
 )
 
 func init() {
+	utils.RegisterPrometheusCollectors(utils.BuildCollector())
 	rand.Seed(time.Now().UnixNano())
 }
 


### PR DESCRIPTION
Adds teleport_build_info metric to Teleport providing the gitref, version, and Go version.