### PR TITLE
Add missing DatabasesReady event

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -838,6 +838,8 @@ func (i *TeleInstance) StartDatabase(conf *service.Config) (*service.TeleportPro
 	conf.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
+	conf.Apps.Enabled = false
+	conf.SSH.Enabled = false
 
 	// Create a new Teleport process and add it to the list of nodes that
 	// compose this "cluster".
@@ -852,6 +854,7 @@ func (i *TeleInstance) StartDatabase(conf *service.Config) (*service.TeleportPro
 	expectedEvents := []string{
 		service.DatabasesIdentityEvent,
 		service.DatabasesReady,
+		service.TeleportReadyEvent,
 	}
 
 	// Start the process and block until the expected events have arrived.
@@ -1109,6 +1112,9 @@ func (i *TeleInstance) Start() error {
 	}
 	if i.Config.Apps.Enabled {
 		expectedEvents = append(expectedEvents, service.AppsReady)
+	}
+	if i.Config.Databases.Enabled {
+		expectedEvents = append(expectedEvents, service.DatabasesReady)
 	}
 
 	// Start the process and block until the expected events have arrived.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -765,6 +765,9 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 	if cfg.Apps.Enabled {
 		eventMapping.In = append(eventMapping.In, AppsReady)
 	}
+	if cfg.Databases.Enabled {
+		eventMapping.In = append(eventMapping.In, DatabasesReady)
+	}
 	if cfg.Metrics.Enabled {
 		eventMapping.In = append(eventMapping.In, MetricsReady)
 	}


### PR DESCRIPTION
Currently DB proxy is not sending `DatabasesReady`. In a consequence during CA rotation periodic sync rotation sync never happens https://github.com/gravitational/teleport/blob/6cb13715ba831d6c54618d232af417783855b298/lib/service/connect.go#L471 and DB proxy fails to re-connect to proxy after Host CA is rotated.