### PR TITLE
Add xauth binary to buildbox for X11 forwarding

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update -y --fix-missing && \
         unzip \
         zip \
         zlib1g-dev \
+        xauth \
         && \
     pip --no-cache-dir install yamllint && \
     dpkg-reconfigure locales && \


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/10164

This PR will be used to reset the buildbox, which is currently based on Master (with breaking changes).