### PR TITLE
[v8] Use buildbox image from quay.io

### DIFF
--- a/.cloudbuild/ci/integration-tests.yaml
+++ b/.cloudbuild/ci/integration-tests.yaml
@@ -11,7 +11,7 @@ steps:
 
   # Run the integration tests. Actual content of this job depends on the changes 
   # detected in the PR
-  - name: quay.io/gravitational/teleport-buildbox:go1.17.2
+  - name: quay.io/gravitational/teleport-buildbox:teleport8
     id: run-tests
     dir: /workspace/.cloudbuild/scripts
     entrypoint: bash

--- a/.cloudbuild/ci/integration-tests.yaml
+++ b/.cloudbuild/ci/integration-tests.yaml
@@ -11,7 +11,7 @@ steps:
 
   # Run the integration tests. Actual content of this job depends on the changes 
   # detected in the PR
-  - name: us-docker.pkg.dev/ci-account/teleport/buildbox-root:v0.1.0
+  - name: quay.io/gravitational/teleport-buildbox:go1.17.1
     id: run-tests
     dir: /workspace/.cloudbuild/scripts
     entrypoint: bash

--- a/.cloudbuild/ci/integration-tests.yaml
+++ b/.cloudbuild/ci/integration-tests.yaml
@@ -11,7 +11,7 @@ steps:
 
   # Run the integration tests. Actual content of this job depends on the changes 
   # detected in the PR
-  - name: quay.io/gravitational/teleport-buildbox:go1.17.1
+  - name: quay.io/gravitational/teleport-buildbox:go1.17.2
     id: run-tests
     dir: /workspace/.cloudbuild/scripts
     entrypoint: bash

--- a/.cloudbuild/ci/lint.yaml
+++ b/.cloudbuild/ci/lint.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: quay.io/gravitational/teleport-buildbox:go1.17.2
+  - name: quay.io/gravitational/teleport-buildbox:teleport8
     id: lint
     args: ['make', 'lint']
 options:

--- a/.cloudbuild/ci/lint.yaml
+++ b/.cloudbuild/ci/lint.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: us-docker.pkg.dev/ci-account/teleport/buildbox-root:v0.1.0
+  - name: quay.io/gravitational/teleport-buildbox:go1.17.1
     id: lint
     args: ['make', 'lint']
 options:

--- a/.cloudbuild/ci/lint.yaml
+++ b/.cloudbuild/ci/lint.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: quay.io/gravitational/teleport-buildbox:go1.17.1
+  - name: quay.io/gravitational/teleport-buildbox:go1.17.2
     id: lint
     args: ['make', 'lint']
 options:

--- a/.cloudbuild/ci/unit-tests.yaml
+++ b/.cloudbuild/ci/unit-tests.yaml
@@ -13,7 +13,7 @@ steps:
 
   # Run the unit tests. Actual content of this job depends on the changes 
   # detected in the PR
-  - name: quay.io/gravitational/teleport-buildbox:go1.17.2
+  - name: quay.io/gravitational/teleport-buildbox:teleport8
     id: run-tests
     dir: /workspace/.cloudbuild/scripts
     entrypoint: bash 

--- a/.cloudbuild/ci/unit-tests.yaml
+++ b/.cloudbuild/ci/unit-tests.yaml
@@ -13,7 +13,7 @@ steps:
 
   # Run the unit tests. Actual content of this job depends on the changes 
   # detected in the PR
-  - name: quay.io/gravitational/teleport-buildbox:go1.17.1
+  - name: quay.io/gravitational/teleport-buildbox:go1.17.2
     id: run-tests
     dir: /workspace/.cloudbuild/scripts
     entrypoint: bash 

--- a/.cloudbuild/ci/unit-tests.yaml
+++ b/.cloudbuild/ci/unit-tests.yaml
@@ -13,7 +13,7 @@ steps:
 
   # Run the unit tests. Actual content of this job depends on the changes 
   # detected in the PR
-  - name: us-docker.pkg.dev/ci-account/teleport/buildbox-root:v0.1.0
+  - name: quay.io/gravitational/teleport-buildbox:go1.17.1
     id: run-tests
     dir: /workspace/.cloudbuild/scripts
     entrypoint: bash 


### PR DESCRIPTION
The use of a re-badged buildbox image (rebadging quay.io/gravitational/teleport-buildbox to us-docker.pkg.dev/ci-account/teleport/buildbox-root) is holdover from when CI builds required separate "root user" and "non-root user" images to execute tests under different contexts.

This requirement has since been lifted by using a Go-based build script in CI, and the having to manually invoke a process to re-badge the buildboxes is, tedious, confusing and causing stoppages.

This patch restores the use of buildboxes from quay.io in CI.