### PR TITLE
Fixed TestDisconnection

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -684,20 +684,6 @@ func (i *TeleInstance) CreateEx(t *testing.T, trustedSecrets []*InstanceSecrets,
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		// if user keys are not present, auto-generate keys:
-		if user.Key == nil || len(user.Key.Pub) == 0 {
-			priv, pub, _ := tconf.Keygen.GenerateKeyPair("")
-			user.Key = &client.Key{
-				Priv: priv,
-				Pub:  pub,
-			}
-		}
-		// sign user's keys:
-		ttl := 24 * time.Hour
-		user.Key.Cert, user.Key.TLSCert, err = auth.GenerateUserTestCerts(user.Key.Pub, teleUser.GetName(), ttl, constants.CertificateFormatStandard, "")
-		if err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -1228,30 +1214,30 @@ func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.Te
 }
 
 // NewClient returns a fully configured and pre-authenticated client
-// (pre-authenticated with server CAs and signed session key)
+// (pre-authenticated with server CAs and signed session key).
 func (i *TeleInstance) NewClient(t *testing.T, cfg ClientConfig) (*client.TeleportClient, error) {
 	tc, err := i.NewUnauthenticatedClient(cfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// configures the client authenticate using the keys from 'secrets':
-	user, ok := i.Secrets.Users[cfg.Login]
-	if !ok {
-		return nil, trace.BadParameter("unknown login %q", cfg.Login)
-	}
-	if user.Key == nil {
-		return nil, trace.BadParameter("user %q has no key", cfg.Login)
-	}
-	_, err = tc.AddKey(user.Key)
+	// Generate certificates for the user simulating login.
+	creds, err := GenerateUserCreds(UserCredsRequest{
+		Process:  i.Process,
+		Username: cfg.Login,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// tell the client to trust given CAs (from secrets). this is the
-	// equivalent of 'known hosts' in openssh
-	cas := i.Secrets.GetCAs(t)
-	for i := range cas {
-		err = tc.AddTrustedCA(cas[i])
+
+	// Add key to client and update CAs that will be trusted (equivalent to
+	// updating "known hosts" with OpenSSH.
+	_, err = tc.AddKey(&creds.Key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, ca := range i.Secrets.GetCAs(t) {
+		err = tc.AddTrustedCA(ca)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -265,7 +265,10 @@ func NewInstance(cfg InstanceConfig) *TeleInstance {
 // GetRoles returns a list of roles to initiate for this secret
 func (s *InstanceSecrets) GetRoles(t *testing.T) []types.Role {
 	var roles []types.Role
-	for _, ca := range s.GetCAs(t) {
+
+	cas, err := s.GetCAs()
+	require.NoError(t, err)
+	for _, ca := range cas {
 		if ca.GetType() != types.UserCA {
 			continue
 		}
@@ -279,7 +282,7 @@ func (s *InstanceSecrets) GetRoles(t *testing.T) []types.Role {
 // GetCAs return an array of CAs stored by the secrets object. In i
 // case we always return hard-coded userCA + hostCA (and they share keys
 // for simplicity)
-func (s *InstanceSecrets) GetCAs(t *testing.T) []types.CertAuthority {
+func (s *InstanceSecrets) GetCAs() ([]types.CertAuthority, error) {
 	hostCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
 		Type:        types.HostCA,
 		ClusterName: s.SiteName,
@@ -298,7 +301,9 @@ func (s *InstanceSecrets) GetCAs(t *testing.T) []types.CertAuthority {
 		Roles:      []string{},
 		SigningAlg: types.CertAuthoritySpecV2_RSA_SHA2_512,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	userCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
 		Type:        types.UserCA,
@@ -318,9 +323,14 @@ func (s *InstanceSecrets) GetCAs(t *testing.T) []types.CertAuthority {
 		Roles:      []string{services.RoleNameForCertAuthority(s.SiteName)},
 		SigningAlg: types.CertAuthoritySpecV2_RSA_SHA2_512,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
-	return []types.CertAuthority{hostCA, userCA}
+	return []types.CertAuthority{
+		hostCA,
+		userCA,
+	}, nil
 }
 
 func (s *InstanceSecrets) AllowedLogins() []string {
@@ -533,10 +543,22 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tconf.Auth.Authorities = append(tconf.Auth.Authorities, i.Secrets.GetCAs(t)...)
+
+	rootCAs, err := i.Secrets.GetCAs()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tconf.Auth.Authorities = append(tconf.Auth.Authorities, rootCAs...)
+
 	tconf.Identities = append(tconf.Identities, i.Secrets.GetIdentity())
+
 	for _, trusted := range trustedSecrets {
-		tconf.Auth.Authorities = append(tconf.Auth.Authorities, trusted.GetCAs(t)...)
+		leafCAs, err := trusted.GetCAs()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		tconf.Auth.Authorities = append(tconf.Auth.Authorities, leafCAs...)
+
 		tconf.Auth.Roles = append(tconf.Auth.Roles, trusted.GetRoles(t)...)
 		tconf.Identities = append(tconf.Identities, trusted.GetIdentity())
 		if trusted.TunnelAddr != "" {
@@ -1215,7 +1237,7 @@ func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.Te
 
 // NewClient returns a fully configured and pre-authenticated client
 // (pre-authenticated with server CAs and signed session key).
-func (i *TeleInstance) NewClient(t *testing.T, cfg ClientConfig) (*client.TeleportClient, error) {
+func (i *TeleInstance) NewClient(cfg ClientConfig) (*client.TeleportClient, error) {
 	tc, err := i.NewUnauthenticatedClient(cfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1236,7 +1258,11 @@ func (i *TeleInstance) NewClient(t *testing.T, cfg ClientConfig) (*client.Telepo
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	for _, ca := range i.Secrets.GetCAs(t) {
+	cas, err := i.Secrets.GetCAs()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, ca := range cas {
 		err = tc.AddTrustedCA(ca)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -326,7 +326,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 			endC := make(chan error)
 			myTerm := NewTerminal(250)
 			go func() {
-				cl, err := teleport.NewClient(t, ClientConfig{
+				cl, err := teleport.NewClient(ClientConfig{
 					Login:        suite.me.Username,
 					Cluster:      Site,
 					Host:         Host,
@@ -577,7 +577,12 @@ func testInteroperability(t *testing.T, suite *integrationTestSuite) {
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("Test %d: %s", i, strings.Fields(tt.inCommand)[0]), func(t *testing.T) {
 			// create new teleport client
-			cl, err := teleport.NewClient(t, ClientConfig{Login: suite.me.Username, Cluster: Site, Host: Host, Port: teleport.GetPortSSHInt()})
+			cl, err := teleport.NewClient(ClientConfig{
+				Login:   suite.me.Username,
+				Cluster: Site,
+				Host:    Host,
+				Port:    teleport.GetPortSSHInt(),
+			})
 			require.NoError(t, err)
 
 			// hook up stdin and stdout to a buffer for reading and writing
@@ -880,7 +885,11 @@ func verifySessionJoin(t *testing.T, username string, teleport *TeleInstance) {
 	// PersonA: SSH into the server, wait one second, then type some commands on stdin:
 	sessionA := make(chan error)
 	openSession := func() {
-		cl, err := teleport.NewClient(t, ClientConfig{Login: username, Cluster: Site, Host: Host})
+		cl, err := teleport.NewClient(ClientConfig{
+			Login:   username,
+			Cluster: Site,
+			Host:    Host,
+		})
 		if err != nil {
 			sessionA <- trace.Wrap(err)
 			return
@@ -904,7 +913,11 @@ func verifySessionJoin(t *testing.T, username string, teleport *TeleInstance) {
 		}
 
 		sessionID := string(sessions[0].ID)
-		cl, err := teleport.NewClient(t, ClientConfig{Login: username, Cluster: Site, Host: Host})
+		cl, err := teleport.NewClient(ClientConfig{
+			Login:   username,
+			Cluster: Site,
+			Host:    Host,
+		})
 		if err != nil {
 			sessionB <- trace.Wrap(err)
 			return
@@ -966,7 +979,12 @@ func testShutdown(t *testing.T, suite *integrationTestSuite) {
 
 	// PersonA: SSH into the server, wait one second, then type some commands on stdin:
 	openSession := func() {
-		cl, err := teleport.NewClient(t, ClientConfig{Login: suite.me.Username, Cluster: Site, Host: Host, Port: teleport.GetPortSSHInt()})
+		cl, err := teleport.NewClient(ClientConfig{
+			Login:   suite.me.Username,
+			Cluster: Site,
+			Host:    Host,
+			Port:    teleport.GetPortSSHInt(),
+		})
 		require.NoError(t, err)
 		cl.Stdout = person
 		cl.Stdin = person
@@ -1207,7 +1225,7 @@ func runDisconnectTest(t *testing.T, suite *integrationTestSuite, tc disconnectT
 
 		openSession := func() {
 			defer cancel()
-			cl, err := teleport.NewClient(t, ClientConfig{
+			cl, err := teleport.NewClient(ClientConfig{
 				Login:   username,
 				Cluster: Site,
 				Host:    Host,
@@ -1318,7 +1336,12 @@ func testEnvironmentVariables(t *testing.T, suite *integrationTestSuite) {
 	cmd := []string{"printenv", testKey}
 
 	// make sure sessions set run command
-	tc, err := teleport.NewClient(t, ClientConfig{Login: suite.me.Username, Cluster: Site, Host: Host, Port: teleport.GetPortSSHInt()})
+	tc, err := teleport.NewClient(ClientConfig{
+		Login:   suite.me.Username,
+		Cluster: Site,
+		Host:    Host,
+		Port:    teleport.GetPortSSHInt(),
+	})
 	require.NoError(t, err)
 
 	tc.Env = map[string]string{testKey: testVal}
@@ -1343,7 +1366,12 @@ func testInvalidLogins(t *testing.T, suite *integrationTestSuite) {
 	cmd := []string{"echo", "success"}
 
 	// try the wrong site:
-	tc, err := teleport.NewClient(t, ClientConfig{Login: suite.me.Username, Cluster: "wrong-site", Host: Host, Port: teleport.GetPortSSHInt()})
+	tc, err := teleport.NewClient(ClientConfig{
+		Login:   suite.me.Username,
+		Cluster: "wrong-site",
+		Host:    Host,
+		Port:    teleport.GetPortSSHInt(),
+	})
 	require.NoError(t, err)
 	err = tc.SSH(context.TODO(), cmd, false)
 	require.Regexp(t, "cluster wrong-site not found", err.Error())
@@ -1462,7 +1490,7 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 	cmd := []string{"echo", "hello world"}
 
 	// directly:
-	tc, err := a.NewClient(t, ClientConfig{
+	tc, err := a.NewClient(ClientConfig{
 		Login:        username,
 		Cluster:      a.Secrets.SiteName,
 		Host:         Host,
@@ -1507,7 +1535,7 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 	waitForActiveTunnelConnections(t, b.Tunnel, a.Secrets.SiteName, 1)
 
 	// via tunnel b->a:
-	tc, err = b.NewClient(t, ClientConfig{
+	tc, err = b.NewClient(ClientConfig{
 		Login:        username,
 		Cluster:      a.Secrets.SiteName,
 		Host:         Host,
@@ -1637,7 +1665,7 @@ func testHA(t *testing.T, suite *integrationTestSuite) {
 		"Two clusters do not see each other: tunnels are not working.")
 
 	cmd := []string{"echo", "hello world"}
-	tc, err := b.NewClient(t, ClientConfig{
+	tc, err := b.NewClient(ClientConfig{
 		Login:   username,
 		Cluster: "cluster-a",
 		Host:    Loopback,
@@ -1795,7 +1823,12 @@ func testMapRoles(t *testing.T, suite *integrationTestSuite) {
 	require.Len(t, nodes, 2)
 
 	cmd := []string{"echo", "hello world"}
-	tc, err := main.NewClient(t, ClientConfig{Login: username, Cluster: clusterAux, Host: Loopback, Port: sshPort})
+	tc, err := main.NewClient(ClientConfig{
+		Login:   username,
+		Cluster: clusterAux,
+		Host:    Loopback,
+		Port:    sshPort,
+	})
 	require.NoError(t, err)
 	output := &bytes.Buffer{}
 	tc.Stdout = output
@@ -2144,9 +2177,10 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 
 	// tell the client to trust aux cluster CAs (from secrets). this is the
 	// equivalent of 'known hosts' in openssh
-	auxCAS := aux.Secrets.GetCAs(t)
-	for i := range auxCAS {
-		err = tc.AddTrustedCA(auxCAS[i])
+	auxCAS, err := aux.Secrets.GetCAs()
+	require.NoError(t, err)
+	for _, auxCA := range auxCAS {
+		err = tc.AddTrustedCA(auxCA)
 		require.NoError(t, err)
 	}
 
@@ -2355,7 +2389,7 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 
 	// Try and connect to a node in the Aux cluster from the Main cluster using
 	// direct dialing.
-	tc, err := main.NewClient(t, ClientConfig{
+	tc, err := main.NewClient(ClientConfig{
 		Login:   username,
 		Cluster: clusterAux,
 		Host:    Loopback,
@@ -2377,7 +2411,7 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 
 	// Try and connect to a node in the Aux cluster from the Main cluster using
 	// tunnel dialing.
-	tunnelClient, err := main.NewClient(t, ClientConfig{
+	tunnelClient, err := main.NewClient(ClientConfig{
 		Login:   username,
 		Cluster: clusterAux,
 		Host:    tunnelNodeHostname,
@@ -3231,7 +3265,7 @@ func testAuditOff(t *testing.T, suite *integrationTestSuite) {
 
 	myTerm := NewTerminal(250)
 	go func() {
-		cl, err := teleport.NewClient(t, ClientConfig{
+		cl, err := teleport.NewClient(ClientConfig{
 			Login:   suite.me.Username,
 			Cluster: Site,
 			Host:    Host,
@@ -3406,7 +3440,7 @@ func testPAM(t *testing.T, suite *integrationTestSuite) {
 			// Create an interactive session and write something to the terminal.
 			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
-				cl, err := teleport.NewClient(t, ClientConfig{
+				cl, err := teleport.NewClient(ClientConfig{
 					Login:   suite.me.Username,
 					Cluster: Site,
 					Host:    Host,
@@ -4230,7 +4264,7 @@ func testWindowChange(t *testing.T, suite *integrationTestSuite) {
 
 	// openSession will open a new session on a server.
 	openSession := func() {
-		cl, err := teleport.NewClient(t, ClientConfig{
+		cl, err := teleport.NewClient(ClientConfig{
 			Login:   suite.me.Username,
 			Cluster: Site,
 			Host:    Host,
@@ -4256,7 +4290,7 @@ func testWindowChange(t *testing.T, suite *integrationTestSuite) {
 		require.NoError(t, err)
 		sessionID := string(sessions[0].ID)
 
-		cl, err := teleport.NewClient(t, ClientConfig{
+		cl, err := teleport.NewClient(ClientConfig{
 			Login:   suite.me.Username,
 			Cluster: Site,
 			Host:    Host,
@@ -4693,7 +4727,7 @@ func testBPFInteractive(t *testing.T, suite *integrationTestSuite) {
 			doneContext, doneCancel := context.WithCancel(context.Background())
 
 			func() {
-				client, err := main.NewClient(t, ClientConfig{
+				client, err := main.NewClient(ClientConfig{
 					Login:   suite.me.Username,
 					Cluster: Site,
 					Host:    Host,
@@ -4935,7 +4969,7 @@ func testSSHExitCode(t *testing.T, suite *integrationTestSuite) {
 			doneContext, doneCancel := context.WithTimeout(context.Background(), time.Second*10)
 			defer doneCancel()
 
-			cli, err := main.NewClient(t, ClientConfig{
+			cli, err := main.NewClient(ClientConfig{
 				Login:       suite.me.Username,
 				Cluster:     Site,
 				Host:        Host,
@@ -5024,7 +5058,7 @@ func testBPFSessionDifferentiation(t *testing.T, suite *integrationTestSuite) {
 
 	// Open a terminal and type "ls" into both and exit.
 	writeTerm := func(term *Terminal) {
-		client, err := main.NewClient(t, ClientConfig{
+		client, err := main.NewClient(ClientConfig{
 			Login:   suite.me.Username,
 			Cluster: Site,
 			Host:    Host,
@@ -5358,7 +5392,7 @@ func eventsInLog(path string, eventName string) ([]events.EventFields, error) {
 
 // runCommandWithCertReissue runs an SSH command and generates certificates for the user
 func runCommandWithCertReissue(t *testing.T, instance *TeleInstance, cmd []string, reissueParams client.ReissueParams, cachePolicy client.CertCachePolicy, cfg ClientConfig) error {
-	tc, err := instance.NewClient(t, cfg)
+	tc, err := instance.NewClient(cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -5383,7 +5417,7 @@ func runCommandWithCertReissue(t *testing.T, instance *TeleInstance, cmd []strin
 // the result. If multiple attempts are requested, a 250 millisecond delay is
 // added between them before giving up.
 func runCommand(t *testing.T, instance *TeleInstance, cmd []string, cfg ClientConfig, attempts int) (string, error) {
-	tc, err := instance.NewClient(t, cfg)
+	tc, err := instance.NewClient(cfg)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1192,10 +1192,6 @@ func runDisconnectTest(t *testing.T, suite *integrationTestSuite, tc disconnectT
 	require.NoError(t, teleport.Start())
 	defer teleport.StopAll()
 
-	// get a reference to site obj:
-	site := teleport.GetSiteAPI(Site)
-	require.NotNil(t, site)
-
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -1211,7 +1207,12 @@ func runDisconnectTest(t *testing.T, suite *integrationTestSuite, tc disconnectT
 
 		openSession := func() {
 			defer cancel()
-			cl, err := teleport.NewClient(t, ClientConfig{Login: username, Cluster: Site, Host: Host, Port: teleport.GetPortSSHInt()})
+			cl, err := teleport.NewClient(t, ClientConfig{
+				Login:   username,
+				Cluster: Site,
+				Host:    Host,
+				Port:    teleport.GetPortSSHInt(),
+			})
 			require.NoError(t, err)
 			cl.Stdout = person
 			cl.Stdin = person
@@ -2968,11 +2969,15 @@ func testExternalClient(t *testing.T, suite *integrationTestSuite) {
 			teleport := suite.newTeleportWithConfig(makeConfig())
 			defer teleport.StopAll()
 
+			// Generate certificates for the user simulating login.
+			creds, err := GenerateUserCreds(UserCredsRequest{
+				Process:  teleport.Process,
+				Username: suite.me.Username,
+			})
+			require.NoError(t, err)
+
 			// Start (and defer close) a agent that runs during this integration test.
-			teleAgent, socketDirPath, socketPath, err := createAgent(
-				suite.me,
-				teleport.Secrets.Users[suite.me.Username].Key.Priv,
-				teleport.Secrets.Users[suite.me.Username].Key.Cert)
+			teleAgent, socketDirPath, socketPath, err := createAgent(suite.me, creds.Key.Priv, creds.Key.Cert)
 			require.NoError(t, err)
 			defer closeAgent(teleAgent, socketDirPath)
 
@@ -3060,11 +3065,15 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 		teleport := suite.newTeleportWithConfig(makeConfig())
 		defer teleport.StopAll()
 
+		// Generate certificates for the user simulating login.
+		creds, err := GenerateUserCreds(UserCredsRequest{
+			Process:  teleport.Process,
+			Username: suite.me.Username,
+		})
+		require.NoError(t, err)
+
 		// Start (and defer close) a agent that runs during this integration test.
-		teleAgent, socketDirPath, socketPath, err := createAgent(
-			suite.me,
-			teleport.Secrets.Users[suite.me.Username].Key.Priv,
-			teleport.Secrets.Users[suite.me.Username].Key.Cert)
+		teleAgent, socketDirPath, socketPath, err := createAgent(suite.me, creds.Key.Priv, creds.Key.Cert)
 		require.NoError(t, err)
 		defer closeAgent(teleAgent, socketDirPath)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5173,6 +5173,9 @@ func testSessionStartContainsAccessRequest(t *testing.T, suite *integrationTestS
 	userRole, err := types.NewRole(userRoleName, types.RoleSpecV4{
 		Options: types.RoleOptions{},
 		Allow: types.RoleConditions{
+			Logins: []string{
+				suite.me.Username,
+			},
 			Request: &types.AccessRequestConditions{
 				Roles: []string{requestedRoleName},
 			},

--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -125,7 +125,7 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 			require.NoError(t, err)
 
 			nodeSSHPort := teleport.GetPortSSHInt()
-			cl, err := teleport.NewClient(t, ClientConfig{
+			cl, err := teleport.NewClient(ClientConfig{
 				Login:   suite.me.Username,
 				Cluster: Site,
 				Host:    Host,

--- a/integration/proxy_helpers_test.go
+++ b/integration/proxy_helpers_test.go
@@ -200,7 +200,7 @@ func (p *ProxySuite) mustConnectToClusterAndRunSSHCommand(t *testing.T, config C
 		nextIterWaitTime = time.Millisecond * 100
 	)
 
-	tc, err := p.root.NewClient(t, config)
+	tc, err := p.root.NewClient(config)
 	require.NoError(t, err)
 
 	output := &bytes.Buffer{}

--- a/integration/proxy_test.go
+++ b/integration/proxy_test.go
@@ -545,7 +545,7 @@ func TestALPNProxyRootLeafAuthDial(t *testing.T) {
 		withTrustedCluster(),
 	)
 
-	client, err := suite.root.NewClient(t, ClientConfig{
+	client, err := suite.root.NewClient(ClientConfig{
 		Login:   username,
 		Cluster: suite.root.Hostname,
 	})
@@ -673,7 +673,7 @@ func TestALPNProxyDialProxySSHWithoutInsecureMode(t *testing.T) {
 	ctx := context.Background()
 	output := &bytes.Buffer{}
 	cmd := []string{"echo", "hello world"}
-	tc, err := rc.NewClient(t, cfg)
+	tc, err := rc.NewClient(cfg)
 	require.NoError(t, err)
 	tc.Stdout = output
 


### PR DESCRIPTION
Stabalized `TestDisconnection` and `TestSessionStartContainsAccessRequest`.

**TestDisconnection**

Integration tests were creating the users SSH and x509 certificates at the time of server creation, specifically at the time of the `TeleInstance` creation.

If any component within the `TeleInstance` was slow to start, for example if the proxy watcher had to be reset as can be seen below, the users certificate would often be expired by the time the SSH request was issued which would lead to the SSH server rejecting the connection and the test failing with an unexpected error.

For most tests this is not an issue, because test certificates are valid for 24 hours. However `TestDisconnection` scopes the TTL of certificates down (often times to about 2 seconds) to test different certificate lifetime disconnection scenarios which would lead to this test being flaky.

Updated integration test logic to instead "issue" the users certificate at the time of client creation instead of server creation.

**TestSessionStartContainsAccessRequest**

Fixed issue with `TestSessionStartContainsAccessRequest` where the login was not being injected into the user role.