### PR TITLE
Reconnect broken LDAP connections

### DIFF
--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -129,9 +129,9 @@ func (r *Reconciler) processRegisteredResource(ctx context.Context, newResources
 		return nil
 	}
 
-	r.log.Infof("%v removed, deleting.", registered)
+	r.log.Infof("%v %v removed, deleting.", registered.GetKind(), registered.GetName())
 	if err := r.cfg.OnDelete(ctx, registered); err != nil {
-		return trace.Wrap(err, "failed to delete %v", registered)
+		return trace.Wrap(err, "failed to delete  %v %v", registered.GetKind(), registered.GetName())
 	}
 
 	return nil
@@ -145,19 +145,19 @@ func (r *Reconciler) processNewResource(ctx context.Context, currentResources ty
 	registered := currentResources.Find(new.GetName())
 	if registered == nil {
 		if r.cfg.Matcher(new) {
-			r.log.Infof("%v %v matches, creating.", new.GetKind(), new.GetMetadata().Name)
+			r.log.Infof("%v %v matches, creating.", new.GetKind(), new.GetName())
 			if err := r.cfg.OnCreate(ctx, new); err != nil {
-				return trace.Wrap(err, "failed to create %v", new)
+				return trace.Wrap(err, "failed to create %v %v", new.GetKind(), new.GetName())
 			}
 			return nil
 		}
-		r.log.Debugf("%v %v doesn't match, not creating.", new.GetKind(), new.GetMetadata().Name)
+		r.log.Debugf("%v %v doesn't match, not creating.", new.GetKind(), new.GetName())
 		return nil
 	}
 
 	// Don't overwrite resource of a different origin.
 	if registered.Origin() != new.Origin() {
-		r.log.Debugf("%v has different origin (%v vs %v), not updating.", new.GetMetadata().Name,
+		r.log.Debugf("%v has different origin (%v vs %v), not updating.", new.GetName(),
 			new.Origin(), registered.Origin())
 		return nil
 	}
@@ -166,19 +166,19 @@ func (r *Reconciler) processNewResource(ctx context.Context, currentResources ty
 	// labels still match.
 	if CompareResources(new, registered) != Equal {
 		if r.cfg.Matcher(new) {
-			r.log.Infof("%v %v updated, updating.", new.GetKind(), new.GetMetadata().Name)
+			r.log.Infof("%v %v updated, updating.", new.GetKind(), new.GetName())
 			if err := r.cfg.OnUpdate(ctx, new); err != nil {
-				return trace.Wrap(err, "failed to update %v", new)
+				return trace.Wrap(err, "failed to update %v %v", new.GetKind(), new.GetName())
 			}
 			return nil
 		}
-		r.log.Infof("%v %v updated and no longer matches, deleting.", new.GetKind(), new.GetMetadata().Name)
+		r.log.Infof("%v %v updated and no longer matches, deleting.", new.GetKind(), new.GetName())
 		if err := r.cfg.OnDelete(ctx, registered); err != nil {
-			return trace.Wrap(err, "failed to delete %v", new)
+			return trace.Wrap(err, "failed to delete %v %v", new.GetKind(), new.GetName())
 		}
 		return nil
 	}
 
-	r.log.Debugf("%v %v is already registered.", new.GetKind(), new.GetMetadata().Name)
+	r.log.Debugf("%v %v is already registered.", new.GetKind(), new.GetName())
 	return nil
 }

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
@@ -113,7 +112,7 @@ func (s *WindowsService) ldapSearchFilter() string {
 
 // getDesktopsFromLDAP discovers Windows hosts via LDAP
 func (s *WindowsService) getDesktopsFromLDAP() types.ResourcesWithLabels {
-	if atomic.LoadInt32(&s.ldapInitialized) == 0 {
+	if !s.ldapReady() {
 		s.cfg.Log.Warn("skipping desktop discovery: LDAP not yet initialized")
 		return nil
 	}


### PR DESCRIPTION
Ensure that our LDAP client returns trace.ConnectionProblem errors
for LDAP error 200 (network error).

When this condition is detected, we re-initialize our LDAP client
to get a fresh connection.

Also clean up some of the errors in the reconciler so that they
include the resources kind and name without stringify-ing the
entire resource.

Lastly, add both a connect and request timeout for our LDAP client,
allowing us to detect connection issues sooner.

Fixes #9808