### PR TITLE
Add verbose logging to label command when debug flag present

### DIFF
--- a/lib/labels/labels.go
+++ b/lib/labels/labels.go
@@ -19,9 +19,7 @@ limitations under the License.
 package labels
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"os/exec"
 	"strings"
 	"sync"
@@ -149,24 +147,14 @@ func (l *Dynamic) periodicUpdateLabel(name string, label types.CommandLabel) {
 
 // updateLabel will run a command, then update the value of a label.
 func (l *Dynamic) updateLabel(name string, label types.CommandLabel) {
-	var logMsg string
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd := exec.Command(label.GetCommand()[0], label.GetCommand()[1:]...)
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
+	out, err := exec.Command(label.GetCommand()[0], label.GetCommand()[1:]...).Output()
 	if err != nil {
-		if logrus.GetLevel() == logrus.DebugLevel {
-			cmdString := strings.Join(label.GetCommand(), " ")
-			logMsg = fmt.Sprintf("Failed to run command '%v' and update label: %v.", cmdString, stderr.String())
-		} else {
-			logMsg = fmt.Sprintf("Failed to run command and update label: %v.", err)
-		}
-		l.c.Log.Error(logMsg)
-		label.SetResult(err.Error() + " output: " + out.String())
+		cmdString := strings.Join(label.GetCommand(), " ")
+		l.c.Log.Errorf("Failed to run command: '%v' and update label: %v.", cmdString, err)
+		label.SetResult(err.Error() + " output: " + string(out))
+
 	} else {
-		label.SetResult(strings.TrimSpace(out.String()))
+		label.SetResult(strings.TrimSpace(string(out)))
 	}
 
 	// Perform the actual label update under a lock.

--- a/lib/labels/labels_test.go
+++ b/lib/labels/labels_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
-"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sirupsen/logrus"
 )
@@ -92,5 +92,5 @@ func TestInvalidCommand(t *testing.T) {
 	val, ok := l.Get()["foo"]
 	require.True(t, ok)
 	require.Contains(t, val.GetResult(), "output:")
-	require.Contains(t,val.GetResult(), l.c.Labels["foo"].GetCommand()[0] )
+	require.Contains(t, val.GetResult(), l.c.Labels["foo"].GetCommand()[0])
 }


### PR DESCRIPTION
This can more easily be achieved by always logging the command, but the issue was framed as only lacking verbosity when debugging. Wanted to keep stdOut and stdErr separate to accommodate for a shorter log output as well when the debug flag is not present.

Fixes #9440