### PR TITLE
Update the PR description for auto webassets udpates

### DIFF
--- a/build.assets/webapps/update-teleport-webassets.sh
+++ b/build.assets/webapps/update-teleport-webassets.sh
@@ -74,7 +74,9 @@ git submodule update --init --recursive
 # set variables based on context from webapps checkout
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 COMMIT=$(git rev-parse --short HEAD)
-COMMIT_DESC=$(git log --decorate=off --oneline -1)
+# use the commit message from webapps, qualifying references to webapps PRs to that they
+# link to the correct PR from the teleport repo (#123 becomes gravitational/webapps#123)
+COMMIT_DESC=$(git log --decorate=off --oneline -1 | sed -E 's.(#[0-9]+).gravitational/webapps\1.g')
 COMMIT_URL="https://github.com/gravitational/webapps/commit/${COMMIT}"
 AUTO_BRANCH_NAME="webapps-auto-pr-$(date +%s)"
 


### PR DESCRIPTION
The script for updating webassets uses the commit message from
webapps as the commit message for the PR to teleport.

This commit message is almost always a merged PR, which has the format:

    do some awesome thing (#123)

Where `#123` is the number of the **webapps** PR that was merged.

The problem with this is, when the teleport PR is created, it interprets
the `#123` as the number of a **teleport** PR. And since the Teleport repo
has a lot more issues/PRs than webapps, Github ends up linking to an old
and completely unrelated PR.

Fix this by replacing `(#123)` with `(gravitational/webapps#123)`, which
Github correctly renders as a link to the webapps PR in question.