### PR TITLE
Document desktop role options for Teleport 9

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -73,9 +73,11 @@ spec:
     # permit_x11_forwarding allows users to use X11 forwarding with openssh clients and servers through the proxy
     permit_x11_forwarding: true
     # Specify whether or not to record the user's desktop sessions.
-    # The cluster's session recording mode must not be set to "off".
     # Desktop session recording is enabled if one or more of the user's
     # roles has enabled recording. Defaults to true if unspecified.
+    # Desktop sessions will never be recorded if auth_service.session_recording
+    # is set to 'off' in teleport.yaml or if the cluster's session_recording_config
+    # resource has set 'mode: off'.
     record_sessions:
       desktop: true
     # Specify whether clipboard sharing should be allowed with the
@@ -92,7 +94,7 @@ spec:
     logins: [root, '{{internal.logins}}']
     # Windows logins a user is allowed to use for desktop sessions.
     windows_desktop_logins: [Administrator, '{{internal.logins}}']
-    # If kubernetes integration is enabled, this setting configures which
+    # If the Kubernetes integration is enabled, this setting configures which
     # kubernetes groups the users of this role will be assigned to.
     # Note that you can refer to a SAML/OIDC trait via the "external" property bag.
     # This allows you to specify Kubernetes group membership in an identity manager:

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -47,7 +47,7 @@ version: v4
 metadata:
   name: example
 spec:
-  # SSH options used for user sessions with default values:
+  # Options used for user sessions with default values:
   options:
     # max_session_ttl defines the TTL (time to live) of SSH certificates
     # issued to the users with this role.
@@ -72,6 +72,17 @@ spec:
     max_sessions: 10
     # permit_x11_forwarding allows users to use X11 forwarding with openssh clients and servers through the proxy
     permit_x11_forwarding: true
+    # Specify whether or not to record the user's desktop sessions.
+    # The cluster's session recording mode must not be set to "off".
+    # Desktop session recording is enabled if one or more of the user's
+    # roles has enabled recording. Defaults to true if unspecified.
+    record_sessions:
+      desktop: true
+    # Specify whether clipboard sharing should be allowed with the
+    # remote desktop (requires a supported browser). Defaults to true
+    # if unspecified. If one or more of the user's roles has disabled
+    # the clipboard, then it will be disabled.
+    desktop_clipboard: true
 
   # The allow section declares a list of resource/verb combinations that are
   # allowed for the users of this role. By default, nothing is allowed.
@@ -81,7 +92,7 @@ spec:
     logins: [root, '{{internal.logins}}']
     # Windows logins a user is allowed to use for desktop sessions.
     windows_desktop_logins: [Administrator, '{{internal.logins}}']
-    # If kubernetes integration is enabled, this setting configures which 
+    # If kubernetes integration is enabled, this setting configures which
     # kubernetes groups the users of this role will be assigned to.
     # Note that you can refer to a SAML/OIDC trait via the "external" property bag.
     # This allows you to specify Kubernetes group membership in an identity manager:
@@ -185,10 +196,10 @@ Teleport provides several pre-defined roles out-of-the-box:
 | Role | Description |
 | --- | --- |
 | `editor` | Allows editing of cluster configuration settings. |
-| `auditor`| Allows reading cluster events, audit logs, and playing back session records. | 
+| `auditor`| Allows reading cluster events, audit logs, and playing back session records. |
 | `access`| Allows access to cluster resources. |
 
-<Details title="Version Warning: Before 8.0" opened={false}> 
+<Details title="Version Warning: Before 8.0" opened={false}>
 Teleport versions prior to 8.0 also included a default `admin` role. This role
 has been deprecated in favor of smaller, more fine-grained roles like the
 presets mentioned above.

--- a/docs/pages/desktop-access/reference.mdx
+++ b/docs/pages/desktop-access/reference.mdx
@@ -64,6 +64,19 @@ version: v4
 metadata:
   name: developer
 spec:
+  options:
+    # Specify whether or not to record the user's desktop sessions.
+    # The cluster's session recording mode must not be set to "off".
+    # Desktop session recording is enabled if one or more of the user's
+    # roles has enabled recording. Defaults to true if unspecified.
+    record_sessions:
+      desktop: true
+
+    # Specify whether clipboard sharing should be allowed with the
+    # remote desktop (requires a supported browser). Defaults to true
+    # if unspecified. If one or more of the user's roles has disabled
+    # the clipboard, then it will be disabled.
+    desktop_clipboard: true
   allow:
     # Label selectors for desktops this role has access to.
     # See above for how labels are applied to desktops.
@@ -76,11 +89,13 @@ spec:
 
 It is possible to use wildcards (`"*"`) to match all desktop labels.
 
-Like with SSH access, the `windows_desktop_logins` field supports the special `{{internal.windows_logins}}` variable
-for local users which will map to any logins that are supplied when the user is created with
+Like with SSH access, the `windows_desktop_logins` field supports the special
+`{{internal.windows_logins}}` variable for local users which will map to any
+logins that are supplied when the user is created with
 `tctl users add alice --windows-logins=Administrator,DBUser`.
 
-For new clusters, the `"access"` role will have `windows_desktop_logins: ["{{internal.windows_logins}}"]` set by default.
+For new clusters, the `access` role will have
+`windows_desktop_logins: ["{{internal.windows_logins}}"]` set by default.
 
 ## CLI
 

--- a/docs/pages/desktop-access/reference.mdx
+++ b/docs/pages/desktop-access/reference.mdx
@@ -66,9 +66,11 @@ metadata:
 spec:
   options:
     # Specify whether or not to record the user's desktop sessions.
-    # The cluster's session recording mode must not be set to "off".
     # Desktop session recording is enabled if one or more of the user's
     # roles has enabled recording. Defaults to true if unspecified.
+    # Desktop sessions will never be recorded if auth_service.session_recording
+    # is set to 'off' in teleport.yaml or if the cluster's session_recording_config
+    # resource has set 'mode: off'.
     record_sessions:
       desktop: true
 

--- a/docs/pages/setup/reference/resources.mdx
+++ b/docs/pages/setup/reference/resources.mdx
@@ -211,6 +211,17 @@ spec:
     # cluster. This setting slows down Teleport performance because it has to track
     # connections cluster-wide.
     max_connections: 2
+    # Specify whether or not to record the user's desktop sessions.
+    # The cluster's session recording mode must not be set to "off".
+    # Desktop session recording is enabled if one or more of the user's
+    # roles has enabled recording. Defaults to true if unspecified.
+    record_sessions:
+      desktop: true
+    # Specify whether clipboard sharing should be allowed with the
+    # remote desktop (requires a supported browser). Defaults to true
+    # if unspecified. If one or more of the user's roles has disabled
+    # the clipboard, then it will be disabled.
+    desktop_clipboard: true
 
   # The allow section declares a list of resource/verb combinations that are
   # allowed for the users of this role. By default, nothing is allowed.

--- a/docs/pages/setup/reference/resources.mdx
+++ b/docs/pages/setup/reference/resources.mdx
@@ -212,9 +212,11 @@ spec:
     # connections cluster-wide.
     max_connections: 2
     # Specify whether or not to record the user's desktop sessions.
-    # The cluster's session recording mode must not be set to "off".
     # Desktop session recording is enabled if one or more of the user's
     # roles has enabled recording. Defaults to true if unspecified.
+    # Desktop sessions will never be recorded if auth_service.session_recording
+    # is set to 'off' in teleport.yaml or if the cluster's session_recording_config
+    # resource has set 'mode: off'.
     record_sessions:
       desktop: true
     # Specify whether clipboard sharing should be allowed with the


### PR DESCRIPTION
Fixes #10160

No backport required, these are specific to Teleport 9+