### PR TITLE
Clean up desktop session error logging

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -68,6 +68,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"io"
 	"os"
 	"runtime/cgo"
 	"sync"
@@ -258,7 +259,9 @@ func (c *Client) start() {
 		var mouseX, mouseY uint32
 		for {
 			msg, err := c.cfg.Conn.InputMessage()
-			if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			} else if err != nil {
 				c.cfg.Log.Warningf("Failed reading TDP input message: %v", err)
 				return
 			}

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"sync"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/sirupsen/logrus"
@@ -144,19 +145,29 @@ func proxyWebsocketConn(ws *websocket.Conn, con net.Conn) error {
 	// Ensure we send binary frames to the browser.
 	ws.PayloadType = websocket.BinaryFrame
 
+	var closeOnce sync.Once
+	close := func() {
+		ws.Close()
+		con.Close()
+	}
+
 	errs := make(chan error, 2)
 	go func() {
-		defer ws.Close()
-		defer con.Close()
+		defer closeOnce.Do(close)
 
 		_, err := io.Copy(ws, con)
+		if utils.IsOKNetworkError(err) {
+			err = nil
+		}
 		errs <- err
 	}()
 	go func() {
-		defer ws.Close()
-		defer con.Close()
+		defer closeOnce.Do(close)
 
 		_, err := io.Copy(con, ws)
+		if utils.IsOKNetworkError(err) {
+			err = nil
+		}
 		errs <- err
 	}()
 


### PR DESCRIPTION
Prior to this change, Teleport would always emit errors to the logs
when a desktop session is closed (for example, when the user closes
their browser tab).

This change ensures that:
- the input and output writing goroutines in the proxy don't race
  to close connections (we use a sync.Once here)
- EOF and other "connection closed" errors are not logged as errors

Fixes #8661