### PR TITLE
[v6.2] Restore quay.io-supplied buildbox images

### DIFF
--- a/.cloudbuild/ci/integration-tests.yaml
+++ b/.cloudbuild/ci/integration-tests.yaml
@@ -11,7 +11,7 @@ steps:
 
   # Set up BCC headers in a volume to replace the incompatible system-level 
   # headers
-  - name: us-docker.pkg.dev/ci-account/teleport/buildbox-root:teleport6.2-v0.1.0
+  - name: quay.io/gravitational/teleport-buildbox:go1.15.5
     id: configure BCC headers
     volumes: 
       - name: bcc-headers
@@ -23,7 +23,7 @@ steps:
 
   # Run the integration tests. Actual content of this job depends on the changes 
   # detected in the PR
-  - name: us-docker.pkg.dev/ci-account/teleport/buildbox-root:teleport6.2-v0.1.0
+  - name: quay.io/gravitational/teleport-buildbox:go1.15.5
     id: run-tests
     volumes: 
       - name: bcc-headers

--- a/.cloudbuild/ci/lint.yaml
+++ b/.cloudbuild/ci/lint.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: us-docker.pkg.dev/ci-account/teleport/buildbox-root:teleport6.2-v0.1.0
+  - name: quay.io/gravitational/teleport-buildbox:go1.15.5
     id: lint
     args: ['make', 'lint']
 options:

--- a/.cloudbuild/ci/unit-tests.yaml
+++ b/.cloudbuild/ci/unit-tests.yaml
@@ -11,7 +11,7 @@ steps:
     id: fetch-history
     args: ['fetch', '--unshallow']
 
-  - name: us-docker.pkg.dev/ci-account/teleport/buildbox-root:teleport6.2-v0.1.0
+  - name: quay.io/gravitational/teleport-buildbox:go1.15.5
     id: configure BCC headers
     volumes: 
       - name: bcc-headers
@@ -23,7 +23,7 @@ steps:
         
   # Run the unit tests. Actual content of this job depends on the changes 
   # detected in the PR
-  - name: us-docker.pkg.dev/ci-account/teleport/buildbox-root:teleport6.2-v0.1.0
+  - name: quay.io/gravitational/teleport-buildbox:go1.15.5
     id: run-tests
     volumes: 
       - name: bcc-headers


### PR DESCRIPTION
The use of a re-badged buildbox image (rebadging quay.io/gravitational/teleport-buildbox to us-docker.pkg.dev/ci-account/teleport/buildbox-root) is holdover from when CI builds required separate "root user" and "non-root user" images to execute tests under different contexts.

This requirement has since been lifted by using a Go-based build script in CI, and the having to manually invoke a process to re-badge the buildboxes is, tedious, confusing and causing stoppages.

This patch restores the use of buildboxes from quay.io in CI