### PR TITLE
Trusted clusters doc: Use wildcard for spec.allow.cluster_labels.env

### DIFF
--- a/docs/pages/setup/admin/trustedclusters.mdx
+++ b/docs/pages/setup/admin/trustedclusters.mdx
@@ -250,7 +250,7 @@ spec:
     # the cluster labels check is not applied. Otherwise, cluster labels are always enforced.
     # This makes the feature backward-compatible.
     cluster_labels:
-      'env': 'staging'
+      'env': '*'
   deny:
     # Cluster labels control what clusters user can connect to. The wildcard ('*') means
     # any cluster. By default none is set in deny rules to preserve backward compatibility


### PR DESCRIPTION
`staging` isn't mentioned anywhere else in the doc, the comment just before it explains what a wildcard is and just before the whole snippet we say:

> We want administrators from "root" (but not regular users!) to have restricted access to "leaf". We want to deny them access to machines with "environment=production" and any Government cluster labeled "customer=gov".

Again, nothing about staging, which leads me to believe it's just a minor oversight.