### PR TITLE
[v8 backport] Add Teleport Cloud instructions to 3 guides

### DIFF
--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -28,15 +28,16 @@ This guide will help you to:
 
 ## Step 1/3. Install and configure Teleport
 
-### Setup Teleport Auth and Proxy services
+### Set up Teleport Auth and Proxy Services
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
-### Setup Teleport Database service
+### Set up Teleport Database Service
 
 (!docs/pages/includes/database-access/token.mdx!)
-
-Start Teleport Database service:
+<Tabs>
+<TabItem label="Self Hosted" scope={["enterprise","oss"]}>
+Start the Teleport Database Service, pointing the `--auth-server` flag to the address of your Teleport Proxy Service:
 
 ```code
 $ teleport db start \
@@ -47,30 +48,42 @@ $ teleport db start \
   --uri=roach.example.com:26257 \
   --labels=env=dev
 ```
+</TabItem>
+<TabItem label="Teleport Cloud" scope={["cloud"]}>
+Start the Teleport Database Service, pointing the `--auth-server` flag at the address of your Teleport Cloud tenant, e.g., `mytenant.teleport.sh`.
+
+```code
+$ teleport db start \
+  --token=/tmp/token \
+  --auth-server=mytenant.teleport.sh \
+  --name=roach \
+  --protocol=cockroachdb \
+  --uri=roach.example.com:26257 \
+  --labels=env=dev
+```
+</TabItem>
+</Tabs>
 
 <Admonition type="note">
   The `--auth-server` flag must point to the Teleport cluster's proxy endpoint
-  because database service always connects back to the cluster over a reverse
+  because the Database Service always connects back to the cluster over a reverse
   tunnel.
 </Admonition>
 
 <Admonition type="tip">
-  You can start Database service using configuration file instead of CLI flags.
+  You can start the Database Service using a configuration file instead of CLI flags.
   See [YAML reference](../reference/configuration.mdx).
 </Admonition>
 
-### Create Teleport user
+### Create a Teleport user
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 
 ## Step 2/3. Configure CockroachDB
 
-### Create CockroachDB user
+### Create a CockroachDB user
 
-Teleport uses [mutual TLS authentication](https://www.cockroachlabs.com/docs/stable/authentication.html#client-authentication)
-with CockroachDB.
-
-Client certificate authentication is available to all CockroachDB users. If you
+Teleport uses mutual TLS authentication with CockroachDB. Client certificate authentication is available to all CockroachDB users. If you
 don't have one, connect to your Cockroach cluster and create it:
 
 ```sql
@@ -84,9 +97,9 @@ Make sure to assign the user proper permissions within the database cluster.
 Refer to [Create User](https://www.cockroachlabs.com/docs/stable/create-user.html)
 in Cockroach docs for more information.
 
-### Setup mutual TLS
+### Set up mutual TLS
 
-To setup mutual TLS authentication, you need to make sure that:
+To set up mutual TLS authentication, you need to make sure that:
 
 - Teleport trusts certificates presented by CockroachDB nodes.
 - CockroachDB trusts client certificates signed by Teleport.
@@ -114,8 +127,8 @@ Teleport will be using to connect to the nodes in the `--host` flag.
   You can specify multiple comma-separated addresses e.g. `--host=roach,node-1,192.168.1.1`.
 </Admonition>
 
-Restart your CockroachDB nodes passing them the directory with generated secrets
-via `--certs-dir` flag:
+Restart your CockroachDB nodes, passing them the directory with generated secrets
+via the `--certs-dir` flag:
 
 ```code
 $ cockroach start \
@@ -125,9 +138,11 @@ $ cockroach start \
 
 ## Step 3/3. Connect
 
-Log into your Teleport cluster, your CockroachDB cluster should appear in the
+Log into your Teleport cluster. Your CockroachDB cluster should appear in the
 list of available databases:
 
+<Tabs>
+<TabItem scope={["enterprise", "oss"]} label="Self Hosted">
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
 $ tsh db ls
@@ -135,6 +150,17 @@ $ tsh db ls
 # ----- ------------------- -------
 # roach Example CockroachDB env=dev
 ```
+</TabItem>
+<TabItem scope={["cloud"]} label="Cloud">
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=alice
+$ tsh db ls
+# Name  Description         Labels
+# ----- ------------------- -------
+# roach Example CockroachDB env=dev
+```
+</TabItem>
+</Tabs>
 
 Fetch short-lived client certificate for it using `tsh db login` command:
 
@@ -160,7 +186,7 @@ $ tsh db connect roach
 ```
 
 <Admonition type="note">
-  Either `cockroach` or `psql` command-line client should be available in PATH
+  Either the `cockroach` or `psql` command-line client should be available in PATH
   in order to be able to connect.
 </Admonition>
 
@@ -173,3 +199,4 @@ $ tsh db logout roach
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+- [CockroachDB client authentication](https://www.cockroachlabs.com/docs/stable/authentication.html#client-authentication)

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -19,15 +19,17 @@ In this guide you will:
 
 ## Step 1/3. Configure Teleport
 
-### Setup Teleport Auth and Proxy services
+### Set up Teleport Auth and Proxy services
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
-### Setup Teleport Database service
+### Set up the Teleport Database Service
 
 (!docs/pages/includes/database-access/token.mdx!)
 
-Start Teleport Database service:
+<Tabs>
+<TabItem label="Self Hosted" scope={["enterprise","oss"]}>
+Start the Teleport Database Service, pointing the `--auth-server` flag at the address of your Teleport Proxy Service:
 
 ```code
 $ teleport db start \
@@ -40,19 +42,39 @@ $ teleport db start \
   --labels=env=dev
 ```
 
+</TabItem>
+<TabItem label="Teleport Cloud" scope={["cloud"]}>
+Start the Teleport Database Service, pointing the `--auth-server` flag at the address of your Teleport Cloud tenant, e.g., `mytenant.teleport.sh`.
+
+```code
+$ teleport db start \
+  --token=/tmp/token \
+  --auth-server=mytenant.teleport.sh \
+  --name=mongodb-atlas \
+  --protocol=mongodb \
+  --uri=mongodb+srv://cluster0.abcde.mongodb.net \
+  --ca-cert=/path/to/letsencrypt/isrgrootx1.pem
+  --labels=env=dev
+```
+
+</TabItem>
+</Tabs>
+
 See below for details on `--uri` and `--ca-cert` flags.
 
 <Admonition type="note">
   The `--auth-server` flag must point to the Teleport cluster's proxy endpoint
-  because database service always connects back to the cluster over a reverse
+  because the Database Service always connects back to the cluster over a reverse
   tunnel.
 </Admonition>
 
 #### Configuration file
 
-If you're starting Database agent with YAML configuration instead of CLI flags,
-the following config is equivalent to the above command:
+If you're starting the Database Agent with a YAML configuration instead of CLI flags,
+the following config is equivalent to the `teleport db start` command shown earlier:
 
+<Tabs>
+<TabItem label="Self Hosted" scope={["enterprise","oss"]}>
 ```yaml
 teleport:
   auth_token: "/tmp/token"
@@ -68,13 +90,31 @@ db_service:
     static_labels:
       env: "dev"
 ```
+</TabItem>
+<TabItem label="Teleport Cloud" scope={["cloud"]}>
+```yaml
+teleport:
+  auth_token: "/tmp/token"
+  auth_servers:
+  - "mytenant.teleport.sh"
+db_service:
+  enabled: "yes"
+  databases:
+  - name: "mongodb-atlas"
+    protocol: "mongodb"
+    uri: "mongodb+srv://cluster0.abcde.mongodb.net"
+    ca_cert_file: "/path/to/letsencrypt/isrgrootx1.pem"
+    static_labels:
+      env: "dev"
+```
+</TabItem>
+</Tabs>
 
-See full [YAML reference](../reference/configuration.mdx) for details.
+See the full [YAML reference](../reference/configuration.mdx) for details.
 
-#### Connection endpoint `--uri`
+#### Connection endpoint
 
-To find out your Atlas cluster's connection endpoint for the URI, use the
-Connect dialog on the Database Deployments overview page:
+You will need to provide your Atlas cluster's connection endpoint for the `db_service.databases[*].uri` configuration option or `--uri` CLI flag. You can find this via the Connect dialog on the Database Deployments overview page:
 
 ![Connect](../../../img/database-access/guides/atlas/atlas-connect-btn@2x.png)
 
@@ -89,17 +129,17 @@ Use only the scheme and hostname parts of the connection string in the URI:
 $ --uri=mongodb+srv://cluster0.abcde.mongodb.net
 ```
 
-#### Atlas CA certificate `--ca-cert`
+#### Atlas CA certificate
 
-MongoDB Atlas uses certificates signed by Let's Encrypt as described in
-[Which certificate authority signs MongoDB Atlas cluster TLS certificates?](https://docs.atlas.mongodb.com/reference/faq/security/#which-certificate-authority-signs-mongodb-atlas-cluster-tls-certificates-)
+MongoDB Atlas uses certificates signed by Let's Encrypt.
 
-Download Let's Encrypt [root certificate](https://letsencrypt.org/certs/isrgrootx1.pem.txt)
-and use it as a CA in the database service configuration:
+Download the Let's Encrypt root certificate and use it as a CA in the database service configuration:
 
 ```code
-$ --ca-cert=/tmp/isrgrootx1.pem
+$ curl -o /tmp/isrgrootx1.pem https://letsencrypt.org/certs/isrgrootx1.pem.txt
 ```
+
+You can then use `/tmp/isrgrootx1.pem` as the value of the `db_service.databases[*].ca_cert_file` configuration option or `--ca-cert` CLI flag.
 
 ### Create Teleport user
 
@@ -138,7 +178,7 @@ authentication method:
 
 ![Add user](../../../img/database-access/guides/atlas/atlas-add-user@2x.png)
 
-Make sure to specify the user as `CN=<user>` like shown above since MongoDB
+Make sure to specify the user as `CN=<user>` as shown above since MongoDB
 treats the entire certificate subject as a username. When connecting to a
 MongoDB cluster, say, as a user `alice`, Teleport will sign an ephemeral
 certificate with `CN=alice` subject.
@@ -152,6 +192,9 @@ certificate with `CN=alice` subject.
 
 Log into your Teleport cluster and see available databases:
 
+<Tabs>
+<TabItem scope={["enterprise", "oss"]} label="Self Hosted">
+
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
 $ tsh db ls
@@ -159,6 +202,18 @@ $ tsh db ls
 # ------------- ----------- --------
 # mongodb-atlas             env=dev
 ```
+
+</TabItem>
+<TabItem scope={["cloud"]} label="Cloud">
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=alice
+$ tsh db ls
+# Name          Description Labels
+# ------------- ----------- --------
+# mongodb-atlas             env=dev
+```
+</TabItem>
+</Tabs>
 
 To connect to a particular database instance, first retrieve its certificate
 using `tsh db login` command:
@@ -201,3 +256,6 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+
+## Further reading
+- [Which certificate authority signs MongoDB Atlas cluster TLS certificates?](https://docs.atlas.mongodb.com/reference/faq/security/#which-certificate-authority-signs-mongodb-atlas-cluster-tls-certificates-)

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -4,8 +4,6 @@ description: How to configure Teleport Database Access with self-hosted MongoDB.
 videoBanner: 6lgVObxoLkc
 ---
 
-# Self-Hosted MongoDB
-
 In this guide you will:
 
 1. Install and configure Teleport for Database Access.
@@ -24,9 +22,9 @@ In this guide you will:
   April 2021 so if you're still using an older version, consider upgrading.
 </Admonition>
 
-## Step 1/3. Install & configure Teleport
+## Step 1/3. Install and configure Teleport
 
-### Setup Teleport Auth and Proxy services
+### Set up the Teleport Auth and Proxy services
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
@@ -34,7 +32,7 @@ In this guide you will:
 
 (!docs/pages/includes/database-access/token.mdx!)
 
-Start Teleport Database service:
+Start the Teleport Database Service, pointing the `--auth-server` flag to the address of your Teleport Proxy Service (for Teleport Cloud users, this will resemble `mytenant.teleport.sh`):
 
 ```code
 $ teleport db start \
@@ -48,7 +46,7 @@ $ teleport db start \
 
 <Admonition type="note">
 The `--auth-server` flag must point to the Teleport cluster's proxy endpoint
-because database service always connects back to the cluster over a reverse
+because the Database Service always connects back to the cluster over a reverse
 tunnel.
 </Admonition>
 
@@ -69,7 +67,7 @@ $ --uri="mongodb://mongo1.example.com:27017,mongo2.example.com:27017/?replicaSet
 ```
 
 <Admonition type="tip">
-  You can start Database service using configuration file instead of CLI flags.
+  You can start the Database Service using a configuration file instead of CLI flags.
   See [YAML reference](../reference/configuration.mdx).
 </Admonition>
 
@@ -106,7 +104,7 @@ db.getSiblingDB("$external").runCommand(
 Update the [roles](https://docs.mongodb.com/manual/tutorial/manage-users-and-roles/)
 accordingly to grant the user appropriate database permissions.
 
-### Setup mutual TLS
+### Set up mutual TLS
 
 (!docs/pages/includes/database-access/tctl-auth-sign.mdx!)
 
@@ -114,7 +112,7 @@ Create the secrets:
 
 <Tabs>
   <TabItem label="Standalone">
-  When connecting to standalone MongoDB, sign certificate for the hostname over
+  When connecting to standalone MongoDB, sign the certificate for the hostname over
   which Teleport will be connecting to it.
 
   For example, if your MongoDB server is accessible at `mongo.example.com`
@@ -126,7 +124,7 @@ Create the secrets:
 
   (!docs/pages/includes/database-access/ttl-note.mdx!)
 
-  The command will create 2 files: `mongo.cas` with Teleport's certificate
+  The command will create two files: `mongo.cas` with Teleport's certificate
   authority and `mongo.crt` with generated certificate and key pair. You will
   need these files to enable mutual TLS on your MongoDB server.
   </TabItem>
@@ -144,7 +142,7 @@ Create the secrets:
 
   (!docs/pages/includes/database-access/ttl-note.mdx!)
 
-  Each command will create 2 files: `mongo1.cas`/`mongo2.cas` with Teleport's
+  Each command will create two files: `mongo1.cas`/`mongo2.cas` with Teleport's
   certificate authority and `mongo1.crt`/`mongo2.crt` with generated certificate
   and key pair. You will need these files to enable mutual TLS on your MongoDB
   servers.

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -216,8 +216,9 @@ for more information.
 
 ## Connect
 
-Once the database service has joined the cluster, login to see the available
-databases:
+Once the database agent has started and joined the cluster, log in to see the
+registered databases. Replace `--proxy` with the address of your Teleport Proxy Service,
+e.g., `mytenant.teleport.sh` for Teleport Cloud users.
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -258,7 +259,7 @@ $ tsh db connect aurora
 ```
 
 <Admonition type="note" title="Note">
-  The `psql` command-line client should be available in PATH in order to be
+  The `psql` command-line client should be available in `PATH` in order to be
   able to connect.
 </Admonition>
 

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -262,7 +262,7 @@ database agent will be using. For example, if the agent runs as an IAM user:
   [AWS reference](../reference/aws.mdx) for details.
 </Admonition>
 
-## Step 4/6. Start database agent
+## Step 4/6. Start the database agent
 
 (!docs/pages/includes/database-access/token.mdx!)
 
@@ -273,7 +273,9 @@ teleport:
   data_dir: /var/lib/teleport
   auth_token: /tmp/token
   auth_servers:
-  - teleport.example.com:3080 # Teleport proxy address to connect to
+  # Teleport proxy address to connect to.
+  # For Teleport Cloud users, this will resemble mytenant.teleport.sh
+  - teleport.example.com:3080
 auth_service:
   enabled: "no"
 proxy_service:
@@ -303,7 +305,7 @@ policies for the discovered databases. Keep in mind that AWS IAM changes may
 not propagate immediately and can take a few minutes to come into effect.
 
 <Admonition type="note" title="AWS credentials">
-  Teleport database agent uses the default credential provider chain to find AWS
+  The Teleport database agent uses the default credential provider chain to find AWS
   credentials. See [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials)
   for more information.
 </Admonition>

--- a/docs/pages/includes/database-access/start-auth-proxy.mdx
+++ b/docs/pages/includes/database-access/start-auth-proxy.mdx
@@ -1,27 +1,48 @@
+<Tabs> 
+<TabItem scope={["oss","enterprise"]} label="Self Hosted">
+Teleport requires a valid TLS certificate to operate and can fetch one
+automatically using Let's Encrypt's ACME protocol. Before Let's Encrypt can
+issue a TLS certificate for the Teleport Proxy host's domain, the ACME protocol
+must verify that an HTTPS server is reachable on port 443 of the host.  
+
+We will assume that you have configured DNS records for `teleport.example.com`
+and `*.teleport.example.com` to point to your Teleport node.
+
+<Admonition type="note" title="Web Proxy Port">
+To support the ACME protocol, Teleport Proxy must listen on port 443, rather
+than the default port 3080.
+</Admonition>
+
 Download the latest version of Teleport for your platform from our
 [downloads page](https://goteleport.com/teleport/download) and follow the
 installation [instructions](../../installation.mdx).
 
-Teleport requires a valid TLS certificate to operate and can fetch one automatically
-using Let's Encrypt [ACME](https://letsencrypt.org/how-it-works/) protocol. We
-will assume that you have configured DNS records for `teleport.example.com` and
-`*.teleport.example.com` to point to the Teleport node.
-
-Generate Teleport config with ACME enabled:
+Generate a Teleport configuration file with ACME enabled:
 
 ```code
 $ teleport configure --cluster-name=teleport.example.com --acme --acme-email=alice@example.com -o file
 ```
 
-<Admonition type="note" title="Web Proxy Port">
-  Teleport uses [TLS-ALPN-01](https://letsencrypt.org/docs/challenge-types/#tls-alpn-01)
-  ACME challenge to validate certificate requests which only works on port `443`.
-  As such, in order to use ACME for certificate management, web proxy needs to
-  be accessible on port `443`.
-</Admonition>
-
-Start Teleport Auth and Proxy services:
+Start the Teleport Auth and Proxy services:
 
 ```code
 $ sudo teleport start
 ```
+</TabItem> 
+<TabItem label="Teleport Cloud" scope={["cloud"]}> 
+If you do not have a Teleport Cloud account, use our [signup form](/signup) to
+get started. Teleport Cloud manages instances of the Proxy Service and Auth
+Service, and automatically issues and renews the required TLS certificate.
+
+You will need to download the Enterprise version of Teleport from the
+[customer portal](https://dashboard.gravitational.com/web/login) to run `tctl`
+commands in Teleport Cloud.
+
+You must log into your cluster before you can run `tctl` commands.
+```code
+$ tsh login --proxy=mytenant.teleport.sh
+$ tctl status
+```
+</TabItem>
+</Tabs>
+

--- a/docs/pages/includes/database-access/token.mdx
+++ b/docs/pages/includes/database-access/token.mdx
@@ -1,4 +1,4 @@
-Database agent requires a valid auth token to connect to the cluster. Generate
+The Database Service requires a valid auth token to connect to the cluster. Generate
 one by running the following command against your Teleport auth server and save
 it in `/tmp/token` on the node which will be running the database agent:
 


### PR DESCRIPTION
Backports #9681

This change addresses three guides mentioned in issue #5845.

- Update the start-auth-proxy partial to include Cloud
  instructions

- Mention Teleport Cloud usage in three guides

- Add minor readability and style guide-related tweaks

* Respond to PR feedback

* Minor tweaks to remaining Database Access guides

- Mention Teleport Cloud
- Add small stylistic changes