### PR TITLE
Check for shell user's home directory as that user

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -464,6 +464,9 @@ const (
 	// RemoteCommandFailure is returned when a command has failed to execute and
 	// we don't have another status code for it.
 	RemoteCommandFailure = 255
+	// HomeDirNotFound is returned when a the "teleport checkhomedir" command cannot
+	// find the user's home directory.
+	HomeDirNotFound = 254
 )
 
 // MaxEnvironmentFileLines is the maximum number of lines in a environment file.
@@ -711,6 +714,10 @@ const (
 	// ForwardSubCommand is the sub-command Teleport uses to re-exec itself
 	// for port forwarding.
 	ForwardSubCommand = "forward"
+
+	// CheckHomeDirSubCommand is the sub-command Teleport uses to re-exec itself
+	// to check if the user's home directory exists.
+	CheckHomeDirSubCommand = "checkhomedir"
 )
 
 const (

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -624,7 +624,7 @@ func TestMain(m *testing.M) {
 	// If the test is re-executing itself, execute the command that comes over
 	// the pipe.
 	if len(os.Args) == 2 &&
-		(os.Args[1] == teleport.ExecSubCommand || os.Args[1] == teleport.ForwardSubCommand) {
+		(os.Args[1] == teleport.ExecSubCommand || os.Args[1] == teleport.ForwardSubCommand || os.Args[1] == teleport.CheckHomeDirSubCommand) {
 		srv.RunAndExit(os.Args[1])
 		return
 	}

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -74,8 +74,7 @@ var wildcardAllow = types.Labels{
 // it as an argument. Otherwise it will run tests as normal.
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
-	if len(os.Args) == 2 &&
-		(os.Args[1] == teleport.ExecSubCommand || os.Args[1] == teleport.ForwardSubCommand) {
+	if srv.IsReexec() {
 		srv.RunAndExit(os.Args[1])
 		return
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -126,8 +126,7 @@ func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
 	// If the test is re-executing itself, execute the command that comes over
 	// the pipe.
-	if len(os.Args) == 2 &&
-		(os.Args[1] == teleport.ExecSubCommand || os.Args[1] == teleport.ForwardSubCommand) {
+	if srv.IsReexec() {
 		srv.RunAndExit(os.Args[1])
 		return
 	}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -75,8 +75,9 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dump := app.Command("configure", "Generate a simple config file to get started.")
 	ver := app.Command("version", "Print the version.")
 	scpc := app.Command("scp", "Server-side implementation of SCP.").Hidden()
-	exec := app.Command("exec", "Used internally by Teleport to re-exec itself to run a command.").Hidden()
-	forward := app.Command("forward", "Used internally by Teleport to re-exec itself to port forward.").Hidden()
+	exec := app.Command(teleport.ExecSubCommand, "Used internally by Teleport to re-exec itself to run a command.").Hidden()
+	forward := app.Command(teleport.ForwardSubCommand, "Used internally by Teleport to re-exec itself to port forward.").Hidden()
+	checkHomeDir := app.Command(teleport.CheckHomeDirSubCommand, "Used internally by Teleport to re-exec itself to check access to a directory.").Hidden()
 	app.HelpFlag.Short('h')
 
 	// define start flags:
@@ -296,6 +297,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		err = onExec()
 	case forward.FullCommand():
 		err = onForward()
+	case checkHomeDir.FullCommand():
+		err = onCheckHome()
 	case ver.FullCommand():
 		utils.PrintVersion()
 	case dbConfigureCreate.FullCommand():
@@ -575,6 +578,14 @@ func onExec() error {
 // Used with "direct-tcpip" channel on Teleport nodes.
 func onForward() error {
 	srv.RunAndExit(teleport.ForwardSubCommand)
+	return nil
+}
+
+// onCheckHome is a subcommand used to re-execute Teleport to check for the
+// existence of the user's home dir. This is needed in cases where the user's
+// home dir isn't visible to the parent process's user.
+func onCheckHome() error {
+	srv.RunAndExit(teleport.CheckHomeDirSubCommand)
 	return nil
 }
 

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -32,7 +32,6 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
@@ -70,7 +69,7 @@ func init() {
 
 	// If the test is re-executing itself, execute the command that comes over
 	// the pipe. Used to test tsh ssh command.
-	if len(os.Args) == 2 && (os.Args[1] == teleport.ExecSubCommand || os.Args[1] == teleport.ForwardSubCommand) {
+	if srv.IsReexec() {
 		srv.RunAndExit(os.Args[1])
 		return
 	}


### PR DESCRIPTION
This PR updates the use's home dir check when starting a shell session to check the dir in the context of the logged in user rather than root. This is done by re-execing teleport with the new subcommand `checkhomedir`.

Another small change: In https://github.com/gravitational/teleport/pull/9413, $HOME would be set to "/" if $HOME doesn't exist. However, in OpenSSH $HOME is not changed when dropping the user into "/", so I updated the logic to match OpenSSH.

Closes https://github.com/gravitational/teleport/issues/10177