### PR TITLE
[v6] fix centos6 build and re-attempt release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.2.27
+## 6.2.28
 
 This release of Teleport contains multiple fixes and improvements.
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=6.2.27
+VERSION=6.2.28
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/build.assets/Dockerfile-centos6
+++ b/build.assets/Dockerfile-centos6
@@ -7,6 +7,12 @@ ENV LANGUAGE=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LC_CTYPE=en_US.UTF-8
 
+# forcibly update yum and curl manually (seems to fix compatibility with vault.centos.org).
+RUN curl -O https://vault.centos.org/6.10/updates/x86_64/Packages/yum-3.2.29-81.el6.centos.0.1.noarch.rpm && \
+    curl -O https://vault.centos.org/6.10/updates/x86_64/Packages/curl-7.19.7-54.el6_10.x86_64.rpm && \
+    curl -O https://vault.centos.org/6.10/updates/x86_64/Packages/libcurl-7.19.7-54.el6_10.x86_64.rpm && \
+    rpm -Uvh libcurl-7.19.7-54.el6_10.x86_64.rpm curl-7.19.7-54.el6_10.x86_64.rpm yum-3.2.29-81.el6.centos.0.1.noarch.rpm
+
 # Replace regular CentOS 6 mirror list with vault.centos.org, as CentOS 6 is EOL
 # and regular mirrors aren't hosted any more.
 RUN sed -i 's%^mirrorlist%#mirrorlist%g' /etc/yum.repos.d/* && \

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-cluster
 apiVersion: v2
-version: "6.2.27"
-appVersion: "6.2.27"
+version: "6.2.28"
+appVersion: "6.2.28"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: "6.2.27"
-appVersion: "6.2.27"
+version: "6.2.28"
+appVersion: "6.2.28"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "6.2.27"
+	Version = "6.2.28"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Fixes centos6 build breakage that was preventing release of `v6.2.27`.