### PR TITLE
Return desktop events in SearchSessionEvents

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1021,7 +1021,7 @@ func getSubPageCheckpoint(e *event) (string, error) {
 // SearchSessionEvents returns session related events only. This is used to
 // find completed session.
 func (l *Log) SearchSessionEvents(fromUTC time.Time, toUTC time.Time, limit int, order types.EventOrder, startKey string, cond *types.WhereExpr) ([]apievents.AuditEvent, string, error) {
-	filter := searchEventsFilter{eventTypes: []string{events.SessionEndEvent}}
+	filter := searchEventsFilter{eventTypes: []string{events.SessionEndEvent, events.WindowsDesktopSessionEndEvent}}
 	if cond != nil {
 		params := condFilterParams{attrValues: make(map[string]interface{}), attrNames: make(map[string]string)}
 		expr, err := fromWhereExpr(cond, &params)

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -360,7 +360,7 @@ func getCheckpointFromEvent(event apievents.AuditEvent) (string, error) {
 
 func (l *FileLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, order types.EventOrder, startKey string, cond *types.WhereExpr) ([]apievents.AuditEvent, string, error) {
 	l.Debugf("SearchSessionEvents(%v, %v, order=%v, limit=%v, cond=%q)", fromUTC, toUTC, order, limit, cond)
-	filter := searchEventsFilter{eventTypes: []string{SessionEndEvent}}
+	filter := searchEventsFilter{eventTypes: []string{SessionEndEvent, WindowsDesktopSessionEndEvent}}
 	if cond != nil {
 		condFn, err := utils.ToFieldsCondition(cond)
 		if err != nil {

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -628,7 +628,7 @@ func (l *Log) searchEventsOnce(fromUTC, toUTC time.Time, namespace string, limit
 // SearchSessionEvents returns session related events only. This is used to
 // find completed sessions.
 func (l *Log) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, order types.EventOrder, startKey string, cond *types.WhereExpr) ([]apievents.AuditEvent, string, error) {
-	filter := searchEventsFilter{eventTypes: []string{events.SessionEndEvent}}
+	filter := searchEventsFilter{eventTypes: []string{events.SessionEndEvent, events.WindowsDesktopSessionEndEvent}}
 	if cond != nil {
 		condFn, err := utils.ToFieldsCondition(cond)
 		if err != nil {

--- a/lib/events/multilog.go
+++ b/lib/events/multilog.go
@@ -147,7 +147,7 @@ func (m *MultiLog) SearchEvents(fromUTC, toUTC time.Time, namespace string, even
 }
 
 // SearchSessionEvents is a flexible way to find session events.
-// Only session.end events are returned by this function.
+// Only session.end and windows.desktop.session.end events are returned by this function.
 // This is used to find completed sessions.
 //
 // Event types to filter can be specified and pagination is handled by an iterator key that allows

--- a/lib/events/writer.go
+++ b/lib/events/writer.go
@@ -117,7 +117,7 @@ func (w *WriterLog) SearchEvents(fromUTC, toUTC time.Time, namespace string, eve
 }
 
 // SearchSessionEvents is a flexible way to find session events.
-// Only session.end events are returned by this function.
+// Only session.end and windows.desktop.session.end events are returned by this function.
 // This is used to find completed sessions.
 //
 // Event types to filter can be specified and pagination is handled by an iterator key that allows


### PR DESCRIPTION
This is the API call that is used to populate the session recordings
page. In order for it to return desktop sessions and SSH sessions,
it needs to search for both `session.end` and
`windows.desktop.session.end` events.

(The previous implementation incorrectly switched to the `SearchSessionEvents` API, which does return both types of events, but bypasses the RBAC for sessions logic)

Updates #9979