### PR TITLE
Label active directory domain controllers

### DIFF
--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -15,9 +15,11 @@
 package desktop
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/go-ldap/ldap/v3"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,6 +56,61 @@ func TestDiscoveryLDAPFilter(t *testing.T) {
 			filter := s.ldapSearchFilter()
 			_, err := ldap.CompileFilter(filter)
 			test.assert(t, err)
+		})
+	}
+}
+
+func TestAppliesLDAPLabels(t *testing.T) {
+	l := make(map[string]string)
+	entry := ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
+		attrDNSHostName: {"foo.example.com"},
+		attrName:        {"foo"},
+		attrOS:          {"Windows Server"},
+		attrOSVersion:   {"6.1"},
+	})
+	applyLabelsFromLDAP(entry, l)
+
+	require.Equal(t, l[types.OriginLabel], types.OriginDynamic)
+	require.Equal(t, l["teleport.dev/dns_host_name"], "foo.example.com")
+	require.Equal(t, l["teleport.dev/computer_name"], "foo")
+	require.Equal(t, l["teleport.dev/os"], "Windows Server")
+	require.Equal(t, l["teleport.dev/os_version"], "6.1")
+}
+
+func TestLabelsDomainControllers(t *testing.T) {
+	for _, test := range []struct {
+		desc   string
+		entry  *ldap.Entry
+		assert require.BoolAssertionFunc
+	}{
+		{
+			desc: "DC",
+			entry: ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
+				attrPrimaryGroupID: {writableDomainControllerGroupID},
+			}),
+			assert: require.True,
+		},
+		{
+			desc: "RODC",
+			entry: ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
+				attrPrimaryGroupID: {readOnlyDomainControllerGroupID},
+			}),
+			assert: require.True,
+		},
+		{
+			desc: "computer",
+			entry: ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
+				attrPrimaryGroupID: {"515"},
+			}),
+			assert: require.False,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			l := make(map[string]string)
+			applyLabelsFromLDAP(test.entry, l)
+
+			b, _ := strconv.ParseBool(l["teleport.dev/is_domain_controller"])
+			test.assert(t, b)
 		})
 	}
 }


### PR DESCRIPTION
We can identify domain controllers and their read-only variant (RODCs)
via the `primaryGroupID` attribute. If we discover a domain controller,
label it with `teleport.dev/is_domain_controller: true`. This will help
identify DCs, which should be treated with extra care (and potentially
filtered out from discovery with an LDAP filter).