### PR TITLE
Ensure docs nav titles use title case consistently

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -29,10 +29,10 @@
           "slug": "/setup/admin/",
           "entries": [
             { "title": "Github SSO", "slug": "/setup/admin/github-sso/" },
-            { "title": "Adding nodes", "slug": "/setup/admin/adding-nodes/" },
+            { "title": "Adding Nodes", "slug": "/setup/admin/adding-nodes/" },
             { "title": "Trusted Clusters", "slug": "/setup/admin/trustedclusters/" },
             { "title": "Labels", "slug": "/setup/admin/labels/" },
-            { "title": "Local users", "slug": "/setup/admin/users/" },
+            { "title": "Local Users", "slug": "/setup/admin/users/" },
             { "title": "Troubleshooting", "slug": "/setup/admin/troubleshooting/" },
             { "title": "Graceful Restarts", "slug": "/setup/admin/graceful-restarts/" },
             { "title": "Daemon", "slug": "/setup/admin/daemon/" }
@@ -72,7 +72,7 @@
             { "title": "Terraform Provider", "slug": "/setup/guides/terraform-provider/" },
             { "title": "Docker", "slug": "/setup/guides/docker/" },
             { "title": "Fluentd", "slug": "/setup/guides/fluentd/" },
-            { "title": "EC2 tags", "slug": "/setup/guides/ec2-tags/" },
+            { "title": "EC2 Tags", "slug": "/setup/guides/ec2-tags/" },
             { "title": "Joining Nodes in AWS", "slug": "/setup/guides/joining-nodes-aws/" }
           ]
         },
@@ -332,7 +332,7 @@
           "slug": "/contributing/documentation/",
           "entries":[
             { "title": "How to Contribute", "slug": "/contributing/documentation/how-to-contribute/" },
-            { "title": "Creating documentation issues", "slug": "/contributing/documentation/issues/"},
+            { "title": "Creating Documentation Issues", "slug": "/contributing/documentation/issues/"},
             { "title": "Style Guide", "slug": "/contributing/documentation/style-guide/" },
             { "title": "UI Reference", "slug": "/contributing/documentation/reference/" }
           ]


### PR DESCRIPTION
In a recent backport PR that added entries to the docs navigation menu, [one comment](https://github.com/gravitational/teleport/pull/10278#discussion_r804212089) pointed out that capitalization of titles in the menu was inconsistent. This PR fixes the inconsistency.