### PR TITLE
Fix Flaky TestProcessKubeCSR

### DIFF
--- a/lib/auth/desktop_test.go
+++ b/lib/auth/desktop_test.go
@@ -23,22 +23,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type testModules struct {
-	modules.Modules
-}
-
-func (m *testModules) Features() modules.Features {
-	return modules.Features{
-		Desktop: false, // Explicily turn off desktop access.
-	}
-}
-
 // TestDesktopAccessDisabled makes sure desktop access can be disabled via modules.
 // Since desktop connections require a cert, this is mediated via the cert generating function.
 func TestDesktopAccessDisabled(t *testing.T) {
 	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testModules{})
+	t.Cleanup(func() { modules.SetModules(defaultModules) })
+	modules.SetModules(&testModules{
+		features: modules.Features{
+			Desktop: false, // Explicily turn off desktop access.
+		},
+	})
 
 	t.Parallel()
 	ctx := context.Background()

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/suite"
@@ -1049,4 +1050,13 @@ func CreateUserAndRoleWithoutRoles(clt clt, username string, allowedLogins []str
 	}
 
 	return user, role, nil
+}
+
+type testModules struct {
+	modules.Modules
+	features modules.Features
+}
+
+func (m *testModules) Features() modules.Features {
+	return m.features
 }

--- a/lib/auth/kube_test.go
+++ b/lib/auth/kube_test.go
@@ -24,13 +24,21 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
 
 func TestProcessKubeCSR(t *testing.T) {
-	t.Parallel()
+	defaultModules := modules.GetModules()
+	t.Cleanup(func() { modules.SetModules(defaultModules) })
+	modules.SetModules(&testModules{
+		features: modules.Features{
+			Kubernetes: true, // test requires kube feature is enabled
+		},
+	})
+
 	s := newAuthSuite(t)
 	const (
 		username = "bob"
@@ -62,7 +70,7 @@ func TestProcessKubeCSR(t *testing.T) {
 	// CSR with unknown roles.
 	_, err = s.a.ProcessKubeCSR(csr)
 	require.Error(t, err)
-	require.True(t, trace.IsNotFound(err))
+	require.True(t, trace.IsNotFound(err), "got: %v", err)
 
 	// Create the user and allow it to request the additional role.
 	_, err = CreateUserRoleAndRequestable(s.a, username, roleB)


### PR DESCRIPTION
The `TestProcessKubeCSR` test in `lib/auth` fails intermittently due to the Kubernetes feature being disabled. The test expects a `NotFound` error but receives an invalid license error instead. Usually other tests enable the Kubernetes feature before this test runs, but occasionally the test executes without Kubernetes and fails.

This change explicitly enables the Kubernetes feature by generalizing a pattern for setting module features used by the `TestDesktopAccessDisabled` test.

The following is the location where the test failed and the output received.

```go
_, err = s.a.ProcessKubeCSR(csr)
require.Error(t, err)
require.True(t, trace.IsNotFound(err), "got: %v", err) // failure
```
```sh
=== CONT  TestProcessKubeCSR
kube_test.go:69: 
  Error Trace:	kube_test.go:69
  Error:      	Should be true
  Test:       	TestProcessKubeCSR
  Messages:   	got: this Teleport cluster is not licensed for Kubernetes, please contact the cluster administrator
```

Flaky Test Tracker: #9492 