### PR TITLE
Fix Reverse Tunnels Not Properly reconnecting

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -963,6 +963,12 @@ type ProxyConfig struct {
 	WebPort int
 	// ReverseTunnelPort is a port for reverse tunnel addresses
 	ReverseTunnelPort int
+	// Disable the web service
+	DisableWebService bool
+	// Disable the web ui
+	DisableWebInterface bool
+	// Disable ALPN routing
+	DisableALPNSNIListener bool
 }
 
 // StartProxy starts another Proxy Server and connects it to the cluster.
@@ -1004,7 +1010,9 @@ func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnel.Server, error)
 	tconf.Proxy.ReverseTunnelListenAddr.Addr = net.JoinHostPort(i.Hostname, fmt.Sprintf("%v", cfg.ReverseTunnelPort))
 	tconf.Proxy.WebAddr.Addr = net.JoinHostPort(i.Hostname, fmt.Sprintf("%v", cfg.WebPort))
 	tconf.Proxy.DisableReverseTunnel = false
-	tconf.Proxy.DisableWebService = true
+	tconf.Proxy.DisableWebService = cfg.DisableWebService
+	tconf.Proxy.DisableWebInterface = cfg.DisableWebInterface
+	tconf.Proxy.DisableALPNSNIListener = cfg.DisableALPNSNIListener
 
 	// Create a new Teleport process and add it to the list of nodes that
 	// compose this "cluster".

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -189,6 +189,7 @@ func TestIntegrations(t *testing.T) {
 	t.Run("PAM", suite.bind(testPAM))
 	t.Run("PortForwarding", suite.bind(testPortForwarding))
 	t.Run("ProxyHostKeyCheck", suite.bind(testProxyHostKeyCheck))
+	t.Run("ReverseTunnelCollapse", suite.bind(testReverseTunnelCollapse))
 	t.Run("RotateChangeSigningAlg", suite.bind(testRotateChangeSigningAlg))
 	t.Run("RotateRollback", suite.bind(testRotateRollback))
 	t.Run("RotateSuccess", suite.bind(testRotateSuccess))
@@ -2484,6 +2485,7 @@ func testDiscoveryRecovers(t *testing.T, suite *integrationTestSuite) {
 			SSHPort:           proxySSHPort,
 			WebPort:           proxyWebPort,
 			ReverseTunnelPort: proxyReverseTunnelPort,
+			DisableWebService: true,
 		}
 		newProxy, err := main.StartProxy(newConfig)
 		require.NoError(t, err)
@@ -2614,6 +2616,7 @@ func testDiscovery(t *testing.T, suite *integrationTestSuite) {
 		SSHPort:           proxySSHPort,
 		WebPort:           proxyWebPort,
 		ReverseTunnelPort: proxyReverseTunnelPort,
+		DisableWebService: true,
 	}
 	secondProxy, err := main.StartProxy(proxyConfig)
 	require.NoError(t, err)
@@ -2692,6 +2695,152 @@ func testDiscovery(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, main.StopAll())
 }
 
+// TestReverseTunnelCollapse makes sure that when a reverse tunnel collapses
+// nodes will reconnect when network connection between the proxy and node
+// is restored.
+func testReverseTunnelCollapse(t *testing.T, suite *integrationTestSuite) {
+	tr := utils.NewTracer(utils.ThisFunction()).Start()
+	t.Cleanup(func() { tr.Stop() })
+
+	lib.SetInsecureDevMode(true)
+	t.Cleanup(func() { lib.SetInsecureDevMode(false) })
+
+	// Create and start load balancer for proxies.
+	frontend := *utils.MustParseAddr(net.JoinHostPort(Loopback, strconv.Itoa(ports.PopInt())))
+	lb, err := utils.NewLoadBalancer(context.TODO(), frontend)
+	require.NoError(t, err)
+	require.NoError(t, lb.Listen())
+	go lb.Serve()
+	t.Cleanup(func() { require.NoError(t, lb.Close()) })
+
+	// Create a Teleport instance with Auth/Proxy.
+	mainConfig := func() (*testing.T, []string, []*InstanceSecrets, *service.Config) {
+		tconf := suite.defaultServiceConfig()
+
+		tconf.Auth.Enabled = true
+
+		tconf.Proxy.Enabled = true
+		tconf.Proxy.TunnelPublicAddrs = []utils.NetAddr{
+			{
+				AddrNetwork: "tcp",
+				Addr:        frontend.String(),
+			},
+		}
+		tconf.Proxy.DisableWebService = false
+		tconf.Proxy.DisableWebInterface = true
+		tconf.Proxy.DisableALPNSNIListener = true
+
+		tconf.SSH.Enabled = false
+
+		return t, nil, nil, tconf
+	}
+	main := suite.newTeleportWithConfig(mainConfig())
+	t.Cleanup(func() { require.NoError(t, main.StopAll()) })
+
+	// Create a Teleport instance with a Proxy.
+	nodePorts := ports.PopIntSlice(3)
+	proxyReverseTunnelPort, proxyWebPort, proxySSHPort := nodePorts[0], nodePorts[1], nodePorts[2]
+	proxyConfig := ProxyConfig{
+		Name:                   "cluster-main-proxy",
+		SSHPort:                proxySSHPort,
+		WebPort:                proxyWebPort,
+		ReverseTunnelPort:      proxyReverseTunnelPort,
+		DisableWebService:      false,
+		DisableWebInterface:    true,
+		DisableALPNSNIListener: true,
+	}
+	proxyTunnel, err := main.StartProxy(proxyConfig)
+	require.NoError(t, err)
+
+	proxyOneBackend := utils.MustParseAddr(net.JoinHostPort(Loopback, main.GetPortReverseTunnel()))
+	lb.AddBackend(*proxyOneBackend)
+	proxyTwoBackend := utils.MustParseAddr(net.JoinHostPort(Loopback, strconv.Itoa(proxyReverseTunnelPort)))
+	lb.AddBackend(*proxyTwoBackend)
+
+	// Create a Teleport instance with a Node.
+	nodeConfig := func() *service.Config {
+		tconf := suite.defaultServiceConfig()
+		tconf.Hostname = "cluster-main-node"
+		tconf.Token = "token"
+		tconf.AuthServers = []utils.NetAddr{
+			{
+				AddrNetwork: "tcp",
+				Addr:        net.JoinHostPort(Loopback, strconv.Itoa(proxyWebPort)),
+			},
+		}
+		tconf.Auth.Enabled = false
+		tconf.Proxy.Enabled = false
+		tconf.SSH.Enabled = true
+
+		return tconf
+	}
+	node, err := main.StartNode(nodeConfig())
+	require.NoError(t, err)
+
+	// Wait for active tunnel connections to be established.
+	waitForActiveTunnelConnections(t, main.Tunnel, Site, 0)
+	waitForActiveTunnelConnections(t, proxyTunnel, Site, 1)
+
+	// Execute the connection via first proxy.
+	cfg := ClientConfig{
+		Login:   suite.me.Username,
+		Cluster: Site,
+		Host:    "cluster-main-node",
+	}
+	_, err = runCommand(t, main, []string{"echo", "hello world"}, cfg, 1)
+	require.Error(t, err)
+
+	cfgProxy := ClientConfig{
+		Login:   suite.me.Username,
+		Cluster: Site,
+		Host:    "cluster-main-node",
+		Proxy:   &proxyConfig,
+	}
+
+	output, err := runCommand(t, main, []string{"echo", "hello world"}, cfgProxy, 10)
+	require.NoError(t, err)
+	require.Equal(t, "hello world\n", output)
+
+	// stop the proxy to collapse the tunnel
+	require.NoError(t, main.StopProxy())
+	waitForActiveTunnelConnections(t, main.Tunnel, Site, 0)
+	waitForActiveTunnelConnections(t, proxyTunnel, Site, 0)
+
+	// Requests going via both proxy will fail.
+	_, err = runCommand(t, main, []string{"echo", "hello world"}, cfg, 1)
+	require.Error(t, err)
+	_, err = runCommand(t, main, []string{"echo", "hello world"}, cfgProxy, 1)
+	require.Error(t, err)
+
+	// wait for the node to reach a degraded state
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	eventC := make(chan service.Event)
+	node.WaitForEvent(ctx, service.TeleportDegradedEvent, eventC)
+	select {
+	case <-eventC:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for node to become degraded")
+	}
+
+	// start the proxy again and ensure the tunnel is re-established
+	proxyTunnel, err = main.StartProxy(proxyConfig)
+	require.NoError(t, err)
+	waitForActiveTunnelConnections(t, main.Tunnel, Site, 0)
+	waitForActiveTunnelConnections(t, proxyTunnel, Site, 1)
+
+	// Requests going to the connected proxy should succeed.
+	_, err = runCommand(t, main, []string{"echo", "hello world"}, cfg, 1)
+	require.Error(t, err)
+	output, err = runCommand(t, main, []string{"echo", "hello world"}, cfgProxy, 40)
+	require.NoError(t, err)
+	require.Equal(t, "hello world\n", output)
+
+	// Stop everything.
+	err = proxyTunnel.Shutdown(context.Background())
+	require.NoError(t, err)
+}
+
 // TestDiscoveryNode makes sure the discovery protocol works with nodes.
 func testDiscoveryNode(t *testing.T, suite *integrationTestSuite) {
 	tr := utils.NewTracer(utils.ThisFunction()).Start()
@@ -2741,6 +2890,7 @@ func testDiscoveryNode(t *testing.T, suite *integrationTestSuite) {
 		SSHPort:           proxySSHPort,
 		WebPort:           proxyWebPort,
 		ReverseTunnelPort: proxyReverseTunnelPort,
+		DisableWebService: true,
 	}
 	proxyTunnel, err := main.StartProxy(proxyConfig)
 	require.NoError(t, err)
@@ -2838,19 +2988,18 @@ func testDiscoveryNode(t *testing.T, suite *integrationTestSuite) {
 func waitForActiveTunnelConnections(t *testing.T, tunnel reversetunnel.Server, clusterName string, expectedCount int) {
 	var lastCount int
 	var lastErr error
-	for i := 0; i < 30; i++ {
+	require.Eventually(t, func() bool {
 		cluster, err := tunnel.GetSite(clusterName)
 		if err != nil {
 			lastErr = err
-			continue
+			return false
 		}
 		lastCount = cluster.GetTunnelsCount()
-		if lastCount >= expectedCount {
-			return
-		}
-		time.Sleep(1 * time.Second)
-	}
-	t.Fatalf("Connections count on %v: %v, expected %v, last error: %v", clusterName, lastCount, expectedCount, lastErr)
+		return lastCount >= expectedCount
+	},
+		30*time.Second,
+		time.Second,
+		"Connections count on %v: %v, expected %v, last error: %v", clusterName, lastCount, expectedCount, lastErr)
 }
 
 // waitForProxyCount waits a set time for the proxy count in clusterName to

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -202,6 +202,8 @@ func (m *AgentPool) processSeekEvents() {
 				// Note that ownership of the lease is transferred to agent
 				// pool for the lifetime of the connection
 				if err := m.addAgent(lease); err != nil {
+					// ensure that lease has been released; OK to call multiple times.
+					lease.Release()
 					m.log.WithError(err).Errorf("Failed to add agent.")
 				}
 			})
@@ -301,8 +303,6 @@ func (m *AgentPool) addAgent(lease track.Lease) error {
 		reverseTunnelDetails: m.getReverseTunnelDetails(),
 	})
 	if err != nil {
-		// ensure that lease has been released; OK to call multiple times.
-		lease.Release()
 		return trace.Wrap(err)
 	}
 	m.log.Debugf("Adding %v.", agent)


### PR DESCRIPTION
Nodes were not generating new agents which prevented reverse tunnels
from being re-established after a collapse. Ensuring we always
release the lease if the agent pool is unable to add a new agent.