### PR TITLE
Add TestModules

### DIFF
--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -316,7 +316,12 @@ func TestHSMRotation(t *testing.T) {
 		t.Skip("Skipping test as SOFTHSM2_PATH is not set")
 	}
 
-	modules.SetModules(keystore.TestModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			HSM: true,
+		},
+	})
 
 	// pick a conservative timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
@@ -392,7 +397,12 @@ func TestHSMDualAuthRotation(t *testing.T) {
 		t.Skip("Skipping test as either etcd or SoftHSM2 is not enabled")
 	}
 
-	modules.SetModules(keystore.TestModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			HSM: true,
+		},
+	})
 
 	// pick a conservative timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
@@ -697,7 +707,12 @@ func TestHSMMigrate(t *testing.T) {
 		t.Skip("Skipping test as either etcd or SoftHSM2 is not enabled")
 	}
 
-	modules.SetModules(keystore.TestModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			HSM: true,
+		},
+	})
 
 	// pick a conservative timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -41,16 +41,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type testWithCloudModules struct {
-	modules.Modules
-}
-
-func (m *testWithCloudModules) Features() modules.Features {
-	return modules.Features{
-		Cloud: true, // Enable cloud feature which is required for account recovery.
-	}
-}
-
 // TestGenerateAndUpsertRecoveryCodes tests the following:
 //  - generation of recovery codes are of correct format
 //  - recovery codes are upserted
@@ -145,9 +135,11 @@ func TestStartAccountRecovery(t *testing.T) {
 	mockEmitter := &events.MockEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	u, err := createUserWithSecondFactors(srv)
 	require.NoError(t, err)
@@ -211,9 +203,11 @@ func TestStartAccountRecovery_WithLock(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	u, err := createUserWithSecondFactors(srv)
 	require.NoError(t, err)
@@ -262,9 +256,11 @@ func TestStartAccountRecovery_UserErrors(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	u, err := createUserWithSecondFactors(srv)
 	require.NoError(t, err)
@@ -322,9 +318,11 @@ func TestVerifyAccountRecovery_WithAuthnErrors(t *testing.T) {
 	mockEmitter := &events.MockEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	u, err := createUserWithSecondFactors(srv)
 	require.NoError(t, err)
@@ -453,9 +451,11 @@ func TestVerifyAccountRecovery_WithLock(t *testing.T) {
 	mockEmitter := &events.MockEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	u, err := createUserWithSecondFactors(srv)
 	require.NoError(t, err)
@@ -520,9 +520,11 @@ func TestVerifyAccountRecovery_WithErrors(t *testing.T) {
 	mockEmitter := &events.MockEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	u, err := createUserWithSecondFactors(srv)
 	require.NoError(t, err)
@@ -617,9 +619,11 @@ func TestCompleteAccountRecovery(t *testing.T) {
 	mockEmitter := &events.MockEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	u, err := createUserWithSecondFactors(srv)
 	require.NoError(t, err)
@@ -744,9 +748,11 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 	mockEmitter := &events.MockEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	u, err := createUserWithSecondFactors(srv)
 	require.NoError(t, err)
@@ -914,9 +920,11 @@ func TestAccountRecoveryFlow(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	cases := []struct {
 		name               string
@@ -1187,9 +1195,11 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	// Enable second factors.
 	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
@@ -1296,9 +1306,11 @@ func TestGetAccountRecoveryCodes(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testWithCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,

--- a/lib/auth/desktop_test.go
+++ b/lib/auth/desktop_test.go
@@ -26,15 +26,12 @@ import (
 // TestDesktopAccessDisabled makes sure desktop access can be disabled via modules.
 // Since desktop connections require a cert, this is mediated via the cert generating function.
 func TestDesktopAccessDisabled(t *testing.T) {
-	defaultModules := modules.GetModules()
-	t.Cleanup(func() { modules.SetModules(defaultModules) })
-	modules.SetModules(&testModules{
-		features: modules.Features{
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
 			Desktop: false, // Explicily turn off desktop access.
 		},
 	})
 
-	t.Parallel()
 	ctx := context.Background()
 	p, err := newTestPack(ctx, t.TempDir())
 	require.NoError(t, err)

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -38,7 +38,6 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/limiter"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/suite"
@@ -1050,13 +1049,4 @@ func CreateUserAndRoleWithoutRoles(clt clt, username string, allowedLogins []str
 	}
 
 	return user, role, nil
-}
-
-type testModules struct {
-	modules.Modules
-	features modules.Features
-}
-
-func (m *testModules) Features() modules.Features {
-	return m.features
 }

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -126,9 +126,12 @@ JhuTMEqUaAOZBoQLn+txjl3nu9WwTThJzlY0L4w=
 )
 
 func TestKeyStore(t *testing.T) {
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(keystore.TestModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			HSM: true,
+		},
+	})
 
 	skipSoftHSM := os.Getenv("SOFTHSM2_PATH") == ""
 	var softHSMConfig keystore.Config
@@ -357,9 +360,12 @@ func TestLicenseRequirement(t *testing.T) {
 	_, err := keystore.NewKeyStore(config)
 	require.Error(t, err)
 
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(keystore.TestModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			HSM: true,
+		},
+	})
 
 	// should succeed when HSM feature is enabled
 	_, err = keystore.NewKeyStore(config)

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,18 +93,4 @@ func SetupSoftHSMTest(t *testing.T) Config {
 		Pin:        "password",
 	}
 	return *cachedConfig
-}
-
-type TestModules struct {
-	modules.Modules
-}
-
-func (t TestModules) Features() modules.Features {
-	return modules.Features{
-		HSM: true,
-	}
-}
-
-func (t TestModules) BuildType() string {
-	return modules.BuildEnterprise
 }

--- a/lib/auth/kube_test.go
+++ b/lib/auth/kube_test.go
@@ -31,10 +31,8 @@ import (
 )
 
 func TestProcessKubeCSR(t *testing.T) {
-	defaultModules := modules.GetModules()
-	t.Cleanup(func() { modules.SetModules(defaultModules) })
-	modules.SetModules(&testModules{
-		features: modules.Features{
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
 			Kubernetes: true, // test requires kube feature is enabled
 		},
 	})

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -50,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/jwt"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
 	"github.com/gravitational/teleport/lib/session"
@@ -3162,10 +3161,6 @@ func (s *TLSSuite) TestEventsPermissions(c *check.C) {
 	}
 }
 
-func (*testModules) BuildType() string {
-	return modules.BuildOSS
-}
-
 // TestEvents tests events suite
 func (s *TLSSuite) TestEvents(c *check.C) {
 	clt, err := s.server.NewClient(TestAdmin())
@@ -3181,7 +3176,6 @@ func (s *TLSSuite) TestEvents(c *check.C) {
 		UsersS:        clt,
 	}
 	suite.Events(c)
-	modules.SetModules(&testModules{})
 }
 
 // TestEventsClusterConfig test cluster configuration

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -18,7 +18,6 @@ package modules_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -41,7 +40,12 @@ func TestValidateAuthPreferenceOnCloud(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	setCloudFeatureFlag(t)
+	modules.SetTestModules(t, &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	authPref := types.DefaultAuthPreference()
 	err = testServer.AuthServer.SetAuthPreference(ctx, authPref)
@@ -60,7 +64,12 @@ func TestValidateSessionRecordingConfigOnCloud(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	setCloudFeatureFlag(t)
+	modules.SetTestModules(t, &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	recConfig := types.DefaultSessionRecordingConfig()
 	err = testServer.AuthServer.SetSessionRecordingConfig(ctx, recConfig)
@@ -69,28 +78,4 @@ func TestValidateSessionRecordingConfigOnCloud(t *testing.T) {
 	recConfig.SetMode(types.RecordAtProxy)
 	err = testServer.AuthServer.SetSessionRecordingConfig(ctx, recConfig)
 	require.EqualError(t, err, "cannot set proxy recording mode on Cloud")
-}
-
-func setCloudFeatureFlag(t *testing.T) {
-	oldModules := modules.GetModules()
-	t.Cleanup(func() { modules.SetModules(oldModules) })
-	modules.SetModules(&cloudModules{})
-}
-
-type cloudModules struct{}
-
-func (m cloudModules) Features() modules.Features {
-	return modules.Features{Cloud: true}
-}
-
-func (m *cloudModules) BuildType() string {
-	return modules.BuildEnterprise
-}
-
-func (m *cloudModules) PrintVersion() {
-	fmt.Println("Teleport Cloud")
-}
-
-func (m *cloudModules) IsBoringBinary() bool {
-	return false
 }

--- a/lib/modules/test.go
+++ b/lib/modules/test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modules
+
+import "testing"
+
+// TestModules implements the Modules interface for testing.
+//
+// Setting Test* fields will return those values from interface
+// methods. IsBoringBinary and PrintVersion functions return the
+// same values from default modules.
+//
+// See SetTestModules for an example.
+type TestModules struct {
+	// TestBuildType is returned from the BuiltType function.
+	TestBuildType string
+	// TestFeatures is returned from the Features function.
+	TestFeatures Features
+
+	defaultModules
+}
+
+// SetTestModules sets the value returned from GetModules to testModules
+// and reverts the change in the test cleanup function.
+// It must not be used in parallel tests.
+//
+//    func TestWithFakeModules(t *testing.T) {
+//       modules.SetTestModules(t, &modules.TestModules{
+//         TestBuildType: modules.BuildEnterprise,
+//         TestFeatures: modules.Features{
+//            Cloud: true,
+//         },
+//       })
+//
+//       // test implementation
+//
+//       // cleanup will revert module changes after test completes
+//    }
+//
+func SetTestModules(t *testing.T, testModules *TestModules) {
+	defaultModules := GetModules()
+	t.Cleanup(func() { SetModules(defaultModules) })
+	SetModules(testModules)
+}
+
+// PrintVersion prints teleport version
+func (m *TestModules) PrintVersion() {
+	m.defaultModules.PrintVersion()
+}
+
+// IsBoringBinary checks if the binary was compiled with BoringCrypto.
+func (m *TestModules) IsBoringBinary() bool {
+	return m.defaultModules.IsBoringBinary()
+}
+
+// Features returns supported features.
+func (m *TestModules) Features() Features {
+	return m.TestFeatures
+}
+
+// BuildType returns build type (OSS or Enterprise).
+func (m *TestModules) BuildType() string {
+	return m.TestBuildType
+}

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -580,21 +580,13 @@ func TestAccessMongoDB(t *testing.T) {
 	}
 }
 
-type testModules struct {
-	modules.Modules
-}
-
-func (m *testModules) Features() modules.Features {
-	return modules.Features{
-		DB: false, // Explicitly turn off database access.
-	}
-}
-
 // TestAccessDisabled makes sure database access can be disabled via modules.
 func TestAccessDisabled(t *testing.T) {
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			DB: false,
+		},
+	})
 
 	ctx := context.Background()
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1943,16 +1943,6 @@ func (s *WebSuite) TestGetClusterDetails(c *C) {
 	c.Assert(nodes, HasLen, cluster.NodeCount)
 }
 
-type testModules struct {
-	modules.Modules
-}
-
-func (m *testModules) Features() modules.Features {
-	return modules.Features{
-		App: false, // Explicily turn off application access.
-	}
-}
-
 func TestClusterDatabasesGet(t *testing.T) {
 	env := newWebPack(t, 1)
 
@@ -2050,9 +2040,11 @@ func TestClusterKubesGet(t *testing.T) {
 // TestApplicationAccessDisabled makes sure application access can be disabled
 // via modules.
 func TestApplicationAccessDisabled(t *testing.T) {
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			App: false,
+		},
+	})
 
 	env := newWebPack(t, 1)
 
@@ -2721,16 +2713,6 @@ func TestWebSessionsRenewAllowsOldBearerTokenToLinger(t *testing.T) {
 	require.True(t, trace.IsAccessDenied(err))
 }
 
-type testCloudModules struct {
-	modules.Modules
-}
-
-func (m *testCloudModules) Features() modules.Features {
-	return modules.Features{
-		Cloud: true, // Explicily turn on cloud feature.
-	}
-}
-
 // TestChangeUserAuthentication_recoveryCodesReturnedForCloud tests for following:
 //  - Recovery codes are not returned for usernames that are not emails
 //  - Recovery codes are returned for usernames that are valid emails
@@ -2748,9 +2730,11 @@ func TestChangeUserAuthentication_recoveryCodesReturnedForCloud(t *testing.T) {
 	require.NoError(t, err)
 
 	// Enable cloud feature.
-	defaultModules := modules.GetModules()
-	defer modules.SetModules(defaultModules)
-	modules.SetModules(&testCloudModules{})
+	modules.SetTestModules(t, &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
 
 	// Creaet a username that is not a valid email format for recovery.
 	teleUser, err := types.NewUser("invalid-name-for-recovery")


### PR DESCRIPTION
This PR adds `TestModules` which allows tests to set fake values to be returned from `modules.GetModules()`. The pattern implemented is an extension of the pattern used when implementing #10355. 

All tests that require test modules have been refactored to use this new implementation.

In some cases, multiple tests in the same package/file require the same features. In such cases, I opted to not create a separate function to set the features and instead inlined each call. Having the features visible in each test outweighed the benefit of saving a few lines of code.

Updates: #9492