### PR TITLE
Add passwordless login/registration support to lib/auth/webauthn

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1514,7 +1514,7 @@ func (a *Server) createRegisterChallenge(ctx context.Context, req *newRegisterCh
 			Identity: identity,
 		}
 
-		credentialCreation, err := webRegistration.Begin(ctx, req.username)
+		credentialCreation, err := webRegistration.Begin(ctx, req.username, false /* passwordless */)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/mocku2f/webauthn.go
+++ b/lib/auth/mocku2f/webauthn.go
@@ -125,7 +125,7 @@ func (muk *Key) SignCredentialCreation(origin string, cc *wanlib.CredentialCreat
 	if aa := cc.Response.AuthenticatorSelection.AuthenticatorAttachment; aa == protocol.Platform {
 		return nil, trace.BadParameter("platform attachment required by authenticator selection")
 	}
-	if rrk := cc.Response.AuthenticatorSelection.RequireResidentKey; rrk != nil && *rrk != muk.AllowResidentKey {
+	if rrk := cc.Response.AuthenticatorSelection.RequireResidentKey; rrk != nil && *rrk && !muk.AllowResidentKey {
 		return nil, trace.BadParameter("resident key required by authenticator selection")
 	}
 	if uv := cc.Response.AuthenticatorSelection.UserVerification; uv == protocol.VerificationRequired && !muk.SetUV {

--- a/lib/auth/mocku2f/webauthn.go
+++ b/lib/auth/mocku2f/webauthn.go
@@ -125,10 +125,10 @@ func (muk *Key) SignCredentialCreation(origin string, cc *wanlib.CredentialCreat
 	if aa := cc.Response.AuthenticatorSelection.AuthenticatorAttachment; aa == protocol.Platform {
 		return nil, trace.BadParameter("platform attachment required by authenticator selection")
 	}
-	if rrk := cc.Response.AuthenticatorSelection.RequireResidentKey; rrk != nil && *rrk {
+	if rrk := cc.Response.AuthenticatorSelection.RequireResidentKey; rrk != nil && *rrk != muk.AllowResidentKey {
 		return nil, trace.BadParameter("resident key required by authenticator selection")
 	}
-	if uv := cc.Response.AuthenticatorSelection.UserVerification; uv == protocol.VerificationRequired {
+	if uv := cc.Response.AuthenticatorSelection.UserVerification; uv == protocol.VerificationRequired && !muk.SetUV {
 		return nil, trace.BadParameter("user verification required by authenticator selection")
 	}
 
@@ -147,6 +147,12 @@ func (muk *Key) SignCredentialCreation(origin string, cc *wanlib.CredentialCreat
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	flags := res.RawResp[0]
+	if flags == u2fRegistrationFlags {
+		// Apply U2F-compabitle authenticatorMakeCredential logic.
+		// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#u2f-authenticatorMakeCredential-interoperability
+		flags = byte(protocol.FlagUserPresent | protocol.FlagAttestedCredentialData)
+	}
 
 	pubKeyCBOR, err := wanlib.U2FKeyToCBOR(&muk.PrivateKey.PublicKey)
 	if err != nil {
@@ -155,9 +161,7 @@ func (muk *Key) SignCredentialCreation(origin string, cc *wanlib.CredentialCreat
 
 	authData := &bytes.Buffer{}
 	authData.Write(appIDHash[:])
-	// Attested credential data present.
-	// https://www.w3.org/TR/webauthn-2/#attested-credential-data.
-	authData.WriteByte(byte(protocol.FlagAttestedCredentialData | protocol.FlagUserPresent))
+	authData.WriteByte(flags)
 	binary.Write(authData, binary.BigEndian, uint32(0)) // counter, zeroed
 	authData.Write(make([]byte, 16))                    // AAGUID, zeroed
 	binary.Write(authData, binary.BigEndian, uint16(len(muk.KeyHandle)))

--- a/lib/auth/webauthn/login.go
+++ b/lib/auth/webauthn/login.go
@@ -32,84 +32,66 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// loginSessionID is used as the per-user session identifier.
-// A fixed identifier means, in essence, that only one concurrent login is
-// allowed.
-const loginSessionID = "login"
-
-// LoginIdentity represents the subset of Identity methods used by LoginFlow.
-// It exists to better scope LoginFlow's use of Identity and to facilitate
-// testing.
-type LoginIdentity interface {
-	userIDStorage
+// loginIdentity contains the subset of services.Identity methods used by
+// loginFlow.
+type loginIdentity interface {
+	userIDStorage                                                                  // MFA
+	GetTeleportUserByWebauthnID(ctx context.Context, webID []byte) (string, error) // Passwordless
 
 	GetMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error)
 	UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error
-	UpsertWebauthnSessionData(ctx context.Context, user, sessionID string, sd *wantypes.SessionData) error
-	GetWebauthnSessionData(ctx context.Context, user, sessionID string) (*wantypes.SessionData, error)
-	DeleteWebauthnSessionData(ctx context.Context, user, sessionID string) error
 }
 
-// WithDevices returns a LoginIdentity backed by a fixed set of devices.
-// The supplied devices are returned in all GetMFADevices calls.
-func WithDevices(identity LoginIdentity, devs []*types.MFADevice) LoginIdentity {
-	return &loginWithDevices{
-		LoginIdentity: identity,
-		devices:       devs,
-	}
+// sessionIdentity abstracts operations over SessionData storage.
+// * MFA uses per-user variants
+// (services.Identity.Update/Get/DeleteWebauthnSessionData methods).
+// * Passwordless uses global variants
+// (services.Identity.Update/Get/DeleteGlobalWebauthnSessionData methods).
+type sessionIdentity interface {
+	Upsert(ctx context.Context, user string, sd *wantypes.SessionData) error
+	Get(ctx context.Context, user string, challenge string) (*wantypes.SessionData, error)
+	Delete(ctx context.Context, user string, challenge string) error
 }
 
-type loginWithDevices struct {
-	LoginIdentity
-	devices []*types.MFADevice
+// loginFlow implements both MFA and Passwordless authentication, exposing an
+// interface that is the union of both login methods.
+type loginFlow struct {
+	U2F         *types.U2F
+	Webauthn    *types.Webauthn
+	identity    loginIdentity
+	sessionData sessionIdentity
 }
 
-func (l *loginWithDevices) GetMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error) {
-	return l.devices, nil
-}
-
-// LoginFlow represents the WebAuthn login procedure (aka authentication).
-//
-// The login flow consists of:
-//
-// 1. Client requests a CredentialAssertion (containing, among other info, a
-//    challenge to be signed)
-// 2. Server runs Begin(), generates a credential assertion.
-// 3. Client validates the assertion, performs a user presence test (usually by
-//    asking the user to touch a secure token), and replies with
-//    CredentialAssertionResponse (containing the signed challenge)
-// 4. Server runs Finish()
-// 5. If all server-side checks are successful, then login/authentication is
-//    complete.
-type LoginFlow struct {
-	U2F      *types.U2F
-	Webauthn *types.Webauthn
-	// Identity is typically an implementation of the Identity service, ie, an
-	// object with access to user, device and MFA storage.
-	Identity LoginIdentity
-}
-
-// Begin is the first step of the LoginFlow.
-// The CredentialAssertion created is relayed back to the client, who in turn
-// performs a user presence check and signs the challenge contained within the
-// assertion.
-// As a side effect Begin may assign (and record in storage) a WebAuthn ID for
-// the user.
-func (f *LoginFlow) Begin(ctx context.Context, user string) (*CredentialAssertion, error) {
+func (f *loginFlow) begin(ctx context.Context, user string, passwordless bool) (*CredentialAssertion, error) {
 	switch {
 	case f.Webauthn.Disabled:
 		return nil, trace.BadParameter("webauthn disabled")
-	case user == "":
+	case user == "" && !passwordless:
 		return nil, trace.BadParameter("user required")
 	}
 
-	// Fetch existing user devices. We need the devices both to set the allowed
-	// credentials for the user (webUser.credentials) and to determine if the U2F
-	// appid extension is necessary.
-	devices, err := f.Identity.GetMFADevices(ctx, user, false /* withSecrets */)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	var u *webUser
+	if passwordless {
+		u = &webUser{} // Issue anonymous challenge.
+	} else {
+		// Use existing devices to set the allowed credentials.
+		devices, err := f.identity.GetMFADevices(ctx, user, false /* withSecrets */)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		webID, err := getOrCreateUserWebauthnID(ctx, user, f.identity)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		u = newWebUser(user, webID, true /* credentialIDOnly */, devices)
+
+		// Let's make sure we have at least one registered credential here, since we
+		// have to allow zero credentials for passwordless below.
+		if len(u.credentials) == 0 {
+			return nil, trace.BadParameter("found no credentials for user")
+		}
 	}
+
 	var opts []wan.LoginOption
 	if f.U2F != nil && f.U2F.AppID != "" {
 		// See https://www.w3.org/TR/webauthn-2/#sctn-appid-extension.
@@ -118,72 +100,116 @@ func (f *LoginFlow) Begin(ctx context.Context, user string) (*CredentialAssertio
 		}))
 	}
 
-	webID, err := getOrCreateUserWebauthnID(ctx, user, f.Identity)
+	// Create the WebAuthn object and issue a new challenge.
+	web, err := newWebAuthn(webAuthnParams{
+		cfg:                     f.Webauthn,
+		rpID:                    f.Webauthn.RPID,
+		requireUserVerification: passwordless,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	u := newWebUser(user, webID, true /* credentialIDOnly */, devices)
-
-	// Create the WebAuthn object and create a new challenge.
-	web, err := newWebAuthn(f.Webauthn, f.Webauthn.RPID, "" /* origin */)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	assertion, sessionData, err := web.BeginLogin(u, opts...)
+	assertion, sessionData, err := beginLogin(passwordless, web, u, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Store SessionData - it's checked against the user response by
-	// LoginFlow.Finish().
+	// Store SessionData - it's checked against the user response by Finish.
 	sessionDataPB, err := sessionToPB(sessionData)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := f.Identity.UpsertWebauthnSessionData(ctx, user, loginSessionID, sessionDataPB); err != nil {
+	if err := f.sessionData.Upsert(ctx, user, sessionDataPB); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return (*CredentialAssertion)(assertion), nil
 }
 
-// Finish is the second and last step of the LoginFlow.
-// It returns the MFADevice used to solve the challenge. If login is successful,
-// Finish has the side effect of updating the counter and last used timestamp of
-// the returned device.
-func (f *LoginFlow) Finish(ctx context.Context, user string, resp *CredentialAssertionResponse) (*types.MFADevice, error) {
+func beginLogin(
+	passwordless bool,
+	web *wan.WebAuthn, user *webUser, opts ...wan.LoginOption) (*protocol.CredentialAssertion, *wan.SessionData, error) {
+	// web.BeginLogin does a length check in the users' credentials, but we have
+	// no known credentials at this stage for passwordless logins.
+	// This leaves us with two options: copy and modify BeginLogin, or code
+	// around it so passwordless goes through. Since copying makes it harder to
+	// apply or benefit from future library updates, coding around it is the
+	// option of choice.
+
+	if passwordless {
+		// Add a mock credential to pass the BeginLogin check.
+		user.credentials = append(user.credentials, wan.Credential{})
+		defer func() { user.credentials = nil }()
+	}
+
+	assertion, sessionData, err := web.BeginLogin(user, opts...)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	if passwordless {
+		// Remove mock credential from resources.
+		assertion.Response.AllowedCredentials = nil
+		sessionData.AllowedCredentialIDs = nil
+	}
+
+	return assertion, sessionData, nil
+}
+
+func (f *loginFlow) finish(ctx context.Context, user string, resp *CredentialAssertionResponse, passwordless bool) (*types.MFADevice, string, error) {
 	switch {
 	case f.Webauthn.Disabled:
-		return nil, trace.BadParameter("webauthn disabled")
-	case user == "":
-		return nil, trace.BadParameter("user required")
+		return nil, "", trace.BadParameter("webauthn disabled")
+	case user == "" && !passwordless:
+		return nil, "", trace.BadParameter("user required")
 	case resp == nil:
 		// resp != nil is good enough to proceed, we leave remaining validations to
 		// duo-labs/webauthn.
-		return nil, trace.BadParameter("credential assertion response required")
+		return nil, "", trace.BadParameter("credential assertion response required")
 	}
 
 	parsedResp, err := parseCredentialResponse(resp)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	}
 
 	origin := parsedResp.Response.CollectedClientData.Origin
 	if err := validateOrigin(origin, f.Webauthn.RPID); err != nil {
 		log.WithError(err).Debugf("WebAuthn: origin validation failed")
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
+	}
+
+	var webID []byte
+	if passwordless {
+		webID = parsedResp.Response.UserHandle
+		if len(webID) == 0 {
+			return nil, "", trace.BadParameter("webauthn user handle required for passwordless")
+		}
+
+		// Fetch user from WebAuthn UserHandle (aka User ID).
+		teleportUser, err := f.identity.GetTeleportUserByWebauthnID(ctx, webID)
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		user = teleportUser
+	} else {
+		// Fetch WebAuthn UserID from user
+		wla, err := f.identity.GetWebauthnLocalAuth(ctx, user)
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		webID = wla.UserID
 	}
 
 	// Find the device used to sign the credentials. It must be a previously
 	// registered device.
-	devices, err := f.Identity.GetMFADevices(ctx, user, false /* withSecrets */)
+	devices, err := f.identity.GetMFADevices(ctx, user, false /* withSecrets */)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	}
 	dev, ok := findDeviceByID(devices, parsedResp.RawID)
-	switch {
-	case !ok:
-		return nil, trace.BadParameter(
+	if !ok {
+		return nil, "", trace.BadParameter(
 			"unknown device credential: %q", base64.RawURLEncoding.EncodeToString(parsedResp.RawID))
 	}
 
@@ -194,35 +220,38 @@ func (f *LoginFlow) Finish(ctx context.Context, user string, resp *CredentialAss
 	rpID := f.Webauthn.RPID
 	switch {
 	case dev.GetU2F() != nil && f.U2F == nil:
-		return nil, trace.BadParameter("U2F device attempted login, but U2F configuration not present")
+		return nil, "", trace.BadParameter("U2F device attempted login, but U2F configuration not present")
 	case dev.GetU2F() != nil:
 		rpID = f.U2F.AppID
 	}
-
-	// Fetch the user web ID, it must exist if they got here.
-	wla, err := f.Identity.GetWebauthnLocalAuth(ctx, user)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	u := newWebUser(user, wla.UserID, false /* credentialIDOnly */, []*types.MFADevice{dev})
+	u := newWebUser(user, webID, false /* credentialIDOnly */, []*types.MFADevice{dev})
 
 	// Fetch the previously-stored SessionData, so it's checked against the user
 	// response.
-	sessionDataPB, err := f.Identity.GetWebauthnSessionData(ctx, user, loginSessionID)
+	challenge := parsedResp.Response.CollectedClientData.Challenge
+	sessionDataPB, err := f.sessionData.Get(ctx, user, challenge)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
+	}
+	if passwordless {
+		sessionDataPB.UserId = webID // Not known on Begin, so can't be recorded.
 	}
 	sessionData := sessionFromPB(sessionDataPB)
 
 	// Create a WebAuthn matching the expected RPID and Origin, then verify the
 	// signed challenge.
-	web, err := newWebAuthn(f.Webauthn, rpID, origin)
+	web, err := newWebAuthn(webAuthnParams{
+		cfg:                     f.Webauthn,
+		rpID:                    rpID,
+		origin:                  origin,
+		requireUserVerification: passwordless,
+	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	}
 	credential, err := web.ValidateLogin(u, *sessionData, parsedResp)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	}
 	if credential.Authenticator.CloneWarning {
 		log.Warnf(
@@ -231,19 +260,19 @@ func (f *LoginFlow) Finish(ctx context.Context, user string, resp *CredentialAss
 
 	// Update last used timestamp and device counter.
 	if err := setCounterAndTimestamps(dev, credential); err != nil {
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	}
-	if err := f.Identity.UpsertMFADevice(ctx, user, dev); err != nil {
-		return nil, trace.Wrap(err)
+	if err := f.identity.UpsertMFADevice(ctx, user, dev); err != nil {
+		return nil, "", trace.Wrap(err)
 	}
 
-	// The user just solved this challenge, so let's make sure it won't be used
+	// The user just solved the challenge, so let's make sure it won't be used
 	// again.
-	if err := f.Identity.DeleteWebauthnSessionData(ctx, user, loginSessionID); err != nil {
-		log.Warnf("WebAuthn: failed to delete login SessionData for user %v", user)
+	if err := f.sessionData.Delete(ctx, user, challenge); err != nil {
+		log.Warnf("WebAuthn: failed to delete login SessionData for user %v (passwordless = %v)", user, passwordless)
 	}
 
-	return dev, nil
+	return dev, user, nil
 }
 
 func parseCredentialResponse(resp *CredentialAssertionResponse) (*protocol.ParsedCredentialAssertionData, error) {

--- a/lib/auth/webauthn/login.go
+++ b/lib/auth/webauthn/login.go
@@ -89,7 +89,7 @@ func (f *loginFlow) begin(ctx context.Context, user string, passwordless bool) (
 		// Let's make sure we have at least one registered credential here, since we
 		// have to allow zero credentials for passwordless below.
 		if len(u.credentials) == 0 {
-			return nil, trace.BadParameter("found no credentials for user")
+			return nil, trace.NotFound("found no credentials for user %q", user)
 		}
 	}
 

--- a/lib/auth/webauthn/login_mfa.go
+++ b/lib/auth/webauthn/login_mfa.go
@@ -28,7 +28,7 @@ import (
 // It exists to better scope LoginFlow's use of Identity and to facilitate
 // testing.
 type LoginIdentity interface {
-	userIDStorage
+	GetWebauthnLocalAuth(ctx context.Context, user string) (*types.WebauthnLocalAuth, error)
 
 	GetMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error)
 	UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error

--- a/lib/auth/webauthn/login_mfa.go
+++ b/lib/auth/webauthn/login_mfa.go
@@ -1,0 +1,131 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthn
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+
+	wantypes "github.com/gravitational/teleport/api/types/webauthn"
+)
+
+// LoginIdentity represents the subset of Identity methods used by LoginFlow.
+// It exists to better scope LoginFlow's use of Identity and to facilitate
+// testing.
+type LoginIdentity interface {
+	userIDStorage
+
+	GetMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error)
+	UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error
+	UpsertWebauthnSessionData(ctx context.Context, user, sessionID string, sd *wantypes.SessionData) error
+	GetWebauthnSessionData(ctx context.Context, user, sessionID string) (*wantypes.SessionData, error)
+	DeleteWebauthnSessionData(ctx context.Context, user, sessionID string) error
+}
+
+// WithDevices returns a LoginIdentity backed by a fixed set of devices.
+// The supplied devices are returned in all GetMFADevices calls.
+func WithDevices(identity LoginIdentity, devs []*types.MFADevice) LoginIdentity {
+	return &loginWithDevices{
+		LoginIdentity: identity,
+		devices:       devs,
+	}
+}
+
+type loginWithDevices struct {
+	LoginIdentity
+	devices []*types.MFADevice
+}
+
+func (l *loginWithDevices) GetMFADevices(_ context.Context, _ string, _ bool) ([]*types.MFADevice, error) {
+	return l.devices, nil
+}
+
+// LoginFlow represents the WebAuthn login procedure (aka authentication).
+//
+// The login flow consists of:
+//
+// 1. Client requests a CredentialAssertion (containing, among other info, a
+//    challenge to be signed)
+// 2. Server runs Begin(), generates a credential assertion.
+// 3. Client validates the assertion, performs a user presence test (usually by
+//    asking the user to touch a secure token), and replies with
+//    CredentialAssertionResponse (containing the signed challenge)
+// 4. Server runs Finish()
+// 5. If all server-side checks are successful, then login/authentication is
+//    complete.
+type LoginFlow struct {
+	U2F      *types.U2F
+	Webauthn *types.Webauthn
+	// Identity is typically an implementation of the Identity service, ie, an
+	// object with access to user, device and MFA storage.
+	Identity LoginIdentity
+}
+
+// Begin is the first step of the LoginFlow.
+// The CredentialAssertion created is relayed back to the client, who in turn
+// performs a user presence check and signs the challenge contained within the
+// assertion.
+// As a side effect Begin may assign (and record in storage) a WebAuthn ID for
+// the user.
+func (f *LoginFlow) Begin(ctx context.Context, user string) (*CredentialAssertion, error) {
+	lf := &loginFlow{
+		U2F:         f.U2F,
+		Webauthn:    f.Webauthn,
+		identity:    mfaIdentity{f.Identity},
+		sessionData: (*userSessionStorage)(f),
+	}
+	return lf.begin(ctx, user, false /* passwordless */)
+}
+
+// Finish is the second and last step of the LoginFlow.
+// It returns the MFADevice used to solve the challenge. If login is successful,
+// Finish has the side effect of updating the counter and last used timestamp of
+// the returned device.
+func (f *LoginFlow) Finish(ctx context.Context, user string, resp *CredentialAssertionResponse) (*types.MFADevice, error) {
+	lf := &loginFlow{
+		U2F:         f.U2F,
+		Webauthn:    f.Webauthn,
+		identity:    mfaIdentity{f.Identity},
+		sessionData: (*userSessionStorage)(f),
+	}
+	dev, _, err := lf.finish(ctx, user, resp, false /* passwordless */)
+	return dev, trace.Wrap(err)
+}
+
+type mfaIdentity struct {
+	LoginIdentity
+}
+
+func (m mfaIdentity) GetTeleportUserByWebauthnID(_ context.Context, _ []byte) (string, error) {
+	return "", errors.New("lookup by webauthn ID not supported for MFA")
+}
+
+// userSessionStorage implements sessionIdentity using LoginFlow.
+type userSessionStorage LoginFlow
+
+func (s *userSessionStorage) Upsert(ctx context.Context, user string, sd *wantypes.SessionData) error {
+	return s.Identity.UpsertWebauthnSessionData(ctx, user, scopeLogin, sd)
+}
+
+func (s *userSessionStorage) Get(ctx context.Context, user string, _ string) (*wantypes.SessionData, error) {
+	return s.Identity.GetWebauthnSessionData(ctx, user, scopeLogin)
+}
+
+func (s *userSessionStorage) Delete(ctx context.Context, user string, _ string) error {
+	return s.Identity.DeleteWebauthnSessionData(ctx, user, scopeLogin)
+}

--- a/lib/auth/webauthn/login_passwordless.go
+++ b/lib/auth/webauthn/login_passwordless.go
@@ -1,0 +1,94 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthn
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+
+	"github.com/gravitational/teleport/api/types"
+
+	wantypes "github.com/gravitational/teleport/api/types/webauthn"
+)
+
+// PasswordlessIdentity represents the subset of Identity methods used by
+// PasswordlessFlow.
+type PasswordlessIdentity interface {
+	GetMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error)
+	UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error
+
+	UpsertGlobalWebauthnSessionData(ctx context.Context, scope, id string, sd *wantypes.SessionData) error
+	GetGlobalWebauthnSessionData(ctx context.Context, scope, id string) (*wantypes.SessionData, error)
+	DeleteGlobalWebauthnSessionData(ctx context.Context, scope, id string) error
+	GetTeleportUserByWebauthnID(ctx context.Context, webID []byte) (string, error)
+}
+
+// PasswordlessFlow provides passwordless authentication.
+type PasswordlessFlow struct {
+	Webauthn *types.Webauthn
+	Identity PasswordlessIdentity
+}
+
+// Begin is the first step of the passwordless login flow.
+// It works similarly to LoginFlow.Begin, but it doesn't require a Teleport
+// username nor implies a previous password-validation step.
+func (f *PasswordlessFlow) Begin(ctx context.Context) (*CredentialAssertion, error) {
+	lf := &loginFlow{
+		Webauthn:    f.Webauthn,
+		identity:    passwordlessIdentity{f.Identity},
+		sessionData: (*globalSessionStorage)(f),
+	}
+	return lf.begin(ctx, "" /* user */, true /* passwordless */)
+}
+
+// Finish is the last step of the passwordless login flow.
+// It works similarly to LoginFlow.Finish, but the user identity is established
+// via the response UserHandle, instead of an explicit Teleport username.
+func (f *PasswordlessFlow) Finish(ctx context.Context, resp *CredentialAssertionResponse) (*types.MFADevice, string, error) {
+	lf := &loginFlow{
+		Webauthn:    f.Webauthn,
+		identity:    passwordlessIdentity{f.Identity},
+		sessionData: (*globalSessionStorage)(f),
+	}
+	return lf.finish(ctx, "" /* user */, resp, true /* passwordless */)
+}
+
+type passwordlessIdentity struct {
+	PasswordlessIdentity
+}
+
+func (p passwordlessIdentity) UpsertWebauthnLocalAuth(ctx context.Context, user string, wla *types.WebauthnLocalAuth) error {
+	return errors.New("webauthn local auth not supported for passwordless")
+}
+
+func (p passwordlessIdentity) GetWebauthnLocalAuth(ctx context.Context, user string) (*types.WebauthnLocalAuth, error) {
+	return nil, errors.New("webauthn local auth not supported for passwordless")
+}
+
+type globalSessionStorage PasswordlessFlow
+
+func (g *globalSessionStorage) Upsert(ctx context.Context, user string, sd *wantypes.SessionData) error {
+	id := base64.RawURLEncoding.EncodeToString(sd.Challenge)
+	return g.Identity.UpsertGlobalWebauthnSessionData(ctx, scopeLogin, id, sd)
+}
+
+func (g *globalSessionStorage) Get(ctx context.Context, user string, challenge string) (*wantypes.SessionData, error) {
+	return g.Identity.GetGlobalWebauthnSessionData(ctx, scopeLogin, challenge)
+}
+
+func (g *globalSessionStorage) Delete(ctx context.Context, user string, challenge string) error {
+	return g.Identity.DeleteGlobalWebauthnSessionData(ctx, scopeLogin, challenge)
+}

--- a/lib/auth/webauthn/login_test.go
+++ b/lib/auth/webauthn/login_test.go
@@ -273,24 +273,27 @@ func TestLoginFlow_Begin_errors(t *testing.T) {
 
 	ctx := context.Background()
 	tests := []struct {
-		name    string
-		user    string
-		wantErr string
+		name          string
+		user          string
+		assertErrType func(error) bool
+		wantErr       string
 	}{
 		{
-			name:    "NOK empty user",
-			wantErr: "user required",
+			name:          "NOK empty user",
+			assertErrType: trace.IsBadParameter,
+			wantErr:       "user required",
 		},
 		{
-			name:    "NOK no registered devices",
-			user:    user,
-			wantErr: "no credentials",
+			name:          "NOK no registered devices",
+			user:          user,
+			assertErrType: trace.IsNotFound,
+			wantErr:       "no credentials",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := webLogin.Begin(ctx, test.user)
-			require.True(t, trace.IsBadParameter(err), "got err = %v, want BadParameter", err)
+			require.True(t, test.assertErrType(err), "got err = %v, want BadParameter", err)
 			require.Contains(t, err.Error(), test.wantErr)
 		})
 	}

--- a/lib/auth/webauthn/login_test.go
+++ b/lib/auth/webauthn/login_test.go
@@ -93,7 +93,7 @@ func TestWebauthnGlobalDisable(t *testing.T) {
 		{
 			name: "RegistrationFlow.Begin",
 			fn: func() error {
-				_, err := registrationFlow.Begin(ctx, user)
+				_, err := registrationFlow.Begin(ctx, user, false /* passwordless */)
 				return err
 			},
 		},
@@ -143,7 +143,7 @@ func TestLoginFlow_BeginFinish(t *testing.T) {
 		Webauthn: webConfig,
 		Identity: identity,
 	}
-	cc, err := webRegistration.Begin(ctx, user)
+	cc, err := webRegistration.Begin(ctx, user, false /* passwordless */)
 	require.NoError(t, err)
 	ccr, err := webKey.SignCredentialCreation(webOrigin, cc)
 	require.NoError(t, err)
@@ -298,7 +298,7 @@ func TestLoginFlow_Finish_errors(t *testing.T) {
 	key, err := mocku2f.Create()
 	require.NoError(t, err)
 	key.PreferRPID = true
-	cc, err := webRegistration.Begin(ctx, user)
+	cc, err := webRegistration.Begin(ctx, user, false /* passwordless */)
 	require.NoError(t, err)
 	ccr, err := key.SignCredentialCreation(webOrigin, cc)
 	require.NoError(t, err)
@@ -415,11 +415,12 @@ func TestPasswordlessFlow_BeginAndFinish(t *testing.T) {
 	require.NoError(t, err)
 	webKey.IgnoreAllowedCredentials = true // Allowed credentials will be empty
 	webKey.SetUV = true                    // Required for passwordless
+	webKey.AllowResidentKey = true         // Required for passwordless
 	webRegistration := &wanlib.RegistrationFlow{
 		Webauthn: webConfig,
 		Identity: identity,
 	}
-	cc, err := webRegistration.Begin(ctx, user)
+	cc, err := webRegistration.Begin(ctx, user, true /* passwordless */)
 	require.NoError(t, err)
 	ccr, err := webKey.SignCredentialCreation(webOrigin, cc)
 	require.NoError(t, err)

--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -194,7 +194,7 @@ func upsertOrGetWebID(ctx context.Context, user string, identity RegistrationIde
 	case trace.IsNotFound(err): // first-time user, create a new ID
 		webID := []byte(uuid.New().String())
 		err := identity.UpsertWebauthnLocalAuth(ctx, user, &types.WebauthnLocalAuth{
-			UserID: webID[:],
+			UserID: webID,
 		})
 		return webID[:], trace.Wrap(err)
 	case err != nil:

--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -158,7 +158,10 @@ func (f *RegistrationFlow) Begin(ctx context.Context, user string) (*CredentialC
 	}
 	u := newWebUser(user, webID, true /* credentialIDOnly */, nil /* devices */)
 
-	web, err := newWebAuthn(f.Webauthn, f.Webauthn.RPID, "" /* origin */)
+	web, err := newWebAuthn(webAuthnParams{
+		cfg:                f.Webauthn,
+		rpID:               f.Webauthn.RPID,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -225,7 +228,11 @@ func (f *RegistrationFlow) Finish(ctx context.Context, user, deviceName string, 
 	}
 	sessionData := sessionFromPB(sessionDataPB)
 
-	web, err := newWebAuthn(f.Webauthn, f.Webauthn.RPID, origin)
+	web, err := newWebAuthn(webAuthnParams{
+		cfg:    f.Webauthn,
+		rpID:   f.Webauthn.RPID,
+		origin: origin,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/webauthn/register_test.go
+++ b/lib/auth/webauthn/register_test.go
@@ -42,49 +42,82 @@ func TestRegistrationFlow_BeginFinish(t *testing.T) {
 	}
 
 	ctx := context.Background()
-
-	// Begin is the first step in registration.
-	credentialCreation, err := webRegistration.Begin(ctx, user)
-	require.NoError(t, err)
-	// Assert some parts of the credentialCreation (it's framework-created, no
-	// need to go too deep).
-	require.NotNil(t, credentialCreation)
-	require.NotEmpty(t, credentialCreation.Response.Challenge)
-	require.Equal(t, webRegistration.Webauthn.RPID, credentialCreation.Response.RelyingParty.ID)
-	// Are we using the correct authenticator selection settings?
-	require.Equal(t, false, *credentialCreation.Response.AuthenticatorSelection.RequireResidentKey)
-	require.Equal(t, protocol.VerificationDiscouraged, credentialCreation.Response.AuthenticatorSelection.UserVerification)
-	// Did we record the SessionData in storage?
-	require.NotEmpty(t, identity.SessionData)
-
-	// Sign CredentialCreation, typically requires user interaction.
-	dev, err := mocku2f.Create()
-	require.NoError(t, err)
-	ccr, err := dev.SignCredentialCreation(origin, credentialCreation)
-	require.NoError(t, err)
-
-	// Finish is the final step in registration.
-	newDevice, err := webRegistration.Finish(ctx, user, "webauthn1", ccr)
-	require.NoError(t, err)
-	// Did we get a proper WebauthnDevice?
-	gotDevice := newDevice.GetWebauthn()
-	require.NotNil(t, gotDevice)
-	require.NotEmpty(t, gotDevice.PublicKeyCbor) // validated indirectly via authentication
-	wantDevice := &types.WebauthnDevice{
-		CredentialId:     dev.KeyHandle,
-		PublicKeyCbor:    gotDevice.PublicKeyCbor,
-		AttestationType:  gotDevice.AttestationType,
-		Aaguid:           make([]byte, 16), // 16 zeroes
-		SignatureCounter: 0,
+	tests := []struct {
+		name                 string
+		user                 string
+		deviceName           string
+		passwordless         bool
+		wantUserVerification protocol.UserVerificationRequirement
+		wantResidentKey      bool
+	}{
+		{
+			name:                 "MFA",
+			user:                 user,
+			deviceName:           "webauthn1",
+			wantUserVerification: protocol.VerificationDiscouraged,
+		},
+		{
+			name:                 "passwordless",
+			user:                 user,
+			deviceName:           "webauthn2",
+			passwordless:         true,
+			wantUserVerification: protocol.VerificationRequired,
+			wantResidentKey:      true,
+		},
 	}
-	if diff := cmp.Diff(wantDevice, gotDevice); diff != "" {
-		t.Errorf("Finish() mismatch (-want +got):\n%s", diff)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			identity.UpdatedDevices = nil // Clear "stored" devices
+
+			// Begin is the first step in registration.
+			credentialCreation, err := webRegistration.Begin(ctx, user, test.passwordless)
+			require.NoError(t, err)
+			// Assert some parts of the credentialCreation (it's framework-created, no
+			// need to go too deep).
+			require.NotNil(t, credentialCreation)
+			require.NotEmpty(t, credentialCreation.Response.Challenge)
+			require.Equal(t, webRegistration.Webauthn.RPID, credentialCreation.Response.RelyingParty.ID)
+			// Are we using the correct authenticator selection settings?
+			require.Equal(t, test.wantResidentKey, *credentialCreation.Response.AuthenticatorSelection.RequireResidentKey)
+			require.Equal(t, test.wantUserVerification, credentialCreation.Response.AuthenticatorSelection.UserVerification)
+			// Did we record the SessionData in storage?
+			require.NotEmpty(t, identity.SessionData)
+
+			// Sign CredentialCreation, typically requires user interaction.
+			dev, err := mocku2f.Create()
+			require.NoError(t, err)
+			dev.SetUV = test.wantUserVerification == protocol.VerificationRequired
+			dev.AllowResidentKey = test.wantResidentKey
+			ccr, err := dev.SignCredentialCreation(origin, credentialCreation)
+			require.NoError(t, err)
+
+			// Finish is the final step in registration.
+			newDevice, err := webRegistration.Finish(ctx, user, test.deviceName, ccr)
+			require.NoError(t, err)
+			require.Equal(t, test.deviceName, newDevice.GetName())
+			// Did we get a proper WebauthnDevice?
+			gotDevice := newDevice.GetWebauthn()
+			require.NotNil(t, gotDevice)
+			require.NotEmpty(t, gotDevice.PublicKeyCbor) // validated indirectly via authentication
+			wantDevice := &types.WebauthnDevice{
+				CredentialId:      dev.KeyHandle,
+				PublicKeyCbor:     gotDevice.PublicKeyCbor,
+				AttestationType:   gotDevice.AttestationType,
+				Aaguid:            make([]byte, 16), // 16 zeroes
+				SignatureCounter:  0,
+				AttestationObject: ccr.AttestationResponse.AttestationObject,
+				ResidentKey:       test.wantResidentKey,
+			}
+			if diff := cmp.Diff(wantDevice, gotDevice); diff != "" {
+				t.Errorf("Finish() mismatch (-want +got):\n%s", diff)
+			}
+			// SessionData was cleared?
+			require.Empty(t, identity.SessionData)
+			// Device created in storage?
+			require.Len(t, identity.UpdatedDevices, 1)
+			require.Equal(t, newDevice, identity.UpdatedDevices[0])
+		})
 	}
-	// SessionData was cleared?
-	require.Empty(t, identity.SessionData)
-	// Device created in storage?
-	require.Len(t, identity.UpdatedDevices, 1)
-	require.Equal(t, newDevice, identity.UpdatedDevices[0])
 }
 
 func TestRegistrationFlow_Begin_errors(t *testing.T) {
@@ -97,7 +130,7 @@ func TestRegistrationFlow_Begin_errors(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err := webRegistration.Begin(ctx, "" /* user */)
+	_, err := webRegistration.Begin(ctx, "" /* user */, false /* passwordless */)
 	require.True(t, trace.IsBadParameter(err)) // user required
 }
 
@@ -113,7 +146,7 @@ func TestRegistrationFlow_Finish_errors(t *testing.T) {
 
 	ctx := context.Background()
 
-	cc, err := webRegistration.Begin(ctx, user)
+	cc, err := webRegistration.Begin(ctx, user, false /* passwordless */)
 	require.NoError(t, err)
 	key, err := mocku2f.Create()
 	require.NoError(t, err)
@@ -163,7 +196,7 @@ func TestRegistrationFlow_Finish_errors(t *testing.T) {
 			user:       user,
 			deviceName: "webauthn2",
 			createResp: func() *wanlib.CredentialCreationResponse {
-				cc, err := webRegistration.Begin(ctx, user)
+				cc, err := webRegistration.Begin(ctx, user, false /* passwordless */)
 				require.NoError(t, err)
 				cc.Response.RelyingParty.ID = "badrpid.com"
 
@@ -178,7 +211,7 @@ func TestRegistrationFlow_Finish_errors(t *testing.T) {
 			user:       user,
 			deviceName: "webauthn2",
 			createResp: func() *wanlib.CredentialCreationResponse {
-				cc, err := webRegistration.Begin(ctx, user)
+				cc, err := webRegistration.Begin(ctx, user, false /* passwordless */)
 				require.NoError(t, err)
 				// Flip a challenge bit, this should be enough to consistently fail
 				// signature checking.
@@ -271,7 +304,7 @@ func TestRegistrationFlow_Finish_attestation(t *testing.T) {
 				Identity: newFakeIdentity(user),
 			}
 
-			cc, err := webRegistration.Begin(ctx, user)
+			cc, err := webRegistration.Begin(ctx, user, false /* passwordless */)
 			require.NoError(t, err)
 
 			dev := test.dev

--- a/lib/auth/webauthn/session.go
+++ b/lib/auth/webauthn/session.go
@@ -19,11 +19,17 @@ package webauthn
 import (
 	"encoding/base64"
 
+	"github.com/duo-labs/webauthn/protocol"
 	"github.com/gravitational/trace"
 
 	wan "github.com/duo-labs/webauthn/webauthn"
 	wantypes "github.com/gravitational/teleport/api/types/webauthn"
 )
+
+// scopeLogin identifies SessionData stored for login.
+// It is used as the scope for global session data and as the sessionID for
+// per-user session data.
+const scopeLogin = "login"
 
 func sessionToPB(sd *wan.SessionData) (*wantypes.SessionData, error) {
 	rawChallenge, err := base64.RawURLEncoding.DecodeString(sd.Challenge)
@@ -34,6 +40,7 @@ func sessionToPB(sd *wan.SessionData) (*wantypes.SessionData, error) {
 		Challenge:        rawChallenge,
 		UserId:           sd.UserID,
 		AllowCredentials: sd.AllowedCredentialIDs,
+		UserVerification: string(sd.UserVerification),
 	}, nil
 }
 
@@ -42,5 +49,6 @@ func sessionFromPB(sd *wantypes.SessionData) *wan.SessionData {
 		Challenge:            base64.RawURLEncoding.EncodeToString(sd.Challenge),
 		UserID:               sd.UserId,
 		AllowedCredentialIDs: sd.AllowCredentials,
+		UserVerification:     protocol.UserVerificationRequirement(sd.UserVerification),
 	}
 }

--- a/lib/auth/webauthn/session.go
+++ b/lib/auth/webauthn/session.go
@@ -26,10 +26,16 @@ import (
 	wantypes "github.com/gravitational/teleport/api/types/webauthn"
 )
 
-// scopeLogin identifies SessionData stored for login.
+// scopeLogin identifies session data stored for login.
 // It is used as the scope for global session data and as the sessionID for
 // per-user session data.
+// Only one in-flight login is supported for MFA / per-user session data.
 const scopeLogin = "login"
+
+// scopeSession is used as the per-user sessionID for registrations.
+// Only one in-flight registration is supported per-user, baring registrations
+// that use in-memory storage.
+const scopeSession = "registration"
 
 func sessionToPB(sd *wan.SessionData) (*wantypes.SessionData, error) {
 	rawChallenge, err := base64.RawURLEncoding.DecodeString(sd.Challenge)

--- a/lib/auth/webauthn/user.go
+++ b/lib/auth/webauthn/user.go
@@ -17,37 +17,10 @@ limitations under the License.
 package webauthn
 
 import (
-	"context"
-
-	"github.com/google/uuid"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
 
 	wan "github.com/duo-labs/webauthn/webauthn"
 )
-
-// userIDStorage is used to keep getOrCreateUserWebauthnID as focused as
-// possible, since it's used both by login and registration.
-type userIDStorage interface {
-	UpsertWebauthnLocalAuth(ctx context.Context, user string, wla *types.WebauthnLocalAuth) error
-	GetWebauthnLocalAuth(ctx context.Context, user string) (*types.WebauthnLocalAuth, error)
-}
-
-func getOrCreateUserWebauthnID(ctx context.Context, user string, identity userIDStorage) ([]byte, error) {
-	wla, err := identity.GetWebauthnLocalAuth(ctx, user)
-	switch {
-	case trace.IsNotFound(err): // first-time user, create a new ID
-		webID := []byte(uuid.New().String())
-		err := identity.UpsertWebauthnLocalAuth(ctx, user, &types.WebauthnLocalAuth{
-			UserID: webID[:],
-		})
-		return webID[:], trace.Wrap(err)
-	case err != nil:
-		return nil, trace.Wrap(err)
-	default:
-		return wla.UserID, nil
-	}
-}
 
 // webUser implements a WebAuthn protocol user.
 // It is used to provide user information to WebAuthn APIs, but has no direct

--- a/lib/auth/webauthncli/login_test.go
+++ b/lib/auth/webauthncli/login_test.go
@@ -417,6 +417,7 @@ func (f *fakeDevice) checkUserPresent() error {
 }
 
 type fakeIdentity struct {
+	User        string
 	Devices     []*types.MFADevice
 	LocalAuth   *types.WebauthnLocalAuth
 	SessionData *wantypes.SessionData
@@ -432,6 +433,13 @@ func (f *fakeIdentity) GetWebauthnLocalAuth(ctx context.Context, user string) (*
 		return nil, trace.NotFound("not found") // code relies on not found to work properly
 	}
 	return f.LocalAuth, nil
+}
+
+func (f *fakeIdentity) GetTeleportUserByWebauthnID(ctx context.Context, webID []byte) (string, error) {
+	if f.User == "" {
+		return "", trace.NotFound("not found")
+	}
+	return f.User, nil
 }
 
 func (f *fakeIdentity) GetMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error) {

--- a/lib/auth/webauthncli/register.go
+++ b/lib/auth/webauthncli/register.go
@@ -178,7 +178,7 @@ func parseU2FRegistrationResponse(resp []byte) (*u2fRegistrationResponse, error)
 	// above.
 	buf := resp
 	if buf[0] != 0x05 {
-		return nil, trace.BadParameter("invalid reserved byte")
+		return nil, trace.BadParameter("invalid reserved byte: %v", buf[0])
 	}
 	buf = buf[1:]
 

--- a/lib/auth/webauthncli/register_test.go
+++ b/lib/auth/webauthncli/register_test.go
@@ -48,6 +48,7 @@ func TestRegister(t *testing.T) {
 			RPID: rpID,
 		},
 		Identity: &fakeIdentity{
+			User:    user,
 			Devices: []*types.MFADevice{registeredKey.mfaDevice},
 		},
 	}

--- a/lib/auth/webauthncli/register_test.go
+++ b/lib/auth/webauthncli/register_test.go
@@ -79,7 +79,7 @@ func TestRegister(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 			defer cancel()
 
-			cc, err := webRegistration.Begin(ctx, user)
+			cc, err := webRegistration.Begin(ctx, user, false /* passwordless */)
 			require.NoError(t, err)
 
 			// Reset/set presence indicator.
@@ -117,7 +117,7 @@ func TestRegister_errors(t *testing.T) {
 		},
 		Identity: &fakeIdentity{},
 	}
-	okCC, err := webRegistration.Begin(ctx, "llama" /* user */)
+	okCC, err := webRegistration.Begin(ctx, "llama" /* user */, false /* passwordless */)
 	require.NoError(t, err)
 
 	tests := []struct {


### PR DESCRIPTION
I've opted to keep MFA and passwordless authorization interfaces separate, as they have slight interface differences, storage needs, and allow for different use-cases.

`LoginFlow`, the existing API, is now focused on MFA. A new type, `PasswordlessFlow`, provides support for passwordless authorization. Both implementations are backed by a private `loginFlow` type, refactored from the guts of the old `LoginFlow`, which is a superset of MFA and Passwordless.

All registration use-cases are provided by the existing `RegistrationFlow`. In this case the change is simpler, as a single `passwordless` parameter suffices. Registration is always performed by a previously-authorized user, so it's storage interactions remain uniform.

Finally, login methods won't create a WebAuthn ID anymore, instead they rely on registration to do it. The simplification relies on the fact that user handles are not mandatory. (They do matter for resident key registration, which does provide them.)

#9160