### PR TITLE
[v8] docs: add warning about auditor role (#10258)

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -81,7 +81,7 @@ spec:
     logins: [root, '{{internal.logins}}']
     # Windows logins a user is allowed to use for desktop sessions.
     windows_desktop_logins: [Administrator, '{{internal.logins}}']
-    # If kubernetes integration is enabled, this setting configures which 
+    # If kubernetes integration is enabled, this setting configures which
     # kubernetes groups the users of this role will be assigned to.
     # Note that you can refer to a SAML/OIDC trait via the "external" property bag.
     # This allows you to specify Kubernetes group membership in an identity manager:
@@ -185,10 +185,10 @@ Teleport provides several pre-defined roles out-of-the-box:
 | Role | Description |
 | --- | --- |
 | `editor` | Allows editing of cluster configuration settings. |
-| `auditor`| Allows reading cluster events, audit logs, and playing back session records. | 
+| `auditor`| Allows reading cluster events, audit logs, and playing back session records. |
 | `access`| Allows access to cluster resources. |
 
-<Details title="Version Warning: Before 8.0" opened={false}> 
+<Details title="Version Warning: Before 8.0" opened={false}>
 Teleport versions prior to 8.0 also included a default `admin` role. This role
 has been deprecated in favor of smaller, more fine-grained roles like the
 presets mentioned above.
@@ -333,10 +333,19 @@ The examples below illustrate how to restrict session access only for the user
 who created the session.
 
 <Details title="Version Warning: Before 8.1" opened={false}>
-Teleport versions prior to 8.1 don't support the roles exemplified below.
-You may to create such roles after an upgrade, but in the event of a cluster
+Teleport versions prior to 8.1 don't support the roles shown below.
+You may create these roles after upgrading, but in the event of a cluster
 downgrade they will become invalid.
 </Details>
+
+<Admonition
+  type="warning"
+  title="Preset Auditor Role"
+>
+In order for these roles to take effect, you must ensure your user doesn't also
+have a more permissive role, like the preset `auditor` role, which allows access
+to all events, sessions, and session recordings.
+</Admonition>
 
 Role for restricted access to session recordings:
 


### PR DESCRIPTION
The default auditor role which is often applied to new users is
very permissive when it comes to sessions and recordings.

This may cause confusion when users attempt to set up RBAC for
sessions, because the more permissive role wins and the new
role doesn't appear to take effect.

Backports #10258