### PR TITLE
Increase GCB UT timeout

### DIFF
--- a/.cloudbuild/ci/unit-tests.yaml
+++ b/.cloudbuild/ci/unit-tests.yaml
@@ -1,4 +1,4 @@
-timeout: 20m
+timeout: 25m
 
 options:
   machineType: 'E2_HIGHCPU_32'
@@ -25,4 +25,4 @@ steps:
           -bucket test-logs     \
           -build $BUILD_ID      \
           -a "test-logs/*.json"
-    timeout: 15m
+    timeout: 20m


### PR DESCRIPTION
Currently our UT on GCB runs in about 15 min and recently more and more build fails on our 15 min timeout with error `failed: context deadline exceeded`.

In the future we should probably optimize the run time, but for now increasing the timeout to 20 min should be sufficient.