### PR TITLE
Limit number of in-flight passwordless challenges

### DIFF
--- a/lib/services/local/export_test.go
+++ b/lib/services/local/export_test.go
@@ -1,0 +1,18 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+// SessionDataLimiter exports sdLimiter for tests.
+var SessionDataLimiter = sdLimiter

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -881,10 +881,6 @@ func (s *IdentityService) DeleteGlobalWebauthnSessionData(ctx context.Context, s
 	return nil
 }
 
-func globalSessionDataPrefix(scope string) []byte {
-	return backend.Key(webauthnPrefix, webauthnGlobalSessionData, scope)
-}
-
 func globalSessionDataKey(scope, id string) []byte {
 	return backend.Key(webauthnPrefix, webauthnGlobalSessionData, scope, id)
 }

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -707,7 +707,7 @@ func TestIdentityService_UpsertGlobalWebauthnSessionData_maxLimit(t *testing.T) 
 		UserVerification: "required",
 	}
 
-	identity, _ := newIdentityService(t)
+	identity := newIdentityService(t, clockwork.NewFakeClock())
 	ctx := context.Background()
 
 	// OK: below limit.


### PR DESCRIPTION
Limits the number of in-flight challenges by counting the number of stored global SessionData instances.

It's important to limit the number of global challenges because they are requested by anonymous users.

#9160