### PR TITLE
TF provider configuration environment variables

### DIFF
--- a/docs/pages/setup/reference/terraform-provider.mdx
+++ b/docs/pages/setup/reference/terraform-provider.mdx
@@ -31,15 +31,15 @@ terraform {
 
 The provider supports the following options:
 
-| Name                    | Type       | Description                                               |
-|-------------------------|------------|-----------------------------------------------------------|
-|                   `addr`|     string | Teleport auth or proxy host:port                          |
-|              `cert_path`|     string | Path to Teleport certificate file                         |
-|     `identity_file_path`|     string | Path to Teleport identity file                            |
-|               `key_path`|     string | Path to Teleport key file                                 |
-|            `profile_dir`|     string | Teleport profile path                                     |
-|           `profile_name`|     string | Teleport profile name                                     |
-|           `root_ca_path`|     string | Path to Teleport CA file                                  |
+| Name                    | Type       | Description                                                                                                                           |
+|-------------------------|------------|---------------------------------------------------------------------------------------------------------------------------------------|
+|                   `addr`|     string | Teleport auth or proxy address in "host:port" format. This value can also be set through the `TF_TELEPORT_ADDR` environment variable. |
+|              `cert_path`|     string | Path to Teleport certificate file. This value can also be set through the `TF_TELEPORT_CERT` environment variable.                    |
+|     `identity_file_path`|     string | Path to Teleport identity file. This value can also be set through the `TF_TELEPORT_IDENTITY_FILE_PATH` environment variable.         |
+|               `key_path`|     string | Path to Teleport key file. This value can also be set through the `TF_TELEPORT_KEY` environment variable.                             |
+|            `profile_dir`|     string | Teleport profile path. This value can also be set through the `TF_TELEPORT_PROFILE_PATH` environment variable.                        |
+|           `profile_name`|     string | Teleport profile name. This value can also be set through the `TF_TELEPORT_PROFILE_NAME` environment variable.                        |
+|           `root_ca_path`|     string | Path to Teleport CA file. This value can also be set through the `TF_TELEPORT_ROOT_CA` environment variable.                          |
 
 You need to specify either:
 

--- a/docs/pages/setup/reference/terraform-provider.mdx
+++ b/docs/pages/setup/reference/terraform-provider.mdx
@@ -31,15 +31,15 @@ terraform {
 
 The provider supports the following options:
 
-| Name                    | Type       | Description                                                                                                                           |
-|-------------------------|------------|---------------------------------------------------------------------------------------------------------------------------------------|
-|                   `addr`|     string | Teleport auth or proxy address in "host:port" format. This value can also be set through the `TF_TELEPORT_ADDR` environment variable. |
-|              `cert_path`|     string | Path to Teleport certificate file. This value can also be set through the `TF_TELEPORT_CERT` environment variable.                    |
-|     `identity_file_path`|     string | Path to Teleport identity file. This value can also be set through the `TF_TELEPORT_IDENTITY_FILE_PATH` environment variable.         |
-|               `key_path`|     string | Path to Teleport key file. This value can also be set through the `TF_TELEPORT_KEY` environment variable.                             |
-|            `profile_dir`|     string | Teleport profile path. This value can also be set through the `TF_TELEPORT_PROFILE_PATH` environment variable.                        |
-|           `profile_name`|     string | Teleport profile name. This value can also be set through the `TF_TELEPORT_PROFILE_NAME` environment variable.                        |
-|           `root_ca_path`|     string | Path to Teleport CA file. This value can also be set through the `TF_TELEPORT_ROOT_CA` environment variable.                          |
+| Name                    | Type       | Description                                           | Environment Variable             |
+|-------------------------|------------|-------------------------------------------------------|----------------------------------|
+|                   `addr`|     string | Teleport auth or proxy address in "host:port" format. | `TF_TELEPORT_ADDR`               |
+|              `cert_path`|     string | Path to Teleport certificate file.                    | `TF_TELEPORT_CERT`               |
+|     `identity_file_path`|     string | Path to Teleport identity file.                       | `TF_TELEPORT_IDENTITY_FILE_PATH` |
+|               `key_path`|     string | Path to Teleport key file.                            | `TF_TELEPORT_KEY`                |
+|            `profile_dir`|     string | Teleport profile path.                                | `TF_TELEPORT_PROFILE_PATH`       |
+|           `profile_name`|     string | Teleport profile name.                                | `TF_TELEPORT_PROFILE_NAME`       |
+|           `root_ca_path`|     string | Path to Teleport CA file.                             | `TF_TELEPORT_ROOT_CA`            |
 
 You need to specify either:
 


### PR DESCRIPTION
## Intent
To document the capability of the TF provider to read its configurations from environment variables.

## Problem
Unless I've missed it, the current documentation for the Teleport Terraform provider doesn't mention anywhere that the provider can be configured through environment variables although it's actually possible.

## Solution
To extend the provider configurations descriptions to mention their corresponding environment variables for each documented attribute.