### PR TITLE
[v8] Add missing action VerbRead to ListResources

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -796,7 +796,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 		return nil, "", trace.NotImplemented("resource type %s does not support pagination", req.ResourceType)
 	}
 
-	if err := a.action(req.Namespace, resourceKind, types.VerbList); err != nil {
+	if err := a.action(req.Namespace, resourceKind, types.VerbList, types.VerbRead); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 


### PR DESCRIPTION
#### Description

ListResources in `v8` only supports listing `app servers` and `db servers` and both should require `list + read`