### PR TITLE
Add missing action VerbRead to ListResources

### DIFF
--- a/api/client/proto/types.go
+++ b/api/client/proto/types.go
@@ -20,7 +20,9 @@ package proto
 import (
 	"time"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+
 	"github.com/gravitational/trace"
 )
 
@@ -73,7 +75,7 @@ func (req *HostCertsRequest) CheckAndSetDefaults() error {
 // CheckAndSetDefaults checks and sets default values.
 func (req *ListResourcesRequest) CheckAndSetDefaults() error {
 	if req.Namespace == "" {
-		return trace.BadParameter("missing parameter namespace")
+		req.Namespace = apidefaults.Namespace
 	}
 
 	if req.Limit <= 0 {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -883,16 +883,19 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 	}
 
 	limit := int(req.Limit)
+	actionVerbs := []string{types.VerbList, types.VerbRead}
+
 	switch req.ResourceType {
-	case types.KindDatabaseServer,
-		types.KindAppServer,
-		types.KindNode,
-		types.KindKubeService:
+	case types.KindNode:
+		actionVerbs = []string{types.VerbList}
+
+	case types.KindDatabaseServer, types.KindAppServer, types.KindKubeService:
+
 	default:
 		return nil, "", trace.NotImplemented("resource type %s does not support pagination", req.ResourceType)
 	}
 
-	if err := a.action(req.Namespace, req.ResourceType, types.VerbList); err != nil {
+	if err := a.action(req.Namespace, req.ResourceType, actionVerbs...); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -887,6 +887,11 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 
 	switch req.ResourceType {
 	case types.KindNode:
+		// We are checking list only for Nodes to keep backwards compatibility.
+		// The read verb got added to GetNodes initially in:
+		//   https://github.com/gravitational/teleport/pull/1209
+		// but got removed shortly afterwards in:
+		//   https://github.com/gravitational/teleport/pull/1224
 		actionVerbs = []string{types.VerbList}
 
 	case types.KindDatabaseServer, types.KindAppServer, types.KindKubeService:

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -1608,11 +1608,11 @@ func TestNodesCRUD(t *testing.T) {
 				cmpopts.IgnoreFields(types.Metadata{}, "ID")))
 			require.Empty(t, nextKey)
 
-			// ListNodes should fail if namespace isn't provided
+			// ListNodes should not fail if namespace is empty
 			_, _, err = clt.ListNodes(ctx, proto.ListNodesRequest{
 				Limit: 1,
 			})
-			require.IsType(t, &trace.BadParameterError{}, err.(*trace.TraceErr).OrigError())
+			require.NoError(t, err)
 
 			// ListNodes should fail if limit is nonpositive
 			_, _, err = clt.ListNodes(ctx, proto.ListNodesRequest{
@@ -1635,9 +1635,9 @@ func TestNodesCRUD(t *testing.T) {
 			require.Empty(t, cmp.Diff([]types.Server{node1, node2}, nodes,
 				cmpopts.IgnoreFields(types.Metadata{}, "ID")))
 
-			// GetNodes should fail if namespace isn't provided
+			// GetNodes should not fail if namespace is empty
 			_, err = clt.GetNodes(ctx, "")
-			require.IsType(t, &trace.BadParameterError{}, err.(*trace.TraceErr).OrigError())
+			require.NoError(t, err)
 		})
 		t.Run("GetNode", func(t *testing.T) {
 			t.Parallel()

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1547,9 +1547,8 @@ func (s *PresenceService) ListResources(ctx context.Context, req proto.ListResou
 }
 
 func (s *PresenceService) listResources(ctx context.Context, req proto.ListResourcesRequest) ([]types.ResourceWithLabels, string, error) {
-	reqLimit := int(req.Limit)
-	if reqLimit <= 0 {
-		return nil, "", trace.BadParameter("nonpositive limit value")
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, "", trace.Wrap(err)
 	}
 
 	var keyPrefix []string
@@ -1582,6 +1581,7 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 	}
 
 	// Get most limit+1 results to determine if there will be a next key.
+	reqLimit := int(req.Limit)
 	maxLimit := reqLimit + 1
 	var resources []types.ResourceWithLabels
 	if err := backend.IterateRange(ctx, s.Backend, rangeStart, rangeEnd, maxLimit, func(items []backend.Item) (stop bool, err error) {
@@ -1668,9 +1668,8 @@ func (s *PresenceService) listResourcesWithSort(ctx context.Context, req proto.L
 
 // FakePaginate is used when we are working with an entire list of resources upfront but still requires pagination.
 func FakePaginate(resources []types.ResourceWithLabels, req proto.ListResourcesRequest) ([]types.ResourceWithLabels, string, error) {
-	limit := int(req.Limit)
-	if limit <= 0 {
-		return nil, "", trace.BadParameter("nonpositive limit value")
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, "", trace.Wrap(err)
 	}
 
 	// Trim resources that precede start key.
@@ -1687,6 +1686,7 @@ func FakePaginate(resources []types.ResourceWithLabels, req proto.ListResourcesR
 
 	// Iterate and filter resources, finding match up to limit+1 (+1 to determine next key),
 	// and halting when we reach page limit.
+	limit := int(req.Limit)
 	var nextKey string
 	var filtered []types.ResourceWithLabels
 	filter := services.MatchResourceFilter{

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1621,6 +1621,10 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 // listResourcesWithSort supports sorting by falling back to retrieving all resources
 // with GetXXXs, filter, and then fake pagination.
 func (s *PresenceService) listResourcesWithSort(ctx context.Context, req proto.ListResourcesRequest) ([]types.ResourceWithLabels, string, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
 	var resources []types.ResourceWithLabels
 	switch req.ResourceType {
 	case types.KindNode:

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -634,7 +634,6 @@ func TestListResources(t *testing.T) {
 
 			resources, nextKey, err := presence.ListResources(ctx, proto.ListResourcesRequest{
 				Limit:        1,
-				Namespace:    apidefaults.Namespace,
 				ResourceType: test.resourceType,
 				StartKey:     "",
 			})
@@ -839,7 +838,6 @@ func TestListResources_Helpers(t *testing.T) {
 	t.Run("test fetching when there is 0 upserted nodes", func(t *testing.T) {
 		req := proto.ListResourcesRequest{
 			ResourceType: types.KindNode,
-			Namespace:    namespace,
 			Limit:        5,
 		}
 		for _, tc := range tests {


### PR DESCRIPTION
#### Description
Its GetXXX's version required `list + read`, only nodes should be `list` only. (Double checked that this should be the case)

#### Related
v8 edit: https://github.com/gravitational/teleport/pull/10421