### PR TITLE
User traits default to empty rather than nil

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -826,7 +826,7 @@ func FetchRoles(roleNames []string, access RoleGetter, traits map[string][]strin
 // missingIdentity returns true if the identity is missing or the identity
 // has no roles or traits.
 func missingIdentity(identity tlsca.Identity) bool {
-	if len(identity.Groups) == 0 || len(identity.Traits) == 0 {
+	if identity.Groups == nil || identity.Traits == nil {
 		return true
 	}
 	return false

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -422,6 +422,14 @@ func (rc *ResourceCommand) createUser(client auth.ClientI, raw services.UnknownR
 		fmt.Printf("user %q has been updated\n", userName)
 
 	} else {
+		if user.GetTraits() == nil {
+			// Traits should be non nil so that the list of traits, empty or not,
+			// will be included in the user's ssh certificates. This is important
+			// to prevent RBAC escalation attacks where the user's traits are
+			// updated on the backend without a new certificate being signed.
+			user.SetTraits(map[string][]string{})
+		}
+
 		if err := client.CreateUser(context.TODO(), user); err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
When a user is added with `tctl users add`, their traits will always be non-nil, even if no logins or other traits are provided. 

However, if the user is added by `tctl create user.yaml`, and `user.yaml` does not define any traits, then the user will have null traits. When this user has an ssh certificate signed, the certificates traits field will be null, leading to the log message:
```
2022-02-01T17:33:50Z WARN             "Failed to find roles or traits in x509 identity for access-plugin. Fetching\tfrom backend. If the identity provider allows username changes, this can potentially allow an attacker to change the role of the existing user." services/role.go:748
```

We currently use `tctl create` to create api users for our [plugins](https://github.com/gravitational/teleport-plugins) and [api examples](https://github.com/gravitational/teleport/tree/master/examples/workflows).

Closes https://github.com/gravitational/teleport/issues/10081