### PR TITLE
Update version thresholds for v5 role downgrade

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -1595,9 +1595,9 @@ func downgradeRole(ctx context.Context, role *types.RoleV5) (*types.RoleV5, erro
 		}
 	}
 
-	minSupportedVersionForV5Roles := semver.New(utils.VersionBeforeAlpha("8.3.0"))
+	minSupportedVersionForV5Roles := semver.New(utils.VersionBeforeAlpha("9.0.0"))
 	if clientVersion == nil || clientVersion.LessThan(*minSupportedVersionForV5Roles) {
-		log.Debugf(`Client version "%s" is unknown or less than 8.3.0, converting role to v4`, clientVersionString)
+		log.Debugf(`Client version "%s" is unknown or less than 9.0.0, converting role to v4`, clientVersionString)
 		downgraded, err := services.DowngradeRoleToV4(role)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -1380,7 +1380,7 @@ func TestRoleVersions(t *testing.T) {
 		},
 		{
 			desc:                "new",
-			clientVersion:       "8.3.0",
+			clientVersion:       "9.0.0",
 			expectedRoleVersion: "v5",
 			assertErr:           require.NoError,
 		},


### PR DESCRIPTION
Since moderated sessions got pushed to 9.0.0. We'll need to update the role downgrade threshold for v5 -> v4 in grpcserver.