### PR TITLE
[v8] Backport: "docs: Updated path to tctl/tsh for Enterprise binaries"

### DIFF
--- a/docs/pages/kubernetes-access/getting-started/cluster.mdx
+++ b/docs/pages/kubernetes-access/getting-started/cluster.mdx
@@ -23,6 +23,12 @@ Let's deploy Teleport in a Kubernetes with SSO and Audit logs:
 />
 
 ## Prerequisites
+- A registered domain name. This is required for Teleport to set up TLS via Let's Encrypt and for Teleport clients to verify the Proxy Service host.
+- A Kubernetes cluster hosted by a cloud provider, which is required for the load balancer we deploy in this guide.
+
+<Admonition title="Local-only setups" type="tip">
+Teleport also supports Kubernetes in on-premise and air-gapped environments. If you would like to try out Teleport on your local machine, we recommend following our [Docker Compose guide](../../getting-started/docker-compose.mdx).
+</Admonition>
 
 (!docs/pages/includes/kubernetes-access/helm-k8s.mdx!)
 
@@ -84,6 +90,12 @@ to create a public IP for Teleport.
     $ echo $MYIP
     # 192.168.2.1
     ```
+
+    If `$MYIP` is blank, your cloud provider may have assigned a hostname to the load balancer rather than an IP address. Run the following command to retrieve the hostname, which you will use in place of `$MYIP` for subsequent commands.
+
+    ```code
+    $ MYIP=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    ```
   </TabItem>
 
   <TabItem label="Enterprise">
@@ -100,6 +112,12 @@ to create a public IP for Teleport.
     $ MYIP=$(kubectl get services teleport-cluster-ent -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     $ echo $MYIP
     # 192.168.2.1
+    ```
+
+    If `$MYIP` is blank, your cloud provider may have assigned a hostname to the load balancer rather than an IP address. Run the following command to retrieve the hostname, which you will use in place of `$MYIP` for subsequent commands.
+
+    ```code
+    $ MYIP=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
     ```
   </TabItem>
 </Tabs>
@@ -211,8 +229,8 @@ For other install options, check out [install guide](../../installation.mdx)
     ```code
     $ curl -L -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
     $ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    $ sudo mv teleport/tsh /usr/local/bin/tsh
-    $ sudo mv teleport/tctl /usr/local/bin/tctl
+    $ sudo mv teleport-ent/tsh /usr/local/bin/tsh
+    $ sudo mv teleport-ent/tctl /usr/local/bin/tctl
     ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Backports #10428 to `branch/v8`

Also includes a couple of other changes made to the `master` version of the docs on the same page which seemed useful.