### PR TITLE
[Backport v8] IAM Joining Docs: Set join_method in token.yaml

### DIFF
--- a/docs/pages/setup/guides/joining-nodes-aws.mdx
+++ b/docs/pages/setup/guides/joining-nodes-aws.mdx
@@ -123,6 +123,9 @@ spec:
   # use the minimal set of roles required
   roles: [Node]
 
+  # set the join method allowed for this token
+  join_method: iam
+
   allow:
   # specify the AWS account which nodes may join from
   - aws_account: "111111111111"
@@ -166,6 +169,9 @@ metadata:
 spec:
   # use the minimal set of roles required
   roles: [Node]
+
+  # set the join method allowed for this token
+  join_method: ec2
 
   # aws_iid_ttl is the amount of time after the EC2 instance is launched during
   # which it should be allowed to join the cluster. Use a short TTL to decrease


### PR DESCRIPTION
Missed this attribute in the original IAM joining docs, it is necessary to configure the token for the IAM join method.