### PR TITLE
Use tdr in Dronegen

### DIFF
--- a/dronegen/drone_cli.go
+++ b/dronegen/drone_cli.go
@@ -20,9 +20,9 @@ import (
 	"os/exec"
 )
 
-func checkDroneCLI() error {
-	if _, err := exec.LookPath("drone"); err != nil {
-		return fmt.Errorf("can't find drone CLI in $PATH: %w; get it from https://docs.drone.io/cli/install/", err)
+func checkTDR() error {
+	if _, err := exec.LookPath("tdr"); err != nil {
+		return fmt.Errorf("can't find tdr in $PATH: %w; get it from https://github.com/gravitational/tdr/", err)
 	}
 	if os.Getenv("DRONE_SERVER") == "" || os.Getenv("DRONE_TOKEN") == "" {
 		return fmt.Errorf("$DRONE_SERVER and/or $DRONE_TOKEN env vars not set; get them at https://drone.teleport.dev/account")
@@ -31,7 +31,7 @@ func checkDroneCLI() error {
 }
 
 func signDroneConfig() error {
-	out, err := exec.Command("drone", "sign", "gravitational/teleport", "--save").CombinedOutput()
+	out, err := exec.Command("tdr", "sign", "gravitational/teleport", "--save").CombinedOutput()
 	if err != nil {
 		if len(out) > 0 {
 			err = fmt.Errorf("drone signing failed: %v\noutput:\n%s", err, out)

--- a/dronegen/main.go
+++ b/dronegen/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	if err := checkDroneCLI(); err != nil {
+	if err := checkTDR(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
After changes to Drone access, [tdr](https://github.com/gravitational/tdr/) is now required to sign `.drone.yml`: https://gravitational.slab.com/posts/drone-ci-bdbtz26a#hb7b2-how-do-i-sign-the-drone-yml-file

This makes Dronegen invoke tdr rather than Drone CLI directly, making dronegen fully work again (regenerate the file + sign).