### PR TITLE
Fix panic in MongoDB message reader

### DIFF
--- a/lib/srv/db/mongodb/protocol/fuzz_test.go
+++ b/lib/srv/db/mongodb/protocol/fuzz_test.go
@@ -23,6 +23,8 @@ package protocol
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func FuzzMongoRead(f *testing.F) {
@@ -31,7 +33,9 @@ func FuzzMongoRead(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, msgBytes []byte) {
 		msg := bytes.NewReader(msgBytes)
-		// ignore errors, check for panics
-		_, _ = ReadMessage(msg)
+
+		require.NotPanics(t, func() {
+			_, _ = ReadMessage(msg)
+		})
 	})
 }

--- a/lib/srv/db/mongodb/protocol/fuzz_test.go
+++ b/lib/srv/db/mongodb/protocol/fuzz_test.go
@@ -1,0 +1,37 @@
+//go:build go1.18
+
+/*
+
+ Copyright 2022 Gravitational, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
+
+package protocol
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzMongoRead(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("000\xa4000000000000"))
+
+	f.Fuzz(func(t *testing.T, msgBytes []byte) {
+		msg := bytes.NewReader(msgBytes)
+		// ignore errors, check for panics
+		_, _ = ReadMessage(msg)
+	})
+}

--- a/lib/srv/db/mongodb/protocol/message.go
+++ b/lib/srv/db/mongodb/protocol/message.go
@@ -96,6 +96,11 @@ func readHeaderAndPayload(reader io.Reader) (*MessageHeader, []byte, error) {
 	if !ok {
 		return nil, nil, trace.BadParameter("failed to read message header %v", header)
 	}
+
+	if length-headerSizeBytes <= 0 {
+		return nil, nil, trace.BadParameter("invalid header %v", header)
+	}
+
 	// Then read the entire message body.
 	payload := make([]byte, length-headerSizeBytes)
 	if _, err := io.ReadFull(reader, payload); err != nil {


### PR DESCRIPTION
I decided to give a shoot to new Go's fuzzer and this is one of my findings. Function `ReadMessage` panics for some inputs. I added a fix for the inputs that fuzzed discovered. I also added a fuzz test guarded by go1.18 for now, as it would fail to build with our current setup.