### PR TITLE
[v8] Backport add teleport_connected_resources metric (#9603)

### DIFF
--- a/docs/pages/setup/reference/metrics.mdx
+++ b/docs/pages/setup/reference/metrics.mdx
@@ -111,6 +111,7 @@ Now you can see the monitoring information by visiting several endpoints:
 | `teleport_build_info` | gauge | Teleport | Provides build information of Teleport including gitref (git describe --long --tags), Go version, and Teleport version. The value of this gauge will always be 1. |
 | `teleport_cache_events` | counter | Teleport | Number of events received by a Teleport service cache. Teleport's Auth Service, Proxy Service, and other services cache incoming events related to their service. |
 | `teleport_cache_stale_events` | counter | Teleport | Number of stale events received by a Teleport service cache. A high percentage of stale events can indicate a degraded backend. |
+| `teleport_connected_resources` | gauge | Teleport Auth | Tracks the number and type of resources connected via keepalives. |
 | `teleport_registered_servers` | gauge | Teleport Auth | The number of Teleport servers (a server consists of one or more Teleport services) that have connected to the Teleport cluster, including the Teleport version. After disconnecting, a Teleport server has a TTL of 10 minutes, so this value will include servers that have recently disconnected but have not reached their TTL. |
 | `teleport_reverse_tunnels_connected` | gauge | Teleport Proxy | Number of reverse SSH tunnels connected to the Teleport Proxy Service by Teleport instances. |
 | `trusted_clusters` | gauge | Teleport | Number of tunnels per state. |

--- a/metrics.go
+++ b/metrics.go
@@ -180,6 +180,9 @@ const (
 	// MetricNamespace defines the teleport prometheus namespace
 	MetricNamespace = "teleport"
 
+	// MetricConnectedResources tracks the number and type of resources connected via keepalives
+	MetricConnectedResources = "connected_resources"
+
 	// MetricBuildInfo tracks build information
 	MetricBuildInfo = "build_info"
 


### PR DESCRIPTION
This adds the Prometheus metric teleport_connected_resources. Gauge increments when the keepalive is established and will decrement whenever the connection is broken/closed.