### PR TITLE
Re-sign .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5035,6 +5035,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 414c0af6ff443ccded856eca24618f1f22ad3419e3fca68d1990540a50fe712d
+hmac: 7212c3b6f83e020958e4c90cacee6b2b746c728ee0a22d3ce4605f40273f0115
 
 ...


### PR DESCRIPTION
In one of the merges the signature for https://github.com/gravitational/teleport/pull/10432 fell out of date, and drone is hanging:

https://drone.platform.teleport.sh/gravitational/teleport/10355