### PR TITLE
Add support for configuring session_recording mode in teleport-cluster helm chart

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -75,6 +75,14 @@ This reference details available values for the `teleport-cluster` chart.
 
 `proxyListenerMode` controls proxy TLS routing used by Teleport. Possible values are `multiplex`.
 
+## `sessionRecording`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `node` | no | `auth_service.session_recording` | ❌ |
+
+`sessionRecording` controls session recording mode. Possible values are `node`, `node-sync`, `proxy`, `proxy-sync`, `off`.
+
 ## `enterprise`
 
 | Type | Default value | Can be used in `custom` mode? |

--- a/examples/chart/teleport-cluster/.lint/session-recording.yaml
+++ b/examples/chart/teleport-cluster/.lint/session-recording.yaml
@@ -1,0 +1,2 @@
+clusterName: test-session-recording
+sessionRecording: "node-sync"

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -58,6 +58,9 @@ data:
   {{- if eq .Values.proxyListenerMode "multiplex" }}
       proxy_listener_mode: multiplex
   {{- end }}
+  {{- if .Values.sessionRecording }}
+      session_recording: {{ .Values.sessionRecording }}
+  {{- end }}
     kubernetes_service:
       enabled: true
   {{- if not .Values.proxyListenerMode }}

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -45,7 +45,8 @@
                 "node-sync",
                 "proxy",
                 "proxy-sync",
-                "off"
+                "off",
+                ""
             ],
             "default": "node"
         },

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -37,6 +37,18 @@
             "type": "string",
             "default": ""
         },
+        "sessionRecording": {
+            "$id": "#/properties/sessionRecording",
+            "type": "string",
+            "enum": [
+                "node",
+                "node-sync",
+                "proxy",
+                "proxy-sync",
+                "off"
+            ],
+            "default": "node"
+        },
         "teleportVersionOverride": {
             "$id": "#/properties/teleportVersionOverride",
             "type": "string",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -27,6 +27,16 @@ authenticationType: local
 # Possible values are 'multiplex'
 proxyListenerMode: ""
 
+# Optional setting for configuring session recording. Possible values are:
+#    "node"  : sessions will be recorded on the node level  (the default)
+#    "node-sync" : session recordings will be streamed from node -> auth -> storage service without being stored on disk at all.
+#    "proxy" : recording on the proxy level, see "Recording Proxy Mode"
+#              (https://goteleport.com/docs/architecture/proxy/#recording-proxy-mode).
+#    "proxy-sync : session recordings will be streamed from proxy -> auth -> storage service without being stored on disk at all.
+#    "off"   : session recording is turned off
+#
+sessionRecording: ""
+
 # ACME is a protocol for getting Web X.509 certificates
 # Note: ACME can only be used for single-instance clusters. It is not suitable for use in HA configurations.
 # Setting acme to 'true' enables the ACME protocol and will attempt to get a free TLS certificate from Let's Encrypt.


### PR DESCRIPTION
Allow for configuring the session_recording mode in the teleport-cluster helm chart.  See the [Teleport Configuration Reference](https://goteleport.com/docs/setup/reference/config/) for more details.