### PR TITLE
docs: fix code block

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -196,7 +196,7 @@ You can also use any other ACME-compatible server.
   ```
   </TabItem>
   <TabItem label="--set">
-  ``code
+  ```code
   $ --set acme=true \
   --set acmeEmail=user@email.com \
   --set acmeURI=https://acme-staging-v02.api.letsencrypt.org/directory
@@ -226,7 +226,7 @@ To disable this, you can set `enabled` to `false`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ``code
+  ```code
   $ --set podSecurityPolicy.enabled=false
   ```
   </TabItem>
@@ -254,7 +254,7 @@ Teleport's RBAC policies to define access rules for the cluster.
   ```
   </TabItem>
   <TabItem label="--set">
-  ``code
+  ```code
   $ --set labels.environment=production \
   --set labels.region=us-east
   ```
@@ -296,7 +296,7 @@ The default is left blank, which will automatically create a `PersistentVolumeCl
   ```
   </TabItem>
   <TabItem label="--set">
-  ``code
+  ```code
   $ --set standalone.existingClaimName=my-existing-pvc-name
   ```
   </TabItem>
@@ -383,7 +383,7 @@ Set to a number higher than `1` for a high availability mode where multiple Tele
   ```
   </TabItem>
   <TabItem label="--set">
-  ``code
+  ```code
   $ --set highAvailability.replicaCount=3
   ```
   </TabItem>


### PR DESCRIPTION
Some code blocks at https://goteleport.com/docs/kubernetes-access/helm/reference/#acmeuri are broken because they use not three but two backquote.

![image](https://user-images.githubusercontent.com/1219666/154784585-8a33f642-1850-49ac-b255-ee9a0f7ebbf9.png)

Backports required:
- branch/v9
- branch/v8
- branch/v7
- branch/v6.2