### PR TITLE
prompt to stderr instead of stdout when login

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2557,7 +2557,7 @@ func (tc *TeleportClient) Ping(ctx context.Context) (*webclient.PingResponse, er
 	// If version checking was requested and the server advertises a minimum version.
 	if tc.CheckVersions && pr.MinClientVersion != "" {
 		if err := utils.CheckVersion(teleport.Version, pr.MinClientVersion); err != nil && trace.IsBadParameter(err) {
-			fmt.Printf(`
+			fmt.Fprintf(tc.Config.Stderr, `
 			WARNING
 			Detected potentially incompatible client and server versions.
 			Minimum client version supported by the server is %v but you are using %v.
@@ -2590,7 +2590,7 @@ func (tc *TeleportClient) ShowMOTD(ctx context.Context) error {
 	}
 
 	if motd.Text != "" {
-		fmt.Printf("%s\nPress [ENTER] to continue.\n", motd.Text)
+		fmt.Fprintf(tc.Config.Stderr, "%s\nPress [ENTER] to continue.\n", motd.Text)
 		// We're re-using the password reader for user acknowledgment for
 		// aesthetic purposes, because we want to hide any garbage the
 		// use might enter at the prompt. Whatever the user enters will
@@ -3044,7 +3044,7 @@ func Username() (string, error) {
 
 // AskOTP prompts the user to enter the OTP token.
 func (tc *TeleportClient) AskOTP() (token string, err error) {
-	fmt.Printf("Enter your OTP token:\n")
+	fmt.Fprintf(tc.Config.Stderr, "Enter your OTP token:\n")
 	token, err = lineFromConsole()
 	if err != nil {
 		fmt.Fprintln(tc.Stderr, err)
@@ -3055,7 +3055,7 @@ func (tc *TeleportClient) AskOTP() (token string, err error) {
 
 // AskPassword prompts the user to enter the password
 func (tc *TeleportClient) AskPassword() (pwd string, err error) {
-	fmt.Printf("Enter password for Teleport user %v:\n", tc.Config.Username)
+	fmt.Fprintf(tc.Config.Stderr, "Enter password for Teleport user %v:\n", tc.Config.Username)
 	pwd, err = passwordFromConsoleFn()
 	if err != nil {
 		fmt.Fprintln(tc.Stderr, err)

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"time"
@@ -239,7 +240,7 @@ func initClient(proxyAddr string, insecure bool, pool *x509.CertPool) (*WebClien
 
 	if insecure {
 		// Skip https cert verification, print a warning that this is insecure.
-		fmt.Printf("WARNING: You are using insecure connection to SSH proxy %v\n", proxyAddr)
+		fmt.Fprintf(os.Stderr, "WARNING: You are using insecure connection to SSH proxy %v\n", proxyAddr)
 		opts = append(opts, roundtrip.HTTPClient(NewInsecureWebClient()))
 	} else if pool != nil {
 		// use custom set of trusted CAs
@@ -294,17 +295,17 @@ func SSHAgentSSOLogin(ctx context.Context, login SSHLoginSSO) (*auth.SSHLoginRes
 	}
 	if execCmd != nil {
 		if err := execCmd.Start(); err != nil {
-			fmt.Printf("Failed to open a browser window for login: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Failed to open a browser window for login: %v\n", err)
 		}
 	}
 
 	// Print the URL to the screen, in case the command that launches the browser did not run.
 	// If Browser is set to the special string teleport.BrowserNone, no browser will be opened.
 	if login.Browser == teleport.BrowserNone {
-		fmt.Printf("Use the following URL to authenticate:\n %v\n", clickableURL)
+		fmt.Fprintf(os.Stderr, "Use the following URL to authenticate:\n %v\n", clickableURL)
 	} else {
-		fmt.Printf("If browser window does not open automatically, open it by ")
-		fmt.Printf("clicking on the link:\n %v\n", clickableURL)
+		fmt.Fprintf(os.Stderr, "If browser window does not open automatically, open it by ")
+		fmt.Fprintf(os.Stderr, "clicking on the link:\n %v\n", clickableURL)
 	}
 
 	select {


### PR DESCRIPTION
Fix #6630.

`tsh kube credentials` command is executed as kubernetes client-go credential plugins.
https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins

client-go captures all stdout of plugin and treats it as `ExecCredential` object.

When session is timeout, `tsh` prompt to relogin.
To avoid client-go's capturing prompt text, prompt to stderr instead of stdout when login.
