### PR TITLE
Disable parallel execution in TestTLSConfiguration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ $(TEST_LOG_DIR):
 #
 .PHONY: test-go
 test-go: ensure-webassets bpf-bytecode roletester rdpclient $(TEST_LOG_DIR) $(RENDER_TESTS)
-test-go: FLAGS ?= '-race'
+test-go: FLAGS ?= -race -timeout=15m
 test-go: PACKAGES = $(shell go list ./... | grep -v integration | grep -v tool/tsh)
 test-go: CHAOS_FOLDERS = $(shell find . -type f -name '*chaos*.go' | xargs dirname | uniq)
 test-go: $(VERSRC) $(TEST_LOG_DIR)

--- a/lib/srv/db/ca_test.go
+++ b/lib/srv/db/ca_test.go
@@ -399,8 +399,6 @@ func TestTLSConfiguration(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			// Run the same scenario for all supported databases.
 			for _, dbType := range []string{
 				defaults.ProtocolPostgres,


### PR DESCRIPTION
`TestTLSConfiguration` keeps failing in GCB. Disabling parallel execution of tests should make it more stable in CI.
Increasing the timeout for test execution was needed as right now our DB runs more than standard Go test 10 minutes limit.