### PR TITLE
Change package name to avoid conflicts

### DIFF
--- a/api/backend/grpc/backend.proto
+++ b/api/backend/grpc/backend.proto
@@ -16,7 +16,7 @@
 // to be used over gRPC.
 
 syntax = "proto3";
-package proto;
+package api.backend.grpc;
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/empty.proto";

--- a/lib/backend/grpcclient/utils.go
+++ b/lib/backend/grpcclient/utils.go
@@ -107,8 +107,8 @@ func toGrpcOpType(in types.OpType) grpcbackend.OpType {
 func ConvertGrpcItemsBackendItems(in []*grpcbackend.Item) []backend.Item {
 	result := make([]backend.Item, 0, len(in))
 
-	for _, v := range in {
-		result = append(result, *ConvertGrpcItemBackendItem(v))
+	for i, v := range in {
+		result[i] = *ConvertGrpcItemBackendItem(v)
 	}
 
 	return result
@@ -120,8 +120,8 @@ func ConvertBackendItemsGrpcItems(in []backend.Item) []*grpcbackend.Item {
 	}
 	result := make([]*grpcbackend.Item, 0, len(in))
 
-	for _, v := range in {
-		result = append(result, ConvertBackendItemGrpcItem(v))
+	for i, v := range in {
+		result[i] = ConvertBackendItemGrpcItem(v)
 	}
 
 	return result


### PR DESCRIPTION
There is a conflict between `backened.proto` and `authservice.proto` for the
`Watch` message type.

Additionally, remove appends when the len of the slice is already known
to avoid getting empty items in the slice via the append