### PR TITLE
[v8 backport] Expose reverse tunnel address to web ui

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -894,10 +894,22 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		PreferredLocalMFA: cap.GetPreferredLocalMFA(),
 	}
 
+	// get tunnel address to display on cloud instances
+	tunnelPublicAddr := ""
+	if h.ClusterFeatures.GetCloud() {
+		proxyConfig, err := h.cfg.ProxySettings.GetProxySettings(r.Context())
+		if err != nil {
+			h.log.WithError(err).Warn("Cannot retrieve ProxySettings, tunnel address won't be set in Web UI.")
+		} else {
+			tunnelPublicAddr = proxyConfig.SSH.TunnelPublicAddr
+		}
+	}
+
 	webCfg := ui.WebConfig{
-		Auth:            authSettings,
-		CanJoinSessions: canJoinSessions,
-		IsCloud:         h.ClusterFeatures.GetCloud(),
+		Auth:                authSettings,
+		CanJoinSessions:     canJoinSessions,
+		IsCloud:             h.ClusterFeatures.GetCloud(),
+		TunnelPublicAddress: tunnelPublicAddr,
 	}
 
 	resource, err := h.cfg.ProxyClient.GetClusterName()

--- a/lib/web/ui/webconfig.go
+++ b/lib/web/ui/webconfig.go
@@ -45,6 +45,8 @@ type WebConfig struct {
 	ProxyClusterName string `json:"proxyCluster,omitempty"`
 	// IsCloud is a flag that determines if cloud features are enabled.
 	IsCloud bool `json:"isCloud,omitempty"`
+	// TunnelPublicAddress is the public ssh tunnel address
+	TunnelPublicAddress string `json:"tunnelPublicAddress,omitempty"`
 }
 
 // WebConfigAuthProvider describes auth. provider


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/10133

webapps v8 backport: gravitational/webapps#616

___

The ultimate purpose is to show the reverse tunnel address on Help & Support screen on the web UI.

On cloud instances, we use a custom reverse tunnel port for each tenant. In the UI, there is no way to know your reverse tunnel address, which is necessary when adding a trusted cluster.

This PR adds the reverse tunnel address to the GRV_CONFIG object that is injected into the web UI. I added it behind a feature flag to only show on cloud only, should we expose it to everyone?

Note that this field is already publicly exposed via GET [proxy server]/webapi/ping.