### PR TITLE
Add support for externally created service account

### DIFF
--- a/examples/chart/teleport-cluster/templates/clusterrolebinding.yaml
+++ b/examples/chart/teleport-cluster/templates/clusterrolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
+  name: {{ .Values.serviceAccount.name | default .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/examples/chart/teleport-cluster/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/deployment.yaml
@@ -202,4 +202,4 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-      serviceAccountName: {{ .Release.Name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}

--- a/examples/chart/teleport-cluster/templates/psp.yaml
+++ b/examples/chart/teleport-cluster/templates/psp.yaml
@@ -58,5 +58,5 @@ roleRef:
   name: {{ .Release.Name }}-psp
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
+  name: {{ .Values.serviceAccount.name | default .Release.Name }}
 {{- end -}}

--- a/examples/chart/teleport-cluster/templates/serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/serviceaccount.yaml
@@ -1,9 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Values.serviceAccount.name | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
 {{- if .Values.annotations.serviceAccount }}
   annotations:
 {{- toYaml .Values.annotations.serviceAccount | nindent 4 }}
 {{- end -}}
+{{- end }}

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -10,6 +10,7 @@
         "chartMode",
         "highAvailability",
         "image",
+        "serviceAccount",
         "enterpriseImage",
         "log",
         "affinity",
@@ -270,6 +271,26 @@
             "type": "string",
             "default": "quay.io/gravitational/teleport"
         },
+        "serviceAccount": {
+            "$id": "#/properties/serviceAccount",
+            "type": "object",
+            "required": [
+                "create",
+                "name"
+            ],
+            "properties": {
+                "create": {
+                    "$id": "#/properties/serviceAccount/properties/create",
+                    "type": "boolean",
+                    "default": true
+                },
+                "name": {
+                    "$id": "#/properties/serviceAccount/properties/name",
+                    "type": "string",
+                    "default": ""
+                }
+            }
+        },
         "enterpriseImage": {
             "$id": "#/properties/enterpriseImage",
             "type": "string",
@@ -299,7 +320,13 @@
                 "level": {
                     "$id": "#/properties/log/properties/level",
                     "type": "string",
-                    "enum": ["DEBUG", "INFO", "WARN", "WARNING", "ERROR"],
+                    "enum": [
+                        "DEBUG",
+                        "INFO",
+                        "WARN",
+                        "WARNING",
+                        "ERROR"
+                    ],
                     "default": "INFO"
                 },
                 "deployment": {

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -154,7 +154,6 @@ highAvailability:
     # This defaults to 'cert-manager.io' which is the default Issuer group.
     issuerGroup: cert-manager.io
 
-
 ##################################################
 # Values that you shouldn't need to change.
 ##################################################
@@ -185,6 +184,13 @@ log:
 # Extra Kubernetes configuration #
 ##################################
 
+# Specifies whether a service account should be created
+serviceAccount:
+  create: true
+  # (optional) Override the name of the service account used by the agent.
+  # If not set and create is true, a name is generated using the release name
+  name: ""
+
 # Affinity for pod assignment
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 # NOTE: If affinity is set here, highAvailability.requireAntiAffinity cannot also be used - you can only set one or the other.
@@ -211,7 +217,8 @@ annotations:
 service:
   type: LoadBalancer
   # Additional entries here will be added to the service spec.
-  spec: {}
+  spec:
+    {}
     # loadBalancerIP: "1.2.3.4"
 
 # Extra arguments to pass to 'teleport start' for the main Teleport pod

--- a/examples/chart/teleport-kube-agent/.lint/clusterrole.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/clusterrole.yaml
@@ -4,4 +4,5 @@ roles: kube
 kubeClusterName: test-kube-cluster
 clusterRoleName: teleport-kube-agent-test
 clusterRoleBindingName: teleport-kube-agent-test
-serviceAccountName: teleport-kube-agent-test
+serviceAccount:
+  name: teleport-kube-agent-test

--- a/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: {{ .Values.clusterRoleName | default .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccountName | default .Release.Name }}
+  name: {{ .Values.serviceAccount.name | default .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -175,5 +175,5 @@ spec:
 {{- if .Values.extraVolumes }}
   {{- toYaml .Values.extraVolumes | nindent 6 }}
 {{- end }}
-      serviceAccountName: {{ .Values.serviceAccountName | default .Release.Name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
 {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/psp.yaml
+++ b/examples/chart/teleport-kube-agent/templates/psp.yaml
@@ -58,5 +58,5 @@ roleRef:
   name: {{ .Release.Name }}-psp
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccountName | default .Release.Name }}
+  name: {{ .Values.serviceAccount.name | default .Release.Name }}
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
+++ b/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
@@ -1,9 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccountName | default .Release.Name }}
+  name: {{ .Values.serviceAccount.name | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
 {{- if .Values.annotations.serviceAccount }}
   annotations:
 {{- toYaml .Values.annotations.serviceAccount | nindent 4 }}
 {{- end -}}
+{{- end }}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -102,7 +102,7 @@ spec:
     {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
   {{- end }}
 {{- end }}
-      serviceAccountName: {{ .Values.serviceAccountName | default .Release.Name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -17,7 +17,7 @@
         "image",
         "clusterRoleName",
         "clusterRoleBindingName",
-        "serviceAccountName",
+        "serviceAccount",
         "secretName",
         "log",
         "affinity",
@@ -205,10 +205,25 @@
                 }
             }
         },
-        "serviceAccountName": {
-            "$id": "#/properties/serviceAccountName",
-            "type": "string",
-            "default": ""
+        "serviceAccount": {
+            "$id": "#/properties/serviceAccount",
+            "type": "object",
+            "required": [
+                "create",
+                "name"
+            ],
+            "properties": {
+                "create": {
+                    "$id": "#/properties/serviceAccount/properties/create",
+                    "type": "boolean",
+                    "default": true
+                },
+                "name": {
+                    "$id": "#/properties/serviceAccount/properties/name",
+                    "type": "string",
+                    "default": ""
+                }
+            }
         },
         "secretName": {
             "$id": "#/properties/secretName",
@@ -227,7 +242,13 @@
                 "level": {
                     "$id": "#/properties/log/properties/level",
                     "type": "string",
-                    "enum": ["DEBUG", "INFO", "WARN", "WARNING", "ERROR"],
+                    "enum": [
+                        "DEBUG",
+                        "INFO",
+                        "WARN",
+                        "WARNING",
+                        "ERROR"
+                    ],
                     "default": "INFO"
                 },
                 "deployment": {

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -129,8 +129,12 @@ imagePullSecrets: []
 clusterRoleName: ""
 # (optional) Override the name of the ClusterRoleBinding used by the agent's service account.
 clusterRoleBindingName: ""
-# (optional) Override the name of the service account used by the agent.
-serviceAccountName: ""
+# Specifies whether a service account should be created
+serviceAccount:
+  create: true
+  # (optional) Override the name of the service account used by the agent.
+  # If not set and create is true, a name is generated using the release name
+  name: ""
 # Name of the Secret to store the teleport join token.
 secretName: teleport-kube-agent-join-token
 


### PR DESCRIPTION

This PR add support to disable the serviceAccount creation to allow a serviceAccount to be created outside the helm chart. This is useful for custom cloud integrations like AWS fine grained IAM and managing the serviceAccount separately.

Brings these charts in line with your newer charts as well as standard `helm create my-chart` format.