### PR TITLE
Added buildscript warnings

### DIFF
--- a/.cloudbuild/scripts/cmd/integration-tests/args.go
+++ b/.cloudbuild/scripts/cmd/integration-tests/args.go
@@ -73,6 +73,8 @@ func (args *commandlineArgs) validate() error {
 	return nil
 }
 
+// NOTE: changing the interface to this build script may require follow-up
+// changes in the cloudbuild yaml for both `teleport` and `teleport.e`
 func parseCommandLine() (*commandlineArgs, error) {
 	args := &commandlineArgs{}
 

--- a/.cloudbuild/scripts/cmd/unit-tests/main.go
+++ b/.cloudbuild/scripts/cmd/unit-tests/main.go
@@ -50,6 +50,8 @@ type commandlineArgs struct {
 	bucket                 string
 }
 
+// NOTE: changing the interface to this build script may require follow-up
+// changes in the cloudbuild yaml for both `teleport` and `teleport.e`
 func parseCommandLine() (commandlineArgs, error) {
 	args := commandlineArgs{}
 


### PR DESCRIPTION
After changes to the `teleport` build scripts cause build failures in `teleport.e`, I thought it might be worth adding a note to warn anyone changing these scripts that follow up tasks may need to be done.