### PR TITLE
[v8] Add a prominent warning to the config reference

### DIFF
--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -11,8 +11,15 @@ By default, it is stored in `/etc/teleport.yaml`.
 
 (!docs/pages/includes/backup-warning.mdx!)
 
-This document aims to be a reference rather than a starting point for a real cluster. To
-get a good starting file, run `teleport configure -o teleport.yaml`.
+This document aims to be a reference rather than a starting point for a real cluster. 
+
+<Admonition type="danger" title="Before using this reference">
+You must edit your configuration file to meet the needs of your environment. Using a copy of the reference configuration will have unintended effects. To create a configuration file that you can use as a starting point, run the following command:
+
+```code
+$ teleport configure -o file
+```
+</Admonition>
 
 ```yaml
 # By default, this file should be stored in /etc/teleport.yaml


### PR DESCRIPTION
Backports #9558

Readers may be tempted to copy the entire reference configuration
for their own Teleport deployments. This changes the config
reference to include a more explicit and prominent warning against
doing so, and recommends using the "teleport configure" command.