### PR TITLE
[v8] Add a Cloud compatibility warning to Helm guides

### DIFF
--- a/docs/pages/kubernetes-access/helm/includes/helm-install.mdx
+++ b/docs/pages/kubernetes-access/helm/includes/helm-install.mdx
@@ -3,6 +3,17 @@
 - [Kubernetes](https://kubernetes.io) >= v(=kubernetes.major_version=).(=kubernetes.minor_version=).0
 - [Helm](https://helm.sh) >= v(=helm.version=)
 
+<Details scopeOnly={true} scope={["cloud"]} title="Teleport Cloud warning">
+This guide shows you how to install the `teleport-cluster` Helm chart, which is intended to help you get started with Teleport by deploying the Auth Service and 
+Proxy Service in a Kubernetes cluster so you can access that cluster via the Kubernetes Service.
+
+Since the Auth and Proxy Services are fully managed in Teleport Cloud, you should install our `teleport-kube-agent` chart, which is intended for deployments where the Auth Service and Proxy Service run outside your Kubernetes cluster.
+
+You can use the `teleport-kube-agent` chart to enable the Application Service and Database Service in addition to the Kubernetes Service.
+
+For more information, see our [Helm chart reference](../reference.mdx#teleport-kube-agent).
+</Details>
+
 Verify that Helm and Kubernetes are installed and up to date.
 
 (!docs/pages/includes/permission-warning.mdx!)


### PR DESCRIPTION
Backports #10023

* Add a Cloud compatibility warning to Helm guides

Our Helm guides show readers how to use the teleport-cluster
chart, which deploys the Auth and Proxy services. This change adds
a note that Cloud users should use our teleport-kube-agent chart
instead.

* Respond to PR review

Mention that the teleport-kube-agent chart allows you to use the
Database Service, Kubernetes Service, and Application Service.