### PR TITLE
[v8] Address Cloud users in guides

### DIFF
--- a/docs/pages/enterprise/hsm.mdx
+++ b/docs/pages/enterprise/hsm.mdx
@@ -4,16 +4,17 @@ description: How to configure Hardware Security Modules to manage your Teleport 
 h1: Teleport HSM Support
 ---
 
-This section will cover:
-
-- Setting up a Teleport auth server to use an HSM to store and handle private
-  keys.
+This guide will show you how to set up the Teleport Auth Server to use a hardware security module (HSM) to store and handle private keys.
 
 ## Prerequisites
 
-- Teleport v(=teleport.version=) Enterprise self-hosted.
+- Teleport v(=teleport.version=) Enterprise (self-hosted).
 - An HSM reachable from your Teleport auth server.
 - The PKCS#11 module for your HSM.
+
+<Details scope={["cloud", "oss"]} opened={true} scopeOnly={true} title="Compabitility Warning">
+Teleport Cloud and Teleport Open Source do not currently support HSM.
+</Details>
 
 While most PKCS#11 HSMs should be supported, the Teleport team tests with AWS
 CloudHSM, YubiHSM2, and SoftHSM2.
@@ -21,21 +22,21 @@ CloudHSM, YubiHSM2, and SoftHSM2.
 ## Step 1/5. Set up your HSM
 
 You will need to set up your HSM and make sure that it is accessible from your
-Teleport auth server. You should create a unique HSM user or token for Teleport
+Teleport Auth Server. You should create a unique HSM user or token for Teleport
 to use.
 
 <Tabs>
   <TabItem label="AWS CloudHSM">
-Before getting started you should create and activate a CloudHSM cluster in
-the VPC where you will run your Teleport auth server. Create a Crypto User (CU)
+Before getting started, you should create and activate a CloudHSM cluster in
+the VPC where you will run your Teleport Auth Server. Create a Crypto User (CU)
 to be used by Teleport. See the AWS CloudHSM
 [User Guide](https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
 for help.
 
-On the EC2 instance where you will run your Teleport auth server:
+On the EC2 instance where you will run your Teleport Auth Server:
 
 1. Add the security group with the same name as your CloudHSM cluster to your
-   EC2 instance, to allow incoming traffic from CloudHSM on ports 2223-2225.
+   EC2 instance to allow incoming traffic from CloudHSM on ports 2223–2225.
 
 2. Install and configure the CloudHSM client by following
    https://docs.aws.amazon.com/cloudhsm/latest/userguide/install-and-configure-client-linux.html.
@@ -63,9 +64,9 @@ On the EC2 instance where you will run your Teleport auth server:
    Teleport with the below capabilities.
    <Admonition type="note">
    YubiHSM2 comes with a default authentication key at slot 1 with password
-   `password`, you should replace and delete it as recommended by Yubico.
+   `password`. You should replace and delete it as recommended by Yubico.
 
-   When creating the authentication key to be used by teleport, the password
+   When creating the authentication key to be used by Teleport, the password
    must have at least 8 characters. The example `hunter22` is used here.
    </Admonition>
 
@@ -77,8 +78,7 @@ On the EC2 instance where you will run your Teleport auth server:
    Stored Authentication key 0x53bf
    ```
 
-   Take note of the hex slot number output above, it will be used in the pin
-   when configuring Teleport.
+   Take note of the hex slot number output above. It will be used when configuring Teleport.
 
 4. Create a `yubihsm_pkcs11.conf` file pointing to your connector
 

--- a/docs/pages/enterprise/sso/azuread.mdx
+++ b/docs/pages/enterprise/sso/azuread.mdx
@@ -4,81 +4,84 @@ description: How to configure SSH access with Active Directory (AD) on Azure usi
 h1: SSH Authentication with Azure Active Directory (AD)
 ---
 
-This guide will cover how to configure [Microsoft Azure Active Directory](https://azure.microsoft.com/en-us/services/active-directory/) to issue
-SSH credentials to specific groups of users with a SAML Authentication Connector. When used in combination with role
-based access control (RBAC) it allows SSH administrators to define policies
-like:
+This guide will cover how to configure Microsoft Azure Active Directory to issue
+SSH credentials to specific groups of users with a SAML Authentication Connector. When used in combination with role-based access control (RBAC), it allows SSH administrators to define policies like:
 
-- Only members of "DBA" Azure AD group can SSH into machines running PostgreSQL.
+- Only members of the "DBA" Azure AD group can SSH into machines running PostgreSQL.
 - Developers must never SSH into production servers.
 
-The following steps configure an example SAML authentication connector matching AzureAD groups with security roles.  You can choose to configure other options.
+The following steps configure an example SAML authentication connector matching Azure AD groups with security roles.  You can choose to configure other options.
 
 <Admonition
   type="warning"
   title="Version Warning"
 >
-  This guide requires an Enterprise version of Teleport.
+  This guide requires either an Enterprise version of Teleport or a Teleport Cloud account.
 </Admonition>
 
 ## Prerequisites
 
 Before you get started you’ll need:
 
-- An Enterprise version of Teleport (=teleport.version=) or greater, downloaded from [https://dashboard.gravitational.com/](https://dashboard.gravitational.com/web/login).
+- Either an Enterprise version of Teleport (downloaded via the [Enterprise dashboard](https://dashboard.gravitational.com/web/login)) or a Teleport Cloud account (sign up for a [free trial](https://goteleport.com/signup/)).
 - An Azure AD admin account with access to creating non-gallery applications (P2 License)
 - To register one or more users in the directory
-- To create at least two security groups in AzureAD and assign one or more users to each group
+- To create at least two security groups in Azure AD and assign one or more users to each group
 
 ## Configure Azure AD
 
-1. Select AzureAD -> Enterprise Applications
+1. Select **Azure AD -> Enterprise Applications**
 
    ![Select Enterprise Applications From Manage](../../../img/azuread/azuread-1-home.png)
 
-2. Select New application
+2. Select **New application**
 
    ![Select New Applications From Manage](../../../img/azuread/azuread-2-newapp.png)
 
-3. Select a "Create your own application"
+3. Select a **Non-gallery application**
 
    ![Select Non-gallery application](../../../img/azuread/azuread-3-selectnongalleryapp.png)
 
-4. Enter the display name (Ex: Teleport)
+4. Enter the display name (e.g, Teleport)
 
    ![Enter application name](../../../img/azuread/azuread-4-enterappname.png)
 
-5.Select properties under Manage and turn off User assignment required
+5. Select **Properties** under **Manage** and set **User assignment required?** to **No**
 
 ![Turn off user assignment](../../../img/azuread/azuread-5-turnoffuserassign.png)
 
-6. Select Single Sign-on under Manage and choose SAML
+6. Select **Single sign-on** under **Manage** and choose **SAML**
 
    ![Select SAML](../../../img/azuread/azuread-6-selectsaml.png)
 
-7. Select to edit Basic SAML Configuration
+7. Edit the **Basic SAML Configuration**
 
    ![Edit Basic SAML Configuration](../../../img/azuread/azuread-7-editbasicsaml.png)
 
-8. Put in the Entity ID and Reply URL the same proxy URL [https://teleport.example.com:3080/v1/webapi/saml/acs](https://teleport.example.com:3080/v1/webapi/saml/acs)
+8. For **Entity ID** and **Reply URL**, enter the same proxy URL.
+  
+   For self-hosted deployments, the URL will be similar to `https://teleport.example.com:3080/v1/webapi/saml/acs`.
+
+   For Teleport Cloud users, the URL will be similar to `https://mytenant.teleport.sh`.
 
    ![Put in Entity ID and Reply URL](../../../img/azuread/azuread-8-entityandreplyurl.png)
 
-9. Edit User Attributes & Claims
+9. Edit **User Attributes & Claims**
 
-   - Edit the Claim Name.  Change the name identifier format to Default. Make sure the source attribute is user.userprincipalname.
+   - Edit the claim name.
+   - Change the name identifier format to **Default**. Make sure the source attribute is `user.userprincipalname`.
 
    ![Confirm Name Identifier](../../../img/azuread/azuread-9a-nameidentifier.png)
 
-   - Add a group Claim to have user security groups available to the connector
+   - Add a group claim to make user security groups available to the connector
 
    ![Put in Security group claim](../../../img/azuread/azuread-9b-groupclaim.png)
 
-   - Add a Claim to pass the username from transforming the AzureAD User name.
+   - Add a claim that transforms an Azure AD username in order to pass it to Teleport.
 
    ![Add a transformed username](../../../img/azuread/azuread-9c-usernameclaim.png)
 
-10. On the SAML Signing Certificate select to download SAML Download the Federation Metadata XML.
+10. In **SAML Signing Certificate**, click the link to download the **Federation Metadata XML**.
 
     ![Download Federation Metadata XML](../../../img/azuread/azuread-10-fedmeatadataxml.png)
 
@@ -91,8 +94,7 @@ Before you get started you’ll need:
 
 ## Create a SAML Connector
 
-Now, create a SAML connector [resource](../../setup/reference/resources.mdx).  Replace the acs element with your Teleport address, update the group IDs with the actual AzureAD group ID values, and insert the downloaded Federation Metadata XML into the entity_descriptor resource.
-Write down this template as `azure-connector.yaml`:
+Now, create a SAML connector resource. Write the following to `azure-connector.yaml`:
 
 ```yaml
 kind: saml
@@ -112,7 +114,10 @@ spec:
     <federationmedata.xml contents>
 ```
 
-Create the connector using `tctl` tool:
+Replace the `acs` field with your Teleport address, update the group IDs in the `attributes_to_roles` field with the actual Azure AD group ID values, and insert the downloaded Federation Metadata XML into the `entity_descriptor` field.
+
+
+Create the connector using `tctl`:
 
 ```code
 $ tctl create azure-connector.yaml
@@ -120,9 +125,9 @@ $ tctl create azure-connector.yaml
 
 <Admonition
   type="tip"
-  title="Automatic signing keypair"
+  title="Automatic signing key pair"
 >
-  Teleport will generate a signing key pair and update SAML connector with `signing_key_pair`
+  Teleport will generate a signing key pair and update the SAML connector with the `signing_key_pair`
   property.
 
   ![Sample Connector Transform](../../../img/azuread/azuread-12-sampleconnector.png)
@@ -134,15 +139,12 @@ $ tctl create azure-connector.yaml
   ```
 </Admonition>
 
-## Create a new Teleport Role
+## Create a new Teleport role
 
-We are going to create a new that'll use external username data from Azure
-to map to a host linux login. 
+Create a Teleport role resource that will use external username data from the Azure AD connector to determine which Linux logins to allow on a host.
 
-In the below role, Devs are only allowed to login to nodes labelled with `access: relaxed`
-Teleport label. Developers can log in as either `ubuntu` to a username that
-arrives in their assertions. Developers also do not have any rules needed to
-obtain admin access to Teleport.
+Users with the following `dev` role are only allowed to log in to nodes with the `access: relaxed` Teleport label. They can log in as either `ubuntu` or a username that
+arrives via the Azure AD connector. Users with this role cannot obtain admin access to Teleport.
 
 ```yaml
 kind: role
@@ -158,7 +160,7 @@ spec:
       access: relaxed
 ```
 
-**Notice:** Replace `ubuntu` with linux login available on your servers!
+Replace `ubuntu` with the Linux login available on your servers.
 
 ```code
 $ tctl create dev.yaml
@@ -166,25 +168,45 @@ $ tctl create dev.yaml
 
 ## Testing
 
-Update the Teleport settings to use the SAML settings to make this the default.
+Update your Teleport configuration to make SAML the default authentication method.
+
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self Hosted">
+In your Teleport configuration file, include the following:
 
 ```yaml
 auth_service:
   authentication:
     type: saml
 ```
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Cloud">
+Apply the following `cluster_auth_preference` resource via `tctl create`.
+
+```yaml
+    kind: cluster_auth_preference
+    version: v2
+    metadata:
+      name: cluster-auth-preference
+    spec:
+      type: "saml"
+```
+</TabItem>
+</Tabs>
+
+The Web UI will now present the option to log in via Microsoft.
 
 ![Login with Microsoft](../../../img/azuread/azure-11-loginwithmsft.png)
 
-The Web UI will now contain a new button: "Login with Microsoft". The CLI is
-the same as before:
 
+
+The CLI is the same as before:
 ```code
 $ tsh --proxy=proxy.example.com login
 ```
 
-This command will print the SSO login URL (and will try to open it
-automatically in a browser).
+This command will print the SSO login URL and will try to open it
+automatically in a browser.
 
 <Admonition
   type="tip"
@@ -194,34 +216,34 @@ automatically in a browser).
   can be passed via `tsh login --auth=connector_name`
 </Admonition>
 
-## Token Encryption
+## Token encryption
 
-AzureAD's SAML token encryption encrypts the SAML assertions sent to Teleport during SSO redirect.
+Azure AD's SAML token encryption encrypts the SAML assertions sent to Teleport during SSO redirect.
 
 <Admonition
   type="tip"
   title="Tip"
 >
   This is Azure Active Directory Premium feature and requires a separate license.
-  You can read more about it [here](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/howto-saml-token-encryption)
+  You can read more about it [here](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/howto-saml-token-encryption).
 </Admonition>
 
-### Setup Teleport Token Encryption
+### Set up Teleport token encryption
 
-Start with generating a public/private key and a certificate. You will setup the public
-certificate with AzureAD and the private key with Teleport.
+Start with generating a public/private key and a certificate. You will set up the public
+certificate with Azure AD and the private key with Teleport.
 
 ```code
 $ openssl req  -nodes -new -x509  -keyout server.key -out server.cer
 ```
 
-If you are modifying the existing connector, first, save it to YAML:
+If you are modifying the existing connector, write the YAML to a file first:
 
 ```code
 $ tctl get saml --with-secrets > azure-out.yaml
 ```
 
-You will spot that Teleport has generated a `signing_key_pair`. This key pair
+You will notice that Teleport has generated a `signing_key_pair`. This key pair
 is used to sign responses.
 
 ```yaml
@@ -355,7 +377,7 @@ $ tctl create -f azure-out.yaml
 
 ### Activate token encryption
 
-- Navigate to Token Encryption section
+- Navigate to **Token Encryption**
 
 ![Navigate to token encryption](../../../img/azuread/azuread-token-encryption-0.png)
 
@@ -371,40 +393,57 @@ If the SSO login with this connector is successful, the encryption works.
 
 ## Troubleshooting
 
-**Access denied**
+### Access denied
 
-If you get "access denied" errors the number one place to check is the audit
-log on the Teleport auth server. It is located in `/var/lib/teleport/log` by
-default and it will contain the detailed reason why a user's login was denied.
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self Hosted">
+If you get "access denied" errors, the number one place to check is the audit
+log on the Teleport Auth Server. It is located in `/var/lib/teleport/log` by
+default and will contain a detailed reason why a user's login was denied.
 
-Example of a user being denied due as the role `clusteradmin` wasn't setup.
+Example of a user being denied because the role `clusteradmin` wasn't set up:
 
 ```json
 {"code":"T1001W","error":"role clusteradmin is not found","event":"user.login","method":"saml","success":false,"time":"2019-06-15T19:38:07Z","uid":"cd9e45d0-b68c-43c3-87cf-73c4e0ec37e9"}
 ```
 
-Some errors (like file-system permissions or misconfigured network) can be
+Some errors (like file-system permissions or a misconfigured network) can be
 diagnosed using Teleport's `stderr` log, which is usually available via:
 
 ```code
 $ sudo journalctl -fu teleport
 ```
 
-If you wish to increase the verbosity of Teleport's syslog, you can pass the
-[`--debug`](../../setup/reference/cli.mdx#teleport-start) flag to `teleport start` command.
+If you wish to increase the verbosity of Teleport's logs, you can pass the
+[`--debug`](../../setup/reference/cli.mdx#teleport-start) flag to the `teleport start` command.
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Cloud">
+If you get "access denied" errors, the number one place to check is the audit
+log on the Teleport Auth Server. You can find it in the **Activity** tab of the Teleport Web UI.
 
-**Failed to process SAML callback**
+Example of a user being denied because the role `clusteradmin` wasn't set up:
 
-If you encounter "Failed to process SAML callback", take a look at the logs.
+```json
+{"code":"T1001W","error":"role clusteradmin is not found","event":"user.login","method":"saml","success":false,"time":"2019-06-15T19:38:07Z","uid":"cd9e45d0-b68c-43c3-87cf-73c4e0ec37e9"}
+```
+</TabItem>
+</Tabs>
+
+### Failed to process SAML callback
+
+If you encounter a "Failed to process SAML callback" error, take a look at the audit log.
 
 ```
 Special characters are not allowed in resource names, please use name composed only from characters,
 hyphens and dots: /web/users/ops_example.com#EXT#@opsexample.onmicrosoft.com/params
 ```
 
-The error above is caused by nameid format that is not compatible with Teleport's naming
-conventions.
+The error above is caused by a Name ID format that is not compatible with Teleport's naming conventions.
 
-Change nameid format to use email instead:
+Change the Name ID format to use email instead:
 
-![Change NameID format to use email](../../../img/azuread/azuread-1-home.png)
+![Change NameID format to use email](../../../img/azuread/azuread-nameid.png)
+
+
+## Further reading
+- [Teleport Configuration Resources Reference](../../setup/reference/resources.mdx)

--- a/docs/pages/enterprise/sso/google-workspace.mdx
+++ b/docs/pages/enterprise/sso/google-workspace.mdx
@@ -27,11 +27,10 @@ to define policies like:
 
 Before you get started you’ll need:
 
-- An Enterprise version of Teleport downloaded from [https://dashboard.gravitational.com/](https://dashboard.gravitational.com/).
-- A Google Workspace Super administrator account. We recommend setting up a separate super admin account with 2FA as opposed to granting your daily user super admin privileges.
-- Ability to create a Google Cloud Platform project.
-   This might require signing up to GCP, but the created project will not require using any paid services. It’s just a side effect of Google Workspace and GCP being closely related.
-- Ability to setup Google Workspace groups.
+- Either an Enterprise version of Teleport (downloaded via the [Enterprise dashboard](https://dashboard.gravitational.com/web/login)) or a Teleport Cloud account (sign up for a [free trial](https://goteleport.com/signup/)).
+- A Google Workspace super administrator account. We recommend setting up a separate super admin account with 2FA as opposed to granting your daily user super admin privileges.
+- Ability to create a Google Cloud project, which requires signing up for Google Cloud. Note that this guide will not require using any paid Google Cloud services.
+- Ability to set up Google Workspace groups.
 
 ## Configuring Google Workspace
 
@@ -54,7 +53,6 @@ behavior is selected depending on the OAuth scopes granted to the service
 account associated with the connector.
 
 <Details title="Version Warning: Before 8.1.2" opened={false}>
-
 Teleport versions prior to 8.1.2 only support fetching groups with direct
 membership with the
 `https://www.googleapis.com/auth/admin.directory.group.readonly` scope.
@@ -64,90 +62,89 @@ on a different domain or subdomain than the user's will be ignored.
 To avoid
 unexpected changes in how access is granted to users for preexisting SSO
 connectors, this behavior will persist even after upgrading, until the `version`
-field of the [connector resource](#create-a-oidc-connector) is changed from `v2`
+field of the [connector resource](#create-an-oidc-connector) is changed from `v2`
 to `v3`.
-
 </Details>
 
 - [Create a new project](https://console.cloud.google.com/projectselector2/apis/dashboard).
   ![creation of a Google Cloud Platform project](../../../img/googleoidc/new-project.png)
+
 - [Configure the OAuth consent screen](https://console.cloud.google.com/apis/credentials/consent):
-  - Select "Internal" as your User Type.
+
+  Select "Internal" as your User Type.
     ![configuration of the OAuth consent screen](../../../img/googleoidc/consent-screen-1.png)
-  - Configure the appearence of your connector by picking a visible name, user support email, etc.
-  - Select the `.../auth/userinfo.email` and `openid` scopes.
+
+  Configure the appearence of your connector by picking a visible name, user support email, etc.
+  
+  Select the `.../auth/userinfo.email` and `openid` scopes.
     ![select email and openid scopes](../../../img/googleoidc/consent-screen-2.png)
+
 - Enable the [Cloud Identity API](https://console.cloud.google.com/apis/library/cloudidentity.googleapis.com) or the [Admin SDK API](https://console.cloud.google.com/apis/library/admin.googleapis.com) for transitive and direct group membership, respectively. Enabling both is fine.
+
 - [Create an OAuth client ID](https://console.cloud.google.com/apis/credentials/oauthclient):
-  - Select "Web application" as the Application type, pick a name, then add `https://<address of proxy server>:3080/v1/webapi/oidc/callback` as an authorized redirect URI.
+
+  Select "Web application" as the Application type, pick a name, then add `https://<address of proxy server>:3080/v1/webapi/oidc/callback` as an authorized redirect URI.
     ![OAuth client ID creation](../../../img/googleoidc/clientid-creation.png)
-  - Copy the Client ID and Client Secret from the next screen or by clicking "Download OAuth client".
+
+  Copy the Client ID and Client Secret from the next screen or by clicking "Download OAuth client".
     ![OAuth client data](../../../img/googleoidc/clientid-data.png)
+
 - [Create a service account](https://console.cloud.google.com/iam-admin/serviceaccounts/create):
-  - Pick a name for your service account. Leave project access grants and user access grants empty.
+
+  Pick a name for your service account. Leave project access grants and user access grants empty.
     ![service account creation](../../../img/googleoidc/serviceacct-creation.png)
-  - Click the newly-created account to view its details, and copy the Unique ID for later.
+  
+  Click the newly-created account to view its details, and copy the Unique ID for later.
     ![service account unique ID](../../../img/googleoidc/serviceacct-uniqueid.png)
-  - Create a new key for the service account, select JSON as the key type, and save the resulting JSON file.
+
+  Create a new key for the service account, select JSON as the key type, and save the resulting JSON file.
     ![service account key creation](../../../img/googleoidc/serviceacct-key.png)
-    This JSON file will need to be uploaded to the Teleport Auth Server, and will be later referenced by
-    the OIDC Connector, under `google_service_account_uri` or inline with `google_service_account`.
+    Later, we will make this JSON available to the Teleport Auth Server via the OIDC Connector configuration, either by referencing a local file or pasting the JSON into the configuration YAML. If you plan to take the first approach, you will need to upload the JSON to the Auth Server.
 
 <Admonition type="note">
-  Teleport requires the service account JSON to be uploaded to all Teleport Auth Servers when setting
-  up in a High Availability config.
+  Teleport requires the service account JSON to be available to all Teleport Auth Server hosts when deploying Teleport in a High Availability configuration. Unless you paste the JSON into the OIDC Connector configuration, you will need to upload the JSON file to all Auth Server hosts.
 </Admonition>
 
 - Configure [domain-wide
   delegation](https://admin.google.com/ac/owl/domainwidedelegation) for your
   newly-created service account:
-  - Click "Add new" and add the numeric Unique ID that you've copied earlier.
+
+  Click "Add new" and add the numeric Unique ID that you've copied earlier.
     ![domain-wide delegation](../../../img/googleoidc/domainwidedelegation.png)
-  - Add either the
+
+  Add either the
     `https://www.googleapis.com/auth/cloud-identity.groups.readonly` scope or
     the `https://www.googleapis.com/auth/admin.directory.group.readonly` scope.
     The scope granted to the service account will determine if Teleport will
     fetch both direct and indirect groups or just direct groups, respectively.
 
-<Admonition
-  type="tip"
-  title="Warning"
->
-  Do not use the email of the service account. The configuration display will look the same but the service account will not have the domain-wide delegation required. The `client_id` field must be the unique ID number captured from the Google Cloud Platform UI. An indicator that this is misconfigured is if you see "invalid Google Workspace credentials for scopes [...]" in your log.
-</Admonition>
 
-<Admonition
-  type="tip"
-  title="Note"
->
-  The email that you set for `google_admin_email` **must** be the email address of a user that has permission to list all groups, users, and group membership in your Google Workspace account. This user will generally need super admin or group admin privileges.
-</Admonition>
+## Create an OIDC connector
 
-## Create a OIDC Connector
-
-Now, create a OIDC connector [resource](../../setup/reference/resources.mdx).
-There are two options for setting the `google_service_account` value.  You can set the JSON file in the auth server and give a URI to the file.
-The second is populating the contents via inline.  Inline is required for Teleport Cloud.
-Write down this template as `gworkspace-connector.yaml`:
-
-
+Create the following OIDC connector [resource spec](../../setup/reference/resources.mdx) as `gworkspace-connector.yaml`. We will explain how to choose values for fields within the resource spec below.
 
 <Tabs>
-  <TabItem label="Google Service Account via URI">
+  <TabItem scope={["oss", "enterprise"]} label="Self Hosted">
     ```yaml
     (!examples/resources/gworkspace-connector.yaml!)
     ```
   </TabItem>
 
-  <TabItem label="Google Service Account via inline (required for Teleport Cloud)">
+  <TabItem scope={["cloud"]} label="Teleport Cloud">
     ```yaml
     (!examples/resources/gworkspace-connector-inline.yaml!)
     ```
   </TabItem>
 </Tabs>
 
+The email that you set for `google_admin_email` **must** be the email address of a user that has permission to list all groups, users, and group membership in your Google Workspace account. This user will generally need super admin or group admin privileges.
 
-Create the connector using `tctl` tool:
+
+Do not use the email of the service account for `google_admin_email`. The configuration display will look the same, but the service account will not have the required domain-wide delegation.
+
+The `client_id` field must be the unique ID number captured from the Google Cloud Platform UI. An indicator that this is misconfigured is if you see "invalid Google Workspace credentials for scopes [...]" in your log.
+
+Create the connector using the `tctl` tool:
 
 ```code
 $ tctl create gworkspace-connector.yaml
@@ -202,22 +199,36 @@ automatically in a browser).
 
 ## Troubleshooting
 
-If you get "access denied" errors the number one place to check is the audit
-log on the Teleport auth server. It is located in `/var/lib/teleport/log` by
-default and it will contain the detailed reason why a user's login was denied.
+<Tabs>
+<TabItem label="Self Hosted" scope={["oss", "enterprise"]}>
+If you get "access denied" errors, the number one place to check is the audit
+log on the Teleport Auth Server. It is located in `/var/lib/teleport/log` by
+default and it will contain a detailed reason why a user's login was denied.
 
-Example of a user being denied due as the role `clusteradmin` wasn't setup.
+Example of a user being denied because the role `clusteradmin` wasn't set up.
 
 ```json
 {"code":"T1001W","error":"role clusteradmin is not found","event":"user.login","method":"oidc","success":false,"time":"2019-06-15T19:38:07Z","uid":"cd9e45d0-b68c-43c3-87cf-73c4e0ec37e9"}
 ```
 
-Some errors (like filesystem permissions or misconfigured network) can be
+Some errors (like filesystem permissions or a misconfigured network) can be
 diagnosed using Teleport's `stderr` log, which is usually available via:
 
 ```code
 $ sudo journalctl -fu teleport
 ```
 
-If you wish to increase the verbosity of Teleport's syslog, you can pass the
-[`--debug`](../../setup/reference/cli.mdx#teleport-start) flag to `teleport start` command.
+If you wish to increase the verbosity of Teleport's logs, you can pass the
+[`--debug`](../../setup/reference/cli.mdx#teleport-start) flag to the `teleport start` command.
+</TabItem>
+<TabItem label="Teleport Cloud" scope={["cloud"]}>
+If you get "access denied" errors, the number one place to check is the audit
+log on the Teleport Auth Server. You can find it in the **Activity** tab of the Teleport Web UI.
+
+Example of a user being denied because the role `clusteradmin` wasn't set up.
+
+```json
+{"code":"T1001W","error":"role clusteradmin is not found","event":"user.login","method":"oidc","success":false,"time":"2019-06-15T19:38:07Z","uid":"cd9e45d0-b68c-43c3-87cf-73c4e0ec37e9"}
+```
+</TabItem>
+</Tabs>

--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -26,7 +26,8 @@ Teleport Enhanced Session Recording mitigates all three concerns by providing ad
 
 ## Prerequisites
 
-Teleport 7.0+ with Enhanced Session Recording requires Linux kernel 5.8 (or above).
+- Teleport 7.0+ (Open Source, Enterprise, or Cloud) with at least one Teleport node. 
+- The node must run Linux kernel 5.8 (or above).
 
 <Admonition type="tip">
   Our Standard Session Recording works with older Linux Kernels. View our [audit log docs](../../architecture/authentication.mdx#audit-log) for more details.
@@ -56,8 +57,7 @@ $ uname -r
 
 ## Step 1/3. Install and configure Teleport node
 
-Follow our [installation instructions](../../installation.mdx) to install Teleport Auth, Proxy
-and Nodes.
+Follow our [installation instructions](../../installation.mdx) to install the Teleport Auth Service, Proxy Service, and Nodes. To get started with Teleport Cloud, sign up for a [free trial](https://goteleport.com/signup/). 
 
 Set up the Teleport node with this `etc/teleport.yaml`. See our [configuration file setup](../../setup/reference/config.mdx) for more instructions.
 

--- a/docs/pages/server-access/guides/restricted-session.mdx
+++ b/docs/pages/server-access/guides/restricted-session.mdx
@@ -9,9 +9,14 @@ With a Restricted Session, Teleport allows the administrator to specify a policy
 apply to SSH sessions. This policy can restrict access to certain resources. Currently
 Teleport supports network restrictions with more types coming in the future.
 
+<Admonition type="tip" title="Compatibility Note">
+This guide applies to Teleport Nodes. You can set up a Restricted Session while running the Open Source, Enterprise, or Cloud versions of the Teleport Auth Service and Proxy Service.
+</Admonition>
+
 ## Prerequisites
 
 Teleport 7.0+ with Restricted Sessions requires Linux kernel 5.8 (or above).
+
 
 You can check your kernel version using the `uname` command. The output should look
 something like the following.
@@ -47,8 +52,7 @@ Network restrictions work similar to a firewall but with several differences:
 
 ## Step 1/4. Install and configure Teleport node
 
-Follow our [installation instructions](../../installation.mdx) to install Teleport Auth, Proxy
-and Nodes.
+Follow our [installation instructions](../../installation.mdx) to install Teleport Auth Service, Proxy Service, and Nodes. For Teleport's managed deployments of the Auth Service and Proxy Service, sign up for a [free trial](https://goteleport.com/signup/) of Teleport Cloud.
 
 Set up the Teleport node with this `/etc/teleport.yaml`. See our [configuration file setup](../../setup/reference/config.mdx) for more instructions.
 

--- a/docs/pages/setup/deployments/aws-terraform.mdx
+++ b/docs/pages/setup/deployments/aws-terraform.mdx
@@ -7,6 +7,13 @@ h1: Running Teleport Enterprise in High Availability mode on AWS
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to use and administrate the resulting Teleport deployment.
 
+<Details scope={["cloud"]} scopeOnly={true} opened={true} title="Teleport Cloud">
+Our reference Terraform code deploys self-hosted instances of the Teleport Auth Service and Proxy Service. Since Teleport Cloud manages these services for you, users interested in Terraform should consult the following guides instead of this one:
+
+- To get started with Teleport and Terraform: [Terraform Provider](../guides/terraform-provider.mdx)
+- For a full reference: [Terraform Provider Resources](../reference/terraform-provider.mdx)
+</Details>
+
 ## Prerequisites
 
 Our code requires Terraform 0.12+. You can [download Terraform here](https://www.terraform.io/downloads.html). We will assume that you have

--- a/docs/pages/setup/guides/docker.mdx
+++ b/docs/pages/setup/guides/docker.mdx
@@ -9,6 +9,10 @@ This section will cover:
 - Getting started with a local Teleport using Docker.
 - Using Teleport with Teleport's native client, `tsh`.
 
+<Details scope={["cloud"]} title="Teleport Cloud" scopeOnly={true} opened={true}>
+Teleport Cloud includes managed instances of Teleport's Auth Service and Proxy Service. Since all of Teleport's services are run from the same binary, you can use our Docker image to run other services (e.g., the Database Service or App Service), or explore the Auth and Proxy Services locally.
+</Details>
+
 ## Prerequisites
 
 - Teleport v(=teleport.version=) Open Source or Enterprise.
@@ -19,6 +23,7 @@ $ docker version
 # Client: Docker Engine - Community
 # Version:           (=docker.version=)
 ```
+
 
 ## Step 1/4. Pick your image
 

--- a/docs/pages/setup/operations/scaling.mdx
+++ b/docs/pages/setup/operations/scaling.mdx
@@ -10,6 +10,10 @@ deployments of Teleport.
 
 - Teleport v(=teleport.version=) Open Source or Enterprise.
 
+<Details scope={["cloud"]} scopeOnly={true} title="Teleport Cloud Compatibility" opened={true}>
+For Teleport Cloud customers, the settings in this guide are configured automatically.
+</Details>
+
 ## Hardware recommendations
 
 Set up Teleport with a [High Availability configuration](../reference/backends.mdx).


### PR DESCRIPTION
Backports #9962

- Edit the Google Workspace SSO guide to mention Teleport
  Cloud in the Prerequisites and add scoped Tabs components.
  Also add clarity edits.

- Edit the Azure AD SSO guide to mention Teleport Cloud and
  included scoped Tabs components.

- Add compabitility warning to the HSM guide, scaling guide,
  Docker guide, restricted session, and aws-terraform guide.

- Mention the cloud in session recording prerequisites.