### PR TITLE
[v9] Restore teleport private deb/rpm gating

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4838,11 +4838,16 @@ steps:
   # this step exits early and skips all remaining steps in the pipeline if the
   # tag looks like a pre-release, to avoid pushing pre-release RPMs and DEBs to
   # our yum / apt repos.
+  - name: Check if repo is public
+    image: alpine
+    commands:
+      - if [ "${DRONE_REPO}" != "gravitational/teleport" ]; then echo "---> Not publishing ${DRONE_REPO} packages to RPM and DEB repos" && exit 78; fi
+
   - name: Check if tag is prerelease
     image: golang:1.17-alpine
     commands:
       - cd /go/src/github.com/gravitational/teleport/build.assets/tooling
-      - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> Not publishing ${DRONE_REPO} packages to RPM and DEB repos' && exit 78)
+      - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> Not publishing ${DRONE_TAG} packages to RPM and DEB repos' && exit 78)
 
   - name: Download RPM repo contents
     image: amazon/aws-cli
@@ -5035,6 +5040,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 7212c3b6f83e020958e4c90cacee6b2b746c728ee0a22d3ce4605f40273f0115
+hmac: 0c5316489efc1bfa9acfd87bed0e2807ec4f2b8e123649c168c9d675e3c8a4cc
 
 ...


### PR DESCRIPTION
v9 backport of https://github.com/gravitational/teleport/pull/10532

## Summary
This gating was removed in #9783, and should not have been.

(cherry picked from commit ef6734597cd31f03ff272a0912d90375f9712128)

## Testing Done
None, beyond making sure the drone signature is correct, and the testing in https://github.com/gravitational/teleport/pull/10532.

