### PR TITLE
[v8] Restore teleport private deb/rpm gating

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5009,11 +5009,16 @@ steps:
   # this step exits early and skips all remaining steps in the pipeline if the
   # tag looks like a pre-release, to avoid pushing pre-release RPMs and DEBs to
   # our yum / apt repos.
+  - name: Check if repo is public
+    image: alpine
+    commands:
+      - if [ "${DRONE_REPO}" != "gravitational/teleport" ]; then echo "---> Not publishing ${DRONE_REPO} packages to RPM and DEB repos" && exit 78; fi
+
   - name: Check if tag is prerelease
     image: golang:1.17-alpine
     commands:
       - cd /go/src/github.com/gravitational/teleport/build.assets/version-check
-      - go run . -tag ${DRONE_TAG} -check prerelease || (echo '---> Not publishing ${DRONE_REPO} packages to RPM and DEB repos' && exit 78)
+      - go run . -tag ${DRONE_TAG} -check prerelease || (echo '---> Not publishing ${DRONE_TAG} packages to RPM and DEB repos' && exit 78)
 
   - name: "RPM: Download RPM repository"
     image: amazon/aws-cli
@@ -5215,6 +5220,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 1c1409a92ceaf1dcc9d9c29d757ab339a37676fff15a1f679a21185b9848ad1a
+hmac: 0486432e47dfd079f2ac8d8a11c82482df07258dfd2d19d6ae02228c25a9e746
 
 ...


### PR DESCRIPTION
v8 backport of https://github.com/gravitational/teleport/pull/10532

## Summary
This gating was removed in #9783, and should not have been.

(cherry picked from commit ef6734597cd31f03ff272a0912d90375f9712128)

## Testing Done
None, beyond making sure the drone signature is correct, and the testing in https://github.com/gravitational/teleport/pull/10532.

## Notes

This is as far back as this needs to go -- the offending chanseset didn't go to v7 or previous.

This will conflict with https://github.com/gravitational/teleport/pull/10436, which touches some of the same lines. The 2nd to merge will need to resolve conflicts.
