### PR TITLE
[v7 backport] Expose reverse tunnel address to web ui

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -102,8 +102,8 @@ type Handler struct {
 	// from configuration
 	sshPort string
 
-	// clusterFeatures contain flags for supported and unsupported features.
-	clusterFeatures proto.Features
+	// ClusterFeatures contain flags for supported and unsupported features.
+	ClusterFeatures proto.Features
 }
 
 // HandlerOption is a functional argument - an option that can be passed
@@ -222,7 +222,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 		cfg:             cfg,
 		log:             newPackageLogger(),
 		clock:           clockwork.NewRealClock(),
-		clusterFeatures: cfg.ClusterFeatures,
+		ClusterFeatures: cfg.ClusterFeatures,
 	}
 
 	for _, o := range opts {
@@ -538,7 +538,7 @@ func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httpr
 		return nil, trace.Wrap(err)
 	}
 
-	userContext, err := ui.NewUserContext(user, roleset, h.clusterFeatures)
+	userContext, err := ui.NewUserContext(user, roleset, h.ClusterFeatures)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -845,9 +845,16 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		AuthType:         authType,
 	}
 
+	// get tunnel address to display on cloud instances
+	tunnelPublicAddr := ""
+	if h.ClusterFeatures.GetCloud() {
+		tunnelPublicAddr = h.cfg.ProxySettings.SSH.TunnelListenAddr
+	}
+
 	webCfg := ui.WebConfig{
-		Auth:            authSettings,
-		CanJoinSessions: canJoinSessions,
+		Auth:                authSettings,
+		CanJoinSessions:     canJoinSessions,
+		TunnelPublicAddress: tunnelPublicAddr,
 	}
 
 	resource, err := h.cfg.ProxyClient.GetClusterName()

--- a/lib/web/ui/webconfig.go
+++ b/lib/web/ui/webconfig.go
@@ -43,6 +43,8 @@ type WebConfig struct {
 	CanJoinSessions bool `json:"canJoinSessions"`
 	// ProxyClusterName is the name of the local cluster
 	ProxyClusterName string `json:"proxyCluster,omitempty"`
+	// TunnelPublicAddress is the public ssh tunnel address
+	TunnelPublicAddress string `json:"tunnelPublicAddress,omitempty"`
 }
 
 // WebConfigAuthProvider describes auth. provider


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/10133

webapps v7 backport: gravitational/webapps#618

__

v8 backport: https://github.com/gravitational/teleport/pull/10514

___

The ultimate purpose is to show the reverse tunnel address on Help & Support screen on the web UI.

On cloud instances, we use a custom reverse tunnel port for each tenant. In the UI, there is no way to know your reverse tunnel address, which is necessary when adding a trusted cluster.

This PR adds the reverse tunnel address to the GRV_CONFIG object that is injected into the web UI. I added it behind a feature flag to only show on cloud only, should we expose it to everyone?

Note that this field is already publicly exposed via GET [proxy server]/webapi/ping.