### PR TITLE
helm: Revert PodSecurityPolicy change

### DIFF
--- a/examples/chart/teleport-cluster/templates/psp.yaml
+++ b/examples/chart/teleport-cluster/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled -}}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ .Release.Name }}

--- a/examples/chart/teleport-kube-agent/templates/psp.yaml
+++ b/examples/chart/teleport-kube-agent/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled -}}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ .Release.Name }}


### PR DESCRIPTION
As per https://github.com/gravitational/teleport/pull/10344#issuecomment-1049264725, changing the `PodSecurityPolicy` from `v1beta1` to `v1` caused issues with installation. There will be a better way to fix this, but for now we'll just revert the change to unblock things.

Backports required:
- `branch/v8`
- `branch/v9`