### PR TITLE
Display correct error message when host is missing in `tctl auth sign`

### DIFF
--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -422,7 +422,7 @@ func (a *AuthCommand) generateDatabaseKeys(clusterAPI auth.ClientI) error {
 // for database access.
 func (a *AuthCommand) generateDatabaseKeysForKey(clusterAPI auth.ClientI, key *client.Key) error {
 	principals := strings.Split(a.genHost, ",")
-	if len(principals) == 0 {
+	if len(principals) == 1 && principals[0] == "" {
 		return trace.BadParameter("at least one hostname must be specified via --host flag")
 	}
 	// For CockroachDB node certificates, CommonName must be "node":


### PR DESCRIPTION
Currently when no `--host` flag is passed to ` tctl auth sign --format=db` 

```
User Message: missing parameter Subject.Common name
```

is being printed instead of intended:

```
User Message: at least one hostname must be specified via --host flag
```

Explanation: https://pkg.go.dev/strings#Split
> If s does not contain sep and sep is not empty, Split returns a slice of length 1 whose only element is s.