### PR TITLE
Standardized language on enterprise/cloud version warning for enterprise guides

### DIFF
--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -15,14 +15,7 @@ Here are the most common scenarios:
 Let's set up Teleport's access requests to require approval of
 two team members for a privileged role `dbadmin`.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
->
-  This guide requires a commercial edition of Teleport. The open source
-  edition of Teleport only supports [Github](../../setup/admin/github-sso.mdx) as
-  an SSO provider.
-</Admonition>
+(!docs/pages/includes/versionwarning.mdx!)
 
 <Admonition title="Note" type="tip">
   The steps below describe how to use Teleport with Mattermost. You can also [integrate with many other providers](../../enterprise/workflow/index.mdx).

--- a/docs/pages/enterprise/hsm.mdx
+++ b/docs/pages/enterprise/hsm.mdx
@@ -6,6 +6,12 @@ h1: Teleport HSM Support
 
 This guide will show you how to set up the Teleport Auth Server to use a hardware security module (HSM) to store and handle private keys.
 
+<Admonition
+  type="warning"
+  title="Version Warning"
+>
+  This guide requires either an Enterprise version of Teleport.
+</Admonition>
 ## Prerequisites
 
 - Teleport v(=teleport.version=) Enterprise (self-hosted).

--- a/docs/pages/enterprise/hsm.mdx
+++ b/docs/pages/enterprise/hsm.mdx
@@ -10,7 +10,7 @@ This guide will show you how to set up the Teleport Auth Server to use a hardwar
   type="warning"
   title="Version Warning"
 >
-  This guide requires either an Enterprise version of Teleport.
+  This guide requires an Enterprise version of Teleport.
 </Admonition>
 ## Prerequisites
 

--- a/docs/pages/enterprise/sso/azuread.mdx
+++ b/docs/pages/enterprise/sso/azuread.mdx
@@ -12,12 +12,7 @@ SSH credentials to specific groups of users with a SAML Authentication Connector
 
 The following steps configure an example SAML authentication connector matching Azure AD groups with security roles.  You can choose to configure other options.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
->
-  This guide requires either an Enterprise version of Teleport or a Teleport Cloud account.
-</Admonition>
+(!docs/pages/includes/versionwarning.mdx!)
 
 ## Prerequisites
 
@@ -59,7 +54,7 @@ Before you get started you’ll need:
    ![Edit Basic SAML Configuration](../../../img/azuread/azuread-7-editbasicsaml.png)
 
 8. For **Entity ID** and **Reply URL**, enter the same proxy URL.
-  
+
    For self-hosted deployments, the URL will be similar to `https://teleport.example.com:3080/v1/webapi/saml/acs`.
 
    For Teleport Cloud users, the URL will be similar to `https://mytenant.teleport.sh`.
@@ -355,7 +350,7 @@ spec:
     private_key: |
       -----BEGIN RSA PRIVATE KEY-----
       New private key
-      -----END RSA PRIVATE KEY-----  
+      -----END RSA PRIVATE KEY-----
   signing_key_pair:
     cert: |
       -----BEGIN CERTIFICATE-----
@@ -372,7 +367,7 @@ version: v2
 Update the connector:
 
 ```code
-$ tctl create -f azure-out.yaml 
+$ tctl create -f azure-out.yaml
 ```
 
 ### Activate token encryption

--- a/docs/pages/enterprise/sso/gitlab.mdx
+++ b/docs/pages/enterprise/sso/gitlab.mdx
@@ -15,12 +15,7 @@ like:
 - Only members of "ProductionKubernetes" can access production Kubernetes clusters
 - Developers must never SSH into production servers.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
->
-  This guide requires a commercial edition of Teleport.
-</Admonition>
+(!docs/pages/includes/versionwarning.mdx!)
 
 ## Enable OIDC Authentication
 

--- a/docs/pages/enterprise/sso/google-workspace.mdx
+++ b/docs/pages/enterprise/sso/google-workspace.mdx
@@ -16,12 +16,7 @@ to define policies like:
 - Developers must never SSH into production servers.
 - ... and many others.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
->
-  This guide requires an enterprise version of Teleport.
-</Admonition>
+(!docs/pages/includes/versionwarning.mdx!)
 
 ## Prerequisites
 
@@ -75,7 +70,7 @@ to `v3`.
     ![configuration of the OAuth consent screen](../../../img/googleoidc/consent-screen-1.png)
 
   Configure the appearence of your connector by picking a visible name, user support email, etc.
-  
+
   Select the `.../auth/userinfo.email` and `openid` scopes.
     ![select email and openid scopes](../../../img/googleoidc/consent-screen-2.png)
 
@@ -93,7 +88,7 @@ to `v3`.
 
   Pick a name for your service account. Leave project access grants and user access grants empty.
     ![service account creation](../../../img/googleoidc/serviceacct-creation.png)
-  
+
   Click the newly-created account to view its details, and copy the Unique ID for later.
     ![service account unique ID](../../../img/googleoidc/serviceacct-uniqueid.png)
 

--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -13,12 +13,7 @@ administrators to define policies like:
 - Developers must never SSH into production servers.
 - ... and many others.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
->
-  This guide requires an Enterprise edition of Teleport.
-</Admonition>
+(!docs/pages/includes/versionwarning.mdx!)
 
 ## Enable OIDC Authentication
 

--- a/docs/pages/enterprise/sso/okta.mdx
+++ b/docs/pages/enterprise/sso/okta.mdx
@@ -15,12 +15,7 @@ like:
 - Only members of "DBA" group can SSH into machines running PostgreSQL.
 - Developers must never SSH into production servers.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
->
-  This guide requires a commercial edition of Teleport.
-</Admonition>
+(!docs/pages/includes/versionwarning.mdx!)
 
 ## Enable SAML Authentication
 
@@ -116,11 +111,11 @@ $ tctl create okta-connector.yaml
 
 ## Create a Developer Teleport Role
 
-We are going to create a new role that'll pull in external information from Okta. Notice 
-`{{external.username}}` login. It configures Teleport to look at *"username"* Okta claim 
-and use that field as an allowed login for each user.  This example uses email as the 
-username format.  The `email.local(external.trait)` function will remove the `@domain` 
-and just have the username prefix.  
+We are going to create a new role that'll pull in external information from Okta. Notice
+`{{external.username}}` login. It configures Teleport to look at *"username"* Okta claim
+and use that field as an allowed login for each user.  This example uses email as the
+username format.  The `email.local(external.trait)` function will remove the `@domain`
+and just have the username prefix.
 
 ```yaml
 kind: role

--- a/docs/pages/enterprise/sso/one-login.mdx
+++ b/docs/pages/enterprise/sso/one-login.mdx
@@ -15,12 +15,7 @@ like:
 - Developers must never SSH into production servers.
 - ... and many others.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
->
-  This guide requires an Enterprise edition of Teleport.
-</Admonition>
+(!docs/pages/includes/versionwarning.mdx!)
 
 ## Enable SAML Authentication
 
@@ -124,7 +119,7 @@ $ tctl create onelogin-connector.yaml
 ## Create a new Teleport Role
 
 We are going to create a new that'll use external username data from OneLogin
-to map to a host linux login. 
+to map to a host linux login.
 
 In the below role, Devs are only allowed to login to nodes labelled with `access: relaxed`
 Teleport label. Developers can log in as either `ubuntu` to a username that

--- a/docs/pages/includes/versionwarning.mdx
+++ b/docs/pages/includes/versionwarning.mdx
@@ -1,0 +1,6 @@
+<Admonition
+  type="warning"
+  title="Version Warning"
+>
+  This guide requires either an Enterprise version of Teleport or a Teleport Cloud account.
+</Admonition>


### PR DESCRIPTION
Added a page include for the version warning you need enterprise or teleport cloud.  Also added version warning to HSM page that wasn't there before.