### PR TITLE
(v9) Fix artifacts path for build-darwin-amd64-pkg-tsh drone pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3113,9 +3113,9 @@ steps:
     ARCH: amd64
     BUILDBOX_PASSWORD:
       from_secret: BUILDBOX_PASSWORD
-    ENT_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
+    ENT_TARBALL_PATH: /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
     OS: darwin
-    OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
+    OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
     WORKSPACE_DIR: /tmp/build-darwin-amd64-pkg-tsh
 - name: Copy Mac pkg artifacts
   commands:
@@ -5040,6 +5040,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 0c5316489efc1bfa9acfd87bed0e2807ec4f2b8e123649c168c9d675e3c8a4cc
+hmac: 2fa9a32bf1f8b0fe5ef6abb7b0cdd30df5cd8813ca2bdbc3fdbd9b1d7296f459
 
 ...


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/10599 backport.