### PR TITLE
(v8) Fix artifacts path for build-darwin-amd64-pkg-tsh drone pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3266,9 +3266,9 @@ steps:
     ARCH: amd64
     BUILDBOX_PASSWORD:
       from_secret: BUILDBOX_PASSWORD
-    ENT_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
+    ENT_TARBALL_PATH: /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
     OS: darwin
-    OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
+    OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
     WORKSPACE_DIR: /tmp/build-darwin-amd64-pkg-tsh
 - name: Copy Mac pkg artifacts
   commands:
@@ -5220,6 +5220,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 3acbcbdb643d0819a97430b05c46591ce9ea72e14f8cb9591d8b13ee96e89ef6
+hmac: c86a7ce07ccdd38eb5e3e458b357d71592f8bda3401cd630774bbc0fbeeadecb
 
 ...


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/10599 backport.