### PR TITLE
Remove possibly racy errno

### DIFF
--- a/lib/srv/uacc/uacc.h
+++ b/lib/srv/uacc/uacc.h
@@ -101,11 +101,6 @@ static int check_abs_path_err(const char* buffer) {
     return 0;
 }
 
-// Allow the Go side to read errno.
-static int get_errno() {
-    return errno;
-}
-
 // The max byte length of the C string representing the TTY name.
 static int max_len_tty_name() {
     return UT_LINESIZE;


### PR DESCRIPTION
@espadolini pointed out a bug with uacc code where in a goroutine could change thread between the cgo call and code to fetch errno. Since errno is a thread local, this could result in fetching errno from another thread.

This PR has been merged into open backports for #10460 