### PR TITLE
Fix meta description clash

### DIFF
--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -12,8 +12,12 @@ security feature that protects users against compromises of their on-disk
 Teleport certificates.
 
 <Admonition type="note">
-  In addition to per-session MFA, enable login MFA in your SSO provider and/or for all [local Teleport
-  users](../../setup/reference/authentication.mdx#local) to improve security.
+
+  In addition to per-session MFA, enable login MFA in your SSO provider and/or
+  for all [local Teleport
+  users](../../setup/reference/authentication.mdx#local-no-authentication-connector)
+  to improve security.
+
 </Admonition>
 
 <Details

--- a/docs/pages/access-controls/guides/u2f.mdx
+++ b/docs/pages/access-controls/guides/u2f.mdx
@@ -128,7 +128,7 @@ $ tsh login --proxy=example.com
 
 <Admonition type="note">
 U2F for logging into Teleport is only required for [local
-users](../../setup/reference/authentication.mdx#local). SSO users should configure
+users](../../setup/reference/authentication.mdx#local-no-authentication-connector). SSO users should configure
 multi-factor authentication in their SSO provider.
 </Admonition>
 

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -142,7 +142,7 @@ $ tsh login --proxy=example.com
 
 <Admonition type="note">
   WebAuthn for logging into Teleport is only required for [local users](
-  ../../setup/reference/authentication.mdx#local). SSO users should configure
+  ../../setup/reference/authentication.mdx#local-no-authentication-connector). SSO users should configure
   multi-factor authentication in their SSO provider.
 </Admonition>
 

--- a/docs/pages/setup/reference/authentication.mdx
+++ b/docs/pages/setup/reference/authentication.mdx
@@ -1,22 +1,21 @@
 ---
 title: Authentication options
-description: Teleport enterprise license file configuration parameters and requirements
+description: A reference for Teleport's authentication connectors
 ---
 
-Teleport uses the concept of "authentication connectors" to authenticate users
-when they execute [`tsh login`](./cli.mdx#tsh-login) command. There are three
-types of authentication connectors:
+Teleport uses the concept of **authentication connectors** to authenticate users
+when they execute the [`tsh login`](./cli.mdx#tsh-login) command. There are three
+types of authentication connectors.
 
 ## Local
 
 Local authentication is used to authenticate against a local Teleport user
-database. This database is managed by [`tctl users`](./cli.mdx#tctl-users-add)
+database. This database is managed by the [`tctl users`](./cli.mdx#tctl-users-add)
 command. Teleport also supports second-factor authentication (2FA) for the local
 connector. There are several possible values (types) of 2FA:
 
-- `otp` is the default. It implements [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
-  standard. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator)
-  or [Authy](https://www.authy.com/) or any other TOTP client.
+- `otp` is the default. It implements the [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
+  standard. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator), [Authy],(https://www.authy.com/) or any other TOTP client.
 - `webauthn` implements the [Web Authentication standard](https://webauthn.guide) for utilizing
   second factor authenticators and hardware devices.
   You can use [YubiKeys](https://www.yubico.com/), [SoloKeys](https://solokeys.com/) or any other authenticator that
@@ -63,13 +62,12 @@ You can modify these settings in the static config `teleport.yaml` or using dyna
 </Tabs>
   
 <Admonition type="note">
-  SSO users can also register 2FA devices, but Teleport will not prompt them for 2FA during login. Login 2FA for SSO users should be handled by the SSO
-  provider.
+  SSO users can also register 2FA devices, but Teleport will not prompt them for 2FA during login. Login 2FA for SSO users should be handled by the SSO provider.
 </Admonition>
 
 ## GitHub
 
-This connector implements Github OAuth 2.0 authentication flow. Please refer to GitHub documentation on [Creating an OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/)
+This connector implements GitHub's OAuth 2.0 authentication flow. Please refer to GitHub's documentation on [Creating an OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/)
 to learn how to create and register an OAuth app.
 
 Here is an example of this setting in the `teleport.yaml` :
@@ -84,9 +82,9 @@ See [Github OAuth 2.0](../admin/github-sso.mdx) for details on how to configure 
 
 ## SAML
 
-<Admonition type="note">
-You need Enterprise edition of Teleport for this option.
-</Admonition>
+<Notice type="note">
+You need the Enterprise edition of Teleport for this option.
+</Notice>
 
 This connector type implements SAML authentication. It can be configured against any external identity manager like Okta or Auth0. This feature is only available for Teleport Enterprise.
 
@@ -100,9 +98,9 @@ auth_service:
 
 ### OIDC
 
-<Admonition type="note">
-You need Enterprise edition of Teleport for this option.
-</Admonition>
+<Notice type="note">
+You need the Enterprise edition of Teleport for this option.
+</Notice>
 
 Teleport implements OpenID Connect (OIDC) authentication, which is similar to SAML in principle.
 

--- a/docs/pages/setup/reference/authentication.mdx
+++ b/docs/pages/setup/reference/authentication.mdx
@@ -3,11 +3,10 @@ title: Authentication options
 description: A reference for Teleport's authentication connectors
 ---
 
-Teleport uses the concept of **authentication connectors** to authenticate users
-when they execute the [`tsh login`](./cli.mdx#tsh-login) command. There are three
-types of authentication connectors.
+Teleport authenticates users with an identity provider via **authentication
+connectors**. There are three types of authentication connectors.
 
-## Local
+## Local (no authentication connector)
 
 Local authentication is used to authenticate against a local Teleport user
 database. This database is managed by the [`tctl users`](./cli.mdx#tctl-users-add)

--- a/docs/pages/setup/reference/license.mdx
+++ b/docs/pages/setup/reference/license.mdx
@@ -7,7 +7,10 @@ Commercial Teleport subscriptions require a valid license. The license file can
 be downloaded from the [Teleport Customer
 Portal](https://dashboard.gravitational.com/web/login).
 
-The Teleport license file contains a X.509 certificate and the corresponding private key in PEM format. Place the downloaded file on Auth servers and set the `license_file` configuration parameter of your `teleport.yaml` to point to the file location:
+The Teleport license file contains an X.509 certificate and the corresponding
+private key in PEM format. Place the downloaded file on your Teleport Auth
+Servers and set the `license_file` configuration parameter of your
+`teleport.yaml` to point to the file location:
 
 ```yaml
 auth_service:
@@ -22,5 +25,5 @@ The `license_file` path can be either absolute or relative to the configured
   type="tip"
   title="NOTE"
 >
-  Only Auth servers require the license. Proxies and Nodes that do not also have Auth role enabled do not need the license.
+  Only Auth Servers require the license. Proxies and Nodes that do not also have Auth role enabled do not need the license.
 </Admonition>


### PR DESCRIPTION
Two docs pages have the same meta description, which hurts SEO.
This changes the meta description of one of the page and uses
this opportunity to do some light copy editing.

Fixes #8713