### PR TITLE
helm: Fix indenting on database autodiscovery

### DIFF
--- a/examples/chart/teleport-kube-agent/aws-and-manual-db.yaml
+++ b/examples/chart/teleport-kube-agent/aws-and-manual-db.yaml
@@ -1,0 +1,21 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: db
+awsDatabases:
+- types: ["rds"]
+  regions: ["us-east-1"]
+  tags:
+    "*": "*"
+- types: ["rds"]
+  regions: ["us-west-2"]
+  tags:
+    "env": "development"
+databases:
+- name: aurora
+  uri: "postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432"
+  protocol: "postgres"
+  labels:
+    database: staging
+annotations:
+  serviceAccount:
+    eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/my-rds-autodiscovery-role

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -56,9 +56,8 @@ data:
       {{- if not (or (.Values.awsDatabases) (.Values.databases)) }}
         {{- fail "'awsDatabases' and/or 'databases' is required in chart values when db role is enabled, see README" }}
       {{- end }}
-      databases:
       {{- if .Values.awsDatabases }}
-        aws:
+      aws:
         {{- range $awsDb := .Values.awsDatabases }}
           {{- if not (hasKey $awsDb "types") }}
             {{- fail "'types' is required for all 'awsDatabases' in chart values when key is set and db role is enabled, see README" }}
@@ -70,13 +69,11 @@ data:
             {{- fail "'tags' is required for all 'awsDatabases' in chart values when key is set and db role is enabled, see README" }}
           {{- end }}
         {{- end }}
-        {{- toYaml .Values.awsDatabases | nindent 8 }}
+        {{- toYaml .Values.awsDatabases | nindent 6 }}
       {{- end }}
       {{- if .Values.databases }}
+      databases:
         {{- range $db := .Values.databases }}
-          {{- if (and ($.Values.awsDatabases) (hasKey $db "aws")) }}
-            {{- fail "The 'aws' key cannot be used under 'databases' when 'awsDatabases' is also set - use autodiscovery for AWS databases, or run a separate agent without awsDatabases" }}
-          {{- end }}
           {{- if not (hasKey $db "name") }}
             {{- fail "'name' is required for all 'databases' in chart values when db role is enabled, see README" }}
           {{- end }}


### PR DESCRIPTION
I had previously assumed that `db_service.aws` and `db_service.databases.aws` were the same key; they are not. This PR fixes this error. It also removes the check for mutual exclusivity that I erroneously added before.

Backports required:
- `branch/v8`
- `branch/v9`