### PR TITLE
[v9] Backport: "helm: Fix enabled clause for db_service when using awsDatabases only"

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -85,9 +85,9 @@ data:
           {{- end }}
         {{- end }}
         {{- toYaml .Values.databases | nindent 6 }}
-      {{- else }}
-      enabled: false
       {{- end }}
+    {{- else }}
+      enabled: false
     {{- end }}
     {{- end }}
 


### PR DESCRIPTION
Backports #10643 to `branch/v9`