### PR TITLE
[v8] Disable BPF tests in CI (#10654)

### DIFF
--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -49,7 +49,13 @@ type Suite struct{}
 
 var _ = check.Suite(&Suite{})
 
-func TestRootBPF(t *testing.T) { check.TestingT(t) }
+func TestRootBPF(t *testing.T) {
+	if !bpfTestEnabled() {
+		t.Skip("BPF testing is disabled")
+	}
+
+	check.TestingT(t)
+}
 
 func (s *Suite) TestWatch(c *check.C) {
 	// This test must be run as root and the host has to be capable of running
@@ -497,4 +503,10 @@ func isRoot() bool {
 		return false
 	}
 	return true
+}
+
+// bpfTestEnabled returns true if BPF tests should run. Tests can be enabled by
+// setting TELEPORT_BPF_TEST environment variable to any value.
+func bpfTestEnabled() bool {
+	return os.Getenv("TELEPORT_BPF_TEST") != ""
 }

--- a/lib/bpf/common.go
+++ b/lib/bpf/common.go
@@ -125,17 +125,17 @@ func (c *Config) CheckAndSetDefaults() error {
 type NOP struct {
 }
 
-// Close will close the NOP service. Note this function does nothing.
+// Close closes the NOP service. Note this function does nothing.
 func (s *NOP) Close() error {
 	return nil
 }
 
-// OpenSession will open a NOP session. Note this function does nothing.
+// OpenSession opens a NOP session. Note this function does nothing.
 func (s *NOP) OpenSession(ctx *SessionContext) (uint64, error) {
 	return 0, nil
 }
 
-// OpenSession will open a NOP session. Note this function does nothing.
+// CloseSession closes a NOP session. Note this function does nothing.
 func (s *NOP) CloseSession(ctx *SessionContext) error {
 	return nil
 }

--- a/lib/restrictedsession/restricted_test.go
+++ b/lib/restrictedsession/restricted_test.go
@@ -141,7 +141,13 @@ type Suite struct {
 
 var _ = check.Suite(&Suite{})
 
-func TestRootRestrictedSession(t *testing.T) { check.TestingT(t) }
+func TestRootRestrictedSession(t *testing.T) {
+	if !bpfTestEnabled() {
+		t.Skip("BPF testing is disabled")
+	}
+
+	check.TestingT(t)
+}
 
 func mustParseIPSpec(cidr string) *net.IPNet {
 	ipnet, err := ParseIPSpec(cidr)
@@ -170,6 +176,7 @@ func (_ *mockClient) DeleteNetworkRestrictions(context.Context) error {
 
 func (s *Suite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests()
+
 	// This test must be run as root and the host has to be capable of running
 	// BPF programs.
 	if !isRoot() {
@@ -499,4 +506,10 @@ func (s *Suite) TestNetwork(c *check.C) {
 // for this package must be run as root.
 func isRoot() bool {
 	return os.Geteuid() == 0
+}
+
+// bpfTestEnabled returns true if BPF tests should run. Tests can be enabled by
+// setting TELEPORT_BPF_TEST environment variable to any value.
+func bpfTestEnabled() bool {
+	return os.Getenv("TELEPORT_BPF_TEST") != ""
 }


### PR DESCRIPTION
Run BPF tests only if TELEPORT_BPF_TEST environment variable is set. This should prevent on running those tests on machines that doesn't support BPF.

Backport #10654