### PR TITLE
[v6.2] Disable BPF tests in CI (#10654)

### DIFF
--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -42,7 +42,13 @@ type Suite struct{}
 
 var _ = check.Suite(&Suite{})
 
-func TestBPF(t *testing.T) { check.TestingT(t) }
+func TestBPF(t *testing.T) {
+	if !bpfTestEnabled() {
+		t.Skip("BPF testing is disabled")
+	}
+
+	check.TestingT(t)
+}
 
 func (s *Suite) TestWatch(c *check.C) {
 	// This test must be run as root and the host has to be capable of running
@@ -441,4 +447,10 @@ func isRoot() bool {
 		return false
 	}
 	return true
+}
+
+// bpfTestEnabled returns true if BPF tests should run. Tests can be enabled by
+// setting TELEPORT_BPF_TEST environment variable to any value.
+func bpfTestEnabled() bool {
+	return os.Getenv("TELEPORT_BPF_TEST") != ""
 }

--- a/lib/bpf/common.go
+++ b/lib/bpf/common.go
@@ -126,17 +126,17 @@ func (c *Config) CheckAndSetDefaults() error {
 type NOP struct {
 }
 
-// Close will close the NOP service. Note this function does nothing.
+// Close closes the NOP service. Note this function does nothing.
 func (s *NOP) Close() error {
 	return nil
 }
 
-// OpenSession will open a NOP session. Note this function does nothing.
+// OpenSession opens a NOP session. Note this function does nothing.
 func (s *NOP) OpenSession(ctx *SessionContext) (uint64, error) {
 	return 0, nil
 }
 
-// OpenSession will open a NOP session. Note this function does nothing.
+// CloseSession closes a NOP session. Note this function does nothing.
 func (s *NOP) CloseSession(ctx *SessionContext) error {
 	return nil
 }


### PR DESCRIPTION
Run BPF tests only if TELEPORT_BPF_TEST environment variable is set. This should prevent on running those tests on machines that doesn't support BPF.

Backport https://github.com/gravitational/teleport/pull/10654