### PR TITLE
Update CI to teleport10 buildbox

### DIFF
--- a/.cloudbuild/ci/integration-tests.yaml
+++ b/.cloudbuild/ci/integration-tests.yaml
@@ -11,7 +11,7 @@ steps:
 
   # Run the integration tests. Actual content of this job depends on the changes 
   # detected in the PR
-  - name: quay.io/gravitational/teleport-buildbox:go1.17.2
+  - name: quay.io/gravitational/teleport-buildbox:teleport10
     id: run-tests
     dir: /workspace/.cloudbuild/scripts
     entrypoint: bash

--- a/.cloudbuild/ci/lint.yaml
+++ b/.cloudbuild/ci/lint.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: quay.io/gravitational/teleport-buildbox:go1.17.2
+  - name: quay.io/gravitational/teleport-buildbox:teleport10
     id: lint
     args: ['make', 'lint']
 options:

--- a/.cloudbuild/ci/unit-tests.yaml
+++ b/.cloudbuild/ci/unit-tests.yaml
@@ -13,7 +13,7 @@ steps:
 
   # Run the unit tests. Actual content of this job depends on the changes 
   # detected in the PR
-  - name: quay.io/gravitational/teleport-buildbox:go1.17.2
+  - name: quay.io/gravitational/teleport-buildbox:teleport10
     id: run-tests
     dir: /workspace/.cloudbuild/scripts
     entrypoint: bash 


### PR DESCRIPTION
Further to the changes in #10611, updates the CI scripts to actually _use_ the generated images.