### PR TITLE
Add rate limiting to passwordless endpoints

### DIFF
--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -1966,62 +1966,75 @@ func TestListResources(t *testing.T) {
 func TestCustomRateLimiting(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name string
-		fn   func(*Client) error
+	ctx := context.Background()
+	tests := []struct {
+		name  string
+		burst int
+		fn    func(*Client) error
 	}{
 		{
 			name: "RPC ChangeUserAuthentication",
 			fn: func(clt *Client) error {
-				_, err := clt.ChangeUserAuthentication(context.Background(), &proto.ChangeUserAuthenticationRequest{})
+				_, err := clt.ChangeUserAuthentication(ctx, &proto.ChangeUserAuthenticationRequest{})
+				return err
+			},
+		},
+		{
+			name:  "RPC CreateAuthenticateChallenge",
+			burst: defaults.LimiterPasswordlessBurst,
+			fn: func(clt *Client) error {
+				_, err := clt.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{})
 				return err
 			},
 		},
 		{
 			name: "RPC GetAccountRecoveryToken",
 			fn: func(clt *Client) error {
-				_, err := clt.GetAccountRecoveryToken(context.Background(), &proto.GetAccountRecoveryTokenRequest{})
+				_, err := clt.GetAccountRecoveryToken(ctx, &proto.GetAccountRecoveryTokenRequest{})
 				return err
 			},
 		},
 		{
 			name: "RPC StartAccountRecovery",
 			fn: func(clt *Client) error {
-				_, err := clt.StartAccountRecovery(context.Background(), &proto.StartAccountRecoveryRequest{})
+				_, err := clt.StartAccountRecovery(ctx, &proto.StartAccountRecoveryRequest{})
 				return err
 			},
 		},
 		{
 			name: "RPC VerifyAccountRecovery",
 			fn: func(clt *Client) error {
-				_, err := clt.VerifyAccountRecovery(context.Background(), &proto.VerifyAccountRecoveryRequest{})
+				_, err := clt.VerifyAccountRecovery(ctx, &proto.VerifyAccountRecoveryRequest{})
 				return err
 			},
 		},
 	}
-
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			// For now since we only have one custom rate limit,
-			// test limit for 1 request per minute with bursts up to 10 requests.
-			const maxAttempts = 11
-			var err error
-
-			// Create new instance per test case, to troubleshoot
-			// which test case specifically failed, otherwise
-			// multiple cases can fail from running cases in parallel.
+			// Create new instance per test case, to troubleshoot which test case
+			// specifically failed, otherwise multiple cases can fail from running
+			// cases in parallel.
 			srv := newTestTLSServer(t)
 			clt, err := srv.NewClient(TestNop())
 			require.NoError(t, err)
 
-			for i := 0; i < maxAttempts; i++ {
-				err = c.fn(clt)
-				require.Error(t, err)
+			var attempts int
+			if test.burst == 0 {
+				attempts = 10 // Good for most tests.
+			} else {
+				attempts = test.burst
 			}
-			require.True(t, trace.IsLimitExceeded(err))
+
+			for i := 0; i < attempts; i++ {
+				err = test.fn(clt)
+				require.False(t, trace.IsLimitExceeded(err), "got err = %v, want non-IsLimitExceeded", err)
+			}
+
+			err = test.fn(clt)
+			require.True(t, trace.IsLimitExceeded(err), "got err = %v, want LimitExceeded", err)
 		})
 	}
 }

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -468,6 +468,17 @@ const (
 	LimiterMaxConcurrentSignatures = 10
 )
 
+// Default rate limits for unauthenticated passwordless endpoints.
+const (
+	// LimiterPasswordlessPeriod is the default period for passwordless limiters.
+	LimiterPasswordlessPeriod = 1 * time.Minute
+	// LimiterPasswordlessAverage is the default average for passwordless
+	// limiters.
+	LimiterPasswordlessAverage = 10
+	// LimiterPasswordlessBurst is the default burst for passwordless limiters.
+	LimiterPasswordlessBurst = 20
+)
+
 const (
 	// HostCertCacheSize is the number of host certificates to cache at any moment.
 	HostCertCacheSize = 4000

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3219,7 +3219,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	var grpcServer *grpc.Server
 	if alpnRouter != nil {
-		grpcServer := grpc.NewServer(
+		grpcServer = grpc.NewServer(
 			grpc.ChainUnaryInterceptor(
 				utils.ErrorConvertUnaryInterceptor,
 				proxyLimiter.UnaryServerInterceptor(),

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -157,6 +157,7 @@ func TestAuthenticate_rateLimiting(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Passwordless endpoints are rate limited because they allow unauthenticated challenge generation. The endpoint rate limits are applied in addition to (pre-existing) storage limits.

Setting limits to Auth only would be sufficient, but it seems best to apply limits to Proxy as well, so we may spare Auth of unnecessary load.

Auth already has a framework for RPC rate limiting, so we took advantage of it. The solution for the Proxy is rather simple - the handler is decorated with the appropriate limits.

#9160