### PR TITLE
[v7] backport #10741 (leaf cluster CA sanitizing)

### DIFF
--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -723,3 +723,46 @@ func (k *JWTKeyPair) CheckAndSetDefaults() error {
 	}
 	return nil
 }
+
+type CertAuthorityFilter map[CertAuthType]string
+
+func (f CertAuthorityFilter) IsEmpty() bool {
+	return len(f) == 0
+}
+
+// Match checks if a given CA matches this filter.
+func (f CertAuthorityFilter) Match(ca CertAuthority) bool {
+	if len(f) == 0 {
+		return true
+	}
+
+	return f[ca.GetType()] == Wildcard || f[ca.GetType()] == ca.GetClusterName()
+}
+
+// IntoMap makes this filter into a map for use as the Filter in a WatchKind.
+func (f CertAuthorityFilter) IntoMap() map[string]string {
+	if len(f) == 0 {
+		return nil
+	}
+
+	m := make(map[string]string, len(f))
+	for caType, name := range f {
+		m[string(caType)] = name
+	}
+	return m
+}
+
+// FromMap converts the provided map into this filter.
+func (f *CertAuthorityFilter) FromMap(m map[string]string) {
+	if len(m) == 0 {
+		*f = nil
+		return
+	}
+
+	*f = make(CertAuthorityFilter, len(m))
+	// there's not a lot of value in rejecting unknown values from the filter
+	for key, val := range m {
+		(*f)[CertAuthType(key)] = val
+	}
+
+}

--- a/api/types/events.go
+++ b/api/types/events.go
@@ -163,7 +163,7 @@ func (kind WatchKind) Matches(e Event) (bool, error) {
 
 // IsTrivial returns true iff the WatchKind only specifies a Kind but no other field.
 func (kind WatchKind) IsTrivial() bool {
-	return kind.SubKind == "" && kind.Name == "" && kind.Version == "" && !kind.LoadSecrets && len(kind.Filter) == 0
+	return kind.SubKind == "" && kind.Name == "" && !kind.LoadSecrets && len(kind.Filter) == 0
 }
 
 // Events returns new events interface

--- a/api/types/events.go
+++ b/api/types/events.go
@@ -150,11 +150,20 @@ func (kind WatchKind) Matches(e Event) (bool, error) {
 				return false, trace.Wrap(err)
 			}
 			return target.Match(res), nil
+		case CertAuthority:
+			var filter CertAuthorityFilter
+			filter.FromMap(kind.Filter)
+			return filter.Match(res), nil
 		default:
-			return false, trace.BadParameter("unfilterable resource type %T", e.Resource)
+			// we don't know about this filter, let the event through
 		}
 	}
 	return true, nil
+}
+
+// IsTrivial returns true iff the WatchKind only specifies a Kind but no other field.
+func (kind WatchKind) IsTrivial() bool {
+	return kind.SubKind == "" && kind.Name == "" && kind.Version == "" && !kind.LoadSecrets && len(kind.Filter) == 0
 }
 
 // Events returns new events interface

--- a/api/types/events/oneof.go
+++ b/api/types/events/oneof.go
@@ -351,6 +351,8 @@ func FromOneOf(in OneOf) (AuditEvent, error) {
 		return e, nil
 	} else if e := in.GetAccessRequestDelete(); e != nil {
 		return e, nil
+	} else if e := in.GetCertificateCreate(); e != nil {
+		return e, nil
 	} else {
 		if in.Event == nil {
 			return nil, trace.BadParameter("failed to parse event, session record is corrupted")

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -304,6 +304,12 @@ func (g *GRPCServer) WatchEvents(watch *proto.Watch, stream proto.AuthService_Wa
 	for _, kind := range watch.Kinds {
 		servicesWatch.Kinds = append(servicesWatch.Kinds, proto.ToWatchKind(kind))
 	}
+
+	if clusterName, err := auth.GetClusterName(); err == nil {
+		// we might want to enforce a filter for older clients in certain conditions
+		maybeFilterCertAuthorityWatches(stream.Context(), clusterName.GetClusterName(), auth.Checker.RoleNames(), &servicesWatch)
+	}
+
 	watcher, err := auth.NewWatcher(stream.Context(), servicesWatch)
 	if err != nil {
 		return trace.Wrap(err)
@@ -331,6 +337,56 @@ func (g *GRPCServer) WatchEvents(watch *proto.Watch, stream proto.AuthService_Wa
 		}
 	}
 }
+
+// maybeFilterCertAuthorityWatches will add filters to the CertAuthority
+// WatchKinds in the watch if the client is authenticated as just a `Node` with
+// no other roles and if the client is older than the cutoff version, and if the
+// WatchKind for KindCertAuthority is trivial, i.e. it's a WatchKind{Kind:
+// KindCertAuthority} with no other fields set. In any other case we will assume
+// that the client knows what it's doing and the cache watcher will still send
+// everything.
+//
+// DELETE IN 10.0, no supported clients should require this at that point
+func maybeFilterCertAuthorityWatches(ctx context.Context, clusterName string, roleNames []string, watch *types.Watch) {
+	if len(roleNames) != 1 || roleNames[0] != string(types.RoleNode) {
+		return
+	}
+
+	clientVersionString, ok := metadata.ClientVersionFromContext(ctx)
+	if !ok {
+		log.Debug("no client version found in grpc context")
+		return
+	}
+
+	clientVersion, err := semver.NewVersion(clientVersionString)
+	if err != nil {
+		log.WithError(err).Debugf("couldn't parse client version %q", clientVersionString)
+		return
+	}
+
+	// we treat the entire previous major version as "old" for this version
+	// check, even if there might have been backports; compliant clients will
+	// supply their own filter anyway
+	if !clientVersion.LessThan(certAuthorityFilterVersionCutoff) {
+		return
+	}
+
+	for i, k := range watch.Kinds {
+		if k.Kind != types.KindCertAuthority || !k.IsTrivial() {
+			continue
+		}
+
+		log.Debugf("Injecting filter for CertAuthority watch for Node-only watcher with version %v", clientVersion)
+		watch.Kinds[i].Filter = types.CertAuthorityFilter{
+			types.HostCA: clusterName,
+			types.UserCA: types.Wildcard,
+		}.IntoMap()
+	}
+}
+
+// certAuthorityFilterVersionCutoff is the version starting from which we stop
+// injecting filters for CertAuthority watches in maybeFilterCertAuthorityWatches.
+var certAuthorityFilterVersionCutoff = *semver.New("9.0.0")
 
 // resourceLabel returns the label for the provided types.Event
 func resourceLabel(event types.Event) string {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -377,10 +377,14 @@ func maybeFilterCertAuthorityWatches(ctx context.Context, clusterName string, ro
 		}
 
 		log.Debugf("Injecting filter for CertAuthority watch for Node-only watcher with version %v", clientVersion)
-		watch.Kinds[i].Filter = types.CertAuthorityFilter{
-			types.HostCA: clusterName,
-			types.UserCA: types.Wildcard,
-		}.IntoMap()
+		watch.Kinds[i].Filter = NodeCertAuthorityFilter(clusterName).IntoMap()
+	}
+}
+
+func NodeCertAuthorityFilter(clusterName string) types.CertAuthorityFilter {
+	return types.CertAuthorityFilter{
+		types.HostCA: clusterName,
+		types.UserCA: types.Wildcard,
 	}
 }
 

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -279,7 +280,22 @@ func (a *Server) RotateExternalCertAuthority(ca types.CertAuthority) error {
 	if err := updated.SetAdditionalTrustedKeys(ca.GetAdditionalTrustedKeys().Clone()); err != nil {
 		return trace.Wrap(err)
 	}
+
+	// a rotation state of "" gets stored as "standby" after
+	// CheckAndSetDefaults, so if `ca` came in with a zeroed rotation we must do
+	// this before checking if `updated` is the same as `existing` or the check
+	// will fail for no reason (CheckAndSetDefaults is idempotent so it's fine
+	// to call it both here and in CompareAndSwapCertAuthority)
 	updated.SetRotation(ca.GetRotation())
+	if err := updated.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// CASing `updated` over `existing` if they're equivalent will only cause
+	// backend and watcher spam for no gain, so we exit early if that's the case
+	if services.CertAuthoritiesEquivalent(existing, updated) {
+		return nil
+	}
 
 	// use compare and swap to protect from concurrent updates
 	// by trusted cluster API

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -493,6 +493,12 @@ func (a *Server) validateTrustedCluster(validateRequest *ValidateTrustedClusterR
 	if remoteClusterName == domainName {
 		return nil, trace.AccessDenied("remote cluster has same name as this cluster: %v", domainName)
 	}
+	_, err = a.GetTrustedCluster(context.TODO(), remoteClusterName)
+	if err == nil {
+		return nil, trace.AccessDenied("remote cluster has same name as trusted cluster: %v", remoteClusterName)
+	} else if !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
 
 	remoteCluster, err := types.NewRemoteCluster(remoteClusterName)
 	if err != nil {

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -10,6 +10,7 @@ import (
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/suite"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -83,6 +84,113 @@ func TestRemoteClusterStatus(t *testing.T) {
 	gotRC.SetResourceID(0)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(rc, gotRC))
+}
+
+func TestValidateTrustedCluster(t *testing.T) {
+	const localClusterName = "localcluster"
+	const validToken = "validtoken"
+
+	testAuth, err := NewTestAuthServer(TestAuthServerConfig{
+		ClusterName: localClusterName,
+		Dir:         t.TempDir(),
+	})
+	require.NoError(t, err)
+	a := testAuth.AuthServer
+
+	tks, err := types.NewStaticTokens(types.StaticTokensSpecV2{
+		StaticTokens: []types.ProvisionTokenV1{{
+			Roles: []types.SystemRole{types.RoleTrustedCluster},
+			Token: validToken,
+		}},
+	})
+	require.NoError(t, err)
+	a.SetStaticTokens(tks)
+
+	_, err = a.validateTrustedCluster(&ValidateTrustedClusterRequest{
+		Token: "invalidtoken",
+		CAs:   []types.CertAuthority{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid cluster token")
+
+	_, err = a.validateTrustedCluster(&ValidateTrustedClusterRequest{
+		Token: validToken,
+		CAs:   []types.CertAuthority{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected exactly one")
+
+	_, err = a.validateTrustedCluster(&ValidateTrustedClusterRequest{
+		Token: validToken,
+		CAs: []types.CertAuthority{
+			suite.NewTestCA(types.HostCA, "rc1"),
+			suite.NewTestCA(types.HostCA, "rc2"),
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected exactly one")
+
+	_, err = a.validateTrustedCluster(&ValidateTrustedClusterRequest{
+		Token: validToken,
+		CAs: []types.CertAuthority{
+			suite.NewTestCA(types.UserCA, "rc3"),
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected host certificate authority")
+
+	_, err = a.validateTrustedCluster(&ValidateTrustedClusterRequest{
+		Token: validToken,
+		CAs: []types.CertAuthority{
+			suite.NewTestCA(types.HostCA, localClusterName),
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "same name as this cluster")
+
+	leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "rc4"))
+	resp, err := a.validateTrustedCluster(&ValidateTrustedClusterRequest{
+		Token: validToken,
+		CAs:   []types.CertAuthority{leafClusterCA},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, resp.CAs, 2)
+	require.ElementsMatch(t,
+		[]types.CertAuthType{types.HostCA, types.UserCA},
+		[]types.CertAuthType{resp.CAs[0].GetType(), resp.CAs[1].GetType()},
+	)
+
+	for _, returnedCA := range resp.CAs {
+		localCA, err := a.GetCertAuthority(types.CertAuthID{
+			Type:       returnedCA.GetType(),
+			DomainName: localClusterName,
+		}, false)
+		require.NoError(t, err)
+		require.True(t, services.CertAuthoritiesEquivalent(localCA, returnedCA))
+	}
+
+	rcs, err := a.GetRemoteClusters()
+	require.NoError(t, err)
+	require.Len(t, rcs, 1)
+	require.Equal(t, leafClusterCA.GetName(), rcs[0].GetName())
+
+	hostCAs, err := a.GetCertAuthorities(types.HostCA, false)
+	require.NoError(t, err)
+	require.Len(t, hostCAs, 2)
+	require.ElementsMatch(t,
+		[]string{localClusterName, leafClusterCA.GetName()},
+		[]string{hostCAs[0].GetName(), hostCAs[1].GetName()},
+	)
+	require.Empty(t, hostCAs[0].GetRoles())
+	require.Empty(t, hostCAs[0].GetRoleMap())
+	require.Empty(t, hostCAs[1].GetRoles())
+	require.Empty(t, hostCAs[1].GetRoleMap())
+
+	userCAs, err := a.GetCertAuthorities(types.UserCA, false)
+	require.NoError(t, err)
+	require.Len(t, userCAs, 1)
+	require.Equal(t, localClusterName, userCAs[0].GetName())
 }
 
 func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *Server {

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -166,19 +166,9 @@ func ForOldRemoteProxy(cfg Config) Config {
 
 // ForNode sets up watch configuration for node
 func ForNode(cfg Config) Config {
-	var caFilter map[string]string
-	if cfg.ClusterConfig != nil {
-		clusterName, err := cfg.ClusterConfig.GetClusterName()
-		if err == nil {
-			caFilter = types.CertAuthorityFilter{
-				types.HostCA: clusterName.GetClusterName(),
-				types.UserCA: types.Wildcard,
-			}.IntoMap()
-		}
-	}
 	cfg.target = "node"
 	cfg.Watches = []types.WatchKind{
-		{Kind: types.KindCertAuthority, Filter: caFilter},
+		{Kind: types.KindCertAuthority, LoadSecrets: false},
 		{Kind: types.KindClusterName},
 		{Kind: types.KindClusterAuditConfig},
 		{Kind: types.KindClusterNetworkingConfig},

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -166,9 +166,19 @@ func ForOldRemoteProxy(cfg Config) Config {
 
 // ForNode sets up watch configuration for node
 func ForNode(cfg Config) Config {
+	var caFilter map[string]string
+	if cfg.ClusterConfig != nil {
+		clusterName, err := cfg.ClusterConfig.GetClusterName()
+		if err == nil {
+			caFilter = types.CertAuthorityFilter{
+				types.HostCA: clusterName.GetClusterName(),
+				types.UserCA: types.Wildcard,
+			}.IntoMap()
+		}
+	}
 	cfg.target = "node"
 	cfg.Watches = []types.WatchKind{
-		{Kind: types.KindCertAuthority, LoadSecrets: false},
+		{Kind: types.KindCertAuthority, Filter: caFilter},
 		{Kind: types.KindClusterName},
 		{Kind: types.KindClusterAuditConfig},
 		{Kind: types.KindClusterNetworkingConfig},

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -396,22 +396,19 @@ func TestNodeCAFiltering(t *testing.T) {
 
 	// this mimics a cache for a node pulling events from the auth server via WatchEvents
 	nodeCache, err := New(ForNode(Config{
-		Events:          p.cache,
-		Trust:           p.cache.trustCache,
-		ClusterConfig:   p.cache.clusterConfigCache,
-		Provisioner:     p.cache.provisionerCache,
-		Users:           p.cache.usersCache,
-		Access:          p.cache.accessCache,
-		DynamicAccess:   p.cache.dynamicAccessCache,
-		Presence:        p.cache.presenceCache,
-		Restrictions:    p.cache.restrictionsCache,
-		Apps:            p.cache.appsCache,
-		Databases:       p.cache.databasesCache,
-		AppSession:      p.cache.appSessionCache,
-		WebSession:      p.cache.webSessionCache,
-		WebToken:        p.cache.webTokenCache,
-		WindowsDesktops: p.cache.windowsDesktopsCache,
-		Backend:         nodeCacheBackend,
+		Events:        p.cache,
+		Trust:         p.cache.trustCache,
+		ClusterConfig: p.cache.clusterConfigCache,
+		Provisioner:   p.cache.provisionerCache,
+		Users:         p.cache.usersCache,
+		Access:        p.cache.accessCache,
+		DynamicAccess: p.cache.dynamicAccessCache,
+		Presence:      p.cache.presenceCache,
+		Restrictions:  p.cache.restrictionsCache,
+		AppSession:    p.cache.appSessionCache,
+		WebSession:    p.cache.webSessionCache,
+		WebToken:      p.cache.webTokenCache,
+		Backend:       nodeCacheBackend,
 	}))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, nodeCache.Close()) })

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -273,6 +273,10 @@ func TestWatchers(t *testing.T) {
 	w, err := p.cache.NewWatcher(ctx, types.Watch{Kinds: []types.WatchKind{
 		{
 			Kind: types.KindCertAuthority,
+			Filter: types.CertAuthorityFilter{
+				types.HostCA: "example.com",
+				types.UserCA: types.Wildcard,
+			}.IntoMap(),
 		},
 		{
 			Kind: types.KindAccessRequest,
@@ -348,6 +352,20 @@ func TestWatchers(t *testing.T) {
 		t.Fatalf("Timeout waiting for event.")
 	}
 
+	// this ca will not be matched by our filter, so the same reasoning applies
+	// as we upsert it and delete it
+	filteredCa := suite.NewTestCA(types.HostCA, "example.net")
+	require.NoError(t, p.trustS.UpsertCertAuthority(filteredCa))
+	require.NoError(t, p.trustS.DeleteCertAuthority(filteredCa.GetID()))
+
+	select {
+	case e := <-w.Events():
+		require.Equal(t, types.OpDelete, e.Type)
+		require.Equal(t, types.KindCertAuthority, e.Resource.GetKind())
+	case <-time.After(time.Second):
+		t.Fatalf("Timeout waiting for event.")
+	}
+
 	// event has arrived, now close the watchers
 	p.backend.CloseWatchers()
 
@@ -357,6 +375,101 @@ func TestWatchers(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatalf("Timeout waiting for close event.")
 	}
+}
+
+func TestNodeCAFiltering(t *testing.T) {
+	ctx := context.Background()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
+		ClusterName: "example.com",
+	})
+	require.NoError(t, err)
+	err = p.cache.clusterConfigCache.UpsertClusterName(clusterName)
+	require.NoError(t, err)
+
+	nodeCacheBackend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, nodeCacheBackend.Close()) })
+
+	// this mimics a cache for a node pulling events from the auth server via WatchEvents
+	nodeCache, err := New(ForNode(Config{
+		Events:          p.cache,
+		Trust:           p.cache.trustCache,
+		ClusterConfig:   p.cache.clusterConfigCache,
+		Provisioner:     p.cache.provisionerCache,
+		Users:           p.cache.usersCache,
+		Access:          p.cache.accessCache,
+		DynamicAccess:   p.cache.dynamicAccessCache,
+		Presence:        p.cache.presenceCache,
+		Restrictions:    p.cache.restrictionsCache,
+		Apps:            p.cache.appsCache,
+		Databases:       p.cache.databasesCache,
+		AppSession:      p.cache.appSessionCache,
+		WebSession:      p.cache.webSessionCache,
+		WebToken:        p.cache.webTokenCache,
+		WindowsDesktops: p.cache.windowsDesktopsCache,
+		Backend:         nodeCacheBackend,
+	}))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, nodeCache.Close()) })
+
+	cacheWatcher, err := nodeCache.NewWatcher(ctx, types.Watch{Kinds: []types.WatchKind{{Kind: types.KindCertAuthority}}})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cacheWatcher.Close()) })
+
+	fetchEvent := func() types.Event {
+		var ev types.Event
+		select {
+		case ev = <-cacheWatcher.Events():
+		case <-time.After(time.Second * 5):
+			t.Fatal("watcher timeout")
+		}
+		return ev
+	}
+	require.Equal(t, types.OpInit, fetchEvent().Type)
+
+	// upsert and delete a local host CA, we expect to see a Put and a Delete event
+	localCA := suite.NewTestCA(types.HostCA, "example.com")
+	require.NoError(t, p.trustS.UpsertCertAuthority(localCA))
+	require.NoError(t, p.trustS.DeleteCertAuthority(localCA.GetID()))
+
+	ev := fetchEvent()
+	require.Equal(t, types.OpPut, ev.Type)
+	require.Equal(t, types.KindCertAuthority, ev.Resource.GetKind())
+	require.Equal(t, "example.com", ev.Resource.GetName())
+
+	ev = fetchEvent()
+	require.Equal(t, types.OpDelete, ev.Type)
+	require.Equal(t, types.KindCertAuthority, ev.Resource.GetKind())
+	require.Equal(t, "example.com", ev.Resource.GetName())
+
+	// upsert and delete a nonlocal host CA, we expect to only see the Delete event
+	nonlocalCA := suite.NewTestCA(types.HostCA, "example.net")
+	require.NoError(t, p.trustS.UpsertCertAuthority(nonlocalCA))
+	require.NoError(t, p.trustS.DeleteCertAuthority(nonlocalCA.GetID()))
+
+	ev = fetchEvent()
+	require.Equal(t, types.OpDelete, ev.Type)
+	require.Equal(t, types.KindCertAuthority, ev.Resource.GetKind())
+	require.Equal(t, "example.net", ev.Resource.GetName())
+
+	// whereas we expect to see the Put and Delete for a trusted *user* CA
+	trustedUserCA := suite.NewTestCA(types.UserCA, "example.net")
+	require.NoError(t, p.trustS.UpsertCertAuthority(trustedUserCA))
+	require.NoError(t, p.trustS.DeleteCertAuthority(trustedUserCA.GetID()))
+
+	ev = fetchEvent()
+	require.Equal(t, types.OpPut, ev.Type)
+	require.Equal(t, types.KindCertAuthority, ev.Resource.GetKind())
+	require.Equal(t, "example.net", ev.Resource.GetName())
+
+	ev = fetchEvent()
+	require.Equal(t, types.OpDelete, ev.Type)
+	require.Equal(t, types.KindCertAuthority, ev.Resource.GetKind())
+	require.Equal(t, "example.net", ev.Resource.GetName())
 }
 
 func waitForRestart(t *testing.T, eventsC <-chan Event) {

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -53,7 +53,9 @@ func setupCollections(c *Cache, watches []types.WatchKind) (map[resourceKind]col
 			if c.Trust == nil {
 				return nil, trace.BadParameter("missing parameter Trust")
 			}
-			collections[resourceKind] = &certAuthority{watch: watch, Cache: c}
+			var filter types.CertAuthorityFilter
+			filter.FromMap(watch.Filter)
+			collections[resourceKind] = &certAuthority{Cache: c, watch: watch, filter: filter}
 		case types.KindStaticTokens:
 			if c.ClusterConfig == nil {
 				return nil, trace.BadParameter("missing parameter ClusterConfig")
@@ -755,6 +757,8 @@ func (c *namespace) watchKind() types.WatchKind {
 type certAuthority struct {
 	*Cache
 	watch types.WatchKind
+	// filter extracted from watch.Filter, to avoid rebuilding it on every event
+	filter types.CertAuthorityFilter
 }
 
 // erase erases all data in the collection
@@ -815,6 +819,19 @@ func (c *certAuthority) fetchCertAuthorities(caType types.CertAuthType) (apply f
 		}
 		return nil, trace.Wrap(err)
 	}
+
+	// this can be removed once we get the ability to fetch CAs with a filter,
+	// but it should be harmless, and it could be kept as additional safety
+	if !c.filter.IsEmpty() {
+		filteredCAs := make([]types.CertAuthority, 0, len(authorities))
+		for _, ca := range authorities {
+			if c.filter.Match(ca) {
+				filteredCAs = append(filteredCAs, ca)
+			}
+		}
+		authorities = filteredCAs
+	}
+
 	return func(ctx context.Context) error {
 		if err := c.trustCache.DeleteAllCertAuthorities(caType); err != nil {
 			if !trace.IsNotFound(err) {
@@ -850,6 +867,9 @@ func (c *certAuthority) processEvent(ctx context.Context, event types.Event) err
 		resource, ok := event.Resource.(types.CertAuthority)
 		if !ok {
 			return trace.BadParameter("unexpected type %T", event.Resource)
+		}
+		if !c.filter.Match(resource) {
+			return nil
 		}
 		if err := c.trustCache.UpsertCertAuthority(resource); err != nil {
 			return trace.Wrap(err)

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -529,7 +529,12 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 		return nil
 	}
 
-	watcher, err := process.newWatcher(conn, types.Watch{Kinds: []types.WatchKind{{Kind: types.KindCertAuthority}}})
+	watcher, err := process.newWatcher(conn, types.Watch{Kinds: []types.WatchKind{{
+		Kind: types.KindCertAuthority,
+		Filter: types.CertAuthorityFilter{
+			types.HostCA: conn.ClientIdentity.ClusterName,
+		}.IntoMap(),
+	}}})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -552,7 +557,7 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 				process.log.Debugf("Skipping event %v for %v", event.Type, event.Resource.GetName())
 				continue
 			}
-			if ca.GetType() != types.HostCA && ca.GetClusterName() != conn.ClientIdentity.ClusterName {
+			if ca.GetType() != types.HostCA || ca.GetClusterName() != conn.ClientIdentity.ClusterName {
 				process.log.Debugf("Skipping event for %v %v", ca.GetType(), ca.GetClusterName())
 				continue
 			}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -529,12 +529,7 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 		return nil
 	}
 
-	watcher, err := process.newWatcher(conn, types.Watch{Kinds: []types.WatchKind{{
-		Kind: types.KindCertAuthority,
-		Filter: types.CertAuthorityFilter{
-			types.HostCA: conn.ClientIdentity.ClusterName,
-		}.IntoMap(),
-	}}})
+	watcher, err := process.newWatcher(conn, types.Watch{Kinds: []types.WatchKind{{Kind: types.KindCertAuthority}}})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -59,6 +59,17 @@ func (s *CA) UpsertCertAuthority(ca types.CertAuthority) error {
 	if err := services.ValidateCertAuthority(ca); err != nil {
 		return trace.Wrap(err)
 	}
+
+	// try to skip writes that would have no effect
+	if existing, err := s.GetCertAuthority(types.CertAuthID{
+		Type:       ca.GetType(),
+		DomainName: ca.GetClusterName(),
+	}, true); err == nil {
+		if services.CertAuthoritiesEquivalent(existing, ca) {
+			return nil
+		}
+	}
+
 	value, err := services.MarshalCertAuthority(ca)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -653,6 +653,21 @@ func (rc *ResourceCommand) Delete(client auth.ClientI) (err error) {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("network restrictions have been reset to defaults (allow all)\n")
+	case types.KindCertAuthority:
+		if rc.ref.SubKind == "" || rc.ref.Name == "" {
+			return trace.BadParameter(
+				"full %s path must be specified (e.g. '%s/%s/clustername')",
+				types.KindCertAuthority, types.KindCertAuthority, types.HostCA,
+			)
+		}
+		err := client.DeleteCertAuthority(types.CertAuthID{
+			Type:       types.CertAuthType(rc.ref.SubKind),
+			DomainName: rc.ref.Name,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("%s '%s/%s' has been deleted\n", types.KindCertAuthority, rc.ref.SubKind, rc.ref.Name)
 	default:
 		return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
 	}


### PR DESCRIPTION
Backport of #10741 and #10020.

As a major version _n_ node can connect to any major version _n+1_ auth, for versions 7 and below (not 8, because v9 will support CA filtering since 9.0.0) we rely entirely on the server-side filter injection for CA filtering.

This also fixes an issue introduced in https://github.com/gravitational/teleport/pull/10226 when backporting https://github.com/gravitational/teleport/pull/9822 down to v6, as in v7 and v6 there's still an if/else if/else chain in events.FromOneOf that was removed in v8 and above.

