### PR TITLE
[v6.2] backport #10741 (leaf cluster CA sanitizing)

### DIFF
--- a/api/types/events/oneof.go
+++ b/api/types/events/oneof.go
@@ -339,6 +339,8 @@ func FromOneOf(in OneOf) (AuditEvent, error) {
 		return e, nil
 	} else if e := in.GetAccessRequestDelete(); e != nil {
 		return e, nil
+	} else if e := in.GetCertificateCreate(); e != nil {
+		return e, nil
 	} else {
 		if in.Event == nil {
 			return nil, trace.BadParameter("failed to parse event, session record is corrupted")

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -469,15 +469,31 @@ func (a *Server) validateTrustedCluster(validateRequest *ValidateTrustedClusterR
 		return nil, trace.Wrap(err)
 	}
 
-	// add remote cluster resource to keep track of the remote cluster
-	var remoteClusterName string
-	for _, certAuthority := range validateRequest.CAs {
-		// don't add a ca with the same as as local cluster name
-		if certAuthority.GetName() == domainName {
-			return nil, trace.AccessDenied("remote certificate authority has same name as cluster certificate authority: %v", domainName)
-		}
-		remoteClusterName = certAuthority.GetName()
+	if len(validateRequest.CAs) != 1 {
+		return nil, trace.AccessDenied("expected exactly one certificate authority, received %v", len(validateRequest.CAs))
 	}
+	remoteCA := validateRequest.CAs[0]
+	err = remoteCA.CheckAndSetDefaults()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if remoteCA.GetName() != remoteCA.GetClusterName() {
+		return nil, trace.AccessDenied("remote CA is inconsistently named, metadata name is %q and spec cluster name is %q", remoteCA.GetName(), remoteCA.GetClusterName())
+	}
+
+	if remoteCA.GetType() != services.HostCA {
+		return nil, trace.AccessDenied("expected host certificate authority, received CA with type %q", remoteCA.GetType())
+	}
+
+	// a host CA shouldn't have a rolemap or roles in the first place
+	remoteCA.SetRoleMap(nil)
+	remoteCA.SetRoles(nil)
+
+	remoteClusterName := remoteCA.GetName()
+	if remoteClusterName == domainName {
+		return nil, trace.AccessDenied("remote cluster has same name as this cluster: %v", domainName)
+	}
+
 	remoteCluster, err := services.NewRemoteCluster(remoteClusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -495,12 +511,9 @@ func (a *Server) validateTrustedCluster(validateRequest *ValidateTrustedClusterR
 		}
 	}
 
-	// token has been validated, upsert the given certificate authority
-	for _, certAuthority := range validateRequest.CAs {
-		err = a.UpsertCertAuthority(certAuthority)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+	err = a.UpsertCertAuthority(remoteCA)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// export local cluster certificate authority and return it to the cluster

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -493,6 +493,12 @@ func (a *Server) validateTrustedCluster(validateRequest *ValidateTrustedClusterR
 	if remoteClusterName == domainName {
 		return nil, trace.AccessDenied("remote cluster has same name as this cluster: %v", domainName)
 	}
+	_, err = a.GetTrustedCluster(context.TODO(), remoteClusterName)
+	if err == nil {
+		return nil, trace.AccessDenied("remote cluster has same name as trusted cluster: %v", remoteClusterName)
+	} else if !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
 
 	remoteCluster, err := services.NewRemoteCluster(remoteClusterName)
 	if err != nil {

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -87,6 +88,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 func TestValidateTrustedCluster(t *testing.T) {
 	const localClusterName = "localcluster"
 	const validToken = "validtoken"
+	ctx := context.Background()
 
 	testAuth, err := NewTestAuthServer(TestAuthServerConfig{
 		ClusterName: localClusterName,
@@ -146,7 +148,24 @@ func TestValidateTrustedCluster(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "same name as this cluster")
 
-	leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "rc4"))
+	trustedCluster, err := types.NewTrustedCluster("trustedcluster",
+		types.TrustedClusterSpecV2{Roles: []string{"nonempty"}})
+	require.NoError(t, err)
+	// use the UpsertTrustedCluster in Presence as we just want the resource in
+	// the backend, we don't want to actually connect
+	_, err = a.Presence.UpsertTrustedCluster(ctx, trustedCluster)
+	require.NoError(t, err)
+
+	_, err = a.validateTrustedCluster(&ValidateTrustedClusterRequest{
+		Token: validToken,
+		CAs: []types.CertAuthority{
+			suite.NewTestCA(types.HostCA, trustedCluster.GetName()),
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "same name as trusted cluster")
+
+	leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster"))
 	resp, err := a.validateTrustedCluster(&ValidateTrustedClusterRequest{
 		Token: validToken,
 		CAs:   []types.CertAuthority{leafClusterCA},

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -517,6 +517,21 @@ func (rc *ResourceCommand) Delete(client auth.ClientI) (err error) {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("kubernetes service %v has been deleted\n", rc.ref.Name)
+	case services.KindCertAuthority:
+		if rc.ref.SubKind == "" || rc.ref.Name == "" {
+			return trace.BadParameter(
+				"full %s path must be specified (e.g. '%s/%s/clustername')",
+				services.KindCertAuthority, services.KindCertAuthority, services.HostCA,
+			)
+		}
+		err := client.DeleteCertAuthority(services.CertAuthID{
+			Type:       services.CertAuthType(rc.ref.SubKind),
+			DomainName: rc.ref.Name,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("%s '%s/%s' has been deleted\n", services.KindCertAuthority, rc.ref.SubKind, rc.ref.Name)
 	default:
 		return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
 	}


### PR DESCRIPTION
Backport of #10741, with an extra check on the consistency of cluster names.

This also fixes an issue introduced in gravitational/teleport#10226 when backporting gravitational/teleport#9822 down to v6, as in v7 and v6 there's still an `if`/`else if`/`else` chain in `events.FromOneOf` that was removed in `v8` and above.