### PR TITLE
[v9] Partial revert of `session.connect` event

### DIFF
--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -203,7 +203,7 @@ func (s *localSite) DialTCP(params DialParams) (net.Conn, error) {
 	}
 	s.log.Debugf("Succeeded dialing %v.", params)
 
-	return newEmitConn(s.srv.ctx, conn, s.client, s.srv.ID), nil
+	return conn, nil
 }
 
 // IsClosed always returns false because localSite is never closed.

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -437,7 +436,7 @@ func (p *transport) directDial(servers []string, serverID string) (net.Conn, err
 	for _, addr := range servers {
 		conn, err := net.Dial("tcp", addr)
 		if err == nil {
-			return newEmitConn(p.closeContext, conn, p.emitter, strings.Split(serverID, ".")[0]), nil
+			return conn, nil
 		}
 
 		errors = append(errors, err)


### PR DESCRIPTION
Partial port of #10156 onto v9. Will be fixed when #9917 is implemented.