### PR TITLE
[v8] Do not block apt publishing if there is a more current pre-release

### DIFF
--- a/build.assets/tooling/cmd/check/main.go
+++ b/build.assets/tooling/cmd/check/main.go
@@ -90,6 +90,12 @@ func checkLatest(ctx context.Context, tag string, gh github.GitHub) error {
 		if r.GetDraft() {
 			continue
 		}
+		// Because pre-releases are not published to apt, we do not want to
+		// consider them when making apt publishing decisions.
+		// see: https://github.com/gravitational/teleport/issues/10800
+		if semver.Prerelease(r.GetTagName()) != "" {
+			continue
+		}
 		tags = append(tags, r.GetTagName())
 	}
 

--- a/build.assets/tooling/cmd/check/main_test.go
+++ b/build.assets/tooling/cmd/check/main_test.go
@@ -105,6 +105,15 @@ func TestCheckLatest(t *testing.T) {
 			},
 			wantErr: require.NoError,
 		},
+		{ // see https://github.com/gravitational/teleport/issues/10800
+			desc: "pass-pre-release",
+			tag:  "v8.3.3",
+			releases: []string{
+				"v9.0.0-beta.1",
+				"v8.3.2",
+			},
+			wantErr: require.NoError,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
v8 backport of https://github.com/gravitational/teleport/pull/10804
## Summary
We do not publish pre-releases to apt repos, but we do publish them to github.  That means we need to filter pre-releases out of the github release list when considering if an apt release should be published.  We don't want v8.3.3 publishing to be blocked by v9.0.0-dev.1, only by v9.0.0.

Contributes to https://github.com/gravitational/teleport/issues/10800

This is as far back as the port needs to go, as v7 apt packages will never be published anyhow.

## Testing Done
None, beyond what was done in the original https://github.com/gravitational/teleport/pull/10804