### PR TITLE
helm: Set default second factor to 'otp'

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -78,7 +78,8 @@ This reference details available values for the `teleport-cluster` chart.
 `authenticationSecondFactor.secondFactor` controls the second factor used for local user authentication. Possible values supported by this chart
 are `off` (not recommended), `on`, `otp`, `optional` and `webauthn`.
 
-When set to `on`, `optional` or `webauthn`, the `authenticationSecondFactor.webauthn` section must also be set.
+When set to `on`, `optional` or `webauthn`, the `authenticationSecondFactor.webauthn` section can also be used. The configured `rp_id` defaults to
+the FQDN which is used to access the Teleport cluster.
 
 ### `authenticationSecondFactor.webauthn`
 

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -75,9 +75,10 @@ This reference details available values for the `teleport-cluster` chart.
 | - | - | - | - | - |
 | `string` | `otp` | Yes | `auth_service.authentication.second_factor` | ❌ |
 
-`authenticationSecondFactor.secondFactor` controls the second factor used for local user authentication. Possible values are `off` (not recommended), `on`, `otp`, `optional` and `webauthn`.
+`authenticationSecondFactor.secondFactor` controls the second factor used for local user authentication. Possible values supported by this chart
+are `off` (not recommended), `on`, `otp`, `optional` and `webauthn`.
 
-When set to `on` or `webauthn`, the `authenticationSecondFactor.webauthn` section must also be set.
+When set to `on`, `optional` or `webauthn`, the `authenticationSecondFactor.webauthn` section must also be set.
 
 ### `authenticationSecondFactor.webauthn`
 

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -73,9 +73,11 @@ This reference details available values for the `teleport-cluster` chart.
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
-| `string` | `on` | Yes | `auth_service.authentication.second_factor` | ❌ |
+| `string` | `otp` | Yes | `auth_service.authentication.second_factor` | ❌ |
 
-`authenticationSecondFactor.secondFactor` controls the second factor used for local user authentication. Possible values are `on`, `optional` and `webauthn`.
+`authenticationSecondFactor.secondFactor` controls the second factor used for local user authentication. Possible values are `off` (not recommended), `on`, `otp`, `optional` and `webauthn`.
+
+When set to `on` or `webauthn`, the `authenticationSecondFactor.webauthn` section must also be set.
 
 ### `authenticationSecondFactor.webauthn`
 

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -59,16 +59,18 @@ data:
     {{- if .Values.authenticationSecondFactor.secondFactor }}
         second_factor: {{ .Values.authenticationSecondFactor.secondFactor }}
     {{- end }}
-    {{- if .Values.authenticationSecondFactor.webauthn }}
+    {{- if not (or (eq .Values.authenticationSecondFactor.secondFactor "off") (eq .Values.authenticationSecondFactor.secondFactor "otp")) }}
         webauthn:
           rp_id: {{ required "clusterName is required in chart values" .Values.clusterName }}
-      {{- if .Values.authenticationSecondFactor.webauthn.attestationAllowedCas }}
+      {{- if .Values.authenticationSecondFactor.webauthn }}
+        {{- if .Values.authenticationSecondFactor.webauthn.attestationAllowedCas }}
           attestation_allowed_cas:
           {{- toYaml .Values.authenticationSecondFactor.webauthn.attestationAllowedCas | nindent 12 }}
-      {{- end }}
-      {{- if .Values.authenticationSecondFactor.webauthn.attestationDeniedCas }}
+        {{- end }}
+        {{- if .Values.authenticationSecondFactor.webauthn.attestationDeniedCas }}
           attestation_denied_cas:
           {{- toYaml .Values.authenticationSecondFactor.webauthn.attestationDeniedCas | nindent 12 }}
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -40,8 +40,8 @@
                 "secondFactor": {
                     "$id": "#/properties/authenticationSecondFactor/properties/secondFactor",
                     "type": "string",
-                    "enum": ["on", "optional", "webauthn"],
-                    "default": "on"
+                    "enum": ["off", "on", "otp", "optional", "webauthn"],
+                    "default": "otp"
                 },
                 "webauthn": {
                     "$id": "#/properties/authenticationSecondFactor/properties/webauthn",


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/9877 set the default for `auth_service.authentication.second_factor` to `on`, which causes an error when a webauthn configuration is not also supplied: `ERROR: missing required webauthn configuration for second factor type "on"`

The actual Teleport default is `otp`, which should be respected in the chart values.

This also adds the potential to set `off`, which is itself a valid option.