### PR TITLE
UX improvements for tbot

### DIFF
--- a/tool/tbot/config/config_test.go
+++ b/tool/tbot/config/config_test.go
@@ -165,7 +165,7 @@ func TestParseSSHVersion(t *testing.T) {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)
-			require.True(t, version.Equal(*test.version))
+			require.True(t, version.Equal(*test.version), "got version = %v, want = %v", version, test.version)
 		}
 	}
 }

--- a/tool/tbot/config/config_test.go
+++ b/tool/tbot/config/config_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/teleport/tool/tbot/identity"
 	"github.com/stretchr/testify/require"
 )
@@ -123,6 +124,50 @@ func TestConfigFile(t *testing.T) {
 	destImplReal, ok := destImpl.(*DestinationDirectory)
 	require.True(t, ok)
 	require.Equal(t, "/tmp/foo", destImplReal.Path)
+}
+
+func TestParseSSHVersion(t *testing.T) {
+	tests := []struct {
+		str     string
+		version *semver.Version
+		err     bool
+	}{
+		{
+			str:     "OpenSSH_8.2p1 Ubuntu-4ubuntu0.4, OpenSSL 1.1.1f  31 Mar 2020",
+			version: semver.New("8.2.1"),
+		},
+		{
+			str:     "OpenSSH_8.8p1, OpenSSL 1.1.1m  14 Dec 2021",
+			version: semver.New("8.8.1"),
+		},
+		{
+			str:     "OpenSSH_7.5p1, OpenSSL 1.0.2s-freebsd  28 May 2019",
+			version: semver.New("7.5.1"),
+		},
+		{
+			str:     "OpenSSH_7.9p1 Raspbian-10+deb10u2, OpenSSL 1.1.1d  10 Sep 2019",
+			version: semver.New("7.9.1"),
+		},
+		{
+			// Couldn't find a full example but in theory patch is optional:
+			str:     "OpenSSH_8.1 foo",
+			version: semver.New("8.1.0"),
+		},
+		{
+			str: "Teleport v8.0.0-dev.40 git:v8.0.0-dev.40-0-ge9194c256 go1.17.2",
+			err: true,
+		},
+	}
+
+	for _, test := range tests {
+		version, err := parseSSHVersion(test.str)
+		if test.err {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.True(t, version.Equal(*test.version))
+		}
+	}
 }
 
 const exampleConfigFile = `

--- a/tool/tbot/config/config_test.go
+++ b/tool/tbot/config/config_test.go
@@ -172,7 +172,7 @@ func TestParseSSHVersion(t *testing.T) {
 
 const exampleConfigFile = `
 auth_server: auth.example.com
-renew_interval: 5m
+renewal_interval: 5m
 onboarding:
   token: foo
   ca_pins:

--- a/tool/tbot/config/config_test.go
+++ b/tool/tbot/config/config_test.go
@@ -30,7 +30,7 @@ func TestConfigDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, DefaultCertificateTTL, cfg.CertificateTTL)
-	require.Equal(t, DefaultRenewInterval, cfg.RenewInterval)
+	require.Equal(t, DefaultRenewInterval, cfg.RenewalInterval)
 
 	storageDest, err := cfg.Storage.GetDestination()
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestConfigFile(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "auth.example.com", cfg.AuthServer)
-	require.Equal(t, time.Minute*5, cfg.RenewInterval)
+	require.Equal(t, time.Minute*5, cfg.RenewalInterval)
 
 	require.NotNil(t, cfg.Onboarding)
 	require.Equal(t, "foo", cfg.Onboarding.Token)

--- a/tool/tbot/config/configtemplate_ssh.go
+++ b/tool/tbot/config/configtemplate_ssh.go
@@ -158,7 +158,7 @@ Host *.{{ .ClusterName }} {{ .ProxyHost }}
 # Flags for all {{ .ClusterName }} hosts except the proxy
 Host *.{{ .ClusterName }} !{{ .ProxyHost }}
     Port 3022
-    ProxyCommand ssh -F {{ .SSHConfigPath }} -l %r -p {{ .ProxyPort }} {{ .ProxyHost }} -s proxy:%h:%p@{{ .ClusterName }}
+    ProxyCommand ssh -F {{ .SSHConfigPath }} -l %r -p {{ .ProxyPort }} {{ .ProxyHost }} -s proxy:$(echo %h | cut -d '.' -f 1):%p@{{ .ClusterName }}
 
 # End generated Teleport configuration
 `))

--- a/tool/tbot/config/configtemplate_ssh.go
+++ b/tool/tbot/config/configtemplate_ssh.go
@@ -55,13 +55,13 @@ var openSSHMinVersionForRSAWorkaround = semver.New("8.5.0")
 func parseSSHVersion(versionString string) (*semver.Version, error) {
 	versionTokens := strings.Split(versionString, " ")
 	if len(versionTokens) == 0 {
-		return nil, trace.Errorf("invalid version string: %s", versionString)
+		return nil, trace.BadParameter("invalid version string: %s", versionString)
 	}
 
 	versionID := versionTokens[0]
 	matches := openSSHVersionRegex.FindStringSubmatch(versionID)
 	if matches == nil {
-		return nil, trace.Errorf("cannot parse version string: %q", versionID)
+		return nil, trace.BadParameter("cannot parse version string: %q", versionID)
 	}
 
 	major, err := strconv.Atoi(matches[1])
@@ -212,13 +212,21 @@ func (c *TemplateSSHClient) Render(ctx context.Context, authClient auth.ClientI,
 }
 
 type sshConfigParameters struct {
-	ClusterName          string
-	KnownHostsPath       string
-	IdentityFilePath     string
-	CertificateFilePath  string
-	ProxyHost            string
-	ProxyPort            string
-	SSHConfigPath        string
+	ClusterName         string
+	KnownHostsPath      string
+	IdentityFilePath    string
+	CertificateFilePath string
+	ProxyHost           string
+	ProxyPort           string
+	SSHConfigPath       string
+
+	// IncludeRSAWorkaround controls whether the RSA deprecation workaround is
+	// included in the generated configuration. Newer versions of OpenSSH
+	// deprecate RSA certificates and, due to a bug in golang's ssh package,
+	// Teleport wrongly advertises its unaffected certificates as a
+	// now-deprecated certificate type. The workaround includes a config
+	// override to re-enable RSA certs for just Teleport hosts, however it is
+	// only supported on OpenSSH 8.5 and later.
 	IncludeRSAWorkaround bool
 }
 

--- a/tool/tbot/config/configtemplate_ssh.go
+++ b/tool/tbot/config/configtemplate_ssh.go
@@ -89,7 +89,7 @@ func parseSSHVersion(versionString string) (*semver.Version, error) {
 	}, nil
 }
 
-// getSSHVersion attempts to query the system SSH for it's current version.
+// getSSHVersion attempts to query the system SSH for its current version.
 func getSSHVersion() (*semver.Version, error) {
 	var out bytes.Buffer
 

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -156,7 +156,7 @@ func onWatch(botConfig *config.BotConfig) error {
 
 func onStart(botConfig *config.BotConfig) error {
 	if botConfig.AuthServer == "" {
-		return trace.BadParameter("An auth server must be set via --auth-server or configuration")
+		return trace.BadParameter("An auth or proxy server must be set via --auth-server or configuration")
 	}
 
 	// First, try to make sure all destinations are usable.
@@ -170,9 +170,6 @@ func onStart(botConfig *config.BotConfig) error {
 		return trace.Wrap(err, "could not read bot storage destination from config")
 	}
 
-	var authClient auth.ClientI
-
-	// TODO: graceful shutdown via signal; see #7066
 	reloadChan := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -184,6 +181,8 @@ func onStart(botConfig *config.BotConfig) error {
 		sha := sha256.Sum256([]byte(botConfig.Onboarding.Token))
 		configTokenHashBytes = []byte(hex.EncodeToString(sha[:]))
 	}
+
+	var authClient auth.ClientI
 
 	// First, attempt to load an identity from storage.
 	ident, err := identity.LoadIdentity(dest, identity.BotKinds()...)

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -68,7 +68,7 @@ func Run(args []string) error {
 	var cf config.CLIConf
 	utils.InitLogger(utils.LoggingForDaemon, logrus.InfoLevel)
 
-	app := utils.InitCLIParser("tbot", "tbot: Teleport Credential Bot").Interspersed(false)
+	app := utils.InitCLIParser("tbot", "tbot: Teleport Machine ID").Interspersed(false)
 	app.Flag("debug", "Verbose logging to stdout").Short('d').BoolVar(&cf.Debug)
 	app.Flag("config", "tbot.yaml path").Short('c').StringVar(&cf.ConfigPath)
 

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -156,7 +156,7 @@ func onWatch(botConfig *config.BotConfig) error {
 
 func onStart(botConfig *config.BotConfig) error {
 	if botConfig.AuthServer == "" {
-		return trace.BadParameter("An auth or proxy server must be set via --auth-server or configuration")
+		return trace.BadParameter("an auth or proxy server must be set via --auth-server or configuration")
 	}
 
 	// First, try to make sure all destinations are usable.
@@ -343,7 +343,7 @@ func checkIdentity(ident *identity.Identity) error {
 	return nil
 }
 
-// handleSignals handles incoming Unix signals
+// handleSignals handles incoming Unix signals.
 func handleSignals(reload chan struct{}, cancel context.CancelFunc) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGHUP, syscall.SIGUSR1)

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -150,7 +150,6 @@ Optionally, if running the bot under an isolated user account, first initialize
 the data directory by running the following command {{ bold "as root" }}:
 
 > tbot init \
-   --auth-server={{.auth_server}} \
    --destination-dir=./tbot-user \
    --bot-user=tbot \
    --reader-user=alice

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -67,6 +67,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, config *service.Confi
 	c.botsAdd.Flag("roles", "Roles the bot is able to assume.").Required().StringVar(&c.botRoles)
 	c.botsAdd.Flag("ttl", "TTL for the bot join token.").DurationVar(&c.tokenTTL)
 	c.botsAdd.Flag("token", "Name of an existing token to use.").StringVar(&c.tokenID)
+	c.botsAdd.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 	// TODO: --ttl for setting a ttl on the join token
 
 	c.botsRemove = bots.Command("rm", "Permanently remove a certificate renewal bot from the cluster.")
@@ -186,6 +187,16 @@ func (c *BotsCommand) AddBot(client auth.ClientI) error {
 	})
 	if err != nil {
 		return trace.WrapWithMessage(err, "error while creating bot")
+	}
+
+	if c.format == teleport.JSON {
+		out, err := json.MarshalIndent(response, "", "  ")
+		if err != nil {
+			return trace.Wrap(err, "failed to marshal CreateBot response")
+		}
+
+		fmt.Println(string(out))
+		return nil
 	}
 
 	// Calculate the CA pins for this cluster. The CA pins are used by the


### PR DESCRIPTION
A last batch of UX tweaks for 9.0:
 - rename `--renew-interval` to `--renewal-interval`
 - add `--oneshot` mode to fetch one set of certs and exit (client side only, no server enforcement yet)
 - add `tbot version` (fixes #10782)
 - add unix signal handling: graceful exit on SIGINT, reload on SIGHUP/SIGUSR1
 - make auth server an optional config option and check it only when needed (i.e. `tbot start`)
 - add `cut` workaround to allow SSH to work without DNS (fixes #10813)
 - fix product name in CLI help (fixes #10926)
 - add `--format=json` to `tctl bots add` (fixes #10783)
 - check SSH version and exclude the RSA deprecation workaround for older SSH clients (fixes #10781)