### PR TITLE
Teleport Plugins release checklist

### DIFF
--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -8,6 +8,13 @@ This checklist is to be run after cutting a release.
   - Example: https://github.com/gravitational/teleport/pull/7033
 - [ ] Create PR to update default AMI versions in Makefile and AMIs.md under https://github.com/gravitational/teleport/blob/master/assets/aws
   - Example command: `TELEPORT_VERSION=6.2.0 make -C assets/aws create-update-pr`
+- [ ] Release [Teleport Plugins](https://github.com/gravitational/teleport-plugins)
+  - `make update-version VERSION=X.Y.Z`
+    - This will update the `teleport/api` version and may lead to linting errors which can be easily resolved.
+    - You may need to update `terraform/gen_teleport.yaml` if there are errors. This can be caused by resource
+    upgrades (e.g. `RoleV4` -> `RoleV5`). Once the necessary changes are made, run `make -C terraform gen-schema`.
+  - Create a new release PR and merge it to master.
+  - Pull master locally and run `make update-tag VERSION=X.Y.Z` to push the new tags.
 
 ### Major releases only
 

--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -9,12 +9,6 @@ This checklist is to be run after cutting a release.
 - [ ] Create PR to update default AMI versions in Makefile and AMIs.md under https://github.com/gravitational/teleport/blob/master/assets/aws
   - Example command: `TELEPORT_VERSION=6.2.0 make -C assets/aws create-update-pr`
 - [ ] Release [Teleport Plugins](https://github.com/gravitational/teleport-plugins)
-  - `make update-version VERSION=X.Y.Z`
-    - This will update the `teleport/api` version and may lead to linting errors which can be easily resolved.
-    - You may need to update `terraform/gen_teleport.yaml` if there are errors. This can be caused by resource
-    upgrades (e.g. `RoleV4` -> `RoleV5`). Once the necessary changes are made, run `make -C terraform gen-schema`.
-  - Create a new release PR and merge it to master.
-  - Pull master locally and run `make update-tag VERSION=X.Y.Z` to push the new tags.
 
 ### Major releases only
 


### PR DESCRIPTION
Add section for Teleport Plugins Release in the post-release checklist, reflecting the changes made in https://github.com/gravitational/teleport-plugins/pull/440.

TODO: Remove `Release Plugins` from https://github.com/gravitational/teleport/issues/10447