### PR TITLE
Fix V5 role in getting started guide.

### DIFF
--- a/docs/pages/kubernetes-access/getting-started/cluster.mdx
+++ b/docs/pages/kubernetes-access/getting-started/cluster.mdx
@@ -164,6 +164,8 @@ metadata:
 spec:
   allow:
     kubernetes_groups: ["system:masters"]
+    kubernetes_labels:
+      '*': '*'
 ```
 
 Create the role and add a user:


### PR DESCRIPTION
Roles require explicit label since V4.
Add missing labels so getting started guide works.