### PR TITLE
Use yamlv3 to parse Teleport configuration

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -14,5 +14,5 @@ require (
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	google.golang.org/grpc v1.43.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -150,8 +150,6 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/api/types/networking_test.go
+++ b/api/types/networking_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestProxyListenerModeMarshalYAML(t *testing.T) {

--- a/assets/backport/go.mod
+++ b/assets/backport/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gravitational/trace v1.1.15
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )
 
 require (
@@ -23,5 +23,4 @@ require (
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/assets/backport/go.sum
+++ b/assets/backport/go.sum
@@ -381,8 +381,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/assets/backport/main.go
+++ b/assets/backport/main.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/teleport/assets/backport/github"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func main() {

--- a/dronegen/main.go
+++ b/dronegen/main.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func main() {
@@ -127,7 +127,7 @@ func parsePipelines(data []byte) ([]parsedPipeline, error) {
 			continue
 		}
 		var p pipeline
-		if err := yaml.UnmarshalStrict(c, &p); err != nil {
+		if err := yaml.Unmarshal(c, &p); err != nil {
 			return nil, err
 		}
 		pipelines = append(pipelines, parsedPipeline{pipeline: p, raw: c})

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/ini.v1 v1.62.0
 	gopkg.in/square/go-jose.v2 v2.5.1
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
@@ -248,6 +247,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -49,7 +49,7 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var validCASigAlgos = []string{
@@ -117,7 +117,7 @@ func ReadConfig(reader io.Reader) (*FileConfig, error) {
 	}
 	var fc FileConfig
 
-	if err := yaml.UnmarshalStrict(bytes, &fc); err != nil {
+	if err := yaml.Unmarshal(bytes, &fc); err != nil {
 		// Remove all newlines in the YAML error, to avoid escaping when printing.
 		return nil, trace.BadParameter("failed parsing the config file: %s", strings.Replace(err.Error(), "\n", "", -1))
 	}

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/suite"
 
 	"gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type ClusterConfigurationSuite struct {

--- a/lib/utils/addr_test.go
+++ b/lib/utils/addr_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type AddrTestSuite struct {

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type options struct {


### PR DESCRIPTION
The storage section of the Teleport YAML configuration file only supports a single level of child keys due to the way the yamlv2 library decodes to an `interface{}`. Upgrading to v3 resolves this issue allowing the creation of nested sections which is desired for upcoming projects such as [SQL Backend](https://github.com/gravitational/teleport/blob/502323590933ad4145f40f001070833556cc0ecf/rfd/0056-sql-backend.md?plain=1#L69).

V2 of the YAML library decoded all child sections to a `map[interface{}]interface{}` resulting in an error when converting to a struct using `utils.ObjectToStruct`. V3 fixed this issue by decoding to `map[string]interface{}` when all keys are strings. 

Example:
```yaml
teleport:
  storage:
    aws:
      name: hello
```

```go
var storage struct {
	Aws struct {
		Name string `json:"name"`
	} `json:"aws"`
}
utils.ObjectToStruct(cfg.Global.Storage.Params, &storage)
// failed to marshal map[aws:map[name:hello]], json: unsupported type: map[interface {}]interface {}
```

Compatibility (from the lib's docs):

> The yaml package supports most of YAML 1.2, but preserves some behavior from 1.1 for backwards compatibility including support for anchors, tags, map merging, etc. Multi-document unmarshalling is not yet implemented. Specifically, as of v3 of the yaml package:
> - YAML 1.1 bools (yes/no, on/off) are supported as long as they are being decoded into a typed bool value. Otherwise they behave as a string. Booleans in YAML 1.2 are true/false only.
> - Octals encode and decode as 0777 per YAML 1.1, rather than 0o777 as specified in YAML 1.2, because most parsers still use the old format. Octals in the 0o777 format are supported though, so new files work.
> - Does not support base-60 floats. These are gone from YAML 1.2, and were actually never supported by this package as it's clearly a poor choice.
