### PR TITLE
Update dronegen to fix build-darwin-amd64-pkg-tsh artifacts path

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3152,9 +3152,9 @@ steps:
     ARCH: amd64
     BUILDBOX_PASSWORD:
       from_secret: BUILDBOX_PASSWORD
-    ENT_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
+    ENT_TARBALL_PATH: /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
     OS: darwin
-    OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
+    OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
     WORKSPACE_DIR: /tmp/build-darwin-amd64-pkg-tsh
 - name: Copy Mac pkg artifacts
   commands:
@@ -5084,6 +5084,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 7bc6b007cceb818562c22dedb8a0371cd3b1b160bd845dda8d0c90e0a19ec21a
+hmac: eb954f5ddc1da7e5f4545ab8a5612fbc381633cd7a29950b9dc47ac19f4b54e1
 
 ...

--- a/dronegen/mac_pkg.go
+++ b/dronegen/mac_pkg.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -56,8 +57,8 @@ func darwinPkgPipeline(name, makeTarget string, pkgGlobs []string) pipeline {
 				"APPLE_USERNAME":    {fromSecret: "APPLE_USERNAME"},
 				"APPLE_PASSWORD":    {fromSecret: "APPLE_PASSWORD"},
 				"BUILDBOX_PASSWORD": {fromSecret: "BUILDBOX_PASSWORD"},
-				"OSS_TARBALL_PATH":  {raw: "/tmp/build-darwin-amd64-pkg/go/artifacts"},
-				"ENT_TARBALL_PATH":  {raw: "/tmp/build-darwin-amd64-pkg/go/artifacts"},
+				"OSS_TARBALL_PATH":  {raw: filepath.Join(p.Workspace.Path, "go/artifacts")},
+				"ENT_TARBALL_PATH":  {raw: filepath.Join(p.Workspace.Path, "go/artifacts")},
 				"OS":                {raw: b.os},
 				"ARCH":              {raw: b.arch},
 			},


### PR DESCRIPTION
Follow up to https://github.com/gravitational/teleport/pull/10599 to fix is in dronegen.