### PR TITLE
(v9) Update dronegen to fix build-darwin-amd64-pkg-tsh artifacts path

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3153,9 +3153,9 @@ steps:
     ARCH: amd64
     BUILDBOX_PASSWORD:
       from_secret: BUILDBOX_PASSWORD
-    ENT_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
+    ENT_TARBALL_PATH: /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
     OS: darwin
-    OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
+    OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
     WORKSPACE_DIR: /tmp/build-darwin-amd64-pkg-tsh
 - name: Copy Mac pkg artifacts
   commands:
@@ -5084,6 +5084,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: f69247ca2ff335bc8902d8de0a67581ccfdc2d1cf210cf41d4bcd7884f5c8d95
+hmac: 50bcc305de81551bda8426a4c9c92ef50a08fea24dbd7f6b616197647d18269e
 
 ...

--- a/dronegen/mac_pkg.go
+++ b/dronegen/mac_pkg.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -56,8 +57,8 @@ func darwinPkgPipeline(name, makeTarget string, pkgGlobs []string) pipeline {
 				"APPLE_USERNAME":    {fromSecret: "APPLE_USERNAME"},
 				"APPLE_PASSWORD":    {fromSecret: "APPLE_PASSWORD"},
 				"BUILDBOX_PASSWORD": {fromSecret: "BUILDBOX_PASSWORD"},
-				"OSS_TARBALL_PATH":  {raw: "/tmp/build-darwin-amd64-pkg/go/artifacts"},
-				"ENT_TARBALL_PATH":  {raw: "/tmp/build-darwin-amd64-pkg/go/artifacts"},
+				"OSS_TARBALL_PATH":  {raw: filepath.Join(p.Workspace.Path, "go/artifacts")},
+				"ENT_TARBALL_PATH":  {raw: filepath.Join(p.Workspace.Path, "go/artifacts")},
 				"OS":                {raw: b.os},
 				"ARCH":              {raw: b.arch},
 			},


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/10861 backport.