### PR TITLE
Fix goroutine and memory leak in watchCertAuthorities

### DIFF
--- a/integration/app_integration_test.go
+++ b/integration/app_integration_test.go
@@ -1254,7 +1254,7 @@ func (p *pack) ensureAuditEvent(t *testing.T, eventType string, checkEvent func(
 // initCertPool initializes root cluster CA pool.
 func (p *pack) initCertPool(t *testing.T) {
 	authClient := p.rootCluster.GetSiteAPI(p.rootCluster.Secrets.SiteName)
-	ca, err := authClient.GetCertAuthority(types.CertAuthID{
+	ca, err := authClient.GetCertAuthority(context.Background(), types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: p.rootCluster.Secrets.SiteName,
 	}, false)

--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -798,7 +798,7 @@ func setupDatabaseTest(t *testing.T, options ...testOptionFunc) *databasePack {
 	p.setupUsersAndRoles(t)
 
 	// Update root's certificate authority on leaf to configure role mapping.
-	ca, err := p.leaf.cluster.Process.GetAuthServer().GetCertAuthority(types.CertAuthID{
+	ca, err := p.leaf.cluster.Process.GetAuthServer().GetCertAuthority(context.Background(), types.CertAuthID{
 		Type:       types.UserCA,
 		DomainName: p.root.cluster.Secrets.SiteName,
 	}, false)

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -486,7 +486,7 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	ca, err := a.GetCertAuthority(types.CertAuthID{
+	ca, err := a.GetCertAuthority(context.Background(), types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: clusterName.GetClusterName(),
 	}, false)

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -167,7 +167,7 @@ func (t *teleportService) waitForLocalAdditionalKeys(ctx context.Context) error 
 			return trace.Wrap(ctx.Err(), "timed out waiting for %s to have local additional keys", t.name)
 		case <-time.After(250 * time.Millisecond):
 		}
-		ca, err := t.process.GetAuthServer().GetCertAuthority(hostCAID, true)
+		ca, err := t.process.GetAuthServer().GetCertAuthority(ctx, hostCAID, true)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -357,7 +357,7 @@ func TestHSMRotation(t *testing.T) {
 	teleportServices = append(teleportServices, proxy)
 
 	log.Debug("TestHSMRotation: sending rotation request init")
-	err = auth1.process.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = auth1.process.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		Type:        types.HostCA,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
@@ -366,7 +366,7 @@ func TestHSMRotation(t *testing.T) {
 	require.NoError(t, teleportServices.waitForPhaseChange(ctx))
 
 	log.Debug("TestHSMRotation: sending rotation request update_clients")
-	err = auth1.process.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = auth1.process.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		Type:        types.HostCA,
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
@@ -375,7 +375,7 @@ func TestHSMRotation(t *testing.T) {
 	require.NoError(t, teleportServices.waitForRestart(ctx))
 
 	log.Debug("TestHSMRotation: sending rotation request update_servers")
-	err = auth1.process.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = auth1.process.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		Type:        types.HostCA,
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
@@ -384,7 +384,7 @@ func TestHSMRotation(t *testing.T) {
 	require.NoError(t, teleportServices.waitForRestart(ctx))
 
 	log.Debug("TestHSMRotation: sending rotation request standby")
-	err = auth1.process.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = auth1.process.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		Type:        types.HostCA,
 		TargetPhase: types.RotationPhaseStandby,
 		Mode:        types.RotationModeManual,
@@ -542,7 +542,7 @@ func TestHSMDualAuthRotation(t *testing.T) {
 	// do a full rotation
 	for _, stage := range stages {
 		log.Debugf("TestHSMDualAuthRotation: Sending rotate request %s", stage.targetPhase)
-		require.NoError(t, auth1.process.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+		require.NoError(t, auth1.process.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 			Type:        types.HostCA,
 			TargetPhase: stage.targetPhase,
 			Mode:        types.RotationModeManual,
@@ -582,7 +582,7 @@ func TestHSMDualAuthRotation(t *testing.T) {
 	// Do another full rotation from the new auth server
 	for _, stage := range stages {
 		log.Debugf("TestHSMDualAuthRotation: Sending rotate request %s", stage.targetPhase)
-		require.NoError(t, auth2.process.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+		require.NoError(t, auth2.process.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 			Type:        types.HostCA,
 			TargetPhase: stage.targetPhase,
 			Mode:        types.RotationModeManual,
@@ -697,7 +697,7 @@ func TestHSMDualAuthRotation(t *testing.T) {
 	}
 	for _, stage := range stages {
 		log.Debugf("TestHSMDualAuthRotation: Sending rotate request %s", stage.targetPhase)
-		require.NoError(t, auth1.process.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+		require.NoError(t, auth1.process.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 			Type:        types.HostCA,
 			TargetPhase: stage.targetPhase,
 			Mode:        types.RotationModeManual,
@@ -862,7 +862,7 @@ func TestHSMMigrate(t *testing.T) {
 	// do a full rotation
 	for _, stage := range stages {
 		log.Debugf("TestHSMMigrate: Sending rotate request %s", stage.targetPhase)
-		require.NoError(t, auth1.process.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+		require.NoError(t, auth1.process.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 			Type:        types.HostCA,
 			TargetPhase: stage.targetPhase,
 			Mode:        types.RotationModeManual,
@@ -890,7 +890,7 @@ func TestHSMMigrate(t *testing.T) {
 	// do a full rotation
 	for _, stage := range stages {
 		log.Debugf("TestHSMMigrate: Sending rotate request %s", stage.targetPhase)
-		require.NoError(t, auth1.process.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+		require.NoError(t, auth1.process.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 			Type:        types.HostCA,
 			TargetPhase: stage.targetPhase,
 			Mode:        types.RotationModeManual,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1905,28 +1905,28 @@ func testMapRoles(t *testing.T, suite *integrationTestSuite) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cid := types.CertAuthID{Type: types.UserCA, DomainName: tt.mainClusterName}
-			mainUserCAs, err := tt.inCluster.Process.GetAuthServer().GetCertAuthority(cid, true)
+			mainUserCAs, err := tt.inCluster.Process.GetAuthServer().GetCertAuthority(ctx, cid, true)
 			tt.outChkMainUserCA(t, err)
 			if err == nil {
 				tt.outChkMainUserCAPrivateKey(t, mainUserCAs.GetActiveKeys().SSH[0].PrivateKey)
 			}
 
 			cid = types.CertAuthID{Type: types.HostCA, DomainName: tt.mainClusterName}
-			mainHostCAs, err := tt.inCluster.Process.GetAuthServer().GetCertAuthority(cid, true)
+			mainHostCAs, err := tt.inCluster.Process.GetAuthServer().GetCertAuthority(ctx, cid, true)
 			tt.outChkMainHostCA(t, err)
 			if err == nil {
 				tt.outChkMainHostCAPrivateKey(t, mainHostCAs.GetActiveKeys().SSH[0].PrivateKey)
 			}
 
 			cid = types.CertAuthID{Type: types.UserCA, DomainName: tt.auxClusterName}
-			auxUserCAs, err := tt.inCluster.Process.GetAuthServer().GetCertAuthority(cid, true)
+			auxUserCAs, err := tt.inCluster.Process.GetAuthServer().GetCertAuthority(ctx, cid, true)
 			tt.outChkAuxUserCA(t, err)
 			if err == nil {
 				tt.outChkAuxUserCAPrivateKey(t, auxUserCAs.GetActiveKeys().SSH[0].PrivateKey)
 			}
 
 			cid = types.CertAuthID{Type: types.HostCA, DomainName: tt.auxClusterName}
-			auxHostCAs, err := tt.inCluster.Process.GetAuthServer().GetCertAuthority(cid, true)
+			auxHostCAs, err := tt.inCluster.Process.GetAuthServer().GetCertAuthority(ctx, cid, true)
 			tt.outChkAuxHostCA(t, err)
 			if err == nil {
 				tt.outChkAuxHostCAPrivateKey(t, auxHostCAs.GetActiveKeys().SSH[0].PrivateKey)
@@ -3678,13 +3678,13 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	t.Logf("Service started. Setting rotation state to %v", types.RotationPhaseUpdateClients)
 
 	// start rotation
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
 	require.NoError(t, err)
 
-	hostCA, err := svc.GetAuthServer().GetCertAuthority(types.CertAuthID{Type: types.HostCA, DomainName: Site}, false)
+	hostCA, err := svc.GetAuthServer().GetCertAuthority(ctx, types.CertAuthID{Type: types.HostCA, DomainName: Site}, false)
 	require.NoError(t, err)
 	t.Logf("Cert authority: %v", auth.CertAuthorityInfo(hostCA))
 
@@ -3693,7 +3693,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// update clients
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -3720,13 +3720,13 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	t.Logf("Service reloaded. Setting rotation state to %v", types.RotationPhaseUpdateServers)
 
 	// move to the next phase
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
 	require.NoError(t, err)
 
-	hostCA, err = svc.GetAuthServer().GetCertAuthority(types.CertAuthID{Type: types.HostCA, DomainName: Site}, false)
+	hostCA, err = svc.GetAuthServer().GetCertAuthority(ctx, types.CertAuthID{Type: types.HostCA, DomainName: Site}, false)
 	require.NoError(t, err)
 	t.Logf("Cert authority: %v", auth.CertAuthorityInfo(hostCA))
 
@@ -3749,13 +3749,13 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	t.Logf("Service reloaded. Setting rotation state to %v.", types.RotationPhaseStandby)
 
 	// complete rotation
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseStandby,
 		Mode:        types.RotationModeManual,
 	})
 	require.NoError(t, err)
 
-	hostCA, err = svc.GetAuthServer().GetCertAuthority(types.CertAuthID{Type: types.HostCA, DomainName: Site}, false)
+	hostCA, err = svc.GetAuthServer().GetCertAuthority(ctx, types.CertAuthID{Type: types.HostCA, DomainName: Site}, false)
 	require.NoError(t, err)
 	t.Logf("Cert authority: %v", auth.CertAuthorityInfo(hostCA))
 
@@ -3827,7 +3827,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	t.Logf("Service started. Setting rotation state to %q.", types.RotationPhaseInit)
 
 	// start rotation
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -3839,7 +3839,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	t.Logf("Setting rotation state to %q.", types.RotationPhaseUpdateClients)
 
 	// start rotation
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -3865,7 +3865,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	t.Logf("Service reloaded. Setting rotation state to %q.", types.RotationPhaseUpdateServers)
 
 	// move to the next phase
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
@@ -3878,7 +3878,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	t.Logf("Service reloaded. Setting rotation state to %q.", types.RotationPhaseRollback)
 
 	// complete rotation
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseRollback,
 		Mode:        types.RotationModeManual,
 	})
@@ -4011,7 +4011,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	t.Logf("Setting rotation state to %v", types.RotationPhaseInit)
 
 	// start rotation
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -4062,7 +4062,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// update clients
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -4082,7 +4082,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	t.Logf("Service reloaded. Setting rotation state to %v", types.RotationPhaseUpdateServers)
 
 	// move to the next phase
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
@@ -4109,7 +4109,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	t.Logf("Service reloaded. Setting rotation state to %v.", types.RotationPhaseStandby)
 
 	// complete rotation
-	err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		TargetPhase: types.RotationPhaseStandby,
 		Mode:        types.RotationModeManual,
 	})
@@ -4147,6 +4147,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 // TestRotateChangeSigningAlg tests the change of CA signing algorithm on
 // manual rotation.
 func testRotateChangeSigningAlg(t *testing.T, suite *integrationTestSuite) {
+	ctx := context.Background()
 	// Start with an instance using default signing alg.
 	tconf := suite.rotationConfig(true)
 	teleport := suite.newTeleportInstance()
@@ -4195,18 +4196,18 @@ func testRotateChangeSigningAlg(t *testing.T, suite *integrationTestSuite) {
 	}
 
 	assertSigningAlg := func(svc *service.TeleportProcess, alg string) {
-		hostCA, err := svc.GetAuthServer().GetCertAuthority(types.CertAuthID{Type: types.HostCA, DomainName: Site}, false)
+		hostCA, err := svc.GetAuthServer().GetCertAuthority(ctx, types.CertAuthID{Type: types.HostCA, DomainName: Site}, false)
 		require.NoError(t, err)
 		require.Equal(t, alg, sshutils.GetSigningAlgName(hostCA))
 
-		userCA, err := svc.GetAuthServer().GetCertAuthority(types.CertAuthID{Type: types.UserCA, DomainName: Site}, false)
+		userCA, err := svc.GetAuthServer().GetCertAuthority(ctx, types.CertAuthID{Type: types.UserCA, DomainName: Site}, false)
 		require.NoError(t, err)
 		require.Equal(t, alg, sshutils.GetSigningAlgName(userCA))
 	}
 
 	rotate := func(svc *service.TeleportProcess, mode string) *service.TeleportProcess {
 		t.Logf("Rotation phase: %q.", types.RotationPhaseInit)
-		err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+		err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 			TargetPhase: types.RotationPhaseInit,
 			Mode:        mode,
 		})
@@ -4217,7 +4218,7 @@ func testRotateChangeSigningAlg(t *testing.T, suite *integrationTestSuite) {
 		require.NoError(t, err)
 
 		t.Logf("Rotation phase: %q.", types.RotationPhaseUpdateClients)
-		err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+		err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 			TargetPhase: types.RotationPhaseUpdateClients,
 			Mode:        mode,
 		})
@@ -4228,7 +4229,7 @@ func testRotateChangeSigningAlg(t *testing.T, suite *integrationTestSuite) {
 		require.NoError(t, err)
 
 		t.Logf("Rotation phase: %q.", types.RotationPhaseUpdateServers)
-		err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+		err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 			TargetPhase: types.RotationPhaseUpdateServers,
 			Mode:        mode,
 		})
@@ -4239,7 +4240,7 @@ func testRotateChangeSigningAlg(t *testing.T, suite *integrationTestSuite) {
 		require.NoError(t, err)
 
 		t.Logf("rotation phase: %q", types.RotationPhaseStandby)
-		err = svc.GetAuthServer().RotateCertAuthority(auth.RotateRequest{
+		err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 			TargetPhase: types.RotationPhaseStandby,
 			Mode:        mode,
 		})
@@ -5832,7 +5833,7 @@ func TestTraitsPropagation(t *testing.T) {
 	})
 
 	// Update root's certificate authority on leaf to configure role mapping.
-	ca, err := lc.Process.GetAuthServer().GetCertAuthority(types.CertAuthID{
+	ca, err := lc.Process.GetAuthServer().GetCertAuthority(context.Background(), types.CertAuthID{
 		Type:       types.UserCA,
 		DomainName: rc.Secrets.SiteName,
 	}, false)

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -1281,7 +1281,7 @@ func kubeProxyClient(cfg kubeProxyConfig) (*kubernetes.Clientset, *rest.Config, 
 	}
 	ttl := roles.AdjustSessionTTL(10 * time.Minute)
 
-	ca, err := authServer.GetCertAuthority(types.CertAuthID{
+	ca, err := authServer.GetCertAuthority(context.Background(), types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)

--- a/integration/proxy_helpers_test.go
+++ b/integration/proxy_helpers_test.go
@@ -338,7 +338,7 @@ func withStandardRoleMapping() proxySuiteOptionsFunc {
 			rc := suite.root
 			lc := suite.leaf
 			role := suite.root.Secrets.Users[mustGetCurrentUser(t).Username].Roles[0]
-			ca, err := lc.Process.GetAuthServer().GetCertAuthority(types.CertAuthID{
+			ca, err := lc.Process.GetAuthServer().GetCertAuthority(context.Background(), types.CertAuthID{
 				Type:       types.UserCA,
 				DomainName: rc.Secrets.SiteName,
 			}, false)
@@ -509,7 +509,7 @@ func mustCreateUserIdentityFile(t *testing.T, tc *TeleInstance, username string)
 	key.Cert = sshCert
 	key.TLSCert = tlsCert
 
-	hostCAs, err := tc.Process.GetAuthServer().GetCertAuthorities(types.HostCA, false)
+	hostCAs, err := tc.Process.GetAuthServer().GetCertAuthorities(context.Background(), types.HostCA, false)
 	require.NoError(t, err)
 	key.TrustedCA = auth.AuthoritiesToTrustedCerts(hostCAs)
 

--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -66,7 +66,7 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 	}
 	// check if it's used by some external cert authorities, e.g.
 	// cert authorities related to external cluster
-	cas, err := a.Trust.GetCertAuthorities(types.UserCA, false)
+	cas, err := a.Trust.GetCertAuthorities(ctx, types.UserCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -104,10 +104,10 @@ type ReadNodeAccessPoint interface {
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 
 	// GetClusterName gets the name of the cluster from the backend.
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
@@ -162,10 +162,10 @@ type ReadProxyAccessPoint interface {
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 
 	// GetClusterName gets the name of the cluster from the backend.
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
@@ -293,10 +293,10 @@ type ReadRemoteProxyAccessPoint interface {
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 
 	// GetClusterName gets the name of the cluster from the backend.
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
@@ -389,10 +389,10 @@ type ReadKubernetesAccessPoint interface {
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 
 	// GetClusterName gets the name of the cluster from the backend.
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
@@ -450,10 +450,10 @@ type ReadAppsAccessPoint interface {
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 
 	// GetClusterName gets the name of the cluster from the backend.
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
@@ -517,10 +517,10 @@ type ReadDatabaseAccessPoint interface {
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 
 	// GetClusterName gets the name of the cluster from the backend.
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
@@ -584,10 +584,10 @@ type ReadWindowsDesktopAccessPoint interface {
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 
 	// GetClusterName gets the name of the cluster from the backend.
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)
@@ -642,10 +642,10 @@ type WindowsDesktopAccessPoint interface {
 // AccessCache is a subset of the interface working on the certificate authorities
 type AccessCache interface {
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 
 	// GetClusterAuditConfig returns cluster audit configuration.
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
@@ -709,10 +709,10 @@ type Cache interface {
 	GetAuthServers() ([]types.Server, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 
 	// GetUser returns a services.User for this cluster.
 	GetUser(name string, withSecrets bool) (types.User, error)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -997,7 +997,7 @@ func (s *APIServer) rotateCertAuthority(auth ClientI, w http.ResponseWriter, r *
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := auth.RotateCertAuthority(req); err != nil {
+	if err := auth.RotateCertAuthority(r.Context(), req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return message("ok"), nil
@@ -1042,7 +1042,7 @@ func (s *APIServer) rotateExternalCertAuthority(auth ClientI, w http.ResponseWri
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := auth.RotateExternalCertAuthority(ca); err != nil {
+	if err := auth.RotateExternalCertAuthority(r.Context(), ca); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return message("ok"), nil
@@ -1053,7 +1053,7 @@ func (s *APIServer) getCertAuthorities(auth ClientI, w http.ResponseWriter, r *h
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	certs, err := auth.GetCertAuthorities(types.CertAuthType(p.ByName("type")), loadKeys)
+	certs, err := auth.GetCertAuthorities(r.Context(), types.CertAuthType(p.ByName("type")), loadKeys)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1077,7 +1077,7 @@ func (s *APIServer) getCertAuthority(auth ClientI, w http.ResponseWriter, r *htt
 		Type:       types.CertAuthType(p.ByName("type")),
 		DomainName: p.ByName("domain"),
 	}
-	ca, err := auth.GetCertAuthority(id, loadKeys)
+	ca, err := auth.GetCertAuthority(r.Context(), id, loadKeys)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -422,7 +422,7 @@ func (a *Server) runPeriodicOperations() {
 		case <-a.closeCtx.Done():
 			return
 		case <-ticker.Chan():
-			err := a.autoRotateCertAuthorities()
+			err := a.autoRotateCertAuthorities(ctx)
 			if err != nil {
 				if trace.IsCompareFailed(err) {
 					log.Debugf("Cert authority has been updated concurrently: %v.", err)
@@ -629,7 +629,7 @@ func (a *Server) GetClusterCACert() (*LocalCAResponse, error) {
 		return nil, trace.Wrap(err)
 	}
 	// Extract the TLS CA for this cluster.
-	hostCA, err := a.GetCache().GetCertAuthority(types.CertAuthID{
+	hostCA, err := a.GetCache().GetCertAuthority(context.TODO(), types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: clusterName.GetClusterName(),
 	}, false)
@@ -656,7 +656,7 @@ func (a *Server) GenerateHostCert(hostPublicKey []byte, hostID, nodeName string,
 	}
 
 	// get the certificate authority that will be signing the public key of the host
-	ca, err := a.Trust.GetCertAuthority(types.CertAuthID{
+	ca, err := a.Trust.GetCertAuthority(context.TODO(), types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: domainName,
 	}, true)
@@ -938,13 +938,14 @@ func (a *Server) GenerateDatabaseTestCert(req DatabaseTestCertRequest) ([]byte, 
 
 // generateUserCert generates user certificates
 func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
+	ctx := context.TODO()
 	err := req.check()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Reject the cert request if there is a matching lock in force.
-	authPref, err := a.GetAuthPreference(context.TODO())
+	authPref, err := a.GetAuthPreference(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1029,7 +1030,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 		}
 	}
 
-	userCA, err := a.Trust.GetCertAuthority(types.CertAuthID{
+	userCA, err := a.Trust.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.UserCA,
 		DomainName: clusterName,
 	}, true)
@@ -1182,7 +1183,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 
 	// also include host CA certs if requested
 	if req.includeHostCA {
-		hostCA, err := a.Trust.GetCertAuthority(types.CertAuthID{
+		hostCA, err := a.Trust.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,
 			DomainName: clusterName,
 		}, false)
@@ -2060,7 +2061,7 @@ func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 	if req.NoCache {
 		client = a.Services
 	}
-	ca, err := client.GetCertAuthority(types.CertAuthID{
+	ca, err := client.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)
@@ -2074,7 +2075,7 @@ func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 	// to the backend, which is a fine tradeoff
 	if !req.NoCache && req.Rotation != nil && !req.Rotation.Matches(ca.GetRotation()) {
 		log.Debugf("Client sent rotation state %v, cache state is %v, using state from the DB.", req.Rotation, ca.GetRotation())
-		ca, err = a.GetCertAuthority(types.CertAuthID{
+		ca, err = a.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,
 			DomainName: clusterName.GetClusterName(),
 		}, true)
@@ -2584,14 +2585,14 @@ func (a *Server) NewKeepAliver(ctx context.Context) (types.KeepAliver, error) {
 
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
-func (a *Server) GetCertAuthority(id types.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
-	return a.GetCache().GetCertAuthority(id, loadSigningKeys, opts...)
+func (a *Server) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
+	return a.GetCache().GetCertAuthority(ctx, id, loadSigningKeys, opts...)
 }
 
 // GetCertAuthorities returns a list of authorities of a given type
 // loadSigningKeys controls whether signing keys should be loaded or not
-func (a *Server) GetCertAuthorities(caType types.CertAuthType, loadSigningKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
-	return a.GetCache().GetCertAuthorities(caType, loadSigningKeys, opts...)
+func (a *Server) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadSigningKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
+	return a.GetCache().GetCertAuthorities(ctx, caType, loadSigningKeys, opts...)
 }
 
 // GenerateCertAuthorityCRL generates an empty CRL for the local CA of a given type.
@@ -2601,7 +2602,7 @@ func (a *Server) GenerateCertAuthorityCRL(ctx context.Context, caType types.Cert
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	ca, err := a.GetCertAuthority(types.CertAuthID{
+	ca, err := a.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       caType,
 		DomainName: clusterName.GetClusterName(),
 	}, true)
@@ -3434,6 +3435,7 @@ func mergeKeySets(a, b types.CAKeySet) types.CAKeySet {
 // addAdditionalTrustedKeysAtomic performs an atomic CompareAndSwap to update
 // the given CA with newKeys added to the AdditionalTrustedKeys
 func (a *Server) addAddtionalTrustedKeysAtomic(
+	ctx context.Context,
 	currentCA types.CertAuthority,
 	newKeys types.CAKeySet,
 	needsUpdate func(types.CertAuthority) bool) error {
@@ -3464,7 +3466,7 @@ func (a *Server) addAddtionalTrustedKeysAtomic(
 		}
 		// else trace.IsCompareFailed(err) == true (CA was concurrently updated)
 
-		currentCA, err = a.Trust.GetCertAuthority(currentCA.GetID(), true)
+		currentCA, err = a.Trust.GetCertAuthority(ctx, currentCA.GetID(), true)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -3499,7 +3501,7 @@ func newKeySet(keyStore keystore.KeyStore, caID types.CertAuthID) (types.CAKeySe
 
 // ensureLocalAdditionalKeys adds additional trusted keys to the CA if they are not
 // already present.
-func (a *Server) ensureLocalAdditionalKeys(ca types.CertAuthority) error {
+func (a *Server) ensureLocalAdditionalKeys(ctx context.Context, ca types.CertAuthority) error {
 	if a.keyStore.HasLocalAdditionalKeys(ca) {
 		// nothing to do
 		return nil
@@ -3510,7 +3512,7 @@ func (a *Server) ensureLocalAdditionalKeys(ca types.CertAuthority) error {
 		return trace.Wrap(err)
 	}
 
-	err = a.addAddtionalTrustedKeysAtomic(ca, newKeySet, func(ca types.CertAuthority) bool {
+	err = a.addAddtionalTrustedKeysAtomic(ctx, ca, newKeySet, func(ca types.CertAuthority) bool {
 		return !a.keyStore.HasLocalAdditionalKeys(ca)
 	})
 	if err != nil {
@@ -3548,7 +3550,7 @@ func (a *Server) createSelfSignedCA(caID types.CertAuthID) error {
 
 // deleteUnusedKeys deletes all teleport keys held in a connected HSM for this
 // auth server which are not currently used in any CAs.
-func (a *Server) deleteUnusedKeys() error {
+func (a *Server) deleteUnusedKeys(ctx context.Context) error {
 	clusterName, err := a.GetClusterName()
 	if err != nil {
 		return trace.Wrap(err)
@@ -3557,7 +3559,7 @@ func (a *Server) deleteUnusedKeys() error {
 	var usedKeys [][]byte
 	for _, caType := range []types.CertAuthType{types.HostCA, types.UserCA, types.JWTSigner} {
 		caID := types.CertAuthID{Type: caType, DomainName: clusterName.GetClusterName()}
-		ca, err := a.Trust.GetCertAuthority(caID, true)
+		ca, err := a.Trust.GetCertAuthority(ctx, caID, true)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -400,28 +400,28 @@ func (a *ServerWithRoles) CreateCertAuthority(ca types.CertAuthority) error {
 }
 
 // RotateCertAuthority starts or restarts certificate authority rotation process.
-func (a *ServerWithRoles) RotateCertAuthority(req RotateRequest) error {
+func (a *ServerWithRoles) RotateCertAuthority(ctx context.Context, req RotateRequest) error {
 	if err := req.CheckAndSetDefaults(a.authServer.clock); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.action(apidefaults.Namespace, types.KindCertAuthority, types.VerbCreate, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.RotateCertAuthority(req)
+	return a.authServer.RotateCertAuthority(ctx, req)
 }
 
 // RotateExternalCertAuthority rotates external certificate authority,
 // this method is called by a remote trusted cluster and is used to update
 // only public keys and certificates of the certificate authority.
-func (a *ServerWithRoles) RotateExternalCertAuthority(ca types.CertAuthority) error {
+func (a *ServerWithRoles) RotateExternalCertAuthority(ctx context.Context, ca types.CertAuthority) error {
 	if ca == nil {
 		return trace.BadParameter("missing certificate authority")
 	}
-	ctx := &services.Context{User: a.context.User, Resource: ca}
-	if err := a.actionWithContext(ctx, apidefaults.Namespace, types.KindCertAuthority, types.VerbRotate); err != nil {
+	sctx := &services.Context{User: a.context.User, Resource: ca}
+	if err := a.actionWithContext(sctx, apidefaults.Namespace, types.KindCertAuthority, types.VerbRotate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.RotateExternalCertAuthority(ca)
+	return a.authServer.RotateExternalCertAuthority(ctx, ca)
 }
 
 // UpsertCertAuthority updates existing cert authority or updates the existing one.
@@ -445,7 +445,7 @@ func (a *ServerWithRoles) CompareAndSwapCertAuthority(new, existing types.CertAu
 	return a.authServer.CompareAndSwapCertAuthority(new, existing)
 }
 
-func (a *ServerWithRoles) GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
+func (a *ServerWithRoles) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
 	if err := a.action(apidefaults.Namespace, types.KindCertAuthority, types.VerbList, types.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -454,10 +454,10 @@ func (a *ServerWithRoles) GetCertAuthorities(caType types.CertAuthType, loadKeys
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.GetCertAuthorities(caType, loadKeys, opts...)
+	return a.authServer.GetCertAuthorities(ctx, caType, loadKeys, opts...)
 }
 
-func (a *ServerWithRoles) GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
+func (a *ServerWithRoles) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
 	if err := a.action(apidefaults.Namespace, types.KindCertAuthority, types.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -466,7 +466,7 @@ func (a *ServerWithRoles) GetCertAuthority(id types.CertAuthID, loadKeys bool, o
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.GetCertAuthority(id, loadKeys, opts...)
+	return a.authServer.GetCertAuthority(ctx, id, loadKeys, opts...)
 }
 
 func (a *ServerWithRoles) GetDomainName() (string, error) {
@@ -3514,7 +3514,7 @@ func (a *ServerWithRoles) GenerateAppToken(ctx context.Context, req types.Genera
 		return "", trace.Wrap(err)
 	}
 
-	session, err := a.authServer.generateAppToken(req.Username, req.Roles, req.URI, req.Expires)
+	session, err := a.authServer.generateAppToken(ctx, req.Username, req.Roles, req.URI, req.Expires)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -269,28 +269,28 @@ func ClientTimeout(timeout time.Duration) roundtrip.ClientParam {
 }
 
 // PostJSON is a generic method that issues http POST request to the server
-func (c *Client) PostJSON(endpoint string, val interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.PostJSON(context.TODO(), endpoint, val))
+func (c *Client) PostJSON(ctx context.Context, endpoint string, val interface{}) (*roundtrip.Response, error) {
+	return httplib.ConvertResponse(c.Client.PostJSON(ctx, endpoint, val))
 }
 
 // PutJSON is a generic method that issues http PUT request to the server
-func (c *Client) PutJSON(endpoint string, val interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.PutJSON(context.TODO(), endpoint, val))
+func (c *Client) PutJSON(ctx context.Context, endpoint string, val interface{}) (*roundtrip.Response, error) {
+	return httplib.ConvertResponse(c.Client.PutJSON(ctx, endpoint, val))
 }
 
 // PostForm is a generic method that issues http POST request to the server
-func (c *Client) PostForm(endpoint string, vals url.Values, files ...roundtrip.File) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.PostForm(context.TODO(), endpoint, vals, files...))
+func (c *Client) PostForm(ctx context.Context, endpoint string, vals url.Values, files ...roundtrip.File) (*roundtrip.Response, error) {
+	return httplib.ConvertResponse(c.Client.PostForm(ctx, endpoint, vals, files...))
 }
 
 // Get issues http GET request to the server
-func (c *Client) Get(u string, params url.Values) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.Get(context.TODO(), u, params))
+func (c *Client) Get(ctx context.Context, u string, params url.Values) (*roundtrip.Response, error) {
+	return httplib.ConvertResponse(c.Client.Get(ctx, u, params))
 }
 
 // Delete issues http Delete Request to the server
-func (c *Client) Delete(u string) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.Delete(context.TODO(), u))
+func (c *Client) Delete(ctx context.Context, u string) (*roundtrip.Response, error) {
+	return httplib.ConvertResponse(c.Client.Delete(ctx, u))
 }
 
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
@@ -299,7 +299,7 @@ func (c *Client) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out, err := c.PostJSON(c.Endpoint("kube", "csr"), req)
+	out, err := c.PostJSON(context.TODO(), c.Endpoint("kube", "csr"), req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -316,7 +316,7 @@ func (c *Client) GetSessions(namespace string) ([]session.Session, error) {
 	if namespace == "" {
 		return nil, trace.BadParameter(MissingNamespaceError)
 	}
-	out, err := c.Get(c.Endpoint("namespaces", namespace, "sessions"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("namespaces", namespace, "sessions"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -336,7 +336,7 @@ func (c *Client) GetSession(namespace string, id session.ID) (*session.Session, 
 	if err := id.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out, err := c.Get(c.Endpoint("namespaces", namespace, "sessions", string(id)), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("namespaces", namespace, "sessions", string(id)), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -352,7 +352,7 @@ func (c *Client) DeleteSession(namespace string, id session.ID) error {
 	if namespace == "" {
 		return trace.BadParameter(MissingNamespaceError)
 	}
-	_, err := c.Delete(c.Endpoint("namespaces", namespace, "sessions", string(id)))
+	_, err := c.Delete(context.TODO(), c.Endpoint("namespaces", namespace, "sessions", string(id)))
 	return trace.Wrap(err)
 }
 
@@ -361,7 +361,7 @@ func (c *Client) CreateSession(sess session.Session) error {
 	if sess.Namespace == "" {
 		return trace.BadParameter(MissingNamespaceError)
 	}
-	_, err := c.PostJSON(c.Endpoint("namespaces", sess.Namespace, "sessions"), createSessionReq{Session: sess})
+	_, err := c.PostJSON(context.TODO(), c.Endpoint("namespaces", sess.Namespace, "sessions"), createSessionReq{Session: sess})
 	return trace.Wrap(err)
 }
 
@@ -370,13 +370,13 @@ func (c *Client) UpdateSession(req session.UpdateRequest) error {
 	if err := req.Check(); err != nil {
 		return trace.Wrap(err)
 	}
-	_, err := c.PutJSON(c.Endpoint("namespaces", req.Namespace, "sessions", string(req.ID)), updateSessionReq{Update: req})
+	_, err := c.PutJSON(context.TODO(), c.Endpoint("namespaces", req.Namespace, "sessions", string(req.ID)), updateSessionReq{Update: req})
 	return trace.Wrap(err)
 }
 
 // GetDomainName returns local auth domain of the current auth server
 func (c *Client) GetDomainName() (string, error) {
-	out, err := c.Get(c.Endpoint("domain"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("domain"), url.Values{})
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -390,7 +390,7 @@ func (c *Client) GetDomainName() (string, error) {
 // GetClusterCACert returns the PEM-encoded TLS certs for the local cluster. If
 // the cluster has multiple TLS certs, they will all be concatenated.
 func (c *Client) GetClusterCACert() (*LocalCAResponse, error) {
-	out, err := c.Get(c.Endpoint("cacert"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("cacert"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -416,19 +416,19 @@ func (c *Client) CreateCertAuthority(ca types.CertAuthority) error {
 }
 
 // RotateCertAuthority starts or restarts certificate authority rotation process.
-func (c *Client) RotateCertAuthority(req RotateRequest) error {
+func (c *Client) RotateCertAuthority(ctx context.Context, req RotateRequest) error {
 	caType := "all"
 	if req.Type != "" {
 		caType = string(req.Type)
 	}
-	_, err := c.PostJSON(c.Endpoint("authorities", caType, "rotate"), req)
+	_, err := c.PostJSON(ctx, c.Endpoint("authorities", caType, "rotate"), req)
 	return trace.Wrap(err)
 }
 
 // RotateExternalCertAuthority rotates external certificate authority,
 // this method is used to update only public keys and certificates of the
 // the certificate authorities of trusted clusters.
-func (c *Client) RotateExternalCertAuthority(ca types.CertAuthority) error {
+func (c *Client) RotateExternalCertAuthority(ctx context.Context, ca types.CertAuthority) error {
 	if err := services.ValidateCertAuthority(ca); err != nil {
 		return trace.Wrap(err)
 	}
@@ -436,7 +436,7 @@ func (c *Client) RotateExternalCertAuthority(ca types.CertAuthority) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.PostJSON(c.Endpoint("authorities", string(ca.GetType()), "rotate", "external"),
+	_, err = c.PostJSON(ctx, c.Endpoint("authorities", string(ca.GetType()), "rotate", "external"),
 		&rotateExternalCertAuthorityRawReq{CA: data})
 	return trace.Wrap(err)
 }
@@ -450,7 +450,7 @@ func (c *Client) UpsertCertAuthority(ca types.CertAuthority) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.PostJSON(c.Endpoint("authorities", string(ca.GetType())),
+	_, err = c.PostJSON(context.TODO(), c.Endpoint("authorities", string(ca.GetType())),
 		&upsertCertAuthorityRawReq{CA: data})
 	return trace.Wrap(err)
 }
@@ -462,11 +462,11 @@ func (c *Client) CompareAndSwapCertAuthority(new, existing types.CertAuthority) 
 }
 
 // GetCertAuthorities returns a list of certificate authorities
-func (c *Client) GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
+func (c *Client) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
 	if err := caType.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out, err := c.Get(c.Endpoint("authorities", string(caType)), url.Values{
+	out, err := c.Get(ctx, c.Endpoint("authorities", string(caType)), url.Values{
 		"load_keys": []string{fmt.Sprintf("%t", loadKeys)},
 	})
 	if err != nil {
@@ -489,11 +489,11 @@ func (c *Client) GetCertAuthorities(caType types.CertAuthType, loadKeys bool, op
 
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
-func (c *Client) GetCertAuthority(id types.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
+func (c *Client) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
 	if err := id.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out, err := c.Get(c.Endpoint("authorities", string(id.Type), id.DomainName), url.Values{
+	out, err := c.Get(ctx, c.Endpoint("authorities", string(id.Type), id.DomainName), url.Values{
 		"load_keys": []string{fmt.Sprintf("%t", loadSigningKeys)},
 	})
 	if err != nil {
@@ -507,7 +507,7 @@ func (c *Client) DeleteCertAuthority(id types.CertAuthID) error {
 	if err := id.Check(); err != nil {
 		return trace.Wrap(err)
 	}
-	_, err := c.Delete(c.Endpoint("authorities", string(id.Type), id.DomainName))
+	_, err := c.Delete(context.TODO(), c.Endpoint("authorities", string(id.Type), id.DomainName))
 	return trace.Wrap(err)
 }
 
@@ -530,7 +530,7 @@ func (c *Client) DeactivateCertAuthority(id types.CertAuthID) error {
 // If token is not supplied, it will be auto generated and returned.
 // If TTL is not supplied, token will be valid until removed.
 func (c *Client) GenerateToken(ctx context.Context, req GenerateTokenRequest) (string, error) {
-	out, err := c.PostJSON(c.Endpoint("tokens"), req)
+	out, err := c.PostJSON(ctx, c.Endpoint("tokens"), req)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -547,7 +547,7 @@ func (c *Client) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out, err := c.PostJSON(c.Endpoint("tokens", "register"), req)
+	out, err := c.PostJSON(ctx, c.Endpoint("tokens", "register"), req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -569,7 +569,7 @@ func (c *Client) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 
 // RegisterNewAuthServer is used to register new auth server with token
 func (c *Client) RegisterNewAuthServer(ctx context.Context, token string) error {
-	_, err := c.PostJSON(c.Endpoint("tokens", "register", "auth"), registerNewAuthServerReq{
+	_, err := c.PostJSON(ctx, c.Endpoint("tokens", "register", "auth"), registerNewAuthServerReq{
 		Token: token,
 	})
 	return trace.Wrap(err)
@@ -603,7 +603,7 @@ func (c *Client) UpsertNodes(namespace string, servers []types.Server) error {
 		Namespace: namespace,
 		Nodes:     bytes,
 	}
-	_, err = c.PutJSON(c.Endpoint("namespaces", namespace, "nodes"), args)
+	_, err = c.PutJSON(context.TODO(), c.Endpoint("namespaces", namespace, "nodes"), args)
 	return trace.Wrap(err)
 }
 
@@ -617,7 +617,7 @@ func (c *Client) UpsertReverseTunnel(tunnel types.ReverseTunnel) error {
 	args := &upsertReverseTunnelRawReq{
 		ReverseTunnel: data,
 	}
-	_, err = c.PostJSON(c.Endpoint("reversetunnels"), args)
+	_, err = c.PostJSON(context.TODO(), c.Endpoint("reversetunnels"), args)
 	return trace.Wrap(err)
 }
 
@@ -628,7 +628,7 @@ func (c *Client) GetReverseTunnel(name string, opts ...services.MarshalOption) (
 
 // GetReverseTunnels returns the list of created reverse tunnels
 func (c *Client) GetReverseTunnels(opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
-	out, err := c.Get(c.Endpoint("reversetunnels"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("reversetunnels"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -655,7 +655,7 @@ func (c *Client) DeleteReverseTunnel(domainName string) error {
 	if strings.TrimSpace(domainName) == "" {
 		return trace.BadParameter("empty domain name")
 	}
-	_, err := c.Delete(c.Endpoint("reversetunnels", domainName))
+	_, err := c.Delete(context.TODO(), c.Endpoint("reversetunnels", domainName))
 	return trace.Wrap(err)
 }
 
@@ -668,7 +668,7 @@ func (c *Client) UpsertTunnelConnection(conn types.TunnelConnection) error {
 	args := &upsertTunnelConnectionRawReq{
 		TunnelConnection: data,
 	}
-	_, err = c.PostJSON(c.Endpoint("tunnelconnections"), args)
+	_, err = c.PostJSON(context.TODO(), c.Endpoint("tunnelconnections"), args)
 	return trace.Wrap(err)
 }
 
@@ -677,7 +677,7 @@ func (c *Client) GetTunnelConnections(clusterName string, opts ...services.Marsh
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing cluster name parameter")
 	}
-	out, err := c.Get(c.Endpoint("tunnelconnections", clusterName), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("tunnelconnections", clusterName), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -698,7 +698,7 @@ func (c *Client) GetTunnelConnections(clusterName string, opts ...services.Marsh
 
 // GetAllTunnelConnections returns all tunnel connections
 func (c *Client) GetAllTunnelConnections(opts ...services.MarshalOption) ([]types.TunnelConnection, error) {
-	out, err := c.Get(c.Endpoint("tunnelconnections"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("tunnelconnections"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -725,7 +725,7 @@ func (c *Client) DeleteTunnelConnection(clusterName string, connName string) err
 	if connName == "" {
 		return trace.BadParameter("missing parameter connection name")
 	}
-	_, err := c.Delete(c.Endpoint("tunnelconnections", clusterName, connName))
+	_, err := c.Delete(context.TODO(), c.Endpoint("tunnelconnections", clusterName, connName))
 	return trace.Wrap(err)
 }
 
@@ -734,7 +734,7 @@ func (c *Client) DeleteTunnelConnections(clusterName string) error {
 	if clusterName == "" {
 		return trace.BadParameter("missing parameter cluster name")
 	}
-	_, err := c.Delete(c.Endpoint("tunnelconnections", clusterName))
+	_, err := c.Delete(context.TODO(), c.Endpoint("tunnelconnections", clusterName))
 	return trace.Wrap(err)
 }
 
@@ -745,7 +745,7 @@ func (c *Client) DeleteAllTokens() error {
 
 // DeleteAllTunnelConnections deletes all tunnel connections
 func (c *Client) DeleteAllTunnelConnections() error {
-	_, err := c.Delete(c.Endpoint("tunnelconnections"))
+	_, err := c.Delete(context.TODO(), c.Endpoint("tunnelconnections"))
 	return trace.Wrap(err)
 }
 
@@ -761,7 +761,7 @@ func (c *Client) GetUserLoginAttempts(user string) ([]services.LoginAttempt, err
 
 // GetRemoteClusters returns a list of remote clusters
 func (c *Client) GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
-	out, err := c.Get(c.Endpoint("remoteclusters"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("remoteclusters"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -785,7 +785,7 @@ func (c *Client) GetRemoteCluster(clusterName string) (types.RemoteCluster, erro
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing cluster name")
 	}
-	out, err := c.Get(c.Endpoint("remoteclusters", clusterName), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("remoteclusters", clusterName), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -797,13 +797,13 @@ func (c *Client) DeleteRemoteCluster(clusterName string) error {
 	if clusterName == "" {
 		return trace.BadParameter("missing parameter cluster name")
 	}
-	_, err := c.Delete(c.Endpoint("remoteclusters", clusterName))
+	_, err := c.Delete(context.TODO(), c.Endpoint("remoteclusters", clusterName))
 	return trace.Wrap(err)
 }
 
 // DeleteAllRemoteClusters deletes all remote clusters
 func (c *Client) DeleteAllRemoteClusters() error {
-	_, err := c.Delete(c.Endpoint("remoteclusters"))
+	_, err := c.Delete(context.TODO(), c.Endpoint("remoteclusters"))
 	return trace.Wrap(err)
 }
 
@@ -816,7 +816,7 @@ func (c *Client) CreateRemoteCluster(rc types.RemoteCluster) error {
 	args := &createRemoteClusterRawReq{
 		RemoteCluster: data,
 	}
-	_, err = c.PostJSON(c.Endpoint("remoteclusters"), args)
+	_, err = c.PostJSON(context.TODO(), c.Endpoint("remoteclusters"), args)
 	return trace.Wrap(err)
 }
 
@@ -830,13 +830,13 @@ func (c *Client) UpsertAuthServer(s types.Server) error {
 	args := &upsertServerRawReq{
 		Server: data,
 	}
-	_, err = c.PostJSON(c.Endpoint("authservers"), args)
+	_, err = c.PostJSON(context.TODO(), c.Endpoint("authservers"), args)
 	return trace.Wrap(err)
 }
 
 // GetAuthServers returns the list of auth servers registered in the cluster.
 func (c *Client) GetAuthServers() ([]types.Server, error) {
-	out, err := c.Get(c.Endpoint("authservers"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("authservers"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -875,13 +875,13 @@ func (c *Client) UpsertProxy(s types.Server) error {
 	args := &upsertServerRawReq{
 		Server: data,
 	}
-	_, err = c.PostJSON(c.Endpoint("proxies"), args)
+	_, err = c.PostJSON(context.TODO(), c.Endpoint("proxies"), args)
 	return trace.Wrap(err)
 }
 
 // GetProxies returns the list of auth servers registered in the cluster.
 func (c *Client) GetProxies() ([]types.Server, error) {
-	out, err := c.Get(c.Endpoint("proxies"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("proxies"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -902,7 +902,7 @@ func (c *Client) GetProxies() ([]types.Server, error) {
 
 // DeleteAllProxies deletes all proxies
 func (c *Client) DeleteAllProxies() error {
-	_, err := c.Delete(c.Endpoint("proxies"))
+	_, err := c.Delete(context.TODO(), c.Endpoint("proxies"))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -914,7 +914,7 @@ func (c *Client) DeleteProxy(name string) error {
 	if name == "" {
 		return trace.BadParameter("missing parameter name")
 	}
-	_, err := c.Delete(c.Endpoint("proxies", name))
+	_, err := c.Delete(context.TODO(), c.Endpoint("proxies", name))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -924,6 +924,7 @@ func (c *Client) DeleteProxy(name string) error {
 // UpsertPassword updates web access password for the user
 func (c *Client) UpsertPassword(user string, password []byte) error {
 	_, err := c.PostJSON(
+		context.TODO(),
 		c.Endpoint("users", user, "web", "password"),
 		upsertPasswordReq{
 			Password: string(password),
@@ -941,7 +942,7 @@ func (c *Client) UpsertUser(user types.User) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.PostJSON(c.Endpoint("users"), &upsertUserRawReq{User: data})
+	_, err = c.PostJSON(context.TODO(), c.Endpoint("users"), &upsertUserRawReq{User: data})
 	return trace.Wrap(err)
 }
 
@@ -952,13 +953,14 @@ func (c *Client) CompareAndSwapUser(ctx context.Context, new, expected types.Use
 
 // ChangePassword updates users password based on the old password.
 func (c *Client) ChangePassword(req services.ChangePasswordReq) error {
-	_, err := c.PutJSON(c.Endpoint("users", req.User, "web", "password"), req)
+	_, err := c.PutJSON(context.TODO(), c.Endpoint("users", req.User, "web", "password"), req)
 	return trace.Wrap(err)
 }
 
 // CheckPassword checks if the suplied web access password is valid.
 func (c *Client) CheckPassword(user string, password []byte, otpToken string) error {
 	_, err := c.PostJSON(
+		context.TODO(),
 		c.Endpoint("users", user, "web", "password", "check"),
 		checkPasswordReq{
 			Password: string(password),
@@ -971,6 +973,7 @@ func (c *Client) CheckPassword(user string, password []byte, otpToken string) er
 // valid web session
 func (c *Client) ExtendWebSession(req WebSessionReq) (types.WebSession, error) {
 	out, err := c.PostJSON(
+		context.TODO(),
 		c.Endpoint("users", req.User, "web", "sessions"), req)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -981,6 +984,7 @@ func (c *Client) ExtendWebSession(req WebSessionReq) (types.WebSession, error) {
 // CreateWebSession creates a new web session for a user
 func (c *Client) CreateWebSession(user string) (types.WebSession, error) {
 	out, err := c.PostJSON(
+		context.TODO(),
 		c.Endpoint("users", user, "web", "sessions"),
 		WebSessionReq{User: user},
 	)
@@ -994,6 +998,7 @@ func (c *Client) CreateWebSession(user string) (types.WebSession, error) {
 // in case if authentication is successful
 func (c *Client) AuthenticateWebUser(req AuthenticateUserRequest) (types.WebSession, error) {
 	out, err := c.PostJSON(
+		context.TODO(),
 		c.Endpoint("users", req.Username, "web", "authenticate"),
 		req,
 	)
@@ -1007,6 +1012,7 @@ func (c *Client) AuthenticateWebUser(req AuthenticateUserRequest) (types.WebSess
 // short lived certificates as a result
 func (c *Client) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
 	out, err := c.PostJSON(
+		context.TODO(),
 		c.Endpoint("users", req.Username, "ssh", "authenticate"),
 		req,
 	)
@@ -1024,6 +1030,7 @@ func (c *Client) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginRespo
 // it is valid, or error otherwise.
 func (c *Client) GetWebSessionInfo(ctx context.Context, user, sessionID string) (types.WebSession, error) {
 	out, err := c.Get(
+		ctx,
 		c.Endpoint("users", user, "web", "sessions", sessionID), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1033,7 +1040,7 @@ func (c *Client) GetWebSessionInfo(ctx context.Context, user, sessionID string) 
 
 // DeleteWebSession deletes the web session specified with sid for the given user
 func (c *Client) DeleteWebSession(user string, sid string) error {
-	_, err := c.Delete(c.Endpoint("users", user, "web", "sessions", sid))
+	_, err := c.Delete(context.TODO(), c.Endpoint("users", user, "web", "sessions", sid))
 	return trace.Wrap(err)
 }
 
@@ -1041,7 +1048,7 @@ func (c *Client) DeleteWebSession(user string, sid string) error {
 // by password. If the pass parameter is an empty string, the key pair
 // is not password-protected.
 func (c *Client) GenerateKeyPair(pass string) ([]byte, []byte, error) {
-	out, err := c.PostJSON(c.Endpoint("keypair"), generateKeyPairReq{Password: pass})
+	out, err := c.PostJSON(context.TODO(), c.Endpoint("keypair"), generateKeyPairReq{Password: pass})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -1058,7 +1065,7 @@ func (c *Client) GenerateKeyPair(pass string) ([]byte, []byte, error) {
 func (c *Client) GenerateHostCert(
 	key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error) {
 
-	out, err := c.PostJSON(c.Endpoint("ca", "host", "certs"),
+	out, err := c.PostJSON(context.TODO(), c.Endpoint("ca", "host", "certs"),
 		generateHostCertReq{
 			Key:         key,
 			HostID:      hostID,
@@ -1082,7 +1089,7 @@ func (c *Client) GenerateHostCert(
 
 // CreateOIDCAuthRequest creates OIDCAuthRequest
 func (c *Client) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*services.OIDCAuthRequest, error) {
-	out, err := c.PostJSON(c.Endpoint("oidc", "requests", "create"), createOIDCAuthRequestReq{
+	out, err := c.PostJSON(context.TODO(), c.Endpoint("oidc", "requests", "create"), createOIDCAuthRequestReq{
 		Req: req,
 	})
 	if err != nil {
@@ -1097,7 +1104,7 @@ func (c *Client) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*services.
 
 // ValidateOIDCAuthCallback validates OIDC auth callback returned from redirect
 func (c *Client) ValidateOIDCAuthCallback(q url.Values) (*OIDCAuthResponse, error) {
-	out, err := c.PostJSON(c.Endpoint("oidc", "requests", "validate"), validateOIDCAuthCallbackReq{
+	out, err := c.PostJSON(context.TODO(), c.Endpoint("oidc", "requests", "validate"), validateOIDCAuthCallbackReq{
 		Query: q,
 	})
 	if err != nil {
@@ -1138,7 +1145,7 @@ func (c *Client) CreateSAMLConnector(ctx context.Context, connector types.SAMLCo
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.PostJSON(c.Endpoint("saml", "connectors"), &createSAMLConnectorRawReq{
+	_, err = c.PostJSON(ctx, c.Endpoint("saml", "connectors"), &createSAMLConnectorRawReq{
 		Connector: data,
 	})
 	if err != nil {
@@ -1149,7 +1156,7 @@ func (c *Client) CreateSAMLConnector(ctx context.Context, connector types.SAMLCo
 
 // CreateSAMLAuthRequest creates SAML AuthnRequest
 func (c *Client) CreateSAMLAuthRequest(req services.SAMLAuthRequest) (*services.SAMLAuthRequest, error) {
-	out, err := c.PostJSON(c.Endpoint("saml", "requests", "create"), createSAMLAuthRequestReq{
+	out, err := c.PostJSON(context.TODO(), c.Endpoint("saml", "requests", "create"), createSAMLAuthRequestReq{
 		Req: req,
 	})
 	if err != nil {
@@ -1164,7 +1171,7 @@ func (c *Client) CreateSAMLAuthRequest(req services.SAMLAuthRequest) (*services.
 
 // ValidateSAMLResponse validates response returned by SAML identity provider
 func (c *Client) ValidateSAMLResponse(re string) (*SAMLAuthResponse, error) {
-	out, err := c.PostJSON(c.Endpoint("saml", "requests", "validate"), validateSAMLResponseReq{
+	out, err := c.PostJSON(context.TODO(), c.Endpoint("saml", "requests", "validate"), validateSAMLResponseReq{
 		Response: re,
 	})
 	if err != nil {
@@ -1205,7 +1212,7 @@ func (c *Client) CreateGithubConnector(connector types.GithubConnector) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.PostJSON(c.Endpoint("github", "connectors"), &createGithubConnectorRawReq{
+	_, err = c.PostJSON(context.TODO(), c.Endpoint("github", "connectors"), &createGithubConnectorRawReq{
 		Connector: bytes,
 	})
 	if err != nil {
@@ -1216,7 +1223,7 @@ func (c *Client) CreateGithubConnector(connector types.GithubConnector) error {
 
 // CreateGithubAuthRequest creates a new request for Github OAuth2 flow
 func (c *Client) CreateGithubAuthRequest(req services.GithubAuthRequest) (*services.GithubAuthRequest, error) {
-	out, err := c.PostJSON(c.Endpoint("github", "requests", "create"),
+	out, err := c.PostJSON(context.TODO(), c.Endpoint("github", "requests", "create"),
 		createGithubAuthRequestReq{Req: req})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1230,7 +1237,7 @@ func (c *Client) CreateGithubAuthRequest(req services.GithubAuthRequest) (*servi
 
 // ValidateGithubAuthCallback validates Github auth callback returned from redirect
 func (c *Client) ValidateGithubAuthCallback(q url.Values) (*GithubAuthResponse, error) {
-	out, err := c.PostJSON(c.Endpoint("github", "requests", "validate"),
+	out, err := c.PostJSON(context.TODO(), c.Endpoint("github", "requests", "validate"),
 		validateGithubAuthCallbackReq{Query: q})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1267,7 +1274,7 @@ func (c *Client) ValidateGithubAuthCallback(q url.Values) (*GithubAuthResponse, 
 
 // EmitAuditEventLegacy sends an auditable event to the auth server (part of events.IAuditLog interface)
 func (c *Client) EmitAuditEventLegacy(event events.Event, fields events.EventFields) error {
-	_, err := c.PostJSON(c.Endpoint("events"), &auditEventReq{
+	_, err := c.PostJSON(context.TODO(), c.Endpoint("events"), &auditEventReq{
 		Event:  event,
 		Fields: fields,
 		// Send "type" as well for backwards compatibility.
@@ -1313,7 +1320,7 @@ func (c *Client) GetSessionChunk(namespace string, sid session.ID, offsetBytes, 
 	if namespace == "" {
 		return nil, trace.BadParameter(MissingNamespaceError)
 	}
-	response, err := c.Get(c.Endpoint("namespaces", namespace, "sessions", string(sid), "stream"), url.Values{
+	response, err := c.Get(context.TODO(), c.Endpoint("namespaces", namespace, "sessions", string(sid), "stream"), url.Values{
 		"offset": []string{strconv.Itoa(offsetBytes)},
 		"bytes":  []string{strconv.Itoa(maxBytes)},
 	})
@@ -1335,7 +1342,7 @@ func (c *Client) UploadSessionRecording(r events.SessionRecording) error {
 		"sid":       []string{string(r.SessionID)},
 		"namespace": []string{r.Namespace},
 	}
-	_, err := c.PostForm(c.Endpoint("namespaces", r.Namespace, "sessions", string(r.SessionID), "recording"), values, file)
+	_, err := c.PostForm(context.TODO(), c.Endpoint("namespaces", r.Namespace, "sessions", string(r.SessionID), "recording"), values, file)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1361,7 +1368,7 @@ func (c *Client) GetSessionEvents(namespace string, sid session.ID, afterN int, 
 	if includePrintEvents {
 		query.Set("print", fmt.Sprintf("%v", includePrintEvents))
 	}
-	response, err := c.Get(c.Endpoint("namespaces", namespace, "sessions", string(sid), "events"), query)
+	response, err := c.Get(context.TODO(), c.Endpoint("namespaces", namespace, "sessions", string(sid), "events"), query)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1401,7 +1408,7 @@ func (c *Client) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, order 
 
 // GetNamespaces returns a list of namespaces
 func (c *Client) GetNamespaces() ([]types.Namespace, error) {
-	out, err := c.Get(c.Endpoint("namespaces"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("namespaces"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1417,7 +1424,7 @@ func (c *Client) GetNamespace(name string) (*types.Namespace, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing namespace name")
 	}
-	out, err := c.Get(c.Endpoint("namespaces", name), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("namespaces", name), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1426,13 +1433,13 @@ func (c *Client) GetNamespace(name string) (*types.Namespace, error) {
 
 // UpsertNamespace upserts namespace
 func (c *Client) UpsertNamespace(ns types.Namespace) error {
-	_, err := c.PostJSON(c.Endpoint("namespaces"), upsertNamespaceReq{Namespace: ns})
+	_, err := c.PostJSON(context.TODO(), c.Endpoint("namespaces"), upsertNamespaceReq{Namespace: ns})
 	return trace.Wrap(err)
 }
 
 // DeleteNamespace deletes namespace by name
 func (c *Client) DeleteNamespace(name string) error {
-	_, err := c.Delete(c.Endpoint("namespaces", name))
+	_, err := c.Delete(context.TODO(), c.Endpoint("namespaces", name))
 	return trace.Wrap(err)
 }
 
@@ -1443,7 +1450,7 @@ func (c *Client) CreateRole(role types.Role) error {
 
 // GetClusterName returns a cluster name
 func (c *Client) GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error) {
-	out, err := c.Get(c.Endpoint("configuration", "name"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("configuration", "name"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1464,7 +1471,7 @@ func (c *Client) SetClusterName(cn types.ClusterName) error {
 		return trace.Wrap(err)
 	}
 
-	_, err = c.PostJSON(c.Endpoint("configuration", "name"), &setClusterNameReq{ClusterName: data})
+	_, err = c.PostJSON(context.TODO(), c.Endpoint("configuration", "name"), &setClusterNameReq{ClusterName: data})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1479,13 +1486,13 @@ func (c *Client) UpsertClusterName(cn types.ClusterName) error {
 
 // DeleteStaticTokens deletes static tokens
 func (c *Client) DeleteStaticTokens() error {
-	_, err := c.Delete(c.Endpoint("configuration", "static_tokens"))
+	_, err := c.Delete(context.TODO(), c.Endpoint("configuration", "static_tokens"))
 	return trace.Wrap(err)
 }
 
 // GetStaticTokens returns a list of static register tokens
 func (c *Client) GetStaticTokens() (types.StaticTokens, error) {
-	out, err := c.Get(c.Endpoint("configuration", "static_tokens"), url.Values{})
+	out, err := c.Get(context.TODO(), c.Endpoint("configuration", "static_tokens"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1505,7 +1512,7 @@ func (c *Client) SetStaticTokens(st types.StaticTokens) error {
 		return trace.Wrap(err)
 	}
 
-	_, err = c.PostJSON(c.Endpoint("configuration", "static_tokens"), &setStaticTokensReq{StaticTokens: data})
+	_, err = c.PostJSON(context.TODO(), c.Endpoint("configuration", "static_tokens"), &setStaticTokensReq{StaticTokens: data})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1564,7 +1571,7 @@ func (c *Client) ValidateTrustedCluster(ctx context.Context, validateRequest *Va
 		return nil, trace.Wrap(err)
 	}
 
-	out, err := c.PostJSON(c.Endpoint("trustedclusters", "validate"), validateRequestRaw)
+	out, err := c.PostJSON(ctx, c.Endpoint("trustedclusters", "validate"), validateRequestRaw)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1950,12 +1957,12 @@ type ClientI interface {
 	NewKeepAliver(ctx context.Context) (types.KeepAliver, error)
 
 	// RotateCertAuthority starts or restarts certificate authority rotation process.
-	RotateCertAuthority(req RotateRequest) error
+	RotateCertAuthority(ctx context.Context, req RotateRequest) error
 
 	// RotateExternalCertAuthority rotates external certificate authority,
 	// this method is used to update only public keys and certificates of the
 	// the certificate authorities of trusted clusters.
-	RotateExternalCertAuthority(ca types.CertAuthority) error
+	RotateExternalCertAuthority(ctx context.Context, ca types.CertAuthority) error
 
 	// ValidateTrustedCluster validates trusted cluster token with
 	// main cluster, in case if validation is successful, main cluster

--- a/lib/auth/clt_test.go
+++ b/lib/auth/clt_test.go
@@ -17,16 +17,25 @@ limitations under the License.
 package auth
 
 import (
+	"context"
 	"crypto/tls"
+	"crypto/x509/pkix"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
 
 func TestClient_DialTimeout(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		desc    string
 		timeout time.Duration
@@ -76,4 +85,101 @@ func TestClient_DialTimeout(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_RequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	testDone := make(chan struct{})
+	sawRoot := make(chan bool, 1)
+	sawSlow := make(chan bool, 1)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/authorities/host/rotate/external" {
+			sawRoot <- true
+			http.Redirect(w, r, "/slow", http.StatusFound)
+			return
+		}
+
+		if r.URL.Path == "/slow" {
+			sawSlow <- true
+			w.Write([]byte("Hello"))
+			w.(http.Flusher).Flush()
+
+			<-testDone
+			return
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(testDone) }) // before srv.Close, to unblock /slow handler
+
+	cfg := apiclient.Config{
+		Addrs: []string{srv.Listener.Addr().String()},
+		Credentials: []apiclient.Credentials{
+			apiclient.LoadTLS(&tls.Config{
+				InsecureSkipVerify: true,
+			}),
+		},
+	}
+	clt, err := NewClient(cfg)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, cfg.Credentials)
+	tlsCfg, err := cfg.Credentials[0].TLSConfig()
+	require.NoError(t, err)
+	srv.TLS = tlsCfg
+
+	srv.StartTLS()
+
+	ca := newCertAuthority(t, "test", types.HostCA)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	err = clt.RotateExternalCertAuthority(ctx, ca)
+	require.ErrorIs(t, trace.Unwrap(err), context.DeadlineExceeded)
+
+	select {
+	case <-sawRoot:
+		// good.
+	default:
+		t.Fatal("handler never got /v2/authorities/host/rotate/external request")
+	}
+
+	select {
+	case <-sawSlow:
+		// good.
+	default:
+		t.Fatal("handler never got /slow request")
+	}
+}
+
+func newCertAuthority(t *testing.T, name string, caType types.CertAuthType) types.CertAuthority {
+	ta := testauthority.New()
+	priv, pub, err := ta.GenerateKeyPair("")
+	require.NoError(t, err)
+
+	// CA for cluster1 with 1 key pair.
+	key, cert, err := tlsca.GenerateSelfSignedCA(pkix.Name{CommonName: name}, nil, time.Minute)
+	require.NoError(t, err)
+
+	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        caType,
+		ClusterName: name,
+		ActiveKeys: types.CAKeySet{
+			SSH: []*types.SSHKeyPair{{
+				PrivateKey:     priv,
+				PrivateKeyType: types.PrivateKeyType_RAW,
+				PublicKey:      pub,
+			}},
+			TLS: []*types.TLSKeyPair{{
+				Cert: cert,
+				Key:  key,
+			}},
+		},
+		Roles:      nil,
+		SigningAlg: types.CertAuthoritySpecV2_RSA_SHA2_256,
+	})
+	require.NoError(t, err)
+	return ca
 }

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -43,7 +43,7 @@ func (s *Server) GenerateDatabaseCert(ctx context.Context, req *proto.DatabaseCe
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	hostCA, err := s.GetCertAuthority(types.CertAuthID{
+	hostCA, err := s.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)
@@ -102,7 +102,7 @@ func (s *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 		return nil, trace.Wrap(err)
 	}
 
-	hostCA, err := s.GetCertAuthority(types.CertAuthID{
+	hostCA, err := s.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: req.ClusterName,
 	}, false)
@@ -144,7 +144,7 @@ func (s *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 	ttl := roles.AdjustSessionTTL(apidefaults.CertDuration)
 
 	// Generate the TLS certificate.
-	userCA, err := s.Trust.GetCertAuthority(types.CertAuthID{
+	userCA, err := s.Trust.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.UserCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)

--- a/lib/auth/desktop.go
+++ b/lib/auth/desktop.go
@@ -45,7 +45,7 @@ func (s *Server) GenerateWindowsDesktopCert(ctx context.Context, req *proto.Wind
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	userCA, err := s.GetCertAuthority(types.CertAuthID{
+	userCA, err := s.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.UserCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -293,7 +293,7 @@ func (a *Server) validateGithubAuthCallback(q url.Values) (*githubAuthResponse, 
 		re.auth.TLSCert = tlsCert
 
 		// Return the host CA for this cluster only.
-		authority, err := a.GetCertAuthority(types.CertAuthID{
+		authority, err := a.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,
 			DomainName: clusterName.GetClusterName(),
 		}, false)

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -486,8 +486,8 @@ func (a *TestAuthServer) Clock() clockwork.Clock {
 }
 
 // Trust adds other server host certificate authority as trusted
-func (a *TestAuthServer) Trust(remote *TestAuthServer, roleMap types.RoleMap) error {
-	remoteCA, err := remote.AuthServer.GetCertAuthority(types.CertAuthID{
+func (a *TestAuthServer) Trust(ctx context.Context, remote *TestAuthServer, roleMap types.RoleMap) error {
+	remoteCA, err := remote.AuthServer.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: remote.ClusterName,
 	}, false)
@@ -498,7 +498,7 @@ func (a *TestAuthServer) Trust(remote *TestAuthServer, roleMap types.RoleMap) er
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	remoteCA, err = remote.AuthServer.GetCertAuthority(types.CertAuthID{
+	remoteCA, err = remote.AuthServer.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.UserCA,
 		DomainName: remote.ClusterName,
 	}, false)

--- a/lib/auth/httpfallback.go
+++ b/lib/auth/httpfallback.go
@@ -48,7 +48,7 @@ func (c *Client) UpsertRole(ctx context.Context, role types.Role) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.PostJSON(c.Endpoint("roles"), &upsertRoleRawReq{Role: data})
+	_, err = c.PostJSON(ctx, c.Endpoint("roles"), &upsertRoleRawReq{Role: data})
 	return trace.Wrap(err)
 }
 
@@ -65,7 +65,7 @@ func (c *Client) GetRole(ctx context.Context, name string) (types.Role, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing name")
 	}
-	out, err := c.Get(c.Endpoint("roles", name), url.Values{})
+	out, err := c.Get(ctx, c.Endpoint("roles", name), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -89,7 +89,7 @@ func (c *Client) DeleteRole(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("missing name")
 	}
-	_, err := c.Delete(c.Endpoint("roles", name))
+	_, err := c.Delete(ctx, c.Endpoint("roles", name))
 	return trace.Wrap(err)
 }
 
@@ -103,7 +103,7 @@ func (c *Client) GetTokens(ctx context.Context, opts ...services.MarshalOption) 
 		return resp, nil
 	}
 
-	out, err := c.Get(c.Endpoint("tokens"), url.Values{})
+	out, err := c.Get(ctx, c.Endpoint("tokens"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -124,7 +124,7 @@ func (c *Client) GetToken(ctx context.Context, token string) (types.ProvisionTok
 		return resp, nil
 	}
 
-	out, err := c.Get(c.Endpoint("tokens", token), url.Values{})
+	out, err := c.Get(ctx, c.Endpoint("tokens", token), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -142,7 +142,7 @@ func (c *Client) DeleteToken(ctx context.Context, token string) error {
 		return nil
 	}
 
-	_, err := c.Delete(c.Endpoint("tokens", token))
+	_, err := c.Delete(ctx, c.Endpoint("tokens", token))
 	return trace.Wrap(err)
 }
 
@@ -160,7 +160,7 @@ func (c *Client) UpsertOIDCConnector(ctx context.Context, connector types.OIDCCo
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.PostJSON(c.Endpoint("oidc", "connectors"), &upsertOIDCConnectorRawReq{
+	_, err = c.PostJSON(ctx, c.Endpoint("oidc", "connectors"), &upsertOIDCConnectorRawReq{
 		Connector: data,
 	})
 	if err != nil {
@@ -182,7 +182,7 @@ func (c *Client) GetOIDCConnector(ctx context.Context, id string, withSecrets bo
 	if id == "" {
 		return nil, trace.BadParameter("missing connector id")
 	}
-	out, err := c.Get(c.Endpoint("oidc", "connectors", id),
+	out, err := c.Get(ctx, c.Endpoint("oidc", "connectors", id),
 		url.Values{"with_secrets": []string{fmt.Sprintf("%t", withSecrets)}})
 	if err != nil {
 		return nil, err
@@ -200,7 +200,7 @@ func (c *Client) GetOIDCConnectors(ctx context.Context, withSecrets bool) ([]typ
 		return resp, nil
 	}
 
-	out, err := c.Get(c.Endpoint("oidc", "connectors"),
+	out, err := c.Get(ctx, c.Endpoint("oidc", "connectors"),
 		url.Values{"with_secrets": []string{fmt.Sprintf("%t", withSecrets)}})
 	if err != nil {
 		return nil, err
@@ -233,7 +233,7 @@ func (c *Client) DeleteOIDCConnector(ctx context.Context, connectorID string) er
 	if connectorID == "" {
 		return trace.BadParameter("missing connector id")
 	}
-	_, err := c.Delete(c.Endpoint("oidc", "connectors", connectorID))
+	_, err := c.Delete(ctx, c.Endpoint("oidc", "connectors", connectorID))
 	return trace.Wrap(err)
 }
 
@@ -251,7 +251,7 @@ func (c *Client) UpsertSAMLConnector(ctx context.Context, connector types.SAMLCo
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.PutJSON(c.Endpoint("saml", "connectors"), &upsertSAMLConnectorRawReq{
+	_, err = c.PutJSON(ctx, c.Endpoint("saml", "connectors"), &upsertSAMLConnectorRawReq{
 		Connector: data,
 	})
 	if err != nil {
@@ -273,7 +273,7 @@ func (c *Client) GetSAMLConnector(ctx context.Context, id string, withSecrets bo
 	if id == "" {
 		return nil, trace.BadParameter("missing connector id")
 	}
-	out, err := c.Get(c.Endpoint("saml", "connectors", id),
+	out, err := c.Get(ctx, c.Endpoint("saml", "connectors", id),
 		url.Values{"with_secrets": []string{fmt.Sprintf("%t", withSecrets)}})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -291,7 +291,7 @@ func (c *Client) GetSAMLConnectors(ctx context.Context, withSecrets bool) ([]typ
 		return resp, nil
 	}
 
-	out, err := c.Get(c.Endpoint("saml", "connectors"),
+	out, err := c.Get(ctx, c.Endpoint("saml", "connectors"),
 		url.Values{"with_secrets": []string{fmt.Sprintf("%t", withSecrets)}})
 	if err != nil {
 		return nil, err
@@ -324,7 +324,7 @@ func (c *Client) DeleteSAMLConnector(ctx context.Context, connectorID string) er
 	if connectorID == "" {
 		return trace.BadParameter("missing connector id")
 	}
-	_, err := c.Delete(c.Endpoint("saml", "connectors", connectorID))
+	_, err := c.Delete(ctx, c.Endpoint("saml", "connectors", connectorID))
 	return trace.Wrap(err)
 }
 
@@ -342,7 +342,7 @@ func (c *Client) UpsertGithubConnector(ctx context.Context, connector types.Gith
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.PutJSON(c.Endpoint("github", "connectors"), &upsertGithubConnectorRawReq{
+	_, err = c.PutJSON(ctx, c.Endpoint("github", "connectors"), &upsertGithubConnectorRawReq{
 		Connector: bytes,
 	})
 	if err != nil {
@@ -361,7 +361,7 @@ func (c *Client) GetGithubConnectors(ctx context.Context, withSecrets bool) ([]t
 		return resp, nil
 	}
 
-	out, err := c.Get(c.Endpoint("github", "connectors"), url.Values{
+	out, err := c.Get(ctx, c.Endpoint("github", "connectors"), url.Values{
 		"with_secrets": []string{strconv.FormatBool(withSecrets)},
 	})
 	if err != nil {
@@ -392,7 +392,7 @@ func (c *Client) GetGithubConnector(ctx context.Context, id string, withSecrets 
 		return resp, nil
 	}
 
-	out, err := c.Get(c.Endpoint("github", "connectors", id), url.Values{
+	out, err := c.Get(ctx, c.Endpoint("github", "connectors", id), url.Values{
 		"with_secrets": []string{strconv.FormatBool(withSecrets)},
 	})
 	if err != nil {
@@ -411,7 +411,7 @@ func (c *Client) DeleteGithubConnector(ctx context.Context, id string) error {
 		return nil
 	}
 
-	_, err := c.Delete(c.Endpoint("github", "connectors", id))
+	_, err := c.Delete(ctx, c.Endpoint("github", "connectors", id))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -427,7 +427,7 @@ func (c *Client) GetTrustedCluster(ctx context.Context, name string) (types.Trus
 		return resp, nil
 	}
 
-	out, err := c.Get(c.Endpoint("trustedclusters", name), url.Values{})
+	out, err := c.Get(ctx, c.Endpoint("trustedclusters", name), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -449,7 +449,7 @@ func (c *Client) GetTrustedClusters(ctx context.Context) ([]types.TrustedCluster
 		return resp, nil
 	}
 
-	out, err := c.Get(c.Endpoint("trustedclusters"), url.Values{})
+	out, err := c.Get(ctx, c.Endpoint("trustedclusters"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -484,7 +484,7 @@ func (c *Client) UpsertTrustedCluster(ctx context.Context, trustedCluster types.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out, err := c.PostJSON(c.Endpoint("trustedclusters"), &upsertTrustedClusterReq{
+	out, err := c.PostJSON(ctx, c.Endpoint("trustedclusters"), &upsertTrustedClusterReq{
 		TrustedCluster: trustedClusterBytes,
 	})
 	if err != nil {
@@ -503,7 +503,7 @@ func (c *Client) DeleteTrustedCluster(ctx context.Context, name string) error {
 		return nil
 	}
 
-	_, err := c.Delete(c.Endpoint("trustedclusters", name))
+	_, err := c.Delete(ctx, c.Endpoint("trustedclusters", name))
 	return trace.Wrap(err)
 }
 
@@ -517,7 +517,7 @@ func (c *Client) DeleteAllNodes(ctx context.Context, namespace string) error {
 		return nil
 	}
 
-	_, err := c.Delete(c.Endpoint("namespaces", namespace, "nodes"))
+	_, err := c.Delete(ctx, c.Endpoint("namespaces", namespace, "nodes"))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -534,7 +534,7 @@ func (c *Client) DeleteNode(ctx context.Context, namespace string, name string) 
 		return nil
 	}
 
-	_, err := c.Delete(c.Endpoint("namespaces", namespace, "nodes", name))
+	_, err := c.Delete(ctx, c.Endpoint("namespaces", namespace, "nodes", name))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -585,7 +585,7 @@ func (c *Client) GetNodes(ctx context.Context, namespace string, opts ...service
 		return resp, nil
 	}
 
-	out, err := c.Get(c.Endpoint("namespaces", namespace, "nodes"), url.Values{})
+	out, err := c.Get(ctx, c.Endpoint("namespaces", namespace, "nodes"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -203,7 +203,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	// if resources are supplied, use them to bootstrap backend state
 	// on initial startup.
 	if len(cfg.Resources) > 0 {
-		firstStart, err := isFirstStart(asrv, cfg)
+		firstStart, err := isFirstStart(ctx, asrv, cfg)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -318,7 +318,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	// generate certificate authorities if they don't exist
 	for _, caType := range []types.CertAuthType{types.HostCA, types.UserCA, types.JWTSigner} {
 		caID := types.CertAuthID{Type: caType, DomainName: cfg.ClusterName.GetClusterName()}
-		ca, err := asrv.GetCertAuthority(caID, true)
+		ca, err := asrv.GetCertAuthority(ctx, caID, true)
 		if err != nil {
 			if !trace.IsNotFound(err) {
 				return nil, trace.Wrap(err)
@@ -343,11 +343,11 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 					// without any active keys. These keys will not be used for
 					// any signing operations until a CA rotation. Only the Host
 					// CA is necessary to issue the Admin identity.
-					if err := asrv.ensureLocalAdditionalKeys(ca); err != nil {
+					if err := asrv.ensureLocalAdditionalKeys(ctx, ca); err != nil {
 						return nil, trace.Wrap(err)
 					}
 					// reload updated CA for below checks
-					if ca, err = asrv.GetCertAuthority(caID, true); err != nil {
+					if ca, err = asrv.GetCertAuthority(ctx, caID, true); err != nil {
 						return nil, trace.Wrap(err)
 					}
 				}
@@ -367,7 +367,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 
 	// Delete any unused keys from the keyStore. This is to avoid exhausting
 	// (or wasting) HSM resources.
-	if err := asrv.deleteUnusedKeys(); err != nil {
+	if err := asrv.deleteUnusedKeys(ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -515,9 +515,10 @@ func createPresets(asrv *Server) error {
 
 // isFirstStart returns 'true' if the auth server is starting for the 1st time
 // on this server.
-func isFirstStart(authServer *Server, cfg InitConfig) (bool, error) {
+func isFirstStart(ctx context.Context, authServer *Server, cfg InitConfig) (bool, error) {
 	// check if the CA exists?
 	_, err := authServer.GetCertAuthority(
+		ctx,
 		types.CertAuthID{
 			DomainName: cfg.ClusterName.GetClusterName(),
 			Type:       types.HostCA,
@@ -948,7 +949,7 @@ func migrateRemoteClusters(ctx context.Context, asrv *Server) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	certAuthorities, err := asrv.GetCertAuthorities(types.HostCA, false)
+	certAuthorities, err := asrv.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -999,7 +1000,7 @@ func migrateRemoteClusters(ctx context.Context, asrv *Server) error {
 func migrateCertAuthorities(ctx context.Context, asrv *Server) error {
 	var errors []error
 	for _, caType := range []types.CertAuthType{types.HostCA, types.UserCA, types.JWTSigner} {
-		cas, err := asrv.GetCertAuthorities(caType, true)
+		cas, err := asrv.GetCertAuthorities(ctx, caType, true)
 		if err != nil {
 			errors = append(errors, trace.Wrap(err, "fetching %v CAs", caType))
 			continue

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -446,13 +446,14 @@ func TestClusterName(t *testing.T) {
 }
 
 func TestCASigningAlg(t *testing.T) {
+	ctx := context.Background()
 	verifyCAs := func(auth *Server, alg string) {
-		hostCAs, err := auth.GetCertAuthorities(types.HostCA, false)
+		hostCAs, err := auth.GetCertAuthorities(ctx, types.HostCA, false)
 		require.NoError(t, err)
 		for _, ca := range hostCAs {
 			require.Equal(t, sshutils.GetSigningAlgName(ca), alg)
 		}
-		userCAs, err := auth.GetCertAuthorities(types.UserCA, false)
+		userCAs, err := auth.GetCertAuthorities(ctx, types.UserCA, false)
 		require.NoError(t, err)
 		for _, ca := range userCAs {
 			require.Equal(t, sshutils.GetSigningAlgName(ca), alg)
@@ -635,7 +636,7 @@ func TestMigrateCertAuthorities(t *testing.T) {
 	var caSpecs []types.CertAuthoritySpecV2
 	for _, typ := range []types.CertAuthType{types.HostCA, types.UserCA, types.JWTSigner} {
 		t.Run(fmt.Sprintf("verify %v CA", typ), func(t *testing.T) {
-			cas, err := as.GetCertAuthorities(typ, true)
+			cas, err := as.GetCertAuthorities(ctx, typ, true)
 			require.NoError(t, err)
 			require.Len(t, cas, 1)
 			caSpecs = append(caSpecs, cas[0].(*types.CertAuthorityV2).Spec)
@@ -857,7 +858,7 @@ func TestIdentityChecker(t *testing.T) {
 	clusterName, err := authServer.GetDomainName()
 	require.NoError(t, err)
 
-	ca, err := authServer.GetCertAuthority(types.CertAuthID{
+	ca, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: clusterName,
 	}, true)

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -17,6 +17,7 @@ limitations under the License.
 package auth
 
 import (
+	"context"
 	"time"
 
 	"github.com/gravitational/teleport"
@@ -62,6 +63,7 @@ type KubeCSRResponse struct {
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
 // signed certificate if successful.
 func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
+	ctx := context.TODO()
 	if !modules.GetModules().Features().Kubernetes {
 		return nil, trace.AccessDenied(
 			"this Teleport cluster is not licensed for Kubernetes, please contact the cluster administrator")
@@ -79,7 +81,7 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	// with special provisions.
 	log.Debugf("Generating certificate to access remote Kubernetes clusters.")
 
-	hostCA, err := s.GetCertAuthority(types.CertAuthID{
+	hostCA, err := s.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: req.ClusterName,
 	}, false)
@@ -109,7 +111,7 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	roleNames := id.Groups
 	// This is a remote user, map roles to local roles first.
 	if id.TeleportCluster != clusterName.GetClusterName() {
-		ca, err := s.GetCertAuthority(types.CertAuthID{Type: types.UserCA, DomainName: id.TeleportCluster}, false)
+		ca, err := s.GetCertAuthority(ctx, types.CertAuthID{Type: types.UserCA, DomainName: id.TeleportCluster}, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -130,7 +132,7 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	// Get the correct cert TTL based on roles.
 	ttl := roles.AdjustSessionTTL(apidefaults.CertDuration)
 
-	userCA, err := s.Trust.GetCertAuthority(types.CertAuthID{
+	userCA, err := s.Trust.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.UserCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -438,7 +438,7 @@ func (s *Server) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginRespo
 	}
 
 	// Return the host CA for this cluster only.
-	authority, err := s.GetCertAuthority(types.CertAuthID{
+	authority, err := s.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: clusterName.GetClusterName(),
 	}, false)

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -582,14 +582,15 @@ func (a *Middleware) WrapContextWithUser(ctx context.Context, conn *tls.Conn) (c
 
 // ClientCertPool returns trusted x509 cerificate authority pool
 func ClientCertPool(client AccessCache, clusterName string) (*x509.CertPool, error) {
+	ctx := context.TODO()
 	pool := x509.NewCertPool()
 	var authorities []types.CertAuthority
 	if clusterName == "" {
-		hostCAs, err := client.GetCertAuthorities(types.HostCA, false)
+		hostCAs, err := client.GetCertAuthorities(ctx, types.HostCA, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		userCAs, err := client.GetCertAuthorities(types.UserCA, false)
+		userCAs, err := client.GetCertAuthorities(ctx, types.UserCA, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -597,12 +598,14 @@ func ClientCertPool(client AccessCache, clusterName string) (*x509.CertPool, err
 		authorities = append(authorities, userCAs...)
 	} else {
 		hostCA, err := client.GetCertAuthority(
+			ctx,
 			types.CertAuthID{Type: types.HostCA, DomainName: clusterName},
 			false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		userCA, err := client.GetCertAuthority(
+			ctx,
 			types.CertAuthID{Type: types.UserCA, DomainName: clusterName},
 			false)
 		if err != nil {

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -365,7 +365,7 @@ func (a *Server) validateOIDCAuthCallback(q url.Values) (*oidcAuthResponse, erro
 
 	// If the request is coming from a browser, create a web session.
 	if req.CreateWebSession {
-		session, err := a.createWebSession(context.TODO(), types.NewWebSessionRequest{
+		session, err := a.createWebSession(ctx, types.NewWebSessionRequest{
 			User:       user.GetName(),
 			Roles:      user.GetRoles(),
 			Traits:     user.GetTraits(),
@@ -389,7 +389,7 @@ func (a *Server) validateOIDCAuthCallback(q url.Values) (*oidcAuthResponse, erro
 		re.auth.TLSCert = tlsCert
 
 		// Return the host CA for this cluster only.
-		authority, err := a.GetCertAuthority(types.CertAuthID{
+		authority, err := a.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,
 			DomainName: clusterName.GetClusterName(),
 		}, false)

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -81,10 +81,10 @@ type AuthorizerAccessPoint interface {
 	GetUser(name string, withSecrets bool) (types.User, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 
 	// GetClusterAuditConfig returns cluster audit configuration.
 	GetClusterAuditConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterAuditConfig, error)
@@ -174,7 +174,7 @@ func (a *authorizer) fromUser(ctx context.Context, userI interface{}) (*Context,
 	case LocalUser:
 		return a.authorizeLocalUser(user)
 	case RemoteUser:
-		return a.authorizeRemoteUser(user)
+		return a.authorizeRemoteUser(ctx, user)
 	case BuiltinRole:
 		return a.authorizeBuiltinRole(ctx, user)
 	case RemoteBuiltinRole:
@@ -190,8 +190,8 @@ func (a *authorizer) authorizeLocalUser(u LocalUser) (*Context, error) {
 }
 
 // authorizeRemoteUser returns checker based on cert authority roles
-func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*Context, error) {
-	ca, err := a.accessPoint.GetCertAuthority(types.CertAuthID{
+func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Context, error) {
+	ca, err := a.accessPoint.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.UserCA,
 		DomainName: u.ClusterName,
 	}, false)

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package auth
 
 import (
+	"context"
 	"crypto/rsa"
 	"crypto/x509/pkix"
 	"time"
@@ -201,7 +202,7 @@ type rotationReq struct {
 // It is possible to switch from automatic to manual by setting the phase
 // to the rollback phase.
 //
-func (a *Server) RotateCertAuthority(req RotateRequest) error {
+func (a *Server) RotateCertAuthority(ctx context.Context, req RotateRequest) error {
 	if err := req.CheckAndSetDefaults(a.clock); err != nil {
 		return trace.Wrap(err)
 	}
@@ -212,7 +213,7 @@ func (a *Server) RotateCertAuthority(req RotateRequest) error {
 
 	caTypes := req.Types()
 	for _, caType := range caTypes {
-		existing, err := a.Trust.GetCertAuthority(types.CertAuthID{
+		existing, err := a.Trust.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       caType,
 			DomainName: clusterName.GetClusterName(),
 		}, true)
@@ -250,7 +251,7 @@ func (a *Server) RotateCertAuthority(req RotateRequest) error {
 // RotateExternalCertAuthority rotates external certificate authority,
 // this method is called by remote trusted cluster and is used to update
 // only public keys and certificates of the certificate authority.
-func (a *Server) RotateExternalCertAuthority(ca types.CertAuthority) error {
+func (a *Server) RotateExternalCertAuthority(ctx context.Context, ca types.CertAuthority) error {
 	if ca == nil {
 		return trace.BadParameter("missing certificate authority")
 	}
@@ -265,7 +266,7 @@ func (a *Server) RotateExternalCertAuthority(ca types.CertAuthority) error {
 		return trace.BadParameter("can not rotate local certificate authority")
 	}
 
-	existing, err := a.Trust.GetCertAuthority(types.CertAuthID{
+	existing, err := a.Trust.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       ca.GetType(),
 		DomainName: ca.GetClusterName(),
 	}, false)
@@ -309,13 +310,13 @@ func (a *Server) RotateExternalCertAuthority(ca types.CertAuthority) error {
 // autoRotateCertAuthorities automatically rotates cert authorities,
 // does nothing if no rotation parameters were set up
 // or it is too early to rotate per schedule
-func (a *Server) autoRotateCertAuthorities() error {
+func (a *Server) autoRotateCertAuthorities(ctx context.Context) error {
 	clusterName, err := a.GetClusterName()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	for _, caType := range []types.CertAuthType{types.HostCA, types.UserCA, types.JWTSigner} {
-		ca, err := a.Trust.GetCertAuthority(types.CertAuthID{
+		ca, err := a.Trust.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       caType,
 			DomainName: clusterName.GetClusterName(),
 		}, true)
@@ -327,7 +328,7 @@ func (a *Server) autoRotateCertAuthorities() error {
 		}
 		// make sure there are local AdditionalKeys during init phase of rotation
 		if ca.GetRotation().Phase == types.RotationPhaseInit {
-			if err := a.ensureLocalAdditionalKeys(ca); err != nil {
+			if err := a.ensureLocalAdditionalKeys(ctx, ca); err != nil {
 				return trace.Wrap(err)
 			}
 		}

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -427,7 +427,7 @@ func (a *Server) validateSAMLResponse(samlResponse string) (*samlAuthResponse, e
 
 	// If the request is coming from a browser, create a web session.
 	if request.CreateWebSession {
-		session, err := a.createWebSession(context.TODO(), types.NewWebSessionRequest{
+		session, err := a.createWebSession(ctx, types.NewWebSessionRequest{
 			User:       user.GetName(),
 			Roles:      user.GetRoles(),
 			Traits:     user.GetTraits(),
@@ -455,7 +455,7 @@ func (a *Server) validateSAMLResponse(samlResponse string) (*samlAuthResponse, e
 		re.auth.TLSCert = tlsCert
 
 		// Return the host CA for this cluster only.
-		authority, err := a.GetCertAuthority(types.CertAuthID{
+		authority, err := a.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,
 			DomainName: clusterName.GetClusterName(),
 		}, false)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -156,13 +156,13 @@ func WaitForAppSession(ctx context.Context, sessionID, user string, ap ReadProxy
 
 // generateAppToken generates an JWT token that will be passed along with every
 // application request.
-func (s *Server) generateAppToken(username string, roles []string, uri string, expires time.Time) (string, error) {
+func (s *Server) generateAppToken(ctx context.Context, username string, roles []string, uri string, expires time.Time) (string, error) {
 	// Get the clusters CA.
 	clusterName, err := s.GetDomainName()
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	ca, err := s.GetCertAuthority(types.CertAuthID{
+	ca, err := s.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.JWTSigner,
 		DomainName: clusterName,
 	}, true)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -116,7 +116,7 @@ func (s *TLSSuite) TestRemoteBuiltinRole(c *check.C) {
 	fixtures.ExpectConnectionProblem(c, err)
 
 	// after trust is established, things are good
-	err = s.server.AuthServer.Trust(remoteServer, nil)
+	err = s.server.AuthServer.Trust(ctx, remoteServer, nil)
 	c.Assert(err, check.IsNil)
 
 	// re initialize client with trust established.
@@ -212,7 +212,7 @@ func (s *TLSSuite) TestRemoteRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// after trust is established, things are good
-	err = s.server.AuthServer.Trust(remoteServer, nil)
+	err = s.server.AuthServer.Trust(ctx, remoteServer, nil)
 	c.Assert(err, check.IsNil)
 
 	remoteProxy, err := remoteServer.NewRemoteClient(
@@ -227,7 +227,7 @@ func (s *TLSSuite) TestRemoteRotation(c *check.C) {
 	gracePeriod := time.Hour
 	remoteServer.AuthServer.privateKey, ok = fixtures.PEMBytes["rsa"]
 	c.Assert(ok, check.Equals, true)
-	err = remoteServer.AuthServer.RotateCertAuthority(RotateRequest{
+	err = remoteServer.AuthServer.RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseInit,
@@ -236,7 +236,7 @@ func (s *TLSSuite) TestRemoteRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// moves to update clients
-	err = remoteServer.AuthServer.RotateCertAuthority(RotateRequest{
+	err = remoteServer.AuthServer.RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseUpdateClients,
@@ -244,7 +244,7 @@ func (s *TLSSuite) TestRemoteRotation(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	remoteCA, err := remoteServer.AuthServer.GetCertAuthority(types.CertAuthID{
+	remoteCA, err := remoteServer.AuthServer.GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: remoteServer.ClusterName,
 		Type:       types.HostCA,
 	}, false)
@@ -254,7 +254,7 @@ func (s *TLSSuite) TestRemoteRotation(c *check.C) {
 	// that is not associated with the remote cluster
 	clone := remoteCA.Clone()
 	clone.SetName(s.server.ClusterName())
-	err = remoteProxy.RotateExternalCertAuthority(clone)
+	err = remoteProxy.RotateExternalCertAuthority(ctx, clone)
 	fixtures.ExpectAccessDenied(c, err)
 
 	// remote proxy can't upsert the certificate authority,
@@ -263,26 +263,26 @@ func (s *TLSSuite) TestRemoteRotation(c *check.C) {
 	fixtures.ExpectAccessDenied(c, err)
 
 	// remote proxy can't read local cert authority with secrets
-	_, err = remoteProxy.GetCertAuthority(types.CertAuthID{
+	_, err = remoteProxy.GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, true)
 	fixtures.ExpectAccessDenied(c, err)
 
 	// no secrets read is allowed
-	_, err = remoteProxy.GetCertAuthority(types.CertAuthID{
+	_, err = remoteProxy.GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, false)
 	c.Assert(err, check.IsNil)
 
 	// remote auth server will get rejected
-	err = remoteAuth.RotateExternalCertAuthority(remoteCA)
+	err = remoteAuth.RotateExternalCertAuthority(ctx, remoteCA)
 	fixtures.ExpectAccessDenied(c, err)
 
 	// remote proxy should be able to perform remote cert authority
 	// rotation
-	err = remoteProxy.RotateExternalCertAuthority(remoteCA)
+	err = remoteProxy.RotateExternalCertAuthority(ctx, remoteCA)
 	c.Assert(err, check.IsNil)
 
 	// newRemoteProxy should be trusted by the auth server
@@ -301,6 +301,7 @@ func (s *TLSSuite) TestRemoteRotation(c *check.C) {
 // TestLocalProxyPermissions tests new local proxy permissions
 // as it's now allowed to update host cert authorities of remote clusters
 func (s *TLSSuite) TestLocalProxyPermissions(c *check.C) {
+	ctx := context.Background()
 	remoteServer, err := NewTestAuthServer(TestAuthServerConfig{
 		Dir:         c.MkDir(),
 		ClusterName: "remote",
@@ -309,10 +310,10 @@ func (s *TLSSuite) TestLocalProxyPermissions(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// after trust is established, things are good
-	err = s.server.AuthServer.Trust(remoteServer, nil)
+	err = s.server.AuthServer.Trust(ctx, remoteServer, nil)
 	c.Assert(err, check.IsNil)
 
-	ca, err := s.server.Auth().GetCertAuthority(types.CertAuthID{
+	ca, err := s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, false)
@@ -326,7 +327,7 @@ func (s *TLSSuite) TestLocalProxyPermissions(c *check.C) {
 	fixtures.ExpectAccessDenied(c, err)
 
 	// local proxy is allowed to update host CA of remote cert authorities
-	remoteCA, err := s.server.Auth().GetCertAuthority(types.CertAuthID{
+	remoteCA, err := s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: remoteServer.ClusterName,
 		Type:       types.HostCA,
 	}, false)
@@ -353,7 +354,7 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 	s.server.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
 	c.Assert(ok, check.Equals, true)
 	gracePeriod := time.Hour
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		Mode:        types.RotationModeAuto,
@@ -362,10 +363,10 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 
 	// advance rotation by clock
 	s.clock.Advance(gracePeriod/3 + time.Minute)
-	err = s.server.Auth().autoRotateCertAuthorities()
+	err = s.server.Auth().autoRotateCertAuthorities(ctx)
 	c.Assert(err, check.IsNil)
 
-	ca, err := s.server.Auth().GetCertAuthority(types.CertAuthID{
+	ca, err := s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, false)
@@ -382,10 +383,10 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 
 	// advance rotation by clock
 	s.clock.Advance((gracePeriod*2)/3 + time.Minute)
-	err = s.server.Auth().autoRotateCertAuthorities()
+	err = s.server.Auth().autoRotateCertAuthorities(ctx)
 	c.Assert(err, check.IsNil)
 
-	ca, err = s.server.Auth().GetCertAuthority(types.CertAuthID{
+	ca, err = s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, false)
@@ -405,9 +406,9 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 
 	// complete rotation - advance rotation by clock
 	s.clock.Advance(gracePeriod/3 + time.Minute)
-	err = s.server.Auth().autoRotateCertAuthorities()
+	err = s.server.Auth().autoRotateCertAuthorities(ctx)
 	c.Assert(err, check.IsNil)
-	ca, err = s.server.Auth().GetCertAuthority(types.CertAuthID{
+	ca, err = s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, false)
@@ -447,7 +448,7 @@ func (s *TLSSuite) TestAutoFallback(c *check.C) {
 	s.server.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
 	c.Assert(ok, check.Equals, true)
 	gracePeriod := time.Hour
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		Mode:        types.RotationModeAuto,
@@ -456,10 +457,10 @@ func (s *TLSSuite) TestAutoFallback(c *check.C) {
 
 	// advance rotation by clock
 	s.clock.Advance(gracePeriod/3 + time.Minute)
-	err = s.server.Auth().autoRotateCertAuthorities()
+	err = s.server.Auth().autoRotateCertAuthorities(ctx)
 	c.Assert(err, check.IsNil)
 
-	ca, err := s.server.Auth().GetCertAuthority(types.CertAuthID{
+	ca, err := s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, false)
@@ -468,7 +469,7 @@ func (s *TLSSuite) TestAutoFallback(c *check.C) {
 	c.Assert(ca.GetRotation().Mode, check.Equals, types.RotationModeAuto)
 
 	// rollback rotation
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseRollback,
@@ -476,7 +477,7 @@ func (s *TLSSuite) TestAutoFallback(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	ca, err = s.server.Auth().GetCertAuthority(types.CertAuthID{
+	ca, err = s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, false)
@@ -503,7 +504,7 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	gracePeriod := time.Hour
 	s.server.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
 	c.Assert(ok, check.Equals, true)
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseUpdateServers,
@@ -512,7 +513,7 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	fixtures.ExpectBadParameter(c, err)
 
 	// starts rotation
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseInit,
@@ -525,7 +526,7 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// clients reconnect
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseUpdateClients,
@@ -545,7 +546,7 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// can't jump to standy
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseStandby,
@@ -554,7 +555,7 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	fixtures.ExpectBadParameter(c, err)
 
 	// advance rotation:
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseUpdateServers,
@@ -571,7 +572,7 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// complete rotation
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseStandby,
@@ -609,7 +610,7 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 	gracePeriod := time.Hour
 	s.server.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
 	c.Assert(ok, check.Equals, true)
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseInit,
@@ -618,7 +619,7 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// move to update clients phase
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseUpdateClients,
@@ -634,7 +635,7 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// advance rotation:
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseUpdateServers,
@@ -643,7 +644,7 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// rollback rotation
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseRollback,
@@ -657,7 +658,7 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// can't jump to other phases
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseUpdateClients,
@@ -666,7 +667,7 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 	fixtures.ExpectBadParameter(c, err)
 
 	// complete rollback
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseStandby,
@@ -686,6 +687,7 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 // TestAppTokenRotation checks that JWT tokens can be rotated and tokens can or
 // can not be validated at the appropriate phase.
 func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
+	ctx := context.Background()
 	client, err := s.server.NewClient(TestBuiltin(types.RoleApp))
 	c.Assert(err, check.IsNil)
 
@@ -701,7 +703,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Check that the "old" CA can be used to verify tokens.
-	oldCA, err := s.server.Auth().GetCertAuthority(types.CertAuthID{
+	oldCA, err := s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.JWTSigner,
 	}, true)
@@ -715,7 +717,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 	// Start rotation and move to initial phase. A new CA will be added (for
 	// verification), but requests will continue to be signed by the old CA.
 	gracePeriod := time.Hour
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.JWTSigner,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseInit,
@@ -724,7 +726,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// At this point in rotation, two JWT key pairs should exist.
-	oldCA, err = s.server.Auth().GetCertAuthority(types.CertAuthID{
+	oldCA, err = s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.JWTSigner,
 	}, true)
@@ -738,7 +740,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 
 	// Move rotation into the update client phase. In this phase, requests will
 	// be signed by the new CA, but the old CA will be around to verify requests.
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.JWTSigner,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseUpdateClients,
@@ -747,7 +749,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// New tokens should now fail to validate with the old key.
-	newJWT, err := client.GenerateAppToken(context.Background(),
+	newJWT, err := client.GenerateAppToken(ctx,
 		types.GenerateAppTokenRequest{
 			Username: "foo",
 			Roles:    []string{"bar", "baz"},
@@ -757,7 +759,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// New tokens will validate with the new key.
-	newCA, err := s.server.Auth().GetCertAuthority(types.CertAuthID{
+	newCA, err := s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.JWTSigner,
 	}, true)
@@ -772,7 +774,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Move rotation into update servers phase.
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.JWTSigner,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseUpdateServers,
@@ -781,7 +783,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// At this point only the phase on the CA should have changed.
-	newCA, err = s.server.Auth().GetCertAuthority(types.CertAuthID{
+	newCA, err = s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.JWTSigner,
 	}, true)
@@ -796,7 +798,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Complete rotation. The old CA will be removed.
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.JWTSigner,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseStandby,
@@ -805,7 +807,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// The new CA should now only have a single key.
-	newCA, err = s.server.Auth().GetCertAuthority(types.CertAuthID{
+	newCA, err = s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.JWTSigner,
 	}, true)
@@ -823,6 +825,7 @@ func (s *TLSSuite) TestAppTokenRotation(c *check.C) {
 // TestRemoteUser tests scenario when remote user connects to the local
 // auth server and some edge cases.
 func (s *TLSSuite) TestRemoteUser(c *check.C) {
+	ctx := context.Background()
 	remoteServer, err := NewTestAuthServer(TestAuthServerConfig{
 		Dir:         c.MkDir(),
 		ClusterName: "remote",
@@ -847,7 +850,7 @@ func (s *TLSSuite) TestRemoteUser(c *check.C) {
 
 	// Establish trust, the request will still fail, there is
 	// no role mapping set up
-	err = s.server.AuthServer.Trust(remoteServer, nil)
+	err = s.server.AuthServer.Trust(ctx, remoteServer, nil)
 	c.Assert(err, check.IsNil)
 	_, err = remoteClient.GetDomainName()
 	fixtures.ExpectAccessDenied(c, err)
@@ -856,7 +859,7 @@ func (s *TLSSuite) TestRemoteUser(c *check.C) {
 	_, localRole, err := CreateUserAndRole(s.server.Auth(), "local-user", []string{"local-role"})
 	c.Assert(err, check.IsNil)
 
-	err = s.server.AuthServer.Trust(remoteServer, types.RoleMap{{Remote: remoteRole.GetName(), Local: []string{localRole.GetName()}}})
+	err = s.server.AuthServer.Trust(ctx, remoteServer, types.RoleMap{{Remote: remoteRole.GetName(), Local: []string{localRole.GetName()}}})
 	c.Assert(err, check.IsNil)
 
 	_, err = remoteClient.GetDomainName()
@@ -1589,7 +1592,7 @@ func (s *TLSSuite) TestGetCertAuthority(c *check.C) {
 	defer nodeClt.Close()
 
 	// node is authorized to fetch CA without secrets
-	ca, err := nodeClt.GetCertAuthority(types.CertAuthID{
+	ca, err := nodeClt.GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, false)
@@ -1602,7 +1605,7 @@ func (s *TLSSuite) TestGetCertAuthority(c *check.C) {
 	}
 
 	// node is not authorized to fetch CA with secrets
-	_, err = nodeClt.GetCertAuthority(types.CertAuthID{
+	_, err = nodeClt.GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, true)
@@ -1626,14 +1629,14 @@ func (s *TLSSuite) TestGetCertAuthority(c *check.C) {
 	defer userClt.Close()
 
 	// user is authorized to fetch CA without secrets
-	_, err = userClt.GetCertAuthority(types.CertAuthID{
+	_, err = userClt.GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, false)
 	c.Assert(err, check.IsNil)
 
 	// user is not authorized to fetch CA with secrets
-	_, err = userClt.GetCertAuthority(types.CertAuthID{
+	_, err = userClt.GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, true)
@@ -2308,7 +2311,7 @@ func (s *TLSSuite) TestGenerateAppToken(c *check.C) {
 	authClient, err := s.server.NewClient(TestBuiltin(types.RoleAdmin))
 	c.Assert(err, check.IsNil)
 
-	ca, err := authClient.GetCertAuthority(types.CertAuthID{
+	ca, err := authClient.GetCertAuthority(context.Background(), types.CertAuthID{
 		Type:       types.JWTSigner,
 		DomainName: s.server.ClusterName(),
 	}, true)
@@ -2864,7 +2867,7 @@ func (s *TLSSuite) TestRegisterCAPin(c *check.C) {
 	c.Assert(err, check.NotNil)
 
 	// Add another cert to the CA (dupe the current one for simplicity)
-	hostCA, err := s.server.AuthServer.AuthServer.GetCertAuthority(types.CertAuthID{
+	hostCA, err := s.server.AuthServer.AuthServer.GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.AuthServer.ClusterName,
 		Type:       types.HostCA,
 	}, true)
@@ -2938,7 +2941,7 @@ func (s *TLSSuite) TestRegisterCAPath(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Extract the root CA public key and write it out to the data dir.
-	hostCA, err := s.server.AuthServer.AuthServer.GetCertAuthority(types.CertAuthID{
+	hostCA, err := s.server.AuthServer.AuthServer.GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.AuthServer.ClusterName,
 		Type:       types.HostCA,
 	}, false)
@@ -3060,7 +3063,7 @@ func (s *TLSSuite) TestEventsPermissions(c *check.C) {
 
 	// start rotation
 	gracePeriod := time.Hour
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseInit,
@@ -3068,7 +3071,7 @@ func (s *TLSSuite) TestEventsPermissions(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	ca, err := s.server.Auth().GetCertAuthority(types.CertAuthID{
+	ca, err := s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, false)
@@ -3197,7 +3200,7 @@ func (s *TLSSuite) TestEventsClusterConfig(c *check.C) {
 
 	// start rotation
 	gracePeriod := time.Hour
-	err = s.server.Auth().RotateCertAuthority(RotateRequest{
+	err = s.server.Auth().RotateCertAuthority(ctx, RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
 		TargetPhase: types.RotationPhaseInit,
@@ -3205,7 +3208,7 @@ func (s *TLSSuite) TestEventsClusterConfig(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	ca, err := s.server.Auth().GetCertAuthority(types.CertAuthID{
+	ca, err := s.server.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       types.HostCA,
 	}, true)

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -98,7 +98,7 @@ func (a *Server) UpsertTrustedCluster(ctx context.Context, trustedCluster types.
 			return nil, trace.Wrap(err)
 		}
 
-		remoteCAs, err := a.establishTrust(trustedCluster)
+		remoteCAs, err := a.establishTrust(ctx, trustedCluster)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -122,7 +122,7 @@ func (a *Server) UpsertTrustedCluster(ctx context.Context, trustedCluster types.
 			return nil, trace.Wrap(err)
 		}
 
-		remoteCAs, err := a.establishTrust(trustedCluster)
+		remoteCAs, err := a.establishTrust(ctx, trustedCluster)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -231,7 +231,7 @@ func (a *Server) DeleteTrustedCluster(ctx context.Context, name string) error {
 	return nil
 }
 
-func (a *Server) establishTrust(trustedCluster types.TrustedCluster) ([]types.CertAuthority, error) {
+func (a *Server) establishTrust(ctx context.Context, trustedCluster types.TrustedCluster) ([]types.CertAuthority, error) {
 	var localCertAuthorities []types.CertAuthority
 
 	domainName, err := a.GetDomainName()
@@ -240,7 +240,7 @@ func (a *Server) establishTrust(trustedCluster types.TrustedCluster) ([]types.Ce
 	}
 
 	// get a list of certificate authorities for this auth server
-	allLocalCAs, err := a.GetCertAuthorities(types.HostCA, false)
+	allLocalCAs, err := a.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -528,6 +528,7 @@ func (a *Server) validateTrustedCluster(ctx context.Context, validateRequest *Va
 	}
 	for _, caType := range []types.CertAuthType{types.HostCA, types.UserCA} {
 		certAuthority, err := a.GetCertAuthority(
+			ctx,
 			types.CertAuthID{Type: caType, DomainName: domainName},
 			false)
 		if err != nil {

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -194,7 +194,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	)
 
 	for _, returnedCA := range resp.CAs {
-		localCA, err := a.GetCertAuthority(types.CertAuthID{
+		localCA, err := a.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       returnedCA.GetType(),
 			DomainName: localClusterName,
 		}, false)
@@ -207,7 +207,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	require.Len(t, rcs, 1)
 	require.Equal(t, leafClusterCA.GetName(), rcs[0].GetName())
 
-	hostCAs, err := a.GetCertAuthorities(types.HostCA, false)
+	hostCAs, err := a.GetCertAuthorities(ctx, types.HostCA, false)
 	require.NoError(t, err)
 	require.Len(t, hostCAs, 2)
 	require.ElementsMatch(t,
@@ -219,7 +219,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	require.Empty(t, hostCAs[1].GetRoles())
 	require.Empty(t, hostCAs[1].GetRoleMap())
 
-	userCAs, err := a.GetCertAuthorities(types.UserCA, false)
+	userCAs, err := a.GetCertAuthorities(ctx, types.UserCA, false)
 	require.NoError(t, err)
 	require.Len(t, userCAs, 1)
 	require.Equal(t, localClusterName, userCAs[0].GetName())

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1200,7 +1200,7 @@ var _ map[getCertAuthorityCacheKey]struct{} // compile-time hashability check
 
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
-func (c *Cache) GetCertAuthority(id types.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
+func (c *Cache) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
 	rg, err := c.read()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1209,8 +1209,10 @@ func (c *Cache) GetCertAuthority(id types.CertAuthID, loadSigningKeys bool, opts
 
 	if !rg.IsCacheRead() && !loadSigningKeys {
 		ta := func(_ types.CertAuthority) {} // compile-time type assertion
-		ci, err := c.fnCache.Get(context.TODO(), getCertAuthorityCacheKey{id}, func() (interface{}, error) {
-			ca, err := rg.trust.GetCertAuthority(id, loadSigningKeys, opts...)
+		ci, err := c.fnCache.Get(ctx, getCertAuthorityCacheKey{id}, func() (interface{}, error) {
+			// use cache's close context instead of request context in order to ensure
+			// that we don't cache a context cancellation error.
+			ca, err := rg.trust.GetCertAuthority(c.ctx, id, loadSigningKeys, opts...)
 			ta(ca)
 			return ca, err
 		})
@@ -1222,13 +1224,13 @@ func (c *Cache) GetCertAuthority(id types.CertAuthID, loadSigningKeys bool, opts
 		return cachedCA.Clone(), nil
 	}
 
-	ca, err := rg.trust.GetCertAuthority(id, loadSigningKeys, opts...)
+	ca, err := rg.trust.GetCertAuthority(ctx, id, loadSigningKeys, opts...)
 	if trace.IsNotFound(err) && rg.IsCacheRead() {
 		// release read lock early
 		rg.Release()
 		// fallback is sane because method is never used
 		// in construction of derivative caches.
-		if ca, err := c.Config.Trust.GetCertAuthority(id, loadSigningKeys, opts...); err == nil {
+		if ca, err := c.Config.Trust.GetCertAuthority(ctx, id, loadSigningKeys, opts...); err == nil {
 			return ca, nil
 		}
 	}
@@ -1243,7 +1245,7 @@ var _ map[getCertAuthoritiesCacheKey]struct{} // compile-time hashability check
 
 // GetCertAuthorities returns a list of authorities of a given type
 // loadSigningKeys controls whether signing keys should be loaded or not
-func (c *Cache) GetCertAuthorities(caType types.CertAuthType, loadSigningKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
+func (c *Cache) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadSigningKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
 	rg, err := c.read()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1251,8 +1253,10 @@ func (c *Cache) GetCertAuthorities(caType types.CertAuthType, loadSigningKeys bo
 	defer rg.Release()
 	if !rg.IsCacheRead() && !loadSigningKeys {
 		ta := func(_ []types.CertAuthority) {} // compile-time type assertion
-		ci, err := c.fnCache.Get(context.TODO(), getCertAuthoritiesCacheKey{caType}, func() (interface{}, error) {
-			cas, err := rg.trust.GetCertAuthorities(caType, loadSigningKeys, opts...)
+		ci, err := c.fnCache.Get(ctx, getCertAuthoritiesCacheKey{caType}, func() (interface{}, error) {
+			// use cache's close context instead of request context in order to ensure
+			// that we don't cache a context cancellation error.
+			cas, err := rg.trust.GetCertAuthorities(c.ctx, caType, loadSigningKeys, opts...)
 			ta(cas)
 			return cas, trace.Wrap(err)
 		})
@@ -1267,7 +1271,7 @@ func (c *Cache) GetCertAuthorities(caType types.CertAuthType, loadSigningKeys bo
 		}
 		return cas, nil
 	}
-	return rg.trust.GetCertAuthorities(caType, loadSigningKeys, opts...)
+	return rg.trust.GetCertAuthorities(ctx, caType, loadSigningKeys, opts...)
 }
 
 // GetStaticTokens gets the list of static tokens used to provision nodes.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -239,6 +239,7 @@ func newPack(dir string, setupConfig func(c Config) Config, opts ...packOption) 
 func TestCA(t *testing.T) {
 	p := newPackForAuth(t)
 	t.Cleanup(p.Close)
+	ctx := context.Background()
 
 	ca := suite.NewTestCA(types.UserCA, "example.com")
 	require.NoError(t, p.trustS.UpsertCertAuthority(ca))
@@ -249,7 +250,7 @@ func TestCA(t *testing.T) {
 		t.Fatalf("timeout waiting for event")
 	}
 
-	out, err := p.cache.GetCertAuthority(ca.GetID(), true)
+	out, err := p.cache.GetCertAuthority(ctx, ca.GetID(), true)
 	require.NoError(t, err)
 	ca.SetResourceID(out.GetResourceID())
 	require.Empty(t, cmp.Diff(ca, out))
@@ -263,7 +264,7 @@ func TestCA(t *testing.T) {
 		t.Fatalf("timeout waiting for event")
 	}
 
-	_, err = p.cache.GetCertAuthority(ca.GetID(), false)
+	_, err = p.cache.GetCertAuthority(ctx, ca.GetID(), false)
 	require.True(t, trace.IsNotFound(err))
 }
 
@@ -576,7 +577,7 @@ func TestCompletenessInit(t *testing.T) {
 
 		p.backend.SetReadError(nil)
 
-		cas, err := p.cache.GetCertAuthorities(types.UserCA, false)
+		cas, err := p.cache.GetCertAuthorities(ctx, types.UserCA, false)
 		// we don't actually care whether the cache ever fully constructed
 		// the CA list.  for the purposes of this test, we just care that it
 		// doesn't return the CA list *unless* it was successfully constructed.
@@ -633,7 +634,7 @@ func TestCompletenessReset(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify that CAs are immediately available
-	cas, err := p.cache.GetCertAuthorities(types.UserCA, false)
+	cas, err := p.cache.GetCertAuthorities(ctx, types.UserCA, false)
 	require.NoError(t, err)
 	require.Len(t, cas, caCount)
 
@@ -644,7 +645,7 @@ func TestCompletenessReset(t *testing.T) {
 		p.backend.SetReadError(nil)
 
 		// load CAs while connection is bad
-		cas, err := p.cache.GetCertAuthorities(types.UserCA, false)
+		cas, err := p.cache.GetCertAuthorities(ctx, types.UserCA, false)
 		// we don't actually care whether the cache ever fully constructed
 		// the CA list.  for the purposes of this test, we just care that it
 		// doesn't return the CA list *unless* it was successfully constructed.
@@ -696,7 +697,7 @@ func TestTombstones(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify that CAs are immediately available
-	cas, err := p.cache.GetCertAuthorities(types.UserCA, false)
+	cas, err := p.cache.GetCertAuthorities(ctx, types.UserCA, false)
 	require.NoError(t, err)
 	require.Len(t, cas, caCount)
 
@@ -732,7 +733,7 @@ func TestTombstones(t *testing.T) {
 
 	// verify that CAs are immediately available despite the fact
 	// that the origin state was never available.
-	cas, err = p.cache.GetCertAuthorities(types.UserCA, false)
+	cas, err = p.cache.GetCertAuthorities(ctx, types.UserCA, false)
 	require.NoError(t, err)
 	require.Len(t, cas, caCount)
 }
@@ -976,7 +977,7 @@ func initStrategy(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	_, err = p.cache.GetCertAuthorities(types.UserCA, false)
+	_, err = p.cache.GetCertAuthorities(ctx, types.UserCA, false)
 	require.True(t, trace.IsConnectionProblem(err))
 
 	ca := suite.NewTestCA(types.UserCA, "example.com")
@@ -998,7 +999,7 @@ func initStrategy(t *testing.T) {
 	}
 	_ = normalizeCA
 
-	out, err := p.cache.GetCertAuthority(ca.GetID(), false)
+	out, err := p.cache.GetCertAuthority(ctx, ca.GetID(), false)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(normalizeCA(ca), normalizeCA(out)))
 
@@ -1012,7 +1013,7 @@ func initStrategy(t *testing.T) {
 	expectNextEvent(t, p.eventsC, WatcherFailed, EventProcessed, Reloading)
 
 	// backend is out, but old value is available
-	out2, err := p.cache.GetCertAuthority(ca.GetID(), false)
+	out2, err := p.cache.GetCertAuthority(ctx, ca.GetID(), false)
 	require.NoError(t, err)
 	require.Equal(t, out.GetResourceID(), out2.GetResourceID())
 	require.Empty(t, cmp.Diff(normalizeCA(ca), normalizeCA(out)))
@@ -1030,7 +1031,7 @@ func initStrategy(t *testing.T) {
 	expectEvent(t, p.eventsC, WatcherStarted)
 
 	// new value is available now
-	out, err = p.cache.GetCertAuthority(ca.GetID(), false)
+	out, err = p.cache.GetCertAuthority(ctx, ca.GetID(), false)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(normalizeCA(ca), normalizeCA(out)))
 }
@@ -1070,7 +1071,7 @@ func TestRecovery(t *testing.T) {
 		t.Fatalf("timeout waiting for event")
 	}
 
-	out, err := p.cache.GetCertAuthority(ca2.GetID(), false)
+	out, err := p.cache.GetCertAuthority(context.Background(), ca2.GetID(), false)
 	require.NoError(t, err)
 	ca2.SetResourceID(out.GetResourceID())
 	types.RemoveCASecrets(ca2)

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -813,17 +813,17 @@ func (c *certAuthority) erase(ctx context.Context) error {
 }
 
 func (c *certAuthority) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
-	applyHostCAs, err := c.fetchCertAuthorities(types.HostCA)
+	applyHostCAs, err := c.fetchCertAuthorities(ctx, types.HostCA)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	applyUserCAs, err := c.fetchCertAuthorities(types.UserCA)
+	applyUserCAs, err := c.fetchCertAuthorities(ctx, types.UserCA)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	applyJWTSigners, err := c.fetchCertAuthorities(types.JWTSigner)
+	applyJWTSigners, err := c.fetchCertAuthorities(ctx, types.JWTSigner)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -839,8 +839,8 @@ func (c *certAuthority) fetch(ctx context.Context) (apply func(ctx context.Conte
 	}, nil
 }
 
-func (c *certAuthority) fetchCertAuthorities(caType types.CertAuthType) (apply func(ctx context.Context) error, err error) {
-	authorities, err := c.Trust.GetCertAuthorities(caType, c.watch.LoadSecrets)
+func (c *certAuthority) fetchCertAuthorities(ctx context.Context, caType types.CertAuthType) (apply func(ctx context.Context) error, err error) {
+	authorities, err := c.Trust.GetCertAuthorities(ctx, caType, c.watch.LoadSecrets)
 	if err != nil {
 		// DELETE IN: 5.1
 		//

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2668,7 +2668,7 @@ func (tc *TeleportClient) GetTrustedCA(ctx context.Context, clusterName string) 
 	}
 
 	// Get the list of host certificates that this cluster knows about.
-	return clt.GetCertAuthorities(types.HostCA, false)
+	return clt.GetCertAuthorities(ctx, types.HostCA, false)
 }
 
 // UpdateTrustedCA connects to the Auth Server and fetches all host certificates

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -902,7 +902,7 @@ func (ap mockAccessPoint) GetKubeServices(ctx context.Context) ([]types.Server, 
 	return ap.kubeServices, nil
 }
 
-func (ap mockAccessPoint) GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
+func (ap mockAccessPoint) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
 	var cas []types.CertAuthority
 	for _, ca := range ap.cas {
 		cas = append(cas, ca)
@@ -910,7 +910,7 @@ func (ap mockAccessPoint) GetCertAuthorities(caType types.CertAuthType, loadKeys
 	return cas, nil
 }
 
-func (ap mockAccessPoint) GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
+func (ap mockAccessPoint) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
 	return ap.cas[id.DomainName], nil
 }
 

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -243,7 +243,7 @@ func (a *Agent) getPrincipalsList() []string {
 }
 
 func (a *Agent) getHostCheckers() ([]ssh.PublicKey, error) {
-	cas, err := a.AccessPoint.GetCertAuthorities(types.HostCA, false)
+	cas, err := a.AccessPoint.GetCertAuthorities(context.TODO(), types.HostCA, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -89,7 +89,7 @@ type fakeClient struct {
 	caKey ssh.PublicKey
 }
 
-func (fc *fakeClient) GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
+func (fc *fakeClient) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
 	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
 		Type:         types.HostCA,
 		ClusterName:  "example.com",

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -89,7 +89,7 @@ type remoteSite struct {
 
 func (s *remoteSite) getRemoteClient() (auth.ClientI, bool, error) {
 	// check if all cert authorities are initiated and if everything is OK
-	ca, err := s.srv.localAccessPoint.GetCertAuthority(types.CertAuthID{Type: types.HostCA, DomainName: s.domainName}, false)
+	ca, err := s.srv.localAccessPoint.GetCertAuthority(s.ctx, types.CertAuthID{Type: types.HostCA, DomainName: s.domainName}, false)
 	if err != nil {
 		return nil, false, trace.Wrap(err)
 	}
@@ -493,7 +493,7 @@ func (s *remoteSite) watchCertAuthorities() error {
 					continue
 				}
 
-				if err := s.remoteClient.RotateExternalCertAuthority(localCA); err != nil {
+				if err := s.remoteClient.RotateExternalCertAuthority(s.ctx, localCA); err != nil {
 					s.WithError(err).Warn("Failed to rotate external ca")
 					return trace.Wrap(err)
 				}
@@ -505,7 +505,7 @@ func (s *remoteSite) watchCertAuthorities() error {
 					continue
 				}
 
-				oldRemoteCA, err := s.localClient.GetCertAuthority(types.CertAuthID{
+				oldRemoteCA, err := s.localClient.GetCertAuthority(s.ctx, types.CertAuthID{
 					Type:       types.HostCA,
 					DomainName: remoteCA.GetClusterName(),
 				}, false)

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -724,7 +724,7 @@ func (s *server) findLocalCluster(sconn *ssh.ServerConn) (*localSite, error) {
 }
 
 func (s *server) getTrustedCAKeysByID(id types.CertAuthID) ([]ssh.PublicKey, error) {
-	ca, err := s.localAccessPoint.GetCertAuthority(id, false)
+	ca, err := s.localAccessPoint.GetCertAuthority(context.TODO(), id, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reversetunnel
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -155,6 +156,6 @@ type mockAccessPoint struct {
 	ca types.CertAuthority
 }
 
-func (ap mockAccessPoint) GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
+func (ap mockAccessPoint) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
 	return ap.ca, nil
 }

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -320,9 +320,9 @@ func (process *TeleportProcess) newWatcher(conn *Connector, watch types.Watch) (
 // TLS client this method uses the local auth server.
 func (process *TeleportProcess) getCertAuthority(conn *Connector, id types.CertAuthID, loadPrivateKeys bool) (types.CertAuthority, error) {
 	if conn.ClientIdentity.ID.Role == types.RoleAdmin || conn.ClientIdentity.ID.Role == types.RoleAuth {
-		return process.localAuth.GetCertAuthority(id, loadPrivateKeys)
+		return process.localAuth.GetCertAuthority(process.ExitContext(), id, loadPrivateKeys)
 	}
-	return conn.Client.GetCertAuthority(id, loadPrivateKeys)
+	return conn.Client.GetCertAuthority(process.ExitContext(), id, loadPrivateKeys)
 }
 
 // reRegister receives new identity credentials for proxy, node and auth.

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -77,7 +77,7 @@ func (s *CA) UpsertCertAuthority(ca types.CertAuthority) error {
 	}
 
 	// try to skip writes that would have no effect
-	if existing, err := s.GetCertAuthority(types.CertAuthID{
+	if existing, err := s.GetCertAuthority(context.TODO(), types.CertAuthID{
 		Type:       ca.GetType(),
 		DomainName: ca.GetClusterName(),
 	}, true); err == nil {
@@ -200,7 +200,7 @@ func (s *CA) ActivateCertAuthority(id types.CertAuthID) error {
 // DeactivateCertAuthority moves a CertAuthority from the normal list to
 // the deactivated list.
 func (s *CA) DeactivateCertAuthority(id types.CertAuthID) error {
-	certAuthority, err := s.GetCertAuthority(id, true)
+	certAuthority, err := s.GetCertAuthority(context.TODO(), id, true)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("can not deactivate cert authority %q which does not exist", id.DomainName)
@@ -234,11 +234,11 @@ func (s *CA) DeactivateCertAuthority(id types.CertAuthID) error {
 
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
-func (s *CA) GetCertAuthority(id types.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
+func (s *CA) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
 	if err := id.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	item, err := s.Get(context.TODO(), backend.Key(authoritiesPrefix, string(id.Type), id.DomainName))
+	item, err := s.Get(ctx, backend.Key(authoritiesPrefix, string(id.Type), id.DomainName))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -263,14 +263,14 @@ func setSigningKeys(ca types.CertAuthority, loadSigningKeys bool) {
 
 // GetCertAuthorities returns a list of authorities of a given type
 // loadSigningKeys controls whether signing keys should be loaded or not
-func (s *CA) GetCertAuthorities(caType types.CertAuthType, loadSigningKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
+func (s *CA) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadSigningKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
 	if err := caType.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Get all items in the bucket.
 	startKey := backend.Key(authoritiesPrefix, string(caType))
-	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
+	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -275,15 +275,16 @@ func (s *ServicesTestSuite) LoginAttempts(c *check.C) {
 }
 
 func (s *ServicesTestSuite) CertAuthCRUD(c *check.C) {
+	ctx := context.Background()
 	ca := NewTestCA(types.UserCA, "example.com")
 	c.Assert(s.CAS.UpsertCertAuthority(ca), check.IsNil)
 
-	out, err := s.CAS.GetCertAuthority(ca.GetID(), true)
+	out, err := s.CAS.GetCertAuthority(ctx, ca.GetID(), true)
 	c.Assert(err, check.IsNil)
 	ca.SetResourceID(out.GetResourceID())
 	fixtures.DeepCompare(c, out, ca)
 
-	cas, err := s.CAS.GetCertAuthorities(types.UserCA, false)
+	cas, err := s.CAS.GetCertAuthorities(ctx, types.UserCA, false)
 	c.Assert(err, check.IsNil)
 	ca2 := ca.Clone().(*types.CertAuthorityV2)
 	ca2.Spec.ActiveKeys.SSH[0].PrivateKey = nil
@@ -294,11 +295,11 @@ func (s *ServicesTestSuite) CertAuthCRUD(c *check.C) {
 	ca2.Spec.JWTKeyPairs[0].PrivateKey = nil
 	fixtures.DeepCompare(c, cas[0], ca2)
 
-	cas, err = s.CAS.GetCertAuthorities(types.UserCA, true)
+	cas, err = s.CAS.GetCertAuthorities(ctx, types.UserCA, true)
 	c.Assert(err, check.IsNil)
 	fixtures.DeepCompare(c, cas[0], ca)
 
-	cas, err = s.CAS.GetCertAuthorities(types.UserCA, true)
+	cas, err = s.CAS.GetCertAuthorities(ctx, types.UserCA, true)
 	c.Assert(err, check.IsNil)
 	fixtures.DeepCompare(c, cas[0], ca)
 
@@ -322,7 +323,7 @@ func (s *ServicesTestSuite) CertAuthCRUD(c *check.C) {
 	err = s.CAS.CompareAndSwapCertAuthority(&newCA, ca)
 	c.Assert(err, check.IsNil)
 
-	out, err = s.CAS.GetCertAuthority(ca.GetID(), true)
+	out, err = s.CAS.GetCertAuthority(ctx, ca.GetID(), true)
 	c.Assert(err, check.IsNil)
 	newCA.SetResourceID(out.GetResourceID())
 	fixtures.DeepCompare(c, &newCA, out)
@@ -1348,7 +1349,7 @@ func (s *ServicesTestSuite) Events(c *check.C) {
 				ca := NewTestCA(types.UserCA, "example.com")
 				c.Assert(s.CAS.UpsertCertAuthority(ca), check.IsNil)
 
-				out, err := s.CAS.GetCertAuthority(*ca.ID(), true)
+				out, err := s.CAS.GetCertAuthority(ctx, *ca.ID(), true)
 				c.Assert(err, check.IsNil)
 
 				c.Assert(s.CAS.DeleteCertAuthority(*ca.ID()), check.IsNil)
@@ -1369,7 +1370,7 @@ func (s *ServicesTestSuite) Events(c *check.C) {
 				ca := NewTestCA(types.UserCA, "example.com")
 				c.Assert(s.CAS.UpsertCertAuthority(ca), check.IsNil)
 
-				out, err := s.CAS.GetCertAuthority(*ca.ID(), false)
+				out, err := s.CAS.GetCertAuthority(ctx, *ca.ID(), false)
 				c.Assert(err, check.IsNil)
 
 				c.Assert(s.CAS.DeleteCertAuthority(*ca.ID()), check.IsNil)

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -16,15 +16,19 @@ limitations under the License.
 
 package services
 
-import "github.com/gravitational/teleport/api/types"
+import (
+	"context"
+
+	"github.com/gravitational/teleport/api/types"
+)
 
 // AuthorityGetter defines interface for fetching cert authority resources.
 type AuthorityGetter interface {
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id types.CertAuthID, loadKeys bool, opts ...MarshalOption) (types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...MarshalOption) (types.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...MarshalOption) ([]types.CertAuthority, error)
 }
 
 // Trust is responsible for managing certificate authorities

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -729,8 +729,13 @@ func (p *databaseCollector) getResourcesAndUpdateCurrent(ctx context.Context) er
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	p.current = newCurrent
-	p.DatabasesC <- databases
-	return nil
+
+	select {
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
+	case p.DatabasesC <- databases:
+		return nil
+	}
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -744,7 +749,10 @@ func (p *databaseCollector) processEventAndUpdateCurrent(ctx context.Context, ev
 	switch event.Type {
 	case types.OpDelete:
 		delete(p.current, event.Resource.GetName())
-		p.DatabasesC <- databasesToSlice(p.current)
+		select {
+		case <-ctx.Done():
+		case p.DatabasesC <- databasesToSlice(p.current):
+		}
 	case types.OpPut:
 		database, ok := event.Resource.(types.Database)
 		if !ok {
@@ -752,7 +760,11 @@ func (p *databaseCollector) processEventAndUpdateCurrent(ctx context.Context, ev
 			return
 		}
 		p.current[database.GetName()] = database
-		p.DatabasesC <- databasesToSlice(p.current)
+		select {
+		case <-ctx.Done():
+		case p.DatabasesC <- databasesToSlice(p.current):
+		}
+
 	default:
 		p.Log.Warnf("Unsupported event type %s.", event.Type)
 		return
@@ -845,8 +857,13 @@ func (p *appCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	p.current = newCurrent
-	p.AppsC <- apps
-	return nil
+
+	select {
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
+	case p.AppsC <- apps:
+		return nil
+	}
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -861,6 +878,12 @@ func (p *appCollector) processEventAndUpdateCurrent(ctx context.Context, event t
 	case types.OpDelete:
 		delete(p.current, event.Resource.GetName())
 		p.AppsC <- appsToSlice(p.current)
+
+		select {
+		case <-ctx.Done():
+		case p.AppsC <- appsToSlice(p.current):
+		}
+
 	case types.OpPut:
 		app, ok := event.Resource.(types.Application)
 		if !ok {
@@ -868,7 +891,11 @@ func (p *appCollector) processEventAndUpdateCurrent(ctx context.Context, event t
 			return
 		}
 		p.current[app.GetName()] = app
-		p.AppsC <- appsToSlice(p.current)
+
+		select {
+		case <-ctx.Done():
+		case p.AppsC <- appsToSlice(p.current):
+		}
 	default:
 		p.Log.Warnf("Unsupported event type %s.", event.Type)
 		return
@@ -961,7 +988,7 @@ func (c *caCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 	)
 
 	if c.WatchHostCA {
-		host, err := c.AuthorityGetter.GetCertAuthorities(types.HostCA, false)
+		host, err := c.AuthorityGetter.GetCertAuthorities(ctx, types.HostCA, false)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -972,7 +999,7 @@ func (c *caCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 	}
 
 	if c.WatchUserCA {
-		user, err := c.AuthorityGetter.GetCertAuthorities(types.UserCA, false)
+		user, err := c.AuthorityGetter.GetCertAuthorities(ctx, types.UserCA, false)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -987,8 +1014,12 @@ func (c *caCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 	c.user = newUser
 	c.lock.Unlock()
 
-	c.CertAuthorityC <- casToSlice(newHost, newUser)
-	return nil
+	select {
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
+	case c.CertAuthorityC <- casToSlice(newHost, newUser):
+		return nil
+	}
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -1008,7 +1039,10 @@ func (c *caCollector) processEventAndUpdateCurrent(ctx context.Context, event ty
 			delete(c.user, event.Resource.GetName())
 		}
 
-		c.CertAuthorityC <- casToSlice(c.host, c.user)
+		select {
+		case <-ctx.Done():
+		case c.CertAuthorityC <- casToSlice(c.host, c.user):
+		}
 	case types.OpPut:
 		ca, ok := event.Resource.(types.CertAuthority)
 		if !ok {
@@ -1023,7 +1057,10 @@ func (c *caCollector) processEventAndUpdateCurrent(ctx context.Context, event ty
 			c.user[ca.GetName()] = ca
 		}
 
-		c.CertAuthorityC <- casToSlice(c.host, c.user)
+		select {
+		case <-ctx.Done():
+		case c.CertAuthorityC <- casToSlice(c.host, c.user):
+		}
 	default:
 		c.Log.Warnf("Unsupported event type %s.", event.Type)
 		return

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -734,8 +734,9 @@ func (p *databaseCollector) getResourcesAndUpdateCurrent(ctx context.Context) er
 	case <-ctx.Done():
 		return trace.Wrap(ctx.Err())
 	case p.DatabasesC <- databases:
-		return nil
 	}
+
+	return nil
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -862,8 +863,8 @@ func (p *appCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 	case <-ctx.Done():
 		return trace.Wrap(ctx.Err())
 	case p.AppsC <- apps:
-		return nil
 	}
+	return nil
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -1018,8 +1019,8 @@ func (c *caCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 	case <-ctx.Done():
 		return trace.Wrap(ctx.Err())
 	case c.CertAuthorityC <- casToSlice(newHost, newUser):
-		return nil
 	}
+	return nil
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -155,7 +155,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	err = s.tlsServer.Auth().UpsertRole(context.Background(), s.role)
 	require.NoError(t, err)
 
-	rootCA, err := s.tlsServer.Auth().GetCertAuthority(types.CertAuthID{
+	rootCA, err := s.tlsServer.Auth().GetCertAuthority(context.Background(), types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: "root.example.com",
 	}, false)

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package srv
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -507,7 +508,7 @@ func (h *AuthHandlers) fetchRoleSet(cert *ssh.Certificate, ca types.CertAuthorit
 // Certificate Authority and returns it.
 func (h *AuthHandlers) authorityForCert(caType types.CertAuthType, key ssh.PublicKey) (types.CertAuthority, error) {
 	// get all certificate authorities for given type
-	cas, err := h.c.AccessPoint.GetCertAuthorities(caType, false)
+	cas, err := h.c.AccessPoint.GetCertAuthorities(context.TODO(), caType, false)
 	if err != nil {
 		h.log.Warnf("%v", trace.DebugReport(err))
 		return nil, trace.Wrap(err)

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -99,7 +99,7 @@ type AccessPoint interface {
 	GetRole(ctx context.Context, name string) (types.Role, error)
 
 	// GetCertAuthorities returns a list of cert authorities
-	GetCertAuthorities(caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error)
 }
 
 // Server is regular or forwarding SSH server.

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -1612,7 +1612,7 @@ func setupTestContext(ctx context.Context, t *testing.T, withDatabases ...withDa
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, testCtx.authClient.Close()) })
 
-	testCtx.hostCA, err = testCtx.authClient.GetCertAuthority(types.CertAuthID{Type: types.HostCA, DomainName: testCtx.clusterName}, false)
+	testCtx.hostCA, err = testCtx.authClient.GetCertAuthority(ctx, types.CertAuthID{Type: types.HostCA, DomainName: testCtx.clusterName}, false)
 	require.NoError(t, err)
 
 	// Auth client, lock watcher and authorizer for database proxy.

--- a/lib/srv/db/common/test.go
+++ b/lib/srv/db/common/test.go
@@ -145,7 +145,7 @@ func MakeTestClientTLSConfig(config TestClientConfig) (*tls.Config, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	ca, err := config.AuthClient.GetCertAuthority(types.CertAuthID{
+	ca, err := config.AuthClient.GetCertAuthority(context.Background(), types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: config.Cluster,
 	}, false)

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -1028,7 +1028,7 @@ func (s *WindowsService) updateCA(ctx context.Context) error {
 	// have to do it here.
 	//
 	// TODO(zmb3): support multiple CA certs per cluster (such as with HSMs).
-	ca, err := s.cfg.AccessPoint.GetCertAuthority(types.CertAuthID{
+	ca, err := s.cfg.AccessPoint.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.UserCA,
 		DomainName: s.clusterName,
 	}, false)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -965,7 +965,7 @@ func (h *Handler) jwks(w http.ResponseWriter, r *http.Request, p httprouter.Para
 	}
 
 	// Fetch the JWT public keys only.
-	ca, err := h.cfg.ProxyClient.GetCertAuthority(types.CertAuthID{
+	ca, err := h.cfg.ProxyClient.GetCertAuthority(r.Context(), types.CertAuthID{
 		Type:       types.JWTSigner,
 		DomainName: clusterName,
 	}, false)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1163,7 +1163,7 @@ func mustStartWindowsDesktopMock(t *testing.T, authClient *auth.Server) *windows
 	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	require.NoError(t, err)
 
-	ca, err := authClient.GetCertAuthority(types.CertAuthID{Type: types.UserCA, DomainName: n.GetClusterName()}, false)
+	ca, err := authClient.GetCertAuthority(context.Background(), types.CertAuthID{Type: types.UserCA, DomainName: n.GetClusterName()}, false)
 	require.NoError(t, err)
 
 	for _, kp := range services.GetTLSCerts(ca) {

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -256,7 +256,7 @@ func configureTLS(c *transportConfig) (*tls.Config, error) {
 	// Configure the pool of certificates that will be used to verify the
 	// identity of the server. This allows the client to verify the identity of
 	// the server it is connecting to.
-	ca, err := c.accessPoint.GetCertAuthority(types.CertAuthID{
+	ca, err := c.accessPoint.GetCertAuthority(context.TODO(), types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: c.identity.RouteToApp.ClusterName,
 	}, false)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -209,9 +209,10 @@ func (c *SessionContext) tryRemoteTLSClient(cluster reversetunnel.RemoteSite) (a
 // ClientTLSConfig returns client TLS authentication associated
 // with the web session context
 func (c *SessionContext) ClientTLSConfig(clusterName ...string) (*tls.Config, error) {
+	ctx := context.TODO()
 	var certPool *x509.CertPool
 	if len(clusterName) == 0 {
-		certAuthorities, err := c.parent.proxyClient.GetCertAuthorities(types.HostCA, false)
+		certAuthorities, err := c.parent.proxyClient.GetCertAuthorities(ctx, types.HostCA, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -220,7 +221,7 @@ func (c *SessionContext) ClientTLSConfig(clusterName ...string) (*tls.Config, er
 			return nil, trace.Wrap(err)
 		}
 	} else {
-		certAuthority, err := c.parent.proxyClient.GetCertAuthority(types.CertAuthID{
+		certAuthority, err := c.parent.proxyClient.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,
 			DomainName: clusterName[0],
 		}, false)
@@ -305,7 +306,8 @@ func (c *SessionContext) GetAgent() (agent.Agent, *ssh.Certificate, error) {
 }
 
 func (c *SessionContext) getCheckers() ([]ssh.PublicKey, error) {
-	cas, err := c.unsafeCachedAuthClient.GetCertAuthorities(types.HostCA, false)
+	ctx := context.TODO()
+	cas, err := c.unsafeCachedAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -826,7 +828,8 @@ func (s *sessionCache) newSessionContextFromSession(session types.WebSession) (*
 }
 
 func (s *sessionCache) tlsConfig(cert, privKey []byte) (*tls.Config, error) {
-	ca, err := s.proxyClient.GetCertAuthority(types.CertAuthID{
+	ctx := context.TODO()
+	ca, err := s.proxyClient.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: s.clusterName,
 	}, false)

--- a/tool/tbot/config/configtemplate_ssh.go
+++ b/tool/tbot/config/configtemplate_ssh.go
@@ -101,7 +101,7 @@ func (c *TemplateSSHClient) Render(ctx context.Context, authClient auth.ClientI,
 		dataDir = ""
 	}
 
-	knownHosts, err := fetchKnownHosts(authClient, clusterName.GetClusterName(), proxyHost)
+	knownHosts, err := fetchKnownHosts(ctx, authClient, clusterName.GetClusterName(), proxyHost)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -163,8 +163,8 @@ Host *.{{ .ClusterName }} !{{ .ProxyHost }}
 # End generated Teleport configuration
 `))
 
-func fetchKnownHosts(client auth.ClientI, clusterName, proxyHosts string) (string, error) {
-	ca, err := client.GetCertAuthority(types.CertAuthID{
+func fetchKnownHosts(ctx context.Context, client auth.ClientI, clusterName, proxyHosts string) (string, error) {
+	ca, err := client.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: clusterName,
 	}, false)

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -133,15 +133,16 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, config *service.Confi
 // TryRun takes the CLI command as an argument (like "auth gen") and executes it
 // or returns match=false if 'cmd' does not belong to it
 func (a *AuthCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+	ctx := context.Background()
 	switch cmd {
 	case a.authGenerate.FullCommand():
-		err = a.GenerateKeys()
+		err = a.GenerateKeys(ctx)
 	case a.authExport.FullCommand():
-		err = a.ExportAuthorities(client)
+		err = a.ExportAuthorities(ctx, client)
 	case a.authSign.FullCommand():
-		err = a.GenerateAndSignKeys(client)
+		err = a.GenerateAndSignKeys(ctx, client)
 	case a.authRotate.FullCommand():
-		err = a.RotateCertAuthority(client)
+		err = a.RotateCertAuthority(ctx, client)
 	default:
 		return false, nil
 	}
@@ -153,7 +154,7 @@ var allowedCertificateTypes = []string{"user", "host", "tls-host", "tls-user", "
 // ExportAuthorities outputs the list of authorities in OpenSSH compatible formats
 // If --type flag is given, only prints keys for CAs of this type, otherwise
 // prints all keys
-func (a *AuthCommand) ExportAuthorities(client auth.ClientI) error {
+func (a *AuthCommand) ExportAuthorities(ctx context.Context, client auth.ClientI) error {
 	var typesToExport []types.CertAuthType
 
 	// this means to export TLS authority
@@ -162,11 +163,11 @@ func (a *AuthCommand) ExportAuthorities(client auth.ClientI) error {
 	// "tls-host" and "tls-user" were added later to allow export of the user
 	// TLS CA.
 	case "tls", "tls-host":
-		return a.exportTLSAuthority(client, types.HostCA, false)
+		return a.exportTLSAuthority(ctx, client, types.HostCA, false)
 	case "tls-user":
-		return a.exportTLSAuthority(client, types.UserCA, false)
+		return a.exportTLSAuthority(ctx, client, types.UserCA, false)
 	case "tls-user-der", "windows":
-		return a.exportTLSAuthority(client, types.UserCA, true)
+		return a.exportTLSAuthority(ctx, client, types.UserCA, true)
 	}
 
 	// if no --type flag is given, export all types
@@ -188,7 +189,7 @@ func (a *AuthCommand) ExportAuthorities(client auth.ClientI) error {
 	// trusted ones)
 	var authorities []types.CertAuthority
 	for _, at := range typesToExport {
-		cas, err := client.GetCertAuthorities(at, a.exportPrivateKeys)
+		cas, err := client.GetCertAuthorities(ctx, at, a.exportPrivateKeys)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -257,12 +258,13 @@ func (a *AuthCommand) ExportAuthorities(client auth.ClientI) error {
 	return nil
 }
 
-func (a *AuthCommand) exportTLSAuthority(client auth.ClientI, typ types.CertAuthType, unpackPEM bool) error {
+func (a *AuthCommand) exportTLSAuthority(ctx context.Context, client auth.ClientI, typ types.CertAuthType, unpackPEM bool) error {
 	clusterName, err := client.GetDomainName()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	certAuthority, err := client.GetCertAuthority(
+		ctx,
 		types.CertAuthID{Type: typ, DomainName: clusterName},
 		a.exportPrivateKeys,
 	)
@@ -295,8 +297,8 @@ func (a *AuthCommand) exportTLSAuthority(client auth.ClientI, typ types.CertAuth
 }
 
 // GenerateKeys generates a new keypair
-func (a *AuthCommand) GenerateKeys() error {
-	keygen := native.New(context.TODO(), native.PrecomputeKeys(0))
+func (a *AuthCommand) GenerateKeys(ctx context.Context) error {
+	keygen := native.New(ctx, native.PrecomputeKeys(0))
 	defer keygen.Close()
 	privBytes, pubBytes, err := keygen.GenerateKeyPair("")
 	if err != nil {
@@ -317,23 +319,23 @@ func (a *AuthCommand) GenerateKeys() error {
 }
 
 // GenerateAndSignKeys generates a new keypair and signs it for role
-func (a *AuthCommand) GenerateAndSignKeys(clusterAPI auth.ClientI) error {
+func (a *AuthCommand) GenerateAndSignKeys(ctx context.Context, clusterAPI auth.ClientI) error {
 	switch a.outputFormat {
 	case identityfile.FormatDatabase, identityfile.FormatMongo, identityfile.FormatCockroach, identityfile.FormatRedis:
-		return a.generateDatabaseKeys(clusterAPI)
+		return a.generateDatabaseKeys(ctx, clusterAPI)
 	}
 	switch {
 	case a.genUser != "" && a.genHost == "":
-		return a.generateUserKeys(clusterAPI)
+		return a.generateUserKeys(ctx, clusterAPI)
 	case a.genUser == "" && a.genHost != "":
-		return a.generateHostKeys(clusterAPI)
+		return a.generateHostKeys(ctx, clusterAPI)
 	default:
 		return trace.BadParameter("--user or --host must be specified")
 	}
 }
 
 // RotateCertAuthority starts or restarts certificate authority rotation process
-func (a *AuthCommand) RotateCertAuthority(client auth.ClientI) error {
+func (a *AuthCommand) RotateCertAuthority(ctx context.Context, client auth.ClientI) error {
 	req := auth.RotateRequest{
 		Type:        types.CertAuthType(a.rotateType),
 		GracePeriod: &a.rotateGracePeriod,
@@ -344,7 +346,7 @@ func (a *AuthCommand) RotateCertAuthority(client auth.ClientI) error {
 	} else {
 		req.Mode = types.RotationModeAuto
 	}
-	if err := client.RotateCertAuthority(req); err != nil {
+	if err := client.RotateCertAuthority(ctx, req); err != nil {
 		return err
 	}
 	if a.rotateTargetPhase != "" {
@@ -356,7 +358,7 @@ func (a *AuthCommand) RotateCertAuthority(client auth.ClientI) error {
 	return nil
 }
 
-func (a *AuthCommand) generateHostKeys(clusterAPI auth.ClientI) error {
+func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI auth.ClientI) error {
 	// only format=openssh is supported
 	if a.outputFormat != identityfile.FormatOpenSSH {
 		return trace.BadParameter("invalid --format flag %q, only %q is supported", a.outputFormat, identityfile.FormatOpenSSH)
@@ -383,7 +385,7 @@ func (a *AuthCommand) generateHostKeys(clusterAPI auth.ClientI) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	hostCAs, err := clusterAPI.GetCertAuthorities(types.HostCA, false)
+	hostCAs, err := clusterAPI.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -410,17 +412,17 @@ func (a *AuthCommand) generateHostKeys(clusterAPI auth.ClientI) error {
 
 // generateDatabaseKeys generates a new unsigned key and signs it with Teleport
 // CA for database access.
-func (a *AuthCommand) generateDatabaseKeys(clusterAPI auth.ClientI) error {
+func (a *AuthCommand) generateDatabaseKeys(ctx context.Context, clusterAPI auth.ClientI) error {
 	key, err := client.NewKey()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return a.generateDatabaseKeysForKey(clusterAPI, key)
+	return a.generateDatabaseKeysForKey(ctx, clusterAPI, key)
 }
 
 // generateDatabaseKeysForKey signs the provided unsigned key with Teleport CA
 // for database access.
-func (a *AuthCommand) generateDatabaseKeysForKey(clusterAPI auth.ClientI, key *client.Key) error {
+func (a *AuthCommand) generateDatabaseKeysForKey(ctx context.Context, clusterAPI auth.ClientI, key *client.Key) error {
 	principals := strings.Split(a.genHost, ",")
 	if len(principals) == 1 && principals[0] == "" {
 		return trace.BadParameter("at least one hostname must be specified via --host flag")
@@ -455,7 +457,7 @@ func (a *AuthCommand) generateDatabaseKeysForKey(clusterAPI auth.ClientI, key *c
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	resp, err := clusterAPI.GenerateDatabaseCert(context.TODO(),
+	resp, err := clusterAPI.GenerateDatabaseCert(ctx,
 		&proto.DatabaseCertRequest{
 			CSR: csr,
 			// Important to include SANs since CommonName has been deprecated
@@ -559,7 +561,7 @@ tls-protocols "TLSv1.2 TLSv1.3"
 `))
 )
 
-func (a *AuthCommand) generateUserKeys(clusterAPI auth.ClientI) error {
+func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI auth.ClientI) error {
 	// Validate --proxy flag.
 	if err := a.checkProxyAddr(clusterAPI); err != nil {
 		return trace.Wrap(err)
@@ -589,7 +591,7 @@ func (a *AuthCommand) generateUserKeys(clusterAPI auth.ClientI) error {
 	}
 	key.ClusterName = a.leafCluster
 
-	if err := a.checkKubeCluster(clusterAPI); err != nil {
+	if err := a.checkKubeCluster(ctx, clusterAPI); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -597,12 +599,12 @@ func (a *AuthCommand) generateUserKeys(clusterAPI auth.ClientI) error {
 	var certUsage proto.UserCertsRequest_CertUsage
 
 	if a.appName != "" {
-		server, err := getApplicationServer(context.TODO(), clusterAPI, a.appName)
+		server, err := getApplicationServer(ctx, clusterAPI, a.appName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		appSession, err := clusterAPI.CreateAppSession(context.TODO(), types.CreateAppSessionRequest{
+		appSession, err := clusterAPI.CreateAppSession(ctx, types.CreateAppSessionRequest{
 			Username:    a.genUser,
 			PublicAddr:  server.GetApp().GetPublicAddr(),
 			ClusterName: a.leafCluster,
@@ -622,7 +624,7 @@ func (a *AuthCommand) generateUserKeys(clusterAPI auth.ClientI) error {
 
 	reqExpiry := time.Now().UTC().Add(a.genTTL)
 	// Request signed certs from `auth` server.
-	certs, err := clusterAPI.GenerateUserCerts(context.TODO(), proto.UserCertsRequest{
+	certs, err := clusterAPI.GenerateUserCerts(ctx, proto.UserCertsRequest{
 		PublicKey:         key.Pub,
 		Username:          a.genUser,
 		Expires:           reqExpiry,
@@ -638,7 +640,7 @@ func (a *AuthCommand) generateUserKeys(clusterAPI auth.ClientI) error {
 	key.Cert = certs.SSH
 	key.TLSCert = certs.TLS
 
-	hostCAs, err := clusterAPI.GetCertAuthorities(types.HostCA, false)
+	hostCAs, err := clusterAPI.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -699,7 +701,7 @@ func (a *AuthCommand) checkLeafCluster(clusterAPI auth.ClientI) error {
 
 }
 
-func (a *AuthCommand) checkKubeCluster(clusterAPI auth.ClientI) error {
+func (a *AuthCommand) checkKubeCluster(ctx context.Context, clusterAPI auth.ClientI) error {
 	if a.outputFormat != identityfile.FormatKubernetes && a.kubeCluster != "" {
 		// User set --kube-cluster-name but it's not actually used for the chosen --format.
 		// Print a warning but continue.
@@ -719,7 +721,7 @@ func (a *AuthCommand) checkKubeCluster(clusterAPI auth.ClientI) error {
 		return nil
 	}
 
-	a.kubeCluster, err = kubeutils.CheckOrSetKubeCluster(context.TODO(), clusterAPI, a.kubeCluster, a.leafCluster)
+	a.kubeCluster, err = kubeutils.CheckOrSetKubeCluster(ctx, clusterAPI, a.kubeCluster, a.leafCluster)
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -237,7 +237,7 @@ func TestAuthSignKubeconfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			// Generate kubeconfig.
-			err := tt.ac.generateUserKeys(client)
+			err := tt.ac.generateUserKeys(context.Background(), client)
 			tt.assertErr(t, err)
 
 			// Validate kubeconfig contents.
@@ -288,7 +288,7 @@ func (c *mockClient) GenerateUserCerts(ctx context.Context, userCertsReq proto.U
 	c.userCertsReq = &userCertsReq
 	return c.userCerts, nil
 }
-func (c *mockClient) GetCertAuthorities(types.CertAuthType, bool, ...services.MarshalOption) ([]types.CertAuthority, error) {
+func (c *mockClient) GetCertAuthorities(context.Context, types.CertAuthType, bool, ...services.MarshalOption) ([]types.CertAuthority, error) {
 	return c.cas, nil
 }
 func (c *mockClient) GetProxies() ([]types.Server, error) {
@@ -402,7 +402,7 @@ func TestCheckKubeCluster(t *testing.T) {
 				leafCluster:  tt.leafCluster,
 				outputFormat: tt.outputFormat,
 			}
-			err := a.checkKubeCluster(client)
+			err := a.checkKubeCluster(context.Background(), client)
 			tt.assertErr(t, err)
 			require.Equal(t, tt.want, a.kubeCluster)
 		})
@@ -539,7 +539,7 @@ func TestGenerateDatabaseKeys(t *testing.T) {
 				genTTL:        time.Hour,
 			}
 
-			err = ac.generateDatabaseKeysForKey(authClient, key)
+			err = ac.generateDatabaseKeysForKey(context.Background(), authClient, key)
 			if test.genKeyErrMsg == "" {
 				require.NoError(t, err)
 			} else {
@@ -652,7 +652,7 @@ func TestGenerateAppCertificates(t *testing.T) {
 				genTTL:        time.Hour,
 				appName:       tc.appName,
 			}
-			err = ac.generateUserKeys(authClient)
+			err = ac.generateUserKeys(context.Background(), authClient)
 			tc.assertErr(t, err)
 			if err != nil {
 				return

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -975,7 +975,7 @@ func (rc *ResourceCommand) getCollection(client auth.ClientI) (ResourceCollectio
 		if rc.ref.SubKind == "" && rc.ref.Name == "" {
 			var allAuthorities []types.CertAuthority
 			for _, caType := range types.CertAuthTypes {
-				authorities, err := client.GetCertAuthorities(caType, rc.withSecrets)
+				authorities, err := client.GetCertAuthorities(ctx, caType, rc.withSecrets)
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
@@ -984,7 +984,7 @@ func (rc *ResourceCommand) getCollection(client auth.ClientI) (ResourceCollectio
 			return &authorityCollection{cas: allAuthorities}, nil
 		}
 		id := types.CertAuthID{Type: types.CertAuthType(rc.ref.SubKind), DomainName: rc.ref.Name}
-		authority, err := client.GetCertAuthority(id, rc.withSecrets)
+		authority, err := client.GetCertAuthority(ctx, id, rc.withSecrets)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/tool/tctl/common/status_command.go
+++ b/tool/tctl/common/status_command.go
@@ -49,7 +49,7 @@ func (c *StatusCommand) Initialize(app *kingpin.Application, config *service.Con
 func (c *StatusCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.status.FullCommand():
-		err = c.Status(client)
+		err = c.Status(context.Background(), client)
 	default:
 		return false, nil
 	}
@@ -57,29 +57,29 @@ func (c *StatusCommand) TryRun(cmd string, client auth.ClientI) (match bool, err
 }
 
 // Status is called to execute "status" CLI command.
-func (c *StatusCommand) Status(client auth.ClientI) error {
-	pingRsp, err := client.Ping(context.TODO())
+func (c *StatusCommand) Status(ctx context.Context, client auth.ClientI) error {
+	pingRsp, err := client.Ping(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	serverVersion := pingRsp.ServerVersion
 	clusterName := pingRsp.ClusterName
 
-	authorities := []types.CertAuthority{}
+	var authorities []types.CertAuthority
 
-	hostCAs, err := client.GetCertAuthorities(types.HostCA, false)
+	hostCAs, err := client.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	authorities = append(authorities, hostCAs...)
 
-	userCAs, err := client.GetCertAuthorities(types.UserCA, false)
+	userCAs, err := client.GetCertAuthorities(ctx, types.UserCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	authorities = append(authorities, userCAs...)
 
-	jwtKeys, err := client.GetCertAuthorities(types.JWTSigner, false)
+	jwtKeys, err := client.GetCertAuthorities(ctx, types.JWTSigner, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -1383,7 +1383,7 @@ func mockSSOLogin(t *testing.T, authServer *auth.Server, user types.User) client
 		require.NoError(t, err)
 
 		// load CA cert
-		authority, err := authServer.GetCertAuthority(types.CertAuthID{
+		authority, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,
 			DomainName: "localhost",
 		}, false)


### PR DESCRIPTION
The CA Watcher was blocking both on writing to a channel when the watcher
was closed and on HTTP calls that had no request timeout or context passed
to cause cancellation.

All resourceWatcher implementations that had a bug which may cause them to block
on writing to a channel forever were fixed by selecting on the write and ctx.Done.

Adding context.Context to all Get/Put/Post/Delete methods on the auth HTTPClient to
force callers to propagate context. Prior all calls used context.TODO which
prevents requests from being properly cancelled.

Add context propagation to RotateCertAuthority, RotateExternalCertAuthority,
GetCertAuthority, GetCertAuthorities. This is needed to get the correct ctx
from the CertAtuhorityWatcher all the way down to the HTTPClient that makes
the call.


Companion PR  https://github.com/gravitational/teleport.e/pull/405

Closes #10648