### PR TITLE
Add support for removing default kubegroups

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1069,7 +1069,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	kubeGroups, kubeUsers, err := req.checker.CheckKubeGroupsAndUsers(sessionTTL, req.overrideRoleTTL)
+	kubeGroups, kubeUsers, _, err := req.checker.CheckKubeGroupsAndUsers(sessionTTL, req.overrideRoleTTL)
 	// NotFound errors are acceptable - this user may have no k8s access
 	// granted and that shouldn't prevent us from issuing a TLS cert.
 	if err != nil && !trace.IsNotFound(err) {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1069,7 +1069,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	kubeGroups, kubeUsers, _, err := req.checker.CheckKubeGroupsAndUsers(sessionTTL, req.overrideRoleTTL)
+	kubePerms, err := req.checker.CheckKubeGroupsAndUsers(sessionTTL, req.overrideRoleTTL)
 	// NotFound errors are acceptable - this user may have no k8s access
 	// granted and that shouldn't prevent us from issuing a TLS cert.
 	if err != nil && !trace.IsNotFound(err) {
@@ -1118,8 +1118,8 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 		RouteToCluster:    req.routeToCluster,
 		KubernetesCluster: req.kubernetesCluster,
 		Traits:            req.traits,
-		KubernetesGroups:  kubeGroups,
-		KubernetesUsers:   kubeUsers,
+		KubernetesGroups:  kubePerms.Groups,
+		KubernetesUsers:   kubePerms.Users,
 		RouteToApp: tlsca.RouteToApp{
 			SessionID:   req.appSessionID,
 			PublicAddr:  req.appPublicAddr,

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -250,7 +250,7 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 	ttl := time.Until(u.Identity.Expires)
 	ttl = checker.AdjustSessionTTL(ttl)
 
-	kubeUsers, kubeGroups, err := checker.CheckKubeGroupsAndUsers(ttl, false)
+	kubeUsers, kubeGroups, _, err := checker.CheckKubeGroupsAndUsers(ttl, false)
 	// IsNotFound means that the user has no k8s users or groups, which is fine
 	// in many cases. The downstream k8s handler will ensure that users/groups
 	// are set if this is a k8s request.

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -250,7 +250,7 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 	ttl := time.Until(u.Identity.Expires)
 	ttl = checker.AdjustSessionTTL(ttl)
 
-	kubeUsers, kubeGroups, _, err := checker.CheckKubeGroupsAndUsers(ttl, false)
+	kubePerms, err := checker.CheckKubeGroupsAndUsers(ttl, false)
 	// IsNotFound means that the user has no k8s users or groups, which is fine
 	// in many cases. The downstream k8s handler will ensure that users/groups
 	// are set if this is a k8s request.
@@ -270,8 +270,8 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 		Groups:           user.GetRoles(),
 		Traits:           wrappers.Traits(traits),
 		Principals:       principals,
-		KubernetesGroups: kubeGroups,
-		KubernetesUsers:  kubeUsers,
+		KubernetesGroups: kubePerms.Groups,
+		KubernetesUsers:  kubePerms.Users,
 		TeleportCluster:  a.clusterName,
 		Expires:          time.Now().Add(ttl),
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -666,10 +666,7 @@ func (f *Forwarder) getKubeGroupsAndUsers(
 	}
 
 	// kubeClusterName not found. Empty list of allowed kube users/groups is returned.
-	return services.KubePermissions{
-		Groups: make([]string, 0),
-		Users:  make([]string, 0),
-	}, nil
+	return services.KubePermissions{}, nil
 }
 
 func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -516,6 +516,7 @@ func (f *Forwarder) setupContext(ctx auth.Context, req *http.Request, isRemoteUs
 	}
 
 	var kubeUsers, kubeGroups []string
+	var denyAuthenticated bool
 	// Only check k8s principals for local clusters.
 	//
 	// For remote clusters, everything will be remapped to new roles on the
@@ -523,7 +524,7 @@ func (f *Forwarder) setupContext(ctx auth.Context, req *http.Request, isRemoteUs
 	if !isRemoteCluster {
 		var err error
 		// check signing TTL and return a list of allowed logins for local cluster based on Kubernetes service labels.
-		kubeGroups, kubeUsers, err = f.getKubeGroupsAndUsers(roles, kubeCluster, sessionTTL)
+		kubeGroups, kubeUsers, denyAuthenticated, err = f.getKubeGroupsAndUsers(roles, kubeCluster, sessionTTL)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -538,8 +539,11 @@ func (f *Forwarder) setupContext(ctx auth.Context, req *http.Request, isRemoteUs
 	// KubeSystemAuthenticated is a builtin group that allows
 	// any user to access common API methods, e.g. discovery methods
 	// required for initial client usage, without it, restricted user's
-	// kubectl clients will not work
-	if !apiutils.SliceContainsStr(kubeGroups, teleport.KubeSystemAuthenticated) {
+	// kubectl clients will not work.
+	//
+	// We add this by default to preserve backwards compatibility but it will be omitted
+	// if explicitly denied in any role the user has.
+	if !denyAuthenticated && !apiutils.SliceContainsStr(kubeGroups, teleport.KubeSystemAuthenticated) {
 		kubeGroups = append(kubeGroups, teleport.KubeSystemAuthenticated)
 	}
 
@@ -638,10 +642,10 @@ func (f *Forwarder) setupContext(ctx auth.Context, req *http.Request, isRemoteUs
 func (f *Forwarder) getKubeGroupsAndUsers(
 	roles services.AccessChecker,
 	kubeClusterName string,
-	sessionTTL time.Duration) (groups, users []string, err error) {
+	sessionTTL time.Duration) (groups, users []string, denyAuthenticated bool, err error) {
 	kubeServices, err := f.cfg.CachingAuthClient.GetKubeServices(f.ctx)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, nil, false, trace.Wrap(err)
 	}
 
 	// Find requested kubernetes cluster name and get allowed kube users/groups names.
@@ -654,15 +658,15 @@ func (f *Forwarder) getKubeGroupsAndUsers(
 			// Get list of allowed kube user/groups based on kubernetes service labels.
 			labels := types.CombineLabels(c.StaticLabels, c.DynamicLabels)
 			labelsMatcher := services.NewKubernetesClusterLabelMatcher(labels)
-			groups, users, err = roles.CheckKubeGroupsAndUsers(sessionTTL, false, labelsMatcher)
+			groups, users, denyAuthenticated, err = roles.CheckKubeGroupsAndUsers(sessionTTL, false, labelsMatcher)
 			if err != nil {
-				return nil, nil, trace.Wrap(err)
+				return nil, nil, false, trace.Wrap(err)
 			}
-			return groups, users, nil
+			return groups, users, denyAuthenticated, nil
 		}
 	}
 	// kubeClusterName not found. Empty list of allowed kube users/groups is returned.
-	return []string{}, []string{}, nil
+	return []string{}, []string{}, false, nil
 }
 
 func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -474,6 +474,33 @@ func TestAuthenticate(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:               "local user, no deny",
+			user:               auth.LocalUser{},
+			roleKubeGroups:     []string{},
+			roleKubeUsers:      []string{"kube-user-a"},
+			roleDenyKubeGroups: []string{},
+			routeToCluster:     "local",
+			haveKubeCreds:      true,
+			tunnel:             tun,
+			kubeServices: []types.Server{&types.ServerV2{
+				Spec: types.ServerSpecV2{
+					KubernetesClusters: []*types.KubernetesCluster{{
+						Name: "local",
+					}},
+				},
+			}},
+
+			wantCtx: &authContext{
+				kubeUsers:   utils.StringsSet([]string{"kube-user-a"}),
+				kubeGroups:  utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
+				kubeCluster: "local",
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -451,6 +451,7 @@ func TestAuthenticate(t *testing.T) {
 			desc:               "deny authenticate",
 			user:               auth.LocalUser{},
 			roleKubeGroups:     []string{},
+			roleKubeUsers:      []string{"kube-user-a"},
 			roleDenyKubeGroups: []string{teleport.KubeSystemAuthenticated},
 			routeToCluster:     "local",
 			haveKubeCreds:      true,
@@ -464,7 +465,7 @@ func TestAuthenticate(t *testing.T) {
 			}},
 
 			wantCtx: &authContext{
-				kubeUsers:   utils.StringsSet([]string{"user-a"}),
+				kubeUsers:   utils.StringsSet([]string{"kube-user-a"}),
 				kubeGroups:  utils.StringsSet([]string{}),
 				kubeCluster: "local",
 				teleportCluster: teleportClusterClient{

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1047,6 +1047,7 @@ func (set RoleSet) AdjustDisconnectExpiredCert(disconnect bool) bool {
 	return disconnect
 }
 
+// KubePermissions contains permission data specifying what kubernetes groups and users to map onto API requests.
 type KubePermissions struct {
 	// Groups is the list of kube groups the user has access to.
 	Groups []string

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1106,10 +1106,11 @@ func (set RoleSet) CheckKubeGroupsAndUsers(ttl time.Duration, overrideTTL bool, 
 		}
 	}
 
-	if !matchedTTL && !denyAuthenticated {
+	if !matchedTTL {
 		return KubePermissions{}, trace.AccessDenied("this user cannot request kubernetes access for %v", ttl)
 	}
-	if len(groups) == 0 && len(users) == 0 && !denyAuthenticated {
+
+	if len(groups) == 0 && len(users) == 0 {
 		return KubePermissions{}, trace.NotFound("this user cannot request kubernetes access, has no assigned groups or users")
 	}
 

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -3979,7 +3979,7 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			matcher := NewKubernetesClusterLabelMatcher(tc.kubeResLabels)
-			gotGroups, gotUsers, err := tc.roles.CheckKubeGroupsAndUsers(time.Hour, true, matcher)
+			gotGroups, gotUsers, _, err := tc.roles.CheckKubeGroupsAndUsers(time.Hour, true, matcher)
 			if tc.errorFunc == nil {
 				require.NoError(t, err)
 			} else {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -3979,15 +3979,15 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			matcher := NewKubernetesClusterLabelMatcher(tc.kubeResLabels)
-			gotGroups, gotUsers, _, err := tc.roles.CheckKubeGroupsAndUsers(time.Hour, true, matcher)
+			permissions, err := tc.roles.CheckKubeGroupsAndUsers(time.Hour, true, matcher)
 			if tc.errorFunc == nil {
 				require.NoError(t, err)
 			} else {
 				tc.errorFunc(t, err)
 			}
 
-			require.ElementsMatch(t, tc.wantUsers, gotUsers)
-			require.ElementsMatch(t, tc.wantGroups, gotGroups)
+			require.ElementsMatch(t, tc.wantUsers, permissions.Users)
+			require.ElementsMatch(t, tc.wantGroups, permissions.Groups)
 		})
 	}
 }


### PR DESCRIPTION
This PR adds special handling if a `system:authenticated` entry is found in the deny section of a role. If present, this prevents the k8s proxy from implicitly adding this role before forwarding the request.