### PR TITLE
Switch to warning in case of resource origin clash.

### DIFF
--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -155,9 +155,9 @@ func (r *Reconciler) processNewResource(ctx context.Context, currentResources ty
 		return nil
 	}
 
-	// Don't overwrite resource of a different origin.
+	// Don't overwrite resource of a different origin (e.g., keep static resource from config and ignore dynamic resource)
 	if registered.Origin() != new.Origin() {
-		r.log.Debugf("%v has different origin (%v vs %v), not updating.", new.GetName(),
+		r.log.Warnf("%v has different origin (%v vs %v), not updating.", new.GetName(),
 			new.Origin(), registered.Origin())
 		return nil
 	}


### PR DESCRIPTION
It is possible to have a resource from different origins:
- `static` (apps, dbs)
- `dynamic` (apps, dbs)
- `cloud` (dbs)

(Note: currently desktops can only be `dynamic` AFAICT, sourced from LDAP)

Currently in this situation we ignore the clash and only issue a debug-level log message. This PR changes that to warning to make it easier to diagnose scenarios such as:
- `dynamic` app fails to show up on as `static` app takes precedence
- `dynamic`/`cloud` db fails to show up on as `static` db takes precedence
- one `dynamic` db and one `cloud` db show up randomly depending on which wins the data race to be the first in the node cache.

Fixes #10797.