### PR TITLE
Fix certificate extension not being included in `tctl auth sign`

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1063,6 +1063,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 		DisallowReissue:       req.disallowReissue,
 		Renewable:             req.renewable,
 		Generation:            req.generation,
+		CertificateExtensions: req.checker.CertificateExtensions(),
 	}
 	sshCert, err := a.Authority.GenerateUserCert(params)
 	if err != nil {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1030,6 +1030,44 @@ func TestEmitSSOLoginFailureEvent(t *testing.T) {
 	})
 }
 
+func TestGenerateUserCertWithCertExtension(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	p, err := newTestPack(ctx, t.TempDir())
+	require.NoError(t, err)
+
+	user, role, err := CreateUserAndRole(p.a, "test-user", []string{})
+	require.NoError(t, err)
+
+	extension := types.CertExtension{
+		Name:  "abc",
+		Value: "cde",
+		Type:  types.CertExtensionType_SSH,
+		Mode:  types.CertExtensionMode_EXTENSION,
+	}
+	options := role.GetOptions()
+	options.CertExtensions = []*types.CertExtension{&extension}
+	role.SetOptions(options)
+
+	keygen := testauthority.New()
+	_, pub, err := keygen.GetNewKeyPairFromPool()
+	require.NoError(t, err)
+	certReq := certRequest{
+		user:      user,
+		checker:   services.NewRoleSet(role),
+		publicKey: pub,
+	}
+	certs, err := p.a.generateUserCert(certReq)
+	require.NoError(t, err)
+
+	key, err := sshutils.ParseCertificate(certs.SSH)
+	require.NoError(t, err)
+
+	val, ok := key.Extensions[extension.Name]
+	require.True(t, ok)
+	require.Equal(t, extension.Value, val)
+}
+
 func TestGenerateUserCertWithLocks(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
This meant that certificates exported with `tctl auth sign` were not including the ssh key extensions.