### PR TITLE
Disable OTP code echoing in terminal

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3045,7 +3045,7 @@ func Username() (string, error) {
 // AskOTP prompts the user to enter the OTP token.
 func (tc *TeleportClient) AskOTP() (token string, err error) {
 	fmt.Fprintf(tc.Config.Stderr, "Enter your OTP token:\n")
-	token, err = lineFromConsole()
+	token, err = passwordFromConsoleFn()
 	if err != nil {
 		fmt.Fprintln(tc.Stderr, err)
 		return "", trace.Wrap(err)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -17,7 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"bufio"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -3164,12 +3163,6 @@ func passwordFromConsole() (string, error) {
 	}()
 
 	bytes, err := term.ReadPassword(fd)
-	return string(bytes), err
-}
-
-// lineFromConsole reads a line from stdin
-func lineFromConsole() (string, error) {
-	bytes, _, err := bufio.NewReader(os.Stdin).ReadLine()
 	return string(bytes), err
 }
 


### PR DESCRIPTION
This hides OTP input in CLI the same way we do for passwords