### PR TITLE
[v9] flaky test: TestDatabaseAccessMongoConnectionCount (#10869)

### DIFF
--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -216,7 +216,7 @@ func TestDatabaseAccessMongoRootCluster(t *testing.T) {
 func TestDatabaseAccessMongoConnectionCount(t *testing.T) {
 	pack := setupDatabaseTest(t)
 
-	connectMongoClient := func(t *testing.T) {
+	connectMongoClient := func(t *testing.T) (serverConnectionCount int32) {
 		// Connect to the database service in root cluster.
 		client, err := mongodb.MakeTestClient(context.Background(), common.TestClientConfig{
 			AuthClient: pack.root.cluster.GetSiteAPI(pack.root.cluster.Secrets.SiteName),
@@ -231,23 +231,39 @@ func TestDatabaseAccessMongoConnectionCount(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
+
 		// Execute a query.
 		_, err = client.Database("test").Collection("test").Find(context.Background(), bson.M{})
 		require.NoError(t, err)
+
+		// Get a server connection count before disconnect.
+		serverConnectionCount = pack.root.mongo.GetActiveConnectionsCount()
+
 		// Disconnect.
 		err = client.Disconnect(context.Background())
 		require.NoError(t, err)
-	}
-	connectMongoClient(t)
 
-	// Get connection count after mongo driver indicated the connection pool.
-	initialConnectionCount := pack.root.mongo.GetActiveConnectionsCount()
+		return serverConnectionCount
+	}
+
+	// Get connection count while the first client is connected.
+	initialConnectionCount := connectMongoClient(t)
+
+	// Check if active connections count is not growing over time when new
+	// clients connect to the mongo server.
 	clientCount := 8
 	for i := 0; i < clientCount; i++ {
-		connectMongoClient(t)
+		// Note that connection count per client fluctuates between 6 and 9.
+		// Use InDelta to avoid flaky test.
+		require.InDelta(t, initialConnectionCount, connectMongoClient(t), 3)
 	}
-	// Check if active connections count is not growing over time when new clients connect to the mongo server.
-	require.Equal(t, initialConnectionCount, pack.root.mongo.GetActiveConnectionsCount())
+
+	// Wait until the server reports no more connections. This usually happens
+	// really quick but wait a little longer just in case.
+	waitUntilNoConnections := func() bool {
+		return 0 == pack.root.mongo.GetActiveConnectionsCount()
+	}
+	require.Eventually(t, waitUntilNoConnections, 5*time.Second, 100*time.Millisecond)
 }
 
 // TestDatabaseAccessMongoLeafCluster tests a scenario where a user connects


### PR DESCRIPTION
backport #10869
- #10869

no cherry-pick conflict