### PR TITLE
Enable desktop access in Web UI in Cloud clusters

### DIFF
--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -216,9 +216,6 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 	var billingAccess access
 	if features.Cloud {
 		billingAccess = newAccess(userRoles, ctx, types.KindBilling)
-
-		// disable access to preview features
-		desktopAccess = access{}
 	}
 
 	logins := getLogins(userRoles)

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -157,7 +157,6 @@ func (s *UserContextSuite) TestNewUserContextCloud(c *check.C) {
 	roleSet := []types.Role{role}
 
 	allowed := access{true, true, true, true, true}
-	denied := access{false, false, false, false, false}
 
 	userContext, err := NewUserContext(user, roleSet, proto.Features{Cloud: true}, true)
 	c.Assert(err, check.IsNil)
@@ -186,5 +185,5 @@ func (s *UserContextSuite) TestNewUserContextCloud(c *check.C) {
 
 	// cloud-specific asserts
 	c.Assert(userContext.ACL.Billing, check.DeepEquals, allowed)
-	c.Assert(userContext.ACL.Desktops, check.DeepEquals, denied)
+	c.Assert(userContext.ACL.Desktops, check.DeepEquals, allowed)
 }


### PR DESCRIPTION
Reverts changes from https://github.com/gravitational/teleport/pull/8858 to enable desktop access in Cloud. We've verified desktop access on Cloud https://github.com/gravitational/cloud/issues/1181. 