### PR TITLE
Updates `tsh ls` for nodes, apps, dbs, and kubes to accept new filter flags

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -877,9 +877,14 @@ func (c *Client) UpsertKubeServiceV2(ctx context.Context, s types.Server) (*type
 // GetKubeServices returns the list of kubernetes services registered in the
 // cluster.
 func (c *Client) GetKubeServices(ctx context.Context) ([]types.Server, error) {
-	resources, err := c.GetResources(ctx, defaults.Namespace, types.KindKubeService)
+	resources, err := GetResourcesWithFilters(ctx, c, proto.ListResourcesRequest{
+		Namespace:    defaults.Namespace,
+		ResourceType: types.KindKubeService,
+	})
 	if err != nil {
-		// DELETE IN 10.0
+		// Underlying ListResources for kube service was not available, use fallback.
+		//
+		// DELETE IN 11.0.0
 		if trace.IsNotImplemented(err) {
 			return c.getKubeServicesFallback(ctx)
 		}
@@ -887,14 +892,9 @@ func (c *Client) GetKubeServices(ctx context.Context) ([]types.Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	servers := make([]types.Server, len(resources))
-	for i, resource := range resources {
-		srv, ok := resource.(types.Server)
-		if !ok {
-			return nil, trace.BadParameter("expected Server resource, got %T", resource)
-		}
-
-		servers[i] = srv
+	servers, err := types.ResourcesWithLabels(resources).AsServers()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return servers, nil
@@ -919,8 +919,14 @@ func (c *Client) getKubeServicesFallback(ctx context.Context) ([]types.Server, e
 
 // GetApplicationServers returns all registered application servers.
 func (c *Client) GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error) {
-	resources, err := c.GetResources(ctx, namespace, types.KindAppServer)
+	resources, err := GetResourcesWithFilters(ctx, c, proto.ListResourcesRequest{
+		Namespace:    namespace,
+		ResourceType: types.KindAppServer,
+	})
 	if err != nil {
+		// Underlying ListResources for app server was not available, use fallback.
+		//
+		// DELETE IN 11.0.0
 		if trace.IsNotImplemented(err) {
 			servers, err := c.getApplicationServersFallback(ctx, namespace)
 			if err != nil {
@@ -933,14 +939,9 @@ func (c *Client) GetApplicationServers(ctx context.Context, namespace string) ([
 		return nil, trace.Wrap(err)
 	}
 
-	servers := make([]types.AppServer, len(resources))
-	for i, resource := range resources {
-		appServer, ok := resource.(types.AppServer)
-		if !ok {
-			return nil, trace.BadParameter("expected AppServer resource, got %T", resource)
-		}
-
-		servers[i] = appServer
+	servers, err := types.ResourcesWithLabels(resources).AsAppServers()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// In addition, we need to fetch legacy application servers.
@@ -1178,8 +1179,14 @@ func (c *Client) DeleteAllKubeServices(ctx context.Context) error {
 
 // GetDatabaseServers returns all registered database proxy servers.
 func (c *Client) GetDatabaseServers(ctx context.Context, namespace string) ([]types.DatabaseServer, error) {
-	resources, err := c.GetResources(ctx, namespace, types.KindDatabaseServer)
+	resources, err := GetResourcesWithFilters(ctx, c, proto.ListResourcesRequest{
+		Namespace:    namespace,
+		ResourceType: types.KindDatabaseServer,
+	})
 	if err != nil {
+		// Underlying ListResources for db server was not available, use fallback.
+		//
+		// DELETE IN 11.0.0
 		if trace.IsNotImplemented(err) {
 			servers, err := c.getDatabaseServersFallback(ctx, namespace)
 			if err != nil {
@@ -1192,14 +1199,9 @@ func (c *Client) GetDatabaseServers(ctx context.Context, namespace string) ([]ty
 		return nil, trace.Wrap(err)
 	}
 
-	servers := make([]types.DatabaseServer, len(resources))
-	for i, resource := range resources {
-		databaseServer, ok := resource.(types.DatabaseServer)
-		if !ok {
-			return nil, trace.BadParameter("expected DatabaseServer resource, got %T", resource)
-		}
-
-		servers[i] = databaseServer
+	servers, err := types.ResourcesWithLabels(resources).AsDatabaseServers()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return servers, nil
@@ -1624,17 +1626,46 @@ func (c *Client) GetNode(ctx context.Context, namespace, name string) (types.Ser
 
 // GetNodes returns a complete list of nodes that the user has access to in the given namespace.
 func (c *Client) GetNodes(ctx context.Context, namespace string) ([]types.Server, error) {
-	return GetNodesWithLabels(ctx, c, namespace, nil)
+	resources, err := GetResourcesWithFilters(ctx, c, proto.ListResourcesRequest{
+		ResourceType: types.KindNode,
+		Namespace:    namespace,
+	})
+	if err != nil {
+		// Underlying ListResources for nodes was not available, use fallback.
+		//
+		// DELETE IN 11.0.0
+		if trace.IsNotImplemented(err) {
+			servers, err := GetNodesWithLabels(ctx, c, namespace, nil)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return servers, nil
+		}
+
+		return nil, trace.Wrap(err)
+	}
+
+	servers, err := types.ResourcesWithLabels(resources).AsServers()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return servers, nil
 }
 
 // NodeClient is an interface used by GetNodesWithLabels to abstract over implementations of
 // the ListNodes method.
+//
+// DELETE IN 11.0.0 with GetNodesWithLabels (used in both api/client/client.go and lib/auth/httpfallback.go)
+// replaced by ListResourcesClient
 type NodeClient interface {
 	ListNodes(ctx context.Context, req proto.ListNodesRequest) (nodes []types.Server, nextKey string, err error)
 }
 
 // GetNodesWithLabels is a helper for getting a list of nodes with optional label-based filtering.  In addition to
 // iterating pages, it also correctly handles downsizing pages when LimitExceeded errors are encountered.
+//
+// DELETE IN 11.0.0 replaced by GetResourcesWithFilters.
 func GetNodesWithLabels(ctx context.Context, clt NodeClient, namespace string, labels map[string]string) ([]types.Server, error) {
 	// Retrieve the complete list of nodes in chunks.
 	var (
@@ -2425,9 +2456,16 @@ func (c *Client) ListResources(ctx context.Context, req proto.ListResourcesReque
 	}, nil
 }
 
-// GetResources retrieves all pages from ListResourcesPage and return all
-// resources.
-func (c *Client) GetResources(ctx context.Context, namespace, resourceType string) ([]types.ResourceWithLabels, error) {
+// ListResourcesClient is an interface used by GetResourcesWithFilters to abstract over implementations of
+// the ListResources method.
+type ListResourcesClient interface {
+	ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
+}
+
+// GetResourcesWithFilters is a helper for getting a list of resources with optional filtering. In addition to
+// iterating pages, it also correctly handles downsizing pages when LimitExceeded errors are encountered.
+func GetResourcesWithFilters(ctx context.Context, clt ListResourcesClient, req proto.ListResourcesRequest) ([]types.ResourceWithLabels, error) {
+	// Retrieve the complete list of resources in chunks.
 	var (
 		resources []types.ResourceWithLabels
 		startKey  string
@@ -2435,15 +2473,20 @@ func (c *Client) GetResources(ctx context.Context, namespace, resourceType strin
 	)
 
 	for {
-		resp, err := c.ListResources(ctx, proto.ListResourcesRequest{
-			Namespace:    namespace,
-			ResourceType: resourceType,
-			StartKey:     startKey,
-			Limit:        chunkSize,
+		resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
+			Namespace:           req.Namespace,
+			ResourceType:        req.ResourceType,
+			StartKey:            startKey,
+			Limit:               chunkSize,
+			Labels:              req.Labels,
+			SearchKeywords:      req.SearchKeywords,
+			PredicateExpression: req.PredicateExpression,
 		})
 		if err != nil {
 			if trace.IsLimitExceeded(err) {
+				// Cut chunkSize in half if gRPC max message size is exceeded.
 				chunkSize = chunkSize / 2
+				// This is an extremely unlikely scenario, but better to cover it anyways.
 				if chunkSize == 0 {
 					return nil, trace.Wrap(trail.FromGRPC(err), "resource is too large to retrieve")
 				}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2208,7 +2208,7 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 
 	// ListNodes expect labels as a value of host
 	tc.Host = ""
-	servers, err := tc.ListNodes(ctx)
+	servers, err := tc.ListNodesWithFilters(ctx)
 	require.NoError(t, err)
 	require.Len(t, servers, 2)
 	tc.Host = Loopback
@@ -3043,7 +3043,6 @@ func waitForNodeCount(ctx context.Context, t *TeleInstance, clusterName string, 
 			return nil
 		}
 		return trace.BadParameter("did not find %v nodes", count)
-
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -4644,7 +4643,7 @@ func testList(t *testing.T, suite *integrationTestSuite) {
 
 			// Get list of nodes and check that the returned nodes match the
 			// expected nodes.
-			nodes, err := userClt.ListNodes(context.Background())
+			nodes, err := userClt.ListNodesWithFilters(context.Background())
 			require.NoError(t, err)
 			for _, node := range nodes {
 				ok := apiutils.SliceContainsStr(tt.outNodes, node.GetHostname())
@@ -5025,7 +5024,7 @@ func testSSHExitCode(t *testing.T, suite *integrationTestSuite) {
 	lsPath, err := exec.LookPath("ls")
 	require.NoError(t, err)
 
-	var tests = []struct {
+	tests := []struct {
 		desc           string
 		command        []string
 		input          string

--- a/lib/auth/httpfallback.go
+++ b/lib/auth/httpfallback.go
@@ -548,6 +548,9 @@ type nodeClient interface {
 
 // GetNodesWithLabels is a helper for getting a list of nodes with optional label-based filtering.  This is essentially
 // a wrapper around client.GetNodesWithLabels that performs fallback on NotImplemented errors.
+//
+// DELETE IN 11.0.0, this function is only called by lib/client/client.go (*ProxyClient).FindServersByLabels
+// which is also marked for deletion (replaced by FindNodesByFilters).
 func GetNodesWithLabels(ctx context.Context, clt nodeClient, namespace string, labels map[string]string) ([]types.Server, error) {
 	nodes, err := client.GetNodesWithLabels(ctx, clt, namespace, labels)
 	if err == nil || !trace.IsNotImplemented(err) {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -171,6 +171,12 @@ type Config struct {
 	// Remote host to connect
 	Host string
 
+	// SearchKeywords host to connect
+	SearchKeywords []string
+
+	// PredicateExpression host to connect
+	PredicateExpression string
+
 	// Labels represent host Labels
 	Labels map[string]string
 
@@ -465,7 +471,6 @@ func (p *ProfileStatus) DatabaseCertPathForCluster(clusterName string, databaseN
 // It's kept in <profile-dir>/keys/<proxy>/<user>-app/<cluster>/<name>-x509.pem
 func (p *ProfileStatus) AppCertPath(name string) string {
 	return keypaths.AppCertPath(p.Dir, p.Name, p.Username, p.Cluster, name)
-
 }
 
 // KubeConfigPath returns path to the specified kubeconfig for this profile.
@@ -1243,7 +1248,12 @@ func (tc *TeleportClient) getTargetNodes(ctx context.Context, proxy *ProxyClient
 		retval = make([]string, 0)
 	)
 	if tc.Labels != nil && len(tc.Labels) > 0 {
-		nodes, err = proxy.FindServersByLabels(ctx, tc.Namespace, tc.Labels)
+		nodes, err = proxy.FindNodesByFilters(ctx, proto.ListResourcesRequest{
+			Namespace:           tc.Namespace,
+			Labels:              tc.Labels,
+			SearchKeywords:      tc.SearchKeywords,
+			PredicateExpression: tc.PredicateExpression,
+		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1503,7 +1513,7 @@ func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipan
 	if sessionID.Check() != nil {
 		return trace.Errorf("Invalid session ID format: %s", string(sessionID))
 	}
-	var notFoundErrorMessage = fmt.Sprintf("session '%s' not found or it has ended", sessionID)
+	notFoundErrorMessage := fmt.Sprintf("session '%s' not found or it has ended", sessionID)
 
 	// connect to proxy:
 	if !tc.Config.ProxySpecified() {
@@ -1894,17 +1904,8 @@ func isRemoteDest(name string) bool {
 	return strings.ContainsRune(name, ':')
 }
 
-// ListNodes returns a list of nodes connected to a proxy
-func (tc *TeleportClient) ListNodes(ctx context.Context) ([]types.Server, error) {
-	var err error
-	// userhost is specified? that must be labels
-	if tc.Host != "" {
-		tc.Labels, err = ParseLabelSpec(tc.Host)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
+// ListNodesWithFilters returns a list of nodes connected to a proxy
+func (tc *TeleportClient) ListNodesWithFilters(ctx context.Context) ([]types.Server, error) {
 	// connect to the proxy and ask it to return a full list of servers
 	proxyClient, err := tc.ConnectToProxy(ctx)
 	if err != nil {
@@ -1912,7 +1913,17 @@ func (tc *TeleportClient) ListNodes(ctx context.Context) ([]types.Server, error)
 	}
 	defer proxyClient.Close()
 
-	return proxyClient.FindServersByLabels(ctx, tc.Namespace, tc.Labels)
+	servers, err := proxyClient.FindNodesByFilters(ctx, proto.ListResourcesRequest{
+		Namespace:           tc.Namespace,
+		Labels:              tc.Labels,
+		SearchKeywords:      tc.SearchKeywords,
+		PredicateExpression: tc.PredicateExpression,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return servers, nil
 }
 
 // ListAppServers returns a list of application servers.
@@ -1990,13 +2001,15 @@ func (tc *TeleportClient) ListAllNodes(ctx context.Context) ([]types.Server, err
 	}
 	defer proxyClient.Close()
 
-	return proxyClient.FindServersByLabels(ctx, tc.Namespace, nil)
+	return proxyClient.FindNodesByFilters(ctx, proto.ListResourcesRequest{
+		Namespace: tc.Namespace,
+	})
 }
 
 // runCommandOnNodes executes a given bash command on a bunch of remote nodes.
 func (tc *TeleportClient) runCommandOnNodes(
-	ctx context.Context, siteName string, nodeAddresses []string, proxyClient *ProxyClient, command []string) error {
-
+	ctx context.Context, siteName string, nodeAddresses []string, proxyClient *ProxyClient, command []string,
+) error {
 	resultsC := make(chan error, len(nodeAddresses))
 	for _, address := range nodeAddresses {
 		go func(address string) {
@@ -3177,9 +3190,9 @@ func lineFromConsole() (string, error) {
 // { "name" -> "value", "long name" -> "quoted value" }
 func ParseLabelSpec(spec string) (map[string]string, error) {
 	tokens := []string{}
-	var openQuotes = false
+	openQuotes := false
 	var tokenStart, assignCount int
-	var specLen = len(spec)
+	specLen := len(spec)
 	// tokenize the label spec:
 	for i, ch := range spec {
 		endOfToken := false
@@ -3215,6 +3228,44 @@ func ParseLabelSpec(spec string) (map[string]string, error) {
 		labels[tokens[i]] = tokens[i+1]
 	}
 	return labels, nil
+}
+
+// ParseSearchKeywords parses a string ie: foo,bar,"quoted value"` into a slice of
+// strings: ["foo", "bar", "quoted value"].
+// Almost a replica to ParseLabelSpec, but with few modifications such as
+// allowing a custom delimiter. Defaults to comma delimiter if not defined.
+func ParseSearchKeywords(spec string, customDelimiter rune) []string {
+	delimiter := customDelimiter
+	if customDelimiter == 0 {
+		delimiter = rune(',')
+	}
+
+	tokens := []string{}
+	openQuotes := false
+	var tokenStart int
+	specLen := len(spec)
+	// tokenize the label search:
+	for i, ch := range spec {
+		endOfToken := false
+		if i+utf8.RuneLen(ch) == specLen {
+			i += utf8.RuneLen(ch)
+			endOfToken = true
+		}
+		switch ch {
+		case '"':
+			openQuotes = !openQuotes
+		case delimiter:
+			if !openQuotes {
+				endOfToken = true
+			}
+		}
+		if endOfToken && i > tokenStart {
+			tokens = append(tokens, strings.TrimSpace(strings.Trim(spec[tokenStart:i], `"`)))
+			tokenStart = i + 1
+		}
+	}
+
+	return tokens
 }
 
 // Executes the given command on the client machine (localhost). If no command is given,
@@ -3353,7 +3404,7 @@ func playSession(sessionEvents []events.EventFields, stream []byte) error {
 		}
 	}
 
-	var errorCh = make(chan error)
+	errorCh := make(chan error)
 	player := newSessionPlayer(sessionEvents, stream, term)
 	// keys:
 	const (

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -34,8 +34,7 @@ func TestMain(m *testing.M) {
 }
 
 // register test suite
-type APITestSuite struct {
-}
+type APITestSuite struct{}
 
 // bootstrap check
 func TestClientAPI(t *testing.T) { check.TestingT(t) }
@@ -277,7 +276,6 @@ func (s *APITestSuite) TestPortsParsing(c *check.C) {
 }
 
 func (s *APITestSuite) TestDynamicPortsParsing(c *check.C) {
-
 	tests := []struct {
 		spec    []string
 		isError bool
@@ -497,6 +495,64 @@ func TestApplyProxySettings(t *testing.T) {
 			err := tc.applyProxySettings(test.settingsIn)
 			require.NoError(t, err)
 			require.EqualValues(t, test.tcConfigOut, tc.Config)
+		})
+	}
+}
+
+func TestParseSearchKeywords(t *testing.T) {
+	t.Parallel()
+
+	expected := [][]string{
+		{},
+		{"foo"},
+		{"foo,bar", "some phrase's", "baz=qux's", "some other  phrase", "another one"},
+		{"服务器环境=测试,操作系统类别", "Linux", "机房=华北"},
+	}
+
+	testCases := []struct {
+		name      string
+		delimiter rune
+		specs     []string
+	}{
+		{
+			name:      "with comma delimiter",
+			delimiter: ',',
+			specs: []string{
+				"",
+				"foo",
+				`"foo,bar","some phrase's",baz=qux's ,"some other  phrase"," another one  "`,
+				`"服务器环境=测试,操作系统类别", Linux , 机房=华北 `,
+			},
+		},
+		{
+			name: "with 0 value delimiter (fallback to comma)",
+			specs: []string{
+				"",
+				"foo",
+				`"foo,bar","some phrase's",baz=qux's ,"some other  phrase"," another one  "`,
+				`"服务器环境=测试,操作系统类别", Linux , 机房=华北 `,
+			},
+		},
+		{
+			name:      "with space delimiter",
+			delimiter: ' ',
+			specs: []string{
+				"",
+				"foo",
+				`foo,bar "some phrase's" baz=qux's "some other  phrase" " another one  "`,
+				`服务器环境=测试,操作系统类别 Linux  机房=华北 `,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for i, spec := range tc.specs {
+				m := ParseSearchKeywords(spec, tc.delimiter)
+				require.Equal(t, expected[i], m)
+			}
 		})
 	}
 }

--- a/lib/kube/utils/utils_test.go
+++ b/lib/kube/utils/utils_test.go
@@ -120,3 +120,33 @@ func kubeService(kubeClusters ...string) types.Server {
 		},
 	}
 }
+
+func TestExtractAndSortKubeClusterNames(t *testing.T) {
+	t.Parallel()
+
+	server1, err := types.NewServer("foo", types.KindNode, types.ServerSpecV2{
+		KubernetesClusters: []*types.KubernetesCluster{
+			{Name: "watermelon"},
+		},
+	})
+	require.NoError(t, err)
+
+	server2, err := types.NewServer("foo", types.KindNode, types.ServerSpecV2{
+		KubernetesClusters: []*types.KubernetesCluster{
+			{Name: "watermelon"},
+		},
+	})
+	require.NoError(t, err)
+
+	server3, err := types.NewServer("bar", types.KindNode, types.ServerSpecV2{
+		KubernetesClusters: []*types.KubernetesCluster{
+			{Name: "banana"},
+			{Name: "apple"},
+			{Name: "pear"},
+		},
+	})
+	require.NoError(t, err)
+
+	names := extractAndSortKubeClusterNames([]types.Server{server1, server2, server3})
+	require.Equal(t, []string{"apple", "banana", "pear", "watermelon"}, names)
+}

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -43,7 +43,7 @@ func onListDatabases(cf *CLIConf) error {
 	}
 	var databases []types.Database
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
-		databases, err = tc.ListDatabases(cf.Context)
+		databases, err = tc.ListDatabases(cf.Context, nil /* custom filter */)
 		return trace.Wrap(err)
 	})
 	if err != nil {
@@ -410,7 +410,12 @@ func getDatabaseInfo(cf *CLIConf, tc *client.TeleportClient, dbName string) (*tl
 func getDatabase(cf *CLIConf, tc *client.TeleportClient, dbName string) (types.Database, error) {
 	var databases []types.Database
 	err := client.RetryWithRelogin(cf.Context, tc, func() error {
-		allDatabases, err := tc.ListDatabases(cf.Context)
+		allDatabases, err := tc.ListDatabases(cf.Context, &proto.ListResourcesRequest{
+			Namespace:           tc.Namespace,
+			PredicateExpression: fmt.Sprintf(`name == "%s"`, dbName),
+		})
+		// Kept for fallback in case an older auth does not apply filters.
+		// DELETE IN 11.0.0
 		for _, database := range allDatabases {
 			if database.GetName() == dbName {
 				databases = append(databases, database)

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -23,13 +23,13 @@ import (
 	"net"
 	"net/url"
 	"os"
-
 	"strings"
 	"time"
 
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
@@ -589,16 +589,26 @@ func (c *kubeCredentialsCommand) writeResponse(key *client.Key, kubeClusterName 
 
 type kubeLSCommand struct {
 	*kingpin.CmdClause
+	labels         string
+	predicateExpr  string
+	searchKeywords string
 }
 
 func newKubeLSCommand(parent *kingpin.CmdClause) *kubeLSCommand {
 	c := &kubeLSCommand{
 		CmdClause: parent.Command("ls", "Get a list of kubernetes clusters"),
 	}
+	c.Flag("search", searchHelp).StringVar(&c.searchKeywords)
+	c.Flag("query", queryHelp).StringVar(&c.predicateExpr)
+	c.Arg("labels", labelHelp).StringVar(&c.labels)
 	return c
 }
 
 func (c *kubeLSCommand) run(cf *CLIConf) error {
+	cf.SearchKeywords = c.searchKeywords
+	cf.UserHost = c.labels
+	cf.PredicateExpression = c.predicateExpr
+
 	tc, err := makeClient(cf, true)
 	if err != nil {
 		return trace.Wrap(err)
@@ -715,10 +725,27 @@ func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleport
 		}
 		teleportCluster = cn.GetClusterName()
 
-		kubeClusters, err = kubeutils.KubeClusterNames(ctx, ac)
+		kubeClusters, err = kubeutils.ListKubeClusterNamesWithFilters(ctx, ac, proto.ListResourcesRequest{
+			SearchKeywords:      tc.SearchKeywords,
+			PredicateExpression: tc.PredicateExpression,
+			Labels:              tc.Labels,
+		})
 		if err != nil {
+			// ListResources for kube service not availalbe, provide fallback.
+			// Fallback does not support filters, so if users
+			// provide them, it does nothing.
+			//
+			// DELETE IN 11.0.0
+			if trace.IsNotImplemented(err) {
+				kubeClusters, err = kubeutils.KubeClusterNames(ctx, ac)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				return nil
+			}
 			return trace.Wrap(err)
 		}
+
 		return nil
 	})
 	if err != nil {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -429,6 +429,9 @@ func Run(args []string, opts ...cliOption) error {
 	lsApps := apps.Command("ls", "List available applications.")
 	lsApps.Flag("verbose", "Show extra application fields.").Short('v').BoolVar(&cf.Verbose)
 	lsApps.Flag("cluster", clusterHelp).StringVar(&cf.SiteName)
+	lsApps.Flag("search", searchHelp).StringVar(&cf.SearchKeywords)
+	lsApps.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
+	lsApps.Arg("labels", labelHelp).StringVar(&cf.UserHost)
 	appLogin := apps.Command("login", "Retrieve short-lived certificate for an app.")
 	appLogin.Arg("app", "App name to retrieve credentials for. Can be obtained from `tsh apps ls` output.").Required().StringVar(&cf.AppName)
 	appLogin.Flag("aws-role", "(For AWS CLI access only) Amazon IAM role ARN or role name.").StringVar(&cf.AWSRole)
@@ -458,6 +461,9 @@ func Run(args []string, opts ...cliOption) error {
 	db.Flag("cluster", clusterHelp).StringVar(&cf.SiteName)
 	dbList := db.Command("ls", "List all available databases.")
 	dbList.Flag("verbose", "Show extra database fields.").Short('v').BoolVar(&cf.Verbose)
+	dbList.Flag("search", searchHelp).StringVar(&cf.SearchKeywords)
+	dbList.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
+	dbList.Arg("labels", labelHelp).StringVar(&cf.UserHost)
 	dbLogin := db.Command("login", "Retrieve credentials for a database.")
 	dbLogin.Arg("db", "Database to retrieve credentials for. Can be obtained from 'tsh db ls' output.").Required().StringVar(&cf.DatabaseService)
 	dbLogin.Flag("db-user", "Optional database user to configure as default.").StringVar(&cf.DatabaseUser)
@@ -2468,7 +2474,7 @@ func onApps(cf *CLIConf) error {
 	// Get a list of all applications.
 	var apps []types.Application
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
-		apps, err = tc.ListApps(cf.Context)
+		apps, err = tc.ListApps(cf.Context, nil /* custom filter */)
 		return err
 	})
 	if err != nil {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -208,6 +208,12 @@ type CLIConf struct {
 	// Format is used to change the format of output
 	Format string
 
+	// SearchKeywords is a list of search keywords to match against resource field values.
+	SearchKeywords string
+
+	// PredicateExpression defines boolean conditions that will be matched against the resource.
+	PredicateExpression string
+
 	// NoRemoteExec will not execute a remote command after connecting to a host,
 	// will block instead. Useful when port forwarding. Equivalent of -N for OpenSSH.
 	NoRemoteExec bool
@@ -329,7 +335,9 @@ const (
 
 	clusterHelp = "Specify the Teleport cluster to connect"
 	browserHelp = "Set to 'none' to suppress browser opening on login"
-
+	searchHelp  = `List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")`
+	queryHelp   = `Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and || (e.g. --query='labels.key1 == "value1" && labels.key2 != "value2"')`
+	labelHelp   = "List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)"
 	// proxyDefaultResolutionTimeout is how long to wait for an unknown proxy
 	// port to be resolved.
 	//
@@ -494,9 +502,11 @@ func Run(args []string, opts ...cliOption) error {
 	// ls
 	ls := app.Command("ls", "List remote SSH nodes")
 	ls.Flag("cluster", clusterHelp).StringVar(&cf.SiteName)
-	ls.Arg("labels", "List of labels to filter node list").StringVar(&cf.UserHost)
 	ls.Flag("verbose", "One-line output (for text format), including node UUIDs").Short('v').BoolVar(&cf.Verbose)
 	ls.Flag("format", "Format output (text, json, names)").Short('f').Default(teleport.Text).StringVar(&cf.Format)
+	ls.Arg("labels", labelHelp).StringVar(&cf.UserHost)
+	ls.Flag("search", searchHelp).StringVar(&cf.SearchKeywords)
+	ls.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
 	// clusters
 	clusters := app.Command("clusters", "List available Teleport clusters")
 	clusters.Flag("quiet", "Quiet mode").Short('q').BoolVar(&cf.Quiet)
@@ -1245,7 +1255,7 @@ func onListNodes(cf *CLIConf) error {
 	// Get list of all nodes in backend and sort by "Node Name".
 	var nodes []types.Server
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
-		nodes, err = tc.ListNodes(cf.Context)
+		nodes, err = tc.ListNodesWithFilters(cf.Context)
 		return err
 	})
 	if err != nil {
@@ -1739,7 +1749,8 @@ func onBenchmark(cf *CLIConf) error {
 	fmt.Printf("\nHistogram\n\n")
 	t := asciitable.MakeTable([]string{"Percentile", "Response Duration"})
 	for _, quantile := range []float64{25, 50, 75, 90, 95, 99, 100} {
-		t.AddRow([]string{fmt.Sprintf("%v", quantile),
+		t.AddRow([]string{
+			fmt.Sprintf("%v", quantile),
 			fmt.Sprintf("%v ms", result.Histogram.ValueAtQuantile(quantile)),
 		})
 	}
@@ -1992,6 +2003,11 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (*client.TeleportClient, erro
 	c.Labels = labels
 	c.KeyTTL = time.Minute * time.Duration(cf.MinsToLive)
 	c.InsecureSkipVerify = cf.InsecureSkipVerify
+	c.PredicateExpression = cf.PredicateExpression
+
+	if cf.SearchKeywords != "" {
+		c.SearchKeywords = client.ParseSearchKeywords(cf.SearchKeywords, ',')
+	}
 
 	// If a TTY was requested, make sure to allocate it. Note this applies to
 	// "exec" command because a shell always has a TTY allocated.
@@ -2185,7 +2201,6 @@ func refuseArgs(command string, args []string) error {
 		} else {
 			return trace.BadParameter("unexpected argument: %s", arg)
 		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
part of [RFD 55](https://github.com/gravitational/teleport/blob/master/rfd%2F0055-webui-ss-paginate-filter.md#client-tsh-and-tctl)

#### Description
- Adds new flags `--search` (keywords), `--query` (predicate), and `labels`.
- Add a search keyword parser that takes in different delimiters (`comma` is used for tsh, `space` is used for web UI)

#### Backwards Compat Test
- [x] tsh vCurrent -> auth v8    (using the new flags here with an older auth silently does not apply the filters)

