### PR TITLE
[v9] Add MariaDB to AWS RDS auto discovery

### DIFF
--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -1,6 +1,7 @@
 ---
-title: Database Access with AWS RDS and Aurora for PostgreSQL and MySQL
-description: How to configure Teleport Database Access with AWS RDS and Aurora for PostgreSQL and MySQL.
+title: Database Access with AWS RDS and Aurora
+h1: Database Access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB
+description: How to configure Teleport Database Access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB.
 ---
 
 This guide will help you to:
@@ -9,9 +10,10 @@ This guide will help you to:
 - Set up Teleport to access your RDS instances and Aurora clusters.
 - Connect to your databases through Teleport.
 
-<Admonition type="note" title="Aurora Serverless">
-  Aurora Serverless does not support IAM authentication at the time of this
-  writing so it can't be used with Database Access.
+<Admonition type="note" title="Supported versions">
+    The following products are not compatible with Database Access as they don't support IAM authentication:
+    - Aurora Serverless.
+    - RDS MariaDB versions lower than 10.6.
 </Admonition>
 
 ## Prerequisites
@@ -318,8 +320,8 @@ Access for RDS. See below how to enable it for your database engine.
   GRANT rds_iam TO alice;
   ```
   </TabItem>
-  <TabItem label="MySQL">
-  MySQL users must have RDS authentication plugin enabled:
+  <TabItem label="MySQL/MariaDB">
+  MySQL and MariaDB users must have the RDS authentication plugin enabled:
 
   ```sql
   CREATE USER alice IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -358,8 +358,57 @@ func TestIsRDSClusterSupported(t *testing.T) {
 				EngineVersion:       aws.String(test.engineVersion),
 			}
 
-			require.Equal(t, test.isSupported, IsRDSClusterSupported(cluster))
+			got, want := IsRDSClusterSupported(cluster), test.isSupported
+			require.Equal(t, want, got, "IsRDSClusterSupported = %v, want = %v", got, want)
+		})
+	}
+}
 
+func TestIsRDSInstanceSupported(t *testing.T) {
+	tests := []struct {
+		name          string
+		engine        string
+		engineVersion string
+		isSupported   bool
+	}{
+		{
+			name:          "non-MariaDB engine",
+			engine:        RDSEnginePostgres,
+			engineVersion: "13.3",
+			isSupported:   true,
+		},
+		{
+			name:          "unsupported MariaDB",
+			engine:        RDSEngineMariaDB,
+			engineVersion: "10.3.28",
+			isSupported:   false,
+		},
+		{
+			name:          "min supported version",
+			engine:        RDSEngineMariaDB,
+			engineVersion: "10.6.2",
+			isSupported:   true,
+		},
+		{
+			name:          "supported version",
+			engine:        RDSEngineMariaDB,
+			engineVersion: "10.8.0",
+			isSupported:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cluster := &rds.DBInstance{
+				DBInstanceArn:       aws.String("arn:aws:rds:us-east-1:1234567890:instance:test"),
+				DBClusterIdentifier: aws.String(test.name),
+				DbiResourceId:       aws.String(uuid.New().String()),
+				Engine:              aws.String(test.engine),
+				EngineVersion:       aws.String(test.engineVersion),
+			}
+
+			got, want := IsRDSInstanceSupported(cluster), test.isSupported
+			require.Equal(t, want, got, "IsRDSInstanceSupported = %v, want = %v", got, want)
 		})
 	}
 }

--- a/lib/srv/db/cloud/watchers/rds.go
+++ b/lib/srv/db/cloud/watchers/rds.go
@@ -106,6 +106,14 @@ func (f *rdsDBInstancesFetcher) getRDSDatabases(ctx context.Context) (types.Data
 	}
 	databases := make(types.Databases, 0, len(instances))
 	for _, instance := range instances {
+		if !services.IsRDSInstanceSupported(instance) {
+			f.log.Debugf("RDS instance %q (engine mode %v, engine version %v) doesn't support IAM authentication. Skipping.",
+				aws.StringValue(instance.DBInstanceIdentifier),
+				aws.StringValue(instance.Engine),
+				aws.StringValue(instance.EngineVersion))
+			continue
+		}
+
 		if !services.IsRDSInstanceAvailable(instance) {
 			f.log.Debugf("The current status of RDS instance %q is %q. Skipping.",
 				aws.StringValue(instance.DBInstanceIdentifier),
@@ -275,7 +283,8 @@ func rdsFilters() []*rds.Filter {
 		Name: aws.String("engine"),
 		Values: aws.StringSlice([]string{
 			services.RDSEnginePostgres,
-			services.RDSEngineMySQL}),
+			services.RDSEngineMySQL,
+			services.RDSEngineMariaDB}),
 	}}
 }
 


### PR DESCRIPTION
Add support for MariaDB AWS RDS with IAM authentication version 10.6+.

Co-authored-by: Paul Gottschling <paul.gottschling@goteleport.com>
Co-authored-by: Alan Parra <alan.parra@goteleport.com>
Co-authored-by: Roman Tkachenko <roman@goteleport.com>

Backport of #10333 to branch/v9