### PR TITLE
Update min Teleport version for Desktop Access

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -858,7 +858,7 @@
     }
   ],
   "variables": {
-    "version": "10.0",
+    "version": "7.0",
     "terraform": {
       "version": "1.0.0"
     },

--- a/docs/config.json
+++ b/docs/config.json
@@ -330,17 +330,17 @@
           "title": "Getting Started",
           "slug": "/kubernetes-access/getting-started/",
            "entries": [
-            { 
-              "title": "Local Demo Cluster", 
+            {
+              "title": "Local Demo Cluster",
               "slug": "/kubernetes-access/getting-started/local/"
             },
-            { 
-              "title": "Cluster", 
-              "slug": "/kubernetes-access/getting-started/cluster/" 
+            {
+              "title": "Cluster",
+              "slug": "/kubernetes-access/getting-started/cluster/"
             },
-            { 
-              "title": "Agent", 
-              "slug": "/kubernetes-access/getting-started/agent/" 
+            {
+              "title": "Agent",
+              "slug": "/kubernetes-access/getting-started/agent/"
             }
           ]
         },
@@ -858,10 +858,7 @@
     }
   ],
   "variables": {
-    "version": "7.0",
-    "helm": {
-      "version": "3.4.2"
-    },
+    "version": "10.0",
     "terraform": {
       "version": "1.0.0"
     },

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -365,7 +365,7 @@ In order to enable Desktop Access in Teleport, add the following section in
 configuration fields, see the
 [configuration reference](./reference/configuration.mdx) page.
 
-<Details title="Desktop Service Configuration" min="7.0" scopeOnly={true} scope={["oss", "enterprise"]}>
+<Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={["oss", "enterprise"]}>
 ```yaml
 windows_desktop_service:
   enabled: yes
@@ -380,7 +380,7 @@ windows_desktop_service:
     base_dn: "*"
 ```
 </Details>
-<Details title="Desktop Service Configuration" min="7.0" scopeOnly={true} scope={"cloud"}>
+<Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={"cloud"}>
 For Teleport Cloud, Windows Desktop Service should establish a reverse tunnel to
 the hosted proxy. This requires setting `auth_servers` to your cloud tenant and
 providing a join token.


### PR DESCRIPTION
Our docs currently refer to Teleport 7.0 on master and branch/v9. This PR updates the version to match the Teleport version on master.