### PR TITLE
[v9] Disable automatic updating of API import path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -728,9 +728,7 @@ version: $(VERSRC)
 # This rule triggers re-generation of version files specified if Makefile changes.
 $(VERSRC): Makefile
 	VERSION=$(VERSION) $(MAKE) -f version.mk setver
-	# Update api module path, but don't fail on error.
-	# Disabled for v9 release.
-	# $(MAKE) update-api-import-path || true
+	# "TODO: Enable automatic updating of API import paths using update-api-import-path target once agreed upon the solution".
 
 # This rule updates the api module path to be in sync with the current api release version.
 # e.g. github.com/gravitational/teleport/api/vX -> github.com/gravitational/teleport/api/vY

--- a/Makefile
+++ b/Makefile
@@ -729,7 +729,8 @@ version: $(VERSRC)
 $(VERSRC): Makefile
 	VERSION=$(VERSION) $(MAKE) -f version.mk setver
 	# Update api module path, but don't fail on error.
-	$(MAKE) update-api-import-path || true
+	# Disabled for v9 release.
+	# $(MAKE) update-api-import-path || true
 
 # This rule updates the api module path to be in sync with the current api release version.
 # e.g. github.com/gravitational/teleport/api/vX -> github.com/gravitational/teleport/api/vY


### PR DESCRIPTION
This will prevent the release of https://pkg.go.dev/github.com/gravitational/teleport in v9 until a solution is agreed upon regarding https://github.com/gravitational/teleport/blob/master/rfd/0010-api.md#versioning