### PR TITLE
Allow MFA devices with `/` in names to be deleted from UI

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -383,7 +383,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 	h.POST("/webapi/mfa/login/begin", h.withLimiter(challengeLimiter, h.mfaLoginBegin))
 	h.POST("/webapi/mfa/login/finish", httplib.MakeHandler(h.mfaLoginFinish))
 	h.POST("/webapi/mfa/login/finishsession", httplib.MakeHandler(h.mfaLoginFinishSession))
-	h.DELETE("/webapi/mfa/token/:token/devices/:devicename", httplib.MakeHandler(h.deleteMFADeviceWithTokenHandle))
+	h.DELETE("/webapi/mfa/token/:token/devices/*devicename", httplib.MakeHandler(h.deleteMFADeviceWithTokenHandle))
 	h.GET("/webapi/mfa/token/:token/devices", httplib.MakeHandler(h.getMFADevicesWithTokenHandle))
 	h.POST("/webapi/mfa/token/:token/authenticatechallenge", httplib.MakeHandler(h.createAuthenticateChallengeWithTokenHandle))
 	h.POST("/webapi/mfa/token/:token/registerchallenge", httplib.MakeHandler(h.createRegisterChallengeWithTokenHandle))

--- a/lib/web/mfa.go
+++ b/lib/web/mfa.go
@@ -60,7 +60,7 @@ func (h *Handler) getMFADevicesHandle(w http.ResponseWriter, r *http.Request, p 
 func (h *Handler) deleteMFADeviceWithTokenHandle(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
 	if err := h.GetProxyClient().DeleteMFADeviceSync(r.Context(), &proto.DeleteMFADeviceSyncRequest{
 		TokenID:    p.ByName("token"),
-		DeviceName: p.ByName("devicename"),
+		DeviceName: p.ByName("devicename")[1:],
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Currently MFA devices with `/` in names can't be removed from UI because `httprouter` can't match correct route as it sees additional path segments despite `:devicename` being correctly escaped (go doesn't treat encoded reserved characters as different from unescaped, deviating from RFC).
This change fixes that by using catch-all route instead, which captures all characters past `/device`.