### PR TITLE
[v8 backport] Fix ACME instructions in start-auth-proxy.mdx

### DIFF
--- a/docs/pages/includes/database-access/start-auth-proxy.mdx
+++ b/docs/pages/includes/database-access/start-auth-proxy.mdx
@@ -1,27 +1,39 @@
 <Tabs> 
-<TabItem scope={["oss","enterprise"]} label="Self Hosted">
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
+Download the latest version of Teleport for your platform from our
+[downloads page](https://goteleport.com/teleport/download) and follow the
+installation [instructions](../../installation.mdx).
+
 Teleport requires a valid TLS certificate to operate and can fetch one
 automatically using Let's Encrypt's ACME protocol. Before Let's Encrypt can
 issue a TLS certificate for the Teleport Proxy host's domain, the ACME protocol
 must verify that an HTTPS server is reachable on port 443 of the host.  
 
-We will assume that you have configured DNS records for `teleport.example.com`
-and `*.teleport.example.com` to point to your Teleport Node.
+You can configure the Teleport Proxy service to complete the Let's Encrypt
+verification process when it starts up.
 
-<Admonition type="note" title="Web Proxy Port">
-To support the ACME protocol, Teleport Proxy must listen on port 443, rather
-than the default port 3080.
-</Admonition>
+Run the following `teleport configure` command, where `tele.example.com` is the
+domain name of your Teleport cluster and `user@example.com` is an email address
+used for notifications (you can use any domain):
 
-Download the latest version of Teleport for your platform from our
-[downloads page](https://goteleport.com/teleport/download) and follow the
-installation [instructions](../../installation.mdx).
+```code
+teleport configure --acme --acme-email=user@example.com --cluster-name=tele.example.com > /etc/teleport.yaml
+```
 
-Teleport requires a valid TLS certificate to operate and can fetch one automatically
-using Let's Encrypt. 
-We will assume that you have configured DNS records for `teleport.example.com` and `*.teleport.example.com` to point to the Teleport Node.
+The `--acme`, `--acme-email`, and `--cluster-name` flags will add the following
+settings to your Teleport configuration file:
 
-(!docs/pages/includes/acme.mdx!)
+```yaml
+proxy_service:
+  enabled: "yes"
+  web_listen_addr: :443
+  public_addr: tele.example.com:443
+  acme:
+    enabled: "yes"
+    email: user@example.com
+```
+
+Port 443 on your Teleport Proxy Service host must allow traffic from all sources.
 
 Next, start the Teleport Auth and Proxy Services:
 


### PR DESCRIPTION
Backports #11013

start-auth-proxy.mdx is a partial used by a number of Database Access
guides. After PR #10824, the partial included garbled instructions for
setting up Teleport with Let's Encrypt, the result of resolving cherry-
pick conflicts during a backport. This change edits these instructions
for clarity.