### PR TITLE
[v9] Backport: Fix quadratic complexity in Reconciler.Reconcile(). (#10989)

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -563,16 +563,6 @@ func DeduplicateDatabases(databases []Database) (result []Database) {
 // Databases is a list of database resources.
 type Databases []Database
 
-// Find returns database with the specified name or nil.
-func (d Databases) Find(name string) Database {
-	for _, database := range d {
-		if database.GetName() == name {
-			return database
-		}
-	}
-	return nil
-}
-
 // ToMap returns these databases as a map keyed by database name.
 func (d Databases) ToMap() map[string]Database {
 	m := make(map[string]Database)

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -90,14 +90,21 @@ type ResourceWithLabels interface {
 // ResourcesWithLabels is a list of labeled resources.
 type ResourcesWithLabels []ResourceWithLabels
 
-// Find returns resource with the specified name or nil.
-func (r ResourcesWithLabels) Find(name string) ResourceWithLabels {
-	for _, resource := range r {
-		if resource.GetName() == name {
-			return resource
-		}
+// ResourcesWithLabelsMap is like ResourcesWithLabels, but a map from resource name to its value.
+type ResourcesWithLabelsMap map[string]ResourceWithLabels
+
+// ToMap returns these databases as a map keyed by database name.
+func (r ResourcesWithLabels) ToMap() ResourcesWithLabelsMap {
+	rm := make(ResourcesWithLabelsMap, len(r))
+
+	// there may be duplicate resources in the input list.
+	// by iterating from end to start, the first resource of given name wins.
+	for i := len(r) - 1; i >= 0; i-- {
+		resource := r[i]
+		rm[resource.GetName()] = resource
 	}
-	return nil
+
+	return rm
 }
 
 // Len returns the slice length.

--- a/api/types/resource_test.go
+++ b/api/types/resource_test.go
@@ -322,3 +322,53 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		})
 	}
 }
+
+func TestResourcesWithLabels_ToMap(t *testing.T) {
+	mkServerHost := func(name string, hostname string) ResourceWithLabels {
+		server, err := NewServerWithLabels(name, KindNode, ServerSpecV2{
+			Hostname: hostname + ".example.com",
+			Addr:     name + ".example.com",
+		}, nil)
+		require.NoError(t, err)
+
+		return server
+	}
+
+	mkServer := func(name string) ResourceWithLabels {
+		return mkServerHost(name, name)
+	}
+
+	tests := []struct {
+		name string
+		r    ResourcesWithLabels
+		want ResourcesWithLabelsMap
+	}{
+		{
+			name: "empty",
+			r:    nil,
+			want: map[string]ResourceWithLabels{},
+		},
+		{
+			name: "simple list",
+			r:    []ResourceWithLabels{mkServer("a"), mkServer("b"), mkServer("c")},
+			want: map[string]ResourceWithLabels{
+				"a": mkServer("a"),
+				"b": mkServer("b"),
+				"c": mkServer("c"),
+			},
+		},
+		{
+			name: "first duplicate wins",
+			r:    []ResourceWithLabels{mkServerHost("a", "a1"), mkServerHost("a", "a2"), mkServerHost("a", "a3")},
+			want: map[string]ResourceWithLabels{
+				"a": mkServerHost("a", "a1"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.r.ToMap(), tt.want)
+		})
+	}
+}

--- a/lib/services/reconciler_test.go
+++ b/lib/services/reconciler_test.go
@@ -156,11 +156,11 @@ func TestReconciler(t *testing.T) {
 				Matcher: func(rwl types.ResourceWithLabels) bool {
 					return MatchResourceLabels(test.selectors, rwl)
 				},
-				GetCurrentResources: func() types.ResourcesWithLabels {
-					return test.registeredResources
+				GetCurrentResources: func() types.ResourcesWithLabelsMap {
+					return test.registeredResources.ToMap()
 				},
-				GetNewResources: func() types.ResourcesWithLabels {
-					return test.newResources
+				GetNewResources: func() types.ResourcesWithLabelsMap {
+					return test.newResources.ToMap()
 				},
 				OnCreate: func(ctx context.Context, r types.ResourceWithLabels) error {
 					onCreateCalls = append(onCreateCalls, r)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -203,10 +203,10 @@ func (m *monitoredApps) setResources(apps types.Apps) {
 	m.resources = apps
 }
 
-func (m *monitoredApps) get() types.ResourcesWithLabels {
+func (m *monitoredApps) get() types.ResourcesWithLabelsMap {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return append(m.static, m.resources...).AsResources()
+	return append(m.static, m.resources...).AsResources().ToMap()
 }
 
 // New returns a new application server.

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -97,8 +97,8 @@ func (s *Server) startResourceWatcher(ctx context.Context) (*services.AppWatcher
 	return watcher, nil
 }
 
-func (s *Server) getResources() (resources types.ResourcesWithLabels) {
-	return s.getApps().AsResources()
+func (s *Server) getResources() (resources types.ResourcesWithLabelsMap) {
+	return s.getApps().AsResources().ToMap()
 }
 
 func (s *Server) onCreate(ctx context.Context, resource types.ResourceWithLabels) error {

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -245,10 +245,10 @@ func (m *monitoredDatabases) setCloud(databases types.Databases) {
 	m.cloud = databases
 }
 
-func (m *monitoredDatabases) get() types.ResourcesWithLabels {
+func (m *monitoredDatabases) get() types.ResourcesWithLabelsMap {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return append(append(m.static, m.resources...), m.cloud...).AsResources()
+	return append(append(m.static, m.resources...), m.cloud...).AsResources().ToMap()
 }
 
 // New returns a new database server.

--- a/lib/srv/db/watcher.go
+++ b/lib/srv/db/watcher.go
@@ -134,11 +134,8 @@ func (s *Server) startCloudWatcher(ctx context.Context) error {
 }
 
 // getResources returns proxied databases as resources.
-func (s *Server) getResources() (resources types.ResourcesWithLabels) {
-	for _, database := range s.getProxiedDatabases() {
-		resources = append(resources, database)
-	}
-	return resources
+func (s *Server) getResources() types.ResourcesWithLabelsMap {
+	return s.getProxiedDatabases().AsResources().ToMap()
 }
 
 // onCreate is called by reconciler when a new database is created.

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -113,7 +113,7 @@ type WindowsService struct {
 	// when desktop discovery is enabled.
 	// no synchronization is necessary because this is only read/written from
 	// the reconciler goroutine.
-	lastDiscoveryResults types.ResourcesWithLabels
+	lastDiscoveryResults types.ResourcesWithLabelsMap
 
 	// Windows hosts discovered via LDAP likely won't resolve with the
 	// default DNS resolver, so we need a custom resolver that will


### PR DESCRIPTION
* Fix quadratic Reconciler.Reconcile() complexity.

Co-authored-by: Alan Parra <alan.parra@goteleport.com>

Backport #10989 .