### PR TITLE
[v9] Backport: Update suggested systemctl command (#10733)

### DIFF
--- a/docs/pages/setup/admin/daemon.mdx
+++ b/docs/pages/setup/admin/daemon.mdx
@@ -53,6 +53,6 @@ administrator must:
 
 1. Replace the Teleport binaries, usually [`teleport`](../reference/cli.mdx#teleport)
    and [`tctl`](../reference/cli.mdx#tctl)
-2. Execute `systemctl restart teleport`
+2. Execute `systemctl reload teleport`
 
 This will perform a graceful restart, i.e. the Teleport daemon will fork a new process to handle new incoming requests, leaving the old daemon process running until existing clients disconnect.


### PR DESCRIPTION
Contrary to current wording `systemctl restart teleport` is *NOT* graceful. The graceful equivalent is `systemctl reload teleport`.

Backport #10733.