### PR TITLE
helm: Adds missing namespaces to ConfigMap

### DIFF
--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.annotations.config }}
   annotations:
     {{- toYaml .Values.annotations.config | nindent 4 }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
@@ -35,6 +35,7 @@ matches snapshot and tests for annotations.yaml:
         kubernetes.io/config: test-annotation
         kubernetes.io/config-different: 2
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for acme-off.yaml:
   1: |
     apiVersion: v1
@@ -69,6 +70,7 @@ matches snapshot for acme-off.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for acme-on.yaml:
   1: |
     apiVersion: v1
@@ -106,6 +108,7 @@ matches snapshot for acme-on.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for acme-uri-staging.yaml:
   1: |
     apiVersion: v1
@@ -143,6 +146,7 @@ matches snapshot for acme-uri-staging.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for affinity.yaml:
   1: |
     apiVersion: v1
@@ -184,6 +188,7 @@ matches snapshot for affinity.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for aws-ha-acme.yaml:
   1: |
     apiVersion: v1
@@ -230,6 +235,7 @@ matches snapshot for aws-ha-acme.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for aws-ha-antiaffinity.yaml:
   1: |
     apiVersion: v1
@@ -273,6 +279,7 @@ matches snapshot for aws-ha-antiaffinity.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for aws-ha-log.yaml:
   1: |
     apiVersion: v1
@@ -319,6 +326,7 @@ matches snapshot for aws-ha-log.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for aws-ha.yaml:
   1: |
     apiVersion: v1
@@ -362,6 +370,7 @@ matches snapshot for aws-ha.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for aws.yaml:
   1: |
     apiVersion: v1
@@ -408,6 +417,7 @@ matches snapshot for aws.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for gcp-ha-acme.yaml:
   1: |
     apiVersion: v1
@@ -454,6 +464,7 @@ matches snapshot for gcp-ha-acme.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for gcp-ha-antiaffinity.yaml:
   1: |
     apiVersion: v1
@@ -497,6 +508,7 @@ matches snapshot for gcp-ha-antiaffinity.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for gcp-ha-log.yaml:
   1: |
     apiVersion: v1
@@ -543,6 +555,7 @@ matches snapshot for gcp-ha-log.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for gcp.yaml:
   1: |
     apiVersion: v1
@@ -589,6 +602,7 @@ matches snapshot for gcp.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for initcontainers.yaml:
   1: |
     apiVersion: v1
@@ -623,6 +637,7 @@ matches snapshot for initcontainers.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for kube-cluster-name.yaml:
   1: |
     apiVersion: v1
@@ -657,6 +672,7 @@ matches snapshot for kube-cluster-name.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for log-basic.yaml:
   1: |
     apiVersion: v1
@@ -691,6 +707,7 @@ matches snapshot for log-basic.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for log-extra.yaml:
   1: |
     apiVersion: v1
@@ -725,6 +742,7 @@ matches snapshot for log-extra.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for log-legacy.yaml:
   1: |
     apiVersion: v1
@@ -759,6 +777,7 @@ matches snapshot for log-legacy.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for priority-class-name.yaml:
   1: |
     apiVersion: v1
@@ -793,6 +812,7 @@ matches snapshot for priority-class-name.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for proxy-listener-mode.yaml:
   1: |
     apiVersion: v1
@@ -827,6 +847,7 @@ matches snapshot for proxy-listener-mode.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for resources.yaml:
   1: |
     apiVersion: v1
@@ -861,6 +882,7 @@ matches snapshot for resources.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for service.yaml:
   1: |
     apiVersion: v1
@@ -895,6 +917,7 @@ matches snapshot for service.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for standalone-customsize.yaml:
   1: |
     apiVersion: v1
@@ -934,6 +957,7 @@ matches snapshot for standalone-customsize.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for standalone-existingpvc.yaml:
   1: |
     apiVersion: v1
@@ -973,6 +997,7 @@ matches snapshot for standalone-existingpvc.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for tolerations.yaml:
   1: |
     apiVersion: v1
@@ -1014,6 +1039,7 @@ matches snapshot for tolerations.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for version-override.yaml:
   1: |
     apiVersion: v1
@@ -1051,6 +1077,7 @@ matches snapshot for version-override.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for volumes.yaml:
   1: |
     apiVersion: v1
@@ -1085,6 +1112,7 @@ matches snapshot for volumes.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for webauthn.yaml:
   1: |
     apiVersion: v1
@@ -1123,3 +1151,4 @@ matches snapshot for webauthn.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE

--- a/examples/chart/teleport-kube-agent/.lint/image-pull-policy-stateful.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/image-pull-policy-stateful.yaml
@@ -1,0 +1,7 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster-name
+storage:
+  enabled: true
+  storageClassName: "aws-gp2"
+imagePullPolicy: Always

--- a/examples/chart/teleport-kube-agent/.lint/image-pull-policy.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/image-pull-policy.yaml
@@ -1,0 +1,5 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube
+kubeClusterName: test-kube-cluster
+imagePullPolicy: Always

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.annotations.config }}
   annotations:
     {{- toYaml .Values.annotations.config | nindent 4 }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -29,6 +29,7 @@ does not generate a config for clusterrole.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 does not generate a config for pdb.yaml:
   1: |
     apiVersion: v1
@@ -60,6 +61,7 @@ does not generate a config for pdb.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot and tests for annotations.yaml:
   1: |
     apiVersion: v1
@@ -94,6 +96,7 @@ matches snapshot and tests for annotations.yaml:
         kubernetes.io/config: test-annotation
         kubernetes.io/config-different: 2
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for affinity.yaml:
   1: |
     apiVersion: v1
@@ -125,6 +128,7 @@ matches snapshot for affinity.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for all-v5.yaml:
   1: |
     apiVersion: v1
@@ -163,6 +167,7 @@ matches snapshot for all-v5.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for all-v6.yaml:
   1: |
     apiVersion: v1
@@ -204,6 +209,7 @@ matches snapshot for all-v6.yaml:
         kubernetes.io/config: test-annotation
         kubernetes.io/config-different: 2
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for aws-databases.yaml:
   1: |
     apiVersion: v1
@@ -234,6 +240,7 @@ matches snapshot for aws-databases.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for backwards-compatibility.yaml:
   1: |
     apiVersion: v1
@@ -265,6 +272,7 @@ matches snapshot for backwards-compatibility.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for db.yaml:
   1: |
     apiVersion: v1
@@ -295,6 +303,7 @@ matches snapshot for db.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for imagepullsecrets.yaml:
   1: |
     apiVersion: v1
@@ -326,6 +335,7 @@ matches snapshot for imagepullsecrets.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for initcontainers.yaml:
   1: |
     apiVersion: v1
@@ -357,6 +367,7 @@ matches snapshot for initcontainers.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for log-basic.yaml:
   1: |
     apiVersion: v1
@@ -388,6 +399,7 @@ matches snapshot for log-basic.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for log-extra.yaml:
   1: |
     apiVersion: v1
@@ -419,6 +431,7 @@ matches snapshot for log-extra.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for log-legacy.yaml:
   1: |
     apiVersion: v1
@@ -450,6 +463,7 @@ matches snapshot for log-legacy.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for node-selector.yaml:
   1: |
     apiVersion: v1
@@ -481,6 +495,7 @@ matches snapshot for node-selector.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for pdb.yaml:
   1: |
     apiVersion: v1
@@ -512,6 +527,7 @@ matches snapshot for pdb.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for resources.yaml:
   1: |
     apiVersion: v1
@@ -543,6 +559,7 @@ matches snapshot for resources.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for stateful.yaml:
   1: |
     apiVersion: v1
@@ -574,6 +591,7 @@ matches snapshot for stateful.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for tolerations.yaml:
   1: |
     apiVersion: v1
@@ -605,6 +623,7 @@ matches snapshot for tolerations.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for volumes.yaml:
   1: |
     apiVersion: v1
@@ -636,3 +655,4 @@ matches snapshot for volumes.yaml:
     kind: ConfigMap
     metadata:
       name: RELEASE-NAME
+      namespace: NAMESPACE


### PR DESCRIPTION
The `ConfigMap` for both the `teleport-cluster` and `teleport-kube-agent` charts was missing a `namespace:` parameter. This is transparently fixed for you when you run `helm install --namespace x`, but applying the output of `helm template --namespace x` (as some wrapper tools do) would result in the `ConfigMap` living in the wrong namespace.

Backports required:
- `branch/v9`

(I'm deliberately not backporting this to `branch/v8` in case it's a breaking change in some environments which depend on the old behaviour)