### PR TITLE
(v9) Missing v9 backports

### DIFF
--- a/docs/pages/application-access/controls.mdx
+++ b/docs/pages/application-access/controls.mdx
@@ -79,6 +79,6 @@ allow:
   - [OIDC](../enterprise/sso/oidc.mdx)
   - [ADFS](../enterprise/sso/adfs.mdx)
   - [Azure AD](../enterprise/sso/azuread.mdx)
-  - [GSuite](../enterprise/sso/azuread.mdx)
+  - [Google Workspace](../enterprise/sso/google-workspace.mdx)
   - [Onelogin](../enterprise/sso/one-login.mdx)
   - [Okta](../enterprise/sso/okta.mdx)

--- a/docs/pages/enterprise/sso/adfs.mdx
+++ b/docs/pages/enterprise/sso/adfs.mdx
@@ -24,17 +24,8 @@ like:
   This guide requires a commercial edition of Teleport.
 </Admonition>
 
-## Enable ADFS Authentication
 
-First, configure Teleport auth server to use ADFS authentication instead of the local
-user database. Update `/etc/teleport.yaml` as shown below and restart the
-teleport daemon.
-
-```yaml
-auth_service:
-    authentication:
-        type: saml
-```
+(!docs/pages/includes/enterprise/samlauthentication.mdx!)
 
 ## Configure ADFS
 

--- a/docs/pages/enterprise/sso/azuread.mdx
+++ b/docs/pages/enterprise/sso/azuread.mdx
@@ -28,6 +28,8 @@ Before you get started you’ll need:
 - To register one or more users in the directory
 - To create at least two security groups in Azure AD and assign one or more users to each group
 
+(!docs/pages/includes/enterprise/samlauthentication.mdx!)
+
 ## Configure Azure AD
 
 1. Select **Azure AD -> Enterprise Applications**
@@ -167,34 +169,6 @@ $ tctl create dev.yaml
 ```
 
 ## Testing
-
-Update your Teleport configuration to make SAML the default authentication method.
-
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self Hosted">
-In your Teleport configuration file, include the following:
-
-```yaml
-auth_service:
-  authentication:
-    type: saml
-```
-</TabItem>
-<TabItem scope={["cloud"]} label="Teleport Cloud">
-Apply the following `cluster_auth_preference` resource via `tctl create`.
-
-```yaml
-    kind: cluster_auth_preference
-    version: v2
-    metadata:
-      name: cluster-auth-preference
-    spec:
-      type: "saml"
-```
-</TabItem>
-</Tabs>
-
-The Web UI will now present the option to log in via Microsoft.
 
 ![Login with Microsoft](../../../img/azuread/azure-11-loginwithmsft.png)
 

--- a/docs/pages/enterprise/sso/gitlab.mdx
+++ b/docs/pages/enterprise/sso/gitlab.mdx
@@ -22,17 +22,7 @@ like:
   This guide requires a commercial edition of Teleport.
 </Admonition>
 
-## Enable OIDC Authentication
-
-First, configure Teleport auth server to use OIDC authentication instead of the local
-user database. Update `/etc/teleport.yaml` as shown below and restart the
-teleport daemon.
-
-```yaml
-auth_service:
-    authentication:
-        type: oidc
-```
+(!docs/pages/includes/enterprise/oidcauthentication.mdx!)
 
 ## Configure GitLab
 

--- a/docs/pages/enterprise/sso/google-workspace.mdx
+++ b/docs/pages/enterprise/sso/google-workspace.mdx
@@ -32,6 +32,8 @@ Before you get started you’ll need:
 - Ability to create a Google Cloud project, which requires signing up for Google Cloud. Note that this guide will not require using any paid Google Cloud services.
 - Ability to set up Google Workspace groups.
 
+(!docs/pages/includes/enterprise/oidcauthentication.mdx!)
+
 ## Configuring Google Workspace
 
 The setup will consist of creating a new project on Google Cloud Platform,

--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -20,17 +20,7 @@ administrators to define policies like:
   This guide requires an Enterprise edition of Teleport.
 </Admonition>
 
-## Enable OIDC Authentication
-
-First, configure Teleport auth server to use OIDC authentication instead of the local
-user database. Update `/etc/teleport.yaml` as show below and restart the
-teleport daemon.
-
-```yaml
-auth_service:
-    authentication:
-        type: oidc
-```
+(!docs/pages/includes/enterprise/oidcauthentication.mdx!)
 
 ## Identity Providers
 

--- a/docs/pages/enterprise/sso/okta.mdx
+++ b/docs/pages/enterprise/sso/okta.mdx
@@ -22,17 +22,7 @@ like:
   This guide requires a commercial edition of Teleport.
 </Admonition>
 
-## Enable SAML Authentication
-
-First, configure Teleport auth server to use SAML authentication instead of the local
-user database. Update `/etc/teleport.yaml` as shown below and restart the
-teleport daemon.
-
-```yaml
-auth_service:
-    authentication:
-        type: saml
-```
+(!docs/pages/includes/enterprise/samlauthentication.mdx!)
 
 ## Configure Okta
 

--- a/docs/pages/enterprise/sso/one-login.mdx
+++ b/docs/pages/enterprise/sso/one-login.mdx
@@ -22,17 +22,7 @@ like:
   This guide requires an Enterprise edition of Teleport.
 </Admonition>
 
-## Enable SAML Authentication
-
-Configure Teleport auth server to use SAML authentication instead of the local
-user database. Update `/etc/teleport.yaml` as shown below and restart the
-teleport daemon.
-
-```yaml
-auth_service:
-    authentication:
-        type: saml
-```
+(!docs/pages/includes/enterprise/samlauthentication.mdx!)
 
 ## Configure Application
 

--- a/docs/pages/includes/enterprise/oidcauthentication.mdx
+++ b/docs/pages/includes/enterprise/oidcauthentication.mdx
@@ -1,0 +1,34 @@
+## Enable default OIDC authentication
+
+Configure Teleport to use OIDC authentication as the default instead of the local
+user database. You can use Dynamic Resources for Teleport Cloud as well as self-hosted deployments.
+
+<Tabs>
+  <TabItem label="Static Config (Self-Hosted)">
+ Update `/etc/teleport.yaml` in the `auth_service` section and restart the `teleport` daemon.
+  ```yaml
+  auth_service:
+    authentication:
+      type: oidc
+
+  ```
+  </TabItem>
+  <TabItem scope={["cloud"]} label="Dynamic Resources (All Editions)">
+  Create a file called `cap.yaml`:
+  ```yaml
+  kind: cluster_auth_preference
+  metadata:
+    name: cluster-auth-preference
+  spec:
+    authentication:
+      type: oidc
+  version: v2
+  ```
+
+  Create a resource:
+
+  ```bash
+  $ tctl create -f cap.yaml
+  ```
+  </TabItem>
+</Tabs>

--- a/docs/pages/includes/enterprise/samlauthentication.mdx
+++ b/docs/pages/includes/enterprise/samlauthentication.mdx
@@ -1,0 +1,33 @@
+## Enable default SAML authentication
+
+Configure Teleport to use SAML authentication as the default instead of the local
+user database. You can use Dynamic Resources for Teleport Cloud as well as self-hosted deployments.
+
+<Tabs>
+  <TabItem label="Static Config (Self-Hosted)">
+ Update `/etc/teleport.yaml` in the `auth_service` section and restart the `teleport` daemon.
+  ```yaml
+  auth_service:
+    authentication:
+      type: saml
+  ```
+  </TabItem>
+  <TabItem scope={["cloud"]} label="Dynamic Resources (All Editions)">
+  Create a file called `cap.yaml`:
+  ```yaml
+  kind: cluster_auth_preference
+  metadata:
+    name: cluster-auth-preference
+  spec:
+    authentication:
+      type: saml
+  version: v2
+  ```
+
+  Create a resource:
+
+  ```bash
+  $ tctl create -f cap.yaml
+  ```
+  </TabItem>
+</Tabs>

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -88,7 +88,7 @@ Enterprise Edition:
 Identity provider admins can assign metadata to a user, such as
 group membership or access permissions. Administrators configure what metadata
 is shared with Teleport. Teleport receives user metadata keys and values as OIDC claims or SAML
-attributes during [signle sign-on redirect flow](https://goteleport.com/blog/how-oidc-authentication-works/):
+attributes during [single sign-on redirect flow](https://goteleport.com/blog/how-oidc-authentication-works/):
 
 ```yaml
 # Alice has an email alice@example.com. Email is a standard OIDC claim.

--- a/docs/pages/kubernetes-access/helm/guides/aws.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/aws.mdx
@@ -322,7 +322,7 @@ $ MY_CLUSTER_REGION='us-west-2'
 $ MYZONE="$(aws route53 list-hosted-zones-by-name --dns-name="${MYZONE_DNS?}" | jq -r '.HostedZones[0].Id' | sed s_/hostedzone/__)"
 $ MYELB="$(kubectl --namespace "${NAMESPACE?}" get "service/${RELEASE_NAME?}" -o jsonpath='{.status.loadBalancer.ingress[*].hostname}')"
 $ MYELB_NAME="${MYELB%%-*}"
-$ MYELB_ZONE="$(aws elb describe-load-balancers --region "${MY_CLUSTER_REGION?}" --load-balancer-names "${MYELB_NAME?}" | jq -r '.LoadBalancerDescriptions[0].CanonicalHostedZoneNameID')"
+$ MYELB_ZONE="$(aws elbv2 describe-load-balancers --region "${MY_CLUSTER_REGION?}" --names "${MYELB_NAME?}" | jq -r '.LoadBalancers[0].CanonicalHostedZoneId')"
 
 # Create a JSON file changeset for AWS.
 $ jq -n --arg dns "${MYDNS?}" --arg elb "${MYELB?}" --arg elbz "${MYELB_ZONE?}" \

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -81,14 +81,6 @@ This reference details available values for the `teleport-cluster` chart.
 
 See [Second Factor - WebAuthn](../../access-controls/guides/webauthn.mdx) for more details.
 
-#### `authenticationSecondFactor.webauthn.rpId`
-
-| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
-| - | - | - | - | - |
-| `string` | `` | Yes | `auth_service.authentication.webauthn.rp_id` | ❌ |
-
-`authenticationSecondFactor.webauthn.rpId` is public domain of the Teleport proxy, excluding protocol (https://) and port number.
-
 #### `authenticationSecondFactor.webauthn.attestationAllowedCas`
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -67,6 +67,52 @@ This reference details available values for the `teleport-cluster` chart.
 
 `authenticationType` controls the authentication scheme used by Teleport. Possible values are `local` and `github` for OSS, plus `oidc`, `saml`, and `false` for Enterprise.
 
+## `authenticationSecondFactor`
+
+### `authenticationSecondFactor.secondFactor`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `on` | Yes | `auth_service.authentication.second_factor` | ❌ |
+
+`authenticationSecondFactor.secondFactor` controls the second factor used for local user authentication. Possible values are `on`, `optional` and `webauthn`.
+
+### `authenticationSecondFactor.webauthn`
+
+See [Second Factor - WebAuthn](../../access-controls/guides/webauthn.mdx) for more details.
+
+#### `authenticationSecondFactor.webauthn.rpId`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `` | Yes | `auth_service.authentication.webauthn.rp_id` | ❌ |
+
+`authenticationSecondFactor.webauthn.rpId` is public domain of the Teleport proxy, excluding protocol (https://) and port number.
+
+#### `authenticationSecondFactor.webauthn.attestationAllowedCas`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `array` | `[]` | No | `auth_service.authentication.webauthn.attestation_allowed_cas` | ❌ |
+
+`authenticationSecondFactor.webauthn.attestationAllowedCas` is an optional allow list of certificate authorities (as local file paths or in-line PEM certificate string) for
+[device verification](https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/Attestation.html).
+This field allows you to restrict which device models and vendors you trust.
+Devices outside of the list will be rejected during registration.
+By default all devices are allowed.
+
+#### `authenticationSecondFactor.webauthn.attestationDeniedCas`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `array` | `[]` | No | `auth_service.authentication.webauthn.attestation_denied_cas` | ❌ |
+
+`authenticationSecondFactor.webauthn.attestationDeniedCas` is optional deny list of certificate authorities (as local file paths or in-line PEM certificate string) for
+[device verification](https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/Attestation.html).
+This field allows you to forbid specific device models and vendors, while allowing all others (provided they clear attestation_allowed_cas as well).
+Devices within this list will be rejected during registration.
+By default no devices are forbidden.
+
 ## `proxyListenerMode`
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -73,9 +73,13 @@ This reference details available values for the `teleport-cluster` chart.
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
-| `string` | `on` | Yes | `auth_service.authentication.second_factor` | ❌ |
+| `string` | `otp` | Yes | `auth_service.authentication.second_factor` | ❌ |
 
-`authenticationSecondFactor.secondFactor` controls the second factor used for local user authentication. Possible values are `on`, `optional` and `webauthn`.
+`authenticationSecondFactor.secondFactor` controls the second factor used for local user authentication. Possible values supported by this chart
+are `off` (not recommended), `on`, `otp`, `optional` and `webauthn`.
+
+When set to `on`, `optional` or `webauthn`, the `authenticationSecondFactor.webauthn` section can also be used. The configured `rp_id` defaults to
+the FQDN which is used to access the Teleport cluster.
 
 ### `authenticationSecondFactor.webauthn`
 

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -96,11 +96,11 @@ teleport:
 
     # Logging configuration. Possible output values to disk via 
     # '/var/lib/teleport/teleport.log',
-    # 'stdout', 'stderr' and 'syslog'. Possible severity values are INFO, WARN
-    # and ERROR (default).
+    # 'stdout', 'stderr' and 'syslog'. Possible severity values are DEBUG, INFO (default), WARN,
+    # and ERROR.
     log:
         output: /var/lib/teleport/teleport.log
-        severity: ERROR
+        severity: INFO
 
         # Log format configuration
         # Possible output values are 'json' and 'text' (default).

--- a/examples/aws/terraform/starter-cluster/vars.tf
+++ b/examples/aws/terraform/starter-cluster/vars.tf
@@ -42,7 +42,7 @@ variable "email" {
 }
 
 
-// SSH key name to provision instances withx
+// SSH key name to provision instances with
 variable "key_name" {
   type = string
 }

--- a/examples/chart/teleport-cluster/.lint/webauthn.yaml
+++ b/examples/chart/teleport-cluster/.lint/webauthn.yaml
@@ -1,0 +1,8 @@
+clusterName: helm-lint
+authenticationSecondFactor:
+  secondFactor: "on"
+  webauthn:
+    attestationAllowedCas:
+      - "/etc/ssl/certs/ca-certificates.crt"
+    attestationDeniedCas:
+      - "/etc/ssl/certs/ca-certificates.crt"

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -55,6 +55,23 @@ data:
   {{- end }}
       authentication:
         type: {{ required "authenticationType is required in chart values" .Values.authenticationType }}
+  {{- if .Values.authenticationSecondFactor }}
+    {{- if .Values.authenticationSecondFactor.secondFactor }}
+        second_factor: {{ .Values.authenticationSecondFactor.secondFactor }}
+    {{- end }}
+    {{- if .Values.authenticationSecondFactor.webauthn }}
+        webauthn:
+          rp_id: {{ required "authenticationSecondFactor.webauthn.rpId is required in chart values to enable webauthn" .Values.authenticationSecondFactor.webauthn.rpId }}
+      {{- if .Values.authenticationSecondFactor.webauthn.attestationAllowedCas }}
+          attestation_allowed_cas:
+          {{- toYaml .Values.authenticationSecondFactor.webauthn.attestationAllowedCas | nindent 12 }}
+      {{- end }}
+      {{- if .Values.authenticationSecondFactor.webauthn.attestationDeniedCas }}
+          attestation_denied_cas:
+          {{- toYaml .Values.authenticationSecondFactor.webauthn.attestationDeniedCas | nindent 12 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
   {{- if eq .Values.proxyListenerMode "multiplex" }}
       proxy_listener_mode: multiplex
   {{- end }}

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -59,16 +59,18 @@ data:
     {{- if .Values.authenticationSecondFactor.secondFactor }}
         second_factor: {{ .Values.authenticationSecondFactor.secondFactor }}
     {{- end }}
-    {{- if .Values.authenticationSecondFactor.webauthn }}
+    {{- if not (or (eq .Values.authenticationSecondFactor.secondFactor "off") (eq .Values.authenticationSecondFactor.secondFactor "otp")) }}
         webauthn:
           rp_id: {{ required "clusterName is required in chart values" .Values.clusterName }}
-      {{- if .Values.authenticationSecondFactor.webauthn.attestationAllowedCas }}
+      {{- if .Values.authenticationSecondFactor.webauthn }}
+        {{- if .Values.authenticationSecondFactor.webauthn.attestationAllowedCas }}
           attestation_allowed_cas:
           {{- toYaml .Values.authenticationSecondFactor.webauthn.attestationAllowedCas | nindent 12 }}
-      {{- end }}
-      {{- if .Values.authenticationSecondFactor.webauthn.attestationDeniedCas }}
+        {{- end }}
+        {{- if .Values.authenticationSecondFactor.webauthn.attestationDeniedCas }}
           attestation_denied_cas:
           {{- toYaml .Values.authenticationSecondFactor.webauthn.attestationDeniedCas | nindent 12 }}
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -61,7 +61,7 @@ data:
     {{- end }}
     {{- if .Values.authenticationSecondFactor.webauthn }}
         webauthn:
-          rp_id: {{ required "authenticationSecondFactor.webauthn.rpId is required in chart values to enable webauthn" .Values.authenticationSecondFactor.webauthn.rpId }}
+          rp_id: {{ required "clusterName is required in chart values" .Values.clusterName }}
       {{- if .Values.authenticationSecondFactor.webauthn.attestationAllowedCas }}
           attestation_allowed_cas:
           {{- toYaml .Values.authenticationSecondFactor.webauthn.attestationAllowedCas | nindent 12 }}

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -46,13 +46,8 @@
                 "webauthn": {
                     "$id": "#/properties/authenticationSecondFactor/properties/webauthn",
                     "type": "object",
-                    "required": ["rpId"],
+                    "required": [],
                     "properties": {
-                        "rpId": {
-                            "$id": "#/properties/authenticationSecondFactor/properties/webauthn/properties/rpId",
-                            "type": "string",
-                            "default": ""
-                        },
                         "attestationAllowedCas": {
                             "$id": "#/properties/authenticationSecondFactor/properties/webauthn/properties/attestationAllowedCas",
                             "type": "array",

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -32,6 +32,41 @@
             "type": "string",
             "default": "local"
         },
+        "authenticationSecondFactor": {
+            "$id": "#/properties/authenticationSecondFactor",
+            "type": "object",
+            "required": [],
+            "properties": {
+                "secondFactor": {
+                    "$id": "#/properties/authenticationSecondFactor/properties/secondFactor",
+                    "type": "string",
+                    "enum": ["on", "optional", "webauthn"],
+                    "default": "on"
+                },
+                "webauthn": {
+                    "$id": "#/properties/authenticationSecondFactor/properties/webauthn",
+                    "type": "object",
+                    "required": ["rpId"],
+                    "properties": {
+                        "rpId": {
+                            "$id": "#/properties/authenticationSecondFactor/properties/webauthn/properties/rpId",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "attestationAllowedCas": {
+                            "$id": "#/properties/authenticationSecondFactor/properties/webauthn/properties/attestationAllowedCas",
+                            "type": "array",
+                            "default": []
+                        },
+                        "attestationDeniedCas": {
+                            "$id": "#/properties/authenticationSecondFactor/properties/webauthn/properties/attestationDeniedCas",
+                            "type": "array",
+                            "default": []
+                        }
+                    }
+                }
+            }
+        },
         "proxyListenerMode": {
             "$id": "#/properties/proxyListenerMode",
             "type": "string",

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -40,8 +40,8 @@
                 "secondFactor": {
                     "$id": "#/properties/authenticationSecondFactor/properties/secondFactor",
                     "type": "string",
-                    "enum": ["on", "optional", "webauthn"],
-                    "default": "on"
+                    "enum": ["off", "on", "otp", "optional", "webauthn"],
+                    "default": "otp"
                 },
                 "webauthn": {
                     "$id": "#/properties/authenticationSecondFactor/properties/webauthn",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -22,6 +22,9 @@ teleportVersionOverride: ""
 # 'false' is required for FedRAMP / FIPS; see https://gravitational.com/teleport/docs/enterprise/ssh-kubernetes-fedramp/
 authenticationType: local
 
+authenticationSecondFactor:
+  secondFactor: "on"
+
 # Teleport supports TLS routing. In this mode, all client connections are wrapped in TLS and multiplexed on one Teleport proxy port.
 # Default mode will not utilize TLS routing and operate in backwards-compatibility mode.
 # Possible values are 'multiplex'

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2557,7 +2557,7 @@ func (tc *TeleportClient) Ping(ctx context.Context) (*webclient.PingResponse, er
 	// If version checking was requested and the server advertises a minimum version.
 	if tc.CheckVersions && pr.MinClientVersion != "" {
 		if err := utils.CheckVersion(teleport.Version, pr.MinClientVersion); err != nil && trace.IsBadParameter(err) {
-			fmt.Printf(`
+			fmt.Fprintf(tc.Config.Stderr, `
 			WARNING
 			Detected potentially incompatible client and server versions.
 			Minimum client version supported by the server is %v but you are using %v.
@@ -2590,7 +2590,7 @@ func (tc *TeleportClient) ShowMOTD(ctx context.Context) error {
 	}
 
 	if motd.Text != "" {
-		fmt.Printf("%s\nPress [ENTER] to continue.\n", motd.Text)
+		fmt.Fprintf(tc.Config.Stderr, "%s\nPress [ENTER] to continue.\n", motd.Text)
 		// We're re-using the password reader for user acknowledgment for
 		// aesthetic purposes, because we want to hide any garbage the
 		// use might enter at the prompt. Whatever the user enters will
@@ -3044,7 +3044,7 @@ func Username() (string, error) {
 
 // AskOTP prompts the user to enter the OTP token.
 func (tc *TeleportClient) AskOTP() (token string, err error) {
-	fmt.Printf("Enter your OTP token:\n")
+	fmt.Fprintf(tc.Config.Stderr, "Enter your OTP token:\n")
 	token, err = lineFromConsole()
 	if err != nil {
 		fmt.Fprintln(tc.Stderr, err)
@@ -3055,7 +3055,7 @@ func (tc *TeleportClient) AskOTP() (token string, err error) {
 
 // AskPassword prompts the user to enter the password
 func (tc *TeleportClient) AskPassword() (pwd string, err error) {
-	fmt.Printf("Enter password for Teleport user %v:\n", tc.Config.Username)
+	fmt.Fprintf(tc.Config.Stderr, "Enter password for Teleport user %v:\n", tc.Config.Username)
 	pwd, err = passwordFromConsoleFn()
 	if err != nil {
 		fmt.Fprintln(tc.Stderr, err)

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"time"
@@ -239,7 +240,7 @@ func initClient(proxyAddr string, insecure bool, pool *x509.CertPool) (*WebClien
 
 	if insecure {
 		// Skip https cert verification, print a warning that this is insecure.
-		fmt.Printf("WARNING: You are using insecure connection to SSH proxy %v\n", proxyAddr)
+		fmt.Fprintf(os.Stderr, "WARNING: You are using insecure connection to SSH proxy %v\n", proxyAddr)
 		opts = append(opts, roundtrip.HTTPClient(NewInsecureWebClient()))
 	} else if pool != nil {
 		// use custom set of trusted CAs
@@ -294,17 +295,17 @@ func SSHAgentSSOLogin(ctx context.Context, login SSHLoginSSO) (*auth.SSHLoginRes
 	}
 	if execCmd != nil {
 		if err := execCmd.Start(); err != nil {
-			fmt.Printf("Failed to open a browser window for login: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Failed to open a browser window for login: %v\n", err)
 		}
 	}
 
 	// Print the URL to the screen, in case the command that launches the browser did not run.
 	// If Browser is set to the special string teleport.BrowserNone, no browser will be opened.
 	if login.Browser == teleport.BrowserNone {
-		fmt.Printf("Use the following URL to authenticate:\n %v\n", clickableURL)
+		fmt.Fprintf(os.Stderr, "Use the following URL to authenticate:\n %v\n", clickableURL)
 	} else {
-		fmt.Printf("If browser window does not open automatically, open it by ")
-		fmt.Printf("clicking on the link:\n %v\n", clickableURL)
+		fmt.Fprintf(os.Stderr, "If browser window does not open automatically, open it by ")
+		fmt.Fprintf(os.Stderr, "clicking on the link:\n %v\n", clickableURL)
 	}
 
 	select {

--- a/rfd/0039-sni-alpn-teleport-proxy-routing.md
+++ b/rfd/0039-sni-alpn-teleport-proxy-routing.md
@@ -103,7 +103,7 @@ In order to expose WEB, Kubernetes proxy services in one teleport proxy port, th
 
 #### Setting SNI value for kubectl CLI:
 
-`tsh kube login` command generates a local kubeconfig.yaml file used during accessing teleport proxy by kubectl CLI. Additional to the current configuration the  tls-server-name  field will be added with appropriate SNI value:
+`tsh kube login` command generates a local kubeconfig.yaml file used during accessing teleport proxy by kubectl CLI. Additional to the current configuration the `tls-server-name` field will be added with appropriate SNI value:
 
 ```yaml
 apiVersion: v1

--- a/rfd/0039-sni-alpn-teleport-proxy-routing.md
+++ b/rfd/0039-sni-alpn-teleport-proxy-routing.md
@@ -103,7 +103,7 @@ In order to expose WEB, Kubernetes proxy services in one teleport proxy port, th
 
 #### Setting SNI value for kubectl CLI:
 
-`tsh kube login` command generates a local kubeconfig.yaml file used during accessing teleport proxy by kubectl CLI. Additional to the current configuration the  tls-server-name  failed will be added with appropriate SNI value:
+`tsh kube login` command generates a local kubeconfig.yaml file used during accessing teleport proxy by kubectl CLI. Additional to the current configuration the  tls-server-name  field will be added with appropriate SNI value:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Missing v9 backports (some were backported to v8, some were only in master):
- https://github.com/gravitational/teleport/pull/10562
- https://github.com/gravitational/teleport/pull/9945
- All commits from https://github.com/gravitational/teleport/pull/10777
- https://github.com/gravitational/teleport/pull/10817


