### PR TITLE
Fix meaning of `bot_name` in bot join tokens

### DIFF
--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -242,7 +242,7 @@ func (s *Server) getBotUsers(ctx context.Context) ([]types.User, error) {
 // random dynamic provision token which allows bots to join with the given
 // botName. Returns the token and any error.
 func (s *Server) checkOrCreateBotToken(ctx context.Context, req *proto.CreateBotRequest) (types.ProvisionToken, error) {
-	resourceName := BotResourceName(req.Name)
+	botName := req.Name
 
 	// if the request includes a TokenID it should already exist
 	if req.TokenID != "" {
@@ -258,9 +258,9 @@ func (s *Server) checkOrCreateBotToken(ctx context.Context, req *proto.CreateBot
 			return nil, trace.BadParameter("token %q is not valid for role %q",
 				req.TokenID, types.RoleBot)
 		}
-		if provisionToken.GetBotName() != resourceName {
+		if provisionToken.GetBotName() != botName {
 			return nil, trace.BadParameter("token %q is valid for bot with name %q, not %q",
-				req.TokenID, provisionToken.GetBotName(), resourceName)
+				req.TokenID, provisionToken.GetBotName(), botName)
 		}
 		switch provisionToken.GetJoinMethod() {
 		case types.JoinMethodToken, types.JoinMethodIAM:
@@ -286,7 +286,7 @@ func (s *Server) checkOrCreateBotToken(ctx context.Context, req *proto.CreateBot
 	tokenSpec := types.ProvisionTokenSpecV2{
 		Roles:      []types.SystemRole{types.RoleBot},
 		JoinMethod: types.JoinMethodToken,
-		BotName:    resourceName,
+		BotName:    botName,
 	}
 	token, err := types.NewProvisionTokenFromSpec(tokenName, time.Now().Add(ttl), tokenSpec)
 	if err != nil {

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -108,7 +108,10 @@ func (a *Server) generateCerts(ctx context.Context, provisionToken types.Provisi
 	if req.Role == types.RoleBot {
 		// bots use this endpoint but get a user cert
 		// botResourceName must be set, enforced in CheckAndSetDefaults
-		botResourceName := provisionToken.GetBotName()
+		botName := provisionToken.GetBotName()
+
+		// Append `bot-` to the bot name to derive its username.
+		botResourceName := BotResourceName(botName)
 		expires := a.GetClock().Now().Add(defaults.DefaultRenewableCertTTL)
 
 		joinMethod := provisionToken.GetJoinMethod()
@@ -141,7 +144,7 @@ func (a *Server) generateCerts(ctx context.Context, provisionToken types.Provisi
 			return nil, trace.BadParameter("unsupported join method %q for bot", joinMethod)
 		}
 
-		log.Infof("Bot %q has joined the cluster.", botResourceName)
+		log.Infof("Bot %q has joined the cluster.", botName)
 		return certs, nil
 	}
 	// generate and return host certificate and keys


### PR DESCRIPTION
The `BotName` / `bot_name` was previously used to refer to the bot _username_ rather than the bot name as entered by users. This leads to confusion as the username is an implemention detail not obviously visible to users.

This changes the meaning of the `bot_name` parameter to instead consistently accept a bot name, which is converted to a username on the backend where needed.

Fixes #10854