### PR TITLE
[v8 backport] Add Cloud compatibility notes to guides

### DIFF
--- a/docs/pages/api/getting-started.mdx
+++ b/docs/pages/api/getting-started.mdx
@@ -16,7 +16,7 @@ Here are the steps we'll walkthrough:
 ## Prerequisites
 
 - Install [Go](https://golang.org/doc/install) (=teleport.golang=)+ and Go development environment.
-- Set up Teleport through the [Getting Started Guide](../getting-started.mdx)
+- Set up Teleport through one of our [getting started guides](../getting-started.mdx). You can also begin a [free trial](https://goteleport.com/signup/) of Teleport Cloud.
 
 ## Step 1/3. Create a user
 
@@ -29,8 +29,8 @@ Here are the steps we'll walkthrough:
 Create a user `api-admin` with the built-in role `editor`:
 
 ```code
-# Run this directly on your auth server
-# Add user and login via web proxy
+# Run this directly on your Auth Server unless you are using Teleport Cloud
+# Add a user and login via the Proxy Service
 $ sudo tctl users add api-admin --roles=editor
 ```
 
@@ -56,10 +56,9 @@ $ go mod init client-demo
 $ go get github.com/gravitational/teleport/api/client
 ```
 
-Create a file `main.go` with the following command, modifying the `Addrs` strings as needed:
+Create a file called `main.go`, modifying the `Addrs` strings as needed:
 
-```bash
-cat > main.go << 'EOF'
+```go
 package main
 
 import (
@@ -74,6 +73,7 @@ func main() {
 
 	clt, err := client.New(ctx, client.Config{
 		Addrs: []string{
+			// Teleport Cloud customers should use <tenantname>.teleport.sh
 			"tele.example.com:443",
 			"tele.example.com:3025",
 			"tele.example.com:3024",
@@ -101,7 +101,7 @@ func main() {
 EOF
 ```
 
-Now you can run the program and connect the client to the Teleport Auth server to fetch the server version.
+Now you can run the program and connect the client to the Teleport Auth Server to fetch the server version.
 
 ```code
 $ go run main.go

--- a/docs/pages/api/getting-started.mdx
+++ b/docs/pages/api/getting-started.mdx
@@ -5,7 +5,8 @@ description: Get started working with the Teleport API programmatically using Go
 
 # Getting Started
 
-In this getting started guide we will use the Teleport API Go client to connect to a Teleport Node configured as an Auth server.
+In this getting started guide we will use the Teleport API Go client to connect
+to a Teleport Node configured as an Auth Server.
 
 Here are the steps we'll walkthrough:
 
@@ -30,7 +31,7 @@ Create a user `api-admin` with the built-in role `editor`:
 
 ```code
 # Run this directly on your Auth Server unless you are using Teleport Cloud
-# Add a user and login via the Proxy Service
+# Add a user and log in via the Proxy Service
 $ sudo tctl users add api-admin --roles=editor
 ```
 
@@ -98,7 +99,6 @@ func main() {
 	log.Printf("Example server response: %s", resp)
 	log.Printf("Server version: %s", resp.ServerVersion)
 }
-EOF
 ```
 
 Now you can run the program and connect the client to the Teleport Auth Server to fetch the server version.

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -10,6 +10,7 @@ tools like [curl](https://man7.org/linux/man-pages/man1/curl.1.html) or Postman.
 
 ## Prerequisites
 
+You will need a running Teleport cluster, either self hosted or in Teleport Cloud.
 We'll assume that you followed the [Getting Started](../getting-started.mdx)
 guide or the general [App Access Usage](./connecting-apps.mdx) guide to connect the web application providing an API to Teleport.
 

--- a/docs/pages/application-access/guides/aws-console.mdx
+++ b/docs/pages/application-access/guides/aws-console.mdx
@@ -6,20 +6,21 @@ videoBanner: GVcy_rffxQw
 
 # AWS Management Console Access
 
-Teleport can automatically sign your users into AWS management console with
+Teleport can automatically sign your users into the AWS management console with
 appropriate IAM roles.
 
 This guide will explain how to:
 
-- Connect your AWS account(-s) to Teleport.
-- Setup example AWS IAM Read Only and Power User roles.
+- Connect your AWS account(s) to Teleport.
+- Set up example AWS IAM Read Only and Power User roles.
 - Use Teleport's role-based access control with AWS IAM roles.
 - View Teleport users' AWS console activity in CloudTrail.
-- Access the AWS Command Line Interface (CLI) through Teleport.
+- Access the AWS Command Line Interface (CLI) through Teleport. 
 
 ## Prerequisites
 
-- Teleport with Application Access. Follow [Getting Started](../getting-started.mdx)
+- A running Teleport cluster, either self hosted or in Teleport Cloud.
+- A Teleport Node with Application Access enabled. Follow the [Getting Started](../getting-started.mdx)
   or [Connecting Apps](./connecting-apps.mdx) guides to get it running.
 - IAM permissions in the AWS account you want to connect.
 - AWS EC2 or other instance where you can assign a IAM Security Role for the Teleport Agent.
@@ -35,7 +36,7 @@ Otherwise, you will receive "400 Bad Request" errors from AWS.
 
 ## Step 1. [Optional] Configure Read Only and Power User roles
 
-AWS provides the `ReadOnlyAccess` and `PowerUserAccess` IAM policies that can be incorporated into roles.  <b>Skip this step</b> if you already have the roles you want to provide access to.
+AWS provides the `ReadOnlyAccess` and `PowerUserAccess` IAM policies that can be incorporated into roles. **Skip this step** if you already have the roles you want to provide access to.
 
 <Admonition type="note">
 These policies may provide too much or not enough access for your intentions. Validate these meet your expectations if you plan on using them.
@@ -68,16 +69,15 @@ Enter a role name and press create role.
 Follow the same steps and select `PowerUserAccess` IAM Policy to create a `ExamplePowerUser` role.
 
 
-## Step 2. Update IAM roles trust relationships
+## Step 2. Update IAM role trust relationships
 
 <Admonition type="note">
-This step is only required if you are allowing access from another account.  The trust relationship will already exist for the same account.
+This step is only required if you are allowing access from another account. The trust relationship will already exist for the same account.
 </Admonition>
 
-Teleport uses AWS [Federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
-service to generate sign-in URLs for users, which relies on the `AssumeRole` API
-for getting temporary security credentials. As such, you would first need to
-update your IAM roles' "Trusted entities" to include AWS account ID.
+Teleport uses AWS [federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html) to generate sign-in URLs for users, which relies on the `AssumeRole` API
+for getting temporary security credentials. 
+You will need to update your IAM roles' "Trusted entities" to include your AWS account ID.
 
 Go to the [Roles](https://console.aws.amazon.com/iamv2/home#/roles) list, pick
 a role and create the following trust policy for it by clicking on "Edit trust
@@ -100,8 +100,9 @@ relationship" button on the "Trust relationships" tab:
 
 See [How to use trust policies with IAM roles](https://aws.amazon.com/blogs/security/how-to-use-trust-policies-with-iam-roles/)
 for more details. After saving the trust policy, the account will show as a
-trusted entity:
-From the EC2 dashboard select Actions -> Security -> Modify IAM Role
+trusted entity.
+
+From the EC2 dashboard select Actions -> Security -> Modify IAM Role.
 ![AWS trusted entities](../../../img/application-access/aws-trusted-entities@2x.png)
 
 Do this for each IAM role your Teleport users will need to assume.
@@ -137,7 +138,7 @@ is using.
 
 The next step is to give your Teleport users permissions to assume IAM roles.
 
-You can do this by creating a role with `aws_role_arns` field listing all IAM
+You can do this by creating a role with the `aws_role_arns` field listing all IAM
 role ARNs this particular role permits its users to assume:
 
 ```yaml
@@ -233,8 +234,8 @@ an IAM role selector:
 
 ![IAM role selector](../../../img/application-access/iam-role-selector.png)
 
-Click on the role you want to assume and you will get redirected to AWS
-management console signed in with the selected role.
+Click on the role you want to assume and you will get redirected to the AWS
+management console, signed in with the selected role.
 
 In the console's top-right corner you should see that you're logged in through
 federated login and the name of your assumed IAM role:
@@ -253,7 +254,7 @@ Note that your federated login session is marked with your Teleport username.
 To view CloudTrail events for your federated sessions, navigate to the CloudTrail
 [dashboard](https://console.aws.amazon.com/cloudtrail/home) and go to "Event history".
 
-Each Teleport federated login session uses Teleport username as the federated
+Each Teleport federated login session uses a Teleport username as the federated
 username which you can search for to get the events history:
 
 ![CloudTrail](../../../img/application-access/cloud-trail.png)
@@ -271,7 +272,7 @@ Logged into AWS app awsconsole-test. Example AWS CLI command:
 $ tsh aws s3 ls
 ```
 
-The `--aws-role` flag allows to specify the AWS IAM role to assume when accessing AWS API. You can either
+The `--aws-role` flag allows you to specify the AWS IAM role to assume when accessing AWS API. You can either
 provide a role name like `--aws-role ExamplePowerUser` or a full role ARN `arn:aws:iam::1234567890:role/ExamplePowerUser`
 
 Now you can use the `tsh aws` command like the native `aws` command-line tool:

--- a/docs/pages/getting-started/docker-compose.mdx
+++ b/docs/pages/getting-started/docker-compose.mdx
@@ -4,10 +4,8 @@ description: How to get started with Teleport Open Source Edition using Docker C
 h1: Get started with Docker Compose
 ---
 
-This section will cover:
-
-- Getting started with a local Teleport cluster using docker compose.
-- Using Teleport with OpenSSH, ansible and Teleport's native client, `tsh`.
+This guide will help you understand how Teleport works by spinning up a demo cluster on your local machine using Docker Compose.
+It will also show you how to use Teleport with OpenSSH, Ansible, and Teleport's native client, `tsh`. 
 
 ## Prerequisites
 

--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -7,6 +7,14 @@ videoBanner: jvaCmQyHghY
 This tutorial will guide you through the steps needed to install and run
 Teleport (=teleport.version=) on Linux machines.
 
+<Details scopeOnly={true} scope={["cloud"]} title="Teleport Cloud">
+This guide deploys the Teleport Auth Service and Proxy Service, which are fully managed in Teleport Cloud. If you are a Teleport Cloud customer, we recommend following our guides for deploying specific services on your Teleport Nodes. Here are some examples:
+
+- [Application Access](../application-access/getting-started.mdx)
+- [Database Access](../database-access/getting-started.mdx)
+- [Server Access](../server-access/getting-started.mdx)
+</Details>
+
 ## Prerequisites
 
 - A Linux machine with a port `443` open
@@ -186,7 +194,7 @@ Here are several common commands and operations you'll likely find useful:
 $ tsh status
 ```
 
-### SSH into a node
+### SSH into a Node
 
 ```code
 # list all SSH servers connected to Teleport
@@ -196,7 +204,7 @@ $ tsh ls
 $ tsh ssh root@node-name
 ```
 
-### Add a node to the cluster
+### Add a Node to the cluster
 
 Generate a short-lived dynamic join token using `tctl`:
 
@@ -204,7 +212,7 @@ Generate a short-lived dynamic join token using `tctl`:
 $ tctl tokens add --type=node
 ```
 
-Bootstrap a new node:
+Bootstrap a new Node:
 
 <Tabs>
   <TabItem label="teleport start">
@@ -267,7 +275,7 @@ Add a new application:
 
 <Tabs>
   <TabItem label="teleport start">
-    Install Teleport on the target node, then start it using a command as shown below.
+    Install Teleport on the target Node, then start it using a command as shown below.
     Review and update `auth-server`, `token`, `app-name`, and `app-uri` before running this command.
 
     ```code


### PR DESCRIPTION
Backports #9969

* Add Cloud compatibility notes to guides

Add Details boxes to some guides that do not mention Teleport
Cloud, indicating how each guide relates to Teleport Cloud users.

* Respond to PR feedback

Removes Details boxes unless necessary to warn users of
incompatibility with Teleport Cloud.

Also makes minor stylistic tweaks.