### PR TITLE
Correct postgresql self-hosted tsh db connect example

### DIFF
--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -179,7 +179,7 @@ $ tsh db login --db-user=postgres --db-name=postgres example
 Once logged in, connect to the database:
 
 ```code
-$ tsh db connect aurora
+$ tsh db connect example
 ```
 
 <Admonition type="note" title="Note">


### PR DESCRIPTION
`tsh db connect` correction to connect to correct db