### PR TITLE
[v9] Fix DeleteRange when the backend sanitizer is used (#11124)

### DIFF
--- a/lib/backend/backend_test.go
+++ b/lib/backend/backend_test.go
@@ -19,6 +19,8 @@ package backend
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParams(t *testing.T) {
@@ -34,5 +36,22 @@ func TestParams(t *testing.T) {
 	path := p.GetString("path")
 	if path != expectedPath {
 		t.Errorf("expected 'path' to be '%v', got '%v'", expectedPath, path)
+	}
+}
+
+func TestRangeEnd(t *testing.T) {
+	for _, test := range []struct {
+		key, expected string
+	}{
+		{"abc", "abd"},
+		{"/foo/bar", "/foo/bas"},
+		{"/xyz", "/xy{"},
+		{"\xFF", "\x00"},
+		{"\xFF\xFF\xFF", "\x00"},
+	} {
+		t.Run(test.key, func(t *testing.T) {
+			end := RangeEnd([]byte(test.key))
+			require.Equal(t, test.expected, string(end))
+		})
 	}
 }

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -30,16 +30,16 @@ import (
 // errorMessage is the error message to return when invalid input is provided by the caller.
 const errorMessage = "special characters are not allowed in resource names, please use name composed only from characters, hyphens, dots, and plus signs: %q"
 
-// whitelistPattern is the pattern of allowed characters for each key within
+// allowPattern is the pattern of allowed characters for each key within
 // the path.
-var whitelistPattern = regexp.MustCompile(`^[0-9A-Za-z@_:.\-/+]*$`)
+var allowPattern = regexp.MustCompile(`^[0-9A-Za-z@_:.\-/+]*$`)
 
-// blacklistPattern matches some unallowed combinations
-var blacklistPattern = regexp.MustCompile(`//`)
+// denyPattern matches some unallowed combinations
+var denyPattern = regexp.MustCompile(`//`)
 
 // isKeySafe checks if the passed in key conforms to whitelist
 func isKeySafe(s []byte) bool {
-	return whitelistPattern.Match(s) && !blacklistPattern.Match(s) && utf8.Valid(s)
+	return allowPattern.Match(s) && !denyPattern.Match(s) && utf8.Valid(s)
 }
 
 // Sanitizer wraps a Backend implementation to make sure all values requested
@@ -118,12 +118,12 @@ func (s *Sanitizer) Delete(ctx context.Context, key []byte) error {
 
 // DeleteRange deletes range of items
 func (s *Sanitizer) DeleteRange(ctx context.Context, startKey []byte, endKey []byte) error {
+	// we only validate the start key, since we often compute the end key
+	// in order to delete a bunch of related entries
 	if !isKeySafe(startKey) {
 		return trace.BadParameter(errorMessage, startKey)
 	}
-	if !isKeySafe(endKey) {
-		return trace.BadParameter(errorMessage, endKey)
-	}
+
 	return s.backend.DeleteRange(ctx, startKey, endKey)
 }
 

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -379,6 +379,8 @@ func (s *IdentityService) DeleteUser(ctx context.Context, user string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	// each user has multiple related entries in the backend,
+	// so use DeleteRange to make sure we get them all
 	startKey := backend.Key(webPrefix, usersPrefix, user)
 	err = s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 	return trace.Wrap(err)

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/trace"
@@ -60,7 +61,6 @@ func TestRecoveryCodesCRUD(t *testing.T) {
 	}
 
 	t.Run("upsert, get, delete recovery codes", func(t *testing.T) {
-		t.Parallel()
 		username := "someuser"
 
 		rc1, err := types.NewRecoveryCodes(mockedCodes, clock.Now(), username)
@@ -100,8 +100,36 @@ func TestRecoveryCodesCRUD(t *testing.T) {
 	})
 
 	t.Run("deleting user deletes recovery codes", func(t *testing.T) {
-		t.Parallel()
 		username := "someuser2"
+
+		// Create a user.
+		userResource := &types.UserV2{}
+		userResource.SetName(username)
+		err := identity.CreateUser(userResource)
+		require.NoError(t, err)
+
+		// Test codes exist for user.
+		rc1, err := types.NewRecoveryCodes(mockedCodes, clock.Now(), username)
+		require.NoError(t, err)
+		err = identity.UpsertRecoveryCodes(ctx, username, rc1)
+		require.NoError(t, err)
+		codes, err := identity.GetRecoveryCodes(ctx, username, true /* withSecrets */)
+		require.NoError(t, err)
+		require.ElementsMatch(t, mockedCodes, codes.GetCodes())
+
+		// Test deletion of recovery code along with user.
+		err = identity.DeleteUser(ctx, username)
+		require.NoError(t, err)
+		_, err = identity.GetRecoveryCodes(ctx, username, true /* withSecrets */)
+		require.True(t, trace.IsNotFound(err))
+	})
+
+	t.Run("deleting user ending with 'z'", func(t *testing.T) {
+		// enable the sanitizer, and use a key ending with z,
+		// which will produce an invalid backend key when we
+		// compute the end range
+		username := "xyz"
+		identity.Backend = backend.NewSanitizer(identity.Backend)
 
 		// Create a user.
 		userResource := &types.UserV2{}
@@ -137,7 +165,6 @@ func TestRecoveryAttemptsCRUD(t *testing.T) {
 	time3 := time1.Add(4 * time.Minute)
 
 	t.Run("create, get, and delete recovery attempts", func(t *testing.T) {
-		t.Parallel()
 		username := "someuser"
 
 		// Test creation of recovery attempt.
@@ -165,7 +192,6 @@ func TestRecoveryAttemptsCRUD(t *testing.T) {
 	})
 
 	t.Run("deleting user deletes recovery attempts", func(t *testing.T) {
-		t.Parallel()
 		username := "someuser2"
 
 		// Create a user, to test deletion of recovery attempts with user.


### PR DESCRIPTION
We no longer require the end key for a DeleteRange operation to be
a valid backend key. This prevented us from deleting resources ending
in 'z', because it would produce an end key that the sanitizer doesn't
like.

Updates #2776
Backports #11124 