### PR TITLE
Remove some uses of ioutil

### DIFF
--- a/.cloudbuild/scripts/internal/artifacts/artifacts_test.go
+++ b/.cloudbuild/scripts/internal/artifacts/artifacts_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +34,7 @@ func write(t *testing.T, data []byte, path ...string) string {
 	t.Helper()
 	filePath := filepath.Join(path...)
 	require.NoError(t, os.MkdirAll(filepath.Dir(filePath), 0777))
-	require.NoError(t, ioutil.WriteFile(filePath, data, 0644))
+	require.NoError(t, os.WriteFile(filePath, data, 0644))
 	return filePath
 }
 

--- a/.cloudbuild/scripts/internal/etcd/start.go
+++ b/.cloudbuild/scripts/internal/etcd/start.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -166,7 +165,7 @@ func waitForEtcdToStart(ctx context.Context, certDir string) error {
 // as started with Start()
 func newHTTPSTransport(certDir string) (*http.Client, error) {
 	caCertPath := path.Join(certDir, "ca-cert.pem")
-	caCert, err := ioutil.ReadFile(caCertPath)
+	caCert, err := os.ReadFile(caCertPath)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed reading CA cert from %s", caCertPath)
 	}

--- a/api/client/credentials.go
+++ b/api/client/credentials.go
@@ -19,7 +19,7 @@ package client
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/identityfile"
@@ -115,7 +115,7 @@ func (c *keypairCreds) TLSConfig() (*tls.Config, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	cas, err := ioutil.ReadFile(c.caFile)
+	cas, err := os.ReadFile(c.caFile)
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}

--- a/api/client/credentials_test.go
+++ b/api/client/credentials_test.go
@@ -19,7 +19,6 @@ package client
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -153,11 +152,11 @@ func TestLoadKeyPair(t *testing.T) {
 	// Write key pair and CAs files from bytes.
 	path := t.TempDir() + "username"
 	certPath, keyPath, caPath := path+".crt", path+".key", path+".cas"
-	err := ioutil.WriteFile(certPath, tlsCert, 0600)
+	err := os.WriteFile(certPath, tlsCert, 0600)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(keyPath, keyPEM, 0600)
+	err = os.WriteFile(keyPath, keyPEM, 0600)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(caPath, tlsCACert, 0600)
+	err = os.WriteFile(caPath, tlsCACert, 0600)
 	require.NoError(t, err)
 
 	// Load key pair from disk.
@@ -185,20 +184,7 @@ func TestLoadProfile(t *testing.T) {
 			SiteName:     "example.com",
 			Username:     "testUser",
 			Dir:          dir,
-		}, false)
-		testProfileContents(t, dir, profileName)
-	})
-
-	// DELETE IN 8.0.0
-	t.Run("old profile", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		writeProfile(t, &profile.Profile{
-			WebProxyAddr: profileName + ":3080",
-			SiteName:     "example.com",
-			Username:     "testUser",
-			Dir:          dir,
-		}, true)
+		})
 		testProfileContents(t, dir, profileName)
 	})
 
@@ -236,24 +222,18 @@ func testProfileContents(t *testing.T, dir, name string) {
 	require.NoError(t, err)
 }
 
-func writeProfile(t *testing.T, p *profile.Profile, oldSSHPath bool) {
+func writeProfile(t *testing.T, p *profile.Profile) {
 	// Save profile and keys to disk.
 	require.NoError(t, p.SaveToDir(p.Dir, true))
 	require.NoError(t, os.MkdirAll(p.KeyDir(), 0700))
 	require.NoError(t, os.MkdirAll(p.ProxyKeyDir(), 0700))
 	require.NoError(t, os.MkdirAll(p.TLSClusterCASDir(), 0700))
-	require.NoError(t, ioutil.WriteFile(p.UserKeyPath(), keyPEM, 0600))
-	require.NoError(t, ioutil.WriteFile(p.TLSCertPath(), tlsCert, 0600))
-	require.NoError(t, ioutil.WriteFile(p.TLSCAPathCluster(p.SiteName), tlsCACert, 0600))
-	require.NoError(t, ioutil.WriteFile(p.KnownHostsPath(), sshCACert, 0600))
-	// If oldSSHPath is specified, write the sshCert to the old ssh cert path.
-	// DELETE IN 8.0.0
-	if oldSSHPath {
-		require.NoError(t, ioutil.WriteFile(p.OldSSHCertPath(), sshCert, 0600))
-		return
-	}
+	require.NoError(t, os.WriteFile(p.UserKeyPath(), keyPEM, 0600))
+	require.NoError(t, os.WriteFile(p.TLSCertPath(), tlsCert, 0600))
+	require.NoError(t, os.WriteFile(p.TLSCAPathCluster(p.SiteName), tlsCACert, 0600))
+	require.NoError(t, os.WriteFile(p.KnownHostsPath(), sshCACert, 0600))
 	require.NoError(t, os.MkdirAll(p.SSHDir(), 0700))
-	require.NoError(t, ioutil.WriteFile(p.SSHCertPath(), sshCert, 0600))
+	require.NoError(t, os.WriteFile(p.SSHCertPath(), sshCert, 0600))
 }
 
 func getExpectedTLSConfig(t *testing.T) *tls.Config {

--- a/api/identityfile/identityfile.go
+++ b/api/identityfile/identityfile.go
@@ -24,7 +24,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -102,7 +101,7 @@ func Write(idFile *IdentityFile, path string) error {
 	if err := encodeIdentityFile(buf, idFile); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := ioutil.WriteFile(path, buf.Bytes(), FilePermissions); err != nil {
+	if err := os.WriteFile(path, buf.Bytes(), FilePermissions); err != nil {
 		return trace.ConvertSystemError(err)
 	}
 	return nil
@@ -139,7 +138,7 @@ func ReadFile(path string) (*IdentityFile, error) {
 	// separate file with -cert.pub suffix.
 	if len(ident.Certs.SSH) == 0 {
 		certFn := keypaths.IdentitySSHCertPath(path)
-		if ident.Certs.SSH, err = ioutil.ReadFile(certFn); err != nil {
+		if ident.Certs.SSH, err = os.ReadFile(certFn); err != nil {
 			return nil, trace.Wrap(err, "could not find SSH cert in the identity file or %v", certFn)
 		}
 	}

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -507,7 +506,7 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 // GenerateConfig generates instance config
 func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSecrets, tconf *service.Config) (*service.Config, error) {
 	var err error
-	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName)
+	dataDir, err := os.MkdirTemp("", "cluster-"+i.Secrets.SiteName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -722,7 +721,7 @@ func (i *TeleInstance) StartReverseTunnelNode(tconf *service.Config) (*service.T
 
 // startNode starts a node and connects it to the cluster.
 func (i *TeleInstance) startNode(tconf *service.Config, authPort string) (*service.TeleportProcess, error) {
-	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName)
+	dataDir, err := os.MkdirTemp("", "cluster-"+i.Secrets.SiteName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -776,7 +775,7 @@ func (i *TeleInstance) startNode(tconf *service.Config, authPort string) (*servi
 }
 
 func (i *TeleInstance) StartApp(conf *service.Config) (*service.TeleportProcess, error) {
-	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName)
+	dataDir, err := os.MkdirTemp("", "cluster-"+i.Secrets.SiteName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -821,7 +820,7 @@ func (i *TeleInstance) StartApp(conf *service.Config) (*service.TeleportProcess,
 
 // StartDatabase starts the database access service with the provided config.
 func (i *TeleInstance) StartDatabase(conf *service.Config) (*service.TeleportProcess, *auth.Client, error) {
-	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName)
+	dataDir, err := os.MkdirTemp("", "cluster-"+i.Secrets.SiteName)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -886,7 +885,7 @@ func (i *TeleInstance) StartDatabase(conf *service.Config) (*service.TeleportPro
 // StartNodeAndProxy starts a SSH node and a Proxy Server and connects it to
 // the cluster.
 func (i *TeleInstance) StartNodeAndProxy(name string, sshPort, proxyWebPort, proxySSHPort int) error {
-	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName)
+	dataDir, err := os.MkdirTemp("", "cluster-"+i.Secrets.SiteName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -973,7 +972,7 @@ type ProxyConfig struct {
 
 // StartProxy starts another Proxy Server and connects it to the cluster.
 func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnel.Server, error) {
-	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName+"-"+cfg.Name)
+	dataDir, err := os.MkdirTemp("", "cluster-"+i.Secrets.SiteName+"-"+cfg.Name)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1192,7 +1191,7 @@ func (i *TeleInstance) NewClientWithCreds(cfg ClientConfig, creds UserCreds) (tc
 // NewUnauthenticatedClient returns a fully configured and pre-authenticated client
 // (pre-authenticated with server CAs and signed session key)
 func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.TeleportClient, err error) {
-	keyDir, err := ioutil.TempDir(i.Config.DataDir, "tsh")
+	keyDir, err := os.MkdirTemp(i.Config.DataDir, "tsh")
 	if err != nil {
 		return nil, err
 	}
@@ -1624,7 +1623,7 @@ func externalSSHCommand(o commandOptions) (*exec.Cmd, error) {
 // clobber your system agent.
 func createAgent(me *user.User, privateKeyByte []byte, certificateBytes []byte) (*teleagent.AgentServer, string, string, error) {
 	// create a path to the unix socket
-	sockDir, err := ioutil.TempDir("", "int-test")
+	sockDir, err := os.MkdirTemp("", "int-test")
 	if err != nil {
 		return nil, "", "", trace.Wrap(err)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -608,7 +607,7 @@ func testInteroperability(t *testing.T, suite *integrationTestSuite) {
 			// if we are looking for the output in a file, look in the file
 			// otherwise check stdout and stderr for the expected output
 			if tt.outFile {
-				bytes, err := ioutil.ReadFile(tempfile)
+				bytes, err := os.ReadFile(tempfile)
 				require.NoError(t, err)
 				require.Contains(t, string(bytes), tt.outContains)
 			} else {
@@ -1543,7 +1542,7 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 
 	// The known_hosts file should have two certificates, the way bytes.Split
 	// works that means the output will be 3 (2 certs + 1 empty).
-	buffer, err := ioutil.ReadFile(keypaths.KnownHostsPath(tc.KeysDir))
+	buffer, err := os.ReadFile(keypaths.KnownHostsPath(tc.KeysDir))
 	require.NoError(t, err)
 	parts := bytes.Split(buffer, []byte("\n"))
 	require.Len(t, parts, 3)
@@ -1554,7 +1553,7 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 		if info.IsDir() {
 			return nil
 		}
-		buffer, err = ioutil.ReadFile(path)
+		buffer, err = os.ReadFile(path)
 		require.NoError(t, err)
 		ok := roots.AppendCertsFromPEM(buffer)
 		require.True(t, ok)
@@ -3253,7 +3252,7 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 	}
 
 	for _, tt := range tests {
-		controlDir, err := ioutil.TempDir("", "teleport-")
+		controlDir, err := os.MkdirTemp("", "teleport-")
 		require.NoError(t, err)
 		defer os.RemoveAll(controlDir)
 		controlPath := filepath.Join(controlDir, "control-path")

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -1452,7 +1451,7 @@ func kubeExec(kubeConfig *rest.Config, args kubeExecArgs) error {
 	// stderr channel is only set if there is no tty allocated
 	// otherwise k8s server gets confused
 	if !args.tty && args.stderr == nil {
-		args.stderr = ioutil.Discard
+		args.stderr = io.Discard
 	}
 	if args.stderr != nil && !args.tty {
 		query.Set("stderr", "true")

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -1829,7 +1828,7 @@ func (s *APIServer) emitAuditEvent(auth ClientI, w http.ResponseWriter, r *http.
 
 // HTTP POST /:version/sessions/:id/slice
 func (s *APIServer) postSessionSlice(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -22,7 +22,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -1309,7 +1309,7 @@ func (c *Client) PostSessionSlice(slice events.SessionSlice) error {
 	// we **must** consume response by reading all of its body, otherwise the http
 	// client will allocate a new connection for subsequent requests
 	defer re.Body.Close()
-	responseBytes, _ := ioutil.ReadAll(re.Body)
+	responseBytes, _ := io.ReadAll(re.Body)
 	return trace.ReadError(re.StatusCode, responseBytes)
 }
 

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -600,7 +600,7 @@ func claimsFromUserInfo(oidcClient *oidc.Client, issuerURL string, accessToken s
 			code == http.StatusForbidden || code == http.StatusMethodNotAllowed {
 			return nil, trace.AccessDenied("bad status code: %v", code)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -254,7 +254,7 @@ func parseSAMLInResponseTo(response string) (string, error) {
 	err := doc.ReadFromBytes(raw)
 	if err != nil {
 		// Attempt to inflate the response in case it happens to be compressed (as with one case at saml.oktadev.com)
-		buf, err := ioutil.ReadAll(flate.NewReader(bytes.NewReader(raw)))
+		buf, err := io.ReadAll(flate.NewReader(bytes.NewReader(raw)))
 		if err != nil {
 			return "", trace.Wrap(err)
 		}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -2950,7 +2949,7 @@ func (s *TLSSuite) TestRegisterCAPath(c *check.C) {
 	c.Assert(certs, check.HasLen, 1)
 	certPem := certs[0]
 	caPath := filepath.Join(s.dataDir, defaults.CACertFile)
-	err = ioutil.WriteFile(caPath, certPem, teleport.FileMaskOwnerOnly)
+	err = os.WriteFile(caPath, certPem, teleport.FileMaskOwnerOnly)
 	c.Assert(err, check.IsNil)
 
 	// Attempt to register with valid CA path, should work.

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -23,7 +23,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -277,7 +277,7 @@ func (cfg *Config) Validate() error {
 		cfg.DialTimeout = apidefaults.DefaultDialTimeout
 	}
 	if cfg.PasswordFile != "" {
-		out, err := ioutil.ReadFile(cfg.PasswordFile)
+		out, err := os.ReadFile(cfg.PasswordFile)
 		if err != nil {
 			return trace.ConvertSystemError(err)
 		}
@@ -313,11 +313,11 @@ func (b *EtcdBackend) reconnect(ctx context.Context) error {
 	tlsConfig := utils.TLSConfig(nil)
 
 	if b.cfg.TLSCertFile != "" {
-		clientCertPEM, err := ioutil.ReadFile(b.cfg.TLSCertFile)
+		clientCertPEM, err := os.ReadFile(b.cfg.TLSCertFile)
 		if err != nil {
 			return trace.ConvertSystemError(err)
 		}
-		clientKeyPEM, err := ioutil.ReadFile(b.cfg.TLSKeyFile)
+		clientKeyPEM, err := os.ReadFile(b.cfg.TLSKeyFile)
 		if err != nil {
 			return trace.ConvertSystemError(err)
 		}
@@ -329,7 +329,7 @@ func (b *EtcdBackend) reconnect(ctx context.Context) error {
 	}
 
 	if b.cfg.TLSCAFile != "" {
-		caCertPEM, err := ioutil.ReadFile(b.cfg.TLSCAFile)
+		caCertPEM, err := os.ReadFile(b.cfg.TLSCAFile)
 		if err != nil {
 			return trace.ConvertSystemError(err)
 		}

--- a/lib/benchmark/benchmark.go
+++ b/lib/benchmark/benchmark.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -157,8 +156,8 @@ func ExportLatencyProfile(path string, h *hdrhistogram.Histogram, ticks int32, v
 // to benchmark spec. It returns benchmark result when completed.
 // This is a blocking function that can be cancelled via context argument.
 func (c *Config) Benchmark(ctx context.Context, tc *client.TeleportClient) (Result, error) {
-	tc.Stdout = ioutil.Discard
-	tc.Stderr = ioutil.Discard
+	tc.Stdout = io.Discard
+	tc.Stderr = io.Discard
 	tc.Stdin = &bytes.Buffer{}
 	var delay time.Duration
 	ctx, cancel := context.WithCancel(ctx)

--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -69,7 +68,7 @@ func (s *Suite) TestWatch(c *check.C) {
 	}
 
 	// Create temporary directory where cgroup2 hierarchy will be mounted.
-	dir, err := ioutil.TempDir("", "cgroup-test")
+	dir, err := os.MkdirTemp("", "cgroup-test")
 	c.Assert(err, check.IsNil)
 	defer os.RemoveAll(dir)
 
@@ -171,7 +170,7 @@ func (s *Suite) TestObfuscate(c *check.C) {
 	// has been executed.
 	go func() {
 		// Create temporary file.
-		file, err := ioutil.TempFile("", "test-script")
+		file, err := os.CreateTemp("", "test-script")
 		c.Assert(err, check.IsNil)
 		defer os.Remove(file.Name())
 
@@ -248,7 +247,7 @@ func (s *Suite) TestScript(c *check.C) {
 	// has been executed.
 	go func() {
 		// Create temporary file.
-		file, err := ioutil.TempFile("", "test-script")
+		file, err := os.CreateTemp("", "test-script")
 		c.Assert(err, check.IsNil)
 		defer os.Remove(file.Name())
 

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -28,9 +28,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
-	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -83,7 +81,7 @@ func New(config *Config) (*Service, error) {
 
 	s := &Service{
 		Config:       config,
-		teleportRoot: path.Join(config.MountPath, teleportRoot, uuid.New().String()),
+		teleportRoot: filepath.Join(config.MountPath, teleportRoot, uuid.New().String()),
 	}
 
 	// Mount the cgroup2 filesystem.
@@ -93,7 +91,6 @@ func New(config *Config) (*Service, error) {
 	}
 
 	log.Debugf("Teleport session hierarchy mounted at: %v.", s.teleportRoot)
-
 	return s, nil
 }
 
@@ -115,7 +112,7 @@ func (s *Service) Close() error {
 
 // Create will create a cgroup for a given session.
 func (s *Service) Create(sessionID string) error {
-	err := os.Mkdir(path.Join(s.teleportRoot, sessionID), fileMode)
+	err := os.Mkdir(filepath.Join(s.teleportRoot, sessionID), fileMode)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -126,33 +123,32 @@ func (s *Service) Create(sessionID string) error {
 // moved to the root controller.
 func (s *Service) Remove(sessionID string) error {
 	// Read in all PIDs for the cgroup.
-	pids, err := readPids(path.Join(s.teleportRoot, sessionID, cgroupProcs))
+	pids, err := readPids(filepath.Join(s.teleportRoot, sessionID, cgroupProcs))
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// Move all PIDs to the root controller. This has to be done before a cgroup
 	// can be removed.
-	err = writePids(path.Join(s.MountPath, cgroupProcs), pids)
+	err = writePids(filepath.Join(s.MountPath, cgroupProcs), pids)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// The rmdir syscall is used to remove a cgroup.
-	err = unix.Rmdir(path.Join(s.teleportRoot, sessionID))
+	err = unix.Rmdir(filepath.Join(s.teleportRoot, sessionID))
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	log.Debugf("Removed cgroup for session: %v.", sessionID)
-
 	return nil
 }
 
 // Place  place a process in the cgroup for that session.
 func (s *Service) Place(sessionID string, pid int) error {
 	// Open cgroup.procs file for the cgroup.
-	filepath := path.Join(s.teleportRoot, sessionID, cgroupProcs)
+	filepath := filepath.Join(s.teleportRoot, sessionID, cgroupProcs)
 	f, err := os.OpenFile(filepath, os.O_APPEND|os.O_WRONLY, fileMode)
 	if err != nil {
 		return trace.Wrap(err)
@@ -213,7 +209,7 @@ func (s *Service) cleanupHierarchy() error {
 	var sessions []string
 
 	// Recursively look within the Teleport hierarchy for cgroups for session.
-	err := filepath.Walk(path.Join(s.teleportRoot), func(path string, info os.FileInfo, _ error) error {
+	err := filepath.Walk(filepath.Join(s.teleportRoot), func(path string, info os.FileInfo, _ error) error {
 		// Only pick up cgroup.procs files.
 		if !pattern.MatchString(path) {
 			return nil
@@ -259,7 +255,7 @@ func (s *Service) mount() error {
 
 	// Check if the Teleport root cgroup exists, if it does the cgroup filesystem
 	// is already mounted, return right away.
-	files, err := ioutil.ReadDir(s.MountPath)
+	files, err := os.ReadDir(s.MountPath)
 	if err == nil && len(files) > 0 {
 		// Create cgroup that will hold Teleport sessions.
 		err = os.MkdirAll(s.teleportRoot, fileMode)
@@ -335,7 +331,7 @@ type fileHandle struct {
 // ID returns the cgroup ID for the given session.
 func (s *Service) ID(sessionID string) (uint64, error) {
 	var fh fileHandle
-	path := path.Join(s.teleportRoot, sessionID)
+	path := filepath.Join(s.teleportRoot, sessionID)
 
 	// Call the "name_to_handle_at" syscall directly (unix.NameToHandleAt is a
 	// thin wrapper around the syscall) instead of calling the glibc wrapper.


### PR DESCRIPTION
Misc cleanup:

- use `filepath` over `path` when working with the filesystem
- stop using the `ioutil` package, which was deprecated in Go 1.17
- Remove some deprecated pre-8.0 code.