### PR TITLE
[v9] Remove mention of max ttl for tctl tokens command (#11148)

### DIFF
--- a/docs/pages/setup/reference/cli.mdx
+++ b/docs/pages/setup/reference/cli.mdx
@@ -955,7 +955,7 @@ $ tctl tokens add --type=TYPE [<flags>]
 | - | - | - | - |
 | `--type` | none | `trusted_cluster`, `node`, `proxy` | Type of token to add |
 | `--value` | none | **string** token value | Value of token to add |
-| `--ttl` | 1h | relative duration like 5s, 2m, or 3h, **maximum 48h** | Set expiration time for token |
+| `--ttl` | 1h | relative duration like 5s, 2m, or 3h | Set expiration time for token |
 
 #### [Global Flags](#tctl-global-flags)
 

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -94,9 +94,10 @@ func (c *TokenCommand) Initialize(app *kingpin.Application, config *service.Conf
 	c.tokenAdd.Flag("type", "Type of token to add").Required().StringVar(&c.tokenType)
 	c.tokenAdd.Flag("value", "Value of token to add").StringVar(&c.value)
 	c.tokenAdd.Flag("labels", "Set token labels, e.g. env=prod,region=us-west").StringVar(&c.labels)
-	c.tokenAdd.Flag("ttl", fmt.Sprintf("Set expiration time for token, default is %v hour, maximum is %v hours",
-		int(defaults.SignupTokenTTL/time.Hour), int(defaults.MaxSignupTokenTTL/time.Hour))).
-		Default(fmt.Sprintf("%v", defaults.SignupTokenTTL)).DurationVar(&c.ttl)
+	c.tokenAdd.Flag("ttl", fmt.Sprintf("Set expiration time for token, default is %v hour",
+		int(defaults.SignupTokenTTL/time.Hour))).
+		Default(fmt.Sprintf("%v", defaults.SignupTokenTTL)).
+		DurationVar(&c.ttl)
 	c.tokenAdd.Flag("app-name", "Name of the application to add").Default("example-app").StringVar(&c.appName)
 	c.tokenAdd.Flag("app-uri", "URI of the application to add").Default("http://localhost:8080").StringVar(&c.appURI)
 	c.tokenAdd.Flag("db-name", "Name of the database to add").StringVar(&c.dbName)


### PR DESCRIPTION
The 48h maximum is enforced for `tctl users add`,
not `tctl tokens add`.

Fixes #11137
Backports #11148 