### PR TITLE
Support role bootstrapping in OSS

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -571,6 +571,11 @@ func checkResourceConsistency(keyStore keystore.KeyStore, clusterName string, re
 			if r.GetName() == clusterName {
 				return trace.BadParameter("trusted cluster has same name as local cluster (%q)", clusterName)
 			}
+		case types.Role:
+			// Some options are only available with enterprise subscription
+			if err := checkRoleFeatureSupport(r); err != nil {
+				return trace.Wrap(err)
+			}
 		default:
 			// No validation checks for this resource type
 		}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -487,6 +487,25 @@ func init() {
 		}
 		return rsc, nil
 	})
+
+	RegisterResourceMarshaler(types.KindRole, func(r types.Resource, opts ...MarshalOption) ([]byte, error) {
+		rsc, ok := r.(types.Role)
+		if !ok {
+			return nil, trace.BadParameter("expected Role, got %T", r)
+		}
+		raw, err := MarshalRole(rsc, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return raw, nil
+	})
+	RegisterResourceUnmarshaler(types.KindRole, func(b []byte, opts ...MarshalOption) (types.Resource, error) {
+		rsc, err := UnmarshalRole(b, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return rsc, nil
+	})
 }
 
 // MarshalResource attempts to marshal a resource dynamically, returning NotImplementedError

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -412,99 +412,99 @@ func getResourceUnmarshaler(kind string) (ResourceUnmarshaler, bool) {
 }
 
 func init() {
-	RegisterResourceMarshaler(types.KindUser, func(r types.Resource, opts ...MarshalOption) ([]byte, error) {
-		rsc, ok := r.(types.User)
+	RegisterResourceMarshaler(types.KindUser, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		user, ok := resource.(types.User)
 		if !ok {
-			return nil, trace.BadParameter("expected User, got %T", r)
+			return nil, trace.BadParameter("expected User, got %T", resource)
 		}
-		raw, err := MarshalUser(rsc, opts...)
+		bytes, err := MarshalUser(user, opts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return raw, nil
+		return bytes, nil
 	})
-	RegisterResourceUnmarshaler(types.KindUser, func(b []byte, opts ...MarshalOption) (types.Resource, error) {
-		rsc, err := UnmarshalUser(b, opts...)
+	RegisterResourceUnmarshaler(types.KindUser, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		user, err := UnmarshalUser(bytes, opts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return rsc, nil
+		return user, nil
 	})
 
-	RegisterResourceMarshaler(types.KindCertAuthority, func(r types.Resource, opts ...MarshalOption) ([]byte, error) {
-		rsc, ok := r.(types.CertAuthority)
+	RegisterResourceMarshaler(types.KindCertAuthority, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		certAuthority, ok := resource.(types.CertAuthority)
 		if !ok {
-			return nil, trace.BadParameter("expected CertAuthority, got %T", r)
+			return nil, trace.BadParameter("expected CertAuthority, got %T", resource)
 		}
-		raw, err := MarshalCertAuthority(rsc, opts...)
+		bytes, err := MarshalCertAuthority(certAuthority, opts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return raw, nil
+		return bytes, nil
 	})
-	RegisterResourceUnmarshaler(types.KindCertAuthority, func(b []byte, opts ...MarshalOption) (types.Resource, error) {
-		rsc, err := UnmarshalCertAuthority(b, opts...)
+	RegisterResourceUnmarshaler(types.KindCertAuthority, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		certAuthority, err := UnmarshalCertAuthority(bytes, opts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return rsc, nil
+		return certAuthority, nil
 	})
 
-	RegisterResourceMarshaler(types.KindTrustedCluster, func(r types.Resource, opts ...MarshalOption) ([]byte, error) {
-		rsc, ok := r.(types.TrustedCluster)
+	RegisterResourceMarshaler(types.KindTrustedCluster, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		trustedCluster, ok := resource.(types.TrustedCluster)
 		if !ok {
-			return nil, trace.BadParameter("expected TrustedCluster, got %T", r)
+			return nil, trace.BadParameter("expected TrustedCluster, got %T", resource)
 		}
-		raw, err := MarshalTrustedCluster(rsc, opts...)
+		bytes, err := MarshalTrustedCluster(trustedCluster, opts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return raw, nil
+		return bytes, nil
 	})
-	RegisterResourceUnmarshaler(types.KindTrustedCluster, func(b []byte, opts ...MarshalOption) (types.Resource, error) {
-		rsc, err := UnmarshalTrustedCluster(b, opts...)
+	RegisterResourceUnmarshaler(types.KindTrustedCluster, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		trustedCluster, err := UnmarshalTrustedCluster(bytes, opts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return rsc, nil
+		return trustedCluster, nil
 	})
 
-	RegisterResourceMarshaler(types.KindGithubConnector, func(r types.Resource, opts ...MarshalOption) ([]byte, error) {
-		rsc, ok := r.(types.GithubConnector)
+	RegisterResourceMarshaler(types.KindGithubConnector, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		githubConnector, ok := resource.(types.GithubConnector)
 		if !ok {
-			return nil, trace.BadParameter("expected GithubConnector, got %T", r)
+			return nil, trace.BadParameter("expected GithubConnector, got %T", resource)
 		}
-		raw, err := MarshalGithubConnector(rsc, opts...)
+		bytes, err := MarshalGithubConnector(githubConnector, opts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return raw, nil
+		return bytes, nil
 	})
-	RegisterResourceUnmarshaler(types.KindGithubConnector, func(b []byte, opts ...MarshalOption) (types.Resource, error) {
-		rsc, err := UnmarshalGithubConnector(b) // XXX: Does not support marshal options.
+	RegisterResourceUnmarshaler(types.KindGithubConnector, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		githubConnector, err := UnmarshalGithubConnector(bytes) // XXX: Does not support marshal options.
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return rsc, nil
+		return githubConnector, nil
 	})
 
-	RegisterResourceMarshaler(types.KindRole, func(r types.Resource, opts ...MarshalOption) ([]byte, error) {
-		rsc, ok := r.(types.Role)
+	RegisterResourceMarshaler(types.KindRole, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		role, ok := resource.(types.Role)
 		if !ok {
-			return nil, trace.BadParameter("expected Role, got %T", r)
+			return nil, trace.BadParameter("expected Role, got %T", resource)
 		}
-		raw, err := MarshalRole(rsc, opts...)
+		bytes, err := MarshalRole(role, opts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return raw, nil
+		return bytes, nil
 	})
-	RegisterResourceUnmarshaler(types.KindRole, func(b []byte, opts ...MarshalOption) (types.Resource, error) {
-		rsc, err := UnmarshalRole(b, opts...)
+	RegisterResourceUnmarshaler(types.KindRole, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		role, err := UnmarshalRole(bytes, opts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return rsc, nil
+		return role, nil
 	})
 }
 

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -136,10 +136,9 @@ func TestTeleportMain(t *testing.T) {
 		require.Equal(t, "start", cmd)
 		require.Equal(t, len(bootstrapEntries), len(conf.Auth.Resources))
 		for i, entry := range bootstrapEntries {
-			t.Log(i)
-			require.Equal(t, entry.kind, conf.Auth.Resources[i].GetKind())
-			require.Equal(t, entry.name, conf.Auth.Resources[i].GetName())
-			require.NoError(t, conf.Auth.Resources[i].CheckAndSetDefaults())
+			require.Equal(t, entry.kind, conf.Auth.Resources[i].GetKind(), entry.fileName)
+			require.Equal(t, entry.name, conf.Auth.Resources[i].GetName(), entry.fileName)
+			require.NoError(t, conf.Auth.Resources[i].CheckAndSetDefaults(), entry.fileName)
 		}
 	})
 }


### PR DESCRIPTION
After this is merged we can remove the dynamic marshaler registration in gravitational/teleport.e#416.

Replaces #7130.

Doublecheck the behavior of `lib/auth.migrateLegacyResources` when backporting this, as the migration will apply to the bootstrapped resources.