### PR TITLE
[v8 backport] Mention Cloud compatibility in three guides

### DIFF
--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -9,13 +9,20 @@ videoBanner: 5Uwhp3IQMHY
 Let's connect to Grafana using Teleport Application Access in three steps:
 
 - Launch Grafana in a Docker container.
-- Install Teleport and configure it to proxy Grafana.
+- Install the Teleport Application Service on a node and configure it to proxy Grafana.
 - Access Grafana through Teleport.
 
 ## Prerequisites
 
-- We will use Docker to launch Grafana in a container. Alternatively, if you have another web application you'd like to protect with App Access, you can use that instead.
-- We will assume your Teleport cluster is accessible at `teleport.example.com` and `*.teleport.example.com`. Configured DNS records are required to automatically fetch a [Let's Encrypt](https://letsencrypt.org) certificate.
+- The Teleport Auth Service and Proxy Service, deployed on your own infrastructure or via Teleport Cloud.
+- A Docker installation, which we will use to launch Grafana in a container. Alternatively, if you have another web application you'd like to protect with Application Access, you can use that instead.
+- A host where you will run the Teleport Application Service.
+
+We will assume your Teleport cluster is accessible at `teleport.example.com` and `*.teleport.example.com`. You can substitute the address of your Teleport Proxy Service. (For Teleport Cloud customers, this will be similar to `mytenant.teleport.sh`.)
+
+<Admonition type="tip" title="Not yet a Teleport user?">
+If you have not yet deployed the Auth Service and Proxy Service, you should follow one of our [getting started guides](../getting-started.mdx).
+</Admonition>
 
 ## Step 1/3. Start Grafana
 
@@ -23,8 +30,7 @@ We've picked Grafana for this tutorial since it's very easy to run with zero
 configuration required. If you have another web application you'd like to
 expose, skip over to **Step 2**.
 
-Grafana can be launched in a [Docker container](https://grafana.com/docs/grafana/latest/installation/docker/)
-with a single command:
+Grafana can be launched in a Docker container with a single command:
 
 ```code
 $ docker run -d -p 3000:3000 grafana/grafana
@@ -33,50 +39,69 @@ $ docker run -d -p 3000:3000 grafana/grafana
 ## Step 2/3. Install and configure Teleport
 (!docs/pages/includes/permission-warning.mdx!)
 
-Download the latest version of Teleport for your platform from our
+On your Application Service host, download the latest version of Teleport for
+your platform from our
 [downloads page](https://goteleport.com/teleport/download).
 
-We will assume that you have configured DNS records for `teleport.example.com`
-and `*.teleport.example.com` to point to the Teleport Proxy Service.
+### Generate a token
 
-### Configure TLS
-Teleport uses TLS to communicate with clients, and can fetch certificates automatically via Let's Encrypt.
+A join token is required to authorize a Teleport Application Service agent to
+join the cluster. Generate a short-lived join token and save it, for example,
+in `/tmp/token` on your Teleport Application Service host:
 
-(!docs/pages/includes/acme.mdx!)
+```code
+$ tctl tokens add \
+    --type=app \
+    --app-name=grafana \
+    --app-uri=http://localhost:3000
+```
 
 ### Start Teleport
+
+On the host where you will run the Teleport Application Service, download the latest version of Teleport for your platform from our
+[downloads page](https://goteleport.com/teleport/download).
+
 Now start Teleport and point it to the application endpoint:
 
 ```code
-$ sudo teleport start \
-  --roles=proxy,auth,app \
-  --app-name=grafana \
-  --app-uri=http://localhost:3000
+$ sudo teleport app start \
+  --name=grafana \
+  --token=/tmp/token \
+  --uri=http://localhost:3000 \
+  --auth-server=https://teleport.example.com:3080
 ```
 
-Make sure to update `--app-name` and `--app-uri` accordingly if you're using
-your own web application.
+Change `https://teleport.example.com:3080` to the address and port of your Teleport Proxy Server. If you are a Teleport Cloud cluster, use your tenant's subdomain, e.g., `mytenant.teleport.sh`. 
+
+Make sure to update `--app-name` and `--app-uri` accordingly if you're using your own web application.
+
+The `--token` flag points to the file on the Application Service host where we stored the token that we generated earlier.
 
 ### Create a user
+
 Next, let's create a user to access the application we've just connected. Teleport has a built-in role called `access` that allows users to access cluster resources. Create a local user assigned this role:
 
 ```code
 $ tctl users add --roles=access alice
 ```
 
-The command will output a signup link. Use it to choose a password and set up a second factor. After that, it will take you to the Teleport web UI.
+The command will output a signup link. Use it to choose a password and set up a second factor. After that, it will take you to the Teleport Web UI.
 
 ## Step 3/3. Access the application
 
 There are a couple of ways to access the proxied application.
 
-Every application is assigned a public address which you use to navigate to
+Every application is assigned a public address that you can use to navigate to
 the application directly. In our sample Grafana application we have provided a public address with
 the `--app-public-addr` flag, so go to `https://grafana.teleport.example.com`
-(replace with your app public address) to access the app. If you're not logged into Teleport,
+to access the app. 
+
+Replace `grafana` with the value of the `--app-name` flag you used when starting the Teleport Application Service and `teleport.example.com` with the address of your Proxy Service.
+
+If you're not logged into Teleport,
 you will need to authenticate before the application will show.
 
-Alternatively, log into the Teleport Web Interface at `https://teleport.example.com` (replace with your proxy public address). All available applications are displayed on the Applications tab. Click on the Grafana application tile to access it.
+Alternatively, log in to the Teleport Web Interface at `https://teleport.example.com` (replace with your Proxy Service's public address). All available applications are displayed on the Applications tab. Click on the Grafana application tile to access it.
 
 ## Next steps
 
@@ -86,3 +111,4 @@ Dive deeper into the topics relevant to your Application Access use-case:
 - Learn about integrating with [JWT tokens](./guides/jwt.mdx) for auth.
 - Learn how to use Application Access with [RESTful APIs](./guides/api-access.mdx).
 - See full configuration and CLI [reference](./reference.mdx).
+- Read about how Let's Encrypt uses the [ACME protocol](https://letsencrypt.org/how-it-works/).

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -6,16 +6,15 @@ videoBanner: EsEvO5ndNDI
 
 # Getting Started
 
-Server Access often involves managing your resources, configuring new clusters, and issuing commands through a CLI or programmatically to an API.
+Server Access involves managing your resources, configuring new clusters, and issuing commands through a CLI or programmatically to an API.
 
 This guide introduces some of these common scenarios and how to interact with Teleport to accomplish them:
 
-1. Creating a Teleport Auth Node cluster we'll add a Teleport SSH Node to.
-2. SSH into the cluster using Teleport.
-3. Introspecting the cluster using Teleport features.
+1. SSH into a cluster using Teleport.
+2. Introspect the cluster using Teleport features.
 
 <Admonition type="tip" title="Tip">
-  This guide also demonstrates how to configure Teleport Nodes into the *Bastion* pattern so that [only a single Node can be accessed publicly](https://goteleport.com/blog/ssh-bastion-host/).
+  This guide also demonstrates how to configure Teleport Nodes using the **bastion pattern** so that only a single Node can be accessed publicly.
 </Admonition>
 
 <Figure
@@ -28,83 +27,61 @@ This guide introduces some of these common scenarios and how to interact with Te
 
 ## Prerequisites
 
-- Two instances of your favorite Linux environment (such as Ubuntu 20.05, CentOS 8.0-1905, or Debian 10).
-- A registered Domain Name with an available subdomain like `tele.example.com`.
-- A Two-Factor Authentication app (such as Authy or Google Authenticator).
+- The Teleport Auth Service and Proxy Service, deployed on your own infrastructure or managed via Teleport Cloud.
+- One host running your favorite Linux environment (such as Ubuntu 20.04, CentOS 8.0-1905, or Debian 10). This will serve as a Teleport Server Access Node.
 - Teleport (=teleport.version=) installed locally.
+
+<Admonition type="tip" title="New Teleport users">
+If you have not yet deployed the Teleport Auth Service and Proxy Service, learn how to do so by following one of our [getting started guides](../getting-started.mdx).
+</Admonition>
 
 (!docs/pages/includes/permission-warning.mdx!)
 
-## Step 1/4. Create a cluster
+## Step 1/4. Install Teleport 
 
-1. Create two new instances of your desired Linux distribution (such as Ubuntu 20.05, CentOS 8.0-1905, or Debian 10).
+1. Create a new instance of your desired Linux distribution (such as Ubuntu 20.04, CentOS 8.0-1905, or Debian 10).
 
-   The first instance will host a public-facing Auth Node `tele.example.com` that will serve as the *Bastion Host* (following the recommended *Bastion*-pattern). As such, leave the following ports open:
+   This instance will be a private resource. Open port 22 so you can initially access, configure, and provision your instance. We'll configure and launch our instance, then demonstrate how to use the `tsh` tool and Teleport in SSH mode thereafter.
 
-   | Port | Service | Description |
-   | - | - | - |
-   | 3023 | Proxy | SSH port clients connect to. A proxy will forward this connection to port `#3022` on the destination Node. |
-   | 3024 | Proxy	SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. |
-   | 443 | Browser | Used to access the Teleport Web UI through a browser with HTTPS. Also used to obtain an ACME TLS (SSL) certificate. |
-   | 22 | Cloud Provider | Used to initially access, configure, and provision your cloud instances. We'll configure and launch our instances then demonstrate how to use the `tsh` tool and Teleport in SSH mode thereafter. |
-
-   Add an `A` record in your domain registrar entry for the `tele` subdomain and map the first IP address to the `tele` subdomain.
-
-   <Figure
-     align="center"
-     bordered
-     caption="Subdomain and IP mapping"
-   >
-     ![Subdomain and IP mapping](../../img/server-access/subdomains.png)
-   </Figure>
-
-   Your second instance will be a private resource. These are the ports you'll want to initially open:
-
-   | Port | Service | Description |
-   | - | - | - |
-   | 22 | Cloud Provider | Used to initially access, configure, and provision your cloud instances. We'll configure and launch our instances then demonstrate how to use the `tsh` tool and Teleport in SSH mode thereafter. |
-
-2. Install Teleport on each instance.
+2. Install Teleport on your instance.
 
    (!docs/pages/includes/install-linux.mdx!)
 
-3. Configure Teleport on the *Bastion Host*.
-
-   Teleport uses TLS to communicate with clients, and can fetch certificates automatically via Let's Encrypt.
-
-   (!docs/pages/includes/acme.mdx!)
-
-   Run the command above on `tele.example.com`.
-
-4. Launch your *Bastion Host* by running:
-
-   ```code
-   # Launch Teleport
-   $ sudo teleport start
-   ```
-
-   Next, we'll create a *join token* to add and start the second Node.
+   Next, we'll create a **join token** to add and start Teleport Server Access on the Node.
 
 ## Step 2/4. Add a Node to the cluster
 
-1. Create a *join token* to add the second Node to the `tele.example.com` cluster. In a *Bastion Host* terminal run the following command:
+1. Create a join token to add the Node to your Teleport cluster. In run the following command, either on your Auth Service host (for self-hosted deployments) or on your local machine (for Teleport Cloud).
+
+<Details scope={["cloud"]} scopeOnly={true} title="Teleport Cloud and tctl">
+Teleport Cloud users must download the Enterprise version of Teleport to their local machines in order to use `tctl`. To do so, visit the [Teleport Customer Portal](https://dashboard.gravitational.com/web/login).
+
+Once this is done, log in to Teleport:
+
+```code
+$ tsh login --proxy=myinstance.teleport.sh
+```
+
+If you have installed `tctl` as your local user, you will not need to run `tctl` commands via `sudo`.
+</Details>
 
    ```code
    # Let's save the token to a file
    $ sudo tctl tokens add --type=node | grep -oP '(?<=token:\s).*' > token.file
    ```
 
-   Each Teleport Node can be configured into SSH mode (Teleport Node) and run as an enhanced SSH server. "Node" mode specifies that the Teleport Node will act and join as an SSH server.
+   Each Teleport Node can be configured into SSH mode and run as an enhanced SSH server. `--type=node` specifies that the Teleport Node will act and join as an SSH server.
 
    `> token.file` indicates that you'd like to save the output to a file name `token.file`.
 
    <Admonition type="tip" title="Tip">
-     This helps to minimize the direct sharing of tokens even when they are *dynamically* generated.
+     This helps to minimize the direct sharing of tokens even when they are dynamically generated.
    </Admonition>
 
-2. Now, create a third terminal and connect to `tele.example.com`.
+2. Now, open a new terminal and connect to the Teleport Auth Service.
 
-   - Save `token.file` to an appropriate, secure, directory you have the rights and access to read on the second instance.
+   - On your Node, save `token.file` to an appropriate, secure, directory you have the rights and access to read.
+   - Start the Node. Change `tele.example.com` to the address of your Teleport Proxy Service. For Teleport Cloud customers, use a tenant address such as `mytenant.teleport.sh`. Assign the `--token` flag to the path where you saved `token.file`.
 
    ```code
    # Join cluster
@@ -114,10 +91,7 @@ This guide introduces some of these common scenarios and how to interact with Te
      --auth-server=tele.example.com:443
    ```
 
-   - Replace the `auth-server` value with the public proxy address of the machine you wish to connect to. By default, the subdomain `tele.example.com` will be available on port `443`.
-   - Supply the secured path to the new Node's `token.file`.
-
-3. Create a user to access the `tele.example.com` Web UI through the following command:
+3. Create a user to access the Web UI through the following command:
 
    ```code
    $ sudo tctl users add tele-admin --roles=editor,access --logins=root,ubuntu,ec2-user
@@ -129,7 +103,7 @@ This guide introduces some of these common scenarios and how to interact with Te
      We've only given `tele-admin` the roles `editor` and `access` according to the *Principle of Least Privilege* (POLP).
    </Admonition>
 
-4. You should now be able to view both Nodes in the Teleport Web interface after logging in as `tele-admin`:
+4. You should now be able to view your Teleport Node in Teleport Web interface after logging in as `tele-admin`:
 
    <Figure
      align="center"
@@ -141,20 +115,20 @@ This guide introduces some of these common scenarios and how to interact with Te
 
 ## Step 3/4. SSH into the server
 
-Now, that we've got our cluster up and running, let's see how easy it is to connect to our two Nodes.
+Now, that we've got our cluster up and running, let's see how easy it is to connect to our Node.
 
 We can use `tsh` to SSH into the cluster:
 
-1. On your local machine, log in through `tsh`:
+1. On your local machine, log in through `tsh`, assigning the `--proxy` flag to the address of your Teleport Proxy Service:
 
    ```code
    # Log in through tsh
    $ tsh login --proxy=tele.example.com --user=tele-admin
    ```
 
-   You'll be prompted to supply the password and One Time Passcode we set up previously.
+   You'll be prompted to supply the password and second factor we set up previously.
 
-2. `tele-admin` will now see:
+2. `tele-admin` will now see something similar to:
 
    ```txt
    Profile URL:        https://tele.example.com:443
@@ -167,7 +141,7 @@ We can use `tsh` to SSH into the cluster:
      Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
    ```
 
-   `tele-admin` is now logged into the `tele.example.com` cluster and *Bastion Host* Node through Teleport SSH.
+   In this example, `tele-admin` is now logged into the `tele.example.com` cluster through Teleport SSH.
 
 3. `tele-admin` can now execute the following to find the cluster's `nodenames`. `nodenames` are used for establishing SSH connections:
 
@@ -176,7 +150,7 @@ We can use `tsh` to SSH into the cluster:
    $ tsh ls
    ```
 
-   The *Bastion Host* Node is located on the bottom line below:
+   In this example, the bastion host Node is located on the bottom line below:
 
    ```txt
    Node Name        Address        Labels                                 
@@ -185,7 +159,7 @@ We can use `tsh` to SSH into the cluster:
    ip-172-31-41-144 127.0.0.1:3022 env=example, hostname=ip-172-31-41-144 
    ```
 
-4. `tele-admin` can SSH into the *Bastion Host* Node by running the following command locally:
+4. `tele-admin` can SSH into the bastion host Node by running the following command locally:
 
    ```code
    # Use tsh to ssh into a Node
@@ -198,7 +172,7 @@ We can use `tsh` to SSH into the cluster:
    - Traverse the Linux file system.
    - Execute desired commands.
 
-   All commands executed by `tele-admin` are recorded and can be replayed in the Teleport Web interface.
+   All commands executed by `tele-admin` are recorded and can be replayed in the Teleport Web UI.
 
    The `tsh ssh` command allows one to do anything they would if they were to SSH into a server using a third-party tool. Compare the two equivalent commands:
 
@@ -220,9 +194,9 @@ We can use `tsh` to SSH into the cluster:
 1. Now, `tele-admin` has the ability to SSH into other Nodes within the cluster, traverse the Linux file system, and execute commands.
 
    - They have visibility into all resources within the cluster due to their defined and assigned roles.
-   - They can also quickly view any Node or grouping of Nodes that've been assigned a `label`.
+   - They can also quickly view any Node or grouping of Nodes that have been assigned a particular label.
 
-2. Execute the following command within your *Bastion Host* console:
+2. Execute the following command within your bastion host console:
 
    ```code
    # List Nodes
@@ -238,44 +212,44 @@ We can use `tsh` to SSH into the cluster:
    ip-172-31-41-144 f3d2a65f-3fa7-451d-b516-68d189ff9ae5 127.0.0.1:3022 env=example,hostname=ip-172-31-41-144                            
    ```
 
-3. Note the "Labels" column on the farthest side. `tele-admin` can query all resources with a shared [label](../setup/admin/labels.mdx) using the command:
+3. Note the "Labels" column on the farthest side. `tele-admin` can query all resources with a shared label using the command:
 
    ```code
    # Query all Nodes with a label
    $ tsh ls env=example
    ```
 
-   - Customized labels can be defined in your `teleport.yaml` configuration file or during Node creation.
-   - This is a convenient feature that allows for more advanced queries.
-   - Suppose an IP address changes, an admin can quickly find the current Node with that label since it remains unchanged.
+   Customized labels can be defined in your `teleport.yaml` configuration file or during Node creation.
 
-4. `tele-admin` can also execute commands on all Nodes that share a label vastly simplifying repeated operations. For example, the command:
+   This is a convenient feature that allows for more advanced queries. If an IP address changes, for example, an admin can quickly find the current Node with that label since it remains unchanged.
+
+4. `tele-admin` can also execute commands on all Nodes that share a label, vastly simplifying repeated operations. For example, the command:
 
    ```code
    # Run the ls command on all Nodes with a label
    $ tsh ssh root@env=example ls
    ``` 
 
-   will execute the `ls` command on each Node displaying the contents of each to the screen.
+   will execute the `ls` command on each Node and display the results in your terminal.
 
 ## Conclusion
 
 <Admonition type="tip" title="Note">
-   We previously configured our Linux instances to leave port `22` open to easily configure and install Teleport. Feel free to compare Teleport SSH to your usual `ssh` commands.
+   We previously configured our Linux instance to leave port `22` open to easily configure and install Teleport. Feel free to compare Teleport SSH to your usual `ssh` commands.
 
-   If you'd like to further experiment with using Teleport according to the *Bastion* pattern:
+   If you'd like to further experiment with using Teleport according to the bastion pattern:
 
-   - Close port `22` on your second, private, Linux instance now that your Node is configured and running.
-   - Optionally close port `22` on your *Bastion Host*.
-   - You'll be able to fully connect to both the *Bastion Host* and the private instance using `tsh ssh`.
+   - Close port `22` on your private Linux instance now that your Teleport Node is configured and running.
+   - For self-hosted deployments, optionally close port `22` on your bastion host.
+   - You'll be able to fully connect to the private instance and, for self-hosted deployments, the bastion host, using `tsh ssh`.
 </Admonition>
 
-To recap, this Getting Started Guide described:
+To recap, this guide described:
 
 1. How to set up and add an SSH Node to a cluster.
 2. Connect to the cluster using `tsh` to manage and introspect resources.
 
-Feel free to shut down, clean up, and delete your resources or use them in further Getting Started exercises.
+Feel free to shut down, clean up, and delete your resources, or use them in further Getting Started exercises.
 
 ## Next steps
 
@@ -284,7 +258,8 @@ Feel free to shut down, clean up, and delete your resources or use them in furth
 - For a complete list of ports used by Teleport, read [The Admin Guide](../setup/reference/networking.mdx).
 
 ## Resources
-
+- [Setting Up an SSH Bastion Host](https://goteleport.com/blog/ssh-bastion-host/)
 - [Announcing Teleport SSH Server](https://goteleport.com/blog/announcing-teleport-ssh-server/)
 - [How to SSH properly](https://goteleport.com/blog/how-to-ssh-properly/)
 - Consider whether [OpenSSH or Teleport SSH](https://goteleport.com/blog/openssh-vs-teleport/) is right for you.
+- [Labels](../setup/admin/labels.mdx)

--- a/docs/pages/setup/guides/joining-nodes-aws.mdx
+++ b/docs/pages/setup/guides/joining-nodes-aws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Joining Nodes in AWS
-description: How to join nodes and proxies running on AWS
+description: How to join Nodes and Proxies running on AWS
 h1: Joining Nodes and Proxies in AWS
 ---
 
@@ -23,7 +23,11 @@ IAM credentials with `ec2:DescribeInstances` permissions are required on your
 Teleport Auth server.
 No IAM credentials are required on the Nodes or Proxies.
 
-The **IAM join method** is available in Teleport 8.3+ cloud or self-hosted.
+<Notice scope={["cloud"]} type="warning">
+Teleport Cloud does not support the EC2 join method.
+</Notice>
+
+The **IAM join method** is available in Teleport 8.3+ Cloud or self-hosted.
 It is available to any Teleport Node or Proxy running anywhere with access to
 IAM credentials, such as an EC2 instance with an attached IAM role.
 No specific permissions or IAM policy is required: an IAM role with no attached
@@ -102,7 +106,7 @@ for details.
 ## Step 2/4. Create the AWS Node Joining token
 
 Configure your Teleport auth server with a special dynamic token which will
-allow nodes from your AWS account to join your Teleport cluster.
+allow Nodes from your AWS account to join your Teleport cluster.
 
 <Tabs>
   <TabItem label="IAM Method">
@@ -132,11 +136,11 @@ spec:
   join_method: iam
 
   allow:
-  # specify the AWS account which nodes may join from
+  # Specify the AWS account that Nodes may join from
   - aws_account: "111111111111"
   # multiple allow rules are supported
   - aws_account: "222222222222"
-  # aws_arn is optional and allows you to restrict the IAM role of joining nodes
+  # aws_arn is optional and allows you to restrict the IAM role of joining Nodes
   - aws_account: "333333333333"
     aws_arn: "arn:aws:sts::111111111111:assumed-role/teleport-node-role/i-*"
 ```
@@ -228,7 +232,7 @@ Kubernetes, Application, or Database roles. The service should be run directly
 on an AWS EC2 instance and must have network access to the AWS EC2 IMDSv2
 (enabled by default for most EC2 instances).
 
-Configure your Teleport node with a custom `teleport.yaml` file. Use the
+Configure your Teleport Node with a custom `teleport.yaml` file. Use the
 `join_params` section with `token_name` matching your token created in Step 2
 and `method: ec2` as shown in the following example config:
 
@@ -252,7 +256,7 @@ proxy_service:
 
 ## Step 4/4. Launch your Teleport Node
 
-Start Teleport on the node and confirm that it is able to connect to and join
+Start Teleport on the Node and confirm that it is able to connect to and join
 your cluster. You're all set!
 
 <Admonition type="note">
@@ -269,11 +273,11 @@ re-running `tctl create -f token.yaml`.
 ### Configuring the EC2 join method for Multiple AWS Accounts
 
 <Admonition type="note">
-This section is not necessary when using the IAM join method, multiple accounts
+This section is not necessary when using the IAM join method. Multiple accounts
 are support by default.
 </Admonition>
 
-In order for Teleport nodes to join from EC2 instances in AWS accounts other
+In order for Teleport Nodes to join from EC2 instances in AWS accounts other
 than the account in which your Teleport auth server is running, Teleport must
 have permissions to assume an IAM role in each of those accounts and call
 `ec2:DescribeInstances` in the foreign account.
@@ -317,7 +321,7 @@ In the AWS account where your Teleport auth server is running:
 2. Attach this `teleport-AssumeRole-policy` to the IAM role your Teleport auth
    server has credentials for, see [Step 1.2](#step-12-attach-the-iam-policy).
 
-When creating the AWS Node Joining token, include an allow rule for each foreign
+When creating the AWS Node joining token, include an allow rule for each foreign
 account and specify the AWS ARN for the foreign
 `teleport-DescribeInstances-role`.
 


### PR DESCRIPTION
Backports #10021

* Mention Cloud compatibility in three guides

Server Access getting started:
- Remove the instructions to install and set up the Auth
  Service, and add references to main Getting Started guides
  and Cloud signup page.
- Add a prerequisite to have deployed the Auth Service and
  Proxy Service.

EC2 joining guide: make it explicit that the Cloud is not
compatible with this. Also make small style tweaks.

App Access getting started page:
- The guide assumes that you are running the Auth Service,
  Proxy Service, and App Service via the same binary, which
  does not work for Cloud users.

* Respond to PR feedback

- Add newlines after headings
- Use teleport app start instead of teleport start --roles=app
- Fix incorrect Ubuntu version number
- Add a Details box explaining tctl usage for Cloud
- Correctly capitalize "Node"