### PR TITLE
Update descriptions in our --help messages

### DIFF
--- a/tool/tctl/common/usage.go
+++ b/tool/tctl/common/usage.go
@@ -17,7 +17,7 @@ limitations under the License.
 package common
 
 const (
-	GlobalHelpString = "CLI Admin tool for the Teleport Auth service. Runs on a host where Teleport Auth is running."
+	GlobalHelpString = "Admin tool for the Teleport Access Plane"
 
 	AddUserHelp = `Notes:
 
@@ -37,12 +37,12 @@ Examples:
 `
 
 	AddNodeHelp = `Notes:
-  This command generates and prints an invitation token another node can use to 
-  join the cluster. 
+  This command generates and prints an invitation token another node can use to
+  join the cluster.
 
 Examples:
 
-  > tctl nodes add 
+  > tctl nodes add
 
   Generates a token when can be used to add a regular SSH node to the cluster.
   The token genrated single-use token will be valid for 30 minutes.
@@ -50,7 +50,7 @@ Examples:
   > tctl nodes add --roles=node,proxy --ttl=1h
 
   Generates a token when can be used to add an SSH node to the cluster which
-  will also be a proxy node. This token can be used multiple times within an 
+  will also be a proxy node. This token can be used multiple times within an
   hour.
 `
 	ListNodesHelp = `Notes:

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -62,7 +62,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	// configure logger for a typical CLI scenario until configuration file is
 	// parsed
 	utils.InitLogger(utils.LoggingForDaemon, log.ErrorLevel)
-	app = utils.InitCLIParser("teleport", "Clustered SSH service. Learn more at https://goteleport.com/teleport")
+	app = utils.InitCLIParser("teleport", "Teleport Access Plane. Learn more at https://goteleport.com")
 
 	// define global flags:
 	var (

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -371,7 +371,7 @@ func Run(args []string, opts ...cliOption) error {
 	moduleCfg := modules.GetModules()
 
 	// configure CLI argument parser:
-	app := utils.InitCLIParser("tsh", "TSH: Teleport Authentication Gateway Client").Interspersed(false)
+	app := utils.InitCLIParser("tsh", "Teleport Command Line Client").Interspersed(false)
 	app.Flag("login", "Remote host login").Short('l').Envar(loginEnvVar).StringVar(&cf.NodeLogin)
 	localUser, _ := client.Username()
 	app.Flag("proxy", "SSH proxy address").Envar(proxyEnvVar).StringVar(&cf.Proxy)


### PR DESCRIPTION
- `tctl`: remove mention of "runs where auth service runs" because tctl can run remotely now
- `teleport`: we do more than SSH these days 
- `tsh`: remove reference to "Teleport Authentication Gateway"