### PR TITLE
Provide link to enterprise docker setup from oss docker

### DIFF
--- a/docs/pages/setup/guides/docker.mdx
+++ b/docs/pages/setup/guides/docker.mdx
@@ -10,7 +10,7 @@ This section will cover:
 - Using Teleport with Teleport's native client, `tsh`.
 
 <Notice scope={["oss", "enterprise"]} type="note" title="Enterprise using Docker" scopeOnly={true}>
-  To run Teleport Enterprise using Docker we recommend following this guide [Run Teleport Enterprise using Docker](../../enterprise/getting-started.mdx#run-teleport-enterprise-using-docker)
+  To run Teleport Enterprise using Docker we recommend following this guide [Run Teleport Enterprise using Docker](../../enterprise/getting-started.mdx#run-teleport-enterprise-using-docker).
 </Notice>
 
 <Details scope={["cloud"]} title="Teleport Cloud" scopeOnly={true} opened={true}>

--- a/docs/pages/setup/guides/docker.mdx
+++ b/docs/pages/setup/guides/docker.mdx
@@ -9,9 +9,9 @@ This section will cover:
 - Getting started with a local Teleport using Docker.
 - Using Teleport with Teleport's native client, `tsh`.
 
-<Admonition scope={["oss", "ent"]} type="note" title="Enterprise using Docker" scopeOnly={true}>
+<Notice scope={["oss", "enterprise"]} type="note" title="Enterprise using Docker" scopeOnly={true}>
   To run Teleport Enterprise using Docker we recommend following this guide [Run Teleport Enterprise using Docker](../../enterprise/getting-started.mdx#run-teleport-enterprise-using-docker)
-</Admonition>
+</Notice>
 
 <Details scope={["cloud"]} title="Teleport Cloud" scopeOnly={true} opened={true}>
 Teleport Cloud includes managed instances of Teleport's Auth Service and Proxy Service. Since all of Teleport's services are run from the same binary, you can use our Docker image to run other services (e.g., the Database Service or App Service), or explore the Auth and Proxy Services locally.

--- a/docs/pages/setup/guides/docker.mdx
+++ b/docs/pages/setup/guides/docker.mdx
@@ -9,13 +9,17 @@ This section will cover:
 - Getting started with a local Teleport using Docker.
 - Using Teleport with Teleport's native client, `tsh`.
 
+<Admonition scope={["oss", "ent"]} type="note" title="Enterprise using Docker" scopeOnly={true}>
+  To run Teleport Enterprise using Docker we recommend following this guide [Run Teleport Enterprise using Docker](../../enterprise/getting-started.mdx#run-teleport-enterprise-using-docker)
+</Admonition>
+
 <Details scope={["cloud"]} title="Teleport Cloud" scopeOnly={true} opened={true}>
 Teleport Cloud includes managed instances of Teleport's Auth Service and Proxy Service. Since all of Teleport's services are run from the same binary, you can use our Docker image to run other services (e.g., the Database Service or App Service), or explore the Auth and Proxy Services locally.
 </Details>
 
 ## Prerequisites
 
-- Teleport v(=teleport.version=) Open Source or Enterprise.
+- Teleport v(=teleport.version=) Open Source.
 - Docker v(=docker.version=) or later.
 
 ```code

--- a/docs/pages/setup/guides/docker.mdx
+++ b/docs/pages/setup/guides/docker.mdx
@@ -10,7 +10,7 @@ This section will cover:
 - Using Teleport with Teleport's native client, `tsh`.
 
 <Notice scope={["oss", "enterprise"]} type="note" title="Enterprise using Docker" scopeOnly={true}>
-  To run Teleport Enterprise using Docker we recommend following this guide [Run Teleport Enterprise using Docker](../../enterprise/getting-started.mdx#run-teleport-enterprise-using-docker).
+  To run Teleport Enterprise using Docker, we recommend following the guide, [Run Teleport Enterprise using Docker](../../enterprise/getting-started.mdx#run-teleport-enterprise-using-docker).
 </Notice>
 
 <Details scope={["cloud"]} title="Teleport Cloud" scopeOnly={true} opened={true}>


### PR DESCRIPTION
The oss docker setup guide didn't have info on the enterprise version.