### PR TITLE
[v9 backport] Situate the Installation guide more clearly (#9524)

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -6,6 +6,11 @@ h1: Installation
 
 Teleport core service [`teleport`](./setup/reference/cli.mdx#teleport) and admin tool [`tctl`](./setup/reference/cli.mdx#tctl) have been designed to run on **Linux** and **Mac** operating systems. The Teleport user client [`tsh`](./setup/reference/cli.mdx#tsh) and UI are available for **Linux, Mac**, and **Windows** operating systems.
 
+<Admonition type="tip" title="First time trying Teleport?">
+If you are new to Teleport, we recommend following our [getting started guides](getting-started.mdx).
+</Admonition>
+
+
 ## Linux
 
 The following examples install the 64-bit version of Teleport binaries, but
@@ -176,3 +181,12 @@ any OS supported by the [Golang toolchain](https://github.com/golang/go/wiki/Min
 
 \[2] *Teleport server does not run on Windows yet, but `tsh` (the Teleport client)
 supports most features on Windows 10 and later.*
+
+## Next steps
+
+Now that you know how to install Teleport, you can enable access to all of your infrastructure. Get started with:
+- [Application Access](application-access/introduction.mdx)
+- [Database Access](database-access/introduction.mdx)
+- [Desktop Access](desktop-access/introduction.mdx)
+- [Kubernetes Access](kubernetes-access/introduction.mdx)
+- [Server Access](server-access/introduction.mdx)


### PR DESCRIPTION
Backports #9524

* Situate the Installation guide more clearly

For a reader who begins their journey through the Teleport docs
with the Installation guide, it can be difficult to determine
what to do after following the guide. This change makes the
relationship between the Installation page and other docs pages
clearer by:

- Adding an Admonition to read the Getting Started guides if you
  have not yet tried Teleport. These guides include installation
  instructions, so they can be our recommended starting place.

- Adding a Next Steps section that links to instructions on
  enabling Teleport for different infrastructure resources.

Closes #9355

* Respond to PR feedback