### PR TITLE
[v9 backport] Fix broken link in the ADFS guide

### DIFF
--- a/docs/pages/enterprise/sso/adfs.mdx
+++ b/docs/pages/enterprise/sso/adfs.mdx
@@ -1,16 +1,14 @@
 ---
-title: SSH Authentication With ADFS How To
-description: How to configure SSH access with Active Directory (ADFS) using Teleport
-h1: SSH Authentication with ADFS
+title: SSO with Active Directory Federation Services
+description: How to configure SSH access with Active Directory Federation Services using Teleport
+h1: Single Sign-On with Active Directory Federation Services
 ---
 
-## Active Directory as an SSO provider for SSH authentication
-
 This guide will cover how to configure Active Directory Federation Services
-[ADFS](https://en.wikipedia.org/wiki/Active_Directory_Federation_Services) to be
+([ADFS](https://en.wikipedia.org/wiki/Active_Directory_Federation_Services)) to be
 a single sign-on (SSO) provider to issue
 SSH credentials to specific groups of users. When used in combination with role
-based access control (RBAC) it allows SSH administrators to define policies
+based access control (RBAC), it allows SSH administrators to define policies
 like:
 
 - Only members of "DBA" group can SSH into machines running PostgreSQL.
@@ -24,16 +22,15 @@ like:
   This guide requires a commercial edition of Teleport.
 </Admonition>
 
-
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)
 
 ## Configure ADFS
 
 You'll need to configure ADFS to export claims about a user (Claims Provider
-Trust in ADFS terminology) and you'll need to configure AD FS to trust
+Trust in ADFS terminology) and you'll need to configure ADFS to trust
 Teleport (a Relying Party Trust in ADFS terminology).
 
-For Claims Provider Trust configuration you'll need to specify at least the
+For Claims Provider Trust configuration, you'll need to specify at least the
 following two incoming claims: `Name ID` and `Group`. `Name ID` should be a
 mapping of the LDAP Attribute `E-Mail-Addresses` to `Name ID`. A group
 membership claim should be used to map users to roles (for example to
@@ -42,29 +39,29 @@ separate normal users and admins).
 ![Name ID Configuration](../../../img/adfs-1.png)
 ![Group Configuration](../../../img/adfs-2.png)
 
-In addition if you are using dynamic roles (see below), it may be useful to map
+In addition, if you are using dynamic roles (see below), it may be useful to map
 the LDAP Attribute `SAM-Account-Name` to `Windows account name` and create
 another mapping of `E-Mail-Addresses` to `UPN`.
 
 ![WAN Configuration](../../../img/adfs-3.png)
 ![UPN Configuration](../../../img/adfs-4.png)
 
-You'll also need to create a Relying Party Trust, use the below information to
-help guide you through the Wizard. Note, for development purposes we recommend
+You'll also need to create a Relying Party Trust. Use the below information to
+help guide you through the Wizard. Note that for development purposes we recommend
 using `https://localhost:3080/v1/webapi/saml/acs` as the Assertion Consumer
 Service (ACS) URL, but for production you'll want to change this to a domain
 that can be accessed by other users as well.
 
 - Create a claims aware trust.
 - Enter data about the relying party manually.
-- Set the display name to something along the lines of "Teleport".
+- Set the display name to something along the lines of `Teleport`.
 - Skip the token encryption certificate.
 - Select *"Enable support for SAML 2.0 Web SSO protocol"* and set the URL to `https://localhost:3080/v1/webapi/saml/acs`.
 - Set the relying party trust identifier to `https://localhost:3080/v1/webapi/saml/acs` as well.
 - For access control policy select *"Permit everyone"*.
 
 Once the Relying Party Trust has been created, update the Claim Issuance Policy
-for it. Like before make sure you send at least `Name ID` and `Group` claims to the
+for it. Like before, make sure you send at least `Name ID` and `Group` claims to the
 relying party (Teleport). If you are using dynamic roles, it may be useful to
 map the LDAP Attribute `SAM-Account-Name` to *"Windows account name"* and create
 another mapping of `E-Mail-Addresses` to *"UPN"*.
@@ -74,10 +71,10 @@ associated with it. To check this open Server Manager then
 *"Tools -> Active Directory Users and Computers"* and select the user and right
 click and open properties. Make sure the email address field is filled out.
 
-## Create Teleport Roles
+## Create Teleport roles
 
-Lets create two Teleport roles: one for administrators and the other is for
-normal users. You can create them using `tctl create {file name}` CLI command
+Let's create two Teleport roles: one for administrators and the other for
+normal users. You can create them using the `tctl create {file name}` CLI command
 or via the Web UI.
 
 ```yaml
@@ -117,13 +114,18 @@ spec:
 
 This role declares:
 
-- Devs are only allowed to login to nodes labelled with `access: relaxed` label.
-- Developers can log in as `ubuntu` user
-- Notice `{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}` login. It configures Teleport to look at
-  *"[http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"](http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname")* ADFS claim and use that field as an allowed login for each user.
-  Also note the double quotes (`"`) and square brackets (`[]`) around the claim name - these are important.
-- Developers also do not have any "allow rules" i.e. they will not be able to
-  see/replay past sessions or re-configure the Teleport cluster.
+- Devs are only allowed to log in to nodes labeled `access: relaxed`.
+- Developers can log in as the `ubuntu` user.
+- Developers will not be able to see or replay past sessions or
+  re-configure the Teleport cluster.
+
+The login
+`{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}`
+configures Teleport to look at the
+`http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname`
+ADFS claim and use that field as an allowed login for each user. Note the
+double quotes (`"`) and square brackets (`[]`) around the claim name—these are
+important.
 
 Next, create a SAML connector [resource](../../setup/reference/resources.mdx):
 
@@ -140,7 +142,7 @@ name is `http://schemas.xmlsoap.org/claims/Group` with a value of *"admins"*
 to the *"admin"* role. Groups with the value *"users"* is being mapped to the
 *"users"* role.
 
-## Export the Signing Key
+## Export the signing key
 
 For the last step, you'll need to export the signing key:
 
@@ -161,8 +163,8 @@ the same as before:
 $ tsh --proxy=proxy.example.com login
 ```
 
-This command will print the SSO login URL (and will try to open it
-automatically in a browser).
+This command will print the SSO login URL and try to open it
+automatically in a browser.
 
 <Admonition
   type="tip"
@@ -176,15 +178,15 @@ automatically in a browser).
   type="note"
   title="IMPORTANT"
 >
-  Teleport only supports sending party initiated flows for SAML 2.0. This
-  means you can not initiate login from your identity provider, you have to
-  initiate login from either the Teleport Web UI or CLI.
-</Admonition>
+  Teleport only supports sending party-initiated flows for SAML 2.0. This means
+  that you cannot initiate login from your identity provider, and must do so
+  from either the Teleport Web UI or CLI.
+  </Admonition>
 
 ## Troubleshooting
 
-If you get "access denied errors" the number one place to check is the audit
-log on the Teleport auth server. It is located in `/var/lib/teleport/log` by
+If you get "access denied" errors, the number one place to check is the audit
+log on the Teleport Auth Server. It is located in `/var/lib/teleport/log` by
 default and it will contain the detailed reason why a user's login was denied.
 
 Some errors (like filesystem permissions or misconfigured network) can be
@@ -195,4 +197,4 @@ $ sudo journalctl -fu teleport
 ```
 
 If you wish to increase the verbosity of Teleport's syslog, you can pass
-`--debug` flag to `teleport start` command.
+`--debug` flag to the `teleport start` command.


### PR DESCRIPTION
Backports #10626

* Fix broken link in the ADFS guide

This was hurting SEO. Since the link was not intended to be
used for navigation, I turned it into code-style text instead.

Also took this opportunity to do some light copy-editing of the
ADFS guide.

Fixes #8714

* Incorporate PR feedback

Also adds a few minor tweaks.