### PR TITLE
[v8 backport] Add Cloud-specific instructions to two guides

### DIFF
--- a/docs/pages/cloud/faq.mdx
+++ b/docs/pages/cloud/faq.mdx
@@ -28,7 +28,7 @@ Currently there is no way to provide your own bucket.
 ### How do I add nodes to Teleport Cloud?
 
 You can connect servers, kubernetes clusters, databases and applications
-using [reverse tunnels](../setup/admin/adding-nodes.mdx#adding-a-node-located-behind-nat).
+using [reverse tunnels](../setup/admin/adding-nodes.mdx).
 
 There is no need to open any ports on your infrastructure for inbound traffic.
 
@@ -55,7 +55,7 @@ $ tctl tokens add --type=node
 ### Are dynamic node tokens available?
 
 After [connecting](#how-can-i-access-the-tctl-admin-tool) `tctl` to Teleport Cloud, users can generate
-[dynamic tokens](../setup/admin/adding-nodes.mdx#short-lived-dynamic-tokens):
+[dynamic tokens](../setup/admin/adding-nodes.mdx):
 
 ```code
 $ tctl nodes add --ttl=5m --roles=node,proxy --token=$(uuid)

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -35,7 +35,7 @@ section of the Admin Manual.
 
 This was a popular customer [request](https://github.com/gravitational/teleport/issues/803) that was added in Teleport version 4.0.
 Once you've upgraded your Teleport Cluster, change the node config option `--auth-server` to point to web proxy address (this would be `public_addr` and `web_listen_addr`
-in file configuration). As defined in [Adding a node located behind NAT - Teleport Node Tunneling](./setup/admin/adding-nodes.mdx#adding-a-node-located-behind-nat)
+in file configuration). For more information, see [Adding Nodes to the Cluster](./setup/admin/adding-nodes.mdx).
 
 ### Can nodes use a single port for reverse tunnels?
 

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,22 +1,34 @@
-<Details title="Before you begin: verify connectivity" opened={false}>
+<Details 
+title="Make sure you can connect to Teleport" 
+scope={["oss", "enterprise"]} 
+scopeOnly={true}
+opened={true}
+>
 
-Verify that your Teleport client is connected:
+Verify that your Teleport client is connected by running the following on your
+Auth Service host:
 
 ```code
 $ tctl status
-
 # Cluster  tele.example.com
 # Version  (=teleport.version=)
 # CA pin   sha256:sha-hash-here
 ```
+</Details>
+<Details 
+title="Make sure you can connect to Teleport" 
+scope={["cloud"]}
+scopeOnly={true}
+opened={true}
+>
 
-<Notice title="Connecting to the cloud" type="note" scope={["cloud"]}>
-To try this flow in the cloud, login into your cluster using `tsh`, then use `tctl` remotely:
+To connect to Teleport, log in to your cluster using `tsh`, then use `tctl` remotely:
 
 ```code
-$ tsh login --proxy=myinstance.teleport.sh
+$ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
 $ tctl status
+# Cluster  myinstance.teleport.sh
+# Version  (=teleport.version=)
+# CA pin   sha256:sha-hash-here
 ```
-</Notice>
-
 </Details>

--- a/docs/pages/kubernetes-access/helm/guides/custom.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/custom.mdx
@@ -28,7 +28,7 @@ migrating your setup from a legacy version of the Helm charts.
 In `custom` mode, the `teleport-cluster` Helm chart does not create a `ConfigMap` containing a `teleport.yaml` file for you, but
 expects that you will provide this yourself.
 
-For this example, we'll be using this `teleport.yaml` configuration file (with appropriately complex [static tokens](../../../setup/admin/adding-nodes.mdx#insecure-static-tokens)):
+For this example, we'll be using this `teleport.yaml` configuration file with a static join token (for more information on join tokens, see [Adding Nodes to the Cluster](../../../setup/admin/adding-nodes.mdx)):
 
 ```bash
 $ cat << EOF > teleport.yaml

--- a/docs/pages/setup/admin/adding-nodes.mdx
+++ b/docs/pages/setup/admin/adding-nodes.mdx
@@ -1,60 +1,54 @@
 ---
-title: Adding Nodes to the cluster
-description: Adding Nodes to the cluster
+title: Adding Nodes to the Cluster
+description: How to add Nodes to your Teleport cluster
 ---
 
-This guide explains how to add nodes to Open Source, Enterprise Teleport,
-self-hosted or cloud editions.
+This guide explains how to add Teleport Nodes to your cluster.
 
 ## Prerequisites
 
-- Installed [Teleport](../../getting-started.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
-- [Tctl admin tool](https://goteleport.com/teleport/download) >= (=teleport.version=)
+<Tabs>
+<TabItem scope={["oss"]} label="Self-Hosted">
+Install Teleport and the `tctl` admin tool version >= (=teleport.version=).
+
+See [Installation](../../installation.mdx) for details.
+
+</TabItem>
+<TabItem
+  scope={["enterprise"]} label="Enterprise">
+Install Teleport and the `tctl` admin tool version >= (=teleport.version=).
+
+To download Teleport Enterprise, visit the
+  [customer portal](https://dashboard.gravitational.com/web/login).
+</TabItem>
+<TabItem scope={["cloud"]}
+  label="Cloud">
+
+Sign up for a Teleport Cloud account. If you do not have one, visit the
+  [sign up page](https://goteleport.com/signup/) to begin your free trial.
+</TabItem>
+</Tabs>
 
 (!docs/pages/includes/tctl.mdx!)
 
-<Admonition type="note">
-For cloud, login with a teleport user with editor privileges:
-```code
-# tsh logs you in and receives short-lived certificates
-$ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
-# try out the connection
-$ tctl get nodes
-```
-</Admonition>
-
 ## Adding Nodes to the cluster
 
-Teleport only allows access to nodes that have joined the cluster.
+Teleport only allows access to Nodes that have joined the cluster.
 
-Once a node joins, it receives its own host certificate signed by the cluster's auth server.
+Once a Node joins, it receives its own host certificate signed by the cluster's
+Auth Service. To receive a host certificate upon joining a cluster, a new
+Teleport host must present an **invite token**.
 
-To receive a host certificate upon joining a cluster, a new Teleport host must present an *invite token*.
+An invite token also defines which role a new host can assume within a cluster:
+`auth`, `proxy`, `node`, `app`, `kube`, or `db`.
 
-An invite token also defines which role a new host can assume within a cluster: `auth`, `proxy`, `node`, `app`, `kube`, or `db`.
+### Generate a token
 
-There are two ways to create invitation tokens:
+Administrators can generate tokens as they are needed. A token can be used
+multiple times until its time to live (TTL) expires.
 
-- **Short-lived Dynamic Tokens** are more secure but require more planning.
-- **Static Tokens** are easy to use, but less secure.
-
-### Short-lived dynamic tokens
-
-Administrators can generate tokens as they are needed.
-
-Such token can be used multiple times until its time to live (TTL)
-expires.
-
-Use the [`tctl`](../reference/cli.mdx#tctl) tool to register a new invitation token (or
-it can also generate a new token for you). In the following example a new token
-is created with a TTL of 5 minutes:
-
-```code
-$ tctl nodes add --ttl=5m --roles=node,proxy --token=secret-value
-# The invite token: secret-value
-```
-
-If `--token` is not provided, [`tctl`](../reference/cli.mdx#tctl) will generate one:
+Use the `tctl` tool to generate a new token. In the following example, a new
+token is created with a TTL of five minutes:
 
 ```code
 # Generate a short-lived invitation token for a new node:
@@ -71,181 +65,17 @@ $ tctl tokens ls
 $ tctl tokens rm (=presets.tokens.first=)
 ```
 
-### Using Node invitation tokens
-
-Both static and short-lived dynamic tokens are used the same way. Execute the following
-command on a new node to add it to a cluster:
+If you want to provide your own token, you can do so using the `--token` flag:
 
 ```code
-# Adding a new regular SSH node to the cluster:
-$ sudo teleport start --roles=node --token=(=presets.tokens.first=) --auth-server=10.0.10.5
-
-# Adding a new regular SSH node using Teleport Node Tunneling:
-$ sudo teleport start --roles=node --token=(=presets.tokens.first=) --auth-server=teleport-proxy.example.com:3080
-
-# Adding a new proxy service on the cluster:
-$ sudo teleport start --roles=proxy --token=(=presets.tokens.first=) --auth-server=10.0.10.5
+$ tctl nodes add --ttl=5m --roles=node,proxy --token=secret-value
+# The invite token: secret-value
 ```
 
-As new nodes come online, they start sending ping requests every few seconds to
-the CA of the cluster. This allows users to explore cluster membership and size:
-
-```code
-$ tctl nodes ls
-
-Node Name     Node ID                                  Address            Labels
----------     -------                                  -------            ------
-turing        d52527f9-b260-41d0-bb5a-e23b0cfe0f8f     10.1.0.5:3022      distro:ubuntu
-dijkstra      c9s93fd9-3333-91d3-9999-c9s93fd98f43     10.1.0.6:3022      distro:debian
-```
-
-## Revoking invitations
-
-As you have seen above, Teleport uses tokens to invite users to a cluster
-(sign-up tokens) or to add new nodes to it (provisioning tokens).
-
-Both types of tokens can be revoked before they can be used. To see a list of
-outstanding tokens, run this command:
-
-```code
-$ tctl tokens ls
-
-# Token                                Role       Expiry Time (UTC)
-# -----                                ----       -----------------
-# (=presets.tokens.first=)     Proxy      never
-# (=presets.tokens.second=)     Node       17 May 16 03:51 UTC
-# (=presets.tokens.third=)     Signup     17 May 16 04:24 UTC
-```
-
-In this example, the first token has a "never" expiry date because it is a
-static token configured via a config file.
-
-The 2nd token with the "Node" role was generated to invite a new node to this
-cluster. And the 3rd token was generated to invite a new user.
-
-The latter two tokens can be deleted (revoked) via [`tctl tokens
-del`](../reference/cli.mdx#tctl-tokens-rm) command:
-
-```code
-$ tctl tokens del (=presets.tokens.first=)
-# Token (=presets.tokens.first=) has been deleted
-```
-
-## Adding a Node located behind NAT
-
-<Admonition type="note">
-  This feature is sometimes called "Teleport IoT" or node tunneling.
-</Admonition>
-
-With the current setup, you've only been able to add nodes that have direct access to the
-auth server and within the internal IP range of the cluster. We recommend
-setting up a [Trusted Cluster](../admin/trustedclusters.mdx) if you have workloads split
-across different networks/clouds.
-
-Teleport Node Tunneling lets you add a remote node to an existing Teleport Cluster through a tunnel.
-This can be useful for IoT applications, or for managing a couple of servers in a different network.
-
-Similar to [Adding Nodes to the Cluster](#adding-nodes-to-the-cluster), use `tctl` to
-create a single-use token for a node, but this time you'll replace the auth
-server IP with the URL of the proxy server. In the example below, we've
-replaced the auth server IP with the proxy web endpoint `teleport-proxy.example.com:3080`.
-
-```code
-$ tctl tokens add --type=node | grep -oP '(?<=token:\s).*' > token.file
-
-# This will save the token to a file.
-# Run this on the new node to join the cluster:
-$ sudo teleport start --roles=node --token=/path/to/token.file --auth-server=teleport-proxy.example.com:3080
-```
-
-Using the ports in the default configuration, the node needs to be able to talk to ports `3080` and `3024` on the proxy. Port `3080` is used to initially fetch the credentials (SSH and TLS certificates) and for discovery (where is the reverse tunnel running, in this case, `3024`). For those using ACME, port `443` is also required. Port `3024 `is used to establish a connection to the auth server through the proxy.
-
-To enable multiplexing so only one port is used, simply set the `tunnel_listen_addr` the same as the
-`web_listen_addr` respectively within the `proxy_service`.  Teleport will automatically recognize using the same port and enable multiplexing. If the log setting is set to DEBUG you will see multiplexing enabled in the server log.
-
-```txt
-DEBU [PROC:1]    Setup Proxy: Reverse tunnel proxy and web proxy listen on the same port, multiplexing is on. service/service.go:1944
-```
-
-<Admonition
-  type="tip"
-  title="Load Balancers"
->
-  The setup above also works even if the cluster uses multiple proxies behind a load balancer (LB) or a DNS entry with multiple values.  This works by the node establishing a tunnel to *every* proxy. This requires that an LB
-  uses a round-robin or a similar balancing algorithm. Do not use sticky load balancing algorithms (a.k.a. "session affinity") with Teleport proxies.
-</Admonition>
-
-## Next Steps
-
-### Untrusted auth servers
-
-Teleport nodes use the HTTPS protocol to offer the join tokens to the auth
-server running on `10.0.10.5` in the example above. In a zero-trust environment,
-you must assume that an attacker can hijack the IP address of the auth server
-e.g. `10.0.10.5`.
-
-To prevent this from happening, you need to supply every new node with an
-additional bit of information about the auth server. This technique is called
-"CA Pinning". It works by asking the auth server to produce a "CA Pin". 
-CA Pin is a hash value of the SPKI header in a certificate. An attacker can't
-easilly forge a matching private key.
-
-On the auth server:
-
-```code
-$ tctl status
-
-# Cluster  staging.example.com
-# User CA  never updated
-# Host CA  never updated
-# CA pin   sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1
-```
-
-The CA pin at the bottom needs to be passed to the new nodes when they're
-starting for the first time, i.e. when they join a cluster:
-
-Via CLI:
-
-```code
-$ sudo teleport start \
-   --roles=node \
-   --token=(=presets.tokens.first=) \
-   --ca-pin=sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1 \
-   --auth-server=10.12.0.6:3025
-```
-
-or via `/etc/teleport.yaml` on a node:
-
-```yaml
-teleport:
-  auth_token: "(=presets.tokens.first=)"
-  ca_pin: "sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
-  auth_servers:
-    - "10.12.0.6:3025"
-```
-
-<Admonition
-  type="warning"
-  title="Warning"
->
-  If a CA pin is not provided, the Teleport Node will join a
-  cluster but it will print a `WARN` message (warning) into its standard error output.
-</Admonition>
-
-<Admonition
-  type="warning"
-  title="Warning"
->
-  The CA pin becomes invalid if a Teleport administrator
-  performs the CA rotation by executing
-  [`tctl auth rotate`](../reference/cli.mdx#tctl-auth-rotate) .
-</Admonition>
-
-### Insecure: Static tokens
-
+<Details scope={["oss","enterprise"]} title="An insecure alternative: static tokens" scopeOnly={true} opened>
 <Admonition type="warning">
 Use short-lived tokens instead of long-lived static tokens.
-Static tokens are easier to steal, guess or leak.
+Static tokens are easier to steal, guess, and leak.
 </Admonition>
 
 Static tokens are defined ahead of time by an administrator and stored in the
@@ -262,3 +92,203 @@ auth_service:
     # new auth servers are stored in /path/to/tokenfile
     - "auth:/path/to/tokenfile"
 ```
+</Details>
+
+### Using Node invitation tokens
+
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} scopeOnly={true} label="Self Hosted">
+Execute one of the following commands on a new Node to add it to a cluster:
+
+```code
+# Adding an SSH Node to the cluster:
+$ sudo teleport start --roles=node --token=(=presets.tokens.first=) --auth-server=10.0.10.5
+
+# Adding a new regular SSH Node using Teleport Node Tunneling:
+$ sudo teleport start --roles=node --token=(=presets.tokens.first=) --auth-server=teleport-proxy.example.com:3080
+
+# Adding a new Proxy Service to the cluster:
+$ sudo teleport start --roles=proxy --token=(=presets.tokens.first=) --auth-server=10.0.10.5
+```
+</TabItem>
+<TabItem scope={["cloud"]} scopeOnly={true} label="Teleport Cloud">
+Execute the following command on a new Node to add it to a cluster. Replace
+`mytenant.teleport.sh` with the domain name of your Teleport Cloud tenant.
+
+```code
+# Adding an SSH Node to the cluster:
+$ sudo teleport start --roles=node --token=(=presets.tokens.first=) --auth-server=mytenant.teleport.sh
+```
+
+</TabItem>
+</Tabs>
+
+
+As new Nodes come online, they start sending ping requests every few seconds to
+the Auth Service. This allows users to explore cluster membership and size:
+
+```code
+$ tctl nodes ls
+
+Node Name     Node ID                                  Address            Labels
+---------     -------                                  -------            ------
+turing        d52527f9-b260-41d0-bb5a-e23b0cfe0f8f     10.1.0.5:3022      distro:ubuntu
+dijkstra      c9s93fd9-3333-91d3-9999-c9s93fd98f43     10.1.0.6:3022      distro:debian
+```
+
+{/* TODO: This lengthy Details box should be a subsection. Using the Details box
+as a workaround until we have a way to control the visibility of subsections
+using the scope switcher */}
+
+<Details scope={["oss", "enterprise"]} scopeOnly={true} title="Node Tunneling" opened>
+Teleport Node Tunneling lets you add a remote Node to an existing Teleport Cluster through a tunnel.
+This can be useful for IoT applications or for managing a couple of servers in a different network.
+
+<Admonition type="note">
+We recommend setting up a [Trusted Cluster](../admin/trustedclusters.mdx) if you
+have workloads split across different networks or clouds.
+</Admonition>
+
+To connect a Node to your cluster via Node Tunneling, use `tctl` to create a
+single-use token for a Node. Instead of supplying the IP of the Auth Service for
+the `--auth-server` flag, you will use the URL of the Proxy Service.
+
+In the example below, we've replaced the auth server IP with the Proxy's web
+endpoint `teleport-proxy.example.com:3080`.
+
+```code
+$ tctl tokens add --type=node | grep -oP '(?<=token:\s).*' > token.file
+
+# This will save the token to a file.
+# Run this on the new node to join the cluster:
+$ sudo teleport start --roles=node --token=/path/to/token.file --auth-server=teleport-proxy.example.com:3080
+```
+
+Using the ports in Teleport's default configuration, the Node needs to be able
+to talk to ports `3080` and `3024` on the Proxy Service. Port `3080` is used to
+initially fetch the credentials (SSH and TLS certificates) and for discovering
+the reverse tunnel. Port `3024 `is used to establish a connection to the Auth
+Service through the Proxy.
+
+For those using ACME, port `443` is also required. 
+
+To enable multiplexing so only one port is used, simply set the
+`tunnel_listen_addr` to the same value as `web_listen_addr` within the
+`proxy_service` section of your configuration file. Teleport will automatically
+recognize that the Proxy Service is using the same port for both addresses and
+enable multiplexing.
+
+If your log setting is set to DEBUG, you will see multiplexing enabled in the
+server log.
+
+```txt
+DEBU [PROC:1]    Setup Proxy: Reverse tunnel proxy and web proxy listen on the same port, multiplexing is on. service/service.go:1944
+```
+
+<Admonition
+  type="tip"
+  title="Load Balancers"
+>
+
+  The setup above also works even if the cluster uses multiple Proxy Service
+  instances behind a load balancer (LB) or a DNS entry with multiple values. In
+  this case, the Node establishes a tunnel to every proxy.
+  
+  This requires that an LB
+  uses a round-robin or a similar balancing algorithm. Do not use sticky load balancing algorithms (a.k.a. "session affinity") with Teleport Proxy Service instances.
+</Admonition>
+
+</Details>
+
+## Revoking invitations
+
+Tokens used for joining Nodes to a cluster can be revoked before they are used.
+To see a list of outstanding tokens, run this command:
+
+```code
+$ tctl tokens ls
+
+# Token                                Role       Expiry Time (UTC)
+# -----                                ----       -----------------
+# (=presets.tokens.first=)     Proxy      never
+# (=presets.tokens.second=)     Node       17 May 16 03:51 UTC
+# (=presets.tokens.third=)     Signup     17 May 16 04:24 UTC
+```
+
+<Admonition type="tip" title="Signup tokens">
+
+The output of `tctl tokens ls` includes tokens used for adding users alongside
+tokens used for adding Nodes to your cluster.
+
+</Admonition>
+
+In this example, the first token has a `never` expiry date because it is a
+static token configured via a config file.
+
+The token with the `Node` role was generated to invite a new Node to this
+cluster. And the third token was generated to invite a new user to sign up.
+
+The latter two tokens can be deleted (revoked) via the `tctl tokens
+del` command:
+
+```code
+$ tctl tokens del (=presets.tokens.first=)
+# Token (=presets.tokens.first=) has been deleted
+```
+
+## Untrusted Auth Servers
+
+Teleport Nodes use the HTTPS protocol to offer an invite token to the Auth Service.
+In a zero-trust environment, you must assume that an attacker can hijack the IP
+address of the Auth Service.
+
+To prevent this from happening, you need to supply every new Node with an
+additional bit of information about the Auth Service. This technique is called
+**CA pinning**. It works by asking the Auth Service to produce a CA pin, a hash
+value of the SPKI header in a certificate. This way, an attacker cannot easily
+forge a matching private key.
+
+Retrieve the CA pin of the Auth Service:
+
+```code
+$ tctl status
+
+# Cluster  staging.example.com
+# User CA  never updated
+# Host CA  never updated
+# CA pin   sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1
+```
+
+The CA pin at the bottom needs to be passed to new Nodes when they're
+starting for the first time, i.e. when they join a cluster. Here is an
+example of running `teleport start` on a Node with a CA pin:
+
+```code
+$ sudo teleport start \
+   --roles=node \
+   --token=(=presets.tokens.first=) \
+   --ca-pin=sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1 \
+   --auth-server=10.12.0.6:3025
+```
+
+You can also supply a CA pin by modifying `/etc/teleport.yaml` on a Node:
+
+```yaml
+teleport:
+  auth_token: "(=presets.tokens.first=)"
+  ca_pin: "sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
+  auth_servers:
+    - "10.12.0.6:3025"
+```
+
+<Admonition
+  type="warning"
+  title="Warnings"
+>
+  - If a CA pin is not provided, the Teleport Node will join a cluster but it will
+  print a `WARN` message (warning).
+  - The CA pin becomes invalid if a Teleport administrator
+  performs the CA rotation by executing
+  [`tctl auth rotate`](../reference/cli.mdx#tctl-auth-rotate) .
+</Admonition>
+

--- a/docs/pages/setup/admin/github-sso.mdx
+++ b/docs/pages/setup/admin/github-sso.mdx
@@ -1,112 +1,146 @@
 ---
-title: GitHub SSO
+title: Set up Single Sign-On with GitHub
 description: Setting up Github SSO
 videoBanner: XjgN2WWFCX8
 ---
 
-This guide explains how to set up Github SSO with Open Source, Enterprise Teleport,
-self-hosted or cloud.
+This guide explains how to set up Github Single Sign On (SSO) for Teleport.
 
 ## Prerequisites
 
-- Installed [Teleport](../../getting-started.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
-- [Tctl admin tool](https://goteleport.com/teleport/download) >= (=teleport.version=)
+<Tabs>
+<TabItem scope={["oss"]} label="Self-Hosted">
+- Install Teleport and the `tctl` admin tool version >= (=teleport.version=).
+
+  See [Installation](../../installation.mdx) for details.
+
+- Create and register a GitHub OAuth App. To do so, follow the instructions in
+  GitHub's documentation.
+
+  [Creating an OAuth App](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app)
+
+  Ensure that your OAuth App's "Authentication callback URL" is
+  `https://PROXY_ADDRESS/v1/webapi/github/`, where `PROXY_ADDRESS` is the public
+  address of the Teleport Proxy Service. 
+</TabItem>
+<TabItem
+  scope={["enterprise"]} label="Enterprise">
+- Install Teleport and the `tctl` admin tool version >= (=teleport.version=).
+
+  To download Teleport Enterprise, visit the
+  [customer portal](https://dashboard.gravitational.com/web/login).
+  
+- Create and register a GitHub OAuth App. To do so, follow the instructions in
+  GitHub's documentation.
+
+  [Creating an OAuth App](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app)
+
+  Ensure that your OAuth App's "Authentication callback URL" is
+  `https://PROXY_ADDRESS/v1/webapi/github/`, where `PROXY_ADDRESS` is the public
+  address of the Teleport Proxy Service. 
+</TabItem>
+<TabItem scope={["cloud"]}
+  label="Cloud">
+
+- Sign up for a Teleport Cloud account. If you do not have one, visit the
+  [sign up page](https://goteleport.com/signup/) to begin your free trial.
+
+- Create and register a GitHub OAuth App. To do so, follow the instructions in GitHub's documentation. 
+
+  [Creating an OAuth App](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app)
+
+  Ensure that your OAuth App's "Authentication callback URL" is
+  `https://PROXY_ADDRESS/v1/webapi/github/`, where `PROXY_ADDRESS` is the domain
+  name of your Teleport Cloud tenant (e.g., mytenant.teleport.sh).
+
+</TabItem>
+</Tabs>
 
 (!docs/pages/includes/tctl.mdx!)
 
-<Admonition type="note">
-For cloud, login with a teleport user with editor privileges:
-```code
-# tsh logs you in and receives short-lived certificates
-$ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
-# try out the connection
-$ tctl get nodes
-```
-</Admonition>
+## Step 1/2. Create a GitHub authentication connector
 
-## Step 1/2. Create Github connector
-
-Define a Github connector:
+Define a GitHub authentication connector by creating a file called `github.yaml`
+with the following content:
 
 ```yaml
-# Create a file called github.yaml:
 kind: github
 version: v3
 metadata:
-  # connector name that will be used with `tsh --auth=github login`
+  # Connector name that will be used with `tsh --auth=github login`
   name: github
 spec:
-  # Client ID of Github OAuth app
+  # Client ID of your GitHub OAuth App
   client_id: <client-id>
-  # Client secret of Github OAuth app
+  # Client secret of your GitHub OAuth App
   client_secret: <client-secret>
-  # Connector display name that will be shown on web UI login screen
-  display: Github
+  # Connector display name that will be shown on the Web UI login screen
+  display: GitHub
   # Callback URL that will be called after successful authentication
   redirect_url: https://<proxy-address>/v1/webapi/github/callback
   # Mapping of org/team memberships onto allowed logins and roles
   teams_to_logins:
-    - organization: octocats # Github organization name
-      team: admins # Github team name within that organization
-      # maps octocats/admins to teleport role access
+    - organization: octocats # GitHub organization name
+      team: admins # GitHub team name within that organization
+      # Maps octocats/admins to the "access" Teleport role
       logins:
         - access
 ```
 
-To obtain a client ID and client secret, please follow Github documentation on
-how to [create and register an OAuth app](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/).
+The values of `client_id`, `client_secret`, and `redirect_url` come from the
+GitHub OAuth App you created earlier.
 
-Be sure to set the "Authorization callback URL" to the same value as `redirect_url` in the resource spec.
+Teleport will request only the `read:org` OAuth scope. Read more about OAuth scopes in GitHub's documentation:
 
-Teleport will request only the `read:org` OAuth scope, you can read more about
-[Github OAuth scopes](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+[Github OAuth scopes](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/)
 
-Finally, create the connector using [`tctl`](../reference/cli.mdx#tctl)
-[resource](../reference/resources.mdx) management command:
+Finally, create the connector using `tctl`:
 
 ```code
 $ tctl create github.yaml
 ```
 
 <Admonition type="tip">
-  When going through the Github authentication flow for the first time,
+  When going through the GitHub authentication flow for the first time,
   the application must be granted access to all organizations that are
   present in the "teams to logins" mapping, otherwise Teleport will not be
-  able to determine team memberships for these orgs.
+  able to determine team memberships for these organizations.
 </Admonition>
 
 ## Step 2/2. Configure authentication preference
 
-Configure Teleport Auth Service Github for authentication:
+Configure the Teleport Auth Service to enable the GitHub authentication
+connector.
 
-<Tabs>
-  <TabItem label="Static Config (self-hosted)">
-  ```yaml
-  # Snippet from /etc/teleport.yaml
-  auth_service:
-    authentication:
-      type: github
-  ```
-  </TabItem>
-  <TabItem label="Dynamic resources (all editions)">
-  Create a file `cap.yaml`:
-  ```yaml
-  kind: cluster_auth_preference
-  metadata:
-    name: cluster-auth-preference
-  spec:
+Create a file called `cap.yaml` with the following content:
+
+```yaml
+kind: cluster_auth_preference
+metadata:
+  name: cluster-auth-preference
+spec:
+  type: github
+  webauthn:
+    rp_id: 'example.teleport.sh'
+version: v2
+```
+
+Create the resource:
+
+```code
+$ tctl create -f cap.yaml
+```
+
+<Details scope={["enterprise", "oss"]} scopeOnly={true} opened title="Static configuration file">
+
+You can also edit your Teleport configuration file to include the following:
+
+```yaml
+# Snippet from /etc/teleport.yaml
+auth_service:
+  authentication:
     type: github
-    webauthn:
-      rp_id: 'example.teleport.sh'
-  version: v2
-  ```
+```
+</Details>
 
-  Create a resource:
-
-  ```code
-  $ tctl create -f cap.yaml
-  ```
-  </TabItem>
-</Tabs>
-
-You can now login with Teleport using `github` SSO.
+You can now log in with Teleport using GitHub SSO.

--- a/docs/pages/setup/admin/trustedclusters.mdx
+++ b/docs/pages/setup/admin/trustedclusters.mdx
@@ -31,7 +31,7 @@ This guide's focus is on more in-depth coverage of trusted clusters features and
   type="tip"
   title="Teleport Node Tunneling"
 >
-  If you have a large number of devices on different networks, such as managed IoT devices or a couple of nodes on a different network you can utilize the [Teleport Node Tunneling](./adding-nodes.mdx#adding-a-node-located-behind-nat).
+  If you have a large number of devices on different networks, such as managed IoT devices or a couple of nodes on a different network you can utilize [Teleport Node Tunneling](./adding-nodes.mdx).
 </Admonition>
 
 ## Introduction

--- a/docs/pages/setup/deployments/aws-terraform.mdx
+++ b/docs/pages/setup/deployments/aws-terraform.mdx
@@ -758,7 +758,7 @@ auth_servers:
 ### Joining nodes via Teleport IoT/node tunneling
 
 To join Teleport nodes from outside the same VPC, you will either need to investigate VPC peering/gateways (out of scope
-for this document) or join your nodes using [Teleport's node tunneling](../admin/adding-nodes.mdx#adding-a-node-located-behind-nat) functionality.
+for this document) or join your nodes using [Teleport's node tunneling](../admin/adding-nodes.mdx) functionality.
 
 With this method, you can join the nodes using the public facing proxy address - `teleport.example.com:443` for our
 example.


### PR DESCRIPTION
Backports #10674

* Add Cloud-specific instructions to two guides

Ensure that users of a particular scope don't see irrelevant info

See #10633

GitHub SSO guide
 - Edit the tctl partial to show only scope-relevant info.
 - Use tabs in the Prerequisites
 - Light edits for clarity

Adding Nodes
- Use Tabs for prerequisites
- Move sections specific to self-hosted deployments into Details
  boxes that are hidden for Cloud users
- Use Tabs components to offer Cloud-specific alternatives to
  examples of commands that presuppose a self-hosted deployment
- Misc clarity edits

* Respond to PR feedback

* Fix linter issues