### PR TITLE
Use the correct arch for 64-bit ARM RPM packages and 32-bit ARM packages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5014,11 +5014,15 @@ steps:
       - |
         # write config files
         mkdir -p /go/reprepro/teleport/conf /go/reprepro/teleport/public
+        # we have to keep listing "arm" even though it's not a real debian arch
+        # because we have released packages for it that are currently in the
+        # repo bucket, and reprepro will error out if it's told to includedeb a
+        # package for an architecture that's not in its configuration
         cat << EOF > /go/reprepro/teleport/conf/distributions
         Origin: teleport
         Label: teleport
         Codename: stable
-        Architectures: i386 amd64 arm arm64
+        Architectures: i386 amd64 arm armhf arm64
         Components: main
         Description: apt repository for teleport
         SignWith: 6282C411
@@ -5084,6 +5088,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 183682ce2c54c6591325843aea0667b442c2232de2f3174ced1761333a5e8f3f
+hmac: 67c18f88ef207c41cb5a2ca671ef691be25353d179cd2a2268ed5b50893b5c38
 
 ...


### PR DESCRIPTION
Similarly to what we currently do for `amd64`, the RPM ecosystem actually uses `aarch64` instead of `arm64`, and our 32-bit ARM builds are for `linux-gnueabihf`, so the correct arch there is `armhf` for DEB and `armv7hl` for RPM.

As Houston expects a specific suffix to identify which files to download, this PR alters build-package such that the arm packages always have a `arm64.foo` or `arm.foo` suffix even if the actual internal arch might be different; in addition, we need to tell our `reprepro` invocation to start building a repository index for the `armhf` arch (while also allowing `arm`, until those packages are deleted from the S3 bucket) - `createrepo` will create indices for all encountered architectures so no changes are needed there.

All of our `{amd64, 386, arm, arm64} x {deb, rpm}` matrix is confirmed building and installing correctly in the various architectures of `ubuntu:18.04` and `centos:centos7` docker containers except for 32-bit ARM, for which the centos container seems to be broken out of the box - not even `yum` works - but our package installs fine in `fedora:35`.