### PR TITLE
Add FIDO2 passwordless login and registration to `tsh`

### DIFF
--- a/lib/auth/webauthn/login.go
+++ b/lib/auth/webauthn/login.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"sort"
 	"time"
 
 	"github.com/duo-labs/webauthn/protocol"
@@ -81,6 +82,17 @@ func (f *loginFlow) begin(ctx context.Context, user string, passwordless bool) (
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+
+		// Sort non-resident keys first, which may cause clients to favor them for
+		// MFA in some scenarios (eg, tsh).
+		sort.Slice(devices, func(i, j int) bool {
+			dev1, dev2 := devices[i], devices[j]
+			web1, web2 := dev1.GetWebauthn(), dev2.GetWebauthn()
+			resident1 := web1 != nil && web1.ResidentKey
+			resident2 := web2 != nil && web2.ResidentKey
+			return !resident1 && resident2
+		})
+
 		u = newWebUser(user, webID, true /* credentialIDOnly */, devices)
 
 		// Let's make sure we have at least one registered credential here, since we

--- a/lib/auth/webauthn/register_test.go
+++ b/lib/auth/webauthn/register_test.go
@@ -125,7 +125,6 @@ func TestRegistrationFlow_BeginFinish(t *testing.T) {
 func TestRegistrationFlow_Begin_excludeList(t *testing.T) {
 	const user = "llama"
 	const rpID = "localhost"
-	const origin = "https://localhost"
 
 	dev1ID := []byte{1, 1, 1} // U2F
 	web1ID := []byte{1, 1, 2} // WebAuthn / MFA

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -129,8 +129,10 @@ func fido2Login(
 	filter := func(dev FIDODevice, info *deviceInfo) (bool, error) {
 		switch {
 		case uv && !info.uvCapable():
+			log.Debugf("FIDO2: Device %v: filtered due to lack of UV", info.path)
 			return false, nil
 		case passwordless && !info.rk:
+			log.Debugf("FIDO2: Device %v: filtered due to lack of RK", info.path)
 			return false, nil
 		case len(allowedCreds) == 0: // Nothing else to check
 			return true, nil
@@ -148,10 +150,13 @@ func fido2Login(
 		if appID == "" {
 			return false, nil
 		}
-		_, err = dev.Assertion(appID, ccdHash[:], allowedCreds, pin, &libfido2.AssertionOpts{
+		if _, err := dev.Assertion(appID, ccdHash[:], allowedCreds, pin, &libfido2.AssertionOpts{
 			UP: libfido2.False,
-		})
-		return err == nil, nil
+		}); err != nil {
+			log.Debugf("FIDO2: Device %v: filtered due to lack of allowed credential", info.path)
+			return false, nil
+		}
+		return true, nil
 	}
 
 	deviceCallback := func(dev FIDODevice, info *deviceInfo, pin string) error {
@@ -398,6 +403,7 @@ func fido2Register(
 	filter := func(dev FIDODevice, info *deviceInfo) (bool, error) {
 		switch {
 		case (plat && !info.plat) || (rrk && !info.rk) || (uv && !info.uvCapable()):
+			log.Debugf("FIDO2: Device %v: filtered due to options", info.path)
 			return false, nil
 		case len(excludeList) == 0:
 			return true, nil
@@ -411,6 +417,7 @@ func fido2Register(
 		case errors.Is(err, libfido2.ErrNoCredentials):
 			return true, nil
 		case err == nil:
+			log.Debugf("FIDO2: Device %v: filtered due to presence of excluded credential", info.path)
 			return false, nil
 		default: // unexpected error
 			return false, trace.Wrap(err)
@@ -630,7 +637,7 @@ func findSuitableDevices(filter deviceFilterFunc, knownPaths map[string]struct{}
 		}
 		log.Debugf("FIDO2: Info for device %v: %#v", path, info)
 
-		di := makeDevInfo(info)
+		di := makeDevInfo(path, info)
 		switch ok, err := filter(dev, di); {
 		case err != nil:
 			return nil, trace.Wrap(err, "device %v: filter", path)
@@ -736,6 +743,7 @@ func selectDevice(ctx context.Context, devices []deviceWithInfo, deviceCallback 
 // Various fields match options under
 // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo.
 type deviceInfo struct {
+	path                           string
 	plat                           bool
 	rk                             bool
 	clientPinCapable, clientPinSet bool
@@ -747,8 +755,8 @@ func (di *deviceInfo) uvCapable() bool {
 	return di.uv || di.clientPinSet
 }
 
-func makeDevInfo(info *libfido2.DeviceInfo) *deviceInfo {
-	di := &deviceInfo{}
+func makeDevInfo(path string, info *libfido2.DeviceInfo) *deviceInfo {
+	di := &deviceInfo{path: path}
 	for _, opt := range info.Options {
 		// See
 		// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo.

--- a/lib/auth/webauthncli/u2f_register_test.go
+++ b/lib/auth/webauthncli/u2f_register_test.go
@@ -35,7 +35,6 @@ func TestRegister(t *testing.T) {
 	const rpID = "example.com"
 	const origin = "https://example.com"
 
-	// Prepare a few fake devices.
 	u2fKey, err := newFakeDevice("u2fkey" /* name */, "" /* appID */)
 	require.NoError(t, err)
 	registeredKey, err := newFakeDevice("regkey" /* name */, rpID /* appID */)
@@ -48,8 +47,17 @@ func TestRegister(t *testing.T) {
 			RPID: rpID,
 		},
 		Identity: &fakeIdentity{
-			User:    user,
-			Devices: []*types.MFADevice{registeredKey.mfaDevice},
+			User: user,
+			Devices: []*types.MFADevice{
+				// Fake a WebAuthn device record, as U2F devices are not excluded from registration.
+				{
+					Device: &types.MFADevice_Webauthn{
+						Webauthn: &types.WebauthnDevice{
+							CredentialId: registeredKey.key.KeyHandle,
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -361,6 +361,11 @@ type Config struct {
 
 	// ExtraProxyHeaders is a collection of http headers to be included in requests to the WebProxy.
 	ExtraProxyHeaders map[string]string
+
+	// Passwordless enables passwordless authentication for TeleportClient.
+	// Affects the TeleportClient.Login and, indirectly, RetryWithRelogin
+	// functions.
+	Passwordless bool
 }
 
 // CachePolicy defines cache policy for local clients
@@ -527,8 +532,8 @@ func (p *ProfileStatus) AppNames() (result []string) {
 	return result
 }
 
-// RetryWithRelogin is a helper error handling method,
-// attempts to relogin and retry the function once
+// RetryWithRelogin is a helper error handling method, attempts to relogin and
+// retry the function once.
 func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) error {
 	err := fn()
 	if err == nil {
@@ -545,9 +550,7 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) 
 	}
 	log.Debugf("Activating relogin on %v.", err)
 
-	// TODO(codingllama): Allow for the passwordless flag to drip down here?
-	//  We'd have to change it to a global flag, but that seems alright.
-	key, err := tc.Login(ctx, false /* pwdless */)
+	key, err := tc.Login(ctx)
 	if err != nil {
 		if trace.IsTrustError(err) {
 			return trace.Wrap(err, "refusing to connect to untrusted proxy %v without --insecure flag\n", tc.Config.SSHProxyAddr)
@@ -2461,10 +2464,11 @@ func (tc *TeleportClient) PingAndShowMOTD(ctx context.Context) (*webclient.PingR
 
 // Login logs the user into a Teleport cluster by talking to a Teleport proxy.
 //
+// If tc.Passwordless is set, then the passwordless authentication flow is used.
+//
 // The returned Key should typically be passed to ActivateKey in order to
 // update local agent state.
-//
-func (tc *TeleportClient) Login(ctx context.Context, pwdless bool) (*Key, error) {
+func (tc *TeleportClient) Login(ctx context.Context) (*Key, error) {
 	// Ping the endpoint to see if it's up and find the type of authentication
 	// supported, also show the message of the day if available.
 	pr, err := tc.PingAndShowMOTD(ctx)
@@ -2482,7 +2486,7 @@ func (tc *TeleportClient) Login(ctx context.Context, pwdless bool) (*Key, error)
 	var response *auth.SSHLoginResponse
 
 	switch authType := pr.Auth.Type; {
-	case pwdless: // Takes precedence over other methods if set.
+	case tc.Passwordless: // Takes precedence over other methods if set.
 		// Do a few sanity checks before obeying.
 		switch {
 		case authType != constants.Local:

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2586,7 +2586,7 @@ func (l pwdlessPrompt) PromptAdditionalTouch() error {
 }
 
 func (tc *TeleportClient) pwdlessLogin(ctx context.Context, pubKey []byte) (*auth.SSHLoginResponse, error) {
-	webClient, _, err := initClient(tc.WebProxyAddr, tc.InsecureSkipVerify, loopbackPool(tc.WebProxyAddr))
+	webClient, webURL, err := initClient(tc.WebProxyAddr, tc.InsecureSkipVerify, loopbackPool(tc.WebProxyAddr))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2611,14 +2611,9 @@ func (tc *TeleportClient) pwdlessLogin(ctx context.Context, pubKey []byte) (*aut
 		return nil, trace.BadParameter("passwordless: user verification requirement too lax (%v)", challenge.WebauthnChallenge.Response.UserVerification)
 	}
 
-	origin := tc.WebProxyAddr
-	if !strings.HasPrefix(origin, "https://") {
-		origin = "https://" + origin
-	}
 	prompt := pwdlessPrompt{Out: tc.Stderr}
-
 	fmt.Fprintln(tc.Stderr, "Tap your security key")
-	mfaResp, _, err := prompts.Webauthn(ctx, origin, tc.Username, challenge.WebauthnChallenge, prompt)
+	mfaResp, _, err := prompts.Webauthn(ctx, webURL.String(), tc.Username, challenge.WebauthnChallenge, prompt)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -173,9 +173,10 @@ func TestTeleportClient_Login_local(t *testing.T) {
 
 			tc, err := client.NewClient(cfg)
 			require.NoError(t, err)
+			tc.Passwordless = test.pwdless
 
 			clock.Advance(30 * time.Second)
-			_, err = tc.Login(ctx, test.pwdless)
+			_, err = tc.Login(ctx)
 			require.NoError(t, err)
 		})
 	}

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -159,7 +159,7 @@ func newMFAAddCommand(parent *kingpin.CmdClause) *mfaAddCommand {
 	c.Flag("type", fmt.Sprintf("Type of the new MFA device (%s)", strings.Join(defaultDeviceTypes, ", "))).
 		StringVar(&c.devType)
 	if wancli.IsFIDO2Available() {
-		c.Flag("pwdless", "Allow passwordless logins").BoolVar(&c.pwdless)
+		c.Flag("allow-passwordless", "Allow passwordless logins").BoolVar(&c.pwdless)
 	}
 	return c
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -45,6 +45,7 @@ import (
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth"
+	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	"github.com/gravitational/teleport/lib/benchmark"
 	"github.com/gravitational/teleport/lib/client"
 	dbprofile "github.com/gravitational/teleport/lib/client/db"
@@ -292,6 +293,9 @@ type CLIConf struct {
 
 	// JoinMode is the participant mode someone is joining a session as.
 	JoinMode string
+
+	// Pwdless instructs tsh to do passwordless login.
+	Pwdless bool
 
 	// displayParticipantRequirements is set if verbose participant requirement information should be printed for moderated sessions.
 	displayParticipantRequirements bool
@@ -551,6 +555,9 @@ func Run(args []string, opts ...cliOption) error {
 	login.Arg("cluster", clusterHelp).StringVar(&cf.SiteName)
 	login.Flag("browser", browserHelp).StringVar(&cf.Browser)
 	login.Flag("kube-cluster", "Name of the Kubernetes cluster to login to").StringVar(&cf.KubernetesCluster)
+	if wancli.IsFIDO2Available() {
+		login.Flag("pwdless", "Do passwordless login").BoolVar(&cf.Pwdless)
+	}
 	login.Alias(loginUsageFooter)
 
 	// logout deletes obtained session certificates in ~/.tsh
@@ -976,7 +983,7 @@ func onLogin(cf *CLIConf) error {
 	// -i flag specified? save the retrieved cert into an identity file
 	makeIdentityFile := (cf.IdentityFileOut != "")
 
-	key, err := tc.Login(cf.Context)
+	key, err := tc.Login(cf.Context, cf.Pwdless)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Passwordless login is enabled by the global `--pwdless` flag. Registration gets a new prompt and an `--allow-passwordless` flag.

UX messages were tweaked to follow the descriptions on [RFD 53: Passwordless FIDO2](https://github.com/gravitational/teleport/blob/master/rfd/0053-passwordless-fido2.md#ux).

Passwordless login requires two touches for all devices (both PIN and biometric). I'd like to get it down to a single touch, at least for the most common situations, but that'll be a follow up to this work.

Passwordless support requires `tsh` to be compiled with the `libfido2` tag, try `go build -tags=libfido2 ./tool/tsh`.

#9160