### PR TITLE
Remove potentially confusing EOF line from snippet

### DIFF
--- a/docs/pages/api/getting-started.mdx
+++ b/docs/pages/api/getting-started.mdx
@@ -5,7 +5,8 @@ description: Get started working with the Teleport API programmatically using Go
 
 # Getting Started
 
-In this getting started guide we will use the Teleport API Go client to connect to a Teleport Node configured as an Auth server.
+In this getting started guide we will use the Teleport API Go client to connect
+to a Teleport Node configured as an Auth Server.
 
 Here are the steps we'll walkthrough:
 
@@ -98,7 +99,6 @@ func main() {
 	log.Printf("Example server response: %s", resp)
 	log.Printf("Server version: %s", resp.ServerVersion)
 }
-EOF
 ```
 
 Now you can run the program and connect the client to the Teleport Auth Server to fetch the server version.


### PR DESCRIPTION
Our API getting started guide includes a go snippet that ends with
"EOF," which is not a Go keyword. If the reader isn't familiar with
Go but wants to follow this guide, the Go compiler will return a syntax
error.

This change puts "EOF" in a comment so this won't happen.

Requires a backport to v9 and v7 but not v8, since this change was made first in response to a backport PR review (#11044).