### PR TITLE
Remove legacy JSON API for host certs

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -969,10 +969,7 @@ func (s *APIServer) registerUsingToken(auth ClientI, w http.ResponseWriter, r *h
 		return nil, trace.Wrap(err)
 	}
 
-	// Teleport 8 clients are still expecting the legacy JSON format.
-	// Teleport 9 clients handle both legacy and new.
-	// TODO(zmb3) return certs directly in Teleport 10
-	return LegacyCertsFromProto(certs), nil
+	return certs, nil
 }
 
 type registerNewAuthServerReq struct {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -557,14 +557,7 @@ func (c *Client) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 		return nil, trace.Wrap(err)
 	}
 
-	// If we got certs, we're done, however, we may be talking to a Teleport 9 or earlier server,
-	// which still sends back the legacy JSON format.
-	if len(certs.SSH) > 0 && len(certs.TLS) > 0 {
-		return &certs, nil
-	}
-
-	// DELETE IN 10.0.0 (zmb3)
-	return UnmarshalLegacyCerts(out.Bytes())
+	return &certs, nil
 }
 
 // RegisterNewAuthServer is used to register new auth server with token

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -19,7 +19,6 @@ package auth
 import (
 	"context"
 	"crypto/x509"
-	"encoding/json"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
@@ -520,40 +519,4 @@ func ReRegister(params ReRegisterParams) (*Identity, error) {
 	}
 
 	return ReadIdentityFromKeyPair(params.PrivateKey, certs)
-}
-
-// LegacyCerts is equivalent to proto.Certs, but uses
-// JSON keys expected by old clients (7.x and earlier)
-// DELETE in 9.0.0 (Joerger/zmb3)
-type LegacyCerts struct {
-	SSHCert    []byte   `json:"cert"`
-	TLSCert    []byte   `json:"tls_cert"`
-	TLSCACerts [][]byte `json:"tls_ca_certs"`
-	SSHCACerts [][]byte `json:"ssh_ca_certs"`
-}
-
-// LegacyCertsFromProto converts proto.Certs to LegacyCerts.
-// DELETE in 10.0.0 (Joerger/zmb3)
-func LegacyCertsFromProto(c *proto.Certs) *LegacyCerts {
-	return &LegacyCerts{
-		SSHCert:    c.SSH,
-		TLSCert:    c.TLS,
-		SSHCACerts: c.SSHCACerts,
-		TLSCACerts: c.TLSCACerts,
-	}
-}
-
-// UnmarshalLegacyCerts unmarshals the a legacy certs response as proto.Certs.
-// DELETE in 10.0.0 (Joerger/zmb3)
-func UnmarshalLegacyCerts(bytes []byte) (*proto.Certs, error) {
-	var lc LegacyCerts
-	if err := json.Unmarshal(bytes, &lc); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &proto.Certs{
-		SSH:        lc.SSHCert,
-		TLS:        lc.TLSCert,
-		TLSCACerts: lc.TLSCACerts,
-		SSHCACerts: lc.SSHCACerts,
-	}, nil
 }

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -434,12 +434,5 @@ func HostCredentials(ctx context.Context, proxyAddr string, insecure bool, req t
 		return nil, trace.Wrap(err)
 	}
 
-	// If we got certs, we're done, however, we may be talking to a Teleport 9 or earlier server,
-	// which still sends back the legacy JSON format.
-	if len(certs.SSH) > 0 && len(certs.TLS) > 0 {
-		return &certs, nil
-	}
-
-	// DELETE IN 10.0.0 (zmb3)
-	return auth.UnmarshalLegacyCerts(resp.Bytes())
+	return &certs, nil
 }

--- a/lib/client/weblogin_test.go
+++ b/lib/client/weblogin_test.go
@@ -24,8 +24,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 
 	"github.com/stretchr/testify/require"
 )
@@ -47,7 +47,7 @@ func TestPlainHttpFallback(t *testing.T) {
 				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(auth.LegacyCerts{})
+				json.NewEncoder(w).Encode(proto.Certs{})
 			},
 			actionUnderTest: func(ctx context.Context, addr string, insecure bool) error {
 				_, err := HostCredentials(ctx, addr, insecure, types.RegisterUsingTokenRequest{})

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2347,10 +2347,7 @@ func (h *Handler) hostCredentials(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	// Teleport 8 clients are still expecting the legacy JSON format.
-	// Teleport 9 clients handle both legacy and new.
-	// TODO(zmb3) return certs directly in Teleport 10
-	return auth.LegacyCertsFromProto(certs), nil
+	return certs, nil
 }
 
 // createSSHCert is a web call that generates new SSH certificate based


### PR DESCRIPTION
This is a follow up to e256170d6053114944f995dd47aa195b202f9e3b.
Now that Teleport 9 is out, we can remove the last traces of
this API for Teleport 10.