### PR TITLE
feat: add support to configure Domain Wildcard in certificate request

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference/teleport-cluster.mdx
+++ b/docs/pages/kubernetes-access/helm/reference/teleport-cluster.mdx
@@ -585,6 +585,43 @@ Setting `highAvailability.certManager.addCommonName` to `true` will instruct `ce
   </TabItem>
 </Tabs>
 
+### `highAvailability.certManager.addDomainWildcard`
+
+| Type | Default value | Can be used in `custom` mode? | `teleport.yaml` equivalent |
+| - | - | - | - |
+| `bool` | `true` | ❌ | `proxy_service.https_keypairs` (to provide your own certificates) |
+
+Setting `highAvailability.certManager.addDomainWildcard` to `false` will not set the domain wildcard field in the certificate signing request to the issuing CA.
+This is useful, if you can't use DNS-01 challenge.
+
+<Admonition type="note" title="Enabling common name field">
+    You must install and configure `cert-manager` in your Kubernetes cluster yourself.
+
+    See the [cert-manager Helm install instructions](https://cert-manager.io/docs/installation/kubernetes/#option-2-install-crds-as-part-of-the-helm-release)
+    and the relevant sections of the [AWS](../guides/aws.mdx#step-47-install-and-configure-cert-manager) and [GCP](../guides/gcp.mdx#step-47-install-and-configure-cert-manager) guides for more information.
+</Admonition>
+
+<Tabs>
+    <TabItem label="values.yaml">
+        ```yaml
+        highAvailability:
+        certManager:
+        enabled: true
+        addCommonName: true
+        addDomainWildcard: true
+        issuerName: letsencrypt-production
+        ```
+    </TabItem>
+    <TabItem label="--set">
+        ```code
+        $ --set highAvailability.certManager.enabled=true \
+        --set highAvailability.certManager.addCommonName=true \
+        --set highAvailability.certManager.addDomainWildcard=true \
+        --set highAvailability.certManager.issuerName=letsencrypt-production
+        ```
+    </TabItem>
+</Tabs>
+
 ### `highAvailability.certManager.issuerName`
 
 | Type | Default value | Can be used in `custom` mode? | `teleport.yaml` equivalent |

--- a/examples/chart/teleport-cluster/.lint/cert-manager-wildcard-off.yaml
+++ b/examples/chart/teleport-cluster/.lint/cert-manager-wildcard-off.yaml
@@ -1,0 +1,11 @@
+clusterName: test-cluster
+chartMode: custom
+highAvailability:
+  replicaCount: 3
+  certManager:
+    addCommonName: true
+    addDomainWildcard: false
+    enabled: true
+    issuerGroup: custom.cert-manager.io
+    issuerName: custom
+    issuerKind: CustomClusterIssuer

--- a/examples/chart/teleport-cluster/templates/certificate.yaml
+++ b/examples/chart/teleport-cluster/templates/certificate.yaml
@@ -13,7 +13,9 @@ spec:
   {{- end }}
   dnsNames:
   - {{ quote $domain }}
+  {{- if .Values.highAvailability.certManager.addDomainWildcard }}
   - {{ quote $domainWildcard }}
+  {{- end }}
   issuerRef:
     name: {{ required "highAvailability.certManager.issuerName is required in chart values" .Values.highAvailability.certManager.issuerName }}
     kind: {{ required "highAvailability.certManager.issuerKind is required in chart values" .Values.highAvailability.certManager.issuerKind }}

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -251,6 +251,11 @@
                             "type": "boolean",
                             "default": "false"
                         },
+                        "addDomainWildcard": {
+                            "$id": "#/properties/highAvailability/properties/certManager/properties/addDomainWildcard",
+                            "type": "boolean",
+                            "default": "true"
+                        },
                         "enabled": {
                             "$id": "#/properties/highAvailability/properties/certManager/properties/enabled",
                             "type": "boolean",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -145,6 +145,8 @@ highAvailability:
   certManager:
     # If set to true, a common name matching the cluster name will be set in the certificate signing request. This is mandatory for some CAs.
     addCommonName: false
+    # If set to false, the wildcard DNS SAN will not be added to the certificate signing request.
+    addDomainWildcard: true
     # If set to true, use cert-manager to get certificates for Teleport to use for TLS termination
     enabled: false
     # Name of the Issuer/ClusterIssuer to use for certs


### PR DESCRIPTION
Hi everyone,

## Introduction

this PR introduces the option to configure domain Wildcards in the certifacte request, when using the `cert-manager` option.

## Background

We are not using the Application Access of Teleport, therfore we have no need to for the `*.tele.example.com` for web apps.

Our `cert-manger` is configured for http-01 challenge and we have a custom ACME compatible endpoint. 

If we can configure the addition of the wildcard domain we dont need the use of DNS-01 challenge.


Partly releated to #7592