### PR TITLE
Allow `:` in label keys

### DIFF
--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -348,7 +348,7 @@ func MatchLabels(resource ResourceWithLabels, labels map[string]string) bool {
 }
 
 // LabelPattern is a regexp that describes a valid label key
-const LabelPattern = `^[a-zA-Z/.0-9_*-]+$`
+const LabelPattern = `^[a-zA-Z/.0-9_:*-]+$`
 
 var validLabelKey = regexp.MustCompile(LabelPattern)
 

--- a/api/types/resource_test.go
+++ b/api/types/resource_test.go
@@ -372,3 +372,26 @@ func TestResourcesWithLabels_ToMap(t *testing.T) {
 		})
 	}
 }
+
+func TestValidLabelKey(t *testing.T) {
+	for _, tc := range []struct {
+		label string
+		valid bool
+	}{
+		{
+			label: "1x/Y*_-",
+			valid: true,
+		},
+		{
+			label: "x:y",
+			valid: true,
+		},
+		{
+			label: "x\\y",
+			valid: false,
+		},
+	} {
+		isValid := IsValidLabelKey(tc.label)
+		require.Equal(t, tc.valid, isValid)
+	}
+}

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -423,7 +423,8 @@ func TestRDSTagsToLabels(t *testing.T) {
 		},
 	}
 	labels := rdsTagsToLabels(rdsTags)
-	require.Equal(t, map[string]string{"Name": "test", "Env": "dev"}, labels)
+	require.Equal(t, map[string]string{"Name": "test", "Env": "dev",
+		"aws:cloudformation:stack-id": "some-id"}, labels)
 }
 
 // TestDatabaseFromRedshiftCluster tests converting an Redshift cluster to a database resource.
@@ -451,10 +452,11 @@ func TestDatabaseFromRedshiftCluster(t *testing.T) {
 			Name:        "mycluster",
 			Description: "Redshift cluster in us-east-1",
 			Labels: map[string]string{
-				types.OriginLabel: types.OriginCloud,
-				labelAccountID:    "1234567890",
-				labelRegion:       "us-east-1",
-				"key":             "val",
+				types.OriginLabel:                 types.OriginCloud,
+				labelAccountID:                    "1234567890",
+				labelRegion:                       "us-east-1",
+				"key":                             "val",
+				"elasticbeanstalk:environment-id": "id",
 			},
 		}, types.DatabaseSpecV3{
 			Protocol: defaults.ProtocolPostgres,

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -86,7 +86,7 @@ func (s *ServicesSuite) TestCommandLabels(c *check.C) {
 	c.Assert(label.Command[0], check.Not(check.Equals), out["a"].GetCommand())
 }
 
-func (s *ServicesSuite) TestLabelKeyValidation(c *check.C) {
+func TestLabelKeyValidation(t *testing.T) {
 	tts := []struct {
 		label string
 		ok    bool
@@ -96,12 +96,12 @@ func (s *ServicesSuite) TestLabelKeyValidation(c *check.C) {
 		{label: "this-that", ok: true},
 		{label: "8675309", ok: true},
 		{label: "", ok: false},
-		{label: "spam:eggs", ok: false},
+		{label: "spam:eggs", ok: true},
 		{label: "cats dogs", ok: false},
 		{label: "wut?", ok: false},
 	}
 	for _, tt := range tts {
-		c.Assert(types.IsValidLabelKey(tt.label), check.Equals, tt.ok, check.Commentf("tt=%+v", tt))
+		require.Equal(t, types.IsValidLabelKey(tt.label), tt.ok)
 	}
 }
 


### PR DESCRIPTION
This fixes #11196 and #11259