### PR TITLE
Upgrade to Go 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
    <img src="https://goteleport.com/blog/images/2020/gravitational-is-teleport-header.png" width=750/>
    <div align="center" style="padding: 25px">
       <a href="https://goteleport.com/docs/">
-      <img src="https://img.shields.io/badge/Teleport-8.0-651FFF.svg" />
+      <img src="https://img.shields.io/badge/Teleport-9.0-651FFF.svg" />
       </a>
       <a href="https://golang.org/">
-      <img src="https://img.shields.io/badge/Go-1.17-7fd5ea.svg" />
+      <img src="https://img.shields.io/github/go-mod/go-version/gravitational/teleport" />
       </a>
       <a href="https://github.com/gravitational/teleport/blob/master/CODE_OF_CONDUCT.md">
       <img src="https://img.shields.io/badge/Contribute-🙌-green.svg" />

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.17
+go 1.18
 
 require (
 	cloud.google.com/go/firestore v1.2.0


### PR DESCRIPTION
With v9 cut it seems like a good time to upgrade to Go 1.18 as early as possible in the release cycle. This will help us get used to it and it's new features (yay generics and everything else!) and figure out if something breaks. If we have a good incentive to stay on 1.17, thats's fine, please note that but I am not aware of any and having generics and other features would be an asset for writing maintainable and fast code.

I don't think it's a sound idea to backport this to v9, keeping it on v10+ seems like a sane idea. I don't think we've done Go version upgrade backports in the past either.