### PR TITLE
lib/events: Rename playback code to make it clear that it is SSH-specific

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1692,7 +1692,7 @@ func PlayFile(ctx context.Context, tarFile io.Reader, sid string) error {
 		return trace.Wrap(err)
 	}
 	defer os.RemoveAll(playbackDir)
-	w, err := events.WriteForPlayback(ctx, session.ID(sid), protoReader, playbackDir)
+	w, err := events.WriteForSSHPlayback(ctx, session.ID(sid), protoReader, playbackDir)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -668,7 +668,7 @@ func (l *AuditLog) downloadSession(namespace string, sid session.ID) error {
 		start = time.Now()
 		l.log.Debugf("Converting %v to playback format.", tarballPath)
 		protoReader := NewProtoReader(tarball)
-		_, err = WriteForPlayback(l.Context, sid, protoReader, l.playbackDir)
+		_, err = WriteForSSHPlayback(l.Context, sid, protoReader, l.playbackDir)
 		if err != nil {
 			l.log.WithError(err).Error("Failed to convert.")
 			return trace.Wrap(err)


### PR DESCRIPTION
Despite SSH and Desktop recordings using the same gzipped protobuf
format for storage, SSH playback requires conversion back to the
legacy events/chunks format. This doesn't apply for desktop playback,
so rename a few of these utilities for clarity.