### PR TITLE
[v8] Backport: "helm: Add support for separate Postgres/Mongo listeners in teleport-cluster chart (#10858)"

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -78,6 +78,83 @@ This reference details available values for the `teleport-cluster` chart.
 
 `proxyListenerMode` controls proxy TLS routing used by Teleport. Possible values are `multiplex`.
 
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  proxyListenerMode: multiplex
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set proxyListenerMode=multiplex
+  ```
+  </TabItem>
+</Tabs>
+
+## `separatePostgresListener`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `bool` | `false` | no | `proxy_service.postgres_listen_addr` | ❌ |
+
+`separatePostgresListener` controls whether Teleport will multiplex PostgreSQL traffic for Teleport Database Access
+over a separate TLS listener to Teleport's web UI.
+
+When `separatePostgresListener` is `false` (the default), PostgreSQL traffic will be directed to port 443 (the default Teleport web
+UI port). This works in situations when Teleport is terminating its own TLS traffic, i.e. when using certificates from LetsEncrypt
+or providing a certificate/private key pair via Teleport's `proxy_service.https_keypairs` config.
+
+When `separatePostgresListener` is `true`, PostgreSQL traffic will be directed to a separate Postgres-only listener on port 5432.
+This also adds the port to the `Service` that the chart creates. This is useful when terminating TLS at a load balancer
+in front of Teleport, such as when using AWS ACM.
+
+These settings will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  separatePostgresListener: true
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set separatePostgresListener=true
+  ```
+  </TabItem>
+</Tabs>
+
+## `separateMongoListener`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `bool` | `false` | no | `proxy_service.mongo_listen_addr` | ❌ |
+
+`separateMongoListener` controls whether Teleport will multiplex PostgreSQL traffic for Teleport Database Access
+over a separate TLS listener to Teleport's web UI.
+
+When `separateMongoListener` is `false` (the default), MongoDB traffic will be directed to port 443 (the default Teleport web
+UI port). This works in situations when Teleport is terminating its own TLS traffic, i.e. when using certificates from LetsEncrypt
+or providing a certificate/private key pair via Teleport's `proxy_service.https_keypairs` config.
+
+When `separateMongoListener` is `true`, MongoDB traffic will be directed to a separate Mongo-only listener on port 27017.
+This also adds the port to the `Service` that the chart creates. This is useful when terminating TLS at a load balancer
+in front of Teleport, such as when using AWS ACM.
+
+These settings will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  separateMongoListener: true
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set separateMongoListener=true
+  ```
+  </TabItem>
+</Tabs>
+
 ## `enterprise`
 
 | Type | Default value | Can be used in `custom` mode? |

--- a/examples/chart/teleport-cluster/.lint/separate-mongo-listener.yaml
+++ b/examples/chart/teleport-cluster/.lint/separate-mongo-listener.yaml
@@ -1,0 +1,2 @@
+clusterName: helm-lint
+separateMongoListener: true

--- a/examples/chart/teleport-cluster/.lint/separate-postgres-listener.yaml
+++ b/examples/chart/teleport-cluster/.lint/separate-postgres-listener.yaml
@@ -1,0 +1,2 @@
+clusterName: helm-lint
+separatePostgresListener: true

--- a/examples/chart/teleport-cluster/templates/NOTES.txt
+++ b/examples/chart/teleport-cluster/templates/NOTES.txt
@@ -9,8 +9,11 @@ NOTE: For certificates to be provisioned, you must also install cert-manager (ht
 
 For more information, please see the Helm guides in the Teleport docs (https://goteleport.com/docs/kubernetes-access/helm/guides/)
 {{- else if (gt (int .Values.highAvailability.replicaCount) 1) }}
-You have requested more than 1 replica but have not enabled cert-manager support (highAvailability.certManager.enabled=true) to get ACME certificates.
+{{- if not (hasKey .Values.annotations.service "service.beta.kubernetes.io/aws-load-balancer-ssl-cert") }}
+You have requested more than 1 replica but have not enabled cert-manager support (highAvailability.certManager.enabled=true) to get ACME certificates, or enabled AWS ACM
+for TLS termination using the service.beta.kubernetes.io/aws-load-balancer-ssl-cert service annotation.
 Your Teleport cluster will not be properly accessible by remote nodes until TLS certificates with the correct clusterName ({{ .Values.clusterName }}) are configured.
 
 For more information, please see the Helm guides in the Teleport docs (https://goteleport.com/docs/kubernetes-access/helm/guides/)
+{{- end }}
 {{- end }}

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -79,6 +79,14 @@ data:
   {{- if not .Values.proxyListenerMode }}
       kube_listen_addr: 0.0.0.0:3026
       mysql_listen_addr: 0.0.0.0:3036
+    {{- if .Values.separatePostgresListener }}
+      postgres_listen_addr: 0.0.0.0:5432
+      postgres_public_addr: {{ .Values.clusterName }}:5432
+    {{- end }}
+    {{- if .Values.separateMongoListener }}
+      mongo_listen_addr: 0.0.0.0:27017
+      mongo_public_addr: {{ .Values.clusterName }}:27017
+    {{- end }}
   {{- end }}
       enabled: true
   {{- if .Values.highAvailability.certManager.enabled }}

--- a/examples/chart/teleport-cluster/templates/service.yaml
+++ b/examples/chart/teleport-cluster/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- $backendProtocol := ternary "ssl" "tcp" (hasKey .Values.annotations.service "service.beta.kubernetes.io/aws-load-balancer-ssl-cert") -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,7 +9,7 @@ metadata:
   {{- if (or (.Values.annotations.service) (eq .Values.chartMode "aws")) }}
   annotations:
     {{- if eq .Values.chartMode "aws" }}
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: {{ $backendProtocol }}
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
     {{- end }}
@@ -43,6 +44,18 @@ spec:
     port: 3036
     targetPort: 3036
     protocol: TCP
+  {{- if .Values.separatePostgresListener }}
+  - name: postgres
+    port: 5432
+    targetPort: 5432
+    protocol: TCP
+  {{- end }}
+  {{- if .Values.separateMongoListener }}
+  - name: mongo
+    port: 27017
+    targetPort: 27017
+    protocol: TCP
+  {{- end }}
   {{- end }}
   selector:
     app: {{ .Release.Name }}

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -37,6 +37,16 @@
             "type": "string",
             "default": ""
         },
+        "separatePostgresListener": {
+            "$id": "#/properties/separatePostgresListener",
+            "type": "boolean",
+            "default": false
+        },
+        "separateMongoListener": {
+            "$id": "#/properties/separateMongoListener",
+            "type": "boolean",
+            "default": false
+        },
         "teleportVersionOverride": {
             "$id": "#/properties/teleportVersionOverride",
             "type": "string",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -27,6 +27,13 @@ authenticationType: local
 # Possible values are 'multiplex'
 proxyListenerMode: ""
 
+# By default, Teleport will multiplex Postgres and MongoDB database connections on the same port as the proxy's web listener (443)
+# Setting either of these values to true will separate the listeners out onto a separate port (5432 for Postgres, 27017 for MongoDB)
+# This is useful when terminating TLS at a load balancer in front of Teleport (such as when using AWS ACM)
+# These settings will not apply if proxyListenerMode is set to "multiplex".
+separatePostgresListener: false
+separateMongoListener: false
+
 # ACME is a protocol for getting Web X.509 certificates
 # Note: ACME can only be used for single-instance clusters. It is not suitable for use in HA configurations.
 # Setting acme to 'true' enables the ACME protocol and will attempt to get a free TLS certificate from Let's Encrypt.


### PR DESCRIPTION
Backports #10858 to `branch/v8`