### PR TITLE
Remove misleading information about tctl for Cloud

### DIFF
--- a/docs/pages/includes/database-access/start-auth-proxy.mdx
+++ b/docs/pages/includes/database-access/start-auth-proxy.mdx
@@ -46,10 +46,6 @@ If you do not have a Teleport Cloud account, use our [signup form](https://gotel
 get started. Teleport Cloud manages instances of the Proxy Service and Auth
 Service, and automatically issues and renews the required TLS certificate.
 
-You will need to download the Enterprise version of Teleport from the
-[customer portal](https://dashboard.gravitational.com/web/login) to run `tctl`
-commands in Teleport Cloud.
-
 You must log into your cluster before you can run `tctl` commands.
 ```code
 $ tsh login --proxy=mytenant.teleport.sh

--- a/docs/pages/kubernetes-access/getting-started/agent.mdx
+++ b/docs/pages/kubernetes-access/getting-started/agent.mdx
@@ -54,13 +54,14 @@ description: Connecting a Kubernetes cluster to Teleport
 - The `jq` tool to process `JSON` output. This is available via common package
   managers.
 
-- The Enterprise version of the `tctl` admin tool. To download this, visit
-the [customer portal](https://dashboard.gravitational.com/web/login).
+- The `tctl` admin tool version >= (=teleport.version=).
 
   ```code
   $ tctl version
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
+
+  See [Installation](../../installation.mdx) for details.
 
   (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
+++ b/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
@@ -53,13 +53,14 @@ This guide will show you how to use Teleport as an access plane for multiple Kub
 - The `jq` tool to process `JSON` output. This is available via common package
   managers
 
-- The Enterprise version of the `tctl` admin tool. To download this, visit
-the [customer portal](https://dashboard.gravitational.com/web/login)
+- The `tctl` admin tool version >= (=teleport.version=).
 
   ```code
   $ tctl version
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
+
+  See [Installation](../../installation.mdx) for details.
 
   (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/kubernetes-access/guides/standalone-teleport.mdx
+++ b/docs/pages/kubernetes-access/guides/standalone-teleport.mdx
@@ -56,13 +56,14 @@ Teleport needs a `kubeconfig` file to authenticate against the Kubernetes API.
 - A host deployed on your own infrastructure to run the Teleport Kubernetes
   Service. See [Installing Teleport](../../installation.mdx) for more details.
 
-- **Optional:** the Enterprise version of the `tctl` admin tool. To download this, visit
-the [customer portal](https://dashboard.gravitational.com/web/login).
+- **Optional:** The `tctl` admin tool version >= (=teleport.version=).
 
   ```code
   $ tctl version
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
+
+  See [Installation](../../installation.mdx) for details.
 
   (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/setup/guides/fluentd.mdx
+++ b/docs/pages/setup/guides/fluentd.mdx
@@ -53,13 +53,14 @@ In this guide, we will explain how to:
 - A Teleport Cloud account. If you do not have one, visit the
   [sign up page](https://goteleport.com/signup/) to begin your free trial.
 
-- The Enterprise version of the `tctl` admin tool. To download this, visit
-the [customer portal](https://dashboard.gravitational.com/web/login).
+- The `tctl` admin tool version >= (=teleport.version=).
 
   ```code
   $ tctl version
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
+
+  See [Installation](../../installation.mdx) for details.
 
   (!docs/pages/includes/tctl.mdx!)
 


### PR DESCRIPTION
The Enterprise version of tctl is only required for SSO connectors.
I've removed instructions to download this in the context of tctl for
Cloud users.

cc @stevenGravy 