### PR TITLE
teleport-cluster chart: set strategy to 'Recreate' if chartMode is 'standalone' (fixes #11484)

### DIFF
--- a/examples/chart/teleport-cluster/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
   {{- else }}
   replicas: 1
   {{- end }}
+  {{- if eq .Values.chartMode "standalone" }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/deployment_test.yaml.snap
@@ -479,6 +479,51 @@ should expose diag port:
     - name: data
       persistentVolumeClaim:
         claimName: RELEASE-NAME
+should have Recreate strategy in standalone mode:
+  1: |
+    containers:
+    - args:
+      - --diag-addr=0.0.0.0:3000
+      image: quay.io/gravitational/teleport:10.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      name: teleport
+      ports:
+      - containerPort: 3000
+        name: diag
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 12
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      volumeMounts:
+      - mountPath: /etc/teleport
+        name: config
+        readOnly: true
+      - mountPath: /var/lib/teleport
+        name: data
+    serviceAccountName: RELEASE-NAME
+    volumes:
+    - name: gcp-credentials
+      secret:
+        secretName: teleport-gcp-credentials
+    - configMap:
+        name: RELEASE-NAME
+      name: config
+    - name: data
+      persistentVolumeClaim:
+        claimName: RELEASE-NAME
 should have multiple replicas when replicaCount is set:
   1: |
     affinity:
@@ -1130,57 +1175,6 @@ should mount extraVolumes and extraVolumeMounts:
     - name: my-mount
       secret:
         secretName: mySecret
-should mount tls.existingSecretName when set in values:
-  1: |
-    containers:
-    - args:
-      - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:10.0.0-dev
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        failureThreshold: 6
-        httpGet:
-          path: /healthz
-          port: diag
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 1
-      name: teleport
-      ports:
-      - containerPort: 3000
-        name: diag
-        protocol: TCP
-      readinessProbe:
-        failureThreshold: 12
-        httpGet:
-          path: /readyz
-          port: diag
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 1
-      volumeMounts:
-      - mountPath: /etc/teleport-tls
-        name: teleport-tls
-        readOnly: true
-      - mountPath: /etc/teleport
-        name: config
-        readOnly: true
-      - mountPath: /var/lib/teleport
-        name: data
-    serviceAccountName: RELEASE-NAME
-    volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
-    - name: teleport-tls
-      secret:
-        secretName: helm-lint-existing-tls-secret
-    - configMap:
-        name: RELEASE-NAME
-      name: config
-    - name: data
-      persistentVolumeClaim:
-        claimName: RELEASE-NAME
 should mount tls.existingCASecretName and set environment when set in values:
   1: |
     containers:
@@ -1303,6 +1297,57 @@ should mount tls.existingCASecretName and set extra environment when set in valu
     - name: data
       persistentVolumeClaim:
         claimName: RELEASE-NAME
+should mount tls.existingSecretName when set in values:
+  1: |
+    containers:
+    - args:
+      - --diag-addr=0.0.0.0:3000
+      image: quay.io/gravitational/teleport:10.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      name: teleport
+      ports:
+      - containerPort: 3000
+        name: diag
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 12
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      volumeMounts:
+      - mountPath: /etc/teleport-tls
+        name: teleport-tls
+        readOnly: true
+      - mountPath: /etc/teleport
+        name: config
+        readOnly: true
+      - mountPath: /var/lib/teleport
+        name: data
+    serviceAccountName: RELEASE-NAME
+    volumes:
+    - name: gcp-credentials
+      secret:
+        secretName: teleport-gcp-credentials
+    - name: teleport-tls
+      secret:
+        secretName: helm-lint-existing-tls-secret
+    - configMap:
+        name: RELEASE-NAME
+      name: config
+    - name: data
+      persistentVolumeClaim:
+        claimName: RELEASE-NAME
 should not do enterprise things when when enterprise is not set in values:
   1: |
     containers:
@@ -1393,6 +1438,165 @@ should not have more than one replica in standalone mode:
     - name: data
       persistentVolumeClaim:
         claimName: RELEASE-NAME
+should not have strategy in AWS mode:
+  1: |
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - RELEASE-NAME
+            topologyKey: kubernetes.io/hostname
+          weight: 50
+    containers:
+    - args:
+      - --diag-addr=0.0.0.0:3000
+      image: quay.io/gravitational/teleport:10.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      name: teleport
+      ports:
+      - containerPort: 3000
+        name: diag
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 12
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      volumeMounts:
+      - mountPath: /etc/teleport
+        name: config
+        readOnly: true
+      - mountPath: /var/lib/teleport
+        name: data
+    serviceAccountName: RELEASE-NAME
+    volumes:
+    - name: gcp-credentials
+      secret:
+        secretName: teleport-gcp-credentials
+    - configMap:
+        name: RELEASE-NAME
+      name: config
+    - emptyDir: {}
+      name: data
+should not have strategy in GCP mode:
+  1: |
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - RELEASE-NAME
+            topologyKey: kubernetes.io/hostname
+          weight: 50
+    containers:
+    - args:
+      - --diag-addr=0.0.0.0:3000
+      image: quay.io/gravitational/teleport:10.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      name: teleport
+      ports:
+      - containerPort: 3000
+        name: diag
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 12
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      volumeMounts:
+      - mountPath: /etc/teleport-secrets
+        name: gcp-credentials
+        readOnly: true
+      - mountPath: /etc/teleport
+        name: config
+        readOnly: true
+      - mountPath: /var/lib/teleport
+        name: data
+    serviceAccountName: RELEASE-NAME
+    volumes:
+    - name: gcp-credentials
+      secret:
+        secretName: teleport-gcp-credentials
+    - configMap:
+        name: RELEASE-NAME
+      name: config
+    - emptyDir: {}
+      name: data
+should not have strategy in custom mode:
+  1: |
+    containers:
+    - args:
+      - --diag-addr=0.0.0.0:3000
+      image: quay.io/gravitational/teleport:10.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      name: teleport
+      ports:
+      - containerPort: 3000
+        name: diag
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 12
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      volumeMounts:
+      - mountPath: /etc/teleport
+        name: config
+        readOnly: true
+      - mountPath: /var/lib/teleport
+        name: data
+    serviceAccountName: RELEASE-NAME
+    volumes:
+    - name: gcp-credentials
+      secret:
+        secretName: teleport-gcp-credentials
+    - configMap:
+        name: RELEASE-NAME
+      name: config
+    - emptyDir: {}
+      name: data
 should not mount TLS secrets when when highAvailability.certManager.enabled is false and tls.existingSecretName is not set:
   1: |
     containers:

--- a/examples/chart/teleport-cluster/tests/deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/deployment_test.yaml
@@ -309,6 +309,45 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should have Recreate strategy in standalone mode
+    set:
+      chartMode: standalone
+      clusterName: helm-lint.example.com
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - matchSnapshot:
+          path: spec.template.spec
+
+  - it: should not have strategy in AWS mode
+    values:
+      - ../.lint/aws-ha.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.strategy
+      - matchSnapshot:
+          path: spec.template.spec
+
+  - it: should not have strategy in GCP mode
+    values:
+      - ../.lint/gcp-ha.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.strategy
+      - matchSnapshot:
+          path: spec.template.spec
+
+  - it: should not have strategy in custom mode
+    set:
+      chartMode: custom
+      clusterName: helm-lint.example.com
+    asserts:
+      - isNull:
+          path: spec.template.spec.strategy
+      - matchSnapshot:
+          path: spec.template.spec
+
   - it: should mount extraVolumes and extraVolumeMounts
     values:
       - ../.lint/volumes.yaml


### PR DESCRIPTION
Fixes #11484 

In standalone mode a PVC is created. The volume cannot be attached to more than one pod (depending on the storage available), so using a `Recreate` strategy is needed to avoid stuck deployments on upgrades.