### PR TITLE
tsh: ignore empty or non-existing config files

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -687,14 +687,12 @@ func Run(args []string, opts ...cliOption) error {
 
 	setEnvFlags(&cf, os.Getenv)
 
-	confOptions, err := loadConfig(cf.HomePath)
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err, "failed to load tsh config from %s",
-			filepath.Join(profile.FullProfilePath(cf.HomePath), tshConfigPath))
+	fullConfigPath := filepath.Join(profile.FullProfilePath(cf.HomePath), tshConfigPath)
+	confOptions, err := loadConfig(fullConfigPath)
+	if err != nil {
+		return trace.Wrap(err, "failed to load tsh config from %s", fullConfigPath)
 	}
-	if confOptions != nil {
-		cf.ExtraProxyHeaders = confOptions.ExtraHeaders
-	}
+	cf.ExtraProxyHeaders = confOptions.ExtraHeaders
 
 	switch command {
 	case ver.FullCommand():

--- a/tool/tsh/tshconfig.go
+++ b/tool/tsh/tshconfig.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 
@@ -47,15 +48,20 @@ type ExtraProxyHeaders struct {
 }
 
 func loadConfig(fullConfigPath string) (*TshConfig, error) {
-	cfg := TshConfig{}
 	configFile, err := os.Open(fullConfigPath)
 	if err != nil {
+		log.Println("found", err)
 		if errors.Is(err, fs.ErrNotExist) {
-			return &cfg, nil
+			return &TshConfig{}, nil
 		}
 		return nil, trace.ConvertSystemError(err)
 	}
 	defer configFile.Close()
+
+	cfg := TshConfig{}
 	err = yaml.NewDecoder(configFile).Decode(&cfg)
+	if errors.Is(err, io.EOF) {
+		return &TshConfig{}, nil
+	}
 	return &cfg, trace.Wrap(err)
 }

--- a/tool/tsh/tshconfig.go
+++ b/tool/tsh/tshconfig.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"errors"
-	"io"
 	"io/fs"
 	"os"
 
@@ -48,27 +47,17 @@ type ExtraProxyHeaders struct {
 }
 
 func loadConfig(fullConfigPath string) (*TshConfig, error) {
-	emptyConfig := &TshConfig{}
-	configFile, err := os.Open(fullConfigPath)
+	bs, err := os.ReadFile(fullConfigPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return emptyConfig, nil
+			return &TshConfig{}, nil
 		}
 		return nil, trace.ConvertSystemError(err)
 	}
-	defer configFile.Close()
-
-	bs, err := io.ReadAll(configFile)
-	if err != nil {
-		return nil, trace.ConvertSystemError(err)
-	}
-	if len(bs) == 0 {
-		return emptyConfig, nil
-	}
 
 	cfg := TshConfig{}
-	if yaml.Unmarshal(bs, &cfg); err != nil {
-		return emptyConfig, trace.ConvertSystemError(err)
+	if err := yaml.Unmarshal(bs, &cfg); err != nil {
+		return nil, trace.ConvertSystemError(err)
 	}
 	return &cfg, nil
 }

--- a/tool/tsh/tshconfig_test.go
+++ b/tool/tsh/tshconfig_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -26,6 +27,16 @@ import (
 func TestLoadConfigNonExistingFile(t *testing.T) {
 	fullFilePath := "/tmp/doesntexist." + uuid.NewString()
 	gotConfig, gotErr := loadConfig(fullFilePath)
+	require.NoError(t, gotErr)
+	require.Equal(t, &TshConfig{}, gotConfig)
+}
+
+func TestLoadConfigEmptyFile(t *testing.T) {
+	file, err := os.CreateTemp("", "test-telelport")
+	require.NoError(t, err)
+	defer os.Remove(file.Name())
+
+	gotConfig, gotErr := loadConfig(file.Name())
 	require.NoError(t, gotErr)
 	require.Equal(t, &TshConfig{}, gotConfig)
 }

--- a/tool/tsh/tshconfig_test.go
+++ b/tool/tsh/tshconfig_test.go
@@ -33,6 +33,7 @@ func TestLoadConfigNonExistingFile(t *testing.T) {
 
 func TestLoadConfigEmptyFile(t *testing.T) {
 	file, err := os.CreateTemp("", "test-telelport")
+	file.Write([]byte(" "))
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
 

--- a/tool/tsh/tshconfig_test.go
+++ b/tool/tsh/tshconfig_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigNonExistingFile(t *testing.T) {
+	fullFilePath := "/tmp/doesntexist." + uuid.NewString()
+	gotConfig, gotErr := loadConfig(fullFilePath)
+	require.NoError(t, gotErr)
+	require.Equal(t, &TshConfig{}, gotConfig)
+}


### PR DESCRIPTION
If the newly created config.yaml didnt exist we would load the default
values and continue the flow
However, we were not resetting the `err`'s value and would have an ERROR
message at the end and an invalid exit code

Most of the commands would reset that variable to the output of the
command's execution
One of them was not: `tsh version`
The version command has no return value, so the program would execute
as expected until the last statement: `trace.Wrap(error)` which would
re-use the `err` variable whose value is the result of the `loadConfig`
method.

We could either reset the `err`s value inside the `PrintVersion` switch
case block or reset it right after we check for `IsNotFound`.

We ended up picking the first option as it seems cleaner

```
 # before
$ make full > /dev/null; build/tsh version
Teleport v10.0.0-dev git:v8.0.0-alpha.1-899-g335adf1f4 go1.18
ERROR: open /home/marco/.tsh/config/config.yaml: no such file or directory

 # after
$ make full > /dev/null; build/tsh version
Teleport v10.0.0-dev git:v8.0.0-alpha.1-899-g335adf1f4 go1.18
```