### PR TITLE
Assign EmitAuditEvent to err for subsequent check.

### DIFF
--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -397,7 +397,7 @@ func (s *Server) validateGenerationLabel(ctx context.Context, user types.User, c
 
 		// Emit an audit event.
 		userMetadata := ClientUserMetadata(ctx)
-		if s.emitter.EmitAuditEvent(s.closeCtx, &apievents.RenewableCertificateGenerationMismatch{
+		if err := s.emitter.EmitAuditEvent(s.closeCtx, &apievents.RenewableCertificateGenerationMismatch{
 			Metadata: apievents.Metadata{
 				Type: events.RenewableCertificateGenerationMismatchEvent,
 				Code: events.RenewableCertificateGenerationMismatchCode,


### PR DESCRIPTION
Looks like an err assignment is missing.

Reviewers picked from git blame.