### PR TITLE
chore: replace user.HomeDir with os.userHomeDir to respect $HOME var

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -233,8 +233,8 @@ func FullProfilePath(dir string) string {
 // defaultProfilePath retrieves the default path of the TSH profile.
 func defaultProfilePath() string {
 	home := os.TempDir()
-	if u, err := user.Current(); err == nil && u.HomeDir != "" {
-		home = u.HomeDir
+	if dirname, err := os.UserHomeDir(); err == nil && dirname != "" {
+		home = dirname
 	}
 	return filepath.Join(home, profileDir)
 }

--- a/lib/client/db/mysql/optionfile.go
+++ b/lib/client/db/mysql/optionfile.go
@@ -41,11 +41,11 @@ type OptionFile struct {
 // Load loads MySQL option file from the default location.
 func Load() (*OptionFile, error) {
 	// Default location is .my.cnf file in the user's home directory.
-	user, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
-	return LoadFromPath(filepath.Join(user.HomeDir, mysqlOptionFile))
+	return LoadFromPath(filepath.Join(homeDir, mysqlOptionFile))
 }
 
 // LoadFromPath loads MySQL option file from the specified path.

--- a/lib/client/db/postgres/servicefile.go
+++ b/lib/client/db/postgres/servicefile.go
@@ -42,11 +42,11 @@ type ServiceFile struct {
 func Load() (*ServiceFile, error) {
 	// Default location is .pg_service.conf file in the user's home directory.
 	// TODO(r0mant): Check PGSERVICEFILE and PGSYSCONFDIR env vars as well.
-	user, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
-	return LoadFromPath(filepath.Join(user.HomeDir, pgServiceFile))
+	return LoadFromPath(filepath.Join(homeDir, pgServiceFile))
 }
 
 // LoadFromPath loads Posrtgres connection service file from the specified path.

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -549,25 +549,30 @@ func onSCP(scpFlags *scp.Flags) (err error) {
 	}
 
 	// get user's home dir (it serves as a default destination)
-	user, err := user.Current()
+	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
 	// see if the target is absolute. if not, use user's homedir to make
 	// it absolute (and if the user doesn't have a homedir, use "/")
 	target := scpFlags.Target[0]
 	if !filepath.IsAbs(target) {
-		if !utils.IsDir(user.HomeDir) {
+		if !utils.IsDir(userHomeDir) {
 			slash := string(filepath.Separator)
 			scpFlags.Target[0] = slash + target
 		} else {
-			scpFlags.Target[0] = filepath.Join(user.HomeDir, target)
+			scpFlags.Target[0] = filepath.Join(userHomeDir, target)
 		}
 	}
 	if !scpFlags.Source && !scpFlags.Sink {
 		return trace.Errorf("remote mode is not supported")
 	}
 
+	user, err := user.Current()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	scpCfg := scp.Config{
 		Flags:       *scpFlags,
 		User:        user.Username,


### PR DESCRIPTION
I've never written Go code before, but this was breaking the tests in Homebrew since it does not respect the `$HOME` variable that we set. I think I got all the places where the old method was used.