### PR TITLE
Fix drone docker build tagging

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4350,6 +4350,7 @@ steps:
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       - docker pull quay.io/gravitational/teleport-buildbox:$BUILDBOX_VERSION || true
       - cd /go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /go/.version.txt)
       - make image-ci publish-ci
 
   - name: Build/push FIPS Docker image


### PR DESCRIPTION
It seems wrong that every git tag pushes to [quay.io/gravitational/teleport-ent-ci:10.0.0-dev](http://quay.io/gravitational/teleport-ent-ci:10.0.0-dev). If that is what we intend to happen I will close this PR.

This fixes an issue where the oss and enterprise docker image builds use
the default value for the VERSION variable set in teleport/Makefile to
tag the docker images.

Now docker images will be tagged with the git tag falling back to the
default value of VERSION when the tag is empty.
