### PR TITLE
Perform single-touch PIN authentication if possible

### DIFF
--- a/lib/auth/webauthncli/api.go
+++ b/lib/auth/webauthncli/api.go
@@ -31,8 +31,9 @@ import (
 // logins.
 // It returns an MFAAuthenticateResponse and the credential user, if a resident
 // credential is used.
-// The caller is expected to prompt the user for action before calling this
-// method.
+// The caller is expected to react to LoginPrompt in order to prompt the user at
+// appropriate times. Login may choose different flows depending on the type of
+// authentication and connected devices.
 func Login(
 	ctx context.Context,
 	origin string, user string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt,
@@ -42,6 +43,7 @@ func Login(
 		return FIDO2Login(ctx, origin, user, assertion, prompt)
 	}
 
+	prompt.PromptTouch()
 	resp, err := U2FLogin(ctx, origin, assertion)
 	return resp, "" /* credentialUser */, err
 }
@@ -50,8 +52,9 @@ func Login(
 // This method blocks until either device authentication is successful or the
 // context is cancelled. Calling Register without a deadline or cancel condition
 // may cause it block forever.
-// The caller is expected to prompt the user for action before calling this
-// method.
+// The caller is expected to react to RegisterPrompt in order to prompt the user
+// at appropriate times. Register may choose different flows depending on the
+// type of authentication and connected devices.
 func Register(
 	ctx context.Context,
 	origin string, cc *wanlib.CredentialCreation, prompt RegisterPrompt) (*proto.MFARegisterResponse, error) {
@@ -60,5 +63,6 @@ func Register(
 		return FIDO2Register(ctx, origin, cc, prompt)
 	}
 
+	prompt.PromptTouch()
 	return U2FRegister(ctx, origin, cc)
 }

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -185,9 +185,7 @@ func fido2Login(
 		if passwordless {
 			// Ask for another touch before the assertion, we used the first touch
 			// in the Credentials() call.
-			if err := prompt.PromptAdditionalTouch(); err != nil {
-				return trace.Wrap(err)
-			}
+			prompt.PromptTouch()
 		}
 
 		opts := &libfido2.AssertionOpts{
@@ -553,6 +551,9 @@ func runOnFIDO2Devices(
 		return trace.Wrap(err)
 	}
 
+	// Ask for touch before select step.
+	prompt.PromptTouch()
+
 	// Be optimistic at first and assume there is no PIN.
 	// We'll get requiresPIN = true if the user picks a PIN-protected device.
 	var pin string
@@ -574,9 +575,7 @@ func runOnFIDO2Devices(
 	// Ask for an additional touch after PIN.
 	// Works for most flows (except passwordless).
 	if !skipAdditionalPrompt {
-		if err := prompt.PromptAdditionalTouch(); err != nil {
-			return trace.Wrap(err)
-		}
+		prompt.PromptTouch()
 	}
 
 	// Run the callback again with the informed PIN.

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -213,8 +213,7 @@ func fido2Login(
 		return nil
 	}
 
-	skipAdditionalPrompt := passwordless
-	if err := runOnFIDO2Devices(ctx, prompt, skipAdditionalPrompt, filter, deviceCallback); err != nil {
+	if err := runOnFIDO2Devices(ctx, prompt, passwordless, filter, deviceCallback); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
@@ -246,6 +245,13 @@ func getPasswordlessCredentials(dev FIDODevice, pin, rpID, user string) (*libfid
 	creds, err := dev.Credentials(rpID, pin)
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	// TODO(codingllama): After this line we should cancel other devices,
+	//  the user picked the current one.
+
+	if user != "" {
+		log.Debugf("FIDO2: Searching credentials for user %q", user)
 	}
 
 	switch {
@@ -454,8 +460,8 @@ func fido2Register(
 		return nil
 	}
 
-	const skipAdditionalPrompt = false
-	if err := runOnFIDO2Devices(ctx, prompt, skipAdditionalPrompt, filter, deviceCallback); err != nil {
+	const passwordless = false
+	if err := runOnFIDO2Devices(ctx, prompt, passwordless, filter, deviceCallback); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -543,7 +549,7 @@ type runPrompt LoginPrompt
 
 func runOnFIDO2Devices(
 	ctx context.Context,
-	prompt runPrompt, skipAdditionalPrompt bool,
+	prompt runPrompt, passwordless bool,
 	filter deviceFilterFunc,
 	deviceCallback deviceCallbackFunc) error {
 	devices, err := findSuitableDevicesOrTimeout(ctx, filter)
@@ -551,30 +557,35 @@ func runOnFIDO2Devices(
 		return trace.Wrap(err)
 	}
 
-	// Ask for touch before select step.
-	prompt.PromptTouch()
+	var dev deviceWithInfo
+	if doEagerPINPrompt(passwordless, devices) {
+		dev = devices[0] // single device guaranteed in this case
+	} else {
+		prompt.PromptTouch() // about to select
 
-	// Be optimistic at first and assume there is no PIN.
-	// We'll get requiresPIN = true if the user picks a PIN-protected device.
-	var pin string
-	dev, requiresPIN, err := selectDevice(ctx, pin, devices, deviceCallback)
-	switch {
-	case err != nil:
-		return trace.Wrap(err)
-	case !requiresPIN:
-		return nil
+		d, requiresPIN, err := selectDevice(ctx, "" /* pin */, devices, deviceCallback)
+		switch {
+		case err != nil:
+			return trace.Wrap(err)
+		case !requiresPIN:
+			return nil
+		}
+		dev = d
 	}
 
 	// Selected device requires PIN, let's use the prompt and run the callback
 	// again.
-	pin, err = prompt.PromptPIN()
-	if err != nil {
+	pin, err := prompt.PromptPIN()
+	switch {
+	case err != nil:
 		return trace.Wrap(err)
+	case pin == "":
+		return libfido2.ErrPinRequired
 	}
 
-	// Ask for an additional touch after PIN.
-	// Works for most flows (except passwordless).
-	if !skipAdditionalPrompt {
+	// Prompt again for a touch if MFA, but don't prompt for passwordless.
+	// The passwordless callback calls the prompt at a more appropriate time.
+	if !passwordless {
 		prompt.PromptTouch()
 	}
 
@@ -582,6 +593,20 @@ func runOnFIDO2Devices(
 	// selectDevice is used since it correctly deals with cancellation.
 	_, _, err = selectDevice(ctx, pin, []deviceWithInfo{dev}, deviceCallback)
 	return trace.Wrap(err)
+}
+
+func doEagerPINPrompt(passwordless bool, devices []deviceWithInfo) bool {
+	// Don't eagerly prompt for PIN if MFA, it usually doesn't require PINs.
+	// Also don't eagerly prompt if >1 device, the touch chooses the device and we
+	// can't know which device will be chosen.
+	if !passwordless || len(devices) > 1 {
+		return false
+	}
+
+	// Only eagerly prompt for PINs if not bio, biometric devices unlock with
+	// touch instead (explicit PIN not required).
+	info := devices[0].info
+	return info.clientPinSet && !info.bioEnroll
 }
 
 func findSuitableDevicesOrTimeout(ctx context.Context, filter deviceFilterFunc) ([]deviceWithInfo, error) {
@@ -652,9 +677,11 @@ func findSuitableDevices(filter deviceFilterFunc, knownPaths map[string]struct{}
 		devs = append(devs, deviceWithInfo{FIDODevice: dev, info: di})
 	}
 
-	if len(devs) == 0 {
+	l := len(devs)
+	if l == 0 {
 		return nil, errors.New("no suitable devices found")
 	}
+	log.Debugf("FIDO2: Found %v suitable devices", l)
 
 	return devs, nil
 }
@@ -744,6 +771,7 @@ type deviceInfo struct {
 	rk                             bool
 	clientPinCapable, clientPinSet bool
 	uv                             bool
+	bioEnroll                      bool
 }
 
 // uvCapable returns true for both "uv" and pin-configured devices.
@@ -766,6 +794,8 @@ func makeDevInfo(path string, info *libfido2.DeviceInfo) *deviceInfo {
 			di.clientPinSet = opt.Value == libfido2.True
 		case "uv":
 			di.uv = opt.Value == libfido2.True
+		case "bioEnroll":
+			di.bioEnroll = opt.Value == libfido2.True
 		}
 	}
 	return di

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -558,7 +558,7 @@ func runOnFIDO2Devices(
 	}
 
 	var dev deviceWithInfo
-	if doEagerPINPrompt(passwordless, devices) {
+	if shouldDoEagerPINPrompt(passwordless, devices) {
 		dev = devices[0] // single device guaranteed in this case
 	} else {
 		prompt.PromptTouch() // about to select
@@ -595,7 +595,7 @@ func runOnFIDO2Devices(
 	return trace.Wrap(err)
 }
 
-func doEagerPINPrompt(passwordless bool, devices []deviceWithInfo) bool {
+func shouldDoEagerPINPrompt(passwordless bool, devices []deviceWithInfo) bool {
 	// Don't eagerly prompt for PIN if MFA, it usually doesn't require PINs.
 	// Also don't eagerly prompt if >1 device, the touch chooses the device and we
 	// can't know which device will be chosen.

--- a/lib/auth/webauthncli/fido2_common.go
+++ b/lib/auth/webauthncli/fido2_common.go
@@ -30,10 +30,10 @@ var FIDO2PollInterval = 200 * time.Millisecond
 type LoginPrompt interface {
 	// PromptPIN prompts the user for their PIN.
 	PromptPIN() (string, error)
-	// PromptAdditionalTouch prompts the user for an additional security key
-	// touch.
-	// Additional touches may be required after PINs and during passwordless flows.
-	PromptAdditionalTouch() error
+	// PromptTouch prompts the user for a security key touch.
+	// In certain situations multiple touches may be required (PIN-protected
+	// devices, passwordless flows, etc).
+	PromptTouch()
 }
 
 // FIDO2Login implements Login for CTAP1 and CTAP2 devices.
@@ -56,10 +56,10 @@ func FIDO2Login(
 type RegisterPrompt interface {
 	// PromptPIN prompts the user for their PIN.
 	PromptPIN() (string, error)
-	// PromptAdditionalTouch prompts the user for an additional security key
-	// touch.
-	// Additional touches may be required after PINs.
-	PromptAdditionalTouch() error
+	// PromptTouch prompts the user for a security key touch.
+	// In certain situations multiple touches may be required (eg, PIN-protected
+	// devices)
+	PromptTouch()
 }
 
 // FIDO2Register implements Register for CTAP1 and CTAP2 devices.

--- a/lib/auth/webauthncli/fido2_prompt.go
+++ b/lib/auth/webauthncli/fido2_prompt.go
@@ -1,0 +1,67 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthncli
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/teleport/lib/utils/prompt"
+)
+
+// DefaultPrompt is a default implementation for LoginPrompt and
+// RegistrationPrompt.
+type DefaultPrompt struct {
+	PINMessage                            string
+	FirstTouchMessage, SecondTouchMessage string
+
+	ctx   context.Context
+	out   io.Writer
+	count int
+}
+
+// NewDefaultPrompt creates a new default prompt.
+// Default messages are suitable for login / authorization. Messages may be
+// customized by setting the appropriate fields.
+func NewDefaultPrompt(ctx context.Context, out io.Writer) *DefaultPrompt {
+	return &DefaultPrompt{
+		PINMessage:         "Enter your security key PIN",
+		FirstTouchMessage:  "Tap your security key",
+		SecondTouchMessage: "Tap your security key again to complete login",
+		ctx:                ctx,
+		out:                out,
+	}
+}
+
+// PromptPIN prompts the user for a PIN.
+func (p *DefaultPrompt) PromptPIN() (string, error) {
+	return prompt.Password(p.ctx, p.out, prompt.Stdin(), p.PINMessage)
+}
+
+// PromptTouch prompts the user for a security key touch, using different
+// messages for first and second prompts.
+func (p *DefaultPrompt) PromptTouch() {
+	if p.count == 0 {
+		p.count++
+		if p.FirstTouchMessage != "" {
+			fmt.Fprintln(p.out, p.FirstTouchMessage)
+		}
+		return
+	}
+	if p.SecondTouchMessage != "" {
+		fmt.Fprintln(p.out, p.SecondTouchMessage)
+	}
+}

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -80,6 +80,31 @@ func init() {
 	}
 }
 
+// Capture common authenticator options.
+var (
+	authOpts = []libfido2.Option{
+		{Name: "rk", Value: "true"},
+		{Name: "up", Value: "true"},
+		{Name: "plat", Value: "false"},
+		{Name: "clientPin", Value: "false"}, // supported but unset
+	}
+	pinOpts = []libfido2.Option{
+		{Name: "rk", Value: "true"},
+		{Name: "up", Value: "true"},
+		{Name: "plat", Value: "false"},
+		{Name: "clientPin", Value: "true"}, // supported and configured
+	}
+	bioOpts = []libfido2.Option{
+		{Name: "rk", Value: "true"},
+		{Name: "up", Value: "true"},
+		{Name: "uv", Value: "true"},
+		{Name: "plat", Value: "false"},
+		{Name: "alwaysUv", Value: "true"},
+		{Name: "bioEnroll", Value: "true"}, // supported and configured
+		{Name: "clientPin", Value: "true"}, // supported and configured
+	}
+)
+
 type noopPrompt struct{}
 
 func (p noopPrompt) PromptPIN() (string, error) {
@@ -110,28 +135,6 @@ func TestFIDO2Login(t *testing.T) {
 	const rpID = "example.com"
 	const appID = "https://example.com"
 	const origin = "https://example.com"
-
-	authOpts := []libfido2.Option{
-		{Name: "rk", Value: "true"},
-		{Name: "up", Value: "true"},
-		{Name: "plat", Value: "false"},
-		{Name: "clientPin", Value: "false"}, // supported but unset
-	}
-	pinOpts := []libfido2.Option{
-		{Name: "rk", Value: "true"},
-		{Name: "up", Value: "true"},
-		{Name: "plat", Value: "false"},
-		{Name: "clientPin", Value: "true"}, // supported and configured
-	}
-	bioOpts := []libfido2.Option{
-		{Name: "rk", Value: "true"},
-		{Name: "up", Value: "true"},
-		{Name: "uv", Value: "true"},
-		{Name: "plat", Value: "false"},
-		{Name: "alwaysUv", Value: "true"},
-		{Name: "bioEnroll", Value: "true"}, // supported and configured
-		{Name: "clientPin", Value: "true"}, // supported and configured
-	}
 
 	// User IDs and names for resident credentials / passwordless.
 	const llamaName = "llama"
@@ -569,6 +572,126 @@ func TestFIDO2Login(t *testing.T) {
 	}
 }
 
+type countingPrompt struct {
+	wancli.LoginPrompt
+	count int
+}
+
+func (cp *countingPrompt) PromptTouch() {
+	cp.count++
+	cp.LoginPrompt.PromptTouch()
+}
+
+func TestFIDO2Login_PromptTouch(t *testing.T) {
+	resetFIDO2AfterTests(t)
+
+	const rpID = "example.com"
+	const origin = "https://example.com"
+	const user = ""
+
+	// auth1 is a FIDO2 authenticator without a PIN configured.
+	auth1 := mustNewFIDO2Device("/auth1", "" /* pin */, &libfido2.DeviceInfo{
+		Options: authOpts,
+	})
+	// pin1 is a FIDO2 authenticator with a PIN and resident credentials.
+	pin1 := mustNewFIDO2Device("/pin1", "supersecretpin1", &libfido2.DeviceInfo{
+		Options: pinOpts,
+	}, &libfido2.Credential{
+		User: libfido2.User{
+			ID:   []byte("alpacaID"),
+			Name: "alpaca",
+		},
+	})
+	// bio1 is a biometric authenticator with configured resident credentials.
+	bio1 := mustNewFIDO2Device("/bio1", "supersecretBIO1pin", &libfido2.DeviceInfo{
+		Options: bioOpts,
+	}, &libfido2.Credential{
+		User: libfido2.User{
+			ID:   []byte("llamaID"),
+			Name: "llama",
+		},
+	})
+
+	mfaAssertion := &wanlib.CredentialAssertion{
+		Response: protocol.PublicKeyCredentialRequestOptions{
+			Challenge:      make([]byte, 32),
+			RelyingPartyID: rpID,
+			AllowedCredentials: []protocol.CredentialDescriptor{
+				{
+					Type:         protocol.PublicKeyCredentialType,
+					CredentialID: auth1.credentialID(),
+				},
+				{
+					Type:         protocol.PublicKeyCredentialType,
+					CredentialID: pin1.credentialID(),
+				},
+				{
+					Type:         protocol.PublicKeyCredentialType,
+					CredentialID: bio1.credentialID(),
+				},
+			},
+		},
+	}
+	pwdlessAssertion := &wanlib.CredentialAssertion{
+		Response: protocol.PublicKeyCredentialRequestOptions{
+			Challenge:        make([]byte, 32),
+			RelyingPartyID:   rpID,
+			UserVerification: protocol.VerificationRequired,
+		},
+	}
+
+	tests := []struct {
+		name        string
+		fido2       *fakeFIDO2
+		assertion   *wanlib.CredentialAssertion
+		prompt      wancli.LoginPrompt
+		wantTouches int
+	}{
+		{
+			name:        "MFA requires single touch",
+			fido2:       newFakeFIDO2(auth1, pin1, bio1),
+			assertion:   mfaAssertion,
+			prompt:      auth1,
+			wantTouches: 1,
+		},
+		{
+			name:        "Passwordless PIN requires single touch",
+			fido2:       newFakeFIDO2(pin1),
+			assertion:   pwdlessAssertion,
+			prompt:      pin1,
+			wantTouches: 1,
+		},
+		{
+			name:        "Passwordless Bio requires two touches",
+			fido2:       newFakeFIDO2(bio1),
+			assertion:   pwdlessAssertion,
+			prompt:      bio1,
+			wantTouches: 2,
+		},
+		{
+			name:        "Passwordless with multiple devices requires two touches",
+			fido2:       newFakeFIDO2(pin1, bio1),
+			assertion:   pwdlessAssertion,
+			prompt:      pin1,
+			wantTouches: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.fido2.setCallbacks()
+
+			// Set a timeout, just in case.
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			prompt := &countingPrompt{LoginPrompt: test.prompt}
+			_, _, err := wancli.FIDO2Login(ctx, origin, user, test.assertion, prompt)
+			require.NoError(t, err, "FIDO2Login errored")
+			assert.Equal(t, test.wantTouches, prompt.count, "FIDO2Login did an unexpected number of touch prompts")
+		})
+	}
+}
+
 func TestFIDO2Login_errors(t *testing.T) {
 	resetFIDO2AfterTests(t)
 
@@ -659,19 +782,6 @@ func TestFIDO2Register(t *testing.T) {
 
 	const rpID = "example.com"
 	const origin = "https://example.com"
-
-	authOpts := []libfido2.Option{
-		{Name: "rk", Value: "true"},
-		{Name: "up", Value: "true"},
-		{Name: "plat", Value: "false"},
-		{Name: "clientPin", Value: "false"}, // supported but unset
-	}
-	pinOpts := []libfido2.Option{
-		{Name: "rk", Value: "true"},
-		{Name: "up", Value: "true"},
-		{Name: "plat", Value: "false"},
-		{Name: "clientPin", Value: "true"}, // supported and configured
-	}
 
 	// auth1 is a FIDO2 authenticator without a PIN configured.
 	auth1 := mustNewFIDO2Device("/path1", "" /* pin */, &libfido2.DeviceInfo{
@@ -1295,7 +1405,12 @@ func (f *fakeFIDO2Device) Cancel() error {
 }
 
 func (f *fakeFIDO2Device) Credentials(rpID string, pin string) ([]*libfido2.Credential, error) {
-	if f.pin != "" {
+	if pin == "" && f.isBio() {
+		// Unlock with user interaction.
+		if err := f.maybeLockUntilInteraction(true); err != nil {
+			return nil, err
+		}
+	} else {
 		if err := f.validatePIN(pin); err != nil {
 			return nil, err
 		}

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -86,9 +86,7 @@ func (p noopPrompt) PromptPIN() (string, error) {
 	return "", nil
 }
 
-func (p noopPrompt) PromptAdditionalTouch() error {
-	return nil
-}
+func (p noopPrompt) PromptTouch() {}
 
 // pinCancelPrompt exercises cancellation after device selection.
 type pinCancelPrompt struct {
@@ -101,9 +99,8 @@ func (p *pinCancelPrompt) PromptPIN() (string, error) {
 	return p.pin, nil
 }
 
-func (p pinCancelPrompt) PromptAdditionalTouch() error {
+func (p pinCancelPrompt) PromptTouch() {
 	// 2nd touch never happens
-	return nil
 }
 
 func TestFIDO2Login(t *testing.T) {
@@ -1266,9 +1263,8 @@ func (f *fakeFIDO2Device) PromptPIN() (string, error) {
 	return f.pin, nil
 }
 
-func (f *fakeFIDO2Device) PromptAdditionalTouch() error {
+func (f *fakeFIDO2Device) PromptTouch() {
 	f.setUP()
-	return nil
 }
 
 func (f *fakeFIDO2Device) credentialID() []byte {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	"github.com/gravitational/teleport/lib/auth"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	"github.com/gravitational/teleport/lib/client/terminal"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -2592,20 +2593,6 @@ func (tc *TeleportClient) Login(ctx context.Context) (*Key, error) {
 	return key, nil
 }
 
-type pwdlessPrompt struct {
-	ctx context.Context
-	out io.Writer
-}
-
-func (p *pwdlessPrompt) PromptPIN() (string, error) {
-	return prompt.Password(p.ctx, p.out, prompt.Stdin(), "Enter your security key PIN")
-}
-
-func (p *pwdlessPrompt) PromptAdditionalTouch() error {
-	fmt.Fprintln(p.out, "Tap your security key again to complete login")
-	return nil
-}
-
 func (tc *TeleportClient) pwdlessLogin(ctx context.Context, pubKey []byte) (*auth.SSHLoginResponse, error) {
 	webClient, webURL, err := initClient(tc.WebProxyAddr, tc.InsecureSkipVerify, loopbackPool(tc.WebProxyAddr))
 	if err != nil {
@@ -2632,8 +2619,7 @@ func (tc *TeleportClient) pwdlessLogin(ctx context.Context, pubKey []byte) (*aut
 		return nil, trace.BadParameter("passwordless: user verification requirement too lax (%v)", challenge.WebauthnChallenge.Response.UserVerification)
 	}
 
-	prompt := &pwdlessPrompt{ctx: ctx, out: tc.Stderr}
-	fmt.Fprintln(tc.Stderr, "Tap your security key")
+	prompt := wancli.NewDefaultPrompt(ctx, tc.Stderr)
 	mfaResp, _, err := promptWebauthn(ctx, webURL.String(), tc.Username, challenge.WebauthnChallenge, prompt)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -141,7 +141,7 @@ func TestTeleportClient_Login_local(t *testing.T) {
 		case got != pin:
 			return nil, errors.New("invalid PIN")
 		}
-		prompt.PromptAdditionalTouch() // Realistically, this would happen too.
+		prompt.PromptTouch() // Realistically, this would happen too.
 		return solveWebauthn(ctx, origin, assertion, prompt)
 	}
 


### PR DESCRIPTION
During passwordless logins, if the only candidate device is PIN protected, we can ask for the PIN right away, saving a touch.

The timing for the the initial touch prompt is now dictated by wancli.Login/wancli.Register, as the touch is not necessarily the first operation to happen anymore.

#9160