### PR TITLE
Use full `hostname` path in example config

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -183,7 +183,7 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 	s.Commands = []CommandLabel{
 		{
 			Name:    "hostname",
-			Command: []string{"hostname"},
+			Command: []string{"/bin/hostname"},
 			Period:  time.Minute,
 		},
 	}


### PR DESCRIPTION
Using `hostname` will generate an error on systems which don't have a `PATH` set that Go can read. `/bin/hostname` is the absolute path to the executable on Macs and modern Linux distros, so using the full path in the example seems to give a better result.

Fixes #11498