### PR TITLE
Fix docs UI reference

### DIFF
--- a/docs/pages/contributing/documentation/reference.mdx
+++ b/docs/pages/contributing/documentation/reference.mdx
@@ -117,7 +117,7 @@ or using some other value will result in resetting it to the `tip`.
 
 If `title` is omitted, `type` will be used instead as the title value.
 
-### Tabs
+## Tabs
 
 <Tabs>
   <TabItem label="First label">


### PR DESCRIPTION
The "Tabs" heading was mistakenly made an H3. This change makes it an
H2 so it appears in the table of contents.