### PR TITLE
Replace template with templatefile to make starter-cluster work on darwin/arm64

### DIFF
--- a/examples/aws/terraform/starter-cluster/cluster.tf
+++ b/examples/aws/terraform/starter-cluster/cluster.tf
@@ -1,22 +1,3 @@
-// Configuration data for teleport.yaml generation
-data "template_file" "node_user_data" {
-  template = file("data.tpl")
-
-  vars = {
-    region                   = var.region
-    cluster_name             = var.cluster_name
-    email                    = var.email
-    domain_name              = var.route53_domain
-    dynamo_table_name        = aws_dynamodb_table.teleport.name
-    dynamo_events_table_name = aws_dynamodb_table.teleport_events.name
-    locks_table_name         = aws_dynamodb_table.teleport_locks.name
-    license_path             = var.license_path
-    s3_bucket                = var.s3_bucket_name
-    use_acm                  = var.use_acm
-    use_letsencrypt          = var.use_letsencrypt
-  }
-}
-
 // Auth, node, proxy (aka Teleport Cluster) on single AWS instance
 resource "aws_instance" "cluster" {
   key_name                    = var.key_name
@@ -25,7 +6,23 @@ resource "aws_instance" "cluster" {
   subnet_id                   = tolist(data.aws_subnet_ids.all.ids)[0]
   vpc_security_group_ids      = [aws_security_group.cluster.id]
   associate_public_ip_address = true
-  user_data                   = data.template_file.node_user_data.rendered
+  // Configuration data for teleport.yaml generation
+  user_data                   = templatefile(
+    "data.tpl",
+    {
+      region                   = var.region
+      cluster_name             = var.cluster_name
+      email                    = var.email
+      domain_name              = var.route53_domain
+      dynamo_table_name        = aws_dynamodb_table.teleport.name
+      dynamo_events_table_name = aws_dynamodb_table.teleport_events.name
+      locks_table_name         = aws_dynamodb_table.teleport_locks.name
+      license_path             = var.license_path
+      s3_bucket                = var.s3_bucket_name
+      use_acm                  = var.use_acm
+      use_letsencrypt          = var.use_letsencrypt
+    }
+  )
   iam_instance_profile        = aws_iam_role.cluster.id
 }
 


### PR DESCRIPTION
Using `template` is deprecated and causes errors when trying to run `terraform init` on `darwin/arm64`:

```
Initializing the backend...

Initializing provider plugins...
- Finding hashicorp/aws versions matching "~> 3.0"...
- Finding latest version of hashicorp/template...
- Installing hashicorp/aws v3.75.1...
- Installed hashicorp/aws v3.75.1 (signed by HashiCorp)
╷
│ Error: Incompatible provider version
│
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your current platform, darwin_arm64.
│
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider
│ may have different platforms supported.
╵
```

Replacing this with the newer `templatefile` directive (added in Terraform 0.12) removes the error.