### PR TITLE
deflake TestHandleConnection

### DIFF
--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -293,6 +293,10 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		s.appServer.Close()
+
+		// wait for the server to close before allowing other cleanup
+		// actions to proceed
+		s.appServer.Wait()
 	})
 
 	return s


### PR DESCRIPTION
This test would sometimes fail when attempting to clean up
t.TempDir(), as there was a race with the app server shutting
down and the deferred cleanup.

Fix the issue by waiting for the server to shut down before proceeding
with the rest of the cleanup actions.

Updates #9492