### PR TITLE
[docs/v9] Remove mention of x509 certs for Machine ID as they're not yet available

### DIFF
--- a/docs/pages/machine-id/introduction.mdx
+++ b/docs/pages/machine-id/introduction.mdx
@@ -13,7 +13,7 @@ role-based access controls and audit.
 Some of the things you can do with Machine ID:
 
 - Machines can retrieve short-lived SSH certificates for CI/CD pipelines.
-- Machines can retrieve short-lived X.509 certificates for use with databases or applications (in Teleport 9.1+)
+- Machines can retrieve short-lived X.509 certificates for use with databases or applications (in Teleport 9.1+).
 - Configure role-based access controls and locking for machines.
 - Capture access events in the audit log.
 

--- a/docs/pages/machine-id/introduction.mdx
+++ b/docs/pages/machine-id/introduction.mdx
@@ -13,7 +13,7 @@ role-based access controls and audit.
 Some of the things you can do with Machine ID:
 
 - Machines can retrieve short-lived SSH certificates for CI/CD pipelines.
-- Machines can retrieve short-lived X.509 certificates for use with databases or applications.
+- Machines can retrieve short-lived X.509 certificates for use with databases or applications (in Teleport 9.1+)
 - Configure role-based access controls and locking for machines.
 - Capture access events in the audit log.
 

--- a/docs/pages/machine-id/introduction.mdx
+++ b/docs/pages/machine-id/introduction.mdx
@@ -13,7 +13,6 @@ role-based access controls and audit.
 Some of the things you can do with Machine ID:
 
 - Machines can retrieve short-lived SSH certificates for CI/CD pipelines.
-- Machines can retrieve short-lived X.509 certificates for use with databases or applications (in Teleport 9.1+).
 - Configure role-based access controls and locking for machines.
 - Capture access events in the audit log.
 


### PR DESCRIPTION
Currently the page is a little confusing as it details functionality that is not yet available.