### PR TITLE
helm: Allow to define static join tokens in helm chart

### DIFF
--- a/examples/chart/teleport-cluster/.lint/static-tokens.yaml
+++ b/examples/chart/teleport-cluster/.lint/static-tokens.yaml
@@ -1,0 +1,4 @@
+clusterName: helm-lint
+staticTokens:
+  - "app,db:insecure-token-one"
+  - "node,proxy:insecure-token-two"

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -54,6 +54,9 @@ data:
   {{- if .Values.enterprise }}
       license_file: '/var/lib/license/license.pem'
   {{- end }}
+  {{- if .Values.staticTokens }}
+      tokens: {{ .Values.staticTokens | toJson }}
+  {{- end }}
       authentication:
         type: {{ required "authenticationType is required in chart values" .Values.authenticationType }}
   {{- if .Values.authenticationSecondFactor }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
@@ -1166,3 +1166,37 @@ matches snapshot for webauthn.yaml:
     metadata:
       name: RELEASE-NAME
       namespace: NAMESPACE
+matches snapshot for static-tokens.yaml:
+  1: |
+    apiVersion: v1
+    data:
+      teleport.yaml: |
+        teleport:
+          log:
+            severity: INFO
+            output: stderr
+            format:
+              output: text
+              extra_fields: ["timestamp","level","component","caller"]
+        auth_service:
+          enabled: true
+          cluster_name: helm-lint
+          tokens: ["app,db:insecure-token-one","node,proxy:insecure-token-two"]
+          authentication:
+            type: local
+            second_factor: otp
+        kubernetes_service:
+          enabled: true
+          listen_addr: 0.0.0.0:3027
+          kube_cluster_name: helm-lint
+        proxy_service:
+          public_addr: 'helm-lint:443'
+          kube_listen_addr: 0.0.0.0:3026
+          mysql_listen_addr: 0.0.0.0:3036
+          enabled: true
+        ssh_service:
+          enabled: false
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME
+      namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/config_test.yaml
@@ -338,3 +338,13 @@ tests:
       - isKind:
           of: ConfigMap
       - matchSnapshot: {}
+
+  - it: matches snapshot for static-tokens.yaml
+    values:
+      - ../.lint/static-tokens.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot: {}

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -72,6 +72,15 @@ labels: {}
 #     kubectl -n ${TELEPORT_NAMESPACE?} create configmap ${HELM_RELEASE_NAME?} --from-file=teleport.yaml
 chartMode: standalone
 
+# List of pre-defined tokens for adding new nodes to a cluster. Each token specifies
+# the role a new node will be allowed to assume. The more secure way to
+# add nodes is to use `tctl nodes add --ttl` command to generate auto-expiring
+# tokens.
+#
+# We recommend to use tools like `pwgen` to generate sufficiently random
+# tokens of 32+ byte length.
+staticTokens: []
+
 ################################################################
 # Standalone-specific settings (only used in "standalone" mode)
 ################################################################


### PR DESCRIPTION
This PR is aiming to resolve #8003, allowing to specify static join tokens in the helm chart of teleport-cluster.