### PR TITLE
Fix `ad-keytab-file` flag on sqlserver docs

### DIFF
--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -224,7 +224,7 @@ your Teleport Proxy Service address and `--uri` to the SQL Server endpoint.
     --name=sqlserver \
     --protocol=sqlserver \
     --uri=sqlserver.example.com:1433 \
-    --ad-keytab=/path/to/teleport.keytab \
+    --ad-keytab-file=/path/to/teleport.keytab \
     --ad-domain=EXAMPLE.COM \
     --ad-spn=MSSQLSvc/sqlserver.example.com:1433 \
     --labels=env=dev
@@ -234,7 +234,7 @@ Provide Active Directory parameters:
 
 | Flag | Description |
 | ---- | ----------- |
-| `--ad-keytab` | Path to Kerberos keytab file generated above. |
+| `--ad-keytab-file` | Path to Kerberos keytab file generated above. |
 | `--ad-domain` | Active Directory domain (Kerberos realm) that SQL Server is joined. |
 | `--ad-spn` | Service Principal Name for SQL Server to fetch Kerberos tickets for. |
 


### PR DESCRIPTION
The purpose of this PR is to fix a wrong flag in the SQL Server docs.

The docs tell the user to use `ad-keytab` but this flag doesn't exist:

```
teleport: error: unknown long flag '--ad-keytab'
```

Instead, it should say `--ad-keytab-file`, see [teleport.go#L213](https://github.com/gravitational/teleport/blob/master/tool/teleport/common/teleport.go#L213) 

Should be ported to v9