### PR TITLE
Fix invalid YAML in Machine ID configuration reference

### DIFF
--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -52,7 +52,11 @@ storage:
 # Destinations specifies where short-lived certificates are stored.
 destinations:
     # Directory specifies where short-lived certificates are stored.
-    - directory: /opt/machine-id
+    - directory:
+        # Configure the path at which to store certificates and other
+        # artifacts.
+        path: /opt/machine-id
+
         # Configure symlink attack prevention. Requires Linux 5.6+.
         # Possible values:
         #   * try-secure (default): Attempt to securely read and write certificates


### PR DESCRIPTION
This fixes a small snippet of invalid YAML in the Machine ID reference configuration. While we do support a shorthand directory path as just a string, the two cannot be combined.

This changes the documented recommendation to always use the more verbose form where `path` and other directory-specific options are fields on a `directory` object.