### PR TITLE
Allow single-touch bio authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -269,6 +269,7 @@ replace (
 	github.com/go-redis/redis/v8 => github.com/gravitational/redis/v8 v8.11.5-0.20220211010318-7af711b76a91
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 	github.com/gravitational/teleport/api => ./api
+	github.com/keys-pub/go-libfido2 => github.com/gravitational/go-libfido2 v1.5.3-0.20220330170708-36815bbb94b7
 	github.com/russellhaering/gosaml2 => github.com/gravitational/gosaml2 v0.0.0-20220318224559-f06932032ae2
 	github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-teleport.2
 	github.com/sirupsen/logrus => github.com/gravitational/logrus v1.4.4-0.20210817004754-047e20245621

--- a/go.sum
+++ b/go.sum
@@ -457,6 +457,8 @@ github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23 h1:havbccu
 github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23/go.mod h1:XL9nebvlfNVvRzRPWdDcWootcyA0l7THiH/A+W1233g=
 github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70 h1:To76nCJtM3DI0mdq3nGLzXqTV1wNOJByxv01+u9/BxM=
 github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70/go.mod h1:88hFR45MpUd23d2vNWE/dYtesU50jKsbz0I9kH7UaBY=
+github.com/gravitational/go-libfido2 v1.5.3-0.20220330170708-36815bbb94b7 h1:RmlCEGmDJBGaglPQ8ixRH7WBw858PQb0tjxKMFzzUSc=
+github.com/gravitational/go-libfido2 v1.5.3-0.20220330170708-36815bbb94b7/go.mod h1:P0V19qHwJNY0htZwZDe9Ilvs/nokGhdFX7faKFyZ6+U=
 github.com/gravitational/go-mssqldb v0.11.1-0.20220202000043-bec708e9bfd0 h1:DC+S+j/tBs/0MnQCC5j7GWWbMGcR3ca5v75ksAU1LJM=
 github.com/gravitational/go-mssqldb v0.11.1-0.20220202000043-bec708e9bfd0/go.mod h1:iiK0YP1ZeepvmBQk/QpLEhhTNJgfzrpArPY/aFvc9yU=
 github.com/gravitational/go-mysql v1.1.1-teleport.2 h1:XZ36BZ7BgslA5ZCyCHjpc1wilFITThIH7cLcbLWKWzM=
@@ -623,8 +625,6 @@ github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALr
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/keybase/go-ps v0.0.0-20190827175125-91aafc93ba19/go.mod h1:hY+WOq6m2FpbvyrI93sMaypsttvaIL5nhVR92dTMUcQ=
-github.com/keys-pub/go-libfido2 v1.5.3-0.20220306005615-8ab03fb1ec27 h1:10nfvqVK4/KINnLT8bDICrRnfguTJ300dNGpW8D2bQo=
-github.com/keys-pub/go-libfido2 v1.5.3-0.20220306005615-8ab03fb1ec27/go.mod h1:P0V19qHwJNY0htZwZDe9Ilvs/nokGhdFX7faKFyZ6+U=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.9.5 h1:U+CaK85mrNNb4k8BNOfgJtJ/gr6kswUCFj6miSzVC6M=

--- a/lib/auth/webauthncli/api.go
+++ b/lib/auth/webauthncli/api.go
@@ -28,6 +28,12 @@ type LoginOpts struct {
 	// User is the desired credential username for login.
 	// If empty, Login may either choose a credential or error due to ambiguity.
 	User string
+	// OptimisticAssertion allows Login to skip credential listing and attempt
+	// to assert directly. The drawback of optimistic assertions is that Login is
+	// unable to guarantee the credential user, even if the User field is set.
+	// Login may decide to forego optimistic assertions if it wouldn't save a
+	// touch.
+	OptimisticAssertion bool
 }
 
 // Login performs client-side, U2F-compatible, Webauthn login.

--- a/lib/auth/webauthncli/api.go
+++ b/lib/auth/webauthncli/api.go
@@ -29,8 +29,10 @@ type LoginOpts struct {
 	// If empty, Login may either choose a credential or error due to ambiguity.
 	User string
 	// OptimisticAssertion allows Login to skip credential listing and attempt
-	// to assert directly. The drawback of optimistic assertions is that Login is
-	// unable to guarantee the credential user, even if the User field is set.
+	// to assert directly. The drawback of an optimistic assertion is that the
+	// authenticator chooses the login credential, so Login can't guarantee that
+	// the User field will be respected. The upside is that it saves a touch for
+	// some devices.
 	// Login may decide to forego optimistic assertions if it wouldn't save a
 	// touch.
 	OptimisticAssertion bool

--- a/lib/auth/webauthncli/api.go
+++ b/lib/auth/webauthncli/api.go
@@ -23,10 +23,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// LoginOpts groups non-mandatory options for Login.
+type LoginOpts struct {
+	// User is the desired credential username for login.
+	// If empty, Login may either choose a credential or error due to ambiguity.
+	User string
+}
+
 // Login performs client-side, U2F-compatible, Webauthn login.
 // This method blocks until either device authentication is successful or the
 // context is cancelled. Calling Login without a deadline or cancel condition
-// may cause it block forever.
+// may cause it to block forever.
 // The informed user is used to disambiguate credentials in case of passwordless
 // logins.
 // It returns an MFAAuthenticateResponse and the credential user, if a resident
@@ -36,11 +43,11 @@ import (
 // authentication and connected devices.
 func Login(
 	ctx context.Context,
-	origin string, user string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt,
+	origin string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt, opts *LoginOpts,
 ) (*proto.MFAAuthenticateResponse, string, error) {
 	if IsFIDO2Available() {
 		log.Debug("FIDO2: Using libfido2 for assertion")
-		return FIDO2Login(ctx, origin, user, assertion, prompt)
+		return FIDO2Login(ctx, origin, assertion, prompt, opts)
 	}
 
 	prompt.PromptTouch()

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -82,7 +82,7 @@ func IsFIDO2Available() bool {
 // fido2Login implements FIDO2Login.
 func fido2Login(
 	ctx context.Context,
-	origin, user string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt,
+	origin string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt, opts *LoginOpts,
 ) (*proto.MFAAuthenticateResponse, string, error) {
 	switch {
 	case origin == "":
@@ -95,6 +95,9 @@ func fido2Login(
 		return nil, "", trace.BadParameter("assertion challenge required")
 	case assertion.Response.RelyingPartyID == "":
 		return nil, "", trace.BadParameter("assertion relying party ID required")
+	}
+	if opts == nil {
+		opts = &LoginOpts{}
 	}
 
 	allowedCreds := assertion.Response.GetAllowedCredentialIDs()
@@ -165,7 +168,7 @@ func fido2Login(
 		var uID []byte
 		var uName string
 		if passwordless {
-			cred, err := getPasswordlessCredentials(dev, pin, rpID, user)
+			cred, err := getPasswordlessCredentials(dev, pin, rpID, opts.User)
 			if err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/auth/webauthncli/fido2_common.go
+++ b/lib/auth/webauthncli/fido2_common.go
@@ -47,9 +47,9 @@ type LoginPrompt interface {
 // IsFIDO2Available.
 func FIDO2Login(
 	ctx context.Context,
-	origin, user string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt,
+	origin string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt, opts *LoginOpts,
 ) (*proto.MFAAuthenticateResponse, string, error) {
-	return fido2Login(ctx, origin, user, assertion, prompt)
+	return fido2Login(ctx, origin, assertion, prompt, opts)
 }
 
 // RegisterPrompt is the user interface for FIDO2Register.

--- a/lib/auth/webauthncli/fido2_other.go
+++ b/lib/auth/webauthncli/fido2_other.go
@@ -35,7 +35,7 @@ func IsFIDO2Available() bool {
 
 func fido2Login(
 	ctx context.Context,
-	origin, user string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt,
+	origin string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt, opts *LoginOpts,
 ) (*proto.MFAAuthenticateResponse, string, error) {
 	return nil, "", errFIDO2Unavailable
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -167,6 +167,9 @@ type HostKeyCallback func(host string, ip net.Addr, key ssh.PublicKey) error
 type Config struct {
 	// Username is the Teleport account username (for logging into Teleport proxies)
 	Username string
+	// ExplicitUsername is true if Username was initially set by the end-user
+	// (for example, using command-line flags).
+	ExplicitUsername bool
 
 	// Remote host to connect
 	Host string
@@ -2621,7 +2624,8 @@ func (tc *TeleportClient) pwdlessLogin(ctx context.Context, pubKey []byte) (*aut
 
 	prompt := wancli.NewDefaultPrompt(ctx, tc.Stderr)
 	mfaResp, _, err := promptWebauthn(ctx, webURL.String(), challenge.WebauthnChallenge, prompt, &wancli.LoginOpts{
-		User: tc.Username,
+		User:                tc.Username,
+		OptimisticAssertion: !tc.ExplicitUsername,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2620,7 +2620,9 @@ func (tc *TeleportClient) pwdlessLogin(ctx context.Context, pubKey []byte) (*aut
 	}
 
 	prompt := wancli.NewDefaultPrompt(ctx, tc.Stderr)
-	mfaResp, _, err := promptWebauthn(ctx, webURL.String(), tc.Username, challenge.WebauthnChallenge, prompt)
+	mfaResp, _, err := promptWebauthn(ctx, webURL.String(), challenge.WebauthnChallenge, prompt, &wancli.LoginOpts{
+		User: tc.Username,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -176,7 +176,10 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			defer cancel()
 
 			prompt.SetStdin(test.inputReader)
-			*client.PromptWebauthn = func(ctx context.Context, origin, _ string, assertion *wanlib.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, string, error) {
+			*client.PromptWebauthn = func(
+				ctx context.Context,
+				origin string, assertion *wanlib.CredentialAssertion, prompt wancli.LoginPrompt, _ *wancli.LoginOpts,
+			) (*proto.MFAAuthenticateResponse, string, error) {
 				resp, err := test.solveWebauthn(ctx, origin, assertion, prompt)
 				return resp, "", err
 			}

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -159,7 +159,9 @@ func PromptMFAChallenge(
 			}}
 
 			const user = ""
-			resp, _, err := promptWebauthn(ctx, origin, user, wanlib.CredentialAssertionFromProto(c.WebauthnChallenge), mfaPrompt)
+			resp, _, err := promptWebauthn(ctx, origin, wanlib.CredentialAssertionFromProto(c.WebauthnChallenge), mfaPrompt, &wancli.LoginOpts{
+				User: user,
+			})
 			respC <- response{kind: "WEBAUTHN", resp: resp, err: err}
 		}()
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -105,6 +105,9 @@ type CLIConf struct {
 	Approve, Deny bool
 	// Username is the Teleport user's username (to login into proxies)
 	Username string
+	// ExplicitUsername is true if Username was initially set by the end-user
+	// (for example, using command-line flags).
+	ExplicitUsername bool
 	// Proxy keeps the hostname:port of the SSH proxy to use
 	Proxy string
 	// TTL defines how long a session must be active (in minutes)
@@ -643,6 +646,8 @@ func Run(args []string, opts ...cliOption) error {
 		app.Usage(args)
 		return trace.Wrap(err)
 	}
+	// Did we initially get the Username from flags/env?
+	cf.ExplicitUsername = cf.Username != ""
 
 	// apply any options after parsing of arguments to ensure
 	// that defaults don't overwrite options.
@@ -1979,6 +1984,7 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (*client.TeleportClient, erro
 	if cf.Username != "" {
 		c.Username = cf.Username
 	}
+	c.ExplicitUsername = cf.ExplicitUsername
 	c.Passwordless = cf.Passwordless
 	// if proxy is set, and proxy is not equal to profile's
 	// loaded addresses, override the values


### PR DESCRIPTION
Introduce the concept of an "optimistic assertion", which allows us to skip credential listing (saving a touch) and go directly for an authenticator assertion.

The downside of an optimistic assertion is that the authenticator picks the credential, meaning that we can't guarantee or choose the user. This should be fine for most people, as they are unlikely to have multiple Teleport users in a single cluster. If the `--user` flag is explicitly provided we'll honor it and do the two-touch ceremony instead.

Optimistic assertions are only applied for biometric authenticators; we already do single-touch for PINs if possible.

This is a bit of an experimental change. It should improve the experience in most scenarios, but we may elect to rollback if the underlying assumption proves itself to be poor.

Note that we now depend on [gravitational/go-libfido2](https://github.com/gravitational/go-libfido2), as the upstream go-libfido2 doesn't yet return the credential ID and user ID in assertions.

#9160