### PR TITLE
Fix key principals not being used when identity files are being used

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -226,6 +226,10 @@ type Config struct {
 	// against Teleport client and obtaining credentials from elsewhere.
 	SkipLocalAuth bool
 
+	// UseKeyPrincipals forces the use of the username from the key principals rather than using
+	// the current user username.
+	UseKeyPrincipals bool
+
 	// Agent is used when SkipLocalAuth is true
 	Agent agent.Agent
 
@@ -2166,7 +2170,7 @@ func (tc *TeleportClient) getProxySSHPrincipal() string {
 		proxyPrincipal = tc.JumpHosts[0].Username
 	}
 	// see if we already have a signed key in the cache, we'll use that instead
-	if !tc.Config.SkipLocalAuth && tc.localAgent != nil {
+	if (!tc.Config.SkipLocalAuth || tc.UseKeyPrincipals) && tc.localAgent != nil {
 		signers, err := tc.localAgent.Signers()
 		if err != nil || len(signers) == 0 {
 			return proxyPrincipal

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1910,6 +1910,10 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (*client.TeleportClient, erro
 	if cf.IdentityFileIn != "" {
 		// Ignore local authentication methods when identity file is provided
 		c.SkipLocalAuth = true
+		// Force the use of the certificate principals so Unix
+		// username does not get used when logging in
+		c.UseKeyPrincipals = hostLogin == ""
+
 		var (
 			key          *client.Key
 			identityAuth ssh.AuthMethod


### PR DESCRIPTION
This was happening as `SkipLocalAuth` was being set to true but was
required for `KeyPrincipals` to be used, this adds a flag that gets
set when the identity file is used to indicate that `KeyPrincipals` are
available and should be used

Fix for #10577 