### PR TITLE
Database CA - trusted cluster changes

### DIFF
--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -49,7 +49,6 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/jonboulle/clockwork"
 	"github.com/siddontang/go-mysql/client"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -1222,15 +1221,16 @@ func (p *databasePack) waitForLeaf(t *testing.T) {
 		case <-time.Tick(500 * time.Millisecond):
 			servers, err := accessPoint.GetDatabaseServers(ctx, apidefaults.Namespace)
 			if err != nil {
-				logrus.WithError(err).Debugf("Leaf cluster access point is unavailable.")
+				// Use root logger as we need a configured logger instance and the root cluster have one.
+				p.root.cluster.log.WithError(err).Debugf("Leaf cluster access point is unavailable.")
 				continue
 			}
 			if !containsDB(servers, p.leaf.mysqlService.Name) {
-				logrus.WithError(err).Debugf("Leaf db service %q is unavailable.", p.leaf.mysqlService.Name)
+				p.root.cluster.log.WithError(err).Debugf("Leaf db service %q is unavailable.", p.leaf.mysqlService.Name)
 				continue
 			}
 			if !containsDB(servers, p.leaf.postgresService.Name) {
-				logrus.WithError(err).Debugf("Leaf db service %q is unavailable.", p.leaf.postgresService.Name)
+				p.root.cluster.log.WithError(err).Debugf("Leaf db service %q is unavailable.", p.leaf.postgresService.Name)
 				continue
 			}
 			return

--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -267,7 +267,7 @@ func (p *phaseWatcher) waitForPhase(phase string, fn func() error) error {
 			Clock:     p.clock,
 			Client:    p.siteAPI,
 		},
-		CertTypes: []types.CertAuthType{p.certType},
+		WatchCertTypes: []types.CertAuthType{p.certType},
 	})
 	if err != nil {
 		return err

--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -132,48 +132,19 @@ func TestDatabaseRotateTrustedCluster(t *testing.T) {
 		clusterLeafName = pack.leaf.cluster.Secrets.SiteName
 	)
 
+	pw := phaseWatcher{
+		clusterRootName: clusterRootName,
+		pollingPeriod:   rootCluster.Process.Config.PollingPeriod,
+		clock:           pack.clock,
+		siteAPI:         rootCluster.GetSiteAPI(clusterLeafName),
+		certType:        types.DatabaseCA,
+	}
+
 	currentDbCA, err := pack.root.dbAuthClient.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.DatabaseCA,
 		DomainName: clusterRootName,
 	}, false)
 	require.NoError(t, err)
-
-	// waitForPhase waits until rootCluster cluster detects the rotation
-	waitForPhase := func(phase string) error {
-		ctx, cancel := context.WithTimeout(context.Background(), rootCluster.Process.Config.PollingPeriod*3)
-		defer cancel()
-
-		watcher, err := services.NewCertAuthorityWatcher(ctx, services.CertAuthorityWatcherConfig{
-			ResourceWatcherConfig: services.ResourceWatcherConfig{
-				Component: teleport.ComponentProxy,
-				Clock:     pack.clock,
-				Client:    rootCluster.GetSiteAPI(clusterLeafName),
-			},
-			WatchDatabaseCA: true,
-		})
-		if err != nil {
-			return err
-		}
-		defer watcher.Close()
-
-		var lastPhase string
-		for i := 0; i < 10; i++ {
-			select {
-			case <-ctx.Done():
-				return trace.CompareFailed("failed to converge to phase %q, last phase %q", phase, lastPhase)
-			case cas := <-watcher.CertAuthorityC:
-				for _, ca := range cas {
-					if ca.GetClusterName() == clusterRootName &&
-						ca.GetType() == types.DatabaseCA &&
-						ca.GetRotation().Phase == phase {
-						return nil
-					}
-					lastPhase = ca.GetRotation().Phase
-				}
-			}
-		}
-		return trace.CompareFailed("failed to converge to phase %q, last phase %q", phase, lastPhase)
-	}
 
 	err = authServer.RotateCertAuthority(ctx, auth.RotateRequest{
 		Type:        types.DatabaseCA,
@@ -182,7 +153,7 @@ func TestDatabaseRotateTrustedCluster(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = waitForPhase(types.RotationPhaseInit)
+	err = pw.waitForPhase(types.RotationPhaseInit)
 	require.NoError(t, err)
 
 	err = authServer.RotateCertAuthority(ctx, auth.RotateRequest{
@@ -192,7 +163,7 @@ func TestDatabaseRotateTrustedCluster(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = waitForPhase(types.RotationPhaseUpdateClients)
+	err = pw.waitForPhase(types.RotationPhaseUpdateClients)
 	require.NoError(t, err)
 
 	err = authServer.RotateCertAuthority(ctx, auth.RotateRequest{
@@ -202,7 +173,7 @@ func TestDatabaseRotateTrustedCluster(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = waitForPhase(types.RotationPhaseUpdateServers)
+	err = pw.waitForPhase(types.RotationPhaseUpdateServers)
 	require.NoError(t, err)
 
 	err = authServer.RotateCertAuthority(ctx, auth.RotateRequest{
@@ -212,7 +183,7 @@ func TestDatabaseRotateTrustedCluster(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = waitForPhase(types.RotationStateStandby)
+	err = pw.waitForPhase(types.RotationStateStandby)
 	require.NoError(t, err)
 
 	rotatedDbCA, err := pack.root.dbAuthClient.GetCertAuthority(ctx, types.CertAuthID{
@@ -250,6 +221,51 @@ func TestDatabaseRotateTrustedCluster(t *testing.T) {
 	// Disconnect.
 	err = dbClient.Close(context.Background())
 	require.NoError(t, err)
+}
+
+type phaseWatcher struct {
+	clusterRootName string
+	pollingPeriod   time.Duration
+	clock           clockwork.Clock
+	siteAPI         types.Events
+	certType        types.CertAuthType
+}
+
+// waitForPhase waits until rootCluster cluster detects the rotation
+func (p *phaseWatcher) waitForPhase(phase string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), p.pollingPeriod*3)
+	defer cancel()
+
+	watcher, err := services.NewCertAuthorityWatcher(ctx, services.CertAuthorityWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentProxy,
+			Clock:     p.clock,
+			Client:    p.siteAPI,
+		},
+		CertTypes: []types.CertAuthType{types.DatabaseCA},
+	})
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	var lastPhase string
+	for i := 0; i < 10; i++ {
+		select {
+		case <-ctx.Done():
+			return trace.CompareFailed("failed to converge to phase %q, last phase %q", phase, lastPhase)
+		case cas := <-watcher.CertAuthorityC:
+			for _, ca := range cas {
+				if ca.GetClusterName() == p.clusterRootName &&
+					ca.GetType() == p.certType &&
+					ca.GetRotation().Phase == phase {
+					return nil
+				}
+				lastPhase = ca.GetRotation().Phase
+			}
+		}
+	}
+	return trace.CompareFailed("failed to converge to phase %q, last phase %q", phase, lastPhase)
 }
 
 // TestDatabaseAccessMySQLRootCluster tests a scenario where a user connects

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -384,7 +384,7 @@ func (s *InstanceSecrets) GetIdentity() *auth.Identity {
 	return i
 }
 
-// GetSiteAPI() is a helper which returns an API endpoint to a site with
+// GetSiteAPI is a helper which returns an API endpoint to a site with
 // a given name. i endpoint implements HTTP-over-SSH access to the
 // site's auth server.
 func (i *TeleInstance) GetSiteAPI(siteName string) auth.ClientI {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4064,7 +4064,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 				Clock:     tconf.Clock,
 				Client:    aux.GetSiteAPI(clusterAux),
 			},
-			CertTypes: []types.CertAuthType{types.HostCA},
+			WatchCertTypes: []types.CertAuthType{types.HostCA},
 		})
 		if err != nil {
 			return err

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4064,7 +4064,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 				Clock:     tconf.Clock,
 				Client:    aux.GetSiteAPI(clusterAux),
 			},
-			WatchHostCA: true,
+			CertTypes: []types.CertAuthType{types.HostCA},
 		})
 		if err != nil {
 			return err

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2164,7 +2164,7 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 		{Remote: mainOps, Local: []string{auxDevs}},
 	})
 
-	// modify trusted cluster resource name so it would not
+	// modify trusted cluster resource name, so it would not
 	// match the cluster name to check that it does not matter
 	trustedCluster.SetName(main.Secrets.SiteName + "-cluster")
 
@@ -2263,7 +2263,7 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 	}
 	require.Error(t, err, "expected tunnel to close and SSH client to start failing")
 
-	// remove trusted cluster from aux cluster side, and recrete right after
+	// remove trusted cluster from aux cluster side, and recreate right after
 	// this should re-establish connection
 	err = aux.Process.GetAuthServer().DeleteTrustedCluster(ctx, trustedCluster.GetName())
 	require.NoError(t, err)
@@ -2305,7 +2305,7 @@ func waitForClusters(tun reversetunnel.Server, expected int) func() bool {
 			return false
 		}
 
-		// Check the expected number of clusters are connected and they have all
+		// Check the expected number of clusters are connected, and they have all
 		// connected with the past 10 seconds.
 		if len(clusters) >= expected {
 			for _, cluster := range clusters {
@@ -2374,7 +2374,7 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 		{Remote: mainDevs, Local: []string{auxDevs}},
 	})
 
-	// modify trusted cluster resource name so it would not
+	// modify trusted cluster resource name, so it would not
 	// match the cluster name to check that it does not matter
 	trustedCluster.SetName(main.Secrets.SiteName + "-cluster")
 
@@ -3732,7 +3732,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// wait until service reload
-	svc, err = suite.waitForReload(serviceC, svc)
+	svc, err = waitForReload(serviceC, svc)
 	require.NoError(t, err)
 	defer svc.Shutdown(context.TODO())
 
@@ -3763,7 +3763,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	t.Logf("Cert authority: %v", auth.CertAuthorityInfo(hostCA))
 
 	// wait until service reloaded
-	svc, err = suite.waitForReload(serviceC, svc)
+	svc, err = waitForReload(serviceC, svc)
 	require.NoError(t, err)
 	defer svc.Shutdown(context.TODO())
 
@@ -3792,7 +3792,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	t.Logf("Cert authority: %v", auth.CertAuthorityInfo(hostCA))
 
 	// wait until service reloaded
-	svc, err = suite.waitForReload(serviceC, svc)
+	svc, err = waitForReload(serviceC, svc)
 	require.NoError(t, err)
 	defer svc.Shutdown(context.TODO())
 
@@ -3878,7 +3878,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// wait until service reload
-	svc, err = s.waitForReload(serviceC, svc)
+	svc, err = waitForReload(serviceC, svc)
 	require.NoError(t, err)
 
 	cfg := ClientConfig{
@@ -3904,7 +3904,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// wait until service reloaded
-	svc, err = s.waitForReload(serviceC, svc)
+	svc, err = waitForReload(serviceC, svc)
 	require.NoError(t, err)
 
 	t.Logf("Service reloaded. Setting rotation state to %q.", types.RotationPhaseRollback)
@@ -3917,7 +3917,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// wait until service reloaded
-	svc, err = s.waitForReload(serviceC, svc)
+	svc, err = waitForReload(serviceC, svc)
 	require.NoError(t, err)
 
 	// old client works
@@ -4101,7 +4101,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// wait until service reloaded
-	svc, err = suite.waitForReload(serviceC, svc)
+	svc, err = waitForReload(serviceC, svc)
 	require.NoError(t, err)
 
 	err = waitForPhase(types.RotationPhaseUpdateClients)
@@ -4121,7 +4121,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// wait until service reloaded
-	svc, err = suite.waitForReload(serviceC, svc)
+	svc, err = waitForReload(serviceC, svc)
 	require.NoError(t, err)
 
 	err = waitForPhase(types.RotationPhaseUpdateServers)
@@ -4149,7 +4149,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// wait until service reloaded
 	t.Log("Waiting for service reload.")
-	svc, err = suite.waitForReload(serviceC, svc)
+	svc, err = waitForReload(serviceC, svc)
 	require.NoError(t, err)
 	t.Log("Service reload completed, waiting for phase.")
 
@@ -4257,7 +4257,7 @@ func testRotateChangeSigningAlg(t *testing.T, suite *integrationTestSuite) {
 		require.NoError(t, err)
 
 		// wait until service reload
-		svc, err = suite.waitForReload(serviceC, svc)
+		svc, err = waitForReload(serviceC, svc)
 		require.NoError(t, err)
 
 		t.Logf("Rotation phase: %q.", types.RotationPhaseUpdateServers)
@@ -4268,7 +4268,7 @@ func testRotateChangeSigningAlg(t *testing.T, suite *integrationTestSuite) {
 		require.NoError(t, err)
 
 		// wait until service reloaded
-		svc, err = suite.waitForReload(serviceC, svc)
+		svc, err = waitForReload(serviceC, svc)
 		require.NoError(t, err)
 
 		t.Logf("rotation phase: %q", types.RotationPhaseStandby)
@@ -4279,7 +4279,7 @@ func testRotateChangeSigningAlg(t *testing.T, suite *integrationTestSuite) {
 		require.NoError(t, err)
 
 		// wait until service reloaded
-		svc, err = suite.waitForReload(serviceC, svc)
+		svc, err = waitForReload(serviceC, svc)
 		require.NoError(t, err)
 
 		return svc
@@ -4367,7 +4367,7 @@ func waitForProcessStart(serviceC chan *service.TeleportProcess) (*service.Telep
 // 2. old service, if present to shut down
 //
 // this helper function allows to serialize tests for reloads.
-func (s *integrationTestSuite) waitForReload(serviceC chan *service.TeleportProcess, old *service.TeleportProcess) (*service.TeleportProcess, error) {
+func waitForReload(serviceC chan *service.TeleportProcess, old *service.TeleportProcess) (*service.TeleportProcess, error) {
 	var svc *service.TeleportProcess
 	select {
 	case svc = <-serviceC:

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -234,6 +234,12 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	}
 	for i := range cfg.Authorities {
 		ca := cfg.Authorities[i]
+
+		// Remove private key from leaf clusters.
+		if domainName != ca.GetClusterName() {
+			ca = ca.Clone()
+			types.RemoveCASecrets(ca)
+		}
 		// Don't re-create CA if it already exists, otherwise
 		// the existing cluster configuration will be corrupted;
 		// this part of code is only used in tests.

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -979,11 +979,13 @@ func TestInitCreatesCertsIfMissing(t *testing.T) {
 func TestMigrateDatabaseCA(t *testing.T) {
 	conf := setupConfig(t)
 
+	// Create only HostCA and UserCA. DatabaseCA should be created on Init().
 	hostCA := suite.NewTestCA(types.HostCA, "me.localhost")
 	userCA := suite.NewTestCA(types.UserCA, "me.localhost")
 
 	conf.Authorities = []types.CertAuthority{hostCA, userCA}
 
+	// Here is where migration happens.
 	auth, err := Init(conf)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -291,7 +291,7 @@ func (a *Server) RotateExternalCertAuthority(ctx context.Context, ca types.CertA
 	// a rotation state of "" gets stored as "standby" after
 	// CheckAndSetDefaults, so if `ca` came in with a zeroed rotation we must do
 	// this before checking if `updated` is the same as `existing` or the check
-	// will fail for no reason (CheckAndSetDefaults is idempotent so it's fine
+	// will fail for no reason (CheckAndSetDefaults is idempotent, so it's fine
 	// to call it both here and in CompareAndSwapCertAuthority)
 	updated.SetRotation(ca.GetRotation())
 	if err := updated.CheckAndSetDefaults(); err != nil {

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -459,8 +459,9 @@ func (s *remoteSite) watchCertAuthorities() error {
 			Clock:     s.clock,
 			Client:    s.localAccessPoint,
 		},
-		WatchUserCA: true,
-		WatchHostCA: true,
+		WatchUserCA:     true,
+		WatchHostCA:     true,
+		WatchDatabaseCA: true,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -496,7 +497,7 @@ func (s *remoteSite) watchCertAuthorities() error {
 			for _, localCA := range cas {
 				if localCA.GetClusterName() != s.srv.ClusterName ||
 					(localCA.GetType() != types.HostCA &&
-						localCA.GetType() != types.UserCA) {
+						localCA.GetType() != types.UserCA && localCA.GetType() != types.DatabaseCA) {
 					continue
 				}
 

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -459,9 +459,7 @@ func (s *remoteSite) watchCertAuthorities() error {
 			Clock:     s.clock,
 			Client:    s.localAccessPoint,
 		},
-		WatchUserCA:     true,
-		WatchHostCA:     true,
-		WatchDatabaseCA: true,
+		CertTypes: []types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA},
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -475,7 +473,7 @@ func (s *remoteSite) watchCertAuthorities() error {
 			Clock:     s.clock,
 			Client:    s.remoteAccessPoint,
 		},
-		WatchHostCA: true,
+		CertTypes: []types.CertAuthType{types.HostCA},
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -459,7 +459,7 @@ func (s *remoteSite) watchCertAuthorities() error {
 			Clock:     s.clock,
 			Client:    s.localAccessPoint,
 		},
-		CertTypes: []types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA},
+		WatchCertTypes: []types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA},
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -473,7 +473,7 @@ func (s *remoteSite) watchCertAuthorities() error {
 			Clock:     s.clock,
 			Client:    s.remoteAccessPoint,
 		},
-		CertTypes: []types.CertAuthType{types.HostCA},
+		WatchCertTypes: []types.CertAuthType{types.HostCA},
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -928,12 +928,12 @@ func (s *server) getRemoteClusters() []*remoteSite {
 }
 
 // GetSite returns a RemoteSite. The first attempt is to find and return a
-// remote site and that is what is returned if a remote remote agent has
+// remote site and that is what is returned if a remote agent has
 // connected to this proxy. Next we loop over local sites and try and try and
 // return a local site. If that fails, we return a cluster peer. This happens
 // when you hit proxy that has never had an agent connect to it. If you end up
 // with a cluster peer your best bet is to wait until the agent has discovered
-// all proxies behind a the load balancer. Note, the cluster peer is a
+// all proxies behind a load balancer. Note, the cluster peer is a
 // services.TunnelConnection that was created by another proxy.
 func (s *server) GetSite(name string) (RemoteSite, error) {
 	s.RLock()

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -977,8 +977,10 @@ type caCollector struct {
 // CertAuthorityMap maps clusterName -> types.CertAuthority
 type CertAuthorityMap map[string]types.CertAuthority
 
+// CertAuthorityTypeMap maps types.CertAuthType -> map(clusterName -> types.CertAuthority)
 type CertAuthorityTypeMap map[types.CertAuthType]CertAuthorityMap
 
+// ToSlice converts CertAuthorityTypeMap to a slice.
 func (cat *CertAuthorityTypeMap) ToSlice() []types.CertAuthority {
 	slice := make([]types.CertAuthority, 0)
 	for _, cert := range *cat {

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -920,8 +920,8 @@ type CertAuthorityWatcherConfig struct {
 	AuthorityGetter
 	// CertAuthorityC receives up-to-date list of all cert authority resources.
 	CertAuthorityC chan []types.CertAuthority
-	// CertTypes stores all certificate types that should be monitored.
-	CertTypes []types.CertAuthType
+	// WatchCertTypes stores all certificate types that should be monitored.
+	WatchCertTypes []types.CertAuthType
 }
 
 // CheckAndSetDefaults checks parameters and sets default values.
@@ -1000,7 +1000,7 @@ func (c *caCollector) resourceKind() string {
 func (c *caCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 	updatedCerts := make(CertAuthorityTypeMap)
 
-	for _, caType := range c.CertTypes {
+	for _, caType := range c.WatchCertTypes {
 		cas, err := c.AuthorityGetter.GetCertAuthorities(ctx, caType, false)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -920,12 +920,8 @@ type CertAuthorityWatcherConfig struct {
 	AuthorityGetter
 	// CertAuthorityC receives up-to-date list of all cert authority resources.
 	CertAuthorityC chan []types.CertAuthority
-	// WatchHostCA indicates that the watcher should monitor types.HostCA
-	WatchHostCA bool
-	// WatchUserCA indicates that the watcher should monitor types.UserCA
-	WatchUserCA bool
-
-	WatchDatabaseCA bool
+	// CertTypes stores all certificate types that should be monitored.
+	CertTypes []types.CertAuthType
 }
 
 // CheckAndSetDefaults checks parameters and sets default values.
@@ -973,10 +969,24 @@ type CertAuthorityWatcher struct {
 // caCollector accompanies resourceWatcher when monitoring cert authority resources.
 type caCollector struct {
 	CertAuthorityWatcherConfig
-	host     map[string]types.CertAuthority
-	user     map[string]types.CertAuthority
-	database map[string]types.CertAuthority
-	lock     sync.RWMutex
+
+	collectedCAs CertAuthorityTypeMap
+	lock         sync.RWMutex
+}
+
+// CertAuthorityMap maps clusterName -> types.CertAuthority
+type CertAuthorityMap map[string]types.CertAuthority
+
+type CertAuthorityTypeMap map[types.CertAuthType]CertAuthorityMap
+
+func (cat *CertAuthorityTypeMap) ToSlice() []types.CertAuthority {
+	slice := make([]types.CertAuthority, 0)
+	for _, cert := range *cat {
+		for _, ca := range cert {
+			slice = append(slice, ca)
+		}
+	}
+	return slice
 }
 
 // resourceKind specifies the resource kind to watch.
@@ -986,55 +996,28 @@ func (c *caCollector) resourceKind() string {
 
 // getResourcesAndUpdateCurrent refreshes the list of current resources.
 func (c *caCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
-	var (
-		newHost map[string]types.CertAuthority
-		newUser map[string]types.CertAuthority
-		newDB   map[string]types.CertAuthority
-	)
+	updatedCerts := make(CertAuthorityTypeMap)
 
-	if c.WatchHostCA {
-		host, err := c.AuthorityGetter.GetCertAuthorities(ctx, types.HostCA, false)
+	for _, caType := range c.CertTypes {
+		cas, err := c.AuthorityGetter.GetCertAuthorities(ctx, caType, false)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		newHost = make(map[string]types.CertAuthority, len(host))
-		for _, ca := range host {
-			newHost[ca.GetName()] = ca
-		}
-	}
 
-	if c.WatchUserCA {
-		user, err := c.AuthorityGetter.GetCertAuthorities(ctx, types.UserCA, false)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		newUser = make(map[string]types.CertAuthority, len(user))
-		for _, ca := range user {
-			newUser[ca.GetName()] = ca
-		}
-	}
-
-	if c.WatchDatabaseCA {
-		db, err := c.AuthorityGetter.GetCertAuthorities(ctx, types.DatabaseCA, false)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		newDB = make(map[string]types.CertAuthority, len(db))
-		for _, ca := range db {
-			newDB[ca.GetName()] = ca
+		updatedCerts[caType] = make(CertAuthorityMap, len(cas))
+		for _, ca := range cas {
+			updatedCerts[caType][ca.GetName()] = ca
 		}
 	}
 
 	c.lock.Lock()
-	c.host = newHost
-	c.user = newUser
-	c.database = newDB
+	c.collectedCAs = updatedCerts
 	c.lock.Unlock()
 
 	select {
 	case <-ctx.Done():
 		return trace.Wrap(ctx.Err())
-	case c.CertAuthorityC <- casToSlice(newHost, newUser, newDB):
+	case c.CertAuthorityC <- c.collectedCAs.ToSlice():
 	}
 	return nil
 }
@@ -1049,19 +1032,17 @@ func (c *caCollector) processEventAndUpdateCurrent(ctx context.Context, event ty
 	defer c.lock.Unlock()
 	switch event.Type {
 	case types.OpDelete:
-		if c.WatchHostCA && event.Resource.GetSubKind() == string(types.HostCA) {
-			delete(c.host, event.Resource.GetName())
-		}
-		if c.WatchUserCA && event.Resource.GetSubKind() == string(types.UserCA) {
-			delete(c.user, event.Resource.GetName())
-		}
-		if c.WatchDatabaseCA && event.Resource.GetSubKind() == string(types.DatabaseCA) {
-			delete(c.database, event.Resource.GetName())
+		caType := types.CertAuthType(event.Resource.GetSubKind())
+
+		// Check if the certificate should be processed.
+		_, found := c.collectedCAs[caType]
+		if found {
+			delete(c.collectedCAs[caType], event.Resource.GetName())
 		}
 
 		select {
 		case <-ctx.Done():
-		case c.CertAuthorityC <- casToSlice(c.host, c.user, c.database):
+		case c.CertAuthorityC <- c.collectedCAs.ToSlice():
 		}
 	case types.OpPut:
 		ca, ok := event.Resource.(types.CertAuthority)
@@ -1070,19 +1051,16 @@ func (c *caCollector) processEventAndUpdateCurrent(ctx context.Context, event ty
 			return
 		}
 
-		if c.WatchHostCA && ca.GetType() == types.HostCA {
-			c.host[ca.GetName()] = ca
-		}
-		if c.WatchUserCA && ca.GetType() == types.UserCA {
-			c.user[ca.GetName()] = ca
-		}
-		if c.WatchDatabaseCA && ca.GetType() == types.DatabaseCA {
-			c.database[ca.GetName()] = ca
+		caType := ca.GetType()
+		_, found := c.collectedCAs[caType]
+		// Check if the certificate should be processed.
+		if found {
+			c.collectedCAs[caType][ca.GetName()] = ca
 		}
 
 		select {
 		case <-ctx.Done():
-		case c.CertAuthorityC <- casToSlice(c.host, c.user, c.database):
+		case c.CertAuthorityC <- c.collectedCAs.ToSlice():
 		}
 	default:
 		c.Log.Warnf("Unsupported event type %s.", event.Type)
@@ -1094,17 +1072,7 @@ func (c *caCollector) processEventAndUpdateCurrent(ctx context.Context, event ty
 func (c *caCollector) GetCurrent() []types.CertAuthority {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return casToSlice(c.host, c.user, c.database)
+	return c.collectedCAs.ToSlice()
 }
 
 func (c *caCollector) notifyStale() {}
-
-func casToSlice(certs ...map[string]types.CertAuthority) []types.CertAuthority {
-	slice := make([]types.CertAuthority, 0)
-	for _, cert := range certs {
-		for _, ca := range cert {
-			slice = append(slice, ca)
-		}
-	}
-	return slice
-}

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -743,7 +743,7 @@ func TestCertAuthorityWatcher(t *testing.T) {
 			},
 		},
 		CertAuthorityC: make(chan []types.CertAuthority, 10),
-		CertTypes:      []types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA},
+		WatchCertTypes: []types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA},
 	})
 	require.NoError(t, err)
 	t.Cleanup(w.Close)

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -742,9 +742,10 @@ func TestCertAuthorityWatcher(t *testing.T) {
 				Events: local.NewEventsService(bk),
 			},
 		},
-		CertAuthorityC: make(chan []types.CertAuthority, 10),
-		WatchUserCA:    true,
-		WatchHostCA:    true,
+		CertAuthorityC:  make(chan []types.CertAuthority, 10),
+		WatchUserCA:     true,
+		WatchHostCA:     true,
+		WatchDatabaseCA: true,
 	})
 	require.NoError(t, err)
 	t.Cleanup(w.Close)

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -742,10 +742,8 @@ func TestCertAuthorityWatcher(t *testing.T) {
 				Events: local.NewEventsService(bk),
 			},
 		},
-		CertAuthorityC:  make(chan []types.CertAuthority, 10),
-		WatchUserCA:     true,
-		WatchHostCA:     true,
-		WatchDatabaseCA: true,
+		CertAuthorityC: make(chan []types.CertAuthority, 10),
+		CertTypes:      []types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA},
 	})
 	require.NoError(t, err)
 	t.Cleanup(w.Close)


### PR DESCRIPTION
This PR contains fixes to https://github.com/gravitational/teleport/pull/9593 mainly around DatabaseCA trusted cluster rotation.