### PR TITLE
[v5] backport #11318 (arm packages)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3278,75 +3278,6 @@ steps:
     commands:
     - aws s3 sync /rpmrepo/teleport/ s3://$AWS_S3_BUCKET/teleport/
 
-  - name: Download DEB repo contents
-    image: amazon/aws-cli
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: DEBREPO_AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: DEBREPO_AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: DEBREPO_AWS_SECRET_ACCESS_KEY
-    volumes:
-      - name: debrepo
-        path: /debrepo
-    commands:
-    # we explicitly want to delete anything present locally which has been deleted
-    # from the upstream S3 bucket
-    - mkdir -p /debrepo/teleport
-    - aws s3 sync s3://$AWS_S3_BUCKET/teleport /debrepo/teleport --delete
-
-  - name: Build DEB repo
-    image: ubuntu:20.04
-    environment:
-      DEBIAN_FRONTEND: noninteractive
-      GNUPGHOME: /tmpfs/gnupg
-      GPG_RPM_SIGNING_ARCHIVE:
-        from_secret: GPG_RPM_SIGNING_ARCHIVE
-    volumes:
-      - name: dockersock
-        path: /var/run
-      - name: debrepo
-        path: /debrepo
-      # for in-memory tmpfs for key material
-      - name: tmpfs
-        path: /tmpfs
-    commands:
-      - |
-        # install needed tools
-        apt-get -y update && apt-get -y install curl gzip gnupg2 reprepro tar
-      - |
-        # write config files
-        mkdir -p /go/reprepro/teleport/conf /go/reprepro/teleport/public
-        cat << EOF > /go/reprepro/teleport/conf/distributions
-        Origin: teleport
-        Label: teleport
-        Codename: stable
-        Architectures: i386 amd64
-        Components: main
-        Description: apt repository for teleport
-        SignWith: 6282C411
-        EOF
-        cat << EOF > /go/reprepro/teleport/conf/options
-        verbose
-        basedir /go/reprepro/teleport
-        EOF
-      - |
-        # extract signing key
-        mkdir -m0700 $GNUPGHOME
-        echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPGHOME
-        chown -R root:root $GNUPGHOME
-      - |
-        # create repo
-        cd /go/reprepro/teleport
-        reprepro --outdir /go/reprepro/teleport/public includedeb stable /go/artifacts/teleport*.deb
-      - |
-        # clean up gnupg
-        rm -rf $GNUPGHOME
-      - |
-        # copy artifacts to PVC
-        cp -r /go/reprepro/teleport /debrepo/
-
   # Deb repo publish disabled for https://github.com/gravitational/teleport/issues/8166
 
 services:
@@ -3376,6 +3307,6 @@ volumes:
 
 ---
 kind: signature
-hmac: e0c9a444f13dc7affad8deabd4d212ebe83bc34e71026151f6481d3b253747f4
+hmac: 71f1a6790d6f57530ff41868fcf90ef376716a7cb1426def0cec3059bed19803
 
 ...


### PR DESCRIPTION
Backport of #11318.

This just completely removes anything related to deb repos (rather than just the publish step) to avoid errors in the pipeline caused by the new `armhf` architecture; v5 did not have arm packages so no changes are required there.