### PR TITLE
Remove references to authentication type 'false' from docs

### DIFF
--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -11,7 +11,7 @@ By default, it is stored in `/etc/teleport.yaml`.
 
 (!docs/pages/includes/backup-warning.mdx!)
 
-This document aims to be a reference rather than a starting point for a real cluster. 
+This document aims to be a reference rather than a starting point for a real cluster.
 
 <Admonition type="danger" title="Before using this reference">
 You must edit your configuration file to meet the needs of your environment. Using a copy of the reference configuration will have unintended effects. To create a configuration file that you can use as a starting point, run the following command:
@@ -30,7 +30,7 @@ version: v2
 # This section of the configuration file applies to all teleport
 # services.
 teleport:
-    # nodename allows one to assign an alternative name this node can be 
+    # nodename allows one to assign an alternative name this node can be
     # reached by. By default it's equal to hostname.
     nodename: graviton
 
@@ -42,14 +42,14 @@ teleport:
     # PID file for Teleport process
     #pid_file: /var/run/teleport.pid
 
-    # Invitation token or file path containing token used to join a cluster. It 
+    # Invitation token or file path containing token used to join a cluster. It
     # is not used on subsequent starts.
     #
     # File path example:
     # auth_token: /var/lib/teleport/tokenjoin
     auth_token: xxxx-token-xxxx
 
-    # Optional CA pin of the auth server. This enables a more secure way of 
+    # Optional CA pin of the auth server. This enables a more secure way of
     # adding new nodes to a cluster. See "Adding Nodes to the Cluster"
     # (https://goteleport.com/docs/admin-guide/#adding-nodes-to-the-cluster).
     ca_pin: "sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
@@ -59,8 +59,8 @@ teleport:
     #
     # This value can be specified as FQDN e.g. host.example.com
     advertise_ip: 10.1.0.5
-    
-    
+
+
     # Teleport provides HTTP endpoints for monitoring purposes. They are
     # disabled by default but you can enable them using the diagnosis address.
     # See the Teleport metrics reference:
@@ -94,7 +94,7 @@ teleport:
         max_connections: 1000
         max_users: 250
 
-    # Logging configuration. Possible output values to disk via 
+    # Logging configuration. Possible output values to disk via
     # '/var/lib/teleport/teleport.log',
     # 'stdout', 'stderr' and 'syslog'. Possible severity values are DEBUG, INFO (default), WARN,
     # and ERROR.
@@ -104,7 +104,7 @@ teleport:
 
         # Log format configuration
         # Possible output values are 'json' and 'text' (default).
-        # Possible extra_fields values include: timestamp, component, caller, 
+        # Possible extra_fields values include: timestamp, component, caller,
         # and level.
         # All extra fields are included by default.
         format:
@@ -112,27 +112,27 @@ teleport:
           extra_fields: [level, timestamp, component, caller]
 
     # Configuration for the storage back-end used for the cluster state and the
-    # audit log. Several back-end types are supported. See the "High 
-    # Availability" section of the Admin Manual 
+    # audit log. Several back-end types are supported. See the "High
+    # Availability" section of the Admin Manual
     # (https://goteleport.com/docs/admin-guide/#high-availability) to learn how
     # to configure DynamoDB, S3, etcd, and other highly available back-ends.
     storage:
-        # By default teleport uses the `data_dir` directory on a local 
+        # By default teleport uses the `data_dir` directory on a local
         # filesystem
         type: dir
 
-        # List of locations where the audit log events will be stored. By 
+        # List of locations where the audit log events will be stored. By
         # default, they are stored in `/var/lib/teleport/log`.
         #
-        # When specifying multiple destinations like this, make sure that 
-        # highly-available storage methods (like DynamoDB or Firestore) are 
-        # specified first, as this is what the Teleport Web UI uses as its 
+        # When specifying multiple destinations like this, make sure that
+        # highly-available storage methods (like DynamoDB or Firestore) are
+        # specified first, as this is what the Teleport Web UI uses as its
         # source of events to display.
         audit_events_uri: ['dynamodb://events_table_name', 'firestore://events_table_name', 'file:///var/lib/teleport/log', 'stdout://']
 
         # Use this setting to configure teleport to store the recorded sessions
-        # in an AWS S3 bucket or use GCP Storage with 'gs://'. See "Using 
-        # Amazon S3" for more information 
+        # in an AWS S3 bucket or use GCP Storage with 'gs://'. See "Using
+        # Amazon S3" for more information
         # (https://goteleport.com/docs/admin-guide/#using-amazon-s3).
         audit_sessions_uri: 's3://example.com/path/to/bucket?region=us-east-1'
 
@@ -141,7 +141,7 @@ teleport:
         continuous_backups: [true|false]
 
         # DynamoDB Specific Section
-        # auto_scaling is used to enable (and define settings for) auto 
+        # auto_scaling is used to enable (and define settings for) auto
         # scaling.
         # default: false
         auto_scaling:  [true|false]
@@ -216,8 +216,8 @@ auth_service:
 
     authentication:
         # default authentication type. possible values are 'local' and 'github'
-        # for OSS and 'oidc', 'saml' and 'false' for Enterprise.
-        # Only local authentication (Teleport's own user DB) & Github is 
+        # for OSS, plus 'oidc' and 'saml' for Enterprise.
+        # Only local authentication (Teleport's own user DB) & Github is
         # supported in the open source version
         type: local
 
@@ -226,7 +226,7 @@ auth_service:
         # (https://goteleport.com/docs/enterprise/ssh-kubernetes-fedramp/)
         #local_auth: true
 
-        # second_factor can be 'off', 'on', 'optional', 'otp', 'webauthn' or 
+        # second_factor can be 'off', 'on', 'optional', 'otp', 'webauthn' or
         # 'u2f'.
         # - 'on' requires otp and either webauthn (preferred) or u2f.
         # - 'optional' allows otp and either webauthn (preferred) or u2f.
@@ -252,9 +252,9 @@ auth_service:
           # https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/Attestation.html).
           # This field allows you to restrict which device models and vendors
           # you trust.
-          # Devices outside of the list will be rejected during registration. 
+          # Devices outside of the list will be rejected during registration.
           # By default all devices are allowed.
-          # If you must use attestation, consider using 
+          # If you must use attestation, consider using
           # `attestation_denied_cas` to forbid troublesome devices instead.
           attestation_allowed_cas:
           - /path/to/allowed_ca.pem
@@ -305,7 +305,7 @@ auth_service:
             # the legitimate proxy.
             facets:
             # app_id should always also be listed as a facet
-            - https://localhost:3080 
+            - https://localhost:3080
             - https://localhost
             - localhost:3080
             - localhost
@@ -334,7 +334,7 @@ auth_service:
     # certificates
     listen_addr: 0.0.0.0:3025
 
-    # The optional DNS name for the auth server if located behind a load 
+    # The optional DNS name for the auth server if located behind a load
     # balancer.
     public_addr: auth.example.com:3025
 
@@ -350,23 +350,23 @@ auth_service:
         - "auth:yyyy"
 
     # Optional setting for configuring session recording. Possible values are:
-    #    "node"      : sessions will be recorded on the node level  (the 
+    #    "node"      : sessions will be recorded on the node level  (the
     #                  default)
-    #    "node-sync" : session recordings will be streamed from 
-    #                  node -> auth -> storage service without being stored on 
+    #    "node-sync" : session recordings will be streamed from
+    #                  node -> auth -> storage service without being stored on
     #                  disk at all.
     #    "proxy"     : recording on the proxy level, see "Recording Proxy Mode"
     #                  (https://goteleport.com/docs/architecture/proxy/#recording-proxy-mode).
-    #    "proxy-sync : session recordings will be streamed from 
+    #    "proxy-sync : session recordings will be streamed from
     #                  proxy -> auth -> storage service without being stored on
     #                  disk at all.
     #    "off"   : session recording is turned off
     #
     session_recording: "node"
 
-    # This setting determines if a Teleport proxy performs strict host key 
+    # This setting determines if a Teleport proxy performs strict host key
     # checks.
-    # Only applicable if session_recording=proxy, see "Recording Proxy Mode" 
+    # Only applicable if session_recording=proxy, see "Recording Proxy Mode"
     # for details
     # (https://goteleport.com/docs/architecture/proxy/#recording-proxy-mode).
     proxy_checks_host_keys: yes
@@ -380,25 +380,25 @@ auth_service:
     # inactivity. The empty string indicates that no message will be sent.
     # (Currently only supported for SSH connections)
     client_idle_timeout_message: ""
-    
+
     # Sets an idle timeout for the Web UI. The default is 10m.
     web_idle_timeout: 10m
 
     # Determines if the clients will be forcefully disconnected when their
-    # certificates expire in the middle of an active SSH session. (default is 
+    # certificates expire in the middle of an active SSH session. (default is
     # 'no')
     disconnect_expired_cert: no
 
     # Determines the interval at which Teleport will send keep-alive messages.
-    # The default is set to 5 minutes (300 seconds) to stay lower than the 
+    # The default is set to 5 minutes (300 seconds) to stay lower than the
     # common load balancer timeout of 350 seconds.
     # keep_alive_count_max is the number of missed keep-alive messages before
     # the server tears down the connection to the client.
     keep_alive_interval: 5m
     keep_alive_count_max: 3
 
-    # Determines the internal session control timeout cluster-wide. This value 
-    # will be used with enterprise max_connections and max_sessions. It's 
+    # Determines the internal session control timeout cluster-wide. This value
+    # will be used with enterprise max_connections and max_sessions. It's
     # unlikely that you'll need to change this.
     # session_control_timeout: 2m
 
@@ -411,22 +411,22 @@ auth_service:
     # and Enterprise subscription plans.
     #
     # The path can be either absolute or relative to the configured `data_dir`
-    # and should point to the license file obtained from Teleport Download 
+    # and should point to the license file obtained from Teleport Download
     # Portal.
     #
     # If not set, by default Teleport will look for the `license.pem` file in
     # the configured `data_dir` .
     license_file: /var/lib/teleport/license.pem
 
-    # Configures a banner message to be displayed to a user logging into the 
+    # Configures a banner message to be displayed to a user logging into the
     # cluster, which must be acknowledged before the user is allowed to log in.
-    # Note that will be shown *before* login, so should not contain any 
+    # Note that will be shown *before* login, so should not contain any
     # confidential information.
-    # Defaults to the empty string, implying no message or acknowledgment is 
+    # Defaults to the empty string, implying no message or acknowledgment is
     # required.
     message_of_the_day: ""
 
-    # Indicates to the clients whether the cluster is running in TLS routing 
+    # Indicates to the clients whether the cluster is running in TLS routing
     # mode with all protocols multiplexed on the proxy's web_listen_addr.
     #
     # Possible values are:
@@ -447,8 +447,8 @@ ssh_service:
     # IP and the port for SSH service to bind to.
     listen_addr: 0.0.0.0:3022
 
-    # The optional public address the SSH service. This is useful if 
-    # administrators want to allow users to connect to nodes directly, 
+    # The optional public address the SSH service. This is useful if
+    # administrators want to allow users to connect to nodes directly,
     # bypassing a Teleport proxy.
     public_addr: node.example.com:3022
 
@@ -458,7 +458,7 @@ ssh_service:
         role: leader
         type: postgres
 
-    # List of the commands to periodically execute. Their output will be used 
+    # List of the commands to periodically execute. Their output will be used
     # as node labels.
     # See "Labeling Nodes" section for more information and more examples
     # (https://goteleport.com/docs/admin-guide/#labeling-nodes-and-applications).
@@ -469,7 +469,7 @@ ssh_service:
       period: 1h0m0s
 
     # Enables reading ~/.tsh/environment before creating a session.
-    # By default it's set to false can be set true here or through the 
+    # By default it's set to false can be set true here or through the
     # command-line flag.
     permit_user_env: false
 
@@ -508,13 +508,13 @@ ssh_service:
     port_forwarding: true
 
     # When x11.enabled is set to yes, users with the "permit_x11_forwarding"
-    # role option will be able to request X11 forwarding sessions with 
+    # role option will be able to request X11 forwarding sessions with
     # "tsh ssh -X".
     #
     # X11 forwarding will only work if the server has the "xauth" binary
     # installed and the Teleport node can open Unix sockets.
     # e.g. "$TEMP/.X11-unix/X[display_number]."
-    x11: 
+    x11:
       # no by default
       enabled: yes
       # display_offset can be used to specify the start of the range of X11
@@ -531,13 +531,13 @@ proxy_service:
     # Turns 'proxy' role on. Default is 'yes'
     enabled: yes
 
-    # ProxyProtocol enables support for HAProxy proxy protocol version 1 when 
+    # ProxyProtocol enables support for HAProxy proxy protocol version 1 when
     # it is turned 'on'.
     # Verify whether the service is in front of a trusted load balancer.
     # The default value is 'on'.
     proxy_protocol: on
 
-    # SSH forwarding/proxy address. Command line (CLI) clients always begin 
+    # SSH forwarding/proxy address. Command line (CLI) clients always begin
     # their SSH sessions by connecting to this port
     #
     # If not set, behavior depends on the config file version:
@@ -548,7 +548,7 @@ proxy_service:
 
     # Reverse tunnel listening address. An auth server (CA) can establish an
     # outbound (from behind the firewall) connection to this address.
-    # This will allow users of the outside CA to connect to 
+    # This will allow users of the outside CA to connect to
     # behind-the-firewall nodes.
     #
     # If not set, behavior depends on the config file version:
@@ -574,16 +574,16 @@ proxy_service:
     public_addr: proxy.example.com:3080
 
     # The DNS name of the proxy SSH endpoint as accessible by cluster clients.
-    # Defaults to the proxy's hostname if not specified. If running multiple 
-    # proxies behind a load balancer, this name must point to the load 
+    # Defaults to the proxy's hostname if not specified. If running multiple
+    # proxies behind a load balancer, this name must point to the load
     # balancer.
     # Use a TCP load balancer because this port uses SSH protocol.
     ssh_public_addr: proxy.example.com:3023
 
     # The DNS name of the tunnel SSH endpoint as accessible by trusted clusters
     # and nodes joining the cluster via Teleport IoT/node tunneling.
-    # Defaults to the proxy's hostname if not specified. If running multiple 
-    # proxies behind a load balancer, this name must point to the load 
+    # Defaults to the proxy's hostname if not specified. If running multiple
+    # proxies behind a load balancer, this name must point to the load
     # balancer. Use a TCP load balancer because this port uses SSH protocol.
     tunnel_public_addr: proxy.example.com:3024
 
@@ -609,7 +609,7 @@ proxy_service:
     #
     # If not set, behavior depends on the config file version:
     #
-    # "v2": listener is not created, MySQL traffic is multiplexed on 
+    # "v2": listener is not created, MySQL traffic is multiplexed on
     #       web_listen_addr
     # "v1": defaults to 0.0.0.0:3036
     mysql_listen_addr: "0.0.0.0:3036"
@@ -619,24 +619,24 @@ proxy_service:
     # instead of multiplexing Postgres protocol on web_listener_addr.
     # postgres_listen_addr: "0.0.0.0:5432"
 
-    # Mongo Proxy listener address. If provided, proxy will use a separate 
+    # Mongo Proxy listener address. If provided, proxy will use a separate
     # listener instead of multiplexing Mongo protocol on web_listener_addr.
     # mongo_listen_addr: "0.0.0.0:27017"
 
     # Address advertised to MySQL clients. If not set, public_addr is used.
     mysql_public_addr: "mysql.teleport.example.com:3306"
 
-    # Address advertised to PostgresSQL clients. If not set, public_addr is 
+    # Address advertised to PostgresSQL clients. If not set, public_addr is
     # used.
     postgres_public_addr: "postgres.teleport.example.com:443"
 
     # Address advertised to Mongo clients. If not set, public_addr is used.
     mongo_public_addr: "mongo.teleport.example.com:443"
 
-    # Get an automatic certificate from Letsencrypt.org using ACME via 
+    # Get an automatic certificate from Letsencrypt.org using ACME via
     # TLS_ALPN-01 challenge.
-    # When using ACME, the cluster name must match the 'public_addr' of 
-    # Teleport and the 'proxy_service' must be publicly accessible over port 
+    # When using ACME, the cluster name must match the 'public_addr' of
+    # Teleport and the 'proxy_service' must be publicly accessible over port
     # 443.
     # Also set using the CLI command:
     # 'teleport configure --acme --acme-email=email@example.com \
@@ -649,8 +649,8 @@ proxy_service:
 app_service:
     # Turns 'app' role on. Default is 'no'
     enabled: yes
-    # Teleport contains a small debug app that can be used to make sure 
-    # Application Access is working correctly. The app outputs JWTs so it can 
+    # Teleport contains a small debug app that can be used to make sure
+    # Application Access is working correctly. The app outputs JWTs so it can
     # be useful when extending your application.
     debug_app: true
     apps:
@@ -691,11 +691,11 @@ kubernetes_service:
     # Optional kubeconfig_file and kube_cluster_name. Exactly one of these must
     # be set.
     #
-    # When running teleport outside of the kubernetes cluster, use 
+    # When running teleport outside of the kubernetes cluster, use
     # kubeconfig_file to provide teleport with cluster credentials.
     #
-    # When running teleport inside of the kubernetes cluster pod, use 
-    # kube_cluster_name to provide a user-visible name. Teleport uses the pod 
+    # When running teleport inside of the kubernetes cluster pod, use
+    # kube_cluster_name to provide a user-visible name. Teleport uses the pod
     # service account credentials to authenticate to its local kubernetes API.
     kubeconfig_file: /secrets/kubeconfig
     kube_cluster_name:

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -18,7 +18,7 @@ kubeClusterName: ""
 # Version of teleport image, if different from chart version in Chart.yaml.
 teleportVersionOverride: ""
 
-# Default authentication type. Possible values are 'local' and 'github' for OSS, plus 'oidc', 'saml', and 'false' for Enterprise.
+# Default authentication type. Possible values are 'local' and 'github' for OSS, plus 'oidc' and 'saml' for Enterprise.
 # 'false' is required for FedRAMP / FIPS; see https://gravitational.com/teleport/docs/enterprise/ssh-kubernetes-fedramp/
 authenticationType: local
 


### PR DESCRIPTION
Setting `auth_service.authentication.type` to `false` doesn't work.

```
ERROR REPORT:
Original Error: *trace.BadParameterError authentication type &#34;false&#34; not supported
Stack Trace:
	/go/src/github.com/gravitational/teleport/api/types/authentication.go:428 github.com/gravitational/teleport/api/types.(*AuthPreferenceV2).CheckAndSetDefaults
	/go/src/github.com/gravitational/teleport/api/types/authentication.go:133 github.com/gravitational/teleport/api/types.newAuthPreferenceWithLabels
	/go/src/github.com/gravitational/teleport/api/types/authentication.go:119 github.com/gravitational/teleport/api/types.NewAuthPreferenceFromConfigFile
	/go/src/github.com/gravitational/teleport/lib/config/fileconf.go:714 github.com/gravitational/teleport/lib/config.(*AuthenticationConfig).Parse
	/go/src/github.com/gravitational/teleport/lib/config/configuration.go:546 github.com/gravitational/teleport/lib/config.applyAuthConfig
	/go/src/github.com/gravitational/teleport/lib/config/configuration.go:384 github.com/gravitational/teleport/lib/config.ApplyFileConfig
	/go/src/github.com/gravitational/teleport/lib/config/configuration.go:1695 github.com/gravitational/teleport/lib/config.Configure
	/go/src/github.com/gravitational/teleport/tool/teleport/common/teleport.go:325 github.com/gravitational/teleport/tool/teleport/common.Run
	/go/src/github.com/gravitational/teleport/tool/teleport/main.go:34 main.main
	/opt/go/src/runtime/proc.go:255 runtime.main
	/opt/go/src/runtime/asm_amd64.s:1581 runtime.goexit
User Message: authentication type &#34;false&#34; not supported
```

We should remove it from the docs.