### PR TITLE
implement in-memory thread-safe tls certificate cache

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -323,6 +323,10 @@ const (
 	// DefaultRedisUsername is a default username used by Redis when
 	// no name is provided at connection time.
 	DefaultRedisUsername = "default"
+
+	// TLSCertificatesCacheReloadInterval is the period after which the in-memory cache of TLS certificates
+	// is refreshed from disk.
+	TLSCertificatesCacheReloadInterval = 24 * time.Hour
 )
 
 var (


### PR DESCRIPTION
Sorry for the duplicate from #9271, the branch had fallen behind. Fixes #3815.

This PR adds an in-memory thread-safe cache for a `[]tls.Certificate`, and functionality to refresh the cache at some point after a fixed interval. In the `TeleportProcess.setupProxyTLSConfig` function the one-time loading of `TeleportProcess.Config.Proxy.KeyPairs` and setting of `tlsconfig.Certificates` is replaced with a solution that makes use of the `GetCertificate` field.

The in-memory cache is populated on startup as usual. Whenever there's a new TLS connection the handler calls the `GetCertificate` method. The previous code uses the `Certificates` field, where the docs say:

```
// Certificates contains one or more certificate chains to present to the
// other side of the connection. The first certificate compatible with the
// peer's requirements is selected automatically.
```

The `GetCertificate` method that we add replicates this functionality precisely. However, the certificate files must always be available on disk.

The in-memory cache is implemented by the struct:

```go

type tlsCertificatesCache struct {
	// reloadInterval defines how long the proxy service will hold certs in-memory before reloading them from disk
	reloadInterval time.Duration

	// mutex synchronizes access to the below fields
	mutex *sync.Mutex

	// certs holds TLS certificates that were loaded from the filesystem paths defined in the Config.Proxy.KeyPairs field
	certs []tls.Certificate
	// lastReloaded holds the last time that certs was reloaded from disk
	lastReloaded time.Time
}
```

**The changes in total are small and have been thoroughly tested**. Are there some other places in the teleport codebase that could also use this functionality?