### PR TITLE
Edit Database Access guides for Cloud users

### DIFF
--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -3,33 +3,50 @@ title: Database Access Getting Started Guide
 description: Getting started with Teleport Database Access and AWS Aurora PostgreSQL.
 ---
 
-# Getting Started
-
 In this getting started guide we will use Teleport Database Access to connect
 to a PostgreSQL AWS Aurora database.
 
 Here's an overview of what we will do:
 
-1. Configure AWS Aurora database with IAM authentication.
-2. Download and install Teleport (=teleport.version=) and connect it to the Aurora database.
-3. Connect to the Aurora database via Teleport.
+1. Configure an AWS Aurora database with IAM authentication.
+2. Join the Aurora database to your Teleport cluster.
+3. Connect to the Aurora database via the Teleport Database Service.
+
+## Prerequisites
+
+<Admonition type="note" title="Supported versions">
+
+Teleport Database Access is available starting from the `6.0.0` Teleport
+release.
+
+</Admonition>
+
+- An AWS account with a PostgreSQL AWS Aurora database and permissions to create
+  and attach IAM policies.
+
+- A host, e.g., an EC2 instance, where you will run the Teleport Database
+  Service.
+
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Set up Aurora
 
-In order to allow Teleport connections to an Aurora instance, it needs to support
-IAM authentication.
+In order to allow Teleport connections to an Aurora instance, the instance needs
+to support IAM authentication.
 
 If you don't have a database provisioned yet, create an instance of an Aurora
 PostgreSQL in the [RDS control panel](https://console.aws.amazon.com/rds/home).
-Make sure to choose "Standard create" database creation method and enable
+Make sure to choose the "Standard create" database creation method and enable
 "Password and IAM database authentication" in the Database Authentication dialog.
 
 For existing Aurora instances, the status of IAM authentication is displayed on
 the Configuration tab and can be enabled by modifying the database instance.
 
 Next, create the following IAM policy and attach it to the AWS user or service
-account. Teleport Database Service will need to use credentials of this AWS user
-or service account in order to use this policy.
+account. The Teleport Database Service will need to use the credentials of this
+AWS user or service account in order to use this policy.
 
 ```json
 {
@@ -55,10 +72,10 @@ with resource ID using IAM auth.
   type="note"
   title="Resource ID"
 >
-  Database resource ID is shown on the Configuration tab of a particular
-  database instance in RDS control panel, under "Resource id". For regular
+  The database resource ID is shown on the Configuration tab of a particular
+  database instance in the RDS control panel, under "Resource id". For regular
   RDS database it starts with `db-` prefix. For Aurora, use the database
-  cluster resource ID (`cluster-`), not individual instance ID.
+  cluster resource ID (`cluster-`), not the individual instance ID.
 </Admonition>
 
 Finally, connect to the database and create a database account with IAM auth
@@ -71,42 +88,55 @@ GRANT rds_iam TO alice;
 ```
 
 For more information about connecting to the PostgreSQL instance directly,
-see Amazon [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ConnectToPostgreSQLInstance.html).
+see the AWS [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ConnectToPostgreSQLInstance.html).
 
 ## Step 2/3. Set up Teleport
 
-Teleport Database Access is available starting from `6.0.0` release.
+### Start the Auth Service and Proxy Service
 
-Download the appropriate version of Teleport for your platform from
-our [downloads page](https://goteleport.com/teleport/download).
+(!docs/pages/includes/database-access/start-auth-proxy.mdx!)
+
+### Start the Teleport Database Service
+
+(!docs/pages/includes/database-access/token.mdx!)
 
 
-### Configure TLS
+<ScopedBlock scope={["oss", "enterprise"]}>
 
-Teleport requires a valid TLS certificate to operate and can fetch one automatically
-using Let's Encrypt.
-
-(!docs/pages/includes/acme.mdx!)
-
-We will assume that you have configured a DNS record for `teleport.example.com` to point to the node where you're launching Teleport.
-
-<Details title="Using Application Access?">
-(!docs/pages/includes/dns-app-access.mdx!)
-</Details>
-
-### Start Teleport
-
-Now start Teleport and point it to your Aurora database instance. Make sure to
-update the database endpoint and region appropriately.
+On the node where you will run the Teleport Database Service, start Teleport and
+point it to your Aurora database instance. Make sure to update the database
+endpoint and region appropriately. The `--auth-server` flag must point to the
+address of your Teleport Proxy Service.
 
 ```code
-$ sudo teleport start --config=/tmp/teleport.yaml \
-  --roles=proxy,auth,db \
+$ teleport db start \
+  --token=/tmp/token \
   --db-name=aurora \
+  --auth-server=teleport.example.com:3080 \
   --db-protocol=postgres \
   --db-uri=postgres-aurora-instance-1.abcdefghijklm.us-west-1.rds.amazonaws.com:5432 \
   --db-aws-region=us-west-1
 ```
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+On the node where you will run the Teleport Database Service, start Teleport and
+point it to your Aurora database instance. Make sure to update the database
+endpoint and region appropriately. The `--auth-server` flag must point to the
+address of your Teleport Cloud tenant.
+
+```code
+$ teleport db start \
+  --token=/tmp/token \
+  --db-name=aurora \
+  --auth-server=mytenant.teleport.sh \
+  --db-protocol=postgres \
+  --db-uri=postgres-aurora-instance-1.abcdefghijklm.us-west-1.rds.amazonaws.com:5432 \
+  --db-aws-region=us-west-1
+```
+
+</ScopedBlock>
 
 <Admonition
   type="note"
@@ -146,15 +176,25 @@ $ tctl users add --roles=access,db alice
 
 ## Step 3/3. Connect
 
-Now that Aurora is configured with IAM authentication, Teleport is running and
+Now that Aurora is configured with IAM authentication, Teleport is running, and
 the local user is created, we're ready to connect to the database.
 
-Log into Teleport with the user we've just created. Make sure to use `tsh`
-version `6.0` or newer that includes Database Access support.
+Log in to Teleport with the user we've just created.
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
 ```
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=alice
+```
+
+</ScopedBlock>
 
 Now we can inspect available databases and retrieve credentials for the
 configured Aurora instance:
@@ -164,8 +204,8 @@ $ tsh db ls
 $ tsh db login aurora
 ```
 
-Finally, connect to the database using `psql` command shown in the output of
-`tsh db login` command, which looks similar to this:
+Finally, connect to the database using the `psql` command shown in the output of
+the `tsh db login` command, which looks similar to this:
 
 ```code
 $ psql "service=<cluster>-aurora user=alice dbname=postgres"

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -23,7 +23,6 @@ release.
 
 - An AWS account with a PostgreSQL AWS Aurora database and permissions to create
   and attach IAM policies.
-
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
 

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -28,26 +28,34 @@ This guide will help you to:
 
 ## Prerequisites
 
-- Teleport version >= `8.1`.
 - Deployed Azure Database for PostgreSQL or MySQL server.
 - Azure Active Directory administrative privileges.
+- A host, e.g., an Azure VM instance, where you will run the Teleport Database
+  Service.
+
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Install and configure Teleport
 
-### Set up Teleport Auth and Proxy Services
+### Set up the Teleport Auth and Proxy Services
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
-### Set up Teleport Database Service
+### Set up the Teleport Database Service
 
 (!docs/pages/includes/database-access/token.mdx!)
 
-Start Teleport Database Service. Make sure to update `--auth-server` to point to
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+Start the Teleport Database Service. Make sure to update `--auth-server` to point to
 your Teleport Proxy Service address and `--uri` to the Azure database server
 endpoint.
 
 <Tabs>
 <TabItem label="PostgreSQL">
+
   ```bash
   $ teleport db start \
     --token=/tmp/token \
@@ -57,8 +65,10 @@ endpoint.
     --uri=example.postgres.database.azure.com:5321 \
     --labels=env=dev
   ```
+
 </TabItem>
 <TabItem label="MySQL">
+
   ```bash
   $ teleport db start \
     --token=/tmp/token \
@@ -68,15 +78,54 @@ endpoint.
     --uri=example.mysql.database.azure.com:3306 \
     --labels=env=dev
   ```
+
 </TabItem>
 </Tabs>
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+Start the Teleport Database Service. Make sure to update `--auth-server` to point to
+your Teleport Cloud tenant address and `--uri` to the Azure database server
+endpoint.
+
+<Tabs>
+<TabItem label="PostgreSQL">
+
+  ```bash
+  $ teleport db start \
+    --token=/tmp/token \
+    --auth-server=mytenant.teleport.sh \
+    --name=azure-db \
+    --protocol=postgres \
+    --uri=example.postgres.database.azure.com:5321 \
+    --labels=env=dev
+  ```
+
+</TabItem>
+<TabItem label="MySQL">
+
+  ```bash
+  $ teleport db start \
+    --token=/tmp/token \
+    --auth-server=mytenant.teleport.sh \
+    --name=azure-db \
+    --protocol=mysql \
+    --uri=example.mysql.database.azure.com:3306 \
+    --labels=env=dev
+  ```
+
+</TabItem>
+</Tabs>
+
+</ScopedBlock>
+
 <Admonition type="tip">
-  You can start Teleport Database Service using a configuration file instead of
-  CLI flags. See [YAML reference](../reference/configuration.mdx).
+  You can start the Teleport Database Service using a configuration file instead of
+  CLI flags. See the [YAML reference](../reference/configuration.mdx).
 </Admonition>
 
-### Create Teleport user
+### Create a Teleport user
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 
@@ -86,11 +135,11 @@ To authenticate with PostgreSQL or MySQL databases, Teleport Database Service
 needs to obtain access tokens from Azure AD. There are a couple of ways to
 achieve that:
 
-- Database Service can be registered as an Azure AD application (via AD's "App
+- The Database Service can be registered as an Azure AD application (via AD's "App
   registrations") and configured with its credentials. This is only recommended
   for development and testing purposes since it requires Azure credentials to
   be present in the Database Service's environment.
-- Database Service can run on an Azure VM with attached managed identity. This
+- The Database Service can run on an Azure VM with attached managed identity. This
   is the recommended way of deploying the Database Service in production since
   it eliminates the need to manage Azure credentials.
 
@@ -142,10 +191,10 @@ achieve that:
 
   ![Registered app secrets](../../../img/database-access/guides/azure/registered-app-secrets@2x.png)
 
-  Teleport Database Service uses Azure SDK's default credential provider chain to
+  The Teleport Database Service uses Azure SDK's default credential provider chain to
   look for credentials. Refer to [Authentication methods](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authorization)
   to pick a method suitable for your use-case. For example, to use
-  environment-based authentication with a client secret, Database Service should
+  environment-based authentication with a client secret, the Database Service should
   have the following environment variables set:
 
   ```bash
@@ -159,7 +208,7 @@ achieve that:
 ## Step 3/4. Create Azure database users
 
 To let Teleport connect to your Azure database authenticating as a service
-principal you need to create Azure AD users for that principal in the database.
+principal, you need to create Azure AD users for that principal in the database.
 
 ### Assign Azure AD administrator
 
@@ -227,8 +276,10 @@ You can create multiple database users for the same service principal.
 
 ## Step 4/4. Connect
 
-Log into your Teleport cluster. Your Azure database should appear in the list of
+Log in to your Teleport cluster. Your Azure database should appear in the list of
 available databases:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -238,14 +289,28 @@ $ tsh db ls
 # azure-db                     env=dev
 ```
 
-Fetch short-lived client certificate for it using `tsh db login` command:
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=alice
+$ tsh db ls
+# Name     Description         Labels
+# -------- ------------------- -------
+# azure-db                     env=dev
+```
+
+</ScopedBlock>
+
+Fetch short-lived client certificate for your Azure database using the
+`tsh db login` command:
 
 ```code
 $ tsh db login --db-user=teleport azure-db
 ```
 
 <Admonition type="tip">
-  You can be logged into multiple databases simultaneously.
+  You can be logged in to multiple databases simultaneously.
 </Admonition>
 
 Now connect to the database:
@@ -256,7 +321,7 @@ $ tsh db connect azure-db
 
 <Admonition type="note">
   The appropriate database command-line client (`psql`, `mysql`) should be
-  available in PATH of the machine you're running `tsh db connect` from.
+  available in `PATH` of the machine you're running `tsh db connect` from.
 </Admonition>
 
 To log out of the database and remove credentials:

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -302,7 +302,7 @@ $ tsh db ls
 
 </ScopedBlock>
 
-Fetch short-lived client certificate for your Azure database using the
+Fetch a short-lived client certificate for your Azure database using the
 `tsh db login` command:
 
 ```code
@@ -321,7 +321,7 @@ $ tsh db connect azure-db
 
 <Admonition type="note">
   The appropriate database command-line client (`psql`, `mysql`) should be
-  available in `PATH` of the machine you're running `tsh db connect` from.
+  available in the `PATH` of the machine you're running `tsh db connect` from.
 </Admonition>
 
 To log out of the database and remove credentials:

--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -21,18 +21,22 @@ This guide will help you to:
 
 ## Prerequisites
 
-- Teleport version `(=teleport.version=)` or higher.
-- CockroachDB cluster. Start a single or a multi-node local cluster in
-  [Docker](https://www.cockroachlabs.com/docs/v21.1/start-a-local-cluster-in-docker-mac.html)
-  if you don't have one.
+- CockroachDB cluster.
+
+- A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
+  Service.
+
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Install and configure Teleport
 
-### Set up Teleport Auth and Proxy Services
+### Set up the Teleport Auth and Proxy Services
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
-### Set up Teleport Database Service
+### Set up the Teleport Database Service
 
 (!docs/pages/includes/database-access/token.mdx!)
 <Tabs>
@@ -48,8 +52,16 @@ $ teleport db start \
   --uri=roach.example.com:26257 \
   --labels=env=dev
 ```
+
+<Admonition type="note">
+  The `--auth-server` flag must point to the Teleport cluster's Proxy Service endpoint
+  because the Database Service always connects back to the cluster over a reverse
+  tunnel.
+</Admonition>
+
 </TabItem>
 <TabItem label="Teleport Cloud" scope={["cloud"]}>
+
 Start the Teleport Database Service, pointing the `--auth-server` flag at the address of your Teleport Cloud tenant, e.g., `mytenant.teleport.sh`.
 
 ```code
@@ -61,14 +73,10 @@ $ teleport db start \
   --uri=roach.example.com:26257 \
   --labels=env=dev
 ```
+
 </TabItem>
 </Tabs>
 
-<Admonition type="note">
-  The `--auth-server` flag must point to the Teleport cluster's proxy endpoint
-  because the Database Service always connects back to the cluster over a reverse
-  tunnel.
-</Admonition>
 
 <Admonition type="tip">
   You can start the Database Service using a configuration file instead of CLI flags.
@@ -95,9 +103,11 @@ mandates client certificate auth.
 
 Make sure to assign the user proper permissions within the database cluster.
 Refer to [Create User](https://www.cockroachlabs.com/docs/stable/create-user.html)
-in Cockroach docs for more information.
+in the CockroachDB documentation for more information.
 
 ### Set up mutual TLS
+
+(!docs/pages/includes/database-access/tctl-auth-sign.mdx!)
 
 To set up mutual TLS authentication, you need to make sure that:
 
@@ -138,7 +148,7 @@ $ cockroach start \
 
 ## Step 3/3. Connect
 
-Log into your Teleport cluster. Your CockroachDB cluster should appear in the
+Log in to your Teleport cluster. Your CockroachDB cluster should appear in the
 list of available databases:
 
 <Tabs>
@@ -186,7 +196,7 @@ $ tsh db connect roach
 ```
 
 <Admonition type="note">
-  Either the `cockroach` or `psql` command-line client should be available in PATH
+  Either the `cockroach` or `psql` command-line client should be available in `PATH`
   in order to be able to connect.
 </Admonition>
 

--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -22,7 +22,6 @@ This guide will help you to:
 ## Prerequisites
 
 - CockroachDB cluster.
-
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
 

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -4,8 +4,6 @@ description: How to configure Teleport Database Access with MongoDB Atlas.
 videoBanner: mu_ZKTjnFJ8
 ---
 
-# MongoDB Atlas
-
 In this guide you will:
 
 1. Configure Teleport for accessing your MongoDB Atlas cluster.
@@ -14,12 +12,18 @@ In this guide you will:
 
 ## Prerequisites
 
-- Teleport version `(=teleport.version=)` or newer.
 - [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) cluster.
+
+- A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
+  Service.
+
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Configure Teleport
 
-### Set up Teleport Auth and Proxy services
+### Set up the Teleport Auth and Proxy services
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
@@ -27,9 +31,15 @@ In this guide you will:
 
 (!docs/pages/includes/database-access/token.mdx!)
 
+Next, start the Database Service.
+
+<ScopedBlock scope={["enterprise","oss"]}>
+
 <Tabs>
-<TabItem label="Self-Hosted" scope={["enterprise","oss"]}>
-Start the Teleport Database Service, pointing the `--auth-server` flag at the address of your Teleport Proxy Service:
+<TabItem label="Teleport CLI">
+
+On the node where you will run the Database Service, start Teleport, pointing
+the `--auth-server` flag at the address of your Teleport Proxy Service:
 
 ```code
 $ teleport db start \
@@ -38,43 +48,22 @@ $ teleport db start \
   --name=mongodb-atlas \
   --protocol=mongodb \
   --uri=mongodb+srv://cluster0.abcde.mongodb.net \
-  --ca-cert=/path/to/letsencrypt/isrgrootx1.pem
+  --ca-cert=/path/to/letsencrypt/isrgrootx1.pem \
   --labels=env=dev
 ```
-
-</TabItem>
-<TabItem label="Teleport Cloud" scope={["cloud"]}>
-Start the Teleport Database Service, pointing the `--auth-server` flag at the address of your Teleport Cloud tenant, e.g., `mytenant.teleport.sh`.
-
-```code
-$ teleport db start \
-  --token=/tmp/token \
-  --auth-server=mytenant.teleport.sh \
-  --name=mongodb-atlas \
-  --protocol=mongodb \
-  --uri=mongodb+srv://cluster0.abcde.mongodb.net \
-  --ca-cert=/path/to/letsencrypt/isrgrootx1.pem
-  --labels=env=dev
-```
-
-</TabItem>
-</Tabs>
-
-See below for details on `--uri` and `--ca-cert` flags.
 
 <Admonition type="note">
-  The `--auth-server` flag must point to the Teleport cluster's proxy endpoint
+  The `--auth-server` flag must point to the Teleport cluster's Proxy Service endpoint
   because the Database Service always connects back to the cluster over a reverse
   tunnel.
 </Admonition>
 
-#### Configuration file
+</TabItem>
+<TabItem label="Configuration file">
 
-If you're starting the Database Agent with a YAML configuration instead of CLI flags,
-the following config is equivalent to the `teleport db start` command shown earlier:
+On the node where you will run the Teleport Database Service, run
+`teleport db start` with the following in `/etc/teleport.yaml`:
 
-<Tabs>
-<TabItem label="Self-Hosted" scope={["enterprise","oss"]}>
 ```yaml
 teleport:
   auth_token: "/tmp/token"
@@ -90,8 +79,38 @@ db_service:
     static_labels:
       env: "dev"
 ```
+
+See the full [YAML reference](../reference/configuration.mdx) for details.
+
 </TabItem>
-<TabItem label="Teleport Cloud" scope={["cloud"]}>
+</Tabs>
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem label="Teleport CLI">
+
+On the node where you will run the Database Service, start Teleport, pointing the
+`--auth-server` flag at the address of your Teleport Cloud tenant, e.g.,
+`mytenant.teleport.sh`.
+
+```code
+$ teleport db start \
+  --token=/tmp/token \
+  --auth-server=mytenant.teleport.sh \
+  --name=mongodb-atlas \
+  --protocol=mongodb \
+  --uri=mongodb+srv://cluster0.abcde.mongodb.net \
+  --ca-cert=/path/to/letsencrypt/isrgrootx1.pem \
+  --labels=env=dev
+```
+
+</TabItem>
+<TabItem label="Configuration file">
+
+On the node where you will run the Teleport Database Service, run
+`teleport db start` with the following in `/etc/teleport.yaml`:
+
 ```yaml
 teleport:
   auth_token: "/tmp/token"
@@ -107,10 +126,14 @@ db_service:
     static_labels:
       env: "dev"
 ```
-</TabItem>
-</Tabs>
 
 See the full [YAML reference](../reference/configuration.mdx) for details.
+
+</TabItem>
+</Tabs>
+</ScopedBlock>
+
+See below for details on how to configure the Teleport Database Service.
 
 #### Connection endpoint
 
@@ -133,7 +156,8 @@ $ --uri=mongodb+srv://cluster0.abcde.mongodb.net
 
 MongoDB Atlas uses certificates signed by Let's Encrypt.
 
-Download the Let's Encrypt root certificate and use it as a CA in the database service configuration:
+Download the Let's Encrypt root certificate and use it as a CA in the Database
+Service configuration:
 
 ```code
 $ curl -o /tmp/isrgrootx1.pem https://letsencrypt.org/certs/isrgrootx1.pem.txt
@@ -223,7 +247,7 @@ $ tsh db login mongodb-atlas
 ```
 
 <Admonition type="tip">
-  You can be logged into multiple databases simultaneously.
+  You can be logged in to multiple databases simultaneously.
 </Admonition>
 
 You can optionally specify the database name and the user to use by default
@@ -239,12 +263,10 @@ Once logged in, connect to the database:
 $ tsh db connect mongodb-atlas
 ```
 
-<Admonition type="note" title="Note">
-  Either the `mongosh` or `mongo` command-line clients should be available in PATH in order to be
-  able to connect. The Database Service attempts to run `mongosh` first and, if `mongosh` is not in PATH, runs `mongo`.
-</Admonition>
+<Admonition type="note" title="Preparing your client environment">
+  Either the `mongosh` or `mongo` command-line clients should be available in `PATH` in order to be
+  able to connect. The Database Service attempts to run `mongosh` first and, if `mongosh` is not in `PATH`, runs `mongo`.
 
-<Admonition type="note" title="Note">
   Teleport 9.0 added support for `mongosh` and made it the default Mongo DB client.
 </Admonition>
 

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -13,7 +13,6 @@ In this guide you will:
 ## Prerequisites
 
 - [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) cluster.
-
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
 

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -12,7 +12,6 @@ In this guide you will:
 
 ## Prerequisites
 
-- Teleport version `7.0` or newer.
 - MongoDB cluster (standalone or replica set) version `(=mongodb.min_version=)` or newer.
 
 <Admonition type="note">
@@ -22,17 +21,27 @@ In this guide you will:
   April 2021 so if you're still using an older version, consider upgrading.
 </Admonition>
 
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
+
 ## Step 1/3. Install and configure Teleport
 
 ### Set up the Teleport Auth and Proxy services
 
+You will need to install Teleport version `7.0` or newer to access self-hosted
+MongoDB instances.
+
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
-### Setup Teleport Database service
+### Set up the Teleport Database service
 
 (!docs/pages/includes/database-access/token.mdx!)
 
-Start the Teleport Database Service, pointing the `--auth-server` flag to the address of your Teleport Proxy Service (for Teleport Cloud users, this will resemble `mytenant.teleport.sh`):
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+Start the Teleport Database Service, pointing the `--auth-server` flag to the
+address of your Teleport Proxy Service:
 
 ```code
 $ teleport db start \
@@ -45,10 +54,30 @@ $ teleport db start \
 ```
 
 <Admonition type="note">
-The `--auth-server` flag must point to the Teleport cluster's proxy endpoint
-because the Database Service always connects back to the cluster over a reverse
-tunnel.
+
+The `--auth-server` flag must point to the Teleport cluster's Proxy Service
+endpoint because the Database Service always connects back to the cluster over a
+reverse tunnel.
+
 </Admonition>
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+Start the Teleport Database Service, pointing the `--auth-server` flag to the
+address of your Teleport Cloud tenant:
+
+```code
+$ teleport db start \
+  --token=/tmp/token \
+  --auth-server=mytenant.teleport.sh \
+  --name=example-mongo \
+  --protocol=mongodb \
+  --uri=mongo.example.com:27017 \
+  --labels=env=dev
+```
+
+</ScopedBlock>
 
 You can specify either a single connection address or a MongoDB
 [connection string](https://docs.mongodb.com/manual/reference/connection-string/)
@@ -68,16 +97,16 @@ $ --uri="mongodb://mongo1.example.com:27017,mongo2.example.com:27017/?replicaSet
 
 <Admonition type="tip">
   You can start the Database Service using a configuration file instead of CLI flags.
-  See [YAML reference](../reference/configuration.mdx).
+  See the [YAML reference](../reference/configuration.mdx) for details.
 </Admonition>
 
-### Create Teleport user
+### Create a Teleport user
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 
 ## Step 2/3. Configure MongoDB
 
-### Create MongoDB user
+### Create a MongoDB user
 
 Teleport will use [X.509 authentication](https://docs.mongodb.com/manual/tutorial/configure-x509-client-authentication/)
 when connecting to a MongoDB instance. Users authenticating with client certificates
@@ -85,7 +114,7 @@ must be created in the `$external` MongoDB authentication database.
 
 MongoDB treats the entire `Subject` line of the client certificate as a username.
 When connecting to a MongoDB server, say as a user `alice`, Teleport will sign
-an ephemeral certificate with `CN=alice` subject.
+an ephemeral certificate with the `CN=alice` subject.
 
 To create this user in the database, connect to it using the `mongosh` or `mongo` shell and run
 the following command:
@@ -125,7 +154,7 @@ Create the secrets:
   (!docs/pages/includes/database-access/ttl-note.mdx!)
 
   The command will create two files: `mongo.cas` with Teleport's certificate
-  authority and `mongo.crt` with generated certificate and key pair. You will
+  authority and `mongo.crt` with the generated certificate and key pair. You will
   need these files to enable mutual TLS on your MongoDB server.
   </TabItem>
   <TabItem label="Replica set">
@@ -143,7 +172,7 @@ Create the secrets:
   (!docs/pages/includes/database-access/ttl-note.mdx!)
 
   Each command will create two files: `mongo1.cas`/`mongo2.cas` with Teleport's
-  certificate authority and `mongo1.crt`/`mongo2.crt` with generated certificate
+  certificate authority and `mongo1.crt`/`mongo2.crt` with the generated certificate
   and key pair. You will need these files to enable mutual TLS on your MongoDB
   servers.
   </TabItem>
@@ -179,16 +208,18 @@ When configuring a replica set, make sure to do it for each member and use
 secrets generated for the particular server.
 
 Once mutual TLS has been enabled, you will no longer be able to connect to
-the cluster without providing a valid client certificate. You can use
+the cluster without providing a valid client certificate. You can use the
 `net.tls.allowConnectionsWithoutCertificates` setting to allow connections
 from clients that do not present a certificate.
 
 See [Configure TLS/SSL](https://docs.mongodb.com/manual/tutorial/configure-ssl/)
-in MongoDB documentation for more details.
+in the MongoDB documentation for more details.
 
 ## Step 3/3. Connect
 
-Log into your Teleport cluster and see available databases:
+Log in to your Teleport cluster and see available databases:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -198,15 +229,28 @@ $ tsh db ls
 # example-mongo Example MongoDB env=dev
 ```
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=alice
+$ tsh db ls
+# Name          Description     Labels
+# ------------- --------------- --------
+# example-mongo Example MongoDB env=dev
+```
+
+</ScopedBlock>
+
 To connect to a particular database instance, first retrieve its certificate
-using `tsh db login` command:
+using the `tsh db login` command:
 
 ```code
 $ tsh db login example-mongo
 ```
 
 <Admonition type="tip">
-  You can be logged into multiple databases simultaneously.
+  You can be logged in to multiple databases simultaneously.
 </Admonition>
 
 You can optionally specify the database name and the user to use by default
@@ -222,12 +266,10 @@ Once logged in, connect to the database:
 $ tsh db connect example-mongo
 ```
 
-<Admonition type="note" title="Note">
-  Either the `mongosh` or `mongo` command-line clients should be available in PATH in order to be
-  able to connect. The Database Service attempts to run `mongosh` first and, if `mongosh` is not in PATH, runs `mongo`.
-</Admonition>
+<Admonition type="note" title="Supported MongoDB clients">
+  Either the `mongosh` or `mongo` command-line clients should be available in `PATH` in order to be
+  able to connect. The Database Service attempts to run `mongosh` first and, if `mongosh` is not in `PATH`, runs `mongo`.
 
-<Admonition type="note" title="Note">
   Teleport 9.0 added support for `mongosh` and made it the default Mongo DB client.
 </Admonition>
 

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -3,18 +3,31 @@ title: Database Access with MySQL on GCP Cloud SQL
 description: How to configure Teleport Database Access with GCP Cloud SQL MySQL.
 ---
 
-# GCP Cloud SQL MySQL
+In this guide, we will show you how to use Teleport Database Access with MySQL
+on Google Cloud SQL.
 
-## Create a service account for the Teleport Database Service
+## Prerequisites
+
+- Google Cloud account
+
+- A host, e.g., a Compute Engine instance, where you will run the Teleport Database
+  Service
+
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
+
+## Step 1/5. Create a service account for the Teleport Database Service
 
 Teleport uses one-time passwords to authenticate with Cloud SQL MySQL. To be
 able to authenticate with a database instance, Teleport must run as a service
 account that has a few of the "Cloud SQL Admin" role permissions. You can create
-a new service account, or modify an existing one to add required permissions.
+a new service account or modify an existing one to add required permissions.
 
 ### Create a service account
 
-If creating a new one, go to the [Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts)
+If creating a new service account, go to the
+[Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts)
 page and create another service account:
 
 ![Create Service Account](../../../img/database-access/guides/cloudsql/service-account-db-service@2x.png)
@@ -27,7 +40,7 @@ Assign the Service Account the "Cloud SQL Admin" role:
 
 <Admonition type="note" title="Service account permissions">
   The default "Cloud SQL Admin" IAM role includes more permissions than the
-  database agent needs to generate one-time user passwords. To further restrict
+  Database Service needs to generate one-time user passwords. To further restrict
   the service account, you can create a role that includes only the following
   permissions:
   ```ini
@@ -53,10 +66,10 @@ Make sure to choose JSON format:
 
 ![Service Account New Key](../../../img/database-access/guides/cloudsql/service-account-new-key@2x.png)
 
-Save the file, your Teleport Database Service will need to use it as GCP
+Save the file. Your Teleport Database Service will need to use it as GCP
 application credentials file.
 
-## Gather Cloud SQL instance information
+## Step 2/5. Gather Cloud SQL instance information
 
 To connect a Cloud SQL database to Teleport, you'll need to gather a few pieces
 of information about the instance.
@@ -87,18 +100,18 @@ file from the Connections tab under Security section:
 
 ![Instance Root Certificate](../../../img/database-access/guides/cloudsql/instance-root-ca@2x.png)
 
-## Setup Teleport Auth and Proxy services
+## Step 3/5. Set up the Teleport Auth and Proxy services
 
-Teleport Database Access for Cloud SQL MySQL is available starting from `7.0`
-release.
+Teleport Database Access for Cloud SQL MySQL is available starting from the
+`7.0` release.
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
 (!docs/pages/includes/database-access/token.mdx!)
 
-### Create user
+### Create a user
 
-Create local Teleport user with the built-in `access` role:
+Create a local Teleport user with the built-in `access` role:
 
 ```code
 $ tctl users add --roles=access alice
@@ -107,7 +120,7 @@ $ tctl users add --roles=access alice
 The `access` role allows users to see all connected database servers, but
 allowed database users are restricted to the user's `db_users` traits. Normally,
 these traits come from the identity provider. For the local user you've just
-created you can update them manually to allow it to connect as a `alice`
+created you can update them manually to allow the user to connect as an `alice`
 database user.
 
 First, export the user resource:
@@ -131,29 +144,31 @@ Update the user:
 $ tctl create alice.yaml -f
 ```
 
-For more detailed information about database access controls see [RBAC](../rbac.mdx)
-documentation.
+For more detailed information about database access controls see the
+[RBAC](../rbac.mdx) documentation.
 
-## Setup Teleport Database service
+## Step 4/5. Set up the Teleport Database service
 
 Below is an example of a database service configuration file that proxies
 a single Cloud SQL MySQL database:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```yaml
 teleport:
   data_dir: /var/lib/teleport-db
   nodename: test
   # Proxy address to connect to. Note that it has to be the proxy address
-  # because database service always connects to the cluster over reverse
+  # because the Database Service always connects to the cluster over a reverse
   # tunnel.
   auth_servers:
   - teleport.example.com:3080
 db_service:
   enabled: "yes"
   # This section contains definitions of all databases proxied by this
-  # service, can contain multiple items.
+  # service. Can contain multiple items.
   databases:
-    # Name of the database proxy instance, used to reference in CLI.
+    # Name of the database proxy instance. Used to reference in CLI.
   - name: "cloudsql"
     # Free-form description of the database proxy instance.
     description: "GCP Cloud SQL MySQL"
@@ -163,7 +178,7 @@ db_service:
     uri: "35.1.2.3:3306"
     # Path to Cloud SQL instance root certificate you downloaded above.
     ca_cert_file: /path/to/cloudsql/instance/root.pem
-    # GCP specific configuration when connecting Cloud SQL instance.
+    # GCP-specific configuration when connecting a Cloud SQL instance.
     gcp:
       # GCP project ID.
       project_id: "<project-id>"
@@ -180,16 +195,60 @@ proxy_service:
   enabled: "no"
 ```
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```yaml
+teleport:
+  data_dir: /var/lib/teleport-db
+  nodename: test
+  # Proxy address to connect to. Use your Teleport Cloud tenant address.
+  auth_servers:
+  - mytenant.teleport.sh
+db_service:
+  enabled: "yes"
+  # This section contains definitions of all databases proxied by this
+  # service. Can contain multiple items.
+  databases:
+    # Name of the database proxy instance. Used to reference in CLI.
+  - name: "cloudsql"
+    # Free-form description of the database proxy instance.
+    description: "GCP Cloud SQL MySQL"
+    # Database protocol.
+    protocol: "mysql"
+    # Database endpoint. For Cloud SQL use instance's public IP address.
+    uri: "35.1.2.3:3306"
+    # Path to Cloud SQL instance root certificate you downloaded above.
+    ca_cert_file: /path/to/cloudsql/instance/root.pem
+    # GCP-specific configuration when connecting a Cloud SQL instance.
+    gcp:
+      # GCP project ID.
+      project_id: "<project-id>"
+      # Cloud SQL instance ID.
+      instance_id: "test"
+    # Labels to assign to the database, used in RBAC.
+    static_labels:
+      env: dev
+auth_service:
+  enabled: "no"
+ssh_service:
+  enabled: "no"
+proxy_service:
+  enabled: "no"
+```
+
+</ScopedBlock>
+
 <Admonition
   type="tip"
   title="Tip"
 >
   A single Teleport process can run multiple different services, for example
-  multiple database access proxies as well as running other services such an
-  SSH service or an application access proxy.
+  multiple Database Access instances as well as other services such the SSH
+  Service or Application Service.
 </Admonition>
 
-Start the database service:
+Start the Database Service:
 
 ```code
 $ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
@@ -197,21 +256,24 @@ $ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
 
 ### GCP credentials
 
-Teleport Database Service must have credentials of `teleport-db-service` GCP
-service account we created [above](#create-a-service-account-for-the-teleport-database-service)
-in order to be able to login.
+The Teleport Database Service must have the credentials of `teleport-db-service` GCP
+service account we created
+[above](#create-a-service-account-for-the-teleport-database-service) in order to
+be able to log in.
 
-The easiest way to ensure that is to set `GOOGLE_APPLICATION_CREDENTIALS`
+The easiest way to ensure that is to set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to point to the JSON credentials file you downloaded
 earlier.
 
 See [Authenticating as a service account](https://cloud.google.com/docs/authentication/production)
-in Google Cloud documentation for more details.
+in the Google Cloud documentation for more details.
 
-## Connect
+## Step 5/5. Connect
 
-Once the database service has joined the cluster, login to see the available
+Once the Database Service has joined the cluster, log in to see the available
 databases:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -221,18 +283,31 @@ $ tsh db ls
 # cloudsql GCP Cloud SQL MySQL env=dev
 ```
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=alice
+$ tsh db ls
+# Name     Description         Labels
+# -------- ------------------- --------
+# cloudsql GCP Cloud SQL MySQL env=dev
+```
+
+</ScopedBlock>
+
 Note that you will only be able to see databases your role has access to. See
-[RBAC](../rbac.mdx) section for more details.
+our [RBAC](../rbac.mdx) guide for more details.
 
 To connect to a particular database server, first retrieve credentials from
-Teleport using `tsh db login` command:
+Teleport using the `tsh db login` command:
 
 ```code
 $ tsh db login cloudsql
 ```
 
 <Admonition type="tip" title="Tip">
-  You can be logged into multiple databases simultaneously.
+  You can be logged in to multiple databases simultaneously.
 </Admonition>
 
 You can optionally specify the database user and database name to use by default

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -9,7 +9,6 @@ on Google Cloud SQL.
 ## Prerequisites
 
 - Google Cloud account
-
 - A host, e.g., a Compute Engine instance, where you will run the Teleport Database
   Service
 
@@ -258,7 +257,7 @@ $ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
 
 The Teleport Database Service must have the credentials of `teleport-db-service` GCP
 service account we created
-[above](#create-a-service-account-for-the-teleport-database-service) in order to
+[above](#step-15-create-a-service-account-for-the-teleport-database-service) in order to
 be able to log in.
 
 The easiest way to ensure that is to set the `GOOGLE_APPLICATION_CREDENTIALS`

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -3,9 +3,30 @@ title: Database Access with Self-Hosted MySQL/MariaDB
 description: How to configure Teleport Database Access with self-hosted MySQL/MariaDB.
 ---
 
-# Self-Hosted MySQL/MariaDB
+This guide will show you how to access a self-hosted MySQL or MariaDB database
+using the Teleport Database Service.
 
-## Create Certificate/Key Pair
+## Prerequisites
+
+- A self-hosted MySQL or MariaDB instance.
+
+- A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
+  Service.
+
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
+
+## Step 1/4. Set up the Teleport Auth and Proxy Services
+
+Teleport Database Access for MySQL is available starting from Teleport version
+`6.0` and MariaDB starting from version `9.0`.
+
+(!docs/pages/includes/database-access/start-auth-proxy.mdx!)
+
+(!docs/pages/includes/database-access/token.mdx!)
+
+## Step 2/4. Create a certificate/key pair
 
 (!docs/pages/includes/database-access/tctl-auth-sign.mdx!)
 
@@ -22,12 +43,12 @@ $ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
 The command will create 3 files: `server.cas`, `server.crt` and `server.key`
 which you'll need to enable mutual TLS on your MySQL server.
 
-## Configure MySQL/MariaDB Server
+## Step 3/4. Configure MySQL/MariaDB
 
 <Tabs>
   <TabItem label="MySQL">
-  To configure MySQL server to accept TLS connections, add the following to
-MySQL configuration file `mysql.cnf`:
+  To configure MySQL to accept TLS connections, add the following to your
+MySQL configuration file, `mysql.cnf`:
 
 ```conf
 [mysqld]
@@ -38,8 +59,8 @@ ssl-key=/path/to/server.key
 ```
   </TabItem>
   <TabItem label="MariaDB">
-  To configure MariaDB server to accept TLS connections, add the following to
-MariaDB configuration file `mysql.cnf`:
+  To configure MariaDB to accept TLS connections, add the following to your
+MariaDB configuration file, `mysql.cnf`:
 
 ```conf
 [mariadb]
@@ -51,7 +72,7 @@ ssl-key=/path/to/server.key
   </TabItem>
 </Tabs>
 
-Additionally, MySQL/MariaDB database user accounts must be configured to require a
+Additionally, your MySQL/MariaDB database user accounts must be configured to require a
 valid client certificate. If you're creating a new user:
 
 ```sql
@@ -64,25 +85,20 @@ If you're updating an existing user:
 ALTER USER 'alice'@'%' REQUIRE SUBJECT '/CN=alice';
 ```
 
-By default the created user may not have access to anything and won't be able
-to connect so let's grant it some permissions:
+By default, the created user may not have access to anything and won't be able
+to connect, so let's grant it some permissions:
 
 ```sql
 GRANT ALL ON `%`.* TO 'alice'@'%';
 ```
 
-See [Configuring MySQL to Use Encrypted Connections](https://dev.mysql.com/doc/refman/8.0/en/using-encrypted-connections.html)
-in MySQL or [Enabling TLS on MariaDB Server](https://mariadb.com/docs/security/encryption/in-transit/enable-tls-server/) in MariaDB documentation for more details.
+See
+[Configuring MySQL to Use Encrypted Connections](https://dev.mysql.com/doc/refman/8.0/en/using-encrypted-connections.html)
+in the MySQL documentation or
+[Enabling TLS on MariaDB Server](https://mariadb.com/docs/security/encryption/in-transit/enable-tls-server/)
+in the MariaDB documentation for more details.
 
-## Setup Teleport Auth and Proxy Services
-
-Teleport Database Access for MySQL is available starting from Teleport version `6.0` and MariaDB starting from version `9.0`.
-
-(!docs/pages/includes/database-access/start-auth-proxy.mdx!)
-
-(!docs/pages/includes/database-access/token.mdx!)
-
-### Create Role and User
+### Create a role and user
 
 Create the role that will allow a user to connect to any database using any
 database account:
@@ -110,10 +126,19 @@ Create the user assigned the `db` role we've just created:
 $ tctl --config=/path/to/teleport-db-role.yaml users add --roles=access,db testuser
 ```
 
-### Start Database Service with CLI Flags
+### Start the Database Service
 
-For a quick try-out, Teleport database service doesn't require a configuration
-file and can be launched using a single CLI command:
+You can configure Teleport to start the Database Service and access MySQL or
+MariaDB by running the `teleport` daemon either with CLI flags or a
+configuration file.
+
+<Tabs>
+<TabItem label="Using CLI flags">
+
+On the host where you will run the Teleport Database Service, run the following
+command:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ teleport db start \
@@ -125,13 +150,35 @@ $ teleport db start \
    --labels=env=dev
 ```
 
-Note that the `--auth-server` flag must point to the Teleport cluster's proxy endpoint
-because database service always connects back to the cluster over a reverse
-tunnel.
+Note that the `--auth-server` flag must point to the Teleport cluster's Proxy
+Service endpoint because Database Service always connects back to the cluster
+over a reverse tunnel.
 
-### Start Database Service with Config File
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
 
-Generate a configuration file at `/etc/teleport.yaml` for the Database Service:
+```code
+$ teleport db start \
+   --token=/tmp/token \
+   --auth-server=mytenant.teleport.sh \
+   --name=test \
+   --protocol=mysql \
+   --uri=mysql.example.com:3306 \
+   --labels=env=dev
+```
+
+Note that the `--auth-server` flag must point to your Teleport Cloud tenant
+address.
+
+</ScopedBlock>
+
+</TabItem>
+<TabItem label="Using a config file">
+
+On the host where you will run the Teleport Database Service, create a
+configuration file at `/etc/teleport.yaml`:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ teleport db configure create \
@@ -144,25 +191,47 @@ $ teleport db configure create \
    --labels=env=dev
 ```
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ teleport db configure create \
+   -o file \
+   --token=/tmp/token \
+   --proxy=mytenant.teleport.sh \
+   --name=test \
+   --protocol=mysql \
+   --uri=mysql.example.com:3306 \
+   --labels=env=dev
+```
+
+</ScopedBlock>
+
 <Admonition
   type="tip"
   title="Tip"
 >
-  A single Teleport process can run multiple different services, for example
-  multiple database access proxies as well as running other services such an
-  SSH service or an application access proxy.
+  A single Teleport process can run multiple services, for example
+  multiple Database Access instances as well as other services such the
+  SSH Service or Application Service.
 </Admonition>
 
-Start the database service:
+Start the Database Service:
 
 ```code
 $ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
 ```
 
-## Connect
+</TabItem>
+</Tabs>
 
-Once the database service has joined the cluster, login to see the available
+
+## Step 4/4. Connect
+
+Once the Database Service has joined the cluster, log in to see the available
 databases:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=testuser
@@ -172,11 +241,24 @@ $ tsh db ls
 # example Example MySQL env=dev
 ```
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=testuser
+$ tsh db ls
+# Name    Description   Labels
+# ------- ------------- --------
+# example Example MySQL env=dev
+```
+
+</ScopedBlock>
+
 Note that you will only be able to see databases your role has access to. See
-[RBAC](../rbac.mdx) section for more details.
+the [RBAC](../rbac.mdx) guide for more details.
 
 To connect to a particular database server, first retrieve credentials from
-Teleport using `tsh db login` command:
+Teleport using the `tsh db login` command:
 
 ```code
 $ tsh db login example
@@ -186,7 +268,7 @@ $ tsh db login example
   type="tip"
   title="Tip"
 >
-  You can be logged into multiple databases simultaneously.
+  You can be logged in to multiple databases simultaneously.
 </Admonition>
 
 You can optionally specify the database name and the user to use by default
@@ -203,7 +285,7 @@ $ tsh db connect example
 ```
 
 <Admonition type="note" title="Note">
-  The `mysql` or `mariadb` command-line client should be available in PATH in order to be
+  The `mysql` or `mariadb` command-line client should be available in `PATH` in order to be
   able to connect. `mariadb` is a default command-line client for MySQL and MariaDB.
 </Admonition>
 

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -9,7 +9,6 @@ using the Teleport Database Service.
 ## Prerequisites
 
 - A self-hosted MySQL or MariaDB instance.
-
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
 

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -4,9 +4,21 @@ description: How to configure Teleport Database Access with GCP Cloud SQL Postgr
 videoBanner: br9LZ3ZXqCk
 ---
 
-# GCP Cloud SQL PostgreSQL
+In this guide, we will show you how to use Teleport Database Access with PostgreSQL
+on Google Cloud SQL.
 
-## Enable Cloud SQL IAM authentication
+## Prerequisites
+
+- Google Cloud account
+
+- A host, e.g., a Compute Engine instance, where you will run the Teleport Database
+  Service
+
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
+
+## Step 1/7. Enable Cloud SQL IAM authentication
 
 Teleport uses [IAM database authentication](https://cloud.google.com/sql/docs/postgres/authentication)
 with Cloud SQL PostgreSQL instances.
@@ -26,7 +38,7 @@ If it isn't enabled, you can add this flag using the "Edit configuration" dialog
 at the bottom of the Configuration panel. Note, changing this setting may
 require a database instance reboot.
 
-## Create a service account for the database
+## Step 2/7. Create a service account for the database
 
 Teleport uses service accounts to connect to Cloud SQL databases.
 
@@ -64,7 +76,7 @@ Press "Add" and your Users table should look similar to this:
 See [Creating and managing IAM users](https://cloud.google.com/sql/docs/postgres/create-manage-iam-users)
 in Google Cloud documentation for more info.
 
-## Create a service account for Teleport Database Service
+## Step 3/7. Create a service account for Teleport Database Service
 
 The final part of GCP configuration is to create a service account for the
 Teleport Database Service.
@@ -72,8 +84,8 @@ Teleport Database Service.
 
 ### Create a service account
 
-If creating a new one, go to the [Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts)
-page and create another service account:
+Go to the [Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts)
+page and create a service account:
 
 ![Create Service Account](../../../img/database-access/guides/cloudsql/service-account-db-service@2x.png)
 
@@ -124,10 +136,10 @@ Make sure to choose JSON format:
 
 ![Service Account New Key](../../../img/database-access/guides/cloudsql/service-account-new-key@2x.png)
 
-Save the file, your Teleport Database Service will need it to be able to generate
+Save the file. The Teleport Database Service will need it to be able to generate
 IAM auth tokens.
 
-## Gather Cloud SQL instance information
+## Step 4/7. Gather Cloud SQL instance information
 
 To connect a Cloud SQL database to Teleport, you'll need to gather a few pieces
 of information about the instance.
@@ -158,16 +170,16 @@ file from the Connections tab under Security section:
 
 ![Instance Root Certificate](../../../img/database-access/guides/cloudsql/instance-root-ca@2x.png)
 
-## Setup Teleport Auth and Proxy services
+## Step 5/7. Set up the Teleport Auth and Proxy services
 
 Teleport Database Access for Cloud SQL PostgreSQL is available starting from
-`6.2` release.
+the `6.2` Teleport release.
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
 (!docs/pages/includes/database-access/token.mdx!)
 
-### Create user
+### Create a user
 
 Create local Teleport user with the built-in `access` role:
 
@@ -210,17 +222,19 @@ $ tctl create alice.yaml -f
 For more detailed information about database access controls see [RBAC](../rbac.mdx)
 documentation.
 
-## Setup Teleport Database service
+## Step 6/7. Set up the Teleport Database service
 
-Below is an example of a database service configuration file that proxies
+Below is an example of a Database Service configuration file that proxies
 a single Cloud SQL PostgreSQL database:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```yaml
 teleport:
   data_dir: /var/lib/teleport-db
   nodename: test
   # Proxy address to connect to. Note that it has to be the proxy address
-  # because database service always connects to the cluster over reverse
+  # because the Database Service always connects to the cluster over a reverse
   # tunnel.
   auth_servers:
   - teleport.example.com:3080
@@ -256,16 +270,61 @@ proxy_service:
   enabled: "no"
 ```
 
-<Admonition
-  type="tip"
-  title="Tip"
->
-  A single Teleport process can run multiple different services, for example
-  multiple database access proxies as well as running other services such an
-  SSH service or an application access proxy.
-</Admonition>
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
 
-Start the database service:
+```yaml
+teleport:
+  data_dir: /var/lib/teleport-db
+  nodename: test
+  # Proxy address to connect to. Use your Teleport Cloud tenant address here.
+  auth_servers:
+  - mytenant.teleport.sh
+db_service:
+  enabled: "yes"
+  # This section contains definitions of all databases proxied by this
+  # service, can contain multiple items.
+  databases:
+    # Name of the database proxy instance, used to reference in CLI.
+  - name: "cloudsql"
+    # Free-form description of the database proxy instance.
+    description: "GCP Cloud SQL PostgreSQL"
+    # Database protocol.
+    protocol: "postgres"
+    # Database endpoint. For Cloud SQL use instance's public IP address.
+    uri: "35.1.2.3:5432"
+    # Path to Cloud SQL instance root certificate you downloaded above.
+    ca_cert_file: /path/to/cloudsql/instance/root.pem
+    # GCP specific configuration when connecting Cloud SQL instance.
+    gcp:
+      # GCP project ID.
+      project_id: "<project-id>"
+      # Cloud SQL instance ID.
+      instance_id: "test"
+    # Labels to assign to the database, used in RBAC.
+    static_labels:
+      env: dev
+auth_service:
+  enabled: "no"
+ssh_service:
+  enabled: "no"
+proxy_service:
+  enabled: "no"
+```
+
+</ScopedBlock>
+
+<Notice
+  type="tip"
+>
+
+  A single Teleport process can run multiple different services, for example
+  multiple Database Access instances as well as other services such the SSH
+  Service or Application Service.
+
+</Notice>
+
+Start the Database Service:
 
 ```code
 $ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
@@ -273,21 +332,24 @@ $ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
 
 ### GCP credentials
 
-Teleport Database Service must have credentials of `teleport-db-service` GCP
-service account we created [above](#create-a-service-account-for-teleport-database-service)
-in order to be able to generate IAM auth tokens.
+The Teleport Database Service must have credentials of `teleport-db-service` GCP
+service account we created
+[above](#create-a-service-account-for-teleport-database-service) in order to be
+able to generate IAM auth tokens.
 
-The easiest way to ensure that is to set `GOOGLE_APPLICATION_CREDENTIALS`
+The easiest way to ensure that is to set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to point to the JSON credentials file you downloaded
 earlier.
 
 See [Authenticating as a service account](https://cloud.google.com/docs/authentication/production)
-in Google Cloud documentation for more details.
+in the Google Cloud documentation for more details.
 
-## Connect
+## Step 7/7. Connect
 
-Once the database service has joined the cluster, login to see the available
+Once the Database Service has joined the cluster, log in to see the available
 databases:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -297,11 +359,24 @@ $ tsh db ls
 # cloudsql GCP Cloud SQL PostgreSQL env=dev
 ```
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=alice
+$ tsh db ls
+# Name     Description              Labels
+# -------- ------------------------ --------
+# cloudsql GCP Cloud SQL PostgreSQL env=dev
+```
+
+</ScopedBlock>
+
 Note that you will only be able to see databases your role has access to. See
-[RBAC](../rbac.mdx) section for more details.
+our [RBAC](../rbac.mdx) guide for more details.
 
 To connect to a particular database server, first retrieve credentials from
-Teleport using `tsh db login` command:
+Teleport using the `tsh db login` command:
 
 ```sh
 $ tsh db login cloudsql
@@ -311,7 +386,7 @@ $ tsh db login cloudsql
   type="tip"
   title="Tip"
 >
-  You can be logged into multiple databases simultaneously.
+  You can be logged in to multiple databases simultaneously.
 </Admonition>
 
 You can optionally specify the database name and the user to use by default
@@ -325,10 +400,13 @@ $ tsh db login --db-user=teleport@<project-id>.iam --db-name=postgres cloudsql
   type="note"
   title="What database user name to use?"
 >
+
   When connecting to the database, use the name of the database service account
-  that you added as IAM database user [above](#create-a-service-account-for-the-database),
-  minus the `.gserviceaccount.com` suffix. The database user name is shown on
-  the Users page of your Cloud SQL instance.
+  that you added as an IAM database user
+  [above](#create-a-service-account-for-the-database), minus the
+  `.gserviceaccount.com` suffix. The database user name is shown on the Users
+  page of your Cloud SQL instance.
+
 </Admonition>
 
 Once logged in, connect to the database:

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -10,7 +10,6 @@ on Google Cloud SQL.
 ## Prerequisites
 
 - Google Cloud account
-
 - A host, e.g., a Compute Engine instance, where you will run the Teleport Database
   Service
 
@@ -334,7 +333,7 @@ $ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
 
 The Teleport Database Service must have credentials of `teleport-db-service` GCP
 service account we created
-[above](#create-a-service-account-for-teleport-database-service) in order to be
+[above](#step-37-create-a-service-account-for-teleport-database-service) in order to be
 able to generate IAM auth tokens.
 
 The easiest way to ensure that is to set the `GOOGLE_APPLICATION_CREDENTIALS`
@@ -403,7 +402,7 @@ $ tsh db login --db-user=teleport@<project-id>.iam --db-name=postgres cloudsql
 
   When connecting to the database, use the name of the database service account
   that you added as an IAM database user
-  [above](#create-a-service-account-for-the-database), minus the
+  [above](#step-27-create-a-service-account-for-the-database), minus the
   `.gserviceaccount.com` suffix. The database user name is shown on the Users
   page of your Cloud SQL instance.
 

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -8,7 +8,6 @@ videoBanner: UFhT52d5bYg
 
 - AWS account with a Redshift cluster and permissions to create and attach IAM
   policies.
-
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
 

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -4,27 +4,33 @@ description: How to configure Teleport Database Access with AWS Redshift Postgre
 videoBanner: UFhT52d5bYg
 ---
 
-# AWS Redshift PostgreSQL
-
 ## Prerequisites
 
-- Teleport version `(=teleport.version=)`.
 - AWS account with a Redshift cluster and permissions to create and attach IAM
   policies.
+
+- A host, e.g., an EC2 instance, where you will run the Teleport Database
+  Service.
+
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/6. Install Teleport
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
-## Step 2/6. Create Teleport user
+## Step 2/6. Create a Teleport user
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 
-## Step 3/6. Create database agent configuration
+## Step 3/6. Create a Database Service configuration
 
 (!docs/pages/includes/database-access/token.mdx!)
 
-Create the Database Service configuration file:
+On the node that is running the Database Service, create a configuration file:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ teleport db configure create \
@@ -33,6 +39,19 @@ $ teleport db configure create \
    --token=/tmp/token \
    --redshift-discovery=us-west-1
 ```
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ teleport db configure create \
+   -o file \
+   --proxy=mytenant.teleport.sh:3080 \
+   --token=/tmp/token \
+   --redshift-discovery=us-west-1
+```
+
+</ScopedBlock>
 
 The command will generate a Database Service configuration with Redshift
 database auto-discovery enabled on the `us-west-1` region and place it at the
@@ -47,28 +66,35 @@ Teleport needs AWS IAM permissions to be able to:
 
 (!docs/pages/includes/database-access/aws-bootstrap.mdx!)
 
-## Step 5/6. Start the database agent
+## Step 5/6. Start the Database Service
+
+Run the following command on the Database Service node:
 
 ```code
 $ teleport start --config=/etc/teleport.yaml
 ```
 
-The agent will discover all Redshift databases according to the configuration
+The Database Service will discover all Redshift databases according to the configuration
 and register them in the cluster. The agent will also attempt to configure IAM
 access policies for the discovered databases. Keep in mind that AWS IAM changes
 may not propagate immediately and can take a few minutes to come into effect.
 
 <Admonition type="note" title="AWS credentials">
-  Teleport database agent uses the default credential provider chain to find AWS
-  credentials. See [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials)
+
+  The Teleport Database Service uses the default credential provider chain to
+  find AWS credentials. See
+  [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials)
   for more information.
+
 </Admonition>
 
 ## Step 6/6. Connect
 
-Once the database agent has started and joined the cluster, log in to see the
-registered databases. Replace `--proxy` with the address of your Teleport Proxy Service,
-e.g., `mytenant.teleport.sh` for Teleport Cloud users.
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+Once the Database Service has started and joined the cluster, log in to see the
+registered databases. Replace `--proxy` with the address of your Teleport Proxy
+Service.
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -78,7 +104,24 @@ $ tsh db ls
 # my-redshift Redshift cluster in us-east-1  ...
 ```
 
-Log into a particular database using the `tsh db login` command:
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+Once the Database Service has started and joined the cluster, log in to see the
+registered databases. Replace `--proxy` with the address of your Teleport Cloud
+tenant.
+
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=alice
+$ tsh db ls
+# Name        Description                    Labels
+# ----------- ------------------------------ --------
+# my-redshift Redshift cluster in us-east-1  ...
+```
+
+</ScopedBlock>
+
+Log in to a particular database using the `tsh db login` command:
 
 ```code
 $ tsh db login my-redshift

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -3,68 +3,32 @@ title: Database Access with Self-Hosted PostgreSQL
 description: How to configure Teleport Database Access with self-hosted PostgreSQL.
 ---
 
-# Self-Hosted PostgreSQL
+This guide will show you how to access a self-hosted PostgreSQL database using
+the Teleport Database Service.
 
-## Create certificate/key pair
+## Prerequisites
 
-(!docs/pages/includes/database-access/tctl-auth-sign.mdx!)
+- A self-hosted PostgreSQL instance.
 
-Create the secrets:
+- A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
+  Service.
 
-```code
-# Export Teleport's certificate authority and generate certificate/key pair
-# for host db.example.com with a 1-year validity period.
-$ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
-```
+(!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/database-access/ttl-note.mdx!)
+(!docs/pages/includes/tctl.mdx!)
 
-The command will create 3 files: `server.cas`, `server.crt` and `server.key`
-which you'll need to enable mutual TLS on your PostgreSQL server.
+## Step 1/5. Set up the Teleport Auth and Proxy services
 
-## Configure PostgreSQL server
-
-To configure PostgreSQL server to accept TLS connections, add the following
-to PostgreSQL configuration file `postgresql.conf`:
-
-```conf
-ssl = on
-ssl_cert_file = '/path/to/server.crt'
-ssl_key_file = '/path/to/server.key'
-ssl_ca_file = '/path/toa/server.cas'
-```
-
-See [Secure TCP/IP Connections with SSL](https://www.postgresql.org/docs/current/ssl-tcp.html)
-in PostgreSQL documentation for more details.
-
-Additionally, PostgreSQL should be configured to require client certificate
-authentication from clients connecting over TLS. This can be done by adding
-the following entries to PostgreSQL host-based authentication file `pg_hba.conf`:
-
-```conf
-hostssl all             all             ::/0                    cert
-hostssl all             all             0.0.0.0/0               cert
-```
-
-You should also ensure that you have no higher-priority `md5` authentication
-rules that will match, otherwise PostgreSQL will offer them first, and the
-certificate-based Teleport login will fail.
-
-See [The pg_hba.conf File](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
-in PostgreSQL documentation for more details.
-
-## Setup Teleport Auth and Proxy services
-
-Teleport Database Access for PostgreSQL is available starting from `6.0`
+Teleport Database Access for PostgreSQL is available starting from the `6.0`
 release.
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
 (!docs/pages/includes/database-access/token.mdx!)
 
-### Create role and user
+### Create a role and user
 
-Create the role that will allow a user to connect to any database using any
+Create a role that will allow a user to connect to any database using any
 database account:
 
 ```bash
@@ -90,10 +54,66 @@ Create the user assigned the `db` role we've just created:
 $ tctl --config=/path/to/teleport.yaml users add --roles=access,db testuser
 ```
 
-### Start Database service with CLI flags
+## Step 2/5. Create a certificate/key pair
 
-You can start Teleport database service without configuration file, using a
+(!docs/pages/includes/database-access/tctl-auth-sign.mdx!)
+
+Create the secrets:
+
+```code
+# Export Teleport's certificate authority and a generate certificate/key pair
+# for host db.example.com with a 1-year validity period.
+$ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
+```
+
+(!docs/pages/includes/database-access/ttl-note.mdx!)
+
+The command will create 3 files: `server.cas`, `server.crt` and `server.key`
+which you'll need to enable mutual TLS on your PostgreSQL server.
+
+## Step 3/5. Configure your PostgreSQL server
+
+To configure your PostgreSQL server to accept TLS connections, add the following
+to the PostgreSQL configuration file, `postgresql.conf`:
+
+```conf
+ssl = on
+ssl_cert_file = '/path/to/server.crt'
+ssl_key_file = '/path/to/server.key'
+ssl_ca_file = '/path/toa/server.cas'
+```
+
+See [Secure TCP/IP Connections with SSL](https://www.postgresql.org/docs/current/ssl-tcp.html)
+in the PostgreSQL documentation for more details.
+
+Additionally, PostgreSQL should be configured to require client certificate
+authentication from clients connecting over TLS. This can be done by adding
+the following entries to PostgreSQL's host-based authentication file `pg_hba.conf`:
+
+```conf
+hostssl all             all             ::/0                    cert
+hostssl all             all             0.0.0.0/0               cert
+```
+
+You should also ensure that you have no higher-priority `md5` authentication
+rules that will match, otherwise PostgreSQL will offer them first, and the
+certificate-based Teleport login will fail.
+
+See [The pg_hba.conf File](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
+in the PostgreSQL documentation for more details.
+
+## Step 4/5. Start the Database Service
+
+On the host where you will run the Teleport Database Service, start Teleport
+with the appropriate configuration.
+
+<Tabs>
+<TabItem label="With CLI flags">
+
+You can start the Teleport Database Service without configuration file using a
 CLI command:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ teleport db start \
@@ -105,13 +125,34 @@ $ teleport db start \
    --labels=env=dev
 ```
 
-Note that the `--auth-server` flag must point to the Teleport cluster's proxy endpoint
-because database service always connects back to the cluster over a reverse
-tunnel.
+Note that the `--auth-server` flag must point to the Teleport cluster's Proxy
+Service endpoint because the Database Service always connects back to the
+cluster over a reverse tunnel.
 
-### Start Database service with config file
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ teleport db start \
+   --token=/tmp/token \
+   --auth-server=mytenant.teleport.sh \
+   --name=test \
+   --protocol=postgres \
+   --uri=postgres.example.com:5432 \
+   --labels=env=dev
+```
+
+Note that the `--auth-server` flag must point to your Teleport Cloud tenant
+address.
+
+</ScopedBlock>
+
+</TabItem>
+<TabItem label="Using a config file">
 
 Generate a configuration file at `/etc/teleport.yaml` for the Database Service:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ teleport db configure create \
@@ -124,13 +165,30 @@ $ teleport db configure create \
    --labels=env=dev
 ```
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ teleport db configure create \
+   -o file \
+   --token=/tmp/token \
+   --proxy=teleport.example.com:3080 \
+   --name=test \
+   --protocol=postgres \
+   --uri=postgres.example.com:5432 \
+   --labels=env=dev
+```
+
+</ScopedBlock>
+
 <Admonition
   type="tip"
   title="Tip"
 >
   A single Teleport process can run multiple different services, for example
-  multiple database access proxies as well as running other services such as an
-  SSH service or an application access proxy.
+  multiple Database Service agents as well as the SSH Service or Application
+  Service.
+  
 </Admonition>
 
 Start the database service:
@@ -139,10 +197,15 @@ Start the database service:
 $ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
 ```
 
-## Connect
+</TabItem>
+</Tabs>
 
-Once the database service has joined the cluster, login to see the available
+## Step 5/5. Connect
+
+Once the Database Service has joined the cluster, log in to see the available
 databases:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=testuser
@@ -151,6 +214,19 @@ $ tsh db ls
 # ------- ------------------ --------
 # example Example PostgreSQL env=dev
 ```
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=testuser
+$ tsh db ls
+# Name    Description        Labels
+# ------- ------------------ --------
+# example Example PostgreSQL env=dev
+```
+
+</ScopedBlock>
 
 Note that you will only be able to see databases your role has access to. See
 [RBAC](../rbac.mdx) section for more details.
@@ -166,7 +242,7 @@ $ tsh db login example
   type="tip"
   title="Tip"
 >
-  You can be logged into multiple databases simultaneously.
+  You can be logged in to multiple databases simultaneously.
 </Admonition>
 
 You can optionally specify the database name and the user to use by default
@@ -183,7 +259,7 @@ $ tsh db connect example
 ```
 
 <Admonition type="note" title="Note">
-  The `psql` command-line client should be available in PATH in order to be
+  The `psql` command-line client should be available in `PATH` in order to be
   able to connect.
 </Admonition>
 

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -9,7 +9,6 @@ the Teleport Database Service.
 ## Prerequisites
 
 - A self-hosted PostgreSQL instance.
-
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
 

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -18,9 +18,15 @@ This guide will help you to:
 
 ## Prerequisites
 
-- Teleport version `(=teleport.version=)`.
 - AWS account with RDS and Aurora databases and permissions to create and attach
   IAM policies.
+
+- A host, e.g., an EC2 instance, where you will run the Teleport Database
+  Service.
+
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Install Teleport
 
@@ -30,11 +36,13 @@ This guide will help you to:
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 
-## Step 3/7. Create a database agent configuration
+## Step 3/7. Create a Database Service configuration
 
 (!docs/pages/includes/database-access/token.mdx!)
 
 Create the Database Service configuration:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ teleport db configure create \
@@ -44,7 +52,20 @@ $ teleport db configure create \
    --rds-discovery=us-west-1
 ```
 
-The command will generate a database agent configuration with RDS/Aurora
+</ScopedBlock>
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+```code
+$ teleport db configure create \
+   -o file \
+   --proxy=mytenant.teleport.sh \
+   --token=/tmp/token \
+   --rds-discovery=us-west-1
+```
+
+</ScopedBlock>
+
+The command will generate a Database Service configuration with RDS/Aurora
 database auto-discovery enabled on the `us-west-1` region and place it at the
 `/etc/teleport.yaml` location.
 
@@ -57,20 +78,20 @@ Teleport needs AWS IAM permissions to be able to:
 
 (!docs/pages/includes/database-access/aws-bootstrap.mdx!)
 
-## Step 5/7. Start the database agent
+## Step 5/7. Start the Database Service
 
-Start the database agent:
+Start the Database Service:
 
 ```code
 $ teleport start --config=/etc/teleport.yaml
 ```
 
-The agent will discover all RDS instances and Aurora clusters according to the
+The Database Service will discover all RDS instances and Aurora clusters according to the
 configuration and register them in the cluster. In addition to the primary
 endpoints of the discovered Aurora clusters, their reader and custom endpoints
 will also be registered.
 
-The agent will also attempt to enable IAM auth and configure IAM access
+The Database Service will also attempt to enable IAM auth and configure IAM access
 policies for the discovered databases. Keep in mind that AWS IAM changes may
 not propagate immediately and can take a few minutes to come into effect.
 
@@ -114,8 +135,10 @@ for more information.
 
 ## Step 7/7. Connect
 
-Once the database agent has started and joined the cluster, login to see the
+Once the Database Service has started and joined the cluster, log in to see the
 registered databases:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -128,20 +151,36 @@ $ tsh db ls
 # aurora-mysql-reader            Aurora cluster in us-west-1 (reader endpoint) ...
 ```
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=alice
+$ tsh db ls
+# Name                           Description                                   Labels
+# ------------------------------ --------------------------------------------- --------
+# postgres-rds                   RDS instance in us-west-1                     ...
+# aurora-mysql                   Aurora cluster in us-west-1                   ...
+# aurora-mysql-custom-myendpoint Aurora cluster in us-west-1 (custom endpoint) ...
+# aurora-mysql-reader            Aurora cluster in us-west-1 (reader endpoint) ...
+```
+
+</ScopedBlock>
+
 <Admonition type="note" title="Note">
   Primary, reader, and custom endpoints of Aurora clusters have names of
   `<cluster-id>`, `<cluster-id>-reader`, and
   `<cluster-id>-custom-<endpoint-name>` respectively.
 </Admonition>
 
-Log into particular database using `tsh db login` command:
+Log in to particular database using `tsh db login` command:
 
 ```code
 $ tsh db login postgres-rds
 ```
 
 <Admonition type="tip" title="Tip">
-  You can be logged into multiple databases simultaneously.
+  You can be logged in to multiple databases simultaneously.
 </Admonition>
 
 You can optionally specify the database name and the user to use by default
@@ -159,7 +198,7 @@ $ tsh db connect postgres-rds
 
 <Admonition type="note" title="Note">
   The appropriate database command-line client (`psql`, `mysql`, `mariadb`) should be
-  available in PATH in order to be able to connect.
+  available in `PATH` in order to be able to connect.
 </Admonition>
 
 To log out of the database and remove credentials:

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -20,7 +20,6 @@ This guide will help you to:
 
 - AWS account with RDS and Aurora databases and permissions to create and attach
   IAM policies.
-
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
 

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -10,7 +10,7 @@ description: How to configure Teleport Database Access with Microsoft SQL Server
   scopeOnly={true}
   min="9.0"
 >
-  Database access for Microsoft SQL Server with Active Directory authentication
+  Database Access for Microsoft SQL Server with Active Directory authentication
   is available starting from Teleport `9.0`.
 </Details>
 
@@ -30,13 +30,16 @@ Directory authentication.
 
 ## Prerequisites
 
-- Teleport version >= `9.0`.
 - A SQL Server database with Active Directory authentication enabled.
 - A Windows machine joined to the same Active Directory domain as the database.
 - A Linux node joined to the same Active Directory domain as the database. This
   guide will walk you through the joining steps if you don't have one.
 
-## Step 1/7. Set up Teleport Auth and Proxy
+(!docs/pages/includes/user-client-prereqs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
+
+## Step 1/7. Set up the Teleport Auth and Proxy
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)
 
@@ -48,7 +51,7 @@ Directory authentication.
 
 <Admonition type="note">
   You can skip this step if you already have a Linux node joined to the same
-  Active Directory domain as your SQL Server.
+  Active Directory domain as your SQL Server instance.
 </Admonition>
 
 The Linux node where the Database Service will run must be joined to the same
@@ -153,7 +156,7 @@ domain:
   </TabItem>
 </Tabs>
 
-Log into your Active Directory using the `kinit` command:
+Log in to Active Directory using the `kinit` command:
 
 ```bash
 $ kinit admin@EXAMPLE.COM
@@ -205,7 +208,7 @@ KVNO Principal
   authentication failures.
 </Admonition>
 
-## Step 5/7. Set up Teleport Database Service
+## Step 5/7. Set up the Teleport Database Service
 
 (!docs/pages/includes/database-access/token.mdx!)
 
@@ -214,7 +217,9 @@ KVNO Principal
   Active Directory domain as the SQL Server.
 </Admonition>
 
-Start Teleport Database Service. Make sure to update `--auth-server` to point to
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+Start the Teleport Database Service. Make sure to update `--auth-server` to point to
 your Teleport Proxy Service address and `--uri` to the SQL Server endpoint.
 
   ```bash
@@ -229,6 +234,28 @@ your Teleport Proxy Service address and `--uri` to the SQL Server endpoint.
     --ad-spn=MSSQLSvc/sqlserver.example.com:1433 \
     --labels=env=dev
   ```
+  
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+Start the Teleport Database Service. Make sure to update `--auth-server` to
+point to your Teleport Cloud tenant address and `--uri` to the SQL Server
+endpoint.
+
+  ```bash
+  $ teleport db start \
+    --token=/tmp/token \
+    --auth-server=mytenant.teleport.sh \
+    --name=sqlserver \
+    --protocol=sqlserver \
+    --uri=sqlserver.example.com:1433 \
+    --ad-keytab-file=/path/to/teleport.keytab \
+    --ad-domain=EXAMPLE.COM \
+    --ad-spn=MSSQLSvc/sqlserver.example.com:1433 \
+    --labels=env=dev
+  ```
+
+</ScopedBlock>
 
 Provide Active Directory parameters:
 
@@ -239,8 +266,8 @@ Provide Active Directory parameters:
 | `--ad-spn` | Service Principal Name for SQL Server to fetch Kerberos tickets for. |
 
 <Admonition type="tip">
-  You can start Teleport Database Service using a configuration file instead of
-  CLI flags. See [YAML reference](../reference/configuration.mdx).
+  You can start the Teleport Database Service using a configuration file instead of
+  CLI flags. See the [YAML reference](../reference/configuration.mdx).
 </Admonition>
 
 ### Service Principal Name
@@ -289,8 +316,10 @@ master> CREATE LOGIN [EXAMPLE\alice] FROM WINDOWS WITH DEFAULT_DATABASE = [maste
 
 ## Step 7/7. Connect
 
-Log into your Teleport cluster. Your SQL Server database should appear in the
+Log in to your Teleport cluster. Your SQL Server database should appear in the
 list of available databases:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -300,6 +329,19 @@ $ tsh db ls
 # sqlserver                     env=dev
 ```
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ tsh login --proxy=mytenant.teleport.sh --user=alice
+$ tsh db ls
+# Name      Description         Labels
+# --------- ------------------- -------
+# sqlserver                     env=dev
+```
+
+</ScopedBlock>
+
 Fetch the short-lived client certificate for it using the `tsh db login` command:
 
 ```code
@@ -307,7 +349,7 @@ $ tsh db login --db-user=teleport sqlserver
 ```
 
 <Admonition type="tip">
-  You can be logged into multiple databases simultaneously.
+  You can be logged in to multiple databases simultaneously.
 </Admonition>
 
 Now connect to the database:
@@ -317,7 +359,7 @@ $ tsh db connect sqlserver
 ```
 
 <Admonition type="note">
-  The `mssql-cli` command-line client should be available in PATH of the machine
+  The `mssql-cli` command-line client should be available in `PATH` of the machine
   you're running `tsh db connect` from.
 </Admonition>
 

--- a/docs/pages/includes/database-access/aws-bootstrap.mdx
+++ b/docs/pages/includes/database-access/aws-bootstrap.mdx
@@ -13,6 +13,8 @@ this command in automatic or manual mode:
   credentials. See [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials) for more information.
 </Admonition>
 
+Run one of the following commands on your Database Service node:
+
 <Tabs>
   <TabItem label="Automatic / IAM User">
   Use this command to bootstrap the permissions automatically when

--- a/docs/pages/includes/database-access/create-user.mdx
+++ b/docs/pages/includes/database-access/create-user.mdx
@@ -37,5 +37,6 @@ Update the user:
 $ tctl create alice.yaml -f
 ```
 
-For more detailed information about database access controls and how to restricted
-access see [RBAC](../../database-access/rbac.mdx) documentation.
+For more detailed information about database access controls and how to
+configure restricted access, see the [RBAC](../../database-access/rbac.mdx)
+documentation.

--- a/docs/pages/includes/database-access/guides-next-steps.mdx
+++ b/docs/pages/includes/database-access/guides-next-steps.mdx
@@ -1,4 +1,4 @@
 - Learn how to [restrict access](../../database-access/rbac.mdx) to certain users and databases.
-- View [High Availability (HA)](../../database-access/guides/ha.mdx) guide.
-- Take a look at YAML configuration [reference](../../database-access/reference/configuration.mdx).
+- View the [High Availability (HA)](../../database-access/guides/ha.mdx) guide.
+- Take a look at the YAML configuration [reference](../../database-access/reference/configuration.mdx).
 - See the full CLI [reference](../../database-access/reference/cli.mdx).

--- a/docs/pages/includes/database-access/start-auth-proxy.mdx
+++ b/docs/pages/includes/database-access/start-auth-proxy.mdx
@@ -1,6 +1,8 @@
 <Tabs> 
 <TabItem scope={["oss","enterprise"]} label="Self-Hosted">
-Download the latest version of Teleport for your platform from our
+
+On the host where you will run the Auth Service and Proxy Service, download the
+latest version of Teleport for your platform from our
 [downloads page](https://goteleport.com/teleport/download) and follow the
 installation [instructions](../../installation.mdx).
 
@@ -40,13 +42,17 @@ Next, start the Teleport Auth and Proxy Services:
 ```code
 $ sudo teleport start
 ```
+
+You will run subsequent `tctl` commands on the host where you started the Auth
+and Proxy Services.
+
 </TabItem> 
 <TabItem label="Teleport Cloud" scope={["cloud"]}> 
 If you do not have a Teleport Cloud account, use our [signup form](https://goteleport.com/signup/) to
 get started. Teleport Cloud manages instances of the Proxy Service and Auth
 Service, and automatically issues and renews the required TLS certificate.
 
-You must log into your cluster before you can run `tctl` commands.
+You must log in to your cluster before you can run `tctl` commands.
 ```code
 $ tsh login --proxy=mytenant.teleport.sh
 $ tctl status

--- a/docs/pages/includes/database-access/start-auth-proxy.mdx
+++ b/docs/pages/includes/database-access/start-auth-proxy.mdx
@@ -4,7 +4,7 @@
 On the host where you will run the Auth Service and Proxy Service, download the
 latest version of Teleport for your platform from our
 [downloads page](https://goteleport.com/teleport/download) and follow the
-installation [instructions](../../installation.mdx).
+installation [instructions](/docs/installation).
 
 Teleport requires a valid TLS certificate to operate and can fetch one
 automatically using Let's Encrypt's ACME protocol. Before Let's Encrypt can

--- a/docs/pages/includes/database-access/tctl-auth-sign.mdx
+++ b/docs/pages/includes/database-access/tctl-auth-sign.mdx
@@ -1,26 +1,21 @@
-Teleport uses mutual TLS authentication with self-hosted databases. As such,
-they must be configured with Teleport's certificate authority to be able to
-verify client certificates and a certificate/key pair that Teleport can verify.
+Teleport uses mutual TLS authentication with self-hosted databases. These
+databases must be configured with Teleport's certificate authority to be
+able to verify client certificates. They also need a certificate/key pair that
+Teleport can verify.
 
-<Tabs>
-  <TabItem label="Self-hosted Teleport">
-  With self-hosted version of Teleport use `tctl auth sign` command
-  [locally](../../architecture/overview.mdx#tctl) on the Teleport Auth server
-  to produce the secrets
-  </TabItem>
-  <TabItem label="Teleport Cloud">
-  With [Teleport Cloud](../../cloud/introduction.mdx) use `tctl auth sign`
-  command on your client machine after logging in with `tsh login`.
+<ScopedBlock scope={["cloud"]}>
 
-  Your Teleport Cloud user must be allowed to impersonate the system role `Db`
-  in order to be able to generate the database certificate, by having the
-  following allow rule in their role:
+Your Teleport Cloud user
+must be allowed to impersonate the system role `Db` in order to be able to
+generate the database certificate.
 
-  ```yaml
-  allow:
-    impersonate:
-      users: ["Db"]
-      roles: ["Db"]
-  ```
-  </TabItem>
-</Tabs>
+Include the following `allow` rule in in your Teleport Cloud user's role:
+
+```yaml
+allow:
+  impersonate:
+    users: ["Db"]
+    roles: ["Db"]
+```
+
+</ScopedBlock>

--- a/docs/pages/includes/database-access/token.mdx
+++ b/docs/pages/includes/database-access/token.mdx
@@ -1,6 +1,6 @@
 The Database Service requires a valid auth token to connect to the cluster. Generate
-one by running the following command against your Teleport auth server and save
-it in `/tmp/token` on the node which will be running the database agent:
+one by running the following command against your Teleport Auth Service and save
+it in `/tmp/token` on the node that will run the Database Service:
 
 ```code
 $ tctl tokens add --type=db

--- a/docs/pages/includes/database-access/ttl-note.mdx
+++ b/docs/pages/includes/database-access/ttl-note.mdx
@@ -1,5 +1,5 @@
 <Admonition type="note" title="TTL">
-  We recommend using shorter TTL but keep mind that you'll need to update the
+  We recommend using a shorter TTL, but keep mind that you'll need to update the
   database server certificate before it expires to not lose the ability to
-  connect, so pick the TTL value that best fits your use-case.
+  connect. Pick the TTL value that best fits your use-case.
 </Admonition>

--- a/docs/pages/includes/user-client-prereqs.mdx
+++ b/docs/pages/includes/user-client-prereqs.mdx
@@ -8,7 +8,7 @@
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
 
-  See [Installation](../../installation.mdx) for details.
+  See [Installation](/docs/installation) for details.
 
 - A host where you will install the Teleport Auth Service and Proxy Service.
 
@@ -37,7 +37,7 @@
 
 - The `tctl` and `tsh` client tools version >= (=teleport.version=).
 
-  You can download these from [Teleport Cloud Downloads](../../cloud/downloads.mdx).
+  You can download these from [Teleport Cloud Downloads](/docs/cloud/downloads).
 
   ```code
   $ tctl version

--- a/docs/pages/includes/user-client-prereqs.mdx
+++ b/docs/pages/includes/user-client-prereqs.mdx
@@ -1,0 +1,51 @@
+<Tabs>
+<TabItem scope={["oss"]} label="Open Source">
+
+- The `tsh` client tool version >= (=teleport.version=).
+
+  ```code
+  $ tsh version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  ```
+
+  See [Installation](../../installation.mdx) for details.
+
+- A host where you will install the Teleport Auth Service and Proxy Service.
+
+- A registered domain name.
+
+</TabItem>
+<TabItem
+  scope={["enterprise"]} label="Enterprise">
+
+- The `tsh` client tool version >= (=teleport.version=), which you can download
+  by visiting the
+  [customer portal](https://dashboard.gravitational.com/web/login).
+
+  ```code
+  $ tsh version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  ```
+
+- A host where you will install the Teleport Auth Service and Proxy Service.
+
+- A registered domain name.
+
+</TabItem>
+<TabItem scope={["cloud"]}
+  label="Teleport Cloud">
+
+- The `tctl` and `tsh` client tools version >= (=teleport.version=).
+
+  You can download these from [Teleport Cloud Downloads](../../cloud/downloads.mdx).
+
+  ```code
+  $ tctl version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+
+  $ tsh version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  ```
+
+</TabItem>
+</Tabs>


### PR DESCRIPTION
This edits Database Access guides that show you how to access
specific databases. These guides follow the same structure and use the
same partials, so it made sense to address them in a single commit.

See #10637

Edits made

- Some Prerequisites sections were either absent or required
  "Teleport," which I've clarified with a scoped Tabs component to
  indicate the appropriate client tools for each deployment type.
  Since we instruct users on deploying the Auth/Proxy later in the
  guide, I restricted this to client tools. Also flesh out the
  Prerequisites a bit in general.

- Add ScopedBlocks for minor details that vary between scopes.

- Ensure that all commands that take place on the Database Service node
  are described correctly as taking place on that node.

- Change the tctl-auth-sign.mdx partial. Since the start-auth-proxy.mdx
  partial now instructs self-hosted users to run tctl commands on the
  Auth Service host, we no longer need the Self-Hosted tab. As a result,
  I have turned the Cloud tab into a ScopedBlock.

- Reorder self-hosted guide sections so users start the Auth/Proxy
  before running "tctl auth sign". Otherwise, this command will not
  work.

- Minor style/grammar tweaks