### PR TITLE
Update syntax to respect TF minimum version (1.0.0)

### DIFF
--- a/examples/resources/terraform/terraform-user-role-cloud.tf
+++ b/examples/resources/terraform/terraform-user-role-cloud.tf
@@ -14,7 +14,7 @@ provider "teleport" {
 }
 
 resource "teleport_role" "terraform-test" {
-  metadata {
+  metadata = {
     name        = "terraform-test"
     description = "Terraform test role"
     labels = {
@@ -22,58 +22,62 @@ resource "teleport_role" "terraform-test" {
     }
   }
   
-  spec {
-    options {
+  spec = {
+    options = {
       forward_agent           = false
       max_session_ttl         = "30m"
       port_forwarding         = false
       client_idle_timeout     = "1h"
       disconnect_expired_cert = true
-      permit_x11_forwarding    = false
+      permit_x11_forwarding   = false
       request_access          = "denied"
     }
 
-    allow {
+    allow = {
       logins = ["this-user-does-not-exist"]
 
-      rules {
-        resources = ["user", "role"]
-        verbs = ["list"]
-      }
-
-      request {
-        roles = ["example"]
-        claims_to_roles {
-          claim = "example"
-          value = "example"
-          roles = ["example"]
+      rules = [
+        {
+          resources = ["user", "role"]
+          verbs = ["list"]
         }
+      ]
+
+      request = {
+        roles = ["example"]
+        claims_to_roles = [
+          {
+            claim = "example"
+            value = "example"
+            roles = ["example"]
+          }
+        ]
       }
 
-      node_labels {
-         key = "example"
+      node_labels = {
+         key = ["example"]
          value = ["yes"]
       }
     }
 
-    deny {
+    deny = {
       logins = ["anonymous"]
     }
   }
 }
 
 resource "teleport_user" "terraform-test" {
-  metadata {
+  metadata = {
     name        = "terraform-test"
     description = "Test terraform user"
-    expires     = "2022-10-12T07:20:50.52Z"
+    expires     = "2022-10-12T07:20:50Z"
 
     labels = {
       test      = "true"
     }
   }
 
-  spec {
+  spec = {
     roles = ["terraform-test"]
   }
 }

--- a/examples/resources/terraform/terraform-user-role-self-hosted.tf
+++ b/examples/resources/terraform/terraform-user-role-self-hosted.tf
@@ -17,7 +17,7 @@ provider "teleport" {
 }
 
 resource "teleport_role" "terraform-test" {
-  metadata {
+  metadata = {
     name        = "terraform-test"
     description = "Terraform test role"
     labels = {
@@ -25,58 +25,62 @@ resource "teleport_role" "terraform-test" {
     }
   }
   
-  spec {
-    options {
+  spec = {
+    options = {
       forward_agent           = false
       max_session_ttl         = "30m"
       port_forwarding         = false
       client_idle_timeout     = "1h"
       disconnect_expired_cert = true
-      permit_x11_forwarding    = false
+      permit_x11_forwarding   = false
       request_access          = "denied"
     }
 
-    allow {
+    allow = {
       logins = ["this-user-does-not-exist"]
 
-      rules {
-        resources = ["user", "role"]
-        verbs = ["list"]
-      }
-
-      request {
-        roles = ["example"]
-        claims_to_roles {
-          claim = "example"
-          value = "example"
-          roles = ["example"]
+      rules = [
+        {
+          resources = ["user", "role"]
+          verbs = ["list"]
         }
+      ]
+
+      request = {
+        roles = ["example"]
+        claims_to_roles = [
+          {
+            claim = "example"
+            value = "example"
+            roles = ["example"]
+          }
+        ]
       }
 
-      node_labels {
-         key = "example"
+      node_labels = {
+         key = ["example"]
          value = ["yes"]
       }
     }
 
-    deny {
+    deny = {
       logins = ["anonymous"]
     }
   }
 }
 
 resource "teleport_user" "terraform-test" {
-  metadata {
+  metadata = {
     name        = "terraform-test"
     description = "Test terraform user"
-    expires     = "2022-10-12T07:20:50.52Z"
+    expires     = "2022-10-12T07:20:50Z"
 
     labels = {
       test      = "true"
     }
   }
 
-  spec {
+  spec = {
     roles = ["terraform-test"]
   }
 }


### PR DESCRIPTION
Most of the changes are related to the strictness of TF v0.12

https://www.terraform.io/language/upgrade-guides/0-12
> Due to the design of the configuration language decoder in
> Terraform v0.11 and earlier, it was in many cases possible to
> interchange the argument syntax (with =) and the block syntax
> (with just braces) when dealing with map arguments vs. nested
> blocks. However, this led to some subtle bugs and limitations,
> so Terraform v0.12 now requires consistent usage of argument
> syntax for arguments and nested block syntax for nested blocks.

This commit validates both examples against Terraform 1

The min terraform version is going to be updated to 1.0.0
https://github.com/gravitational/teleport/pull/11650

Fixes #11652