### PR TITLE
Deflake TestCtrlCCapture

### DIFF
--- a/lib/srv/termmanager.go
+++ b/lib/srv/termmanager.go
@@ -68,7 +68,7 @@ func NewTermManager() *TermManager {
 		closed:            false,
 		readStateUpdate:   sync.NewCond(&sync.Mutex{}),
 		incoming:          make(chan []byte, 100),
-		terminateNotifier: make(chan struct{}),
+		terminateNotifier: make(chan struct{}, 1),
 	}
 }
 

--- a/lib/srv/termmanager_test.go
+++ b/lib/srv/termmanager_test.go
@@ -41,7 +41,7 @@ func TestCTRLCCapture(t *testing.T) {
 	m := NewTermManager()
 	r, w := io.Pipe()
 	m.AddReader("foo", r)
-	go w.Write([]byte("\x03"))
+	w.Write([]byte("\x03"))
 
 	select {
 	case <-m.TerminateNotifier():


### PR DESCRIPTION
As evidenced in https://github.com/gravitational/teleport/issues/9492#issuecomment-1086926043 this test for `TermManager` is flaky. The reasoning for it is in the linked comment.

This PR fixes the test flakiness, to do this I considered the following approaches
1. Remove the default case when sending a termination notification
2. Use a buffered channel

I investigated 1 but quickly realized that there would be issues. If we remove the default case, two concurrent notifications might attempt to send on the channel, as of the first notification, the channel will close and the second one will result in a panic which is highly undesirable.

A buffered approach seems more promising, this ensures that we can always catch the one termination notification in the test as the write no longer has to be in the background but that any additional ones will be discarded due to the default case which is desirable since the session shall terminate after the first one.