### PR TITLE
Support building for amd64 windows on arm64 hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ CGOFLAG ?= CGO_ENABLED=1
 CGOFLAG_TSH ?= CGO_ENABLED=1
 # Windows requires extra parameters to cross-compile with CGO.
 ifeq ("$(OS)","windows")
+ARCH ?= amd64
+ifneq ("$(ARCH)","amd64")
+$(error "Building for windows requires ARCH=amd64")
+endif
 BUILDFLAGS = $(ADDFLAGS) -ldflags '-w -s' -buildmode=exe
 CGOFLAG = CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++
 CGOFLAG_TSH = $(CGOFLAG)


### PR DESCRIPTION
Without this change, running `make -C build.assets release-windows-unsigned` will fail on arm64 hosts because `ARCH` gets autodetected as `arm64` and we end up launching

```
GOOS=windows GOARCH=arm64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ go build -tags "" -o build/tsh  -ldflags '-w -s' -buildmode=exe ./tool/tsh
```

which is obviously not going to work. As there doesn't seem to be a `mingw-w64` toolchain targeting arm64 we simply enforce `ARCH=amd64` when `OS=windows`.