### PR TITLE
Kube agent instructions on matching to server version

### DIFF
--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -33,7 +33,7 @@ remotely:
 $ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
 $ tctl status
 # Cluster  myinstance.teleport.sh
-# Version  (=teleport.version=)
+# Version  (=cloud.version=)
 # CA pin   sha256:sha-hash-here
 ```
 

--- a/docs/pages/kubernetes-access/getting-started/agent.mdx
+++ b/docs/pages/kubernetes-access/getting-started/agent.mdx
@@ -54,11 +54,11 @@ description: Connecting a Kubernetes cluster to Teleport
 - The `jq` tool to process `JSON` output. This is available via common package
   managers.
 
-- The `tctl` admin tool version >= (=teleport.version=).
+- The `tctl` admin tool version >= (=cloud.version=).
 
   ```code
   $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport v(=cloud.version=) go(=teleport.golang=)
   ```
 
   See [Installation](../../installation.mdx) for details.
@@ -102,6 +102,12 @@ $ echo $TOKEN
 
 ## Step 2/2. Deploy teleport-kube-agent
 
+<Notice type="tip" >
+
+The Teleport agent version should be the same as the Teleport Cluster version 
+or up to one major version back.  You can set the version override with the override variable, ex: `--set teleportVersionOverride=(=teleport.version=)`.
+
+</Notice>
 
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
@@ -136,8 +142,10 @@ $ helm repo update
 
 # Install Kubernetes agent. It dials back to the Teleport cluster at $PROXY_ADDR
 $ CLUSTER='cookie'
+# Run the helm install specifying to match to the Teleport Cloud version of Teleport
 $ helm install teleport-agent teleport/teleport-kube-agent --set kubeClusterName=${CLUSTER?} \
-  --set proxyAddr=${PROXY_ADDR?} --set authToken=${TOKEN?} --create-namespace --namespace=teleport-agent
+  --set proxyAddr=${PROXY_ADDR?} --set authToken=${TOKEN?} --create-namespace --namespace=teleport-agent \
+  --set teleportVersionOverride=(=cloud.version=)
 ```
 
 </TabItem>

--- a/docs/pages/kubernetes-access/getting-started/agent.mdx
+++ b/docs/pages/kubernetes-access/getting-started/agent.mdx
@@ -136,7 +136,7 @@ commands, assigning `PROXY_ADDR` to the address of your Teleport Cloud tenant.
 
 ```code
 # Add teleport-agent chart to charts repository
-$ PROXY_ADDR=mytenant.teleport.sh
+$ PROXY_ADDR=mytenant.teleport.sh:443
 $ helm repo add teleport https://charts.releases.teleport.dev
 $ helm repo update
 


### PR DESCRIPTION
Provided the override version number to match to the cloud version.  Also instructions that the agent should be the same or previous major version. 