### PR TITLE
RFD: Passwordless cluster settings

### DIFF
--- a/rfd/0052-passwordless.md
+++ b/rfd/0052-passwordless.md
@@ -466,7 +466,7 @@ auth_service:
     passwordless: true
 
     # Sets passwordless as the default connector.
-    connector_name: local:passwordless
+    connector_name: passwordless
 ```
 
 `cluster_auth_preference` / [AuthPreferenceSpecV2](
@@ -483,26 +483,24 @@ spec:
   webauthn:
     rp_id: example.com
   allow_passwordless: true
-  connector_name: local:passwordless
+  connector_name: passwordless
 ```
 
 #### Virtual connectors
 
 The design extends the [`local` users connector](
 https://goteleport.com/docs/architecture/users/#multiple-identity-sources) by
-adding the `local:passwordless` connector, a variant that uses passwordless
-logins.
+adding the `passwordless` connector, a variant that uses passwordless logins.
 
 Users may manually change their login method, as long as the cluster supports
-it, by running `tsh login --auth=local` or `tsh login
---auth=local:passwordless`. `tsh` and Web UI should check the connector name
-from `/ping` endpoints and react accordingly.
+it, by running `tsh login --auth=local` or `tsh login --auth=passwordless`.
+`tsh` and Web UI should check the connector name from `/ping` endpoints and
+react accordingly.
 
-`local:passwordless` is now a system-reserved connector name, taking precedence
-over similarly named connectors. Furthermore, the design suggests forbidding
-user-created connectors from containing the `:` character, so that other virtual
-connectors may be added, as necessary. (For example,
-`$connector_name:passwordless` for OIDC and SAML.)
+`passwordless` is now a system-reserved connector name, taking precedence over
+equally named connectors. A similar solution using virtual connectors could be
+used to "decorate" existing OIDC/SAML connectors for passwordless, but this is
+left for a future design.
 
 <!--
 References:

--- a/rfd/0052-passwordless.md
+++ b/rfd/0052-passwordless.md
@@ -214,8 +214,8 @@ it shouldn't pose a maintenance burden.
 package webauthn;
 
 message User {
-  // ID is the Teleport user ID.
-  string id = 1;
+  // Teleport user ID.
+  string teleport_user = 1;
 }
 ```
 
@@ -235,10 +235,10 @@ package types;
 message WebauthnDevice {
   // (existing fields omitted)
 
-  // Authenticator data returned during registration.
-  // Stored for audit and migration purposes.
-  // May be absent in legacy entries (Teleport 9.x or earlier).
-  bytes authenticator_data = 6;
+  // Raw attestation object, as returned by the authentication during
+  // registration.
+  // Absent for legacy entries.
+  bytes attestation_object = 6;
 
   // True if the device is the result of a requested resident key
   // (ie, it is passwordless-capable).
@@ -309,10 +309,10 @@ type MFAChallengeRequest struct {
 ```proto
 package proto; // api/client/proto
 
-message CreateAuthenticateChallengeRequest {
-  message ContextUser {}
-  message Passwordless {}
+message ContextUser {}
+message Passwordless {}
 
+message CreateAuthenticateChallengeRequest {
   oneof Request {
     // (existing fields omitted)
 

--- a/rfd/0052-passwordless.md
+++ b/rfd/0052-passwordless.md
@@ -255,16 +255,17 @@ https://www.w3.org/TR/webauthn-2/#enumdef-userverificationrequirement) is set to
 
 WebAuthn challenge storage is currently [scoped per-user](
 https://github.com/gravitational/teleport/blob/master/rfd/0040-webauthn-support.md#webauthn-challenge-storage).
-For passwordless we require a global challenge storage, since challenges may be
-issued to an anonymous user. For simplicity, the global challenge storage will
-replace the current per-user storage.
+For passwordless we require a global challenge storage, since challenges are
+issued to anonymous users. Per-user challenge storage is kept for MFA
+(multi-factor authentication) and registration, since they aren't subject to the
+same limitations as the global storage (see the [security](#security) section
+for details).
 
 The new key space for challenges is `/webauthn/sessionData/{scope}/{id}`, where
-`{scope}` is either `login` or `registration` and `{id}` is the base64 raw URL
-encoding of the challenge. As in the current implementation, challenges are
-deleted as soon as they are "spent" by a user.
+`{scope}` is limited to `login` and `{id}` is the base64 raw URL encoding of the
+challenge. Challenges are deleted as soon as they are "spent" by a user.
 
-The  [SessionData](
+The [SessionData](
 https://github.com/gravitational/teleport/blob/f423f7fedc088b97cb666c13dcdcf54bd289b1bf/api/types/webauthn/webauthn.proto#L45)
 proto is modified as below:
 
@@ -451,11 +452,7 @@ mitigations:
 
 1. A simple, in-memory, IP based rate limiter for sensitive endpoints
    (mitigation for rudimentary DDoS attacks)
-2. A circular in-memory buffer to storage challenges
-   (mitigation for storage bloat attacks)
-
-<!-- As noted by Alexey, this may require digging into the Teleport caching
-system to make it work in HA mode). -->
+2. A storage hard limit on in-flight global challenges
 
 (Note that "entropy attacks" are
 [not really](https://www.2uo.de/myths-about-urandom/#what-about-entropy-running-low)

--- a/rfd/0053-passwordless-fido2.md
+++ b/rfd/0053-passwordless-fido2.md
@@ -172,7 +172,7 @@ Authentication diagram below:
      ┌─────────────┐             │                   ┌───┐                                       ┌────────┐
      │authenticator│            ┌┴┐                  │tsh│                                       │Teleport│
      └──────┬──────┘           user                  └─┬─┘                                       └───┬────┘
-            │                   │  tsh login --pwdless │                                             │
+            │                   │       tsh login      │                                             │
             │                   │ ─────────────────────>                                             │
             │                   │                      │                                             │
             │                   │                      │        CreateAuthenticateChallenge()        │
@@ -341,9 +341,10 @@ keys with storage limitations.
 **CLI clients (aka `tsh`)**
 
 Similarly to browser-based authentication, `tsh login` needs to know beforehand
-whether to go for the "regular" or "passwordless" flow. The decision needs to
-come from the user, otherwise we risk a needless hardware key prompt (and the
-clunky UX that comes with it).
+whether to go for the "regular" or "passwordless" flow. The decision comes from
+the [passwordless cluster settings](
+https://github.com/gravitational/teleport/blob/master/rfd/0052-passwordless.md#cluster-settings),
+with a possible user-override via the `--auth` flag.
 
 Example of a login with multiple hardware keys, PIN, and multiple credentials
 (some steps may be skipped in simpler scenarios, see the
@@ -460,7 +461,7 @@ actor user
 participant tsh
 participant "Teleport" as server
 
-user -> tsh: tsh login --pwdless
+user -> tsh: tsh login
 
 tsh -> server: CreateAuthenticateChallenge()\n(no user or password informed)
 server -> tsh: challenge

--- a/rfd/0054-passwordless-macos.md
+++ b/rfd/0054-passwordless-macos.md
@@ -287,7 +287,7 @@ registered for "example.com")
 `tsh login --proxy=example.com --user=llama` behaves as above, but using a
 specific user
 
-`tsh login --auth=local:passwordless --mfa-mode=platform --proxy=example.com
+`tsh login --auth=passwordless --mfa-mode=platform --proxy=example.com
 --user=llama` is the zero ambiguity, (needlessly) long form of the above.
 
 `tsh mfa add` adds support for Touch ID, both for authentication and registering

--- a/rfd/0054-passwordless-macos.md
+++ b/rfd/0054-passwordless-macos.md
@@ -167,28 +167,14 @@ registered in the Enclave _without_ user interaction. Because all Touch ID keys
 are functionally resident keys, as long as the server supports passwordless,
 then `tsh` is free to use it.
 
-If Touch ID passwordless authentication is possible, then it is the preferred
-authentication mode and is used by default.
-
-If passwordless is not possible, but Touch ID is present, then Touch ID MFA is
-also preferred and used by default.
+If Touch ID keys are present, then it's the preferred method of authentication,
+both for passwordless and MFA.
 
 To allow users agency over the eager behaviors of Touch ID, `tsh` is augmented
-with the following flags:
+with the global `--mfa-mode` flag:
 
-* `tsh --pwdless-mode={auto,on,off}` - activate/deactivate passwordless
-  authentication
-
-    `auto` is the default behavior described above (passwordless is preferred
-    if we are certain it may be used)
-
-    `on` enables passwordless logins (`tsh login --pwdless`, described in the
-    [Passwordless FIDO2 RFD][passwordless fido2], is a shortcut to it)
-
-    `off` disables passwordless logins
-
-* `tsh --mfa-mode={auto,platform,cross-platform}` - choose whether to use
-  platform or cross-platform MFA
+`tsh --mfa-mode={auto,platform,cross-platform}` - choose whether to use platform
+or cross-platform MFA
 
     `auto` is the default behavior described above, which favors Touch ID
 
@@ -196,11 +182,6 @@ with the following flags:
     portable FIDO2 keys
 
     `cross-platform` prefers FIDO2 or OTP (aka `tsh` behavior prior to this RFD)
-
-Both `--pwdless-mode` and `--mfa-mode` may be specified for fine-grained control
-over `tsh` authentication logic. Note that those flags apply not only to
-`tsh login`, but also for any commands that require re-authentication (such as
-`tsh mfa add`).
 
 Finally, if there are Touch ID credentials for multiple users and the login user
 is not known, `tsh login` may prompt the user to specify the `--user` flag.
@@ -300,13 +281,13 @@ and [Passwordless RFDs][passwordless rfd].
 UX is discussed throughout the design, but here is a summary of changes:
 
 `tsh login --proxy=example.com` will automatically do passwordless Touch ID
-login, if possible (server allows passwordless, appropriate hardware exists, one
-credential registered for "example.com")
+login, if appropriate (server allows passwordless, hardware present, credential
+registered for "example.com")
 
 `tsh login --proxy=example.com --user=llama` behaves as above, but using a
 specific user
 
-`tsh login --pwdless-mode=on --mfa-mode=platform --proxy=example.com
+`tsh login --auth=local:passwordless --mfa-mode=platform --proxy=example.com
 --user=llama` is the zero ambiguity, (needlessly) long form of the above.
 
 `tsh mfa add` adds support for Touch ID, both for authentication and registering

--- a/rfd/0054-passwordless-macos.md
+++ b/rfd/0054-passwordless-macos.md
@@ -32,14 +32,19 @@ In order to make use of the Keychain Sharing services, required for Secure
 Enclave protection, the `tsh` macOS binary needs to be:
 
 1. Code signed,
-2. Contain the necessary entitlements to use the Keychain; and
+2. Contain the necessary entitlements to use the Keychain,
 3. Embed a matching [provisioning profile](
-   https://developer.apple.com/forums/thread/685723).
+   https://developer.apple.com/forums/thread/685723); and
+4. Notarized
+
+<!--
+TODO(codingllama): Add more details about notarization.
+-->
 
 The requirements above mean that `tsh` needs to be [packaged in a macOS .app](
 https://developer.apple.com/documentation/xcode/signing-a-daemon-with-a-restricted-entitlement)
-for distribution, mainly so the provisioning profile is embedded within the
-binary. An account enrolled in the Apple Developer Program is also necessary.
+for distribution. An account enrolled in the Apple Developer Program is also
+necessary.
 
 See below for an example of the necessary entitlements:
 
@@ -151,7 +156,7 @@ hidden [`tsh` support commands](#tsh-support-commands) for a manual cleanup.
 
 ### Authentication
 
-Authentication offers a plethora of options, depending on both server settings
+Authentication offers a plethora of options, depending both on server settings
 (otp, webauthn, passwordless) and client state (FIDO2 keys present, Touch ID
 keys registered). In order to decide which flow to follow, `tsh` must first
 assess what is possible, preferably without asking for unnecessary user
@@ -220,8 +225,8 @@ $ tsh login --proxy=example.com
 Detecting Touch ID support is important so `tsh` may enable/disable related
 features as appropriate.
 
-Apart from Go build tags, which are a rather coarse "detection" mechanism, we
-can take inspiration from [Chromium's implementation](
+Apart from Go build tags, which are a rather coarse detection mechanism, we can
+take inspiration from [Chromium's implementation](
 https://github.com/chromium/chromium/blob/c4d3c31083a2e1481253ff2d24298a1dfe19c754/device/fido/mac/touch_id_context.mm#L126)
 and do the following checks:
 


### PR DESCRIPTION
Include cluster-wide settings for passwordless in the base design.

The base requirements for the changes are:

1. Admins may configure a cluster to be fully passwordless (login and registrations default to passwordless)
2. Passwordless logins are possible in `tsh` without additional flags (assuming a pwdless cluster)
3. `tsh --auth=local` is used as the fallback for local, non-passwordless login

The design takes advantage of the `--auth` flag and the existing `local` auth connector, extending it by adding the `passwordless` connector. It also takes advantage of the existing `connector_name` setting, thus introducing few configuration changes and reusing concepts already in Teleport.

The `--pwdless` (FIDO2) and `--pwdless-mode` (Touch ID) flags are removed from the design.

I've taken the opportunity to update the designs with a few changes that happened during implementation.