### PR TITLE
Session fixes

### DIFF
--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -405,6 +405,7 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					Rules: []types.Rule{
 						types.NewRule(types.KindNode, services.RW()),
 						types.NewRule(types.KindSSHSession, services.RW()),
+						types.NewRule(types.KindSession, services.RO()),
 						types.NewRule(types.KindEvent, services.RW()),
 						types.NewRule(types.KindProxy, services.RO()),
 						types.NewRule(types.KindCertAuthority, services.ReadNoSecrets()),

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -507,8 +507,8 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 	}
 
 	findSession := func() (*session, bool) {
-		reg.mu.Lock()
-		defer reg.mu.Unlock()
+		reg.sessionsMux.Lock()
+		defer reg.sessionsMux.Unlock()
 		return reg.findSessionLocked(rsession.ID(ssid))
 	}
 

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -20,14 +20,10 @@ limitations under the License.
 package srv
 
 import (
-	"context"
 	"fmt"
-	"io"
-	"net"
 	"os"
 	os_exec "os/exec"
 	"os/user"
-	"path/filepath"
 	"strconv"
 	"syscall"
 	"testing"
@@ -36,38 +32,11 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
-	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
-	"github.com/gravitational/teleport/lib/auth"
-	authority "github.com/gravitational/teleport/lib/auth/testauthority"
-	"github.com/gravitational/teleport/lib/backend/lite"
-	"github.com/gravitational/teleport/lib/bpf"
-	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/events/eventstest"
-	"github.com/gravitational/teleport/lib/fixtures"
-	"github.com/gravitational/teleport/lib/pam"
-	restricted "github.com/gravitational/teleport/lib/restrictedsession"
-	"github.com/gravitational/teleport/lib/services"
-	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
-
-	"github.com/jonboulle/clockwork"
-	"github.com/moby/term"
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
-
-// ExecSuite also implements ssh.ConnMetadata
-type ExecSuite struct {
-	usr        *user.User
-	ctx        *ServerContext
-	localAddr  net.Addr
-	remoteAddr net.Addr
-	a          *auth.Server
-}
-
-var _ = check.Suite(&ExecSuite{})
 
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise it will run tests as normal.
@@ -85,155 +54,101 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func (s *ExecSuite) SetUpSuite(c *check.C) {
-	ctx := context.TODO()
-	bk, err := lite.NewWithConfig(ctx, lite.Config{Path: c.MkDir()})
-	c.Assert(err, check.IsNil)
+func TestLoginDefsParser(t *testing.T) {
+	expectedEnvSuPath := "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/bar"
+	expectedSuPath := "PATH=/usr/local/bin:/usr/bin:/bin:/foo"
 
-	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
-		ClusterName: "localhost",
-	})
-	c.Assert(err, check.IsNil)
-
-	c.Assert(err, check.IsNil)
-	s.a, err = auth.NewServer(&auth.InitConfig{
-		Backend:     bk,
-		Authority:   authority.New(),
-		ClusterName: clusterName,
-	})
-	c.Assert(err, check.IsNil)
-	err = s.a.SetClusterName(clusterName)
-	c.Assert(err, check.IsNil)
-
-	// set static tokens
-	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
-		StaticTokens: []types.ProvisionTokenV1{},
-	})
-	c.Assert(err, check.IsNil)
-	err = s.a.SetStaticTokens(staticTokens)
-	c.Assert(err, check.IsNil)
-
-	dir := c.MkDir()
-	f, err := os.Create(filepath.Join(dir, "fake"))
-	c.Assert(err, check.IsNil)
-
-	s.usr, _ = user.Current()
-	cert, err := apisshutils.ParseCertificate([]byte(fixtures.UserCertificateStandard))
-	c.Assert(err, check.IsNil)
-	s.ctx = &ServerContext{
-		ConnectionContext: &sshutils.ConnectionContext{
-			ServerConn: &ssh.ServerConn{Conn: s},
-		},
-		IsTestStub:  true,
-		ClusterName: "localhost",
-		srv: &fakeServer{
-			accessPoint: s.a,
-			auditLog:    events.NewDiscardAuditLog(),
-			id:          "00000000-0000-0000-0000-000000000000",
-		},
-		Identity: IdentityContext{
-			Login:        s.usr.Username,
-			TeleportUser: "galt",
-			Certificate:  cert,
-		},
-		session:     &session{id: "xxx", term: &fakeTerminal{f: f}},
-		ExecRequest: &localExec{Ctx: s.ctx},
-		request: &ssh.Request{
-			Type: sshutils.ExecRequest,
-		},
-	}
-
-	term, err := newLocalTerminal(s.ctx)
-	c.Assert(err, check.IsNil)
-	term.SetTermType("xterm")
-	s.ctx.session.term = term
-
-	s.localAddr, _ = utils.ParseAddr("127.0.0.1:3022")
-	s.remoteAddr, _ = utils.ParseAddr("10.0.0.5:4817")
+	require.Equal(t, expectedEnvSuPath, getDefaultEnvPath("0", "../../fixtures/login.defs"))
+	require.Equal(t, expectedSuPath, getDefaultEnvPath("1000", "../../fixtures/login.defs"))
+	require.Equal(t, defaultEnvPath, getDefaultEnvPath("1000", "bad/file"))
 }
 
-func (s *ExecSuite) TearDownSuite(c *check.C) {
-	s.ctx.session.term.Close()
-}
+func TestOSCommandPrep(t *testing.T) {
+	srv := newMockServerWithBackend(t)
+	scx := newExecServerContext(t, srv)
 
-func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
+	usr, err := user.Current()
+	require.NoError(t, err)
+
 	expectedEnv := []string{
 		"LANG=en_US.UTF-8",
 		getDefaultEnvPath(strconv.Itoa(os.Geteuid()), defaultLoginDefsPath),
-		fmt.Sprintf("HOME=%s", s.usr.HomeDir),
-		fmt.Sprintf("USER=%s", s.usr.Username),
+		fmt.Sprintf("HOME=%s", usr.HomeDir),
+		fmt.Sprintf("USER=%s", usr.Username),
 		"SHELL=/bin/sh",
 		"SSH_CLIENT=10.0.0.5 4817 3022",
 		"SSH_CONNECTION=10.0.0.5 4817 127.0.0.1 3022",
 		"TERM=xterm",
-		fmt.Sprintf("SSH_TTY=%v", s.ctx.session.term.TTY().Name()),
+		fmt.Sprintf("SSH_TTY=%v", scx.session.term.TTY().Name()),
 		"SSH_SESSION_ID=xxx",
 		"SSH_SESSION_WEBPROXY_ADDR=<proxyhost>:3080",
-		"SSH_TELEPORT_HOST_UUID=00000000-0000-0000-0000-000000000000",
+		"SSH_TELEPORT_HOST_UUID=test",
 		"SSH_TELEPORT_CLUSTER_NAME=localhost",
-		"SSH_TELEPORT_USER=galt",
+		"SSH_TELEPORT_USER=teleportUser",
 	}
 
 	// Empty command (simple shell).
-	execCmd, err := s.ctx.ExecCommand()
-	c.Assert(err, check.IsNil)
-	cmd, err := buildCommand(execCmd, s.usr, nil, nil, nil)
-	c.Assert(err, check.IsNil)
-	c.Assert(cmd, check.NotNil)
-	c.Assert(cmd.Path, check.Equals, "/bin/sh")
-	c.Assert(cmd.Args, check.DeepEquals, []string{"-sh"})
-	c.Assert(cmd.Dir, check.Equals, s.usr.HomeDir)
-	c.Assert(cmd.Env, check.DeepEquals, expectedEnv)
-	c.Assert(cmd.SysProcAttr.Pdeathsig, check.Equals, syscall.SIGKILL)
+	execCmd, err := scx.ExecCommand()
+	require.NoError(t, err)
+
+	cmd, err := buildCommand(execCmd, usr, nil, nil, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, cmd)
+	require.Equal(t, "/bin/sh", cmd.Path)
+	require.Equal(t, []string{"-sh"}, cmd.Args)
+	require.Equal(t, usr.HomeDir, cmd.Dir)
+	require.Equal(t, expectedEnv, cmd.Env)
+	require.Equal(t, syscall.SIGKILL, cmd.SysProcAttr.Pdeathsig)
 
 	// Non-empty command (exec a prog).
-	s.ctx.ExecRequest.SetCommand("ls -lh /etc")
-	execCmd, err = s.ctx.ExecCommand()
-	c.Assert(err, check.IsNil)
-	cmd, err = buildCommand(execCmd, s.usr, nil, nil, nil)
-	c.Assert(err, check.IsNil)
-	c.Assert(cmd, check.NotNil)
-	c.Assert(cmd.Path, check.Equals, "/bin/sh")
-	c.Assert(cmd.Args, check.DeepEquals, []string{"/bin/sh", "-c", "ls -lh /etc"})
-	c.Assert(cmd.Dir, check.Equals, s.usr.HomeDir)
-	c.Assert(cmd.Env, check.DeepEquals, expectedEnv)
-	c.Assert(cmd.SysProcAttr.Pdeathsig, check.Equals, syscall.SIGKILL)
+	scx.ExecRequest.SetCommand("ls -lh /etc")
+	execCmd, err = scx.ExecCommand()
+	require.NoError(t, err)
+
+	cmd, err = buildCommand(execCmd, usr, nil, nil, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, cmd)
+	require.Equal(t, "/bin/sh", cmd.Path)
+	require.Equal(t, []string{"/bin/sh", "-c", "ls -lh /etc"}, cmd.Args)
+	require.Equal(t, usr.HomeDir, cmd.Dir)
+	require.Equal(t, expectedEnv, cmd.Env)
+	require.Equal(t, syscall.SIGKILL, cmd.SysProcAttr.Pdeathsig)
 
 	// Command without args.
-	s.ctx.ExecRequest.SetCommand("top")
-	execCmd, err = s.ctx.ExecCommand()
-	c.Assert(err, check.IsNil)
-	cmd, err = buildCommand(execCmd, s.usr, nil, nil, nil)
-	c.Assert(err, check.IsNil)
-	c.Assert(cmd.Path, check.Equals, "/bin/sh")
-	c.Assert(cmd.Args, check.DeepEquals, []string{"/bin/sh", "-c", "top"})
-	c.Assert(cmd.SysProcAttr.Pdeathsig, check.Equals, syscall.SIGKILL)
+	scx.ExecRequest.SetCommand("top")
+	execCmd, err = scx.ExecCommand()
+	require.NoError(t, err)
+
+	cmd, err = buildCommand(execCmd, usr, nil, nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "/bin/sh", cmd.Path)
+	require.Equal(t, []string{"/bin/sh", "-c", "top"}, cmd.Args)
+	require.Equal(t, syscall.SIGKILL, cmd.SysProcAttr.Pdeathsig)
+
+	if os.Geteuid() != 0 {
+		t.Skip("skipping portion of test which must run as root")
+	}
 
 	// Missing home directory - HOME should still be set to the given
 	// home dir, but the command should set it's CWD to root instead.
-	s.usr.HomeDir = "/wrong/place"
+	usr.HomeDir = "/wrong/place"
 	root := string(os.PathSeparator)
 	expectedEnv[2] = "HOME=/wrong/place"
-	cmd, err = buildCommand(execCmd, s.usr, nil, nil, nil)
-	c.Assert(err, check.IsNil)
-	c.Assert(cmd.Dir, check.Equals, root)
-	c.Assert(cmd.Env, check.DeepEquals, expectedEnv)
-}
+	cmd, err = buildCommand(execCmd, usr, nil, nil, nil)
+	require.NoError(t, err)
 
-func (s *ExecSuite) TestLoginDefsParser(c *check.C) {
-	expectedEnvSuPath := "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/bar"
-	expectedSuPath := "PATH=/usr/local/bin:/usr/bin:/bin:/foo"
-
-	c.Assert(getDefaultEnvPath("0", "../../fixtures/login.defs"), check.Equals, expectedEnvSuPath)
-	c.Assert(getDefaultEnvPath("1000", "../../fixtures/login.defs"), check.Equals, expectedSuPath)
-	c.Assert(getDefaultEnvPath("1000", "bad/file"), check.Equals, defaultEnvPath)
+	require.Equal(t, root, cmd.Dir)
+	require.Equal(t, expectedEnv, cmd.Env)
 }
 
 // TestEmitExecAuditEvent make sure the full command and exit code for a
 // command is always recorded.
-func (s *ExecSuite) TestEmitExecAuditEvent(c *check.C) {
-	fakeServer, ok := s.ctx.srv.(*fakeServer)
-	c.Assert(ok, check.Equals, true)
+func TestEmitExecAuditEvent(t *testing.T) {
+	srv := newMockServerWithBackend(t)
+	scx := newExecServerContext(t, srv)
 
 	var tests = []struct {
 		inCommand  string
@@ -264,50 +179,28 @@ func (s *ExecSuite) TestEmitExecAuditEvent(c *check.C) {
 		},
 	}
 	for _, tt := range tests {
-		emitExecAuditEvent(s.ctx, tt.inCommand, tt.inError)
-		execEvent := fakeServer.LastEvent().(*apievents.Exec)
-		c.Assert(execEvent.Command, check.Equals, tt.outCommand)
-		c.Assert(execEvent.ExitCode, check.Equals, tt.outCode)
+		emitExecAuditEvent(scx, tt.inCommand, tt.inError)
+		execEvent := srv.MockEmitter.LastEvent().(*apievents.Exec)
+		require.Equal(t, tt.outCommand, execEvent.Command)
+		require.Equal(t, tt.outCode, execEvent.ExitCode)
 	}
 }
 
 // TestContinue tests if the process hangs if a continue signal is not sent
 // and makes sure the process continues once it has been sent.
-func (s *ExecSuite) TestContinue(c *check.C) {
+func TestContinue(t *testing.T) {
+	srv := newMockServerWithBackend(t)
+	scx := newExecServerContext(t, srv)
+
+	// Configure Session Context to re-exec "ls".
 	var err error
-
 	lsPath, err := os_exec.LookPath("ls")
-	c.Assert(err, check.IsNil)
-
-	// Create a fake context that will be used to configure a command that will
-	// re-exec "ls".
-	ctx := &ServerContext{
-		ConnectionContext: &sshutils.ConnectionContext{},
-		IsTestStub:        true,
-		srv: &fakeServer{
-			accessPoint: s.a,
-			auditLog:    events.NewDiscardAuditLog(),
-			id:          "00000000-0000-0000-0000-000000000000",
-		},
-	}
-	ctx.Identity.Login = s.usr.Username
-	ctx.Identity.TeleportUser = "galt"
-	ctx.ServerConn = &ssh.ServerConn{Conn: s}
-	ctx.ExecRequest = &localExec{
-		Ctx:     ctx,
-		Command: lsPath,
-	}
-	ctx.cmdr, ctx.cmdw, err = os.Pipe()
-	c.Assert(err, check.IsNil)
-	ctx.contr, ctx.contw, err = os.Pipe()
-	c.Assert(err, check.IsNil)
-	ctx.request = &ssh.Request{
-		Type: sshutils.ExecRequest,
-	}
+	require.NoError(t, err)
+	scx.ExecRequest.SetCommand(lsPath)
 
 	// Create an exec.Cmd to execute through Teleport.
-	cmd, err := ConfigureCommand(ctx)
-	c.Assert(err, check.IsNil)
+	cmd, err := ConfigureCommand(scx)
+	require.NoError(t, err)
 
 	// Create a channel that will be used to signal that execution is complete.
 	cmdDone := make(chan error, 1)
@@ -322,211 +215,37 @@ func (s *ExecSuite) TestContinue(c *check.C) {
 	// process should not have exited yet.
 	select {
 	case err := <-cmdDone:
-		c.Fatalf("Process exited before continue with error %v", err)
+		t.Fatalf("Process exited before continue with error %v", err)
 	case <-time.After(5 * time.Second):
 	}
 
 	// Close the continue pipe to signal to Teleport to now execute the
 	// requested program.
-	err = ctx.contw.Close()
-	c.Assert(err, check.IsNil)
+	err = scx.contw.Close()
+	require.NoError(t, err)
 
 	// Program should have executed now. If the complete signal has not come
 	// over the context, something failed.
 	select {
 	case <-time.After(5 * time.Second):
-		c.Fatalf("Timed out waiting for process to finish.")
+		t.Fatalf("Timed out waiting for process to finish.")
 	case err := <-cmdDone:
-		c.Assert(err, check.IsNil)
+		require.NoError(t, err)
 	}
 }
 
-// Implementation of ssh.Conn interface.
-func (s *ExecSuite) User() string                                           { return s.usr.Username }
-func (s *ExecSuite) SessionID() []byte                                      { return []byte{1, 2, 3} }
-func (s *ExecSuite) ClientVersion() []byte                                  { return []byte{1} }
-func (s *ExecSuite) ServerVersion() []byte                                  { return []byte{1} }
-func (s *ExecSuite) RemoteAddr() net.Addr                                   { return s.remoteAddr }
-func (s *ExecSuite) LocalAddr() net.Addr                                    { return s.localAddr }
-func (s *ExecSuite) Close() error                                           { return nil }
-func (s *ExecSuite) SendRequest(string, bool, []byte) (bool, []byte, error) { return false, nil, nil }
-func (s *ExecSuite) OpenChannel(string, []byte) (ssh.Channel, <-chan *ssh.Request, error) {
-	return nil, nil, nil
-}
-func (s *ExecSuite) Wait() error { return nil }
+func newExecServerContext(t *testing.T, srv Server) *ServerContext {
+	scx := newTestServerContext(t, srv)
 
-type fakeTerminal struct {
-	f *os.File
-}
+	term, err := newLocalTerminal(scx)
+	require.NoError(t, err)
+	term.SetTermType("xterm")
 
-// AddParty adds another participant to this terminal. We will keep the
-// Terminal open until all participants have left.
-func (f *fakeTerminal) AddParty(delta int) {
-}
+	scx.session = &session{id: "xxx"}
+	scx.session.term = term
+	scx.request = &ssh.Request{Type: sshutils.ExecRequest}
 
-// Run will run the terminal.
-func (f *fakeTerminal) Run() error {
-	return nil
-}
+	t.Cleanup(func() { require.NoError(t, scx.session.term.Close()) })
 
-// Wait will block until the terminal is complete.
-func (f *fakeTerminal) Wait() (*ExecResult, error) {
-	return nil, nil
-}
-
-// Continue will resume execution of the process after it completes its
-// pre-processing routine (placed in a cgroup).
-func (f *fakeTerminal) Continue() {}
-
-// Kill will force kill the terminal.
-func (f *fakeTerminal) Kill() error {
-	return nil
-}
-
-// PTY returns the PTY backing the terminal.
-func (f *fakeTerminal) PTY() io.ReadWriter {
-	return nil
-}
-
-// TTY returns the TTY backing the terminal.
-func (f *fakeTerminal) TTY() *os.File {
-	return f.f
-}
-
-// PID returns the PID of the Teleport process that was re-execed.
-func (f *fakeTerminal) PID() int {
-	return 1
-}
-
-// Close will free resources associated with the terminal.
-func (f *fakeTerminal) Close() error {
-	return f.f.Close()
-}
-
-// GetWinSize returns the window size of the terminal.
-func (f *fakeTerminal) GetWinSize() (*term.Winsize, error) {
-	return &term.Winsize{}, nil
-}
-
-// SetWinSize sets the window size of the terminal.
-func (f *fakeTerminal) SetWinSize(params rsession.TerminalParams) error {
-	return nil
-}
-
-// GetTerminalParams is a fast call to get cached terminal parameters
-// and avoid extra system call.
-func (f *fakeTerminal) GetTerminalParams() rsession.TerminalParams {
-	return rsession.TerminalParams{}
-}
-
-// SetTerminalModes sets the terminal modes from "pty-req"
-func (f *fakeTerminal) SetTerminalModes(ssh.TerminalModes) {}
-
-// GetTermType gets the terminal type set in "pty-req"
-func (f *fakeTerminal) GetTermType() string {
-	return "xterm"
-}
-
-// SetTermType sets the terminal type from "pty-req"
-func (f *fakeTerminal) SetTermType(string) {
-}
-
-// fakeServer is stub for tests
-type fakeServer struct {
-	auditLog events.IAuditLog
-	eventstest.MockEmitter
-	accessPoint AccessPoint
-	id          string
-}
-
-func (f *fakeServer) Context() context.Context {
-	return context.TODO()
-}
-
-func (f *fakeServer) ID() string {
-	return f.id
-}
-
-func (f *fakeServer) HostUUID() string {
-	return f.id
-}
-
-func (f *fakeServer) GetNamespace() string {
-	return ""
-}
-
-func (f *fakeServer) AdvertiseAddr() string {
-	return ""
-}
-
-func (f *fakeServer) Component() string {
-	return ""
-}
-
-func (f *fakeServer) PermitUserEnvironment() bool {
-	return true
-}
-
-func (f *fakeServer) GetAccessPoint() AccessPoint {
-	return f.accessPoint
-}
-
-func (f *fakeServer) GetSessionServer() rsession.Service {
-	return nil
-}
-
-func (f *fakeServer) GetDataDir() string {
-	return ""
-}
-
-func (f *fakeServer) GetPAM() (*pam.Config, error) {
-	return nil, nil
-}
-
-func (f *fakeServer) GetClock() clockwork.Clock {
-	return nil
-}
-
-func (f *fakeServer) GetInfo() types.Server {
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "localhost"
-	}
-
-	return &types.ServerV2{
-		Kind:    types.KindNode,
-		Version: types.V2,
-		Metadata: types.Metadata{
-			Name:      "",
-			Namespace: "",
-			Labels:    make(map[string]string),
-		},
-		Spec: types.ServerSpecV2{
-			CmdLabels: make(map[string]types.CommandLabelV2),
-			Addr:      "",
-			Hostname:  hostname,
-			UseTunnel: false,
-			Version:   teleport.Version,
-		},
-	}
-}
-
-func (f *fakeServer) GetUtmpPath() (string, string) {
-	return "", ""
-}
-
-func (f *fakeServer) UseTunnel() bool {
-	return false
-}
-
-func (f *fakeServer) GetBPF() bpf.BPF {
-	return &bpf.NOP{}
-}
-
-func (f *fakeServer) GetRestrictedSessionManager() restricted.Manager {
-	return &restricted.NOP{}
-}
-
-func (f *fakeServer) GetLockWatcher() *services.LockWatcher {
-	return nil
+	return scx
 }

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -64,7 +64,7 @@ func TestLoginDefsParser(t *testing.T) {
 }
 
 func TestOSCommandPrep(t *testing.T) {
-	srv := newMockServerWithBackend(t)
+	srv := newMockServer(t)
 	scx := newExecServerContext(t, srv)
 
 	usr, err := user.Current()
@@ -147,7 +147,7 @@ func TestOSCommandPrep(t *testing.T) {
 // TestEmitExecAuditEvent make sure the full command and exit code for a
 // command is always recorded.
 func TestEmitExecAuditEvent(t *testing.T) {
-	srv := newMockServerWithBackend(t)
+	srv := newMockServer(t)
 	scx := newExecServerContext(t, srv)
 
 	var tests = []struct {
@@ -189,7 +189,7 @@ func TestEmitExecAuditEvent(t *testing.T) {
 // TestContinue tests if the process hangs if a continue signal is not sent
 // and makes sure the process continues once it has been sent.
 func TestContinue(t *testing.T) {
-	srv := newMockServerWithBackend(t)
+	srv := newMockServer(t)
 	scx := newExecServerContext(t, srv)
 
 	// Configure Session Context to re-exec "ls".

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -297,7 +297,10 @@ func New(c ServerConfig) (*Server, error) {
 	s.kexAlgorithms = c.KEXAlgorithms
 	s.macAlgorithms = c.MACAlgorithms
 
-	s.sessionRegistry, err = srv.NewSessionRegistry(s, s.authClient)
+	s.sessionRegistry, err = srv.NewSessionRegistry(srv.SessionRegistryConfig{
+		Srv:                   s,
+		SessionTrackerService: s.authClient,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2015-2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package srv
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"os"
+	"os/user"
+	"testing"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/backend/lite"
+	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/pam"
+	restricted "github.com/gravitational/teleport/lib/restrictedsession"
+	"github.com/gravitational/teleport/lib/services"
+	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func newTestServerContext(t *testing.T, srv Server) *ServerContext {
+	usr, err := user.Current()
+	require.NoError(t, err)
+
+	cert, err := apisshutils.ParseCertificate([]byte(fixtures.UserCertificateStandard))
+	require.NoError(t, err)
+
+	sshConn := &mockSSHConn{}
+	sshConn.localAddr, _ = utils.ParseAddr("127.0.0.1:3022")
+	sshConn.remoteAddr, _ = utils.ParseAddr("10.0.0.5:4817")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	scx := &ServerContext{
+		Entry: logrus.NewEntry(logrus.StandardLogger()),
+		ConnectionContext: &sshutils.ConnectionContext{
+			ServerConn: &ssh.ServerConn{Conn: sshConn},
+		},
+		env:                    make(map[string]string),
+		SessionRecordingConfig: types.DefaultSessionRecordingConfig(),
+		IsTestStub:             true,
+		ClusterName:            "localhost",
+		srv:                    srv,
+		Identity: IdentityContext{
+			Login:        usr.Username,
+			TeleportUser: "teleportUser",
+			Certificate:  cert,
+		},
+		cancelContext: ctx,
+		cancel:        cancel,
+	}
+
+	scx.ExecRequest = &localExec{Ctx: scx}
+
+	scx.cmdr, scx.cmdw, err = os.Pipe()
+	require.NoError(t, err)
+
+	scx.contr, scx.contw, err = os.Pipe()
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, scx.Close()) })
+
+	return scx
+}
+
+func newMockServerWithBackend(t *testing.T) *mockServer {
+	ctx := context.Background()
+
+	bk, err := lite.NewWithConfig(ctx, lite.Config{Path: t.TempDir()})
+	require.NoError(t, err)
+
+	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
+		ClusterName: "localhost",
+	})
+	require.NoError(t, err)
+
+	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
+		StaticTokens: []types.ProvisionTokenV1{},
+	})
+	require.NoError(t, err)
+
+	authServer, err := auth.NewServer(&auth.InitConfig{
+		Backend:      bk,
+		Authority:    testauthority.New(),
+		ClusterName:  clusterName,
+		StaticTokens: staticTokens,
+	})
+	require.NoError(t, err)
+
+	return &mockServer{
+		auth:        authServer,
+		MockEmitter: &eventstest.MockEmitter{},
+	}
+}
+
+type mockServer struct {
+	*eventstest.MockEmitter
+	auth      *auth.Server
+	component string
+	clock     clockwork.Clock
+}
+
+// ID is the unique ID of the server.
+func (m *mockServer) ID() string {
+	return "test"
+}
+
+// HostUUID is the UUID of the underlying host. For the forwarding
+// server this is the proxy the forwarding server is running in.
+func (m *mockServer) HostUUID() string {
+	return "test"
+}
+
+// GetNamespace returns the namespace the server was created in.
+func (m *mockServer) GetNamespace() string {
+	return "test"
+}
+
+// AdvertiseAddr is the publicly addressable address of this server.
+func (m *mockServer) AdvertiseAddr() string {
+	return "test"
+}
+
+// Component is the type of server, forwarding or regular.
+func (m *mockServer) Component() string {
+	return m.component
+}
+
+// PermitUserEnvironment returns if reading environment variables upon
+// startup is allowed.
+func (m *mockServer) PermitUserEnvironment() bool {
+	return false
+}
+
+// GetAccessPoint returns an AccessPoint for this cluster.
+func (m *mockServer) GetAccessPoint() AccessPoint {
+	return m.auth
+}
+
+// GetSessionServer returns a session server.
+func (m *mockServer) GetSessionServer() rsession.Service {
+	return rsession.NewDiscardSessionServer()
+}
+
+// GetDataDir returns data directory of the server
+func (m *mockServer) GetDataDir() string {
+	return "test"
+}
+
+// GetPAM returns PAM configuration for this server.
+func (m *mockServer) GetPAM() (*pam.Config, error) {
+	return &pam.Config{}, nil
+}
+
+// GetClock returns a clock setup for the server
+func (m *mockServer) GetClock() clockwork.Clock {
+	if m.clock != nil {
+		return m.clock
+	}
+	return clockwork.NewRealClock()
+}
+
+// GetInfo returns a services.Server that represents this server.
+func (m *mockServer) GetInfo() types.Server {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "localhost"
+	}
+
+	return &types.ServerV2{
+		Kind:    types.KindNode,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name:      "",
+			Namespace: "",
+			Labels:    make(map[string]string),
+		},
+		Spec: types.ServerSpecV2{
+			CmdLabels: make(map[string]types.CommandLabelV2),
+			Addr:      "",
+			Hostname:  hostname,
+			UseTunnel: false,
+			Version:   teleport.Version,
+		},
+	}
+}
+
+// UseTunnel used to determine if this node has connected to this cluster
+// using reverse tunnel.
+func (m *mockServer) UseTunnel() bool {
+	return false
+}
+
+// GetBPF returns the BPF service used for enhanced session recording.
+func (m *mockServer) GetBPF() bpf.BPF {
+	return &bpf.NOP{}
+
+}
+
+// GetRestrictedSessionManager returns the manager for restricting user activity
+func (m *mockServer) GetRestrictedSessionManager() restricted.Manager {
+	return &restricted.NOP{}
+}
+
+// Context returns server shutdown context
+func (m *mockServer) Context() context.Context {
+	return context.Background()
+}
+
+// GetUtmpPath returns the path of the user accounting database and log. Returns empty for system defaults.
+func (m *mockServer) GetUtmpPath() (utmp, wtmp string) {
+	return "test", "test"
+}
+
+// GetLockWatcher gets the server's lock watcher.
+func (m *mockServer) GetLockWatcher() *services.LockWatcher {
+	return nil
+}
+
+// Implementation of ssh.Conn interface.
+type mockSSHConn struct {
+	remoteAddr net.Addr
+	localAddr  net.Addr
+}
+
+func (c *mockSSHConn) User() string {
+	return ""
+}
+
+func (c *mockSSHConn) SessionID() []byte {
+	return []byte{1, 2, 3}
+}
+
+func (c *mockSSHConn) ClientVersion() []byte {
+	return []byte{1}
+}
+
+func (c *mockSSHConn) ServerVersion() []byte {
+	return []byte{1}
+}
+
+func (c *mockSSHConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+
+func (c *mockSSHConn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+func (c *mockSSHConn) Close() error {
+	return nil
+}
+
+func (c *mockSSHConn) SendRequest(string, bool, []byte) (bool, []byte, error) {
+	return false, nil, nil
+}
+
+func (c *mockSSHConn) OpenChannel(string, []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	return nil, nil, nil
+}
+
+func (c *mockSSHConn) Wait() error {
+	return nil
+}
+
+type mockSSHChannel struct {
+	stdIn  io.ReadCloser
+	stdOut io.WriteCloser
+	stdErr io.ReadWriter
+}
+
+func newMockSSHChannel() ssh.Channel {
+	stdIn, stdOut := io.Pipe()
+	return &mockSSHChannel{
+		stdIn:  stdIn,
+		stdOut: stdOut,
+		stdErr: new(bytes.Buffer),
+	}
+}
+
+// Read reads up to len(data) bytes from the channel.
+func (c *mockSSHChannel) Read(data []byte) (int, error) {
+	return c.stdIn.Read(data)
+}
+
+// Write writes len(data) bytes to the channel.
+func (c *mockSSHChannel) Write(data []byte) (int, error) {
+	return c.stdOut.Write(data)
+}
+
+// Close signals end of channel use. No data may be sent after this
+// call.
+func (c *mockSSHChannel) Close() error {
+	return trace.NewAggregate(c.stdIn.Close(), c.stdOut.Close())
+}
+
+// CloseWrite signals the end of sending in-band
+// data. Requests may still be sent, and the other side may
+// still send data
+func (c *mockSSHChannel) CloseWrite() error {
+	return trace.NewAggregate(c.stdOut.Close())
+}
+
+// SendRequest sends a channel request.  If wantReply is true,
+// it will wait for a reply and return the result as a
+// boolean, otherwise the return value will be false. Channel
+// requests are out-of-band messages so they may be sent even
+// if the data stream is closed or blocked by flow control.
+// If the channel is closed before a reply is returned, io.EOF
+// is returned.
+func (c *mockSSHChannel) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {
+	return true, nil
+}
+
+// Stderr returns an io.ReadWriter that writes to this channel
+// with the extended data type set to stderr. Stderr may
+// safely be read and written from a different goroutine than
+// Read and Write respectively.
+func (c *mockSSHChannel) Stderr() io.ReadWriter {
+	return c.stdErr
+}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -639,7 +639,10 @@ func New(addr utils.NetAddr,
 		trace.ComponentFields: logrus.Fields{},
 	})
 
-	s.reg, err = srv.NewSessionRegistry(s, auth)
+	s.reg, err = srv.NewSessionRegistry(srv.SessionRegistryConfig{
+		Srv:                   s,
+		SessionTrackerService: auth,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/bpf"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/pam"
 	restricted "github.com/gravitational/teleport/lib/restrictedsession"
@@ -1542,64 +1541,6 @@ func TestGlobalRequestRecordingProxy(t *testing.T) {
 	response, err = strconv.ParseBool(string(responseBytes))
 	require.NoError(t, err)
 	require.True(t, response)
-}
-
-// TestSessionTracker tests session tracker lifecycle
-func TestSessionTracker(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	f := newFixture(t)
-
-	se, err := f.ssh.clt.NewSession()
-	require.NoError(t, err)
-	t.Cleanup(func() { se.Close() })
-
-	// start interactive SSH session (new shell):
-	err = se.Shell()
-	require.NoError(t, err)
-
-	// session tracker should be created
-	var tracker types.SessionTracker
-	trackerFound := func() bool {
-		trackers, err := f.testSrv.Auth().GetActiveSessionTrackers(ctx)
-		require.NoError(t, err)
-
-		if len(trackers) == 1 {
-			tracker = trackers[0]
-			return true
-		}
-		return false
-	}
-	require.Eventually(t, trackerFound, time.Second*5, time.Second)
-
-	// Advance the clock to trigger the session tracker expiration to be extended
-	f.clock.Advance(defaults.SessionTrackerExpirationUpdateInterval)
-
-	// The session's expiration should be updated
-	trackerUpdated := func() bool {
-		updatedTracker, err := f.testSrv.Auth().GetSessionTracker(ctx, tracker.GetSessionID())
-		require.NoError(t, err)
-		return updatedTracker.Expiry().Equal(tracker.Expiry().Add(defaults.SessionTrackerExpirationUpdateInterval))
-	}
-	require.Eventually(t, trackerUpdated, time.Second*5, time.Millisecond*1000)
-
-	// Close the session from the client side
-	err = se.Close()
-	require.NoError(t, err)
-
-	// Wait for linger to block on clock, then advance.
-	f.clock.BlockUntil(3)
-	f.clock.Advance(defaults.SessionIdlePeriod)
-
-	// Once the session is closed, the tracker should be termianted.
-	// Once the last set expiration is up, the tracker should be delted.
-	f.clock.Advance(defaults.SessionTrackerTTL)
-
-	trackerExpired := func() bool {
-		_, err := f.testSrv.Auth().GetSessionTracker(ctx, tracker.GetSessionID())
-		return trace.IsNotFound(err)
-	}
-	require.Eventually(t, trackerExpired, time.Second*5, time.Millisecond*100)
 }
 
 // rawNode is a basic non-teleport node which holds a

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1587,6 +1587,7 @@ func TestSessionTracker(t *testing.T) {
 	err = se.Close()
 	require.NoError(t, err)
 
+	// Wait for linger to block on clock, then advance.
 	f.clock.BlockUntil(3)
 	f.clock.Advance(defaults.SessionIdlePeriod)
 

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1470,10 +1470,6 @@ func (s *session) addParty(p *party, mode types.SessionParticipantMode) error {
 			defer s.term.AddParty(-1)
 			_, err := io.Copy(s.inWriter, p)
 			s.log.Debugf("Copying from Party %v to session writer completed with error %v.", p.id, err)
-
-			// Close the party in case it isn't already closed. This may
-			// happen if the party's underying ssh connection was closed.
-			p.Close()
 		}()
 	}
 

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -94,7 +94,6 @@ type SessionRegistryConfig struct {
 }
 
 func (sc *SessionRegistryConfig) CheckAndSetDefaults() error {
-
 	if sc.SessionTrackerService == nil {
 		return trace.BadParameter("session tracker service is required")
 	}
@@ -201,7 +200,6 @@ func (s *SessionRegistry) OpenSession(ch ssh.Channel, ctx *ServerContext) error 
 		return trace.Wrap(err)
 	}
 	ctx.setSession(sess)
-	ctx.AddCloser(sess)
 	s.addSession(sess)
 	ctx.Infof("Creating (interactive) session %v.", sid)
 

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -278,16 +278,6 @@ func TestInteractiveSession(t *testing.T) {
 		require.NoError(t, err)
 		require.Eventually(t, sess.isStopped, time.Second*5, time.Millisecond*500)
 	})
-
-	t.Run("SessionContextClosed", func(t *testing.T) {
-		t.Parallel()
-		sess := testOpenSession(t, reg)
-
-		// Closing the session context should close the session
-		err := sess.scx.Close()
-		require.NoError(t, err)
-		require.Eventually(t, sess.isStopped, time.Second*5, time.Millisecond*500)
-	})
 }
 
 // TestParties tests the party mechanisms within an interactive session,

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -18,7 +18,6 @@ package srv
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -303,35 +302,15 @@ func TestParties(t *testing.T) {
 	require.Equal(t, 2, len(sess.getParties()))
 	testJoinSession(t, reg, sess)
 	require.Equal(t, 3, len(sess.getParties()))
-	testJoinSession(t, reg, sess)
-	require.Equal(t, 4, len(sess.getParties()))
 
 	// If a party leaves, the session should remove the party and continue.
 	p := sess.getParties()[0]
 	p.Close()
 
 	partyIsRemoved := func() bool {
-		return len(sess.getParties()) == 3 && !sess.isStopped()
-	}
-	require.Eventually(t, partyIsRemoved, time.Second*5, time.Millisecond*500)
-
-	fmt.Print("\n\n\n\n")
-
-	// If a party loses connection, the session should close and remove the party and continue.
-	p = sess.getParties()[0]
-	err = p.ch.Close()
-	require.NoError(t, err)
-
-	partyIsRemoved = func() bool {
 		return len(sess.getParties()) == 2 && !sess.isStopped()
 	}
 	require.Eventually(t, partyIsRemoved, time.Second*5, time.Millisecond*500)
-
-	p.closeOnce.Do(func() {
-		t.Fatalf("party should be closed already")
-	})
-
-	fmt.Print("\n\n\n\n")
 
 	// If a party's session context is closed, the party should leave the session.
 	p = sess.getParties()[0]

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -18,16 +18,14 @@ package srv
 
 import (
 	"context"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/pam"
-	restricted "github.com/gravitational/teleport/lib/restrictedsession"
-	"github.com/gravitational/teleport/lib/services"
-	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
@@ -76,103 +74,6 @@ func TestParseAccessRequestIDs(t *testing.T) {
 
 }
 
-type mockServer struct {
-	events.StreamEmitter
-}
-
-// ID is the unique ID of the server.
-func (m *mockServer) ID() string {
-	return "test"
-}
-
-// HostUUID is the UUID of the underlying host. For the forwarding
-// server this is the proxy the forwarding server is running in.
-func (m *mockServer) HostUUID() string {
-	return "test"
-}
-
-// GetNamespace returns the namespace the server was created in.
-func (m *mockServer) GetNamespace() string {
-	return "test"
-}
-
-// AdvertiseAddr is the publicly addressable address of this server.
-func (m *mockServer) AdvertiseAddr() string {
-	return "test"
-}
-
-// Component is the type of server, forwarding or regular.
-func (m *mockServer) Component() string {
-	return teleport.ComponentNode
-}
-
-// PermitUserEnvironment returns if reading environment variables upon
-// startup is allowed.
-func (m *mockServer) PermitUserEnvironment() bool {
-	return false
-}
-
-// GetAccessPoint returns an AccessPoint for this cluster.
-func (m *mockServer) GetAccessPoint() AccessPoint {
-	return nil
-}
-
-// GetSessionServer returns a session server.
-func (m *mockServer) GetSessionServer() rsession.Service {
-	return nil
-}
-
-// GetDataDir returns data directory of the server
-func (m *mockServer) GetDataDir() string {
-	return "test"
-}
-
-// GetPAM returns PAM configuration for this server.
-func (m *mockServer) GetPAM() (*pam.Config, error) {
-	return nil, nil
-}
-
-// GetClock returns a clock setup for the server
-func (m *mockServer) GetClock() clockwork.Clock {
-	return clockwork.NewRealClock()
-}
-
-// GetInfo returns a services.Server that represents this server.
-func (m *mockServer) GetInfo() types.Server {
-	return nil
-}
-
-// UseTunnel used to determine if this node has connected to this cluster
-// using reverse tunnel.
-func (m *mockServer) UseTunnel() bool {
-	return false
-}
-
-// GetBPF returns the BPF service used for enhanced session recording.
-func (m *mockServer) GetBPF() bpf.BPF {
-	return nil
-}
-
-// GetRestrictedSessionManager returns the manager for restricting user activity
-func (m *mockServer) GetRestrictedSessionManager() restricted.Manager {
-	return nil
-}
-
-// Context returns server shutdown context
-func (m *mockServer) Context() context.Context {
-	return context.Background()
-}
-
-// GetUtmpPath returns the path of the user accounting database and log. Returns empty for system defaults.
-func (m *mockServer) GetUtmpPath() (utmp, wtmp string) {
-	return "test", "test"
-}
-
-// GetLockWatcher gets the server's lock watcher.
-func (m *mockServer) GetLockWatcher() *services.LockWatcher {
-	return nil
-}
-
 func TestSession_newRecorder(t *testing.T) {
 	proxyRecording, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
 		Mode: types.RecordAtProxy,
@@ -211,7 +112,9 @@ func TestSession_newRecorder(t *testing.T) {
 				id:  "test",
 				log: logger,
 				registry: &SessionRegistry{
-					srv: &mockServer{},
+					srv: &mockServer{
+						component: teleport.ComponentNode,
+					},
 				},
 			},
 			sctx: &ServerContext{
@@ -230,7 +133,9 @@ func TestSession_newRecorder(t *testing.T) {
 				id:  "test",
 				log: logger,
 				registry: &SessionRegistry{
-					srv: &mockServer{},
+					srv: &mockServer{
+						component: teleport.ComponentNode,
+					},
 				},
 			},
 			sctx: &ServerContext{
@@ -249,12 +154,16 @@ func TestSession_newRecorder(t *testing.T) {
 				id:  "test",
 				log: logger,
 				registry: &SessionRegistry{
-					srv: &mockServer{},
+					srv: &mockServer{
+						component: teleport.ComponentNode,
+					},
 				},
 			},
 			sctx: &ServerContext{
 				SessionRecordingConfig: nodeRecording,
-				srv:                    &mockServer{},
+				srv: &mockServer{
+					component: teleport.ComponentNode,
+				},
 			},
 			errAssertion: require.Error,
 			recAssertion: require.Nil,
@@ -265,12 +174,16 @@ func TestSession_newRecorder(t *testing.T) {
 				id:  "test",
 				log: logger,
 				registry: &SessionRegistry{
-					srv: &mockServer{},
+					srv: &mockServer{
+						component: teleport.ComponentNode,
+					},
 				},
 			},
 			sctx: &ServerContext{
 				SessionRecordingConfig: nodeRecordingSync,
-				srv:                    &mockServer{},
+				srv: &mockServer{
+					component: teleport.ComponentNode,
+				},
 			},
 			errAssertion: require.Error,
 			recAssertion: require.Nil,
@@ -281,14 +194,16 @@ func TestSession_newRecorder(t *testing.T) {
 				id:  "test",
 				log: logger,
 				registry: &SessionRegistry{
-					srv: &mockServer{},
+					srv: &mockServer{
+						component: teleport.ComponentNode,
+					},
 				},
 			},
 			sctx: &ServerContext{
 				ClusterName:            "test",
 				SessionRecordingConfig: nodeRecordingSync,
 				srv: &mockServer{
-					StreamEmitter: &events.DiscardEmitter{},
+					MockEmitter: &eventstest.MockEmitter{},
 				},
 			},
 			errAssertion: require.NoError,
@@ -308,4 +223,161 @@ func TestSession_newRecorder(t *testing.T) {
 			tt.recAssertion(t, rec)
 		})
 	}
+}
+
+// TestInteractiveSession tests interaction session lifecycles.
+// Multiple sessions are opened in parallel tests to test for
+// deadlocks between session registry, sessions, and parties.
+func TestInteractiveSession(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	srv := newMockServerWithBackend(t)
+	srv.clock = clock
+	srv.component = teleport.ComponentNode
+
+	reg, err := NewSessionRegistry(srv, srv.auth)
+	require.NoError(t, err)
+	t.Cleanup(func() { reg.Close() })
+
+	t.Run("Stop", func(t *testing.T) {
+		t.Parallel()
+		sess := testOpenSession(t, reg)
+
+		// Stopping the session should trigger the session
+		// to end and cleanup in the background
+		sess.Stop()
+
+		sessionClosed := func() bool {
+			reg.mu.Lock()
+			defer reg.mu.Unlock()
+			_, found := reg.findSessionLocked(sess.id)
+			return !found
+		}
+		require.Eventually(t, sessionClosed, time.Second*5, time.Millisecond*500)
+	})
+
+	t.Run("BrokenRecorder", func(t *testing.T) {
+		t.Parallel()
+		sess := testOpenSession(t, reg)
+
+		// The recorder might be closed in the case of an error downstream.
+		// Closing the session recorder should result in the session ending.
+		err := sess.recorder.Close(context.Background())
+		require.NoError(t, err)
+		require.Eventually(t, sess.isStopped, time.Second*5, time.Millisecond*500)
+	})
+
+	t.Run("SessionContextClosed", func(t *testing.T) {
+		t.Parallel()
+		sess := testOpenSession(t, reg)
+
+		// Closing the session context should close the session
+		err := sess.scx.Close()
+		require.NoError(t, err)
+		require.Eventually(t, sess.isStopped, time.Second*5, time.Millisecond*500)
+	})
+
+	t.Run("PartyContextClosed", func(t *testing.T) {
+		t.Parallel()
+		sess := testOpenSession(t, reg)
+
+		// Retrieve party and and close its server context
+		parties := sess.getParties()
+		require.Equal(t, 1, len(parties))
+		err := parties[0].ctx.Close()
+		require.NoError(t, err)
+
+		// Check that closing the ctx closed the party
+		parties[0].closeOnce.Do(func() {
+			t.Fatalf("party should be closed already")
+		})
+	})
+}
+
+// TestMultiplartySession tests the party mechanisms within an interactive session,
+// including party leave, party disconnect, and lingerAndDie.
+func TestMultipartySession(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	srv := newMockServerWithBackend(t)
+	srv.clock = clock
+	srv.component = teleport.ComponentNode
+
+	reg, err := NewSessionRegistry(srv, srv.auth)
+	require.NoError(t, err)
+	t.Cleanup(func() { reg.Close() })
+
+	// Create a session with 3 parties
+	sess := testOpenSession(t, reg)
+	require.Equal(t, 1, len(sess.getParties()))
+	testJoinSession(t, reg, sess)
+	require.Equal(t, 2, len(sess.getParties()))
+	testJoinSession(t, reg, sess)
+	require.Equal(t, 3, len(sess.getParties()))
+
+	// If a party leaves, the session should remove the party and continue.
+	sess.getParties()[0].Close()
+	partyIsRemoved := func() bool {
+		return len(sess.getParties()) == 2 && !sess.isStopped()
+	}
+	require.Eventually(t, partyIsRemoved, time.Second*5, time.Millisecond*500)
+
+	// If one party loses connection, the session should remove the party and continue.
+	require.NoError(t, sess.getParties()[0].ch.Close())
+	partyIsRemoved = func() bool {
+		return len(sess.getParties()) == 1 && !sess.isStopped()
+	}
+	require.Eventually(t, partyIsRemoved, time.Second*5, time.Millisecond*500)
+
+	// If all parties are gone, the session should linger for a short duration.
+	sess.getParties()[0].Close()
+	require.False(t, sess.isStopped())
+	clock.BlockUntil(2)
+
+	// If a party connects to the lingering session, it will continue.
+	testJoinSession(t, reg, sess)
+	require.Equal(t, 1, len(sess.getParties()))
+
+	clock.Advance(sess.lingerTTL)
+	require.False(t, sess.isStopped())
+
+	// If no parties remain it should be closed after the duration.
+	sess.getParties()[0].Close()
+	require.False(t, sess.isStopped())
+	clock.BlockUntil(2)
+
+	clock.Advance(sess.lingerTTL)
+	require.Eventually(t, sess.isStopped, time.Second*5, time.Millisecond*500)
+}
+
+func testOpenSession(t *testing.T, reg *SessionRegistry) *session {
+	scx := newTestServerContext(t, reg.srv)
+
+	// Open a new session
+	sshChanOpen := newMockSSHChannel()
+	go func() {
+		// Consume stdout sent to the channel
+		io.ReadAll(sshChanOpen)
+	}()
+
+	err := reg.OpenSession(sshChanOpen, scx)
+	require.NoError(t, err)
+
+	require.NotNil(t, scx.session)
+	return scx.session
+}
+
+func testJoinSession(t *testing.T, reg *SessionRegistry, sess *session) {
+	scx := newTestServerContext(t, reg.srv)
+	scx.setSession(sess)
+
+	// Open a new session
+	sshChanOpen := newMockSSHChannel()
+	go func() {
+		// Consume stdout sent to the channel
+		io.ReadAll(sshChanOpen)
+	}()
+
+	err := reg.OpenSession(sshChanOpen, scx)
+	require.NoError(t, err)
 }

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -230,7 +230,7 @@ func (t *terminal) Continue() {
 
 // Kill will force kill the terminal.
 func (t *terminal) Kill() error {
-	if t.cmd.Process != nil {
+	if t.cmd != nil && t.cmd.Process != nil {
 		if err := t.cmd.Process.Kill(); err != nil {
 			if err.Error() != "os: process already finished" {
 				return trace.Wrap(err)

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -46,9 +46,9 @@ func (t *TermHandlers) HandleExec(ch ssh.Channel, req *ssh.Request, ctx *ServerC
 	// If a terminal was previously allocated for this command, run command in
 	// an interactive session. Otherwise run it in an exec session.
 	if ctx.GetTerm() != nil {
-		return t.SessionRegistry.OpenSession(ch, req, ctx)
+		return t.SessionRegistry.OpenSession(ch, ctx)
 	}
-	return t.SessionRegistry.OpenExecSession(ch, req, ctx)
+	return t.SessionRegistry.OpenExecSession(ch, ctx)
 }
 
 // HandlePTYReq handles requests of type "pty-req" which allocate a TTY for
@@ -110,7 +110,7 @@ func (t *TermHandlers) HandleShell(ch ssh.Channel, req *ssh.Request, ctx *Server
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := t.SessionRegistry.OpenSession(ch, req, ctx); err != nil {
+	if err := t.SessionRegistry.OpenSession(ch, ctx); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/srv/termmanager.go
+++ b/lib/srv/termmanager.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -55,7 +54,7 @@ type TermManager struct {
 	// we only support one concurrent reader so this isn't mutex protected
 	remaining         []byte
 	readStateUpdate   *sync.Cond
-	closed            bool
+	closed            chan struct{}
 	lastWasBroadcast  bool
 	terminateNotifier chan struct{}
 }
@@ -65,14 +64,15 @@ func NewTermManager() *TermManager {
 	return &TermManager{
 		writers:           make(map[string]io.Writer),
 		readerState:       make(map[string]bool),
-		closed:            false,
+		closed:            make(chan struct{}),
 		readStateUpdate:   sync.NewCond(&sync.Mutex{}),
 		incoming:          make(chan []byte, 100),
 		terminateNotifier: make(chan struct{}, 1),
 	}
 }
 
-func (g *TermManager) writeToClients(p []byte) int {
+// writeToClients writes to underlying clients
+func (g *TermManager) writeToClients(p []byte) {
 	g.lastWasBroadcast = false
 	g.history = truncateFront(append(g.history, p...), maxHistoryBytes)
 
@@ -84,6 +84,7 @@ func (g *TermManager) writeToClients(p []byte) int {
 				log.Warnf("Failed to write to remote terminal: %v", err)
 			}
 
+			// Let term manager decide how to handle broken party writers
 			if g.OnWriteError != nil {
 				g.OnWriteError(key, err)
 			}
@@ -92,7 +93,6 @@ func (g *TermManager) writeToClients(p []byte) int {
 		}
 	}
 
-	return len(p)
 }
 
 func (g *TermManager) TerminateNotifier() <-chan struct{} {
@@ -102,6 +102,10 @@ func (g *TermManager) TerminateNotifier() <-chan struct{} {
 func (g *TermManager) Write(p []byte) (int, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
+
+	if g.isClosed() {
+		return 0, io.EOF
+	}
 
 	if g.on {
 		g.writeToClients(p)
@@ -146,11 +150,17 @@ func (g *TermManager) Read(p []byte) (int, error) {
 	on := <-c
 	for {
 		if !on {
-			on = <-c
-			continue
+			select {
+			case <-g.closed:
+				return 0, io.EOF
+			case on = <-c:
+				continue
+			}
 		}
 
 		select {
+		case <-g.closed:
+			return 0, io.EOF
 		case on = <-c:
 			continue
 		case g.remaining = <-g.incoming:
@@ -162,13 +172,8 @@ func (g *TermManager) Read(p []byte) (int, error) {
 	}
 }
 
-// writeUnconditional allows unconditional writes to the underlying writers.
-func (g *TermManager) writeUnconditional(p []byte) (int, error) {
-	return g.writeToClients(p), nil
-}
-
 // BroadcastMessage injects a message into the stream.
-func (g *TermManager) BroadcastMessage(message string) error {
+func (g *TermManager) BroadcastMessage(message string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	data := []byte("Teleport > " + message + "\r\n")
@@ -177,18 +182,17 @@ func (g *TermManager) BroadcastMessage(message string) error {
 	} else {
 		g.lastWasBroadcast = true
 	}
-	_, err := g.writeUnconditional(data)
-	return trace.Wrap(err)
+
+	g.writeToClients(data)
 }
 
 // On allows data to flow through the manager.
-func (g *TermManager) On() error {
+func (g *TermManager) On() {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.on = true
 	g.readStateUpdate.Broadcast()
-	_, err := g.writeUnconditional(g.buffer)
-	return trace.Wrap(err)
+	g.writeToClients(g.buffer)
 }
 
 // Off buffers incoming writes and reads until turned on again.
@@ -228,7 +232,7 @@ func (g *TermManager) AddReader(name string, r io.Reader) {
 				// This is the ASCII control code for CTRL+C.
 				if b == 0x03 {
 					g.mu.Lock()
-					if !g.on && !g.closed {
+					if !g.on && !g.isClosed() {
 						select {
 						case g.terminateNotifier <- struct{}{}:
 						default:
@@ -241,7 +245,7 @@ func (g *TermManager) AddReader(name string, r io.Reader) {
 
 			g.incoming <- buf[:n]
 			g.mu.Lock()
-			if g.closed || g.readerState[name] {
+			if g.isClosed() || g.readerState[name] {
 				g.mu.Unlock()
 				return
 			}
@@ -268,9 +272,18 @@ func (g *TermManager) Close() {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	if !g.closed {
-		g.closed = true
+	if !g.isClosed() {
+		close(g.closed)
 		close(g.terminateNotifier)
+	}
+}
+
+func (g *TermManager) isClosed() bool {
+	select {
+	case <-g.closed:
+		return true
+	default:
+		return false
 	}
 }
 


### PR DESCRIPTION
This PR reworks session ending logic to fix session freezing, deadlocks, race conditions, and other session end failures.

### Changes
- Split session end logic into two parts - `Stop` and `Close`
  - Stop can be called from anywhere to kill the session terminal, disconnect clients, and trigger background goroutines to complete cleanup (upload session recording, emit audit events, etc.)
  - Close is only called by the session creator to release remaining resources which can't be removed immediately. Stop will trigger Close.
- Rework party leaving logic, which was prone to deadlocks before - https://github.com/gravitational/teleport/pull/11647
- Fix session `lingerAndDie` logic, which could occur multiple times for a session, and could occur even after the session was closed.
- Fixed session freezing when the session is terminated, whether it is force terminated due to moderated sessions, or due to an internal server error.
  - `sess.io.Write` and `sess.io.Read` will now return `io.EOF` if `sess.io` is closed, unblocking the `io.Copy` loops and allowing session cleanup to complete.
- Session will no longer continue if the session recorder is broken, instead it will trigger `sess.Stop` with `s.io.OnWriteError`
- Session uploads will no longer fail due to the session writer closing before the uploader completes.
- Fix issue where exec sessions are closed immediately, preventing audit writing and stream recording.

### TODO:
 - Add tests (if possible), although it should be largely covered with existing tests

Closes https://github.com/gravitational/teleport/issues/10983
Related https://github.com/gravitational/teleport/issues/11599 - session.end event is more reliable now