### PR TITLE
Backport tsh: ignore empty or non-existing config files

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -637,14 +637,12 @@ func Run(args []string, opts ...cliOption) error {
 
 	setEnvFlags(&cf, os.Getenv)
 
-	confOptions, err := loadConfig(cf.HomePath)
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err, "failed to load tsh config from %s",
-			filepath.Join(profile.FullProfilePath(cf.HomePath), tshConfigPath))
+	fullConfigPath := filepath.Join(profile.FullProfilePath(cf.HomePath), tshConfigPath)
+	confOptions, err := loadConfig(fullConfigPath)
+	if err != nil {
+		return trace.Wrap(err, "failed to load tsh config from %s", fullConfigPath)
 	}
-	if confOptions != nil {
-		cf.ExtraProxyHeaders = confOptions.ExtraHeaders
-	}
+	cf.ExtraProxyHeaders = confOptions.ExtraHeaders
 
 	switch command {
 	case ver.FullCommand():

--- a/tool/tsh/tshconfig.go
+++ b/tool/tsh/tshconfig.go
@@ -17,10 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"errors"
+	"io/fs"
 	"os"
-	"path/filepath"
 
-	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v2"
 )
@@ -46,14 +46,18 @@ type ExtraProxyHeaders struct {
 	Headers map[string]string `yaml:"headers,omitempty"`
 }
 
-func loadConfig(homePath string) (*TshConfig, error) {
-	confPath := filepath.Join(profile.FullProfilePath(homePath), tshConfigPath)
-	configFile, err := os.Open(confPath)
+func loadConfig(fullConfigPath string) (*TshConfig, error) {
+	bs, err := os.ReadFile(fullConfigPath)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return &TshConfig{}, nil
+		}
 		return nil, trace.ConvertSystemError(err)
 	}
-	defer configFile.Close()
+
 	cfg := TshConfig{}
-	err = yaml.NewDecoder(configFile).Decode(&cfg)
-	return &cfg, trace.Wrap(err)
+	if err := yaml.Unmarshal(bs, &cfg); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	return &cfg, nil
 }

--- a/tool/tsh/tshconfig_test.go
+++ b/tool/tsh/tshconfig_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigNonExistingFile(t *testing.T) {
+	fullFilePath := "/tmp/doesntexist." + uuid.NewString()
+	gotConfig, gotErr := loadConfig(fullFilePath)
+	require.NoError(t, gotErr)
+	require.Equal(t, &TshConfig{}, gotConfig)
+}
+
+func TestLoadConfigEmptyFile(t *testing.T) {
+	file, err := os.CreateTemp("", "test-telelport")
+	file.Write([]byte(" "))
+	require.NoError(t, err)
+	defer os.Remove(file.Name())
+
+	gotConfig, gotErr := loadConfig(file.Name())
+	require.NoError(t, gotErr)
+	require.Equal(t, &TshConfig{}, gotConfig)
+}

--- a/tool/tsh/tshconfig_test.go
+++ b/tool/tsh/tshconfig_test.go
@@ -33,9 +33,11 @@ func TestLoadConfigNonExistingFile(t *testing.T) {
 
 func TestLoadConfigEmptyFile(t *testing.T) {
 	file, err := os.CreateTemp("", "test-telelport")
-	file.Write([]byte(" "))
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
+
+	_, err = file.Write([]byte(" "))
+	require.NoError(t, err)
 
 	gotConfig, gotErr := loadConfig(file.Name())
 	require.NoError(t, gotErr)


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/11495 and the subsequent fix https://github.com/gravitational/teleport/pull/11603