### PR TITLE
Move Cloud download binaries into tables

### DIFF
--- a/docs/pages/cloud/downloads.mdx
+++ b/docs/pages/cloud/downloads.mdx
@@ -14,12 +14,14 @@ install and run Teleport.
 
 Binaries include:
 
-- `teleport`: the Teleport binary that you can run within your private networks
-  to enable access to resources in your infrastructure
-- `tctl`: a client tool for managing Teleport resources
-- `tsh`: a client tool for accessing resources within your cluster
-- `tbot`: a client tool you will use to associate a bot user with a machine
-  identity
+|Binary|Purpose|
+|---|---|
+|`teleport`|The Teleport binary that you can run within your private networks to enable access to resources in your infrastructure|
+|`tctl`| A client tool for managing Teleport resources|
+|`tsh`| A client tool for accessing resources within your cluster|
+|`tbot`| A client tool you will use to associate a bot user with a machine identity|
+
+Here are the available archives:
 
 Description                        | | | | |
 -----------------------------------|-|-|-|-|
@@ -34,12 +36,14 @@ to install and run Teleport.
 
 Binaries include:
 
-- `teleport`: the Teleport binary that you can run within your private networks
-  to enable access to resources in your infrastructure
-- `tctl`: a client tool for managing Teleport resources
-- `tsh`: a client tool for accessing resources within your cluster
-- `tbot`: a client tool you will use to associate a bot user with a machine
-  identity
+|Binary|Purpose|
+|---|---|
+|`teleport`|The Teleport binary that you can run within your private networks to enable access to resources in your infrastructure|
+|`tctl`| A client tool for managing Teleport resources|
+|`tsh`| A client tool for accessing resources within your cluster|
+|`tbot`| A client tool you will use to associate a bot user with a machine identity|
+
+Here are the available archives:
 
 Description                        | | | | |
 -----------------------------------|-|-|-|-|
@@ -54,7 +58,11 @@ workstations.
 
 Binaries include:
 
-- `tsh`: a client tool for accessing resources within your cluster
+|Binary|Purpose|
+|---|---|
+|`tsh`|A client tool for accessing resources within your cluster|
+
+Here are the available archives:
 
 Description                        | |
 -----------------------------------|-|


### PR DESCRIPTION
This change aims to make the Cloud Downloads page a bit neater
looking.

As discussed @russjones 