### PR TITLE
[v7] Add Cloud instructions to five guides

### DIFF
--- a/docs/pages/database-access/architecture.mdx
+++ b/docs/pages/database-access/architecture.mdx
@@ -3,8 +3,6 @@ title: Database Access Architecture
 description: How Teleport Database Access works.
 ---
 
-# Database Access Architecture
-
 This section provides an overview of Teleport Database Access inner workings.
 
 ## How it works
@@ -15,9 +13,22 @@ Let's take a look at a sample Database Access deployment:
 
 In it, we have the following Teleport components:
 
+<ScopedBlock scope={["oss", "enterprise"]}>
+
 - [Teleport Proxy](../architecture/proxy.mdx). A stateless service
-  that performs a function of an authentication gateway, serves web UI and
+  that performs a function of an authentication gateway, serves the Web UI, and
   accepts database (and other) client connections.
+  
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+- [Teleport Proxy](../architecture/proxy.mdx). A stateless service that performs
+  a function of an authentication gateway, serves the Web UI, and accepts
+  database (and other) client connections. This service is accessible at your
+  Teleport Cloud tenant URL, e.g., `mytenant.teleport.sh`.
+
+</ScopedBlock>
+
 - [Teleport Auth](../architecture/authentication.mdx). Serves as
   cluster's certificate authority, handles user authentication/authorization
   and issues short-lived client certificates.

--- a/docs/pages/database-access/faq.mdx
+++ b/docs/pages/database-access/faq.mdx
@@ -3,54 +3,77 @@ title: Database Access FAQ
 description: Frequently asked questions about Teleport Database Access.
 ---
 
-# Database Access FAQ
-
 ## Which database protocols does Teleport Database Access support?
 
 Teleport Database Access currently supports PostgreSQL, MySQL, and MongoDB
 protocols.
 
-For PostgreSQL and MySQL, both self-hosted and cloud-hosted versions such as AWS
-RDS, Aurora (except for Serverless version which doesn't support IAM auth),
-Redshift, and GCP Cloud SQL are supported. See available [guides](./guides.mdx)
-for all supported configurations.
+For PostgreSQL and MySQL, the following Cloud-hosted versions are supported in addition to self-hosted deployments:
+
+- Amazon RDS
+- Amazon Aurora (except for Amazon Aurora Serverless, which doesn't support IAM authentication)
+- Amazon Redshift
+- Google Cloud SQL
+- Azure Database
+
+See the available [guides](./guides.mdx) for all supported configurations.
 
 ## Which PostgreSQL protocol features are not supported?
 
 The following PostgreSQL protocol features aren't currently supported:
 
 - [Canceling requests in progress](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.9).
-  Cancel requests issued by the PostgreSQL clients connected to Teleport proxy
-  won't be passed to the database server.
-- Any of the [authentication methods](https://www.postgresql.org/docs/current/auth-methods.html)
+  Cancel requests issued by the PostgreSQL clients connected to the Teleport
+  Proxy Service won't be passed to the database server.
+- Any [authentication methods](https://www.postgresql.org/docs/current/auth-methods.html)
   except for client certificate authentication and IAM authentication for cloud
   databases.
 
-## Can database clients use public address different from web public address?
+## Can database clients use a public address different from the web public address?
 
-Teleport administrators can set `postgres_public_addr` and `mysql_public_addr`
-proxy configuration fields to public addresses over which respective database
-clients should connect. See [Proxy Configuration](./reference/configuration.mdx#proxy-configuration)
-for more details.
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
-This is useful when Teleport web proxy UI is running behind an L7 load balancer
-(e.g. ALB in AWS) in which case PostgreSQL/MySQL proxy need to be exposed on a
-plain TCP load balancer (e.g. NLB in AWS).
+When configuring the Teleport Proxy Service, administrators can set the
+`postgres_public_addr` and `mysql_public_addr` configuration fields to public
+addresses over which respective database clients should connect. See
+[Proxy Configuration](./reference/configuration.mdx#proxy-configuration) for
+more details.
+
+This is useful when the Teleport Web UI is running behind an L7 load balancer
+(e.g. ALB in AWS), in which case the PostgreSQL/MySQL proxy needs to be exposed
+on a plain TCP load balancer (e.g. NLB in AWS).
+
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Cloud">
+
+In Teleport Cloud, the Proxy Service uses the following ports for
+Database Access client traffic:
+
+|Configuration setting|Port|
+|---|---|
+|`mysql_public_addr`|`3036`|
+|`postgres_public_addr`|`443`|
+|`mongo_public_addr`|`443`|
+
+</TabItem>
+</Tabs>
 
 ## Do you support X database client?
 
-Teleport relies on client certificates for authentication so any database client
-that supports this method of authentication and uses modern TLS (1.2+) should
-work.
+Teleport relies on client certificates for authentication, so any database
+client that supports this method of authentication and uses modern TLS (1.2+)
+should work.
 
-Standard command-line clients such as `psql`, `mysql`, or `mongo` are supported,
-there are also instructions for configuring select [graphical clients](./guides/gui-clients.mdx).
+Standard command-line clients such as `psql`, `mysql`, `mongo` or `mongosh` are
+supported. There are also instructions for configuring select
+[graphical clients](./guides/gui-clients.mdx).
 
 ## When will you support X database?
 
 We plan to support more databases in the future based on customer demand.
 
 See if the database you're interested in has already been requested among
-[Github issues](https://github.com/gravitational/teleport/labels/database-access)
+[GitHub issues](https://github.com/gravitational/teleport/labels/database-access)
 or open a [new issue](https://github.com/gravitational/teleport/issues/new/choose)
 to register your interest.

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -3,11 +3,11 @@ title: Database Access CLI Reference
 description: CLI reference for Teleport Database Access.
 ---
 
-# Database Access CLI Reference
-
 ## teleport db start
 
 Starts Teleport Database Service agent.
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
 $ teleport db start \
@@ -18,13 +18,27 @@ $ teleport db start \
     --uri=postgres.example.com:5432
 ```
 
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+$ teleport db start \
+    --token=/path/to/token \
+    --auth-server=mytenant.teleport.sh:3080 \
+    --name=example \
+    --protocol=postgres \
+    --uri=postgres.mytenant.teleport.sh:5432
+```
+
+</ScopedBlock>
+
 | Flag | Description |
 | - | - |
 | `-d/--debug` | Enable verbose logging to stderr. |
 | `--pid-file` | Full path to the PID file. By default no PID file will be created. |
-| `--auth-server` | Address of the Teleport proxy server. |
-| `--token` | Invitation token to register with an auth server. |
-| `--ca-pin` | CA pin to validate the auth server. |
+| `--auth-server` | Address of the Teleport Proxy Service. |
+| `--token` | Invitation token to register with the Auth Service. |
+| `--ca-pin` | CA pin to validate the Auth Service. |
 | `-c/--config` | Path to a configuration file (default `/etc/teleport.yaml`). |
 | `--labels` | Comma-separated list of labels for this node, for example `env=dev,app=web`. |
 | `--fips` | Start Teleport in FedRAMP/FIPS 140-2 mode. |

--- a/docs/pages/database-access/reference/configuration.mdx
+++ b/docs/pages/database-access/reference/configuration.mdx
@@ -53,6 +53,9 @@ db_service:
 
 ## Proxy configuration
 
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
+
 The following Proxy service configuration is relevant for Database Access:
 
 <Admonition
@@ -81,4 +84,95 @@ proxy_service:
   postgres_public_addr: "postgres.teleport.example.com:443"
   # Address advertised to MySQL clients. If not set, public_addr is used.
   mysql_public_addr: "mysql.teleport.example.com:3306"
+```
+
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Cloud">
+
+Teleport Cloud automatically configures the Teleport Proxy Service with the
+following settings that are relevant to Database Access. This reference
+configuration uses `mytenant.teleport.sh` in place of your Teleport Cloud tenant
+address.
+
+```yaml
+proxy_service:
+  enabled: "yes"
+  # PostgreSQL proxy is listening on the regular web proxy port.
+  web_listen_addr: "0.0.0.0:3080"
+  # MySQL proxy is listening on a separate port.
+  mysql_listen_addr: "0.0.0.0:3036"
+  # Database clients will connect to the Proxy Service over this hostname.
+  public_addr: "mytenant.teleport.sh:443"
+  # Address advertised to MySQL clients.
+  mysql_public_addr: "mytenant.teleport.sh:3036"
+  # Address advertised to PostgreSQL clients.
+  postgres_public_addr: "mytenant.teleport.sh:443"
+```
+
+</TabItem>
+</Tabs>
+
+## Database resource
+
+Full YAML spec of database resources managed by `tctl` resource commands:
+
+```yaml
+kind: db
+version: v3
+metadata:
+  # Database resource name.
+  name: example
+
+  # Database resource description.
+  description: "Example database"
+
+  # Database resource static labels.
+  labels:
+    env: example
+
+spec:
+  # Database protocol.
+  protocol: "postgres"
+
+  # Database connection endpoint.
+  uri: "localhost:5432"
+
+  # Optional CA for validating the database certificate.
+  ca_cert: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+
+  # Optional AWS configuration for RDS/Aurora/Redshift. Can be auto-detected from the endpoint.
+  aws:
+    # Region the database is deployed in.
+    region: "us-east-1"
+    # Redshift specific configuration.
+    redshift:
+      # Redshift cluster identifier.
+      cluster_id: "redshift-cluster-1"
+
+  # Optional GCP configuration for Cloud SQL.
+  gcp:
+    # GCP project ID.
+    project_id: "xxx-1234"
+    # Cloud SQL instance ID.
+    instance_id: "example"
+
+  # Settings specific to Active Directory authentication e.g. for SQL Server.
+  ad:
+    # Path to Kerberos keytab file.
+    keytab_file: /path/to/keytab
+    # Active Directory domain name.
+    domain: EXAMPLE.COM
+    # Service Principal Name to obtain Kerberos tickets for.
+    spn: MSSQLSvc/ec2amaz-4kn05du.dbadir.teleportdemo.net:1433
+    # Optional path to Kerberos configuration file. Defaults to /etc/krb5.conf.
+    krb5_file: /etc/krb5.conf
+
+  # Optional dynamic labels.
+  dynamic_labels:
+  - name: "hostname"
+    command: ["hostname"]
+    period: 1m0s
 ```


### PR DESCRIPTION
Backports #11516

* Add Cloud instructions to five guides

See #10637

Database Access FAQ

- Add tabbed instructions where answers differ for Cloud/Self-Hosted

- Style/grammar tweaks

Dynamic Registration

- While this guide is edition agnostic, I have added the tctl.mdx
  partial so Cloud users know to log in to Teleport before running
  tctl commands.

Configuration reference

- The only part that required different instructions for Cloud users
  was the reference configuration for the Proxy Service. I have
  supplied  the values hardcoded in Teleport Cloud.

CLI reference

- Add ScopedBlocks where examples mention proxy.example.com--use a
  Cloud tenant address for Cloud readers.

- Light style/grammar edits

Architecture

- This guide is mostly edition agnostic. After the overview diagram,
  I used a ScopedBlock to make it clear to Cloud users that the Proxy
  Service uses the Teleport Cloud tenant address.

* Respond to PR feedback

Also remove mongo_public_addr from the Cloud proxy_service config,
since this was included incorrectly.