### PR TITLE
[v7] Add hint when the user receives an error about an "unknown certificate authority" (#11550)

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -158,7 +158,7 @@ func (process *TeleportProcess) connect(role types.SystemRole) (conn *Connector,
 			// made. So provide a more user friendly error as a hint of what
 			// they can do to resolve the issue.
 			if strings.Contains(err.Error(), "certificate signed by unknown authority") {
-				process.log.Error("Was this node already registered to a different cluster? To join this node to a new cluster, remove `/var/lib/teleport` and try again")
+				process.log.Errorf("Was this node already registered to a different cluster? To join this node to a new cluster, remove `%s` and try again", process.Config.DataDir)
 			}
 			return nil, trace.Wrap(err)
 		}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -19,6 +19,7 @@ package service
 import (
 	"crypto/tls"
 	"path/filepath"
+	"strings"
 
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/teleport/api/constants"
@@ -150,6 +151,15 @@ func (process *TeleportProcess) connect(role types.SystemRole) (conn *Connector,
 		process.log.Infof("Connecting to the cluster %v with TLS client certificate.", identity.ClusterName)
 		clt, err := process.newClient(process.Config.AuthServers, identity)
 		if err != nil {
+			// In the event that a user is attempting to connect a machine to
+			// a different cluster it will give a cryptic warning about an
+			// unknown certificate authority. Unfortunately we cannot intercept
+			// this error as it comes from the http package before a request is
+			// made. So provide a more user friendly error as a hint of what
+			// they can do to resolve the issue.
+			if strings.Contains(err.Error(), "certificate signed by unknown authority") {
+				process.log.Error("Was this node already registered to a different cluster? To join this node to a new cluster, remove `/var/lib/teleport` and try again")
+			}
 			return nil, trace.Wrap(err)
 		}
 		return &Connector{
@@ -837,18 +847,18 @@ func (process *TeleportProcess) newClient(authServers []utils.NetAddr, identity 
 
 	logger := process.log.WithField("auth-addrs", utils.NetAddrsToStrings(authServers))
 	logger.Debug("Attempting to connect to Auth Server directly.")
-	directClient, err := process.newClientDirect(authServers, tlsConfig)
-	if err == nil {
+	directClient, directErr := process.newClientDirect(authServers, tlsConfig)
+	if directErr == nil {
 		logger.Debug("Connected to Auth Server with direct connection.")
 		return directClient, nil
 	}
 	logger.Debug("Failed to connect to Auth Server directly.")
 	// store err in directLogger, only log it if tunnel dial fails.
-	directErrLogger := logger.WithError(err)
+	directErrLogger := logger.WithError(directErr)
 
 	// Don't attempt to connect through a tunnel as a proxy or auth server.
 	if identity.ID.Role == types.RoleAuth || identity.ID.Role == types.RoleProxy {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(directErr)
 	}
 
 	logger.Debug("Attempting to discover reverse tunnel address.")
@@ -862,7 +872,9 @@ func (process *TeleportProcess) newClient(authServers []utils.NetAddr, identity 
 	if err != nil {
 		directErrLogger.Debug("Failed to connect to Auth Server directly.")
 		logger.WithError(err).Debug("Failed to connect to Auth Server through tunnel.")
-		return nil, trace.Errorf("Failed to connect to Auth Server directly or over tunnel, no methods remaining.")
+		return nil, trace.WrapWithMessage(
+			trace.NewAggregate(directErr, err),
+			trace.Errorf("Failed to connect to Auth Server directly or over tunnel, no methods remaining."))
 	}
 
 	logger.Debug("Connected to Auth Server through tunnel.")


### PR DESCRIPTION
Backports #11550 

* Intercept and update error message when there is a certificate error joining a node.

* Log out error hint and return full wrapped error.

* Updated error message.