### PR TITLE
Terraform Ref: add base64 to provider options

### DIFF
--- a/docs/pages/setup/reference/terraform-provider.mdx
+++ b/docs/pages/setup/reference/terraform-provider.mdx
@@ -47,7 +47,7 @@ The provider supports the following options:
 You need to specify at least one of:
 
 - `cert_path`, `key_path`,`root_ca_path` and `addr` to connect using key files.
-- `cert_base64`, `key_base64`,`root_ca_base64` and `addr` to connect using base64 encoded key.
+- `cert_base64`, `key_base64`,`root_ca_base64` and `addr` to connect using a base64-encoded key.
 - `identity_file_path` and `addr` to connect using identity file.
 - `profile_name` and `profile_dir` (both can be empty) and Teleport will try to connect using current profile from `~/.tsh`
 

--- a/docs/pages/setup/reference/terraform-provider.mdx
+++ b/docs/pages/setup/reference/terraform-provider.mdx
@@ -51,7 +51,7 @@ You need to specify at least one of:
 - `identity_file_path` and `addr` to connect using identity file.
 - `profile_name` and `profile_dir` (both can be empty) and Teleport will try to connect using current profile from `~/.tsh`
 
-If more than one is provided, they will be tried by the order above until one succeeds.
+If more than one are provided, they will be tried in the order above until one succeeds.
 
 Example:
 

--- a/docs/pages/setup/reference/terraform-provider.mdx
+++ b/docs/pages/setup/reference/terraform-provider.mdx
@@ -35,15 +35,19 @@ The provider supports the following options:
 |-------------------------|------------|-------------------------------------------------------|----------------------------------|
 |                   `addr`|     string | Teleport auth or proxy address in "host:port" format. | `TF_TELEPORT_ADDR`               |
 |              `cert_path`|     string | Path to Teleport certificate file.                    | `TF_TELEPORT_CERT`               |
+|            `cert_base64`|     string | Teleport certificate as base64.                       | `TF_TELEPORT_CERT_BASE64`        |
 |     `identity_file_path`|     string | Path to Teleport identity file.                       | `TF_TELEPORT_IDENTITY_FILE_PATH` |
 |               `key_path`|     string | Path to Teleport key file.                            | `TF_TELEPORT_KEY`                |
+|             `key_base64`|     string | Teleport key as base64.                               | `TF_TELEPORT_KEY_BASE64`        |
 |            `profile_dir`|     string | Teleport profile path.                                | `TF_TELEPORT_PROFILE_PATH`       |
 |           `profile_name`|     string | Teleport profile name.                                | `TF_TELEPORT_PROFILE_NAME`       |
 |           `root_ca_path`|     string | Path to Teleport CA file.                             | `TF_TELEPORT_ROOT_CA`            |
+|         `root_ca_base64`|     string | Teleport CA as base64.                                | `TF_TELEPORT_ROOT_CA_BASE64`     |
 
 You need to specify either:
 
 - `cert_path`, `key_path`,`root_ca_path` and `addr` to connect using key files.
+- `cert_base64`, `key_base64`,`root_ca_base64` and `addr` to connect using base64 encoded key.
 - `identity_file_path` and `addr` to connect using identity file.
 - `profile_name` and `profile_dir` (both can be empty) and Teleport will try to connect using current profile from `~/.tsh`
 

--- a/docs/pages/setup/reference/terraform-provider.mdx
+++ b/docs/pages/setup/reference/terraform-provider.mdx
@@ -38,18 +38,20 @@ The provider supports the following options:
 |            `cert_base64`|     string | Teleport certificate as base64.                       | `TF_TELEPORT_CERT_BASE64`        |
 |     `identity_file_path`|     string | Path to Teleport identity file.                       | `TF_TELEPORT_IDENTITY_FILE_PATH` |
 |               `key_path`|     string | Path to Teleport key file.                            | `TF_TELEPORT_KEY`                |
-|             `key_base64`|     string | Teleport key as base64.                               | `TF_TELEPORT_KEY_BASE64`        |
+|             `key_base64`|     string | Teleport key as base64.                               | `TF_TELEPORT_KEY_BASE64`         |
 |            `profile_dir`|     string | Teleport profile path.                                | `TF_TELEPORT_PROFILE_PATH`       |
 |           `profile_name`|     string | Teleport profile name.                                | `TF_TELEPORT_PROFILE_NAME`       |
 |           `root_ca_path`|     string | Path to Teleport CA file.                             | `TF_TELEPORT_ROOT_CA`            |
 |         `root_ca_base64`|     string | Teleport CA as base64.                                | `TF_TELEPORT_ROOT_CA_BASE64`     |
 
-You need to specify either:
+You need to specify at least one of:
 
 - `cert_path`, `key_path`,`root_ca_path` and `addr` to connect using key files.
 - `cert_base64`, `key_base64`,`root_ca_base64` and `addr` to connect using base64 encoded key.
 - `identity_file_path` and `addr` to connect using identity file.
 - `profile_name` and `profile_dir` (both can be empty) and Teleport will try to connect using current profile from `~/.tsh`
+
+If more than one is provided, they will be tried by the order above until one succeeds.
 
 Example:
 


### PR DESCRIPTION
We added the possibility to use base64 encoded strings in the teleport's
terraform plugin here
https://github.com/gravitational/teleport-plugins/pull/476

This PR aims to update the reference docs accordingly