### PR TITLE
Add manual websocket pingloop

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1063,6 +1063,15 @@ func (s *WebSuite) TestTerminalPing(c *C) {
 		return err
 	})
 
+	go func() {
+		for {
+			_, _, err := ws.ReadMessage()
+			if err != nil {
+				return
+			}
+		}
+	}()
+
 	select {
 	case <-done:
 	case <-time.After(time.Minute):

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -161,11 +161,17 @@ func (s *WebSuite) SetUpTest(c *C) {
 	s.user = u.Username
 	s.clock = clockwork.NewFakeClock()
 
+	networkingConfig, err := types.NewClusterNetworkingConfigFromConfigFile(types.ClusterNetworkingConfigSpecV2{
+		KeepAliveInterval: types.Duration(time.Second),
+	})
+	c.Assert(err, IsNil)
+
 	s.server, err = auth.NewTestServer(auth.TestServerConfig{
 		Auth: auth.TestAuthServerConfig{
-			ClusterName: "localhost",
-			Dir:         c.MkDir(),
-			Clock:       s.clock,
+			ClusterName:             "localhost",
+			Dir:                     c.MkDir(),
+			Clock:                   s.clock,
+			ClusterNetworkingConfig: networkingConfig,
 		},
 	})
 	c.Assert(err, IsNil)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1041,7 +1041,7 @@ func (s *WebSuite) TestResizeTerminal(c *C) {
 	}
 }
 
-// TestTerminalPing tests that the server sends continous ping control messages.
+// TestTerminalPing tests that the server sends continuous ping control messages.
 func (s *WebSuite) TestTerminalPing(c *C) {
 	ws, err := s.makeTerminal(s.authPack(c, "foo"))
 	c.Assert(err, IsNil)
@@ -1064,7 +1064,7 @@ func (s *WebSuite) TestTerminalPing(c *C) {
 		return err
 	})
 
-	// We need to continously read incoming messages in order to process ping messages.
+	// We need to continuously read incoming messages in order to process ping messages.
 	// We only care about receiving a ping here so dropping them is fine.
 	go func() {
 		for {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -162,7 +162,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 	s.clock = clockwork.NewFakeClock()
 
 	networkingConfig, err := types.NewClusterNetworkingConfigFromConfigFile(types.ClusterNetworkingConfigSpecV2{
-		KeepAliveInterval: types.Duration(time.Second * 10),
+		KeepAliveInterval: types.Duration(10 * time.Second),
 	})
 	c.Assert(err, IsNil)
 
@@ -1045,8 +1045,8 @@ func (s *WebSuite) TestTerminalPing(c *C) {
 	ws, err := s.makeTerminal(s.authPack(c, "foo"))
 	c.Assert(err, IsNil)
 	defer ws.Close()
-	closed := false
 
+	closed := false
 	done := make(chan struct{})
 	ws.SetPingHandler(func(message string) error {
 		if closed == false {
@@ -1065,7 +1065,7 @@ func (s *WebSuite) TestTerminalPing(c *C) {
 
 	select {
 	case <-done:
-	case <-time.After(time.Minute * 5):
+	case <-time.After(time.Minute):
 		c.Fatal("timeout waiting for ping")
 	}
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1045,13 +1045,13 @@ func (s *WebSuite) TestTerminalPing(c *C) {
 	ws, err := s.makeTerminal(s.authPack(c, "foo"))
 	c.Assert(err, IsNil)
 	defer ws.Close()
-	closed := new(bool)
+	closed := false
 
 	done := make(chan struct{})
 	ws.SetPingHandler(func(message string) error {
-		if *closed == false {
+		if closed == false {
 			close(done)
-			*closed = true
+			closed = true
 		}
 
 		err := ws.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(time.Second))

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1041,6 +1041,7 @@ func (s *WebSuite) TestResizeTerminal(c *C) {
 	}
 }
 
+// TestTerminalPing tests that the server sends continous ping control messages.
 func (s *WebSuite) TestTerminalPing(c *C) {
 	ws, err := s.makeTerminal(s.authPack(c, "foo"))
 	c.Assert(err, IsNil)
@@ -1063,6 +1064,8 @@ func (s *WebSuite) TestTerminalPing(c *C) {
 		return err
 	})
 
+	// We need to continously read incoming messages in order to process ping messages.
+	// We only care about receiving a ping here so dropping them is fine.
 	go func() {
 		for {
 			_, _, err := ws.ReadMessage()

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -128,7 +128,6 @@ func NewTerminal(ctx context.Context, req TerminalRequest, authProvider AuthProv
 		authProvider: authProvider,
 		encoder:      unicode.UTF8.NewEncoder(),
 		decoder:      unicode.UTF8.NewDecoder(),
-		readDeadline: time.Now().Add(req.KeepAliveInterval),
 		wsLock:       &sync.Mutex{},
 	}, nil
 }

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -233,8 +233,6 @@ func (t *TerminalHandler) startPingLoop(ws *websocket.Conn) {
 	tickerCh := time.NewTicker(t.params.KeepAliveInterval)
 	defer tickerCh.Stop()
 
-	terminateMessage := func() { t.log.Debug("Terminating websocket ping loop.") }
-
 	for {
 		select {
 		case <-tickerCh.C:
@@ -247,7 +245,7 @@ func (t *TerminalHandler) startPingLoop(ws *websocket.Conn) {
 				return
 			}
 		case <-t.terminalContext.Done():
-			terminateMessage()
+			t.log.Debug("Terminating websocket ping loop.")
 			return
 		}
 	}

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -240,7 +240,9 @@ func (t *TerminalHandler) startPingLoop(ws *websocket.Conn) {
 		select {
 		case <-tickerCh.C:
 			for {
-				deadline := time.Now().Add(t.params.KeepAliveInterval)
+				// A short deadline is used here to detect a broken connection quickly.
+				// If this is just a temporary issue, we will retry shortly anyway.
+				deadline := time.Now().Add(time.Second)
 				if err := ws.WriteControl(websocket.PingMessage, nil, deadline); err != nil {
 					if e, ok := err.(net.Error); ok && e.Temporary() {
 						t.log.Warnf("Temporary issue attempting to send ping frame to web client: %v.", err)

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -78,6 +78,8 @@ type TerminalRequest struct {
 	InteractiveCommand []string `json:"-"`
 
 	// KeepAliveInterval is the interval for sending ping frames to web client.
+	// This value is pulled from the cluster network config and
+	// guaranteed to be set to a nonzero value as it's enforced by the configuration.
 	KeepAliveInterval time.Duration
 }
 
@@ -204,8 +206,6 @@ func (t *TerminalHandler) Serve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// KeepAliveInterval is pulled from the cluster network config and
-	// guaranteed to be set to a nonzero value.
 	ws.SetReadDeadline(deadlineForInterval(t.params.KeepAliveInterval))
 	t.handler(ws, r)
 }

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -737,6 +737,9 @@ func (w *terminalStream) Close() error {
 	return w.ws.Close()
 }
 
+// deadlineForInterval returns a suitable network read deadline for a given ping interval.
+// We chose to take the current time plus twice the interval to allow the timeframe of one interval
+// to wait for a returned pong message.
 func deadlineForInterval(interval time.Duration) time.Time {
 	return time.Now().Add(interval * 2)
 }


### PR DESCRIPTION
This PR readds the pre-v9 websocket pingloop. The documentation for the new websocket library used in v9 caused some confusion on my end about interactions with proxies. We need this to send more frequent ping messages manually to avoid websocket termination by proxy.

Fixes #11763 