### PR TITLE
Fix `data_dir` comment referencing link that doesn't exist

### DIFF
--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -35,8 +35,8 @@ teleport:
     nodename: graviton
 
     # Data directory where Teleport daemon keeps its data.
-    # See "Filesystem Layout" for more details
-    # (https://goteleport.com/docs/admin-guide/#filesystem-layout).
+    # See "Storage backends" for more details
+    # (https://goteleport.com/docs/setup/reference/backends/).
     data_dir: /var/lib/teleport
 
     # PID file for Teleport process


### PR DESCRIPTION
The comment on `data_dir` in the config reference(https://goteleport.com/docs/setup/reference/config/)  was linking to a resource that doesn't exist.

https://goteleport.com/docs/setup/reference/backends/ seems to be the best fitting page here