### PR TITLE
Decrease MongoDB test client connection timeout

### DIFF
--- a/lib/srv/db/mongodb/test.go
+++ b/lib/srv/db/mongodb/test.go
@@ -52,7 +52,7 @@ func MakeTestClient(ctx context.Context, config common.TestClientConfig, opts ..
 				// interval and server selection timeout so access errors are
 				// returned to the client quicker.
 				SetHeartbeatInterval(500 * time.Millisecond).
-				SetServerSelectionTimeout(time.Second),
+				SetServerSelectionTimeout(2 * time.Second),
 		}, opts...)...)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/db/mongodb/test.go
+++ b/lib/srv/db/mongodb/test.go
@@ -52,7 +52,7 @@ func MakeTestClient(ctx context.Context, config common.TestClientConfig, opts ..
 				// interval and server selection timeout so access errors are
 				// returned to the client quicker.
 				SetHeartbeatInterval(500 * time.Millisecond).
-				SetServerSelectionTimeout(5 * time.Second),
+				SetServerSelectionTimeout(time.Second),
 		}, opts...)...)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Decreasing this timeout reduces the overall execution time of db package from 2:40m down to 1:40m (tested locally).