### PR TITLE
Hide navigation menu items based on scope

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -18,15 +18,18 @@
           "entries": [
             {
               "title": "Linux Server",
-              "slug": "/getting-started/linux-server/"
+              "slug": "/getting-started/linux-server/",
+              "hideInScopes": ["enterprise", "cloud"]
             },
             {
               "title": "Docker Compose",
-              "slug": "/getting-started/docker-compose/"
+              "slug": "/getting-started/docker-compose/",
+              "hideInScopes": ["enterprise", "cloud"]
             },
             {
               "title": "DigitalOcean",
-              "slug": "/getting-started/digitalocean/"
+              "slug": "/getting-started/digitalocean/",
+              "hideInScopes": ["enterprise", "cloud"]
             }
           ]
         },
@@ -89,18 +92,22 @@
         {
           "title": "Deployments",
           "slug": "/setup/deployments/",
+          "hideInScopes": "cloud",
           "entries": [
             {
               "title": "AWS Terraform",
-              "slug": "/setup/deployments/aws-terraform/"
+              "slug": "/setup/deployments/aws-terraform/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "GCP",
-              "slug": "/setup/deployments/gcp/"
+              "slug": "/setup/deployments/gcp/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "IBM",
-              "slug": "/setup/deployments/ibm/"
+              "slug": "/setup/deployments/ibm/",
+              "hideInScopes": "cloud"
             }
           ]
         },
@@ -110,7 +117,8 @@
           "entries": [
             {
               "title": "Scaling",
-              "slug": "/setup/operations/scaling/"
+              "slug": "/setup/operations/scaling/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Upgrading",
@@ -166,7 +174,8 @@
             },
             {
               "title": "Joining Nodes via AWS EC2",
-              "slug": "/setup/guides/joining-nodes-aws-ec2/"
+              "slug": "/setup/guides/joining-nodes-aws-ec2/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Using Teleport's CA with GitHub",
@@ -208,7 +217,8 @@
             },
             {
               "title": "Storage Backends",
-              "slug": "/setup/reference/backends/"
+              "slug": "/setup/reference/backends/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Networking",
@@ -300,7 +310,8 @@
             },
             {
               "title": "Recording Proxy Mode",
-              "slug": "/server-access/guides/recording-proxy-mode/"
+              "slug": "/server-access/guides/recording-proxy-mode/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "BPF Session Recording",
@@ -334,9 +345,10 @@
               "title": "Local Demo Cluster",
               "slug": "/kubernetes-access/getting-started/local/"
             },
-            {
-              "title": "Cluster",
-              "slug": "/kubernetes-access/getting-started/cluster/"
+            { 
+              "title": "Cluster", 
+              "slug": "/kubernetes-access/getting-started/cluster/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Agent",
@@ -369,26 +381,32 @@
         {
           "title": "Helm Guides",
           "slug": "/kubernetes-access/helm/guides/",
+          "hideInScopes": "cloud",
           "entries": [
             {
               "title": "AWS EKS Cluster",
-              "slug": "/kubernetes-access/helm/guides/aws/"
+              "slug": "/kubernetes-access/helm/guides/aws/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Google Cloud GKE Cluster",
-              "slug": "/kubernetes-access/helm/guides/gcp/"
+              "slug": "/kubernetes-access/helm/guides/gcp/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "DigitalOcean Kubernetes Cluster",
-              "slug": "/kubernetes-access/helm/guides/digitalocean/"
+              "slug": "/kubernetes-access/helm/guides/digitalocean/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Customize Deployment Config",
-              "slug": "/kubernetes-access/helm/guides/custom/"
+              "slug": "/kubernetes-access/helm/guides/custom/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Migrating From Older Charts",
-              "slug": "/kubernetes-access/helm/guides/migration/"
+              "slug": "/kubernetes-access/helm/guides/migration/",
+              "hideInScopes": "cloud"
             }
           ]
         },
@@ -398,7 +416,8 @@
           "entries": [
             {
               "title": "teleport-cluster",
-              "slug": "/kubernetes-access/helm/reference/teleport-cluster/"
+              "slug": "/kubernetes-access/helm/reference/teleport-cluster/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "teleport-kube-agent",
@@ -654,7 +673,8 @@
             },
             {
               "title": "Dual Authorization",
-              "slug": "/access-controls/guides/dual-authz/"
+              "slug": "/access-controls/guides/dual-authz/",
+              "hideInScopes": "oss"
             },
             {
               "title": "Impersonation",
@@ -662,7 +682,8 @@
             },
             {
               "title": "Moderated Sessions",
-              "slug": "/access-controls/guides/moderated-sessions/"
+              "slug": "/access-controls/guides/moderated-sessions/",
+              "hideInScopes": "oss"
             }
           ]
         },
@@ -714,61 +735,75 @@
         },
         {
           "title": "Getting Started",
-          "slug": "/enterprise/getting-started/"
+          "slug": "/enterprise/getting-started/",
+          "hideInScopes": ["oss", "cloud"]
         },
         {
           "title": "Single Sign-On (SSO)",
           "slug": "/enterprise/sso/",
+          "hideInScopes": ["oss"],
           "entries": [
             {
               "title": "Azure Active Directory (AD)",
-              "slug": "/enterprise/sso/azuread/"
+              "slug": "/enterprise/sso/azuread/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "Active Directory (ADFS)",
-              "slug": "/enterprise/sso/adfs/"
+              "slug": "/enterprise/sso/adfs/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "Google Workspace",
-              "slug": "/enterprise/sso/google-workspace/"
+              "slug": "/enterprise/sso/google-workspace/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "GitLab",
-              "slug": "/enterprise/sso/gitlab/"
+              "slug": "/enterprise/sso/gitlab/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "OneLogin",
-              "slug": "/enterprise/sso/one-login/"
+              "slug": "/enterprise/sso/one-login/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "OIDC",
-              "slug": "/enterprise/sso/oidc/"
+              "slug": "/enterprise/sso/oidc/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "Okta",
-              "slug": "/enterprise/sso/okta/"
+              "slug": "/enterprise/sso/okta/",
+              "hideInScopes": ["oss"]
             }
           ]
         },
         {
           "title": "Access Requests",
-          "slug": "/enterprise/workflow/"
+          "slug": "/enterprise/workflow/",
+          "hideInScopes": ["oss"]
         },
         {
           "title": "FedRAMP",
-          "slug": "/enterprise/fedramp/"
+          "slug": "/enterprise/fedramp/",
+          "hideInScopes": ["cloud", "oss"]
         },
         {
           "title": "SOC2",
-          "slug": "/enterprise/soc2/"
+          "slug": "/enterprise/soc2/",
+          "hideInScopes": ["cloud", "oss"]
         },
         {
           "title": "HSM",
-          "slug": "/enterprise/hsm/"
+          "slug": "/enterprise/hsm/",
+          "hideInScopes": ["cloud", "oss"]
         },
         {
           "title": "Enterprise License File",
-          "slug": "/enterprise/license/"
+          "slug": "/enterprise/license/",
+          "hideInScopes": ["cloud", "oss"]
         }
       ]
     },
@@ -782,19 +817,23 @@
         },
         {
           "title": "Getting Started",
-          "slug": "/cloud/getting-started/"
+          "slug": "/cloud/getting-started/",
+          "hideInScopes": ["oss", "enterprise"]
         },
         {
           "title": "Architecture",
-          "slug": "/cloud/architecture/"
+          "slug": "/cloud/architecture/",
+          "hideInScopes": ["oss", "enterprise"]
         },
         {
           "title": "Downloads",
-          "slug": "/cloud/downloads/"
+          "slug": "/cloud/downloads/",
+          "hideInScopes": ["oss", "enterprise"]
         },
         {
           "title": "FAQ",
-          "slug": "/cloud/faq/"
+          "slug": "/cloud/faq/",
+          "hideInScopes": ["oss", "enterprise"]
         }
       ]
     },

--- a/docs/pages/access-controls/guides.mdx
+++ b/docs/pages/access-controls/guides.mdx
@@ -5,9 +5,11 @@ layout: tocless-doc
 ---
 
 <ul>
+  <ScopedBlock scope={["cloud", "enterprise"]}>
   <li>
     [Dual Authorization](./guides/dual-authz.mdx). Protect access to critial resources with dual authorization.
   </li>
+  </ScopedBlock>
   <li>
     [Role Templates](./guides/role-templates.mdx). Setup dynamic access policies with Role Templates.
   </li>
@@ -23,7 +25,9 @@ layout: tocless-doc
   <li>
     [Locking](./guides/locking.mdx). Lock access to active user sessions or hosts.
   </li>
+  <ScopedBlock scope={["cloud", "enterprise"]}>
   <li>
     [Moderated Sessions](./guides/moderated-sessions.mdx). Require session auditors and allow fine-grained live session access.
   </li>
+  </ScopedBlock>
 </ul>

--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -13,14 +13,21 @@ Here are the most common scenarios:
 Let's set up Teleport's access requests to require the approval of two team members
 for a privileged role `dbadmin`.
 
-<Notice
+<Admonition
   type="danger"
   scope="oss"
+  scopeOnly
 >
   This guide requires a commercial edition of Teleport. The open source
   edition of Teleport only supports [GitHub](../../setup/admin/github-sso.mdx) as
   an SSO provider.
-</Notice>
+
+  You can also view this guide as:
+
+  - A [Teleport Cloud user](./dual-authz.mdx/?scope=cloud)
+  - A [Teleport Enterprise user](./dual-authz.mdx/?scope=enterprise)
+
+</Admonition>
 
 <Admonition title="Note" type="tip">
   The steps below describe how to use Teleport with Mattermost. You can also [integrate with many other providers](../../enterprise/workflow/index.mdx).

--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -4,11 +4,16 @@ description: Moderated Sessions
 h1: Moderated Sessions
 ---
 
-<Notice type="warning" scope="oss">
+<Admonition type="warning" scope="oss" scopeOnly>
 
   Moderated Sessions requires Teleport Enterprise or Teleport Cloud.
 
-</Notice>
+  You can also view this guide as:
+
+  - A [Teleport Cloud user](./moderated-sessions.mdx/?scope=cloud)
+  - A [Teleport Enterprise user](./moderated-sessions.mdx/?scope=enterprise)
+
+</Admonition>
 
 ## Introduction
 

--- a/docs/pages/cloud/introduction.mdx
+++ b/docs/pages/cloud/introduction.mdx
@@ -5,12 +5,47 @@ h1: Teleport cloud
 videoBanner: 1jhKOtBinm4
 ---
 
-We run Teleport Cloud as hosted, managed Teleport as a service.
-Connect your nodes, web applications, kubernetes clusters and databases.
-Sign up [here](https://goteleport.com/get-started/).
+Teleport Cloud is a fully managed deployment of Teleport Enterprise.
+
+We host the Teleport Auth Service and Proxy Service and take care of upgrades,
+and you connect your Nodes, web applications, Kubernetes clusters, databases,
+and Windows desktops.
+
+Visit our [sign up page](https://goteleport.com/signup/) to begin a free trial.
+
+<TileSet>
+<ScopedBlock scope={["oss", "enterprise"]}>
+<Tile 
+icon="cloud"
+title="Teleport Cloud docs"
+href="./introduction.mdx/?scope=cloud"
+>
+View the docs as a Teleport Cloud user.
+</Tile>
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+  <Tile icon="cloud" title="Getting Started" href="./getting-started.mdx">
+    Follow this guide to access your first server via Teleport Cloud.
+  </Tile>
+  <Tile icon="cloud" title="Architecture" href="./architecture.mdx">
+    Security, availability, and networking information.
+  </Tile>
+  <Tile icon="cloud" title="Downloads" href="./downloads.mdx">
+    How to download agent and client binaries for your Teleport Cloud deployment.
+  </Tile>
+  <Tile icon="cloud" title="FAQ" href="./faq.mdx">
+    Get answers to frequently asked questions about Teleport Cloud.
+  </Tile>
+
+</ScopedBlock>
+</TileSet>
+
+
+
 
 ## Next Steps
 
-- Get started with cloud [in 5 minutes](./getting-started.mdx).
 - Join the [Teleport Discussons](https://github.com/gravitational/teleport/discussions) and ask a question.
 - Join the [Slack channel](https://goteleport.com/slack).

--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -8,6 +8,13 @@ Welcome to the Quick Start Guide for Teleport Enterprise.
 
 (!docs/pages/includes/cloud/cloudmanagedadvisory.mdx!)
 
+<Notice type="tip" scope={["oss", "cloud"]}>
+
+You can also view this guide as a
+[Teleport Enterprise user](./getting-started.mdx/?scope=enterprise).
+
+</Notice>
+
 The goal of this document is to show off the basic capabilities of Teleport.
 There are three types of services Teleport nodes can run: `nodes`, `proxies`
 and `auth servers`.

--- a/docs/pages/enterprise/hsm.mdx
+++ b/docs/pages/enterprise/hsm.mdx
@@ -12,9 +12,11 @@ This guide will show you how to set up the Teleport Auth Server to use a hardwar
 - An HSM reachable from your Teleport auth server.
 - The PKCS#11 module for your HSM.
 
-<Details scope={["cloud", "oss"]} opened={true} scopeOnly={true} title="Compatibility Warning">
+<Admonition type="warning" scope={["cloud", "oss"]} opened={true} scopeOnly={true} title="Compatibility Warning">
 Teleport Cloud and Teleport Open Source do not currently support HSM.
-</Details>
+
+You can view this guide as a [Teleport Enterprise user](./hsm.mdx/?scope=enterprise).
+</Admonition>
 
 While most PKCS#11 HSMs should be supported, the Teleport team tests with AWS
 CloudHSM, YubiHSM2, and SoftHSM2.

--- a/docs/pages/enterprise/introduction.mdx
+++ b/docs/pages/enterprise/introduction.mdx
@@ -4,9 +4,25 @@ description: Introduction to features and benefits of using Teleport Enterprise.
 h1: Teleport Enterprise
 ---
 
-This section will give an overview of Teleport Enterprise, the commercial product built around
- Teleport Open Source core. For those that want to jump right in, you can play
-with the [Getting Started Guide for Teleport Enterprise](getting-started.mdx).
+Teleport Enterprise is a commercial product built around Teleport's open source
+core.
+
+<ScopedBlock scope={["oss", "cloud"]}>
+<TileSet>
+<Tile
+title="Teleport Enterprise docs"
+href="./introduction.mdx/?scope=enterprise"
+icon="building"
+>
+Learn more about Teleport Enterprise.
+</Tile>
+</TileSet>
+</ScopedBlock>
+
+<ScopedBlock scope={["enterprise"]}>
+
+For those that want to jump right in, you can play with the
+[Getting Started Guide for Teleport Enterprise](getting-started.mdx).
 
 The table below gives a quick overview of the benefits of Teleport Enterprise.
 
@@ -83,3 +99,5 @@ See [Access Requests Guide for more information](workflow/index.mdx)
 ## License file
 
 Commercial Teleport subscriptions require a valid license. See [Enterprise License File](./license.mdx) for how to manage the file in your Teleport Enterprise deployment.
+
+</ScopedBlock>

--- a/docs/pages/enterprise/sso.mdx
+++ b/docs/pages/enterprise/sso.mdx
@@ -4,8 +4,30 @@ description: How to set up single sign-on (SSO) for SSH using Teleport
 h1: Single Sign-On (SSO) for SSH
 ---
 
-Users of the Enterprise edition of Teleport can login with SSH, Kubernetes, Databases and Web applications
-through a Single Sign-On (SSO) provider used the rest of the organization.
+Users of the Enterprise edition of Teleport can log in to servers, Kubernetes
+clusters, databases, web applications, and Windows desktops through your
+organization's Single Sign-On (SSO) provider.
+
+<ScopedBlock scope="oss">
+<TileSet>
+    <Tile 
+    icon="bolt"
+    title="Use SSO with Teleport Cloud"
+    href="./sso.mdx/?scope=cloud"
+  >
+    Learn how to use Teleport's SSO integrations in Teleport Cloud.
+    </Tile>
+    <Tile 
+    icon="bolt"
+    title="Use SSO with Teleport Enterprise"
+    href="./sso.mdx/?scope=enterprise"
+  >
+    Learn how to use Teleport's SSO integrations in Teleport Enterprise.
+    </Tile>
+  </TileSet>
+</ScopedBlock>
+
+<ScopedBlock scope={["enterprise", "cloud"]}>
 
 <TileSet>
   <Tile icon="bolt" title="Azure Active Directory (AD)" href="./sso/azuread.mdx">
@@ -30,6 +52,8 @@ through a Single Sign-On (SSO) provider used the rest of the organization.
     Configure Okta SSO for SSH, Kubernetes, databases, desktops and web apps.
   </Tile>
 </TileSet>
+
+</ScopedBlock>
 
 ## How does SSO work?
 

--- a/docs/pages/enterprise/sso/adfs.mdx
+++ b/docs/pages/enterprise/sso/adfs.mdx
@@ -18,8 +18,16 @@ like:
 <Admonition
   type="warning"
   title="Version Warning"
+  scope="oss"
+  scopeOnly
 >
   This guide requires a commercial edition of Teleport.
+
+  You can also view this guide as:
+
+  - A [Teleport Cloud user](./azuread.mdx/?scope=cloud)
+  - A [Teleport Enterprise user](./azuread.mdx/?scope=enterprise)
+
 </Admonition>
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)

--- a/docs/pages/enterprise/sso/azuread.mdx
+++ b/docs/pages/enterprise/sso/azuread.mdx
@@ -15,8 +15,16 @@ The following steps configure an example SAML authentication connector matching 
 <Admonition
   type="warning"
   title="Version Warning"
+  scope="oss"
+  scopeOnly
 >
   This guide requires either an Enterprise version of Teleport or a Teleport Cloud account.
+
+  You can also view this guide as:
+
+  - A [Teleport Cloud user](./azuread.mdx/?scope=cloud)
+  - A [Teleport Enterprise user](./azuread.mdx/?scope=enterprise)
+
 </Admonition>
 
 ## Prerequisites

--- a/docs/pages/enterprise/sso/gitlab.mdx
+++ b/docs/pages/enterprise/sso/gitlab.mdx
@@ -18,8 +18,16 @@ like:
 <Admonition
   type="warning"
   title="Version Warning"
+  scope="oss"
+  scopeOnly
 >
   This guide requires a commercial edition of Teleport.
+
+  You can also view this guide as:
+
+  - A [Teleport Cloud user](./gitlab.mdx/?scope=cloud)
+  - A [Teleport Enterprise user](./gitlab.mdx/?scope=enterprise)
+
 </Admonition>
 
 ## Enable default OIDC authentication

--- a/docs/pages/enterprise/sso/google-workspace.mdx
+++ b/docs/pages/enterprise/sso/google-workspace.mdx
@@ -16,14 +16,20 @@ to define policies like:
 - Developers must never SSH into production servers.
 - ... and many others.
 
-<Notice
+<Admonition
   type="warning"
   scope={["oss"]}
+  scopeOnly
 >
 
   This guide requires Teleport Cloud or Teleport Enterprise.
 
-</Notice>
+  You can also view this guide as:
+
+  - A [Teleport Cloud user](./google-workspace.mdx/?scope=cloud)
+  - A [Teleport Enterprise user](./google-workspace.mdx/?scope=enterprise)
+
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -16,8 +16,16 @@ administrators to define policies like:
 <Admonition
   type="warning"
   title="Version Warning"
+  scope="oss"
+  scopeOnly
 >
-  This guide requires an Enterprise edition of Teleport.
+  This guide requires a commercial edition of Teleport.
+
+  You can also view this guide as:
+
+  - A [Teleport Cloud user](./oidc.mdx/?scope=cloud)
+  - A [Teleport Enterprise user](./oidc.mdx/?scope=enterprise)
+
 </Admonition>
 
 ## Enable default OIDC authentication

--- a/docs/pages/enterprise/sso/okta.mdx
+++ b/docs/pages/enterprise/sso/okta.mdx
@@ -18,8 +18,16 @@ like:
 <Admonition
   type="warning"
   title="Version Warning"
+  scope="oss"
+  scopeOnly
 >
   This guide requires a commercial edition of Teleport.
+
+  You can also view this guide as:
+
+  - A [Teleport Cloud user](./okta.mdx/?scope=cloud)
+  - A [Teleport Enterprise user](./okta.mdx/?scope=enterprise)
+
 </Admonition>
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)

--- a/docs/pages/enterprise/sso/one-login.mdx
+++ b/docs/pages/enterprise/sso/one-login.mdx
@@ -18,8 +18,16 @@ like:
 <Admonition
   type="warning"
   title="Version Warning"
+  scope="oss"
+  scopeOnly
 >
   This guide requires an Enterprise edition of Teleport.
+
+  You can also view this guide as:
+
+  - A [Teleport Cloud user](./one-login.mdx/?scope=cloud)
+  - A [Teleport Enterprise user](./one-login.mdx/?scope=enterprise)
+
 </Admonition>
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)

--- a/docs/pages/enterprise/workflow/index.mdx
+++ b/docs/pages/enterprise/workflow/index.mdx
@@ -6,6 +6,21 @@ h1: Teleport Access Requests
 
 #### Approving Requests using an External Integration
 
+<Admonition
+  type="warning"
+  title="Version Warning"
+  scope="oss"
+  scopeOnly
+>
+  This guide requires an Enterprise edition of Teleport.
+
+  You can also view this guide as:
+
+  - A [Teleport Cloud user](./index.mdx/?scope=cloud)
+  - A [Teleport Enterprise user](./index.mdx/?scope=enterprise)
+
+</Admonition>
+
 - [Integrating Teleport with Slack](ssh-approval-slack.mdx)
 - [Integrating Teleport with Mattermost](ssh-approval-mattermost.mdx)
 - [Integrating Teleport with Jira Cloud](ssh-approval-jira-cloud.mdx)

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -4,7 +4,33 @@ description: Getting started with Teleport - identity-aware access plane for SSH
 layout: tocless-doc
 ---
 
+Follow these guides to get started using Teleport.
+
 <TileSet>
+<ScopedBlock scope={["cloud", "enterprise"]}>
+
+  <Tile 
+  icon="stack"
+  title="Open Source Teleport"
+  href="./getting-started.mdx/?scope=oss"
+  >
+  Learn how to host your own open source Teleport deployment.
+  </Tile>
+  <Tile
+  icon="building"
+  title="Teleport Enterprise"
+  href="./enterprise/introduction.mdx/?scope=enterprise"
+  >
+
+  Get started with a self-hosted Teleport Enterprise deployment, which gives you
+  more advanced features and full customization.
+
+  </Tile>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss"]}>
+
   <Tile icon="server" title="Linux" href="./getting-started/linux-server.mdx">
     Get started with Teleport on a standalone Linux server.
   </Tile>
@@ -14,7 +40,9 @@ layout: tocless-doc
   <Tile icon="kubernetes" title="Kubernetes" href="./kubernetes-access/getting-started/local.mdx">
     Get started with Teleport and Kubernetes.
   </Tile>
-  <Tile icon="cloud" title="Cloud" href="https://goteleport.com/signup">
+
+</ScopedBlock>
+  <Tile icon="cloud" title="Teleport Cloud" href="https://goteleport.com/signup">
     Try Teleport hosted by us in the cloud for free.
   </Tile>
 </TileSet>

--- a/docs/pages/getting-started/digitalocean.mdx
+++ b/docs/pages/getting-started/digitalocean.mdx
@@ -15,6 +15,15 @@ This tutorial will guide you through quickly getting started with Teleport on Di
 
 (!docs/pages/includes/cloud/cloudmanagedadvisory.mdx!)
 
+<Notice scope="cloud" type="tip">
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./digitalocean.mdx/?scope=oss)
+- A [Teleport Enterprise user](./digitalocean.mdx/?scope=enterprise)
+
+</Notice>
+
 ## Prerequisites
 - A Fully Qualified Domain Name (FQDN).
 - A two-factor authenticator app (e.g., [Google Authenticator](https://www.google.com/landing/2step/)).

--- a/docs/pages/getting-started/docker-compose.mdx
+++ b/docs/pages/getting-started/docker-compose.mdx
@@ -9,6 +9,15 @@ It will also show you how to use Teleport with OpenSSH, Ansible, and Teleport's 
 
 (!docs/pages/includes/cloud/cloudmanagedadvisory.mdx!)
 
+<Notice scope="cloud" type="tip">
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./docker-compose.mdx/?scope=oss)
+- A [Teleport Enterprise user](./docker-compose.mdx/?scope=enterprise)
+
+</Notice>
+
 ## Prerequisites
 
 - Teleport v(=teleport.version=) Open Source or Enterprise.

--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -9,6 +9,15 @@ Teleport (=teleport.version=) on Linux machines.
 
 (!docs/pages/includes/cloud/cloudmanagedadvisory.mdx!)
 
+<Notice scope="cloud" type="tip">
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./linux-server.mdx/?scope=oss)
+- A [Teleport Enterprise user](./linux-server.mdx/?scope=enterprise)
+
+</Notice>
+
 ## Prerequisites
 
 - A Linux machine with a port `443` open

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -10,10 +10,12 @@ layout: tocless-doc
     ![Teleport ](../../img/k8s/mini-diagrams/teleport-in-k8s-mono.svg)
     Quickly see how Teleport works with Kubernetes on your laptop.
   </Tile>
-  <Tile title="Teleport Cluster in Kubernetes" href="./getting-started/cluster.mdx">
-    ![Teleport ](../../img/k8s/mini-diagrams/teleport-in-k8s-mono.svg)
-    Deploy a standalone Teleport cluster in a Kubernetes cluster.
-  </Tile>
+  <ScopedBlock scope={["oss", "enterprise"]}>
+    <Tile title="Teleport Cluster in Kubernetes" href="./getting-started/cluster.mdx">
+      ![Teleport ](../../img/k8s/mini-diagrams/teleport-in-k8s-mono.svg)
+      Deploy a standalone Teleport cluster in a Kubernetes cluster.
+    </Tile>
+  </ScopedBlock>
   <Tile title="Teleport Kubernetes Agent" href="./getting-started/agent.mdx">
     ![Kubernetes agent](../../img/k8s/mini-diagrams/k8s-to-teleport-mono.svg)
     Connect a Kubernetes cluster to an existing Teleport cluster.

--- a/docs/pages/kubernetes-access/getting-started/cluster.mdx
+++ b/docs/pages/kubernetes-access/getting-started/cluster.mdx
@@ -22,6 +22,11 @@ This guide shows you how to deploy the Teleport Auth Service and Proxy Service o
 Instead, Teleport Cloud users should consult the following guide, which shows you how to connect a Teleport Kubernetes Service node to an existing Teleport cluster.
 
 [Connect a Kubernetes Cluster to Teleport](./agent.mdx)
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./cluster.mdx/?scope=oss)
+- A [Teleport Enterprise user](./cluster.mdx/?scope=enterprise)
 </Details>
 
 ## Follow along with our video guide

--- a/docs/pages/kubernetes-access/helm/guides.mdx
+++ b/docs/pages/kubernetes-access/helm/guides.mdx
@@ -4,6 +4,12 @@ description: How to install and configure Teleport in Kubernetes using Helm
 layout: tocless-doc
 ---
 
+## Helm guides
+
+These guides show you how to set up a full self-hosted Teleport deployment using
+our `teleport-cluster` Helm chart.
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 <TileSet>
     <Tile icon="kubernetes" title="Standalone Teleport Cluster" href="../getting-started.mdx">
         Getting started with Kubernetes Access
@@ -18,6 +24,25 @@ layout: tocless-doc
         Running a Teleport cluster in Kubernetes with a custom Teleport config
     </Tile>
 </TileSet>
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+<TileSet>
+    <Tile 
+    icon="wrench"
+    title="Open Source Teleport"
+    href="./guides.mdx/?scope=oss"
+  >
+    Learn how to deploy an open source Teleport cluster using Helm.
+    </Tile>
+    <Tile 
+    icon="wrench"
+    title="Teleport Enterprise"
+    href="./guides.mdx/?scope=enterprise"
+  >
+    Learn how to deploy a Teleport Enterprise cluster using Helm.
+    </Tile>
+  </TileSet>
+</ScopedBlock>
 
 ## Migration Guides
 

--- a/docs/pages/kubernetes-access/helm/guides/aws.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/aws.mdx
@@ -8,6 +8,15 @@ using Teleport Helm charts and AWS products (DynamoDB and S3).
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
 
+<Admonition type="tip" scope="cloud" scopeOnly>
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./aws.mdx/?scope=oss)
+- A [Teleport Enterprise user](./aws.mdx/?scope=enterprise)
+
+</Admonition>
+
 ## Prerequisites
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/kubernetes-access/helm/guides/custom.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/custom.mdx
@@ -11,6 +11,15 @@ migrating your setup from a legacy version of the Helm charts.
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
 
+<Admonition type="tip" scope="cloud" scopeOnly>
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./custom.mdx/?scope=oss)
+- A [Teleport Enterprise user](./custom.mdx/?scope=enterprise)
+
+</Admonition>
+
 ## Prerequisites
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/kubernetes-access/helm/guides/digitalocean.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/digitalocean.mdx
@@ -7,6 +7,15 @@ This guide will show you how to get started with Teleport on DigitalOcean Kubern
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
 
+<Admonition type="tip" scope="cloud" scopeOnly>
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./digitalocean.mdx/?scope=oss)
+- A [Teleport Enterprise user](./digitalocean.mdx/?scope=enterprise)
+
+</Admonition>
+
 ## Prerequisites
 - DigitalOcean account.
 - Your workstation configured with [kubectl](https://kubernetes.io/docs/tasks/tools/), [Helm](https://helm.sh/docs/intro/install/), [doctl](https://docs.digitalocean.com/reference/doctl/how-to/install/), and the Teleport [tsh](https://goteleport.com/docs/installation/) client.

--- a/docs/pages/kubernetes-access/helm/guides/gcp.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/gcp.mdx
@@ -8,6 +8,15 @@ using Teleport Helm charts and Google Cloud Platform products (Firestore and Goo
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
 
+<Notice scope="cloud" type="tip">
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./gcp.mdx/?scope=oss)
+- A [Teleport Enterprise user](./gcp.mdx/?scope=enterprise)
+
+</Notice>
+
 ## Prerequisites
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/kubernetes-access/helm/guides/migration.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/migration.mdx
@@ -15,6 +15,15 @@ to use the newer `teleport-cluster` Helm chart instead.
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
 
+<Admonition type="tip" scope="cloud" scopeOnly>
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./migration.mdx/?scope=oss)
+- A [Teleport Enterprise user](./migration.mdx/?scope=enterprise)
+
+</Admonition>
+
 ## Prerequisites
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -4,12 +4,14 @@ description: A list of values that can be set using Teleport Helm charts and the
 ---
 
 <TileSet>
-<Tile href="./reference/teleport-cluster.mdx" icon="kubernetes" title="teleport-cluster">
-![Teleport ](../../../img/k8s/mini-diagrams/teleport-in-k8s-mono.svg)
+<ScopedBlock scope={["oss", "enterprise"]}>
+    <Tile href="./reference/teleport-cluster.mdx" icon="kubernetes" title="teleport-cluster">
+    ![Teleport ](../../../img/k8s/mini-diagrams/teleport-in-k8s-mono.svg)
 
-Deploy the Teleport Auth Service and Proxy Service on Kubernetes.
+    Deploy the Teleport Auth Service and Proxy Service on Kubernetes.
 
-</Tile>
+    </Tile>
+</ScopedBlock>
 <Tile href="./reference/teleport-kube-agent.mdx" icon="kubernetes" title="teleport-kube-agent">
 ![Kubernetes agent](../../../img/k8s/mini-diagrams/k8s-to-teleport-mono.svg)
 

--- a/docs/pages/kubernetes-access/helm/reference/teleport-cluster.mdx
+++ b/docs/pages/kubernetes-access/helm/reference/teleport-cluster.mdx
@@ -7,14 +7,19 @@ The `teleport-cluster` Helm chart is used to deploy the Teleport Auth Service
 and Proxy Service, which is ideal for getting started with a self-hosted Teleport
 cluster on Kubernetes.
 
-<Notice scope={["cloud"]} type="warning">
+<Details scope={["cloud"]} title="Teleport Cloud">
 
 Teleport Cloud manages the Auth Service and Proxy Service for you. Use the
 `teleport-cluster` chart if you are interested in hosting Teleport yourself, or
 use the [`teleport-kube-agent`](./teleport-kube-agent.mdx) chart to deploy the
 Kubernetes Service, Application Service, or Database Service.
 
-</Notice>
+You can also view this guide as:
+
+- An [Open Source Teleport user](./teleport-cluster.mdx/?scope=oss)
+- A [Teleport Enterprise user](./teleport-cluster.mdx/?scope=enterprise)
+
+</Details>
 
 You can
 [browse the source on GitHub](https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-cluster).

--- a/docs/pages/server-access/guides.mdx
+++ b/docs/pages/server-access/guides.mdx
@@ -14,9 +14,11 @@ layout: tocless-doc
   <Tile icon="server" title="OpenSSH Guide" href="./guides/openssh.mdx">
     How to use Teleport on legacy systems with OpenSSH and sshd.
   </Tile>
-  <Tile icon="server" title="Recording Proxy Mode" href="./guides/recording-proxy-mode.mdx">
-    How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
-  </Tile>
+  <ScopedBlock scope={["oss", "enterprise"]}>
+    <Tile icon="server" title="Recording Proxy Mode" href="./guides/recording-proxy-mode.mdx">
+      How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
+    </Tile>
+  </ScopedBlock>
   <Tile icon="server" title="BPF Session Recording" href="./guides/bpf-session-recording.mdx">
     How to use BPF to record SSH session commands, modified files and network connections.
   </Tile>

--- a/docs/pages/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/server-access/guides/recording-proxy-mode.mdx
@@ -3,15 +3,19 @@ title: Teleport Recording Proxy Mode
 description: Use Recording Proxy Mode to capture OpenSSH server activity
 ---
 
-<Notice scope={["cloud"]} type="warning">
+<Admonition scope={["cloud"]} type="warning" scopeOnly>
 
 Teleport Cloud only supports session recording at the Node level. If you are
 interested in setting up session recording, read our
 [Server Access Getting Started Guide](../getting-started.mdx) so you can start
 replacing your OpenSSH servers with Teleport Nodes.
 
-</Notice>
+You can also view this guide as:
 
+- An [Open Source Teleport user](./recording-proxy-mode.mdx/?scope=oss)
+- A [Teleport Enterprise user](./recording-proxy-mode.mdx/?scope=enterprise)
+
+</Admonition>
 
 <Figure
   align="center"

--- a/docs/pages/setup/deployments.mdx
+++ b/docs/pages/setup/deployments.mdx
@@ -4,6 +4,29 @@ description: Teleport Installation and Configuration Reference Deployment Guides
 layout: tocless-doc
 ---
 
+These guides show you how to set up a full self-hosted Teleport deployment on
+the platform of your choice.
+
+<ScopedBlock scope="cloud">
+<TileSet>
+    <Tile 
+    icon="wrench"
+    title="Open Source Teleport"
+    href="./deployments.mdx/?scope=oss"
+  >
+    View our deployment guides as an Open Source Teleport user.
+    </Tile>
+    <Tile 
+    icon="wrench"
+    title="Teleport Enterprise"
+    href="./deployments.mdx/?scope=enterprise"
+  >
+    View our deployment guides as a Teleport Enterprise user.
+    </Tile>
+  </TileSet>
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 <ul>
   <li>
     [AWS Terraform](./deployments/aws-terraform.mdx). Deploy HA Teleport with Terraform Provider on AWS.
@@ -15,3 +38,4 @@ layout: tocless-doc
     [IBM Cloud](./deployments/ibm.mdx). Deploy HA Teleport on IBM cloud.
   </li>
 </ul>
+</ScopedBlock>

--- a/docs/pages/setup/deployments/aws-terraform.mdx
+++ b/docs/pages/setup/deployments/aws-terraform.mdx
@@ -14,6 +14,15 @@ Our reference Terraform code deploys self-hosted instances of the Teleport Auth 
 - For a full reference: [Terraform Provider Resources](../reference/terraform-provider.mdx)
 </Details>
 
+<Notice scope="cloud" type="tip">
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./aws-terraform.mdx/?scope=oss)
+- A [Teleport Enterprise user](./aws-terraform.mdx/?scope=enterprise)
+
+</Notice>
+
 ## Prerequisites
 
 Our code requires Terraform 0.12+. You can [download Terraform here](https://www.terraform.io/downloads.html). We will assume that you have

--- a/docs/pages/setup/deployments/gcp.mdx
+++ b/docs/pages/setup/deployments/gcp.mdx
@@ -7,13 +7,18 @@ We've created this guide to give customers a high level overview of how to use T
 on [Google Cloud](https://cloud.google.com/gcp/) (GCP). This guide provides a high level
 introduction leading to a deep dive into how to setup and run Teleport in production.
 
-<Notice type="warning" scope={["cloud"]}>
+<Details scope={["cloud"]} scopeOnly opened>
 
 This guide shows you how to deploy the Auth Service and Proxy Service, which
 Teleport Cloud manages for you. You can read this guide if you are interested in
 learning about self-hosting Teleport on Google Cloud.
 
-</Notice>
+You can also view this guide as:
+
+- An [Open Source Teleport user](./gcp.mdx/?scope=oss)
+- A [Teleport Enterprise user](./gcp.mdx/?scope=enterprise)
+
+</Details>
 
 We have split this guide into:
 

--- a/docs/pages/setup/deployments/ibm.mdx
+++ b/docs/pages/setup/deployments/ibm.mdx
@@ -7,13 +7,18 @@ We've created this guide to give customers a high level overview of how to use T
 on the [IBM Cloud](https://www.ibm.com/cloud). This guide provides a high level
 introduction leading to a deep dive into how to setup and run Teleport in production.
 
-<Notice type="warning" scope={["cloud"]}>
+<Details scope={["cloud"]} scopeOnly opened>
 
 This guide shows you how to deploy the Auth Service and Proxy Service, which
 Teleport Cloud manages for you. You can read this guide if you are interested in
 learning about self-hosting Teleport on IBM Cloud.
 
-</Notice>
+You can also view this guide as:
+
+- An [Open Source Teleport user](./ibm.mdx/?scope=oss)
+- A [Teleport Enterprise user](./ibm.mdx/?scope=enterprise)
+
+</Details>
 
 We have split this guide into:
 

--- a/docs/pages/setup/guides.mdx
+++ b/docs/pages/setup/guides.mdx
@@ -9,5 +9,7 @@ layout: tocless-doc
   - [Fluentd Event Forwarder](./guides/fluentd.mdx). Forwarding events with Fluentd and the Teleport Events Handler.
   - [EC2 tags as Teleport Nodes](./guides/ec2-tags.mdx). How to set up Teleport Node labels based on EC2 tags.
   - [Joining Nodes via AWS IAM Role](./guides/joining-nodes-aws-iam.mdx). Use the IAM join method to add Nodes to your Teleport cluster on AWS.
+  <ScopedBlock scope={["oss", "enterprise"]}>
   - [Joining Nodes via AWS EC2 Identity Document](./guides/joining-nodes-aws-ec2.mdx). Use the EC2 join method to add Nodes to your Teleport cluster on AWS.
+  </ScopedBlock>
   - [Using Teleport's Certificate Authority with GitHub](./guides/ssh-key-extensions.mdx). Use Teleport's short-lived certificates with GitHub's Certificate Authority.

--- a/docs/pages/setup/guides/joining-nodes-aws-ec2.mdx
+++ b/docs/pages/setup/guides/joining-nodes-aws-ec2.mdx
@@ -7,13 +7,18 @@ This guide will explain how to use the **EC2 join method** to configure Teleport
 nodes and Proxies to join your Teleport cluster without sharing any secrets when
 they are running in AWS.
 
-<Notice type="warning" scope={["cloud"]}>
+<Admonition type="warning" scope={["cloud"]} scopeOnly>
 
 The EC2 join method is not available in Teleport Cloud. Teleport Cloud customers
 can use the [IAM join method](./joining-nodes-aws-iam.mdx) or
 [secret tokens](../admin/adding-nodes.mdx).
 
-</Notice>
+You can also view this guide as:
+
+- An [Open Source Teleport user](./joining-nodes-aws-ec2.mdx/?scope=oss)
+- A [Teleport Enterprise user](./joining-nodes-aws-ec2.mdx/?scope=enterprise)
+
+</Admonition>
 
 The EC2 join method is available in self-hosted versions of Teleport 7.3+. It is
 available to any Teleport node or Proxy running on an EC2 instance. Only one

--- a/docs/pages/setup/operations.mdx
+++ b/docs/pages/setup/operations.mdx
@@ -11,9 +11,11 @@ For guides on the fundamentals of setting up your cluster, you should consult
 the [Cluster Administration Guides](./admin.mdx) section.
 
 <TileSet>
-  <Tile href="./operations/scaling.mdx" title="Scaling" icon="wrench">
-  How to configure Teleport for large-scale deployments.
-  </Tile>
+  <ScopedBlock scope={["oss", "enterprise"]}>
+    <Tile href="./operations/scaling.mdx" title="Scaling" icon="wrench">
+    How to configure Teleport for large-scale deployments.
+    </Tile>
+  </ScopedBlock>
   <Tile href="./operations/upgrading.mdx" title="Upgrading" icon="wrench">
   Learn about how to upgrade your Teleport cluster while ensuring that components remain compatible.
   </Tile>
@@ -23,7 +25,9 @@ the [Cluster Administration Guides](./admin.mdx) section.
   <Tile href="./operations/ca-rotation.mdx" title="CA Rotation" icon="wrench">
   Rotating Teleport certificate authorities.
   </Tile>
-  <Tile href="./operations/tls-routing.mdx" title="TLS Routing Migration" icon="wrench">
-  Migrating your Teleport cluster to single-port TLS routing mode.
-  </Tile>
+  <ScopedBlock scope={["oss", "enterprise"]}>
+    <Tile href="./operations/tls-routing.mdx" title="TLS Routing Migration" icon="wrench">
+    Migrating your Teleport cluster to single-port TLS routing mode.
+    </Tile>
+  </ScopedBlock>
 </TileSet>

--- a/docs/pages/setup/operations/scaling.mdx
+++ b/docs/pages/setup/operations/scaling.mdx
@@ -6,9 +6,14 @@ description: How to configure Teleport for large-scale deployments
 This section covers recommended configurations for large-scale
 deployments of Teleport.
 
-<Notice type="warning" scope={["cloud"]}>
+<Admonition type="tip" scope={["cloud"]} scopeOnly>
 For Teleport Cloud customers, the settings in this guide are configured automatically.
-</Notice>
+
+You can also view this guide as:
+
+- An [Open Source Teleport user](./scaling.mdx/?scope=oss)
+- A [Teleport Enterprise user](./scaling.mdx/?scope=enterprise)
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/setup/reference.mdx
+++ b/docs/pages/setup/reference.mdx
@@ -26,9 +26,11 @@ layout: tocless-doc
   <li>
     [Authentication](./reference/authentication.mdx). Cluster authentication options.
   </li>
+  <ScopedBlock scope={["oss", "enterprise"]}>
   <li>
     [Backends](./reference/backends.mdx). Supported storage backends.
   </li>
+  </ScopedBlock>
   <li>
     [Networking](./reference/networking.mdx). Ports, protocols and networking requirements.
   </li>

--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -8,12 +8,17 @@ default everything is stored in a local directory at the Auth server.
 Integration with other storage types is implemented based on the nature of the
 stored data (size, read/write ratio, mutability, etc.).
 
-<Notice scope={["cloud"]} type="tip">
+<Admonition scope={["cloud"]} type="tip" scopeOnly>
 
 Teleport Cloud manages Auth Service and Proxy Service data for you, so there is
 no need to configure a backend.
 
-</Notice>
+You can also view this guide as:
+
+- An [Open Source Teleport user](./backends.mdx/?scope=oss)
+- A [Teleport Enterprise user](./backends.mdx/?scope=enterprise)
+
+</Admonition>
 
 | Data type | Description | Supported storage backends |
 | - | - | - |


### PR DESCRIPTION
Hide navigation menu items based on scope
    
Closes #11383

Note that this PR depends on merging a gravitational/docs PR:
    
https://github.com/gravitational/docs/pull/51

Ensure that no visitor to the Teleport docs site sees content that is
irrelevant to their scope (e.g., Cloud, Open Source, or Enterprise) by
hiding scope-irrelevant content from the navigation menu.

In some cases, e.g., the introduction pages for the Cloud, Getting
Started, and Enterprise sections, the content is irrelevant to certain
scopes but a reader still may want to find out more.

One possibility would be to leave these section as-is for readers with
an unintend scope. However, these readers would see edition warnings in
the pages within a section unless they changed the value of the scope
picker.

As an alternative, this change used ScopedBlock to display links to
the relevant scope for users with a scope that is not intended for
a given menu page.

Also directs Enterprise visitors to the Getting Started menu page
to the Enterprise Getting Started page with an "enterprise" scope.
This fixes #10594.

Finally, wherever we include a warning at the top of an
edition-incompatible guide, I've added links to the scopes that
are supported for that guide. This should make it easier for
users to realize that they can adjust the scope to have the intended
docs experience.