### PR TITLE
Teleport Email Plugin: add docs for access request using email

### DIFF
--- a/docs/pages/enterprise/workflow/index.mdx
+++ b/docs/pages/enterprise/workflow/index.mdx
@@ -11,6 +11,7 @@ h1: Teleport Access Requests
 - [Integrating Teleport with Jira Cloud](ssh-approval-jira-cloud.mdx)
 - [Integrating Teleport with Jira Server](ssh-approval-jira-server.mdx)
 - [Integrating Teleport with PagerDuty](ssh-approval-pagerduty.mdx)
+- [Integrating Teleport with Email](ssh-approval-email.mdx)
 
 ## Access Requests Setup
 

--- a/docs/pages/enterprise/workflow/ssh-approval-email.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-email.mdx
@@ -1,0 +1,180 @@
+---
+title: Teleport's integration with Email
+description: This guide explains how to setup a Email plugin for Teleport for privilege elevation approvals.
+h1: Teleport Email Plugin Setup
+---
+
+This guide will talk through how to set up Teleport with Email.
+Teleport's Email integration notifies individuals or mailing lists of Access Requests.
+
+## Setup
+
+### Prerequisites
+
+This guide assumes that you have:
+
+- A running Teleport Cluster
+- Admin privileges with access to `tctl`
+- SMTP or Mailgun credentials to send emails
+
+Teleport Cloud requires that plugins connect through the Proxy Service (`mytenant.teleport.sh:443`).
+Open Source and Enterprise installations can connect to the Auth Service (`auth.example.com:3025`) directly.
+
+### Create a user and role for access
+
+(!docs/pages/includes/plugins/rbac.mdx!)
+
+### Export the access-plugin certificate
+
+(!docs/pages/includes/plugins/identity-export.mdx!)
+
+We'll reference these files later when [configuring the plugin](#configuring-the-teleport-email-plugin).
+
+### Email provider
+
+You must have an email provider to be able to send the emails.
+
+You can either create a Mailgun account or use SMTP configuration (mode details below).
+
+## Installing the Teleport Email plugin
+
+We recommend installing the Teleport Plugins alongside the Teleport Proxy.
+This is an ideal location as plugins have a low memory footprint, and will require both public internet access and Teleport Auth access.
+We currently only provide linux-amd64 binaries, you can also compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/email).
+
+**Install the plugin**
+
+<Tabs>
+<TabItem label="Download">
+  ```code
+  $ curl -L https://get.gravitational.com/teleport-access-email-v(=teleport.version=)-linux-amd64-bin.tar.gz
+  $ tar -xzf teleport-access-email-v(=teleport.version=)-linux-amd64-bin.tar.gz
+  $ cd teleport-access-email
+  $ ./install
+  ```
+</TabItem>
+<TabItem label="From Source">
+  To install from source you need `git` and `go >= (=teleport.golang=)` installed.
+
+  ```code
+  # Checkout teleport-plugins
+  $ git clone https://github.com/gravitational/teleport-plugins.git
+  $ cd teleport-plugins/access/email
+  $ make
+  # plugin is located at build/teleport-email
+  ```
+</TabItem>
+</Tabs>
+
+
+Run `./install` from `teleport-email` or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
+
+### Configuring the Teleport Email plugin
+
+Teleport Email uses a config file in TOML format.
+Generate a boilerplate config by running the following command:
+
+```code
+$ teleport-email configure > teleport-email.toml
+$ sudo mv teleport-email.toml /etc
+```
+
+#### Editing the config file
+
+In the Teleport section, use the identity file(s) you generated with `tctl auth sign`.
+The plugin installer creates a folder for those files in `/var/lib/teleport/plugins/email/`. 
+
+Move the certificates to this folder, then edit the configuration file (`teleport-email.toml`) based on the reference below to ensure that the appropriate settings point to your identity file(s). 
+
+<Tabs>
+  <TabItem label="OpenSource, Enterprise" scope={["oss","enterprise"]}>
+```conf
+(!examples/resources/plugins/teleport-email.toml!)
+```
+</TabItem>
+
+  <TabItem label="Cloud" scope={["cloud"]}>
+
+```conf
+(!examples/resources/plugins/teleport-email-proxy.toml!)
+```
+</TabItem>
+</Tabs>
+
+## Test run
+
+Assuming that Teleport is running and the configurations are correct, you can now run the plugin and test the workflow!
+
+```code
+$ teleport-email start
+```
+
+If everything works fine, the log output should look like this:
+
+```code
+$ teleport-email start
+INFO Starting Teleport Access Email Plugin 9.0.3 email/app.go:93
+INFO Using Mailgun as email transport domain:REDACTED.mailgun.org email/client.go:62
+INFO Plugin is ready email/app.go:114
+```
+
+### Testing the approval workflow
+
+You can create a test permissions request with `tctl` and check if the plugin works as expected like this:
+
+#### Create a test permissions request behalf of a user
+
+```code
+# Replace USERNAME with a Teleport local user, and TARGET_ROLE with a Teleport Role
+$ tctl request create USERNAME --roles=TARGET_ROLE
+```
+
+A user can also try using `--request-roles` flag.
+
+```code
+# Example with a user trying to request a role DBA.
+$ tsh login --request-roles=dba
+```
+
+#### Access the request trough the web ui
+
+You should have receive an email containing the request, it should look something like this:
+```
+You have a new Role Request:
+
+ID: 0c2e9b2b-0090-4bd8-b476-7dd81dac00d6
+Cluster: ship.marco.mydemo
+User: contractor
+Role(s): dev
+Link: https://ship.marco.mydemo/web/requests/0c2e9b2b-0090-4bd8-b476-7dd81dac00d6
+
+Status: ⏳ PENDING
+```
+
+You can follow that link and approve or deny the request
+
+### Log in and request a role
+
+You can also test the full workflow from the user's perspective using `tsh`:
+
+```code
+# tsh login --request-roles=REQUESTED_ROLE
+Seeking request approval... (id: 8f77d2d1-2bbf-4031-a300-58926237a807)
+```
+
+You should now see a new request in Teleport, and receive an email about the request with instructions.
+
+### Set up systemd
+
+In production, we recommend starting the Teleport plugin daemon via an init system like systemd.
+Here's the recommended Teleport plugin service unit file for systemd:
+
+```ini
+(!examples/systemd/plugins/teleport-email.service!)
+```
+
+Save this as `teleport-email.service`.
+
+## Feedback
+
+If you have any issues with this plugin please create an [issue here](https://github.com/gravitational/teleport-plugins/issues/new).

--- a/examples/resources/plugins/teleport-email-proxy.toml
+++ b/examples/resources/plugins/teleport-email-proxy.toml
@@ -1,0 +1,23 @@
+# example email plugin configuration TOML file
+
+[teleport]
+addr = "teleport.example.com:443"           # Teleport Auth Server GRPC API address
+identity = "/var/lib/teleport-plugin/access-plugin-email.pem"
+[mailgun]
+domain = "your-domain-name"
+private_key = "xoxb-11xx"
+# private_key_file = "/var/lib/teleport/plugins/email/mailgun_private_key"
+[smtp]
+host = "smtp.gmail.com"
+port = 587
+username = "username@gmail.com"
+password = ""
+# password_file = "/var/lib/teleport/plugins/email/smtp_password"
+[delivery]
+sender = "noreply@example.com" # From: email address
+[role_to_recipients]
+"dev" = "dev-manager@example.com" # All requests to 'dev' role will be sent to this address
+"*" = ["root@example.com", "admin@example.com"] # These recipients will receive review requests not handled by the roles above
+[log]
+output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/email.log"
+severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".

--- a/examples/resources/plugins/teleport-email.toml
+++ b/examples/resources/plugins/teleport-email.toml
@@ -1,0 +1,25 @@
+# example email plugin configuration TOML file
+
+[teleport]
+addr = "auth.example.com:3025"           # Teleport Auth Server GRPC API address
+client_key = "/var/lib/teleport/plugins/email/auth.key" # Teleport GRPC client secret key
+client_crt = "/var/lib/teleport/plugins/email/auth.crt" # Teleport GRPC client certificate
+root_cas = "/var/lib/teleport/plugins/email/auth.cas"   # Teleport cluster CA certs
+[mailgun]
+domain = "your-domain-name"
+private_key = "xoxb-11xx"
+# private_key_file = "/var/lib/teleport/plugins/email/mailgun_private_key"
+[smtp]
+host = "smtp.gmail.com"
+port = 587
+username = "username@gmail.com"
+password = ""
+# password_file = "/var/lib/teleport/plugins/email/smtp_password"
+[delivery]
+sender = "noreply@example.com" # From: email address
+[role_to_recipients]
+"dev" = "dev-manager@example.com" # All requests to 'dev' role will be sent to this address
+"*" = ["root@example.com", "admin@example.com"] # These recipients will receive review requests not handled by the roles above
+[log]
+output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/email.log"
+severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".

--- a/examples/systemd/plugins/teleport-email.service
+++ b/examples/systemd/plugins/teleport-email.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Teleport Email Plugin
+After=network.target
+
+[Service]
+Type=simple
+Restart=on-failure
+ExecStart=/usr/local/bin/teleport-email start --config=/etc/teleport-email.toml
+ExecReload=/bin/kill -HUP $MAINPID
+PIDFile=/run/teleport-email.pid
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add the email plugin documentation

Contains features to be deployed here
https://github.com/gravitational/teleport-plugins/pull/488

Partially rendered version https://github.com/gravitational/teleport/blob/marco/add_email_plugin/docs/pages/enterprise/workflow/ssh-approval-email.mdx