### PR TITLE
Mention scoped Admonitions

### DIFF
--- a/docs/pages/contributing/documentation/reference.mdx
+++ b/docs/pages/contributing/documentation/reference.mdx
@@ -117,6 +117,10 @@ or using some other value will result in resetting it to the `tip`.
 
 If `title` is omitted, `type` will be used instead as the title value.
 
+`scope` is an optional property that specifies the component's
+[scope](./reference.mdx#scopes). If the `scopeOnly` property is provided and the
+user-selected scope is not included in `scope`, the `Admonition` will be hidden.
+
 ## Tabs
 
 <Tabs>


### PR DESCRIPTION
Since we can now adjust the visibility of Admonitions based on scope,
this change explains how the `scope` and `scopeOnly` attributes work
in the Admonition component within the docs UI reference.