### PR TITLE
Added support for JumpCloud.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -455,6 +455,8 @@ const (
 	Ping = "ping"
 	// Okta should be used for Okta OIDC providers.
 	Okta = "okta"
+	// JumpCloud is an identity provider.
+	JumpCloud = "jumpcloud"
 )
 
 const (


### PR DESCRIPTION
**Description**

JumpCloud uses the same canonicalization algorithm as ADFS. Add provider switch for JumpCloud to use a C14N10 exclusive canonicalizer.