### PR TITLE
Display elapsed time in render-tests output

### DIFF
--- a/build.assets/tooling/cmd/render-tests/main.go
+++ b/build.assets/tooling/cmd/render-tests/main.go
@@ -37,6 +37,7 @@ import (
 
 var covPattern = regexp.MustCompile(`^coverage: (\d+\.\d+)\% of statements`)
 
+// matches `event` in src/cmd/internal/test2json/test2json.go
 type TestEvent struct {
 	Time           time.Time // encodes as an RFC3339-format string
 	Action         string
@@ -131,7 +132,7 @@ readloop:
 			if args.report == byTest {
 				switch event.Action {
 				case actionPass, actionFail, actionSkip:
-					fmt.Printf("%s: %s\n", event.Action, event.FullName())
+					fmt.Printf("%s (in %.2fs): %s\n", event.Action, event.ElapsedSeconds, event.FullName())
 				}
 			}
 
@@ -161,7 +162,7 @@ readloop:
 						}
 
 						// only display package results as progress messages
-						fmt.Printf("%s %s: %s\n", covText, event.Action, event.Package)
+						fmt.Printf("%s %s (in %.2fs): %s\n", covText, event.Action, event.ElapsedSeconds, event.Package)
 					}
 
 					// Don't need this no more


### PR DESCRIPTION
Example unit test output:
```
 70.5% pass (in 27.87s): github.com/gravitational/teleport/lib/events/filesessions
 55.5% pass (in 0.23s): github.com/gravitational/teleport/lib/session
 76.3% pass (in 5.21s): github.com/gravitational/teleport/lib/backend/lite
------ skip (in 0.00s): github.com/gravitational/teleport/examples/bench
------ skip (in 0.00s): github.com/gravitational/teleport/examples/jwt
------ skip (in 0.00s): github.com/gravitational/teleport/lib
 46.8% pass (in 11.86s): github.com/gravitational/teleport/lib/services
 73.0% pass (in 0.54s): github.com/gravitational/teleport/lib/srv/app/aws
 64.8% pass (in 0.33s): github.com/gravitational/teleport/lib/datalog
 24.4% pass (in 0.30s): github.com/gravitational/teleport/lib/client/db
 65.9% pass (in 0.33s): github.com/gravitational/teleport/lib/srv/desktop/tdp
```

Example integration test output:
```
pass (in 27.12s): github.com/gravitational/teleport/integration.TestAppServersHA/LeafHTTPApp
pass (in 29.00s): github.com/gravitational/teleport/integration.TestAppServersHA/LeafWebSocketApp
pass (in 123.66s): github.com/gravitational/teleport/integration.TestAppServersHA
pass (in 6.19s): github.com/gravitational/teleport/integration.TestDatabaseAccessPostgresRootCluster
pass (in 6.34s): github.com/gravitational/teleport/integration.TestDatabaseAccessPostgresLeafCluster
skip (in 0.00s): github.com/gravitational/teleport/integration.TestDatabaseRotateTrustedCluster
pass (in 5.54s): github.com/gravitational/teleport/integration.TestDatabaseAccessMySQLRootCluster
```