### PR TITLE
Fix authservice.pb.go

### DIFF
--- a/api/client/proto/authservice.pb.go
+++ b/api/client/proto/authservice.pb.go
@@ -11003,7 +11003,7 @@ type AuthServiceClient interface {
 	MaintainSessionPresence(ctx context.Context, opts ...grpc.CallOption) (AuthService_MaintainSessionPresenceClient, error)
 	// CreateSessionTracker creates a new session tracker resource.
 	CreateSessionTracker(ctx context.Context, in *CreateSessionTrackerRequest, opts ...grpc.CallOption) (*types.SessionTrackerV1, error)
-	// GetSessionTrackerRequest fetches a session tracker resource.
+	// GetSessionTracker fetches a session tracker resource.
 	GetSessionTracker(ctx context.Context, in *GetSessionTrackerRequest, opts ...grpc.CallOption) (*types.SessionTrackerV1, error)
 	// GetActiveSessionTrackers returns a list of active sessions.
 	GetActiveSessionTrackers(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (AuthService_GetActiveSessionTrackersClient, error)
@@ -13179,7 +13179,7 @@ type AuthServiceServer interface {
 	MaintainSessionPresence(AuthService_MaintainSessionPresenceServer) error
 	// CreateSessionTracker creates a new session tracker resource.
 	CreateSessionTracker(context.Context, *CreateSessionTrackerRequest) (*types.SessionTrackerV1, error)
-	// GetSessionTrackerRequest fetches a session tracker resource.
+	// GetSessionTracker fetches a session tracker resource.
 	GetSessionTracker(context.Context, *GetSessionTrackerRequest) (*types.SessionTrackerV1, error)
 	// GetActiveSessionTrackers returns a list of active sessions.
 	GetActiveSessionTrackers(*empty.Empty, AuthService_GetActiveSessionTrackersServer) error

--- a/api/client/proto/authservice.proto
+++ b/api/client/proto/authservice.proto
@@ -1646,9 +1646,6 @@ service AuthService {
     // CreateSessionTracker creates a new session tracker resource.
     rpc CreateSessionTracker(CreateSessionTrackerRequest) returns (types.SessionTrackerV1);
 
-    // UpsertSessionTracker upserts a session tracker resource.
-    rpc UpsertSessionTracker(types.SessionTrackerV1) returns (google.protobuf.Empty);
-
     // GetSessionTracker fetches a session tracker resource.
     rpc GetSessionTracker(GetSessionTrackerRequest) returns (types.SessionTrackerV1);
 


### PR DESCRIPTION
Removes an accidental addition to `authservice.proto` from https://github.com/gravitational/teleport/pull/11551.