### PR TITLE
Increase UT timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -508,7 +508,7 @@ test-go: FLAGS ?= '-race'
 test-go: PACKAGES = $(shell go list ./... | grep -v integration | grep -v tool/tsh)
 test-go: CHAOS_FOLDERS = $(shell find . -type f -name '*chaos*.go' | xargs dirname | uniq)
 test-go: $(VERSRC) $(TEST_LOG_DIR)
-	$(CGOFLAG) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(ROLETESTER_TAG) $(RDPCLIENT_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS) \
+	$(CGOFLAG) go test -timeout 30m -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(ROLETESTER_TAG) $(RDPCLIENT_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \
 		| ${RENDER_TESTS}
 # rdpclient and libfido2 don't play well together, so we run libfido2 tests


### PR DESCRIPTION
Currently UT in package `github.com/gravitational/teleport/lib/srv/db` are failing in CI with the error:
```
panic: test timed out after 10m0s
```
This change increase the timeout for UT. I set the timeout to 30 min as our tests in CI will be still terminated after the GCB timeout anyways: https://github.com/gravitational/teleport/blob/809e60c318cf98207f0db40795faff5020baaa07/.cloudbuild/ci/unit-tests.yaml#L28