### PR TITLE
Fix lint errors on Go 1.18

### DIFF
--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -187,7 +187,10 @@ func (roles SystemRoles) String() string {
 
 // Set sets the value of the teleport role from string, used to integrate with CLI tools
 func (r *SystemRole) Set(v string) error {
-	val := SystemRole(strings.Title(v))
+	if len(v) > 0 {
+		v = strings.ToUpper(v[:1]) + v[1:]
+	}
+	val := SystemRole(v)
 	if err := val.Check(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1563,7 +1563,6 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 	require.NoError(t, werr)
 	ok := roots.AppendCertsFromPEM(buffer)
 	require.True(t, ok)
-	require.Len(t, roots.Subjects(), 2)
 
 	// wait for active tunnel connections to be established
 	waitForActiveTunnelConnections(t, b.Tunnel, a.Secrets.SiteName, 1)

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -107,7 +107,6 @@ func (s ForwarderSuite) TestRequestCertificate(c *check.C) {
 	c.Assert(err, check.IsNil)
 	// All fields except b.key are predictable.
 	c.Assert(b.Certificates[0].Certificate[0], check.DeepEquals, cl.lastCert.Raw)
-	c.Assert(len(b.RootCAs.Subjects()), check.Equals, 1)
 
 	// Check the KubeCSR fields.
 	c.Assert(cl.gotCSR.Username, check.DeepEquals, ctx.User.GetName())
@@ -708,6 +707,7 @@ func TestNewClusterSessionRemote(t *testing.T) {
 
 	// Make sure newClusterSession obtained a new client cert instead of using f.creds.
 	require.Equal(t, f.cfg.AuthClient.(*mockCSRClient).lastCert.Raw, sess.tlsConfig.Certificates[0].Certificate[0])
+	//lint:ignore SA1019 there's no non-deprecated public API for testing the contents of the RootCAs pool
 	require.Equal(t, [][]byte{f.cfg.AuthClient.(*mockCSRClient).ca.Cert.RawSubject}, sess.tlsConfig.RootCAs.Subjects())
 	require.Equal(t, 1, f.clientCredentials.Len())
 }
@@ -755,6 +755,7 @@ func TestNewClusterSessionDirect(t *testing.T) {
 
 	// Make sure newClusterSession obtained a new client cert instead of using f.creds.
 	require.Equal(t, f.cfg.AuthClient.(*mockCSRClient).lastCert.Raw, sess.tlsConfig.Certificates[0].Certificate[0])
+	//lint:ignore SA1019 there's no non-deprecated public API for testing the contents of the RootCAs pool
 	require.Equal(t, [][]byte{f.cfg.AuthClient.(*mockCSRClient).ca.Cert.RawSubject}, sess.tlsConfig.RootCAs.Subjects())
 	require.Equal(t, 1, f.clientCredentials.Len())
 }

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -180,7 +180,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 				log.Debugf("Ignoring unsupported cluster name %q.", info.ServerName)
 			}
 		}
-		pool, err := auth.DefaultClientCertPool(accessPoint, clusterName)
+		pool, _, err := auth.DefaultClientCertPool(accessPoint, clusterName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -314,10 +314,12 @@ func (c *UserCertParams) CheckAndSetDefaults() error {
 	return nil
 }
 
-// CertPoolFromCertAuthorities returns certificate pools from TLS certificates
-// set up in the certificate authorities list
-func CertPoolFromCertAuthorities(cas []types.CertAuthority) (*x509.CertPool, error) {
+// CertPoolFromCertAuthorities returns a certificate pool from the TLS certificates
+// set up in the certificate authorities list, as well as the number of certificates
+// that were added to the pool.
+func CertPoolFromCertAuthorities(cas []types.CertAuthority) (*x509.CertPool, int, error) {
 	certPool := x509.NewCertPool()
+	count := 0
 	for _, ca := range cas {
 		keyPairs := ca.GetTrustedTLSKeyPairs()
 		if len(keyPairs) == 0 {
@@ -326,12 +328,13 @@ func CertPoolFromCertAuthorities(cas []types.CertAuthority) (*x509.CertPool, err
 		for _, keyPair := range keyPairs {
 			cert, err := tlsca.ParseCertificatePEM(keyPair.Cert)
 			if err != nil {
-				return nil, trace.Wrap(err)
+				return nil, 0, trace.Wrap(err)
 			}
 			certPool.AddCert(cert)
+			count++
 		}
 	}
-	return certPool, nil
+	return certPool, count, nil
 }
 
 // CertPool returns certificate pools from TLS certificates

--- a/lib/services/authority_test.go
+++ b/lib/services/authority_test.go
@@ -80,25 +80,29 @@ func TestCertPoolFromCertAuthorities(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("ca1 with 1 cert", func(t *testing.T) {
-		pool, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca1})
+		pool, count, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca1})
+		require.NotNil(t, pool)
 		require.NoError(t, err)
-		require.Len(t, pool.Subjects(), 1)
+		require.Equal(t, 1, count)
 	})
 	t.Run("ca2 with 2 certs", func(t *testing.T) {
-		pool, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca2})
+		pool, count, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca2})
+		require.NotNil(t, pool)
 		require.NoError(t, err)
-		require.Len(t, pool.Subjects(), 2)
+		require.Equal(t, 2, count)
 	})
 	t.Run("ca3 with 1 cert", func(t *testing.T) {
-		pool, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca3})
+		pool, count, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca3})
+		require.NotNil(t, pool)
 		require.NoError(t, err)
-		require.Len(t, pool.Subjects(), 1)
+		require.Equal(t, 1, count)
 	})
 
 	t.Run("ca1 + ca2 + ca3 with 4 certs total", func(t *testing.T) {
-		pool, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca1, ca2, ca3})
+		pool, count, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca1, ca2, ca3})
+		require.NotNil(t, pool)
 		require.NoError(t, err)
-		require.Len(t, pool.Subjects(), 4)
+		require.Equal(t, 4, count)
 	})
 }
 

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -775,7 +775,7 @@ func (s *Server) getConfigForClient(info *tls.ClientHelloInfo) (*tls.Config, err
 
 	// Fetch list of CAs that could have signed this certificate. If clusterName
 	// is empty, all CAs that this cluster knows about are returned.
-	pool, err := auth.DefaultClientCertPool(s.c.AccessPoint, clusterName)
+	pool, _, err := auth.DefaultClientCertPool(s.c.AccessPoint, clusterName)
 	if err != nil {
 		// If this request fails, return nil and fallback to the default ClientCAs.
 		s.log.Debugf("Failed to retrieve client pool: %v.", trace.DebugReport(err))

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -1636,7 +1636,7 @@ func (c *testContext) makeTLSConfig(t *testing.T) *tls.Config {
 	conf := utils.TLSConfig(nil)
 	conf.Certificates = append(conf.Certificates, cert)
 	conf.ClientAuth = tls.VerifyClientCertIfGiven
-	conf.ClientCAs, err = auth.DefaultClientCertPool(c.authServer, c.clusterName)
+	conf.ClientCAs, _, err = auth.DefaultClientCertPool(c.authServer, c.clusterName)
 	require.NoError(t, err)
 	return conf
 }

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -688,7 +688,7 @@ func getConfigForClient(conf *tls.Config, ap auth.ReadDatabaseAccessPoint, log l
 				log.Debugf("Ignoring unsupported cluster name %q.", info.ServerName)
 			}
 		}
-		pool, err := auth.ClientCertPool(ap, clusterName, caTypes...)
+		pool, _, err := auth.ClientCertPool(ap, clusterName, caTypes...)
 		if err != nil {
 			log.WithError(err).Error("Failed to retrieve client CA pool.")
 			return nil, nil // Fall back to the default config.

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -83,6 +83,12 @@ type TLSCredentials struct {
 	Cert       []byte
 }
 
+// macMaxTLSCertValidityPeriod is the maximum validitiy period
+// for a TLS certificate enforced by macOS.
+// As of Go 1.18, certificates are validated via the system
+// verifier and not in Go.
+const macMaxTLSCertValidityPeriod = 825 * 24 * time.Hour
+
 // GenerateSelfSignedCert generates a self-signed certificate that
 // is valid for given domain names and ips, returns PEM-encoded bytes with key and cert
 func GenerateSelfSignedCert(hostNames []string) (*TLSCredentials, error) {
@@ -91,7 +97,7 @@ func GenerateSelfSignedCert(hostNames []string) (*TLSCredentials, error) {
 		return nil, trace.Wrap(err)
 	}
 	notBefore := time.Now()
-	notAfter := notBefore.Add(time.Hour * 24 * 365 * 10) // 10 years
+	notAfter := notBefore.Add(macMaxTLSCertValidityPeriod)
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -83,7 +83,7 @@ type TLSCredentials struct {
 	Cert       []byte
 }
 
-// macMaxTLSCertValidityPeriod is the maximum validitiy period
+// macMaxTLSCertValidityPeriod is the maximum validity period
 // for a TLS certificate enforced by macOS.
 // As of Go 1.18, certificates are validated via the system
 // verifier and not in Go.

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -49,13 +49,9 @@ func SetupTLSConfig(config *tls.Config, cipherSuites []uint16) {
 		config.CipherSuites = cipherSuites
 	}
 
-	// Pick the servers preferred ciphersuite, not the clients.
-	config.PreferServerCipherSuites = true
-
 	config.MinVersion = tls.VersionTLS12
 	config.SessionTicketsDisabled = false
-	config.ClientSessionCache = tls.NewLRUClientSessionCache(
-		DefaultLRUCapacity)
+	config.ClientSessionCache = tls.NewLRUClientSessionCache(DefaultLRUCapacity)
 }
 
 // CreateTLSConfiguration sets up default TLS configuration

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -216,7 +216,7 @@ func (c *SessionContext) ClientTLSConfig(clusterName ...string) (*tls.Config, er
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		certPool, err = services.CertPoolFromCertAuthorities(certAuthorities)
+		certPool, _, err = services.CertPoolFromCertAuthorities(certAuthorities)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/tool/tctl/common/status_command.go
+++ b/tool/tctl/common/status_command.go
@@ -19,7 +19,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/teleport/api/constants"
@@ -94,7 +93,7 @@ func (c *StatusCommand) Status(ctx context.Context, client auth.ClientI) error {
 			if ca.GetClusterName() != clusterName {
 				continue
 			}
-			info := fmt.Sprintf("%v CA ", strings.Title(string(ca.GetType())))
+			info := fmt.Sprintf("%v CA ", string(ca.GetType()))
 			rotation := ca.GetRotation()
 			standbyPhase := rotation.Phase == types.RotationPhaseStandby || rotation.Phase == ""
 			if standbyPhase && len(ca.GetAdditionalTrustedKeys().SSH) > 0 {
@@ -133,7 +132,7 @@ func (c *StatusCommand) Status(ctx context.Context, client auth.ClientI) error {
 				if ca.GetClusterName() == clusterName {
 					continue
 				}
-				info := fmt.Sprintf("Remote %v CA %q", strings.Title(string(ca.GetType())), ca.GetClusterName())
+				info := fmt.Sprintf("Remote %v CA %q", string(ca.GetType()), ca.GetClusterName())
 				rotation := ca.GetRotation()
 				table.AddRow([]string{info, rotation.String()})
 			}

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -704,9 +704,6 @@ func TestIdentityRead(t *testing.T) {
 	conf, err := k.TeleportClientTLSConfig(nil, []string{"one"})
 	require.NoError(t, err)
 	require.NotNil(t, conf)
-
-	// ensure that at least root CA was successfully loaded
-	require.Greater(t, len(conf.RootCAs.Subjects()), 0)
 }
 
 func TestFormatConnectCommand(t *testing.T) {


### PR DESCRIPTION
Go 1.18 introduces new deprecations, which result in new lint warnings/errors.

Fix these now so that when we're ready to move to Go 1.18 we have less things to worry about.

Best reviewed commit-by-commit since each commit fixes a separate issue.