### PR TITLE
Add a toggle for FIDO2 integration

### DIFF
--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -76,7 +77,9 @@ var fidoNewDevice = func(path string) (FIDODevice, error) {
 
 // IsFIDO2Available returns true if libfido2 is available in the current build.
 func IsFIDO2Available() bool {
-	return true
+	val, ok := os.LookupEnv("TSH_FIDO2")
+	// Default to enabled, otherwise obey the env variable.
+	return !ok || val == "1"
 }
 
 // fido2Login implements FIDO2Login.

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -126,6 +127,48 @@ func (p *pinCancelPrompt) PromptPIN() (string, error) {
 
 func (p pinCancelPrompt) PromptTouch() {
 	// 2nd touch never happens
+}
+
+func TestIsFIDO2Available(t *testing.T) {
+	const fido2Key = "TSH_FIDO2"
+	defer func() {
+		os.Unsetenv(fido2Key)
+	}()
+
+	tests := []struct {
+		name   string
+		setenv func()
+		want   bool
+	}{
+		{
+			name: "TSH_FIDO2 unset",
+			setenv: func() {
+				os.Unsetenv(fido2Key)
+			},
+			want: true,
+		},
+		{
+			name: "TSH_FIDO2=1",
+			setenv: func() {
+				os.Setenv(fido2Key, "1")
+			},
+			want: true,
+		},
+		{
+			name: "TSH_FIDO2=0",
+			setenv: func() {
+				os.Setenv(fido2Key, "0")
+			},
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.setenv()
+			got := wancli.IsFIDO2Available()
+			require.Equal(t, test.want, got, "IsFIDO2Available")
+		})
+	}
 }
 
 func TestFIDO2Login(t *testing.T) {


### PR DESCRIPTION
Allow users to disable FIDO2 integration in `tsh` binaries that do have it. This is a safety toggle for cases where the libraries happen to cause problems, even though the binary loads and runs.

#9160