### PR TITLE
[branch/v9] Update teleport-plugin guides to reference docker images for downloads

### DIFF
--- a/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
@@ -82,19 +82,34 @@ In the webhook settings page, make sure that the webhook will only send Issue Up
 
 We recommend installing Teleport plugins alongside the Teleport Proxy. This is an ideal
 location as plugins have a low memory footprint, and will require both public internet access
-and Teleport Auth access. We currently only provide linux-amd64 binaries, you can also
-compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/jira).
+and Teleport Auth Service access. 
 
-```code
-$ wget https://get.gravitational.com/teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ cd teleport-access-jira/
-$ ./install
-$ which teleport-jira
-# /usr/local/bin/teleport-jira
-```
+<Tabs>
+<TabItem label="Download">
+  ```code
+  $ curl -L -O https://get.gravitational.com/teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ tar -xzf teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ cd teleport-access-jira
+  $ ./install
+  ```
+</TabItem>
+<TabItem label="From Source">
+  To install from source you need `git` and `go` installed. If you do not have Go installed, visit the Go [downloads page](https://go.dev/dl/).
 
-Run `./install` in from 'teleport-jira' or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
+  ```code
+  # Checkout teleport-plugins
+  $ git clone https://github.com/gravitational/teleport-plugins.git
+  $ cd teleport-plugins/access/jira
+  $ make
+  ```
+Run `./install` from `teleport-jira` or place the executable in `/usr/bin` or `/usr/local/bin` on the server installation.
+</TabItem>
+<TabItem label="Docker">
+  ```code
+  $ docker pull quay.io/gravitational/teleport-plugin-jira:(=teleport.plugin.version=)
+  ```
+</TabItem>
+</Tabs>
 
 ### Configuration file
 

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
@@ -94,22 +94,34 @@ Teleport Jira Plugin will listen for a webhook that Jira Server sends when a req
 
 We recommend installing Teleport plugins alongside the Teleport Proxy. This is an ideal
 location as plugins have a low memory footprint, and will require both public internet access
-and Teleport Auth access. We currently only provide linux-amd64 binaries, you can also
-compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/jira).
+and Teleport Auth Service access. 
 
-```code
-$ wget https://get.gravitational.com/teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ cd teleport-access-jira/
-$ sudo ./install
-# Teleport Jira Plugin binaries have been copied to /usr/local/bin
-# You can run teleport-jira configure > /etc/teleport-jira.toml to bootstrap your config file.
-$ which teleport-jira
-# /usr/local/bin/teleport-jira
-```
+<Tabs>
+<TabItem label="Download">
+  ```code
+  $ curl -L -O https://get.gravitational.com/teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ tar -xzf teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ cd teleport-access-jira
+  $ ./install
+  ```
+</TabItem>
+<TabItem label="From Source">
+  To install from source you need `git` and `go` installed. If you do not have Go installed, visit the Go [downloads page](https://go.dev/dl/).
 
-Run `sudo ./install` from 'teleport-jira' or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
-
+  ```code
+  # Checkout teleport-plugins
+  $ git clone https://github.com/gravitational/teleport-plugins.git
+  $ cd teleport-plugins/access/jira
+  $ make
+  ```
+Run `./install` from `teleport-jira` or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
+</TabItem>
+<TabItem label="Docker">
+  ```code
+  $ docker pull quay.io/gravitational/teleport-plugin-jira:(=teleport.plugin.version=)
+  ```
+</TabItem>
+</Tabs>
 
 ## Configuration file
 

--- a/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
@@ -73,19 +73,34 @@ We'll reference these files later when [configuring the plugins](#configuring-ma
 
 We recommend installing the Teleport Plugins alongside the Teleport Proxy. This is an ideal
 location as plugins have a low memory footprint, and will require both public internet access
-and Teleport Auth access. We currently only provide linux-amd64 binaries, you can also
-compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/mattermost).
+and Teleport Auth Service access. 
 
-```code
-$ wget https://get.gravitational.com/teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ cd teleport-access-mattermost
-$ ./install
-$ which teleport-mattermost
-# /usr/local/bin/teleport-mattermost
-```
+<Tabs>
+<TabItem label="Download">
+  ```code
+  $ curl -L -O https://get.gravitational.com/teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ tar -xzf teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ cd teleport-access-mattermost
+  $ ./install
+  ```
+</TabItem>
+<TabItem label="From Source">
+  To install from source you need `git` and `go` installed. If you do not have Go installed, visit the Go [downloads page](https://go.dev/dl/).
 
-Run `./install` in from 'teleport-mattermost' or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
+  ```code
+  # Checkout teleport-plugins
+  $ git clone https://github.com/gravitational/teleport-plugins.git
+  $ cd teleport-plugins/access/mattermost
+  $ make
+  ```
+Run `./install` from `teleport-mattermost` or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
+</TabItem>
+<TabItem label="Docker">
+  ```code
+  $ docker pull quay.io/gravitational/teleport-plugin-mattermost:(=teleport.plugin.version=)
+  ```
+</TabItem>
+</Tabs>
 
 ### Configuring Mattermost bot
 

--- a/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
@@ -49,19 +49,34 @@ In your PagerDuty dashboard, go to **Configuration → API Access → Create New
 
 We recommend installing Teleport plugins alongside the Teleport Proxy. This is an ideal
 location as plugins have a low memory footprint, and will require both public internet access
-and Teleport Auth access. We currently only provide linux-amd64 binaries, you can also
-compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/pagerduty).
+and Teleport Auth Service access. 
 
-```bash
-$ wget https://get.gravitational.com/teleport-access-pagerduty-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-pagerduty-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-$ cd teleport-access-pagerduty/
-$ ./install
-$ which teleport-pagerduty
-/usr/local/bin/teleport-pagerduty
-```
+<Tabs>
+<TabItem label="Download">
+  ```code
+  $ curl -L -O https://get.gravitational.com/teleport-access-pagerduty-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ tar -xzf teleport-access-pagerduty-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ cd teleport-access-pagerduty
+  $ ./install
+  ```
+</TabItem>
+<TabItem label="From Source">
+  To install from source you need `git` and `go` installed. If you do not have Go installed, visit the Go [downloads page](https://go.dev/dl/).
 
-Run `./install` in from 'teleport-pagerduty' or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
+  ```code
+  # Checkout teleport-plugins
+  $ git clone https://github.com/gravitational/teleport-plugins.git
+  $ cd teleport-plugins/access/pagerduty
+  $ make
+  ```
+Run `./install` from `teleport-pagerduty` or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
+</TabItem>
+<TabItem label="Docker">
+  ```code
+  $ docker pull quay.io/gravitational/teleport-plugin-pagerduty:(=teleport.plugin.version=)
+  ```
+</TabItem>
+</Tabs>
 
 ### Config file
 

--- a/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
@@ -93,14 +93,14 @@ compile these plugins from [source](https://github.com/gravitational/teleport-pl
 <Tabs>
 <TabItem label="Download">
   ```code
-  $ curl -L https://get.gravitational.com/teleport-access-slack-v(=teleport.version=)-linux-amd64-bin.tar.gz
-  $ tar -xzf teleport-access-slack-v(=teleport.version=)-linux-amd64-bin.tar.gz
+  $ curl -L -O https://get.gravitational.com/teleport-access-slack-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ tar -xzf teleport-access-slack-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
   $ cd teleport-access-slack
   $ ./install
   ```
 </TabItem>
 <TabItem label="From Source">
-  To install from source you need `git` and `go >= (=teleport.golang=)` installed.
+  To install from source you need `git` and `go` installed. If you do not have Go installed, visit the Go [downloads page](https://go.dev/dl/).
 
   ```code
   # Checkout teleport-plugins
@@ -108,11 +108,14 @@ compile these plugins from [source](https://github.com/gravitational/teleport-pl
   $ cd teleport-plugins/access/slack
   $ make
   ```
+Run `./install` from `teleport-slack` or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
+</TabItem>
+<TabItem label="Docker">
+  ```code
+  $ docker pull quay.io/gravitational/teleport-plugin-slack:(=teleport.plugin.version=)
+  ```
 </TabItem>
 </Tabs>
-
-
-Run `./install` from `teleport-slack` or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
 
 ### Configuring the Teleport Slack plugin
 

--- a/docs/pages/setup/guides/fluentd.mdx
+++ b/docs/pages/setup/guides/fluentd.mdx
@@ -85,15 +85,20 @@ from Teleport's events API, and forwards them to Fluentd.
 <Tabs>
   <TabItem label="Linux">
   ```code
-  $ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.version=)-linux-amd64-bin.tar.gz
-  $ tar -zxvf teleport-event-handler-v(=teleport.version=)-linux-amd64-bin.tar.gz
+  $ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
   ```
   </TabItem>
 
   <TabItem label="MacOS">
   ```code
-  $ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.version=)-darwin-amd64-bin.tar.gz
-  $ tar -zxvf teleport-event-handler-v(=teleport.version=)-linux-amd64-bin.tar.gz
+  $ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
+  $ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  ```
+  </TabItem>
+  <TabItem label="Docker">
+  ```code
+  $ docker pull quay.io/gravitational/teleport-plugin-event-handler:(=teleport.plugin.version=)
   ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Backports #11617 into `branch/v9`

