### PR TITLE
[v7] Extract tabbed Prerequisites into a partial

### DIFF
--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -13,8 +13,7 @@ with creating your own role.
 
 ## Prerequisites
 
-- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../cloud/introduction.mdx) >= (=teleport.version=)
-- [Tctl admin tool](https://goteleport.com/teleport/download) >= (=teleport.version=)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 (!docs/pages/includes/permission-warning.mdx!)
 

--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -13,14 +13,13 @@ Here are the most common scenarios:
 Let's set up Teleport's access requests to require approval of
 two team members for a privileged role `dbadmin`.
 
-<Admonition
+<Notice
   type="warning"
-  title="Version Warning"
 >
   This guide requires a commercial edition of Teleport. The open source
-  edition of Teleport only supports [Github](../../setup/admin/github-sso.mdx) as
+  edition of Teleport only supports [GitHub](../../setup/admin/github-sso.mdx) as
   an SSO provider.
-</Admonition>
+</Notice>
 
 <Admonition title="Note" type="tip">
   The steps below describe how to use Teleport with Mattermost. You can also [integrate with many other providers](../../enterprise/workflow/index.mdx).
@@ -28,8 +27,45 @@ two team members for a privileged role `dbadmin`.
 
 ## Prerequisites
 
-- Installed [Teleport Enterprise](../../enterprise/introduction.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
-- [Tctl enterprise admin tool](https://goteleport.com/teleport/download) >= (=teleport.version=)
+<Tabs>
+<TabItem
+  scope={["enterprise"]} label="Enterprise">
+
+- A running Teleport cluster. For details on how to set this up, see our Enterprise
+  [Getting Started](/docs/enterprise/getting-started) guide.
+
+- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=),
+  which you can download by visiting the
+  [customer portal](https://dashboard.gravitational.com/web/login).
+
+  ```code
+  $ tctl version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  
+  $ tsh version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  ```
+
+</TabItem>
+<TabItem scope={["cloud"]}
+  label="Teleport Cloud">
+
+- A Teleport Cloud account. If you do not have one, visit the
+  [sign up page](https://goteleport.com/signup/) to begin your free trial.
+
+- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
+  To download these tools, visit the [Downloads](/docs/cloud/downloads) page.
+
+  ```code
+  $ tctl version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  
+  $ tsh version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  ```
+
+</TabItem>
+</Tabs>
 - Mattermost installed.
 
 <Admonition

--- a/docs/pages/access-controls/guides/impersonation.mdx
+++ b/docs/pages/access-controls/guides/impersonation.mdx
@@ -15,8 +15,7 @@ non-interactive CI/CD user Jenkins and a security scanner.
 
 ## Prerequisites
 
-- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
-- [Tctl admin tool](https://goteleport.com/teleport/download) >= (=teleport.version=)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -28,8 +28,7 @@ A lock can target the following objects or attributes:
 
 ## Prerequisites
 
-- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
-- [Tctl admin tool](https://goteleport.com/teleport/download) >= (=teleport.version=)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -29,10 +29,27 @@ that protects users against compromises of their on-disk Teleport certificates.
 
 ## Prerequisites
 
-- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - [U2F configured](u2f.mdx) on this cluster
 - U2F hardware device, such as Yubikey or Solokey
 - Web browser that [supports U2F](https://caniuse.com/u2f) (if using SSH from the Teleport Web UI)
+
+(!docs/pages/includes/tctl.mdx!)
+
+<Admonition type="note" title="Per-session MFA with FIPS" scope="enterprise" scopeOnly>
+Teleport FIPS builds disable local users. To configure WebAuthn in order to use
+per-session MFA with FIPS builds, provide the following in your `teleport.yaml`:
+
+```yaml
+teleport:
+  auth_service:
+    local_auth: false
+    second_factor: optional
+    webauthn:
+      rp_id: teleport.example.com
+```
+</Admonition>
 
 ## Configuration
 

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -19,8 +19,7 @@ Let's explore how Teleport's role templates provide a way to describe these and 
 
 ## Prerequisites
 
-- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
-- [Tctl admin tool](https://goteleport.com/teleport/download) >= (=teleport.version=)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/access-controls/guides/u2f.mdx
+++ b/docs/pages/access-controls/guides/u2f.mdx
@@ -12,9 +12,12 @@ into individual SSH nodes or Kubernetes clusters (`tsh ssh` and `kubectl`).
 
 ## Prerequisites
 
-- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - U2F hardware device, such as Yubikey or Solokey
 - Web browser that [supports U2F](https://caniuse.com/u2f)
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Enable U2F support
 

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -1,0 +1,53 @@
+{/* 
+TODO: Since we can't control the directory level of the page that uses this
+partial, and it is currently not possible to include absolute paths to MDX 
+files in partials, this partial uses relative URL paths instead.
+*/}
+<Tabs>
+<TabItem scope={["oss"]} label="Open Source">
+
+- A running Teleport cluster. For details on how to set this up, see one of our
+  [Getting Started](/docs/getting-started) guides. 
+
+- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
+
+  ```code
+  $ tctl version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+
+  $ tsh version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  ```
+
+  See [Installation](/docs/installation.mdx) for details.
+
+</TabItem>
+<TabItem
+  scope={["enterprise"]} label="Enterprise">
+
+- A running Teleport cluster. For details on how to set this up, see our Enterprise
+  [Getting Started](/docs/enterprise/getting-started) guide.
+
+- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=),
+  which you can download by visiting the
+  [customer portal](https://dashboard.gravitational.com/web/login).
+
+  ```code
+  $ tctl version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  
+  $ tsh version
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  ```
+
+</TabItem>
+<TabItem scope={["cloud"]}
+  label="Teleport Cloud">
+
+- A Teleport Cloud account. If you do not have one, visit the
+  [sign up page](https://goteleport.com/signup/) to begin your free trial.
+- The `tctl` admin tool and `tsh` client tool. To download these tools, visit
+  the [Downloads](https://goteleport.com/download/) page.
+
+</TabItem>
+</Tabs>

--- a/docs/pages/kubernetes-access/getting-started/agent.mdx
+++ b/docs/pages/kubernetes-access/getting-started/agent.mdx
@@ -5,11 +5,7 @@ description: Connecting Kubernetes cluster to Teleport
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Open Source">
-
-- A running Teleport cluster. For details on how to set this up, see one of our
-  [Getting Started](../../getting-started.mdx) guides. 
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
   The following configuration options must be set in `/etc/teleport.yaml` on
   your Proxy Service host:
@@ -22,71 +18,6 @@ description: Connecting Kubernetes cluster to Teleport
   ```
 
 - The `jq` tool to process `JSON` output. This is available via common package managers.
-
-- The `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-  (!docs/pages/includes/tctl.mdx!)
-
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-
-- A running Teleport cluster. For details on how to set this up, see one of our
-  [Getting Started](../../getting-started.mdx) guides.
-
-  The following configuration options must be set in `/etc/teleport.yaml` on
-  your Proxy Service host:
-
-  ```yaml
-  proxy_service:
-    # ...
-    public_addr: proxy.example.com:3080
-    kube_listen_addr: 0.0.0.0:3026 
-  ```
-
-- The `jq` tool to process `JSON` output. This is available via common package managers.
-
-- The `tctl` admin tool version >= (=teleport.version=), which you can download
-  by visiting the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-
-  ```code
-  $ tctl version
-  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  (!docs/pages/includes/tctl.mdx!)
-
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Teleport Cloud">
-
-- A Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
-
-- The `jq` tool to process `JSON` output. This is available via common package
-  managers.
-
-- The `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-  (!docs/pages/includes/tctl.mdx!)
-
-</TabItem>
-</Tabs>
 
 (!docs/pages/includes/kubernetes-access/helm-k8s.mdx!)
 

--- a/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
+++ b/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
@@ -5,73 +5,21 @@ description: Connecting a Kubernetes cluster to Teleport.
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Open Source">
-
-- A Teleport cluster running on Kubernetes, version >=
-  v(=kubernetes.major_version=).(=kubernetes.minor_version=).0. We will assume
-  that you have followed the
-  [Kubernetes with SSO](../getting-started/cluster.mdx) guide
-- The `jq` tool to process `JSON` output. This is available via common package managers
-- An additional Kubernetes cluster version >=
-  v(=kubernetes.major_version=).(=kubernetes.minor_version=).0
-- Helm >= (=helm.version=)
-
-(!docs/pages/includes/helm.mdx!)
-
-
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-
-- A Teleport cluster running on Kubernetes, version >=
-  v(=kubernetes.major_version=).(=kubernetes.minor_version=).0. We will assume
-  that you have followed the
-  [Kubernetes with SSO](../getting-started/cluster.mdx) guide
-- The `jq` tool to process `JSON` output. This is available via common package managers
-- An additional Kubernetes cluster version >=
-  v(=kubernetes.major_version=).(=kubernetes.minor_version=).0
-- Helm >= (=helm.version=)
-
-(!docs/pages/includes/helm.mdx!)
-
-
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Teleport Cloud">
-
-- A Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - The Teleport Kubernetes Service running in a Kubernetes cluster, version >=
   v(=kubernetes.major_version=).(=kubernetes.minor_version=).0. We will assume
   that you have already followed
   [Connect a Kubernetes Cluster to Teleport](../getting-started/agent.mdx)
-
 - The `jq` tool to process `JSON` output. This is available via common package
   managers
-
-- The `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-  (!docs/pages/includes/tctl.mdx!)
-
 - An additional Kubernetes cluster version >=
   v(=kubernetes.major_version=).(=kubernetes.minor_version=).0
-
 - Helm >= (=helm.version=)
 
 (!docs/pages/includes/helm.mdx!)
 
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/tctl.mdx!)
 
 ## Connecting clusters
 

--- a/docs/pages/kubernetes-access/guides/standalone-teleport.mdx
+++ b/docs/pages/kubernetes-access/guides/standalone-teleport.mdx
@@ -11,64 +11,17 @@ Teleport needs a `kubeconfig` file to authenticate against the Kubernetes API.
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Open Source">
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- A running Teleport cluster. For details on how to set this up, see one of our
-  [Getting Started](../../getting-started.mdx) guides.
-
-- **Optional:** the `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-  (!docs/pages/includes/tctl.mdx!)
-
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-
-- A running Teleport cluster. For details on how to set this up, see one of our
-  [Getting Started](../../getting-started.mdx) guides.
-
-- **Optional:** the `tctl` admin tool version >= (=teleport.version=), which you can download
-  by visiting the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  (!docs/pages/includes/tctl.mdx!)
-
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Teleport Cloud">
-
-- A Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
+- A Kubernetes cluster you would like to access.
 
 - A host deployed on your own infrastructure to run the Teleport Kubernetes
-  Service. See [Installing Teleport](../../installation.mdx) for more details.
+  Service. This can run outside of your Kubernetes cluster. 
+  
+  See [Installing Teleport](../../installation.mdx) for details on installing
+  the `teleport` binary.
 
-- **Optional:** The `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-  (!docs/pages/includes/tctl.mdx!)
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/2. Generate a kubeconfig
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -25,52 +25,10 @@ This guide introduces some of these common scenarios and how to interact with Te
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Self-Hosted">
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- A running Teleport cluster, version >= (=teleport.version=). For details on how to set this up,
-  see [Getting Started on a Linux
-  Server](../getting-started/linux-server.mdx).
-
-- One host running your favorite Linux environment (such as Ubuntu 20.04, CentOS
-  8.0-1905, or Debian 10). This will serve as a Teleport Server Access Node.
-
-- The `tsh` client tool version >= (=teleport.version=).
-
-  See [Installation](../installation.mdx) for details.
-
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-
-- A running Teleport cluster, version >= (=teleport.version=). For details on setting this up, see
-  our [Enterprise getting started guide](../enterprise/getting-started.mdx).
-
-- One host running your favorite Linux environment (such as Ubuntu 20.04, CentOS
-  8, or Debian 10). This will serve as a Teleport Server Access Node.
-  
-- The `tsh` client tool version >= (=teleport.version=).
-
-  You can download this by visiting the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-
-
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Teleport Cloud">
-
-- A Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
-
-- One host running your favorite Linux environment (such as Ubuntu 20.04, CentOS
-  8.0-1905, or Debian 10). This will serve as a Teleport Server Access Node.
-  
-- The `tsh` and `tctl` client tools version >= (=teleport.version=).
-
-  See [Installation](../installation.mdx) for details.
-
-</TabItem>
-</Tabs>
+- One host running a Linux environment (such as Ubuntu 20.04, CentOS
+  8.0, or Debian 10). This will serve as a Teleport Node.
 
 (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -30,7 +30,10 @@ Teleport Enhanced Session Recording mitigates all three concerns by providing ad
 
 ## Prerequisites
 
-Teleport 7.0+ with Enhanced Session Recording requires Linux kernel 5.8 (or above).
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+- At least one host that you will use to run the Teleport Node Service. The host
+  must run Linux kernel 5.8 (or above).
 
   You can check your kernel version using the `uname` command. The output should look
   something like the following.

--- a/docs/pages/server-access/guides/restricted-session.mdx
+++ b/docs/pages/server-access/guides/restricted-session.mdx
@@ -11,15 +11,17 @@ Teleport supports network restrictions with more types coming in the future.
 
 ## Prerequisites
 
-Teleport 7.0+ with Restricted Sessions requires Linux kernel 5.8 (or above).
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-You can check your kernel version using the `uname` command. The output should look
-something like the following.
+- Linux kernel 5.8 (or above).
 
-```code
-$ uname -r
-# 5.8.17
-```
+  You can check your kernel version using the `uname` command. The output should look
+  something like the following.
+
+  ```code
+  $ uname -r
+  # 5.8.17
+  ```
 
 Follow our [installation instructions](../../installation.mdx) to install the Teleport Auth, Proxy
 and Nodes.

--- a/docs/pages/server-access/guides/vscode.mdx
+++ b/docs/pages/server-access/guides/vscode.mdx
@@ -8,27 +8,14 @@ This guide explains how to use Teleport and Visual Studio Code's remote SSH exte
 
 ## Prerequisites
 
-- [tsh client tool](https://goteleport.com/teleport/download) >= (=teleport.version=).
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - OpenSSH client.
-- Visual Studio Code with the [Remote - SSH extension](https://code.visualstudio.com/docs/remote/ssh#_system-requirements).
-- The Teleport Auth Service and Proxy Service, deployed on your own infrastructure or managed via Teleport Cloud.
-- One or more Teleport Nodes with Server Access enabled. If you have not yet done this, read the [Server Access Getting Started Guide](../getting-started.mdx) to learn how.
-
-<Details 
-scopeOnly={true}
-scope={["oss", "enterprise"]}
-opened={false}
-title="Haven't deployed the Auth and Proxy Services?" >
-Follow one of our [getting started](../getting-started.mdx) guides to learn how to deploy the Teleport Auth Service and Proxy Service in your environment.
-</Details>
-
-<Details 
-scopeOnly={true}
-scope={["cloud"]}
-opened={false}
-title="Not yet a Teleport customer?" >
-Sign up for a [free trial](/signup/) of Teleport Cloud to get started.
-</Details>
+- Visual Studio Code with the [Remote - SSH extension](https://code.visualstudio.com/docs/remote/ssh#_system-requirements)
+for the Remote - SSH extension.
+- One or more Teleport Nodes with Server Access enabled. If you have not yet
+  done this, read the
+  [Server Access Getting Started Guide](../getting-started.mdx) to learn how.
 
 <Admonition type="note">
 Linux and MacOS clients should rely on their operating system-provided OpenSSH

--- a/docs/pages/setup/admin/adding-nodes.mdx
+++ b/docs/pages/setup/admin/adding-nodes.mdx
@@ -7,27 +7,7 @@ This guide explains how to add Teleport Nodes to your cluster.
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Self-Hosted">
-Install Teleport and the `tctl` admin tool version >= (=teleport.version=).
-
-See [Installation](../../installation.mdx) for details.
-
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-Install Teleport and the `tctl` admin tool version >= (=teleport.version=).
-
-To download Teleport Enterprise, visit the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Cloud">
-
-Sign up for a Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
-</TabItem>
-</Tabs>
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/setup/admin/github-sso.mdx
+++ b/docs/pages/setup/admin/github-sso.mdx
@@ -8,11 +8,7 @@ This guide explains how to set up Github Single Sign On (SSO) for Teleport.
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Self-Hosted">
-- Install Teleport and the `tctl` admin tool version >= (=teleport.version=).
-
-  See [Installation](../../installation.mdx) for details.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - Create and register a GitHub OAuth App. To do so, follow the instructions in
   GitHub's documentation.
@@ -21,40 +17,7 @@ This guide explains how to set up Github Single Sign On (SSO) for Teleport.
 
   Ensure that your OAuth App's "Authentication callback URL" is
   `https://PROXY_ADDRESS/v1/webapi/github/`, where `PROXY_ADDRESS` is the public
-  address of the Teleport Proxy Service. 
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-- Install Teleport and the `tctl` admin tool version >= (=teleport.version=).
-
-  To download Teleport Enterprise, visit the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-  
-- Create and register a GitHub OAuth App. To do so, follow the instructions in
-  GitHub's documentation.
-
-  [Creating an OAuth App](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app)
-
-  Ensure that your OAuth App's "Authentication callback URL" is
-  `https://PROXY_ADDRESS/v1/webapi/github/`, where `PROXY_ADDRESS` is the public
-  address of the Teleport Proxy Service. 
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Cloud">
-
-- Sign up for a Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
-
-- Create and register a GitHub OAuth App. To do so, follow the instructions in GitHub's documentation. 
-
-  [Creating an OAuth App](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app)
-
-  Ensure that your OAuth App's "Authentication callback URL" is
-  `https://PROXY_ADDRESS/v1/webapi/github/`, where `PROXY_ADDRESS` is the domain
-  name of your Teleport Cloud tenant (e.g., mytenant.teleport.sh).
-
-</TabItem>
-</Tabs>
+  address of the Teleport Proxy Service.
 
 (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/setup/admin/labels.mdx
+++ b/docs/pages/setup/admin/labels.mdx
@@ -7,8 +7,7 @@ This guide explains how to label Teleport Nodes.
 
 ## Prerequisites
 
-- Installed [Teleport](../../getting-started.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
-- [Tctl admin tool](https://goteleport.com/teleport/download) >= (=teleport.version=)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/setup/admin/users.mdx
+++ b/docs/pages/setup/admin/users.mdx
@@ -7,8 +7,7 @@ This guide explains how to invite users and manage local user accounts.
 
 ## Prerequisites
 
-- Installed [Teleport](../../getting-started.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
-- [Tctl admin tool](https://goteleport.com/teleport/download) >= (=teleport.version=)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/setup/guides/ec2-tags.mdx
+++ b/docs/pages/setup/guides/ec2-tags.mdx
@@ -8,8 +8,9 @@ This section will explain how to setup Teleport node labels based on EC2 tags.
 
 ## Prerequisites
 
-- Teleport v(=teleport.version=) Open Source or Enterprise.
-- AWS instance running Teleport
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+- An AWS EC2 instance running a Teleport node
 
 ## Step 1/3. Deploy the script
 

--- a/docs/pages/setup/guides/fluentd.mdx
+++ b/docs/pages/setup/guides/fluentd.mdx
@@ -10,64 +10,12 @@ In this guide, we will explain how to:
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Self-Hosted">
-
-- A running Teleport cluster. For details on how to set this up, see [Getting
-  Started on a Linux Server](../../getting-started/linux-server.mdx).
-
-- The `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-  (!docs/pages/includes/tctl.mdx!)
-
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-
-- A running Teleport cluster. For details on setting this up, see our
-  [Enterprise getting started guide](../../enterprise/getting-started.mdx).
-
-- The `tctl` admin tool version >= (=teleport.version=), which you can download
-  by visiting the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  (!docs/pages/includes/tctl.mdx!)
-
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Teleport Cloud">
-
-- A Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
-
-- The `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-  (!docs/pages/includes/tctl.mdx!)
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - Fluentd version v(=fluentd.version=).
 - Docker version v(=docker.version=).
+
+(!docs/pages/includes/tctl.mdx!)
 
 Create a folder called `fluentd` to hold configuration and plugin state:
 

--- a/docs/pages/setup/guides/terraform-provider.mdx
+++ b/docs/pages/setup/guides/terraform-provider.mdx
@@ -11,22 +11,7 @@ This guide will explain how to:
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Self-Hosted">
-
-- A running Teleport cluster. For details on how to set this up, see [Getting
-  Started on a Linux Server](../../getting-started/linux-server.mdx).
-
-- The `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-  (!docs/pages/includes/tctl.mdx!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 
@@ -35,60 +20,9 @@ This guide will explain how to:
   # Terraform v(=terraform.version=)
   ```
 
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
+(!docs/pages/includes/tctl.mdx!)
 
-- A running Teleport cluster. For details on setting this up, see our
-  [Enterprise getting started guide](../../enterprise/getting-started.mdx).
-
-- The `tctl` admin tool version >= (=teleport.version=), which you can download
-  by visiting the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  (!docs/pages/includes/tctl.mdx!)
-
-- [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
-
-  ```code
-  $ terraform version
-  # Terraform v(=terraform.version=)
-  ```
-
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Cloud">
-
-- A Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
-
-- The Enterprise version of the `tctl` admin tool. To download this, visit
-the [customer portal](https://dashboard.gravitational.com/web/login).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  (!docs/pages/includes/tctl.mdx!)
-
-- [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
-
-  ```code
-  $ terraform version
-  # Terraform v(=terraform.version=)
-  ```
-
-</TabItem>
-</Tabs>
-
-
-Create a folder `teleport-terraform` to hold some temporary files:
+Create a folder called `teleport-terraform` to hold some temporary files:
 
 ```code
 $ mkdir -p teleport-terraform

--- a/docs/pages/setup/operations/ca-rotation.mdx
+++ b/docs/pages/setup/operations/ca-rotation.mdx
@@ -5,57 +5,9 @@ description: How to rotate Teleport's certificate authority
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Self-Hosted">
-
-- A running Teleport cluster. For details on how to set this up, see [Getting
-  Started on a Linux Server](../../getting-started/linux-server.mdx).
-
-- The `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-
-- A running Teleport cluster. For details on setting this up, see our
-  [Enterprise getting started guide](../../enterprise/getting-started.mdx).
-
-- The `tctl` admin tool version >= (=teleport.version=), which you can download
-  by visiting the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Cloud">
-
-- A Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
-
-- The Enterprise version of the `tctl` admin tool. To download this, visit
-the [customer portal](https://dashboard.gravitational.com/web/login).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 (!docs/pages/includes/tctl.mdx!)
-
 
 ## Certificate Authority rotation
 


### PR DESCRIPTION
Backports #11710

While editing guides in certain sections to accommodate Cloud users
(#10631), I introduced some inconsistencies into the way the
Prerequisites sections in these guides provide instructions for users
of Cloud, Open Source, and Enterprise Teleport.

This change adds a partial that provides tabbed instructions to users
of different Teleport editions when a guide requires a running Auth and
Proxy Service. It then includes this partial where relevant in guides
that fall under the scope of #10631.

This helps ensure that cross-edition instructions are consistent in our
guides, and makes it easier to edit additional guides to accommodate
users of different editions.

Caveats:

- Since this change covers a lot of guides, it aims to be as small as
  possible. While all of these guides included links in their
  Prerequisites sections, for example, replacing these links with full
  instructions was out of the scope of this guide. This change should
  still make it easier to make further edits, e.g., in response to
  #11538.

- We still need to change other elements of some guides to accommodate
  Cloud users. The current change only aims to standardize the
  Prerequisites section.