### PR TITLE
feat(helm): allow exposing extra ports in service

### DIFF
--- a/examples/chart/teleport-cluster/templates/service.yaml
+++ b/examples/chart/teleport-cluster/templates/service.yaml
@@ -57,5 +57,8 @@ spec:
     protocol: TCP
   {{- end }}
   {{- end }}
+  {{- with .Values.service.extraPorts }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   selector:
     app: {{ .Release.Name }}

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -239,6 +239,11 @@ service:
   # Additional entries here will be added to the service spec.
   spec: {}
     # loadBalancerIP: "1.2.3.4"
+  extraPorts: []
+  # - name: diag
+  #   port: 3000
+  #   targetPort: 3000
+  #   protocol: TCP
 
 # Extra arguments to pass to 'teleport start' for the main Teleport pod
 extraArgs: []


### PR DESCRIPTION
Hello,

This pull request is an attempt to discuss a new feature request. I preferred opening a pull request instead of an issue to discuss on an actual example. I have already tested the proposed changes.

I want to expose additional ports on the Service. Specifically, I need to expose the diagnostic port (hardcoded at `3000` in your deployment).
I deploy the service as `type: "ClusterIP"` and then use an Ingress to expose it. I've chosen this solution because I deploy it on GKE, and I have a GKE-specific ingress that provides an SSL certificate and other helpful features. Among those, it checks for the service healthiness and eventually diverts traffic from it while Kubernetes is recovering it. Unfortunately, you don't expose the diagnostic port on which runs the `/healthz` endpoint, and I can't use any public path (such as `/webapi/ping`) because they all answer with a redirect.

If you allow exposing extra ports, I can expose port 3000 and use it for my GCP health check.

This feature is not breaking, as it's fully backward compatible and doesn't expose any additional port unless you override the default value.

@webvictim 