### PR TITLE
[v9] Backport  "Document Okta OIDC provider workaround" (#11948)

### DIFF
--- a/docs/pages/enterprise/sso.mdx
+++ b/docs/pages/enterprise/sso.mdx
@@ -150,6 +150,7 @@ values to match your identity provider:
   the [OIDC guide](./sso/oidc.mdx#optional-acr-values) for details.
 - `ping` (SAML and OIDC): Required for compatibility with Ping Identity (including
   PingOne and PingFederate).
+- `okta` (OIDC): Required when using Okta as an OIDC provider.
 
 At this time, the `spec.provider` field should not be set for any other identity providers.
 


### PR DESCRIPTION
This is the docs counterpart to #11718

Backports #11948