### PR TITLE
[v8] Backport: docs: Don't lint external links (#11940)

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -419,7 +419,7 @@ docsbox:
 .PHONY:test-docs
 test-docs: docsbox
 	docker run --platform=linux/amd64 -i $(NOROOT) -v $$(pwd)/..:/src/content $(DOCSBOX) \
-		/bin/sh -c "yarn markdown-lint-external-links"
+		/bin/sh -c "yarn markdown-lint"
 
 #
 # Builds assets needed by CentOS 6 in a container.


### PR DESCRIPTION
Backports #11940 to `branch/v8`