### PR TITLE
[v7] Backport: docs: Don't lint external links (#11940)

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -332,5 +332,5 @@ docsbox:
 .PHONY: test-docs
 test-docs: DOCS_VERSION := $(shell grep -E ^VERSION $(MAKEFILE_ROOT_DIR)/Makefile | cut -d= -f2 | cut -d. -f1-2)
 test-docs: docsbox
-	docker run -i $(NOROOT) -v $$(pwd)/..:/src/content/$(DOCS_VERSION) $(DOCSBOX) \
-		/bin/sh -c "yarn markdown-lint-external-links"
+	docker run --platform=linux/amd64 -i $(NOROOT) -v $$(pwd)/..:/src/content $(DOCSBOX) \
+		/bin/sh -c "yarn markdown-lint"


### PR DESCRIPTION
Backports #11940 to `branch/v7`