### PR TITLE
Do not sync Database CA if leaf 9.0

### DIFF
--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -428,7 +428,7 @@ func (s *remoteSite) compareAndSwapCertAuthority(ca types.CertAuthority) error {
 	return trace.CompareFailed("remote certificate authority rotation has been updated")
 }
 
-func (s *remoteSite) updateCertAuthorities(retry utils.Retry) {
+func (s *remoteSite) updateCertAuthorities(retry utils.Retry, remoteClusterVersion string) {
 	s.Debugf("Watching for cert authority changes.")
 
 	for {
@@ -441,7 +441,7 @@ func (s *remoteSite) updateCertAuthorities(retry utils.Retry) {
 			return
 		}
 
-		err := s.watchCertAuthorities()
+		err := s.watchCertAuthorities(remoteClusterVersion)
 		if err != nil {
 			switch {
 			case trace.IsNotFound(err):
@@ -460,7 +460,21 @@ func (s *remoteSite) updateCertAuthorities(retry utils.Retry) {
 	}
 }
 
-func (s *remoteSite) watchCertAuthorities() error {
+func (s *remoteSite) watchCertAuthorities(remoteClusterVersion string) error {
+	localWatchedTypes := []types.CertAuthType{types.HostCA, types.UserCA}
+
+	// Delete in 11.0.
+	ver10orAbove, err := utils.MinVerWithoutPreRelease(remoteClusterVersion, "10.0.0")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if ver10orAbove {
+		localWatchedTypes = append(localWatchedTypes, types.DatabaseCA)
+	} else {
+		s.Debugf("connected to remote cluster in version %s. Database CA won't be propagated.", remoteClusterVersion)
+	}
+
 	localWatcher, err := services.NewCertAuthorityWatcher(s.ctx, services.CertAuthorityWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentProxy,
@@ -468,7 +482,7 @@ func (s *remoteSite) watchCertAuthorities() error {
 			Clock:     s.clock,
 			Client:    s.localAccessPoint,
 		},
-		WatchCertTypes: []types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA},
+		WatchCertTypes: localWatchedTypes,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -503,8 +517,7 @@ func (s *remoteSite) watchCertAuthorities() error {
 		case cas := <-localWatcher.CertAuthorityC:
 			for _, localCA := range cas {
 				if localCA.GetClusterName() != s.srv.ClusterName ||
-					(localCA.GetType() != types.HostCA &&
-						localCA.GetType() != types.UserCA && localCA.GetType() != types.DatabaseCA) {
+					!localWatcher.IsWatched(localCA.GetType()) {
 					continue
 				}
 

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -464,7 +464,7 @@ func (s *remoteSite) watchCertAuthorities(remoteClusterVersion string) error {
 	localWatchedTypes := []types.CertAuthType{types.HostCA, types.UserCA}
 
 	// Delete in 11.0.
-	ver10orAbove, err := utils.MinVerWithoutPreRelease(remoteClusterVersion, "10.0.0")
+	ver10orAbove, err := utils.MinVerWithoutPreRelease(remoteClusterVersion, constants.DatabaseCAMinVersion)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/reversetunnel/remotesite_test.go
+++ b/lib/reversetunnel/remotesite_test.go
@@ -1,0 +1,68 @@
+/*
+
+ Copyright 2022 Gravitational, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
+
+package reversetunnel
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_remoteSite_getLocalWatchedCerts(t *testing.T) {
+	tests := []struct {
+		name           string
+		clusterVersion string
+		want           []types.CertAuthType
+		wantErr        bool
+	}{
+		{
+			name:           "pre Database CA, only Host and User CA",
+			clusterVersion: "9.0.0",
+			want:           []types.CertAuthType{types.HostCA, types.UserCA},
+		},
+		{
+			name:           "all certs should be returned",
+			clusterVersion: "10.0.0",
+			want:           []types.CertAuthType{types.HostCA, types.UserCA, types.DatabaseCA},
+		},
+		{
+			name:           "invalid version",
+			clusterVersion: "foo",
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &remoteSite{
+				Entry: log.NewEntry(utils.NewLoggerForTests()),
+			}
+			got, err := s.getLocalWatchedCerts(tt.clusterVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getLocalWatchedCerts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1115,7 +1115,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 		return nil, trace.Wrap(err)
 	}
 
-	go remoteSite.updateCertAuthorities(caRetry)
+	go remoteSite.updateCertAuthorities(caRetry, remoteVersion)
 
 	lockRetry, err := utils.NewLinear(utils.LinearConfig{
 		First:  utils.HalfJitter(srv.Config.PollingPeriod),

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -943,6 +943,16 @@ func (cfg *CertAuthorityWatcherConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
+// IsWatched return true if the given certificate auth type is being observer by the watcher.
+func (cfg *CertAuthorityWatcherConfig) IsWatched(certType types.CertAuthType) bool {
+	for _, observedType := range cfg.WatchCertTypes {
+		if observedType == certType {
+			return true
+		}
+	}
+	return false
+}
+
 // NewCertAuthorityWatcher returns a new instance of CertAuthorityWatcher.
 func NewCertAuthorityWatcher(ctx context.Context, cfg CertAuthorityWatcherConfig) (*CertAuthorityWatcher, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {


### PR DESCRIPTION
When in an existing trusted cluster the root cluster is being updated to v10 this warning message shows in the logs, as leaf still being in v9 doesn't know about Database CA introduced in v10:
```
2022-04-18T15:09:07-04:00 WARN [PROXY:SER] Failed to rotate external ca error:[
ERROR REPORT:
Original Error: *trace.BadParameterError &#39;db&#39; authority type is not supported
Stack Trace:

Caught:
	/home/jnyckowski/projects/teleport/lib/httplib/httplib.go:142 github.com/gravitational/teleport/lib/httplib.ConvertResponse
	/home/jnyckowski/projects/teleport/lib/auth/clt.go:273 github.com/gravitational/teleport/lib/auth.(*Client).PostJSON
	/home/jnyckowski/projects/teleport/lib/auth/clt.go:439 github.com/gravitational/teleport/lib/auth.(*Client).RotateExternalCertAuthority
	/home/jnyckowski/projects/teleport/lib/reversetunnel/remotesite.go:502 github.com/gravitational/teleport/lib/reversetunnel.(*remoteSite).watchCertAuthorities
	/home/jnyckowski/projects/teleport/lib/reversetunnel/remotesite.go:435 github.com/gravitational/teleport/lib/reversetunnel.(*remoteSite).updateCertAuthorities
	/home/jnyckowski/sdk/go1.18/src/runtime/asm_amd64.s:1571 runtime.goexit
User Message: &#39;db&#39; authority type is not supported
] cluster:example.com reversetunnel/remotesite.go:503
```

This PR add a version check to skip the Database CA sync if the leaf is in the lower version then v10, so this warning is not being printed.