### PR TITLE
[v9] Add JSON and YAML to several tsh commands (#11681)

### DIFF
--- a/lib/utils/jsontools.go
+++ b/lib/utils/jsontools.go
@@ -90,6 +90,17 @@ func FastMarshal(v interface{}) ([]byte, error) {
 	return data, nil
 }
 
+// FastMarshal uses the json-iterator library for fast JSON marshalling
+// with indentation. Note, this function unmarshals floats with 6 digits precision.
+func FastMarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	data, err := SafeConfig.MarshalIndent(v, prefix, indent)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return data, nil
+}
+
 const yamlDocDelimiter = "---"
 
 // WriteYAML detects whether value is a list

--- a/tool/tsh/access_request.go
+++ b/tool/tsh/access_request.go
@@ -17,18 +17,19 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
 )
@@ -100,21 +101,34 @@ func onRequestList(cf *CLIConf) error {
 		}
 		reqs = filtered
 	}
-	switch cf.Format {
-	case teleport.Text:
+
+	format := strings.ToLower(cf.Format)
+	switch format {
+	case teleport.Text, "":
 		if err := showRequestTable(reqs); err != nil {
 			return trace.Wrap(err)
 		}
-	case teleport.JSON:
-		ser, err := json.MarshalIndent(reqs, "", "  ")
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeAccessRequests(reqs, format)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("%s\n", ser)
+		fmt.Println(out)
 	default:
 		return trace.BadParameter("unsupported format %q", cf.Format)
 	}
 	return nil
+}
+
+func serializeAccessRequests(reqs []types.AccessRequest, format string) (string, error) {
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(reqs, "", "  ")
+	} else {
+		out, err = yaml.Marshal(reqs)
+	}
+	return string(out), trace.Wrap(err)
 }
 
 func onRequestShow(cf *CLIConf) error {
@@ -136,6 +150,37 @@ func onRequestShow(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
+	format := strings.ToLower(cf.Format)
+	switch format {
+	case teleport.Text, "":
+		err = printRequest(req)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeAccessRequest(req, format)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(out)
+	default:
+		return trace.BadParameter("unsupported format %q", cf.Format)
+	}
+	return nil
+}
+
+func serializeAccessRequest(req types.AccessRequest, format string) (string, error) {
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(req, "", "  ")
+	} else {
+		out, err = yaml.Marshal(req)
+	}
+	return string(out), trace.Wrap(err)
+}
+
+func printRequest(req types.AccessRequest) error {
 	reason := "[none]"
 	if r := req.GetRequestReason(); r != "" {
 		reason = fmt.Sprintf("%q", r)
@@ -154,7 +199,7 @@ func onRequestShow(cf *CLIConf) error {
 	table.AddRow([]string{"Reviewers:", reviewers + " (suggested)"})
 	table.AddRow([]string{"Status:", req.GetState().String()})
 
-	_, err = table.AsBuffer().WriteTo(os.Stdout)
+	_, err := table.AsBuffer().WriteTo(os.Stdout)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/help.go
+++ b/tool/tsh/help.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package main
 
+import (
+	"fmt"
+	"strings"
+)
+
 const (
 	// loginUsageFooter is printed at the bottom of `tsh help login` output
 	loginUsageFooter = `NOTES:
@@ -34,3 +39,8 @@ EXAMPLES:
   Select cluster "two" using existing credentials and proxy:
   $ tsh login two`
 )
+
+// formatFlagDescription creates the description for the --format flag.
+func formatFlagDescription(formats ...string) string {
+	return fmt.Sprintf("Format output (%s)", strings.Join(formats, ", "))
+}

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -28,7 +28,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/gravitational/kingpin"
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -41,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
+	"github.com/gravitational/teleport/lib/utils"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -462,12 +465,14 @@ func (c *kubeExecCommand) run(cf *CLIConf) error {
 
 type kubeSessionsCommand struct {
 	*kingpin.CmdClause
+	format string
 }
 
 func newKubeSessionsCommand(parent *kingpin.CmdClause) *kubeSessionsCommand {
 	c := &kubeSessionsCommand{
 		CmdClause: parent.Command("sessions", "Get a list of active kubernetes sessions."),
 	}
+	c.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&c.format, defaultFormats...)
 
 	return c
 }
@@ -494,8 +499,31 @@ func (c *kubeSessionsCommand) run(cf *CLIConf) error {
 		return filteredSessions[i].GetCreated().Before(filteredSessions[j].GetCreated())
 	})
 
-	printSessions(filteredSessions)
+	format := strings.ToLower(c.format)
+	switch format {
+	case teleport.Text, "":
+		printSessions(filteredSessions)
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeKubeSessions(sessions, format)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(out)
+	default:
+		return trace.BadParameter("unsupported format %q", c.format)
+	}
 	return nil
+}
+
+func serializeKubeSessions(sessions []types.SessionTracker, format string) (string, error) {
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(sessions, "", "  ")
+	} else {
+		out, err = yaml.Marshal(sessions)
+	}
+	return string(out), trace.Wrap(err)
 }
 
 func printSessions(sessions []types.SessionTracker) {
@@ -505,7 +533,7 @@ func printSessions(sessions []types.SessionTracker) {
 	}
 
 	output := table.AsBuffer().String()
-	print(output)
+	fmt.Println(output)
 }
 
 type kubeCredentialsCommand struct {
@@ -603,6 +631,7 @@ type kubeLSCommand struct {
 	labels         string
 	predicateExpr  string
 	searchKeywords string
+	format         string
 }
 
 func newKubeLSCommand(parent *kingpin.CmdClause) *kubeLSCommand {
@@ -611,6 +640,7 @@ func newKubeLSCommand(parent *kingpin.CmdClause) *kubeLSCommand {
 	}
 	c.Flag("search", searchHelp).StringVar(&c.searchKeywords)
 	c.Flag("query", queryHelp).StringVar(&c.predicateExpr)
+	c.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&c.format, defaultFormats...)
 	c.Arg("labels", labelHelp).StringVar(&c.labels)
 	return c
 }
@@ -630,23 +660,53 @@ func (c *kubeLSCommand) run(cf *CLIConf) error {
 	}
 
 	selectedCluster := selectedKubeCluster(currentTeleportCluster)
-
-	var t asciitable.Table
-	if cf.Quiet {
-		t = asciitable.MakeHeadlessTable(2)
-	} else {
-		t = asciitable.MakeTable([]string{"Kube Cluster Name", "Selected"})
-	}
-	for _, cluster := range kubeClusters {
-		var selectedMark string
-		if cluster == selectedCluster {
-			selectedMark = "*"
+	format := strings.ToLower(c.format)
+	switch format {
+	case teleport.Text, "":
+		var t asciitable.Table
+		if cf.Quiet {
+			t = asciitable.MakeHeadlessTable(2)
+		} else {
+			t = asciitable.MakeTable([]string{"Kube Cluster Name", "Selected"})
 		}
-		t.AddRow([]string{cluster, selectedMark})
+		for _, cluster := range kubeClusters {
+			var selectedMark string
+			if cluster == selectedCluster {
+				selectedMark = "*"
+			}
+			t.AddRow([]string{cluster, selectedMark})
+		}
+		fmt.Println(t.AsBuffer().String())
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeKubeClusters(kubeClusters, selectedCluster, format)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(out)
+	default:
+		return trace.BadParameter("unsupported format %q", cf.Format)
 	}
-	fmt.Println(t.AsBuffer().String())
 
 	return nil
+}
+
+func serializeKubeClusters(kubeClusters []string, selectedCluster, format string) (string, error) {
+	type cluster struct {
+		KubeClusterName string `json:"kube_cluster_name"`
+		Selected        bool   `json:"selected"`
+	}
+	clusterInfo := make([]cluster, 0, len(kubeClusters))
+	for _, cl := range kubeClusters {
+		clusterInfo = append(clusterInfo, cluster{cl, cl == selectedCluster})
+	}
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(clusterInfo, "", "  ")
+	} else {
+		out, err = yaml.Marshal(clusterInfo)
+	}
+	return string(out), trace.Wrap(err)
 }
 
 func selectedKubeCluster(currentTeleportCluster string) string {

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -28,13 +28,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/gravitational/kingpin"
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/u2f"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/prompt"
 	"github.com/gravitational/trace"
 	"github.com/pquerna/otp"
@@ -72,6 +75,7 @@ func newMFACommand(app *kingpin.Application) mfaCommands {
 type mfaLSCommand struct {
 	*kingpin.CmdClause
 	verbose bool
+	format  string
 }
 
 func newMFALSCommand(parent *kingpin.CmdClause) *mfaLSCommand {
@@ -79,6 +83,7 @@ func newMFALSCommand(parent *kingpin.CmdClause) *mfaLSCommand {
 		CmdClause: parent.Command("ls", "Get a list of registered MFA devices"),
 	}
 	c.Flag("verbose", "Print more information about MFA devices").Short('v').BoolVar(&c.verbose)
+	c.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&c.format, defaultFormats...)
 	return c
 }
 
@@ -114,8 +119,32 @@ func (c *mfaLSCommand) run(cf *CLIConf) error {
 	// Sort by name before printing.
 	sort.Slice(devs, func(i, j int) bool { return devs[i].GetName() < devs[j].GetName() })
 
-	printMFADevices(devs, c.verbose)
+	format := strings.ToLower(c.format)
+	switch format {
+	case teleport.Text, "":
+		printMFADevices(devs, c.verbose)
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeMFADevices(devs, format)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(out)
+	default:
+		return trace.BadParameter("unsupported format %q", c.format)
+	}
+
 	return nil
+}
+
+func serializeMFADevices(devs []*types.MFADevice, format string) (string, error) {
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(devs, "", "  ")
+	} else {
+		out, err = yaml.Marshal(devs)
+	}
+	return string(out), trace.Wrap(err)
 }
 
 func printMFADevices(devs []*types.MFADevice, verbose bool) {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -41,6 +40,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/asciitable"
@@ -64,6 +64,7 @@ import (
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
+	"github.com/ghodss/yaml"
 	gops "github.com/google/gops/agent"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
@@ -369,6 +370,9 @@ const (
 // cliOption is used in tests to inject/override configuration within Run
 type cliOption func(*CLIConf) error
 
+// defaultFormats is the default set of formats to use for commands that have the --format flag.
+var defaultFormats = []string{teleport.Text, teleport.JSON, teleport.YAML}
+
 // Run executes TSH client. same as main() but easier to test
 func Run(args []string, opts ...cliOption) error {
 	var cf CLIConf
@@ -417,6 +421,7 @@ func Run(args []string, opts ...cliOption) error {
 	app.Flag("bind-addr", "Override host:port used when opening a browser for cluster logins").Envar(bindAddrEnvVar).StringVar(&cf.BindAddr)
 	app.HelpFlag.Short('h')
 	ver := app.Command("version", "Print the version")
+	ver.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaultFormats...)
 	// ssh
 	ssh := app.Command("ssh", "Run shell or execute a command on a remote SSH node")
 	ssh.Arg("[user@]host", "Remote hostname and the login to use").Required().StringVar(&cf.UserHost)
@@ -448,6 +453,7 @@ func Run(args []string, opts ...cliOption) error {
 	lsApps.Flag("cluster", clusterHelp).StringVar(&cf.SiteName)
 	lsApps.Flag("search", searchHelp).StringVar(&cf.SearchKeywords)
 	lsApps.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
+	lsApps.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaultFormats...)
 	lsApps.Arg("labels", labelHelp).StringVar(&cf.UserHost)
 	appLogin := apps.Command("login", "Retrieve short-lived certificate for an app.")
 	appLogin.Arg("app", "App name to retrieve credentials for. Can be obtained from `tsh apps ls` output.").Required().StringVar(&cf.AppName)
@@ -456,8 +462,9 @@ func Run(args []string, opts ...cliOption) error {
 	appLogout.Arg("app", "App to remove credentials for.").StringVar(&cf.AppName)
 	appConfig := apps.Command("config", "Print app connection information.")
 	appConfig.Arg("app", "App to print information for. Required when logged into multiple apps.").StringVar(&cf.AppName)
-	appConfig.Flag("format", fmt.Sprintf("Optional print format, one of: %q to print app address, %q to print CA cert path, %q to print cert path, %q print key path, %q to print example curl command.",
-		appFormatURI, appFormatCA, appFormatCert, appFormatKey, appFormatCURL)).StringVar(&cf.Format)
+	appConfig.Flag("format", fmt.Sprintf("Optional print format, one of: %q to print app address, %q to print CA cert path, %q to print cert path, %q print key path, %q to print example curl command, %q or %q to print everything as JSON or YAML.",
+		appFormatURI, appFormatCA, appFormatCert, appFormatKey, appFormatCURL, appFormatJSON, appFormatYAML),
+	).Short('f').StringVar(&cf.Format)
 
 	// Local TLS proxy.
 	proxy := app.Command("proxy", "Run local TLS proxy allowing connecting to Teleport in single-port mode")
@@ -478,6 +485,7 @@ func Run(args []string, opts ...cliOption) error {
 	dbList.Flag("verbose", "Show extra database fields.").Short('v').BoolVar(&cf.Verbose)
 	dbList.Flag("search", searchHelp).StringVar(&cf.SearchKeywords)
 	dbList.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
+	dbList.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaultFormats...)
 	dbList.Arg("labels", labelHelp).StringVar(&cf.UserHost)
 	dbLogin := db.Command("login", "Retrieve credentials for a database.")
 	dbLogin.Arg("db", "Database to retrieve credentials for. Can be obtained from 'tsh db ls' output.").Required().StringVar(&cf.DatabaseService)
@@ -486,6 +494,7 @@ func Run(args []string, opts ...cliOption) error {
 	dbLogout := db.Command("logout", "Remove database credentials.")
 	dbLogout.Arg("db", "Database to remove credentials for.").StringVar(&cf.DatabaseService)
 	dbEnv := db.Command("env", "Print environment variables for the configured database.")
+	dbEnv.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaultFormats...)
 	dbEnv.Arg("db", "Print environment for the specified database").StringVar(&cf.DatabaseService)
 	// --db flag is deprecated in favor of positional argument for consistency with other commands.
 	dbEnv.Flag("db", "Print environment for the specified database.").Hidden().StringVar(&cf.DatabaseService)
@@ -493,7 +502,8 @@ func Run(args []string, opts ...cliOption) error {
 	dbConfig.Arg("db", "Print information for the specified database.").StringVar(&cf.DatabaseService)
 	// --db flag is deprecated in favor of positional argument for consistency with other commands.
 	dbConfig.Flag("db", "Print information for the specified database.").Hidden().StringVar(&cf.DatabaseService)
-	dbConfig.Flag("format", fmt.Sprintf("Print format: %q to print in table format (default), %q to print connect command.", dbFormatText, dbFormatCommand)).StringVar(&cf.Format)
+	dbConfig.Flag("format", fmt.Sprintf("Print format: %q to print in table format (default), %q to print connect command, %q or %q to print in JSON or YAML.",
+		dbFormatText, dbFormatCommand, dbFormatJSON, dbFormatYAML)).Short('f').EnumVar(&cf.Format, dbFormatText, dbFormatCommand, dbFormatJSON, dbFormatYAML)
 	dbConnect := db.Command("connect", "Connect to a database.")
 	dbConnect.Arg("db", "Database service name to connect to.").StringVar(&cf.DatabaseService)
 	dbConnect.Flag("db-user", "Optional database user to log in as.").StringVar(&cf.DatabaseUser)
@@ -509,7 +519,9 @@ func Run(args []string, opts ...cliOption) error {
 	// play
 	play := app.Command("play", "Replay the recorded SSH session")
 	play.Flag("cluster", clusterHelp).StringVar(&cf.SiteName)
-	play.Flag("format", "Format output (json, pty)").Short('f').Default(teleport.PTY).StringVar(&cf.Format)
+	play.Flag("format", formatFlagDescription(
+		teleport.PTY, teleport.JSON, teleport.YAML,
+	)).Short('f').Default(teleport.PTY).EnumVar(&cf.Format, teleport.PTY, teleport.JSON, teleport.YAML)
 	play.Arg("session-id", "ID of the session to play").Required().StringVar(&cf.SessionID)
 
 	// scp
@@ -524,12 +536,15 @@ func Run(args []string, opts ...cliOption) error {
 	ls := app.Command("ls", "List remote SSH nodes")
 	ls.Flag("cluster", clusterHelp).StringVar(&cf.SiteName)
 	ls.Flag("verbose", "One-line output (for text format), including node UUIDs").Short('v').BoolVar(&cf.Verbose)
-	ls.Flag("format", "Format output (text, json, names)").Short('f').Default(teleport.Text).StringVar(&cf.Format)
+	ls.Flag("format", formatFlagDescription(
+		teleport.Text, teleport.JSON, teleport.YAML, teleport.Names,
+	)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, teleport.Text, teleport.JSON, teleport.YAML, teleport.Names)
 	ls.Arg("labels", labelHelp).StringVar(&cf.UserHost)
 	ls.Flag("search", searchHelp).StringVar(&cf.SearchKeywords)
 	ls.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
 	// clusters
 	clusters := app.Command("clusters", "List available Teleport clusters")
+	clusters.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaultFormats...)
 	clusters.Flag("quiet", "Quiet mode").Short('q').BoolVar(&cf.Quiet)
 
 	// login logs in with remote proxy and obtains a "session certificate" which gets
@@ -540,7 +555,7 @@ func Run(args []string, opts ...cliOption) error {
 		identityfile.DefaultFormat,
 		identityfile.FormatOpenSSH,
 		identityfile.FormatKubernetes,
-	)).Default(string(identityfile.DefaultFormat)).StringVar((*string)(&cf.IdentityFormat))
+	)).Default(string(identityfile.DefaultFormat)).Short('f').StringVar((*string)(&cf.IdentityFormat))
 	login.Flag("overwrite", "Whether to overwrite the existing identity file.").BoolVar(&cf.IdentityOverwrite)
 	login.Flag("request-roles", "Request one or more extra roles").StringVar(&cf.DesiredRoles)
 	login.Flag("request-reason", "Reason for requesting additional roles").StringVar(&cf.RequestReason)
@@ -576,22 +591,25 @@ func Run(args []string, opts ...cliOption) error {
 	// The status command shows which proxy the user is logged into and metadata
 	// about the certificate.
 	status := app.Command("status", "Display the list of proxy servers and retrieved certificates")
+	status.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaultFormats...)
 
 	// The environment command prints out environment variables for the configured
 	// proxy and cluster. Can be used to create sessions "sticky" to a terminal
 	// even if the user runs "tsh login" again in another window.
 	environment := app.Command("env", "Print commands to set Teleport session environment variables")
+	environment.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaultFormats...)
 	environment.Flag("unset", "Print commands to clear Teleport session environment variables").BoolVar(&cf.unsetEnvironment)
 
 	req := app.Command("request", "Manage access requests").Alias("requests")
 
 	reqList := req.Command("ls", "List access requests").Alias("list")
-	reqList.Flag("format", "Format output (text, json)").Short('f').Default(teleport.Text).StringVar(&cf.Format)
+	reqList.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaultFormats...)
 	reqList.Flag("reviewable", "Only show requests reviewable by current user").BoolVar(&cf.ReviewableRequests)
 	reqList.Flag("suggested", "Only show requests that suggest current user as reviewer").BoolVar(&cf.SuggestedRequests)
 	reqList.Flag("my-requests", "Only show requests created by current user").BoolVar(&cf.MyRequests)
 
 	reqShow := req.Command("show", "Show request details").Alias("details")
+	reqShow.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaultFormats...)
 	reqShow.Arg("request-id", "ID of the target request").Required().StringVar(&cf.RequestID)
 
 	reqCreate := req.Command("new", "Create a new access request").Alias("create")
@@ -686,7 +704,7 @@ func Run(args []string, opts ...cliOption) error {
 
 	switch command {
 	case ver.FullCommand():
-		utils.PrintVersion()
+		err = onVersion(&cf)
 	case ssh.FullCommand():
 		err = onSSH(&cf)
 	case bench.FullCommand():
@@ -784,9 +802,46 @@ func Run(args []string, opts ...cliOption) error {
 	return trace.Wrap(err)
 }
 
+// onVersion prints version info.
+func onVersion(cf *CLIConf) error {
+	format := strings.ToLower(cf.Format)
+	switch format {
+	case teleport.Text, "":
+		utils.PrintVersion()
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeVersion(format)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(out)
+	default:
+		return trace.BadParameter("unsupported format %q", cf.Format)
+	}
+	return nil
+}
+
+func serializeVersion(format string) (string, error) {
+	versionInfo := struct {
+		Version string `json:"version"`
+		Gitref  string `json:"gitref"`
+		Runtime string `json:"runtime"`
+	}{
+		teleport.Version, teleport.Gitref, runtime.Version(),
+	}
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(versionInfo, "", "  ")
+	} else {
+		out, err = yaml.Marshal(versionInfo)
+	}
+	return string(out), trace.Wrap(err)
+}
+
 // onPlay replays a session with a given ID
 func onPlay(cf *CLIConf) error {
-	switch cf.Format {
+	format := strings.ToLower(cf.Format)
+	switch format {
 	case teleport.PTY:
 		switch {
 		case path.Ext(cf.SessionID) == ".tar":
@@ -828,7 +883,13 @@ func onPlay(cf *CLIConf) error {
 				// when playing from a file, id is not included, this
 				// makes the outputs otherwise identical
 				delete(event, "id")
-				e, err := utils.FastMarshal(event)
+				var e []byte
+				var err error
+				if format == teleport.JSON {
+					e, err = utils.FastMarshal(event)
+				} else {
+					e, err = yaml.Marshal(event)
+				}
 				if err != nil {
 					return trace.Wrap(err)
 				}
@@ -1424,24 +1485,39 @@ func executeAccessRequest(cf *CLIConf, tc *client.TeleportClient) error {
 }
 
 func printNodes(nodes []types.Server, format string, verbose bool) error {
-	switch strings.ToLower(format) {
-	case teleport.Text:
+	format = strings.ToLower(format)
+	switch format {
+	case teleport.Text, "":
 		printNodesAsText(nodes, verbose)
-	case teleport.JSON:
-		out, err := json.MarshalIndent(nodes, "", "  ")
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeNodes(nodes, format)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Println(string(out))
+		fmt.Println(out)
 	case teleport.Names:
 		for _, n := range nodes {
 			fmt.Println(n.GetHostname())
 		}
 	default:
-		return trace.BadParameter("unsupported format. try 'json', 'text', or 'names'")
+		return trace.BadParameter("unsupported format %q", format)
 	}
 
 	return nil
+}
+
+func serializeNodes(nodes []types.Server, format string) (string, error) {
+	if nodes == nil {
+		nodes = []types.Server{}
+	}
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(nodes, "", "  ")
+	} else {
+		out, err = yaml.Marshal(nodes)
+	}
+	return string(out), trace.Wrap(err)
 }
 
 func printNodesAsText(nodes []types.Server, verbose bool) {
@@ -1499,7 +1575,38 @@ func sortedLabels(labels map[string]string) string {
 	return strings.Join(append(result, namespaced...), ",")
 }
 
-func showApps(apps []types.Application, active []tlsca.RouteToApp, verbose bool) {
+func showApps(apps []types.Application, active []tlsca.RouteToApp, format string, verbose bool) error {
+	format = strings.ToLower(format)
+	switch format {
+	case teleport.Text, "":
+		showAppsAsText(apps, active, verbose)
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeApps(apps, format)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(out)
+	default:
+		return trace.BadParameter("unsupported format %q", format)
+	}
+	return nil
+}
+
+func serializeApps(apps []types.Application, format string) (string, error) {
+	if apps == nil {
+		apps = []types.Application{}
+	}
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(apps, "", "  ")
+	} else {
+		out, err = yaml.Marshal(apps)
+	}
+	return string(out), trace.Wrap(err)
+}
+
+func showAppsAsText(apps []types.Application, active []tlsca.RouteToApp, verbose bool) {
 	// In verbose mode, print everything on a single line and include host UUID.
 	// In normal mode, chunk the labels, print two per line and allow multiple
 	// lines per node.
@@ -1541,7 +1648,38 @@ func showApps(apps []types.Application, active []tlsca.RouteToApp, verbose bool)
 	}
 }
 
-func showDatabases(clusterFlag string, databases []types.Database, active []tlsca.RouteToDatabase, verbose bool) {
+func showDatabases(clusterFlag string, databases []types.Database, active []tlsca.RouteToDatabase, format string, verbose bool) error {
+	format = strings.ToLower(format)
+	switch format {
+	case teleport.Text, "":
+		showDatabasesAsText(clusterFlag, databases, active, verbose)
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeDatabases(databases, format)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(out)
+	default:
+		return trace.BadParameter("unsupported format %q", format)
+	}
+	return nil
+}
+
+func serializeDatabases(databases []types.Database, format string) (string, error) {
+	if databases == nil {
+		databases = []types.Database{}
+	}
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(databases, "", "  ")
+	} else {
+		out, err = yaml.Marshal(databases)
+	}
+	return string(out), trace.Wrap(err)
+}
+
+func showDatabasesAsText(clusterFlag string, databases []types.Database, active []tlsca.RouteToDatabase, verbose bool) {
 	if verbose {
 		t := asciitable.MakeTable([]string{"Name", "Description", "Protocol", "Type", "URI", "Labels", "Connect", "Expires"})
 		for _, database := range databases {
@@ -1655,30 +1793,70 @@ func onListClusters(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	isSelected := func(clusterName string) bool {
+		return profile != nil && clusterName == profile.Cluster
+	}
 	showSelected := func(clusterName string) string {
-		if profile != nil && clusterName == profile.Cluster {
+		if isSelected(clusterName) {
 			return "*"
 		}
 		return ""
 	}
 
-	var t asciitable.Table
-	if cf.Quiet {
-		t = asciitable.MakeHeadlessTable(4)
-	} else {
-		t = asciitable.MakeTable([]string{"Cluster Name", "Status", "Cluster Type", "Selected"})
-	}
+	format := strings.ToLower(cf.Format)
+	switch format {
+	case teleport.Text, "":
+		var t asciitable.Table
+		if cf.Quiet {
+			t = asciitable.MakeHeadlessTable(4)
+		} else {
+			t = asciitable.MakeTable([]string{"Cluster Name", "Status", "Cluster Type", "Selected"})
+		}
 
-	t.AddRow([]string{
-		rootClusterName, teleport.RemoteClusterStatusOnline, "root", showSelected(rootClusterName),
-	})
-	for _, cluster := range leafClusters {
 		t.AddRow([]string{
-			cluster.GetName(), cluster.GetConnectionStatus(), "leaf", showSelected(cluster.GetName()),
+			rootClusterName, teleport.RemoteClusterStatusOnline, "root", showSelected(rootClusterName),
 		})
+		for _, cluster := range leafClusters {
+			t.AddRow([]string{
+				cluster.GetName(), cluster.GetConnectionStatus(), "leaf", showSelected(cluster.GetName()),
+			})
+		}
+		fmt.Println(t.AsBuffer().String())
+	case teleport.JSON, teleport.YAML:
+		rootClusterInfo := clusterInfo{rootClusterName, teleport.RemoteClusterStatusOnline, "root", isSelected(rootClusterName)}
+		leafClusterInfo := make([]clusterInfo, 0, len(leafClusters))
+		for _, leaf := range leafClusters {
+			leafClusterInfo = append(leafClusterInfo, clusterInfo{leaf.GetName(), leaf.GetConnectionStatus(), "leaf", isSelected(leaf.GetName())})
+		}
+		out, err := serializeClusters(rootClusterInfo, leafClusterInfo, format)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(out)
+	default:
+		return trace.BadParameter("unsupported format %q", cf.Format)
 	}
-	fmt.Println(t.AsBuffer().String())
 	return nil
+}
+
+type clusterInfo struct {
+	ClusterName string `json:"cluster_name"`
+	Status      string `json:"status"`
+	ClusterType string `json:"cluster_type"`
+	Selected    bool   `json:"selected"`
+}
+
+func serializeClusters(rootCluster clusterInfo, leafClusters []clusterInfo, format string) (string, error) {
+	clusters := []clusterInfo{rootCluster}
+	clusters = append(clusters, leafClusters...)
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(clusters, "", "  ")
+	} else {
+		out, err = yaml.Marshal(clusters)
+	}
+	return string(out), trace.Wrap(err)
 }
 
 // onSSH executes 'tsh ssh' command
@@ -2337,7 +2515,17 @@ func onStatus(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	printProfiles(cf.Debug, profile, profiles)
+	format := strings.ToLower(cf.Format)
+	switch format {
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeProfiles(profile, profiles, format)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(out)
+	default:
+		printProfiles(cf.Debug, profile, profiles)
+	}
 
 	if profile == nil {
 		return trace.NotFound("Not logged in.")
@@ -2349,6 +2537,66 @@ func onStatus(cf *CLIConf) error {
 	}
 
 	return nil
+}
+
+type profileInfo struct {
+	ProxyURL          string          `json:"profile_url"`
+	Username          string          `json:"username"`
+	ActiveRequests    []string        `json:"active_requests,omitempty"`
+	Cluster           string          `json:"cluster"`
+	Roles             []string        `json:"roles,omitempty"`
+	Traits            wrappers.Traits `json:"traits,omitempty"`
+	Logins            []string        `json:"logins,omitempty"`
+	KubernetesEnabled bool            `json:"kubernetes_enabled"`
+	KubernetesCluster string          `json:"kubernetes_cluster,omitempty"`
+	KubernetesUsers   []string        `json:"kubernetes_users,omitempty"`
+	KubernetesGroups  []string        `json:"kubernetes_groups,omitempty"`
+	Databases         []string        `json:"databases,omitempty"`
+	ValidUntil        time.Time       `json:"valid_until"`
+	Extensions        []string        `json:"extensions,omitempty"`
+}
+
+func makeProfileInfo(p *client.ProfileStatus) *profileInfo {
+	if p == nil {
+		return nil
+	}
+	return &profileInfo{
+		ProxyURL:          p.ProxyURL.String(),
+		Username:          p.Username,
+		ActiveRequests:    p.ActiveRequests.AccessRequests,
+		Cluster:           p.Cluster,
+		Roles:             p.Roles,
+		Traits:            p.Traits,
+		Logins:            p.Logins,
+		KubernetesEnabled: p.KubeEnabled,
+		KubernetesCluster: selectedKubeCluster(p.Cluster),
+		KubernetesUsers:   p.KubeUsers,
+		KubernetesGroups:  p.KubeGroups,
+		Databases:         p.DatabaseServices(),
+		ValidUntil:        p.ValidUntil,
+		Extensions:        p.Extensions,
+	}
+}
+
+func serializeProfiles(profile *client.ProfileStatus, profiles []*client.ProfileStatus, format string) (string, error) {
+	profileData := struct {
+		Active   *profileInfo   `json:"active,omitempty"`
+		Profiles []*profileInfo `json:"profiles"`
+	}{makeProfileInfo(profile), []*profileInfo{}}
+	for _, prof := range profiles {
+		profileData.Profiles = append(profileData.Profiles, makeProfileInfo(prof))
+	}
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(profileData, "", "  ")
+	} else {
+		out, err = yaml.Marshal(profileData)
+	}
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return string(out), nil
 }
 
 func printProfiles(debug bool, profile *client.ProfileStatus, profiles []*client.ProfileStatus) {
@@ -2508,8 +2756,7 @@ func onApps(cf *CLIConf) error {
 		return apps[i].GetName() < apps[j].GetName()
 	})
 
-	showApps(apps, profile.Apps, cf.Verbose)
-	return nil
+	return trace.Wrap(showApps(apps, profile.Apps, cf.Format, cf.Verbose))
 }
 
 // onEnvironment handles "tsh env" command.
@@ -2519,24 +2766,55 @@ func onEnvironment(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	// Print shell built-in commands to set (or unset) environment.
-	switch {
-	case cf.unsetEnvironment:
-		fmt.Printf("unset %v\n", proxyEnvVar)
-		fmt.Printf("unset %v\n", clusterEnvVar)
-		fmt.Printf("unset %v\n", kubeClusterEnvVar)
-		fmt.Printf("unset %v\n", teleport.EnvKubeConfig)
-	case !cf.unsetEnvironment:
-		fmt.Printf("export %v=%v\n", proxyEnvVar, profile.ProxyURL.Host)
-		fmt.Printf("export %v=%v\n", clusterEnvVar, profile.Cluster)
-		if kubeName := selectedKubeCluster(profile.Cluster); kubeName != "" {
-			fmt.Printf("export %v=%v\n", kubeClusterEnvVar, kubeName)
-			fmt.Printf("# set %v to a standalone kubeconfig for the selected kube cluster\n", teleport.EnvKubeConfig)
-			fmt.Printf("export %v=%v\n", teleport.EnvKubeConfig, profile.KubeConfigPath(kubeName))
+	format := strings.ToLower(cf.Format)
+	switch format {
+	case teleport.Text, "":
+		// Print shell built-in commands to set (or unset) environment.
+		switch {
+		case cf.unsetEnvironment:
+			fmt.Printf("unset %v\n", proxyEnvVar)
+			fmt.Printf("unset %v\n", clusterEnvVar)
+			fmt.Printf("unset %v\n", kubeClusterEnvVar)
+			fmt.Printf("unset %v\n", teleport.EnvKubeConfig)
+		case !cf.unsetEnvironment:
+			kubeName := selectedKubeCluster(profile.Cluster)
+			fmt.Printf("export %v=%v\n", proxyEnvVar, profile.ProxyURL.Host)
+			fmt.Printf("export %v=%v\n", clusterEnvVar, profile.Cluster)
+			if kubeName != "" {
+				fmt.Printf("export %v=%v\n", kubeClusterEnvVar, kubeName)
+				fmt.Printf("# set %v to a standalone kubeconfig for the selected kube cluster\n", teleport.EnvKubeConfig)
+				fmt.Printf("export %v=%v\n", teleport.EnvKubeConfig, profile.KubeConfigPath(kubeName))
+			}
 		}
+	case teleport.JSON, teleport.YAML:
+		out, err := serializeEnvironment(profile, format)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(out)
 	}
 
 	return nil
+}
+
+func serializeEnvironment(profile *client.ProfileStatus, format string) (string, error) {
+	env := map[string]string{
+		proxyEnvVar:   profile.ProxyURL.Host,
+		clusterEnvVar: profile.Cluster,
+	}
+	kubeName := selectedKubeCluster(profile.Cluster)
+	if kubeName != "" {
+		env[kubeClusterEnvVar] = kubeName
+		env[teleport.EnvKubeConfig] = profile.KubeConfigPath(kubeName)
+	}
+	var out []byte
+	var err error
+	if format == teleport.JSON {
+		out, err = utils.FastMarshalIndent(env, "", "  ")
+	} else {
+		out, err = yaml.Marshal(env)
+	}
+	return string(out), trace.Wrap(err)
 }
 
 // envGetter is used to read in the environment. In production "os.Getenv"

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -23,12 +23,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ghodss/yaml"
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -38,6 +42,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/backend"
@@ -1456,4 +1461,579 @@ func setHomePath(path string) cliOption {
 		cf.HomePath = path
 		return nil
 	}
+}
+
+func testSerialization(t *testing.T, expected string, serializer func(string) (string, error)) {
+	out, err := serializer(teleport.JSON)
+	require.NoError(t, err)
+	require.JSONEq(t, expected, out)
+
+	out, err = serializer(teleport.YAML)
+	require.NoError(t, err)
+	outJSON, err := yaml.YAMLToJSON([]byte(out))
+	require.NoError(t, err)
+	require.JSONEq(t, expected, string(outJSON))
+}
+
+func TestSerializeVersion(t *testing.T) {
+	expected := fmt.Sprintf(`{"version": %q, "gitref": %q, "runtime": %q}`,
+		teleport.Version, teleport.Gitref, runtime.Version())
+	testSerialization(t, expected, serializeVersion)
+}
+
+func TestSerializeApps(t *testing.T) {
+	expected := `
+	[{
+		"kind": "app",
+		"version": "v3",
+		"metadata": {
+			"name": "my app",
+			"description": "this is the description",
+			"labels": {
+				"a": "1",
+				"b": "2"
+			}
+		},
+		"spec": {
+			"uri": "https://example.com",
+			"insecure_skip_verify": false
+		}
+	}]
+	`
+	app, err := types.NewAppV3(types.Metadata{
+		Name:        "my app",
+		Description: "this is the description",
+		Labels:      map[string]string{"a": "1", "b": "2"},
+	}, types.AppSpecV3{
+		URI: "https://example.com",
+	})
+	require.NoError(t, err)
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeApps([]types.Application{app}, f)
+	})
+}
+
+func TestSerializeAppsEmpty(t *testing.T) {
+	testSerialization(t, "[]", func(f string) (string, error) {
+		return serializeApps(nil, f)
+	})
+}
+
+func TestSerializeAppConfig(t *testing.T) {
+	expected := `
+	{
+		"name": "my app",
+		"uri": "https://example.com",
+		"ca": "/path/to/ca",
+		"cert": "/path/to/cert",
+		"key": "/path/to/key",
+		"curl": "curl https://example.com"
+	}
+	`
+	appConfig := &appConfigInfo{
+		Name: "my app",
+		URI:  "https://example.com",
+		CA:   "/path/to/ca",
+		Cert: "/path/to/cert",
+		Key:  "/path/to/key",
+		Curl: "curl https://example.com",
+	}
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeAppConfig(appConfig, f)
+	})
+}
+
+func TestSerializeDatabases(t *testing.T) {
+	expected := `
+	[{
+    "kind": "db",
+    "version": "v3",
+    "metadata": {
+      "name": "my db",
+      "description": "this is the description",
+      "labels": {"a": "1", "b": "2"}
+    },
+    "spec": {
+      "protocol": "mongodb",
+      "uri": "mongodb://example.com",
+      "aws": {
+        "redshift": {},
+        "rds": {
+          "iam_auth": false
+        }
+      },
+      "gcp": {},
+      "azure": {},
+      "tls": {
+        "mode": 0
+      },
+      "ad": {
+        "keytab_file": "",
+        "domain": "",
+        "spn": ""
+      }
+    },
+    "status": {
+      "aws": {
+        "redshift": {},
+        "rds": {
+          "iam_auth": false
+        }
+      }
+    }
+  }]
+	`
+	db, err := types.NewDatabaseV3(types.Metadata{
+		Name:        "my db",
+		Description: "this is the description",
+		Labels:      map[string]string{"a": "1", "b": "2"},
+	}, types.DatabaseSpecV3{
+		Protocol: "mongodb",
+		URI:      "mongodb://example.com",
+	})
+	require.NoError(t, err)
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeDatabases([]types.Database{db}, f)
+	})
+}
+
+func TestSerializeDatabasesEmpty(t *testing.T) {
+	testSerialization(t, "[]", func(f string) (string, error) {
+		return serializeDatabases(nil, f)
+	})
+}
+
+func TestSerializeDatabaseEnvironment(t *testing.T) {
+	expected := `
+	{
+		"A": "1",
+		"B": "2"
+	}
+	`
+	env := map[string]string{
+		"A": "1",
+		"B": "2",
+	}
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeDatabaseEnvironment(env, f)
+	})
+}
+
+func TestSerializeDatabaseConfig(t *testing.T) {
+	expected := `
+	{
+		"name": "my db",
+		"host": "example.com",
+		"port": 27017,
+		"ca": "/path/to/ca",
+		"cert": "/path/to/cert",
+		"key": "/path/to/key"
+	}
+	`
+	configInfo := &dbConfigInfo{
+		Name: "my db",
+		Host: "example.com",
+		Port: 27017,
+		CA:   "/path/to/ca",
+		Cert: "/path/to/cert",
+		Key:  "/path/to/key",
+	}
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeDatabaseConfig(configInfo, f)
+	})
+}
+
+func TestSerializeNodes(t *testing.T) {
+	expected := `
+	[{
+    "kind": "node",
+    "version": "v2",
+    "metadata": {
+      "name": "my server"
+    },
+    "spec": {
+      "addr": "https://example.com",
+      "hostname": "example.com",
+      "rotation": {
+        "current_id": "",
+        "started": "0001-01-01T00:00:00Z",
+        "last_rotated": "0001-01-01T00:00:00Z",
+        "schedule": {
+          "update_clients": "0001-01-01T00:00:00Z",
+          "update_servers": "0001-01-01T00:00:00Z",
+          "standby": "0001-01-01T00:00:00Z"
+        }
+      },
+      "version": "v2"
+    }
+  }]
+	`
+	node, err := types.NewServer("my server", "node", types.ServerSpecV2{
+		Addr:     "https://example.com",
+		Hostname: "example.com",
+		Version:  "v2",
+	})
+	require.NoError(t, err)
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeNodes([]types.Server{node}, f)
+	})
+}
+
+func TestSerializeNodesEmpty(t *testing.T) {
+	testSerialization(t, "[]", func(f string) (string, error) {
+		return serializeNodes(nil, f)
+	})
+}
+
+func TestSerializeClusters(t *testing.T) {
+	expected := `
+	[
+		{
+			"cluster_name": "rootCluster",
+			"status": "online",
+			"cluster_type": "root",
+			"selected": true
+		},
+		{
+			"cluster_name": "leafCluster",
+			"status": "offline",
+			"cluster_type": "leaf",
+			"selected": false
+		}
+	]
+	`
+	root := clusterInfo{
+		ClusterName: "rootCluster",
+		Status:      teleport.RemoteClusterStatusOnline,
+		ClusterType: "root",
+		Selected:    true,
+	}
+	leafClusters := []clusterInfo{
+		{
+			ClusterName: "leafCluster",
+			Status:      teleport.RemoteClusterStatusOffline,
+			ClusterType: "leaf",
+			Selected:    false,
+		},
+	}
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeClusters(root, leafClusters, f)
+	})
+}
+
+func TestSerializeProfiles(t *testing.T) {
+	expected := `
+	{
+  "active": {
+    "profile_url": "example.com",
+    "username": "test",
+    "active_requests": [
+      "1",
+      "2",
+      "3"
+    ],
+    "cluster": "main",
+    "roles": [
+      "a",
+      "b",
+      "c"
+    ],
+    "traits": {
+      "a": [
+  "1",
+  "2",
+  "3"
+]
+    },
+    "logins": [
+      "a",
+      "b",
+      "c"
+    ],
+    "kubernetes_enabled": true,
+    "kubernetes_users": [
+      "x"
+    ],
+    "kubernetes_groups": [
+      "y"
+    ],
+    "databases": [
+      "z"
+    ],
+    "valid_until": "1970-01-01T00:00:00Z",
+    "extensions": [
+      "7",
+      "8",
+      "9"
+    ]
+  },
+  "profiles": [
+    {
+      "profile_url": "example.com",
+      "username": "test2",
+      "cluster": "other",
+      "kubernetes_enabled": false,
+      "valid_until": "1970-01-01T00:00:00Z"
+    }
+  ]
+}
+	`
+	aTime := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+	p, err := url.Parse("example.com")
+	require.NoError(t, err)
+	activeProfile := &client.ProfileStatus{
+		ProxyURL:       *p,
+		Username:       "test",
+		ActiveRequests: services.RequestIDs{AccessRequests: []string{"1", "2", "3"}},
+		Cluster:        "main",
+		Roles:          []string{"a", "b", "c"},
+		Traits:         wrappers.Traits{"a": []string{"1", "2", "3"}},
+		Logins:         []string{"a", "b", "c"},
+		KubeEnabled:    true,
+		KubeUsers:      []string{"x"},
+		KubeGroups:     []string{"y"},
+		Databases:      []tlsca.RouteToDatabase{{ServiceName: "z"}},
+		ValidUntil:     aTime,
+		Extensions:     []string{"7", "8", "9"},
+	}
+	otherProfile := &client.ProfileStatus{
+		ProxyURL:   *p,
+		Username:   "test2",
+		Cluster:    "other",
+		ValidUntil: aTime,
+	}
+
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeProfiles(activeProfile, []*client.ProfileStatus{otherProfile}, f)
+	})
+}
+
+func TestSerializeProfilesNoOthers(t *testing.T) {
+	expected := `
+	{
+		"active": {
+      "profile_url": "example.com",
+      "username": "test",
+      "cluster": "main",
+      "kubernetes_enabled": false,
+      "valid_until": "1970-01-01T00:00:00Z"
+    },
+		"profiles": []
+	}
+	`
+	aTime := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+	p, err := url.Parse("example.com")
+	require.NoError(t, err)
+	profile := &client.ProfileStatus{
+		ProxyURL:   *p,
+		Username:   "test",
+		Cluster:    "main",
+		ValidUntil: aTime,
+	}
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeProfiles(profile, nil, f)
+	})
+}
+
+func TestSerializeProfilesNoActive(t *testing.T) {
+	expected := `
+	{
+		"profiles": []
+	}
+	`
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeProfiles(nil, nil, f)
+	})
+}
+
+func TestSerializeEnvironment(t *testing.T) {
+	expected := fmt.Sprintf(`
+	{
+		%q: "example.com",
+		%q: "main"
+	}
+	`, proxyEnvVar, clusterEnvVar)
+	p, err := url.Parse("https://example.com")
+	require.NoError(t, err)
+	profile := &client.ProfileStatus{
+		ProxyURL: *p,
+		Cluster:  "main",
+	}
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeEnvironment(profile, f)
+	})
+}
+
+func TestSerializeAccessRequests(t *testing.T) {
+	expected := `
+	{
+    "kind": "access_request",
+    "version": "v3",
+    "metadata": {
+      "name": "test"
+    },
+    "spec": {
+      "user": "user",
+      "roles": [
+        "a",
+        "b",
+        "c"
+      ],
+      "state": 1,
+      "created": "0001-01-01T00:00:00Z",
+      "expires": "0001-01-01T00:00:00Z"
+    }
+  }
+	`
+	req, err := types.NewAccessRequest("test", "user", "a", "b", "c")
+	require.NoError(t, err)
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeAccessRequest(req, f)
+	})
+	expected2 := fmt.Sprintf("[%v]", expected)
+	testSerialization(t, expected2, func(f string) (string, error) {
+		return serializeAccessRequests([]types.AccessRequest{req}, f)
+	})
+}
+
+func TestSerializeKubeSessions(t *testing.T) {
+	aTime := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+	expected := `
+	[
+  {
+    "kind": "session_tracker",
+    "version": "v1",
+    "metadata": {
+      "name": "id"
+    },
+    "spec": {
+      "session_id": "id",
+      "kind": "session-kind",
+      "state": 1,
+      "created": "1970-01-01T00:00:00Z",
+      "expires": "1970-01-01T00:00:00Z",
+      "attached": "arbitrary attached data",
+      "reason": "some reason",
+      "invited": [
+        "a",
+        "b",
+        "c"
+      ],
+      "target_hostname": "example.com",
+      "target_address": "https://example.com",
+      "cluster_name": "cluster",
+      "login": "login",
+      "participants": [
+        {
+          "id": "some-id",
+          "user": "test",
+          "mode": "mode",
+          "last_active": "1970-01-01T00:00:00Z"
+        }
+      ],
+      "kubernetes_cluster": "kc",
+      "host_user": "test",
+      "host_roles": [
+        {
+          "name": "policy",
+          "version": "v1",
+          "require_session_join": [
+            {
+              "name": "policy",
+              "filter": "filter",
+              "kinds": [
+                "x",
+                "y",
+                "z"
+              ],
+              "count": 1,
+              "modes": [
+                "mode",
+                "mode-1",
+                "mode-2"
+              ],
+              "on_leave": "do something"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]
+	`
+	tracker, err := types.NewSessionTracker(types.SessionTrackerSpecV1{
+		SessionID:    "id",
+		Kind:         "session-kind",
+		State:        types.SessionState_SessionStateRunning,
+		Created:      aTime,
+		Expires:      aTime,
+		AttachedData: "arbitrary attached data",
+		Reason:       "some reason",
+		Invited:      []string{"a", "b", "c"},
+		Hostname:     "example.com",
+		Address:      "https://example.com",
+		ClusterName:  "cluster",
+		Login:        "login",
+		Participants: []types.Participant{
+			{
+				ID:         "some-id",
+				User:       "test",
+				Mode:       "mode",
+				LastActive: aTime,
+			},
+		},
+		KubernetesCluster: "kc",
+		HostUser:          "test",
+		HostPolicies: []*types.SessionTrackerPolicySet{
+			{
+				Name:    "policy",
+				Version: "v1",
+				RequireSessionJoin: []*types.SessionRequirePolicy{
+					{
+						Name:    "policy",
+						Filter:  "filter",
+						Kinds:   []string{"x", "y", "z"},
+						Count:   1,
+						Modes:   []string{"mode", "mode-1", "mode-2"},
+						OnLeave: "do something",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeKubeSessions([]types.SessionTracker{tracker}, f)
+	})
+}
+
+func TestSerializeKubeClusters(t *testing.T) {
+	expected := `
+	[
+		{
+			"kube_cluster_name": "cluster1",
+			"selected": true
+		},
+		{
+			"kube_cluster_name": "cluster2",
+			"selected": false
+		}
+	]
+	`
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeKubeClusters([]string{"cluster1", "cluster2"}, "cluster1", f)
+	})
+}
+
+func TestSerializeMFADevices(t *testing.T) {
+	aTime := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+	expected := `
+	[
+  {"metadata":{"Name":"my device"},"id":"id","addedAt":"1970-01-01T00:00:00Z","lastUsed":"1970-01-01T00:00:00Z"}
+	]
+	`
+	dev := types.NewMFADevice("my device", "id", aTime)
+	testSerialization(t, expected, func(f string) (string, error) {
+		return serializeMFADevices([]*types.MFADevice{dev}, f)
+	})
 }


### PR DESCRIPTION
This PR adds support for JSON and YAML output to several `tsh` commands via the --format flag.

Backport of #11681.