### PR TITLE
Fix globbing for Moderated Sessions join policies

### DIFF
--- a/lib/auth/session_access.go
+++ b/lib/auth/session_access.go
@@ -151,9 +151,9 @@ func (e *SessionAccessEvaluator) matchesJoin(allow *types.SessionJoinPolicy) boo
 
 	for _, policySet := range e.policySets {
 		for _, allowRole := range allow.Roles {
-			expr := utils.GlobToRegexp(policySet.Name)
+			expr := utils.GlobToRegexp(allowRole)
 			// GlobToRegexp makes sure this is always a valid regexp.
-			matched, _ := regexp.MatchString(expr, allowRole)
+			matched, _ := regexp.MatchString(expr, policySet.Name)
 
 			if matched {
 				return true

--- a/lib/auth/session_access.go
+++ b/lib/auth/session_access.go
@@ -149,13 +149,12 @@ func (e *SessionAccessEvaluator) matchesJoin(allow *types.SessionJoinPolicy) boo
 		return false
 	}
 
-	for _, policySet := range e.policySets {
-		for _, allowRole := range allow.Roles {
-			expr := utils.GlobToRegexp(allowRole)
-			// GlobToRegexp makes sure this is always a valid regexp.
-			matched, _ := regexp.MatchString(expr, policySet.Name)
+	for _, allowRole := range allow.Roles {
+		// GlobToRegexp makes sure this is always a valid regexp.
+		expr := regexp.MustCompile(utils.GlobToRegexp(allowRole))
 
-			if matched {
+		for _, policySet := range e.policySets {
+			if expr.MatchString(policySet.Name) {
 				return true
 			}
 		}

--- a/lib/auth/session_access_test.go
+++ b/lib/auth/session_access_test.go
@@ -219,6 +219,30 @@ func successJoinTestCase(t *testing.T) joinTestCase {
 	}
 }
 
+func successGlobJoinTestCase(t *testing.T) joinTestCase {
+	hostRole, err := types.NewRole("host", types.RoleSpecV5{})
+	require.NoError(t, err)
+	participantRole, err := types.NewRole("participant", types.RoleSpecV5{})
+	require.NoError(t, err)
+
+	participantRole.SetSessionJoinPolicies([]*types.SessionJoinPolicy{{
+		Roles: []string{"*"},
+		Kinds: []string{string(types.SSHSessionKind)},
+		Modes: []string{string("*")},
+	}})
+
+	return joinTestCase{
+		name:        "success",
+		host:        hostRole,
+		sessionKind: types.SSHSessionKind,
+		participant: SessionAccessContext{
+			Username: "participant",
+			Roles:    []types.Role{participantRole},
+		},
+		expected: true,
+	}
+}
+
 func failRoleJoinTestCase(t *testing.T) joinTestCase {
 	hostRole, err := types.NewRole("host", types.RoleSpecV5{})
 	require.NoError(t, err)
@@ -264,6 +288,7 @@ func failKindJoinTestCase(t *testing.T) joinTestCase {
 func TestSessionAccessJoin(t *testing.T) {
 	testCases := []joinTestCase{
 		successJoinTestCase(t),
+		successGlobJoinTestCase(t),
 		failRoleJoinTestCase(t),
 		failKindJoinTestCase(t),
 	}


### PR DESCRIPTION
A switchup caused globbing in the roles field of a moderated sessions join policy to not work. This PR fixes it.