### PR TITLE
[v8] Backport: docs: Don't lint external links when running in CI (#12058)

### DIFF
--- a/.cloudbuild/ci/doc-tests.yaml
+++ b/.cloudbuild/ci/doc-tests.yaml
@@ -1,11 +1,9 @@
 steps:
   - name: quay.io/gravitational/next:main
     id: docs-test
-    env:
-      - WITH_EXTERNAL_LINKS=true
     entrypoint: /bin/bash
     dir: /src
-    args: 
-      - -c 
-      - ln -s /workspace /src/content && yarn markdown-lint-external-links
+    args:
+      - -c
+      - ln -s /workspace /src/content && yarn markdown-lint
     timeout: 10m

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -419,7 +419,7 @@ docsbox:
 .PHONY:test-docs
 test-docs: docsbox
 	docker run --platform=linux/amd64 -i $(NOROOT) -v $$(pwd)/..:/src/content $(DOCSBOX) \
-		/bin/sh -c "yarn markdown-lint"
+		/bin/sh -c "yarn markdown-lint-external-links"
 
 #
 # Builds assets needed by CentOS 6 in a container.


### PR DESCRIPTION
Original behaviour did not take effect in CI due to a different entrypoint.

This restores the original behaviour (which will link external links when using make -C build.assets test-docs) but disables the external linting in CI for reliability.

Updates #11940