### PR TITLE
[branch/v7] Prevent goroutine leak in oidc client (#11974)

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2847,6 +2847,7 @@ const (
 type oidcClient struct {
 	client *oidc.Client
 	config oidc.ClientConfig
+	cancel context.CancelFunc
 }
 
 // samlProvider is internal structure that stores SAML client and its config

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -69,6 +69,7 @@ func (a *Server) getOIDCClient(conn types.OIDCConnector) (*oidc.Client, error) {
 		return clientPack.client, nil
 	}
 
+	clientPack.cancel()
 	delete(a.oidcClients, conn.GetName())
 	return nil, trace.NotFound("connector %v has updated the configuration and is invalidated", conn.GetName())
 
@@ -81,26 +82,36 @@ func (a *Server) createOIDCClient(conn types.OIDCConnector) (*oidc.Client, error
 		return nil, trace.Wrap(err)
 	}
 
-	doneSyncing := make(chan struct{})
+	// SyncProviderConfig doesn't take a context for cancellation, instead it
+	// returns a channel that has to be closed to stop the sync. To ensure that
+	// the sync is eventually stopped we create a child context of the server context, which
+	// is cancelled either on deletion of the connector or shutdown of the server.
+	// This will cause syncCtx.Done() to unblock, at which point we can close the stop channel.
+	firstSync := make(chan struct{})
+	syncCtx, syncCancel := context.WithCancel(a.closeCtx)
 	go func() {
-		defer close(doneSyncing)
-		client.SyncProviderConfig(conn.GetIssuerURL())
+		stop := client.SyncProviderConfig(conn.GetIssuerURL())
+		close(firstSync)
+		<-syncCtx.Done()
+		close(stop)
 	}()
 
 	select {
-	case <-doneSyncing:
+	case <-firstSync:
 	case <-time.After(defaults.WebHeadersTimeout):
+		syncCancel()
 		return nil, trace.ConnectionProblem(nil,
 			"timed out syncing oidc connector %v, ensure URL %q is valid and accessible and check configuration",
 			conn.GetName(), conn.GetIssuerURL())
 	case <-a.closeCtx.Done():
+		syncCancel()
 		return nil, trace.ConnectionProblem(nil, "auth server is shutting down")
 	}
 
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
-	a.oidcClients[conn.GetName()] = &oidcClient{client: client, config: config}
+	a.oidcClients[conn.GetName()] = &oidcClient{client: client, config: config, cancel: syncCancel}
 
 	return client, nil
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `branch/v7`:
 - [Prevent goroutine leak in oidc client (#11974)](https://github.com/gravitational/teleport/pull/11974)

<!--- Backport version: 8.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)