### PR TITLE
[branch/v8] Prevent goroutine leak in oidc client (#11974)

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3682,6 +3682,7 @@ const (
 type oidcClient struct {
 	client *oidc.Client
 	config oidc.ClientConfig
+	cancel context.CancelFunc
 }
 
 // samlProvider is internal structure that stores SAML client and its config


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `branch/v8`:
 - [Prevent goroutine leak in oidc client (#11974)](https://github.com/gravitational/teleport/pull/11974)

<!--- Backport version: 8.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)