### PR TITLE
Kubernetes enabled and user/groups advisory

### DIFF
--- a/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
+++ b/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
@@ -35,7 +35,7 @@ RBAC to Teleport roles if the user has no `Kubernetes groups` or `Kubernetes use
 
 </Details>
 <Details
-title="Confirm User has Kubernetes access"
+title="Confirm that your user has Kubernetes access"
 scope={["cloud"]}
 scopeOnly={true}
 opened={true}

--- a/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
+++ b/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
@@ -5,7 +5,7 @@ scopeOnly={true}
 opened={true}
 >
 
-Confirm the `Kubernetes` status is `enabled` within the cluster and the user has Kubernetes groups
+Confirm that `tsh status` shows `Kubernetes:enabled` and the user has Kubernetes groups
 or users assigned.
 
 ```code

--- a/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
+++ b/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
@@ -1,0 +1,63 @@
+<Details
+title="Confirm Kubernetes is enabled in Teleport"
+scope={["oss", "enterprise"]}
+scopeOnly={true}
+opened={true}
+>
+
+Confirm the `Kubernetes` status is `enabled` within the cluster and the user has Kubernetes groups
+or users assigned.
+
+```code
+$ tsh status
+ Profile URL:        https://teleport.example.com:443
+  Logged in as:       bob
+  Cluster:            teleport.example.com
+  Roles:              access,editor
+  Logins:             bob
+  Kubernetes:         enabled
+  Kubernetes groups:  developer
+  Valid until:        2022-04-20 22:39:15 -0400 EDT [valid for 12h0m0s]
+  Extensions:         permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty
+```
+
+If Kubernetes is `disabled` then the `kube_listen_addr` needs setting within the `proxy_service` as below. Restart
+the Teleport process after setting this. 
+
+```yaml
+proxy_service:
+  enabled: true
+  kube_listen_addr: 0.0.0.0:3026
+```
+
+See the [Teleport Kubernetes Access Controls](/docs/kubernetes-access/controls) for configuring Kubernetes
+RBAC to Teleport roles if the user has no `Kubernetes groups` or `Kubernetes users`.
+
+</Details>
+<Details
+title="Confirm User has Kubernetes access"
+scope={["cloud"]}
+scopeOnly={true}
+opened={true}
+>
+
+The Teleport user access the Kubernetes cluster will need Kubernetes groups or users
+to connect to the Kubernetes cluster as.
+
+```code
+$ tsh status
+ Profile URL:        https://example.teleport.sh:443
+  Logged in as:       bob
+  Cluster:            example.teleport.sh
+  Roles:              access,editor
+  Logins:             bob
+  Kubernetes:         enabled
+  Kubernetes groups:  developer
+  Valid until:        2022-04-20 22:39:15 -0400 EDT [valid for 12h0m0s]
+  Extensions:         permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty
+```
+
+See the [Teleport Kubernetes Access Controls](/docs/kubernetes-access/controls) for configuring Kubernetes
+RBAC to Teleport roles if the user has no `Kubernetes groups` or `Kubernetes users`.
+
+</Details>

--- a/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
+++ b/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
@@ -41,8 +41,8 @@ scopeOnly={true}
 opened={true}
 >
 
-The Teleport user access the Kubernetes cluster will need Kubernetes groups or users
-to connect to the Kubernetes cluster as.
+The Teleport user accessing the Kubernetes cluster will need to be assigned Kubernetes groups
+or users that they can use to make requests to the Kubernetes cluster.
 
 ```code
 $ tsh status

--- a/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
+++ b/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
@@ -57,7 +57,7 @@ $ tsh status
   Extensions:         permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-See the [Teleport Kubernetes Access Controls](/docs/kubernetes-access/controls) for configuring Kubernetes
+See the [Teleport Kubernetes Access Controls](/docs/kubernetes-access/controls) guide for configuring Kubernetes
 RBAC to Teleport roles if the user has no `Kubernetes groups` or `Kubernetes users`.
 
 </Details>

--- a/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
+++ b/docs/pages/includes/kubernetes-access/confirm-k8s.mdx
@@ -30,7 +30,7 @@ proxy_service:
   kube_listen_addr: 0.0.0.0:3026
 ```
 
-See the [Teleport Kubernetes Access Controls](/docs/kubernetes-access/controls) for configuring Kubernetes
+See the [Teleport Kubernetes Access Controls](/docs/kubernetes-access/controls) guide for configuring Kubernetes
 RBAC to Teleport roles if the user has no `Kubernetes groups` or `Kubernetes users`.
 
 </Details>

--- a/docs/pages/kubernetes-access/getting-started/agent.mdx
+++ b/docs/pages/kubernetes-access/getting-started/agent.mdx
@@ -11,6 +11,8 @@ description: Connecting a Kubernetes cluster to Teleport
 
 (!docs/pages/includes/kubernetes-access/helm-k8s.mdx!)
 
+(!docs/pages/includes/kubernetes-access/confirm-k8s.mdx!)
+
 (!docs/pages/includes/tctl.mdx!)
 
 ## Deployment overview

--- a/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
+++ b/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
@@ -21,6 +21,8 @@ This guide will show you how to use Teleport as an access plane for multiple Kub
 
 (!docs/pages/includes/helm.mdx!)
 
+(!docs/pages/includes/kubernetes-access/confirm-k8s.mdx!)
+
 (!docs/pages/includes/tctl.mdx!)
 
 ## Connecting clusters

--- a/docs/pages/kubernetes-access/guides/standalone-teleport.mdx
+++ b/docs/pages/kubernetes-access/guides/standalone-teleport.mdx
@@ -21,6 +21,8 @@ Teleport needs a `kubeconfig` file to authenticate against the Kubernetes API.
   See [Installing Teleport](../../installation.mdx) for details on installing
   the `teleport` binary.
 
+(!docs/pages/includes/kubernetes-access/confirm-k8s.mdx!)
+
 (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/2. Generate a kubeconfig


### PR DESCRIPTION
Kubernetes agent and other installations often fail due to lack of k8s enabled and no user/groups in a user role.