### PR TITLE
Simplify user creation in database access guides

### DIFF
--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -110,41 +110,7 @@ Teleport Database Access for Cloud SQL MySQL is available starting from the
 
 ### Create a user
 
-Create a local Teleport user with the built-in `access` role:
-
-```code
-$ tctl users add --roles=access alice
-```
-
-The `access` role allows users to see all connected database servers, but
-allowed database users are restricted to the user's `db_users` traits. Normally,
-these traits come from the identity provider. For the local user you've just
-created you can update them manually to allow the user to connect as an `alice`
-database user.
-
-First, export the user resource:
-
-```code
-$ tctl get users/alice > alice.yaml
-```
-
-Update the resource to include the following traits:
-
-```yaml
-traits:
-  # Database account names the user will be allowed to use.
-  db_users:
-  - alice
-```
-
-Update the user:
-
-```code
-$ tctl create alice.yaml -f
-```
-
-For more detailed information about database access controls see the
-[RBAC](../rbac.mdx) documentation.
+(!docs/pages/includes/database-access/create-user.mdx!)
 
 ## Step 4/5. Set up the Teleport Database service
 

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -97,33 +97,9 @@ in the MySQL documentation or
 [Enabling TLS on MariaDB Server](https://mariadb.com/docs/security/encryption/in-transit/enable-tls-server/)
 in the MariaDB documentation for more details.
 
-### Create a role and user
+### Create a Teleport user
 
-Create the role that will allow a user to connect to any database using any
-database account:
-
-```code
-tctl --config=/path/to/teleport-db-role.yaml create <<EOF
-kind: role
-version: v5
-metadata:
-  name: db
-spec:
-  allow:
-    db_labels:
-      '*': '*'
-    db_names:
-    - '*'
-    db_users:
-    - '*'
-EOF
-```
-
-Create the user assigned the `db` role we've just created:
-
-```code
-$ tctl --config=/path/to/teleport-db-role.yaml users add --roles=access,db testuser
-```
+(!docs/pages/includes/database-access/create-user.mdx!)
 
 ### Start the Database Service
 

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -180,46 +180,7 @@ the `6.2` Teleport release.
 
 ### Create a user
 
-Create local Teleport user with the built-in `access` role:
-
-```code
-$ tctl users add --roles=access alice
-```
-
-The `access` role allows users to see all connected database servers, but
-database names and accounts are restricted to the user's `db_names` and
-`db_users` traits. Normally, these traits come from the identity provider. For
-the local user you've just created you can update them manually to allow it to
-connect to the `postgres` database as a `teleport@<project-id>.iam` database
-service account.
-
-First, export the user resource:
-
-```code
-$ tctl get users/alice > alice.yaml
-```
-
-Update the resource to include the following traits:
-
-```yaml
-traits:
-  # Database account names the user will be allowed to use.
-  # Note: replace <project-id> with your GCP project ID.
-  db_users:
-  - teleport@<project-id>.iam
-  # Database names the user will be allowed to connect to.
-  db_names:
-  - postgres
-```
-
-Update the user:
-
-```code
-$ tctl create alice.yaml -f
-```
-
-For more detailed information about database access controls see [RBAC](../rbac.mdx)
-documentation.
+(!docs/pages/includes/database-access/create-user.mdx!)
 
 ## Step 6/7. Set up the Teleport Database service
 

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -25,33 +25,9 @@ release.
 
 (!docs/pages/includes/database-access/token.mdx!)
 
-### Create a role and user
+### Create a Teleport user
 
-Create a role that will allow a user to connect to any database using any
-database account:
-
-```code
-tctl --config=/path/to/teleport.yaml create <<EOF
-kind: role
-version: v5
-metadata:
-  name: db
-spec:
-  allow:
-    db_labels:
-      '*': '*'
-    db_names:
-    - '*'
-    db_users:
-    - '*'
-EOF
-```
-
-Create the user assigned the `db` role we've just created:
-
-```code
-$ tctl --config=/path/to/teleport.yaml users add --roles=access,db testuser
-```
+(!docs/pages/includes/database-access/create-user.mdx!)
 
 ## Step 2/5. Create a certificate/key pair
 

--- a/docs/pages/includes/database-access/create-user.mdx
+++ b/docs/pages/includes/database-access/create-user.mdx
@@ -1,42 +1,22 @@
 Create a local Teleport user with the built-in `access` role:
 
 ```code
-$ tctl users add --roles=access alice
+$ tctl users add \
+  --roles=access \
+  --db-users=\* \
+  --db-names=\* \
+  alice
 ```
 
-The `access` role allows users to see all connected database servers, but
-database names and accounts are restricted to the user's `db_names` and
-`db_users` traits. Normally, these traits come from the identity provider. For
-the local user you've just created you can update them manually to allow it to
-connect to any database as any database user.
+| Flag | Description |
+| ---- | ----------- |
+| `--roles` | List of roles to assign to the user. The builtin `access` role allows them to connect to any database server registered with Teleport. |
+| `--db-users` | List of database usernames the user will be allowed to use when connecting to the databases. A wildcard allows any user. |
+| `--db-names` | List of logical databases (aka schemas) the user will be allowed to connect to within a database server. A wildcard allows any database. |
 
-First, export the user resource:
-
-```code
-$ tctl get users/alice > alice.yaml
-```
-
-Update the resource to include the following traits:
-
-```yaml
-traits:
-  db_users:
-  - "*"
-  db_names:
-  - "*"
-```
-
-<Admonition type="note">
-  The `db_names` property only has effect on PostgreSQL and MongoDB database
-  engines.
+<Admonition type="warning">
+  Database names are only enforced for PostgreSQL and MongoDB databases.
 </Admonition>
 
-Update the user:
-
-```code
-$ tctl create alice.yaml -f
-```
-
-For more detailed information about database access controls and how to
-configure restricted access, see the [RBAC](../../database-access/rbac.mdx)
-documentation.
+For more detailed information about database access controls and how to restrict
+access see [RBAC](../../database-access/rbac.mdx) documentation.

--- a/docs/pages/setup/reference/cli.mdx
+++ b/docs/pages/setup/reference/cli.mdx
@@ -819,20 +819,25 @@ $ tctl help
 Generates a user invitation token:
 
 ```code
-$ tctl users add [<flags>] <account> [<local-logins>]
+$ tctl users add [<flags>] <account>
 ```
 
 #### Arguments
 
 - `<account>` - The Teleport user account name.
-- `<local-logins>` - A comma-separated list of local UNIX users this account can log in as. If unspecified the account will be mapped to an OS user of the same name. See examples below.
 
 #### Flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--k8s-groups` | none | a kubernetes group | Kubernetes groups to assign to a user, e.g. `system:masters` |
-| `--k8s-users` | none | a kubernetes user | Kubernetes user to assign to a user, e.g. `jenkins` |
+| `--roles` | none | Comma-separated strings | List of Teleport roles to assign to the new user |
+| `--logins` | none | Comma-separated strings | List of allowed SSH logins for the new user |
+| `--kubernetes-groups` | none | Comma-separated strings | Kubernetes groups to assign to a user, e.g. `system:masters` |
+| `--kubernetes-users` | none | Comma-separated strings | Kubernetes user to assign to a user, e.g. `jenkins` |
+| `--db-users` | none | Comma-separated strings | List of allowed database users for the new user |
+| `--db-names` | none | Comma-separated strings | List of allowed database names for the new user |
+| `--windows-logins` | none | Comma-separated strings | List of allowed Windows logins for the new user |
+| `--aws-role-arns` | none | Comma-separated strings | List of allowed AWS role ARNs for the new user |
 | `--ttl` | 1h | relative duration like 5s, 2m, or 3h, **maximum 48h** | Set expiration time for token |
 
 #### Global flags


### PR DESCRIPTION
A few tweaks:

- Take advantage of the feature implemented in https://github.com/gravitational/teleport/pull/12102 and simplify "create Teleport user" instructions in database access guides. Users no longer need to export/edit the user.
- Make sure that all guides use the "create user" include page. Some older ones weren't using it.
- Update obsolete `tctl users add` CLI reference.