### PR TITLE
Use os.UserHomeDir instead of implementing it ourselves

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -647,12 +647,6 @@ const (
 	// KubeConfigFile is a default filename where k8s stores its user local config
 	KubeConfigFile = "config"
 
-	// EnvHome is home environment variable
-	EnvHome = "HOME"
-
-	// EnvUserProfile is the home directory environment variable on Windows.
-	EnvUserProfile = "USERPROFILE"
-
 	// KubeRunTests turns on kubernetes tests
 	KubeRunTests = "TEST_KUBE"
 

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -19,10 +19,8 @@ package utils
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/trace"
 )
 
@@ -35,9 +33,9 @@ import (
 // It also makes sure that base dir exists
 func EnsureLocalPath(customPath string, defaultLocalDir, defaultLocalPath string) (string, error) {
 	if customPath == "" {
-		homeDir := getHomeDir()
-		if homeDir == "" {
-			return "", trace.BadParameter("no path provided and environment variable %v is not not set", teleport.EnvHome)
+		homeDir, err := os.UserHomeDir()
+		if err != nil || homeDir == "" {
+			return "", trace.BadParameter("could not get user home dir: %v", err)
 		}
 		customPath = filepath.Join(homeDir, defaultLocalDir, defaultLocalPath)
 	}
@@ -153,18 +151,4 @@ func StatDir(path string) (os.FileInfo, error) {
 		return nil, trace.BadParameter("%v is not a directory", path)
 	}
 	return fi, nil
-}
-
-// getHomeDir returns the home directory based off the OS.
-func getHomeDir() string {
-	// TODO(zmb3): use os.UserHomeDir instead and remove these constants
-	switch runtime.GOOS {
-	case constants.LinuxOS:
-		return os.Getenv(teleport.EnvHome)
-	case constants.DarwinOS:
-		return os.Getenv(teleport.EnvHome)
-	case constants.WindowsOS:
-		return os.Getenv(teleport.EnvUserProfile)
-	}
-	return ""
 }


### PR DESCRIPTION
```
➜ go doc os.UserHomeDir
package os // import "os"

func UserHomeDir() (string, error)
    UserHomeDir returns the current user's home directory.

    On Unix, including macOS, it returns the $HOME environment variable. On
    Windows, it returns %USERPROFILE%. On Plan 9, it returns the $home
    environment variable.
```