### PR TITLE
[v9] backport #12150 (`ProxyKube` readiness)

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -190,6 +190,7 @@ func TestIntegrations(t *testing.T) {
 	t.Run("PortForwarding", suite.bind(testPortForwarding))
 	t.Run("ProxyHostKeyCheck", suite.bind(testProxyHostKeyCheck))
 	t.Run("ReverseTunnelCollapse", suite.bind(testReverseTunnelCollapse))
+	t.Run("Readyz", suite.bind(testReadyz))
 	t.Run("RotateChangeSigningAlg", suite.bind(testRotateChangeSigningAlg))
 	t.Run("RotateRollback", suite.bind(testRotateRollback))
 	t.Run("RotateSuccess", suite.bind(testRotateSuccess))
@@ -3662,6 +3663,45 @@ func testPAM(t *testing.T, suite *integrationTestSuite) {
 			}
 		})
 	}
+}
+
+func testReadyz(t *testing.T, suite *integrationTestSuite) {
+	// TODO: test more service combinations
+
+	recConfig, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
+		Mode: types.RecordOff,
+	})
+	require.NoError(t, err)
+
+	tconf := suite.defaultServiceConfig()
+	tconf.Auth.Enabled = true
+	tconf.Auth.SessionRecordingConfig = recConfig
+	tconf.Proxy.Enabled = true
+	tconf.Proxy.DisableWebInterface = true
+	tconf.Proxy.Kube.Enabled = true
+	// fire up the proxy kube service
+	tconf.Proxy.Kube.ListenAddr = utils.NetAddr{
+		AddrNetwork: "tcp",
+		Addr:        "127.0.0.1:0",
+	}
+	tconf.SSH.Enabled = false
+	tconf.DiagnosticAddr = utils.NetAddr{
+		AddrNetwork: "tcp",
+		Addr:        "127.0.0.1:0",
+	}
+
+	teleport := suite.newTeleportWithConfig(t, nil, nil, tconf)
+	t.Cleanup(func() { require.NoError(t, teleport.StopAll()) })
+
+	diagAddr, err := teleport.Process.DiagnosticAddr()
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://%s/readyz", diagAddr))
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 500*time.Millisecond)
 }
 
 // testRotateSuccess tests full cycle cert authority rotation

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -156,6 +156,8 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		}
 	} else {
 		log.Debug("No local kube credentials on proxy, will not start kubernetes_service heartbeats")
+		// Report the component as being ready.
+		cfg.OnHeartbeat(nil)
 	}
 
 	return server, nil


### PR DESCRIPTION
Backport of #12150.