### PR TITLE
helm: Add support for additional labels to `teleport-kube-agent`

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -11,9 +11,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
-{{- if .Values.clusterLabels }}
-  {{- toYaml .Values.clusterLabels | nindent 4 }}
-{{- end }}
+  {{- if .Values.additionalLabels }}
+    {{- toYaml .Values.additionalLabels | nindent 4 }}
+  {{- end }}
   {{- if .Values.annotations.deployment }}
   annotations:
     {{- toYaml .Values.annotations.deployment | nindent 4 }}
@@ -23,6 +23,9 @@ spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}
+  {{- if .Values.additionalLabels }}
+    {{- toYaml .Values.additionalLabels | nindent 6 }}
+  {{- end }}
   template:
     metadata:
       annotations:
@@ -33,6 +36,9 @@ spec:
 {{- end }}
       labels:
         app: {{ .Release.Name }}
+    {{- if .Values.additionalLabels }}
+      {{- toYaml .Values.additionalLabels | nindent 8 }}
+    {{- end }}
     spec:
       {{- if or .Values.affinity (gt (int $replicaCount) 1) }}
       affinity:

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
+{{- if .Values.clusterLabels }}
+  {{- toYaml .Values.clusterLabels | nindent 4 }}
+{{- end }}
   {{- if .Values.annotations.deployment }}
   annotations:
     {{- toYaml .Values.annotations.deployment | nindent 4 }}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -11,8 +11,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
-  {{- if .Values.clusterLabels }}
-    {{- toYaml .Values.clusterLabels | nindent 4 }}
+  {{- if .Values.additionalLabels }}
+    {{- toYaml .Values.additionalLabels | nindent 4 }}
   {{- end }}
 spec:
   serviceName: {{ .Release.Name }}
@@ -20,6 +20,9 @@ spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}
+  {{- if .Values.additionalLabels }}
+    {{- toYaml .Values.additionalLabels | nindent 6 }}
+  {{- end }}
   template:
     metadata:
       annotations:
@@ -30,6 +33,9 @@ spec:
 {{- end }}
       labels:
         app: {{ .Release.Name }}
+    {{- if .Values.additionalLabels }}
+      {{- toYaml .Values.additionalLabels | nindent 8 }}
+    {{- end }}
     spec:
       securityContext:
         fsGroup: 9807

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
+  {{- if .Values.clusterLabels }}
+    {{- toYaml .Values.clusterLabels | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ .Release.Name }}
   replicas: {{ $replicaCount }}

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -167,6 +167,10 @@ affinity: {}
 # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
 nodeSelector: {}
 
+# Kubernetes deployment labels to apply
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+clusterLabels: {}
+
 # Kubernetes annotations to apply
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 annotations:

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -5,9 +5,9 @@
 # Join token for the cluster.
 # Leave empty if the secret "teleport-kube-agent-join-token"
 # has been created before and contains a valid join token
-authToken: ""
+authToken: "test"
 # Address of the teleport proxy with port (usually :3080).
-proxyAddr: ""
+proxyAddr: "proxy.example.com"
 # Comma-separated list of roles to enable (any of: kube,db,app)
 roles: "kube"
 
@@ -16,7 +16,7 @@ roles: "kube"
 ################################################################
 
 # Name for this kubernetes cluster to be used by teleport users.
-kubeClusterName: ""
+kubeClusterName: "test"
 
 ################################################################
 # Values that must be provided if Application access is enabled.
@@ -169,7 +169,9 @@ nodeSelector: {}
 
 # Kubernetes deployment labels to apply
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-clusterLabels: {}
+additionalLabels: {
+  "key": "value"
+}
 
 # Kubernetes annotations to apply
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
Added additional label options for deployments and statefulsets to allow customers to utilize Helm Charts with Fargate, istio, and other deployment models that require custom labels.

Resolves #8702 