### PR TITLE
[branch/v7] Respect Firestore commit write limits (#12111)

### DIFF
--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -24,6 +24,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 	apiv1 "cloud.google.com/go/firestore/apiv1/admin"
+	"github.com/gravitational/trace/trail"
 	"google.golang.org/api/option"
 	adminpb "google.golang.org/genproto/googleapis/firestore/admin/v1"
 	"google.golang.org/grpc"
@@ -206,6 +207,8 @@ const (
 	idDocProperty = "id"
 	// timeInBetweenIndexCreationStatusChecks
 	timeInBetweenIndexCreationStatusChecks = time.Second * 10
+	// commitLimit is the maximum number of writes per commit
+	commitLimit = 500
 )
 
 // GetName is a part of backend API and it returns Firestore backend type
@@ -394,23 +397,12 @@ func (b *Backend) GetRange(ctx context.Context, startKey []byte, endKey []byte, 
 
 // DeleteRange deletes range of items with keys between startKey and endKey
 func (b *Backend) DeleteRange(ctx context.Context, startKey, endKey []byte) error {
-	docSnaps, err := b.getRangeDocs(ctx, startKey, endKey, backend.DefaultRangeLimit)
+	docs, err := b.getRangeDocs(ctx, startKey, endKey, backend.DefaultRangeLimit)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(docSnaps) == 0 {
-		// Nothing to delete.
-		return nil
-	}
-	batch := b.svc.Batch()
-	for _, docSnap := range docSnaps {
-		batch.Delete(docSnap.Ref)
-	}
-	_, err = batch.Commit(ctx)
-	if err != nil {
-		return ConvertGRPCError(err)
-	}
-	return nil
+
+	return trace.Wrap(b.deleteDocuments(docs))
 }
 
 // Get returns a single item or not found error
@@ -681,21 +673,35 @@ func (b *Backend) purgeExpiredDocuments() error {
 			return nil
 		case <-t.C:
 			expiryTime := b.clock.Now().UTC().Unix()
-			numDeleted := 0
-			batch := b.svc.Batch()
-			docs, _ := b.svc.Collection(b.CollectionName).Where(expiresDocProperty, "<=", expiryTime).Documents(b.clientContext).GetAll()
-			for _, doc := range docs {
-				batch.Delete(doc.Ref)
-				numDeleted++
+			docs, err := b.svc.Collection(b.CollectionName).Where(expiresDocProperty, "<=", expiryTime).Documents(b.clientContext).GetAll()
+			if err != nil {
+				b.Logger.WithError(trail.FromGRPC(err)).Warn("Failed to get expired documents")
+				continue
 			}
-			if numDeleted > 0 {
-				_, err := batch.Commit(b.clientContext)
-				if err != nil {
-					return ConvertGRPCError(err)
-				}
+
+			if err := b.deleteDocuments(docs); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 	}
+}
+
+// deleteDocuments removes documents from firestore in batches to stay within the
+// firestore write limits
+func (b *Backend) deleteDocuments(docs []*firestore.DocumentSnapshot) error {
+	for i := 0; i < len(docs); i += commitLimit {
+		batch := b.svc.Batch()
+
+		for j := 0; j < commitLimit && i+j < len(docs); j++ {
+			batch.Delete(docs[i+j].Ref)
+		}
+
+		if _, err := batch.Commit(b.clientContext); err != nil {
+			return ConvertGRPCError(err)
+		}
+	}
+
+	return nil
 }
 
 // ConvertGRPCError converts GRPC errors


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `branch/v7`:
 - [Respect Firestore commit write limits (#12111)](https://github.com/gravitational/teleport/pull/12111)

<!--- Backport version: 8.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)