### PR TITLE
Add a partial for agent installs in Teleport Cloud

### DIFF
--- a/docs/pages/includes/install-agent-cloud.mdx
+++ b/docs/pages/includes/install-agent-cloud.mdx
@@ -1,0 +1,13 @@
+On the host where you will run your Teleport Node, install a version of
+Teleport that is compatible with the Teleport Cloud version, v(=cloud.version=):
+
+```code
+$ curl https://get.gravitational.com/teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz.sha256
+# <checksum> <filename>
+$ curl -O https://get.gravitational.com/teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
+$ shasum -a 256 teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
+# Verify that the checksums match
+$ tar -xzf teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
+$ cd teleport
+$ sudo ./install
+```

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -42,9 +42,19 @@ This guide introduces some of these common scenarios and how to interact with Te
    We'll configure and launch our instance, then demonstrate how to use the
    `tsh` tool and Teleport in SSH mode.
 
-2. Install Teleport on your instance.
+2. <ScopedBlock scope={["oss", "enterprise"]}>
 
-   (!docs/pages/includes/install-linux.mdx!)
+    On the host where you will run your Teleport Node, follow the instructions for
+    your environment to install Teleport.
+
+    (!docs/pages/includes/install-linux.mdx!)
+
+    </ScopedBlock>
+    <ScopedBlock scope={["cloud"]}>
+
+    (!docs/pages/includes/install-agent-cloud.mdx!)
+
+    </ScopedBlock>
 
    Next, we'll create a **join token** so you can start the Teleport Node and
    add it to your cluster.

--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -74,10 +74,19 @@ Teleport Enhanced Session Recording mitigates all three concerns by providing ad
 
 ### Install Teleport on your Node
 
+<ScopedBlock scope={["oss", "enterprise"]}>
+
 On the host where you will run your Teleport Node, follow the instructions for
 your environment to install Teleport.
 
 (!docs/pages/includes/install-linux.mdx!)
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+(!docs/pages/includes/install-agent-cloud.mdx!)
+
+</ScopedBlock>
 
 ### Generate a token
 

--- a/docs/pages/setup/admin/adding-nodes.mdx
+++ b/docs/pages/setup/admin/adding-nodes.mdx
@@ -15,9 +15,19 @@ This guide explains how to add Teleport Nodes to your cluster.
 
 ## Step 1/3. Install Teleport on your Node
 
-On the Linux server that you will use for your Teleport Node, run the appropriate installation commands for your platform:
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+On the host where you will run your Teleport Node, follow the instructions for
+your environment to install Teleport.
 
 (!docs/pages/includes/install-linux.mdx!)
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+(!docs/pages/includes/install-agent-cloud.mdx!)
+
+</ScopedBlock>
 
 ## Step 2/3. Join your Node to the cluster
 


### PR DESCRIPTION
If a user installs an agent version that is greater than the control
plane version, the agent will not be able to contact the control plane
(e.g., it will call a gRPC method that the control plane doesn't
recognize). The current partial for installing Teleport on a Linux host
includes only instructions for installing the latest version. Since
Teleport Cloud is behind the latest version, I have added a partial for
installing a Cloud-compatible agent and included it for Cloud users
in guides that require installing a Teleport agent.