### PR TITLE
[v9] docker: Add lint-helm to build.assets Makefile

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -269,6 +269,11 @@ lint: buildbox
 	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BUILDBOX) \
 		/bin/bash -c "make -C $(SRCDIR) lint"
 
+.PHONY:lint-helm
+lint-helm: buildbox
+	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BUILDBOX) \
+		/bin/bash -c "make -C $(SRCDIR) lint-helm"
+
 #
 # Starts shell inside the build container
 #


### PR DESCRIPTION
Backports #12178 to `branch/v9`