### PR TITLE
Automatically create backport Pull Requests

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -1,5 +1,5 @@
 # This workflow is run whenever a pull request is opened, re-opened, or taken
-# out of draft (ready for review). 
+# out of draft (ready for review).
 #
 # NOTE: pull_request_target behaves the same as pull_request except it grants a
 # read/write token to workflows running on a pull request from a fork. While

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,33 @@
+# This workflow will create backport Pull Requests whenever a pull request with
+# the appropriate labels is merged.
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+
+# Limit the permissions on the GitHub token for this workflow to the subset
+# that is required. In this case, the backport workflow needs to be able to
+# create branches and create/update PRs, so it needs write access to
+# "pull-requests" and "contents" permissions.
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  backport-pull-request:
+    name: Backport Pull Request
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout master branch of Teleport repository. This is to prevent an
+      # attacker from submitting their own bot logic.
+      - name: Checkout master branch
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Installing the latest version of Go.
+        uses: actions/setup-go@v2
+      # Run "backport" subcommand on bot.
+      - name: Backport PR
+        run: cd .github/workflows/robot && go run main.go -workflow=backport -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"

--- a/.github/workflows/robot/internal/bot/assign_test.go
+++ b/.github/workflows/robot/internal/bot/assign_test.go
@@ -49,9 +49,11 @@ func TestBackportReviewers(t *testing.T) {
 		{
 			desc: "backport-original-pr-number-approved",
 			pull: github.PullRequest{
-				Author:      "baz",
-				Repository:  "bar",
-				UnsafeHead:  "baz/fix",
+				Author:     "baz",
+				Repository: "bar",
+				UnsafeHead: github.Branch{
+					Ref: "baz/fix",
+				},
 				UnsafeTitle: "Backport #0 to branch/v8",
 				UnsafeBody:  "",
 				Fork:        false,
@@ -66,9 +68,11 @@ func TestBackportReviewers(t *testing.T) {
 		{
 			desc: "backport-original-url-approved",
 			pull: github.PullRequest{
-				Author:      "baz",
-				Repository:  "bar",
-				UnsafeHead:  "baz/fix",
+				Author:     "baz",
+				Repository: "bar",
+				UnsafeHead: github.Branch{
+					Ref: "baz/fix",
+				},
 				UnsafeTitle: "Fixed an issue",
 				UnsafeBody:  "https://github.com/gravitational/teleport/pull/0",
 				Fork:        false,
@@ -83,9 +87,12 @@ func TestBackportReviewers(t *testing.T) {
 		{
 			desc: "backport-multiple-reviews",
 			pull: github.PullRequest{
-				Author:      "baz",
-				Repository:  "bar",
-				UnsafeHead:  "baz/fix",
+				Author:     "baz",
+				Repository: "bar",
+				UnsafeHead: github.Branch{
+					Ref: "baz/fix",
+				},
+
 				UnsafeTitle: "Fixed feature",
 				UnsafeBody:  "",
 				Fork:        false,
@@ -103,9 +110,11 @@ func TestBackportReviewers(t *testing.T) {
 		{
 			desc: "backport-original-not-found",
 			pull: github.PullRequest{
-				Author:      "baz",
-				Repository:  "bar",
-				UnsafeHead:  "baz/fix",
+				Author:     "baz",
+				Repository: "bar",
+				UnsafeHead: github.Branch{
+					Ref: "baz/fix",
+				},
 				UnsafeTitle: "Fixed feature",
 				UnsafeBody:  "",
 				Fork:        false,

--- a/.github/workflows/robot/internal/bot/backport.go
+++ b/.github/workflows/robot/internal/bot/backport.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bot
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"os/exec"
+	"path"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/gravitational/teleport/.github/workflows/robot/internal/github"
+
+	"github.com/gravitational/trace"
+)
+
+// Backport will create backport Pull Requests (if requested) when a Pull
+// Request is merged.
+func (b *Bot) Backport(ctx context.Context) error {
+	if !b.c.Review.IsInternal(b.c.Environment.Author) {
+		return trace.BadParameter("automatic backports are only supported for internal contributors")
+	}
+
+	pull, err := b.c.GitHub.GetPullRequest(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.Number)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Extract backport branches names from labels attached to the Pull
+	// Request. If no backports were requested, return right away.
+	branches := findBranches(pull.UnsafeLabels)
+	if len(branches) == 0 {
+		return nil
+	}
+
+	// Get workflow logs URL, will be attached to any backport failure.
+	u, err := b.workflowLogsURL(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.RunID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var rows []row
+	var failed bool
+
+	// Loop over all requested backport branches and create backport branch and
+	// GitHub Pull Request.
+	for _, base := range branches {
+		head := fmt.Sprintf("bot/backport-%v-%v", b.c.Environment.Number, base)
+
+		// Create and push git branch for backport to GitHub.
+		err := b.createBackportBranch(ctx,
+			b.c.Environment.Organization,
+			b.c.Environment.Repository,
+			b.c.Environment.Number,
+			base,
+			pull,
+			head,
+		)
+		if err != nil {
+			log.Printf("Failed to create backport branch: %v.", err)
+			failed = true
+			rows = append(rows, row{
+				Branch: base,
+				Failed: true,
+				Link:   u,
+			})
+			continue
+		}
+
+		// Create Pull Request for backport.
+		number, err := b.c.GitHub.CreatePullRequest(ctx,
+			b.c.Environment.Organization,
+			b.c.Environment.Repository,
+			fmt.Sprintf("[%v] %v", strings.Trim(base, "branch/"), pull.UnsafeTitle),
+			head,
+			base,
+			fmt.Sprintf("Backport #%v to %v", b.c.Environment.Number, base),
+			false)
+		if err != nil {
+			log.Printf("Failed to create backport Pull Request: %v", err)
+			failed = true
+			rows = append(rows, row{
+				Branch: base,
+				Failed: true,
+				Link:   u,
+			})
+			continue
+		}
+
+		rows = append(rows, row{
+			Branch: base,
+			Failed: false,
+			Link: url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+				Path:   path.Join(b.c.Environment.Organization, b.c.Environment.Repository, "pull", strconv.Itoa(number)),
+			},
+		})
+	}
+
+	// Leave a comment on the Pull Request with a table that outlines the
+	// requested backports and outcome.
+	err = b.updatePullRequest(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.Number,
+		data{
+			Author: b.c.Environment.Author,
+			Failed: failed,
+			Rows:   rows,
+		})
+	return trace.Wrap(err)
+}
+
+// findBranches looks through the labels attached to a Pull Request for all the
+// backport branches the user requested.
+func findBranches(labels []string) []string {
+	var branches []string
+
+	for _, label := range labels {
+		if !strings.HasPrefix(label, "backport/") {
+			continue
+		}
+
+		branch := strings.TrimPrefix(label, "backport/")
+		if !branchPattern.MatchString(branch) {
+			continue
+		}
+
+		branches = append(branches, branch)
+	}
+
+	sort.Strings(branches)
+	return branches
+}
+
+// createBackportBranch will create and push a git branch with all the commits
+// from a Pull Request on it.
+//
+// TODO(russjones): Refactor to use go-git (so similar git library) instead of
+// executing git from disk.
+func (b *Bot) createBackportBranch(ctx context.Context, organization string, repository string, number int, base string, pull github.PullRequest, newHead string) error {
+	if err := git("config", "--global", "user.name", "github-actions"); err != nil {
+		log.Printf("Failed to set user.name: %v.", err)
+	}
+	if err := git("config", "--global", "user.email", "github-actions@goteleport.com"); err != nil {
+		log.Printf("Failed to set user.email: %v.", err)
+	}
+
+	// Download base and head from origin (GitHub).
+	if err := git("fetch", "origin", base, pull.UnsafeHead.Ref); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Checkout the base branch then rebase commits from Pull Request ontop of
+	// it. See https://stackoverflow.com/a/29916361 for more details.
+	newParent := base
+	oldParent := pull.UnsafeBase.SHA
+	until := pull.UnsafeHead.SHA
+	if err := git("checkout", base); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := git("rebase", "--onto", newParent, oldParent, until); err != nil {
+		if er := git("rebase", "--abort"); er != nil {
+			return trace.NewAggregate(err, er)
+		}
+		return trace.Wrap(err)
+	}
+
+	// Checkout and push a branch to origin (GitHub).
+	if err := git("checkout", "-b", newHead); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := git("push", "origin", newHead); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// updatePullRequest will leave a comment on the Pull Request with the status
+// of backports.
+func (b *Bot) updatePullRequest(ctx context.Context, organization string, repository string, number int, d data) error {
+	var buf bytes.Buffer
+
+	t := template.Must(template.New("table").Parse(table))
+	if err := t.Execute(&buf, d); err != nil {
+		return trace.Wrap(err)
+	}
+
+	err := b.c.GitHub.CreateComment(ctx,
+		organization,
+		repository,
+		number,
+		buf.String())
+	return trace.Wrap(err)
+}
+
+// workflowLogsURL returns the workflow logs URL.
+func (b *Bot) workflowLogsURL(ctx context.Context, organization string, repository string, runID int64) (url.URL, error) {
+	jobs, err := b.c.GitHub.ListWorkflowJobs(ctx,
+		organization,
+		repository,
+		runID)
+	if err != nil {
+		return url.URL{}, trace.Wrap(err)
+	}
+	if len(jobs) != 1 {
+		return url.URL{}, trace.BadParameter("invalid number of jobs %v", len(jobs))
+	}
+
+	return url.URL{
+		Scheme:   "https",
+		Host:     "github.com",
+		Path:     path.Join(b.c.Environment.Organization, b.c.Environment.Repository, "runs", strconv.FormatInt(jobs[0].ID, 10)),
+		RawQuery: url.Values{"check_suite_focus": []string{"true"}}.Encode(),
+	}, nil
+}
+
+// git will execute the "git" program on disk.
+func git(args ...string) error {
+	cmd := exec.Command("git", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return trace.BadParameter(string(bytes.TrimSpace(out)))
+	}
+	return nil
+}
+
+// data is injected into the template to render outcome of all backport
+// attempts.
+type data struct {
+	// Author of the Pull Request. Used to @author on GitHub so they get a
+	// notification.
+	Author string
+
+	// Failed is used to indicate if any backports failed.
+	Failed bool
+
+	// Rows represent backports.
+	Rows []row
+}
+
+// row represents a single backport attempt.
+type row struct {
+	// Failed is used to indicate if this backport failed.
+	Failed bool
+
+	// Branch is the name of the backport branch.
+	Branch string
+
+	// Link is a URL pointing to the created backport Pull Request.
+	Link url.URL
+}
+
+// table is a template that is written to the origin GitHub Pull Request with
+// the outcome of the backports.
+const table = `
+{{if .Failed}}
+@{{.Author}} Some backports failed, see table below.
+{{end}}
+
+| Branch | Result |
+|--------|--------|
+{{- range .Rows}}
+| {{.Branch}} | {{if .Failed}}[Failed]({{.Link}}){{else}}{{.Link}}{{end}} |
+{{- end}}
+`
+
+// branchPattern defines valid backport branch names.
+var branchPattern = regexp.MustCompile(`(^branch\/v[0-9]+$)|(^master$)`)

--- a/.github/workflows/robot/internal/bot/backport_test.go
+++ b/.github/workflows/robot/internal/bot/backport_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindBranches(t *testing.T) {
+	branches := findBranches([]string{
+		"backport/branch/v7",
+		"backport/branchv8",
+		"backport/master",
+		"backport/foo",
+		"branch/v9",
+	})
+	require.ElementsMatch(t, branches, []string{
+		"branch/v7",
+		"master",
+	})
+}

--- a/.github/workflows/robot/internal/bot/bot.go
+++ b/.github/workflows/robot/internal/bot/bot.go
@@ -41,6 +41,9 @@ type Client interface {
 	// GetPullRequest returns a specific Pull Request.
 	GetPullRequest(ctx context.Context, organization string, repository string, number int) (github.PullRequest, error)
 
+	// CreatePullRequest will create a Pull Request.
+	CreatePullRequest(ctx context.Context, organization string, repository string, title string, head string, base string, body string, draft bool) (int, error)
+
 	// ListPullRequests returns a list of Pull Requests.
 	ListPullRequests(ctx context.Context, organization string, repository string, state string) ([]github.PullRequest, error)
 
@@ -50,11 +53,17 @@ type Client interface {
 	// AddLabels will add labels to an Issue or Pull Request.
 	AddLabels(ctx context.Context, organization string, repository string, number int, labels []string) error
 
+	// CreateComment will leave a comment on an Issue or Pull Request.
+	CreateComment(ctx context.Context, organization string, repository string, number int, comment string) error
+
 	// ListWorkflows lists all workflows within a repository.
 	ListWorkflows(ctx context.Context, organization string, repository string) ([]github.Workflow, error)
 
 	// ListWorkflowRuns is used to list all workflow runs for an ID.
 	ListWorkflowRuns(ctx context.Context, organization string, repository string, branch string, workflowID int64) ([]github.Run, error)
+
+	// ListWorkflowJobs lists all jobs for a workflow run.
+	ListWorkflowJobs(ctx context.Context, organization string, repository string, runID int64) ([]github.Job, error)
 
 	// DeleteWorkflowRun is used to delete a workflow run.
 	DeleteWorkflowRun(ctx context.Context, organization string, repository string, runID int64) error

--- a/.github/workflows/robot/internal/bot/bot_test.go
+++ b/.github/workflows/robot/internal/bot/bot_test.go
@@ -133,6 +133,18 @@ func (f *fakeGithub) ListWorkflowRuns(ctx context.Context, organization string, 
 	return nil, nil
 }
 
+func (f *fakeGithub) ListWorkflowJobs(ctx context.Context, organization string, repository string, runID int64) ([]github.Job, error) {
+	return nil, nil
+}
+
 func (f *fakeGithub) DeleteWorkflowRun(ctx context.Context, organization string, repository string, runID int64) error {
 	return nil
+}
+
+func (f *fakeGithub) CreateComment(ctx context.Context, organization string, repository string, number int, comment string) error {
+	return nil
+}
+
+func (f *fakeGithub) CreatePullRequest(ctx context.Context, organization string, repository string, title string, head string, base string, body string, draft bool) (int, error) {
+	return 0, nil
 }

--- a/.github/workflows/robot/internal/bot/dismiss.go
+++ b/.github/workflows/robot/internal/bot/dismiss.go
@@ -49,7 +49,7 @@ func (b *Bot) Dismiss(ctx context.Context) error {
 		if pull.Fork {
 			// HEAD could be controlled by an attacker, however, all this would allow is
 			// the attacker to dismiss a workflow run.
-			if err := b.dismiss(ctx, b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHead); err != nil {
+			if err := b.dismiss(ctx, b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHead.Ref); err != nil {
 				log.Printf("Failed to dismiss workflow: %v %v %v: %v.", b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHead, err)
 				continue
 			}

--- a/.github/workflows/robot/internal/env/env.go
+++ b/.github/workflows/robot/internal/env/env.go
@@ -19,6 +19,7 @@ package env
 import (
 	"encoding/json"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -34,6 +35,9 @@ type Environment struct {
 
 	// Number is the PR number.
 	Number int
+
+	// RunID is the GitHub Actions workflow run ID.
+	RunID int64
 
 	// Author is the author of the PR.
 	Author string
@@ -80,10 +84,16 @@ func New() (*Environment, error) {
 		}, nil
 	}
 
+	runID, err := strconv.ParseInt(os.Getenv(githubRunID), 10, 64)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &Environment{
 		Organization: event.Repository.Owner.Login,
 		Repository:   event.Repository.Name,
 		Number:       event.PullRequest.Number,
+		RunID:        runID,
 		Author:       event.PullRequest.User.Login,
 		UnsafeHead:   event.PullRequest.UnsafeHead.UnsafeRef,
 		UnsafeBase:   event.PullRequest.UnsafeBase.UnsafeRef,
@@ -128,4 +138,7 @@ const (
 	// githubRepository is an environment variable that contains the organization
 	// and repository name.
 	githubRepository = "GITHUB_REPOSITORY"
+
+	// githubRunID is an environment variable that contains the workflow run ID.
+	githubRunID = "GITHUB_RUN_ID"
 )

--- a/.github/workflows/robot/internal/env/env_test.go
+++ b/.github/workflows/robot/internal/env/env_test.go
@@ -85,6 +85,8 @@ func TestEnvironment(t *testing.T) {
 			require.NoError(t, err)
 			err = os.Setenv(githubEventPath, test.path)
 			require.NoError(t, err)
+			err = os.Setenv(githubRunID, "1")
+			require.NoError(t, err)
 
 			environment, err := New()
 			if test.err {

--- a/.github/workflows/robot/internal/github/github.go
+++ b/.github/workflows/robot/internal/github/github.go
@@ -75,7 +75,7 @@ type Review struct {
 func (c *Client) ListReviews(ctx context.Context, organization string, repository string, number int) ([]Review, error) {
 	var reviews []Review
 
-	opt := &go_github.ListOptions{
+	opts := &go_github.ListOptions{
 		Page:    0,
 		PerPage: perPage,
 	}
@@ -84,7 +84,7 @@ func (c *Client) ListReviews(ctx context.Context, organization string, repositor
 			organization,
 			repository,
 			number,
-			opt)
+			opts)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -100,7 +100,7 @@ func (c *Client) ListReviews(ctx context.Context, organization string, repositor
 		if resp.NextPage == 0 {
 			break
 		}
-		opt.Page = resp.NextPage
+		opts.Page = resp.NextPage
 	}
 
 	// Sort oldest review first.
@@ -121,6 +121,15 @@ type PullRequest struct {
 	Number int
 	// State is the state of the submitted review.
 	State string
+	// UnsafeBase is the base of the branch.
+	//
+	// UnsafeBase can be attacker controlled and should not be used in any
+	// security sensitive context. For example, don't use it when crafting a URL
+	// to send a request to or an access decision. See the following link for
+	// more details:
+	//
+	// https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
+	UnsafeBase Branch
 	// UnsafeHead is the name head of the branch.
 	//
 	// UnsafeHead can be attacker controlled and should not be used in any
@@ -129,7 +138,7 @@ type PullRequest struct {
 	// more details:
 	//
 	// https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
-	UnsafeHead string
+	UnsafeHead Branch
 	// UnsafeTitle is the title of the Pull Request.
 	//
 	// UnsafeTitle can be attacker controlled and should not be used in any
@@ -148,15 +157,32 @@ type PullRequest struct {
 	//
 	// https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
 	UnsafeBody string
+	// UnsafeLabels are the labels attached to the Pull Request.
+	//
+	// UnsafeLabels can be attacker controlled and should not be used in any
+	// security sensitive context. For example, don't use it when crafting a URL
+	// to send a request to or an access decision. See the following link for
+	// more details:
+	//
+	// https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
+	UnsafeLabels []string
 	// Fork determines if the pull request is from a fork.
 	Fork bool
+}
+
+// Branch is a git Branch.
+type Branch struct {
+	// Ref is a human readable name branch name.
+	Ref string
+	// SHA is the SHA1 hash of the commit.
+	SHA string
 }
 
 // ListReviewers returns a list of reviewers that have yet to submit a review.
 func (c *Client) ListReviewers(ctx context.Context, organization string, repository string, number int) ([]string, error) {
 	var reviewers []string
 
-	opt := &go_github.ListOptions{
+	opts := &go_github.ListOptions{
 		Page:    0,
 		PerPage: perPage,
 	}
@@ -165,7 +191,7 @@ func (c *Client) ListReviewers(ctx context.Context, organization string, reposit
 			organization,
 			repository,
 			number,
-			opt)
+			opts)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -177,7 +203,7 @@ func (c *Client) ListReviewers(ctx context.Context, organization string, reposit
 		if resp.NextPage == 0 {
 			break
 		}
-		opt.Page = resp.NextPage
+		opts.Page = resp.NextPage
 	}
 
 	return reviewers, nil
@@ -193,15 +219,28 @@ func (c *Client) GetPullRequest(ctx context.Context, organization string, reposi
 		return PullRequest{}, trace.Wrap(err)
 	}
 
+	var labels []string
+	for _, label := range pull.Labels {
+		labels = append(labels, label.GetName())
+	}
+
 	return PullRequest{
-		Author:      pull.GetUser().GetLogin(),
-		Repository:  repository,
-		Number:      pull.GetNumber(),
-		State:       pull.GetState(),
-		UnsafeHead:  pull.GetHead().GetRef(),
-		UnsafeTitle: pull.GetTitle(),
-		UnsafeBody:  pull.GetBody(),
-		Fork:        pull.GetHead().GetRepo().GetFork(),
+		Author:     pull.GetUser().GetLogin(),
+		Repository: repository,
+		Number:     pull.GetNumber(),
+		State:      pull.GetState(),
+		UnsafeBase: Branch{
+			Ref: pull.GetBase().GetRef(),
+			SHA: pull.GetBase().GetSHA(),
+		},
+		UnsafeHead: Branch{
+			Ref: pull.GetHead().GetRef(),
+			SHA: pull.GetHead().GetSHA(),
+		},
+		UnsafeTitle:  pull.GetTitle(),
+		UnsafeBody:   pull.GetBody(),
+		UnsafeLabels: labels,
+		Fork:         pull.GetHead().GetRepo().GetFork(),
 	}, nil
 }
 
@@ -209,7 +248,7 @@ func (c *Client) GetPullRequest(ctx context.Context, organization string, reposi
 func (c *Client) ListPullRequests(ctx context.Context, organization string, repository string, state string) ([]PullRequest, error) {
 	var pulls []PullRequest
 
-	opt := &go_github.PullRequestListOptions{
+	opts := &go_github.PullRequestListOptions{
 		State: state,
 		ListOptions: go_github.ListOptions{
 			Page:    0,
@@ -220,27 +259,40 @@ func (c *Client) ListPullRequests(ctx context.Context, organization string, repo
 		page, resp, err := c.client.PullRequests.List(ctx,
 			organization,
 			repository,
-			opt)
+			opts)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
 		for _, pull := range page {
+			var labels []string
+			for _, label := range pull.Labels {
+				labels = append(labels, label.GetName())
+			}
+
 			pulls = append(pulls, PullRequest{
-				Author:      pull.GetUser().GetLogin(),
-				Repository:  repository,
-				Number:      pull.GetNumber(),
-				State:       pull.GetState(),
-				UnsafeHead:  pull.GetHead().GetRef(),
-				UnsafeTitle: pull.GetTitle(),
-				UnsafeBody:  pull.GetBody(),
-				Fork:        pull.GetHead().GetRepo().GetFork(),
+				Author:     pull.GetUser().GetLogin(),
+				Repository: repository,
+				Number:     pull.GetNumber(),
+				State:      pull.GetState(),
+				UnsafeBase: Branch{
+					Ref: pull.GetBase().GetRef(),
+					SHA: pull.GetBase().GetSHA(),
+				},
+				UnsafeHead: Branch{
+					Ref: pull.GetHead().GetRef(),
+					SHA: pull.GetHead().GetSHA(),
+				},
+				UnsafeTitle:  pull.GetTitle(),
+				UnsafeBody:   pull.GetBody(),
+				UnsafeLabels: labels,
+				Fork:         pull.GetHead().GetRepo().GetFork(),
 			})
 		}
 		if resp.NextPage == 0 {
 			break
 		}
-		opt.Page = resp.NextPage
+		opts.Page = resp.NextPage
 	}
 
 	return pulls, nil
@@ -250,7 +302,7 @@ func (c *Client) ListPullRequests(ctx context.Context, organization string, repo
 func (c *Client) ListFiles(ctx context.Context, organization string, repository string, number int) ([]string, error) {
 	var files []string
 
-	opt := &go_github.ListOptions{
+	opts := &go_github.ListOptions{
 		Page:    0,
 		PerPage: perPage,
 	}
@@ -259,7 +311,7 @@ func (c *Client) ListFiles(ctx context.Context, organization string, repository 
 			organization,
 			repository,
 			number,
-			opt)
+			opts)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -271,7 +323,7 @@ func (c *Client) ListFiles(ctx context.Context, organization string, repository 
 		if resp.NextPage == 0 {
 			break
 		}
-		opt.Page = resp.NextPage
+		opts.Page = resp.NextPage
 	}
 
 	return files, nil
@@ -305,7 +357,7 @@ type Workflow struct {
 func (c *Client) ListWorkflows(ctx context.Context, organization string, repository string) ([]Workflow, error) {
 	var workflows []Workflow
 
-	opt := &go_github.ListOptions{
+	opts := &go_github.ListOptions{
 		Page:    0,
 		PerPage: perPage,
 	}
@@ -313,7 +365,7 @@ func (c *Client) ListWorkflows(ctx context.Context, organization string, reposit
 		page, resp, err := c.client.Actions.ListWorkflows(ctx,
 			organization,
 			repository,
-			opt)
+			opts)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -333,7 +385,7 @@ func (c *Client) ListWorkflows(ctx context.Context, organization string, reposit
 		if resp.NextPage == 0 {
 			break
 		}
-		opt.Page = resp.NextPage
+		opts.Page = resp.NextPage
 	}
 
 	return workflows, nil
@@ -351,7 +403,7 @@ type Run struct {
 func (c *Client) ListWorkflowRuns(ctx context.Context, organization string, repository string, branch string, workflowID int64) ([]Run, error) {
 	var runs []Run
 
-	opt := &go_github.ListWorkflowRunsOptions{
+	opts := &go_github.ListWorkflowRunsOptions{
 		Branch: branch,
 		ListOptions: go_github.ListOptions{
 			Page:    0,
@@ -363,7 +415,7 @@ func (c *Client) ListWorkflowRuns(ctx context.Context, organization string, repo
 			organization,
 			repository,
 			workflowID,
-			opt)
+			opts)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -382,7 +434,7 @@ func (c *Client) ListWorkflowRuns(ctx context.Context, organization string, repo
 		if resp.NextPage == 0 {
 			break
 		}
-		opt.Page = resp.NextPage
+		opts.Page = resp.NextPage
 	}
 
 	return runs, nil
@@ -406,6 +458,84 @@ func (c *Client) DeleteWorkflowRun(ctx context.Context, organization string, rep
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+// CreateComment will leave a comment on an Issue or Pull Request.
+func (c *Client) CreateComment(ctx context.Context, organization string, repository string, number int, comment string) error {
+	_, _, err := c.client.Issues.CreateComment(ctx,
+		organization,
+		repository,
+		number,
+		&go_github.IssueComment{
+			Body: &comment,
+		})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// CreatePullRequest will create a Pull Request.
+func (c *Client) CreatePullRequest(ctx context.Context, organization string, repository string, title string, head string, base string, body string, draft bool) (int, error) {
+	pull, _, err := c.client.PullRequests.Create(ctx,
+		organization,
+		repository,
+		&go_github.NewPullRequest{
+			Title: &title,
+			Head:  &head,
+			Base:  &base,
+			Body:  &body,
+			Draft: &draft,
+		})
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	return pull.GetNumber(), nil
+}
+
+// ListWorkflowJobs lists all jobs for a workflow run.
+func (c *Client) ListWorkflowJobs(ctx context.Context, organization string, repository string, runID int64) ([]Job, error) {
+	var jobs []Job
+
+	opts := &go_github.ListWorkflowJobsOptions{
+		ListOptions: go_github.ListOptions{
+			Page:    0,
+			PerPage: perPage,
+		},
+	}
+	for {
+		page, resp, err := c.client.Actions.ListWorkflowJobs(ctx,
+			organization,
+			repository,
+			runID,
+			opts)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		for _, job := range page.Jobs {
+			jobs = append(jobs, Job{
+				Name: job.GetName(),
+				ID:   job.GetID(),
+			})
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return jobs, nil
+}
+
+// Job is a job within a workflow run.
+type Job struct {
+	// Name of the workflow job.
+	Name string
+
+	// ID of the job.
+	ID int64
 }
 
 const (

--- a/.github/workflows/robot/main.go
+++ b/.github/workflows/robot/main.go
@@ -60,6 +60,8 @@ func main() {
 		err = b.Dismiss(ctx)
 	case "label":
 		err = b.Label(ctx)
+	case "backport":
+		err = b.Backport(ctx)
 	default:
 		err = trace.BadParameter("unknown workflow: %v", workflow)
 	}


### PR DESCRIPTION
Added the ability to automatically create backport Pull Requests if Pull Requests contains labels with the following pattern: `backport/branch/(v[0-9]+|master)`.

Note: The `Automatically delete head branches` setting will have to be turned off for this to work.