### PR TITLE
feat(chart) Add hostAliases values

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference/teleport-cluster.mdx
+++ b/docs/pages/kubernetes-access/helm/reference/teleport-cluster.mdx
@@ -1276,6 +1276,33 @@ A list of extra arguments to pass to the `teleport start` command when running a
   </TabItem>
 </Tabs>
 
+## `hostAliases`
+
+| Type | Default value | Can be used in `custom` mode? |
+| - | - | - |
+| `list` | `[]` | ✅  |
+
+[Kubernetes reference](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)
+
+A list of extra host aliases to be set on the main Teleport container.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  hostAliases:
+  - hostnames:
+    - root.teleport.internal
+    ip: 10.10.0.1
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set "hostAliases[0].hostnames[0]=root.teleport.internal" \
+  --set "hostAliases[0].ip=10.10.0.1"
+  ```
+  </TabItem>
+</Tabs>
+
 ## `extraEnv`
 
 | Type | Default value | Can be used in `custom` mode? |

--- a/examples/chart/teleport-cluster/.lint/host-aliases.yaml
+++ b/examples/chart/teleport-cluster/.lint/host-aliases.yaml
@@ -1,0 +1,13 @@
+clusterName: helm-lint.example.com
+hostAliases:
+- hostnames:
+  - root.teleport.internal
+  ip: 10.10.0.1
+- hostnames:
+  - mongo.db
+  - mongodb.internal
+  ip: 10.10.1.1
+- hostnames:
+  - elastic.search
+  - elasticsearch.internal
+  ip: 10.10.1.2

--- a/examples/chart/teleport-cluster/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/deployment.yaml
@@ -82,6 +82,10 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 6 }}
       {{- end }}
+      {{- if .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml .Values.hostAliases | nindent 6 }}
+      {{- end }}
 {{- if .Values.initContainers }}
       initContainers: {{- toYaml .Values.initContainers | nindent 6 }}
   {{- if .Values.resources }}

--- a/examples/chart/teleport-cluster/tests/deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/deployment_test.yaml
@@ -425,6 +425,35 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should set host aliases when hostAliases set in values
+    values:
+      - ../.lint/host-aliases.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.hostAliases[0].hostnames
+          content: "root.teleport.internal"
+      - equal:
+          path: spec.template.spec.hostAliases[0].ip
+          value: "10.10.0.1"
+      - contains:
+          path: spec.template.spec.hostAliases[1].hostnames
+          content: "mongo.db"
+      - contains:
+          path: spec.template.spec.hostAliases[1].hostnames
+          content: "mongodb.internal"
+      - equal:
+          path: spec.template.spec.hostAliases[1].ip
+          value: "10.10.1.1"
+      - contains:
+          path: spec.template.spec.hostAliases[2].hostnames
+          content: "elastic.search"
+      - contains:
+          path: spec.template.spec.hostAliases[2].hostnames
+          content: "elasticsearch.internal"
+      - equal:
+          path: spec.template.spec.hostAliases[2].ip
+          value: "10.10.1.2"
+
   - it: should provision initContainer correctly when set in values
     values:
       - ../.lint/initcontainers.yaml

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -21,6 +21,7 @@
         "initContainers",
         "resources",
         "tolerations",
+        "hostAliases",
         "probeTimeoutSeconds"
     ],
     "properties": {
@@ -535,6 +536,11 @@
         },
         "tolerations": {
             "$id": "#/properties/tolerations",
+            "type": "array",
+            "default": []
+        },
+        "hostAliases": {
+            "$id": "#/properties/hostAliases",
             "type": "array",
             "default": []
         },

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -292,3 +292,7 @@ tolerations: []
 # Timeouts for the readiness and liveness probes
 # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 probeTimeoutSeconds: 1
+
+# List of hosts and IPs that will be injected into the pod's hosts file
+# https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+hostAliases: []


### PR DESCRIPTION
Hello,

I need to use a custom dns resolution for some service so I suggest to add `hostAliases` to the `teleport-cluster` chart values.

My use case is to federate teleport clusters having private ip for internal teleport communications and external ip for external connection. I have no custom DNS server and have a single host name for the root teleport. With that feature I am able to make certificate valid for a single host name with 2 different routes (and two different ips) without having multiple DNS servers.