### PR TITLE
Update predicate doc example to use bracket notation

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -213,6 +213,10 @@
             {
               "title": "Networking",
               "slug": "/setup/reference/networking/"
+            },
+            {
+              "title": "Predicate Language",
+              "slug": "/setup/reference/predicate-language/"
             }
           ]
         }
@@ -325,7 +329,7 @@
         {
           "title": "Getting Started",
           "slug": "/kubernetes-access/getting-started/",
-           "entries": [
+          "entries": [
             {
               "title": "Local Demo Cluster",
               "slug": "/kubernetes-access/getting-started/local/"
@@ -397,8 +401,8 @@
               "slug": "/kubernetes-access/helm/reference/teleport-cluster/"
             },
             {
-               "title": "teleport-kube-agent",
-               "slug": "/kubernetes-access/helm/reference/teleport-kube-agent/"
+              "title": "teleport-kube-agent",
+              "slug": "/kubernetes-access/helm/reference/teleport-kube-agent/"
             }
           ]
         },

--- a/docs/pages/setup/reference/cli.mdx
+++ b/docs/pages/setup/reference/cli.mdx
@@ -1448,7 +1448,7 @@ $ tsh ls --search=staging,mac
 
 # List nodes using predicate language. This query searches for nodes with labels
 # with key `env` equal to `staging` and key `os` equal to `mac`.
-$ tsh ls --query='labels.env == "staging" && equals(labels.os, "mac")'
+$ tsh ls --query='labels["env"] == "staging" && equals(labels["os"], "mac")'
 ```
 
 ## Experimental features

--- a/docs/pages/setup/reference/predicate-language.mdx
+++ b/docs/pages/setup/reference/predicate-language.mdx
@@ -46,26 +46,26 @@ For common resource fields, we defined shortened field names that can easily be 
 
 | Short Field    | Actual Field Equivalent                                     | Example                   |
 |----------------|-------------------------------------------------------------|---------------------------|
-| `labels.<key>` | `resource.metadata.labels` + `resource.spec.dynamic_labels` | `labels.env == "staging"` |
+| `labels.<key>` | `resource.metadata.labels` + `resource.spec.dynamic_labels` | `labels["env"] == "staging"` |
 | `name`         | `resource.metadata.name`                                    | `name == "jenkins"`       |
 
 The language supports the following operators:
 
 | Operator | Meaning                              | Example                                             |
 |----------|--------------------------------------|-----------------------------------------------------|
-| ==       | equal to                             | `labels.env == "prod"` or `labels["env"] == "prod"` |
-| !=       | not equal to                         | `labels.env != "prod"`                              |
-| &&       | and (all conditions must match)      | `labels.env == "prod" && labels.os == "mac"`        |
-| \|\|     | or  (any one condition should match) | `labels.env == "dev" \|\| labels.env == "qa"`       |
-| !        | not (used with functions)            | `!equals(labels.env, "prod")`                       |
+| ==       | equal to                             | `labels["env"] == "prod"` or `labels["env"] == "prod"` |
+| !=       | not equal to                         | `labels["env"] != "prod"`                              |
+| &&       | and (all conditions must match)      | `labels["env"] == "prod" && labels.os == "mac"`        |
+| \|\|     | or  (any one condition should match) | `labels["env"] == "dev" \|\| labels["env"] == "qa"`       |
+| !        | not (used with functions)            | `!equals(labels["env"], "prod")`                       |
 
 The language also supports the following functions:
 
 | Functions (with examples)             | Description                                                |
 |---------------------------------------|------------------------------------------------------------|
-| `equals(labels.env, "prod")`          | resources with label key `env` equal to label value `prod` |
-| `exists(labels.env)`                  | resources with a label key `env`; label value unchecked    |
-| `!exists(labels.env)`                 | resources without a label key `env`; label value unchecked |
+| `equals(labels["env"], "prod")`          | resources with label key `env` equal to label value `prod` |
+| `exists(labels["env"])`                  | resources with a label key `env`; label value unchecked    |
+| `!exists(labels["env"])`                 | resources without a label key `env`; label value unchecked |
 | `search("foo", "bar", "some phrase")` | fuzzy match against common resource fields                 |
 
 See some [examples](cli.mdx#filter-examples) of the different ways you can filter resources.

--- a/docs/pages/setup/reference/predicate-language.mdx
+++ b/docs/pages/setup/reference/predicate-language.mdx
@@ -44,28 +44,29 @@ perform more sophisticated searches using the predicate language.
 
 For common resource fields, we defined shortened field names that can easily be accessed by:
 
-| Short Field    | Actual Field Equivalent                                     | Example                   |
-|----------------|-------------------------------------------------------------|---------------------------|
-| `labels.<key>` | `resource.metadata.labels` + `resource.spec.dynamic_labels` | `labels["env"] == "staging"` |
-| `name`         | `resource.metadata.name`                                    | `name == "jenkins"`       |
+| Short Field       | Actual Field Equivalent                                     | Example                      |
+|-------------------|-------------------------------------------------------------|------------------------------|
+| `labels["<key>"]` | `resource.metadata.labels` + `resource.spec.dynamic_labels` | `labels["env"] == "staging"` |
+| `name`            | `resource.metadata.name`                                    | `name == "jenkins"`          |
 
 The language supports the following operators:
 
-| Operator | Meaning                              | Example                                             |
-|----------|--------------------------------------|-----------------------------------------------------|
-| ==       | equal to                             | `labels["env"] == "prod"` or `labels["env"] == "prod"` |
+| Operator | Meaning                              | Example                                                |
+|----------|--------------------------------------|--------------------------------------------------------|
+| ==       | equal to                             | `labels["env"] == "prod"` or ``labels[`env`] == "prod"`` |
 | !=       | not equal to                         | `labels["env"] != "prod"`                              |
-| &&       | and (all conditions must match)      | `labels["env"] == "prod" && labels.os == "mac"`        |
-| \|\|     | or  (any one condition should match) | `labels["env"] == "dev" \|\| labels["env"] == "qa"`       |
+| &&       | and (all conditions must match)      | `labels["env"] == "prod" && labels["os"] == "mac"`     |
+| \|\|     | or  (any one condition should match) | `labels["env"] == "dev" \|\| labels["env"] == "qa"`    |
 | !        | not (used with functions)            | `!equals(labels["env"], "prod")`                       |
 
 The language also supports the following functions:
 
 | Functions (with examples)             | Description                                                |
 |---------------------------------------|------------------------------------------------------------|
-| `equals(labels["env"], "prod")`          | resources with label key `env` equal to label value `prod` |
-| `exists(labels["env"])`                  | resources with a label key `env`; label value unchecked    |
-| `!exists(labels["env"])`                 | resources without a label key `env`; label value unchecked |
+| `equals(labels["env"], "prod")`       | resources with label key `env` equal to label value `prod` |
+| `exists(labels["env"])`               | resources with a label key `env`; label value unchecked    |
+| `!exists(labels["env"])`              | resources without a label key `env`; label value unchecked |
 | `search("foo", "bar", "some phrase")` | fuzzy match against common resource fields                 |
+
 
 See some [examples](cli.mdx#filter-examples) of the different ways you can filter resources.

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	searchHelp = `List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")`
-	queryHelp  = `Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and || (e.g. --query='labels.key1 == "value1" && labels.key2 != "value2"')`
+	queryHelp  = `Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and || (e.g. --query='labels["key1"] == "value1" && labels["key2"] != "value2"')`
 	labelHelp  = "List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)"
 )
 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -356,7 +356,7 @@ const (
 	clusterHelp = "Specify the Teleport cluster to connect"
 	browserHelp = "Set to 'none' to suppress browser opening on login"
 	searchHelp  = `List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")`
-	queryHelp   = `Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and || (e.g. --query='labels.key1 == "value1" && labels.key2 != "value2"')`
+	queryHelp   = `Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and || (e.g. --query='labels["key1"] == "value1" && labels["key2"] != "value2"')`
 	labelHelp   = "List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)"
 	// proxyDefaultResolutionTimeout is how long to wait for an unknown proxy
 	// port to be resolved.


### PR DESCRIPTION
#### Description
Train users to use the bracket notation e.g `labels["env"]` instead of dot notation `labels.env`.  `vulcand` library uses `go/token` that reserves the below keywords and cannot be used as selector name e.g `labels.type`. Bracket notation is also required for labels with special characters

![image](https://user-images.githubusercontent.com/43280172/165354680-e6547129-8624-41d2-9aa1-c0e6410aa64d.png)


```
 break
 case
 chan
 const
 continue
 default
 defer
 else
 fallthrough
 for
 func
 go
 goto
 if
 import
 interface
 map
 package
 range
 return
 select
 struct
 switch
 type
 var
```

part of https://github.com/gravitational/teleport/issues/12193