### PR TITLE
Fix race on TestFIDO2Login/NOK_cancel_after_PIN

### DIFF
--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -439,12 +439,12 @@ func TestFIDO2Login(t *testing.T) {
 		},
 		{
 			name:   "NOK cancel after PIN",
-			fido2:  newFakeFIDO2(auth1, pin1),
-			setUP:  pin1.setUP,
-			prompt: &pinCancelPrompt{pin: pin1.pin}, // cancel set on test body
+			fido2:  newFakeFIDO2(pin3, bio2),        // pin3 and bio2 have resident credentials
+			setUP:  pin3.setUP,                      // user chooses pin3, but cancels before further touches
+			prompt: &pinCancelPrompt{pin: pin3.pin}, // cancel set on test body
 			createAssertion: func() *wanlib.CredentialAssertion {
 				cp := *baseAssertion
-				cp.Response.AllowedCredentials = nil
+				cp.Response.AllowedCredentials = nil // passwordless forces PIN
 				cp.Response.UserVerification = protocol.VerificationRequired
 				return &cp
 			},


### PR DESCRIPTION
Fixes a rather exoteric race condition where a goroutine beats an already-cancelled context in a select.

The select in question sits on selectDevice / fido2.go#L729. It is not an error for the select to go either way, instead this is a failure of test setup. The fix is simple: we use authenticators that do have resident credentials for the test, so their Assertion operations block waiting for user interaction, eliminating the race in the test in question.

Example flaky execution: https://console.cloud.google.com/cloud-build/builds/ceaa0674-db49-444b-b059-a17e01b0328f?project=ci-account

#9160