### PR TITLE
[branch/v7] Create remote site cache based on remote auth version (#12130)

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -306,16 +306,25 @@ func (a *Agent) handleGlobalRequests(ctx context.Context, requestCh <-chan *ssh.
 
 			switch r.Type {
 			case versionRequest:
-				err := r.Reply(true, []byte(teleport.Version))
+				// reply with the auth server version
+				pong, err := a.Client.Ping(ctx)
 				if err != nil {
-					log.Debugf("Failed to reply to %v request: %v.", r.Type, err)
+					a.log.WithError(err).Warnf("Failed to ping auth server in response to %v request.", r.Type)
+					if err := r.Reply(false, []byte("Failed to retrieve auth version")); err != nil {
+						a.log.Debugf("Failed to reply to %v request: %v.", r.Type, err)
+						continue
+					}
+				}
+
+				if err := r.Reply(true, []byte(pong.ServerVersion)); err != nil {
+					a.log.Debugf("Failed to reply to %v request: %v.", r.Type, err)
 					continue
 				}
 			default:
 				// This handles keep-alive messages and matches the behaviour of OpenSSH.
 				err := r.Reply(false, nil)
 				if err != nil {
-					log.Debugf("Failed to reply to %v request: %v.", r.Type, err)
+					a.log.Debugf("Failed to reply to %v request: %v.", r.Type, err)
 					continue
 				}
 			}

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -18,6 +18,7 @@ package reversetunnel
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -159,4 +160,71 @@ type mockAccessPoint struct {
 
 func (ap mockAccessPoint) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
 	return ap.ca, nil
+}
+
+func TestCreateRemoteAccessPoint(t *testing.T) {
+	cases := []struct {
+		name           string
+		version        string
+		assertion      require.ErrorAssertionFunc
+		oldRemoteProxy bool
+	}{
+		{
+			name:      "invalid version",
+			assertion: require.Error,
+		},
+		{
+			name:      "remote running 8.0.0",
+			assertion: require.NoError,
+			version:   "8.0.0",
+		},
+		{
+			name:      "remote running 7.0.0",
+			assertion: require.NoError,
+			version:   "7.0.0",
+		},
+		{
+			name:           "remote running 6.0.0",
+			assertion:      require.NoError,
+			version:        "6.0.0",
+			oldRemoteProxy: true,
+		},
+		{
+			name:           "remote running 5.0.0",
+			assertion:      require.NoError,
+			version:        "5.0.0",
+			oldRemoteProxy: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			newProxyFn := func(clt auth.ClientI, cacheName []string) (auth.AccessPoint, error) {
+				if tt.oldRemoteProxy {
+					return nil, errors.New("expected to create an old remote proxy")
+				}
+
+				return nil, nil
+			}
+
+			oldProxyFn := func(clt auth.ClientI, cacheName []string) (auth.AccessPoint, error) {
+				if !tt.oldRemoteProxy {
+					return nil, errors.New("expected to create an new remote proxy")
+				}
+
+				return nil, nil
+			}
+
+			clt := &mockAuthClient{}
+			srv := &server{
+				log: utils.NewLoggerForTests(),
+				Config: Config{
+					NewCachingAccessPoint:         newProxyFn,
+					NewCachingAccessPointOldProxy: oldProxyFn,
+				},
+			}
+			_, err := createRemoteAccessPoint(srv, clt, tt.version, "test")
+			tt.assertion(t, err)
+		})
+	}
 }

--- a/lib/utils/ver.go
+++ b/lib/utils/ver.go
@@ -45,3 +45,32 @@ func CheckVersion(currentVersion, minVersion string) error {
 func VersionBeforeAlpha(version string) string {
 	return version + "-aa"
 }
+
+// MinVerWithoutPreRelease compares semver strings, but skips prerelease. This allows to compare
+// two versions and ignore dev,alpha,beta, etc. strings.
+func MinVerWithoutPreRelease(currentVersion, minVersion string) (bool, error) {
+	currentSemver, minSemver, err := versionStringToSemver(currentVersion, minVersion)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	// Erase pre-release string, so only version is compared.
+	currentSemver.PreRelease = ""
+	minSemver.PreRelease = ""
+
+	return !currentSemver.LessThan(*minSemver), nil
+}
+
+func versionStringToSemver(ver1, ver2 string) (*semver.Version, *semver.Version, error) {
+	v1Semver, err := semver.NewVersion(ver1)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "unsupported version format, need semver format: %q, e.g 1.0.0", v1Semver)
+	}
+
+	v2Semver, err := semver.NewVersion(ver2)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "unsupported version format, need semver format: %q, e.g 1.0.0", v2Semver)
+	}
+
+	return v1Semver, v2Semver, nil
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `branch/v7`:
 - [Create remote site cache based on remote auth version (#12130)](https://github.com/gravitational/teleport/pull/12130)

<!--- Backport version: 8.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)