### PR TITLE
Use self-signed certs on top of system pool.

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3181,9 +3181,15 @@ func loopbackPool(proxyAddr string) *x509.CertPool {
 		return nil
 	}
 	log.Debugf("attempting to use loopback pool for local proxy addr: %v", proxyAddr)
-	certPool := x509.NewCertPool()
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		log.Debugf("could not open system cert pool, using empty cert pool instead: %v", err)
+		certPool = x509.NewCertPool()
+	}
 
 	certPath := filepath.Join(defaults.DataDir, defaults.SelfSignedCertPath)
+	log.Debugf("reading self-signed certs from: %v", certPath)
+
 	pemByte, err := os.ReadFile(certPath)
 	if err != nil {
 		log.Debugf("could not open any path in: %v", certPath)


### PR DESCRIPTION
When connecting to [localhost proxy](https://github.com/gravitational/teleport/blob/fae9f885e22cf3b7a65847fdb7a1335b227140ed/lib/client/api.go#L3179), `tsh` will disregard any certs in the system pool if it can find certs in the file `/var/lib/teleport/webproxy_cert.pem`. (Note: this is fixed path and it disregards any data-dir configured in `/etc/teleport.yaml`).

While using the trusted cert file is useful, discarding the system pool of certs is not. Here an example where `curl` has no trouble connecting to the proxy, while `tsh` fails to do so:

```code
$ tsh login --proxy=boson.tener.io:3080
ERROR: Get "https://boson.tener.io:3080/webapi/ping": x509: certificate signed by unknown authority

$ curl https://boson.tener.io:3080
<a href="/web">Found</a>.
```

The proposed fix is to use the certs from the special file on top of the system pool, not instead of it.