### PR TITLE
Networking page update

### DIFF
--- a/docs/pages/setup/reference/networking.mdx
+++ b/docs/pages/setup/reference/networking.mdx
@@ -113,7 +113,7 @@ numbers for each service.
 | 3023 | Proxy | SSH port clients connect to. The Proxy Service will forward this connection to port `#3022` on the destination Node. |
 | 3024 | Proxy | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. |
 | 3025 | Auth | SSH port used by the Auth Service to serve its API to other Nodes in a cluster. |
-| 3080 | Proxy | HTTPS connection to authenticate `tsh` users into the cluster. The same connection is used to serve a Web UI. |
+| 3080 | Proxy | HTTPS connection to authenticate `tsh` users into the cluster. Typically set to 443 instead of the default 3080. The same connection is used to serve a Web UI. In addition to HTTPS, WebSocket traffic, wss://..., is used on this port. |
 | 3026 | Kubernetes | HTTPS Kubernetes proxy `proxy_service.kube_listen_addr` |
 | 3027 | Kubernetes | Kubernetes Service `kubernetes_service.listen_addr` |
 | 3028 | Desktop | Desktop Service `windows_desktop_service.listen_addr` |
@@ -141,10 +141,9 @@ Teleport Cloud tenant URL, e.g., `mytenant.teleport.sh`.
 
 | Port | Service | Description |
 | - | - | - |
-| 3022 | Node | SSH port. This is Teleport's equivalent of port `#22` for SSH. |
 | 3023 | Proxy | SSH port clients connect to. The Proxy Service will forward this connection to port `#3022` on the destination Node. |
 | 3024 | Proxy | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. |
-| 3080 | Proxy | HTTPS connection to authenticate `tsh` users into the cluster. The same connection is used to serve a Web UI. |
+| 443 | Proxy | HTTPS connection to authenticate `tsh` users into the cluster. The same connection is used to serve a Web UI. WebSocket traffic is used as part of the Web interaction. |
 | 3026 | Kubernetes | HTTPS Kubernetes proxy `proxy_service.kube_listen_addr` |
 | 3027 | Kubernetes | Kubernetes Service `kubernetes_service.listen_addr` |
 | 3028 | Desktop | Desktop Service `windows_desktop_service.listen_addr` |

--- a/docs/pages/setup/reference/networking.mdx
+++ b/docs/pages/setup/reference/networking.mdx
@@ -143,7 +143,7 @@ Teleport Cloud tenant URL, e.g., `mytenant.teleport.sh`.
 | - | - | - |
 | 3023 | Proxy | SSH port clients connect to. The Proxy Service will forward this connection to port `#3022` on the destination Node. |
 | 3024 | Proxy | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. |
-| 443 | Proxy | HTTPS connection to authenticate `tsh` users into the cluster. The same connection is used to serve a Web UI. WebSocket traffic is used as part of the Web interaction. |
+| 443 | Proxy | HTTPS connection to authenticate `tsh` users into the cluster. The same connection is used to serve a Web UI and any WebSocket traffic.|
 | 3026 | Kubernetes | HTTPS Kubernetes proxy `proxy_service.kube_listen_addr` |
 | 3027 | Kubernetes | Kubernetes Service `kubernetes_service.listen_addr` |
 | 3028 | Desktop | Desktop Service `windows_desktop_service.listen_addr` |

--- a/docs/pages/setup/reference/networking.mdx
+++ b/docs/pages/setup/reference/networking.mdx
@@ -113,7 +113,7 @@ numbers for each service.
 | 3023 | Proxy | SSH port clients connect to. The Proxy Service will forward this connection to port `#3022` on the destination Node. |
 | 3024 | Proxy | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. |
 | 3025 | Auth | SSH port used by the Auth Service to serve its API to other Nodes in a cluster. |
-| 3080 | Proxy | HTTPS connection to authenticate `tsh` users into the cluster. Typically set to 443 instead of the default 3080. The same connection is used to serve a Web UI. In addition to HTTPS, WebSocket traffic, wss://..., is used on this port. |
+| 3080 | Proxy | HTTPS connection to authenticate `tsh` users into the cluster. Typically made available through the 443 port on a load balancer forwarded to 3080. The same connection is used to serve a Web UI. In addition to HTTPS, WebSocket traffic, wss://..., is used on this port. |
 | 3026 | Kubernetes | HTTPS Kubernetes proxy `proxy_service.kube_listen_addr` |
 | 3027 | Kubernetes | Kubernetes Service `kubernetes_service.listen_addr` |
 | 3028 | Desktop | Desktop Service `windows_desktop_service.listen_addr` |


### PR DESCRIPTION
Include websocket usge
Remove `3022` report on cloud which doesn't apply
Mention 443 is used for web port.