### PR TITLE
Gracefully degrade `tsh db ls` in case fetching roles fails.

### DIFF
--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -71,7 +71,7 @@ func onListDatabases(cf *CLIConf) error {
 
 	roleSet, err := services.FetchRoles(profile.Roles, cluster, profile.Traits)
 	if err != nil {
-		return trace.Wrap(err)
+		log.Debugf("Failed to fetch user roles: %v.", err)
 	}
 
 	sort.Slice(databases, func(i, j int) bool {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1705,6 +1705,11 @@ func serializeDatabases(databases []types.Database, format string) (string, erro
 }
 
 func getUsersForDb(database types.Database, roleSet services.RoleSet) string {
+	// may happen if fetching the role set failed for any reason.
+	if roleSet == nil {
+		return "(unknown)"
+	}
+
 	dbUsers := roleSet.EnumerateDatabaseUsers(database)
 	allowed := dbUsers.Allowed()
 

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -2100,33 +2100,35 @@ func Test_getUsersForDb(t *testing.T) {
 			database: dbProd,
 			result:   "[dev]",
 		},
-
 		{
 			name:     "roleDevStage x dbStage",
 			roles:    services.RoleSet{roleDevStage},
 			database: dbStage,
 			result:   "[*], except: [superuser]",
 		},
-
 		{
 			name:     "roleDevStage x dbProd",
 			roles:    services.RoleSet{roleDevStage},
 			database: dbProd,
 			result:   "(none)",
 		},
-
 		{
 			name:     "roleDevProd x dbStage",
 			roles:    services.RoleSet{roleDevProd},
 			database: dbStage,
 			result:   "(none)",
 		},
-
 		{
 			name:     "roleDevProd x dbProd",
 			roles:    services.RoleSet{roleDevProd},
 			database: dbProd,
 			result:   "[dev]",
+		},
+		{
+			name:     "no role set",
+			roles:    nil,
+			database: dbProd,
+			result:   "(unknown)",
 		},
 	}
 


### PR DESCRIPTION
When accessing the remote clusters, a user may get a different set of roles and traits than in the original cluster. This can cause the code to fail to fetch the set of applicable roles, which breaks the entire command. As a stop-gap measure this PR changes that behavior to a graceful degradation where we don't calculate the available user names and show `(unknown)` instead.

The complete fix is proposed in #12281, but it requires discussion about the proper way to fix the issue.

Fixes https://github.com/gravitational/teleport/issues/12239

Caused by https://github.com/gravitational/teleport/pull/10458