### PR TITLE
Show Proxy version when `tsh version` is called

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -848,12 +848,20 @@ func Run(args []string, opts ...cliOption) error {
 
 // onVersion prints version info.
 func onVersion(cf *CLIConf) error {
+	proxyVersion, err := fetchProxyVersion(cf)
+	if err != nil {
+		fmt.Fprintf(cf.Stderr(), "Failed to fetch proxy version: %s\n", err)
+	}
+
 	format := strings.ToLower(cf.Format)
 	switch format {
 	case teleport.Text, "":
 		utils.PrintVersion()
+		if proxyVersion != "" {
+			fmt.Printf("Proxy version: %s\n", proxyVersion)
+		}
 	case teleport.JSON, teleport.YAML:
-		out, err := serializeVersion(format)
+		out, err := serializeVersion(format, proxyVersion)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -861,16 +869,50 @@ func onVersion(cf *CLIConf) error {
 	default:
 		return trace.BadParameter("unsupported format %q", cf.Format)
 	}
+
 	return nil
 }
 
-func serializeVersion(format string) (string, error) {
+// fetchProxyVersion returns the current version of the Teleport Proxy.
+func fetchProxyVersion(cf *CLIConf) (string, error) {
+	profile, _, err := client.Status(cf.HomePath, cf.Proxy)
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return "", nil
+		}
+		return "", trace.Wrap(err)
+	}
+
+	if profile == nil {
+		return "", nil
+	}
+
+	tc, err := makeClient(cf, false)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	ctx, cancel := context.WithTimeout(cf.Context, time.Second*5)
+	defer cancel()
+	pingRes, err := tc.Ping(ctx)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return pingRes.ServerVersion, nil
+}
+
+func serializeVersion(format string, proxyVersion string) (string, error) {
 	versionInfo := struct {
-		Version string `json:"version"`
-		Gitref  string `json:"gitref"`
-		Runtime string `json:"runtime"`
+		Version      string `json:"version"`
+		Gitref       string `json:"gitref"`
+		Runtime      string `json:"runtime"`
+		ProxyVersion string `json:"proxyVersion,omitempty"`
 	}{
-		teleport.Version, teleport.Gitref, runtime.Version(),
+		teleport.Version,
+		teleport.Gitref,
+		runtime.Version(),
+		proxyVersion,
 	}
 	var out []byte
 	var err error


### PR DESCRIPTION
Addresses #11986 

This allows users to see which version of the proxy they are connected when using `tsh`.

The output looks as follows:
```
# ./build/tsh version --format json                                               
{
  "version": "10.0.0-dev",
  "gitref": "teleport-connect-preview-1.0.0.dev.1-15-gb3e2ed09e",
  "runtime": "go1.18.1",
  "proxyVersion": "9.1.2"
}
# ./build/tsh version              
Teleport v10.0.0-dev git:teleport-connect-preview-1.0.0.dev.1-15-gb3e2ed09e go1.18.1
Proxy version: 9.1.2
```

If an error occurs fetching the proxy version, the client version is still displayed, as otherwise this would impair your ability to diagnose the fault.
```
# ./build/tsh version --format json 
Failed to fetch proxy version: flux capacitor overloaded
{
  "version": "10.0.0-dev",
  "gitref": "teleport-connect-preview-1.0.0.dev.1-15-gb3e2ed09e",
  "runtime": "go1.18.1"
}
# ./build/tsh version              
Failed to fetch proxy version: flux capacitor overloaded
Teleport v10.0.0-dev git:teleport-connect-preview-1.0.0.dev.1-15-gb3e2ed09e go1.18.1
```

If the user is not logged in, then there will be no change in the version information output.