### PR TITLE
Replace title-less Details boxes with ScopedBlocks

### DIFF
--- a/docs/pages/includes/plugins/rbac.mdx
+++ b/docs/pages/includes/plugins/rbac.mdx
@@ -4,8 +4,7 @@ Using an existing Teleport cluster, create the following `user` and `role` resou
 $ tctl create -f YAML_PATH.yaml
 ```
 
-<Details opened={true} 
-  scopeOnly={true}
+<ScopedBlock
   scope={["cloud"]}
 >
 Teleport Cloud requires authenticating with a role that has [`impersonation`](https://goteleport.com/docs/access-controls/guides/impersonation/) rights and can create the `access-plugin` role and user. Log in with `tsh` with a user that has this role or has a role with these `allow` rules.
@@ -29,7 +28,7 @@ spec:
         verbs: ['create','update','read','list','delete']
 
 ```
-</Details>
+</ScopedBlock>
 
 
 Create a non-interactive bot user and role called `access-plugin`.

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -60,14 +60,14 @@ Before you create a bot user, you need to determine which role(s) you want to
 assign to it. You can use the `tctl` command below to examine what roles exist
 on your system.
 
-<Details scope={["cloud"]} scopeOnly={true}>
+<ScopedBlock scope={["cloud"]}>
 On your client machine, log in to Teleport using `tsh`, then use `tctl` to examine
 what roles exist on your system.
-</Details>
-<Details scope={["oss","enterprise"]} scopeOnly={true}>
+</ScopedBlock>
+<ScopedBlock scope={["oss","enterprise"]}>
 Connect to the Teleport Auth Server and use `tctl` to examine what roles exist on
 your system.
-</Details>
+</ScopedBlock>
 
 ```code
 $ tctl get roles --format=text
@@ -173,20 +173,20 @@ the foreground to better understand how it works.
 
 Replace the following fields with values from your own cluster.
 
-<Details scope={["cloud"]} scopeOnly={true}>
+<ScopedBlock scope={["cloud"]}>
 - `token` is the token output by the `tctl bots add` command or the name of your IAM method token
 - `ca-pin` is the CA Pin for your Teleport cluster, and is output by the `tctl bots add` command
 - `destination-dir` is where Machine ID writes renewable certificates, which are only used by Machine ID and should not be used by applications and tools
 - `data-dir` is where Machine ID writes the short-lived certificate. This certificate should be used by applications and tools
 - `auth-server` is the address of your Teleport Cloud Proxy Server, for example `example.teleport.sh:443`
-</Details>
-<Details scope={["oss","enterprise"]} scopeOnly={true}>
+</ScopedBlock>
+<ScopedBlock scope={["oss","enterprise"]}>
 - `token` is the token output by the `tctl bots add` command or the name of your IAM method token
 - `ca-pin` is the CA Pin for your Teleport cluster, and is output by the `tctl bots add` command
 - `destination-dir` is where Machine ID writes renewable certificates, which are only used by Machine ID and should not be used by applications and tools
 - `data-dir` is where Machine ID writes the short-lived certificate. This certificate should be used by applications and tools
 - `auth-server` is the address of your Teleport Auth Server, for example `auth.example.com:3025`
-</Details>
+</ScopedBlock>
 
 Now that Machine ID has successfully started, let's investigate the
 `/opt/machine-id` directory to see what was written to disk.

--- a/docs/pages/machine-id/guides/jenkins.mdx
+++ b/docs/pages/machine-id/guides/jenkins.mdx
@@ -94,15 +94,15 @@ spec:
       "group": "api"
 ```
 
-<Details scope={["cloud"]} scopeOnly={true}>
+<ScopedBlock scope={["cloud"]}>
 On your client machine, log in to Teleport using `tsh` before using `tctl`.
 
 ```code
 $ tctl create -f api-workers.yaml
 $ tctl bots add jenkins --roles=api-workers
 ```
-</Details>
-<Details scope={["oss","enterprise"]} scopeOnly={true}>
+</ScopedBlock>
+<ScopedBlock scope={["oss","enterprise"]}>
 Connect to the Teleport Auth Server and use `tctl` to examine what roles exist on
 your system.
 
@@ -110,7 +110,7 @@ your system.
 $ tctl create -f api-workers.yaml
 $ tctl bots add jenkins --roles=api-workers
 ```
-</Details>
+</ScopedBlock>
 
 Machine ID allows you to use Linux Access Control Lists (ACLs) to control
 access to certificates on disk. You will use this to limit the access Jenkins
@@ -142,7 +142,7 @@ $ sudo tbot init \
 
 Next, you need to start Machine ID in the background of each Jenkins worker.
 
-<Details scope={["cloud"]} scopeOnly={true}>
+<ScopedBlock scope={["cloud"]}>
   First create a configuration file for Machine ID at `/etc/tbot.yaml`.
 
   ```yaml
@@ -157,8 +157,8 @@ Next, you need to start Machine ID in the background of each Jenkins worker.
   destinations:
     - directory: /opt/machine-id
   ```
-</Details>
-<Details scope={["oss","enterprise"]} scopeOnly={true}>
+</ScopedBlock>
+<ScopedBlock scope={["oss","enterprise"]}>
 First create a configuration file for Machine ID at `/etc/tbot.yaml`.
   ```yaml
   auth_server: "auth.example.com:3025"
@@ -172,7 +172,7 @@ First create a configuration file for Machine ID at `/etc/tbot.yaml`.
   destinations:
     - directory: /opt/machine-id
   ```
-</Details>
+</ScopedBlock>
 
 Next, create a systemd.unit file at `/etc/systemd/system/machine-id.service`.
 

--- a/docs/pages/machine-id/reference/cli.mdx
+++ b/docs/pages/machine-id/reference/cli.mdx
@@ -8,7 +8,8 @@ description: CLI reference for Teleport Machine ID.
 Starts the Machine ID client `tbot`, fetching and writing certificates to disk
 at a set interval.
 
-<Details scope={["cloud"]} scopeOnly={true}>
+<ScopedBlock scope={["cloud"]}>
+
 ```code
 $ tbot start \
    --data-dir=/var/lib/teleport/bot \
@@ -18,8 +19,11 @@ $ tbot start \
    --ca-pin=sha256:1111111111111111111111111111111111111111111111111111111111111111 \
    --auth-server=example.teleport.sh:443
 ```
-</Details>
-<Details scope={["oss","enterprise"]} scopeOnly={true}>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss","enterprise"]}>
+
 ```code
 $ tbot start \
    --data-dir=/var/lib/teleport/bot \
@@ -29,7 +33,8 @@ $ tbot start \
    --ca-pin=sha256:1111111111111111111111111111111111111111111111111111111111111111 \
    --auth-server=auth.example.com:3025
 ```
-</Details>
+
+</ScopedBlock>
 
 | Flag                 | Description                                                                                    |
 |----------------------|------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
We will be adding a linter rule that prohibits Details boxes that lack
titles, letting us implement the ability to link directly to a Details
box. In some places in the docs, Details boxes are used purely to
adjust the visibility of Markdown based on scope. Now that we have a
ScopedBlock component, we can use this instead.