### PR TITLE
[v9] Never use `--tlsUseSystemCA` and `--tlsCAFile` together with `mongosh`

### DIFF
--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -381,17 +381,17 @@ func (c *CLICommandBuilder) getMongoCommand() *exec.Cmd {
 			flags.tlsCertKeyFile,
 			c.profile.DatabaseCertPathForCluster(c.tc.SiteName, c.db.ServiceName))
 
-		// mongosh does not load system CAs by default which will cause issues if
-		// the proxy presents a certificate signed by a non-recognized authority
-		// which your system trusts (e.g. mkcert).
-		if hasMongosh {
-			args = append(args, "--tlsUseSystemCA")
-		}
-
 		if c.options.caPath != "" {
 			// caPath is set only if mongo connects to the Teleport Proxy via ALPN SNI Local Proxy
 			// and connection is terminated by proxy identity certificate.
 			args = append(args, []string{flags.tlsCAFile, c.options.caPath}...)
+		} else {
+			// mongosh does not load system CAs by default which will cause issues if
+			// the proxy presents a certificate signed by a non-recognized authority
+			// which your system trusts (e.g. mkcert).
+			if hasMongosh {
+				args = append(args, "--tlsUseSystemCA")
+			}
 		}
 	}
 

--- a/lib/client/db/dbcmd/dbcmd_test.go
+++ b/lib/client/db/dbcmd/dbcmd_test.go
@@ -373,6 +373,25 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 				"mydb"},
 		},
 		{
+			name:         "mongosh",
+			dbProtocol:   defaults.ProtocolMongoDB,
+			databaseName: "mydb",
+			opts: []ConnectCommandFunc{
+				WithLocalProxy("localhost", 12345, "/tmp/keys/example.com/cas/example.com.pem")},
+			execer: &fakeExec{
+				execOutput: map[string][]byte{
+					"mongosh": []byte("1.1.6"),
+				},
+			},
+			cmd: []string{"mongosh",
+				"--host", "localhost",
+				"--port", "12345",
+				"--tls",
+				"--tlsCertificateKeyFile", "/tmp/keys/example.com/bob-db/db.example.com/mysql-x509.pem",
+				"--tlsCAFile", "/tmp/keys/example.com/cas/example.com.pem",
+				"mydb"},
+		},
+		{
 			name:         "mongosh no TLS",
 			dbProtocol:   defaults.ProtocolMongoDB,
 			databaseName: "mydb",


### PR DESCRIPTION
Backport #12361 to branch/v9