### PR TITLE
Add cluster labels to 'tsh clusters' output

### DIFF
--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -1756,12 +1756,14 @@ func TestSerializeClusters(t *testing.T) {
 			"cluster_name": "rootCluster",
 			"status": "online",
 			"cluster_type": "root",
+			"labels": null,
 			"selected": true
 		},
 		{
 			"cluster_name": "leafCluster",
 			"status": "offline",
 			"cluster_type": "leaf",
+			"labels": {"foo": "bar", "baz": "boof"},
 			"selected": false
 		}
 	]
@@ -1777,7 +1779,11 @@ func TestSerializeClusters(t *testing.T) {
 			ClusterName: "leafCluster",
 			Status:      teleport.RemoteClusterStatusOffline,
 			ClusterType: "leaf",
-			Selected:    false,
+			Labels: map[string]string{
+				"foo": "bar",
+				"baz": "boof",
+			},
+			Selected: false,
 		},
 	}
 	testSerialization(t, expected, func(f string) (string, error) {


### PR DESCRIPTION
Fixes #5306.

Example output:
```
Cluster Name  Status Cluster Type Labels           Selected 
------------- ------ ------------ ---------------- -------- 
test_cluster  online root                          *        
test_cluster2 online leaf         bar=baz,foo=asdf 
```