### PR TITLE
Desktop access: add teleport.dev/ou label

### DIFF
--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -63,10 +63,12 @@ func TestDiscoveryLDAPFilter(t *testing.T) {
 func TestAppliesLDAPLabels(t *testing.T) {
 	l := make(map[string]string)
 	entry := ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
-		attrDNSHostName: {"foo.example.com"},
-		attrName:        {"foo"},
-		attrOS:          {"Windows Server"},
-		attrOSVersion:   {"6.1"},
+		attrDNSHostName:       {"foo.example.com"},
+		attrName:              {"foo"},
+		attrOS:                {"Windows Server"},
+		attrOSVersion:         {"6.1"},
+		attrDistinguishedName: {"CN=foo,OU=IT,DC=goteleport,DC=com"},
+		attrCommonName:        {"foo"},
 	})
 	applyLabelsFromLDAP(entry, l)
 
@@ -75,6 +77,7 @@ func TestAppliesLDAPLabels(t *testing.T) {
 	require.Equal(t, l[types.TeleportNamespace+"/computer_name"], "foo")
 	require.Equal(t, l[types.TeleportNamespace+"/os"], "Windows Server")
 	require.Equal(t, l[types.TeleportNamespace+"/os_version"], "6.1")
+	require.Equal(t, l[types.TeleportNamespace+"/ou"], "OU=IT,DC=goteleport,DC=com")
 }
 
 func TestLabelsDomainControllers(t *testing.T) {


### PR DESCRIPTION
Automatically label discovered desktops with the LDAP
organizational unit they belong to. This expands the
ability to define RBAC rules based on OU.

![image](https://user-images.githubusercontent.com/7527103/167208895-22ae806d-1a09-4ab9-93b0-a45502535bac.png)

Updates #12326