### PR TITLE
lib/events: Remove Legacy (Teleport 4.4) upload handler

### DIFF
--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -62,19 +62,12 @@ func (a *AuditTestSuite) makeLog(c *check.C, dataDir string) (*AuditLog, error) 
 // creates a file-based audit log and returns a proper *AuditLog pointer
 // instead of the usual IAuditLog interface
 func (a *AuditTestSuite) makeLogWithClock(c *check.C, dataDir string, clock clockwork.Clock) (*AuditLog, error) {
-	handler, err := NewLegacyHandler(LegacyHandlerConfig{
-		Handler: NewMemoryUploader(),
-		Dir:     dataDir,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	alog, err := NewAuditLog(AuditLogConfig{
 		DataDir:       dataDir,
 		ServerID:      "server1",
 		Clock:         clock,
 		UIDGenerator:  utils.NewFakeUID(),
-		UploadHandler: handler,
+		UploadHandler: NewMemoryUploader(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -975,14 +975,7 @@ func initUploadHandler(ctx context.Context, auditConfig types.ClusterAuditConfig
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		wrapper, err := events.NewLegacyHandler(events.LegacyHandlerConfig{
-			Handler: handler,
-			Dir:     dataDir,
-		})
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return wrapper, nil
+		return handler, nil
 	}
 	uri, err := utils.ParseSessionsURI(auditConfig.AuditSessionsURI())
 	if err != nil {


### PR DESCRIPTION
This removes a special case for Teleport 4.4 and earlier uploads, which used an old unpacked format.