### PR TITLE
Reduce verbosity of missing kernel support warning for secure symlink

### DIFF
--- a/tool/tbot/botfs/fs_linux.go
+++ b/tool/tbot/botfs/fs_linux.go
@@ -98,10 +98,13 @@ func openSymlinksMode(path string, symlinksMode SymlinksMode) (*os.File, error) 
 	case SymlinksTrySecure:
 		file, err = openSecure(path)
 		if err == unix.ENOSYS {
-			log.Warnf("Failed to write to %q securely due to missing "+
-				"syscall; falling back to regular file write. Set "+
-				"`symlinks: insecure` on this destination to disable this "+
-				"warning.", path)
+			missingSyscallWarning.Do(func() {
+				log.Warnf("Failed to write to %q securely due to missing "+
+					"syscall; falling back to regular file write. Set "+
+					"`symlinks: insecure` on this destination to disable this "+
+					"warning.", path)
+			})
+
 			file, err = openStandard(path)
 			if err != nil {
 				return nil, trace.Wrap(err)


### PR DESCRIPTION
Closes #11755

Follows the same solution as used elsewhere, using a `sync.Once` to ensure warnings related to the missing syscall are only displayed once. This is a bit of a hacky solution, but matches the solution already in use, and only controls a log message.