### PR TITLE
Clarify S3 get params

### DIFF
--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -233,7 +233,8 @@ teleport:
 The AWS authentication settings above can be omitted if the machine itself is
 running on an EC2 instance with an IAM role.
 
-The optional `GET` parameters shown below are teleport-specific options to configure how Teleport interacts with an S3 endpoint, including S3-compatible endpoints.
+You can add optional query parameters to the S3 URL. The Teleport Auth
+Service reads these parameters to configure its interactions with S3:
 
 `s3://bucket/path?region=us-east-1&endpoint=mys3.example.com&insecure=false&disablesse=false&acl=private`
 

--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -233,7 +233,7 @@ teleport:
 The AWS authentication settings above can be omitted if the machine itself is
 running on an EC2 instance with an IAM role.
 
-The optional `GET` parameters shown below control how Teleport interacts with an S3 endpoint, including S3-compatible endpoints.
+The optional `GET` parameters shown below are teleport-specific options to configure how Teleport interacts with an S3 endpoint, including S3-compatible endpoints.
 
 `s3://bucket/path?region=us-east-1&endpoint=mys3.example.com&insecure=false&disablesse=false&acl=private`
 


### PR DESCRIPTION
The get parameters that control teleport's interaction with an S3 endpoint give the impression that this is some kind of `s3://` URL standard. This is not the case, so calling that out should help clarify.