### PR TITLE
Deflake TestTSHSSH

### DIFF
--- a/tool/tsh/tsh_helper_test.go
+++ b/tool/tsh/tsh_helper_test.go
@@ -226,7 +226,10 @@ func runTeleport(t *testing.T, cfg *service.Config) *service.TeleportProcess {
 	process, err := service.NewTeleport(cfg)
 	require.NoError(t, err)
 	require.NoError(t, process.Start())
-	t.Cleanup(func() { require.NoError(t, process.Close()) })
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
 	waitForEvents(t, process, service.ProxyWebServerReady, service.NodeSSHReady)
 	return process
 }


### PR DESCRIPTION
When shutting down, wait for the Teleport process to terminate, this
ensures that Go doesn't try to delete the TempDir while we're still
writing to it.