### PR TITLE
Remove unused KeyStore config field from Teleport config

### DIFF
--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -131,9 +131,6 @@ type Config struct {
 	// Keygen points to a key generator implementation
 	Keygen sshca.Authority
 
-	// KeyStore configuration. Handles CA private keys which may be held in a HSM.
-	KeyStore keystore.Config
-
 	// HostUUID is a unique UUID of this host (it will be known via this UUID within
 	// a teleport cluster). It's automatically generated on 1st start
 	HostUUID string


### PR DESCRIPTION
As far as I can tell, this is actually located at `Config.Auth.KeyStore` and the value at `Config.Keystore` had no references to it, and was a duplicate left behind during a refactor or similar.

I could be missing something, but it makes sense to me that this configuration only exists in one place.