### PR TITLE
Additions to the teleport-cluster helm chart

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference/teleport-cluster.mdx
+++ b/docs/pages/kubernetes-access/helm/reference/teleport-cluster.mdx
@@ -142,6 +142,28 @@ By default no devices are forbidden.
   </TabItem>
 </Tabs>
 
+## `proxyKubePublicAddr`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `nil` | no | `proxy_service.kube_public_addr` | ❌ |
+
+`proxyKubePublicAddr` configures the public address for the kubernetes proxy to listen on (e.g. k8s.example.com:443)
+
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  proxyKubePublicAddr: k8s.example.com:443
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set proxyKubePublicAddr=k8s.example.com:443
+  ```
+  </TabItem>
+</Tabs>
+
 ## `separatePostgresListener`
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |

--- a/examples/chart/teleport-cluster/.lint/proxy-kube-public-address.yaml
+++ b/examples/chart/teleport-cluster/.lint/proxy-kube-public-address.yaml
@@ -1,0 +1,2 @@
+clusterName: teleport.example.com
+proxyKubePublicAddr: k8s.example.com:3026

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -98,6 +98,9 @@ data:
       public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
   {{- if not .Values.proxyListenerMode }}
       kube_listen_addr: 0.0.0.0:3026
+    {{- if .Values.proxyKubePublicAddr }}
+      kube_public_addr: {{ .Values.proxyKubePublicAddr }}
+    {{- end }}
       mysql_listen_addr: 0.0.0.0:3036
     {{- if .Values.separatePostgresListener }}
       postgres_listen_addr: 0.0.0.0:5432

--- a/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
@@ -845,6 +845,40 @@ matches snapshot for priority-class-name.yaml:
     metadata:
       name: RELEASE-NAME
       namespace: NAMESPACE
+matches snapshot for proxy-kube-public-address.yaml:
+  1: |
+    apiVersion: v1
+    data:
+      teleport.yaml: |-
+        teleport:
+          log:
+            severity: INFO
+            output: stderr
+            format:
+              output: text
+              extra_fields: ["timestamp","level","component","caller"]
+        auth_service:
+          enabled: true
+          cluster_name: teleport.example.com
+          authentication:
+            type: local
+            second_factor: otp
+        kubernetes_service:
+          enabled: true
+          listen_addr: 0.0.0.0:3027
+          kube_cluster_name: teleport.example.com
+        proxy_service:
+          public_addr: 'teleport.example.com:443'
+          kube_listen_addr: 0.0.0.0:3026
+          kube_public_addr: k8s.example.com:3026
+          mysql_listen_addr: 0.0.0.0:3036
+          enabled: true
+        ssh_service:
+          enabled: false
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for proxy-listener-mode.yaml:
   1: |
     apiVersion: v1

--- a/examples/chart/teleport-cluster/tests/config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/config_test.yaml
@@ -259,6 +259,16 @@ tests:
           of: ConfigMap
       - matchSnapshot: {}
 
+  - it: matches snapshot for proxy-kube-public-address.yaml
+    values:
+      - ../.lint/proxy-kube-public-address.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot: {}
+
   - it: matches snapshot for resources.yaml
     values:
       - ../.lint/resources.yaml

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -69,6 +69,11 @@
             "type": "string",
             "default": ""
         },
+        "proxyKubePublicAddr": {
+            "$id": "#/properties/proxyKubePublicAddr",
+            "type": "string",
+            "default": ""
+        },
         "separatePostgresListener": {
             "$id": "#/properties/separatePostgresListener",
             "type": "boolean",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -30,6 +30,10 @@ authenticationSecondFactor:
 # Possible values are 'multiplex'
 proxyListenerMode: ""
 
+# Re-configures the teleport kubernetes proxy to listen on a different public address/port rather than the default 
+# cluster address (e.g. k8s.example.com:443 instead of teleport.example.com:3026)
+proxyKubePublicAddr: ""
+
 # By default, Teleport will multiplex Postgres and MongoDB database connections on the same port as the proxy's web listener (443)
 # Setting either of these values to true will separate the listeners out onto a separate port (5432 for Postgres, 27017 for MongoDB)
 # This is useful when terminating TLS at a load balancer in front of Teleport (such as when using AWS ACM)


### PR DESCRIPTION
Intention is to add:

- configuration for proxy_service.kube_public_addr
- option to not include kubernetes listening port on the main service (to be worked on upon  approval)

Please note item #1 has been implemented already as part of this PR

Please kindly help validate if everything is okay :)

Cheers!