### PR TITLE
fix: Add auditRedentionPeriod to cluster's helm chart

### DIFF
--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -33,6 +33,7 @@ data:
         {{- end }}
         audit_sessions_uri: s3://{{ required "aws.sessionRecordingBucket is required in chart values" .Values.aws.sessionRecordingBucket }}
         continuous_backups: {{ required "aws.backups is required in chart values" .Values.aws.backups }}
+        audit_retention_period: {{ .Values.storage.audit.retentionPeriod }}
   {{- else if eq .Values.chartMode "gcp" }}
       storage:
         type: firestore
@@ -47,6 +48,7 @@ data:
         audit_events_uri: ['firestore://{{ required "gcp.auditLogTable is required in chart values" .Values.gcp.auditLogTable }}?projectID={{ required "gcp.projectId is required in chart values" .Values.gcp.projectId }}{{ empty .Values.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}']
         {{- end }}
         audit_sessions_uri: "gs://{{ required "gcp.sessionRecordingBucket is required in chart values" .Values.gcp.sessionRecordingBucket }}?projectID={{ required "gcp.projectId is required in chart values" .Values.gcp.projectId }}{{ empty .Values.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}"
+        audit_retention_period: {{ .Values.storage.audit.retentionPeriod }}
   {{- end }}
     auth_service:
       enabled: true

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -178,6 +178,23 @@
                 }
             }
         },
+        "storage": {
+            "$id": "#/properties/storage",
+            "type": "object",
+            "properties": {
+                "audit": {
+                    "$id": "#/properties/storage/audit",
+                    "type": "object",
+                    "properties": {
+                        "retentionPeriod": {
+                            "$id": "#/properties/storage/audit/retentionPeriod",
+                            "type": "string",
+                            "default": "365d"
+                        }
+                    }
+                }
+            }
+        },
         "aws": {
             "$id": "#/properties/aws",
             "type": "object",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -87,6 +87,13 @@ persistence:
   # Ignored if existingClaimName is provided.
   volumeSize: 10Gi
 
+######################################################################
+# Agnostic storage properties
+######################################################################
+storage:
+  audit:
+    retentionPeriod: 365d
+
 ##################################################
 # AWS-specific settings (only used in "aws" mode)
 ##################################################


### PR DESCRIPTION
This is to make sure the default ttl is realy 1 year as mentioned in the documentation [1].
From what can be seen, at least in dynamo db, the keys are expiring in around 50 days.