### PR TITLE
Opportunistically match inputs with detectProto

### DIFF
--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -333,6 +333,32 @@ func TestMux(t *testing.T) {
 		require.NotNil(t, err)
 	})
 
+	// TooShort make sure that multiplexer closes connections
+	// that do not have enough data to detect the protocol
+	t.Run("TooShort", func(t *testing.T) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.Nil(t, err)
+
+		mux, err := New(Config{
+			Listener:            listener,
+			EnableProxyProtocol: true,
+		})
+		require.Nil(t, err)
+		go mux.Serve()
+		defer mux.Close()
+
+		conn, err := net.Dial("tcp", listener.Addr().String())
+		require.Nil(t, err)
+		defer conn.Close()
+
+		_, err = fmt.Fprintf(conn, "POST")
+		require.Nil(t, err)
+
+		// connection should be closed
+		_, err = conn.Read(make([]byte, 1))
+		require.Equal(t, err, io.EOF)
+	})
+
 	// UnknownProtocol make sure that multiplexer closes connection
 	// with unknown protocol
 	t.Run("UnknownProtocol", func(t *testing.T) {

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -333,32 +333,6 @@ func TestMux(t *testing.T) {
 		require.NotNil(t, err)
 	})
 
-	// TooShort make sure that multiplexer closes connections
-	// that do not have enough data to detect the protocol
-	t.Run("TooShort", func(t *testing.T) {
-		listener, err := net.Listen("tcp", "127.0.0.1:0")
-		require.Nil(t, err)
-
-		mux, err := New(Config{
-			Listener:            listener,
-			EnableProxyProtocol: true,
-		})
-		require.Nil(t, err)
-		go mux.Serve()
-		defer mux.Close()
-
-		conn, err := net.Dial("tcp", listener.Addr().String())
-		require.Nil(t, err)
-		defer conn.Close()
-
-		_, err = fmt.Fprintf(conn, "POST")
-		require.Nil(t, err)
-
-		// connection should be closed
-		_, err = conn.Read(make([]byte, 1))
-		require.Equal(t, err, io.EOF)
-	})
-
 	// UnknownProtocol make sure that multiplexer closes connection
 	// with unknown protocol
 	t.Run("UnknownProtocol", func(t *testing.T) {

--- a/lib/multiplexer/wrappers.go
+++ b/lib/multiplexer/wrappers.go
@@ -71,11 +71,7 @@ func (c *Conn) Protocol() Protocol {
 
 // Detect detects the connection protocol by peeking into the first few bytes.
 func (c *Conn) Detect() (Protocol, error) {
-	bytes, err := c.reader.Peek(8)
-	if err != nil {
-		return ProtoUnknown, trace.Wrap(err)
-	}
-	proto, err := detectProto(bytes)
+	proto, err := detectProto(c.reader)
 	if err != nil && !trace.IsBadParameter(err) {
 		return ProtoUnknown, trace.Wrap(err)
 	}


### PR DESCRIPTION
Both detectProto and isHTTP assume the input byte slice is only 3 bytes,
but both callers of detectProto always pass in 8 bytes. Also, some cases
truncate protocol prefixes that are larger than 3 bytes assuming that the
input is 3 bytes but other cases don't. To make things consistent and more
accurate, document that at least 8 bytes are required, and add a check for
good measure.