### PR TITLE
Implement touch ID registration and login

### DIFF
--- a/lib/auth/touchid/.clangd
+++ b/lib/auth/touchid/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Add: [-Wall, -xobjective-c, -fblocks, -fobjc-arc]

--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -115,6 +115,7 @@ func Register(origin string, cc *wanlib.CredentialCreation) (*wanlib.CredentialC
 		// ES256 is all we can do.
 		if param.Type == protocol.PublicKeyCredentialType && param.Algorithm == webauthncose.AlgES256 {
 			ok = true
+			break
 		}
 	}
 	if !ok {

--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -1,0 +1,365 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package touchid
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/duo-labs/webauthn/protocol/webauthncose"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/gravitational/trace"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+)
+
+var (
+	ErrAttemptFailed      = errors.New("login attempt failed")
+	ErrCredentialNotFound = errors.New("credential not found")
+	ErrNotAvailable       = errors.New("touch ID not available")
+)
+
+var native nativeTID
+
+// nativeTID represents the native Touch ID interface.
+type nativeTID interface {
+	IsAvailable() bool
+
+	Register(rpID, user string, userHandle []byte) (*CredentialInfo, error)
+	Authenticate(credentialID string, digest []byte) ([]byte, error)
+
+	// FindCredentials finds credentials without user interaction.
+	// An empty user means "all users".
+	FindCredentials(rpID, user string) ([]CredentialInfo, error)
+}
+
+// CredentialInfo holds information about a Secure Enclave credential.
+type CredentialInfo struct {
+	UserHandle   []byte
+	CredentialID string
+	RPID         string
+	User         string
+	PublicKey    *ecdsa.PublicKey
+
+	// publicKeyRaw is used internally to return public key data from native
+	// register requests.
+	publicKeyRaw []byte
+}
+
+// IsAvailable returns true if Touch ID is available in the system.
+// Presently, IsAvailable is hidden behind a somewhat cheap check, so it may be
+// prone to false positives (for example, a binary compiled with Touch ID
+// support but not properly signed/notarized).
+// In case of false positives, other Touch IDs should fail gracefully.
+func IsAvailable() bool {
+	// TODO(codingllama): Consider adding more depth to availability checks.
+	//  They are prone to false positives as it stands.
+	return native.IsAvailable()
+}
+
+// Register creates a new Secure Enclave-backed biometric credential.
+func Register(origin string, cc *wanlib.CredentialCreation) (*wanlib.CredentialCreationResponse, error) {
+	if !native.IsAvailable() {
+		return nil, ErrNotAvailable
+	}
+
+	// Ignored cc fields:
+	// - Timeout - we don't control touch ID timeouts (also the server is free to
+	//   enforce it)
+	// - CredentialExcludeList - we always allow re-registering (for various
+	//   reasons).
+	// - Extensions - none supported
+	// - Attestation - we always to our best (packed/self-attestation).
+	//   The server is free to ignore/reject.
+	switch {
+	case origin == "":
+		return nil, errors.New("origin required")
+	case cc == nil:
+		return nil, errors.New("credential creation required")
+	case len(cc.Response.Challenge) == 0:
+		return nil, errors.New("challenge required")
+	// Note: we don't need other RelyingParty fields, but technically they would
+	// be required as well.
+	case cc.Response.RelyingParty.ID == "":
+		return nil, errors.New("relying party ID required")
+	case len(cc.Response.User.ID) == 0:
+		return nil, errors.New("user ID required")
+	case cc.Response.User.Name == "":
+		return nil, errors.New("user name required")
+	case cc.Response.AuthenticatorSelection.AuthenticatorAttachment == protocol.CrossPlatform:
+		return nil, fmt.Errorf("cannot fulfil authenticator attachment %q", cc.Response.AuthenticatorSelection.AuthenticatorAttachment)
+	}
+	ok := false
+	for _, param := range cc.Response.Parameters {
+		// ES256 is all we can do.
+		if param.Type == protocol.PublicKeyCredentialType && param.Algorithm == webauthncose.AlgES256 {
+			ok = true
+		}
+	}
+	if !ok {
+		return nil, errors.New("cannot fulfil credential parameters, only ES256 are supported")
+	}
+
+	rpID := cc.Response.RelyingParty.ID
+	user := cc.Response.User.Name
+	userHandle := cc.Response.User.ID
+
+	// TODO(codingllama): Handle double registrations and failures after key
+	//  creation.
+	resp, err := native.Register(rpID, user, userHandle)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	credentialID := resp.CredentialID
+	pubKeyRaw := resp.publicKeyRaw
+
+	// Parse public key and transform to the required CBOR object.
+	pubKey := pubKeyFromRawAppleKey(pubKeyRaw)
+	x := make([]byte, 32) // x and y must have exactly 32 bytes in EC2PublicKeyData.
+	y := make([]byte, 32)
+	pubKey.X.FillBytes(x)
+	pubKey.Y.FillBytes(y)
+
+	pubKeyCBOR, err := cbor.Marshal(
+		&webauthncose.EC2PublicKeyData{
+			PublicKeyData: webauthncose.PublicKeyData{
+				KeyType:   int64(webauthncose.EllipticKey),
+				Algorithm: int64(webauthncose.AlgES256),
+			},
+			// See https://datatracker.ietf.org/doc/html/rfc8152#section-13.1.
+			Curve:  1, // P-256
+			XCoord: x,
+			YCoord: y,
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	attData, err := makeAttestationData(
+		protocol.CreateCeremony, origin, rpID, cc.Response.Challenge,
+		&credentialData{
+			id:         credentialID,
+			pubKeyCBOR: pubKeyCBOR,
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	sig, err := native.Authenticate(credentialID, attData.digest)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	attObj, err := cbor.Marshal(protocol.AttestationObject{
+		RawAuthData: attData.rawAuthData,
+		Format:      "packed",
+		AttStatement: map[string]interface{}{
+			"alg": int64(webauthncose.AlgES256),
+			"sig": sig,
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &wanlib.CredentialCreationResponse{
+		PublicKeyCredential: wanlib.PublicKeyCredential{
+			Credential: wanlib.Credential{
+				ID:   credentialID,
+				Type: string(protocol.PublicKeyCredentialType),
+			},
+			RawID: []byte(credentialID),
+		},
+		AttestationResponse: wanlib.AuthenticatorAttestationResponse{
+			AuthenticatorResponse: wanlib.AuthenticatorResponse{
+				ClientDataJSON: attData.ccdJSON,
+			},
+			AttestationObject: attObj,
+		},
+	}, nil
+}
+
+func pubKeyFromRawAppleKey(pubKeyRaw []byte) *ecdsa.PublicKey {
+	// "For an elliptic curve public key, the format follows the ANSI X9.63
+	// standard using a byte string of 04 || X || Y. (...) All of these
+	// representations use constant size integers, including leading zeros as
+	// needed."
+	// https://developer.apple.com/documentation/security/1643698-seckeycopyexternalrepresentation?language=objc
+	pubKeyRaw = pubKeyRaw[1:] // skip 0x04
+	l := len(pubKeyRaw) / 2
+	x := pubKeyRaw[:l]
+	y := pubKeyRaw[l:]
+
+	return &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     (&big.Int{}).SetBytes(x),
+		Y:     (&big.Int{}).SetBytes(y),
+	}
+}
+
+type credentialData struct {
+	id         string
+	pubKeyCBOR []byte
+}
+
+type attestationResponse struct {
+	ccdJSON     []byte
+	rawAuthData []byte
+	digest      []byte
+}
+
+// TODO(codingllama): Share a single definition with webauthncli / mocku2f.
+type collectedClientData struct {
+	Type      string `json:"type"`
+	Challenge string `json:"challenge"`
+	Origin    string `json:"origin"`
+}
+
+func makeAttestationData(ceremony protocol.CeremonyType, origin, rpID string, challenge []byte, cred *credentialData) (*attestationResponse, error) {
+	// Sanity check.
+	isCreate := ceremony == protocol.CreateCeremony
+	if isCreate && cred == nil {
+		return nil, fmt.Errorf("cred required for %q ceremony", ceremony)
+	}
+
+	ccd := &collectedClientData{
+		Type:      string(ceremony),
+		Challenge: base64.RawURLEncoding.EncodeToString(challenge),
+		Origin:    origin,
+	}
+	ccdJSON, err := json.Marshal(ccd)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ccdHash := sha256.Sum256(ccdJSON)
+	rpIDHash := sha256.Sum256([]byte(rpID))
+
+	flags := byte(protocol.FlagUserPresent | protocol.FlagUserVerified)
+	if isCreate {
+		flags |= byte(protocol.FlagAttestedCredentialData)
+	}
+
+	authData := &bytes.Buffer{}
+	authData.Write(rpIDHash[:])
+	authData.WriteByte(flags)
+	binary.Write(authData, binary.BigEndian, uint32(0)) // signature counter
+	// Attested credential data begins here.
+	if isCreate {
+		authData.Write(make([]byte, 16))                               // aaguid
+		binary.Write(authData, binary.BigEndian, uint16(len(cred.id))) // credentialIdLength
+		authData.Write([]byte(cred.id))
+		authData.Write(cred.pubKeyCBOR)
+	}
+	rawAuthData := authData.Bytes()
+
+	dataToSign := append(rawAuthData, ccdHash[:]...)
+	digest := sha256.Sum256(dataToSign)
+	return &attestationResponse{
+		ccdJSON:     ccdJSON,
+		rawAuthData: rawAuthData,
+		digest:      digest[:],
+	}, nil
+}
+
+// Login authenticates using a Secure Enclave-backed biometric credential.
+// It returns the assertion response and the user that owns the credential to
+// sign it.
+func Login(origin, user string, assertion *wanlib.CredentialAssertion) (*wanlib.CredentialAssertionResponse, string, error) {
+	if !native.IsAvailable() {
+		return nil, "", ErrNotAvailable
+	}
+
+	// Ignored assertion fields:
+	// - Timeout - we don't control touch ID timeouts (also the server is free to
+	//   enforce it)
+	// - UserVerification - always performed
+	// - Extensions - none supported
+	switch {
+	case origin == "":
+		return nil, "", errors.New("origin required")
+	case assertion == nil:
+		return nil, "", errors.New("assertion required")
+	case len(assertion.Response.Challenge) == 0:
+		return nil, "", errors.New("challenge required")
+	case assertion.Response.RelyingPartyID == "":
+		return nil, "", errors.New("relying party ID required")
+	}
+
+	// TODO(codingllama): Share the same LAContext between search and
+	//  authentication, so we can protect both with user interaction.
+	rpID := assertion.Response.RelyingPartyID
+	infos, err := native.FindCredentials(rpID, user)
+	switch {
+	case err != nil:
+		return nil, "", err
+	case len(infos) == 0:
+		return nil, "", ErrCredentialNotFound
+	}
+
+	// Verify infos against allowed credentials, if any.
+	var cred *CredentialInfo
+	if len(assertion.Response.AllowedCredentials) > 0 {
+		for _, info := range infos {
+			for _, allowedCred := range assertion.Response.AllowedCredentials {
+				if info.CredentialID == string(allowedCred.CredentialID) {
+					cred = &info
+					break
+				}
+			}
+		}
+	} else {
+		cred = &infos[0]
+	}
+	if cred == nil {
+		return nil, "", ErrCredentialNotFound
+	}
+
+	attData, err := makeAttestationData(protocol.AssertCeremony, origin, rpID, assertion.Response.Challenge, nil /* cred */)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	sig, err := native.Authenticate(cred.CredentialID, attData.digest)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	return &wanlib.CredentialAssertionResponse{
+		PublicKeyCredential: wanlib.PublicKeyCredential{
+			Credential: wanlib.Credential{
+				ID:   cred.CredentialID,
+				Type: string(protocol.PublicKeyCredentialType),
+			},
+			RawID: []byte(cred.CredentialID),
+		},
+		AssertionResponse: wanlib.AuthenticatorAssertionResponse{
+			AuthenticatorResponse: wanlib.AuthenticatorResponse{
+				ClientDataJSON: attData.ccdJSON,
+			},
+			AuthenticatorData: attData.rawAuthData,
+			Signature:         sig,
+			UserHandle:        cred.UserHandle,
+		},
+	}, cred.User, nil
+}

--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -40,9 +40,8 @@ var (
 	ErrNotAvailable       = errors.New("touch ID not available")
 )
 
-var native nativeTID
-
 // nativeTID represents the native Touch ID interface.
+// Implementors must provide a global variable called `native`.
 type nativeTID interface {
 	IsAvailable() bool
 

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -196,6 +196,7 @@ func findCredentialsImpl(rpID, user string, find func(C.LabelFilter, **C.Credent
 		pubKeyRaw, err := base64.StdEncoding.DecodeString(pubKeyB64)
 		if err != nil {
 			log.WithError(err).Warnf("Failed to decode public key for credential %q", credentialID)
+			// Do not return or break here, we want the defers to run in all items.
 		}
 
 		infos[i] = CredentialInfo{

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -94,7 +94,7 @@ func (*touchIDImpl) Register(rpID, user string, userHandle []byte) (*CredentialI
 const labelSeparator = " "
 
 func makeLabel(rpID, user string) string {
-	return fmt.Sprintf("%v%v%v", rpID, labelSeparator, user)
+	return rpID + labelSeparator + user
 }
 
 func splitLabel(label string) (string, string) {

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -27,7 +27,6 @@ package touchid
 import "C"
 
 import (
-	"crypto/ecdsa"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -193,13 +192,10 @@ func findCredentialsImpl(rpID, user string, find func(C.LabelFilter, **C.Credent
 		}
 
 		// ECDSA public key
-		var pubKey *ecdsa.PublicKey
 		pubKeyB64 := C.GoString(infoC.pub_key_b64)
 		pubKeyRaw, err := base64.StdEncoding.DecodeString(pubKeyB64)
 		if err != nil {
-			log.WithError(err).Warn("Failed to decode public key for credential %q", credentialID)
-		} else {
-			pubKey = pubKeyFromRawAppleKey(pubKeyRaw)
+			log.WithError(err).Warnf("Failed to decode public key for credential %q", credentialID)
 		}
 
 		infos[i] = CredentialInfo{
@@ -207,7 +203,7 @@ func findCredentialsImpl(rpID, user string, find func(C.LabelFilter, **C.Credent
 			CredentialID: credentialID,
 			RPID:         rpID,
 			User:         user,
-			PublicKey:    pubKey,
+			publicKeyRaw: pubKeyRaw,
 		}
 	}
 	return infos, int(res)

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -1,0 +1,214 @@
+//go:build touchid
+// +build touchid
+
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package touchid
+
+// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc
+// #cgo LDFLAGS: -framework CoreFoundation -framework Foundation -framework LocalAuthentication -framework Security
+// #include <stdlib.h>
+// #include "authenticate.h"
+// #include "credential_info.h"
+// #include "credentials.h"
+// #include "register.h"
+import "C"
+
+import (
+	"crypto/ecdsa"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	native = &touchIDImpl{}
+}
+
+type touchIDImpl struct{}
+
+func (*touchIDImpl) IsAvailable() bool {
+	// TODO(codingllama): Write a deeper check that looks at binary
+	//  signature/entitlements/etc.
+	return true
+}
+
+func (*touchIDImpl) Register(rpID, user string, userHandle []byte) (*CredentialInfo, error) {
+	credentialID := uuid.NewString()
+	userHandleB64 := base64.RawURLEncoding.EncodeToString(userHandle)
+
+	var req C.CredentialInfo
+	req.label = C.CString(makeLabel(rpID, user))
+	req.app_label = C.CString(credentialID)
+	req.app_tag = C.CString(userHandleB64)
+	defer func() {
+		C.free(unsafe.Pointer(req.label))
+		C.free(unsafe.Pointer(req.app_label))
+		C.free(unsafe.Pointer(req.app_tag))
+	}()
+
+	var errMsgC, pubKeyC *C.char
+	defer func() {
+		C.free(unsafe.Pointer(errMsgC))
+		C.free(unsafe.Pointer(pubKeyC))
+	}()
+
+	if res := C.Register(req, &pubKeyC, &errMsgC); res != 0 {
+		errMsg := C.GoString(errMsgC)
+		return nil, errors.New(errMsg)
+	}
+
+	pubKeyB64 := C.GoString(pubKeyC)
+	pubKeyRaw, err := base64.StdEncoding.DecodeString(pubKeyB64)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &CredentialInfo{
+		CredentialID: credentialID,
+		publicKeyRaw: pubKeyRaw,
+	}, nil
+}
+
+// rpID are domain names, so it's safe to assume they won't have spaces in them.
+// https://www.w3.org/TR/webauthn-2/#relying-party-identifier
+const labelSeparator = " "
+
+func makeLabel(rpID, user string) string {
+	return fmt.Sprintf("%v%v%v", rpID, labelSeparator, user)
+}
+
+func splitLabel(label string) (string, string) {
+	idx := strings.Index(label, labelSeparator)
+	if idx == -1 {
+		return "", ""
+	}
+	rpID := label[0:idx]
+	user := label[idx+1:]
+	return rpID, user
+}
+
+func (*touchIDImpl) Authenticate(credentialID string, digest []byte) ([]byte, error) {
+	var req C.AuthenticateRequest
+	req.app_label = C.CString(credentialID)
+	req.digest = C.CString(string(digest))
+	req.digest_len = C.int(len(digest))
+	defer func() {
+		C.free(unsafe.Pointer(req.app_label))
+		C.free(unsafe.Pointer(req.digest))
+	}()
+
+	var sigOutC, errMsgC *C.char
+	defer func() {
+		C.free(unsafe.Pointer(sigOutC))
+		C.free(unsafe.Pointer(errMsgC))
+	}()
+
+	if res := C.Authenticate(req, &sigOutC, &errMsgC); res != 0 {
+		errMsg := C.GoString(errMsgC)
+		return nil, errors.New(errMsg)
+	}
+
+	sigB64 := C.GoString(sigOutC)
+	return base64.StdEncoding.DecodeString(sigB64)
+}
+
+func (*touchIDImpl) FindCredentials(rpID, user string) ([]CredentialInfo, error) {
+	infos, res := findCredentialsImpl(rpID, user, func(filter C.LabelFilter, infosC **C.CredentialInfo) C.int {
+		return C.FindCredentials(filter, infosC)
+	})
+	if res < 0 {
+		return nil, fmt.Errorf("failed to find credentials: status %d", res)
+	}
+	return infos, nil
+}
+
+func findCredentialsImpl(rpID, user string, find func(C.LabelFilter, **C.CredentialInfo) C.int) ([]CredentialInfo, int) {
+	var filterC C.LabelFilter
+	if user == "" {
+		filterC.kind = C.LABEL_PREFIX
+	}
+	filterC.value = C.CString(makeLabel(rpID, user))
+	defer C.free(unsafe.Pointer(filterC.value))
+
+	var infosC *C.CredentialInfo
+	defer C.free(unsafe.Pointer(infosC))
+
+	res := find(filterC, &infosC)
+	if res < 0 {
+		return nil, int(res)
+	}
+
+	start := unsafe.Pointer(infosC)
+	size := unsafe.Sizeof(C.CredentialInfo{})
+	infos := make([]CredentialInfo, res)
+	for i := 0; i < int(res); i++ {
+		// IMPORTANT: The defer below is used to free the pointers inside infos.
+		// It relies on the fact that we never error out of the function after
+		// this point, otherwise some instances would leak.
+		infoC := (*C.CredentialInfo)(unsafe.Add(start, uintptr(i)*size))
+		defer func() {
+			C.free(unsafe.Pointer(infoC.label))
+			C.free(unsafe.Pointer(infoC.app_label))
+			C.free(unsafe.Pointer(infoC.app_tag))
+			C.free(unsafe.Pointer(infoC.pub_key_b64))
+		}()
+
+		// user@rpid
+		label := C.GoString(infoC.label)
+		rpID, user := splitLabel(label)
+		if rpID == "" || user == "" {
+			log.Debugf("Skipping credential with unexpected label: %q", label)
+			continue
+		}
+
+		// credential ID / UUID
+		credentialID := C.GoString(infoC.app_label)
+
+		// user handle
+		appTag := C.GoString(infoC.app_tag)
+		userHandle, err := base64.RawURLEncoding.DecodeString(appTag)
+		if err != nil {
+			log.Debugf("Skipping credential with unexpected application tag: %q", appTag)
+			continue
+		}
+
+		// ECDSA public key
+		var pubKey *ecdsa.PublicKey
+		pubKeyB64 := C.GoString(infoC.pub_key_b64)
+		pubKeyRaw, err := base64.StdEncoding.DecodeString(pubKeyB64)
+		if err != nil {
+			log.WithError(err).Warn("Failed to decode public key for credential %q", credentialID)
+		} else {
+			pubKey = pubKeyFromRawAppleKey(pubKeyRaw)
+		}
+
+		infos[i] = CredentialInfo{
+			UserHandle:   userHandle,
+			CredentialID: credentialID,
+			RPID:         rpID,
+			User:         user,
+			PublicKey:    pubKey,
+		}
+	}
+	return infos, int(res)
+}

--- a/lib/auth/touchid/api_other.go
+++ b/lib/auth/touchid/api_other.go
@@ -1,0 +1,40 @@
+//go:build !touchid
+// +build !touchid
+
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package touchid
+
+func init() {
+	native = noopNative{}
+}
+
+type noopNative struct{}
+
+func (noopNative) IsAvailable() bool {
+	return false
+}
+
+func (noopNative) Register(rpID, user string, userHandle []byte) (*CredentialInfo, error) {
+	return nil, ErrNotAvailable
+}
+
+func (noopNative) Authenticate(credentialID string, digest []byte) ([]byte, error) {
+	return nil, ErrNotAvailable
+}
+
+func (noopNative) FindCredentials(rpID, user string) ([]CredentialInfo, error) {
+	return nil, ErrNotAvailable
+}

--- a/lib/auth/touchid/api_other.go
+++ b/lib/auth/touchid/api_other.go
@@ -17,9 +17,7 @@
 
 package touchid
 
-func init() {
-	native = noopNative{}
-}
+var native nativeTID = noopNative{}
 
 type noopNative struct{}
 

--- a/lib/auth/touchid/api_test.go
+++ b/lib/auth/touchid/api_test.go
@@ -1,0 +1,216 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package touchid_test
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"testing"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/duo-labs/webauthn/webauthn"
+	"github.com/google/uuid"
+	"github.com/gravitational/teleport/lib/auth/touchid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+)
+
+func TestRegisterAndLogin(t *testing.T) {
+	n := *touchid.Native
+	t.Cleanup(func() {
+		*touchid.Native = n
+	})
+
+	const llamaUser = "llama"
+
+	web, err := webauthn.New(&webauthn.Config{
+		RPDisplayName: "Teleport",
+		RPID:          "teleport",
+		RPOrigin:      "https://goteleport.com",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		webUser         *fakeUser
+		origin, user    string
+		modifyAssertion func(a *wanlib.CredentialAssertion)
+		wantUser        string
+	}{
+		{
+			name:    "passwordless",
+			webUser: &fakeUser{id: []byte{1, 2, 3, 4, 5}, name: llamaUser},
+			origin:  web.Config.RPOrigin,
+			modifyAssertion: func(a *wanlib.CredentialAssertion) {
+				a.Response.AllowedCredentials = nil // aka passwordless
+			},
+			wantUser: llamaUser,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			*touchid.Native = &fakeNative{}
+
+			webUser := test.webUser
+			origin := test.origin
+			user := test.user
+
+			// Registration section.
+			cc, sessionData, err := web.BeginRegistration(webUser)
+			require.NoError(t, err)
+
+			ccr, err := touchid.Register(origin, (*wanlib.CredentialCreation)(cc))
+			require.NoError(t, err, "Register failed")
+
+			// We have to marshal and parse ccr due to an unavoidable quirk of the
+			// webauthn API.
+			body, err := json.Marshal(ccr)
+			require.NoError(t, err)
+			parsedCCR, err := protocol.ParseCredentialCreationResponseBody(bytes.NewReader(body))
+			require.NoError(t, err, "ParseCredentialCreationResponseBody failed")
+
+			cred, err := web.CreateCredential(webUser, *sessionData, parsedCCR)
+			require.NoError(t, err, "CreateCredential failed")
+			// Save credential for Login test below.
+			webUser.credentials = append(webUser.credentials, *cred)
+
+			// Login section.
+			a, sessionData, err := web.BeginLogin(webUser)
+			require.NoError(t, err, "BeginLogin failed")
+			assertion := (*wanlib.CredentialAssertion)(a)
+			test.modifyAssertion(assertion)
+
+			assertionResp, actualUser, err := touchid.Login(origin, user, assertion)
+			require.NoError(t, err, "Login failed")
+			assert.Equal(t, test.wantUser, actualUser, "actualUser mismatch")
+
+			// Same as above: easiest way to validate the assertion is to marshal
+			// and then parse the body.
+			body, err = json.Marshal(assertionResp)
+			require.NoError(t, err)
+			parsedAssertion, err := protocol.ParseCredentialRequestResponseBody(bytes.NewReader(body))
+			require.NoError(t, err, "ParseCredentialRequestResponseBody failed")
+
+			_, err = web.ValidateLogin(webUser, *sessionData, parsedAssertion)
+			require.NoError(t, err, "ValidatLogin failed")
+		})
+	}
+}
+
+type credentialHandle struct {
+	rpID, user string
+	id         string
+	userHandle []byte
+	key        *ecdsa.PrivateKey
+}
+
+type fakeNative struct {
+	creds []credentialHandle
+}
+
+func (f *fakeNative) Authenticate(credentialID string, data []byte) ([]byte, error) {
+	var key *ecdsa.PrivateKey
+	for _, cred := range f.creds {
+		if cred.id == credentialID {
+			key = cred.key
+			break
+		}
+	}
+	if key == nil {
+		return nil, touchid.ErrCredentialNotFound
+	}
+
+	return key.Sign(rand.Reader, data, crypto.SHA256)
+}
+
+func (f *fakeNative) IsAvailable() bool {
+	return true
+}
+
+func (f *fakeNative) FindCredentials(rpID, user string) ([]touchid.CredentialInfo, error) {
+	var resp []touchid.CredentialInfo
+	for _, cred := range f.creds {
+		if cred.rpID == rpID && (user == "" || cred.user == user) {
+			resp = append(resp, touchid.CredentialInfo{
+				UserHandle:   cred.userHandle,
+				CredentialID: cred.id,
+				RPID:         cred.rpID,
+				User:         cred.user,
+				PublicKey:    &cred.key.PublicKey,
+			})
+		}
+	}
+	return resp, nil
+}
+
+func (f *fakeNative) Register(rpID, user string, userHandle []byte) (*touchid.CredentialInfo, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	id := uuid.NewString()
+	f.creds = append(f.creds, credentialHandle{
+		rpID:       rpID,
+		user:       user,
+		id:         id,
+		userHandle: userHandle,
+		key:        key,
+	})
+
+	// Marshal key into the raw Apple format.
+	pubKeyApple := make([]byte, 1+32+32)
+	pubKeyApple[0] = 0x04
+	key.X.FillBytes(pubKeyApple[1:33])
+	key.Y.FillBytes(pubKeyApple[33:])
+
+	info := &touchid.CredentialInfo{
+		CredentialID: id,
+	}
+	info.SetPublicKeyRaw(pubKeyApple)
+	return info, nil
+}
+
+type fakeUser struct {
+	id          []byte
+	name        string
+	credentials []webauthn.Credential
+}
+
+func (u *fakeUser) WebAuthnCredentials() []webauthn.Credential {
+	return u.credentials
+}
+
+func (u *fakeUser) WebAuthnDisplayName() string {
+	return u.name
+}
+
+func (u *fakeUser) WebAuthnID() []byte {
+	return u.id
+}
+
+func (u *fakeUser) WebAuthnIcon() string {
+	return ""
+}
+
+func (u *fakeUser) WebAuthnName() string {
+	return u.name
+}

--- a/lib/auth/touchid/authenticate.h
+++ b/lib/auth/touchid/authenticate.h
@@ -1,0 +1,18 @@
+#ifndef AUTHENTICATE_H_
+#define AUTHENTICATE_H_
+
+#include "credential_info.h"
+
+typedef struct AuthenticateRequest {
+  const char *app_label;
+  const char *digest;
+  int digest_len;
+} AuthenticateRequest;
+
+// Authenticate finds the key specified by app_label and signs the digest using
+// it. The digest is expected to be in SHA256.
+// Authenticate requires user interaction.
+// Returns zero if successful, non-zero otherwise.
+int Authenticate(AuthenticateRequest req, char **sigB64Out, char **errOut);
+
+#endif // AUTHENTICATE_H_

--- a/lib/auth/touchid/authenticate.h
+++ b/lib/auth/touchid/authenticate.h
@@ -1,3 +1,17 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef AUTHENTICATE_H_
 #define AUTHENTICATE_H_
 

--- a/lib/auth/touchid/authenticate.h
+++ b/lib/auth/touchid/authenticate.h
@@ -15,12 +15,14 @@
 #ifndef AUTHENTICATE_H_
 #define AUTHENTICATE_H_
 
+#include <stddef.h>
+
 #include "credential_info.h"
 
 typedef struct AuthenticateRequest {
   const char *app_label;
   const char *digest;
-  int digest_len;
+  size_t digest_len;
 } AuthenticateRequest;
 
 // Authenticate finds the key specified by app_label and signs the digest using

--- a/lib/auth/touchid/authenticate.m
+++ b/lib/auth/touchid/authenticate.m
@@ -1,0 +1,61 @@
+// go:build touchid
+//  +build touchid
+
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "authenticate.h"
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
+
+#include "common.h"
+
+int Authenticate(AuthenticateRequest req, char **sigB64Out, char **errOut) {
+  NSData *appLabel = [NSData dataWithBytes:req.app_label
+                                    length:strlen(req.app_label)];
+  NSDictionary *query = @{
+    (id)kSecClass : (id)kSecClassKey,
+    (id)kSecAttrKeyType : (id)kSecAttrKeyTypeECSECPrimeRandom,
+    (id)kSecMatchLimit : (id)kSecMatchLimitOne,
+    (id)kSecReturnRef : @YES,
+    (id)kSecAttrApplicationLabel : appLabel,
+  };
+  SecKeyRef privateKey = NULL;
+  OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query,
+                                        (CFTypeRef *)&privateKey);
+  if (status != errSecSuccess) {
+    *errOut = CopyNSString([NSString
+        stringWithFormat:@"credential query failed: status %d", status]);
+    return -1;
+  }
+
+  NSData *digest = [NSData dataWithBytes:req.digest length:req.digest_len];
+  CFErrorRef error = NULL;
+  CFDataRef sig = SecKeyCreateSignature(
+      privateKey, kSecKeyAlgorithmECDSASignatureDigestX962SHA256,
+      (__bridge CFDataRef)digest, &error);
+  if (error) {
+    NSError *nsError = (__bridge_transfer NSError *)error;
+    *errOut = CopyNSString([nsError localizedDescription]);
+    CFRelease(privateKey);
+    return -1;
+  }
+  NSData *nsSig = (__bridge_transfer NSData *)sig;
+  *sigB64Out = CopyNSString([nsSig base64EncodedStringWithOptions:0]);
+
+  CFRelease(privateKey);
+  return 0;
+}

--- a/lib/auth/touchid/authenticate.m
+++ b/lib/auth/touchid/authenticate.m
@@ -37,8 +37,9 @@ int Authenticate(AuthenticateRequest req, char **sigB64Out, char **errOut) {
   OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query,
                                         (CFTypeRef *)&privateKey);
   if (status != errSecSuccess) {
-    *errOut = CopyNSString([NSString
-        stringWithFormat:@"credential query failed: status %d", status]);
+    CFStringRef err = SecCopyErrorMessageString(status, NULL);
+    NSString *nsErr = (__bridge_transfer NSString *)err;
+    *errOut = CopyNSString(nsErr);
     return -1;
   }
 

--- a/lib/auth/touchid/common.h
+++ b/lib/auth/touchid/common.h
@@ -1,0 +1,10 @@
+#ifndef COMMON_H_
+#define COMMON_H_
+
+#import <Foundation/Foundation.h>
+
+// CopyNSString duplicates an NSString into an UTF-8 encoded C string.
+// The caller is expected to free the returned pointer.
+char *CopyNSString(NSString *val);
+
+#endif // COMMON_H_

--- a/lib/auth/touchid/common.h
+++ b/lib/auth/touchid/common.h
@@ -1,3 +1,17 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef COMMON_H_
 #define COMMON_H_
 

--- a/lib/auth/touchid/common.m
+++ b/lib/auth/touchid/common.m
@@ -1,0 +1,26 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build touchid
+// +build touchid
+
+#include "common.h"
+
+#import <Foundation/Foundation.h>
+
+#include <string.h>
+
+char *CopyNSString(NSString *val) {
+  return strdup([val UTF8String]);
+}

--- a/lib/auth/touchid/credential_info.h
+++ b/lib/auth/touchid/credential_info.h
@@ -1,0 +1,25 @@
+#ifndef CREDENTIAL_INFO_H_
+#define CREDENTIAL_INFO_H_
+
+// CredentialInfo represents a credential stored in the Secure Enclave.
+typedef struct CredentialInfo {
+  // label is the label for the Keychain entry.
+  // In practice, the label is a combination of RPID and username.
+  const char *label;
+
+  // app_label is the application label for the Keychain entry.
+  // In practice, the app_label is the credential ID.
+  const char *app_label;
+
+  // app_tag is the application tag for the Keychain entry.
+  // In practice, the app_tag is the WebAuthn user handle.
+  const char *app_tag;
+
+  // pub_key_b64 is the public key representation, encoded as a standard base64
+  // string.
+  // Refer to
+  // https://developer.apple.com/documentation/security/1643698-seckeycopyexternalrepresentation?language=objc.
+  const char *pub_key_b64;
+} CredentialInfo;
+
+#endif // CREDENTIAL_INFO_H_

--- a/lib/auth/touchid/credential_info.h
+++ b/lib/auth/touchid/credential_info.h
@@ -1,3 +1,17 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef CREDENTIAL_INFO_H_
 #define CREDENTIAL_INFO_H_
 

--- a/lib/auth/touchid/credentials.h
+++ b/lib/auth/touchid/credentials.h
@@ -1,3 +1,17 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef CREDENTIALS_H_
 #define CREDENTIALS_H_
 

--- a/lib/auth/touchid/credentials.h
+++ b/lib/auth/touchid/credentials.h
@@ -1,0 +1,22 @@
+#ifndef CREDENTIALS_H_
+#define CREDENTIALS_H_
+
+#include "credential_info.h"
+
+// LabelFilterKind is a way to filter by label.
+typedef enum LabelFilterKind { LABEL_EXACT, LABEL_PREFIX } LabelFilterKind;
+
+// LabelFilter specifies how to filter credentials by label.
+typedef struct LabelFilter {
+  LabelFilterKind kind;
+  const char *value;
+} LabelFilter;
+
+// FindCredentials finds all credentials matching a certain label filter.
+// Returns the numbers of credentials assigned to the infos array, or negative
+// on failure (typically an OSStatus code). The caller is expected to free infos
+// (and their contents!).
+// User interaction is not required.
+int FindCredentials(LabelFilter filter, CredentialInfo **infosOut);
+
+#endif // CREDENTIALS_H_

--- a/lib/auth/touchid/credentials.m
+++ b/lib/auth/touchid/credentials.m
@@ -21,6 +21,7 @@
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
 
+#include <limits.h>
 #include <stdlib.h>
 
 #include "common.h"
@@ -63,6 +64,10 @@ int FindCredentials(LabelFilter filter, CredentialInfo **infosOut) {
   NSString *nsFilter = [NSString stringWithUTF8String:filter.value];
 
   CFIndex count = CFArrayGetCount(items);
+  // Guard against overflows, just in case we ever get that many credentials.
+  if (count > INT_MAX) {
+    count = INT_MAX;
+  }
   *infosOut = calloc(count, sizeof(CredentialInfo));
   int infosLen = 0;
   for (CFIndex i = 0; i < count; i++) {

--- a/lib/auth/touchid/credentials.m
+++ b/lib/auth/touchid/credentials.m
@@ -1,0 +1,109 @@
+// go:build touchid
+//  +build touchid
+
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "credentials.h"
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+
+bool matchesLabelFilter(LabelFilter filter, const char *label) {
+  switch (filter.kind) {
+  case LABEL_EXACT:
+    return strcmp(label, filter.value) == 0;
+  case LABEL_PREFIX:
+    return strstr(label, filter.value) == label;
+  }
+  return -1;
+}
+
+int FindCredentials(LabelFilter filter, CredentialInfo **infosOut) {
+  NSDictionary *query = @{
+    (id)kSecClass : (id)kSecClassKey,
+    (id)kSecAttrKeyType : (id)kSecAttrKeyTypeECSECPrimeRandom,
+    (id)kSecMatchLimit : (id)kSecMatchLimitAll,
+    (id)kSecReturnRef : @YES,
+    (id)kSecReturnAttributes : @YES,
+  };
+  CFArrayRef items = NULL;
+  OSStatus status =
+      SecItemCopyMatching((CFDictionaryRef)query, (CFTypeRef *)&items);
+  switch (status) {
+  case errSecSuccess:
+    break; // continue below
+  case errSecItemNotFound:
+    return 0; // aka no items found
+  default:
+    // Not possible afaik, but let's make sure we keep up the method contract.
+    if (status >= 0) {
+      status = status * -1;
+    }
+    return status;
+  }
+
+  CFIndex count = CFArrayGetCount(items);
+  *infosOut = calloc(count, sizeof(CredentialInfo));
+  int infosLen = 0;
+  for (CFIndex i = 0; i < count; i++) {
+    CFDictionaryRef attrs = CFArrayGetValueAtIndex(items, i);
+
+    CFStringRef label = CFDictionaryGetValue(attrs, kSecAttrLabel);
+    NSString *nsLabel = (__bridge NSString *)label;
+    if (!matchesLabelFilter(filter, [nsLabel UTF8String])) {
+      continue;
+    }
+
+    CFDataRef appTag = CFDictionaryGetValue(attrs, kSecAttrApplicationTag);
+    NSString *nsAppTag =
+        [[NSString alloc] initWithData:(__bridge NSData *)appTag
+                              encoding:NSUTF8StringEncoding];
+
+    CFDataRef appLabel = CFDictionaryGetValue(attrs, kSecAttrApplicationLabel);
+    NSString *nsAppLabel =
+        [[NSString alloc] initWithData:(__bridge NSData *)appLabel
+                              encoding:NSUTF8StringEncoding];
+
+    // Copy public key representation.
+    SecKeyRef privKey = (SecKeyRef)CFDictionaryGetValue(attrs, kSecValueRef);
+    SecKeyRef pubKey = SecKeyCopyPublicKey(privKey);
+    char *pubKeyB64 = NULL;
+    if (pubKey) {
+      CFDataRef pubKeyRep =
+          SecKeyCopyExternalRepresentation(pubKey, NULL /*error*/);
+      if (pubKeyRep) {
+        NSData *pubKeyData = CFBridgingRelease(pubKeyRep);
+        pubKeyB64 = CopyNSString([pubKeyData base64EncodedStringWithOptions:0]);
+      }
+      CFRelease(pubKey);
+    }
+
+    (*infosOut + infosLen)->label = CopyNSString(nsLabel);
+    (*infosOut + infosLen)->app_label = CopyNSString(nsAppLabel);
+    (*infosOut + infosLen)->app_tag = CopyNSString(nsAppTag);
+    (*infosOut + infosLen)->pub_key_b64 = pubKeyB64;
+    infosLen++;
+  }
+
+  CFRelease(items);
+  return infosLen;
+}

--- a/lib/auth/touchid/export_test.go
+++ b/lib/auth/touchid/export_test.go
@@ -1,0 +1,23 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package touchid
+
+// Native exposes the native touch ID implementation so that it may be replaced
+// by tests.
+var Native = &native
+
+func (c *CredentialInfo) SetPublicKeyRaw(b []byte) {
+	c.publicKeyRaw = b
+}

--- a/lib/auth/touchid/register.h
+++ b/lib/auth/touchid/register.h
@@ -1,3 +1,17 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef REGISTER_H_
 #define REGISTER_H_
 

--- a/lib/auth/touchid/register.h
+++ b/lib/auth/touchid/register.h
@@ -1,0 +1,12 @@
+#ifndef REGISTER_H_
+#define REGISTER_H_
+
+#include "credential_info.h"
+
+// Register creates a new private key in the Secure Enclave.
+// Creating new keys doesn't require user interaction, only attempting to use
+// the key does.
+// Returns zero if successful, non-zero otherwise.
+int Register(CredentialInfo req, char **pubKeyB64Out, char **errOut);
+
+#endif // REGISTER_H_

--- a/lib/auth/touchid/register.m
+++ b/lib/auth/touchid/register.m
@@ -1,0 +1,90 @@
+// go:build touchid
+//  +build touchid
+
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "register.h"
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
+
+#include <string.h>
+
+#include "common.h"
+
+int Register(CredentialInfo req, char **pubKeyB64Out, char **errOut) {
+  CFErrorRef error = NULL;
+  SecAccessControlRef access = SecAccessControlCreateWithFlags(
+      kCFAllocatorDefault, kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+      kSecAccessControlPrivateKeyUsage | kSecAccessControlBiometryAny, &error);
+  if (error) {
+    NSError *nsError = CFBridgingRelease(error);
+    *errOut = CopyNSString([nsError localizedDescription]);
+    return -1;
+  }
+
+  NSDictionary *attributes = @{
+    // Enclave requires EC/256 bits keys.
+    (id)kSecAttrKeyType : (id)kSecAttrKeyTypeECSECPrimeRandom,
+    (id)kSecAttrKeySizeInBits : @256,
+    (id)kSecAttrTokenID : (id)kSecAttrTokenIDSecureEnclave,
+
+    (id)kSecPrivateKeyAttrs : @{
+      (id)kSecAttrIsPermanent : @YES,
+      (id)kSecAttrAccessControl : (__bridge id)access,
+
+      (id)kSecAttrLabel : [NSString stringWithUTF8String:req.label],
+      (id)kSecAttrApplicationLabel :
+          [NSData dataWithBytes:req.app_label length:strlen(req.app_label)],
+      (id)kSecAttrApplicationTag : [NSData dataWithBytes:req.app_tag
+                                                  length:strlen(req.app_tag)],
+    },
+  };
+  SecKeyRef privateKey =
+      SecKeyCreateRandomKey((__bridge CFDictionaryRef)(attributes), &error);
+  if (error) {
+    NSError *nsError = CFBridgingRelease(error);
+    *errOut = CopyNSString([nsError localizedDescription]);
+    CFRelease(access);
+    return -1;
+  }
+
+  SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+  if (!publicKey) {
+    *errOut = CopyNSString(@"failed to copy public key");
+    CFRelease(privateKey);
+    CFRelease(access);
+    return -1;
+  }
+
+  CFDataRef publicKeyRep = SecKeyCopyExternalRepresentation(publicKey, &error);
+  if (error) {
+    NSError *nsError = CFBridgingRelease(error);
+    *errOut = CopyNSString([nsError localizedDescription]);
+    CFRelease(publicKey);
+    CFRelease(privateKey);
+    CFRelease(access);
+    return -1;
+  }
+  NSData *publicKeyData = CFBridgingRelease(publicKeyRep);
+  *pubKeyB64Out =
+      CopyNSString([publicKeyData base64EncodedStringWithOptions:0]);
+
+  CFRelease(publicKey);
+  CFRelease(privateKey);
+  CFRelease(access);
+  return 0;
+}


### PR DESCRIPTION
Introduce the touchid package and add the ability to register and login using Secure Enclave keys.

The code is not yet wired to tsh, plus there are additional parts to come (listing and deleting keys). This is tricky to properly execute, as the Secure Enclave requires, at the very least, a signed binary and a provisioning profile installed. Future PRs will attempt to bridge that gap and provide ways for Teleport devs to compile and run this locally as well (but not for external devs, sorry).

I've elected to keep native as simple as I could. Objc uses ARC for memory management and good old C uses malloc/free, but there are relatively few naked pointers (many of which are handled by Go with defer-frees). I've kept the language boundary in plan C, so it's easier to reason about the Go<->C bridge.

The package is protected by the `touchid` build tag, but a good part of it exists outside of it - that is in hope that it gets well exercised by CI. In the near future the build tag will be used as a proxy for good builds (ie, if tagged then we assume signed, notarized, etc) - this makes releasing safer in the short time, without us having to code too many safeguards.

#9160