### PR TITLE
[v9] Update help message for `add token` command and allow token removal from the `rm` command. (#12118)

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -630,6 +630,11 @@ func (rc *ResourceCommand) Delete(client auth.ClientI) (err error) {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("role %q has been deleted\n", rc.ref.Name)
+	case types.KindToken:
+		if err = client.DeleteToken(ctx, rc.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("token %q has been deleted\n", rc.ref.Name)
 	case types.KindSAMLConnector:
 		if err = client.DeleteSAMLConnector(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -91,7 +91,7 @@ func (c *TokenCommand) Initialize(app *kingpin.Application, config *service.Conf
 
 	// tctl tokens add ..."
 	c.tokenAdd = tokens.Command("add", "Create a invitation token")
-	c.tokenAdd.Flag("type", "Type of token to add").Required().StringVar(&c.tokenType)
+	c.tokenAdd.Flag("type", "Type(s) of token to add, e.g. --type=node,app,db").Required().StringVar(&c.tokenType)
 	c.tokenAdd.Flag("value", "Value of token to add").StringVar(&c.value)
 	c.tokenAdd.Flag("labels", "Set token labels, e.g. env=prod,region=us-west").StringVar(&c.labels)
 	c.tokenAdd.Flag("ttl", fmt.Sprintf("Set expiration time for token, default is %v hour",


### PR DESCRIPTION
* Update tokens add messaging to outline that it can be a list of tokens.

* Allow deleting tokens with rm.