### PR TITLE
Add nil check for billing mode in AWS DynamoDB events driver

### DIFF
--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -17,8 +17,6 @@ limitations under the License.
 package events
 
 import (
-	"reflect"
-
 	"github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/utils"
@@ -28,9 +26,14 @@ import (
 	"encoding/json"
 )
 
-// isInterfaceNil uses some reflect magic to check if an interface is nil.
-func isInterfaceNil(a interface{}) bool {
-	return a == nil || reflect.ValueOf(a).IsNil()
+// isInterfaceNil checks if an interface is a string.
+func isInterfaceString(a interface{}) bool {
+	switch a.(type) {
+	case string:
+		return true
+	default:
+		return false
+	}
 }
 
 // FromEventFields converts from the typed dynamic representation
@@ -47,7 +50,7 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 	var eventType string
 	var e events.AuditEvent
 	i, ok := fields[EventType]
-	if !ok || isInterfaceNil(i) {
+	if !ok || !isInterfaceString(i) {
 		eventType = "event-type-nil"
 	} else {
 		eventType = fields.GetString(EventType)

--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -17,6 +17,8 @@ limitations under the License.
 package events
 
 import (
+	"reflect"
+
 	"github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/utils"
@@ -25,6 +27,11 @@ import (
 
 	"encoding/json"
 )
+
+// isInterfaceNil uses some reflect magic to check if an interface is nil.
+func isInterfaceNil(a interface{}) bool {
+	return a == nil || reflect.ValueOf(a).IsNil()
+}
 
 // FromEventFields converts from the typed dynamic representation
 // to the new typed interface-style representation.
@@ -37,8 +44,14 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	eventType := fields.GetString(EventType)
+	var eventType string
 	var e events.AuditEvent
+	i, ok := fields[EventType]
+	if !ok || isInterfaceNil(i) {
+		eventType = "event-type-nil"
+	} else {
+		eventType = fields.GetString(EventType)
+	}
 
 	switch eventType {
 	case SessionPrintEvent:

--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -26,16 +26,6 @@ import (
 	"encoding/json"
 )
 
-// isInterfaceString checks if an interface is a string.
-func isInterfaceString(a interface{}) bool {
-	switch a.(type) {
-	case string:
-		return true
-	default:
-		return false
-	}
-}
-
 // FromEventFields converts from the typed dynamic representation
 // to the new typed interface-style representation.
 //
@@ -49,11 +39,15 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 
 	getFieldEmpty := func(field string) string {
 		i, ok := fields[field]
-		if !ok || !isInterfaceString(i) {
+		if !ok {
+			return ""
+		}
+		s, ok := i.(string)
+		if !ok {
 			return ""
 		}
 
-		return i.(string)
+		return s
 	}
 
 	var eventType = getFieldEmpty(EventType)

--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -42,11 +42,7 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 		if !ok {
 			return ""
 		}
-		s, ok := i.(string)
-		if !ok {
-			return ""
-		}
-
+		s, _ := i.(string)
 		return s
 	}
 

--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -51,7 +51,7 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 	var e events.AuditEvent
 	i, ok := fields[EventType]
 	if !ok || !isInterfaceString(i) {
-		eventType = "event-type-nil"
+		eventType = ""
 	} else {
 		eventType = fields.GetString(EventType)
 	}
@@ -257,8 +257,15 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 		unknown.Type = UnknownEvent
 		unknown.Code = UnknownCode
 		unknown.UnknownType = eventType
-		unknown.UnknownCode = fields.GetString(EventCode)
 		unknown.Data = string(data)
+
+		i, ok = fields[EventCode]
+		if !ok || !isInterfaceString(i) {
+			unknown.UnknownCode = ""
+		} else {
+			unknown.UnknownCode = fields.GetString(EventCode)
+		}
+
 		return unknown, nil
 	}
 

--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -51,9 +51,9 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 		i, ok := fields[field]
 		if !ok || !isInterfaceString(i) {
 			return ""
-		} else {
-			return i.(string)
 		}
+
+		return i.(string)
 	}
 
 	var eventType = getFieldEmpty(EventType)

--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -47,14 +47,17 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	var eventType string
-	var e events.AuditEvent
-	i, ok := fields[EventType]
-	if !ok || !isInterfaceString(i) {
-		eventType = ""
-	} else {
-		eventType = fields.GetString(EventType)
+	getFieldEmpty := func(field string) string {
+		i, ok := fields[field]
+		if !ok || !isInterfaceString(i) {
+			return ""
+		} else {
+			return i.(string)
+		}
 	}
+
+	var eventType = getFieldEmpty(EventType)
+	var e events.AuditEvent
 
 	switch eventType {
 	case SessionPrintEvent:
@@ -257,15 +260,8 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 		unknown.Type = UnknownEvent
 		unknown.Code = UnknownCode
 		unknown.UnknownType = eventType
+		unknown.UnknownCode = getFieldEmpty(EventCode)
 		unknown.Data = string(data)
-
-		i, ok = fields[EventCode]
-		if !ok || !isInterfaceString(i) {
-			unknown.UnknownCode = ""
-		} else {
-			unknown.UnknownCode = fields.GetString(EventCode)
-		}
-
 		return unknown, nil
 	}
 

--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -26,7 +26,7 @@ import (
 	"encoding/json"
 )
 
-// isInterfaceNil checks if an interface is a string.
+// isInterfaceString checks if an interface is a string.
 func isInterfaceString(a interface{}) bool {
 	switch a.(type) {
 	case string:

--- a/lib/events/dynamic_test.go
+++ b/lib/events/dynamic_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/events/dynamic_test.go
+++ b/lib/events/dynamic_test.go
@@ -63,6 +63,7 @@ func TestDynamicKnownType(t *testing.T) {
 	}
 
 	event, err := FromEventFields(fields)
+	printEvent := event.(*events.SessionPrint)
 	require.NoError(t, err)
-	require.Equal(t, SessionPrintEvent, event.GetType())
+	require.Equal(t, SessionPrintEvent, printEvent.GetType())
 }

--- a/lib/events/dynamic_test.go
+++ b/lib/events/dynamic_test.go
@@ -63,7 +63,7 @@ func TestDynamicKnownType(t *testing.T) {
 	}
 
 	event, err := FromEventFields(fields)
-	printEvent := event.(*events.SessionPrint)
 	require.NoError(t, err)
+	printEvent := event.(*events.SessionPrint)
 	require.Equal(t, SessionPrintEvent, printEvent.GetType())
 }

--- a/lib/events/dynamic_test.go
+++ b/lib/events/dynamic_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/api/types/events"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDynamicTypeUnknown checks that we correctly translate unknown events strings into the correct proto type.
+func TestDynamicUnknownType(t *testing.T) {
+	fields := EventFields{
+		EventType: "suspicious-cert-event",
+		EventCode: "foobar",
+	}
+
+	event, err := FromEventFields(fields)
+	require.NoError(t, err)
+
+	require.Equal(t, UnknownEvent, event.GetType())
+	require.Equal(t, UnknownCode, event.GetCode())
+	unknownEvent := event.(*events.Unknown)
+	require.Equal(t, "suspicious-cert-event", unknownEvent.UnknownType)
+	require.Equal(t, "foobar", unknownEvent.UnknownCode)
+}
+
+// TestDynamicNotSet checks that we properly handle cases where the event type is not set.
+func TestDynamicTypeNotSet(t *testing.T) {
+	fields := EventFields{
+		"foo": "bar",
+	}
+
+	event, err := FromEventFields(fields)
+	require.NoError(t, err)
+
+	require.Equal(t, UnknownEvent, event.GetType())
+	require.Equal(t, UnknownCode, event.GetCode())
+	unknownEvent := event.(*events.Unknown)
+	require.Equal(t, "", unknownEvent.UnknownType)
+	require.Equal(t, "", unknownEvent.UnknownCode)
+}
+
+// TestDynamicTypeUnknown checks that we correctly translate known events into the correct proto type.
+func TestDynamicKnownType(t *testing.T) {
+	fields := EventFields{
+		EventType: "print",
+	}
+
+	event, err := FromEventFields(fields)
+	require.NoError(t, err)
+	require.Equal(t, SessionPrintEvent, event.GetType())
+}

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1079,16 +1079,9 @@ func (l *Log) getBillingModeIsProvisioned(ctx context.Context) (bool, error) {
 
 	// Perform pessimistic nil-checks, assume the table is provisioned if they are true.
 	// Otherwise, actually check the billing mode.
-	switch {
-	case table.BillingModeSummary == nil:
-		fallthrough
-	case table.BillingModeSummary.BillingMode == nil:
-		fallthrough
-	case *table.BillingModeSummary.BillingMode == dynamodb.BillingModeProvisioned:
-		return true, nil
-	default:
-		return false, nil
-	}
+	return table.BillingModeSummary == nil ||
+		table.BillingModeSummary.BillingMode == nil ||
+		*table.BillingModeSummary.BillingMode == dynamodb.BillingModeProvisioned, nil
 }
 
 // indexExists checks if a given index exists on a given table and that it is active or updating.

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -124,10 +124,13 @@ func (s *DynamoeventsSuite) TestSizeBreak(c *check.C) {
 	const eventCount int = 10
 	for i := 0; i < eventCount; i++ {
 		err := s.Log.EmitAuditEvent(context.Background(), &apievents.UserLogin{
-			Method:             events.LoginMethodSAML,
-			Status:             apievents.Status{Success: true},
-			UserMetadata:       apievents.UserMetadata{User: "bob"},
-			Metadata:           apievents.Metadata{Time: s.Clock.Now().UTC().Add(time.Second * time.Duration(i))},
+			Method:       events.LoginMethodSAML,
+			Status:       apievents.Status{Success: true},
+			UserMetadata: apievents.UserMetadata{User: "bob"},
+			Metadata: apievents.Metadata{
+				Type: events.UserLoginEvent,
+				Time: s.Clock.Now().UTC().Add(time.Second * time.Duration(i)),
+			},
 			IdentityAttributes: apievents.MustEncodeMap(map[string]interface{}{"test.data": blob}),
 		})
 		c.Assert(err, check.IsNil)
@@ -313,7 +316,9 @@ func (s *DynamoeventsLargeTableSuite) TestLargeTableRetrieve(c *check.C) {
 			Method:       events.LoginMethodSAML,
 			Status:       apievents.Status{Success: true},
 			UserMetadata: apievents.UserMetadata{User: "bob"},
-			Metadata:     apievents.Metadata{Time: s.Clock.Now().UTC()},
+			Metadata: apievents.Metadata{
+				Type: events.UserLoginEvent,
+				Time: s.Clock.Now().UTC()},
 		})
 		c.Assert(err, check.IsNil)
 	}


### PR DESCRIPTION
Turns out, AWS is inconsistent in what fields they set and they *don't always*  set the `BillingModeSummary` field if the table is in provisioned mode. Wasn't able to find that noted anywhere so I assumed it would be, this turned out to be incorrect.

This PR adds some pessimistic null-checks and assumed the billing mode is provisioned if the fields are not set. Still not sure *when*  they are set, just that they *sometimes aren't*. This was further not helped by our AWS tests somehow not failing on a panic, they just seem to pause and continue? That's for another PR though.

This also fixes a panic case in `dynamic.go` if the provided map is lacking an event type key which caused AWS tests to fail.

Fix #12443 