### PR TITLE
Fix flaky integration test: increase deadline

### DIFF
--- a/integration/proxy_helpers_test.go
+++ b/integration/proxy_helpers_test.go
@@ -201,7 +201,7 @@ func (p *ProxySuite) addNodeToLeafCluster(t *testing.T, tunnelNodeHostname strin
 
 func (p *ProxySuite) mustConnectToClusterAndRunSSHCommand(t *testing.T, config ClientConfig) {
 	const (
-		deadline         = time.Second
+		deadline         = time.Second * 5
 		nextIterWaitTime = time.Millisecond * 100
 	)
 


### PR DESCRIPTION
### What 
Fix flaky `mustConnectToClusterAndRunSSHCommand` function by increasing deadline time to 5s 

[#GCB](https://console.cloud.google.com/cloud-build/builds;region=global/8bf0b665-eef3-4286-8fec-a7d877128818;step=0?project=ci-account)
Error: 
```go
 proxy_helpers_test.go:220: 
        	Error Trace:	proxy_helpers_test.go:220
        	            				proxy_test.go:195
        	Error:      	Received unexpected error:
        	            	failed connecting to node clusterauxnode. connection rejected: failed dialing through tunnel (no tunnel connection found: no node reverse tunnel for  found) or directly (dial tcp: lookup clusterauxnode on 127.0.0.11:53: no such host)
```