### PR TITLE
Fix panic in getBillingModeIsProvisioned call

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1074,7 +1074,15 @@ func (l *Log) getBillingModeIsProvisioned(ctx context.Context) (bool, error) {
 		return false, trace.Wrap(err)
 	}
 
-	return *table.Table.BillingModeSummary.BillingMode == dynamodb.BillingModeProvisioned, nil
+	if table.Table == nil {
+		return false, trace.BadParameter("failed to get billing mode: table.Table is nil")
+	}
+	if table.Table.BillingModeSummary == nil {
+		return false, trace.BadParameter("failed to get billing mode: table.Table.BillingModeSummary is nil")
+	}
+
+	// In case of nil BillingMode by default the PAY_PER_REQUEST mode will be returned.
+	return aws.StringValue(table.Table.BillingModeSummary.BillingMode) == dynamodb.BillingModeProvisioned, nil
 }
 
 // indexExists checks if a given index exists on a given table and that it is active or updating.


### PR DESCRIPTION
### What 

Fix panic in getBillingModeIsProvisioned function occurring when teleport v9.2.0 is used in cloud stage. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3705540]

goroutine 1 [running, locked to thread]:
github.com/gravitational/teleport/lib/events/dynamoevents.(*Log).getBillingModeIsProvisioned(0xc000716000, {0x5c522f8, 0xc0007d7240})
	/go/src/github.com/gravitational/teleport/lib/events/dynamoevents/dynamoevents.go:1177 +0xc0
github.com/gravitational/teleport/lib/events/dynamoevents.New({0x5c522f8, 0xc0007d7240}, {{0xc000123c00, 0x9}, {0xc00078ab0b, 0x33}, 0xa, 0xa, 0xc000dc6c20, {0x5c74978, ...}, ...}, ...)
	/go/src/github.com/gravitational/teleport/lib/events/dynamoevents/dynamoevents.go:307 +0x56c
github.com/gravitational/teleport/lib/service.initExternalLog({0x5c522f8, 0xc0007d7240}, {0x5d02670, 0xc0007ec420}, {0xc000b36090, 0x15}, {0x5cd9340, 0xc0005fcea0})
	/go/src/github.com/gravitational/teleport/lib/service/service.go:1078 +0x878
github.com/gravitational/teleport/lib/service.(*TeleportProcess).initAuthService(0xc00079b7c0)
	/go/src/github.com/gravitational/teleport/lib/service/service.go:1183 +0x3c5
github.com/gravitational/teleport/lib/service.NewTeleport(0xc00074b800)
	/go/src/github.com/gravitational/teleport/lib/service/service.go:807 +0x1572
github.com/gravitational/teleport/e/tool/teleport/process.NewTeleport(0xc00074b800)
	/go/src/github.com/gravitational/teleport/e/tool/teleport/process/process.go:67 +0x3b1
github.com/gravitational/teleport/lib/service.Run({_, _}, {{0x4a778ba, 0x2}, {0xc000156300, 0x11}, {0xc0007881e0, 0x28}, {0x0, 0x0}, ...}, ...)
	/go/src/github.com/gravitational/teleport/lib/service/service.go:506 +0xba
main.main()
	/go/src/github.com/gravitational/teleport/e/tool/teleport/main.go:27 +0x26f
```

TODO: Check what default billing mode should be used in case of BillingMode == nil 