### PR TITLE
Add roles needed in dynamic reg app and db docs

### DIFF
--- a/docs/pages/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/application-access/guides/dynamic-registration.mdx
@@ -57,7 +57,7 @@ spec:
 
 See the full app resource spec [reference](../reference.mdx#application-resource).
 
-The user's role creating the dynamic registration must have access to the 
+The user creating the dynamic registration needs to have a role with access to the 
 application labels and the `app` resource.  In this example role the user can only
 create and maintain application services labeled `env: test`.
 ```yaml

--- a/docs/pages/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/application-access/guides/dynamic-registration.mdx
@@ -57,6 +57,29 @@ spec:
 
 See the full app resource spec [reference](../reference.mdx#application-resource).
 
+The user's role creating the dynamic registration must have access to the 
+application labels and the `app` resource.  In this example role the user can only
+create and maintain application services labeled `env: test`.
+```yaml
+kind: role
+metadata:
+  name: dynamicappregexample
+spec:
+  allow:
+    app_labels:      
+      env: test
+    rules:
+    - resources:
+      - app
+      verbs:
+      - list
+      - create
+      - read
+      - update
+      - delete
+version: v5
+```
+
 To create an application resource, run:
 
 ```code

--- a/docs/pages/database-access/guides/dynamic-registration.mdx
+++ b/docs/pages/database-access/guides/dynamic-registration.mdx
@@ -58,6 +58,31 @@ spec:
   uri: "localhost:5432"
 ```
 
+
+The user's role creating the dynamic registration must have access to the 
+database labels and the `db` resource.  In this example role the user can only
+create and maintain database services labeled `env: prod` and `engine: postgres`.
+```yaml
+kind: role
+metadata:
+  name: dynamicregexample
+spec:
+  allow:
+    db_labels:
+      engine: postgres
+      env: prod
+    rules:
+    - resources:
+      - db
+      verbs:
+      - list
+      - create
+      - read
+      - update
+      - delete
+version: v5
+```
+
 See the full database resource spec [reference](../reference/configuration.mdx#database-resource).
 
 To create a database resource, run:

--- a/docs/pages/database-access/guides/dynamic-registration.mdx
+++ b/docs/pages/database-access/guides/dynamic-registration.mdx
@@ -59,7 +59,7 @@ spec:
 ```
 
 
-The user's role creating the dynamic registration must have access to the 
+The user creating the dynamic registration needs to have a role with access to the 
 database labels and the `db` resource.  In this example role the user can only
 create and maintain database services labeled `env: prod` and `engine: postgres`.
 ```yaml


### PR DESCRIPTION
Added in example roles that allow for registering app and db registrations.  This is required for desktop maintaining of app & db registrations through `tctl`. 