### PR TITLE
Add ExactKey function to create absolute storage paths

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -404,6 +404,14 @@ func Key(parts ...string) []byte {
 	return internalKey("", parts...)
 }
 
+// ExactKey is like Key, except a Separator is appended to the result
+// path of Key. This is to ensure range matching of a path will only
+// math child paths and not other paths that have the resulting path
+// as a prefix.
+func ExactKey(parts ...string) []byte {
+	return append(Key(parts...), Separator)
+}
+
 func internalKey(internalPrefix string, parts ...string) []byte {
 	return []byte(strings.Join(append([]string{internalPrefix}, parts...), string(Separator)))
 }

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -671,7 +671,7 @@ func (s *PresenceService) DeleteTunnelConnections(clusterName string) error {
 	if clusterName == "" {
 		return trace.BadParameter("missing cluster name")
 	}
-	startKey := backend.Key(tunnelConnectionsPrefix, clusterName)
+	startKey := backend.ExactKey(tunnelConnectionsPrefix, clusterName)
 	err := s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
 	return trace.Wrap(err)
 }

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -390,7 +390,7 @@ func (s *IdentityService) DeleteUser(ctx context.Context, user string) error {
 	}
 	// each user has multiple related entries in the backend,
 	// so use DeleteRange to make sure we get them all
-	startKey := backend.Key(webPrefix, usersPrefix, user)
+	startKey := backend.ExactKey(webPrefix, usersPrefix, user)
 	err = s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 	return trace.Wrap(err)
 }

--- a/lib/services/local/usertoken.go
+++ b/lib/services/local/usertoken.go
@@ -68,13 +68,13 @@ func (s *IdentityService) DeleteUserToken(ctx context.Context, tokenID string) e
 		return trace.Wrap(err)
 	}
 
-	startKey := backend.Key(userTokenPrefix, tokenID)
+	startKey := backend.ExactKey(userTokenPrefix, tokenID)
 	if err = s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)); err != nil {
 		return trace.Wrap(err)
 	}
 
 	// DELETE IN 9.0.0 also delete any tokens with old prefix.
-	startKey = backend.Key(LegacyPasswordTokensPrefix, tokenID)
+	startKey = backend.ExactKey(LegacyPasswordTokensPrefix, tokenID)
 	return trace.Wrap(s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 }
 


### PR DESCRIPTION
Storage paths returned by Key do not contain a trailing slash, which will
cause range matching to match on paths that contain the original path as
a prefix. By using ExactKey, range matching will only match sub-paths.

Fixes #5188.