### PR TITLE
Re-add grace period to Upload completer for backwards compatibility.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -292,6 +292,11 @@ const (
 	// AbandonedUploadPollingRate defines how often to check for
 	// abandoned uploads which need to be completed.
 	AbandonedUploadPollingRate = SessionTrackerTTL / 6
+
+	// UploadGracePeriod is a period after which non-completed
+	// upload is considered abandoned and will be completed by the reconciler
+	// DELETE IN 11.0.0
+	UploadGracePeriod = 24 * time.Hour
 )
 
 var (

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -614,11 +614,14 @@ type StreamUpload struct {
 	ID string
 	// SessionID is a session ID of the upload
 	SessionID session.ID
+	// Initiated contains the timestamp of when the upload
+	// was initiated, not always initialized
+	Initiated time.Time
 }
 
 // String returns user friendly representation of the upload
 func (u StreamUpload) String() string {
-	return fmt.Sprintf("Upload(session=%v, id=%v)", u.SessionID, u.ID)
+	return fmt.Sprintf("Upload(session=%v, id=%v, initiated=%v)", u.SessionID, u.ID, u.Initiated)
 }
 
 // CheckAndSetDefaults checks and sets default values

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -51,6 +51,10 @@ type UploadCompleterConfig struct {
 	CheckPeriod time.Duration
 	// Clock is used to override clock in tests
 	Clock clockwork.Clock
+	// DELETE IN 11.0.0 in favor of SessionTrackerService
+	// GracePeriod is the period after which an upload's session
+	// tracker will be check to see if it's an abandoned upload.
+	GracePeriod time.Duration
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -73,20 +77,8 @@ func (cfg *UploadCompleterConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-// StartNewUploadCompleter starts an upload completer background process. It can
-// be closed by closing the provided context.
-func StartNewUploadCompleter(ctx context.Context, cfg UploadCompleterConfig) error {
-	uc, err := newUploadCompleter(cfg)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	go uc.start(ctx)
-	return nil
-}
-
-// newUploadCompleter returns a new instance of the upload completer without
-// starting it. Useful in tests.
-func newUploadCompleter(cfg UploadCompleterConfig) (*UploadCompleter, error) {
+// NewUploadCompleter returns a new UploadCompleter.
+func NewUploadCompleter(cfg UploadCompleterConfig) (*UploadCompleter, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -95,19 +87,37 @@ func newUploadCompleter(cfg UploadCompleterConfig) (*UploadCompleter, error) {
 		log: log.WithFields(log.Fields{
 			trace.Component: teleport.Component(cfg.Component, "completer"),
 		}),
+		closeC: make(chan struct{}),
 	}
 	return u, nil
+}
+
+// StartNewUploadCompleter starts an upload completer background process that will
+// will close once the provided ctx is closed.
+func StartNewUploadCompleter(ctx context.Context, cfg UploadCompleterConfig) error {
+	uc, err := NewUploadCompleter(cfg)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	go uc.Serve(ctx)
+	return nil
 }
 
 // UploadCompleter periodically scans uploads that have not been completed
 // and completes them
 type UploadCompleter struct {
-	cfg UploadCompleterConfig
-	log *log.Entry
+	cfg    UploadCompleterConfig
+	log    *log.Entry
+	closeC chan struct{}
 }
 
-// start starts a goroutine to periodically check for and complete abandoned uploads
-func (u *UploadCompleter) start(ctx context.Context) {
+// Close stops the UploadCompleter
+func (u *UploadCompleter) Close() {
+	close(u.closeC)
+}
+
+// Serve runs the upload completer until closed or until ctx is cancelled.
+func (u *UploadCompleter) Serve(ctx context.Context) error {
 	periodic := interval.New(interval.Config{
 		Duration:      u.cfg.CheckPeriod,
 		FirstDuration: utils.HalfJitter(u.cfg.CheckPeriod),
@@ -121,8 +131,10 @@ func (u *UploadCompleter) start(ctx context.Context) {
 			if err := u.checkUploads(ctx); err != nil {
 				u.log.WithError(err).Warningf("Failed to check uploads.")
 			}
+		case <-u.closeC:
+			return nil
 		case <-ctx.Done():
-			return
+			return trace.Wrap(ctx.Err(), "Context canceled")
 		}
 	}
 }
@@ -153,6 +165,16 @@ func (u *UploadCompleter) checkUploads(ctx context.Context) error {
 
 	// Complete upload for any uploads without an active session tracker
 	for _, upload := range uploads {
+		// DELETE IN 11.0.0
+		// To support v9/v8 versions which do not use SessionTrackerService,
+		// sessions are only considered abandoned after the provided grace period.
+		if u.cfg.GracePeriod != 0 {
+			gracePoint := upload.Initiated.Add(u.cfg.GracePeriod)
+			if gracePoint.After(u.cfg.Clock.Now()) {
+				return nil
+			}
+		}
+
 		if apiutils.SliceContainsStr(activeSessionIDs, upload.SessionID.String()) {
 			continue
 		}

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -171,6 +171,8 @@ func (u *UploadCompleter) checkUploads(ctx context.Context) error {
 		if u.cfg.GracePeriod != 0 {
 			gracePoint := upload.Initiated.Add(u.cfg.GracePeriod)
 			if gracePoint.After(u.cfg.Clock.Now()) {
+				// uploads are ordered oldest to newest, stop checking
+				// once an upload doesn't exceed the grace point
 				return nil
 			}
 		}

--- a/lib/events/complete_test.go
+++ b/lib/events/complete_test.go
@@ -213,7 +213,14 @@ type mockSessionTrackerService struct {
 }
 
 func (m *mockSessionTrackerService) GetActiveSessionTrackers(ctx context.Context) ([]types.SessionTracker, error) {
-	return nil, trace.NotImplemented("")
+	var trackers []types.SessionTracker
+	for _, tracker := range m.trackers {
+		// mock session tracker expiration
+		if tracker.Expiry().After(m.clock.Now()) {
+			trackers = append(trackers, tracker)
+		}
+	}
+	return trackers, nil
 }
 
 func (m *mockSessionTrackerService) GetSessionTracker(ctx context.Context, sessionID string) (types.SessionTracker, error) {
@@ -227,17 +234,17 @@ func (m *mockSessionTrackerService) GetSessionTracker(ctx context.Context, sessi
 }
 
 func (m *mockSessionTrackerService) CreateSessionTracker(ctx context.Context, req *proto.CreateSessionTrackerRequest) (types.SessionTracker, error) {
-	return nil, trace.NotImplemented("")
+	return nil, trace.NotImplemented("CreateSessionTracker is not implemented")
 }
 
 func (m *mockSessionTrackerService) UpdateSessionTracker(ctx context.Context, req *proto.UpdateSessionTrackerRequest) error {
-	return trace.NotImplemented("")
+	return trace.NotImplemented("UpdateSessionTracker is not implemented")
 }
 
 func (m *mockSessionTrackerService) RemoveSessionTracker(ctx context.Context, sessionID string) error {
-	return trace.NotImplemented("")
+	return trace.NotImplemented("RemoveSessionTracker is not implemented")
 }
 
 func (m *mockSessionTrackerService) UpdatePresence(ctx context.Context, sessionID, user string) error {
-	return trace.NotImplemented("")
+	return trace.NotImplemented("UpdatePresence is not implemented")
 }

--- a/lib/events/eventstest/mock.go
+++ b/lib/events/eventstest/mock.go
@@ -20,12 +20,8 @@ import (
 	"context"
 	"sync"
 
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/session"
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // MockEmitter is an emitter that stores all emitted events.
@@ -90,47 +86,5 @@ func (e *MockEmitter) Close(ctx context.Context) error {
 }
 
 func (e *MockEmitter) Complete(ctx context.Context) error {
-	return nil
-}
-
-type MockSessionTrackerService struct {
-	Clock        clockwork.Clock
-	MockTrackers []types.SessionTracker
-}
-
-func (m *MockSessionTrackerService) GetActiveSessionTrackers(ctx context.Context) ([]types.SessionTracker, error) {
-	var trackers []types.SessionTracker
-	for _, tracker := range m.MockTrackers {
-		// mock session tracker expiration
-		if tracker.Expiry().After(m.Clock.Now()) {
-			trackers = append(trackers, tracker)
-		}
-	}
-	return trackers, nil
-}
-
-func (m *MockSessionTrackerService) GetSessionTracker(ctx context.Context, sessionID string) (types.SessionTracker, error) {
-	for _, tracker := range m.MockTrackers {
-		// mock session tracker expiration
-		if tracker.GetSessionID() == sessionID && tracker.Expiry().After(m.Clock.Now()) {
-			return tracker, nil
-		}
-	}
-	return nil, trace.NotFound("tracker not found")
-}
-
-func (m *MockSessionTrackerService) CreateSessionTracker(ctx context.Context, req *proto.CreateSessionTrackerRequest) (types.SessionTracker, error) {
-	return nil, nil
-}
-
-func (m *MockSessionTrackerService) UpdateSessionTracker(ctx context.Context, req *proto.UpdateSessionTrackerRequest) error {
-	return nil
-}
-
-func (m *MockSessionTrackerService) RemoveSessionTracker(ctx context.Context, sessionID string) error {
-	return nil
-}
-
-func (m *MockSessionTrackerService) UpdatePresence(ctx context.Context, sessionID, user string) error {
 	return nil
 }

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -30,7 +30,6 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -45,8 +44,6 @@ type UploaderConfig struct {
 	ScanDir string
 	// Clock is the clock replacement
 	Clock clockwork.Clock
-	// Context is an optional context
-	Context context.Context
 	// ScanPeriod is a uploader dir scan period
 	ScanPeriod time.Duration
 	// ConcurrentUploads sets up how many parallel uploads to schedule
@@ -79,9 +76,6 @@ func (cfg *UploaderConfig) CheckAndSetDefaults() error {
 	if cfg.ScanPeriod <= 0 {
 		cfg.ScanPeriod = defaults.UploaderScanPeriod
 	}
-	if cfg.Context == nil {
-		cfg.Context = context.Background()
-	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()
 	}
@@ -92,40 +86,20 @@ func (cfg *UploaderConfig) CheckAndSetDefaults() error {
 }
 
 // NewUploader creates new disk based session logger
-func NewUploader(cfg UploaderConfig, sessionTracker services.SessionTrackerService) (*Uploader, error) {
+func NewUploader(cfg UploaderConfig) (*Uploader, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	handler, err := NewHandler(Config{
-		Directory: cfg.ScanDir,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
-	ctx, cancel := context.WithCancel(cfg.Context)
 	uploader := &Uploader{
 		cfg: cfg,
 		log: log.WithFields(log.Fields{
 			trace.Component: cfg.Component,
 		}),
-		cancel:    cancel,
-		ctx:       ctx,
+		closeC:    make(chan struct{}),
 		auditLog:  cfg.AuditLog,
 		semaphore: make(chan struct{}, cfg.ConcurrentUploads),
 		eventsCh:  make(chan events.UploadEvent, cfg.ConcurrentUploads),
-	}
-
-	// upload completer scans for uploads that have been initiated, but not completed
-	// by the client (aborted or crashed) and completes them. It will be closed once
-	// the uploader context is closed.
-	err = events.StartNewUploadCompleter(uploader.ctx, events.UploadCompleterConfig{
-		Uploader:       handler,
-		AuditLog:       cfg.AuditLog,
-		SessionTracker: sessionTracker,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
 	}
 
 	return uploader, nil
@@ -150,10 +124,13 @@ type Uploader struct {
 	cfg UploaderConfig
 	log *log.Entry
 
-	cancel   context.CancelFunc
-	ctx      context.Context
 	eventsCh chan events.UploadEvent
 	auditLog events.IAuditLog
+	closeC   chan struct{}
+}
+
+func (u *Uploader) Close() {
+	close(u.closeC)
 }
 
 func (u *Uploader) writeSessionError(sessionID session.ID, err error) error {
@@ -180,7 +157,7 @@ func (u *Uploader) checkSessionError(sessionID session.ID) (bool, error) {
 }
 
 // Serve runs the uploader until stopped
-func (u *Uploader) Serve() error {
+func (u *Uploader) Serve(ctx context.Context) error {
 	backoff, err := utils.NewLinear(utils.LinearConfig{
 		Step:  u.cfg.ScanPeriod,
 		Max:   u.cfg.ScanPeriod * 100,
@@ -191,11 +168,14 @@ func (u *Uploader) Serve() error {
 	}
 	for {
 		select {
-		case <-u.ctx.Done():
+		case <-u.closeC:
 			return nil
+		case <-ctx.Done():
+			u.Close()
+			return nil
+		case event := <-u.eventsCh:
 			// Successful and failed upload events are used to speed up and
 			// slow down the scans and uploads.
-		case event := <-u.eventsCh:
 			switch {
 			case event.Error == nil:
 				backoff.ResetToDelay()
@@ -222,7 +202,7 @@ func (u *Uploader) Serve() error {
 		// Tick at scan period but slow down (and speeds up) on errors.
 		case <-backoff.After():
 			var failed bool
-			if _, err := u.Scan(); err != nil {
+			if _, err := u.Scan(ctx); err != nil {
 				if trace.Unwrap(err) != errContext {
 					failed = true
 					u.log.WithError(err).Warningf("Uploader scan failed.")
@@ -248,7 +228,7 @@ type ScanStats struct {
 }
 
 // Scan scans the streaming directory and uploads recordings
-func (u *Uploader) Scan() (*ScanStats, error) {
+func (u *Uploader) Scan(ctx context.Context) (*ScanStats, error) {
 	files, err := os.ReadDir(u.cfg.ScanDir)
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
@@ -264,7 +244,7 @@ func (u *Uploader) Scan() (*ScanStats, error) {
 			continue
 		}
 		stats.Scanned++
-		if err := u.startUpload(fi.Name()); err != nil {
+		if err := u.startUpload(ctx, fi.Name()); err != nil {
 			if trace.IsCompareFailed(err) {
 				u.log.Debugf("Scan is skipping recording %v that is locked by another process.", fi.Name())
 				continue
@@ -295,11 +275,6 @@ func (u *Uploader) checkpointFilePath(sid session.ID) string {
 // sessionErrorFilePath returns a path to checkpoint file for a session
 func (u *Uploader) sessionErrorFilePath(sid session.ID) string {
 	return filepath.Join(u.cfg.ScanDir, sid.String()+errorExt)
-}
-
-// Close closes all operations
-func (u *Uploader) Close() {
-	u.cancel()
 }
 
 type upload struct {
@@ -370,7 +345,7 @@ func (u *upload) removeFiles() error {
 	return trace.NewAggregate(errs...)
 }
 
-func (u *Uploader) startUpload(fileName string) error {
+func (u *Uploader) startUpload(ctx context.Context, fileName string) error {
 	sessionID, err := sessionIDFromPath(fileName)
 	if err != nil {
 		return trace.Wrap(err)
@@ -416,7 +391,7 @@ func (u *Uploader) startUpload(fileName string) error {
 	}
 
 	start := time.Now()
-	if err := u.takeSemaphore(); err != nil {
+	if err := u.takeSemaphore(ctx); err != nil {
 		if err := upload.Close(); err != nil {
 			u.log.WithError(err).Warningf("Failed to close upload.")
 		}
@@ -426,7 +401,7 @@ func (u *Uploader) startUpload(fileName string) error {
 		u.log.Debugf("Semaphore acquired in %v for upload %v.", time.Since(start), fileName)
 	}
 	go func() {
-		if err := u.upload(upload); err != nil {
+		if err := u.upload(ctx, upload); err != nil {
 			u.log.WithError(err).Warningf("Upload failed.")
 			u.emitEvent(events.UploadEvent{
 				SessionID: string(upload.sessionID),
@@ -444,8 +419,8 @@ func (u *Uploader) startUpload(fileName string) error {
 	return nil
 }
 
-func (u *Uploader) upload(up *upload) error {
-	defer u.releaseSemaphore()
+func (u *Uploader) upload(ctx context.Context, up *upload) error {
+	defer u.releaseSemaphore(ctx)
 	defer func() {
 		if err := up.Close(); err != nil {
 			u.log.WithError(err).Warningf("Failed to close upload.")
@@ -458,12 +433,12 @@ func (u *Uploader) upload(up *upload) error {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		stream, err = u.cfg.Streamer.CreateAuditStream(u.ctx, up.sessionID)
+		stream, err = u.cfg.Streamer.CreateAuditStream(ctx, up.sessionID)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 	} else {
-		stream, err = u.cfg.Streamer.ResumeAuditStream(u.ctx, up.sessionID, status.UploadID)
+		stream, err = u.cfg.Streamer.ResumeAuditStream(ctx, up.sessionID, status.UploadID)
 		if err != nil {
 			if !trace.IsNotFound(err) {
 				return trace.Wrap(err)
@@ -472,7 +447,7 @@ func (u *Uploader) upload(up *upload) error {
 				"Upload for sesion %v, upload ID %v is not found starting a new upload from scratch.",
 				up.sessionID, status.UploadID)
 			status = nil
-			stream, err = u.cfg.Streamer.CreateAuditStream(u.ctx, up.sessionID)
+			stream, err = u.cfg.Streamer.CreateAuditStream(ctx, up.sessionID)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -480,7 +455,7 @@ func (u *Uploader) upload(up *upload) error {
 	}
 
 	defer func() {
-		if err := stream.Close(u.ctx); err != nil {
+		if err := stream.Close(ctx); err != nil {
 			if trace.Unwrap(err) != io.EOF {
 				u.log.WithError(err).Debugf("Failed to close stream.")
 			}
@@ -491,16 +466,19 @@ func (u *Uploader) upload(up *upload) error {
 	// if it was successful get the first status update
 	// sent by the server after create.
 	select {
+	case <-u.closeC:
+		return trace.Errorf("operation has been cancelled, uploader is closed")
 	case <-stream.Status():
 	case <-time.After(defaults.NetworkRetryDuration):
 		return trace.ConnectionProblem(nil, "timeout waiting for stream status update")
-	case <-u.ctx.Done():
-		return trace.ConnectionProblem(u.ctx.Err(), "operation has been cancelled")
+	case <-ctx.Done():
+		return trace.ConnectionProblem(ctx.Err(), "operation has been cancelled")
+
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go u.monitorStreamStatus(u.ctx, up, stream, cancel)
+	go u.monitorStreamStatus(ctx, up, stream, cancel)
 
 	for {
 		event, err := up.reader.Read(ctx)
@@ -514,12 +492,12 @@ func (u *Uploader) upload(up *upload) error {
 		if status != nil && event.GetIndex() <= status.LastEventIndex {
 			continue
 		}
-		if err := stream.EmitAuditEvent(u.ctx, event); err != nil {
+		if err := stream.EmitAuditEvent(ctx, event); err != nil {
 			return trace.Wrap(err)
 		}
 	}
 
-	if err := stream.Complete(u.ctx); err != nil {
+	if err := stream.Complete(ctx); err != nil {
 		u.log.WithError(err).Error("Failed to complete upload.")
 		return trace.Wrap(err)
 	}
@@ -566,20 +544,20 @@ func (u *Uploader) monitorStreamStatus(ctx context.Context, up *upload, stream a
 
 var errContext = fmt.Errorf("context has closed")
 
-func (u *Uploader) takeSemaphore() error {
+func (u *Uploader) takeSemaphore(ctx context.Context) error {
 	select {
 	case u.semaphore <- struct{}{}:
 		return nil
-	case <-u.ctx.Done():
+	case <-ctx.Done():
 		return errContext
 	}
 }
 
-func (u *Uploader) releaseSemaphore() error {
+func (u *Uploader) releaseSemaphore(ctx context.Context) error {
 	select {
 	case <-u.semaphore:
 		return nil
-	case <-u.ctx.Done():
+	case <-ctx.Done():
 		return errContext
 	}
 }

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -113,9 +113,6 @@ func NewUploader(cfg UploaderConfig) (*Uploader, error) {
 // It keeps checkpoints of the upload state and resumes
 // the upload that have been aborted.
 //
-// The uploader completes the sessions that have been
-// abandoned longer than the grace period.
-//
 // It marks corrupted session files to skip their processing.
 //
 type Uploader struct {

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -171,7 +171,6 @@ func (u *Uploader) Serve(ctx context.Context) error {
 		case <-u.closeC:
 			return nil
 		case <-ctx.Done():
-			u.Close()
 			return nil
 		case event := <-u.eventsCh:
 			// Successful and failed upload events are used to speed up and

--- a/lib/events/gcssessions/gcsstream.go
+++ b/lib/events/gcssessions/gcsstream.go
@@ -43,6 +43,7 @@ func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*even
 	upload := events.StreamUpload{
 		ID:        uuid.New().String(),
 		SessionID: sessionID,
+		Initiated: time.Now().UTC(),
 	}
 	if err := upload.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -251,7 +252,8 @@ func (h *Handler) ListParts(ctx context.Context, upload events.StreamUpload) ([]
 	return parts, nil
 }
 
-// ListUploads lists uploads that have been initiated but not completed
+// ListUploads lists uploads that have been initiated but not completed with
+// earlier uploads returned first
 func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error) {
 	i := h.gcsClient.Bucket(h.Config.Bucket).Objects(ctx, &storage.Query{
 		Prefix: h.uploadsPrefix(),
@@ -273,6 +275,7 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+		upload.Initiated = attrs.Created
 		uploads = append(uploads, *upload)
 	}
 	return uploads, nil

--- a/lib/events/s3sessions/s3stream.go
+++ b/lib/events/s3sessions/s3stream.go
@@ -196,6 +196,7 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 			uploads = append(uploads, events.StreamUpload{
 				ID:        *upload.UploadId,
 				SessionID: h.fromPath(*upload.Key),
+				Initiated: *upload.Initiated,
 			})
 		}
 		if !*re.IsTruncated {
@@ -204,6 +205,11 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 		keyMarker = re.KeyMarker
 		uploadIDMarker = re.UploadIdMarker
 	}
+
+	sort.Slice(uploads, func(i, j int) bool {
+		return uploads[i].Initiated.Before(uploads[j].Initiated)
+	})
+
 	return uploads, nil
 }
 

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -1087,6 +1087,9 @@ type MemoryUpload struct {
 	sessionID session.ID
 	//completed specifies upload as completed
 	completed bool
+	// Initiated contains the timestamp of when the upload
+	// was initiated, not always initialized
+	Initiated time.Time
 }
 
 func (m *MemoryUploader) trySendEvent(event UploadEvent) {
@@ -1115,10 +1118,14 @@ func (m *MemoryUploader) CreateUpload(ctx context.Context, sessionID session.ID)
 		ID:        uuid.New().String(),
 		SessionID: sessionID,
 	}
+	if m.Clock != nil {
+		upload.Initiated = m.Clock.Now()
+	}
 	m.uploads[upload.ID] = &MemoryUpload{
 		id:        upload.ID,
 		sessionID: sessionID,
 		parts:     make(map[int64][]byte),
+		Initiated: upload.Initiated,
 	}
 	return upload, nil
 }
@@ -1173,18 +1180,23 @@ func (m *MemoryUploader) UploadPart(ctx context.Context, upload StreamUpload, pa
 	return &StreamPart{Number: partNumber}, nil
 }
 
-// ListUploads lists uploads that have been initiated but not completed
+// ListUploads lists uploads that have been initiated but not completed with
+// earlier uploads returned first.
 func (m *MemoryUploader) ListUploads(ctx context.Context) ([]StreamUpload, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
-	out := make([]StreamUpload, 0, len(m.uploads))
+	uploads := make([]StreamUpload, 0, len(m.uploads))
 	for id, upload := range m.uploads {
-		out = append(out, StreamUpload{
+		uploads = append(uploads, StreamUpload{
 			ID:        id,
 			SessionID: upload.sessionID,
+			Initiated: upload.Initiated,
 		})
 	}
-	return out, nil
+	sort.Slice(uploads, func(i, j int) bool {
+		return uploads[i].Initiated.Before(uploads[j].Initiated)
+	})
+	return uploads, nil
 }
 
 // GetParts returns upload parts uploaded up to date, sorted by part number

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
@@ -76,7 +77,14 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 
 	// Start uploader that will scan a path on disk and upload completed
 	// sessions to the auth server.
-	err = process.initUploaderService(accessPoint, conn.Client, conn.Client)
+	uploaderCfg := filesessions.UploaderConfig{
+		Streamer: accessPoint,
+		AuditLog: conn.Client,
+	}
+	completerCfg := events.UploadCompleterConfig{
+		SessionTracker: conn.Client,
+	}
+	err = process.initUploaderService(uploaderCfg, completerCfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/filesessions"
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -85,7 +86,14 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 
 	// Start uploader that will scan a path on disk and upload completed
 	// sessions to the Auth Server.
-	if err := process.initUploaderService(accessPoint, conn.Client, conn.Client); err != nil {
+	uploaderCfg := filesessions.UploaderConfig{
+		Streamer: accessPoint,
+		AuditLog: conn.Client,
+	}
+	completerCfg := events.UploadCompleterConfig{
+		SessionTracker: conn.Client,
+	}
+	if err := process.initUploaderService(uploaderCfg, completerCfg); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1281,6 +1281,10 @@ func (process *TeleportProcess) initAuthService() error {
 			Component:      teleport.ComponentAuth,
 			AuditLog:       process.auditLog,
 			SessionTracker: authServer.Services,
+			// DELETE IN 11.0.0
+			// Provide a grace period so that Auth does not prematurely upload
+			// sessions which don't have a session tracker (v9.2 and earlier)
+			GracePeriod: defaults.UploadGracePeriod,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -1949,7 +1953,15 @@ func (process *TeleportProcess) initSSH() error {
 		// init uploader service for recording SSH node, if proxy is not
 		// enabled on this node, because proxy stars uploader service as well
 		if !cfg.Proxy.Enabled {
-			if err := process.initUploaderService(authClient, conn.Client, conn.Client); err != nil {
+			uploaderCfg := filesessions.UploaderConfig{
+				Streamer: authClient,
+				AuditLog: conn.Client,
+			}
+			completerCfg := events.UploadCompleterConfig{
+				SessionTracker: conn.Client,
+				GracePeriod:    defaults.UploadGracePeriod,
+			}
+			if err := process.initUploaderService(uploaderCfg, completerCfg); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -2070,7 +2082,7 @@ func (process *TeleportProcess) registerWithAuthServer(role types.SystemRole, ev
 
 // initUploadService starts a file-based uploader that scans the local streaming logs directory
 // (data/log/upload/streaming/default/)
-func (process *TeleportProcess) initUploaderService(streamer events.Streamer, auditLog events.IAuditLog, sessionTracker services.SessionTrackerService) error {
+func (process *TeleportProcess) initUploaderService(uploaderCfg filesessions.UploaderConfig, completerCfg events.UploadCompleterConfig) error {
 	log := process.log.WithFields(logrus.Fields{
 		trace.Component: teleport.Component(teleport.ComponentAuditLog, process.id),
 	})
@@ -2101,20 +2113,19 @@ func (process *TeleportProcess) initUploaderService(streamer events.Streamer, au
 		}
 	}
 
-	fileUploader, err := filesessions.NewUploader(filesessions.UploaderConfig{
-		ScanDir:  filepath.Join(path...),
-		Streamer: streamer,
-		AuditLog: auditLog,
-		EventsC:  process.Config.UploadEventsC,
-	}, sessionTracker)
+	uploaderCfg.ScanDir = filepath.Join(path...)
+	uploaderCfg.EventsC = process.Config.UploadEventsC
+	fileUploader, err := filesessions.NewUploader(uploaderCfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
 	process.RegisterFunc("fileuploader.service", func() error {
-		err := fileUploader.Serve()
+		err := fileUploader.Serve(process.ExitContext())
 		if err != nil {
 			log.WithError(err).Errorf("File uploader server exited with error.")
 		}
+
 		return nil
 	})
 
@@ -2122,6 +2133,36 @@ func (process *TeleportProcess) initUploaderService(streamer events.Streamer, au
 		log.Infof("File uploader is shutting down.")
 		fileUploader.Close()
 		log.Infof("File uploader has shut down.")
+	})
+
+	// upload completer scans for uploads that have been initiated, but not completed
+	// by the client (aborted or crashed) and completes them. It will be closed once
+	// the uploader context is closed.
+	handler, err := filesessions.NewHandler(filesessions.Config{
+		Directory: filepath.Join(path...),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	completerCfg.Uploader = handler
+	completerCfg.AuditLog = uploaderCfg.AuditLog
+	uploadCompleter, err := events.NewUploadCompleter(completerCfg)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	process.RegisterFunc("fileuploadcompleter.service", func() error {
+		if err := uploadCompleter.Serve(process.ExitContext()); err != nil {
+			log.WithError(err).Errorf("File uploader server exited with error.")
+		}
+		return nil
+	})
+
+	process.OnExit("fileuploadcompleter.shutdown", func(payload interface{}) {
+		log.Infof("File upload completer is shutting down.")
+		uploadCompleter.Close()
+		log.Infof("File upload completer has shut down.")
 	})
 
 	return nil
@@ -3297,7 +3338,14 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		log.Infof("Exited.")
 	})
 
-	if err := process.initUploaderService(accessPoint, conn.Client, conn.Client); err != nil {
+	uploaderCfg := filesessions.UploaderConfig{
+		Streamer: accessPoint,
+		AuditLog: conn.Client,
+	}
+	completerCfg := events.UploadCompleterConfig{
+		SessionTracker: conn.Client,
+	}
+	if err := process.initUploaderService(uploaderCfg, completerCfg); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -3551,7 +3599,14 @@ func (process *TeleportProcess) initApps() {
 
 		// Start uploader that will scan a path on disk and upload completed
 		// sessions to the Auth Server.
-		if err := process.initUploaderService(accessPoint, conn.Client, conn.Client); err != nil {
+		uploaderCfg := filesessions.UploaderConfig{
+			Streamer: accessPoint,
+			AuditLog: conn.Client,
+		}
+		completerCfg := events.UploadCompleterConfig{
+			SessionTracker: conn.Client,
+		}
+		if err := process.initUploaderService(uploaderCfg, completerCfg); err != nil {
 			return trace.Wrap(err)
 		}
 


### PR DESCRIPTION
Fixes backwards compatibility issues that came from https://github.com/gravitational/teleport/pull/11551

Specifically, If a node starts a session recording in proxy/sync modes (which records the session directly on the Proxy/Auth servers), then the upload completer in the Proxy/Auth services will periodically check for a corresponding `SessionTracker` for any uncompleted uploads on disk.

Since pre-v9 sessions do not create session trackers for ongoing sessions, the Proxy/Auth servers will incorrectly assume that their uploads are abandoned. As a result, the upload will be completed prematurely and result in an error in the session due to the audit writer being closed on Proxy/Auth side.

Changes:
- Re-add grace period to Upload completer for backwards compatibility.
- Provide grace period to upload completer in Proxy and Auth services so that proxy/sync recording works with old nodes.
- Further decouple uploader from upload completer so that they can be configured as standalone processes more easily.

TODO: manually test and fix any failing tests