### PR TITLE
Wire touch ID login and registration to tsh

### DIFF
--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -35,7 +35,6 @@ import (
 )
 
 var (
-	ErrAttemptFailed      = errors.New("login attempt failed")
 	ErrCredentialNotFound = errors.New("credential not found")
 	ErrNotAvailable       = errors.New("touch ID not available")
 )

--- a/lib/auth/touchid/attempt.go
+++ b/lib/auth/touchid/attempt.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package touchid
+
+import (
+	"errors"
+
+	"github.com/gravitational/trace"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+)
+
+// ErrAttemptFailed is returned by AttemptLogin for attempts that failed before
+// user interaction.
+type ErrAttemptFailed struct {
+	// Err is the underlying failure for the attempt.
+	Err error
+}
+
+func (e *ErrAttemptFailed) Error() string {
+	return e.Err.Error()
+}
+
+func (e *ErrAttemptFailed) Unwrap() error {
+	return e.Err
+}
+
+func (e *ErrAttemptFailed) Is(target error) bool {
+	_, ok := target.(*ErrAttemptFailed)
+	return ok
+}
+
+func (e *ErrAttemptFailed) As(target interface{}) bool {
+	tt, ok := target.(*ErrAttemptFailed)
+	if ok {
+		tt.Err = e.Err
+		return true
+	}
+	return false
+}
+
+// AttemptLogin attempts a touch ID login.
+// It returns ErrAttemptFailed if the attempt failed before user interaction.
+// See Login.
+func AttemptLogin(origin, user string, assertion *wanlib.CredentialAssertion) (*wanlib.CredentialAssertionResponse, string, error) {
+	resp, actualUser, err := Login(origin, user, assertion)
+	switch {
+	case errors.Is(err, ErrNotAvailable), errors.Is(err, ErrCredentialNotFound):
+		return nil, "", &ErrAttemptFailed{Err: err}
+	case err != nil:
+		return nil, "", trace.Wrap(err)
+	}
+	return resp, actualUser, nil
+}

--- a/lib/auth/webauthncli/api.go
+++ b/lib/auth/webauthncli/api.go
@@ -16,8 +16,11 @@ package webauthncli
 
 import (
 	"context"
+	"errors"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/lib/auth/touchid"
+	"github.com/gravitational/trace"
 
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 	log "github.com/sirupsen/logrus"
@@ -64,6 +67,36 @@ func Login(
 	ctx context.Context,
 	origin string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt, opts *LoginOpts,
 ) (*proto.MFAAuthenticateResponse, string, error) {
+	var attachment AuthenticatorAttachment
+	var user string
+	if opts != nil {
+		attachment = opts.AuthenticatorAttachment
+		user = opts.User
+	}
+
+	switch attachment {
+	case AttachmentCrossPlatform:
+		log.Debug("Cross-platform login")
+		return crossPlatformLogin(ctx, origin, assertion, prompt, opts)
+	case AttachmentPlatform:
+		log.Debug("Platform login")
+		return platformLogin(origin, user, assertion)
+	default:
+		log.Debug("Attempting platform login")
+		resp, credentialUser, err := platformLogin(origin, user, assertion)
+		if !errors.Is(err, &touchid.ErrAttemptFailed{}) {
+			return resp, credentialUser, trace.Wrap(err)
+		}
+
+		log.WithError(err).Debug("Platform login failed, falling back to cross-platform")
+		return crossPlatformLogin(ctx, origin, assertion, prompt, opts)
+	}
+}
+
+func crossPlatformLogin(
+	ctx context.Context,
+	origin string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt, opts *LoginOpts,
+) (*proto.MFAAuthenticateResponse, string, error) {
 	if IsFIDO2Available() {
 		log.Debug("FIDO2: Using libfido2 for assertion")
 		return FIDO2Login(ctx, origin, assertion, prompt, opts)
@@ -72,6 +105,18 @@ func Login(
 	prompt.PromptTouch()
 	resp, err := U2FLogin(ctx, origin, assertion)
 	return resp, "" /* credentialUser */, err
+}
+
+func platformLogin(origin, user string, assertion *wanlib.CredentialAssertion) (*proto.MFAAuthenticateResponse, string, error) {
+	resp, credentialUser, err := touchid.AttemptLogin(origin, user, assertion)
+	if err != nil {
+		return nil, "", err
+	}
+	return &proto.MFAAuthenticateResponse{
+		Response: &proto.MFAAuthenticateResponse_Webauthn{
+			Webauthn: wanlib.CredentialAssertionResponseToProto(resp),
+		},
+	}, credentialUser, nil
 }
 
 // Register performs client-side, U2F-compatible, Webauthn registration.

--- a/lib/auth/webauthncli/api.go
+++ b/lib/auth/webauthncli/api.go
@@ -23,6 +23,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// AuthenticatorAttachment allows callers to choose a specific attachment.
+type AuthenticatorAttachment int
+
+const (
+	AttachmentAuto AuthenticatorAttachment = iota
+	AttachmentCrossPlatform
+	AttachmentPlatform
+)
+
 // LoginOpts groups non-mandatory options for Login.
 type LoginOpts struct {
 	// User is the desired credential username for login.
@@ -36,6 +45,8 @@ type LoginOpts struct {
 	// Login may decide to forego optimistic assertions if it wouldn't save a
 	// touch.
 	OptimisticAssertion bool
+	// AuthenticatorAttachment specifies the desired authenticator attachment.
+	AuthenticatorAttachment AuthenticatorAttachment
 }
 
 // Login performs client-side, U2F-compatible, Webauthn login.

--- a/lib/auth/webauthncli/u2f_login.go
+++ b/lib/auth/webauthncli/u2f_login.go
@@ -39,6 +39,9 @@ func U2FLogin(ctx context.Context, origin string, assertion *wanlib.CredentialAs
 		return nil, trace.BadParameter("origin required")
 	case assertion == nil:
 		return nil, trace.BadParameter("assertion required")
+	case len(assertion.Response.AllowedCredentials) == 0 &&
+		assertion.Response.UserVerification == protocol.VerificationRequired:
+		return nil, trace.BadParameter("Passwordless not supported in U2F mode. Please install a recent version of tsh.")
 	case len(assertion.Response.Challenge) == 0:
 		return nil, trace.BadParameter("assertion challenge required")
 	case assertion.Response.RelyingPartyID == "":

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1670,8 +1670,8 @@ func (proxy *ProxyClient) sessionSSHCertificate(ctx context.Context, nodeAddr No
 			NodeName:       nodeName(nodeAddr.Addr),
 			RouteToCluster: nodeAddr.Cluster,
 		},
-		func(ctx context.Context, proxyAddr string, c *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
-			return PromptMFAChallenge(ctx, c, proxyAddr, nil /* opts */)
+		func(ctx context.Context, _ string, c *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+			return proxy.teleportClient.PromptMFAChallenge(ctx, c, nil /* optsOverride */)
 		},
 	)
 	if err != nil {

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -156,7 +156,7 @@ func PromptMFAChallenge(ctx context.Context, c *proto.MFAAuthenticateChallenge, 
 			var msg string
 			if !quiet {
 				if hasWebauthn {
-					msg = fmt.Sprintf("Tap any %[1]ssecurity key or enter a code from a %[1]sOTP device", promptDevicePrefix, promptDevicePrefix)
+					msg = fmt.Sprintf("Tap any %ssecurity key or enter a code from a %sOTP device", promptDevicePrefix, promptDevicePrefix)
 				} else {
 					msg = fmt.Sprintf("Enter an OTP code from a %sdevice", promptDevicePrefix)
 				}

--- a/lib/client/presence.go
+++ b/lib/client/presence.go
@@ -86,7 +86,7 @@ func solveMFA(ctx context.Context, term io.Writer, tc *TeleportClient, challenge
 	// We don't support TOTP for live presence.
 	challenge.TOTP = nil
 
-	response, err := PromptMFAChallenge(ctx, challenge, tc.Config.WebProxyAddr, &PromptMFAChallengeOpts{
+	response, err := tc.PromptMFAChallenge(ctx, challenge, &PromptMFAChallengeOpts{
 		Quiet: true,
 	})
 	if err != nil {

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
 
 const (
@@ -219,6 +220,8 @@ type SSHLoginMFA struct {
 	// Apart from the obvious benefits, UseStrongestAuth also avoids stdin
 	// hijacking issues from MFA prompts, as a single auth method is used.
 	UseStrongestAuth bool
+	// AuthenticatorAttachment is the desired authenticator attachment.
+	AuthenticatorAttachment wancli.AuthenticatorAttachment
 }
 
 // initClient creates a new client to the HTTPS web proxy.
@@ -394,7 +397,8 @@ func SSHAgentMFALogin(ctx context.Context, login SSHLoginMFA) (*auth.SSHLoginRes
 	}
 
 	respPB, err := PromptMFAChallenge(ctx, challengePB, login.ProxyAddr, &PromptMFAChallengeOpts{
-		UseStrongestAuth: login.UseStrongestAuth,
+		UseStrongestAuth:        login.UseStrongestAuth,
+		AuthenticatorAttachment: login.AuthenticatorAttachment,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -341,7 +341,7 @@ func (c *mfaAddCommand) addDeviceRPC(
 		if authChallenge == nil {
 			return trace.BadParameter("server bug: server sent %T when client expected AddMFADeviceResponse_ExistingMFAChallenge", resp.Response)
 		}
-		authResp, err := client.PromptMFAChallenge(ctx, authChallenge, tc.Config.WebProxyAddr, &client.PromptMFAChallengeOpts{
+		authResp, err := tc.PromptMFAChallenge(ctx, authChallenge, &client.PromptMFAChallengeOpts{
 			PromptDevicePrefix: "*registered*",
 		})
 		if err != nil {
@@ -547,7 +547,7 @@ func (c *mfaRemoveCommand) run(cf *CLIConf) error {
 		if authChallenge == nil {
 			return trace.BadParameter("server bug: server sent %T when client expected DeleteMFADeviceResponse_MFAChallenge", resp.Response)
 		}
-		authResp, err := client.PromptMFAChallenge(cf.Context, authChallenge, tc.Config.WebProxyAddr, nil /* opts */)
+		authResp, err := tc.PromptMFAChallenge(cf.Context, authChallenge, nil /* optsOverride */)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/touchid"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/prompt"
@@ -42,7 +43,6 @@ import (
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
 
-	wantypes "github.com/gravitational/teleport/api/types/webauthn"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
@@ -50,10 +50,23 @@ import (
 const (
 	totpDeviceType     = "TOTP"
 	webauthnDeviceType = "WEBAUTHN"
+	touchIDDeviceType  = "TOUCHID"
 )
 
-// defaultDeviceTypes lists the supported device types for `tsh mfa add`.
-var defaultDeviceTypes = []string{totpDeviceType, webauthnDeviceType}
+var (
+	totpDeviceTypes = []string{totpDeviceType}
+	webDeviceTypes  = initWebDevs()
+
+	// defaultDeviceTypes lists the supported device types for `tsh mfa add`.
+	defaultDeviceTypes = append(totpDeviceTypes, webDeviceTypes...)
+)
+
+func initWebDevs() []string {
+	if touchid.IsAvailable() {
+		return []string{webauthnDeviceType, touchIDDeviceType}
+	}
+	return []string{webauthnDeviceType}
+}
 
 type mfaCommands struct {
 	ls  *mfaLSCommand
@@ -188,7 +201,7 @@ func newMFAAddCommand(parent *kingpin.CmdClause) *mfaAddCommand {
 	}
 	c.Flag("name", "Name of the new MFA device").StringVar(&c.devName)
 	c.Flag("type", fmt.Sprintf("Type of the new MFA device (%s)", strings.Join(defaultDeviceTypes, ", "))).
-		StringVar(&c.devType)
+		EnumVar(&c.devType, defaultDeviceTypes...)
 
 	if wancli.IsFIDO2Available() {
 		var allowPwdless bool
@@ -215,7 +228,6 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 	}
 	ctx := cf.Context
 
-	deviceTypes := defaultDeviceTypes
 	if c.devType == "" {
 		// If we are prompting the user for the device type, then take a glimpse at
 		// server-side settings and adjust the options accordingly.
@@ -224,21 +236,13 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		deviceTypes = deviceTypesFromPreferredMFA(pingResp.Auth.PreferredLocalMFA)
 
-		c.devType, err = prompt.PickOne(ctx, os.Stdout, prompt.Stdin(), "Choose device type", deviceTypes)
+		c.devType, err = prompt.PickOne(
+			ctx, os.Stdout, prompt.Stdin(),
+			"Choose device type", deviceTypesFromSecondFactor(pingResp.Auth.SecondFactor))
 		if err != nil {
 			return trace.Wrap(err)
 		}
-	}
-
-	m := map[string]proto.DeviceType{
-		totpDeviceType:     proto.DeviceType_DEVICE_TYPE_TOTP,
-		webauthnDeviceType: proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
-	}
-	devType := m[c.devType]
-	if devType == proto.DeviceType_DEVICE_TYPE_UNSPECIFIED {
-		return trace.BadParameter("unknown device type %q, must be one of %v", c.devType, strings.Join(deviceTypes, ", "))
 	}
 
 	if c.devName == "" {
@@ -250,25 +254,27 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 	}
 	c.devName = strings.TrimSpace(c.devName)
 	if c.devName == "" {
-		return trace.BadParameter("device name can not be empty")
+		return trace.BadParameter("device name cannot be empty")
 	}
 
 	// If passwordless is supported but unset, then ask the user.
-	if devType != proto.DeviceType_DEVICE_TYPE_WEBAUTHN {
-		pwdless := false
-		c.pwdless = &pwdless // only WebAuthn does passwordless
-	}
-	if c.pwdless == nil {
-		answer, err := prompt.PickOne(ctx, os.Stdout, prompt.Stdin(), "Allow passwordless logins", []string{"YES", "NO"})
-		if err != nil {
-			return trace.Wrap(err)
+	var pwdless bool
+	switch c.devType {
+	case webauthnDeviceType:
+		// Ask the user?
+		if c.pwdless == nil {
+			answer, err := prompt.PickOne(ctx, os.Stdout, prompt.Stdin(), "Allow passwordless logins", []string{"YES", "NO"})
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			pwdless = answer == "YES"
 		}
-		val := answer == "YES"
-		c.pwdless = &val
+	case touchIDDeviceType:
+		pwdless = true // Touch ID is always a resident key/passwordless
 	}
-	pwdless := c.pwdless != nil && *c.pwdless
+	c.pwdless = &pwdless
 
-	dev, err := c.addDeviceRPC(ctx, tc, c.devName, devType, pwdless)
+	dev, err := c.addDeviceRPC(ctx, tc)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -277,27 +283,28 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 	return nil
 }
 
-func deviceTypesFromPreferredMFA(preferredMFA constants.SecondFactorType) []string {
-	log.Debugf("Got server-side preferred local MFA: %v", preferredMFA)
-
-	m := map[constants.SecondFactorType]string{
-		constants.SecondFactorOTP:      totpDeviceType,
-		constants.SecondFactorWebauthn: webauthnDeviceType,
-	}
-
-	switch preferredType, ok := m[preferredMFA]; {
-	case !ok: // Empty or unknown suggestion, fallback to defaults.
+func deviceTypesFromSecondFactor(sf constants.SecondFactorType) []string {
+	switch sf {
+	case constants.SecondFactorOTP:
+		return totpDeviceTypes
+	case constants.SecondFactorWebauthn:
+		return webDeviceTypes
+	default:
 		return defaultDeviceTypes
-	case preferredType == totpDeviceType: // OTP only
-		return []string{preferredType}
-	default: // OTP + MFA
-		return []string{totpDeviceType, preferredType}
 	}
 }
 
-func (c *mfaAddCommand) addDeviceRPC(
-	ctx context.Context,
-	tc *client.TeleportClient, devName string, devType proto.DeviceType, passwordless bool) (*types.MFADevice, error) {
+func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportClient) (*types.MFADevice, error) {
+	devTypePB := map[string]proto.DeviceType{
+		totpDeviceType:     proto.DeviceType_DEVICE_TYPE_TOTP,
+		webauthnDeviceType: proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
+		touchIDDeviceType:  proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
+	}[c.devType]
+	// Sanity check.
+	if devTypePB == proto.DeviceType_DEVICE_TYPE_UNSPECIFIED {
+		return nil, trace.BadParameter("unexpected device type: %q", c.devType)
+	}
+
 	var dev *types.MFADevice
 	if err := client.RetryWithRelogin(ctx, tc, func() error {
 		pc, err := tc.ConnectToProxy(ctx)
@@ -319,13 +326,13 @@ func (c *mfaAddCommand) addDeviceRPC(
 		}
 		// Init.
 		usage := proto.DeviceUsage_DEVICE_USAGE_MFA
-		if passwordless {
+		if c.pwdless != nil && *c.pwdless {
 			usage = proto.DeviceUsage_DEVICE_USAGE_PASSWORDLESS
 		}
 		if err := stream.Send(&proto.AddMFADeviceRequest{Request: &proto.AddMFADeviceRequest_Init{
 			Init: &proto.AddMFADeviceRequestInit{
-				DeviceName:  devName,
-				DeviceType:  devType,
+				DeviceName:  c.devName,
+				DeviceType:  devTypePB,
 				DeviceUsage: usage,
 			},
 		}}); err != nil {
@@ -342,7 +349,7 @@ func (c *mfaAddCommand) addDeviceRPC(
 			return trace.BadParameter("server bug: server sent %T when client expected AddMFADeviceResponse_ExistingMFAChallenge", resp.Response)
 		}
 		authResp, err := tc.PromptMFAChallenge(ctx, authChallenge, &client.PromptMFAChallengeOpts{
-			PromptDevicePrefix: "*registered*",
+			PromptDevicePrefix: "*registered* ",
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -362,7 +369,7 @@ func (c *mfaAddCommand) addDeviceRPC(
 		if regChallenge == nil {
 			return trace.BadParameter("server bug: server sent %T when client expected AddMFADeviceResponse_NewMFARegisterChallenge", resp.Response)
 		}
-		regResp, err := promptRegisterChallenge(ctx, tc.Config.WebProxyAddr, regChallenge)
+		regResp, err := promptRegisterChallenge(ctx, tc.WebProxyAddr, c.devType, regChallenge)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -389,14 +396,21 @@ func (c *mfaAddCommand) addDeviceRPC(
 	return dev, nil
 }
 
-func promptRegisterChallenge(ctx context.Context, proxyAddr string, c *proto.MFARegisterChallenge) (*proto.MFARegisterResponse, error) {
+func promptRegisterChallenge(ctx context.Context, proxyAddr, devType string, c *proto.MFARegisterChallenge) (*proto.MFARegisterResponse, error) {
 	switch c.Request.(type) {
 	case *proto.MFARegisterChallenge_TOTP:
 		return promptTOTPRegisterChallenge(ctx, c.GetTOTP())
 	case *proto.MFARegisterChallenge_Webauthn:
-		// WebAuthn prompt doesn't take in "r" because it reads directly from stdin
-		// using term.ReadPassword.
-		return promptWebauthnRegisterChallenge(ctx, proxyAddr, c.GetWebauthn())
+		origin := proxyAddr
+		if !strings.HasPrefix(proxyAddr, "https://") {
+			origin = "https://" + origin
+		}
+		cc := wanlib.CredentialCreationFromProto(c.GetWebauthn())
+
+		if devType == touchIDDeviceType {
+			return promptTouchIDRegisterChallenge(origin, cc)
+		}
+		return promptWebauthnRegisterChallenge(ctx, origin, cc)
 	default:
 		return nil, trace.BadParameter("server bug: unexpected registration challenge type: %T", c.Request)
 	}
@@ -478,11 +492,7 @@ func promptTOTPRegisterChallenge(ctx context.Context, c *proto.TOTPRegisterChall
 	}}, nil
 }
 
-func promptWebauthnRegisterChallenge(ctx context.Context, proxyAddr string, cc *wantypes.CredentialCreation) (*proto.MFARegisterResponse, error) {
-	origin := proxyAddr
-	if !strings.HasPrefix(proxyAddr, "https://") {
-		origin = "https://" + origin
-	}
+func promptWebauthnRegisterChallenge(ctx context.Context, origin string, cc *wanlib.CredentialCreation) (*proto.MFARegisterResponse, error) {
 	log.Debugf("WebAuthn: prompting MFA devices with origin %q", origin)
 
 	prompt := wancli.NewDefaultPrompt(ctx, os.Stdout)
@@ -490,8 +500,22 @@ func promptWebauthnRegisterChallenge(ctx context.Context, proxyAddr string, cc *
 	prompt.FirstTouchMessage = "Tap your *new* security key"
 	prompt.SecondTouchMessage = "Tap your *new* security key again to complete registration"
 
-	resp, err := wancli.Register(ctx, origin, wanlib.CredentialCreationFromProto(cc), prompt)
+	resp, err := wancli.Register(ctx, origin, cc, prompt)
 	return resp, trace.Wrap(err)
+}
+
+func promptTouchIDRegisterChallenge(origin string, cc *wanlib.CredentialCreation) (*proto.MFARegisterResponse, error) {
+	log.Debugf("Touch ID: prompting registration with origin %q", origin)
+
+	ccr, err := touchid.Register(origin, cc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &proto.MFARegisterResponse{
+		Response: &proto.MFARegisterResponse_Webauthn{
+			Webauthn: wanlib.CredentialCreationResponseToProto(ccr),
+		},
+	}, nil
 }
 
 type mfaRemoveCommand struct {


### PR DESCRIPTION
Add the `--mfa-mode` flag and wire touch ID into tsh authn/registration.

In the default MFA mode (auto), touch ID should be eager if there is a credential present in the system. Users may change this behavior using other MFA modes.

See https://github.com/gravitational/teleport/blob/master/rfd/0054-passwordless-macos.md.

#9160