### PR TITLE
tctl: Respect TELEPORT_HOME value when grabbing profile

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -863,6 +863,7 @@ func (c *Config) LoadProfile(profileDir string, proxyName string) error {
 	c.MySQLProxyAddr = cp.MySQLProxyAddr
 	c.MongoProxyAddr = cp.MongoProxyAddr
 	c.TLSRoutingEnabled = cp.TLSRoutingEnabled
+	c.KeysDir = profileDir
 
 	c.LocalForwardPorts, err = ParsePortForwardSpec(cp.ForwardedPorts)
 	if err != nil {

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -221,7 +221,7 @@ func applyConfig(ccf *GlobalCLIFlags, cfg *service.Config) (*authclient.Config, 
 		// No config file or identity file.
 		// Try the extension loader.
 		log.Debug("No config file or identity file, loading auth config via extension.")
-		authConfig, err := loadConfigFromProfile(ccf, cfg)
+		authConfig, err := LoadConfigFromProfile(ccf, cfg)
 		if err == nil {
 			return authConfig, nil
 		}
@@ -315,8 +315,8 @@ func (m *sshTrustedHostKeyWrapper) GetKnownHostKeys(hostname string) ([]ssh.Publ
 	return trustedKeys, nil
 }
 
-// loadConfigFromProfile applies config from ~/.tsh/ profile if it's present
-func loadConfigFromProfile(ccf *GlobalCLIFlags, cfg *service.Config) (*authclient.Config, error) {
+// LoadConfigFromProfile applies config from ~/.tsh/ profile if it's present
+func LoadConfigFromProfile(ccf *GlobalCLIFlags, cfg *service.Config) (*authclient.Config, error) {
 	if ccf.IdentityFilePath != "" {
 		return nil, trace.NotFound("identity has been supplied, skip loading the config")
 	}
@@ -325,8 +325,7 @@ func loadConfigFromProfile(ccf *GlobalCLIFlags, cfg *service.Config) (*authclien
 	if len(ccf.AuthServerAddr) != 0 {
 		proxyAddr = ccf.AuthServerAddr[0]
 	}
-
-	profile, _, err := client.Status("", proxyAddr)
+	profile, _, err := client.Status(cfg.TeleportHome, proxyAddr)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)

--- a/tool/tsh/tctl_test.go
+++ b/tool/tsh/tctl_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2015-2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/tool/tctl/common"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigFromProfile(t *testing.T) {
+	tmpHomePath := t.TempDir()
+	connector := mockConnector(t)
+
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetRoles([]string{"access"})
+
+	authProcess, proxyProcess := makeTestServers(t, withBootstrap(connector, alice))
+
+	authServer := authProcess.GetAuthServer()
+	require.NotNil(t, authServer)
+
+	proxyAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	err = Run([]string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--auth", connector.GetName(),
+		"--proxy", proxyAddr.String(),
+	}, setHomePath(tmpHomePath), cliOption(func(cf *CLIConf) error {
+		cf.mockSSOLogin = mockSSOLogin(t, authServer, alice)
+		return nil
+	}))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		ccf  *common.GlobalCLIFlags
+		cfg  *service.Config
+		want error
+	}{
+		{
+			name: "teleportHome is valid dir",
+			ccf:  &common.GlobalCLIFlags{},
+			cfg: &service.Config{
+				TeleportHome: tmpHomePath,
+			},
+			want: nil,
+		}, {
+			name: "teleportHome is nonexistent dir",
+			ccf:  &common.GlobalCLIFlags{},
+			cfg: &service.Config{
+				TeleportHome: "some/dir/that/does/not/exist",
+			},
+			want: trace.NotFound("profile is not found"),
+		}, {
+			name: "teleportHome is not specified",
+			ccf:  &common.GlobalCLIFlags{},
+			cfg:  &service.Config{},
+			want: trace.NotFound("profile is not found"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := common.LoadConfigFromProfile(tc.ccf, tc.cfg)
+			if tc.want != nil {
+				require.Error(t, err, tc.want)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Also when grabbing local key store

Closes https://github.com/gravitational/teleport/issues/12308

before:
tctl does not correctly load profile when TELEPORT_HOME is set to a non default location but ~/.tsh is empty
after:
value of TELEPORT_HOME is passed correctly to load profile
