### PR TITLE
Clarify our version compatibility guarantees

### DIFF
--- a/docs/pages/setup/operations/upgrading.mdx
+++ b/docs/pages/setup/operations/upgrading.mdx
@@ -6,7 +6,7 @@ description: How to upgrade Teleport components
 ## Production releases
 
 <Notice type="warning">
-Avoid running pre-releases (release candidates) in production environments.
+  Avoid running pre-releases (release candidates) in production environments.
 </Notice>
 
 The Teleport development team uses [Semantic Versioning](https://semver.org/),
@@ -15,10 +15,10 @@ use.
 
 ## Component compatibility
 
-<Details 
-scope={["cloud"]} 
-scopeOnly 
-opened 
+<Details
+scope={["cloud"]}
+scopeOnly
+opened
 title="Auth Service and Proxy Service versions">
 
 In Teleport Cloud, we manage the Auth and Proxy Services for you. You can
@@ -38,11 +38,16 @@ compatible.
 
 When running multiple binaries of Teleport within a cluster, the following rules apply:
 
-- **Patch and minor** versions are always compatible, for example, any 5.0.1 component will work with any 5.0.3 component and 6.1.0 component will work with any 6.7.0 component.
-- Major versions are always compatible with the **previous** major release. This means you must not attempt to upgrade from 5.x.x straight to 7.x.x. You must upgrade to 6.x.x first.
-- The above applies to both clients and servers. For example, a 6.x.x Proxy Service is
-  compatible with 5.x.x Nodes and 5.x.x `tsh`. But we don't guarantee that a
-  7.x.x `tsh` will work with a 5.x.x Proxy Service.
+- **Patch and minor** versions are always compatible, for example, any 8.0.1
+  component will work with any 8.0.3 component and any 8.1.0 component will work
+  with any 8.3.0 component.
+- Major versions are always compatible with the **previous** major release. This
+  means you must not attempt to upgrade from 6.x.x straight to 8.x.x. You must
+  upgrade to 7.x.x first.
+  - Servers support clients that are 1 major version behind, but do not support
+    clients that are on a newer major version. For example, a 8.x.x Proxy service
+    is compatible with 7.x.x Nodes and 7.x.x `tsh`, but we don't guarantee that a
+    9.x.x Node will with with an 8.x.x Proxy Service.
 
 ## Backup
 
@@ -54,8 +59,11 @@ Back up before upgrading. We have more instructions in [Backing up Teleport](./b
 <TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
 When upgrading a single Teleport cluster:
 
-1. **Upgrade the Auth Service first**. The Auth Service keeps the cluster state and, if there are data format changes introduced in the new version, will perform necessary migrations.
-2. Upgrade Proxy Service instances. These are stateless and can be upgraded in any sequence or at the same time.
+1. **Upgrade the Auth Service first**. The Auth Service keeps the cluster state
+   and, if there are data format changes introduced in the new version, will
+   perform necessary migrations.
+2. Upgrade Proxy Service instances. These are stateless and can be upgraded in
+   any sequence or at the same time.
 3. Finally, upgrade your Teleport Nodes in any sequence or at the same time.
 
 <Admonition
@@ -64,16 +72,18 @@ When upgrading a single Teleport cluster:
 >
   If several Auth Service instances are running in the High Availability configuration
   (for example, in an AWS Auto Scaling group), you must shrink the group to
-  **just one Auth Service** before performing an upgrade. 
-  
-  While Teleport will attempt to perform any necessary migrations, we recommend users create a backup of their backend before upgrading the Auth Server as a
-  precaution. This allows for a safe rollback in case the migration itself fails.
+  **just one Auth Service** before performing an upgrade.
+
+While Teleport will attempt to perform any necessary migrations, we recommend users create a backup of their backend before upgrading the Auth Server as a
+precaution. This allows for a safe rollback in case the migration itself fails.
+
 </Admonition>
 
 When upgrading multiple clusters:
 
 1. First, upgrade the root cluster, i.e. the one that other clusters trust.
 2. Upgrade the Trusted Clusters.
+
 </TabItem>
 <TabItem scope={["cloud"]} label="Teleport Cloud">
 
@@ -84,5 +94,6 @@ When upgrading multiple clusters:
 
 1. First, upgrade the root cluster, i.e. the one that other clusters trust.
 2. Upgrade the Trusted Clusters.
+
 </TabItem>
 </Tabs>

--- a/docs/pages/setup/operations/upgrading.mdx
+++ b/docs/pages/setup/operations/upgrading.mdx
@@ -41,13 +41,12 @@ When running multiple binaries of Teleport within a cluster, the following rules
 - **Patch and minor** versions are always compatible, for example, any 8.0.1
   component will work with any 8.0.3 component and any 8.1.0 component will work
   with any 8.3.0 component.
-- Major versions are always compatible with the **previous** major release. This
-  means you must not attempt to upgrade from 6.x.x straight to 8.x.x. You must
-  upgrade to 7.x.x first.
-  - Servers support clients that are 1 major version behind, but do not support
-    clients that are on a newer major version. For example, a 8.x.x Proxy service
-    is compatible with 7.x.x Nodes and 7.x.x `tsh`, but we don't guarantee that a
-    9.x.x Node will with with an 8.x.x Proxy Service.
+- Servers support clients that are 1 major version behind, but do not support
+  clients that are on a newer major version. For example, an 8.x.x Proxy Service
+  is compatible with 7.x.x Nodes and 7.x.x `tsh`, but we don't guarantee that a
+  9.x.x Node will work with an 8.x.x Proxy Service. This also means you must not
+  attempt to upgrade from 6.x.x straight to 8.x.x. You must upgrade to 7.x.x
+  first.
 
 ## Backup
 

--- a/rfd/0012-teleport-versioning.md
+++ b/rfd/0012-teleport-versioning.md
@@ -31,6 +31,7 @@ Teleport has ~4 big releases per year.
 
 Up to v5.0.0, Teleport used a versioning scheme that looks like semver (but
 actually isn't):
+
 - a minor version is bumped for all regular releases (e.g. 4.3 -> 4.4)
 - a major version is bumped when a release _feels_ particularly significant
   (e.g. 4.4 -> 5.0 with introduction of application access)
@@ -40,14 +41,15 @@ Our compatibility promise is:
 
 > When running multiple binaries of Teleport within a cluster (nodes, proxies, clients, etc), the following rules apply:
 >
-> * Patch versions are always compatible, for example any 4.0.1 component will work with any 4.0.3 component.
-> * Other versions are always compatible with their previous release. This means you must not attempt to upgrade from 4.1 straight to 4.3. You must upgrade to 4.2 first.
-> * Teleport clients tsh for users and tctl for admins may not be compatible with different versions of the teleport service.
+> - Patch versions are always compatible, for example any 4.0.1 component will work with any 4.0.3 component.
+> - Other versions are always compatible with their previous release. This means you must not attempt to upgrade from 4.1 straight to 4.3. You must upgrade to 4.2 first.
+> - Teleport clients tsh for users and tctl for admins may not be compatible with different versions of the teleport service.
 
 The 2nd point is crucial: we **never** break compatibility with a previous
 release (be it a major or a minor version bump).
 
 The downsides of this versioning scheme are:
+
 - the distinction between major and minor version bumps is largely driven by
   business/product and has no technical difference
 - a user that doesn't read our upgrade docs carefully can assume semver
@@ -74,6 +76,7 @@ Therefore, I propose to switch to a more semver-like scheme, starting with 6.0.
     but still in testing, built from `branch/vN`
 
 The benefits are:
+
 - Major version bumps clearly communicate to users to exercise caution when
   upgrading, and read release notes
 - Minor/patch version bumps are a no-brainer and can be automated
@@ -82,8 +85,8 @@ The benefits are:
 
 ### Compatibility
 
-`vN.*.*` binaries are compatible with any other `vN.*.*` or `vN-1.*.*` binaries
-(both client and server).
+`vN.*.*` client binaries (Nodes, `tsh`, etc.) are compatible with any other
+`vN.*.*` or `vN+1.*.*` servers.
 
 Users are free to use any `vN.*.*` versions throughout their deployment, after
 upgrading everything from `vN-1.*.*`.
@@ -92,6 +95,7 @@ upgrading everything from `vN-1.*.*`.
 
 Teleport officially supports the latest major version and two previous major
 versions. For example:
+
 - `v8.*.*` (latest)
 - `v7.*.*`
 - `v6.*.*`
@@ -99,13 +103,13 @@ versions. For example:
 ### Git branches
 
 Teleport has several branches related to releases:
+
 - `main` - main development branch
 - `branch/vX` - for upcoming minor releases
   - created when `vX.0.0-rc.1` is cut
-- `branch/vX.Y` - for patch releases
-  - created when `vX.Y.0` is cut
 
 Here are how different kinds of changes made map to those branches:
+
 - work towards the next major release
   - merged into `main`
 - work towards the next minor release
@@ -114,7 +118,6 @@ Here are how different kinds of changes made map to those branches:
 - bugfixes that need to be backported
   - merged into `main`
   - backported into `branch/vX`
-  - backported into the latest `branch/vX.Y`
   - repeat for all `vX` that need the backport
 - bugfixes that _do not_ need to be backported
   - merged into `main`


### PR DESCRIPTION
Our upgrade procedure has always been such that servers (proxy/auth)
should be upgraded before upgrading nodes or other agents. This is
because servers can tolerate old clients, but servers do not necessarily
support newer clients (this sometimes works, but is not a supported
configuration).

While this has been the case in practice, it's not entirely clear in
our docs. The docs just say "applies to clients and servers" and never
gave a specific example of a new client trying to connect to an old
server.

Also update the versioning RFD to be more accurate with reality
(we no longer maintain release branches for minor versions).