### PR TITLE
Solidify convention for functions defined in Go called by Rust

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
@@ -30,18 +30,18 @@ pub const CHANNEL_NAME: &str = "cliprdr";
 /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeclip/fb9b7e0b-6db4-41c2-b83c-f889c1ee7688
 pub struct Client {
     clipboard: HashMap<u32, Vec<u8>>,
-    on_remote_copy: Box<dyn Fn(Vec<u8>)>,
+    on_remote_copy: Box<dyn Fn(Vec<u8>) -> RdpResult<()>>,
     vchan: vchan::Client,
 }
 
 impl Default for Client {
     fn default() -> Self {
-        Self::new(Box::new(|_| {}))
+        Self::new(Box::new(|_| Ok(())))
     }
 }
 
 impl Client {
-    pub fn new(on_remote_copy: Box<dyn Fn(Vec<u8>)>) -> Self {
+    pub fn new(on_remote_copy: Box<dyn Fn(Vec<u8>) -> RdpResult<()>>) -> Self {
         Client {
             clipboard: HashMap::new(),
             on_remote_copy,
@@ -284,7 +284,7 @@ impl Client {
             resp.data.truncate(resp.data.len() - 1);
         }
 
-        (self.on_remote_copy)(resp.data);
+        (self.on_remote_copy)(resp.data)?;
 
         Ok(vec![])
     }
@@ -1013,8 +1013,9 @@ mod tests {
     fn invokes_callback_with_clipboard_data() {
         let (send, recv) = channel();
 
-        let mut c = Client::new(Box::new(move |vec| {
+        let mut c = Client::new(Box::new(move |vec| -> RdpResult<()> {
             send.send(vec).unwrap();
+            Ok(())
         }));
 
         let data_resp = FormatDataResponsePDU {

--- a/lib/srv/desktop/rdp/rdpclient/src/errors.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/errors.rs
@@ -19,6 +19,10 @@ pub fn invalid_data_error(msg: &str) -> Error {
     Error::RdpError(RdpError::new(RdpErrorKind::InvalidData, msg))
 }
 
+pub fn try_error(msg: &str) -> Error {
+    Error::TryError(msg.to_string())
+}
+
 // NTSTATUS_OK is a Windows NTStatus value that means "success".
 pub const NTSTATUS_OK: u32 = 0;
 // SPECIAL_NO_RESPONSE is our custom (not defined by Windows) NTStatus value that means "don't send


### PR DESCRIPTION
#### Background
Golang's `C.CString` [documentation](https://pkg.go.dev/cmd/cgo) says
```go
// Go string to C string
// The C string is allocated in the C heap using malloc.
// It is the caller's responsibility to arrange for it to be
// freed, such as by calling C.free (be sure to include stdlib.h
// if C.free is needed).
func C.CString(string) *C.char
```

and gives an example usage:
```go
package main

// #include <stdio.h>
// #include <stdlib.h>
//
// static void myprint(char* s) {
//   printf("%s\n", s);
// }
import "C"
import "unsafe"

func main() {
	cs := C.CString("Hello from stdio")
	C.myprint(cs)
	C.free(unsafe.Pointer(cs))
}
```

For our purposes, we're defining *functions on the Go side which are called by the Rust side* which return `CGOError`'s like
```go
//export defined_in_go
func defined_in_go C.CGOError {
    return C.CString("some error")
}
```
(e.g. `handle_remote_copy`). 

We could ensure this `C.CString` memory is freed by always doing
```go
//export defined_in_go
func defined_in_go C.CGOError {
    errStr := C.CString("some error")
    defer C.free(unsafe.Pointer(errStr))
    return errStr
}
```
however doing so would mean that the memory is freed before we have a chance to use it on the Rust side

```rust
unsafe {
    err = defined_in_go(client_ref, &mut cbitmap) as CGOError; // memory pointed to by err has already been freed
    debug!(err) // tries to use invalid memory
}
```

#### This PR
- Updates `handle_cgo_error` to handle `nil` errors as well 
- Adds instructions in the comments for how to properly use it
- Wraps all go-side-defined functions with it

Thereby setting up a new convention for handling this.