### PR TITLE
`CGOError` --> `CGOErrCode`

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -226,7 +226,7 @@ func (c *Client) connect(ctx context.Context) error {
 		C.bool(c.cfg.AllowClipboard),
 	)
 	if res.err != C.ErrCodeSuccess {
-		return trace.ConnectionProblem(nil, "connect_rdp failed on the Rust side")
+		return trace.ConnectionProblem(nil, "RDP connection failed")
 	}
 	c.rustClient = res.client
 	return nil
@@ -291,7 +291,6 @@ func (c *Client) start() {
 						wheel:  C.PointerWheelNone,
 					},
 				); err != C.ErrCodeSuccess {
-					c.cfg.Log.Debugf("write_rdp_pointer failed on the Rust side")
 					return
 				}
 			case tdp.MouseButton:
@@ -317,7 +316,6 @@ func (c *Client) start() {
 						wheel:  C.PointerWheelNone,
 					},
 				); err != C.ErrCodeSuccess {
-					c.cfg.Log.Debugf("write_rdp_pointer failed on the Rust side")
 					return
 				}
 			case tdp.MouseWheel:
@@ -346,7 +344,6 @@ func (c *Client) start() {
 						wheel_delta: C.int16_t(m.Delta),
 					},
 				); err != C.ErrCodeSuccess {
-					c.cfg.Log.Debugf("write_rdp_pointer failed on the Rust side")
 					return
 				}
 			case tdp.KeyboardButton:
@@ -357,7 +354,6 @@ func (c *Client) start() {
 						down: m.State == tdp.ButtonPressed,
 					},
 				); err != C.ErrCodeSuccess {
-					c.cfg.Log.Debugf("write_rdp_keyboard failed on the Rust side")
 					return
 				}
 			case tdp.ClipboardData:
@@ -367,7 +363,6 @@ func (c *Client) start() {
 						(*C.uint8_t)(unsafe.Pointer(&m[0])),
 						C.uint32_t(len(m)),
 					); err != C.ErrCodeSuccess {
-						c.cfg.Log.Debugf("update_clipboard failed on the Rust side")
 						return
 					}
 				} else {
@@ -454,7 +449,7 @@ func (c *Client) Close() {
 		c.handle.Delete()
 
 		if err := C.close_rdp(c.rustClient); err != C.ErrCodeSuccess {
-			c.cfg.Log.Warningf("close_rdp failed on the Rust side")
+			c.cfg.Log.Warningf("failed to close the RDP client")
 		}
 	})
 }

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -66,7 +66,6 @@ import "C"
 import (
 	"context"
 	"errors"
-	"fmt"
 	"image"
 	"io"
 	"os"
@@ -226,8 +225,8 @@ func (c *Client) connect(ctx context.Context) error {
 		C.uint16_t(c.clientHeight),
 		C.bool(c.cfg.AllowClipboard),
 	)
-	if err := cgoError(res.err); err != nil {
-		return trace.Wrap(err)
+	if res.err != C.ErrCodeSuccess {
+		return trace.ConnectionProblem(nil, "connect_rdp failed on the Rust side")
 	}
 	c.rustClient = res.client
 	return nil
@@ -245,7 +244,7 @@ func (c *Client) start() {
 
 		// C.read_rdp_output blocks for the duration of the RDP connection and
 		// calls handle_bitmap repeatedly with the incoming bitmaps.
-		if err := cgoError(C.read_rdp_output(c.rustClient)); err != nil {
+		if err := C.read_rdp_output(c.rustClient); err != C.ErrCodeSuccess {
 			c.cfg.Log.Warningf("Failed reading RDP output frame: %v", err)
 
 			// close the TDP connection to the browser
@@ -283,7 +282,7 @@ func (c *Client) start() {
 			switch m := msg.(type) {
 			case tdp.MouseMove:
 				mouseX, mouseY = m.X, m.Y
-				if err := cgoError(C.write_rdp_pointer(
+				if err := C.write_rdp_pointer(
 					c.rustClient,
 					C.CGOMousePointerEvent{
 						x:      C.uint16_t(m.X),
@@ -291,8 +290,8 @@ func (c *Client) start() {
 						button: C.PointerButtonNone,
 						wheel:  C.PointerWheelNone,
 					},
-				)); err != nil {
-					c.cfg.Log.Warningf("Failed forwarding RDP mouse pointer: %v", err)
+				); err != C.ErrCodeSuccess {
+					c.cfg.Log.Warningf("write_rdp_pointer failed on the Rust side")
 					return
 				}
 			case tdp.MouseButton:
@@ -308,7 +307,7 @@ func (c *Client) start() {
 				default:
 					button = C.PointerButtonNone
 				}
-				if err := cgoError(C.write_rdp_pointer(
+				if err := C.write_rdp_pointer(
 					c.rustClient,
 					C.CGOMousePointerEvent{
 						x:      C.uint16_t(mouseX),
@@ -317,8 +316,8 @@ func (c *Client) start() {
 						down:   m.State == tdp.ButtonPressed,
 						wheel:  C.PointerWheelNone,
 					},
-				)); err != nil {
-					c.cfg.Log.Warningf("Failed forwarding RDP mouse button: %v", err)
+				); err != C.ErrCodeSuccess {
+					c.cfg.Log.Warningf("write_rdp_pointer failed on the Rust side")
 					return
 				}
 			case tdp.MouseWheel:
@@ -337,7 +336,7 @@ func (c *Client) start() {
 				default:
 					wheel = C.PointerWheelNone
 				}
-				if err := cgoError(C.write_rdp_pointer(
+				if err := C.write_rdp_pointer(
 					c.rustClient,
 					C.CGOMousePointerEvent{
 						x:           C.uint16_t(mouseX),
@@ -346,29 +345,29 @@ func (c *Client) start() {
 						wheel:       uint32(wheel),
 						wheel_delta: C.int16_t(m.Delta),
 					},
-				)); err != nil {
-					c.cfg.Log.Warningf("Failed forwarding RDP mouse wheel: %v", err)
+				); err != C.ErrCodeSuccess {
+					c.cfg.Log.Warningf("write_rdp_pointer failed on the Rust side")
 					return
 				}
 			case tdp.KeyboardButton:
-				if err := cgoError(C.write_rdp_keyboard(
+				if err := C.write_rdp_keyboard(
 					c.rustClient,
 					C.CGOKeyboardEvent{
 						code: C.uint16_t(m.KeyCode),
 						down: m.State == tdp.ButtonPressed,
 					},
-				)); err != nil {
-					c.cfg.Log.Warningf("Failed forwarding RDP key press: %v", err)
+				); err != C.ErrCodeSuccess {
+					c.cfg.Log.Warningf("write_rdp_keyboard failed on the Rust side")
 					return
 				}
 			case tdp.ClipboardData:
 				if len(m) > 0 {
-					if err := cgoError(C.update_clipboard(
+					if err := C.update_clipboard(
 						c.rustClient,
 						(*C.uint8_t)(unsafe.Pointer(&m[0])),
 						C.uint32_t(len(m)),
-					)); err != nil {
-						c.cfg.Log.Warningf("Failed forwarding RDP clipboard data: %v", err)
+					); err != C.ErrCodeSuccess {
+						c.cfg.Log.Warningf("update_clipboard failed on the Rust side")
 						return
 					}
 				} else {
@@ -382,11 +381,11 @@ func (c *Client) start() {
 }
 
 //export handle_bitmap
-func handle_bitmap(handle C.uintptr_t, cb *C.CGOBitmap) C.CGOError {
+func handle_bitmap(handle C.uintptr_t, cb *C.CGOBitmap) C.CGOErrCode {
 	return cgo.Handle(handle).Value().(*Client).handleBitmap(cb)
 }
 
-func (c *Client) handleBitmap(cb *C.CGOBitmap) C.CGOError {
+func (c *Client) handleBitmap(cb *C.CGOBitmap) C.CGOErrCode {
 	// Notify the input forwarding goroutine that we're ready for input.
 	// Input can only be sent after connection was established, which we infer
 	// from the fact that a bitmap was sent.
@@ -415,26 +414,28 @@ func (c *Client) handleBitmap(cb *C.CGOBitmap) C.CGOError {
 	copy(img.Pix, data)
 
 	if err := c.cfg.Conn.OutputMessage(tdp.NewPNG(img, c.cfg.Encoder)); err != nil {
-		return C.CString(fmt.Sprintf("failed to send PNG frame %v: %v", img.Rect, err))
+		c.cfg.Log.Errorf("failed to send PNG frame %v: %v", img.Rect, err)
+		return C.ErrCodeFailure
 	}
-	return nil
+	return C.ErrCodeSuccess
 }
 
 //export handle_remote_copy
-func handle_remote_copy(handle C.uintptr_t, data *C.uint8_t, length C.uint32_t) C.CGOError {
+func handle_remote_copy(handle C.uintptr_t, data *C.uint8_t, length C.uint32_t) C.CGOErrCode {
 	goData := C.GoBytes(unsafe.Pointer(data), C.int(length))
 	return cgo.Handle(handle).Value().(*Client).handleRemoteCopy(goData)
 }
 
 // handleRemoteCopy is called from Rust when data is copied
 // on the remote desktop
-func (c *Client) handleRemoteCopy(data []byte) C.CGOError {
+func (c *Client) handleRemoteCopy(data []byte) C.CGOErrCode {
 	c.cfg.Log.Debugf("Received %d bytes of clipboard data from Windows desktop", len(data))
 
 	if err := c.cfg.Conn.OutputMessage(tdp.ClipboardData(data)); err != nil {
-		return C.CString(fmt.Sprintf("failed to send clipboard data: %v", err))
+		c.cfg.Log.Errorf("failed handling remote copy: %v", err)
+		return C.ErrCodeFailure
 	}
-	return nil
+	return C.ErrCodeSuccess
 }
 
 // Wait blocks until the client disconnects and runs the cleanup.
@@ -452,8 +453,8 @@ func (c *Client) Close() {
 	c.closeOnce.Do(func() {
 		c.handle.Delete()
 
-		if err := cgoError(C.close_rdp(c.rustClient)); err != nil {
-			c.cfg.Log.Warningf("Error closing RDP connection: %v", err)
+		if err := C.close_rdp(c.rustClient); err != C.ErrCodeSuccess {
+			c.cfg.Log.Warningf("close_rdp failed on the Rust side")
 		}
 	})
 }
@@ -472,20 +473,4 @@ func (c *Client) UpdateClientActivity() {
 	c.clientActivityMu.Lock()
 	c.clientLastActive = time.Now().UTC()
 	c.clientActivityMu.Unlock()
-}
-
-// cgoError converts from a CGO-originated error to a Go error, copying the
-// error string and releasing the CGO data.
-func cgoError(s C.CGOError) error {
-	if s == nil {
-		return nil
-	}
-	gs := C.GoString(s)
-	C.free_rust_string(s)
-	return errors.New(gs)
-}
-
-//export free_go_string
-func free_go_string(s *C.char) {
-	C.free(unsafe.Pointer(s))
 }

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -291,7 +291,7 @@ func (c *Client) start() {
 						wheel:  C.PointerWheelNone,
 					},
 				); err != C.ErrCodeSuccess {
-					c.cfg.Log.Warningf("write_rdp_pointer failed on the Rust side")
+					c.cfg.Log.Debugf("write_rdp_pointer failed on the Rust side")
 					return
 				}
 			case tdp.MouseButton:
@@ -317,7 +317,7 @@ func (c *Client) start() {
 						wheel:  C.PointerWheelNone,
 					},
 				); err != C.ErrCodeSuccess {
-					c.cfg.Log.Warningf("write_rdp_pointer failed on the Rust side")
+					c.cfg.Log.Debugf("write_rdp_pointer failed on the Rust side")
 					return
 				}
 			case tdp.MouseWheel:
@@ -346,7 +346,7 @@ func (c *Client) start() {
 						wheel_delta: C.int16_t(m.Delta),
 					},
 				); err != C.ErrCodeSuccess {
-					c.cfg.Log.Warningf("write_rdp_pointer failed on the Rust side")
+					c.cfg.Log.Debugf("write_rdp_pointer failed on the Rust side")
 					return
 				}
 			case tdp.KeyboardButton:
@@ -357,7 +357,7 @@ func (c *Client) start() {
 						down: m.State == tdp.ButtonPressed,
 					},
 				); err != C.ErrCodeSuccess {
-					c.cfg.Log.Warningf("write_rdp_keyboard failed on the Rust side")
+					c.cfg.Log.Debugf("write_rdp_keyboard failed on the Rust side")
 					return
 				}
 			case tdp.ClipboardData:
@@ -367,7 +367,7 @@ func (c *Client) start() {
 						(*C.uint8_t)(unsafe.Pointer(&m[0])),
 						C.uint32_t(len(m)),
 					); err != C.ErrCodeSuccess {
-						c.cfg.Log.Warningf("update_clipboard failed on the Rust side")
+						c.cfg.Log.Debugf("update_clipboard failed on the Rust side")
 						return
 					}
 				} else {

--- a/lib/srv/desktop/rdp/rdpclient/librdprs.h
+++ b/lib/srv/desktop/rdp/rdpclient/librdprs.h
@@ -20,6 +20,11 @@
  */
 #define CHANNEL_CHUNK_LEGNTH 1600
 
+typedef enum CGOErrCode {
+  ErrCodeSuccess,
+  ErrCodeFailure,
+} CGOErrCode;
+
 typedef enum CGOPointerButton {
   PointerButtonNone,
   PointerButtonLeft,
@@ -46,14 +51,9 @@ typedef enum CGOPointerWheel {
  */
 typedef struct Client Client;
 
-/**
- * CGOError is an alias for a C string pointer, for C API clarity.
- */
-typedef char *CGOError;
-
 typedef struct ClientOrError {
   struct Client *client;
-  CGOError err;
+  enum CGOErrCode err;
 } ClientOrError;
 
 /**
@@ -126,7 +126,7 @@ struct ClientOrError connect_rdp(uintptr_t go_ref,
  *
  * `client_ptr` must be a valid pointer to a Client.
  */
-CGOError update_clipboard(struct Client *client_ptr, uint8_t *data, uint32_t len);
+enum CGOErrCode update_clipboard(struct Client *client_ptr, uint8_t *data, uint32_t len);
 
 /**
  * `read_rdp_output` reads incoming RDP bitmap frames from client at client_ref and forwards them to
@@ -137,28 +137,28 @@ CGOError update_clipboard(struct Client *client_ptr, uint8_t *data, uint32_t len
  * `client_ptr` must be a valid pointer to a Client.
  * `handle_bitmap` *must not* free the memory of CGOBitmap.
  */
-CGOError read_rdp_output(struct Client *client_ptr);
+enum CGOErrCode read_rdp_output(struct Client *client_ptr);
 
 /**
  * # Safety
  *
  * client_ptr must be a valid pointer to a Client.
  */
-CGOError write_rdp_pointer(struct Client *client_ptr, struct CGOMousePointerEvent pointer);
+enum CGOErrCode write_rdp_pointer(struct Client *client_ptr, struct CGOMousePointerEvent pointer);
 
 /**
  * # Safety
  *
  * client_ptr must be a valid pointer to a Client.
  */
-CGOError write_rdp_keyboard(struct Client *client_ptr, struct CGOKeyboardEvent key);
+enum CGOErrCode write_rdp_keyboard(struct Client *client_ptr, struct CGOKeyboardEvent key);
 
 /**
  * # Safety
  *
  * client_ptr must be a valid pointer to a Client.
  */
-CGOError close_rdp(struct Client *client_ptr);
+enum CGOErrCode close_rdp(struct Client *client_ptr);
 
 /**
  * free_rdp lets the Go side inform us when it's done with Client and it can be dropped.
@@ -176,8 +176,6 @@ void free_rdp(struct Client *client_ptr);
  */
 void free_rust_string(char *s);
 
-extern void free_go_string(char *s);
+extern enum CGOErrCode handle_bitmap(uintptr_t client_ref, struct CGOBitmap *b);
 
-extern CGOError handle_bitmap(uintptr_t client_ref, struct CGOBitmap *b);
-
-extern CGOError handle_remote_copy(uintptr_t client_ref, uint8_t *data, uint32_t len);
+extern enum CGOErrCode handle_remote_copy(uintptr_t client_ref, uint8_t *data, uint32_t len);

--- a/lib/srv/desktop/rdp/rdpclient/librdprs.h
+++ b/lib/srv/desktop/rdp/rdpclient/librdprs.h
@@ -21,8 +21,8 @@
 #define CHANNEL_CHUNK_LEGNTH 1600
 
 typedef enum CGOErrCode {
-  ErrCodeSuccess,
-  ErrCodeFailure,
+  ErrCodeSuccess = 0,
+  ErrCodeFailure = 1,
 } CGOErrCode;
 
 typedef enum CGOPointerButton {

--- a/lib/srv/desktop/rdp/rdpclient/src/errors.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/errors.rs
@@ -19,6 +19,10 @@ pub fn invalid_data_error(msg: &str) -> Error {
     Error::RdpError(RdpError::new(RdpErrorKind::InvalidData, msg))
 }
 
+pub fn try_error(msg: &str) -> Error {
+    Error::TryError(msg.to_string())
+}
+
 // NTSTATUS_OK is a Windows NTStatus value that means "success".
 pub const NTSTATUS_OK: u32 = 0;
 // SPECIAL_NO_RESPONSE is our custom (not defined by Windows) NTStatus value that means "don't send

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -701,8 +701,8 @@ unsafe fn from_go_array(len: u32, ptr: *mut u8) -> Vec<u8> {
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
 pub enum CGOErrCode {
-    ErrCodeSuccess,
-    ErrCodeFailure,
+    ErrCodeSuccess = 0,
+    ErrCodeFailure = 1,
 }
 
 // These functions are defined on the Go side. Look for functions with '//export funcname'

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -511,9 +511,7 @@ fn read_rdp_output_inner(client: &Client) -> Option<String> {
             _ => {}
         }
         if err != CGOErrCode::ErrCodeSuccess {
-            return Some(format!(
-                "failed forwarding RDP bitmap frame: handle_bitmap failed on the Go side",
-            ));
+            return Some("failed forwarding RDP bitmap frame: handle_bitmap failed on the Go side");
         }
     }
     None

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -255,9 +255,7 @@ fn connect_rdp_inner(
                 if handle_remote_copy(go_ref, v.as_ptr() as _, v.len() as u32)
                     != CGOErrCode::ErrCodeSuccess
                 {
-                    return Err(errors::try_error(
-                        "handle_remote_copy failed on the Go side",
-                    ));
+                    return Err(errors::try_error("failed to handle remote copy"));
                 }
             }
             Ok(())
@@ -511,7 +509,7 @@ fn read_rdp_output_inner(client: &Client) -> Option<String> {
             _ => {}
         }
         if err != CGOErrCode::ErrCodeSuccess {
-            return Some("failed forwarding RDP bitmap frame: handle_bitmap failed on the Go side");
+            return Some("failed forwarding RDP bitmap frame".to_string());
         }
     }
     None

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -72,10 +72,13 @@ impl Client {
     fn into_raw(self: Box<Self>) -> *mut Self {
         Box::into_raw(self)
     }
-    unsafe fn from_ptr<'a>(ptr: *const Self) -> Result<&'a Client, CGOError> {
+    unsafe fn from_ptr<'a>(ptr: *const Self) -> Result<&'a Client, CGOErrCode> {
         match ptr.as_ref() {
             Some(c) => Ok(c),
-            None => Err(to_cgo_error("invalid Rust client pointer".to_string())),
+            None => {
+                error!("invalid Rust client pointer");
+                Err(CGOErrCode::ErrCodeFailure)
+            }
         }
     }
     unsafe fn from_raw(ptr: *mut Self) -> Box<Self> {
@@ -86,7 +89,7 @@ impl Client {
 #[repr(C)]
 pub struct ClientOrError {
     client: *mut Client,
-    err: CGOError,
+    err: CGOErrCode,
 }
 
 impl From<Result<Client, ConnectError>> for ClientOrError {
@@ -94,12 +97,15 @@ impl From<Result<Client, ConnectError>> for ClientOrError {
         match r {
             Ok(client) => ClientOrError {
                 client: Box::new(client).into_raw(),
-                err: CGO_OK,
+                err: CGOErrCode::ErrCodeSuccess,
             },
-            Err(e) => ClientOrError {
-                client: ptr::null_mut(),
-                err: to_cgo_error(format!("{:?}", e)),
-            },
+            Err(e) => {
+                error!("{:?}", e);
+                ClientOrError {
+                    client: ptr::null_mut(),
+                    err: CGOErrCode::ErrCodeFailure,
+                }
+            }
         }
     }
 }
@@ -244,8 +250,17 @@ fn connect_rdp_inner(
 
     // Client for the "cliprdr" channel - clipboard sharing.
     let cliprdr = if params.allow_clipboard {
-        Some(cliprdr::Client::new(Box::new(move |v| unsafe {
-            handle_remote_copy(go_ref, v.as_ptr() as _, v.len() as u32);
+        Some(cliprdr::Client::new(Box::new(move |v| -> RdpResult<()> {
+            unsafe {
+                if handle_remote_copy(go_ref, v.as_ptr() as _, v.len() as u32)
+                    != CGOErrCode::ErrCodeSuccess
+                {
+                    return Err(errors::try_error(
+                        "handle_remote_copy failed on the Go side",
+                    ));
+                }
+            }
+            Ok(())
         })))
     } else {
         None
@@ -398,7 +413,7 @@ pub unsafe extern "C" fn update_clipboard(
     client_ptr: *mut Client,
     data: *mut u8,
     len: u32,
-) -> CGOError {
+) -> CGOErrCode {
     let client = match Client::from_ptr(client_ptr) {
         Ok(client) => client,
         Err(cgo_error) => {
@@ -413,17 +428,18 @@ pub unsafe extern "C" fn update_clipboard(
             Ok(messages) => {
                 for message in messages {
                     if let Err(e) = lock.mcs.write(&cliprdr::CHANNEL_NAME.to_string(), message) {
-                        return to_cgo_error(format!(
-                            "failed writing cliprdr format list: {:?}",
-                            e
-                        ));
+                        error!("failed writing cliprdr format list: {:?}", e);
+                        return CGOErrCode::ErrCodeFailure;
                     }
                 }
-                CGO_OK
+                CGOErrCode::ErrCodeSuccess
             }
-            Err(e) => to_cgo_error(format!("failed updating clipboard: {:?}", e)),
+            Err(e) => {
+                error!("failed updating clipboard: {:?}", e);
+                CGOErrCode::ErrCodeFailure
+            }
         },
-        None => CGO_OK,
+        None => CGOErrCode::ErrCodeSuccess,
     }
 }
 
@@ -435,7 +451,7 @@ pub unsafe extern "C" fn update_clipboard(
 /// `client_ptr` must be a valid pointer to a Client.
 /// `handle_bitmap` *must not* free the memory of CGOBitmap.
 #[no_mangle]
-pub unsafe extern "C" fn read_rdp_output(client_ptr: *mut Client) -> CGOError {
+pub unsafe extern "C" fn read_rdp_output(client_ptr: *mut Client) -> CGOErrCode {
     let client = match Client::from_ptr(client_ptr) {
         Ok(client) => client,
         Err(cgo_error) => {
@@ -443,9 +459,10 @@ pub unsafe extern "C" fn read_rdp_output(client_ptr: *mut Client) -> CGOError {
         }
     };
     if let Some(err) = read_rdp_output_inner(client) {
-        to_cgo_error(err)
+        error!("{}", err);
+        CGOErrCode::ErrCodeFailure
     } else {
-        CGO_OK
+        CGOErrCode::ErrCodeSuccess
     }
 }
 
@@ -457,7 +474,7 @@ fn read_rdp_output_inner(client: &Client) -> Option<String> {
     // Wait for some data to be available on the TCP socket FD before consuming it. This prevents
     // us from locking the mutex in Client permanently while no data is available.
     while wait_for_fd(tcp_fd as usize) {
-        let mut err = CGO_OK;
+        let mut err = CGOErrCode::ErrCodeSuccess;
         let res = client
             .rdp_client
             .lock()
@@ -475,7 +492,7 @@ fn read_rdp_output_inner(client: &Client) -> Option<String> {
                         }
                     };
                     unsafe {
-                        err = handle_bitmap(client_ref, &mut cbitmap) as CGOError;
+                        err = handle_bitmap(client_ref, &mut cbitmap) as CGOErrCode;
                     };
                 }
                 // These should never really be sent by the server to us.
@@ -493,9 +510,10 @@ fn read_rdp_output_inner(client: &Client) -> Option<String> {
             }
             _ => {}
         }
-        if err != CGO_OK {
-            let err_str = unsafe { from_cgo_error(err) };
-            return Some(format!("failed forwarding RDP bitmap frame: {}", err_str));
+        if err != CGOErrCode::ErrCodeSuccess {
+            return Some(format!(
+                "failed forwarding RDP bitmap frame: handle_bitmap failed on the Go side",
+            ));
         }
     }
     None
@@ -560,7 +578,7 @@ impl From<CGOMousePointerEvent> for PointerEvent {
 pub unsafe extern "C" fn write_rdp_pointer(
     client_ptr: *mut Client,
     pointer: CGOMousePointerEvent,
-) -> CGOError {
+) -> CGOErrCode {
     let client = match Client::from_ptr(client_ptr) {
         Ok(client) => client,
         Err(cgo_error) => {
@@ -574,9 +592,10 @@ pub unsafe extern "C" fn write_rdp_pointer(
         .write(RdpEvent::Pointer(pointer.into()));
 
     if let Err(e) = res {
-        to_cgo_error(format!("failed writing RDP pointer event: {:?}", e))
+        error!("failed writing RDP pointer event: {:?}", e);
+        CGOErrCode::ErrCodeFailure
     } else {
-        CGO_OK
+        CGOErrCode::ErrCodeSuccess
     }
 }
 
@@ -608,7 +627,7 @@ impl From<CGOKeyboardEvent> for KeyboardEvent {
 pub unsafe extern "C" fn write_rdp_keyboard(
     client_ptr: *mut Client,
     key: CGOKeyboardEvent,
-) -> CGOError {
+) -> CGOErrCode {
     let client = match Client::from_ptr(client_ptr) {
         Ok(client) => client,
         Err(cgo_error) => {
@@ -621,9 +640,10 @@ pub unsafe extern "C" fn write_rdp_keyboard(
         .unwrap()
         .write(RdpEvent::Key(key.into()));
     if let Err(e) = res {
-        to_cgo_error(format!("failed writing RDP keyboard event: {:?}", e))
+        error!("failed writing RDP keyboard event: {:?}", e);
+        CGOErrCode::ErrCodeFailure
     } else {
-        CGO_OK
+        CGOErrCode::ErrCodeSuccess
     }
 }
 
@@ -631,7 +651,7 @@ pub unsafe extern "C" fn write_rdp_keyboard(
 ///
 /// client_ptr must be a valid pointer to a Client.
 #[no_mangle]
-pub unsafe extern "C" fn close_rdp(client_ptr: *mut Client) -> CGOError {
+pub unsafe extern "C" fn close_rdp(client_ptr: *mut Client) -> CGOErrCode {
     let client = match Client::from_ptr(client_ptr) {
         Ok(client) => client,
         Err(cgo_error) => {
@@ -639,9 +659,10 @@ pub unsafe extern "C" fn close_rdp(client_ptr: *mut Client) -> CGOError {
         }
     };
     if let Err(e) = client.rdp_client.lock().unwrap().shutdown() {
-        to_cgo_error(format!("failed writing RDP keyboard event: {:?}", e))
+        error!("failed writing RDP keyboard event: {:?}", e);
+        CGOErrCode::ErrCodeFailure
     } else {
-        CGO_OK
+        CGOErrCode::ErrCodeSuccess
     }
 }
 
@@ -677,33 +698,18 @@ unsafe fn from_go_array(len: u32, ptr: *mut u8) -> Vec<u8> {
     slice::from_raw_parts(ptr, len as usize).to_vec()
 }
 
-/// CGOError is an alias for a C string pointer, for C API clarity.
-pub type CGOError = *mut c_char;
-
-/// CGO_OK is a CGOError value that means "success".
-const CGO_OK: CGOError = ptr::null_mut();
-
-fn to_cgo_error(s: String) -> CGOError {
-    CString::new(s).expect("CString::new failed").into_raw()
-}
-
-/// from_cgo_error copies CGOError into a String and frees the underlying Go memory.
-///
-/// # Safety
-///
-/// The pointer inside the CGOError must point to a valid null terminated Go string.
-unsafe fn from_cgo_error(e: CGOError) -> String {
-    let s = from_go_string(e);
-    free_go_string(e);
-    s
+#[repr(C)]
+#[derive(Copy, Clone, PartialEq)]
+pub enum CGOErrCode {
+    ErrCodeSuccess,
+    ErrCodeFailure,
 }
 
 // These functions are defined on the Go side. Look for functions with '//export funcname'
 // comments.
 extern "C" {
-    fn free_go_string(s: *mut c_char);
-    fn handle_bitmap(client_ref: usize, b: *mut CGOBitmap) -> CGOError;
-    fn handle_remote_copy(client_ref: usize, data: *mut u8, len: u32) -> CGOError;
+    fn handle_bitmap(client_ref: usize, b: *mut CGOBitmap) -> CGOErrCode;
+    fn handle_remote_copy(client_ref: usize, data: *mut u8, len: u32) -> CGOErrCode;
 }
 
 /// Payload is a generic type used to represent raw incoming RDP messages for parsing.


### PR DESCRIPTION
Rather than passing errors via C-strings, we pass them as integers which removes a major potential memory leak/error footgun

(Credit to @zmb3 for this idea)