### PR TITLE
Prevent ListResources from ignoring limit

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -800,7 +800,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 		return nil, "", trace.Wrap(err)
 	}
 
-	var resources []types.Resource
+	page := make([]types.Resource, 0, limit)
 	nextKey, err := a.authServer.IterateResourcePages(ctx, req, func(nextPage []types.Resource) (bool, error) {
 		for _, resource := range nextPage {
 			if err := a.checkAccessToResource(resource); err != nil {
@@ -811,16 +811,25 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 				return false, trace.Wrap(err)
 			}
 
-			resources = append(resources, resource)
+			page = append(page, resource)
+			if len(page) == limit {
+				// page is filled, stop processing
+				return true, nil
+			}
 		}
 
-		return len(resources) == limit, nil
+		return len(page) == limit, nil
 	})
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	return resources, nextKey, nil
+	// Filled a page, reset nextKey in case the last node was cut out.
+	if len(page) == limit {
+		nextKey = backend.NextPaginationKey(page[len(page)-1])
+	}
+
+	return page, nextKey, nil
 }
 
 func (a *ServerWithRoles) checkAccessToResource(resource types.Resource) error {
@@ -865,7 +874,7 @@ func (a *ServerWithRoles) filterAndListNodes(ctx context.Context, req proto.List
 		for _, node := range filteredPage {
 			if len(page) == limit {
 				// page is filled, stop processing
-				break
+				return true, nil
 			}
 			if node.MatchAgainst(realLabels) {
 				page = append(page, node)


### PR DESCRIPTION
ListResources was missing a check on whether or not the limit was
reached after each possible allowed resource was added to the page.
This manifests when certain resources are filter out by deny rules,
causing the page size check at the end of IterateResources to never
be correct. In this scenario, the entire set of resources will be
returned. This can lead to resource exhaustion and sending messages
that exceed the gRPC limit. As a result of this the api client will
keep issuing more ListResources requests with a smaller limit until
the limit reaches 1.

To prevent the scenario above, ListResources now matches it's companion
filterAndListNodes. Whenever an item is added to the returned page,
we now check if the limit has been reached, instead of only after
processing an entire page retrieved from the cache.