### PR TITLE
Add `tsh touchid ls` and `rm` commands

### DIFF
--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -54,6 +54,8 @@ type nativeTID interface {
 	// ListCredentials lists all registered credentials.
 	// Requires user interaction.
 	ListCredentials() ([]CredentialInfo, error)
+
+	DeleteCredential(credentialID string) error
 }
 
 // CredentialInfo holds information about a Secure Enclave credential.
@@ -402,4 +404,13 @@ func ListCredentials() ([]CredentialInfo, error) {
 	}
 
 	return infos, nil
+}
+
+// DeleteCredential deletes a Secure Enclave credential.
+// Requires user interaction.
+func DeleteCredential(credentialID string) error {
+	if !native.IsAvailable() {
+		return ErrNotAvailable
+	}
+	return native.DeleteCredential(credentialID)
 }

--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/trace"
 
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -397,9 +398,9 @@ func ListCredentials() ([]CredentialInfo, error) {
 		info := &infos[i]
 		key, err := pubKeyFromRawAppleKey(info.publicKeyRaw)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			log.Warnf("Failed to convert public key: %v", err)
 		}
-		info.PublicKey = key
+		info.PublicKey = key // this is OK, even if it's nil
 		info.publicKeyRaw = nil
 	}
 

--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -384,10 +384,7 @@ func Login(origin, user string, assertion *wanlib.CredentialAssertion) (*wanlib.
 // ListCredentials lists all registered Secure Enclave credentials.
 // Requires user interaction.
 func ListCredentials() ([]CredentialInfo, error) {
-	if !native.IsAvailable() {
-		return nil, ErrNotAvailable
-	}
-
+	// Skipped IsAvailable check in favor of a direct call to native.
 	infos, err := native.ListCredentials()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -410,8 +407,6 @@ func ListCredentials() ([]CredentialInfo, error) {
 // DeleteCredential deletes a Secure Enclave credential.
 // Requires user interaction.
 func DeleteCredential(credentialID string) error {
-	if !native.IsAvailable() {
-		return ErrNotAvailable
-	}
+	// Skipped IsAvailable check in favor of a direct call to native.
 	return native.DeleteCredential(credentialID)
 }

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -29,7 +29,6 @@ import "C"
 import (
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"strings"
 	"unsafe"
 
@@ -141,7 +140,7 @@ func (touchIDImpl) FindCredentials(rpID, user string) ([]CredentialInfo, error) 
 		return C.FindCredentials(filterC, infosC)
 	})
 	if res < 0 {
-		return nil, fmt.Errorf("failed to find credentials: status %d", res)
+		return nil, trace.BadParameter("failed to find credentials: status %d", res)
 	}
 	return infos, nil
 }

--- a/lib/auth/touchid/api_other.go
+++ b/lib/auth/touchid/api_other.go
@@ -40,3 +40,7 @@ func (noopNative) FindCredentials(rpID, user string) ([]CredentialInfo, error) {
 func (noopNative) ListCredentials() ([]CredentialInfo, error) {
 	return nil, ErrNotAvailable
 }
+
+func (noopNative) DeleteCredential(credentialID string) error {
+	return ErrNotAvailable
+}

--- a/lib/auth/touchid/api_other.go
+++ b/lib/auth/touchid/api_other.go
@@ -36,3 +36,7 @@ func (noopNative) Authenticate(credentialID string, digest []byte) ([]byte, erro
 func (noopNative) FindCredentials(rpID, user string) ([]CredentialInfo, error) {
 	return nil, ErrNotAvailable
 }
+
+func (noopNative) ListCredentials() ([]CredentialInfo, error) {
+	return nil, ErrNotAvailable
+}

--- a/lib/auth/touchid/api_test.go
+++ b/lib/auth/touchid/api_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/duo-labs/webauthn/protocol"
@@ -159,6 +160,10 @@ func (f *fakeNative) FindCredentials(rpID, user string) ([]touchid.CredentialInf
 		}
 	}
 	return resp, nil
+}
+
+func (f *fakeNative) ListCredentials() ([]touchid.CredentialInfo, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (f *fakeNative) Register(rpID, user string, userHandle []byte) (*touchid.CredentialInfo, error) {

--- a/lib/auth/touchid/api_test.go
+++ b/lib/auth/touchid/api_test.go
@@ -142,6 +142,10 @@ func (f *fakeNative) Authenticate(credentialID string, data []byte) ([]byte, err
 	return key.Sign(rand.Reader, data, crypto.SHA256)
 }
 
+func (f *fakeNative) DeleteCredential(credentialID string) error {
+	return errors.New("not implemented")
+}
+
 func (f *fakeNative) IsAvailable() bool {
 	return true
 }

--- a/lib/auth/touchid/authenticate.m
+++ b/lib/auth/touchid/authenticate.m
@@ -1,5 +1,5 @@
-// go:build touchid
-//  +build touchid
+//go:build touchid
+// +build touchid
 
 // Copyright 2022 Gravitational, Inc
 //

--- a/lib/auth/touchid/common.m
+++ b/lib/auth/touchid/common.m
@@ -1,3 +1,6 @@
+//go:build touchid
+// +build touchid
+
 // Copyright 2022 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build touchid
-// +build touchid
-
 #include "common.h"
 
 #import <Foundation/Foundation.h>
@@ -22,5 +22,8 @@
 #include <string.h>
 
 char *CopyNSString(NSString *val) {
-  return strdup([val UTF8String]);
+  if (val) {
+    return strdup([val UTF8String]);
+  }
+  return strdup("");
 }

--- a/lib/auth/touchid/credentials.h
+++ b/lib/auth/touchid/credentials.h
@@ -33,4 +33,12 @@ typedef struct LabelFilter {
 // User interaction is not required.
 int FindCredentials(LabelFilter filter, CredentialInfo **infosOut);
 
+// ListCredentials finds all registered credentials.
+// Returns the numbers of credentials assigned to the infos array, or negative
+// on failure (typically an OSStatus code). The caller is expected to free infos
+// (and their contents!).
+// Requires user interaction.
+int ListCredentials(const char *reason, CredentialInfo **infosOut,
+                    char **errOut);
+
 #endif // CREDENTIALS_H_

--- a/lib/auth/touchid/credentials.h
+++ b/lib/auth/touchid/credentials.h
@@ -41,4 +41,9 @@ int FindCredentials(LabelFilter filter, CredentialInfo **infosOut);
 int ListCredentials(const char *reason, CredentialInfo **infosOut,
                     char **errOut);
 
+// DeleteCredential deletes a credential by its app_label.
+// Requires user interaction.
+// Returns zero if successful, non-zero otherwise (typically an OSStatus).
+int DeleteCredential(const char *reason, const char *appLabel, char **errOut);
+
 #endif // CREDENTIALS_H_

--- a/lib/auth/touchid/credentials.m
+++ b/lib/auth/touchid/credentials.m
@@ -19,10 +19,13 @@
 
 #import <CoreFoundation/CoreFoundation.h>
 #import <Foundation/Foundation.h>
+#import <LocalAuthentication/LocalAuthentication.h>
 #import <Security/Security.h>
 
 #include <limits.h>
 #include <stdlib.h>
+
+#include <dispatch/dispatch.h>
 
 #include "common.h"
 
@@ -37,7 +40,8 @@ BOOL matchesLabelFilter(LabelFilterKind kind, NSString *filter,
   return NO;
 }
 
-int FindCredentials(LabelFilter filter, CredentialInfo **infosOut) {
+int findCredentials(BOOL applyFilter, LabelFilter filter,
+                    CredentialInfo **infosOut) {
   NSDictionary *query = @{
     (id)kSecClass : (id)kSecClassKey,
     (id)kSecAttrKeyType : (id)kSecAttrKeyTypeECSECPrimeRandom,
@@ -75,7 +79,7 @@ int FindCredentials(LabelFilter filter, CredentialInfo **infosOut) {
 
     CFStringRef label = CFDictionaryGetValue(attrs, kSecAttrLabel);
     NSString *nsLabel = (__bridge NSString *)label;
-    if (!matchesLabelFilter(filter.kind, nsFilter, nsLabel)) {
+    if (applyFilter && !matchesLabelFilter(filter.kind, nsFilter, nsLabel)) {
       continue;
     }
 
@@ -112,4 +116,44 @@ int FindCredentials(LabelFilter filter, CredentialInfo **infosOut) {
 
   CFRelease(items);
   return infosLen;
+}
+
+int FindCredentials(LabelFilter filter, CredentialInfo **infosOut) {
+  return findCredentials(YES /* applyFilter */, filter, infosOut);
+}
+
+int ListCredentials(const char *reason, CredentialInfo **infosOut,
+                    char **errOut) {
+  LAContext *ctx = [[LAContext alloc] init];
+
+  __block LabelFilter filter;
+  filter.kind = LABEL_PREFIX;
+  filter.value = "";
+
+  __block int res;
+  __block NSString *nsError;
+
+  // A semaphore is needed, otherwise we return before the prompt has a chance
+  // to resolve.
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  [ctx evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+      localizedReason:[NSString stringWithUTF8String:reason]
+                reply:^void(BOOL success, NSError *_Nullable error) {
+                  if (success) {
+                    res =
+                        findCredentials(NO /* applyFilter */, filter, infosOut);
+                  } else {
+                    res = -1;
+                    nsError = [error localizedDescription];
+                  }
+                  dispatch_semaphore_signal(sema);
+                }];
+  dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+  // sema released by ARC.
+
+  if (nsError) {
+    *errOut = CopyNSString(nsError);
+  }
+
+  return res;
 }

--- a/lib/auth/touchid/credentials.m
+++ b/lib/auth/touchid/credentials.m
@@ -1,5 +1,5 @@
-// go:build touchid
-//  +build touchid
+//go:build touchid
+// +build touchid
 
 // Copyright 2022 Gravitational, Inc
 //
@@ -131,7 +131,7 @@ int ListCredentials(const char *reason, CredentialInfo **infosOut,
   filter.value = "";
 
   __block int res;
-  __block NSString *nsError;
+  __block NSString *nsError = NULL;
 
   // A semaphore is needed, otherwise we return before the prompt has a chance
   // to resolve.
@@ -146,6 +146,7 @@ int ListCredentials(const char *reason, CredentialInfo **infosOut,
                     res = -1;
                     nsError = [error localizedDescription];
                   }
+
                   dispatch_semaphore_signal(sema);
                 }];
   dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
@@ -173,7 +174,7 @@ int DeleteCredential(const char *reason, const char *appLabel, char **errOut) {
   LAContext *ctx = [[LAContext alloc] init];
 
   __block int res;
-  __block NSString *nsError;
+  __block NSString *nsError = NULL;
 
   // A semaphore is needed, otherwise we return before the prompt has a chance
   // to resolve.

--- a/lib/auth/touchid/register.m
+++ b/lib/auth/touchid/register.m
@@ -1,5 +1,5 @@
-// go:build touchid
-//  +build touchid
+//go:build touchid
+// +build touchid
 
 // Copyright 2022 Gravitational, Inc
 //

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -176,8 +176,6 @@ func PromptMFAChallenge(ctx context.Context, c *proto.MFAAuthenticateChallenge, 
 				},
 			}
 		}()
-	} else if !quiet {
-		fmt.Fprintf(os.Stderr, "Tap any %ssecurity key\n", promptDevicePrefix)
 	}
 
 	// Fire Webauthn goroutine.
@@ -192,8 +190,15 @@ func PromptMFAChallenge(ctx context.Context, c *proto.MFAAuthenticateChallenge, 
 			log.Debugf("WebAuthn: prompting devices with origin %q", origin)
 
 			prompt := wancli.NewDefaultPrompt(ctx, os.Stderr)
-			prompt.FirstTouchMessage = "" // First prompt printed above.
+
+			// Let OTP take over the prompt if present, but otherwise delegate to
+			// WebAuthn.
+			prompt.FirstTouchMessage = ""
+			if !hasTOTP && !quiet {
+				prompt.FirstTouchMessage = fmt.Sprintf("Tap any %ssecurity key\n", promptDevicePrefix)
+			}
 			prompt.SecondTouchMessage = fmt.Sprintf("Tap your %ssecurity key to complete login", promptDevicePrefix)
+
 			mfaPrompt := &mfaPrompt{LoginPrompt: prompt, otpCancelAndWait: func() {
 				otpCancel()
 				otpWait.Wait()

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -195,7 +195,7 @@ func PromptMFAChallenge(ctx context.Context, c *proto.MFAAuthenticateChallenge, 
 			// WebAuthn.
 			prompt.FirstTouchMessage = ""
 			if !hasTOTP && !quiet {
-				prompt.FirstTouchMessage = fmt.Sprintf("Tap any %ssecurity key\n", promptDevicePrefix)
+				prompt.FirstTouchMessage = fmt.Sprintf("Tap any %ssecurity key", promptDevicePrefix)
 			}
 			prompt.SecondTouchMessage = fmt.Sprintf("Tap your %ssecurity key to complete login", promptDevicePrefix)
 

--- a/tool/tsh/touchid.go
+++ b/tool/tsh/touchid.go
@@ -27,12 +27,14 @@ import (
 
 type touchIDCommand struct {
 	ls *touchIDLsCommand
+	rm *touchIDRmCommand
 }
 
 func newTouchIDCommand(app *kingpin.Application) *touchIDCommand {
 	tid := app.Command("touchid", "Manage Touch ID credentials").Hidden()
 	return &touchIDCommand{
 		ls: newTouchIDLsCommand(tid),
+		rm: newTouchIDRmCommand(tid),
 	}
 }
 
@@ -74,5 +76,35 @@ func (c *touchIDLsCommand) run(cf *CLIConf) error {
 	}
 	fmt.Println(t.AsBuffer().String())
 
+	return nil
+}
+
+type touchIDRmCommand struct {
+	*kingpin.CmdClause
+
+	credentialID string
+}
+
+func newTouchIDRmCommand(app *kingpin.CmdClause) *touchIDRmCommand {
+	c := &touchIDRmCommand{
+		CmdClause: app.Command("rm", "Remove a Touch ID credential").Hidden(),
+	}
+	c.Arg("id", "ID of the Touch ID credential to remove").Required().StringVar(&c.credentialID)
+	return c
+}
+
+func (c *touchIDRmCommand) FullCommand() string {
+	if c.CmdClause == nil {
+		return "touchid rm"
+	}
+	return c.CmdClause.FullCommand()
+}
+
+func (c *touchIDRmCommand) run(cf *CLIConf) error {
+	if err := touchid.DeleteCredential(c.credentialID); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf("Touch ID credential %q removed.\n", c.credentialID)
 	return nil
 }

--- a/tool/tsh/touchid.go
+++ b/tool/tsh/touchid.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gravitational/kingpin"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/touchid"
+	"github.com/gravitational/trace"
+)
+
+type touchIDCommand struct {
+	ls *touchIDLsCommand
+}
+
+func newTouchIDCommand(app *kingpin.Application) *touchIDCommand {
+	tid := app.Command("touchid", "Manage Touch ID credentials").Hidden()
+	return &touchIDCommand{
+		ls: newTouchIDLsCommand(tid),
+	}
+}
+
+type touchIDLsCommand struct {
+	*kingpin.CmdClause
+}
+
+func newTouchIDLsCommand(app *kingpin.CmdClause) *touchIDLsCommand {
+	return &touchIDLsCommand{
+		CmdClause: app.Command("ls", "Get a list of system Touch ID credentials").Hidden(),
+	}
+}
+
+func (c *touchIDLsCommand) run(cf *CLIConf) error {
+	infos, err := touchid.ListCredentials()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	sort.Slice(infos, func(i, j int) bool {
+		i1 := &infos[i]
+		i2 := &infos[j]
+		if cmp := strings.Compare(i1.RPID, i2.RPID); cmp != 0 {
+			return cmp < 0
+		}
+		if cmp := strings.Compare(i1.User, i2.User); cmp != 0 {
+			return cmp < 0
+		}
+		return i1.CredentialID < i2.CredentialID
+	})
+
+	t := asciitable.MakeTable([]string{"RPID", "User", "Key Handle"})
+	for _, info := range infos {
+		t.AddRow([]string{
+			info.RPID,
+			info.User,
+			info.CredentialID,
+		})
+	}
+	fmt.Println(t.AsBuffer().String())
+
+	return nil
+}

--- a/tool/tsh/touchid.go
+++ b/tool/tsh/touchid.go
@@ -19,9 +19,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gravitational/kingpin"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/touchid"
+
+	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 )
 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -859,6 +859,8 @@ func Run(args []string, opts ...cliOption) error {
 		err = onFIDO2Diag(&cf)
 	case tid != nil && command == tid.ls.FullCommand():
 		err = tid.ls.run(&cf)
+	case tid != nil && command == tid.rm.FullCommand():
+		err = tid.rm.run(&cf)
 	default:
 		// This should only happen when there's a missing switch case above.
 		err = trace.BadParameter("command %q not configured", command)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -761,109 +761,113 @@ func Run(args []string, opts ...cliOption) error {
 	}
 	cf.ExtraProxyHeaders = confOptions.ExtraHeaders
 
-	switch {
-	case command == ver.FullCommand():
+	switch command {
+	case ver.FullCommand():
 		err = onVersion(&cf)
-	case command == ssh.FullCommand():
+	case ssh.FullCommand():
 		err = onSSH(&cf)
-	case command == bench.FullCommand():
+	case bench.FullCommand():
 		err = onBenchmark(&cf)
-	case command == join.FullCommand():
+	case join.FullCommand():
 		err = onJoin(&cf)
-	case command == scp.FullCommand():
+	case scp.FullCommand():
 		err = onSCP(&cf)
-	case command == play.FullCommand():
+	case play.FullCommand():
 		err = onPlay(&cf)
-	case command == ls.FullCommand():
+	case ls.FullCommand():
 		err = onListNodes(&cf)
-	case command == clusters.FullCommand():
+	case clusters.FullCommand():
 		err = onListClusters(&cf)
-	case command == login.FullCommand():
+	case login.FullCommand():
 		err = onLogin(&cf)
-	case command == logout.FullCommand():
+	case logout.FullCommand():
 		if err := refuseArgs(logout.FullCommand(), args); err != nil {
 			return trace.Wrap(err)
 		}
 		err = onLogout(&cf)
-	case command == show.FullCommand():
+	case show.FullCommand():
 		err = onShow(&cf)
-	case command == status.FullCommand():
+	case status.FullCommand():
 		err = onStatus(&cf)
-	case command == lsApps.FullCommand():
+	case lsApps.FullCommand():
 		err = onApps(&cf)
-	case command == appLogin.FullCommand():
+	case appLogin.FullCommand():
 		err = onAppLogin(&cf)
-	case command == appLogout.FullCommand():
+	case appLogout.FullCommand():
 		err = onAppLogout(&cf)
-	case command == appConfig.FullCommand():
+	case appConfig.FullCommand():
 		err = onAppConfig(&cf)
-	case command == kube.credentials.FullCommand():
+	case kube.credentials.FullCommand():
 		err = kube.credentials.run(&cf)
-	case command == kube.ls.FullCommand():
+	case kube.ls.FullCommand():
 		err = kube.ls.run(&cf)
-	case command == kube.login.FullCommand():
+	case kube.login.FullCommand():
 		err = kube.login.run(&cf)
-	case command == kube.sessions.FullCommand():
+	case kube.sessions.FullCommand():
 		err = kube.sessions.run(&cf)
-	case command == kube.exec.FullCommand():
+	case kube.exec.FullCommand():
 		err = kube.exec.run(&cf)
-	case command == kube.join.FullCommand():
+	case kube.join.FullCommand():
 		err = kube.join.run(&cf)
 
-	case command == proxySSH.FullCommand():
+	case proxySSH.FullCommand():
 		err = onProxyCommandSSH(&cf)
-	case command == proxyDB.FullCommand():
+	case proxyDB.FullCommand():
 		err = onProxyCommandDB(&cf)
-	case command == proxyApp.FullCommand():
+	case proxyApp.FullCommand():
 		err = onProxyCommandApp(&cf)
 
-	case command == dbList.FullCommand():
+	case dbList.FullCommand():
 		err = onListDatabases(&cf)
-	case command == dbLogin.FullCommand():
+	case dbLogin.FullCommand():
 		err = onDatabaseLogin(&cf)
-	case command == dbLogout.FullCommand():
+	case dbLogout.FullCommand():
 		err = onDatabaseLogout(&cf)
-	case command == dbEnv.FullCommand():
+	case dbEnv.FullCommand():
 		err = onDatabaseEnv(&cf)
-	case command == dbConfig.FullCommand():
+	case dbConfig.FullCommand():
 		err = onDatabaseConfig(&cf)
-	case command == dbConnect.FullCommand():
+	case dbConnect.FullCommand():
 		err = onDatabaseConnect(&cf)
-	case command == environment.FullCommand():
+	case environment.FullCommand():
 		err = onEnvironment(&cf)
-	case command == mfa.ls.FullCommand():
+	case mfa.ls.FullCommand():
 		err = mfa.ls.run(&cf)
-	case command == mfa.add.FullCommand():
+	case mfa.add.FullCommand():
 		err = mfa.add.run(&cf)
-	case command == mfa.rm.FullCommand():
+	case mfa.rm.FullCommand():
 		err = mfa.rm.run(&cf)
-	case command == reqList.FullCommand():
+	case reqList.FullCommand():
 		err = onRequestList(&cf)
-	case command == reqShow.FullCommand():
+	case reqShow.FullCommand():
 		err = onRequestShow(&cf)
-	case command == reqCreate.FullCommand():
+	case reqCreate.FullCommand():
 		err = onRequestCreate(&cf)
-	case command == reqReview.FullCommand():
+	case reqReview.FullCommand():
 		err = onRequestReview(&cf)
-	case command == reqSearch.FullCommand():
+	case reqSearch.FullCommand():
 		err = onRequestSearch(&cf)
-	case command == config.FullCommand():
+	case config.FullCommand():
 		err = onConfig(&cf)
-	case command == configProxy.FullCommand():
+	case configProxy.FullCommand():
 		err = onConfigProxy(&cf)
-	case command == aws.FullCommand():
+	case aws.FullCommand():
 		err = onAWS(&cf)
-	case command == daemonStart.FullCommand():
+	case daemonStart.FullCommand():
 		err = onDaemonStart(&cf)
-	case command == f2Diag.FullCommand():
+	case f2Diag.FullCommand():
 		err = onFIDO2Diag(&cf)
-	case tid != nil && command == tid.ls.FullCommand():
-		err = tid.ls.run(&cf)
-	case tid != nil && command == tid.rm.FullCommand():
-		err = tid.rm.run(&cf)
 	default:
-		// This should only happen when there's a missing switch case above.
-		err = trace.BadParameter("command %q not configured", command)
+		// Handle commands that might not be available.
+		switch {
+		case tid != nil && command == tid.ls.FullCommand():
+			err = tid.ls.run(&cf)
+		case tid != nil && command == tid.rm.FullCommand():
+			err = tid.rm.run(&cf)
+		default:
+			// This should only happen when there's a missing switch case above.
+			err = trace.BadParameter("command %q not configured", command)
+		}
 	}
 
 	if trace.IsNotImplemented(err) {


### PR DESCRIPTION
Implement touch ID credential management via `tsh touchid ls` and `tsh touchid rm`.

Departs slightly from RFD command names in order to better match the `tsh mfa`.

See https://github.com/gravitational/teleport/blob/master/rfd/0054-passwordless-macos.md.

#9160