### PR TITLE
Disable `ssh_service` for app configs

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -414,9 +414,7 @@ ${CA_PINS_CONFIG}
 auth_service:
   enabled: no
 ssh_service:
-  enabled: yes
-  labels:
-    serving_app: "${APP_NAME}"
+  enabled: no
 proxy_service:
   enabled: no
 app_service:


### PR DESCRIPTION
This PR disables the `ssh_service` from the config file generated by the auto-install scripts for apps.

Recently, some changes were made and the token generated by the web UI to use with the auto-install script now allows only the `app` role, instead of both `app` and `node`. This caused the script to log errors since the agent tries to join with an unauthorized role.

The script is working and adding the app, but it logs errors.

See https://github.com/gravitational/teleport/issues/12514#issuecomment-1121145862 for some details.

Needs backporting to v9

Closes #12514