### PR TITLE
[branch/v7] Add context.Context to GetReverseTunnels (#12373)

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -67,7 +67,7 @@ type ReadAccessPoint interface {
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
 	// GetReverseTunnels returns  a list of reverse tunnels
-	GetReverseTunnels(opts ...services.MarshalOption) ([]types.ReverseTunnel, error)
+	GetReverseTunnels(ctx context.Context, opts ...services.MarshalOption) ([]types.ReverseTunnel, error)
 
 	// GetClusterName returns cluster name
 	GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -567,7 +567,7 @@ func (s *APIServer) upsertReverseTunnel(auth ClientI, w http.ResponseWriter, r *
 
 // getReverseTunnels returns a list of reverse tunnels
 func (s *APIServer) getReverseTunnels(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	reverseTunnels, err := auth.GetReverseTunnels()
+	reverseTunnels, err := auth.GetReverseTunnels(r.Context())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2231,8 +2231,8 @@ func (a *Server) IterateNodePages(ctx context.Context, req proto.ListNodesReques
 }
 
 // GetReverseTunnels is a part of auth.AccessPoint implementation
-func (a *Server) GetReverseTunnels(opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
-	return a.GetCache().GetReverseTunnels(opts...)
+func (a *Server) GetReverseTunnels(ctx context.Context, opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
+	return a.GetCache().GetReverseTunnels(ctx, opts...)
 }
 
 // GetProxies is a part of auth.AccessPoint implementation

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -804,14 +804,14 @@ func (a *ServerWithRoles) GetReverseTunnel(name string, opts ...services.Marshal
 	return a.authServer.GetReverseTunnel(name, opts...)
 }
 
-func (a *ServerWithRoles) GetReverseTunnels(opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
+func (a *ServerWithRoles) GetReverseTunnels(ctx context.Context, opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
 	if err := a.action(apidefaults.Namespace, types.KindReverseTunnel, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if err := a.action(apidefaults.Namespace, types.KindReverseTunnel, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetReverseTunnels(opts...)
+	return a.authServer.GetReverseTunnels(ctx, opts...)
 }
 
 func (a *ServerWithRoles) DeleteReverseTunnel(domainName string) error {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -659,8 +659,8 @@ func (c *Client) GetReverseTunnel(name string, opts ...services.MarshalOption) (
 }
 
 // GetReverseTunnels returns the list of created reverse tunnels
-func (c *Client) GetReverseTunnels(opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
-	out, err := c.Get(context.TODO(), c.Endpoint("reversetunnels"), url.Values{})
+func (c *Client) GetReverseTunnels(ctx context.Context, opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
+	out, err := c.Get(ctx, c.Endpoint("reversetunnels"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1470,13 +1470,13 @@ func (c *Cache) GetAuthServers() ([]types.Server, error) {
 }
 
 // GetReverseTunnels is a part of auth.AccessPoint implementation
-func (c *Cache) GetReverseTunnels(opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
+func (c *Cache) GetReverseTunnels(ctx context.Context, opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
 	rg, err := c.read()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer rg.Release()
-	return rg.presence.GetReverseTunnels(opts...)
+	return rg.presence.GetReverseTunnels(ctx, opts...)
 }
 
 // GetProxies is a part of auth.AccessPoint implementation

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1454,7 +1454,7 @@ func TestReverseTunnels(t *testing.T) {
 		t.Fatalf("timeout waiting for event")
 	}
 
-	out, err := p.cache.GetReverseTunnels()
+	out, err := p.cache.GetReverseTunnels(context.Background())
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 
@@ -1467,7 +1467,7 @@ func TestReverseTunnels(t *testing.T) {
 	err = p.presenceS.UpsertReverseTunnel(tunnel)
 	require.NoError(t, err)
 
-	out, err = p.presenceS.GetReverseTunnels()
+	out, err = p.presenceS.GetReverseTunnels(context.Background())
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	tunnel = out[0]
@@ -1479,7 +1479,7 @@ func TestReverseTunnels(t *testing.T) {
 		t.Fatalf("timeout waiting for event")
 	}
 
-	out, err = p.cache.GetReverseTunnels()
+	out, err = p.cache.GetReverseTunnels(context.Background())
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 
@@ -1495,7 +1495,7 @@ func TestReverseTunnels(t *testing.T) {
 		t.Fatalf("timeout waiting for event")
 	}
 
-	out, err = p.cache.GetReverseTunnels()
+	out, err = p.cache.GetReverseTunnels(context.Background())
 	require.NoError(t, err)
 	require.Empty(t, out)
 }

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -446,7 +446,7 @@ func (c *reverseTunnel) erase(ctx context.Context) error {
 }
 
 func (c *reverseTunnel) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
-	resources, err := c.Presence.GetReverseTunnels()
+	resources, err := c.Presence.GetReverseTunnels(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -167,7 +167,7 @@ func (w *RemoteClusterTunnelManager) Run(ctx context.Context) {
 func (w *RemoteClusterTunnelManager) Sync(ctx context.Context) error {
 	// Fetch desired reverse tunnels and convert them to a set of
 	// remoteClusterKeys.
-	wantTunnels, err := w.cfg.AuthClient.GetReverseTunnels()
+	wantTunnels, err := w.cfg.AuthClient.GetReverseTunnels(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/reversetunnel/rc_manager_test.go
+++ b/lib/reversetunnel/rc_manager_test.go
@@ -171,7 +171,7 @@ type mockAuthClient struct {
 	reverseTunnelsErr error
 }
 
-func (c mockAuthClient) GetReverseTunnels(...services.MarshalOption) ([]types.ReverseTunnel, error) {
+func (c mockAuthClient) GetReverseTunnels(context.Context, ...services.MarshalOption) ([]types.ReverseTunnel, error) {
 	return c.reverseTunnels, c.reverseTunnelsErr
 }
 

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -466,9 +466,9 @@ func (s *PresenceService) GetReverseTunnel(name string, opts ...services.Marshal
 }
 
 // GetReverseTunnels returns a list of registered servers
-func (s *PresenceService) GetReverseTunnels(opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
+func (s *PresenceService) GetReverseTunnels(ctx context.Context, opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
 	startKey := backend.Key(reverseTunnelsPrefix)
-	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
+	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -103,7 +103,7 @@ type Presence interface {
 	GetReverseTunnel(name string, opts ...MarshalOption) (types.ReverseTunnel, error)
 
 	// GetReverseTunnels returns a list of registered servers
-	GetReverseTunnels(opts ...MarshalOption) ([]types.ReverseTunnel, error)
+	GetReverseTunnels(ctx context.Context, opts ...MarshalOption) ([]types.ReverseTunnel, error)
 
 	// DeleteReverseTunnel deletes reverse tunnel by it's domain name
 	DeleteReverseTunnel(domainName string) error

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -515,14 +515,14 @@ func newReverseTunnel(clusterName string, dialAddrs []string) *types.ReverseTunn
 }
 
 func (s *ServicesTestSuite) ReverseTunnelsCRUD(c *check.C) {
-	out, err := s.PresenceS.GetReverseTunnels()
+	out, err := s.PresenceS.GetReverseTunnels(context.Background())
 	c.Assert(err, check.IsNil)
 	c.Assert(len(out), check.Equals, 0)
 
 	tunnel := newReverseTunnel("example.com", []string{"example.com:2023"})
 	c.Assert(s.PresenceS.UpsertReverseTunnel(tunnel), check.IsNil)
 
-	out, err = s.PresenceS.GetReverseTunnels()
+	out, err = s.PresenceS.GetReverseTunnels(context.Background())
 	c.Assert(err, check.IsNil)
 	c.Assert(out, check.HasLen, 1)
 	tunnel.SetResourceID(out[0].GetResourceID())
@@ -531,7 +531,7 @@ func (s *ServicesTestSuite) ReverseTunnelsCRUD(c *check.C) {
 	err = s.PresenceS.DeleteReverseTunnel(tunnel.Spec.ClusterName)
 	c.Assert(err, check.IsNil)
 
-	out, err = s.PresenceS.GetReverseTunnels()
+	out, err = s.PresenceS.GetReverseTunnels(context.Background())
 	c.Assert(err, check.IsNil)
 	c.Assert(len(out), check.Equals, 0)
 
@@ -1691,7 +1691,7 @@ func (s *ServicesTestSuite) Events(c *check.C) {
 				tunnel := newReverseTunnel("example.com", []string{"example.com:2023"})
 				c.Assert(s.PresenceS.UpsertReverseTunnel(tunnel), check.IsNil)
 
-				out, err := s.PresenceS.GetReverseTunnels()
+				out, err := s.PresenceS.GetReverseTunnels(context.Background())
 				c.Assert(err, check.IsNil)
 
 				err = s.PresenceS.DeleteReverseTunnel(tunnel.Spec.ClusterName)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -843,7 +843,7 @@ func (rc *ResourceCommand) getCollection(client auth.ClientI) (ResourceCollectio
 		return &githubCollection{connectors}, nil
 	case types.KindReverseTunnel:
 		if rc.ref.Name == "" {
-			tunnels, err := client.GetReverseTunnels()
+			tunnels, err := client.GetReverseTunnels(context.Background())
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `branch/v7`:
 - [Add context.Context to GetReverseTunnels (#12373)](https://github.com/gravitational/teleport/pull/12373)

<!--- Backport version: 8.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)