### PR TITLE
App access JWT improvements

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -531,6 +531,9 @@ const (
 	// membership information
 	TraitTeams = "github_teams"
 
+	// TraitJWT is the name of the trait containing JWT header for app access.
+	TraitJWT = "jwt"
+
 	// TraitInternalLoginsVariable is the variable used to store allowed
 	// logins for local accounts.
 	TraitInternalLoginsVariable = "{{internal.logins}}"
@@ -558,6 +561,10 @@ const (
 	// TraitInternalAWSRoleARNs is the variable used to store allowed AWS
 	// role ARNs for local accounts.
 	TraitInternalAWSRoleARNs = "{{internal.aws_role_arns}}"
+
+	// TraitInternalJWTVariable is the variable used to store JWT token for
+	// app sessions.
+	TraitInternalJWTVariable = "{{internal.jwt}}"
 )
 
 // SCP is Secure Copy.

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -270,9 +270,11 @@ requests forwarded to a web application.
     headers:
     # Inject a static header.
     - "X-Custom-Header: example"
-    # Inject hedaers with internal/external user traits.
+    # Inject headers with internal/external user traits.
     - "X-Internal-Trait: {{internal.logins}}"
     - "X-External-Trait: {{external.env}}"
+    # Inject header with Teleport-signed JWT token.
+    - "Authorization: Bearer {{internal.jwt}}"
     # Override Host header.
     - "Host: dashboard.example.com"
 ```
@@ -285,6 +287,10 @@ Rewritten header values support the same templating variables as [role templates
 In the example above, `X-Internal-Trait` header will be populated with the value
 of internal user trait `logins` and `X-External-Trait` header will get the value
 of the user's external `env` trait coming from the identity provider.
+
+Additionally, the `{{internal.jwt}}` template variable will be replaced with
+a JWT token signed by Teleport that contains user identity information. See
+[Integrating with JWTs](./jwt.mdx) for more details.
 
 ## View applications in Teleport
 

--- a/docs/pages/application-access/guides/jwt.mdx
+++ b/docs/pages/application-access/guides/jwt.mdx
@@ -69,6 +69,24 @@ The JWT will be sent with the header: `Teleport-Jwt-Assertion`.
 eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiaHR0cDovLzEyNy4wLjAuMTozNDY3OSJdLCJleHAiOjE2MDM5NDM4MDAsImlzcyI6ImF3cyIsIm5iZiI6MTYwMzgzNTc5NSwicm9sZXMiOlsiYWRtaW4iXSwic3ViIjoiYmVuYXJlbnQiLCJ1c2VybmFtZSI6ImJlbmFyZW50In0.PZGUyFfhEWl22EDniWRLmKAjb3fL0D4cTmkxEfb-Q30hVMzVhka5WB8AUsPsLPVhTzsQ6Nkk1DnXHdz6oxrqDDfumuRrDnpJpjiXj_l0D3bExrchN61enzBHxSD13VkRIqP1V6l4i8yt8kXDIBWc-QejLTodA_GtczkDfnnpuAfaxIbD7jEwF27KI4kZu7uES9LMu2iCLdV9ZqarA-6HeDhXPA37OJ3P6eVQzYpgaOBYro5brEiVpuJLr1yA0gncmR4FqmhCpCj-KmHi2vmjmJAuuHId6HZoEZJjC9IAsNlrSA4GHH9j82o7FF1F4J2s38bRy3wZv46MT8X8-QBSpg
 ```
 
+## Inject JWT
+
+You can inject a JWT token into any header using [headers passthrough](./connecting-apps.mdx#headers-passthrough)
+configuration and the `{{internal.jwt}}` template variable. This variable will
+be replaced with JWT token signed by Teleport JWT CA containing user identity
+information like described above.
+
+For example:
+
+```yaml
+- name: "elasticsearch"
+  uri: https://localhost:4321
+  public_addr: elastic.example.com
+  rewrite:
+    headers:
+    - "Authorization: Bearer {{internal.jwt}}"
+```
+
 ## Validate JWT
 
 Teleport provides a JSON Web Key Set (`jwks`) endpoint to verify that the JWT

--- a/integration/app_integration_test.go
+++ b/integration/app_integration_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -314,6 +315,11 @@ func TestAppAccessJWT(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, status)
 
+	// Verify JWT token.
+	verifyJWT(t, pack, token, pack.jwtAppURI)
+}
+
+func verifyJWT(t *testing.T, pack *pack, token, appURI string) {
 	// Get and unmarshal JWKs
 	status, body, err := pack.makeRequest("", http.MethodGet, "/.well-known/jwks.json")
 	require.NoError(t, err)
@@ -335,7 +341,7 @@ func TestAppAccessJWT(t *testing.T) {
 	claims, err := key.Verify(jwt.VerifyParams{
 		Username: pack.username,
 		RawToken: token,
-		URI:      pack.jwtAppURI,
+		URI:      appURI,
 	})
 	require.NoError(t, err)
 	require.Equal(t, pack.username, claims.Username)
@@ -445,6 +451,11 @@ func TestAppAccessRewriteHeadersRoot(t *testing.T) {
 							Name:  forward.XForwardedServer,
 							Value: "rewritten-x-forwarded-server-header",
 						},
+						// Make sure we can insert JWT token in custom header.
+						{
+							Name:  "X-JWT",
+							Value: teleport.TraitInternalJWTVariable,
+						},
 					},
 				},
 			},
@@ -462,17 +473,25 @@ func TestAppAccessRewriteHeadersRoot(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, status)
-	require.Contains(t, resp, "X-Teleport-Cluster: root")
-	require.Contains(t, resp, "X-External-Env: production")
-	require.Contains(t, resp, "Host: example.com")
-	require.Contains(t, resp, "X-Existing: rewritten-existing-header")
-	require.NotContains(t, resp, "X-Existing: existing")
-	require.NotContains(t, resp, "rewritten-app-jwt-header")
-	require.NotContains(t, resp, "rewritten-app-cf-header")
-	require.NotContains(t, resp, "rewritten-x-forwarded-for-header")
-	require.NotContains(t, resp, "rewritten-x-forwarded-host-header")
-	require.NotContains(t, resp, "rewritten-x-forwarded-proto-header")
-	require.NotContains(t, resp, "rewritten-x-forwarded-server-header")
+
+	// Dumper app just dumps HTTP request so we should be able to read it back.
+	req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(resp)))
+	require.NoError(t, err)
+	require.Equal(t, req.Host, "example.com")
+	require.Equal(t, req.Header.Get("X-Teleport-Cluster"), "root")
+	require.Equal(t, req.Header.Get("X-External-Env"), "production")
+	require.Equal(t, req.Header.Get("X-Existing"), "rewritten-existing-header")
+	require.NotEqual(t, req.Header.Get(teleport.AppJWTHeader), "rewritten-app-jwt-header")
+	require.NotEqual(t, req.Header.Get(teleport.AppCFHeader), "rewritten-app-cf-header")
+	require.NotEqual(t, req.Header.Get(forward.XForwardedFor), "rewritten-x-forwarded-for-header")
+	require.NotEqual(t, req.Header.Get(forward.XForwardedHost), "rewritten-x-forwarded-host-header")
+	require.NotEqual(t, req.Header.Get(forward.XForwardedProto), "rewritten-x-forwarded-proto-header")
+	require.NotEqual(t, req.Header.Get(forward.XForwardedServer), "rewritten-x-forwarded-server-header")
+
+	// Verify JWT tokens.
+	for _, header := range []string{teleport.AppJWTHeader, teleport.AppCFHeader, "X-JWT"} {
+		verifyJWT(t, pack, req.Header.Get(header), dumperServer.URL)
+	}
 }
 
 // TestAppAccessRewriteHeadersLeaf validates that http headers from application

--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -159,6 +159,7 @@ func (k *Key) Sign(p SignParams) (string, error) {
 			Issuer:    k.config.ClusterName,
 			Audience:  josejwt.Audience{p.URI},
 			NotBefore: josejwt.NewNumericDate(k.config.Clock.Now().Add(-10 * time.Second)),
+			IssuedAt:  josejwt.NewNumericDate(k.config.Clock.Now()),
 			Expiry:    josejwt.NewNumericDate(p.Expires),
 		},
 		Username: p.Username,

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -445,7 +445,7 @@ func ApplyValueTraits(val string, traits map[string][]string) ([]string, error) 
 		case teleport.TraitLogins, teleport.TraitWindowsLogins,
 			teleport.TraitKubeGroups, teleport.TraitKubeUsers,
 			teleport.TraitDBNames, teleport.TraitDBUsers,
-			teleport.TraitAWSRoleARNs:
+			teleport.TraitAWSRoleARNs, teleport.TraitJWT:
 		default:
 			return nil, trace.BadParameter("unsupported variable %q", variable.Name())
 		}


### PR DESCRIPTION
Couple improvements/fixes for app access' JWT integration. Specifically:

- Include `iat` (`IssuedAt`) claim which wasn't present before. Some apps that support JWT auth require it.
- Add ability to inject JWT in any header via `{{internal.jwt}}` template variable. With this change, you can for example have the following app configuration to pass JWT in Authorization header:

```yaml
apps:
- name: "example"
  uri: http://localhost:9200
  rewrite:
    headers:
    - "Authorization: Bearer {{internal.jwt}}"
```

These changes are required to support JWT authentication in more applications.  For example, with these changes I was able to successfully configure JWT authentication/authorization with ElasticSearch:

https://www.elastic.co/guide/en/elasticsearch/reference/current/jwt-realm.html
