### PR TITLE
fix: reduce redundant GetRoles call in ServerWithRoles.GetActiveSessionTrackers()

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -264,14 +264,15 @@ func (a *ServerWithRoles) GetActiveSessionTrackers(ctx context.Context) ([]types
 		return nil, trace.Wrap(err)
 	}
 
+	joinerRoles, err := a.authServer.GetRoles(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	
 	var filteredSessions []types.SessionTracker
 
 	for _, sess := range sessions {
 		evaluator := NewSessionAccessEvaluator(sess.GetHostPolicySets(), sess.GetSessionKind())
-		joinerRoles, err := a.authServer.GetRoles(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 
 		modes, err := evaluator.CanJoin(SessionAccessContext{Roles: joinerRoles})
 		if err == nil || len(modes) > 0 {


### PR DESCRIPTION
Hi, I got high CPU, Memory usage when use large active session

![image](https://user-images.githubusercontent.com/23460502/167771120-4bccbba1-163f-4117-8cc5-218795f4c2e0.png)
![image](https://user-images.githubusercontent.com/23460502/167771129-28d15053-8310-4b24-9323-0a5df3bc51d7.png)

After profiling, I found `ServerWithRoles.GetActiveSessionTrackers()` consumes almost all CPU, Memory
![CPU Profile](https://user-images.githubusercontent.com/23460502/167771950-f0a57663-9306-49a2-a7e6-169879ac7f71.png)
![Memory Profile](https://user-images.githubusercontent.com/23460502/167771967-14503814-3412-444e-9a71-4e8422d4c40a.png)

I think it doesn't need to get roles inside for-loop

This change should not affect to any behavier, so I didn't change any tests cases.

Since I use teleport enterprise binaries, I hope this change can be applied quickly.

Thanks