### PR TITLE
Re-add PAM build tag back to `tctl` build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ all: version
 # If you are considering changing this behavior, please consult with dev team first
 .PHONY: $(BUILDDIR)/tctl
 $(BUILDDIR)/tctl: roletester
-	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -tags "$(FIPS_TAG) $(ROLETESTER_TAG)" -o $(BUILDDIR)/tctl $(BUILDFLAGS) ./tool/tctl
+	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -tags "$(PAM_TAG) $(FIPS_TAG) $(ROLETESTER_TAG)" -o $(BUILDDIR)/tctl $(BUILDFLAGS) ./tool/tctl
 
 .PHONY: $(BUILDDIR)/teleport
 $(BUILDDIR)/teleport: ensure-webassets bpf-bytecode rdpclient


### PR DESCRIPTION
Fixes #12547 

I'm not sure if this is the best solution, but it fixes the bug for now. It may be difficult to fix this otherwise as `tctl` loads the main teleport config which checks for the inclusion of pam when configured, even if `tctl` itself may not leverage it.

Partially undoes https://github.com/gravitational/teleport/pull/11666

We will need to ensure we backport this into the versions that the original PR was backported into.