### PR TITLE
Fix linter after Go 1.18 upgrade

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     - revive
     - staticcheck
     - structcheck
-    - typecheck
     - unused
     - unconvert
     - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,3 +41,4 @@ output:
 run:
   skip-dirs-use-default: false
   timeout: 5m
+  go: '1.18'

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -142,8 +142,8 @@ RUN mkdir -p /opt && cd /opt && curl -L https://github.com/gravitational/libbpf/
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install golangci-lint.
-RUN (curl -L https://github.com/golangci/golangci-lint/releases/download/v1.44.0/golangci-lint-1.44.0-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz && \
-     cp golangci-lint-1.44.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ && \
+RUN (curl -L https://github.com/golangci/golangci-lint/releases/download/v1.46.0/golangci-lint-1.46.0-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz && \
+     cp golangci-lint-1.46.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ && \
      rm -r golangci-lint*)
 
 # Install helm.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4870,7 +4870,7 @@ func testBPFInteractive(t *testing.T, suite *integrationTestSuite) {
 	// Check if BPF tests can be run on this host.
 	err := canTestBPF()
 	if err != nil {
-		t.Skip(fmt.Sprintf("Tests for BPF functionality can not be run: %v.", err))
+		t.Skipf("Tests for BPF functionality can not be run: %v.", err)
 		return
 	}
 
@@ -4998,7 +4998,7 @@ func testBPFExec(t *testing.T, suite *integrationTestSuite) {
 	// Check if BPF tests can be run on this host.
 	err := canTestBPF()
 	if err != nil {
-		t.Skip(fmt.Sprintf("Tests for BPF functionality can not be run: %v.", err))
+		t.Skipf("Tests for BPF functionality can not be run: %v.", err)
 		return
 	}
 
@@ -5233,7 +5233,7 @@ func testBPFSessionDifferentiation(t *testing.T, suite *integrationTestSuite) {
 	// Check if BPF tests can be run on this host.
 	err := canTestBPF()
 	if err != nil {
-		t.Skip(fmt.Sprintf("Tests for BPF functionality can not be run: %v.", err))
+		t.Skipf("Tests for BPF functionality can not be run: %v.", err)
 		return
 	}
 

--- a/lib/events/gcssessions/gcsstream_test.go
+++ b/lib/events/gcssessions/gcsstream_test.go
@@ -19,7 +19,6 @@ package gcssessions
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"os"
 	"testing"
@@ -73,9 +72,8 @@ func TestStreams(t *testing.T) {
 	ctx := context.Background()
 	uri := os.Getenv(teleport.GCSTestURI)
 	if uri == "" {
-		t.Skip(
-			fmt.Sprintf("Skipping GCS tests, set env var %q, details here: https://goteleport.com/teleport/docs/gcp-guide/",
-				teleport.GCSTestURI))
+		t.Skipf("Skipping GCS tests, set env var %q, details here: https://goteleport.com/teleport/docs/gcp-guide/",
+			teleport.GCSTestURI)
 	}
 	u, err := url.Parse(uri)
 	require.Nil(t, err)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -981,7 +981,7 @@ func TestSessionHijack(t *testing.T) {
 	t.Parallel()
 	_, err := user.Lookup(teleportTestUser)
 	if err != nil {
-		t.Skip(fmt.Sprintf("user %v is not found, skipping test", teleportTestUser))
+		t.Skipf("user %v is not found, skipping test", teleportTestUser)
 	}
 
 	f := newFixture(t)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1089,7 +1089,7 @@ func TestTerminalPing(t *testing.T) {
 		err := ws.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(time.Second))
 		if err == websocket.ErrCloseSent {
 			return nil
-		} else if e, ok := err.(net.Error); ok && e.Temporary() {
+		} else if e, ok := err.(net.Error); ok && e.Timeout() {
 			return nil
 		}
 		return err


### PR DESCRIPTION
We need to pull in a newer version of golangci-lint which vendors linters that are compatible with 1.18.

Additionally, fix new warnings that came up as a result of the ugprade.

Lastly, disable the typecheck linter because it fails due to our use of the `e` submodule. Fear not, compile errors will still be caught by the CI build.