### PR TITLE
Add a more complete Teleport Cloud introduction

### DIFF
--- a/docs/pages/cloud/introduction.mdx
+++ b/docs/pages/cloud/introduction.mdx
@@ -17,7 +17,6 @@ The following management tasks are handled for you:
   maintenance, and network configuration
 - Auth Service backend management
 - DNS record management
-- Certificate authority rotation
 
 A Teleport Cloud account takes minutes to set up. After that, you can define
 roles, register SSO providers, and start connecting all of your infrastructure,

--- a/docs/pages/cloud/introduction.mdx
+++ b/docs/pages/cloud/introduction.mdx
@@ -1,21 +1,23 @@
 ---
 title: Teleport Cloud
-description: Teleport Cloud is a fully managed deployment of Teleport.
+description: Teleport Cloud is a deployment of the Auth and Proxy Services managed by a dedicated team.
 videoBanner: 1jhKOtBinm4
 ---
 
-Teleport Cloud is a fully managed deployment of the Teleport Auth Service and
-Proxy Service. 
+Teleport Cloud is a deployment of the Auth Service and Proxy Service,
+managed by a dedicated team at Teleport.
 
 When you [sign up for a Teleport Cloud account](https://goteleport.com/signup/), you will receive a subdomain of
 `teleport.sh` that is dedicated to your tenant and points to the Teleport Proxy
 Service. 
 
-The following management tasks are handled for you:
+Our Teleport Cloud team handles the following tasks for you:
 
 - Auth and Proxy Service upgrades, security patches, scaling, monitoring,
   maintenance, and network configuration
 - Auth Service backend management
+- Backup and restore of cluster data
+- Storage of audit logs and session recordings
 - DNS record management
 
 A Teleport Cloud account takes minutes to set up. After that, you can define

--- a/docs/pages/cloud/introduction.mdx
+++ b/docs/pages/cloud/introduction.mdx
@@ -1,36 +1,60 @@
 ---
-title: Cloud
-description: Teleport as a service
-h1: Teleport cloud
+title: Teleport Cloud
+description: Teleport Cloud is a fully managed deployment of Teleport.
 videoBanner: 1jhKOtBinm4
 ---
 
-Teleport Cloud is a fully managed deployment of Teleport Enterprise.
+Teleport Cloud is a fully managed deployment of the Teleport Auth Service and
+Proxy Service. 
 
-We host the Teleport Auth Service and Proxy Service and take care of upgrades,
-and you connect your Nodes, web applications, Kubernetes clusters, databases,
-and Windows desktops.
+When you [sign up for a Teleport Cloud account](https://goteleport.com/signup/), you will receive a subdomain of
+`teleport.sh` that is dedicated to your tenant and points to the Teleport Proxy
+Service. 
 
-Visit our [sign up page](https://goteleport.com/signup/) to begin a free trial.
+The following management tasks are handled for you:
+
+- Auth and Proxy Service upgrades, security patches, scaling, monitoring,
+  maintenance, and network configuration
+- Auth Service backend management
+- DNS record management
+- Certificate authority rotation
+
+A Teleport Cloud account takes minutes to set up. After that, you can define
+roles, register SSO providers, and start connecting all of your infrastructure,
+including servers, databases, Kubernetes clusters, applications, Windows
+desktops, and service accounts.
+
+## Next steps
 
 <TileSet>
+<Tile icon="cloud" title="Sign up" href="https://goteleport.com/signup/">
 
-  <Tile icon="cloud" title="Getting Started" href="./getting-started.mdx/?scope=cloud">
-    Follow this guide to access your first server via Teleport Cloud.
-  </Tile>
-  <Tile icon="cloud" title="Architecture" href="./architecture.mdx/">
-    Security, availability, and networking information.
-  </Tile>
-  <Tile icon="cloud" title="Downloads" href="./downloads.mdx/">
-    How to download agent and client binaries for your Teleport Cloud deployment.
-  </Tile>
-  <Tile icon="cloud" title="FAQ" href="./faq.mdx/">
-    Get answers to frequently asked questions about Teleport Cloud.
-  </Tile>
+Sign up for a free trial of Teleport Cloud
 
+</Tile>
+<Tile icon="cloud" title="Get started" href="./getting-started.mdx/?scope=cloud">
+
+Start using your Teleport Cloud account
+
+</Tile>
+<Tile icon="cloud" title="Download Teleport" href="./downloads.mdx">
+
+Download Teleport binaries for your agents and clients
+
+</Tile>
 </TileSet>
 
-## Next Steps
+## Learn more
 
-- Join the [Teleport Discussons](https://github.com/gravitational/teleport/discussions) and ask a question.
-- Join the [Slack channel](https://goteleport.com/slack).
+<TileSet>
+<Tile icon="cloud" title="Architecture" href="./architecture.mdx">
+
+Learn more about how Teleport Cloud works
+
+</Tile>
+<Tile icon="cloud" title="FAQ" href="./faq.mdx">
+
+Get answers to frequently asked questions about Teleport Cloud
+
+</Tile>
+</TileSet>


### PR DESCRIPTION
Fixes #11226

- Include more detail about what Teleport Cloud encompasses
- Explain the benefits of Teleport Cloud
- Add Tiles to link to all pages in the /docs/cloud section