### PR TITLE
[v8] Replace title-less Details boxes with ScopedBlocks

### DIFF
--- a/docs/pages/includes/plugins/rbac.mdx
+++ b/docs/pages/includes/plugins/rbac.mdx
@@ -4,8 +4,7 @@ Using an existing Teleport cluster, create the following `user` and `role` resou
 $ tctl create -f YAML_PATH.yaml
 ```
 
-<Details opened={true} 
-  scopeOnly={true}
+<ScopedBlock
   scope={["cloud"]}
 >
 Teleport Cloud requires authenticating with a role that has [`impersonation`](https://goteleport.com/docs/access-controls/guides/impersonation/) rights and can create the `access-plugin` role and user. Log in with `tsh` with a user that has this role or has a role with these `allow` rules.
@@ -29,7 +28,7 @@ spec:
         verbs: ['create','update','read','list','delete']
 
 ```
-</Details>
+</ScopedBlock>
 
 
 Create a non-interactive bot user and role called `access-plugin`.


### PR DESCRIPTION
Backports #12358

We will be adding a linter rule that prohibits Details boxes that lack
titles, letting us implement the ability to link directly to a Details
box. In some places in the docs, Details boxes are used purely to
adjust the visibility of Markdown based on scope. Now that we have a
ScopedBlock component, we can use this instead.