### PR TITLE
(v9) Add JWT auth guide for ElasticSearch

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -239,16 +239,12 @@
           "slug": "/application-access/getting-started/"
         },
         {
-          "title": "Guides",
+          "title": "Access Guides",
           "slug": "/application-access/guides/",
           "entries": [
             {
               "title": "Connecting Apps",
               "slug": "/application-access/guides/connecting-apps/"
-            },
-            {
-              "title": "Integrating with JWT",
-              "slug": "/application-access/guides/jwt/"
             },
             {
               "title": "API Access",
@@ -261,6 +257,20 @@
             {
               "title": "Dynamic Registration",
               "slug": "/application-access/guides/dynamic-registration/"
+            }
+          ]
+        },
+        {
+          "title": "JWT Guides",
+          "slug": "/application-access/jwt/",
+          "entries": [
+            {
+              "title": "Introduction",
+              "slug": "/application-access/jwt/introduction/"
+            },
+            {
+              "title": "ElasticSearch",
+              "slug": "/application-access/jwt/elasticsearch/"
             }
           ]
         },
@@ -1174,6 +1184,11 @@
     {
       "source": "/cluster/",
       "destination": "/kubernetes-access/guides/multiple-clusters/",
+      "permanent": true
+    },
+    {
+      "source": "/application-access/guides/jwt/",
+      "destination": "/application-access/jwt/",
       "permanent": true
     }
   ]

--- a/docs/pages/application-access/controls.mdx
+++ b/docs/pages/application-access/controls.mdx
@@ -73,7 +73,7 @@ allow:
 
 - View access controls [Getting Started](../access-controls/getting-started.mdx)
   and other available [guides](../access-controls/guides.mdx).
-- Learn about using [JWT tokens](./guides/jwt.mdx) to implement access controls
+- Learn about using [JWT tokens](./jwt/introduction.mdx) to implement access controls
   in your application.
 - Integrate with your identity provider:
   - [OIDC](../enterprise/sso/oidc.mdx)

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -122,7 +122,7 @@ Alternatively, log in to the Teleport Web Interface at `https://teleport.example
 Dive deeper into the topics relevant to your Application Access use-case:
 
 - Learn in more detail about [connecting applications](./guides/connecting-apps.mdx) with Application Access.
-- Learn about integrating with [JWT tokens](./guides/jwt.mdx) for auth.
+- Learn about integrating with [JWT tokens](./jwt/introduction.mdx) for auth.
 - Learn how to use Application Access with [RESTful APIs](./guides/api-access.mdx).
 - See full configuration and CLI [reference](./reference.mdx).
 - Read about how Let's Encrypt uses the [ACME protocol](https://letsencrypt.org/how-it-works/).

--- a/docs/pages/application-access/guides.mdx
+++ b/docs/pages/application-access/guides.mdx
@@ -4,12 +4,11 @@ description: Guides for configuring Teleport Application Access.
 layout: tocless-doc
 ---
 
+These guides explain basic Teleport Application Access usage.
+
 <TileSet>
   <Tile icon="window" title="Connecting Applications" href="./guides/connecting-apps.mdx">
     How to use Teleport for Application Access.
-  </Tile>
-  <Tile icon="window" title="JWT Tokens" href="./guides/jwt.mdx">
-    How to use JWT tokens with Teleport Application Access for app authentication.
   </Tile>
   <Tile icon="window" title="API Access" href="./guides/api-access.mdx">
     How to access REST APIs with Teleport Application Access.

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -290,7 +290,7 @@ of the user's external `env` trait coming from the identity provider.
 
 Additionally, the `{{internal.jwt}}` template variable will be replaced with
 a JWT token signed by Teleport that contains user identity information. See
-[Integrating with JWTs](./jwt.mdx) for more details.
+[Integrating with JWTs](../jwt/introduction.mdx) for more details.
 
 ## View applications in Teleport
 

--- a/docs/pages/application-access/introduction.mdx
+++ b/docs/pages/application-access/introduction.mdx
@@ -39,16 +39,15 @@ internal dashboards and applications, such as:
 
 Get started with Application Access in a 10 minute [guide](./getting-started.mdx).
 
-## Guides
+## Access guides
+
+These guides explain basic Teleport Application Access usage.
 
 <TileSet>
   <Tile icon="window" title="Connecting Applications" href="./guides/connecting-apps.mdx">
     How to use Teleport for Application Access.
   </Tile>
-  <Tile icon="window" title="JWT Tokens" href="./guides/jwt.mdx">
-    How to use JWT tokens with Teleport Application Access for app authentication.
-  </Tile>
-    <Tile icon="window" title="API Access" href="./guides/api-access.mdx">
+  <Tile icon="window" title="API Access" href="./guides/api-access.mdx">
     How to access REST APIs with Teleport Application Access.
   </Tile>
   <Tile icon="cloud" title="AWS Console Access" href="./guides/aws-console.mdx">
@@ -59,6 +58,21 @@ Get started with Application Access in a 10 minute [guide](./getting-started.mdx
   </Tile>
     <Tile icon="window" title="Interactive Lab" href="https://play.instruqt.com/teleport/invite/rgvuva4gzkon">
     Try Teleport using our guided Teleport Application Access lab.
+  </Tile>
+</TileSet>
+
+## JWT guides
+
+These guides explain how web apps behind Teleport Application Access can
+leverage Teleport-signed JWT tokens to implement authentication and
+authorization.
+
+<TileSet>
+  <Tile icon="window" title="Introduction" href="./jwt/introduction.mdx">
+    Introduction to JWT tokens with Application Access.
+  </Tile>
+  <Tile icon="window" title="Elasticsearch" href="./jwt/elasticsearch.mdx">
+    How to use JWT authentication with Elasticsearch.
   </Tile>
 </TileSet>
 

--- a/docs/pages/application-access/jwt.mdx
+++ b/docs/pages/application-access/jwt.mdx
@@ -1,0 +1,18 @@
+---
+title: Application Access JWT Authentication
+description: Guides for using Teleport Application Access JWT authentication.
+layout: tocless-doc
+---
+
+These guides explain how web apps behind Teleport Application Access can
+leverage Teleport-signed JWT tokens to implement authentication and
+authorization.
+
+<TileSet>
+  <Tile icon="window" title="Introduction" href="./jwt/introduction.mdx">
+    Introduction to JWT tokens with Application Access.
+  </Tile>
+  <Tile icon="window" title="Elasticsearch" href="./jwt/elasticsearch.mdx">
+    How to use JWT authentication with Elasticsearch.
+  </Tile>
+</TileSet>

--- a/docs/pages/application-access/jwt/elasticsearch.mdx
+++ b/docs/pages/application-access/jwt/elasticsearch.mdx
@@ -1,0 +1,114 @@
+---
+title: Using JWT authentication with Elasticsearch
+description: How to use JWT authentication with Elasticsearch
+---
+
+This guide will help you configure Elasticsearch [JWT authentication](https://www.elastic.co/guide/en/elasticsearch/reference/current/jwt-realm.html)
+with Teleport Application Access.
+
+<Details title="Version warning" opened={true}>
+  Elasticsearch supports JWT authentication starting from version `8.2.0`.
+</Details>
+
+## Prerequisites
+
+- Teleport cluster version >= `9.3` with running Auth/Proxy Services or Teleport Cloud account.
+- Running [Application Service](../guides/connecting-apps.mdx).
+- Elasticsearch cluster version >= `8.2.0`.
+
+## Step 1/3. Enable a JWT realm in Elasticsearch
+
+Update your Elasticsearch configuration file, `elasticsearch.yaml`, to enable a
+JWT realm:
+
+```yaml
+xpack.security.authc.realms.jwt.jwt1:
+  order: 1
+  client_authentication.type: none
+  pkc_jwkset_path: https://proxy.example.com/.well-known/jwks.json
+  claims.principal: sub
+  claims.groups: roles
+  allowed_issuer: example-cluster
+  allowed_audiences: ["https://elasticsearch.example.com:9200"]
+```
+
+Let's take a closer look at the parameters and their values:
+
+- Set `client_authentication.type` to `none`, otherwise Elasticsearch requires
+  clients to send a shared secret value with each request.
+- Set `pkc_jwkset_path` to the JWT key set file URL of your Teleport Proxy. It
+  is available at `https://<proxy>/.well-known/jwks.json` endpoint. You can
+  also download the JSON file from the same URL and point the path directly to
+  it instead of using a URL.
+- Set `claims.principal` and `claims.groups` to `sub` and `roles` respectively.
+  These are the claims Teleport uses to pass user and role information in JWT
+  tokens. Keep in mind that **users and roles must exist** in Elasticsearch.
+- Set `allowed_issuer` to the name of your Teleport cluster.
+- Set `allowed_audiences` to the URL which Teleport Application Service will
+  use to connect to Elasticsearch.
+
+<Admonition title="Elasticsearch role mapping" type="note">
+  Note that when using JWT authentication, you cannot map user roles using the
+  standard Elasticsearch `role_mapping.yml` file. Instead, you need to set the
+  role mapping using the API. See [JWT realm authorization](https://www.elastic.co/guide/en/elasticsearch/reference/current/jwt-realm.html#jwt-authorization)
+  for details.
+</Admonition>
+
+## Step 2/3. Register an Elasticsearch application in Teleport
+
+In your Teleport App Service configuration file, `teleport.yaml`, register an
+entry for Elasticsearch:
+
+```yaml
+app_service:
+  enabled: "yes"
+  apps:
+  - name: "elastic"
+    uri: https://elasticsearch.example.com:9200
+    rewrite:
+      headers:
+      - "Authorization: Bearer {{internal.jwt}}"
+```
+
+<Admonition type="tip">
+  You can also use [dynamic registration](../guides/dynamic-registration.mdx).
+</Admonition>
+
+Elasticsearch requires a JWT token to be passed inside the `Authorization`
+header. The header rewrite configuration above will replace the `{{internal.jwt}}`
+template variable with a Teleport-signed JWT token in each request.
+
+## Step 3/3. Connect to the ElasticSearch API
+
+Log into your Teleport cluster with `tsh login` and make sure your Elasticsearch
+application is available:
+
+```code
+$ tsh app ls
+Application Description   Public Address               Labels
+----------- ------------- ---------------------------- -------------------------------
+elastic                   elastic.teleport.example.com
+```
+
+Fetch a short-lived X.509 certificate for Elasticsearch:
+
+```code
+$ tsh app login elastic
+```
+
+Then you can use the `curl` command to communicate with the Elasticsearch API,
+which will authenticate you as your Teleport user:
+
+```code
+$ curl \
+  --cacert ~/.tsh/keys/teleport.example.com/cas/root.pem \
+  --cert ~/.tsh/keys/teleport.example.com/alice-app/example-cluster/elastic-x509.pem \
+  --key ~/.tsh/keys/teleport.example.com/alice \
+  https://elastic.teleport.example.com/_security/user | jq
+```
+
+## Next steps
+
+- Get more information about integrating with [Teleport JWT tokens](./introduction.mdx).
+- Learn more about [accessing APIs](../guides/api-access.mdx) with Application Access.
+- Take a look at [Access Controls](../controls.mdx) with Application Access.

--- a/docs/pages/application-access/jwt/introduction.mdx
+++ b/docs/pages/application-access/jwt/introduction.mdx
@@ -71,7 +71,7 @@ eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiaHR0cDovLzEyNy4wLjAuMTozNDY3OSJ
 
 ## Inject JWT
 
-You can inject a JWT token into any header using [headers passthrough](./connecting-apps.mdx#headers-passthrough)
+You can inject a JWT token into any header using [headers passthrough](../guides/connecting-apps.mdx#headers-passthrough)
 configuration and the `{{internal.jwt}}` template variable. This variable will
 be replaced with JWT token signed by Teleport JWT CA containing user identity
 information like described above.
@@ -109,3 +109,11 @@ can be trusted. This endpoint is `https://[cluster-name]:3080/.well-known/jwks.j
 
 See the example Go program used to validate Teleport's JWT tokens on our
 [Github](https://github.com/gravitational/teleport/blob/v(=teleport.version=)/examples/jwt/verify-jwt.go).
+
+## Application guides
+
+Many existing web applications and APIs support JWT authentication.
+
+The following guides are currently available showing how to configure it:
+
+- [ElasticSearch](./elasticsearch.mdx)


### PR DESCRIPTION
Following https://github.com/gravitational/teleport/pull/12567, I wanted to add a guide showing how to configure JWT authn with ElasticSearch.

I've factored out JWT into a separate section, will add Grafana to it later as well.