### PR TITLE
[v7] Client timeout fixes

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -48,6 +48,7 @@ func newWebClient(insecure bool, pool *x509.CertPool) *http.Client {
 				InsecureSkipVerify: insecure,
 			},
 		},
+		Timeout: defaults.DefaultDialTimeout,
 	}
 }
 


### PR DESCRIPTION
Backport #12557 to branch/v7

Only the timeout in `webclient` was added, as v7 doesn't have TLS routing. Unlike the `webclient` in `master`, the timeout is unconditionally set to`defaults.DialTimeout`. This will need changes if we end up needing different timeouts in different places.