### PR TITLE
Update Teleport Enterprise information

### DIFF
--- a/docs/pages/enterprise/introduction.mdx
+++ b/docs/pages/enterprise/introduction.mdx
@@ -17,6 +17,8 @@ The table below gives a quick overview of the benefits of Teleport Enterprise.
 | [Single Sign-On (SSO)](#sso) | Allows Teleport to integrate with existing enterprise identity systems. Examples include Active Directory, GitHub, Google Apps and numerous identity middleware solutions like Auth0, Okta, and so on. Teleport supports SAML and OAuth/OpenID Connect protocols to interact with them. |
 | [Access Requests](workflow/index.mdx) | User interface for teams to create and review requests to access infrastructure with escalated privileges. |
 | [FedRAMP/FIPS](#fedrampfips) | Access controls to meet the requirements in a FedRAMP System Security Plan (SSP). This includes a FIPS 140-2 friendly build of Teleport Enterprise as well as a variety of improvements to aid in complying with security controls even in FedRAMP High environments. |
+| [Hardware Security Module support](./hsm.mdx)|The Teleport Auth Service can use your organization's HSM to generate TLS credentials, ensuring a highly reliable and secure public key infrastructure.|
+| [Moderated Sessions](../access-controls/guides/moderated-sessions.mdx)|Allow or require moderators to be present in SSH or Kubernetes sessions.|
 | Commercial Support | Support SLA with guaranteed response times. |
 
 <Admonition
@@ -81,6 +83,29 @@ See our [FedRAMP for SSH and Kubernetes](fedramp.mdx) guide for more infromation
 With Teleport we've introduced the ability for users to request additional roles. The Access Request API makes it easy to dynamically approve or deny these requests.
 
 See [Access Requests Guide for more information](workflow/index.mdx)
+
+## Hardware Security Module support
+
+Teleport relies on a TLS private key and certificate in order to encrypt traffic
+and authenticate clients. With Teleport Enterprise, you can configure Teleport
+to use TLS credentials based on your organization's Hardware Security Module,
+improving the security and reliability of Teleport's public key infrastructure.
+
+See [HSM Support](./hsm.mdx) for more information.
+
+## Moderated Sessions
+
+Moderated Sessions are SSH or Kubernetes sessions that certain Teleport users
+can participate in, observe, or terminate at will. 
+
+Teleport administrators can configure a role so that, when a user with the role
+starts a session, another user *must* join the session, satisfying your
+organization's security requirements.
+
+It is also possible to configure a role to *allow* another user to join a
+session, which is useful for teams that need to collaborate at the terminal.
+
+See [Moderated Sessions](../access-controls/guides/moderated-sessions.mdx) for more information.
 
 ## License file
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -1,47 +1,42 @@
 ---
 title: Teleport FAQ
-description: Frequently asked questions about using Teleport
-h1: FAQ
+description: Frequently Asked Questions About Using Teleport
+h1: Teleport FAQ
 ---
 
-## Community FAQ
+## Can I use Teleport in production today?
 
-### Can I use Teleport in production today?
-
-Teleport has been deployed on server clusters with thousands of nodes at
+Teleport has been deployed on server clusters with thousands of hosts at
 Fortune 500 companies. It has been through several security audits from
 nationally recognized technology security companies, so we are comfortable with
 the stability of Teleport from a security perspective.
 
-### Can Teleport be deployed in agentless mode?
+## Can Teleport be deployed in agentless mode?
 
 Yes. Teleport can be deployed with a tiny footprint as an authentication
-gateway/proxy and you can keep your existing SSH servers on the nodes. But some
-innovating Teleport features, such as cluster introspection, will not be
-available unless the Teleport SSH daemon is present on all cluster nodes.
+gateway/proxy and you can keep your existing SSH servers on Teleport Nodes. But
+some innovating Teleport features, such as cluster introspection, will not be
+available unless the Teleport SSH daemon is present on all cluster Nodes.
 
-### Can I use OpenSSH with a Teleport cluster?
+## Can I use OpenSSH with a Teleport cluster?
 
 Yes, this question comes up often and is related to the previous one. Take a
 look at [Using OpenSSH Guide](./server-access/guides/openssh.mdx).
 
-### Can I connect to nodes behind a firewall?
+## Can I connect to Nodes behind a firewall?
 
 Yes, Teleport supports reverse SSH tunnels out of the box. To configure
-behind-firewall clusters refer to [Trusted Clusters](./setup/admin/trustedclusters.mdx)
-section of the Admin Manual.
+behind-firewall clusters refer to our
+[Trusted Clusters](./setup/admin/trustedclusters.mdx) guide.
 
-### Can individual nodes create reverse tunnels to a proxy server without creating a new cluster?
+## Can individual agents create reverse tunnels to the Proxy Service without creating a new cluster?
 
-This was a popular customer
-[request](https://github.com/gravitational/teleport/issues/803) that was added
-in Teleport version 4.0. Change the node config option `--auth-server` flag when
-running the `teleport` daemon on an agent to point to the Proxy Service address
-(this would be `public_addr` and `web_listen_addr` in file configuration). For
-more information, see
+Yes. When running a Teleport agent, use the `--auth-server` flag to point to the
+Proxy Service address (this would be `public_addr` and `web_listen_addr` in your
+file configuration). For more information, see
 [Adding Nodes to the Cluster](./setup/admin/adding-nodes.mdx).
 
-### Can nodes use a single port for reverse tunnels?
+## Can Nodes use a single port for reverse tunnels?
 
 Yes, Teleport supports tunnel multiplexing on a single port. Set the
 `tunnel_listen_addr` to use the same port as the `web_listen_addr` address
@@ -50,99 +45,35 @@ multiplexing with that configuration.
 
 ## How is Open Source different from Enterprise?
 
-Open Source Teleport is licensed under the Apache 2 License, and must be
-self-hosted. Enterprise Teleport is commercially licensed and is available in
-both self-hosted and cloud deployments.
+Teleport provides three offerings:
 
-<table>
-  <thead>
-    <tr>
-      <th>Capability/Offering</th>
-      <th>Open Source</th>
-      <th>Enterprise</th>
-    </tr>
-  </thead>
+- Open Source
+- Enterprise
+- Cloud
 
-  <tbody>
-    <tr>
-      <td>License</td>
-      <td>Apache 2</td>
-      <td>Commercial</td>
-    </tr>
-    <tr>
-      <td>Role-Based Access Control</td>
-      <td>&#10004;</td>
-      <td>&#10004;</td>
-    </tr>
-    <tr>
-      <td>Cloud-hosted</td>
-      <td>&#10006;</td>
-      <td>&#10004;</td>
-    </tr>
-    <tr>
-      <td>Self-hosted</td>
-      <td>&#10004;</td>
-      <td>&#10004;</td>
-    </tr>
-    <tr>
-      <td>Single Sign-On</td>
-      <td>GitHub only</td>
-      <td>GitHub, Google, OIDC, SAML</td>
-    </tr>
-    <tr>
-      <td>Access Requests</td>
-      <td>Limited</td>
-      <td>&#10004; [Dual authorization, mandatory requests](./access-controls/guides/dual-authz.mdx)</td>
-    </tr>
-    <tr>
-      <td>FedRAMP Control</td>
-      <td>&#10006;</td>
-      <td>[Compiled with FIPS-certified crypto libraries, FedRAMP control features](./enterprise/fedramp.mdx)</td>
-    </tr>
-    <tr>
-      <td>PCI DSS Features</td>
-      <td>Limited</td>
-      <td>&#10004;</td>
-    </tr>
-    <tr>
-      <td>SOC2 Features</td>
-      <td>Limited</td>
-      <td>&#10004;</td>
-    </tr>
-    <tr>
-      <td>Annual or Multi-Year contracts, Volume Discounts</td>
-      <td>&#10006;</td>
-      <td>&#10004;</td>
-    </tr>
-    <tr>
-      <td>Support</td>
-      <td>Best-effort, community</td>
-      <td>24x7 support with premium SLAs & account managers</td>
-    </tr>
-  </tbody>
-</table>
+||Open Source|Enterprise|Cloud|
+|---|---|---|---|
+|Auth and Proxy Service management|Self-hosted|Self-hosted|Fully managed|
+|License|Apache 2|Commercial|Commercial|
+|Role-Based Access Control|&#10004;|&#10004;|&#10004;|
+|Single Sign-On|GitHub|GitHub, Google Workspace, OIDC, SAML|GitHub, Google Workspace, OIDC, SAML|
+|[Access Requests](./access-controls/guides/dual-authz.mdx)|Limited|&#10004;|&#10004;|
+|[FedRAMP Control](./enterprise/fedramp.mdx)|&#10006;|&#10004;|&#10006;|
+|PCI DSS Features|Limited|&#10004;|&#10004;|&#10004;|
+|SOC2 Features|Limited|&#10004;|&#10004;|
+|Annual or multi-year contracts, volume discounts|&#10006;|&#10004;|&#10004;|
+|Support|Best-effort, community|24x7 support with premium SLAs and account managers|24x7 support with premium SLAs and account managers|
+|[Hardware Security Module support](./enterprise/hsm.mdx)|&#10006;|&#10004;|&#10006;|
+|[Moderated Sessions](./access-controls/guides/moderated-sessions.mdx)|&#10006;|&#10004;|&#10004;|
 
 ## Which version of Teleport is supported?
 
 Teleport provides security-critical support for the current and two previous releases. With our typical release cadence, this means a release is usually supported for 9 months.
 
-| Release | Long Term Support | Release Date | Min tsh version |
-| - | - | - | - |
-| 6.2 | No | May 21th, 2021 | 3.0.0 |
-| 6.1 | No | April 9th, 2021 | 3.0.0|
-| 6 | Yes | March 4th, 2021 | 3.0.0 |
-| 5.0 | Yes | November 24th, 2020 | 3.0.0 |
-| 4.4 | Yes | October 20th, 2020 | 3.0.0 |
-| 4.3 (EOL) | Yes | July 8th, 2020 | 3.0.0 |
-| 4.2 (EOL) | Yes | December 19th, 2019 | 3.0.0 |
+See our [Upgrading](./setup/operations/upgrading.mdx) guide for more
+information.
 
-
-**How should I upgrade my cluster?**
-
-Please follow our guidelines for [upgrading](./setup/admin/graceful-restarts.mdx).
-We recommend that the Auth Server should be upgraded first, and the proxy bumped thereafter.
-
-### Does Web UI support copy and paste?
+## Does the Web UI support copy and paste?
 
 Yes. You can copy and paste using a mouse. If you prefer a keyboard, Teleport employs
 `tmux`-like "prefix" mode. To enter prefix mode, use the `Ctrl`+`A` keyboard shortcut.
@@ -154,26 +85,29 @@ mode by pressing `[`. When in text selection mode:
 - Select text by toggling `space`.
 - And, copy it via `Ctrl`+`C`.
 
-### What TCP ports does Teleport use?
+## What TCP ports does Teleport use?
 
-Please refer to the [Ports](./setup/reference/networking.mdx) section of the Admin Manual.
+Please refer to our [Networking](./setup/reference/networking.mdx) guide.
 
-### Does Teleport support authentication via OAuth, SAML, or Active Directory?
+## Does Teleport support authentication via OAuth, SAML, or Active Directory?
 
 Teleport offers this feature for the [Enterprise versions of Teleport](enterprise/introduction.mdx).
 
-### Does Teleport send any data back to the cloud?
+## Does Teleport send any data back to the cloud?
 
-The Open-Source Edition of Teleport does not send any information to
-Gravitational and can be used on servers without internet access. The
-commercial versions of Teleport may or may not be configured to send anonymized information to Gravitational, depending on the license purchased. This information contains the following:
+The open source and Enterprise editions of Teleport do not send any information
+to our company, and can be used on servers without internet access. 
+
+The commercial editions of Teleport can optionally be configured to send
+anonymized information, depending on the license purchased. This information
+contains the following:
 
 - Anonymized user ID: SHA256 hash of a username with a randomly generated prefix.
 - Anonymized server ID: SHA256 hash of a server IP with a randomly generated prefix.
 
-This allows Teleport to print a warning if users are exceeding the usage limits
-of their license. The reporting library code is
+This allows Teleport Cloud and Teleport Enterprise to print a warning if users
+are exceeding the usage limits of their license. The reporting library code is
 [on GitHub](https://github.com/gravitational/reporting).
 
 Reach out to `sales@goteleport.com` if you have questions about the commercial
-edition of Teleport.
+editions of Teleport.


### PR DESCRIPTION
Fixes #12582

Some of our Enterpise information is out of date.

Teleport Enterprise introduction:

- Add information on HSM support and Moderated Sessions

Teleport FAQ:

- Update the edition comparison table.
- Promote each question to an H2 header, allowing it to appear in the
  table of contents sidebar.
- Update some outdated terms.
- Convert the edition comparison table from HTMl to Markdown for ease
  of reading.
- Remove the version support table since it is long out of date.