### PR TITLE
[v8] Make the Linux Server guide more usable

### DIFF
--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -5,7 +5,8 @@ videoBanner: jvaCmQyHghY
 ---
 
 This tutorial will guide you through the steps needed to install and run
-Teleport (=teleport.version=) on Linux machines.
+Teleport (=teleport.version=) on a Linux machine, then show you how to use
+Teleport to configure access to resources.
 
 <Details scopeOnly={true} scope={["cloud"]} title="Teleport Cloud">
 This guide deploys the Teleport Auth Service and Proxy Service, which are fully managed in Teleport Cloud. If you are a Teleport Cloud customer, we recommend following our guides for deploying specific services on your Teleport Nodes. Here are some examples:
@@ -15,29 +16,57 @@ This guide deploys the Teleport Auth Service and Proxy Service, which are fully 
 - [Server Access](../server-access/getting-started.mdx)
 </Details>
 
-## Prerequisites
+We will run the following Teleport services:
 
-- A Linux machine with a port `443` open
-- A two-factor authenticator app such as [Authy](https://authy.com/download/), [Google Authenticator](https://www.google.com/landing/2step/), or [Microsoft Authenticator](https://www.microsoft.com/en-us/account/authenticator)
-- An SSH client like OpenSSH
-- Access to a DNS service such as Amazon Route 53 or CoreDNS
-
-<Admonition title="Local-only setups" type="tip">
-If you would like to try out Teleport on your local machine—e.g., you do not have access to a DNS server or internal public key infrastructure—we recommend following our [Docker Compose guide](./docker-compose.mdx).
-</Admonition>
-
-## Step 1/4. Install Teleport on a Linux host
-
-Run the following commands to install the Teleport binary on your system:
-
-(!docs/pages/includes/install-linux.mdx!)
-
-Take a look at the [Installation Guide](../installation.mdx) for more options.
+- **Teleport Auth Service:** The certificate authority for your cluster. It
+  issues certificates and conducts authentication challenges. The Auth Service
+  is typically inaccessible outside your private network.
+- **Teleport Proxy Service:** The cluster frontend, which handles user requests,
+  forwards user credentials to the Auth Service, and communicates with Teleport
+  instances that enable access to specific resources in your infrastructure.
+- **Teleport Application Service:** Enables secure access to web applications in
+  private networks. In this tutorial, we will use Teleport to access a simple
+  web service.
+- **Teleport SSH Service:** An SSH server implementation that takes advantage of
+  Teleport's short-lived certificates, sophisticated RBAC, session recording,
+  and other features.
 
 (!docs/pages/includes/permission-warning.mdx!)
 
-### Configure DNS
-Teleport uses TLS to provide secure access to its Proxy Service and Auth Service, and this requires a domain name that clients can use to verify Teleport's certificate.
+## Prerequisites
+
+- A Linux machine with only port `443` open to ingress traffic. You must be able
+  to install and run software on the machine. Either configure access to your
+  machine via SSH for the initial setup (and open an SSH port in addition port
+  `443`) or enter the commands in this guide into an Amazon EC2
+  [user data script](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html),
+  Google Compute Engine
+  [startup script](https://cloud.google.com/compute/docs/instances/startup-scripts),
+  or similar.
+- A two-factor authenticator app such as [Authy](https://authy.com/download/), [Google Authenticator](https://www.google.com/landing/2step/), or [Microsoft Authenticator](https://www.microsoft.com/en-us/account/authenticator)
+- `python3` installed on your Linux machine. We will use this to run a simple
+  HTTP file server, so you can use another HTTP server if you have one
+  installed.
+
+You must also have one of the following:
+- A registered domain name.
+- An authoritative DNS nameserver managed by your organization, plus an existing
+  certificate authority. If using this approach, ensure that your browser is
+  configured to use your organization's nameserver.
+
+<Admonition title="Local-only setups" type="tip">
+
+If you would like to try out Teleport on your local machine—e.g., you do not
+have access to DNS resources or internal public key infrastructure—we recommend
+following our [Docker Compose guide](./docker-compose.mdx).
+
+</Admonition>
+
+## Step 1/6. Configure DNS
+
+Teleport uses TLS to provide secure access to its Proxy Service and Auth
+Service, and this requires a domain name that clients can use to verify
+Teleport's certificate.
 
 Teleport uses TLS to provide secure access to its Proxy Service and Auth Service, and this requires a domain name that clients can use to verify Teleport's certificate. To get started, set up two `A` records for `tele.example.com` and `*.tele.example.com` pointing to the IP/FQDN of the machine with Teleport installed.
 
@@ -52,9 +81,55 @@ Teleport uses TLS to provide secure access to its Proxy Service and Auth Service
   ```
 </Admonition>
 
+## Step 2/6. Run a simple web service
+
+Create a directory on your Linux machine called `demo-app` and run the following
+command:
+
+```code
+$ cat<<EOF>>demo-app/index.html
+<!DOCTYPE html>
+<html><head><title>Welcome!</title><head>
+<body>
+<h1>Welcome to your Teleport cluster!</h1>
+</body>
+</html>
+EOF
+```
+
+Run a simple HTTP service on port 9000 that returns your welcome page:
+
+```code
+$ nohup python3 -m http.server 9000 --directory demo-app &
+```
+
+Since port 9000 is not open on your Linux host, there is currently no way to
+access the web service from your local machine. We will configure Teleport to
+enable you to access the web service securely.
+
+## Step 3/6. Set up Teleport on your Linux host
+
+### Install Teleport
+
+Run the appropriate commands for your environment to install the Teleport binary
+on your Linux host:
+
+(!docs/pages/includes/install-linux.mdx!)
+
+<Details title="Don't see your system here?" opened={false}>
+
+Take a look at the [Installation Guide](../installation.mdx) for more options.
+
+</Details>
+
 ### Configure Teleport
 
-Next, generate a configuration file for Teleport using the `teleport configure` command. This command requires information about a TLS certificate and private key. If your environment allows your Teleport Auth Server to be reachable via the public internet, we recommend using Let's Encrypt to generate your key and certificate automatically. Otherwise, you can use a key and certificate provided via your organization's internal public key infrastructure.
+Generate a configuration file for Teleport using the `teleport configure` command.
+This command requires information about a TLS certificate and private key.
+
+If you are running Teleport on the internet, we recommend using Let's Encrypt to
+receive your key and certificate automatically. For private networks or custom
+deployments, use your own private key and certificate.
 
 <Tabs>
   <TabItem label="Public internet deployment with Let's Encrypt">
@@ -62,7 +137,7 @@ Next, generate a configuration file for Teleport using the `teleport configure` 
 
   </TabItem>
 
-  <TabItem label="Private net deployment">
+  <TabItem label="Private network deployment">
   On your Teleport host, place a valid private key and a certificate chain in `/var/lib/teleport/privkey.pem`
   and `/var/lib/teleport/fullchain.pem` respectively.
 
@@ -81,11 +156,27 @@ Next, generate a configuration file for Teleport using the `teleport configure` 
 
 </Tabs>
 
+Next, configure Teleport to provide secure access to your web service. Edit your
+Teleport configuration file (`/etc/teleport.yaml`) to include the following,
+replacing `teleport.example.com` with the domain name of your Teleport cluster.
+
+```yaml
+app_service:
+    enabled: yes
+    apps:
+    - name: "demo"
+      uri: "http://localhost:9000"
+      public_addr: "demo.teleport.example.com"
+```
 
 ## Start Teleport
 
+On your Linux machine, run the following command to start the `teleport` daemon
+(this depends on how you installed Telport earlier).
+
 <Tabs>
   <TabItem label="Package manager RPM/DEB">
+
     ```code
     $ sudo systemctl start teleport
     ```
@@ -98,36 +189,67 @@ Next, generate a configuration file for Teleport using the `teleport configure` 
   </TabItem>
 </Tabs>
 
-You can access Teleport's Web UI via HTTPS at the domain you created earlier.
+You can access Teleport's Web UI via HTTPS at the domain you created earlier
+(e.g., `https://teleport.example.com`). You should see a welcome screen similar
+to the following:
 
-## Step 2/4. Create a Teleport user and set up two-factor authentication
+![Teleport User Registration](../../img/quickstart/login.png)
 
-In this example, we'll create a new Teleport user `teleport-admin`, which is allowed to log into
-SSH hosts as any of the principals `root`, `ubuntu`, or `ec2-user`.
+## Step 4/6. Create a Teleport user and set up two-factor authentication
+
+In this step, we'll create a new Teleport user, `teleport-admin`, which is
+allowed to log into SSH hosts as any of the principals `root`, `ubuntu`, or
+`ec2-user`.
+
+On your Linux machine, run the following command:
 
 ```code
 # tctl is an administrative tool that is used to configure Teleport's auth service.
-$ tctl users add teleport-admin --roles=editor,access --logins=root,ubuntu,ec2-user
+$ sudo tctl users add teleport-admin --roles=editor,access --logins=root,ubuntu,ec2-user
 ```
 
-Teleport will always enforce the use of two-factor authentication by default. It supports One-Time
-Passwords (OTP) and second factor authenticators (WebAuthn). This quick start will use OTP—you'll
-need an OTP-compatible app that can scan a QR code.
+The command prints a message similar to the following:
 
-![Teleport User Registration](../../img/quickstart/login.png)
+```text
+User "teleport-admin" has been created but requires a password. Share this URL with the user to complete user setup, link is valid for 1h:
+https://teleport.example.com:443/web/invite/123abc456def789ghi123abc456def78
+
+NOTE: Make sure teleport.example.com:443 points at a Teleport proxy which users can access.
+```
+
+Visit the provided URL in order to create your Teleport user.
 
 <Admonition
   type="tip"
   title="OS User Mappings"
 >
-  The OS users that you specify (`root`, `ubuntu` and `ec2-user` in our examples) must exist!
-  On Linux, if a user does not already exist, you can create it with `adduser <login>`. If you
-  do not have the permission to create new users on the Linux host, run `tctl users add teleport $(whoami)` to explicitly allow Teleport to authenticate as the user that you have currently logged in as. If you do not map to an existing OS user, you will get authentication errors later on in this tutorial!
+
+  The users that you specify in the `logins` flag (e.g., `root`, `ubuntu` and
+  `ec2-user` in our examples) must exist on your Linux machine. Otherwise, you
+  will get authentication errors later in this tutorial.
+
+  If a user does not already exist, you can create it with `adduser <login>`.
+  
+  If you do not have the permission to create new users on the Linux host, run
+  `tctl users add teleport $(whoami)` to explicitly allow Teleport to
+  authenticate as the user that you have currently logged in as.
+  
 </Admonition>
+
+Teleport enforces the use of two-factor authentication by default. It supports
+one-time passwords (OTP) and second-factor authenticators (WebAuthn). In this
+guide, you will need to enroll an OTP authenticator application using the QR
+code on the Teleport welcome screen.
 
 ![Teleport UI Dashboard](../../img/quickstart/teleport-nodes.png)
 
-### Install a Teleport client locally
+## Step 5/6. Log in using tsh
+
+`tsh` is our client tool. It helps you log in to Teleport clusters and obtain
+short-lived credentials. It can also be used to list resources registered with
+Teleport, such as servers, applications, and Kubernetes clusters.
+
+Install `tsh` on your local machine:
 
 <Tabs>
   <TabItem label="Mac">
@@ -171,135 +293,93 @@ need an OTP-compatible app that can scan a QR code.
   </TabItem>
 </Tabs>
 
-## Step 3/4. Log in using tsh
-
-`tsh` is our client tool. It helps you log into Teleport clusters and obtain short-lived credentials. It can also be used to list servers, applications, and Kubernetes clusters registered with Teleport.
-
 Log in to receive short-lived certificates from Teleport:
 
 ```code
 # Replace teleport.example.com with your Teleport cluster's public address as configured above.
 $ tsh login --proxy=teleport.example.com --user=teleport-admin
+> Profile URL:        https://teleport.example.com:443
+  Logged in as:       teleport-admin
+  Cluster:            teleport.example.com
+  Roles:              access, editor
+  Logins:             root, ubuntu, ec2-user
+  Kubernetes:         enabled
+  Valid until:        2022-04-26 03:04:46 -0400 EDT [valid for 12h0m0s]
+  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-## Step 4/4. Have fun with Teleport!
+## Step 6/6. Access resources
 
-Congrats! You've completed setting up Teleport! Now, feel free to have fun and explore the many features Teleport has to offer.
+Congrats! You've completed setting up Teleport and signed in to your cluster.
+Now you can use Teleport to quickly access resources.
 
-Here are several common commands and operations you'll likely find useful:
+### Visit your demo website
 
-### View Status
+Now that you have logged in to Teleport, you can see the demo website you
+started earlier. Visit `https://demo.teleport.example.com`, replacing
+`teleport.example.com` with the domain name of your Teleport cluster.
+
+You can use the Teleport Application Service to configure access to any web
+application in your private network, including HTTP management endpoints for
+popular infrastructure technologies.
+
+### SSH into your Node
+
+You also configured the Teleport SSH Service, meaning that you can easily access
+your Linux machine after logging in to Teleport.
+
+See the logins you can use to access a Node:
 
 ```code
 $ tsh status
+> Profile URL:        https://teleport.example.com:443
+  Logged in as:       teleport-admin
+  Cluster:            teleport.example.com
+  Roles:              access, editor
+  Logins:             root, ubuntu, ec2-user
+  Kubernetes:         enabled
+  Valid until:        2022-04-26 04:55:59 -0400 EDT [valid for 11h38m0s]
+  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-### SSH into a Node
+List all SSH servers connected to Teleport:
 
 ```code
-# list all SSH servers connected to Teleport
 $ tsh ls
-
-# ssh into `node-name` as `root`
-$ tsh ssh root@node-name
+Node Name        Address        Labels                                
+---------------- -------------- ------------------------------------- 
+mynode 127.0.0.1:3022 env=example,hostname=mynode
 ```
 
-### Add a Node to the cluster
-
-Generate a short-lived dynamic join token using `tctl`:
+SSH into `mynode` as `root`:
 
 ```code
-$ tctl tokens add --type=node
+$ tsh ssh root@mynode
 ```
 
-Bootstrap a new Node:
+## Next steps
 
-<Tabs>
-  <TabItem label="teleport start">
-    Replace `auth_servers` with the hostname and port of your Teleport cluster,
-    `token` with the token you generated above.
+### Add resources
 
-    ```code
-    $ sudo teleport start \
-    --roles=node \
-    --auth-server=https://teleport.example.com:443 \
-    --token=${TOKEN?} \
-    --labels=env=demo
-    ```
-  </TabItem>
+Now that you know how to set up a Teleport cluster, learn how to register all of the
+resources in your infrastructure with Teleport:
 
-  <TabItem label="cloud-config">
-    Replace `auth_servers` with the hostname and port of your Teleport cluster,
-    `auth_token` with the token you generated above.
+- [Applications](../application-access/getting-started.mdx)
+- [Databases](../database-access/getting-started.mdx)
+- [Kubernetes clusters](../kubernetes-access/getting-started.mdx)
+- [Servers](../server-access/getting-started.mdx)
+- [Windows desktops](../desktop-access/getting-started.mdx)
 
-    ```ini
-    #cloud-config
+### Manage your cluster
 
-    package_upgrade: true
+You can also check out our collection of step-by-step guides for common
+Teleport tasks, such as:
 
-    write_files:
-    - path: /etc/teleport.yaml
-        content: |
-            teleport:
-                auth_token: ""
-                auth_servers:
-                    - "https://teleport.example.com:443"
-            auth_service:
-                enabled: false
-            proxy_service:
-                enabled: false
-            ssh_service:
-                enabled: true
-                labels:
-                    env: demo
-
-    runcmd:
-    - 'mkdir -p /tmp/teleport'
-    - 'cd /tmp/teleport && curl -O https://get.gravitational.com/teleport_(=teleport.version=)_amd64.deb'
-    - 'dpkg -i /tmp/teleport/teleport_(=teleport.version=)_amd64.deb'
-    - 'systemctl enable teleport.service'
-    - 'systemctl start teleport.service'
-    ```
-  </TabItem>
-</Tabs>
-
-### Add an application to your Teleport cluster
-
-Generate a short-lived dynamic token to join apps:
-
-```code
-$ tctl tokens add --type=app
-```
-
-Add a new application:
-
-<Tabs>
-  <TabItem label="teleport start">
-    Install Teleport on the target Node, then start it using a command as shown below.
-    Review and update `auth-server`, `token`, `app-name`, and `app-uri` before running this command.
-
-    ```code
-    $ sudo teleport start \
-    --roles=app \
-    --token=${TOKEN?} \
-    --auth-server=teleport.example.com:3080 \
-    --app-name=example-app  \ # Change "example-app" to the name of your application.
-    --app-uri=http://localhost:8080  # Change "http://localhost:8080" to the address of your application.
-    ```
-  </TabItem>
-</Tabs>
-
-## Guides
-
-Check out our collection of step-by-step guides for common Teleport tasks.
-
-- [Install Teleport](../installation.mdx)
-- [Admin Guides](../setup/admin.mdx)
-- [Share Sessions](../server-access/guides/tsh.mdx#sharing-sessions)
-- [Manage Users](../setup/admin/users.mdx)
-- [Github SSO](../setup/admin/github-sso.mdx)
-- [Label Nodes](../setup/admin/labels.mdx)
-- [Teleport with OpenSSH](../server-access/guides/openssh.mdx)
+- [Managing users](../setup/admin/users.mdx)
+- [Setting up single sign-on with GitHub](../setup/admin/github-sso.mdx)
+- [Recording SSH sessions](../server-access/guides/bpf-session-recording.mdx)
+- [Labeling Teleport resources](../setup/admin/labels.mdx)
 
 ## Further reading
+
 - How Let's Encrypt uses the [ACME protocol](https://letsencrypt.org/how-it-works/) to issue certificates

--- a/docs/pages/includes/acme.mdx
+++ b/docs/pages/includes/acme.mdx
@@ -5,12 +5,16 @@ Proxy Service.
 You can configure the Teleport Proxy Service to complete the Let's Encrypt
 verification process when it starts up.
 
-Run the following `teleport configure` command, where `tele.example.com` is the
+On the host where you will start the Teleport Auth Service and Proxy Service,
+run the following `teleport configure` command, where `tele.example.com` is the
 domain name of your Teleport cluster and `user@example.com` is an email address
 used for notifications (you can use any domain):
 
 ```code
-teleport configure --acme --acme-email=user@example.com --cluster-name=tele.example.com > /etc/teleport.yaml
+$ DOMAIN=tele.example.com
+$ EMAIL=user@example.com
+$ teleport configure --acme --acme-email=${EMAIL?} --cluster-name=${DOMAIN?} | \
+ sudo tee /etc/teleport.yaml > /dev/null
 ```
 
 The `--acme`, `--acme-email`, and `--cluster-name` flags will add the following

--- a/docs/pages/includes/permission-warning.mdx
+++ b/docs/pages/includes/permission-warning.mdx
@@ -1,12 +1,21 @@
 <Details title="Before you begin: read security tips" opened={false}>
-  The examples below may include the use of the `sudo` keyword, token UUIDs, and users with
-  elevated privileges to make following each step easier. 
 
-  We recommend you follow the best practices to avoid security incidents:
+  When running Teleport in production, we recommend that you follow the
+  practices below to avoid security incidents. These practices may differ from
+  the examples used in this guide, which are intended for demo environments:
 
-  1. Avoid using `sudo` in production environments unless it's necessary.
-  2. Create new, non-root, users and use test instances for experimenting with Teleport.
-  3. You can run many Teleport's services as a non root. For example, auth, proxy, application access, kubernetes access, and database access services can run as a non-root user. Only the SSH/node service requires root access. You will need root permissions (or the `CAP_NET_BIND_SERVICE` capability) to make Teleport listen on a port numbered < `1024` (e.g. `443`)
-  4. Follow the "Principle of Least Privilege" (PoLP) and "Zero Admin" best practices. Don't give users permissive roles when giving them more restrictive `access,editor` roles will do instead.
-  5. Save tokens into a file rather than sharing tokens directly as strings.
+  - Avoid using `sudo` in production environments unless it's necessary.
+  - Create new, non-root, users and use test instances for experimenting with Teleport.
+  - Run Teleport's services as a non-root user unless required. Only the SSH
+    Service requires root access. Note that you will need root permissions (or
+    the `CAP_NET_BIND_SERVICE` capability) to make Teleport listen on a port
+    numbered < `1024` (e.g. `443`).
+  - Follow the "Principle of Least Privilege" (PoLP). Don't give users
+    permissive roles when giving them more restrictive roles will do instead.
+    For example, assign users the built-in `access,editor` roles.
+  - When joining a Teleport agent to a cluster, save the invitation token to a
+    file. Otherwise, the token will be visible when examining the `teleport`
+    command that started the agent, e.g., via the `history` command on a
+    compromised system.
+
 </Details>


### PR DESCRIPTION
Backports #12236

* Make the Linux Server guide more usable

See #11841

- Since this guide is a popular entree into Teleport, I've added an
  introductory passage explaining the services that will be run during
  this guide.

- Expand the prerequisites to add some context.

- Turn "Configure DNS" into the first step. This part can be slightly
  tricky since the user needs to plan how they'll create DNS records
  using the resources available to them, so putting it first ensures
  that the rest of the guide, which is more straightforward, can
  continue uninterrupted.

- Add a section that tells the user to run a simple HTTP static file
  server that returns a welcome page. Then add instructions to enable
  Application Access for the web service. This is a straightforward
  way to  demonstrate Teleport's ability to access resources in private
  networks in addition to Server Access.

- Show the expected outputs of commands.

- Make the final section more specific and easier to follow. Add
  subsections for accessing your Linux machine via the SSH Service and
  the simple web service that was started earlier via Application
  Access.

- Remove the "Add a Node to the cluster" instructions. The user already
  added a Node to the cluster by running "teleport configure," so I
  wanted to use the last section of the guide to emphasize accessing
  resources, rather than further setup work.

- Updated the "Next steps" section to include links to getting started
  guides for all resource services and Machine ID.

- Edited the acme.mdx partial so multiline commands include assignments
  for environment variables first. This way, it's easier to copy the
  command and edit the variables. Also added a command to retrieve your
  public IP address.

- Clarify permission-warning.mdx.

- Misc additional clarity tweaks.

* Respond to PR feedback