### PR TITLE
Add proxy initiated agent reconnects

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -457,6 +457,13 @@ func (a *agent) handleGlobalRequests(ctx context.Context, requests <-chan *ssh.R
 				}
 			case reconnectRequest:
 				a.log.Debugf("Receieved reconnect advisory request from proxy.")
+				if r.WantReply {
+					err := a.client.Reply(r, true, nil)
+					if err != nil {
+						return trace.Wrap(err)
+					}
+				}
+
 				// Fire off stop but continue to handle global requests until the
 				// context is canceled to allow the agent to drain.
 				go a.Stop()

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -460,7 +460,7 @@ func (a *agent) handleGlobalRequests(ctx context.Context, requests <-chan *ssh.R
 				if r.WantReply {
 					err := a.client.Reply(r, true, nil)
 					if err != nil {
-						return trace.Wrap(err)
+						a.log.Debugf("Failed to reply to %v request: %v.", r.Type, err)
 					}
 				}
 

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -455,6 +455,11 @@ func (a *agent) handleGlobalRequests(ctx context.Context, requests <-chan *ssh.R
 					a.log.Debugf("Failed to reply to %v request: %v.", r.Type, err)
 					continue
 				}
+			case reconnectRequest:
+				a.log.Debugf("Receieved reconnect advisory request from proxy.")
+				// Fire off stop but continue to handle global requests until the
+				// context is canceled to allow the agent to drain.
+				go a.Stop()
 			default:
 				// This handles keep-alive messages and matches the behaviour of OpenSSH.
 				err := a.client.Reply(r, false, nil)
@@ -636,6 +641,7 @@ const (
 	chanHeartbeat    = "teleport-heartbeat"
 	chanDiscovery    = "teleport-discovery"
 	chanDiscoveryReq = "discovery"
+	reconnectRequest = "reconnect@goteleport.com"
 )
 
 const (

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -131,7 +131,10 @@ type Server interface {
 	Start() error
 	// Close closes server's operations immediately
 	Close() error
-	// Shutdown performs graceful server shutdown
+	// PreShutdown closes listeners and begins draining connections without
+	// closing open connections.
+	PreShutdown(context.Context) error
+	// Shutdown performs graceful server shutdown closing open connections.
 	Shutdown(context.Context) error
 	// Wait waits for server to close all outstanding operations
 	Wait()

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -131,9 +131,9 @@ type Server interface {
 	Start() error
 	// Close closes server's operations immediately
 	Close() error
-	// PreShutdown closes listeners and begins draining connections without
+	// DrainConnections closes listeners and begins draining connections without
 	// closing open connections.
-	PreShutdown(context.Context) error
+	DrainConnections(context.Context) error
 	// Shutdown performs graceful server shutdown closing open connections.
 	Shutdown(context.Context) error
 	// Wait waits for server to close all outstanding operations

--- a/lib/reversetunnel/conn.go
+++ b/lib/reversetunnel/conn.go
@@ -211,7 +211,7 @@ func (c *remoteConn) updateProxies(proxies []types.Server) {
 }
 
 func (c *remoteConn) adviseReconnect() error {
-	_, _, err := c.sconn.SendRequest(reconnectRequest, false, nil)
+	_, _, err := c.sconn.SendRequest(reconnectRequest, true, nil)
 	return trace.Wrap(err)
 }
 

--- a/lib/reversetunnel/conn.go
+++ b/lib/reversetunnel/conn.go
@@ -210,6 +210,11 @@ func (c *remoteConn) updateProxies(proxies []types.Server) {
 	}
 }
 
+func (c *remoteConn) adviseReconnect() error {
+	_, _, err := c.sconn.SendRequest(reconnectRequest, false, nil)
+	return trace.Wrap(err)
+}
+
 // sendDiscoveryRequest sends a discovery request with up to date
 // list of connected proxies
 func (c *remoteConn) sendDiscoveryRequest(req discoveryRequest) error {

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -222,9 +222,9 @@ func (s *localSite) IsClosed() bool { return false }
 // Close always returns nil because a localSite isn't closed.
 func (s *localSite) Close() error { return nil }
 
-// adviceReconnect sends reconnects to agents in the background blocking until
+// adviseReconnect sends reconnects to agents in the background blocking until
 // the requests complete or the context is done.
-func (s *localSite) adviceReconnect(ctx context.Context) {
+func (s *localSite) adviseReconnect(ctx context.Context) {
 	wg := &sync.WaitGroup{}
 	s.remoteConnsMtx.Lock()
 	for _, conns := range s.remoteConns {

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -575,9 +575,9 @@ func (s *server) Close() error {
 	return s.srv.Close()
 }
 
-// PreShutdown closes the listener and sends reconnects to connected agents without
+// DrainConnections closes the listener and sends reconnects to connected agents without
 // closing open connections.
-func (s *server) PreShutdown(ctx context.Context) error {
+func (s *server) DrainConnections(ctx context.Context) error {
 	// Ensure listener is closed before sending reconnects.
 	err := s.srv.Close()
 	s.srv.Wait(ctx)

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -585,7 +585,7 @@ func (s *server) PreShutdown(ctx context.Context) error {
 	s.RLock()
 	for _, site := range s.localSites {
 		s.log.Debugf("Advising reconnect to local site: %s", site.GetName())
-		go site.adviceReconnect(ctx)
+		go site.adviseReconnect(ctx)
 	}
 
 	for _, site := range s.remoteSites {

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -575,9 +575,9 @@ func (s *server) Close() error {
 	return s.srv.Close()
 }
 
-// Drain closes the listener and sends reconnects to connected agents without
+// PreShutdown closes the listener and sends reconnects to connected agents without
 // closing open connections.
-func (s *server) Drain(ctx context.Context) error {
+func (s *server) PreShutdown(ctx context.Context) error {
 	// Ensure listener is closed before sending reconnects.
 	err := s.srv.Close()
 	s.srv.Wait(ctx)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3400,11 +3400,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			log.Infof("Shutting down gracefully.")
 			ctx := payloadContext(payload, log)
 			if tsrv != nil {
-				if drainer, ok := tsrv.(interface {
-					Drain(context.Context) error
-				}); ok {
-					warnOnErr(drainer.Drain(ctx), log)
-				}
+				warnOnErr(tsrv.PreShutdown(ctx), log)
 			}
 			warnOnErr(sshProxy.Shutdown(ctx), log)
 			if tsrv != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3399,6 +3399,13 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		} else {
 			log.Infof("Shutting down gracefully.")
 			ctx := payloadContext(payload, log)
+			if tsrv != nil {
+				if drainer, ok := tsrv.(interface {
+					Drain(context.Context) error
+				}); ok {
+					warnOnErr(drainer.Drain(ctx), log)
+				}
+			}
 			warnOnErr(sshProxy.Shutdown(ctx), log)
 			if tsrv != nil {
 				warnOnErr(tsrv.Shutdown(ctx), log)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3400,7 +3400,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			log.Infof("Shutting down gracefully.")
 			ctx := payloadContext(payload, log)
 			if tsrv != nil {
-				warnOnErr(tsrv.PreShutdown(ctx), log)
+				warnOnErr(tsrv.DrainConnections(ctx), log)
 			}
 			warnOnErr(sshProxy.Shutdown(ctx), log)
 			if tsrv != nil {

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -351,7 +351,7 @@ func (s *Server) Close() error {
 		if utils.IsUseOfClosedNetworkError(err) {
 			return nil
 		}
-		return err
+		return trace.Wrap(err)
 	}
 
 	return nil


### PR DESCRIPTION
This adds agent reconnects. During shutdown a proxy will close its reverse tunnel listern and then send reconnect requests to each agent.

Once a reconnect is received by an agent is calls `Stop()` which changes the agent state to `Closed`, releases its claim to the proxy, and leaves the connection open to drain open transports.

This allows the agent to reconnect to the proxy on the new listener, or connect to a new proxy, which helps minimize the time an agent could be unreachable.