### PR TITLE
[v9] Optionally skip unshallowing step (#10978)

### DIFF
--- a/.cloudbuild/scripts/cmd/integration-tests/args.go
+++ b/.cloudbuild/scripts/cmd/integration-tests/args.go
@@ -34,6 +34,7 @@ type commandlineArgs struct {
 	artifactSearchPatterns customflag.StringArray
 	bucket                 string
 	githubKeySrc           string
+	skipUnshallow          bool
 }
 
 // validate ensures the suplied arguments are valid & internally consistent.
@@ -85,6 +86,7 @@ func parseCommandLine() (*commandlineArgs, error) {
 	flag.StringVar(&args.bucket, "bucket", "", "The artifact storage bucket.")
 	flag.Var(&args.artifactSearchPatterns, "a", "Path to artifacts. May be shell-globbed, and have multiple entries.")
 	flag.StringVar(&args.githubKeySrc, "key-secret", "", "Location of github deploy token, as a Google Cloud Secret")
+	flag.BoolVar(&args.skipUnshallow, "skip-unshallow", false, "Skip unshallowing the repository.")
 
 	flag.Parse()
 

--- a/.cloudbuild/scripts/cmd/integration-tests/main.go
+++ b/.cloudbuild/scripts/cmd/integration-tests/main.go
@@ -68,11 +68,13 @@ func innerMain() error {
 		}
 	}
 
-	unshallowCtx, unshallowCancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer unshallowCancel()
-	err = git.UnshallowRepository(unshallowCtx, args.workspace, deployKey)
-	if err != nil {
-		return trace.Wrap(err, "unshallow failed")
+	if !args.skipUnshallow {
+		unshallowCtx, unshallowCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer unshallowCancel()
+		err = git.UnshallowRepository(unshallowCtx, args.workspace, deployKey)
+		if err != nil {
+			return trace.Wrap(err, "unshallow failed")
+		}
 	}
 
 	moduleCacheDir := filepath.Join(os.TempDir(), gomodcacheDir)

--- a/.cloudbuild/scripts/cmd/unit-tests/main.go
+++ b/.cloudbuild/scripts/cmd/unit-tests/main.go
@@ -51,6 +51,7 @@ type commandlineArgs struct {
 	artifactSearchPatterns customflag.StringArray
 	bucket                 string
 	githubKeySrc           string
+	skipUnshallow          bool
 }
 
 func parseCommandLine() (commandlineArgs, error) {
@@ -63,6 +64,7 @@ func parseCommandLine() (commandlineArgs, error) {
 	flag.StringVar(&args.bucket, "bucket", "", "The artifact storage bucket.")
 	flag.Var(&args.artifactSearchPatterns, "a", "Path to artifacts. May be globbed, and have multiple entries.")
 	flag.StringVar(&args.githubKeySrc, "key-secret", "", "Location of github deploy token, as a Google Cloud Secret")
+	flag.BoolVar(&args.skipUnshallow, "skip-unshallow", false, "Skip unshallowing the repository.")
 
 	flag.Parse()
 
@@ -121,11 +123,13 @@ func run() error {
 		}
 	}
 
-	unshallowCtx, unshallowCancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer unshallowCancel()
-	err = git.UnshallowRepository(unshallowCtx, args.workspace, deployKey)
-	if err != nil {
-		return trace.Wrap(err, "unshallow failed")
+	if !args.skipUnshallow {
+		unshallowCtx, unshallowCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer unshallowCancel()
+		err = git.UnshallowRepository(unshallowCtx, args.workspace, deployKey)
+		if err != nil {
+			return trace.Wrap(err, "unshallow failed")
+		}
 	}
 
 	log.Println("Analysing code changes")


### PR DESCRIPTION
GCB checks out code for testing a PR as a shallow clone. The `teleport`  build requires unshallowing the clone in order to run analytics on the change, so it runs `git fetch --unshallow` to get the whole repo.

Unfortunately, the `teleport.e` repo already has a full teleport repository when it runs the test scripts, so unshallowing fails.

This change allows the unit & integration testing scripts to optionally skip the unshallow step, so that the teleport.e build triggers can succeed.

See-Also: gravitational/teleport.e#440