### PR TITLE
Add role notes to the teleport-kube-agent intro

### DIFF
--- a/docs/pages/kubernetes-access/getting-started/agent.mdx
+++ b/docs/pages/kubernetes-access/getting-started/agent.mdx
@@ -120,7 +120,7 @@ spec:
     kubernetes_labels:
       '*': '*'
     kubernetes_groups:
-    - system:masters
+    - view
     kubernetes_users:
     - USER
   deny: {}

--- a/docs/pages/kubernetes-access/getting-started/agent.mdx
+++ b/docs/pages/kubernetes-access/getting-started/agent.mdx
@@ -29,7 +29,7 @@ domain name, e.g., `mytenant.teleport.sh`, rather than `teleport.example.com`.
   ![Kubernetes agent](../../../img/k8s/agent.svg)
 </Figure>
 
-## Step 1/2. Get a join token
+## Step 1/3. Get a join token
 
 In order to start the Teleport Kubernetes Service, we will need to request a
 join token from the Teleport Auth Service:
@@ -40,7 +40,7 @@ $ TOKEN=$(tctl nodes add --roles=kube --ttl=10000h --format=json | jq -r '.[0]')
 $ echo $TOKEN
 ```
 
-## Step 2/2. Deploy teleport-kube-agent
+## Step 2/3. Deploy teleport-kube-agent
 
 <Notice type="tip" >
 
@@ -90,6 +90,68 @@ $ helm install teleport-agent teleport/teleport-kube-agent --set kubeClusterName
 
 </TabItem>
 </Tabs>
+
+## Step 3/3 Access your Kubernetes cluster
+
+### Grant access to your Teleport user
+
+To use Teleport to interact with a Kubernetes cluster, your Teleport roles must
+allow access from your Kubernetes user and groups. Ensure that you have a
+Teleport role that grants access to the cluster you plan to interact with.
+
+Run the following command to get the Kubernetes user for your current context:
+
+```code
+$ kubectl config view \
+-o jsonpath="{.contexts[?(@.context.cluster==\"$(kubectl config current-context)\")].context.user}"
+cookie
+```
+
+Create a file called `kube-user.yaml` with the following content, replacing
+`USER` with the output of the command above.
+
+```yaml
+kind: role
+metadata:
+  name: kube-user
+version: v5
+spec:
+  allow:
+    kubernetes_labels:
+      '*': '*'
+    kubernetes_groups:
+    - system:masters
+    kubernetes_users:
+    - USER
+  deny: {}
+```
+
+Retrieve your user:
+
+```code
+$ TELEPORT_USER=myuser
+$ tctl get user/${TELEPORT_USER?} > user.yaml
+```
+
+Add `kube-user` to your Teleport user's list of roles:
+
+```diff
+   roles:
+   - access
+   - auditor
++  - kube-user
+```
+
+Apply your changes:
+
+```code
+$ tctl create -f kube-user.yaml
+$ tctl create -f user.yaml
+```
+
+Log out of Teleport and log in again.
+
+### View pods in your cluster
 
 List connected clusters using `tsh kube ls` and switch between
 them using `tsh kube login`:


### PR DESCRIPTION
Fixes #10480

Previously, the "Connect a Kubernetes Cluster to Teleport" guide
instructed the user to run "tsh kube login" to a cluster they
may not be authorized to access. This change adds explicit instructions
to authorize your user's Teleport role to interact with your cluster.