### PR TITLE
[branch/v8] Revert usage of NodeWatcher in web api (#12586)

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1914,12 +1914,12 @@ func (h *Handler) siteNodeConnect(
 	req.ProxyHostPort = h.ProxyHostPort()
 	req.Cluster = site.GetName()
 
-	watcher, err := site.NodeWatcher()
+	clt, err := ctx.GetUserClient(site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	term, err := NewTerminal(*req, watcher, ctx)
+	term, err := NewTerminal(r.Context(), *req, clt, ctx)
 	if err != nil {
 		h.log.WithError(err).Error("Unable to create terminal.")
 		return nil, trace.Wrap(err)
@@ -1943,6 +1943,11 @@ type siteSessionGenerateResponse struct {
 // siteSessionCreate generates a new site session that can be used by UI
 // The ServerID from request can be in the form of hostname, uuid, or ip address.
 func (h *Handler) siteSessionGenerate(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	clt, err := ctx.GetUserClient(site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var req *siteSessionGenerateReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1950,12 +1955,12 @@ func (h *Handler) siteSessionGenerate(w http.ResponseWriter, r *http.Request, p 
 
 	namespace := apidefaults.Namespace
 	if req.Session.ServerID != "" {
-		watcher, err := site.NodeWatcher()
+		servers, err := clt.GetNodes(r.Context(), namespace)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		hostname, _, err := resolveServerHostPort(req.Session.ServerID, watcher)
+		hostname, _, err := resolveServerHostPort(req.Session.ServerID, servers)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/web/ui/cluster.go
+++ b/lib/web/ui/cluster.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"time"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
@@ -91,7 +92,7 @@ func GetClusterDetails(ctx context.Context, site reversetunnel.RemoteSite, opts 
 		return nil, trace.Wrap(err)
 	}
 
-	watcher, err := site.NodeWatcher()
+	nodes, err := clt.GetNodes(ctx, apidefaults.Namespace, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -120,7 +121,7 @@ func GetClusterDetails(ctx context.Context, site reversetunnel.RemoteSite, opts 
 		Name:          site.GetName(),
 		LastConnected: site.GetLastConnected(),
 		Status:        site.GetStatus(),
-		NodeCount:     watcher.NodeCount(),
+		NodeCount:     len(nodes),
 		PublicURL:     proxyHost,
 		AuthVersion:   authVersion,
 		ProxyVersion:  proxyVersion,


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `branch/v8`:
 - [Revert usage of NodeWatcher in web api (#12586)](https://github.com/gravitational/teleport/pull/12586)

<!--- Backport version: 8.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)