### PR TITLE
Propagate context to reversetunnel.Resolvers

### DIFF
--- a/lib/auth/authclient/authclient.go
+++ b/lib/auth/authclient/authclient.go
@@ -79,7 +79,7 @@ func Connect(ctx context.Context, cfg *Config) (auth.ClientI, error) {
 		// TODO(nic): this logic should be implemented once and reused in IoT
 		// nodes.
 
-		resolver := reversetunnel.WebClientResolver(ctx, cfg.AuthServers, lib.IsInsecureDevMode())
+		resolver := reversetunnel.WebClientResolver(cfg.AuthServers, lib.IsInsecureDevMode())
 		resolver, err = reversetunnel.CachingResolver(resolver, nil /* clock */)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -279,7 +279,7 @@ func (m *AgentPool) getReverseTunnelDetails() *reverseTunnelDetails {
 // transfers into the AgentPool, and will be released when the AgentPool
 // is done with it.
 func (m *AgentPool) addAgent(lease track.Lease) error {
-	addr, err := m.cfg.Resolver()
+	addr, err := m.cfg.Resolver(m.ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/reversetunnel/rc_manager_test.go
+++ b/lib/reversetunnel/rc_manager_test.go
@@ -33,7 +33,7 @@ func TestRemoteClusterTunnelManagerSync(t *testing.T) {
 	t.Parallel()
 
 	resolverFn := func(addr string) Resolver {
-		return func() (*utils.NetAddr, error) {
+		return func(ctx context.Context) (*utils.NetAddr, error) {
 			return &utils.NetAddr{
 				Addr:        addr,
 				AddrNetwork: "tcp",
@@ -160,8 +160,8 @@ func TestRemoteClusterTunnelManagerSync(t *testing.T) {
 				// Tweaks to get comparison working with our complex types.
 				cmp.AllowUnexported(remoteClusterKey{}),
 				cmp.Comparer(func(a, b *AgentPool) bool {
-					aAddr, aErr := a.cfg.Resolver()
-					bAddr, bErr := b.cfg.Resolver()
+					aAddr, aErr := a.cfg.Resolver(context.Background())
+					bAddr, bErr := b.cfg.Resolver(context.Background())
 
 					if aAddr != bAddr && aErr != bErr {
 						return false

--- a/lib/reversetunnel/resolver.go
+++ b/lib/reversetunnel/resolver.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Resolver looks up reverse tunnel addresses
-type Resolver func() (*utils.NetAddr, error)
+type Resolver func(ctx context.Context) (*utils.NetAddr, error)
 
 // CachingResolver wraps the provided Resolver with one that will cache the previous result
 // for 3 seconds to reduce the number of resolutions in an effort to mitigate potentially
@@ -39,9 +39,9 @@ func CachingResolver(resolver Resolver, clock clockwork.Clock) (Resolver, error)
 	if err != nil {
 		return nil, err
 	}
-	return func() (*utils.NetAddr, error) {
-		a, err := cache.Get(context.TODO(), "resolver", func() (interface{}, error) {
-			return resolver()
+	return func(ctx context.Context) (*utils.NetAddr, error) {
+		a, err := cache.Get(ctx, "resolver", func() (interface{}, error) {
+			return resolver(ctx)
 		})
 		if err != nil {
 			return nil, err
@@ -52,8 +52,8 @@ func CachingResolver(resolver Resolver, clock clockwork.Clock) (Resolver, error)
 
 // WebClientResolver returns a Resolver which uses the web proxy to
 // discover where the SSH reverse tunnel server is running.
-func WebClientResolver(ctx context.Context, addrs []utils.NetAddr, insecureTLS bool) Resolver {
-	return func() (*utils.NetAddr, error) {
+func WebClientResolver(addrs []utils.NetAddr, insecureTLS bool) Resolver {
+	return func(ctx context.Context) (*utils.NetAddr, error) {
 		var errs []error
 		for _, addr := range addrs {
 			// In insecure mode, any certificate is accepted. In secure mode the hosts
@@ -88,7 +88,7 @@ func StaticResolver(address string) Resolver {
 		addr.Addr = utils.ReplaceUnspecifiedHost(addr, defaults.HTTPListenPort)
 	}
 
-	return func() (*utils.NetAddr, error) {
+	return func(context.Context) (*utils.NetAddr, error) {
 		return addr, err
 	}
 }

--- a/lib/reversetunnel/resolver_test.go
+++ b/lib/reversetunnel/resolver_test.go
@@ -53,7 +53,7 @@ func TestStaticResolver(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			addr, err := StaticResolver(tt.address)()
+			addr, err := StaticResolver(tt.address)(context.Background())
 			tt.errorAssertionFn(t, err)
 			if err != nil {
 				return
@@ -107,7 +107,7 @@ func TestResolveViaWebClient(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(defaults.TunnelPublicAddrEnvar, tt.address)
-			addr, err := WebClientResolver(context.Background(), tt.addrs, true)()
+			addr, err := WebClientResolver(tt.addrs, true)(context.Background())
 			tt.errorAssertionFn(t, err)
 			if err != nil {
 				return
@@ -119,7 +119,7 @@ func TestResolveViaWebClient(t *testing.T) {
 }
 
 func TestCachingResolver(t *testing.T) {
-	randomResolver := func() (*utils.NetAddr, error) {
+	randomResolver := func(context.Context) (*utils.NetAddr, error) {
 		return &utils.NetAddr{
 			Addr:        uuid.New().String(),
 			AddrNetwork: uuid.New().String(),
@@ -128,25 +128,26 @@ func TestCachingResolver(t *testing.T) {
 	}
 
 	clock := clockwork.NewFakeClock()
+	ctx := context.Background()
 	resolver, err := CachingResolver(randomResolver, clock)
 	require.NoError(t, err)
 
-	addr, err := resolver()
+	addr, err := resolver(ctx)
 	require.NoError(t, err)
 
-	addr2, err := resolver()
+	addr2, err := resolver(ctx)
 	require.NoError(t, err)
 
 	require.Equal(t, addr, addr2)
 
 	clock.Advance(time.Hour)
 
-	addr3, err := resolver()
+	addr3, err := resolver(ctx)
 	require.NoError(t, err)
 
 	require.NotEqual(t, addr2, addr3)
 
-	addr4, err := resolver()
+	addr4, err := resolver(ctx)
 	require.NoError(t, err)
 
 	require.Equal(t, addr3, addr4)

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -85,7 +85,7 @@ func (t *TunnelAuthDialer) DialContext(ctx context.Context, _, _ string) (net.Co
 		proxy.WithInsecureSkipTLSVerify(t.InsecureSkipTLSVerify),
 	}
 
-	addr, err := t.Resolver()
+	addr, err := t.Resolver(ctx)
 	if err != nil {
 		t.Log.Errorf("Failed to resolve tunnel address %v", err)
 		return nil, trace.Wrap(err)

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -900,7 +900,7 @@ func (process *TeleportProcess) newClient(authServers []utils.NetAddr, identity 
 }
 
 func (process *TeleportProcess) newClientThroughTunnel(authServers []utils.NetAddr, tlsConfig *tls.Config, sshConfig *ssh.ClientConfig) (*auth.Client, error) {
-	resolver := reversetunnel.WebClientResolver(process.ExitContext(), authServers, lib.IsInsecureDevMode())
+	resolver := reversetunnel.WebClientResolver(authServers, lib.IsInsecureDevMode())
 
 	resolver, err := reversetunnel.CachingResolver(resolver, process.Clock)
 	if err != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3995,7 +3995,7 @@ func (process *TeleportProcess) initDebugApp() {
 // singleProcessModeResolver returns the reversetunnel.Resolver that should be used when running all components needed
 // within the same process. It's used for development and demo purposes.
 func (process *TeleportProcess) singleProcessModeResolver(mode types.ProxyListenerMode) reversetunnel.Resolver {
-	return func() (*utils.NetAddr, error) {
+	return func(ctx context.Context) (*utils.NetAddr, error) {
 		addr, ok := process.singleProcessMode(mode)
 		if !ok {
 			return nil, trace.BadParameter(`failed to find reverse tunnel address, if running in single process mode, make sure "auth_service", "proxy_service", and "app_service" are all enabled`)


### PR DESCRIPTION
Pass a `context.Context` to `reversetunnel.Resolver`
so that cancellation is respected. Prior to this,
only the `WebClientResolver` took a context, but it
was during construction, and so it used the TeleportProcess
context instead of the callers' context. Using the correct
context should eliminate any possible hangs.

This also updates the FnCache to automatically expire any
entries whose loadFn resulted in a `context.Cancelled` error.
Doing so eliminates the need for callers to ensure they pass
a context that won't cancel and be cached anymore.