### PR TITLE
Hide Access Controls links/pages based on scope

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -675,7 +675,8 @@
             },
             {
               "title": "Dual Authorization",
-              "slug": "/access-controls/guides/dual-authz/"
+              "slug": "/access-controls/guides/dual-authz/",
+              "hideInScopes": "oss"
             },
             {
               "title": "Impersonation",
@@ -683,7 +684,8 @@
             },
             {
               "title": "Moderated Sessions",
-              "slug": "/access-controls/guides/moderated-sessions/"
+              "slug": "/access-controls/guides/moderated-sessions/",
+              "hideInScopes": "oss"
             }
           ]
         },

--- a/docs/pages/access-controls/guides.mdx
+++ b/docs/pages/access-controls/guides.mdx
@@ -5,9 +5,11 @@ layout: tocless-doc
 ---
 
 <ul>
+  <ScopedBlock scope={["cloud", "enterprise"]}>
   <li>
     [Dual Authorization](./guides/dual-authz.mdx). Protect access to critial resources with dual authorization.
   </li>
+  </ScopedBlock>
   <li>
     [Role Templates](./guides/role-templates.mdx). Setup dynamic access policies with Role Templates.
   </li>
@@ -23,7 +25,9 @@ layout: tocless-doc
   <li>
     [Locking](./guides/locking.mdx). Lock access to active user sessions or hosts.
   </li>
+  <ScopedBlock scope={["cloud", "enterprise"]}>
   <li>
     [Moderated Sessions](./guides/moderated-sessions.mdx). Require session auditors and allow fine-grained live session access.
   </li>
+  </ScopedBlock>
 </ul>

--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -10,17 +10,27 @@ Here are the most common scenarios:
 - Improve the security of your system and prevent one successful phishing attack from compromising your system.
 - Satisfy FedRAMP AC-3 Dual authorization control that requires approval of two authorized individuals.
 
-Let's set up Teleport's access requests to require the approval of two team members
-for a privileged role `dbadmin`.
+In this guide, we will set up Teleport's access requests to require the approval
+of two team members for a privileged role `dbadmin`.
 
-<Notice
-  type="danger"
-  scope="oss"
->
+<ScopedBlock scope="oss">
+
   This guide requires a commercial edition of Teleport. The open source
   edition of Teleport only supports [GitHub](../../setup/admin/github-sso.mdx) as
   an SSO provider.
-</Notice>
+
+  View this guide as a user of another Teleport edition:
+
+  <TileSet>
+  <Tile href="./dual-authz.mdx/?scope=cloud" title="Teleport Cloud" icon="cloud">
+  </Tile>
+  <Tile href="./dual-authz.mdx/?scope=enterprise" title="Teleport Enterprise" icon="building">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["enterprise", "cloud"]}>
 
 <Admonition title="Note" type="tip">
   The steps below describe how to use Teleport with Mattermost. You can also [integrate with many other providers](../../enterprise/workflow/index.mdx).
@@ -245,5 +255,7 @@ To fix the problem, update the Auth Service with a public address, and restart T
 auth_service:
   public_addr: ['localhost:3025', 'example.com:3025']
 ```
+
+</ScopedBlock>
 
 </ScopedBlock>

--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -4,11 +4,6 @@ description: Moderated Sessions
 h1: Moderated Sessions
 ---
 
-<Notice type="warning" scope="oss">
-
-  Moderated Sessions requires Teleport Enterprise or Teleport Cloud.
-
-</Notice>
 
 ## Introduction
 
@@ -16,6 +11,23 @@ Moderated Sessions allows Teleport administrators to define requirements for
 other users to be present in a Server or Kubernetes Access session. Depending on
 the requirements, these users can observe the session in real time, participate
 in the session, and terminate the session at will.
+
+<ScopedBlock scope="oss">
+
+  Moderated Sessions requires Teleport Enterprise or Teleport Cloud.
+
+  View this guide as a user of another Teleport edition:
+
+  <TileSet>
+  <Tile href="./moderated-sessions.mdx/?scope=cloud" title="Teleport Cloud" icon="cloud">
+  </Tile>
+  <Tile href="./moderated-sessions.mdx/?scope=enterprise" title="Teleport Enterprise" icon="building">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 ### Use cases
 
@@ -214,3 +226,5 @@ example be used to enable notifications over some external communication system.
 ## RFD
 
 - [Moderated Sessions](https://github.com/gravitational/teleport/blob/master/rfd/0043-kubeaccess-multiparty.md)
+
+</ScopedBlock>


### PR DESCRIPTION
See #11383

Ensure that no visitor to the Teleport docs site sees content that is
irrelevant to their scope (e.g., Cloud, Open Source, or Enterprise) by
hiding scope-irrelevant content from the navigation menu and menu
pages.

For pages that are only relevant to a specific scope, show users with
unintended scopes a menu of links to supported scopes.

This PR focuses on the Access Controls section.