### PR TITLE
Hide Cloud links/pages based on scope

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -822,7 +822,7 @@
         },
         {
           "title": "Architecture",
-          "slug": "/cloud/architecture/"        
+          "slug": "/cloud/architecture/"
         },
         {
           "title": "Downloads",

--- a/docs/config.json
+++ b/docs/config.json
@@ -817,15 +817,17 @@
         },
         {
           "title": "Getting Started",
-          "slug": "/cloud/getting-started/"
+          "slug": "/cloud/getting-started/",
+          "hideInScopes": ["oss", "enterprise"]
         },
         {
           "title": "Architecture",
-          "slug": "/cloud/architecture/"
+          "slug": "/cloud/architecture/"        
         },
         {
           "title": "Downloads",
-          "slug": "/cloud/downloads/"
+          "slug": "/cloud/downloads/",
+          "hideInScopes": ["oss", "enterprise"]
         },
         {
           "title": "FAQ",

--- a/docs/pages/cloud/introduction.mdx
+++ b/docs/pages/cloud/introduction.mdx
@@ -5,12 +5,32 @@ h1: Teleport cloud
 videoBanner: 1jhKOtBinm4
 ---
 
-We run Teleport Cloud as hosted, managed Teleport as a service.
-Connect your nodes, web applications, kubernetes clusters and databases.
-Sign up [here](https://goteleport.com/get-started/).
+Teleport Cloud is a fully managed deployment of Teleport Enterprise.
+
+We host the Teleport Auth Service and Proxy Service and take care of upgrades,
+and you connect your Nodes, web applications, Kubernetes clusters, databases,
+and Windows desktops.
+
+Visit our [sign up page](https://goteleport.com/signup/) to begin a free trial.
+
+<TileSet>
+
+  <Tile icon="cloud" title="Getting Started" href="./getting-started.mdx/?scope=cloud">
+    Follow this guide to access your first server via Teleport Cloud.
+  </Tile>
+  <Tile icon="cloud" title="Architecture" href="./architecture.mdx/">
+    Security, availability, and networking information.
+  </Tile>
+  <Tile icon="cloud" title="Downloads" href="./downloads.mdx/">
+    How to download agent and client binaries for your Teleport Cloud deployment.
+  </Tile>
+  <Tile icon="cloud" title="FAQ" href="./faq.mdx/">
+    Get answers to frequently asked questions about Teleport Cloud.
+  </Tile>
+
+</TileSet>
 
 ## Next Steps
 
-- Get started with cloud [in 5 minutes](./getting-started.mdx).
 - Join the [Teleport Discussons](https://github.com/gravitational/teleport/discussions) and ask a question.
 - Join the [Slack channel](https://goteleport.com/slack).


### PR DESCRIPTION
See #11383

Help ensure that no visitor to the Teleport docs site sees content that
is irrelevant to their scope (e.g., Cloud, Open Source, or Enterprise) by
hiding scope-irrelevant content from the navigation menu and menu
pages.

For pages that aren't step-by-step guides and are meant to convey
general information about a Teleport edition, show these pages in all
scopes so users who are curious about another scope can get the
information they need.

This PR focuses on the Cloud section, and also fleshes out the
introduction page to the Cloud section a bit.