### PR TITLE
Hide Enterprise links/pages based on scope

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -735,61 +735,75 @@
         },
         {
           "title": "Getting Started",
-          "slug": "/enterprise/getting-started/"
+          "slug": "/enterprise/getting-started/",
+          "hideInScopes": ["oss", "cloud"]
         },
         {
           "title": "Single Sign-On (SSO)",
           "slug": "/enterprise/sso/",
+          "hideInScopes": ["oss"],
           "entries": [
             {
               "title": "Azure Active Directory (AD)",
-              "slug": "/enterprise/sso/azuread/"
+              "slug": "/enterprise/sso/azuread/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "Active Directory (ADFS)",
-              "slug": "/enterprise/sso/adfs/"
+              "slug": "/enterprise/sso/adfs/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "Google Workspace",
-              "slug": "/enterprise/sso/google-workspace/"
+              "slug": "/enterprise/sso/google-workspace/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "GitLab",
-              "slug": "/enterprise/sso/gitlab/"
+              "slug": "/enterprise/sso/gitlab/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "OneLogin",
-              "slug": "/enterprise/sso/one-login/"
+              "slug": "/enterprise/sso/one-login/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "OIDC",
-              "slug": "/enterprise/sso/oidc/"
+              "slug": "/enterprise/sso/oidc/",
+              "hideInScopes": ["oss"]
             },
             {
               "title": "Okta",
-              "slug": "/enterprise/sso/okta/"
+              "slug": "/enterprise/sso/okta/",
+              "hideInScopes": ["oss"]
             }
           ]
         },
         {
           "title": "Access Requests",
-          "slug": "/enterprise/workflow/"
+          "slug": "/enterprise/workflow/",
+          "hideInScopes": ["oss"]
         },
         {
           "title": "FedRAMP",
-          "slug": "/enterprise/fedramp/"
+          "slug": "/enterprise/fedramp/",
+          "hideInScopes": ["cloud", "oss"]
         },
         {
           "title": "SOC2",
-          "slug": "/enterprise/soc2/"
+          "slug": "/enterprise/soc2/",
+          "hideInScopes": ["oss"]
         },
         {
           "title": "HSM",
-          "slug": "/enterprise/hsm/"
+          "slug": "/enterprise/hsm/",
+          "hideInScopes": ["cloud", "oss"]
         },
         {
           "title": "Enterprise License File",
-          "slug": "/enterprise/license/"
+          "slug": "/enterprise/license/",
+          "hideInScopes": ["cloud", "oss"]
         }
       ]
     },

--- a/docs/pages/enterprise/fedramp.mdx
+++ b/docs/pages/enterprise/fedramp.mdx
@@ -1,11 +1,24 @@
 ---
-title: FedRAMP compliance for Infrastructure access 
-description: How to configure SSH, Kubernetes, database, and web app access to be FedRAMP compliant, including support for FIPS 140-2
-h1: FedRAMP for SSH, Kubernetes, Databases and Web Apps.
+title: FedRAMP Compliance for Infrastructure Access 
+description: How to configure SSH, Kubernetes, database, and web app access to be FedRAMP compliant, including support for FIPS 140-2.
 ---
 
 Teleport provides the foundation to meet FedRAMP requirements for the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS\_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high
 level overview of how Teleport FIPS mode works and how it can help your company to become FedRAMP certified.
+
+<ScopedBlock scope={["oss", "cloud"]}>
+
+This guide is intended for Teleport Enterprise users.
+
+<TileSet>
+<Tile title="View this guide as a Teleport Enterprise user" icon="building" href="./fedramp.mdx/?scope=enterprise">
+
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope="enterprise">
 
 ### Obtain FedRAMP certification with Teleport
 
@@ -145,3 +158,5 @@ is emitted to the Audit Log.
 - Removes all uses of non-compliant algorithms like NaCl and replace with compliant algorithms like AES-GCM.
 - Teleport is compiled  with [BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678)
 - User, host and CA certificates (and host keys for recording proxy mode) should only use 2048-bit RSA private keys.
+
+</ScopedBlock>

--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -4,35 +4,48 @@ description: How to set up and configure Teleport Enterprise for SSH
 h1: Teleport Enterprise Quick Start
 ---
 
-Welcome to the Quick Start Guide for Teleport Enterprise.
+This guide shows you how to get up and running with Teleport Enterprise.
 
-(!docs/pages/includes/cloud/cloudmanagedadvisory.mdx!)
+<ScopedBlock scope={["oss", "cloud"]}>
 
-The goal of this document is to show off the basic capabilities of Teleport.
-There are three types of services Teleport nodes can run: `nodes`, `proxies`
-and `auth servers`.
+This guide is intended for Teleport Enterprise users.
 
-- **Auth servers** store user accounts and
-  provide authentication and authorization services for every node and every
-  user in a cluster.
-- **Proxy servers** route client connection requests to the appropriate node and serve a
-  Web UI which can also be used to log into SSH nodes. Every client-to-node
-  connection in Teleport must be routed via a proxy.
-- **Nodes** provide access to resources including SSH, Kubernetes, web applications
-  and databases.  In this quick start guide we are highlighting the SSH service. This SSH service
-  is similar to the `sshd` daemon you may be familiar
-  with. When a node receives a connection request, the request is authenticated
-  through the cluster's auth server.
+<TileSet>
+<Tile title="View this guide as a Teleport Enterprise user" icon="building" href="./getting-started.mdx/?scope=enterprise">
 
-The `teleport` daemon runs all three of these services by default. This Quick
-Start Guide will be using this default behavior to create a cluster and
-interact with it using Teleport's client-side tools:
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope="enterprise">
+
+There are three types of services Teleport can run:
+
+- **Auth Service** stores user accounts and provides authentication and
+  authorization for every agent and every user in a cluster.
+- **Proxy Service** routes client connection requests to the appropriate agent
+  and serves a Web UI that can also be used to access resources.
+- **Agents** provide access to resources including SSH servers, Kubernetes
+  clusters, web applications and databases. 
+  
+In this guide, we will highlight the Teleport SSH Service. The SSH Service is
+similar to the `sshd` daemon you may be familiar with. SSH Service instances are
+called **Teleport Nodes**. When a Teleport Node receives a connection request,
+the request is authenticated through the cluster's Auth Service.
+
+The `teleport` daemon runs all three of these services by default.
+
+This guide will run a Teleport cluster consisting of the Auth Service, Proxy
+Service, and SSH Service, and interact with the cluster using Teleport's
+client-side tools:
 
 | Tool | Description |
 | - | - |
-| tctl | Cluster administration tool used to invite nodes to a cluster and manage user accounts. |
-| tsh | Allows users to authenticate and access resources via their local machine. `tsh`'s ssh functionality is similar in principle to OpenSSH's `ssh`. Users can login into remote SSH nodes, list and search for nodes in a cluster, securely upload/download files, etc. |
-| browser | You can use your web browser to login into any Teleport node by opening `https://<proxy-host>:3080`. |
+| tctl | Cluster administration tool used to invite Nodes to a cluster and manage user accounts. |
+| tsh | Allows users to authenticate and access resources via their local machine. `tsh`'s SSH functionality is similar in principle to OpenSSH's `ssh`. Users can log in to remote Nodes, list and search for Nodes in a cluster, securely upload/download files, etc. |
+| browser | You can use your web browser to log in to any Teleport Node by opening `https://<proxy-host>:3080`. |
+
 
 ## Prerequisites
 
@@ -456,3 +469,5 @@ Usually the error will be reported there. Common reasons for failure are:
 If something is not working, please reach out to us by creating a ticket in your [customer portal](https://dashboard.gravitational.com/web/login).
 Customers who have purchased the premium support package can also ping us through
 your Slack channel.
+
+</ScopedBlock>

--- a/docs/pages/enterprise/hsm.mdx
+++ b/docs/pages/enterprise/hsm.mdx
@@ -4,7 +4,22 @@ description: How to configure Hardware Security Modules to manage your Teleport 
 h1: Teleport HSM Support
 ---
 
-This guide will show you how to set up the Teleport Auth Server to use a hardware security module (HSM) to store and handle private keys.
+This guide will show you how to set up the Teleport Auth Service to use a
+hardware security module (HSM) to store and handle private keys.
+
+<ScopedBlock scope={["oss", "cloud"]}>
+
+This guide is intended for Teleport Enterprise users.
+
+<TileSet>
+<Tile title="View this guide as a Teleport Enterprise user" icon="building" href="./hsm.mdx/?scope=enterprise">
+
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope="enterprise">
 
 ## Prerequisites
 
@@ -12,9 +27,11 @@ This guide will show you how to set up the Teleport Auth Server to use a hardwar
 - An HSM reachable from your Teleport auth server.
 - The PKCS#11 module for your HSM.
 
-<Details scope={["cloud", "oss"]} opened={true} scopeOnly={true} title="Compatibility Warning">
+<Admonition type="warning" scope={["cloud", "oss"]} opened={true} scopeOnly={true} title="Compatibility Warning">
 Teleport Cloud and Teleport Open Source do not currently support HSM.
-</Details>
+
+You can view this guide as a [Teleport Enterprise user](./hsm.mdx/?scope=enterprise).
+</Admonition>
 
 While most PKCS#11 HSMs should be supported, the Teleport team tests with AWS
 CloudHSM, YubiHSM2, and SoftHSM2.
@@ -203,3 +220,5 @@ access to the cluster and have to re-join.
 You are all set! Check the teleport logs for `Creating new HSM key pair` to
 confirm that the feature is working. You can also check that keys were created
 in your HSM using your HSM's admin tool.
+
+</ScopedBlock>

--- a/docs/pages/enterprise/introduction.mdx
+++ b/docs/pages/enterprise/introduction.mdx
@@ -4,9 +4,11 @@ description: Introduction to features and benefits of using Teleport Enterprise.
 h1: Teleport Enterprise
 ---
 
-This section will give an overview of Teleport Enterprise, the commercial product built around
- Teleport Open Source core. For those that want to jump right in, you can play
-with the [Getting Started Guide for Teleport Enterprise](getting-started.mdx).
+Teleport Enterprise is a commercial product built around Teleport's open source
+core.
+
+For those that want to jump right in, you can play with the
+[Getting Started Guide for Teleport Enterprise](getting-started.mdx/?scope=enterprise).
 
 The table below gives a quick overview of the benefits of Teleport Enterprise.
 

--- a/docs/pages/enterprise/license.mdx
+++ b/docs/pages/enterprise/license.mdx
@@ -3,13 +3,33 @@ title: Enterprise License File
 description: Teleport enterprise license file configuration parameters and requirements
 ---
 
-Commercial self-hosted Teleport subscriptions require a valid license. The license file can
-be downloaded from the [Teleport Customer
-Portal](https://dashboard.gravitational.com/web/login). When downloading the file, the products you are licensed to use will be listed in the browser. 
+This guide explains the use of a license file with Teleport Enterprise.
 
-<Admonition type="tip" >
-Teleport Cloud manages licensing for customers, and there is no need to manage license files yourself. 
-</Admonition>
+<ScopedBlock scope={["oss", "cloud"]}>
+
+This guide is intended for Teleport Enterprise users.
+
+<ScopedBlock scope="cloud">
+
+Teleport Cloud manages licensing for customers, and there is no need to manage
+license files yourself.
+
+</ScopedBlock>
+
+<TileSet>
+<Tile title="View this guide as a Teleport Enterprise user" icon="building" href="./license.mdx/?scope=enterprise">
+
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope="enterprise">
+
+Commercial self-hosted Teleport subscriptions require a valid license. The
+license file can be downloaded from the [Teleport Customer
+Portal](https://dashboard.gravitational.com/web/login). When downloading the
+file, the products you are licensed to use will be listed in the browser.
 
 The Teleport license file contains an X.509 certificate and the corresponding
 private key in PEM format. Place the downloaded file on your Teleport Auth
@@ -31,3 +51,5 @@ Attempts to use unlicensed products will result in an error message and users wi
 ```code
 this Teleport cluster is not licensed for database access, please contact the cluster administrator
 ```
+
+</ScopedBlock>

--- a/docs/pages/enterprise/soc2.mdx
+++ b/docs/pages/enterprise/soc2.mdx
@@ -7,6 +7,25 @@ h1: SOC2 Compliance for SSH, Kubernetes, Databases, Desktops and Web Apps
 Teleport is designed to meet SOC2 requirements for the purposes of accessing infrastructure, change management and system operations. This document outlines a high
 level overview of how Teleport can be used to help your company to become SOC2 certified.
 
+<ScopedBlock
+  scope={["oss"]}
+>
+
+  This guide requires Teleport Cloud or Teleport Enterprise.
+
+  View this guide as the user of another Teleport edition:
+
+  <TileSet>
+  <Tile icon="cloud" title="Teleport Cloud" href="./soc2.mdx/?scope=cloud">
+  </Tile>
+  <Tile icon="building" title="Teleport Enterprise" href="./soc2.mdx/?scope=enterprise">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
+
 ## Achieving SOC2 Compliance with Teleport
 SOC2 or Service Organization Controls were developed by the American Institute of CPAs (AICPA). They are based on five trust service areas: security, availability, processing integrity, confidentiality and privacy. 
 
@@ -74,3 +93,5 @@ Each principle has many “Points of Focus” which will apply differently to di
 | CC7.4 - Periodically Evaluates Incidents | Periodically, management reviews incidents related to security, availability, processing integrity, confidentiality, and privacy and identifies the need for system changes based on incident patterns and root causes. | [Use Session recording and audit logs to find patterns that lead to incidents.](../server-access/guides/bpf-session-recording.mdx)  | 
 | CC7.5 - Determines Root Cause of the Event | The root cause of the event is determined. | [Use Session recording and audit logs to find root cause.](../server-access/guides/bpf-session-recording.mdx) | 
 | CC7.5 - Improves Response and Recovery Procedures | Lessons learned are analyzed and the incident-response plan and recovery procedures are improved. | [Replay Session recordings at your &#39;after action review&#39; or postmortem meetings](../server-access/guides/bpf-session-recording.mdx) | 
+
+</ScopedBlock>

--- a/docs/pages/enterprise/sso.mdx
+++ b/docs/pages/enterprise/sso.mdx
@@ -4,8 +4,30 @@ description: How to set up single sign-on (SSO) for SSH using Teleport
 h1: Single Sign-On (SSO) for SSH
 ---
 
-Users of the Enterprise edition of Teleport can login with SSH, Kubernetes, Databases and Web applications
-through a Single Sign-On (SSO) provider used the rest of the organization.
+Users of the Enterprise edition of Teleport can log in to servers, Kubernetes
+clusters, databases, web applications, and Windows desktops through your
+organization's Single Sign-On (SSO) provider.
+
+<ScopedBlock scope="oss">
+<TileSet>
+    <Tile 
+    icon="bolt"
+    title="Use SSO with Teleport Cloud"
+    href="./sso.mdx/?scope=cloud"
+  >
+    Learn how to use Teleport's SSO integrations in Teleport Cloud.
+    </Tile>
+    <Tile 
+    icon="bolt"
+    title="Use SSO with Teleport Enterprise"
+    href="./sso.mdx/?scope=enterprise"
+  >
+    Learn how to use Teleport's SSO integrations in Teleport Enterprise.
+    </Tile>
+  </TileSet>
+</ScopedBlock>
+
+<ScopedBlock scope={["enterprise", "cloud"]}>
 
 <TileSet>
   <Tile icon="bolt" title="Azure Active Directory (AD)" href="./sso/azuread.mdx">
@@ -293,3 +315,4 @@ spec:
       'env': 'dev'
 version: v5
 ```
+</ScopedBlock>

--- a/docs/pages/enterprise/sso/adfs.mdx
+++ b/docs/pages/enterprise/sso/adfs.mdx
@@ -4,7 +4,7 @@ description: How to configure SSH access with Active Directory Federation Servic
 h1: Single Sign-On with Active Directory Federation Services
 ---
 
-This guide will cover how to configure Active Directory Federation Services
+This guide will explain how to configure Active Directory Federation Services
 ([ADFS](https://en.wikipedia.org/wiki/Active_Directory_Federation_Services)) to be
 a single sign-on (SSO) provider to issue
 SSH credentials to specific groups of users. When used in combination with role
@@ -15,12 +15,24 @@ like:
 - Developers must never SSH into production servers.
 - ... and many others.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
+<ScopedBlock
+  scope={["oss"]}
 >
-  This guide requires a commercial edition of Teleport.
-</Admonition>
+
+  This guide requires Teleport Cloud or Teleport Enterprise.
+
+  View this guide as the user of another Teleport edition:
+
+  <TileSet>
+  <Tile icon="cloud" title="Teleport Cloud" href="./adfs.mdx/?scope=cloud">
+  </Tile>
+  <Tile icon="building" title="Teleport Enterprise" href="./adfs.mdx/?scope=enterprise">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)
 
@@ -186,3 +198,5 @@ automatically in a browser.
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+
+</ScopedBlock>

--- a/docs/pages/enterprise/sso/azuread.mdx
+++ b/docs/pages/enterprise/sso/azuread.mdx
@@ -12,12 +12,24 @@ SSH credentials to specific groups of users with a SAML Authentication Connector
 
 The following steps configure an example SAML authentication connector matching Azure AD groups with security roles.  You can choose to configure other options.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
+<ScopedBlock
+  scope={["oss"]}
 >
-  This guide requires either an Enterprise version of Teleport or a Teleport Cloud account.
-</Admonition>
+
+  This guide requires Teleport Cloud or Teleport Enterprise.
+
+  View this guide as the user of another Teleport edition:
+
+  <TileSet>
+  <Tile icon="cloud" title="Teleport Cloud" href="./azuread.mdx/?scope=cloud">
+  </Tile>
+  <Tile icon="building" title="Teleport Enterprise" href="./azuread.mdx/?scope=enterprise">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 ## Prerequisites
 
@@ -387,3 +399,5 @@ Change the Name ID format to use email instead:
 
 ## Further reading
 - [Teleport Configuration Resources Reference](../../setup/reference/resources.mdx)
+
+</ScopedBlock>

--- a/docs/pages/enterprise/sso/gitlab.mdx
+++ b/docs/pages/enterprise/sso/gitlab.mdx
@@ -15,12 +15,24 @@ like:
 - Only members of "ProductionKubernetes" can access production Kubernetes clusters
 - Developers must never SSH into production servers.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
+<ScopedBlock
+  scope={["oss"]}
 >
-  This guide requires a commercial edition of Teleport.
-</Admonition>
+
+  This guide requires Teleport Cloud or Teleport Enterprise.
+
+  View this guide as the user of another Teleport edition:
+
+  <TileSet>
+  <Tile icon="cloud" title="Teleport Cloud" href="./gitlab.mdx/?scope=cloud">
+  </Tile>
+  <Tile icon="building" title="Teleport Enterprise" href="./gitlab.mdx/?scope=enterprise">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 ## Enable default OIDC authentication
 
@@ -179,3 +191,5 @@ automatically in a browser).
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+
+</ScopedBlock>

--- a/docs/pages/enterprise/sso/google-workspace.mdx
+++ b/docs/pages/enterprise/sso/google-workspace.mdx
@@ -5,9 +5,7 @@ h1: SSH Authentication with Google Workspace (G Suite)
 videoBanner: WTLWc6nnPfk
 ---
 
-## Google Workspace as SSO for SSH
-
-This guide will cover how to configure [Google Workspace](https://workspace.google.com/) to be a
+This guide will explain how to configure [Google Workspace](https://workspace.google.com/) to be a
 single sign-on (SSO) provider to issue SSH credentials to specific groups of users.
 When used in combination with role based access control (RBAC) it allows SSH administrators
 to define policies like:
@@ -16,14 +14,24 @@ to define policies like:
 - Developers must never SSH into production servers.
 - ... and many others.
 
-<Notice
-  type="warning"
+<ScopedBlock
   scope={["oss"]}
 >
 
   This guide requires Teleport Cloud or Teleport Enterprise.
 
-</Notice>
+  View this guide as the user of another Teleport edition:
+
+  <TileSet>
+  <Tile icon="cloud" title="Teleport Cloud" href="./google-workspace.mdx/?scope=cloud">
+  </Tile>
+  <Tile icon="building" title="Teleport Enterprise" href="./google-workspace.mdx/?scope=enterprise">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 ## Prerequisites
 
@@ -346,3 +354,5 @@ automatically in a browser).
 - [Google Workspace Cloud Identity API](https://cloud.google.com/identity)
 - [Google Workspace Directory API](https://developers.google.com/admin-sdk/directory)
 - [How nested Google Workspace groups work](https://support.google.com/a/answer/167100?hl=en)
+
+</ScopedBlock>

--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -4,7 +4,7 @@ description: How to configure SSH access with OAuth2 or OIDC (OpenID connect) us
 h1: OAuth2 / OIDC Authentication for SSH
 ---
 
-This guide will cover how to configure an SSO provider using [OpenID Connect](http://openid.net/connect/)
+This guide will explain how to configure an SSO provider using [OpenID Connect](http://openid.net/connect/)
 (also known as OIDC) to issue SSH credentials to a specific groups of users.
 When used in combination with role based access control (RBAC) it allows SSH
 administrators to define policies like:
@@ -13,12 +13,24 @@ administrators to define policies like:
 - Developers must never SSH into production servers.
 - ... and many others.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
+<ScopedBlock
+  scope={["oss"]}
 >
-  This guide requires an Enterprise edition of Teleport.
-</Admonition>
+
+  This guide requires Teleport Cloud or Teleport Enterprise.
+
+  View this guide as the user of another Teleport edition:
+
+  <TileSet>
+  <Tile icon="cloud" title="Teleport Cloud" href="./oidc.mdx/?scope=cloud">
+  </Tile>
+  <Tile icon="building" title="Teleport Enterprise" href="./oidc.mdx/?scope=enterprise">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 ## Enable default OIDC authentication
 
@@ -221,3 +233,5 @@ identity provider if you are not automatically redirected.
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+
+</ScopedBlock>

--- a/docs/pages/enterprise/sso/okta.mdx
+++ b/docs/pages/enterprise/sso/okta.mdx
@@ -15,12 +15,24 @@ like:
 - Only members of "DBA" group can SSH into machines running PostgreSQL.
 - Developers must never SSH into production servers.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
+<ScopedBlock
+  scope={["oss"]}
 >
-  This guide requires a commercial edition of Teleport.
-</Admonition>
+
+  This guide requires Teleport Cloud or Teleport Enterprise.
+
+  View this guide as the user of another Teleport edition:
+
+  <TileSet>
+  <Tile icon="cloud" title="Teleport Cloud" href="./okta.mdx/?scope=cloud">
+  </Tile>
+  <Tile icon="building" title="Teleport Enterprise" href="./okta.mdx/?scope=enterprise">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)
 
@@ -169,3 +181,5 @@ automatically in a browser).
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+
+</ScopedBlock>

--- a/docs/pages/enterprise/sso/one-login.mdx
+++ b/docs/pages/enterprise/sso/one-login.mdx
@@ -4,9 +4,7 @@ description: How to configure SSH access using One Login as an SSO provider
 h1: SSH Authentication with OneLogin
 ---
 
-## Using OneLogin as a single sign-on (SSO) provider for SSH
-
-This guide will cover how to configure [OneLogin](https://www.onelogin.com/) to issue
+This guide will explain how to configure [OneLogin](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role
 based access control (RBAC) it allows SSH administrators to define policies
 like:
@@ -15,12 +13,24 @@ like:
 - Developers must never SSH into production servers.
 - ... and many others.
 
-<Admonition
-  type="warning"
-  title="Version Warning"
+<ScopedBlock
+  scope={["oss"]}
 >
-  This guide requires an Enterprise edition of Teleport.
-</Admonition>
+
+  This guide requires Teleport Cloud or Teleport Enterprise.
+
+  View this guide as the user of another Teleport edition:
+
+  <TileSet>
+  <Tile icon="cloud" title="Teleport Cloud" href="./one-login.mdx/?scope=cloud">
+  </Tile>
+  <Tile icon="building" title="Teleport Enterprise" href="./one-login.mdx/?scope=enterprise">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)
 
@@ -175,3 +185,5 @@ automatically in a browser).
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+
+</ScopedBlock>

--- a/docs/pages/enterprise/workflow/index.mdx
+++ b/docs/pages/enterprise/workflow/index.mdx
@@ -4,7 +4,28 @@ description: Teleport allows users to request new roles with elevated privileges
 h1: Teleport Access Requests
 ---
 
-#### Approving Requests using an External Integration
+With Teleport, users can request additional roles via a third-party
+communication service. The Access Request API makes it easy to dynamically
+approve or deny these requests.
+
+<ScopedBlock
+  scope={["oss"]}
+>
+
+  This guide requires Teleport Cloud or Teleport Enterprise.
+
+  View this guide as the user of another Teleport edition:
+
+  <TileSet>
+  <Tile icon="cloud" title="Teleport Cloud" href="./index.mdx/?scope=cloud">
+  </Tile>
+  <Tile icon="building" title="Teleport Enterprise" href="./index.mdx/?scope=enterprise">
+  </Tile>
+  </TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 - [Integrating Teleport with Slack](ssh-approval-slack.mdx)
 - [Integrating Teleport with Mattermost](ssh-approval-mattermost.mdx)
@@ -13,11 +34,6 @@ h1: Teleport Access Requests
 - [Integrating Teleport with PagerDuty](ssh-approval-pagerduty.mdx)
 
 ## Access Requests Setup
-
-Teleport has the ability for users to request additional roles. The
-Access Request API makes it easy to dynamically approve or deny these requests.
-
-### Setup
 
 **Contractor Role**
 This role allows the contractor to request the role DBA.
@@ -261,3 +277,5 @@ $ tctl request approve --roles=role-1,role-3 --reason='Approved, but not role-2 
 | Jira Server | | Project Board | [Setup Jira Server](ssh-approval-jira-server.mdx) |
 | Jira Cloud | | Project Board | [Setup Jira Cloud](ssh-approval-jira-cloud.mdx) |
 | PagerDuty | | Schedule | [Setup PagerDuty](ssh-approval-pagerduty.mdx) |
+
+</ScopedBlock>


### PR DESCRIPTION
See #11383

Ensure that no visitor to the Teleport docs site sees content that is
irrelevant to their scope (e.g., Cloud, Open Source, or Enterprise) by
hiding scope-irrelevant content from the navigation menu.

In some cases, e.g., the introduction pages for the Cloud, Getting
Started, and Enterprise sections, the content is irrelevant to certain
scopes but a reader still may want to find out more. This change
preserves purely informational content for all scopes, while including
links to other scopes.

This PR focuses on the Enterprise section.