### PR TITLE
Hide Getting Started pages/links based on scope

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -18,7 +18,8 @@
           "entries": [
             {
               "title": "Linux Server",
-              "slug": "/getting-started/linux-server/"
+              "slug": "/getting-started/linux-server/",
+              "hideInScopes": ["enterprise", "cloud"]
             },
             {
               "title": "Docker Compose",
@@ -26,7 +27,8 @@
             },
             {
               "title": "DigitalOcean",
-              "slug": "/getting-started/digitalocean/"
+              "slug": "/getting-started/digitalocean/",
+              "hideInScopes": ["enterprise", "cloud"]
             }
           ]
         },

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -4,20 +4,60 @@ description: Getting started with Teleport - identity-aware access plane for SSH
 layout: tocless-doc
 ---
 
+Follow these guides to get started using Teleport.
+
+## Try a lab on your local machine
+
 <TileSet>
-  <Tile icon="server" title="Linux" href="./getting-started/linux-server.mdx">
-    Get started with Teleport on a standalone Linux server.
-  </Tile>
-  <Tile icon="bolt" title="Docker" href="./getting-started/docker-compose.mdx">
-    Try Teleport locally using Docker Compose.
-  </Tile>
-  <Tile icon="kubernetes" title="Kubernetes" href="./kubernetes-access/getting-started/local.mdx">
-    Get started with Teleport and Kubernetes.
-  </Tile>
-  <Tile icon="cloud" title="Cloud" href="https://goteleport.com/signup">
-    Try Teleport hosted by us in the cloud for free.
-  </Tile>
   <Tile icon="bolt" title="Interactive Lab" href="https://play.instruqt.com/teleport/invite/rgvuva4gzkon">
     Try Teleport using our guided interactive labs.
   </Tile>
+  <Tile icon="bolt" title="Docker Compose Lab" href="./getting-started/docker-compose.mdx">
+    Try Teleport locally using Docker Compose.
+  </Tile>
+    <Tile icon="kubernetes" title="Kubernetes Lab" href="./kubernetes-access/getting-started/local.mdx">
+    See how Teleport runs on Kubernetes with this local lab.
+  </Tile>
 </TileSet>
+
+## Deploy to production
+
+<TileSet>
+  <Tile 
+  icon="stack"
+  title="Open Source Teleport"
+  href="./getting-started/linux-server/?scope=oss"
+  >
+
+  Learn how to host your own open source Teleport deployment on a standalone
+  Linux server.
+
+  </Tile>
+  <Tile
+  icon="stack"
+  title="Teleport on DigitalOcean"
+  href="./getting-started/digitalocean/?scope=oss"
+  >
+
+  Use our DigitalOcean 1-Click App to quickly spin up Teleport on a droplet.
+    
+  </Tile>
+  <Tile
+  icon="building"
+  title="Teleport Enterprise"
+  href="./enterprise/introduction.mdx/?scope=enterprise"
+  >
+
+  Get started with a self-hosted Teleport Enterprise deployment, which gives you
+  more advanced features and full customization.
+
+  </Tile>
+
+  <Tile icon="cloud" title="Teleport Cloud" href="https://goteleport.com/signup">
+
+    Try Teleport hosted by us in the cloud for free.
+
+  </Tile>
+</TileSet>
+
+

--- a/docs/pages/getting-started/digitalocean.mdx
+++ b/docs/pages/getting-started/digitalocean.mdx
@@ -4,16 +4,31 @@ description: How to install Teleport on DigitalOcean?
 videoBanner: voHQlSX_czE
 ---
 
+This tutorial will guide you through quickly getting started with Teleport on
+DigitalOcean with the Teleport 1-Click Droplet app.
 
-<Admonition
-  type="note"
-  title="Note"
+<ScopedBlock scope={["enterprise", "cloud"]}>
+
+This guide is intended for users of Teleport Open Source.
+
+<TileSet>
+<Tile 
+href="./digitalocean.mdx/?scope=oss"
+icon="stack"
+title="View this guide as a Teleport Open Source user"
 >
-This tutorial will guide you through quickly getting started with Teleport on DigitalOcean with Teleport 1-Click Droplet app. If you are looking for a manual installation, refer to our [Linux installation guide](./linux-server.mdx). 
+</Tile>
+</TileSet>
 
-</Admonition>
+</ScopedBlock>
 
-(!docs/pages/includes/cloud/cloudmanagedadvisory.mdx!)
+<ScopedBlock scope="oss">
+
+<Notice type="tip">
+
+If you are looking for a manual installation, refer to our [Linux installation guide](./linux-server.mdx). 
+
+</Notice>
 
 ## Prerequisites
 - A Fully Qualified Domain Name (FQDN).
@@ -119,3 +134,5 @@ You can also secure access to databases, DigitalOcean Marketplace apps, and Kube
     Secure access to Windows Server.
   </Tile>
 </TileSet>
+
+</ScopedBlock>

--- a/docs/pages/getting-started/docker-compose.mdx
+++ b/docs/pages/getting-started/docker-compose.mdx
@@ -4,10 +4,32 @@ description: How to get started with Teleport Open Source Edition using Docker C
 h1: Get started with Docker Compose
 ---
 
-This guide will help you understand how Teleport works by spinning up a demo cluster on your local machine using Docker Compose.
-It will also show you how to use Teleport with OpenSSH, Ansible, and Teleport's native client, `tsh`. 
+This guide will help you understand how Teleport works by spinning up a demo
+cluster on your local machine using Docker Compose. It will also show you how to
+use Teleport with OpenSSH, Ansible, and Teleport's native client, `tsh`.
 
-(!docs/pages/includes/cloud/cloudmanagedadvisory.mdx!)
+<Admonition title="Production deployments" type="tip">
+
+This guide is intended as a local lab for educational purposes. If you would
+like to set up Teleport for production usage, please see:
+
+<ScopedBlock scope="oss">
+
+[Getting Started on a Linux Server](./linux-server.mdx)
+
+</ScopedBlock>
+<ScopedBlock scope="cloud">
+
+[Getting Started](../cloud/getting-started.mdx)
+
+</ScopedBlock>
+<ScopedBlock scope="enterprise">
+
+[Getting Started](../enterprise/getting-started.mdx)
+
+</ScopedBlock>
+
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -8,7 +8,51 @@ This tutorial will guide you through the steps needed to install and run
 Teleport (=teleport.version=) on a Linux machine, then show you how to use
 Teleport to configure access to resources.
 
-(!docs/pages/includes/cloud/cloudmanagedadvisory.mdx!)
+<ScopedBlock scope="enterprise">
+
+This guide is intended for users of the self-hosted, Open Source edition of
+Teleport.
+
+<TileSet>
+<Tile 
+href="./linux-server.mdx/?scope=oss" 
+title="View this guide as a Teleport Open Source user"
+icon="stack"
+>
+</Tile>
+<Tile 
+href="../enterprise/getting-started.mdx/" 
+title="View the Enterprise Getting Started Guide"
+icon="building"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope="cloud">
+
+This guide is intended for users of the self-hosted, Open Source edition of
+Teleport.
+
+<TileSet>
+<Tile 
+href="./linux-server.mdx/?scope=oss" 
+title="View this guide as a Teleport Open Source user"
+icon="stack"
+>
+</Tile>
+<Tile 
+href="../cloud/getting-started.mdx/" 
+title="View the Teleport Cloud Getting Started Guide"
+icon="cloud"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope="oss">
 
 We will run the following Teleport services:
 
@@ -367,3 +411,5 @@ Teleport tasks, such as:
 ## Further reading
 
 - How Let's Encrypt uses the [ACME protocol](https://letsencrypt.org/how-it-works/) to issue certificates
+
+</ScopedBlock>


### PR DESCRIPTION
See #11383

Help ensure that no visitor to the Teleport docs site sees content that
is irrelevant to their scope (e.g., Cloud, Open Source, or Enterprise) by
hiding scope-irrelevant content from the navigation menu and menu
pages.

For pages that aren't step-by-step guides and are meant to convey
general information about a Teleport edition, show these pages in all
scopes so users who are curious about another scope can get the
information they need.

This page focuses on the Getting Started section.

Also reorganizes the getting-started.mdx menu page with the assumption
that users of all editions will visit this page for some of their first
guidance on using Teleport. With this change, getting-started.mdx now
includes links to Getting Started guides in all editions, plus all of
our local labs.

- fixes #10594
- fixes #10199