### PR TITLE
[v9] Fix session tracker backwards compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ ssh.config
 
 # build tooling
 build.assets/tooling/bin/** 
+
+# Go workspace files
+go.work
+go.work.sum

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -170,7 +170,12 @@ func (u *UploadCompleter) checkUploads(ctx context.Context) error {
 		if _, err := u.cfg.SessionTracker.GetSessionTracker(ctx, upload.SessionID.String()); err == nil {
 			continue
 		} else if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
+			// Ignore access denied errors, which we may get if the auth
+			// server is v9.2.1 or earlier, since only node, proxy, and
+			// kube roles had permission to create session trackers.
+			if !trace.IsAccessDenied(err) {
+				return trace.Wrap(err)
+			}
 		}
 
 		parts, err := u.cfg.Uploader.ListParts(ctx, upload)

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -261,6 +261,13 @@ func (s *Server) createTracker(sess *sessionChunk, identity *tlsca.Identity) err
 	s.log.Debugf("Creating tracker for session chunk %v", sess.id)
 	tracker, err := srv.NewSessionTracker(s.closeContext, trackerSpec, s.c.AuthClient)
 	if err != nil {
+		// Ignore access denied errors, which we will get if the auth
+		// server is v9.2.1 or earlier, since only node, proxy, and
+		// kube roles had permission to create session trackers.
+		if trace.IsAccessDenied(err) {
+			s.log.Debugf("Insufficient permissions to create session tracker, skipping session tracking for session chunk %v", sess.id)
+			return nil
+		}
 		return trace.Wrap(err)
 	}
 

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -897,6 +897,13 @@ func (s *Server) trackSession(ctx context.Context, sessionCtx *common.Session) e
 	s.log.Debugf("Creating tracker for session %v", sessionCtx.ID)
 	tracker, err := srv.NewSessionTracker(s.closeContext, trackerSpec, s.cfg.AuthClient)
 	if err != nil {
+		// Ignore access denied errors, which we will get if the auth
+		// server is v9.2.1 or earlier, since only node, proxy, and
+		// kube roles had permission to create session trackers.
+		if trace.IsAccessDenied(err) {
+			s.log.Debugf("Insufficient permissions to create session tracker, skipping session tracking for session %v", sessionCtx.ID)
+			return nil
+		}
 		return trace.Wrap(err)
 	}
 

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -1281,6 +1281,13 @@ func (s *WindowsService) trackSession(ctx context.Context, id *tlsca.Identity, w
 	s.cfg.Log.Debugf("Creating tracker for session %v", sessionID)
 	tracker, err := srv.NewSessionTracker(ctx, trackerSpec, s.cfg.AuthClient)
 	if err != nil {
+		// Ignore access denied errors, which we will get if the auth
+		// server is v9.2.1 or earlier, since only node, proxy, and
+		// kube roles had permission to create session trackers.
+		if trace.IsAccessDenied(err) {
+			s.cfg.Log.Debugf("Insufficient permissions to create session tracker, skipping session tracking for session %v", sessionID)
+			return nil
+		}
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Ignore access denied errors when creating/getting a session tracker as `db`, `app`, or `windows desktop` service. This fixes compatibility with auth servers which are between v9.0.0 and v9.2.1, where access was only granted to `proxy`, `kube`, and `node` roles.

This change does not need to be applied to master (v10)