### PR TITLE
Hide Kubernetes Access menu items based on scope

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -346,9 +346,10 @@
               "title": "Local Demo Cluster",
               "slug": "/kubernetes-access/getting-started/local/"
             },
-            {
-              "title": "Cluster",
-              "slug": "/kubernetes-access/getting-started/cluster/"
+            { 
+              "title": "Cluster", 
+              "slug": "/kubernetes-access/getting-started/cluster/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Agent",
@@ -381,26 +382,32 @@
         {
           "title": "Helm Guides",
           "slug": "/kubernetes-access/helm/guides/",
+          "hideInScopes": "cloud",
           "entries": [
             {
               "title": "AWS EKS Cluster",
-              "slug": "/kubernetes-access/helm/guides/aws/"
+              "slug": "/kubernetes-access/helm/guides/aws/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Google Cloud GKE Cluster",
-              "slug": "/kubernetes-access/helm/guides/gcp/"
+              "slug": "/kubernetes-access/helm/guides/gcp/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "DigitalOcean Kubernetes Cluster",
-              "slug": "/kubernetes-access/helm/guides/digitalocean/"
+              "slug": "/kubernetes-access/helm/guides/digitalocean/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Customize Deployment Config",
-              "slug": "/kubernetes-access/helm/guides/custom/"
+              "slug": "/kubernetes-access/helm/guides/custom/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Migrating From Older Charts",
-              "slug": "/kubernetes-access/helm/guides/migration/"
+              "slug": "/kubernetes-access/helm/guides/migration/",
+              "hideInScopes": "cloud"
             }
           ]
         },

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -5,6 +5,13 @@ videoBanner: VPGYLEMTdJ8
 layout: tocless-doc
 ---
 
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+## Deploy Teleport on Kubernetes
+
+See how you can deploy the Teleport Auth Service and Proxy Service on a
+Kubernetes cluster.
+
 <TileSet>
   <Tile title="Try Teleport on a Local Kubernetes Cluster" href="./getting-started/local.mdx">
     ![Teleport ](../../img/k8s/mini-diagrams/teleport-in-k8s-mono.svg)
@@ -14,8 +21,20 @@ layout: tocless-doc
     ![Teleport ](../../img/k8s/mini-diagrams/teleport-in-k8s-mono.svg)
     Deploy a standalone Teleport cluster in a Kubernetes cluster.
   </Tile>
+</TileSet>
+
+</ScopedBlock>
+
+## Use Teleport to access a Kubernetes cluster
+
+Register your Kubernetes clusters with Teleport for secure `kubectl`
+connections, fine-grained RBAC, and more.
+
+<TileSet>
   <Tile title="Teleport Kubernetes Agent" href="./getting-started/agent.mdx">
     ![Kubernetes agent](../../img/k8s/mini-diagrams/k8s-to-teleport-mono.svg)
-    Connect a Kubernetes cluster to an existing Teleport cluster.
+
+    Get started with Teleport Kubernetes Access.
+
   </Tile>
 </TileSet>

--- a/docs/pages/kubernetes-access/getting-started/cluster.mdx
+++ b/docs/pages/kubernetes-access/getting-started/cluster.mdx
@@ -3,7 +3,39 @@ title: Getting Started - Kubernetes with SSO
 description: Getting started with Teleport. Let's deploy Teleport in a Kubernetes with SSO and Audit logs
 ---
 
-# Getting Started
+<ScopedBlock title="Teleport Cloud customers" scope={["cloud"]}>
+This guide shows you how to deploy the Teleport Auth Service and Proxy Service on a Kubernetes cluster. These services are fully managed in Teleport Cloud.
+
+Instead, Teleport Cloud users should consult the following guide, which shows you how to connect a Teleport Kubernetes Service agent to an existing Teleport cluster:
+
+<TileSet>
+<Tile
+title="Connect a Kubernetes Cluster to Teleport"
+href="./agent.mdx"
+icon="kubernetes"
+>
+</Tile>
+</TileSet>
+
+You can also view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+href="./cluster.mdx/?scope=oss"
+title="Open Source"
+icon="stack"
+>
+</Tile>
+<Tile
+href="./cluster.mdx/?scope=enterprise"
+title="Enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 Teleport can provide secure, unified access to your Kubernetes clusters. This guide will show you how to:
 
@@ -15,14 +47,6 @@ While completing this guide, you will deploy a single Teleport pod running the A
 <Admonition type="tip" title="Have an existing Teleport cluster?">
 If you are already running Teleport on another platform, you can use your existing Teleport deployment to access your Kubernetes cluster. [Follow our guide](./agent.mdx) to connect your Kubernetes cluster to Teleport.
 </Admonition>
-
-<Details title="Teleport Cloud customers" scopeOnly={true} scope={["cloud"]}>
-This guide shows you how to deploy the Teleport Auth Service and Proxy Service on a Kubernetes cluster. These services are fully managed in Teleport Cloud.
-
-Instead, Teleport Cloud users should consult the following guide, which shows you how to connect a Teleport Kubernetes Service node to an existing Teleport cluster.
-
-[Connect a Kubernetes Cluster to Teleport](./agent.mdx)
-</Details>
 
 ## Follow along with our video guide
 
@@ -352,3 +376,5 @@ the default one in case there is a problem.
 - [Setup CI/CD Access with Teleport](../guides/cicd.mdx)
 - [Federated Access using Trusted Clusters](../guides/federation.mdx)
 - [Single-Sign On and Kubernetes Access Control](../controls.mdx)
+
+</ScopedBlock>

--- a/docs/pages/kubernetes-access/helm/guides.mdx
+++ b/docs/pages/kubernetes-access/helm/guides.mdx
@@ -4,6 +4,12 @@ description: How to install and configure Teleport in Kubernetes using Helm
 layout: tocless-doc
 ---
 
+## Helm guides
+
+These guides show you how to set up a full self-hosted Teleport deployment using
+our `teleport-cluster` Helm chart.
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 <TileSet>
     <Tile icon="kubernetes" title="Standalone Teleport Cluster" href="../getting-started.mdx">
         Getting started with Kubernetes Access
@@ -18,11 +24,52 @@ layout: tocless-doc
         Running a Teleport cluster in Kubernetes with a custom Teleport config
     </Tile>
 </TileSet>
-
-## Migration Guides
-
-- [Migrating from the legacy `teleport` chart](./guides/migration.mdx)
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+<TileSet>
+    <Tile 
+    icon="stack"
+    title="Open Source Teleport"
+    href="./guides.mdx/?scope=oss"
+  >
+    Learn how to deploy an open source Teleport cluster using Helm.
+    </Tile>
+    <Tile 
+    icon="building"
+    title="Teleport Enterprise"
+    href="./guides.mdx/?scope=enterprise"
+  >
+    Learn how to deploy a Teleport Enterprise cluster using Helm.
+    </Tile>
+  </TileSet>
+</ScopedBlock>
 
 ## Detailed Helm chart references
 
-- [Helm chart reference](./reference.mdx)
+<TileSet>
+<Tile href="./reference/teleport-cluster.mdx" icon="kubernetes" title="teleport-cluster">
+
+Deploy the `teleport` daemon on Kubernetes with preset configurations for the
+Auth and Proxy Services and support for any Teleport service configuration.
+
+</Tile>
+<Tile href="./reference/teleport-kube-agent.mdx" icon="kubernetes" title="teleport-kube-agent">
+
+Deploy the Teleport Kubernetes Service, Application Service, or Database Service on Kubernetes.
+
+</Tile>
+</TileSet>
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+## Migration Guides
+
+<TileSet>
+<Tile
+href="./guides/migration.mdx"
+title="Migrating from the legacy Teleport chart"
+icon="kubernetes"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>

--- a/docs/pages/kubernetes-access/helm/guides/aws.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/aws.mdx
@@ -6,7 +6,30 @@ description: Install and configure an HA Teleport cluster using an AWS EKS clust
 In this guide, we'll go through how to set up a High Availability Teleport cluster with multiple replicas in Kubernetes
 using Teleport Helm charts and AWS products (DynamoDB and S3).
 
+<ScopedBlock scope="cloud">
+
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
+
+You can also view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+href="./aws.mdx/?scope=oss"
+title="Open Source"
+icon="stack"
+>
+</Tile>
+<Tile
+href="./aws.mdx/?scope=enterprise"
+title="Enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ## Prerequisites
 
@@ -532,3 +555,5 @@ Teleport cluster.
 See the [high availability section of our Helm chart reference](../reference/teleport-cluster.mdx#highavailability) for more details on high availability.
 
 Read the [`cert-manager` documentation](https://cert-manager.io/docs/).
+
+</ScopedBlock>

--- a/docs/pages/kubernetes-access/helm/guides/custom.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/custom.mdx
@@ -1,5 +1,5 @@
 ---
-title: Running a Teleport cluster with a custom configuration using Helm
+title: Running Teleport with a Custom Configuration using Helm
 description: Install and configure a Teleport cluster with a custom configuration using Helm
 ---
 
@@ -9,7 +9,40 @@ config file using Teleport Helm charts.
 This setup can be useful when you already have an existing Teleport cluster and would like to start running it in Kubernetes, or when
 migrating your setup from a legacy version of the Helm charts.
 
-(!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
+<ScopedBlock title="Teleport Cloud customers" scope={["cloud"]}>
+
+Teleport Cloud users should consult the following guide, which shows
+you how to connect a Teleport Kubernetes Service agent to an existing Teleport
+cluster:
+
+<TileSet>
+<Tile
+title="Connect a Kubernetes Cluster to Teleport"
+href="./agent.mdx"
+icon="kubernetes"
+>
+</Tile>
+</TileSet>
+
+You can also view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+href="./custom.mdx/?scope=oss"
+title="Open Source"
+icon="stack"
+>
+</Tile>
+<Tile
+href="./custom.mdx/?scope=enterprise"
+title="Enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ## Prerequisites
 
@@ -240,3 +273,5 @@ $ helm --namespace teleport uninstall teleport
 
 You can follow our [Getting Started with Teleport guide](../../../setup/guides/docker.mdx#step-34-creating-a-teleport-user) to finish setting up your
 Teleport cluster.
+
+</ScopedBlock>

--- a/docs/pages/kubernetes-access/helm/guides/digitalocean.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/digitalocean.mdx
@@ -3,11 +3,50 @@ title: Get started with Teleport on DigitalOcean Kubernetes
 description: How to get started with Teleport on DigitalOcean Kubernetes
 ---
 
-This guide will show you how to get started with Teleport on DigitalOcean Kubernetes. 
+<ScopedBlock title="Teleport Cloud customers" scope={["cloud"]}>
 
-(!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
+This guide shows you how to deploy the Teleport Auth Service and Proxy Service
+on a DigitalOcean Kubernetes cluster. These services are fully managed in
+Teleport Cloud.
+
+Instead, Teleport Cloud users should consult the following guide, which shows
+you how to connect a Teleport Kubernetes Service agent to an existing Teleport
+cluster:
+
+<TileSet>
+<Tile
+title="Connect a Kubernetes Cluster to Teleport"
+href="./agent.mdx"
+icon="kubernetes"
+>
+</Tile>
+</TileSet>
+
+You can also view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+href="./digitalocean.mdx/?scope=oss"
+title="Open Source"
+icon="stack"
+>
+</Tile>
+<Tile
+href="./digitalocean.mdx/?scope=enterprise"
+title="Enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+This guide will show you how to get started with Teleport on DigitalOcean
+Kubernetes.
 
 ## Prerequisites
+
 - DigitalOcean account.
 - Your workstation configured with [kubectl](https://kubernetes.io/docs/tasks/tools/), [Helm](https://helm.sh/docs/intro/install/), [doctl](https://docs.digitalocean.com/reference/doctl/how-to/install/), and the Teleport [tsh](https://goteleport.com/docs/installation/) client.
 
@@ -189,3 +228,5 @@ Teleport keeps an audit log of access to a Kubernetes cluster. In the screenshot
 - [Setup CI/CD Access with Teleport](../../guides/cicd.mdx)
 - [Federated Access using Trusted Clusters](../../guides/federation.mdx)
 - [Single-Sign On and Kubernetes Access Control](../../controls.mdx)
+
+</ScopedBlock>

--- a/docs/pages/kubernetes-access/helm/guides/gcp.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/gcp.mdx
@@ -6,7 +6,30 @@ description: Install and configure an HA Teleport cluster using a Google Cloud G
 In this guide, we'll go through how to set up a High Availability Teleport cluster with multiple replicas in Kubernetes
 using Teleport Helm charts and Google Cloud Platform products (Firestore and Google Cloud Storage).
 
+<ScopedBlock scope="cloud">
+
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
+
+You can also view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+href="./gcp.mdx/?scope=oss"
+title="Open Source"
+icon="stack"
+>
+</Tile>
+<Tile
+href="./gcp.mdx/?scope=enterprise"
+title="Enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ## Prerequisites
 
@@ -464,3 +487,5 @@ You can follow our [Getting Started with Teleport guide](../../../setup/guides/d
 Teleport cluster.
 
 See the [high availability section of our Helm chart reference](../reference/teleport-cluster.mdx#highavailability) for more details on high availability.
+
+</ScopedBlock>

--- a/docs/pages/kubernetes-access/helm/guides/migration.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/migration.mdx
@@ -13,7 +13,30 @@ to use the newer `teleport-cluster` Helm chart instead.
   consider [following a different guide](../guides.mdx) and storing your cluster's data in AWS DynamoDB or Google Cloud Firestore.
 </Admonition>
 
+<ScopedBlock scope="cloud">
+
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
+
+You can also view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+href="./gcp.mdx/?scope=oss"
+title="Open Source"
+icon="stack"
+>
+</Tile>
+<Tile
+href="./gcp.mdx/?scope=enterprise"
+title="Enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ## Prerequisites
 
@@ -247,3 +270,5 @@ To uninstall the `teleport-cluster` chart, use `helm uninstall <release-name>`. 
 ```code
 $ helm --namespace teleport-cluster uninstall teleport
 ```
+
+</ScopedBlock>

--- a/docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx
+++ b/docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx
@@ -1,4 +1,3 @@
-<Details scopeOnly={true} scope={["cloud"]} title="Teleport Cloud warning">
 This guide shows you how to install the `teleport-cluster` Helm chart, which is intended to help you get started with Teleport by deploying the Auth Service and 
 Proxy Service in a Kubernetes cluster so you can access that cluster via the Kubernetes Service.
 
@@ -7,4 +6,3 @@ Since the Auth and Proxy Services are fully managed in Teleport Cloud, you shoul
 You can use the `teleport-kube-agent` chart to enable the Application Service and Database Service in addition to the Kubernetes Service.
 
 For more information, see our [Helm chart reference](../reference/teleport-kube-agent.mdx).
-</Details>

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -7,7 +7,8 @@ description: A list of values that can be set using Teleport Helm charts and the
 <Tile href="./reference/teleport-cluster.mdx" icon="kubernetes" title="teleport-cluster">
 ![Teleport ](../../../img/k8s/mini-diagrams/teleport-in-k8s-mono.svg)
 
-Deploy the Teleport Auth Service and Proxy Service on Kubernetes.
+Deploy the `teleport` daemon on Kubernetes with preset configurations for the
+Auth and Proxy Services and support for any Teleport service configuration.
 
 </Tile>
 <Tile href="./reference/teleport-kube-agent.mdx" icon="kubernetes" title="teleport-kube-agent">

--- a/docs/pages/kubernetes-access/helm/reference/teleport-cluster.mdx
+++ b/docs/pages/kubernetes-access/helm/reference/teleport-cluster.mdx
@@ -3,18 +3,10 @@ title: teleport-cluster Chart Reference
 description: Values that can be set using the teleport-cluster Helm chart
 ---
 
-The `teleport-cluster` Helm chart is used to deploy the Teleport Auth Service
-and Proxy Service, which is ideal for getting started with a self-hosted Teleport
-cluster on Kubernetes.
-
-<Notice scope={["cloud"]} type="warning">
-
-Teleport Cloud manages the Auth Service and Proxy Service for you. Use the
-`teleport-cluster` chart if you are interested in hosting Teleport yourself, or
-use the [`teleport-kube-agent`](./teleport-kube-agent.mdx) chart to deploy the
-Kubernetes Service, Application Service, or Database Service.
-
-</Notice>
+The `teleport-cluster` Helm chart deploys the `teleport` daemon on Kubernetes.
+You can use our preset configurations to deploy the Auth Service and Proxy
+Service, or a custom configuration to deploy agent services such as the Teleport
+Kubernetes Service or Database Service.
 
 You can
 [browse the source on GitHub](https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-cluster).

--- a/docs/pages/kubernetes-access/introduction.mdx
+++ b/docs/pages/kubernetes-access/introduction.mdx
@@ -34,7 +34,30 @@ Set up SSO, capture audit events, and sessions with Teleport running in a Kubern
 
 ## Getting started
 
-Configure Kubernetes Access in a ten-minute [Getting Started](./getting-started.mdx) guide.
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+### Deploy Teleport on Kubernetes
+
+<TileSet>
+  <Tile icon="kubernetes" title="Try Teleport on a Local Kubernetes Cluster" href="./getting-started/local.mdx">
+    Quickly see how Teleport works with Kubernetes on your laptop.
+  </Tile>
+  <Tile icon="kubernetes" title="Teleport Cluster in Kubernetes" href="./getting-started/cluster.mdx">
+    Deploy a standalone Teleport cluster in a Kubernetes cluster.
+  </Tile>
+</TileSet>
+
+
+### Use Teleport to access a Kubernetes cluster
+</ScopedBlock>
+
+<TileSet>
+  <Tile icon="kubernetes" title="Teleport Kubernetes Agent" href="./getting-started/agent.mdx">
+
+    Get started with Teleport Kubernetes Access.
+
+  </Tile>
+</TileSet>
 
 ## Guides
 


### PR DESCRIPTION
See #11383

Help ensure that no visitor to the Teleport docs site sees content that
is irrelevant to their scope (e.g., Cloud, Open Source, or Enterprise) by
hiding scope-irrelevant content from the navigation menu and menu
pages.

For pages that aren't step-by-step guides and are meant to convey
general information about a Teleport edition, show these pages in all
scopes so users who are curious about another scope can get the
information they need.

This PR focuses on the Kubernetes Access section.

It also adds a short note at the top of the teleport-cluter Helm chart
reference that the chart supports custom agent configurations along with
the Auth/Proxy.