### PR TITLE
Hide Server Access menu items based on scope

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -311,7 +311,8 @@
             },
             {
               "title": "Recording Proxy Mode",
-              "slug": "/server-access/guides/recording-proxy-mode/"
+              "slug": "/server-access/guides/recording-proxy-mode/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "BPF Session Recording",

--- a/docs/pages/server-access/guides.mdx
+++ b/docs/pages/server-access/guides.mdx
@@ -14,9 +14,11 @@ layout: tocless-doc
   <Tile icon="server" title="OpenSSH Guide" href="./guides/openssh.mdx">
     How to use Teleport on legacy systems with OpenSSH and sshd.
   </Tile>
-  <Tile icon="server" title="Recording Proxy Mode" href="./guides/recording-proxy-mode.mdx">
-    How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
-  </Tile>
+  <ScopedBlock scope={["oss", "enterprise"]}>
+    <Tile icon="server" title="Recording Proxy Mode" href="./guides/recording-proxy-mode.mdx">
+      How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
+    </Tile>
+  </ScopedBlock>
   <Tile icon="server" title="BPF Session Recording" href="./guides/bpf-session-recording.mdx">
     How to use BPF to record SSH session commands, modified files and network connections.
   </Tile>

--- a/docs/pages/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/server-access/guides/recording-proxy-mode.mdx
@@ -3,15 +3,9 @@ title: Teleport Recording Proxy Mode
 description: Use Recording Proxy Mode to capture OpenSSH server activity
 ---
 
-<Notice scope={["cloud"]} type="warning">
-
-Teleport Cloud only supports session recording at the Node level. If you are
-interested in setting up session recording, read our
-[Server Access Getting Started Guide](../getting-started.mdx) so you can start
-replacing your OpenSSH servers with Teleport Nodes.
-
-</Notice>
-
+Teleport Recording Proxy Mode was added to allow Teleport users
+to enable session recording for servers running `sshd`, which is helpful
+when gradually transitioning large server fleets to Teleport.
 
 <Figure
   align="center"
@@ -21,9 +15,34 @@ replacing your OpenSSH servers with Teleport Nodes.
   ![Teleport OpenSSH Recording Proxy](../../../img/server-access/openssh-proxy.svg)
 </Figure>
 
-Teleport Recording Proxy Mode was added to allow Teleport users
-to enable session recording for OpenSSH's servers running `sshd`, which is helpful
-when gradually transitioning large server fleets to Teleport.
+
+<ScopedBlock scope={["cloud"]}>
+
+Teleport Cloud only supports session recording at the Node level. If you are
+interested in setting up session recording, read our
+[Server Access Getting Started Guide](../getting-started.mdx) so you can start
+replacing your OpenSSH servers with Teleport Nodes.
+
+You can also view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+href="./recording-proxy-mode.mdx/?scope=oss"
+icon="stack"
+title="Open Source Teleport"
+>
+</Tile>
+<Tile
+href="./recording-proxy-mode.mdx/?scope=enterprise"
+icon="building"
+title="Teleport Enterprise"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 We consider Recording Proxy Mode to be less secure than recording at the Node
 level for two reasons:
@@ -251,3 +270,5 @@ dropped.
 
 To increase the concurrency level, increase the value to something like
 `MaxStartups 50:30:100`. This allows 50 concurrent connections and a max of 100.
+
+</ScopedBlock>

--- a/docs/pages/server-access/introduction.mdx
+++ b/docs/pages/server-access/introduction.mdx
@@ -28,4 +28,28 @@ Teleport Server Access is designed for the following kinds of scenarios:
 
 ## Guides
 
-- [Using Teleport with PAM](./guides/ssh-pam.mdx)
+<TileSet>
+  <Tile icon="server" title="Using Teleport with PAM" href="./guides/ssh-pam.mdx">
+    How to configure Teleport SSH with PAM (Pluggable Authentication Modules).
+  </Tile>
+  <Tile icon="server" title="Using Teleport with Ansible" href="./guides/ansible.mdx">
+    How to configure Teleport SSH with Ansible.
+  </Tile>
+  <Tile icon="server" title="OpenSSH Guide" href="./guides/openssh.mdx">
+    How to use Teleport on legacy systems with OpenSSH and sshd.
+  </Tile>
+  <ScopedBlock scope={["oss", "enterprise"]}>
+    <Tile icon="server" title="Recording Proxy Mode" href="./guides/recording-proxy-mode.mdx">
+      How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
+    </Tile>
+  </ScopedBlock>
+  <Tile icon="server" title="BPF Session Recording" href="./guides/bpf-session-recording.mdx">
+    How to use BPF to record SSH session commands, modified files and network connections.
+  </Tile>
+  <Tile icon="server" title="Restricted Session" href="./guides/restricted-session.mdx">
+    How to configure and use Restricted Session to apply security policies to SSH sessions.
+  </Tile>
+  <Tile icon="server" title="Visual Studio Code" href="./guides/vscode.mdx">
+    How to remotely develop with Visual Studio Code and Teleport.
+  </Tile>
+</TileSet>


### PR DESCRIPTION
See #11383

Help ensure that no visitor to the Teleport docs site sees content that
is irrelevant to their scope (e.g., Cloud, Open Source, or Enterprise) by
hiding scope-irrelevant content from the navigation menu and menu
pages.

For pages that aren't step-by-step guides and are meant to convey
general information about a Teleport edition, show these pages in all
scopes so users who are curious about another scope can get the
information they need.

This PR focuses on the Server Access section.

It also includes links to all Server Access guides in the intro page,
since only the PAM guide was included before.