### PR TITLE
Hide Setup menu items based on scope

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -89,18 +89,22 @@
         {
           "title": "Deployments",
           "slug": "/setup/deployments/",
+          "hideInScopes": "cloud",
           "entries": [
             {
               "title": "AWS Terraform",
-              "slug": "/setup/deployments/aws-terraform/"
+              "slug": "/setup/deployments/aws-terraform/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "GCP",
-              "slug": "/setup/deployments/gcp/"
+              "slug": "/setup/deployments/gcp/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "IBM",
-              "slug": "/setup/deployments/ibm/"
+              "slug": "/setup/deployments/ibm/",
+              "hideInScopes": "cloud"
             }
           ]
         },
@@ -110,7 +114,8 @@
           "entries": [
             {
               "title": "Scaling",
-              "slug": "/setup/operations/scaling/"
+              "slug": "/setup/operations/scaling/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Upgrading a Cluster",
@@ -166,7 +171,8 @@
             },
             {
               "title": "Joining Nodes via AWS EC2",
-              "slug": "/setup/guides/joining-nodes-aws-ec2/"
+              "slug": "/setup/guides/joining-nodes-aws-ec2/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Using Teleport's CA with GitHub",
@@ -208,7 +214,8 @@
             },
             {
               "title": "Storage Backends",
-              "slug": "/setup/reference/backends/"
+              "slug": "/setup/reference/backends/",
+              "hideInScopes": "cloud"
             },
             {
               "title": "Networking",

--- a/docs/pages/setup/deployments.mdx
+++ b/docs/pages/setup/deployments.mdx
@@ -4,6 +4,29 @@ description: Teleport Installation and Configuration Reference Deployment Guides
 layout: tocless-doc
 ---
 
+These guides show you how to set up a full self-hosted Teleport deployment on
+the platform of your choice.
+
+<ScopedBlock scope="cloud">
+<TileSet>
+    <Tile 
+    icon="wrench"
+    title="Open Source Teleport"
+    href="./deployments.mdx/?scope=oss"
+  >
+    View our deployment guides as an Open Source Teleport user.
+    </Tile>
+    <Tile 
+    icon="wrench"
+    title="Teleport Enterprise"
+    href="./deployments.mdx/?scope=enterprise"
+  >
+    View our deployment guides as a Teleport Enterprise user.
+    </Tile>
+  </TileSet>
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 <ul>
   <li>
     [AWS Terraform](./deployments/aws-terraform.mdx). Deploy HA Teleport with Terraform Provider on AWS.
@@ -15,3 +38,4 @@ layout: tocless-doc
     [IBM Cloud](./deployments/ibm.mdx). Deploy HA Teleport on IBM cloud.
   </li>
 </ul>
+</ScopedBlock>

--- a/docs/pages/setup/deployments/aws-terraform.mdx
+++ b/docs/pages/setup/deployments/aws-terraform.mdx
@@ -5,14 +5,56 @@ h1: Running Teleport Enterprise in High Availability mode on AWS
 ---
 
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
-and describe how to use and administrate the resulting Teleport deployment.
+and describe how to manage the resulting Teleport deployment.
 
-<Details scope={["cloud"]} scopeOnly={true} opened={true} title="Teleport Cloud">
-Our reference Terraform code deploys self-hosted instances of the Teleport Auth Service and Proxy Service. Since Teleport Cloud manages these services for you, users interested in Terraform should consult the following guides instead of this one:
+<ScopedBlock scope="cloud">
 
-- To get started with Teleport and Terraform: [Terraform Provider](../guides/terraform-provider.mdx)
-- For a full reference: [Terraform Provider Resources](../reference/terraform-provider.mdx)
-</Details>
+Our reference Terraform code deploys self-hosted instances of the Teleport Auth
+Service and Proxy Service. Since Teleport Cloud manages these services for you,
+users interested in Terraform should consult the following guides instead of
+this one:
+
+<TileSet>
+<Tile
+href="../guides/terraform-provider.mdx"
+title="Getting started"
+icon="wrench"
+>
+
+Read our guide to using Teleport and Terraform
+
+</Tile>
+<Tile
+href="../reference/terraform-provider.mdx"
+title="Reference"
+icon="wrench"
+>
+
+Read our Terraform provider reference
+
+</Tile>
+</TileSet>
+
+You can also view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+title="Open Source Teleport"
+href="./aws-terraform.mdx/?scope=oss"
+icon="stack"
+>
+</Tile>
+<Tile
+title="Teleport Enterprise"
+href="./aws-terraform.mdx/?scope=enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ## Prerequisites
 
@@ -841,3 +883,5 @@ $ ./connect.sh proxy 1
 # connect to the node
 $ ./connect.sh node
 ```
+
+</ScopedBlock>

--- a/docs/pages/setup/deployments/gcp.mdx
+++ b/docs/pages/setup/deployments/gcp.mdx
@@ -3,17 +3,35 @@ title: Running Teleport on GCP
 description: How to install and configure Gravitational Teleport on GCP for SSH and Kubernetes access.
 ---
 
-We've created this guide to give customers a high level overview of how to use Teleport
-on [Google Cloud](https://cloud.google.com/gcp/) (GCP). This guide provides a high level
-introduction leading to a deep dive into how to setup and run Teleport in production.
+We've created this guide to give customers an overview of how to use Teleport on
+[Google Cloud](https://cloud.google.com/gcp/) (GCP). This guide provides a
+high-level introduction to setting up and running Teleport in production.
 
-<Notice type="warning" scope={["cloud"]}>
+<ScopedBlock scope="cloud">
 
 This guide shows you how to deploy the Auth Service and Proxy Service, which
-Teleport Cloud manages for you. You can read this guide if you are interested in
-learning about self-hosting Teleport on Google Cloud.
+Teleport Cloud manages for you.
 
-</Notice>
+You can view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+title="Open Source Teleport"
+href="./gcp.mdx/?scope=oss"
+icon="stack"
+>
+</Tile>
+<Tile
+title="Teleport Enterprise"
+href="./gcp.mdx/?scope=enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 We have split this guide into:
 
@@ -221,3 +239,5 @@ proxy_service:
 **4. Add Users**
 
 Follow [adding users](../../enterprise/getting-started.mdx#adding-users) or integrate with [Google Workspace](../../enterprise/sso/google-workspace.mdx) to provide SSO access.
+
+</ScopedBlock>

--- a/docs/pages/setup/deployments/ibm.mdx
+++ b/docs/pages/setup/deployments/ibm.mdx
@@ -3,17 +3,35 @@ title: Running Teleport on IBM Cloud
 description: How to install and configure Gravitational Teleport on IBM cloud for SSH and Kubernetes access.
 ---
 
-We've created this guide to give customers a high level overview of how to use Teleport
-on the [IBM Cloud](https://www.ibm.com/cloud). This guide provides a high level
-introduction leading to a deep dive into how to setup and run Teleport in production.
+We've created this guide to give customers an overview of how to use Teleport on
+[IBM Cloud](https://www.ibm.com/cloud). This guide provides a high-level
+introduction to setting up and running Teleport in production.
 
-<Notice type="warning" scope={["cloud"]}>
+<ScopedBlock scope="cloud">
 
 This guide shows you how to deploy the Auth Service and Proxy Service, which
-Teleport Cloud manages for you. You can read this guide if you are interested in
-learning about self-hosting Teleport on IBM Cloud.
+Teleport Cloud manages for you.
 
-</Notice>
+You can view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+title="Open Source Teleport"
+href="./ibm.mdx/?scope=oss"
+icon="stack"
+>
+</Tile>
+<Tile
+title="Teleport Enterprise"
+href="./ibm.mdx/?scope=enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 We have split this guide into:
 
@@ -198,3 +216,5 @@ the Teleport Proxy public address.
     # (see public_addr section below)
     public_addr: proxy.example.com:3080
 ```
+
+</ScopedBlock>

--- a/docs/pages/setup/guides.mdx
+++ b/docs/pages/setup/guides.mdx
@@ -9,5 +9,7 @@ layout: tocless-doc
   - [Fluentd Event Forwarder](./guides/fluentd.mdx). Forwarding events with Fluentd and the Teleport Events Handler.
   - [EC2 tags as Teleport Nodes](./guides/ec2-tags.mdx). How to set up Teleport Node labels based on EC2 tags.
   - [Joining Nodes via AWS IAM Role](./guides/joining-nodes-aws-iam.mdx). Use the IAM join method to add Nodes to your Teleport cluster on AWS.
+  <ScopedBlock scope={["oss", "enterprise"]}>
   - [Joining Nodes via AWS EC2 Identity Document](./guides/joining-nodes-aws-ec2.mdx). Use the EC2 join method to add Nodes to your Teleport cluster on AWS.
+  </ScopedBlock>
   - [Using Teleport's Certificate Authority with GitHub](./guides/ssh-key-extensions.mdx). Use Teleport's short-lived certificates with GitHub's Certificate Authority.

--- a/docs/pages/setup/guides/joining-nodes-aws-ec2.mdx
+++ b/docs/pages/setup/guides/joining-nodes-aws-ec2.mdx
@@ -7,13 +7,32 @@ This guide will explain how to use the **EC2 join method** to configure Teleport
 nodes and Proxies to join your Teleport cluster without sharing any secrets when
 they are running in AWS.
 
-<Notice type="warning" scope={["cloud"]}>
+<ScopedBlock scope="cloud">
 
 The EC2 join method is not available in Teleport Cloud. Teleport Cloud customers
 can use the [IAM join method](./joining-nodes-aws-iam.mdx) or
 [secret tokens](../admin/adding-nodes.mdx).
 
-</Notice>
+You can view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+title="Open Source Teleport"
+href="./joining-nodes-aws-ec2.mdx/?scope=oss"
+icon="stack"
+>
+</Tile>
+<Tile
+title="Teleport Enterprise"
+href="./joining-nodes-aws-ec2.mdx/?scope=enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 The EC2 join method is available in self-hosted versions of Teleport 7.3+. It is
 available to any Teleport node or Proxy running on an EC2 instance. Only one
@@ -33,7 +52,7 @@ scopeOnly
 There are two other AWS join methods available depending on your use case.
 
 The **IAM join method** is available in self-hosted editions of Teleport 8.3+.
-It is available to any Teleport node or Proxy running anywhere with access to
+It is available to any Teleport Node or Proxy running anywhere with access to
 IAM credentials, such as an EC2 instance with an attached IAM role. No specific
 permissions or IAM policy is required: an IAM role with no attached policies is
 sufficient. No IAM credentials are required on the Teleport Auth Service.
@@ -282,3 +301,5 @@ spec:
     - us-west-2
     aws_role: "arn:aws:iam::333333333333:role/teleport-DescribeInstances-role"
 ```
+
+</ScopedBlock>

--- a/docs/pages/setup/operations.mdx
+++ b/docs/pages/setup/operations.mdx
@@ -11,9 +11,11 @@ For guides on the fundamentals of setting up your cluster, you should consult
 the [Cluster Administration Guides](./admin.mdx) section.
 
 <TileSet>
-  <Tile href="./operations/scaling.mdx" title="Scaling" icon="wrench">
-  How to configure Teleport for large-scale deployments.
-  </Tile>
+  <ScopedBlock scope={["oss", "enterprise"]}>
+    <Tile href="./operations/scaling.mdx" title="Scaling" icon="wrench">
+    How to configure Teleport for large-scale deployments.
+    </Tile>
+  </ScopedBlock>
   <Tile href="./operations/upgrading.mdx" title="Upgrading" icon="wrench">
   Learn about how to upgrade your Teleport cluster while ensuring that components remain compatible.
   </Tile>
@@ -23,7 +25,9 @@ the [Cluster Administration Guides](./admin.mdx) section.
   <Tile href="./operations/ca-rotation.mdx" title="CA Rotation" icon="wrench">
   Rotating Teleport certificate authorities.
   </Tile>
-  <Tile href="./operations/tls-routing.mdx" title="TLS Routing Migration" icon="wrench">
-  Migrating your Teleport cluster to single-port TLS routing mode.
-  </Tile>
+  <ScopedBlock scope={["oss", "enterprise"]}>
+    <Tile href="./operations/tls-routing.mdx" title="TLS Routing Migration" icon="wrench">
+    Migrating your Teleport cluster to single-port TLS routing mode.
+    </Tile>
+  </ScopedBlock>
 </TileSet>

--- a/docs/pages/setup/operations/scaling.mdx
+++ b/docs/pages/setup/operations/scaling.mdx
@@ -3,12 +3,34 @@ title: Scaling
 description: How to configure Teleport for large-scale deployments
 ---
 
-This section covers recommended configurations for large-scale
+This section explains the recommended configuration settings for large-scale
 deployments of Teleport.
 
-<Notice type="warning" scope={["cloud"]}>
-For Teleport Cloud customers, the settings in this guide are configured automatically.
-</Notice>
+<ScopedBlock scope="cloud">
+
+For Teleport Cloud customers, the settings in this guide are configured
+automatically.
+
+You can view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+title="Open Source Teleport"
+href="./scaling.mdx/?scope=oss"
+icon="stack"
+>
+</Tile>
+<Tile
+title="Teleport Enterprise"
+href="./scaling.mdx/?scope=enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ## Prerequisites
 
@@ -53,3 +75,5 @@ $ cat /proc/$(pidof teleport)/limits
 # Limit                     Soft Limit           Hard Limit           Units
 # Max open files            65536                65536                files
 ```
+
+</ScopedBlock>

--- a/docs/pages/setup/reference.mdx
+++ b/docs/pages/setup/reference.mdx
@@ -26,9 +26,11 @@ layout: tocless-doc
   <li>
     [Authentication](./reference/authentication.mdx). Cluster authentication options.
   </li>
+  <ScopedBlock scope={["oss", "enterprise"]}>
   <li>
     [Backends](./reference/backends.mdx). Supported storage backends.
   </li>
+  </ScopedBlock>
   <li>
     [Networking](./reference/networking.mdx). Ports, protocols and networking requirements.
   </li>

--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -8,12 +8,31 @@ default everything is stored in a local directory at the Auth server.
 Integration with other storage types is implemented based on the nature of the
 stored data (size, read/write ratio, mutability, etc.).
 
-<Notice scope={["cloud"]} type="tip">
+<ScopedBlock scope={["cloud"]}>
 
 Teleport Cloud manages Auth Service and Proxy Service data for you, so there is
 no need to configure a backend.
 
-</Notice>
+You can view this guide as a user of another Teleport edition:
+
+<TileSet>
+<Tile
+title="Open Source Teleport"
+href="./backends.mdx/?scope=oss"
+icon="stack"
+>
+</Tile>
+<Tile
+title="Teleport Enterprise"
+href="./backends.mdx/?scope=enterprise"
+icon="building"
+>
+</Tile>
+</TileSet>
+
+</ScopedBlock>
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 | Data type | Description | Supported storage backends |
 | - | - | - |
@@ -684,3 +703,5 @@ $ psql -d postgres
 postgres=# CREATE DATABASE teleport;
 postgres=# GRANT ALL PRIVILEGES ON DATABASE teleport TO dbuser;
 ```
+
+</ScopedBlock>


### PR DESCRIPTION
See #11383

Help ensure that no visitor to the Teleport docs site sees content that
is irrelevant to their scope (e.g., Cloud, Open Source, or Enterprise) by
hiding scope-irrelevant content from the navigation menu and menu
pages.

For pages that aren't step-by-step guides and are meant to convey
general information about a Teleport edition, show these pages in all
scopes so users who are curious about another scope can get the
information they need.

This PR focuses on the Setup section.