### PR TITLE
Adds redirects for deprecated docs versions

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -929,6 +929,31 @@
   },
   "redirects": [
     {
+      "source": "/ver/6.2/:path*",
+      "destination": "/older-versions",
+      "permanent": true
+    },
+    {
+      "source": "/ver/6.1/:path*",
+      "destination": "/older-versions",
+      "permanent": true
+    },
+    {
+      "source": "/ver/6.0/:path*",
+      "destination": "/older-versions",
+      "permanent": true
+    },
+    {
+      "source": "/ver/5.0/:path*",
+      "destination": "/older-versions",
+      "permanent": true
+    },
+    {
+      "source": "/ver/4.0/:path*",
+      "destination": "/older-versions",
+      "permanent": true
+    },
+    {
       "source": "/user-manual/",
       "destination": "/server-access/guides/tsh/",
       "permanent": true


### PR DESCRIPTION
These redirects will push any path matching `/ver/xx` to the new Older Versions indexing page. 