### PR TITLE
[v8] Ensure h2 has precedence over http/1.1

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3349,12 +3349,12 @@ func (process *TeleportProcess) setupProxyTLSConfig(conn *Connector, tsrv revers
 		tlsConfig = m.TLSConfig()
 		utils.SetupTLSConfig(tlsConfig, cfg.CipherSuites)
 
-		// If ACME protocol was enabled add all known TLS Routing protocols.
-		// Go 1.17 introduced strict ALPN https://golang.org/doc/go1.17#ALPN If a client protocol is not recognized
-		// the TLS handshake will fail.
-		supportedProtocols := alpncommon.ProtocolsToString(alpncommon.SupportedProtocols)
-		tlsConfig.NextProtos = apiutils.Deduplicate(append(tlsConfig.NextProtos, supportedProtocols...))
+		tlsConfig.NextProtos = apiutils.Deduplicate(append(tlsConfig.NextProtos, acme.ALPNProto))
 	}
+
+	// Go 1.17 introduced strict ALPN https://golang.org/doc/go1.17#ALPN If a client protocol is not recognized
+	// the TLS handshake will fail.
+	tlsConfig.NextProtos = apiutils.Deduplicate(append(tlsConfig.NextProtos, alpncommon.ProtocolsToString(alpncommon.SupportedProtocols)...))
 
 	for _, pair := range process.Config.Proxy.KeyPairs {
 		process.Config.Log.Infof("Loading TLS certificate %v and key %v.", pair.Certificate, pair.PrivateKey)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -488,6 +488,7 @@ func TestSetupProxyTLSConfig(t *testing.T) {
 			name:        "ACME enabled, teleport ALPN protocols should be appended",
 			acmeEnabled: true,
 			wantNextProtos: []string{
+				// Ensure h2 has precedence over http/1.1.
 				"h2",
 				"http/1.1",
 				"acme-tls/1",
@@ -502,8 +503,17 @@ func TestSetupProxyTLSConfig(t *testing.T) {
 		{
 			name:        "ACME disabled",
 			acmeEnabled: false,
-			// If server NextProtos list is empty server allows for connection with any protocol.
-			wantNextProtos: nil,
+			wantNextProtos: []string{
+				// Ensure h2 has precedence over http/1.1.
+				"h2",
+				"http/1.1",
+				"teleport-postgres",
+				"teleport-mysql",
+				"teleport-mongodb",
+				"teleport-proxy-ssh",
+				"teleport-reversetunnel",
+				"teleport-auth@",
+			},
 		},
 	}
 

--- a/lib/srv/alpnproxy/common/protocols.go
+++ b/lib/srv/alpnproxy/common/protocols.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package common
 
-import "golang.org/x/crypto/acme"
-
 // Protocol is the TLS ALPN protocol type.
 type Protocol string
 
@@ -56,14 +54,13 @@ const (
 
 // SupportedProtocols is the list of supported ALPN protocols.
 var SupportedProtocols = []Protocol{
-	acme.ALPNProto,
+	ProtocolHTTP2,
+	ProtocolHTTP,
 	ProtocolPostgres,
 	ProtocolMySQL,
 	ProtocolMongoDB,
 	ProtocolProxySSH,
 	ProtocolReverseTunnel,
-	ProtocolHTTP,
-	ProtocolHTTP2,
 	ProtocolAuth,
 }
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/12740 to branch/v8