### PR TITLE
Add labels to output of 'tsh kube ls'

### DIFF
--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -151,10 +151,10 @@ type KubeServicesPresence interface {
 	GetKubeServices(context.Context) ([]types.Server, error)
 }
 
-// KubeClusterNames returns a sorted list of unique kubernetes clusters
-// registered in p.
+// KubeClusterNames returns a sorted list of unique kubernetes cluster
+// names registered in p.
 //
-// DELETE IN 11.0.0, replaced by ListKubeClusterNamesWithFilters
+// DELETE IN 11.0.0, replaced by ListKubeClustersWithFilters
 func KubeClusterNames(ctx context.Context, p KubeServicesPresence) ([]string, error) {
 	kss, err := p.GetKubeServices(ctx)
 	if err != nil {
@@ -163,9 +163,31 @@ func KubeClusterNames(ctx context.Context, p KubeServicesPresence) ([]string, er
 	return extractAndSortKubeClusterNames(kss), nil
 }
 
-// ListKubeClusterNamesWithFilters returns a sorted list of unique kubernetes clusters
+func extractAndSortKubeClusterNames(kss []types.Server) []string {
+	kubeClusters := extractAndSortKubeClusters(kss)
+	kubeClusterNames := make([]string, len(kubeClusters))
+	for i := range kubeClusters {
+		kubeClusterNames[i] = kubeClusters[i].Name
+	}
+
+	return kubeClusterNames
+}
+
+// KubeClusters returns a sorted list of unique kubernetes clusters
 // registered in p.
-func ListKubeClusterNamesWithFilters(ctx context.Context, p client.ListResourcesClient, req proto.ListResourcesRequest) ([]string, error) {
+//
+// DELETE IN 11.0.0, replaced by ListKubeClustersWithFilters
+func KubeClusters(ctx context.Context, p KubeServicesPresence) ([]*types.KubernetesCluster, error) {
+	kss, err := p.GetKubeServices(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return extractAndSortKubeClusters(kss), nil
+}
+
+// ListKubeClusterWithFilters returns a sorted list of unique kubernetes clusters
+// registered in p.
+func ListKubeClustersWithFilters(ctx context.Context, p client.ListResourcesClient, req proto.ListResourcesRequest) ([]*types.KubernetesCluster, error) {
 	req.ResourceType = types.KindKubeService
 	var kss []types.Server
 
@@ -179,22 +201,25 @@ func ListKubeClusterNamesWithFilters(ctx context.Context, p client.ListResources
 		return nil, trace.Wrap(err)
 	}
 
-	return extractAndSortKubeClusterNames(kss), nil
+	return extractAndSortKubeClusters(kss), nil
 }
 
-func extractAndSortKubeClusterNames(kss []types.Server) []string {
-	kubeClusters := make(map[string]struct{})
+func extractAndSortKubeClusters(kss []types.Server) []*types.KubernetesCluster {
+	uniqueClusters := make(map[string]*types.KubernetesCluster)
 	for _, ks := range kss {
 		for _, kc := range ks.GetKubernetesClusters() {
-			kubeClusters[kc.Name] = struct{}{}
+			uniqueClusters[kc.Name] = kc
 		}
 	}
-	kubeClusterNames := make([]string, 0, len(kubeClusters))
-	for n := range kubeClusters {
-		kubeClusterNames = append(kubeClusterNames, n)
+	kubeClusters := make([]*types.KubernetesCluster, 0, len(uniqueClusters))
+	for _, cluster := range uniqueClusters {
+		kubeClusters = append(kubeClusters, cluster)
 	}
-	sort.Strings(kubeClusterNames)
-	return kubeClusterNames
+	sort.Slice(kubeClusters, func(i, j int) bool {
+		return kubeClusters[i].Name < kubeClusters[j].Name
+	})
+
+	return kubeClusters
 }
 
 // CheckOrSetKubeCluster validates kubeClusterName if it's set, or a sane

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -685,14 +685,24 @@ func (c *kubeLSCommand) run(cf *CLIConf) error {
 		if cf.Quiet {
 			t = asciitable.MakeHeadlessTable(2)
 		} else {
-			t = asciitable.MakeTable([]string{"Kube Cluster Name", "Selected"})
+			t = asciitable.MakeTable([]string{"Kube Cluster Name", "Labels", "Selected"})
 		}
 		for _, cluster := range kubeClusters {
 			var selectedMark string
-			if cluster == selectedCluster {
+			if cluster.Name == selectedCluster {
 				selectedMark = "*"
 			}
-			t.AddRow([]string{cluster, selectedMark})
+
+			labels := make([]string, 0, len(cluster.StaticLabels)+len(cluster.DynamicLabels))
+			for key, value := range cluster.StaticLabels {
+				labels = append(labels, fmt.Sprintf("%s=%s", key, value))
+			}
+			for key, value := range cluster.DynamicLabels {
+				labels = append(labels, fmt.Sprintf("%s=%s", key, value.Result))
+			}
+			sort.Strings(labels)
+
+			t.AddRow([]string{cluster.Name, strings.Join(labels, " "), selectedMark})
 		}
 		fmt.Println(t.AsBuffer().String())
 	case teleport.JSON, teleport.YAML:
@@ -708,14 +718,24 @@ func (c *kubeLSCommand) run(cf *CLIConf) error {
 	return nil
 }
 
-func serializeKubeClusters(kubeClusters []string, selectedCluster, format string) (string, error) {
+func serializeKubeClusters(kubeClusters []*types.KubernetesCluster, selectedCluster, format string) (string, error) {
 	type cluster struct {
-		KubeClusterName string `json:"kube_cluster_name"`
-		Selected        bool   `json:"selected"`
+		KubeClusterName string            `json:"kube_cluster_name"`
+		Labels          map[string]string `json:"labels"`
+		Selected        bool              `json:"selected"`
 	}
 	clusterInfo := make([]cluster, 0, len(kubeClusters))
 	for _, cl := range kubeClusters {
-		clusterInfo = append(clusterInfo, cluster{cl, cl == selectedCluster})
+		labels := cl.StaticLabels
+		for key, value := range cl.DynamicLabels {
+			labels[key] = value.Result
+		}
+
+		clusterInfo = append(clusterInfo, cluster{
+			KubeClusterName: cl.Name,
+			Labels:          labels,
+			Selected:        cl.Name == selectedCluster,
+		})
 	}
 	var out []byte
 	var err error
@@ -764,7 +784,8 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if !apiutils.SliceContainsStr(kubeClusters, c.kubeCluster) {
+	clusterNames := kubeClustersToStrings(kubeClusters)
+	if !apiutils.SliceContainsStr(clusterNames, c.kubeCluster) {
 		return trace.NotFound("kubernetes cluster %q not found, check 'tsh kube ls' for a list of known clusters", c.kubeCluster)
 	}
 
@@ -797,7 +818,7 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 	return nil
 }
 
-func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleportCluster string, kubeClusters []string, err error) {
+func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleportCluster string, kubeClusters []*types.KubernetesCluster, err error) {
 	err = client.RetryWithRelogin(ctx, tc, func() error {
 		pc, err := tc.ConnectToProxy(ctx)
 		if err != nil {
@@ -816,7 +837,7 @@ func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleport
 		}
 		teleportCluster = cn.GetClusterName()
 
-		kubeClusters, err = kubeutils.ListKubeClusterNamesWithFilters(ctx, ac, proto.ListResourcesRequest{
+		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, ac, proto.ListResourcesRequest{
 			SearchKeywords:      tc.SearchKeywords,
 			PredicateExpression: tc.PredicateExpression,
 			Labels:              tc.Labels,
@@ -828,7 +849,7 @@ func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleport
 			//
 			// DELETE IN 11.0.0
 			if trace.IsNotImplemented(err) {
-				kubeClusters, err = kubeutils.KubeClusterNames(ctx, ac)
+				kubeClusters, err = kubeutils.KubeClusters(ctx, ac)
 				if err != nil {
 					return trace.Wrap(err)
 				}
@@ -848,11 +869,20 @@ func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleport
 	return teleportCluster, kubeClusters, nil
 }
 
+func kubeClustersToStrings(kubeClusters []*types.KubernetesCluster) []string {
+	names := make([]string, len(kubeClusters))
+	for i, cluster := range kubeClusters {
+		names[i] = cluster.Name
+	}
+
+	return names
+}
+
 // kubernetesStatus holds teleport client information necessary to populate the user's kubeconfig.
 type kubernetesStatus struct {
 	clusterAddr         string
 	teleportClusterName string
-	kubeClusters        []string
+	kubeClusters        []*types.KubernetesCluster
 	credentials         *client.Key
 	tlsServerName       string
 }
@@ -923,10 +953,11 @@ func buildKubeConfigUpdate(cf *CLIConf, kubeStatus *kubernetesStatus) (*kubeconf
 		return v, nil
 	}
 
+	clusterNames := kubeClustersToStrings(kubeStatus.kubeClusters)
 	v.Exec = &kubeconfig.ExecValues{
 		TshBinaryPath:     cf.executablePath,
 		TshBinaryInsecure: cf.InsecureSkipVerify,
-		KubeClusters:      kubeStatus.kubeClusters,
+		KubeClusters:      clusterNames,
 		Env:               make(map[string]string),
 	}
 
@@ -936,7 +967,7 @@ func buildKubeConfigUpdate(cf *CLIConf, kubeStatus *kubernetesStatus) (*kubeconf
 
 	// Only switch the current context if kube-cluster is explicitly set on the command line.
 	if cf.KubernetesCluster != "" {
-		if !apiutils.SliceContainsStr(kubeStatus.kubeClusters, cf.KubernetesCluster) {
+		if !apiutils.SliceContainsStr(clusterNames, cf.KubernetesCluster) {
 			return nil, trace.BadParameter("Kubernetes cluster %q is not registered in this Teleport cluster; you can list registered Kubernetes clusters using 'tsh kube ls'.", cf.KubernetesCluster)
 		}
 		v.Exec.SelectCluster = cf.KubernetesCluster

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -944,8 +944,15 @@ func TestKubeConfigUpdate(t *testing.T) {
 			kubeStatus: &kubernetesStatus{
 				clusterAddr:         "https://a.example.com:3026",
 				teleportClusterName: "a.example.com",
-				kubeClusters:        []string{"dev", "prod"},
-				credentials:         creds,
+				kubeClusters: []*types.KubernetesCluster{
+					{
+						Name: "dev",
+					},
+					{
+						Name: "prod",
+					},
+				},
+				credentials: creds,
 			},
 			errorAssertion: require.NoError,
 			expectedValues: &kubeconfig.Values{
@@ -969,8 +976,15 @@ func TestKubeConfigUpdate(t *testing.T) {
 			kubeStatus: &kubernetesStatus{
 				clusterAddr:         "https://a.example.com:3026",
 				teleportClusterName: "a.example.com",
-				kubeClusters:        []string{"dev", "prod"},
-				credentials:         creds,
+				kubeClusters: []*types.KubernetesCluster{
+					{
+						Name: "dev",
+					},
+					{
+						Name: "prod",
+					},
+				},
+				credentials: creds,
 			},
 			errorAssertion: require.NoError,
 			expectedValues: &kubeconfig.Values{
@@ -994,8 +1008,15 @@ func TestKubeConfigUpdate(t *testing.T) {
 			kubeStatus: &kubernetesStatus{
 				clusterAddr:         "https://a.example.com:3026",
 				teleportClusterName: "a.example.com",
-				kubeClusters:        []string{"dev", "prod"},
-				credentials:         creds,
+				kubeClusters: []*types.KubernetesCluster{
+					{
+						Name: "dev",
+					},
+					{
+						Name: "prod",
+					},
+				},
+				credentials: creds,
 			},
 			errorAssertion: func(t require.TestingT, err error, _ ...interface{}) {
 				require.True(t, trace.IsBadParameter(err))
@@ -1011,7 +1032,7 @@ func TestKubeConfigUpdate(t *testing.T) {
 			kubeStatus: &kubernetesStatus{
 				clusterAddr:         "https://a.example.com:3026",
 				teleportClusterName: "a.example.com",
-				kubeClusters:        []string{},
+				kubeClusters:        []*types.KubernetesCluster{},
 				credentials:         creds,
 			},
 			errorAssertion: require.NoError,
@@ -1031,8 +1052,15 @@ func TestKubeConfigUpdate(t *testing.T) {
 			kubeStatus: &kubernetesStatus{
 				clusterAddr:         "https://a.example.com:3026",
 				teleportClusterName: "a.example.com",
-				kubeClusters:        []string{"dev", "prod"},
-				credentials:         creds,
+				kubeClusters: []*types.KubernetesCluster{
+					{
+						Name: "dev",
+					},
+					{
+						Name: "prod",
+					},
+				},
+				credentials: creds,
 			},
 			errorAssertion: require.NoError,
 			expectedValues: &kubeconfig.Values{
@@ -2085,16 +2113,35 @@ func TestSerializeKubeClusters(t *testing.T) {
 	[
 		{
 			"kube_cluster_name": "cluster1",
+			"labels": {"cmd": "result", "foo": "bar"},
 			"selected": true
 		},
 		{
 			"kube_cluster_name": "cluster2",
+			"labels": null,
 			"selected": false
 		}
 	]
 	`
+
+	clusters := []*types.KubernetesCluster{
+		{
+			Name: "cluster1",
+			StaticLabels: map[string]string{
+				"foo": "bar",
+			},
+			DynamicLabels: map[string]types.CommandLabelV2{
+				"cmd": {
+					Result: "result",
+				},
+			},
+		},
+		{
+			Name: "cluster2",
+		},
+	}
 	testSerialization(t, expected, func(f string) (string, error) {
-		return serializeKubeClusters([]string{"cluster1", "cluster2"}, "cluster1", f)
+		return serializeKubeClusters(clusters, "cluster1", f)
 	})
 }
 


### PR DESCRIPTION
Example output:

```
Kube Cluster Name Labels             Selected 
----------------- ------------------ --------
cluster1          foo=bar,cmd=result *
```

Fixes #11203.
