### PR TITLE
Adds `/older-versions` index page

### DIFF
--- a/docs/pages/older-versions.mdx
+++ b/docs/pages/older-versions.mdx
@@ -1,0 +1,14 @@
+---
+title: Older Versions of the Teleport Documentation
+description: Links to older versions of the Teleport docs.
+h1: GitHub links to older versions of the Teleport Docs
+layout: tocless-doc
+---
+
+Deprecated versions of the Teleport docs can be found at the GitHub links below:
+
+[Teleport 6.2](https://github.com/gravitational/teleport/tree/branch/v6.2) <br/>
+[Teleport 6.1](https://github.com/gravitational/teleport/tree/branch/v6.1) <br/>
+[Teleport 6.0](https://github.com/gravitational/teleport/tree/branch/v6.0) <br/>
+[Teleport 5](https://github.com/gravitational/teleport/tree/branch/5.0) <br/>
+[Teleport 4](https://github.com/gravitational/teleport/tree/branch/4.4) <br/>


### PR DESCRIPTION
- Will be backported to v8, v7 (already exists in v9) - UPDATE will probably not be backported, redirected instead.
- Part of plan to sunset older docs versions