### PR TITLE
Use a marker for Keychain labels

### DIFF
--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -357,6 +357,7 @@ func Login(origin, user string, assertion *wanlib.CredentialAssertion) (*wanlib.
 		return nil, "", trace.Wrap(err)
 	}
 
+	log.Debug("Prompting for Touch ID")
 	sig, err := native.Authenticate(cred.CredentialID, attData.digest)
 	if err != nil {
 		return nil, "", trace.Wrap(err)

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -29,7 +29,6 @@ import "C"
 import (
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"strings"
 	"unsafe"
 
@@ -60,13 +59,13 @@ func makeLabel(rpID, user string) string {
 
 func parseLabel(label string) (*parsedLabel, error) {
 	if !strings.HasPrefix(label, rpIDUserMarker) {
-		return nil, fmt.Errorf("label has unexpected prefix: %q", label)
+		return nil, trace.BadParameter("label has unexpected prefix: %q", label)
 	}
 	l := label[len(rpIDUserMarker):]
 
 	idx := strings.Index(l, labelSeparator)
 	if idx == -1 {
-		return nil, fmt.Errorf("label separator not found: %q", label)
+		return nil, trace.BadParameter("label separator not found: %q", label)
 	}
 
 	return &parsedLabel{

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -29,6 +29,7 @@ import "C"
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"strings"
 	"unsafe"
 
@@ -37,6 +38,42 @@ import (
 
 	log "github.com/sirupsen/logrus"
 )
+
+const (
+	// rpIDUserMarker is the marker for labels containing RPID and username.
+	// The marker is useful to tell apart labels written by tsh from other entries
+	// (for example, a mysterious "iMessage Signing Key" shows up in some macs).
+	rpIDUserMarker = "t01/"
+
+	// rpID are domain names, so it's safe to assume they won't have spaces in them.
+	// https://www.w3.org/TR/webauthn-2/#relying-party-identifier
+	labelSeparator = " "
+)
+
+type parsedLabel struct {
+	rpID, user string
+}
+
+func makeLabel(rpID, user string) string {
+	return rpIDUserMarker + rpID + labelSeparator + user
+}
+
+func parseLabel(label string) (*parsedLabel, error) {
+	if !strings.HasPrefix(label, rpIDUserMarker) {
+		return nil, fmt.Errorf("label has unexpected prefix: %q", label)
+	}
+	l := label[len(rpIDUserMarker):]
+
+	idx := strings.Index(l, labelSeparator)
+	if idx == -1 {
+		return nil, fmt.Errorf("label separator not found: %q", label)
+	}
+
+	return &parsedLabel{
+		rpID: l[0:idx],
+		user: l[idx+1:],
+	}, nil
+}
 
 var native nativeTID = &touchIDImpl{}
 
@@ -83,24 +120,6 @@ func (touchIDImpl) Register(rpID, user string, userHandle []byte) (*CredentialIn
 		CredentialID: credentialID,
 		publicKeyRaw: pubKeyRaw,
 	}, nil
-}
-
-// rpID are domain names, so it's safe to assume they won't have spaces in them.
-// https://www.w3.org/TR/webauthn-2/#relying-party-identifier
-const labelSeparator = " "
-
-func makeLabel(rpID, user string) string {
-	return rpID + labelSeparator + user
-}
-
-func splitLabel(label string) (string, string) {
-	idx := strings.Index(label, labelSeparator)
-	if idx == -1 {
-		return "", ""
-	}
-	rpID := label[0:idx]
-	user := label[idx+1:]
-	return rpID, user
 }
 
 func (touchIDImpl) Authenticate(credentialID string, digest []byte) ([]byte, error) {
@@ -154,6 +173,11 @@ func (touchIDImpl) ListCredentials() ([]CredentialInfo, error) {
 	defer C.free(unsafe.Pointer(errMsgC))
 
 	infos, res := readCredentialInfos(func(infosOut **C.CredentialInfo) C.int {
+		// ListCredentials lists all Keychain entries we have access to, without
+		// prefix-filtering labels, for example.
+		// Unexpected entries are removed via readCredentialInfos. This behavior is
+		// intentional, as it lets us glimpse into otherwise inaccessible Keychain
+		// contents.
 		return C.ListCredentials(reasonC, infosOut, &errMsgC)
 	})
 	if res < 0 {
@@ -198,9 +222,9 @@ func readCredentialInfos(find func(**C.CredentialInfo) C.int) ([]CredentialInfo,
 		credentialID := appLabel
 
 		// user@rpid
-		rpID, user := splitLabel(label)
-		if rpID == "" || user == "" {
-			log.Debugf("Skipping credential %q: unexpected label: %q", credentialID, label)
+		parsedLabel, err := parseLabel(label)
+		if err != nil {
+			log.Debugf("Skipping credential %q: %v", credentialID, err)
 			continue
 		}
 
@@ -222,8 +246,8 @@ func readCredentialInfos(find func(**C.CredentialInfo) C.int) ([]CredentialInfo,
 		infos = append(infos, CredentialInfo{
 			UserHandle:   userHandle,
 			CredentialID: credentialID,
-			RPID:         rpID,
-			User:         user,
+			RPID:         parsedLabel.rpID,
+			User:         parsedLabel.user,
 			publicKeyRaw: pubKeyRaw,
 		})
 	}

--- a/lib/utils/prompt/confirmation.go
+++ b/lib/utils/prompt/confirmation.go
@@ -99,7 +99,9 @@ func Input(ctx context.Context, out io.Writer, in Reader, question string) (stri
 // the answer is read from in.
 // The in reader has to be a terminal.
 func Password(ctx context.Context, out io.Writer, in SecureReader, question string) (string, error) {
-	fmt.Fprintf(out, "%s:\n", question)
+	if question != "" {
+		fmt.Fprintf(out, "%s:\n", question)
+	}
 	answer, err := in.ReadPassword(ctx)
 	if err != nil {
 		return "", trace.Wrap(err, "failed reading prompt response")

--- a/tool/tsh/touchid.go
+++ b/tool/tsh/touchid.go
@@ -67,7 +67,7 @@ func (c *touchIDLsCommand) run(cf *CLIConf) error {
 		return i1.CredentialID < i2.CredentialID
 	})
 
-	t := asciitable.MakeTable([]string{"RPID", "User", "Key Handle"})
+	t := asciitable.MakeTable([]string{"RPID", "User", "Credential ID"})
 	for _, info := range infos {
 		t.AddRow([]string{
 			info.RPID,


### PR DESCRIPTION
Adding a "marker" to Keychain labels lets us detect unexpected entries (which I did see happen) and gives us flexibility to change formats in the future.

A marker in the "label" field seems to be enough to achieve the purposes above, so I stopped at that. Added a couple minor UX tweaks as well.

#9160