### PR TITLE
Set TELEPORT_ETCD_TEST=yes.

### DIFF
--- a/.cloudbuild/scripts/cmd/unit-tests/main.go
+++ b/.cloudbuild/scripts/cmd/unit-tests/main.go
@@ -179,8 +179,9 @@ func run() error {
 func runUnitTests(workspace string) error {
 	cmd := exec.Command("make", "test")
 	cmd.Dir = workspace
-	cmd.Env = append(os.Environ(), "TELEPORT_ETCD_TEST=yes")
-	cmd.Env = append(os.Environ(), "TELEPORT_XAUTH_TEST=yes")
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "TELEPORT_ETCD_TEST=yes")
+	cmd.Env = append(cmd.Env, "TELEPORT_XAUTH_TEST=yes")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
As far as I can tell, we have a bug in our current code:

```go
	cmd.Env = append(os.Environ(), "TELEPORT_ETCD_TEST=yes")
	cmd.Env = append(os.Environ(), "TELEPORT_XAUTH_TEST=yes")
```
Given the above, `cmd.Env` will **not** have "TELEPORT_ETCD_TEST=yes" set.
