### PR TITLE
[v9] Remove non-https facets from documentation (#12776)

### DIFF
--- a/docs/pages/access-controls/guides/u2f.mdx
+++ b/docs/pages/access-controls/guides/u2f.mdx
@@ -3,7 +3,7 @@ title: Second Factor - U2F
 description: Configuring U2F support in Teleport clusters.
 ---
 
-#  U2F ( Hardware Tokens) 
+#  U2F (Hardware Tokens)
 
 <Admonition type="tip">
   Consider updating your cluster to use [WebAuthn](./webauthn.mdx) as the second
@@ -42,8 +42,6 @@ auth_service:
        facets:
        - "https://example.com"      # app_id should always also be listed as a facet
        - "https://example.com:443"
-       - "example.com:443"
-       - "example.com"
        device_attestation_cas:
        - "/path/to/u2f_attestation_ca.pem"
 ```
@@ -76,9 +74,8 @@ The fields in the above snippet are:
 
   For compatibility with multiple browsers, it's recommended to write down the
   proxy address in several formats. For example, if your `app_id` is
-  `https://example.com`, your `facets` should include
-  `https://example.com:443`, `https://example.com`, `example.com:443` and
-  `example.com`.
+  `https://example.com`, your `facets` should include `https://example.com`
+  (same as the app_id) and `https://example.com:443`.
 
 - `device_attestation_cas` - optional list of certificate authorities (as local
   file paths or in-line PEM certificate string) for U2F [device

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -347,6 +347,7 @@ auth_service:
             # app_id should always also be listed as a facet
             - https://localhost:3080
             - https://localhost
+            # localhost allows non-https facets as well
             - localhost:3080
             - localhost
 


### PR DESCRIPTION
Non-https facets aren't allowed since #12208.

I'm doing this on master just for consistency, but it only applies to v9. We are
sunsetting U2F mode in v10, so some of those docs/functionality are actually due
a cleanup on my part. See #10375.

* Remove non-https facets from documentation
* Add localhost non-https facets as an example