### PR TITLE
Enable touchid builds on Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -535,7 +535,7 @@ steps:
   - export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH
   - cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
   - rustup override set $RUST_VERSION
-  - make clean release OS=$OS ARCH=$ARCH
+  - make clean release OS=$OS ARCH=$ARCH TOUCHID=yes
   environment:
     ARCH: amd64
     GOCACHE: /tmp/push-build-darwin-amd64/go/cache
@@ -2954,7 +2954,7 @@ steps:
   - export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH
   - cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
   - rustup override set $RUST_VERSION
-  - make clean release OS=$OS ARCH=$ARCH
+  - make clean release OS=$OS ARCH=$ARCH TOUCHID=yes
   environment:
     ARCH: amd64
     GOCACHE: /tmp/build-darwin-amd64/go/cache
@@ -5388,6 +5388,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 911be33673b40e57c1d482bfcebeec7fef697e5cb52ceea9c4cddcd268bed4d1
+hmac: 350d7354fc9de834704c0158c259b0d5e4e372d38e628391b47ec7d32cf71715
 
 ...

--- a/dronegen/drone_cli.go
+++ b/dronegen/drone_cli.go
@@ -25,7 +25,7 @@ func checkTDR() error {
 		return fmt.Errorf("can't find tdr in $PATH: %w; get it from https://github.com/gravitational/tdr/", err)
 	}
 	if os.Getenv("DRONE_SERVER") == "" || os.Getenv("DRONE_TOKEN") == "" {
-		return fmt.Errorf("$DRONE_SERVER and/or $DRONE_TOKEN env vars not set; get them at https://drone.teleport.dev/account")
+		return fmt.Errorf("$DRONE_SERVER and/or $DRONE_TOKEN env vars not set; get them at https://drone.platform.teleport.sh/account")
 	}
 	return nil
 }

--- a/dronegen/mac.go
+++ b/dronegen/mac.go
@@ -268,7 +268,7 @@ func darwinTagBuildCommands() []string {
 		`export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH`,
 		`cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport`,
 		`rustup override set $RUST_VERSION`,
-		`make clean release OS=$OS ARCH=$ARCH`,
+		`make clean release OS=$OS ARCH=$ARCH TOUCHID=yes`,
 	}
 }
 


### PR DESCRIPTION
Add the `TOUCHID=yes` Makefile toggle and enable it on Drone.

Complements #12751.

#9160