### PR TITLE
Exit with an error if the auth server is too old

### DIFF
--- a/docs/pages/setup/operations/upgrading.mdx
+++ b/docs/pages/setup/operations/upgrading.mdx
@@ -50,6 +50,10 @@ When running multiple binaries of Teleport within a cluster, the following rules
   9.x.x Node will work with an 8.x.x Proxy Service. This also means you must not
   attempt to upgrade from 6.x.x straight to 8.x.x. You must upgrade to 7.x.x
   first.
+- Proxy Services and Nodes do not support Auth Services that are on an older major
+  version, and will fail to connect to older Auth Services by default. This behavior
+  can be overridden by passing `--skip-version-check` when starting Proxy Services and
+  Nodes.
 
 ## Backup
 

--- a/docs/pages/setup/reference/cli.mdx
+++ b/docs/pages/setup/reference/cli.mdx
@@ -60,6 +60,7 @@ clusters.
 | `--labels` | none | **string** comma-separated list | assigns a set of labels to a node, for example env=dev,app=web. See the explanation of labeling mechanism in the [Labeling Nodes](../admin/labels.mdx) section. |
 | `--insecure` | none | none | disable certificate validation on Proxy Service, validation still occurs on Auth Service. |
 | `--fips` | none | none | start Teleport in FedRAMP/FIPS 140-2 mode. |
+| `--skip-version-check` | `false` | `true` or `false` | Skips version checks between the Auth Server this Teleport agent |
 | `--diag-addr` | none | none | Enable diagnostic endpoints |
 | `--permit-user-env` | none | none | flag reads in environment variables from `~/.tsh/environment` when creating a session. |
 | `--app-name` | none | none | Name of the application to start |

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -110,6 +110,10 @@ type CommandLineFlags struct {
 	// configuration.
 	FIPS bool
 
+	// SkipVersionCheck allows Teleport to connect to auth servers that
+	// have an earlier major version number.
+	SkipVersionCheck bool
+
 	// AppName is the name of the application to proxy.
 	AppName string
 
@@ -1785,6 +1789,11 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 				return trace.BadParameter("non-FIPS compliant proxy settings: \"proxy_checks_host_keys\" must be true")
 			}
 		}
+	}
+
+	// apply --skip-version-check flag.
+	if clf.SkipVersionCheck {
+		cfg.SkipVersionCheck = clf.SkipVersionCheck
 	}
 
 	// Apply diagnostic address flag.

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -225,6 +225,10 @@ type Config struct {
 	// FIPS means FedRAMP/FIPS 140-2 compliant configuration was requested.
 	FIPS bool
 
+	// SkipVersionCheck means the version checking between server and client
+	// will be skipped.
+	SkipVersionCheck bool
+
 	// BPFConfig holds configuration for the BPF service.
 	BPFConfig *bpf.Config
 

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -222,6 +222,9 @@ type Config struct {
 	// Clock is used to control time in tests.
 	Clock clockwork.Clock
 
+	// TeleportVersion is used to control the Teleport version in tests.
+	TeleportVersion string
+
 	// FIPS means FedRAMP/FIPS 140-2 compliant configuration was requested.
 	FIPS bool
 

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -109,7 +109,12 @@ func (process *TeleportProcess) authServerTooOld(resp *proto.PingResponse) error
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	teleportVersion, err := semver.NewVersion(teleport.Version)
+
+	version := teleport.Version
+	if process.Config.TeleportVersion != "" {
+		version = process.Config.TeleportVersion
+	}
+	teleportVersion, err := semver.NewVersion(version)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -136,6 +136,10 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		"Start Teleport in FedRAMP/FIPS 140-2 mode.").
 		Default("false").
 		BoolVar(&ccf.FIPS)
+	start.Flag("skip-version-check",
+		"Skip version checking between server and client.").
+		Default("false").
+		BoolVar(&ccf.SkipVersionCheck)
 	// All top-level --app-XXX flags are deprecated in favor of
 	// "teleport start app" subcommand.
 	start.Flag("app-name",


### PR DESCRIPTION
If the auth server's major version is less than the connecting Teleport
agent, the agent will now log an error and exit to avoid cryptic errors like
in #11161. '--skip-version-check' flag was added so users can override this
behavior if they wish.

Fixes #11854.