### PR TITLE
Forward Client IP to Auth Server when passing through the reversetunnel

### DIFF
--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -634,6 +634,7 @@ func (s *server) handleTransport(sconn *ssh.ServerConn, nch ssh.NewChannel) {
 		component:        teleport.ComponentReverseTunnelServer,
 		localClusterName: s.ClusterName,
 		emitter:          s.Emitter,
+		sconn:            sconn,
 	}
 	go t.start()
 }


### PR DESCRIPTION
I've hacked together a proof of concept for using PROXY protocol to forward the remote clients address to the auth server when the connection is passing through the proxy. I've tested this and I now see the correct remote address in the http and GRPC handlers of the auth server when using `tctl`.

# Why ?

Currently, when requests (such as from `tctl`) are proxied via the Proxy SSH reversetunnel, the auth server sees the remote address as `127.0.0.1` or the hosts own IP address. When the connection is direct-dialled, the auth server sees the correct remote address. This obscures where the connections are coming from, and prevents us adding this information to audit events, which can make it harder for users of Teleport to correctly track who is running actions.

# What I'm not sure about:

TODO: Fill this out.

- What if the Auth server does not have PROXY protocol enabled ? Is there a way we can force this to be enabled for Proxy <-> Auth server communications ?
- Trust issues.