### PR TITLE
Ensure `tctl` outputs all debug log messages

### DIFF
--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -196,6 +196,7 @@ func applyConfig(ccf *GlobalCLIFlags, cfg *service.Config) (*authclient.Config, 
 		utils.InitLogger(utils.LoggingForCLI, log.DebugLevel)
 		log.Debugf("Debug logging has been enabled.")
 	}
+	cfg.Log = log.StandardLogger()
 
 	// If the config file path provided is not a blank string, load the file and apply its values
 	var fileConf *config.FileConfig


### PR DESCRIPTION
Closes #12801 

Whilst `tctl` configures the global logger when `-d` is provided, it previously injected a `utils.NewLogger()` into components which use the `cfg.Log` field (as this is the default provided by `service.MakeDefaultConfig()` and this meant some debug log messages were not output. This change injects `logrus.StandardLogger()` into those components, so the configured log level/output rules take affect. See #12801 for an example of a log message that is not correctly output.

An alternative implementation would be to instantiate a new logger, and configure it the same as `utils.InitLogger` configures it. I'm also open to this is you consider that preferable. 