### PR TITLE
`tbot` CA Rotation support

### DIFF
--- a/tool/tbot/renew.go
+++ b/tool/tbot/renew.go
@@ -372,6 +372,8 @@ func renewIdentityViaAuth(
 	cfg *config.BotConfig,
 ) (*identity.Identity, error) {
 	// TODO: enforce expiration > renewal period (by what mwargin?)
+	//   This should be ignored if a renewal has been triggered manually or
+	//   by a CA rotation.
 
 	// If using the IAM join method we always go through the initial join flow
 	// and fetch new nonrenewable certs


### PR DESCRIPTION
Closes #10891 

Updates `tbot` to handle CA rotations.

## Implementation

My gut feeling is that triggering the standard renewal mechanism is the best course of action here. It avoids having distinct logic for fetching the new CAs and certificates issued by them, and prevents the risk of a renewal loop run conflicting with an in-progress CA rotation. For a large part, the auth server manages the logic behind what certificates and CAs should be assigned to `tbot`.

## Other

Do we want to backport this?