### PR TITLE
[v7] Optionally skip unshallowing step

### DIFF
--- a/.cloudbuild/scripts/cmd/integration-tests/args.go
+++ b/.cloudbuild/scripts/cmd/integration-tests/args.go
@@ -24,12 +24,12 @@ import (
 )
 
 type commandlineArgs struct {
-	workspace    string
-	targetBranch string
-	commitSHA    string
-	skipChown    bool
-	githubKeySrc string
-	skipUnshallow          bool
+	workspace     string
+	targetBranch  string
+	commitSHA     string
+	skipChown     bool
+	githubKeySrc  string
+	skipUnshallow bool
 }
 
 // validate ensures the suplied arguments are valid & internally consistent.

--- a/.cloudbuild/scripts/cmd/integration-tests/args.go
+++ b/.cloudbuild/scripts/cmd/integration-tests/args.go
@@ -29,6 +29,7 @@ type commandlineArgs struct {
 	commitSHA    string
 	skipChown    bool
 	githubKeySrc string
+	skipUnshallow          bool
 }
 
 // validate ensures the suplied arguments are valid & internally consistent.
@@ -61,6 +62,7 @@ func parseCommandLine() (*commandlineArgs, error) {
 	flag.StringVar(&args.commitSHA, "commit", "HEAD", "The PR's latest commit SHA")
 	flag.BoolVar(&args.skipChown, "skip-chown", false, "Skip reconfiguring the workspace for a nonroot user.")
 	flag.StringVar(&args.githubKeySrc, "key-secret", "", "Location of github deploy token, as a Google Cloud Secret")
+	flag.BoolVar(&args.skipUnshallow, "skip-unshallow", false, "Skip unshallowing the repository.")
 
 	flag.Parse()
 

--- a/.cloudbuild/scripts/cmd/integration-tests/main.go
+++ b/.cloudbuild/scripts/cmd/integration-tests/main.go
@@ -68,11 +68,13 @@ func innerMain() error {
 		}
 	}
 
-	unshallowCtx, unshallowCancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer unshallowCancel()
-	err = git.UnshallowRepository(unshallowCtx, args.workspace, deployKey)
-	if err != nil {
-		return trace.Wrap(err, "unshallow failed")
+	if !args.skipUnshallow {
+		unshallowCtx, unshallowCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer unshallowCancel()
+		err = git.UnshallowRepository(unshallowCtx, args.workspace, deployKey)
+		if err != nil {
+			return trace.Wrap(err, "unshallow failed")
+		}
 	}
 
 	gomodcache := fmt.Sprintf("GOMODCACHE=%s", path.Join(args.workspace, gomodcacheDir))

--- a/.cloudbuild/scripts/cmd/unit-tests/main.go
+++ b/.cloudbuild/scripts/cmd/unit-tests/main.go
@@ -51,6 +51,7 @@ type commandlineArgs struct {
 	targetBranch string
 	commitSHA    string
 	githubKeySrc string
+	skipUnshallow          bool
 }
 
 func parseCommandLine() (commandlineArgs, error) {
@@ -103,11 +104,13 @@ func innerMain() error {
 		}
 	}
 
-	unshallowCtx, unshallowCancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer unshallowCancel()
-	err = git.UnshallowRepository(unshallowCtx, args.workspace, deployKey)
-	if err != nil {
-		return trace.Wrap(err, "unshallow failed")
+	if !args.skipUnshallow {
+		unshallowCtx, unshallowCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer unshallowCancel()
+		err = git.UnshallowRepository(unshallowCtx, args.workspace, deployKey)
+		if err != nil {
+			return trace.Wrap(err, "unshallow failed")
+		}
 	}
 
 	log.Println("Analysing code changes")

--- a/.cloudbuild/scripts/cmd/unit-tests/main.go
+++ b/.cloudbuild/scripts/cmd/unit-tests/main.go
@@ -47,11 +47,11 @@ func main() {
 }
 
 type commandlineArgs struct {
-	workspace    string
-	targetBranch string
-	commitSHA    string
-	githubKeySrc string
-	skipUnshallow          bool
+	workspace     string
+	targetBranch  string
+	commitSHA     string
+	githubKeySrc  string
+	skipUnshallow bool
 }
 
 func parseCommandLine() (commandlineArgs, error) {

--- a/.cloudbuild/scripts/internal/changes/changes.go
+++ b/.cloudbuild/scripts/internal/changes/changes.go
@@ -77,7 +77,7 @@ func isDocChange(path string) bool {
 	path = strings.ToLower(path)
 	return strings.HasPrefix(path, "docs/") ||
 		strings.HasSuffix(path, ".mdx") ||
-		strings.HasSuffix(path, ".md") || 
+		strings.HasSuffix(path, ".md") ||
 		strings.HasPrefix(path, "rfd/")
 }
 


### PR DESCRIPTION
Adds the `-skip-unshallow` flag support that was supposed to be included with #12814.

See-Also: #12814