### PR TITLE
Fix help string for "tctl version"

### DIFF
--- a/docs/pages/setup/reference/cli.mdx
+++ b/docs/pages/setup/reference/cli.mdx
@@ -169,7 +169,7 @@ $ tsh help
 
 ### tsh version
 
-Prints client version:
+Print the version of your `tsh` binary:
 
 ```code
 $ tsh version
@@ -1468,7 +1468,7 @@ $ tctl top http://127.0.0.1:3000 5s
 
 ### tctl version
 
-Print client version:
+Print the version of your `tctl` binary:
 
 ```code
 tctl version

--- a/docs/pages/setup/reference/cli.mdx
+++ b/docs/pages/setup/reference/cli.mdx
@@ -1468,7 +1468,7 @@ $ tctl top http://127.0.0.1:3000 5s
 
 ### tctl version
 
-Print cluster version:
+Print client version:
 
 ```code
 tctl version

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -58,7 +58,7 @@ func Run(args []string, stdout io.Writer) error {
 	app.Flag("config", "Path to a configuration file.").Short('c').StringVar(&cf.ConfigPath)
 	app.HelpFlag.Short('h')
 
-	versionCmd := app.Command("version", "Print the version")
+	versionCmd := app.Command("version", "Print the version of your tbot binary")
 
 	startCmd := app.Command("start", "Starts the renewal bot, writing certificates to the data dir at a set interval.")
 	startCmd.Flag("auth-server", "Address of the Teleport Auth Server (On-Prem installs) or Proxy Server (Cloud installs).").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -137,7 +137,7 @@ func Run(commands []CLICommand) {
 		BoolVar(&ccf.Insecure)
 
 	// "version" command is always available:
-	ver := app.Command("version", "Print cluster version")
+	ver := app.Command("version", "Print the version")
 	app.HelpFlag.Short('h')
 
 	// parse CLI commands+flags:

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -137,7 +137,7 @@ func Run(commands []CLICommand) {
 		BoolVar(&ccf.Insecure)
 
 	// "version" command is always available:
-	ver := app.Command("version", "Print the version")
+	ver := app.Command("version", "Print the version of your tctl binary")
 	app.HelpFlag.Short('h')
 
 	// parse CLI commands+flags:

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -79,7 +79,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	start := app.Command("start", "Starts the Teleport service.")
 	status := app.Command("status", "Print the status of the current SSH session.")
 	dump := app.Command("configure", "Generate a simple config file to get started.")
-	ver := app.Command("version", "Print the version.")
+	ver := app.Command("version", "Print the version of your teleport binary.")
 	scpc := app.Command("scp", "Server-side implementation of SCP.").Hidden()
 	exec := app.Command(teleport.ExecSubCommand, "Used internally by Teleport to re-exec itself to run a command.").Hidden()
 	forward := app.Command(teleport.ForwardSubCommand, "Used internally by Teleport to re-exec itself to port forward.").Hidden()

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -495,7 +495,7 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 		EnumVar(&cf.MFAMode, modes...)
 	app.HelpFlag.Short('h')
 
-	ver := app.Command("version", "Print the version")
+	ver := app.Command("version", "Print the version of your tsh binary")
 	ver.Flag("format", formatFlagDescription(defaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaultFormats...)
 	// ssh
 	ssh := app.Command("ssh", "Run shell or execute a command on a remote SSH node")


### PR DESCRIPTION
`tctl version`, just as `tsh version`, prints out the version of the binary itself, not the version of the cluster it's connected to, e.g.:

```console
$ tctl version
Teleport v9.1.2 git: go1.17.10
```

The cluster version can be discovered by running `tctl status`:

```console
$ tctl status
Cluster  localhost
Version  9.1.2
Host CA  never updated
User CA  never updated
Jwt CA   never updated
CA pin   sha256:5ab93c1a05d0fe58c66c8f3ad2e406d15e45446b606919c2e03bb1d3a8ac68e6
```