### PR TITLE
Add a link from the older docs versions page

### DIFF
--- a/docs/pages/older-versions.mdx
+++ b/docs/pages/older-versions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Older Versions of the Teleport Documentation
 description: Links to older versions of the Teleport docs.
-h1: GitHub links to older versions of the Teleport Docs
+h1: Older Versions of the Teleport Documentation
 layout: tocless-doc
 ---
 
@@ -12,3 +12,5 @@ Deprecated versions of the Teleport docs can be found at the GitHub links below:
 [Teleport 6.0](https://github.com/gravitational/teleport/tree/branch/v6.0) <br/>
 [Teleport 5](https://github.com/gravitational/teleport/tree/branch/5.0) <br/>
 [Teleport 4](https://github.com/gravitational/teleport/tree/branch/4.4) <br/>
+
+You can also [return to the main documentation site](../).


### PR DESCRIPTION
If a reader uses the docs version picker to select "Older Versions",
they will navigate to a page where the current version is still
the version they had previously selected. This change adds a link to
the main docs site to make navigation easier.

This is a provisional solution to tide us over until we have a better
way to handle unsupported versions in our docs version picker.

CC @C-STYR 