### PR TITLE
Remove deprecated Auth HTTP Tokens endpoints

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -789,7 +789,7 @@ type Cache interface {
 	GetStaticTokens() (types.StaticTokens, error)
 
 	// GetTokens returns all active (non-expired) provisioning tokens
-	GetTokens(ctx context.Context, opts ...services.MarshalOption) ([]types.ProvisionToken, error)
+	GetTokens(ctx context.Context) ([]types.ProvisionToken, error)
 
 	// GetToken finds and returns token by ID
 	GetToken(ctx context.Context, token string) (types.ProvisionToken, error)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -219,12 +219,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	// SSO diag info
 	srv.GET("/:version/sso/diag/:auth/:id", srv.withAuth(srv.getSSODiagnosticInfo))
 
-	// Provisioning tokens- Moved to grpc
-	// DELETE IN 8.0
-	srv.GET("/:version/tokens", srv.withAuth(srv.getTokens))
-	srv.GET("/:version/tokens/:token", srv.withAuth(srv.getToken))
-	srv.DELETE("/:version/tokens/:token", srv.withAuth(srv.deleteToken))
-
 	// Audit logs AKA events
 	srv.GET("/:version/events", srv.withAuth(srv.searchEvents))
 	srv.GET("/:version/events/session", srv.withAuth(srv.searchSessionEvents))
@@ -634,33 +628,6 @@ func (s *APIServer) deleteTrustedCluster(auth ClientI, w http.ResponseWriter, r 
 	}
 
 	return message("ok"), nil
-}
-
-// getTokens returns a list of active provisioning tokens. expired (inactive) tokens are not returned
-func (s *APIServer) getTokens(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	tokens, err := auth.GetTokens(r.Context())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return types.ProvisionTokensToV1(tokens), nil
-}
-
-// getTokens returns provisioning token by name
-func (s *APIServer) getToken(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	token, err := auth.GetToken(r.Context(), p.ByName("token"))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return token, nil
-}
-
-// deleteToken deletes (revokes) a token by its value
-func (s *APIServer) deleteToken(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	token := p.ByName("token")
-	if err := auth.DeleteToken(r.Context(), token); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return message(fmt.Sprintf("Token %v deleted", token)), nil
 }
 
 func (s *APIServer) deleteWebSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3366,7 +3366,8 @@ func groupByDeviceType(devs []*types.MFADevice, groupWebauthn bool) devicesByTyp
 // username.
 func (a *Server) validateMFAAuthResponse(
 	ctx context.Context,
-	resp *proto.MFAAuthenticateResponse, user string, passwordless bool) (*types.MFADevice, string, error) {
+	resp *proto.MFAAuthenticateResponse, user string, passwordless bool,
+) (*types.MFADevice, string, error) {
 	// Sanity check user/passwordless.
 	if user == "" && !passwordless {
 		return nil, "", trace.BadParameter("user required")
@@ -3474,7 +3475,8 @@ func (a *Server) addAddtionalTrustedKeysAtomic(
 	ctx context.Context,
 	currentCA types.CertAuthority,
 	newKeys types.CAKeySet,
-	needsUpdate func(types.CertAuthority) bool) error {
+	needsUpdate func(types.CertAuthority) bool,
+) error {
 	for {
 		select {
 		case <-a.closeCtx.Done():

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -271,7 +271,6 @@ func (a *ServerWithRoles) CreateSessionTracker(ctx context.Context, tracker type
 		return nil, trace.Wrap(err)
 	}
 	return tracker, nil
-
 }
 
 func (a *ServerWithRoles) filterSessionTracker(ctx context.Context, joinerRoles []types.Role, tracker types.SessionTracker) bool {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1463,11 +1463,11 @@ func (a *ServerWithRoles) DeleteToken(ctx context.Context, token string) error {
 	return a.authServer.DeleteToken(ctx, token)
 }
 
-func (a *ServerWithRoles) GetTokens(ctx context.Context, opts ...services.MarshalOption) ([]types.ProvisionToken, error) {
+func (a *ServerWithRoles) GetTokens(ctx context.Context) ([]types.ProvisionToken, error) {
 	if err := a.action(apidefaults.Namespace, types.KindToken, types.VerbList, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetTokens(ctx, opts...)
+	return a.authServer.GetTokens(ctx)
 }
 
 func (a *ServerWithRoles) GetToken(ctx context.Context, token string) (types.ProvisionToken, error) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1043,8 +1043,8 @@ func (c *Client) DeleteWebSession(user string, sid string) error {
 // plain text format, signs it using Host Certificate Authority private key and returns the
 // resulting certificate.
 func (c *Client) GenerateHostCert(
-	key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error) {
-
+	key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration,
+) ([]byte, error) {
 	out, err := c.PostJSON(context.TODO(), c.Endpoint("ca", "host", "certs"),
 		generateHostCertReq{
 			Key:         key,
@@ -1659,6 +1659,15 @@ func (c *Client) DeleteAllLocks(context.Context) error {
 
 func (c *Client) UpdatePresence(ctx context.Context, sessionID, user string) error {
 	return trace.NotImplemented(notImplementedMessage)
+}
+
+// GetTokens returns a list of active invitation tokens for nodes and users
+func (c *Client) GetTokens(ctx context.Context, opts ...services.MarshalOption) ([]types.ProvisionToken, error) {
+	resp, err := c.APIClient.GetTokens(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
 }
 
 // WebService implements features used by Web UI clients

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1661,15 +1661,6 @@ func (c *Client) UpdatePresence(ctx context.Context, sessionID, user string) err
 	return trace.NotImplemented(notImplementedMessage)
 }
 
-// GetTokens returns a list of active invitation tokens for nodes and users
-func (c *Client) GetTokens(ctx context.Context, opts ...services.MarshalOption) ([]types.ProvisionToken, error) {
-	resp, err := c.APIClient.GetTokens(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
 // WebService implements features used by Web UI clients
 type WebService interface {
 	// GetWebSessionInfo checks if a web sesion is valid, returns session id in case if
@@ -1882,7 +1873,7 @@ type IdentityService interface {
 // of adding new nodes, auth servers and proxies to the cluster
 type ProvisioningService interface {
 	// GetTokens returns a list of active invitation tokens for nodes and users
-	GetTokens(ctx context.Context, opts ...services.MarshalOption) (tokens []types.ProvisionToken, err error)
+	GetTokens(ctx context.Context) (tokens []types.ProvisionToken, err error)
 
 	// GetToken returns provisioning token
 	GetToken(ctx context.Context, token string) (types.ProvisionToken, error)

--- a/lib/auth/httpfallback.go
+++ b/lib/auth/httpfallback.go
@@ -93,59 +93,6 @@ func (c *Client) DeleteRole(ctx context.Context, name string) error {
 	return trace.Wrap(err)
 }
 
-// GetTokens returns a list of active invitation tokens for nodes and users
-func (c *Client) GetTokens(ctx context.Context, opts ...services.MarshalOption) ([]types.ProvisionToken, error) {
-	if resp, err := c.APIClient.GetTokens(ctx); err != nil {
-		if !trace.IsNotImplemented(err) {
-			return nil, trace.Wrap(err)
-		}
-	} else {
-		return resp, nil
-	}
-
-	out, err := c.Get(ctx, c.Endpoint("tokens"), url.Values{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var tokens []types.ProvisionTokenV1
-	if err := json.Unmarshal(out.Bytes(), &tokens); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return types.ProvisionTokensFromV1(tokens), nil
-}
-
-// GetToken returns provisioning token
-func (c *Client) GetToken(ctx context.Context, token string) (types.ProvisionToken, error) {
-	if resp, err := c.APIClient.GetToken(ctx, token); err != nil {
-		if !trace.IsNotImplemented(err) {
-			return nil, trace.Wrap(err)
-		}
-	} else {
-		return resp, nil
-	}
-
-	out, err := c.Get(ctx, c.Endpoint("tokens", token), url.Values{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return services.UnmarshalProvisionToken(out.Bytes())
-}
-
-// DeleteToken deletes a given provisioning token on the auth server (CA). It
-// could be a reset password token or a machine token
-func (c *Client) DeleteToken(ctx context.Context, token string) error {
-	if err := c.APIClient.DeleteToken(ctx, token); err != nil {
-		if !trace.IsNotImplemented(err) {
-			return trace.Wrap(err)
-		}
-	} else {
-		return nil
-	}
-
-	_, err := c.Delete(ctx, c.Endpoint("tokens", token))
-	return trace.Wrap(err)
-}
-
 // UpsertOIDCConnector updates or creates OIDC connector
 func (c *Client) UpsertOIDCConnector(ctx context.Context, connector types.OIDCConnector) error {
 	if err := c.APIClient.UpsertOIDCConnector(ctx, connector); err != nil {

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1239,13 +1239,13 @@ func (c *Cache) GetStaticTokens() (types.StaticTokens, error) {
 }
 
 // GetTokens returns all active (non-expired) provisioning tokens
-func (c *Cache) GetTokens(ctx context.Context, opts ...services.MarshalOption) ([]types.ProvisionToken, error) {
+func (c *Cache) GetTokens(ctx context.Context) ([]types.ProvisionToken, error) {
 	rg, err := c.read()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer rg.Release()
-	return rg.provisioner.GetTokens(ctx, opts...)
+	return rg.provisioner.GetTokens(ctx)
 }
 
 // GetToken finds and returns token by ID

--- a/lib/services/local/provisioning.go
+++ b/lib/services/local/provisioning.go
@@ -97,7 +97,7 @@ func (s *ProvisioningService) DeleteToken(ctx context.Context, token string) err
 }
 
 // GetTokens returns all active (non-expired) provisioning tokens
-func (s *ProvisioningService) GetTokens(ctx context.Context, opts ...services.MarshalOption) ([]types.ProvisionToken, error) {
+func (s *ProvisioningService) GetTokens(ctx context.Context) ([]types.ProvisionToken, error) {
 	startKey := backend.Key(tokensPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
@@ -105,8 +105,11 @@ func (s *ProvisioningService) GetTokens(ctx context.Context, opts ...services.Ma
 	}
 	tokens := make([]types.ProvisionToken, len(result.Items))
 	for i, item := range result.Items {
-		t, err := services.UnmarshalProvisionToken(item.Value,
-			services.AddOptions(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires))...)
+		t, err := services.UnmarshalProvisionToken(
+			item.Value,
+			services.WithResourceID(item.ID),
+			services.WithExpires(item.Expires),
+		)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/provisioning.go
+++ b/lib/services/provisioning.go
@@ -41,7 +41,7 @@ type Provisioner interface {
 	DeleteAllTokens() error
 
 	// GetTokens returns all non-expired tokens
-	GetTokens(ctx context.Context, opts ...MarshalOption) ([]types.ProvisionToken, error)
+	GetTokens(ctx context.Context) ([]types.ProvisionToken, error)
 }
 
 // MustCreateProvisionToken returns a new valid provision token


### PR DESCRIPTION
Part of #6394

I'm pretty confident on the first commit, which retains an overrided version of `GetTokens` in `auth.Client` in order to retain `...services.MarshalOptions` in the function signature. This means that there are no changes needed to interfaces across the codebase.

After some consideration, I realised that this opts was not being used. So this second commit removes this from across the codebase, meaning that `GetTokens` can be dropped entirely from `auth.Client`. If I'm missing some wider context here, please let me know and I can just drop the second commit. 