### PR TITLE
[v8] Set `TELEPORT_ETCD_TEST=yes`. (#12784)

### DIFF
--- a/.cloudbuild/scripts/cmd/unit-tests/main.go
+++ b/.cloudbuild/scripts/cmd/unit-tests/main.go
@@ -47,11 +47,11 @@ func main() {
 }
 
 type commandlineArgs struct {
-	workspace    string
-	targetBranch string
-	commitSHA    string
-	githubKeySrc string
-	skipUnshallow          bool
+	workspace     string
+	targetBranch  string
+	commitSHA     string
+	githubKeySrc  string
+	skipUnshallow bool
 }
 
 func parseCommandLine() (commandlineArgs, error) {
@@ -150,8 +150,10 @@ func runUnitTests(workspace string) error {
 
 	cmd := exec.Command("make", "test")
 	cmd.Dir = workspace
-	cmd.Env = append(os.Environ(), gomodcache, "TELEPORT_ETCD_TEST=yes")
-	cmd.Env = append(os.Environ(), "TELEPORT_XAUTH_TEST=yes")
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, gomodcache)
+	cmd.Env = append(cmd.Env, "TELEPORT_ETCD_TEST=yes")
+	cmd.Env = append(cmd.Env, "TELEPORT_XAUTH_TEST=yes")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/12784 to v8.