### PR TITLE
Fix link in Authentication options docs

### DIFF
--- a/docs/pages/setup/reference/authentication.mdx
+++ b/docs/pages/setup/reference/authentication.mdx
@@ -14,7 +14,7 @@ command. Teleport also supports multi-factor authentication (MFA) for the local
 connector. There are several possible values (types) of MFA:
 
 - `otp` is the default. It implements the [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
-  standard. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator), [Authy],(https://www.authy.com/) or any other TOTP client.
+  standard. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator), [Authy](https://www.authy.com/) or any other TOTP client.
 - `webauthn` implements the [Web Authentication standard](https://webauthn.guide) for utilizing
   second factor authenticators and hardware devices.
   You can use [YubiKeys](https://www.yubico.com/), [SoloKeys](https://solokeys.com/) or any other authenticator that


### PR DESCRIPTION
This link in https://goteleport.com/docs/setup/reference/authentication/ currently looks like this:
<img width="920" alt="Screenshot 2022-05-24 at 11 13 36" src="https://user-images.githubusercontent.com/4520516/170008487-08e8d21f-bad4-4a94-9e80-70b6e9f634f5.png">