### PR TITLE
Fix kube context update during tsh login call

### DIFF
--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -22,15 +22,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/utils"
-
 	"github.com/gravitational/trace"
-
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 var log = logrus.WithFields(logrus.Fields{

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -31,12 +31,13 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/utils/prompt"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils/prompt"
 
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -1003,10 +1004,11 @@ func TestKubeConfigUpdate(t *testing.T) {
 			expectedValues: nil,
 		},
 		{
-			desc: "no kube clusters",
+			desc: "no kube clusters with identity file out",
 			cf: &CLIConf{
 				executablePath:    "/bin/tsh",
 				KubernetesCluster: "",
+				IdentityFileOut:   "/tmp/id.pem",
 			},
 			kubeStatus: &kubernetesStatus{
 				clusterAddr:         "https://a.example.com:3026",
@@ -1020,6 +1022,22 @@ func TestKubeConfigUpdate(t *testing.T) {
 				ClusterAddr:         "https://a.example.com:3026",
 				TeleportClusterName: "a.example.com",
 				Exec:                nil,
+			},
+		},
+		{
+			desc: "no kube clusters with no identity file out",
+			cf: &CLIConf{
+				executablePath:    "/bin/tsh",
+				KubernetesCluster: "",
+			},
+			kubeStatus: &kubernetesStatus{
+				clusterAddr:         "https://a.example.com:3026",
+				teleportClusterName: "a.example.com",
+				kubeClusters:        []string{},
+				credentials:         creds,
+			},
+			errorAssertion: func(t require.TestingT, err error, _ ...interface{}) {
+				require.True(t, trace.IsNotFound(err))
 			},
 		},
 		{


### PR DESCRIPTION
## What

Fix tsh login Kube context modification in case of empty `kubeClusters` (no Kube cluster registered in teleport cluster) and missing IdentityFileOut flag. 

## Why 
Right now the tsh login modifies the user's current Kubernetes context and changes it to teleport cluster even if there is no Kube cluster registered within the teleport cluster.  This happens when TLSRouting is enabled where the kube service listener is always configured in teleport proxy. 


Before:
```sh
$ kubectl config current-context
gke_teleport-dev-320620_europe-central2-a_marek-test-cluster-1

tsh login --proxy=ice-berg.dev:3080 --user=marek

$ kubectl config current-context
main
```
After:
```sh
$ kubectl config current-context 
gke_teleport-dev-320620_europe-central2-a_marek-test-cluster-1

tsh login --proxy=ice-berg.dev:3080 --user=marek

$ kubectl config current-context
gke_teleport-dev-320620_europe-central2-a_marek-test-cluster-1
```

Related: 
- https://github.com/gravitational/teleport/issues/6045
- https://github.com/gravitational/teleport/pull/6721