### PR TITLE
Fix dialing nonexistent auth servers

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -104,6 +104,9 @@ type agentConfig struct {
 	clock clockwork.Clock
 	// log is an optional logger.
 	log logrus.FieldLogger
+	// localAuthAddresses is a list of auth servers to use when dialing back to
+	// the local cluster.
+	localAuthAddresses []string
 }
 
 // checkAndSetDefaults ensures an agentConfig contains required parameters.

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -128,6 +128,9 @@ type AgentPoolConfig struct {
 	IsRemoteCluster bool
 	// DisableCreateHostUser disables host user creation on a node.
 	DisableCreateHostUser bool
+	// LocalAuthAddresses is a list of auth servers to use when dialing back to
+	// the local cluster.
+	LocalAuthAddresses []string
 }
 
 // CheckAndSetDefaults checks and sets defaults.
@@ -489,15 +492,16 @@ func (p *AgentPool) newAgent(ctx context.Context, tracker *track.Tracker, lease 
 	}
 
 	agent, err := newAgent(agentConfig{
-		addr:          *addr,
-		keepAlive:     p.runtimeConfig.keepAliveInterval,
-		sshDialer:     dialer,
-		transporter:   p,
-		versionGetter: p,
-		tracker:       tracker,
-		lease:         lease,
-		clock:         p.Clock,
-		log:           p.log,
+		addr:               *addr,
+		keepAlive:          p.runtimeConfig.keepAliveInterval,
+		sshDialer:          dialer,
+		transporter:        p,
+		versionGetter:      p,
+		tracker:            tracker,
+		lease:              lease,
+		clock:              p.Clock,
+		log:                p.log,
+		localAuthAddresses: p.LocalAuthAddresses,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -551,6 +555,7 @@ func (p *AgentPool) transport(ctx context.Context, channel ssh.Channel, requests
 		channel:             channel,
 		requestCh:           requests,
 		log:                 p.log,
+		authServers:         p.LocalAuthAddresses,
 	}
 }
 

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -78,6 +78,9 @@ type RemoteClusterTunnelManagerConfig struct {
 	FIPS bool
 	// Log is the logger
 	Log logrus.FieldLogger
+	// LocalAuthServers is a list of auth servers to use when dialing back to
+	// the local cluster.
+	LocalAuthServers []string
 }
 
 func (c *RemoteClusterTunnelManagerConfig) CheckAndSetDefaults() error {
@@ -220,6 +223,7 @@ func realNewAgentPool(ctx context.Context, cfg RemoteClusterTunnelManagerConfig,
 		KubeDialAddr:        cfg.KubeDialAddr,
 		ReverseTunnelServer: cfg.ReverseTunnelServer,
 		FIPS:                cfg.FIPS,
+		LocalAuthServers:    cfg.LocalAuthServers,
 		// RemoteClusterManager only runs on proxies.
 		Component: teleport.ComponentProxy,
 

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -78,9 +78,9 @@ type RemoteClusterTunnelManagerConfig struct {
 	FIPS bool
 	// Log is the logger
 	Log logrus.FieldLogger
-	// LocalAuthServers is a list of auth servers to use when dialing back to
+	// LocalAuthAddresses is a list of auth servers to use when dialing back to
 	// the local cluster.
-	LocalAuthServers []string
+	LocalAuthAddresses []string
 }
 
 func (c *RemoteClusterTunnelManagerConfig) CheckAndSetDefaults() error {
@@ -223,7 +223,7 @@ func realNewAgentPool(ctx context.Context, cfg RemoteClusterTunnelManagerConfig,
 		KubeDialAddr:        cfg.KubeDialAddr,
 		ReverseTunnelServer: cfg.ReverseTunnelServer,
 		FIPS:                cfg.FIPS,
-		LocalAuthServers:    cfg.LocalAuthServers,
+		LocalAuthAddresses:  cfg.LocalAuthAddresses,
 		// RemoteClusterManager only runs on proxies.
 		Component: teleport.ComponentProxy,
 

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -661,6 +661,7 @@ func (s *server) handleTransport(sconn *ssh.ServerConn, nch ssh.NewChannel) {
 		log:              s.log,
 		closeContext:     s.ctx,
 		authClient:       s.LocalAccessPoint,
+		authServers:      s.LocalAuthServers,
 		channel:          channel,
 		requestCh:        requestCh,
 		component:        teleport.ComponentReverseTunnelServer,

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -216,6 +216,10 @@ type Config struct {
 
 	// CircuitBreakerConfig configures the auth client circuit breaker
 	CircuitBreakerConfig breaker.Config
+
+	// LocalAuthAddresses is a list of auth servers to use when dialing back to
+	// the local cluster.
+	LocalAuthAddresses []string
 }
 
 // CheckAndSetDefaults checks parameters and sets default values
@@ -661,7 +665,7 @@ func (s *server) handleTransport(sconn *ssh.ServerConn, nch ssh.NewChannel) {
 		log:              s.log,
 		closeContext:     s.ctx,
 		authClient:       s.LocalAccessPoint,
-		authServers:      s.LocalAuthServers,
+		authServers:      s.LocalAuthAddresses,
 		channel:          channel,
 		requestCh:        requestCh,
 		component:        teleport.ComponentReverseTunnelServer,

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -143,6 +143,7 @@ type transport struct {
 	log          logrus.FieldLogger
 	closeContext context.Context
 	authClient   auth.ProxyAccessPoint
+	authServers  []string
 	channel      ssh.Channel
 	requestCh    <-chan *ssh.Request
 
@@ -210,19 +211,7 @@ func (p *transport) start() {
 	switch dreq.Address {
 	// Connect to an Auth Server.
 	case RemoteAuthServer:
-		authServers, err := p.authClient.GetAuthServers()
-		if err != nil {
-			p.reply(req, false, []byte("connection rejected: failed to connect to auth server"))
-			return
-		}
-		if len(authServers) == 0 {
-			p.log.Warn("No auth servers registered in the cluster.")
-			p.reply(req, false, []byte("connection rejected: failed to connect to auth server"))
-			return
-		}
-		for _, as := range authServers {
-			servers = append(servers, as.GetAddr())
-		}
+		servers = p.authServers
 	// Connect to the Kubernetes proxy.
 	case LocalKubernetes:
 		switch p.component {

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -211,6 +211,13 @@ func (p *transport) start() {
 	switch dreq.Address {
 	// Connect to an Auth Server.
 	case RemoteAuthServer:
+		if len(p.authServers) <= 0 {
+			p.log.Errorf("connection rejected: no auth servers configured")
+			p.reply(req, false, []byte("no auth servers configured"))
+
+			return
+		}
+
 		servers = p.authServers
 	// Connect to the Kubernetes proxy.
 	case LocalKubernetes:
@@ -295,6 +302,9 @@ func (p *transport) start() {
 	// Dial was successful.
 	if err := req.Reply(true, []byte("Connected.")); err != nil {
 		p.log.Errorf("Failed responding OK to %q request: %v", req.Type, err)
+		if err := conn.Close(); err != nil {
+			p.log.Errorf("Failed closing connection: %v", err)
+		}
 		return
 	}
 	p.log.Debugf("Successfully dialed to %v %q, start proxying.", dreq.Address, dreq.ServerID)
@@ -379,7 +389,7 @@ func (p *transport) getConn(servers []string, r *sshutils.DialReq) (net.Conn, bo
 
 		errTun := err
 		p.log.Debugf("Attempting to dial directly %v.", servers)
-		conn, err = p.directDial(servers, r.ServerID)
+		conn, err = p.directDial(servers)
 		if err != nil {
 			return nil, false, trace.ConnectionProblem(err, "failed dialing through tunnel (%v) or directly (%v)", errTun, err)
 		}
@@ -427,12 +437,19 @@ func (p *transport) reply(req *ssh.Request, ok bool, msg []byte) {
 	}
 }
 
-// directDial attempst to directly dial to the target host.
-func (p *transport) directDial(servers []string, serverID string) (net.Conn, error) {
-	var errors []error
+// directDial attempts to directly dial to the target host.
+func (p *transport) directDial(servers []string) (net.Conn, error) {
+	if len(servers) <= 0 {
+		return nil, trace.BadParameter("no servers to dial")
+	}
 
+	var errors []error
 	for _, addr := range servers {
-		conn, err := net.Dial("tcp", addr)
+		dialer := net.Dialer{
+			Timeout: apidefaults.DefaultDialTimeout,
+		}
+
+		conn, err := dialer.DialContext(p.closeContext, "tcp", addr)
 		if err == nil {
 			return conn, nil
 		}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3103,6 +3103,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				NodeWatcher:          nodeWatcher,
 				CertAuthorityWatcher: caWatcher,
 				CircuitBreakerConfig: process.Config.CircuitBreakerConfig,
+				LocalAuthAddresses:   utils.NetAddrsToStrings(process.Config.AuthServers),
 			})
 		if err != nil {
 			return trace.Wrap(err)
@@ -3299,7 +3300,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		ReverseTunnelServer: tsrv,
 		FIPS:                process.Config.FIPS,
 		Log:                 rcWatchLog,
-		LocalAuthServers:    utils.NetAddrsToStrings(process.Config.AuthServers),
+		LocalAuthAddresses:  utils.NetAddrsToStrings(process.Config.AuthServers),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3299,6 +3299,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		ReverseTunnelServer: tsrv,
 		FIPS:                process.Config.FIPS,
 		Log:                 rcWatchLog,
+		LocalAuthServers:    utils.NetAddrsToStrings(process.Config.AuthServers),
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Provide the list of auth servers from configuration to the reverse
tunnel subsystem so that they can be used to establish connections
to the remote auth server instead of fetching individual auth server
addresses from the backend. This prevents any expired auth servers
from getting into the list to be dialed.

Fixes #12798