### PR TITLE
Refactor to use clockwork.Timer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,12 +62,11 @@ require (
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/johannesboyne/gofakes3 v0.0.0-20210217223559-02ffa763be97
-	github.com/jonboulle/clockwork v0.2.2
+	github.com/jonboulle/clockwork v0.3.0
 	github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/keys-pub/go-libfido2 v1.5.3-0.20220306005615-8ab03fb1ec27
-	github.com/kr/pretty v0.3.0
 	github.com/kr/pty v1.1.8
 	github.com/mailgun/lemma v0.0.0-20170619173223-4214099fb348
 	github.com/mailgun/timetools v0.0.0-20170619190023-f3a7b8ffff47
@@ -198,6 +197,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d // indirect
 	github.com/klauspost/compress v1.9.5 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect

--- a/go.sum
+++ b/go.sum
@@ -660,8 +660,9 @@ github.com/johannesboyne/gofakes3 v0.0.0-20210217223559-02ffa763be97 h1:HmtrCKYP
 github.com/johannesboyne/gofakes3 v0.0.0-20210217223559-02ffa763be97/go.mod h1:J4FxOevfdoOz0ZKqoWO3l2QSQqrNpWLBRQCxU/t8R00=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
+github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531 h1:hgVxRoDDPtQE68PT4LFvNlPz2nBKd3OMlGKIQ69OmR4=

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -118,11 +118,15 @@ func (u *UploadCompleter) Close() {
 
 // Serve runs the upload completer until closed or until ctx is cancelled.
 func (u *UploadCompleter) Serve(ctx context.Context) error {
-	periodic := interval.New(interval.Config{
+	periodic, err := interval.New(interval.Config{
 		Duration:      u.cfg.CheckPeriod,
 		FirstDuration: utils.HalfJitter(u.cfg.CheckPeriod),
 		Jitter:        utils.NewSeventhJitter(),
+		Clock:         u.cfg.Clock,
 	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	defer periodic.Stop()
 
 	for {

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -488,11 +488,15 @@ func (process *TeleportProcess) periodicSyncRotationState() error {
 		return nil
 	}
 
-	periodic := interval.New(interval.Config{
+	periodic, err := interval.New(interval.Config{
 		Duration:      process.Config.RotationConnectionInterval,
 		FirstDuration: utils.HalfJitter(process.Config.RotationConnectionInterval),
 		Jitter:        utils.NewSeventhJitter(),
+		Clock:         process.Clock,
 	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	defer periodic.Stop()
 
 	for {
@@ -548,11 +552,15 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 	}
 	defer watcher.Close()
 
-	periodic := interval.New(interval.Config{
+	periodic, err := interval.New(interval.Config{
 		Duration:      process.Config.PollingPeriod,
 		FirstDuration: utils.HalfJitter(process.Config.PollingPeriod),
 		Jitter:        utils.NewSeventhJitter(),
+		Clock:         process.Clock,
 	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	defer periodic.Stop()
 	for {
 		select {

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -566,12 +566,12 @@ func (h *Heartbeat) announce() error {
 	case HeartbeatStateKeepAlive:
 		keepAlive := *h.keepAlive
 		keepAlive.Expires = h.Clock.Now().UTC().Add(h.ServerTTL)
-		timeout := time.NewTimer(h.KeepAlivePeriod)
+		timeout := h.Clock.NewTimer(h.KeepAlivePeriod)
 		defer timeout.Stop()
 		select {
 		case <-h.cancelCtx.Done():
 			return nil
-		case <-timeout.C:
+		case <-timeout.Chan():
 			h.Warningf("Blocked on keep alive send, going to reset.")
 			h.reset(HeartbeatStateInit)
 			return trace.ConnectionProblem(nil, "timeout sending keep alive")


### PR DESCRIPTION
clockwork v0.3.0 added support for fake timers. This updates the
dependency version and migrates existing use of time.NewTimer to
use clock.NewTimer where applicable.