### PR TITLE
[v7] Make the Labeling guide easier to follow

### DIFF
--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -4,17 +4,21 @@ scope={["oss", "enterprise"]}
 scopeOnly={true}
 opened={true}
 >
-Verify that your Teleport client is connected:
+
+To connect to Teleport, log in to your cluster using `tsh`, then use `tctl`
+remotely:
 
 ```code
+$ tsh login --proxy=teleport.example.com --user=email@example.com
 $ tctl status
-# Cluster  tele.example.com
+# Cluster  teleport.example.com
 # Version  (=teleport.version=)
-# CA pin   sha256:sha-hash-here
+# CA pin   (=presets.ca_pin=)
 ```
 
-Remain logged in to your Auth Service host so you can run subsequent `tctl`
-commands in this guide.
+You can run subsequent `tctl` commands in this guide on your local machine.
+
+For full privileges, you can also run `tctl` commands on your Auth Service host.
 
 </Details>
 <Details 

--- a/docs/pages/setup/admin/labels.mdx
+++ b/docs/pages/setup/admin/labels.mdx
@@ -1,9 +1,37 @@
 ---
 title: Labels
-description: Labeling Nodes and Applications
+description: Labeling Teleport resources
 ---
 
-This guide explains how to label Teleport Nodes.
+Teleport allows you to add arbitrary key-value pairs to applications, servers,
+databases, and other resources in your cluster. You can use these to filter
+resources when making queries via `tctl` and `tsh` as well as to limit the
+resources that Teleport roles can access.
+
+This guide explains how to add labels to Teleport resources.
+
+There are two kinds of labels:
+
+### Static labels
+
+Static labels are hardcoded in a `teleport` daemon's configuration file and do
+not change over time while the `teleport` process is running. An example of a static
+label is a Node's environment, e.g., `staging` vs. `production`.
+
+### Dynamic labels
+
+Dynamic labels, also known as **label commands**, allow you to generate labels
+at runtime. The `teleport` daemon will execute an external command on its host
+at a configurable frequency and the output of the command becomes the label's
+value.
+
+This is especially useful for decoupling the label's value from your Teleport
+configuration. For example, if you start Teleport on an Amazon EC2 instance, you
+can set a `region` label based on a command that sends a request to the EC2
+[instance metadata API](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html).
+This means that you can keep your configuration the same for each Node (and set
+the configuration within an Amazon Machine Image) while enabling users to search for Nodes by AWS
+region.
 
 ## Prerequisites
 
@@ -11,56 +39,241 @@ This guide explains how to label Teleport Nodes.
 
 (!docs/pages/includes/tctl.mdx!)
 
-## Labeling nodes and applications
+- A host where you will run a Teleport Node. In this guide, we will apply labels
+  to this Node.
 
-In addition to specifying a custom name for each Node, Teleport also allows for
-the application of arbitrary key-value pairs to each Node or app, called labels.
-There are two kinds of labels:
+<Admonition title="Resources you can label" type="tip">
 
-- **static labels** do not change over time while the `teleport` process is
-  running. Examples of static labels are the physical location of Nodes and the
-  name of the environment (e.g., staging vs. production).
-- **dynamic labels**, also known as "label commands," allow you to generate
-  labels at runtime. Teleport will execute an external command on a Node at a
-  configurable frequency and the output of the command becomes the label value.
-  Examples include reporting load averages, the presence of a process, and the time after
-  the last reboot.
+You can label any resource managed by Teleport using the instructions in this
+guide. See the following guides for how to add resources to a Teleport cluster:
 
-There are two ways to configure Node labels.
+|Guide|Notes on labeling|
+|---|---|
+|[Applications](../../application-access/getting-started.mdx)||
+|[Databases](../../database-access/getting-started.mdx)|Teleport can discover some AWS-hosted databases automatically. In this case, labels will also be automatically applied. |
+|[Kubernetes clusters](../../kubernetes-access/getting-started.mdx)||
+|[Servers](../../server-access/getting-started.mdx)||
 
-- Via command line, by using the `--labels` flag with the `teleport start`
-   command.
-- Using the `/etc/teleport.yaml` configuration file on a Node.
+</Admonition>
 
-To define labels as command line arguments, use the `--labels` flag as shown
-below. This method works well for static labels or simple commands:
+## Step 1/3. Prepare your Node
+
+### Install Teleport on your Node
+
+On the host where you will run your Teleport Node, follow the instructions for
+your environment to install Teleport.
+
+(!docs/pages/includes/install-linux.mdx!)
+
+### Generate a token
+
+On your local machine, use the `tctl` tool to generate an invite token that your
+Node will use to join the cluster. In the following example, a new token is
+created with a TTL of five minutes:
 
 ```code
-$ sudo teleport start --labels uptime=[1m:"uptime -p"],kernel=[1h:"uname -r"]
+# Generate a short-lived invitation token for a new node:
+$ tctl nodes add --ttl=5m --roles=node
+# The invite token: (=presets.tokens.first=)
+
+# You can also list all generated non-expired tokens:
+$ tctl tokens ls
+# Token                            Type            Expiry Time
+# ------------------------         -----------     ---------------
+# (=presets.tokens.first=)         Node            25 Sep 18 00:21 UTC
 ```
 
-Alternatively, you can update `labels` via a configuration file:
+Copy the token. On the remote host that you will add to your Teleport cluster as a
+Node, assign the token to an environment variable:
+
+```code
+$ export INVITE_TOKEN=<token>
+```
+
+We will use this in the next step.
+
+## Step 2/3. Apply a static label to your Node
+
+You can configure Node labels by editing Teleport's configuration file, then
+starting Teleport.
+
+On the host where you will run your Node, paste the following content into
+`/etc/teleport.yaml` and adjust it for your environment:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 ```yaml
+version: v2
+teleport:
+  auth_servers:
+    # The address of your Auth Service. You can also use a Proxy Service
+    # address, e.g., tele.example.com:443, if your Auth Service is not
+    # exposed to the internet.
+    - tele.example.com:3025
+
+auth_service:
+  enabled: false
+
+proxy_service:
+  enabled: false
+
 ssh_service:
-  enabled: "yes"
-  # ...
+  enabled: true
   # Static labels are simple key/value pairs:
   labels:
-    environment: test
-app_service:
-  # ..
-  labels:
-    environment: test
+    environment: dev
 ```
 
-To configure dynamic labels via a configuration file, define a `commands` array
-as shown below:
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
 
 ```yaml
+version: v2
+teleport:
+  auth_servers:
+    # Your Teleport Cloud tenant address
+    - mytenant.teleport.sh:443
+
+auth_service:
+  enabled: false
+
+proxy_service:
+  enabled: false
+
+ssh_service:
+  enabled: true
+  # Static labels are simple key/value pairs:
+  labels:
+    environment: dev
+```
+
+</ScopedBlock>
+
+Next, start Teleport with the invite token you created earlier:
+
+```code
+$ sudo teleport start --token=${INVITE_TOKEN?}
+```
+
+Verify that you have added the label by running the following on your local
+machine. Your Teleport user must be authorized to access the Node.
+
+```code
+$ tsh ls --query 'labels["environment"]=="dev"'
+Node Name    Address    Labels          
+------------ ---------- --------------- 
+bdcb47b87ad6 ⟵ Tunnel environment=dev
+```
+
+<Details title="Don't see your Node?" opened={false}>
+
+First, check the logs for your Node to ensure the SSH Service is running. Your logs should resemble the following:
+
+```text
+2022-04-27T14:44:23Z INFO [NODE:1]    Service is starting in tunnel mode. service/service.go:1993
+2022-04-27T14:44:23Z INFO [PROC:1]    The new service has started successfully. Starting syncing rotation status with period 10m0s. service/connect.go:482
+2022-04-27T14:44:23Z INFO             Service has started successfully. service/service.go:523
+2022-04-27T14:44:24Z INFO [NODE:PROX] Connected. addr:172.17.0.2:40184 remote-addr:192.0.2.0:443 leaseID:1 target:teleport.example.com:443 reversetunnel/agent.go:409
+```
+
+Next, ensure that your Teleport user has a login that corresponds to a user on
+your Node.
+
+Run the following command to get the current logins for your user:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+```code
+$ tsh status
+> Profile URL:        https://teleport.example.com:443
+  Logged in as:       myuser
+  Cluster:            teleport.example.com
+  Roles:              access, editor
+  Logins:             -teleport-nologin-d4bc1dad-ce49-4bbe-925d-a67f8d2d6afe
+  Kubernetes:         enabled
+  Valid until:        2022-04-27 22:26:50 -0400 EDT [valid for 11h40m0s]
+  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
+```
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+tsh status
+> Profile URL:        https://mytenant.teleport.sh:443
+  Logged in as:       myuser
+  Cluster:            mytenant.teleport.sh
+  Roles:              access, editor
+  Logins:             -teleport-nologin-d4bc1dad-ce49-4bbe-925d-a67f8d2d6afe
+  Kubernetes:         enabled
+  Valid until:        2022-04-27 22:26:50 -0400 EDT [valid for 11h40m0s]
+  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
+```
+
+</ScopedBlock>
+
+In this example, `-teleport-nologin-d4bc1dad-ce49-4bbe-925d-a67f8d2d6afe` means
+that no logins have been assigned to the user.
+
+To add logins, retrieve your user configuration as YAML:
+
+```code
+# Replace "myuser" with your Teleport username
+$ tctl get user/myuser > user.yaml
+```
+
+Edit the `logins` field for your user. Each login must exist as a user on the
+host:
+
+```diff
+     db_users: null
+     kubernetes_groups: null
+     kubernetes_users: null
+-    logins: null
++    logins: 
++      - root
+     windows_logins: null
+ version: v2
+```
+
+Apply your changes:
+
+```code
+$ tctl create -f user.yaml 
+user "myuser" has been updated
+```
+
+Log out of your cluster, then log in again. You should now see your Node when
+you run `tsh ls`.
+
+</Details>
+
+## Step 3/3. Apply dynamic labels via commands
+
+Before following this step, stop Teleport on your Node.
+
+As with static labels, you can apply dynamic labels by editing the
+Teleport configuration file.
+
+Edit `/etc/teleport.yaml` to define a `commands` array as shown below:
+
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+```yaml
+version: v2
+teleport:
+  auth_servers:
+    - tele.example.com:3025
+
+auth_service:
+  enabled: false
+
+proxy_service:
+  enabled: false
+
 ssh_service:
   enabled: "yes"
-  # Dynamic labels AKA "commands":
+  # Configure dynamic labels using the "commands" field:
   commands:
   - name: hostname
     command: [hostname]
@@ -70,15 +283,38 @@ ssh_service:
     # This setting tells Teleport to execute the command above
     # once an hour. This value cannot be less than one minute.
     period: 1h0m0s
-app_service:
+```
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```yaml
+version: v2
+teleport:
+  auth_servers:
+    - mytenant.teleport.sh:443
+
+auth_service:
+  enabled: false
+
+proxy_service:
+  enabled: false
+
+ssh_service:
   enabled: "yes"
-  # ...
-  # Dynamic labels (historically called "commands"):
+  # Configure dynamic labels using the "commands" field:
   commands:
   - name: hostname
     command: [hostname]
     period: 1m0s
+  - name: arch
+    command: [uname, -p]
+    # This setting tells Teleport to execute the command above
+    # once an hour. This value cannot be less than one minute.
+    period: 1h0m0s
 ```
+
+</ScopedBlock>
 
 Notice that the `command` setting is an array where the first element
 is a valid executable and each subsequent element is an argument.
@@ -102,7 +338,45 @@ how `'` and `"` are interchangeable, so you can use them for nested quotations.
 command: ["/bin/sh", "-c", "uname -a | egrep -o '[0-9]+\\.[0-9]+\\.[0-9]+'"]
 ```
 
-The executable named in the `command` field must be the path to a valid
-executable command. The executable permission bit must be set and shell scripts
-must have a [shebang line](https://en.wikipedia.org/wiki/Shebang_\(Unix\)).
+<Notice type="warning">
 
+When configuring a command to generate dynamic labels, the executable named
+within your command must be the path to a valid file. The executable permission
+bit must be set and shell scripts must have a
+[shebang line](https://en.wikipedia.org/wiki/Shebang_\(Unix\)).
+
+</Notice>
+
+Once you have configured your labels, start Teleport with the invite token you
+created earlier:
+
+```code
+$ sudo teleport start --token=${INVITE_TOKEN?}
+```
+
+Verify that you have added the labels by running the following on your local
+machine. Your Teleport user must be authorized to access the Node.
+
+```code
+$ tsh ls
+Node Name         Address    Labels          
+----------------- ---------- --------------- 
+ip-192-0-2-0      ⟵ Tunnel arch=x86_64,hostname=ip-172-30-156-233 
+```
+
+<Details title="Problems re-joining the Node?">
+
+Try creating another invite token using the `tctl nodes add` command from earlier
+and starting your Node again.
+
+If this doesn't work, delete the directory your Node uses to maintain its state,
+`/var/lib/teleport`, and try again.
+
+</Details>
+
+
+## Next steps: Using labels
+
+Once you have labeled your resources, you can limit the access that different
+roles have to specific classes of resources. For more information, see
+[Teleport Role Templates](../../access-controls/guides/role-templates.mdx).


### PR DESCRIPTION
Backports #12034

* Make the Labeling guide easier to follow

See #11841

The current guide is a conceptual introduction to Teleport's labeling
functionality. Since we cover this information in our reference guides,
I wanted to make it possible for readers to follow this guide as a
tutorial and get started labeling resources quickly.

- Introduce labels at the beginning of the guide to set the stage
  conceptually before the steps begin.
- Clarify in the Prerequisites section that the instructions in the
  guide apply to any Teleport resource, not just Nodes
- Require a host for running a Teleport Node in the Prerequisites and
  include instructions for starting the Node. Previously, we included
  sample commands/config for applications as well. Requiring a Node
  and including setup instructions for that Node will ensure that all
  instructions in the guide can be followed easily.
- Add scoped instructions via Tabs and ScopedBlocks.
- Reorganize sections into a series of steps.
- Add commands to verify that labels have been added.

* Respond to PR feedback

* Improve the Labeling guide for self-hosted users

See: #11841

- Edit tctl.mdx: Users of self-hosted Teleport can run tctl commands
  from their local machines after logging in to a cluster, just like
  they can with Teleport Cloud. I have edited tctl.mdx to instruct self-
  hosted users to use tctl remotely. This way, users won't need to
  access their Auth Service hosts in order to follow the guides that
  use tctl.mdx.

- Add steps for fixing unexpected "tsh ls" output

Also applies PR feedback.

- Add provisions for labeling specific resources as a table near the
  top of the page.
- Remove the option to add labels using CLI flags.
- Fix command output spacing

Also misc. clarity tweaks.

* Respond to PR feedback