### PR TITLE
Drop validation and references to U2F Facets

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -527,9 +527,6 @@ func (u *U2F) Check() error {
 	if u.AppID == "" {
 		return trace.BadParameter("u2f configuration missing app_id")
 	}
-	if len(u.Facets) == 0 {
-		return trace.BadParameter("u2f configuration missing facets")
-	}
 	for _, ca := range u.DeviceAttestationCAs {
 		if err := isValidAttestationCert(ca); err != nil {
 			return trace.BadParameter("u2f configuration has an invalid attestation CA: %v", err)

--- a/api/types/authentication_authpreference_test.go
+++ b/api/types/authentication_authpreference_test.go
@@ -84,12 +84,6 @@ func TestAuthPreferenceV2_CheckAndSetDefaults_secondFactor(t *testing.T) {
 
 	minimalU2F := &types.U2F{
 		AppID: "https://localhost:3080",
-		Facets: []string{
-			"https://localhost:3080",
-			"https://localhost",
-			"localhost:3080",
-			"localhost",
-		},
 	}
 	minimalWeb := &types.Webauthn{
 		RPID: "localhost",
@@ -155,7 +149,6 @@ func TestAuthPreferenceV2_CheckAndSetDefaults_secondFactor(t *testing.T) {
 			spec: types.AuthPreferenceSpecV2{
 				U2F: &types.U2F{
 					AppID:                "https://example.com:1234",
-					Facets:               []string{"https://example.com:1234"},
 					DeviceAttestationCAs: []string{yubicoU2FCA},
 				},
 			},
@@ -179,8 +172,7 @@ func TestAuthPreferenceV2_CheckAndSetDefaults_secondFactor(t *testing.T) {
 			secondFactors: secondFactorWebActive,
 			spec: types.AuthPreferenceSpecV2{
 				U2F: &types.U2F{
-					AppID:  "teleport", // "teleport" gets parsed as a Path, not a Host.
-					Facets: []string{"teleport"},
+					AppID: "teleport", // "teleport" gets parsed as a Path, not a Host.
 				},
 			},
 			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -3217,7 +3217,8 @@ type U2F struct {
 	// AppID returns the application ID for universal second factor.
 	AppID string `protobuf:"bytes,1,opt,name=AppID,proto3" json:"app_id,omitempty"`
 	// Facets returns the facets for universal second factor.
-	// DELETE IN 11.0, time to sunset U2F (codingllama).
+	// Deprecated: Kept for backwards compatibility reasons, but Facets have no
+	// effect since Teleport v10, when Webauthn replaced the U2F implementation.
 	Facets []string `protobuf:"bytes,2,rep,name=Facets,proto3" json:"facets,omitempty"`
 	// DeviceAttestationCAs contains the trusted attestation CAs for U2F
 	// devices.

--- a/api/types/types.proto
+++ b/api/types/types.proto
@@ -1081,9 +1081,7 @@ message U2F {
     // AppID returns the application ID for universal second factor.
     string AppID = 1 [ (gogoproto.jsontag) = "app_id,omitempty" ];
 
-    // Facets returns the facets for universal second factor.
-    // DELETE IN 11.0, time to sunset U2F (codingllama).
-    repeated string Facets = 2 [ (gogoproto.jsontag) = "facets,omitempty" ];
+    reserved 2; // repeated string Facets
 
     // DeviceAttestationCAs contains the trusted attestation CAs for U2F
     // devices.

--- a/api/types/types.proto
+++ b/api/types/types.proto
@@ -1081,7 +1081,10 @@ message U2F {
     // AppID returns the application ID for universal second factor.
     string AppID = 1 [ (gogoproto.jsontag) = "app_id,omitempty" ];
 
-    reserved 2; // repeated string Facets
+    // Facets returns the facets for universal second factor.
+    // Kept for backwards compatibility reasons, but Facets have no effect since
+    // Teleport v10, when Webauthn replaced the U2F implementation.
+    repeated string Facets = 2 [ (gogoproto.jsontag) = "facets,omitempty" ];
 
     // DeviceAttestationCAs contains the trusted attestation CAs for U2F
     // devices.

--- a/api/types/types.proto
+++ b/api/types/types.proto
@@ -1082,8 +1082,8 @@ message U2F {
     string AppID = 1 [ (gogoproto.jsontag) = "app_id,omitempty" ];
 
     // Facets returns the facets for universal second factor.
-    // Kept for backwards compatibility reasons, but Facets have no effect since
-    // Teleport v10, when Webauthn replaced the U2F implementation.
+    // Deprecated: Kept for backwards compatibility reasons, but Facets have no
+    // effect since Teleport v10, when Webauthn replaced the U2F implementation.
     repeated string Facets = 2 [ (gogoproto.jsontag) = "facets,omitempty" ];
 
     // DeviceAttestationCAs contains the trusted attestation CAs for U2F

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -73,8 +73,7 @@ func TestServer_CreateAuthenticateChallenge_authPreference(t *testing.T) {
 				Type:         constants.Local,
 				SecondFactor: constants.SecondFactorWebauthn,
 				U2F: &types.U2F{
-					AppID:  "https://localhost",
-					Facets: []string{"https://localhost"},
+					AppID: "https://localhost",
 				},
 			},
 			assertChallenge: func(challenge *proto.MFAAuthenticateChallenge) {
@@ -103,10 +102,6 @@ func TestServer_CreateAuthenticateChallenge_authPreference(t *testing.T) {
 				SecondFactor: constants.SecondFactorWebauthn,
 				U2F: &types.U2F{
 					AppID: "https://myoldappid.com",
-					Facets: []string{
-						"https://myoldappid.com",
-						"https://localhost",
-					},
 				},
 				Webauthn: &types.Webauthn{
 					RPID: "myexplicitid",

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -577,8 +577,7 @@ func newU2FAuthPreferenceFromConfigFile(t *testing.T) types.AuthPreference {
 		Type:         constants.Local,
 		SecondFactor: constants.SecondFactorU2F,
 		U2F: &types.U2F{
-			AppID:  "foo",
-			Facets: []string{"bar", "baz"},
+			AppID: "foo",
 		},
 	})
 	require.NoError(t, err)

--- a/lib/auth/webauthncli/u2f_login_test.go
+++ b/lib/auth/webauthncli/u2f_login_test.go
@@ -77,8 +77,7 @@ func TestLogin(t *testing.T) {
 	}
 	loginFlow := &wanlib.LoginFlow{
 		U2F: &types.U2F{
-			AppID:  appID,
-			Facets: []string{appID, rpID},
+			AppID: appID,
 		},
 		Webauthn: &types.Webauthn{
 			RPID: rpID,

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -705,8 +705,7 @@ func TestApplyConfig(t *testing.T) {
 			Type:         constants.Local,
 			SecondFactor: constants.SecondFactorOTP,
 			U2F: &types.U2F{
-				AppID:  "app-id",
-				Facets: []string{"https://localhost:3080"},
+				AppID: "app-id",
 				DeviceAttestationCAs: []string{
 					string(u2fCAFromFile),
 					`-----BEGIN CERTIFICATE-----

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -861,7 +861,9 @@ func (a *AuthenticationConfig) Parse() (types.AuthPreference, error) {
 }
 
 type UniversalSecondFactor struct {
-	AppID                string   `yaml:"app_id"`
+	AppID string `yaml:"app_id"`
+	// Facets kept only to avoid breakages during Teleport updates.
+	// Webauthn is now used instead of U2F.
 	Facets               []string `yaml:"facets"`
 	DeviceAttestationCAs []string `yaml:"device_attestation_cas"`
 }
@@ -873,7 +875,6 @@ func (u *UniversalSecondFactor) Parse() (*types.U2F, error) {
 	}
 	return &types.U2F{
 		AppID:                u.AppID,
-		Facets:               u.Facets,
 		DeviceAttestationCAs: attestationCAs,
 	}, nil
 }

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -123,8 +123,6 @@ auth_service:
   authentication:
     u2f:
       app_id: "app-id"
-      facets:
-      - https://localhost:3080
       device_attestation_cas:
       - "testdata/u2f_attestation_ca.pem"
       - |

--- a/lib/web/apiserver_ping_test.go
+++ b/lib/web/apiserver_ping_test.go
@@ -49,8 +49,7 @@ func TestPing(t *testing.T) {
 				Type:         constants.Local,
 				SecondFactor: constants.SecondFactorOptional,
 				U2F: &types.U2F{
-					AppID:  "https://example.com",
-					Facets: []string{"https://example.com"},
+					AppID: "https://example.com",
 				},
 				Webauthn: &types.Webauthn{
 					RPID: "example.com",


### PR DESCRIPTION
U2F facets don't serve a purpose since Webauthn became the de-facto MFA mechanism. This should make it easier for users to write v10-style authentication configs.

The remaining U2F fields are still relevant for when we derive Webauthn settings from U2F, so those are kept (and validated).

Note that we still keep the fileconf field, since we don't want configs to needlessly break during version upgrades.

#10375