### PR TITLE
Fix CA rotation docs inconsistently providing `--type` flag

### DIFF
--- a/docs/pages/setup/operations/ca-rotation.mdx
+++ b/docs/pages/setup/operations/ca-rotation.mdx
@@ -77,8 +77,8 @@ the phase transitions look like this:
   and gotchas before going with semi-automatic version.
 </Admonition>
 
-It is possible to rotate a specific set of Certificate Authorities using the 
-`--type` flag. If this flag is not provided, then all Certificate Authorities
+It is possible to rotate a specific set of certificate authorities using the 
+`--type` flag. If this flag is not provided, then all certificate authorities
 will be rotated. 
 
 ## Manual rotation

--- a/docs/pages/setup/operations/ca-rotation.mdx
+++ b/docs/pages/setup/operations/ca-rotation.mdx
@@ -77,6 +77,10 @@ the phase transitions look like this:
   and gotchas before going with semi-automatic version.
 </Admonition>
 
+It is possible to rotate a specific set of Certificate Authorities using the 
+`--type` flag. If this flag is not provided, then all Certificate Authorities
+will be rotated. 
+
 ## Manual rotation
 
 In manual mode, we manually transition between phases while monitoring the state
@@ -87,7 +91,7 @@ of the cluster.
 Initiate the manual rotation of host certificate authorities:
 
 ```code
-$ tctl auth rotate --phase=init --manual --type=host
+$ tctl auth rotate --phase=init --manual
 Updated rotation phase to "init". To check status use 'tctl status'
 ```
 


### PR DESCRIPTION
Closes #12822

The current CA rotation docs provide the flag in the first step, and then omit it for all further steps. This causes an unexpected error as detailed in #12822.

This PR removes the usage of the flag, and also includes a short explanation of the `--type` flag.