### PR TITLE
Add Kubernetes as an origin label

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -321,13 +321,17 @@ const (
 	// OriginCloud is an origin value indicating that the resource was
 	// imported from a cloud provider.
 	OriginCloud = "cloud"
+
+	// OriginKubernetes is an origin value indicating that the resource was
+	// created from the Kubernetes Operator.
+	OriginKubernetes = "kubernetes"
 )
 
 // EC2HostnameTag is the name of the EC2 tag used to override a node's hostname.
 const EC2HostnameTag = "TeleportHostname"
 
 // OriginValues lists all possible origin values.
-var OriginValues = []string{OriginDefaults, OriginConfigFile, OriginDynamic, OriginCloud}
+var OriginValues = []string{OriginDefaults, OriginConfigFile, OriginDynamic, OriginCloud, OriginKubernetes}
 
 const (
 	// RecordAtNode is the default. Sessions are recorded at Teleport nodes.


### PR DESCRIPTION
We are developing a K8S Operator for Teleport

We want to keep track of the resources created by the operator.
We'll set the `metadata.labels[OriginLabel]` to `kubernetes`

To do so, we must create this new constant and add it to the list of
possible Origins