### PR TITLE
[v9] Ensure `tctl` outputs all debug log messages

### DIFF
--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -195,6 +195,7 @@ func applyConfig(ccf *GlobalCLIFlags, cfg *service.Config) (*authclient.Config, 
 		utils.InitLogger(utils.LoggingForCLI, log.DebugLevel)
 		log.Debugf("Debug logging has been enabled.")
 	}
+	cfg.Log = log.StandardLogger()
 
 	// If the config file path provided is not a blank string, load the file and apply its values
 	var fileConf *config.FileConfig


### PR DESCRIPTION
Backport #12807 to branch/v9