### PR TITLE
Refine the organization of /docs/getting-started

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -27,14 +27,6 @@
             {
               "title": "Docker Compose",
               "slug": "/getting-started/docker-compose/"
-            },
-            {
-              "title": "DigitalOcean",
-              "slug": "/getting-started/digitalocean/",
-              "hideInScopes": [
-                "enterprise",
-                "cloud"
-              ]
             }
           ]
         },
@@ -113,6 +105,11 @@
               "title": "IBM",
               "slug": "/setup/deployments/ibm/",
               "hideInScopes": "cloud"
+            },
+            {
+              "title": "Digital Ocean",
+              "slug": "/setup/deployments/digitalocean/",
+              "hideInScopes": ["enterprise", "cloud"]
             }
           ]
         },
@@ -1262,6 +1259,11 @@
     {
       "source": "/application-access/guides/jwt/",
       "destination": "/application-access/jwt/",
+      "permanent": true
+    },
+    {
+      "source": "/getting-started/digitalocean/",
+      "destination": "/setup/deployments/digitalocean/",
       "permanent": true
     }
   ]

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -9,8 +9,8 @@ Follow these guides to get started using Teleport.
 ## Try a lab on your local machine
 
 <TileSet>
-  <Tile icon="bolt" title="Interactive Lab" href="https://play.instruqt.com/teleport/invite/rgvuva4gzkon">
-    Try Teleport using our guided interactive labs.
+  <Tile icon="bolt" title="Online Interactive Labs" href="https://play.instruqt.com/teleport/invite/rgvuva4gzkon">
+    Try Teleport quickly using our guided Instruqt labs.
   </Tile>
   <Tile icon="bolt" title="Docker Compose Lab" href="./getting-started/docker-compose.mdx">
     Try Teleport locally using Docker Compose.
@@ -34,15 +34,6 @@ Follow these guides to get started using Teleport.
 
   </Tile>
   <Tile
-  icon="stack"
-  title="Teleport on DigitalOcean"
-  href="./getting-started/digitalocean/?scope=oss"
-  >
-
-  Use our DigitalOcean 1-Click App to quickly spin up Teleport on a droplet.
-    
-  </Tile>
-  <Tile
   icon="building"
   title="Teleport Enterprise"
   href="./enterprise/introduction.mdx/?scope=enterprise"
@@ -53,7 +44,7 @@ Follow these guides to get started using Teleport.
 
   </Tile>
 
-  <Tile icon="cloud" title="Teleport Cloud" href="https://goteleport.com/signup">
+  <Tile icon="cloud" title="Teleport Cloud" href="./cloud/getting-started/?scope=cloud">
 
     Try Teleport hosted by us in the cloud for free.
 

--- a/docs/pages/setup/deployments.mdx
+++ b/docs/pages/setup/deployments.mdx
@@ -27,15 +27,31 @@ the platform of your choice.
 </ScopedBlock>
 
 <ScopedBlock scope={["oss", "enterprise"]}>
-<ul>
-  <li>
-    [AWS Terraform](./deployments/aws-terraform.mdx). Deploy HA Teleport with Terraform Provider on AWS.
-  </li>
-  <li>
-    [GCP](./deployments/gcp.mdx). Deploy HA Teleport on GCP.
-  </li>
-  <li>
-    [IBM Cloud](./deployments/ibm.mdx). Deploy HA Teleport on IBM cloud.
-  </li>
-</ul>
+<TileSet>
+  <ScopedBlock scope="oss">
+  <Tile
+  title="DigitalOcean"
+  href="./deployments/digitalocean/"
+  >
+
+    Use our DigitalOcean 1-Click App to quickly spin up Teleport on a droplet.
+    
+  </Tile>
+  </ScopedBlock>
+  <Tile href="./deployments/aws-terraform.mdx" title="AWS Terraform">
+
+    Deploy HA Teleport with Terraform Provider on AWS.
+
+  </Tile>
+  <Tile href="./deployments/gcp.mdx" title="GCP">
+
+    Deploy HA Teleport on GCP.
+
+  </Tile>
+  <Tile href="./deployments/ibm.mdx" title="IBM Cloud">
+
+    Deploy HA Teleport on IBM cloud.
+
+  </Tile>
+</TileSet>
 </ScopedBlock>

--- a/docs/pages/setup/deployments/digitalocean.mdx
+++ b/docs/pages/setup/deployments/digitalocean.mdx
@@ -26,7 +26,7 @@ title="View this guide as a Teleport Open Source user"
 
 <Notice type="tip">
 
-If you are looking for a manual installation, refer to our [Linux installation guide](./linux-server.mdx). 
+If you are looking for a manual installation, refer to our [Linux installation guide](../../getting-started/linux-server.mdx). 
 
 </Notice>
 
@@ -40,19 +40,19 @@ If you are looking for a manual installation, refer to our [Linux installation g
 Head over to the Teleport page on [DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps/teleport) and click the “Create a Droplet” button:
 
 <Figure align="left" bordered caption="Teleport 1-Click droplet page">
-  ![Teleport 1-Click droplet page](../../img/quickstart/digitalocean/1click-droplet-page.png)
+  ![Teleport 1-Click droplet page](../../../img/quickstart/digitalocean/1click-droplet-page.png)
 </Figure>
 
 
 Once you click the button, DigitalOcean redirects you to the control panel to configure resources for the Teleport droplet. This step is similar to how you create a regular [droplet in DigitalOcean](https://docs.digitalocean.com/products/droplets/how-to/create/). Teleport is very lightweight, and if you are just trying out Teleport, you can select the $5 droplet. Make sure you select "SSH keys" as the SSH authentication method as it is more secure than a password.
 <Figure align="left" bordered caption="Create a droplet">
-  ![Create a droplet](../../img/quickstart/digitalocean/create-droplet.png)
+  ![Create a droplet](../../../img/quickstart/digitalocean/create-droplet.png)
 </Figure>
 
 It will take a few minutes before our newly created Teleport droplet is ready. Once the droplet is ready, configure your FQDN with the public IP address of the droplet as an IP address for the `A` record of your domain name. 
 For example, refer to the image below; we use the domain name `example.com`. The resulting domain we are using as an FQDN is `tele.example.com`, pointing to our Teleport droplet's public IP `192.168.200.200`.
 <Figure align="left" bordered caption="Configure DNS">
-  ![Configure DNS](../../img/quickstart/digitalocean/fqdn.png)
+  ![Configure DNS](../../../img/quickstart/digitalocean/fqdn.png)
 </Figure>
 
 ## Step 2/3. Configure Teleport
@@ -99,14 +99,14 @@ Open the link copied in the previous step in the browser to complete the setup p
 1. Scan the QR code with your two-factor authentication app (e.g., Google Authenticator)
 2. Set a password and enter the TOTP code generated from the two-factor authentication app.
 <Figure align="left" bordered caption="Set up user">
-  ![Set up user](../../img/quickstart/digitalocean/setup-user.png)
+  ![Set up user](../../../img/quickstart/digitalocean/setup-user.png)
 </Figure>
 
 
 Once you set up a password and provide a valid TOTP code, the user setup process will be complete, and you will be redirected to Teleport Web UI:
 
 <Figure align="left" bordered caption="Teleport Web UI">
-  ![Teleport Web UI](../../img/quickstart/digitalocean/webui.png)
+  ![Teleport Web UI](../../../img/quickstart/digitalocean/webui.png)
 </Figure>
 
 
@@ -114,7 +114,7 @@ Congrats! You've completed setting up Teleport.
 
 ## Next steps
 Finally, you are a step closer to managing secure access to your infrastructure hosted in DigitalOcean.
-Teleport lets you enable [certificate-based authentication for SSH](../server-access/getting-started.mdx) access. If you want to protect public access to internal applications such as GitLab or Grafana, check out our getting started guide on [Application Access](../application-access/getting-started.mdx).  
+Teleport lets you enable [certificate-based authentication for SSH](../../server-access/getting-started.mdx) access. If you want to protect public access to internal applications such as GitLab or Grafana, check out our getting started guide on [Application Access](../../application-access/getting-started.mdx).  
 
 You can also secure access to databases, DigitalOcean Marketplace apps, and Kubernetes clusters using Teleport. Below are the links to get started further:
 <TileSet>


### PR DESCRIPTION
Fixes #12921

This removes the DigitalOcean link on the /docs/getting-started page
and moves the DigitalOcean guide into /docs/setup/deployments, which is
a more appropriate home. Now, the "Deploy to production" section of
/docs/getting-started only includes links to the Getting Started
guide for the Open Source, Cloud, and Enterprise editions, making it
clearer to users that there are three editions and that we have separate
content for each one.

This also changes the href of the Teleport Cloud link on the Getting
Started page to /cloud/getting-started/?scope=cloud to be
consistent with the other links, which direct users to guides.