### PR TITLE
fix: add wildcard cert and dns record for acm based setups

### DIFF
--- a/examples/aws/terraform/ha-autoscale-cluster/acm.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/acm.tf
@@ -10,6 +10,10 @@ resource "aws_acm_certificate" "cert" {
   validation_method = "DNS"
   count             = var.use_acm ? 1 : 0
 
+  subject_alternative_names = [
+    "*.${var.route53_domain}"
+  ]
+
   lifecycle {
     create_before_destroy = true
   }

--- a/examples/aws/terraform/ha-autoscale-cluster/route53.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/route53.tf
@@ -33,6 +33,19 @@ resource "aws_route53_record" "proxy_acm" {
   }
 }
 
+resource "aws_route53_record" "proxy_acm_wildcard" {
+  zone_id = data.aws_route53_zone.proxy.zone_id
+  name    = "*.${var.route53_domain}"
+  type    = "A"
+  count   = var.use_acm ? 1 : 0
+
+  alias {
+    name                   = aws_lb.proxy_acm[0].dns_name
+    zone_id                = aws_lb.proxy_acm[0].zone_id
+    evaluate_target_health = false
+  }
+}
+
 // ACM (NLB)
 resource "aws_route53_record" "proxy_acm_nlb_alias" {
   zone_id = data.aws_route53_zone.proxy.zone_id


### PR DESCRIPTION
Using ACM, a wildcard record should be created so that applications proxied could easily work "out of the box".