### PR TITLE
Ensure tctl commands include login instructions

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -37,8 +37,9 @@ To see the list of roles in a Teleport cluster, an administrator can execute:
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
-# Log in to your cluster with tsh so you can use tctl.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --user=myuser --proxy=teleport.example.com
 $ tctl get roles
 ```

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -41,6 +41,9 @@ join the cluster. Generate a short-lived join token and save it for example
 in `/tmp/token`:
 
 ```code
+# Log in to your cluster with tsh so you can use tctl.
+# You can also run tctl on your Auth Service host.
+$ tsh login --user=myuser --proxy=teleport.example.com
 $ tctl tokens add \
     --type=app \
     --app-name=grafana \

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -41,8 +41,9 @@ join the cluster. Generate a short-lived join token and save it for example
 in `/tmp/token`:
 
 ```code
-# Log in to your cluster with tsh so you can use tctl.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --user=myuser --proxy=teleport.example.com
 $ tctl tokens add \
     --type=app \

--- a/docs/pages/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/application-access/guides/dynamic-registration.mdx
@@ -85,8 +85,9 @@ To create an application resource, run:
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
-# Log in to your Teleport cluster so you can use tctl remotely.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create app.yaml
 ```

--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -100,8 +100,9 @@ assume that you have created a YAML file called `app.yaml` with your configurati
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
-# Log in to your Teleport cluster.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --proxy=teleport.example.com --user=myuser
 # Create the resource
 $ tctl create -f app.yaml
@@ -111,7 +112,7 @@ $ tctl create -f app.yaml
 <ScopedBlock scope={["cloud"]}>
 
 ```code
-# Log in to your Teleport cluster.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
 $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 # Create the resource.
 $ tctl create -f app.yaml

--- a/docs/pages/database-access/reference/configuration.mdx
+++ b/docs/pages/database-access/reference/configuration.mdx
@@ -171,8 +171,9 @@ assume that you have created a YAML file called `db.yaml` with your configuratio
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
-# Log in to your Teleport cluster.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --proxy=teleport.example.com --user=myuser
 # Create the resource
 $ tctl create -f db.yaml
@@ -182,7 +183,7 @@ $ tctl create -f db.yaml
 <ScopedBlock scope={["cloud"]}>
 
 ```code
-# Log in to your Teleport cluster
+# Log in to your Teleport cluster so you can use tctl from your local machine.
 $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 # Create the resource
 $ tctl create -f db.yaml

--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -50,8 +50,9 @@ new CA using the following command:
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
-# Log in to your Teleport cluster so you can use tctl remotely.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl auth export --type=windows >user-ca.cer
 ```

--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -90,8 +90,9 @@ Create the connector:
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
-# Log in to your Teleport cluster so you can use tctl remotely.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create oidc-connector.yaml
 ```
@@ -100,7 +101,7 @@ $ tctl create oidc-connector.yaml
 <ScopedBlock scope={["cloud"]}>
 
 ```code
-# Log in to your Teleport cluster so you can use tctl remotely
+# Log in to your Teleport cluster so you can use tctl remotely.
 $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl create oidc-connector.yaml
 ```

--- a/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
@@ -40,6 +40,8 @@ Here is an example of sending an access request via Teleport's Slack plugin:
 
 (!/docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
+(!/docs/pages/includes/tctl.mdx!)
+
 ## Step 1/7. Install the Teleport Slack plugin
 
 We currently only provide `linux-amd64` binaries. You can also compile these plugins

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -123,8 +123,9 @@ Create or update this role using `tctl`:
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
-# Log in to your Teleport cluster so you can use tctl remotely.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create -f member.yaml
 ```

--- a/docs/pages/kubernetes-access/guides/cicd.mdx
+++ b/docs/pages/kubernetes-access/guides/cicd.mdx
@@ -43,8 +43,9 @@ Generate a `kubeconfig` using the `jenkins` user and its roles using [`tctl auth
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
-# Log in to your Teleport cluster so you can use tctl remotely.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --proxy=teleport.example.com --user=myuser
 # Create a new local user for Jenkins
 $ tctl users add jenkins --roles=robot

--- a/docs/pages/server-access/guides/tsh.mdx
+++ b/docs/pages/server-access/guides/tsh.mdx
@@ -352,7 +352,10 @@ In this example, we're creating a certificate with a TTL of one hour for the
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
-# To be executed on a Teleport Auth Server
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
+$ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl auth sign --ttl=1h --user=jenkins --out=jenkins.pem
 ```
 

--- a/docs/pages/setup/guides/ssh-key-extensions.mdx
+++ b/docs/pages/setup/guides/ssh-key-extensions.mdx
@@ -18,8 +18,9 @@ In order to export the Teleport CA, execute the following command:
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
-# Log in to your Teleport cluster so you can use tctl remotely.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl auth export --type=user | sed 's/^cert-authority //g'
 ```

--- a/docs/pages/setup/operations/backup-restore.mdx
+++ b/docs/pages/setup/operations/backup-restore.mdx
@@ -114,9 +114,10 @@ When migrating backends, you should back up your Auth Service's
 ### Example of backing up and restoring a cluster
 
 ```code
-# Log in to your cluster with tsh so you can use tctl.
-# You can also run tctl on your Auth Service host.
-$ tsh login --user=myuser --proxy=teleport.example.com
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
+$ tsh login --proxy=teleport.example.com --user=myuser
 # Export dynamic configuration state from old cluster
 $ tctl get all --with-secrets > state.yaml
 
@@ -177,8 +178,9 @@ When migrating backends, you should back up your Auth Service's
 ### Example of backing up and restoring a cluster
 
 ```code
-# Log in to your cluster with tsh so you can use tctl.
-# You can also run tctl on your Auth Service host.
+# Log in to your cluster with tsh so you can use tctl from your local machine.
+# You can also run tctl on your Auth Service host without running "tsh login"
+# first.
 $ tsh login --user=myuser --proxy=teleport.example.com
 # Export dynamic configuration state from old cluster
 $ tctl get all --with-secrets > state.yaml

--- a/docs/pages/setup/operations/backup-restore.mdx
+++ b/docs/pages/setup/operations/backup-restore.mdx
@@ -114,6 +114,9 @@ When migrating backends, you should back up your Auth Service's
 ### Example of backing up and restoring a cluster
 
 ```code
+# Log in to your cluster with tsh so you can use tctl.
+# You can also run tctl on your Auth Service host.
+$ tsh login --user=myuser --proxy=teleport.example.com
 # Export dynamic configuration state from old cluster
 $ tctl get all --with-secrets > state.yaml
 
@@ -174,6 +177,9 @@ When migrating backends, you should back up your Auth Service's
 ### Example of backing up and restoring a cluster
 
 ```code
+# Log in to your cluster with tsh so you can use tctl.
+# You can also run tctl on your Auth Service host.
+$ tsh login --user=myuser --proxy=teleport.example.com
 # Export dynamic configuration state from old cluster
 $ tctl get all --with-secrets > state.yaml
 
@@ -216,12 +222,15 @@ also apply to a new cluster being bootstrapped from the state of an old cluster:
 </TabItem>
 <TabItem scope={["cloud"]} label="Teleport Cloud">
 
-In Teleport Cloud, backend data is managed for you automatically. If you would
-like to migrate configuration resources to a self-hosted Teleport cluster,
-follow our recommended backup practice of storing configuration resources in a
-git repository and running `tctl create -f` regularly for each resource. This
-will enable you to keep your configuration resources up to date regardless of
-storage backend.
+In Teleport Cloud, backend data is managed for you automatically. 
+
+If you would like to migrate configuration resources to a self-hosted Teleport
+cluster, follow our recommended backup practice of storing configuration
+resources in a git repository and running `tctl create -f` regularly for each
+resource. 
+
+This will enable you to keep your configuration resources up to date regardless
+of storage backend.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
See #10192

Add the tctl.mdx partial or a "tsh login" command in some pages that
include example tctl commands. Note that this change does not address
SSO guides, which will be handled separately.

Where a guide requires a complete restructuring to provide full context,
"docs/pages/application-access/guides/connecting-apps.mdx", I've added
"tsh login" instruction above the first tctl command.