### PR TITLE
Release 7.3.21 (amended)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 This release of Teleport contains multiple bug fixes and stability improvements.
 
 * Fixed issue with `tctl` not outputting debug logs. [#12918](https://github.com/gravitational/teleport/pull/12918)
+* Fixed issue with Kubernetes access not working when using system CA pool. [#12876](https://github.com/gravitational/teleport/pull/12876)
 * Improved proxy restart stability. [#12694](https://github.com/gravitational/teleport/pull/12694)
 * Improved memory usage in large clusters. [#12722](https://github.com/gravitational/teleport/pull/12722)
 


### PR DESCRIPTION
Amend changelog to include https://github.com/gravitational/teleport/pull/12876 which got merged after the original 7.3.21 PR. 7.3.21 tag hasn't been created yet.