### PR TITLE
[v9] Add `tbot proxy` and `tbot db` wrapper commands (#12687)

### DIFF
--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -604,6 +604,17 @@ func ReadAtMost(r io.Reader, limit int64) ([]byte, error) {
 	return data, nil
 }
 
+// HasPrefixAny determines if any of the string values have the given prefix.
+func HasPrefixAny(prefix string, values []string) bool {
+	for _, val := range values {
+		if strings.HasPrefix(val, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ErrLimitReached means that the read limit is reached.
 var ErrLimitReached = &trace.LimitExceededError{Message: "the read limit is reached"}
 

--- a/tool/tbot/config/config_destination.go
+++ b/tool/tbot/config/config_destination.go
@@ -118,13 +118,18 @@ func (dc *DestinationConfig) ListSubdirectories() ([]string, error) {
 	// properly on the fly.
 	var subdirs []string
 
+	dest, err := dc.GetDestination()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	for _, config := range dc.Configs {
 		template, err := config.GetConfigTemplate()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		for _, file := range template.Describe() {
+		for _, file := range template.Describe(dest) {
 			if file.IsDir {
 				subdirs = append(subdirs, file.Name)
 			}

--- a/tool/tbot/config/configtemplate.go
+++ b/tool/tbot/config/configtemplate.go
@@ -88,7 +88,7 @@ type Template interface {
 	// statically as this must be callable without any auth clients (or any
 	// secrets) for use with `tbot init`. If an arbitrary number of files must
 	// be generated, they should be placed in a subdirectory.
-	Describe() []FileDescription
+	Describe(destination destination.Destination) []FileDescription
 
 	// Render writes the config template to the destination.
 	Render(ctx context.Context, authClient auth.ClientI, currentIdentity *identity.Identity, destination *DestinationConfig) error

--- a/tool/tbot/config/configtemplate_cockroach.go
+++ b/tool/tbot/config/configtemplate_cockroach.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client/identityfile"
+	"github.com/gravitational/teleport/tool/tbot/destination"
 	"github.com/gravitational/teleport/tool/tbot/identity"
 	"github.com/gravitational/trace"
 )
@@ -47,7 +48,7 @@ func (t *TemplateCockroach) Name() string {
 	return TemplateCockroachName
 }
 
-func (t *TemplateCockroach) Describe() []FileDescription {
+func (t *TemplateCockroach) Describe(destination destination.Destination) []FileDescription {
 	return []FileDescription{
 		{
 			Name:  t.DirName,

--- a/tool/tbot/config/configtemplate_identity.go
+++ b/tool/tbot/config/configtemplate_identity.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client/identityfile"
+	"github.com/gravitational/teleport/tool/tbot/destination"
 	"github.com/gravitational/teleport/tool/tbot/identity"
 	"github.com/gravitational/trace"
 )
@@ -46,7 +47,7 @@ func (t *TemplateIdentity) Name() string {
 	return TemplateIdentityName
 }
 
-func (t *TemplateIdentity) Describe() []FileDescription {
+func (t *TemplateIdentity) Describe(destination destination.Destination) []FileDescription {
 	return []FileDescription{
 		{
 			Name: t.FileName,

--- a/tool/tbot/config/configtemplate_mongo.go
+++ b/tool/tbot/config/configtemplate_mongo.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client/identityfile"
+	"github.com/gravitational/teleport/tool/tbot/destination"
 	"github.com/gravitational/teleport/tool/tbot/identity"
 	"github.com/gravitational/trace"
 )
@@ -47,7 +48,7 @@ func (t *TemplateMongo) Name() string {
 	return TemplateMongoName
 }
 
-func (t *TemplateMongo) Describe() []FileDescription {
+func (t *TemplateMongo) Describe(destination destination.Destination) []FileDescription {
 	return []FileDescription{
 		{
 			Name: t.Prefix + ".crt",

--- a/tool/tbot/config/configtemplate_ssh_client.go
+++ b/tool/tbot/config/configtemplate_ssh_client.go
@@ -20,18 +20,20 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/tbot/destination"
 	"github.com/gravitational/teleport/tool/tbot/identity"
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
@@ -113,8 +115,8 @@ func getSSHVersion() (*semver.Version, error) {
 }
 
 func (c *TemplateSSHClient) CheckAndSetDefaults() error {
-	if c.ProxyPort == 0 {
-		c.ProxyPort = defaults.SSHProxyListenPort
+	if c.ProxyPort != 0 {
+		log.Warn("ssh_client's proxy_port parameter is deprecated and will be removed in a future release.")
 	}
 	return nil
 }
@@ -123,16 +125,27 @@ func (c *TemplateSSHClient) Name() string {
 	return TemplateSSHClientName
 }
 
-func (c *TemplateSSHClient) Describe() []FileDescription {
-	return []FileDescription{
-		{
-			Name: "ssh_config",
-		},
+func (c *TemplateSSHClient) Describe(destination destination.Destination) []FileDescription {
+	ret := []FileDescription{
 		{
 			Name: "known_hosts",
 		},
 	}
+
+	// Only include ssh_config if we're using a filesystem destination as
+	// otherwise ssh_config will not be sensible.
+	if _, ok := destination.(*DestinationDirectory); ok {
+		ret = append(ret, FileDescription{
+			Name: "ssh_config",
+		})
+	}
+
+	return ret
 }
+
+// sshConfigUnsupportedWarning is used to ensure we don't spam log messages if
+// using non-filesystem backends.
+var sshConfigUnsupportedWarning sync.Once
 
 func (c *TemplateSSHClient) Render(ctx context.Context, authClient auth.ClientI, currentIdentity *identity.Identity, destination *DestinationConfig) error {
 	dest, err := destination.GetDestination()
@@ -155,34 +168,42 @@ func (c *TemplateSSHClient) Render(ctx context.Context, authClient auth.ClientI,
 		return trace.BadParameter("proxy %+v has no usable public address: %v", ping.ProxyPublicAddr, err)
 	}
 
-	// TODO: ideally it'd be nice to fetch this dynamically
-	// TODO: eventually we could consider including `tsh proxy`
-	// functionality and sidestep this entirely.
-	proxyPort := strconv.Itoa(int(c.ProxyPort))
-
 	// Backend note: Prefer to use absolute paths for filesystem backends.
 	// If the backend is something else, use "". ssh_config will generate with
 	// paths relative to the destination. This doesn't work with ssh in
 	// practice so adjusting the config for impossible-to-determine-in-advance
 	// destination backends is left as an exercise to the user.
-	var dataDir string
+	var destDir string
 	if dir, ok := dest.(*DestinationDirectory); ok {
-		dataDir, err = filepath.Abs(dir.Path)
+		destDir, err = filepath.Abs(dir.Path)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 	} else {
-		dataDir = ""
+		destDir = ""
 	}
 
+	// We'll write known_hosts regardless of destination type, it's still
+	// useful alongside a manually-written ssh_config.
 	knownHosts, err := fetchKnownHosts(ctx, authClient, clusterName.GetClusterName(), proxyHost)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	knownHostsPath := filepath.Join(dataDir, knownHostsName)
 	if err := dest.Write(knownHostsName, []byte(knownHosts)); err != nil {
 		return trace.Wrap(err)
+	}
+
+	// If destDir is unset, we're not using a filesystem destination and
+	// ssh_config will not be sensible. Log a note and bail early without
+	// writing ssh_config. (Future users of k8s secrets will need to bring
+	// their own config, we can't predict where paths will be in practice.)
+	if destDir == "" {
+		sshConfigUnsupportedWarning.Do(func() {
+			log.Infof("Note: no ssh_config will be written for non-filesystem "+
+				"destination %s.", dest)
+		})
+		return nil
 	}
 
 	// Default to including the RSA deprecation workaround.
@@ -197,19 +218,24 @@ func (c *TemplateSSHClient) Render(ctx context.Context, authClient auth.ClientI,
 		log.Debugf("OpenSSH version %s will use workaround for RSA deprecation", version)
 	}
 
+	executablePath, err := os.Executable()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	var sshConfigBuilder strings.Builder
-	identityFilePath := filepath.Join(dataDir, identity.PrivateKeyKey)
-	certificateFilePath := filepath.Join(dataDir, identity.SSHCertKey)
-	sshConfigPath := filepath.Join(dataDir, sshConfigName)
+	knownHostsPath := filepath.Join(destDir, knownHostsName)
+	identityFilePath := filepath.Join(destDir, identity.PrivateKeyKey)
+	certificateFilePath := filepath.Join(destDir, identity.SSHCertKey)
 	if err := sshConfigTemplate.Execute(&sshConfigBuilder, sshConfigParameters{
 		ClusterName:          clusterName.GetClusterName(),
 		ProxyHost:            proxyHost,
-		ProxyPort:            proxyPort,
 		KnownHostsPath:       knownHostsPath,
 		IdentityFilePath:     identityFilePath,
 		CertificateFilePath:  certificateFilePath,
-		SSHConfigPath:        sshConfigPath,
 		IncludeRSAWorkaround: rsaWorkaround,
+		TBotPath:             executablePath,
+		DestinationDir:       destDir,
 	}); err != nil {
 		return trace.Wrap(err)
 	}
@@ -227,8 +253,8 @@ type sshConfigParameters struct {
 	IdentityFilePath    string
 	CertificateFilePath string
 	ProxyHost           string
-	ProxyPort           string
-	SSHConfigPath       string
+	TBotPath            string
+	DestinationDir      string
 
 	// IncludeRSAWorkaround controls whether the RSA deprecation workaround is
 	// included in the generated configuration. Newer versions of OpenSSH
@@ -241,7 +267,7 @@ type sshConfigParameters struct {
 }
 
 var sshConfigTemplate = template.Must(template.New("ssh-config").Parse(`
-# Begin generated Teleport configuration for {{ .ProxyHost }} from tbot config
+# Begin generated Teleport configuration for {{ .ProxyHost }} by tbot
 
 # Common flags for all {{ .ClusterName }} hosts
 Host *.{{ .ClusterName }} {{ .ProxyHost }}
@@ -254,7 +280,7 @@ Host *.{{ .ClusterName }} {{ .ProxyHost }}
 # Flags for all {{ .ClusterName }} hosts except the proxy
 Host *.{{ .ClusterName }} !{{ .ProxyHost }}
     Port 3022
-    ProxyCommand ssh -F {{ .SSHConfigPath }} -l %r -p {{ .ProxyPort }} {{ .ProxyHost }} -s proxy:$(echo %h | cut -d '.' -f 1):%p@{{ .ClusterName }}
+    ProxyCommand "{{ .TBotPath }}" proxy --destination-dir={{ .DestinationDir }} --proxy={{ .ProxyHost }} ssh --cluster={{ .ClusterName }}  %r@%h:%p
 
 # End generated Teleport configuration
 `))

--- a/tool/tbot/config/configtemplate_tls.go
+++ b/tool/tbot/config/configtemplate_tls.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client/identityfile"
+	"github.com/gravitational/teleport/tool/tbot/destination"
 	"github.com/gravitational/teleport/tool/tbot/identity"
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
@@ -94,7 +95,7 @@ func (t *TemplateTLS) Name() string {
 	return TemplateTLSName
 }
 
-func (t *TemplateTLS) Describe() []FileDescription {
+func (t *TemplateTLS) Describe(destination destination.Destination) []FileDescription {
 	return []FileDescription{
 		{
 			Name: t.Prefix + ".key",

--- a/tool/tbot/config/configtemplate_tls_cas.go
+++ b/tool/tbot/config/configtemplate_tls_cas.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/tool/tbot/destination"
 	"github.com/gravitational/teleport/tool/tbot/identity"
 	"github.com/gravitational/trace"
 )
@@ -75,7 +76,7 @@ func (t *TemplateTLSCAs) Name() string {
 	return TemplateTLSCAsName
 }
 
-func (t *TemplateTLSCAs) Describe() []FileDescription {
+func (t *TemplateTLSCAs) Describe(destination destination.Destination) []FileDescription {
 	return []FileDescription{
 		{
 			Name: t.UserCAPath,

--- a/tool/tbot/configtemplate_test.go
+++ b/tool/tbot/configtemplate_test.go
@@ -39,7 +39,7 @@ func validateTemplate(t *testing.T, tplI config.Template, dest destination.Desti
 	t.Helper()
 
 	// First, make sure all advertised files exist.
-	for _, file := range tplI.Describe() {
+	for _, file := range tplI.Describe(dest) {
 		// Don't bother checking directories, they're meant to be black
 		// boxes. We could implement type-specific checks if we really
 		// wanted.

--- a/tool/tbot/db.go
+++ b/tool/tbot/db.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/tbot/config"
+	"github.com/gravitational/teleport/tool/tbot/tshwrap"
+	"github.com/gravitational/trace"
+)
+
+func onDBCommand(botConfig *config.BotConfig, cf *config.CLIConf) error {
+	wrapper, err := tshwrap.New()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := tshwrap.CheckTSHSupported(wrapper); err != nil {
+		return trace.Wrap(err)
+	}
+
+	destination, err := tshwrap.GetDestination(botConfig, cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	destinationPath, err := tshwrap.GetDestinationPath(destination)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	identityTemplate, err := tshwrap.GetIdentityTemplate(destination)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	env, err := tshwrap.GetEnvForTSH(destination)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	identityPath := filepath.Join(destinationPath, identityTemplate.FileName)
+	identity, err := tshwrap.LoadIdentity(identityPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	args := []string{"-i", identityPath, "db", "--proxy=" + cf.Proxy}
+	if cf.Cluster != "" {
+		// If we caught --cluster in our args, pass it through.
+		args = append(args, "--cluster="+cf.Cluster)
+	} else if !utils.HasPrefixAny("--cluster", cf.RemainingArgs) {
+		// If no `--cluster` was provided after a `--`, pass along the cluster
+		// name in the identity.
+		args = append(args, "--cluster="+identity.RouteToCluster)
+	}
+	args = append(args, cf.RemainingArgs...)
+
+	// Pass through the debug flag, and prepend to satisfy argument ordering
+	// needs (`-d` must precede `db`).
+	if botConfig.Debug {
+		args = append([]string{"-d"}, args...)
+	}
+
+	return trace.Wrap(wrapper.Exec(env, args...), "executing `tsh db`")
+}

--- a/tool/tbot/init.go
+++ b/tool/tbot/init.go
@@ -45,6 +45,11 @@ func getInitArtifacts(destination *config.DestinationConfig) (map[string]bool, e
 	// true = directory, false = regular file
 	toCreate := map[string]bool{}
 
+	destImpl, err := destination.GetDestination()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Collect all base artifacts and filter for the destination.
 	for _, artifact := range identity.GetArtifacts() {
 		if artifact.Matches(identity.DestinationKinds()...) {
@@ -59,7 +64,7 @@ func getInitArtifacts(destination *config.DestinationConfig) (map[string]bool, e
 			return nil, trace.Wrap(err)
 		}
 
-		for _, file := range template.Describe() {
+		for _, file := range template.Describe(destImpl) {
 			toCreate[file.Name] = file.IsDir
 		}
 	}

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -98,10 +98,37 @@ func Run(args []string, stdout io.Writer) error {
 
 	watchCmd := app.Command("watch", "Watch a destination directory for changes.").Hidden()
 
+	dbCmd := app.Command("db", "Execute database commands through tsh")
+	dbCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Required().StringVar(&cf.Proxy)
+	dbCmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&cf.DestinationDir)
+	dbCmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&cf.Cluster)
+	dbRemaining := config.RemainingArgs(dbCmd.Arg(
+		"args",
+		"Arguments to `tsh db ...`; prefix with `-- ` to ensure flags are passed correctly.",
+	))
+
+	proxyCmd := app.Command("proxy", "Start a local TLS proxy via tsh to connect to Teleport in single-port mode")
+	proxyCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Required().StringVar(&cf.Proxy)
+	proxyCmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&cf.DestinationDir)
+	proxyCmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&cf.Cluster)
+	proxyRemaining := config.RemainingArgs(proxyCmd.Arg(
+		"args",
+		"Arguments to `tsh proxy ...`; prefix with `-- ` to ensure flags are passed correctly.",
+	))
+
 	command, err := app.Parse(args)
 	if err != nil {
 		app.Usage(args)
 		return trace.Wrap(err)
+	}
+
+	// Remaining args are stored directly to a []string rather than written to
+	// a shared ref like most other kingpin args, so we'll need to manually
+	// move them to the remaining args field.
+	if len(*dbRemaining) > 0 {
+		cf.RemainingArgs = *dbRemaining
+	} else if len(*proxyRemaining) > 0 {
+		cf.RemainingArgs = *proxyRemaining
 	}
 
 	// While in debug mode, send logs to stdout.
@@ -125,6 +152,10 @@ func Run(args []string, stdout io.Writer) error {
 		err = onInit(botConfig, &cf)
 	case watchCmd.FullCommand():
 		err = onWatch(botConfig)
+	case dbCmd.FullCommand():
+		err = onDBCommand(botConfig, &cf)
+	case proxyCmd.FullCommand():
+		err = onProxyCommand(botConfig, &cf)
 	default:
 		// This should only happen when there's a missing switch case above.
 		err = trace.BadParameter("command %q not configured", command)

--- a/tool/tbot/proxy.go
+++ b/tool/tbot/proxy.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/gravitational/teleport/tool/tbot/config"
+	"github.com/gravitational/teleport/tool/tbot/tshwrap"
+	"github.com/gravitational/trace"
+)
+
+func onProxyCommand(botConfig *config.BotConfig, cf *config.CLIConf) error {
+	wrapper, err := tshwrap.New()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := tshwrap.CheckTSHSupported(wrapper); err != nil {
+		return trace.Wrap(err)
+	}
+
+	destination, err := tshwrap.GetDestination(botConfig, cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	destinationPath, err := tshwrap.GetDestinationPath(destination)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	identityTemplate, err := tshwrap.GetIdentityTemplate(destination)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	env, err := tshwrap.GetEnvForTSH(destination)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	identityPath := filepath.Join(destinationPath, identityTemplate.FileName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// TODO(timothyb89):  We could consider supporting a --cluster passthrough
+	//  here as in `tbot db ...`.
+	args := []string{"-i", identityPath, "proxy", "--proxy=" + cf.Proxy}
+	args = append(args, cf.RemainingArgs...)
+
+	// Pass through the debug flag, and prepend to satisfy argument ordering
+	// needs (`-d` must precede `proxy`).
+	if botConfig.Debug {
+		args = append([]string{"-d"}, args...)
+	}
+
+	return trace.Wrap(wrapper.Exec(env, args...), "executing `tsh proxy`")
+}

--- a/tool/tbot/tshwrap/wrap.go
+++ b/tool/tbot/tshwrap/wrap.go
@@ -1,0 +1,309 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tshwrap
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/identityfile"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/tool/tbot/config"
+	"github.com/gravitational/teleport/tool/tbot/identity"
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// TSHVarName is the name of the environment variable that can override the
+	// tsh path that would otherwise be located on the $PATH.
+	TSHVarName = "TSH"
+
+	// TSHMinVersion is the minimum version of tsh that supports Machine ID
+	// proxies.
+	TSHMinVersion = "9.3.0"
+)
+
+var log = logrus.WithFields(logrus.Fields{
+	trace.Component: teleport.ComponentTBot,
+})
+
+// capture runs a command (presumably tsh) with the given arguments and
+// returns it's captured stdout. Stderr is ignored. Errors are returned per
+// exec.Command().Output() semantics.
+func capture(tshPath string, args ...string) ([]byte, error) {
+	out, err := exec.Command(tshPath, args...).Output()
+	if err != nil {
+		return nil, trace.Wrap(err, "error executing tsh")
+	}
+
+	return out, nil
+}
+
+// Wrapper is a wrapper to execute `tsh` commands via a subprocess.
+type Wrapper struct {
+	// path is a path to the tsh executable
+	path string
+
+	// capture is the function for capturing a command's output. It may be
+	// overridden by tests for mocking purposes, but by default is expected to
+	// execute an actual tsh binary on the host system.
+	capture func(tshPath string, args ...string) ([]byte, error)
+}
+
+// New creates a new tsh wrapper. If a $TSH var is set it uses that path,
+// otherwise looks for tsh on the OS path.
+func New() (*Wrapper, error) {
+	if val, ok := os.LookupEnv(TSHVarName); ok {
+		return &Wrapper{
+			path:    val,
+			capture: capture,
+		}, nil
+	}
+
+	binary := "tsh"
+	if runtime.GOOS == constants.WindowsOS {
+		binary = "tsh.exe"
+	}
+
+	path, err := exec.LookPath(binary)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &Wrapper{
+		path:    path,
+		capture: capture,
+	}, nil
+}
+
+// Exec runs tsh with the given environment variables and arguments. The child
+// process inherits stdin/stdout/stderr and runs until completion. Errors are
+// returned per `exec.Command().Run()` semantics.
+func (w *Wrapper) Exec(env map[string]string, args ...string) error {
+	// The subprocess should inherit the environment plus our vars. Our env
+	// vars will safely overwrite those from the environment, per `exec.Cmd`
+	// docs.
+	environ := os.Environ()
+	for k, v := range env {
+		// In case of similar keys, last env var wins.
+		environ = append(environ, k+"="+v)
+	}
+
+	log.Debugf("executing %s with env=%+v and args=%+v", w.path, env, args)
+
+	child := exec.Command(w.path, args...)
+	child.Env = environ
+	child.Stdin = os.Stdin
+	child.Stdout = os.Stdout
+	child.Stderr = os.Stderr
+
+	return trace.Wrap(child.Run(), "unable to execute tsh")
+}
+
+// GetTSHVersion queries the system tsh for its version.
+func GetTSHVersion(w *Wrapper) (*semver.Version, error) {
+	rawVersion, err := w.capture("version", "-f", "json")
+	if err != nil {
+		return nil, trace.Wrap(err, "querying tsh version")
+	}
+
+	versionInfo := struct {
+		Version string `json:"version"`
+	}{}
+	if err := json.Unmarshal(rawVersion, &versionInfo); err != nil {
+		return nil, trace.Wrap(err, "error deserializing tsh version from string: %s", rawVersion)
+	}
+
+	sv, err := semver.NewVersion(versionInfo.Version)
+	if err != nil {
+		return nil, trace.Wrap(err, "error parsing tsh version: %s", versionInfo.Version)
+	}
+
+	return sv, nil
+}
+
+// CheckTSHSupported checks if the current tsh supports Machine ID.
+func CheckTSHSupported(w *Wrapper) error {
+	version, err := GetTSHVersion(w)
+	if err != nil {
+		return trace.Wrap(err, "unable to determine tsh version")
+	}
+
+	minVersion := semver.New(TSHMinVersion)
+	if version.LessThan(*minVersion) {
+		return trace.BadParameter(
+			"installed tsh version %s does not support Machine ID proxies, "+
+				"please upgrade to at least %s",
+			version, minVersion,
+		)
+	}
+
+	log.Debugf("tsh version %s is supported", version)
+
+	return nil
+}
+
+// GetDestination attempts to select an unambiguous destination, either from
+// CLI or YAML config. It returns an error if the selected destination is
+// invalid.
+func GetDestination(botConfig *config.BotConfig, cf *config.CLIConf) (*config.DestinationConfig, error) {
+	// Note: this only supports filesystem destinations.
+	if cf.DestinationDir != "" {
+		dest, err := botConfig.GetDestinationByPath(cf.DestinationDir)
+		if err != nil {
+			return nil, trace.Wrap(err, "unable to find destination %s in the "+
+				"configuration; has the configuration file been "+
+				"specified with `-c <path>`?", cf.DestinationDir)
+		}
+
+		return dest, nil
+	}
+
+	if len(botConfig.Destinations) == 0 {
+		return nil, trace.BadParameter("either --destination-dir or a config file must be specified")
+	} else if len(botConfig.Destinations) > 1 {
+		return nil, trace.BadParameter("the config file contains multiple destinations; a --destination-dir must be specified")
+	}
+
+	return botConfig.Destinations[0], nil
+}
+
+// GetDestinationPath returns a path to a filesystem destination.
+func GetDestinationPath(destination *config.DestinationConfig) (string, error) {
+	destinationImpl, err := destination.GetDestination()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	destinationDir, ok := destinationImpl.(*config.DestinationDirectory)
+	if !ok {
+		return "", trace.BadParameter("destination %s must be a directory", destinationImpl)
+	}
+
+	return destinationDir.Path, nil
+}
+
+// GetTLSCATemplate returns the TLS CA template for the given destination. It's
+// a required template so this should never fail.
+func GetTLSCATemplate(destination *config.DestinationConfig) (*config.TemplateTLSCAs, error) {
+	tpl := destination.GetConfigByName(config.TemplateTLSCAsName)
+	if tpl == nil {
+		return nil, trace.NotFound("no template with name %s found, this is a bug", config.TemplateTLSCAsName)
+	}
+
+	tlsCAs, ok := tpl.(*config.TemplateTLSCAs)
+	if !ok {
+		return nil, trace.BadParameter("invalid TLS CA template")
+	}
+
+	return tlsCAs, nil
+}
+
+// GetIdentityTemplate returns the identity template for the given destination.
+// This is a required template so it _should_ never fail.
+func GetIdentityTemplate(destination *config.DestinationConfig) (*config.TemplateIdentity, error) {
+	tpl := destination.GetConfigByName(config.TemplateIdentityName)
+	if tpl == nil {
+		return nil, trace.NotFound("no template with name %s found, this is a bug", config.TemplateIdentityName)
+	}
+
+	identity, ok := tpl.(*config.TemplateIdentity)
+	if !ok {
+		return nil, trace.BadParameter("invalid identity template")
+	}
+
+	return identity, nil
+}
+
+// mergeEnv applies the given value to each key inside the specified map.
+func mergeEnv(m map[string]string, value string, keys []string) {
+	for _, key := range keys {
+		m[key] = value
+	}
+}
+
+// GetEnvForTSH returns a map of environment variables needed to properly wrap
+// tsh so that it uses our Machine ID certificates where necessary.
+func GetEnvForTSH(destination *config.DestinationConfig) (map[string]string, error) {
+	tlsCAs, err := GetTLSCATemplate(destination)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	destPath, err := GetDestinationPath(destination)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// The env var interface does allow us to set specific resource names for
+	// everything but also has generic fallbacks. We'll use the fallbacks for
+	// now but could eventually communicate more info to tsh if desired.
+	env := make(map[string]string)
+	mergeEnv(env, filepath.Join(destPath, identity.PrivateKeyKey), client.VirtualPathEnvNames(client.VirtualPathKey, nil))
+
+	// Database certs are a bit awkward since a few databases (cockroach) have
+	// special naming requirements. We can document around these for now and
+	// automate later. (I don't think tsh handles this perfectly today anyway).
+	mergeEnv(env, filepath.Join(destPath, identity.TLSCertKey), client.VirtualPathEnvNames(client.VirtualPathDatabase, nil))
+
+	mergeEnv(env, filepath.Join(destPath, identity.TLSCertKey), client.VirtualPathEnvNames(client.VirtualPathApp, nil))
+
+	// We don't want to provide a fallback for CAs since it would be ambiguous,
+	// so we'll specify them exactly.
+	env[client.VirtualPathEnvName(client.VirtualPathCA, client.VirtualPathCAParams(types.UserCA))] =
+		filepath.Join(destPath, tlsCAs.UserCAPath)
+	env[client.VirtualPathEnvName(client.VirtualPathCA, client.VirtualPathCAParams(types.HostCA))] =
+		filepath.Join(destPath, tlsCAs.HostCAPath)
+
+	// TODO(timothyb89): Kubernetes support. We don't generate kubeconfigs yet, so we have
+	// nothing to give tsh for now.
+
+	return env, nil
+}
+
+// LoadIdentity loads a Teleport identity from an identityfile. Secondary bot
+// identities are not loadable, so we'll just read the Teleport identity (which
+// is required for tsh to function anyway).
+func LoadIdentity(identityPath string) (*tlsca.Identity, error) {
+	f, err := os.Open(identityPath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer f.Close()
+
+	idFile, err := identityfile.Read(f)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cert, err := tlsca.ParseCertificatePEM(idFile.Certs.TLS)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	parsed, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+	return parsed, trace.Wrap(err)
+}

--- a/tool/tbot/tshwrap/wrap_test.go
+++ b/tool/tbot/tshwrap/wrap_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tshwrap
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/tool/tbot/config"
+	"github.com/gravitational/teleport/tool/tbot/identity"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTSHSupported ensures that the tsh version check works as expected (and,
+// implicitly, that the version capture and parsing works.)
+func TestTSHSupported(t *testing.T) {
+	version := func(v string) []byte {
+		return []byte(fmt.Sprintf(`{"version": "%s"}`, v))
+	}
+
+	tests := []struct {
+		name   string
+		out    []byte
+		err    error
+		expect func(t require.TestingT, err error, msgAndArgs ...interface{})
+	}{
+		{
+			// Before `-f json` is supported
+			name:   "very old tsh",
+			err:    trace.Errorf("unsupported"),
+			expect: require.Error,
+		},
+		{
+			name:   "too old",
+			out:    version("9.2.0"),
+			expect: require.Error,
+		},
+		{
+			name:   "supported",
+			out:    version(TSHMinVersion),
+			expect: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapper := Wrapper{
+				path: "tsh", // path is arbitrary here
+				capture: func(tshPaths string, args ...string) ([]byte, error) {
+					if tt.err != nil {
+						return nil, tt.err
+					}
+					return tt.out, nil
+				},
+			}
+
+			tt.expect(t, CheckTSHSupported(&wrapper))
+		})
+	}
+}
+
+// TestGetEnvForTSH ensures we generate a valid minimum subset of environment
+// parameters needed for tsh wrappers to work.
+func TestGetEnvForTSH(t *testing.T) {
+	destination := config.DestinationConfig{
+		DestinationMixin: config.DestinationMixin{
+			Directory: &config.DestinationDirectory{
+				Path: "/foo",
+			},
+		},
+	}
+	require.NoError(t, destination.CheckAndSetDefaults())
+
+	p, err := GetDestinationPath(&destination)
+	require.NoError(t, err)
+
+	tlsCAs, err := GetTLSCATemplate(&destination)
+	require.NoError(t, err)
+
+	expected := map[string]string{
+		client.VirtualPathEnvName(client.VirtualPathKey, nil):      filepath.Join(p, identity.PrivateKeyKey),
+		client.VirtualPathEnvName(client.VirtualPathDatabase, nil): filepath.Join(p, identity.TLSCertKey),
+		client.VirtualPathEnvName(client.VirtualPathApp, nil):      filepath.Join(p, identity.TLSCertKey),
+
+		client.VirtualPathEnvName(client.VirtualPathCA, client.VirtualPathCAParams(types.UserCA)): filepath.Join(p, tlsCAs.UserCAPath),
+		client.VirtualPathEnvName(client.VirtualPathCA, client.VirtualPathCAParams(types.HostCA)): filepath.Join(p, tlsCAs.HostCAPath),
+	}
+
+	env, err := GetEnvForTSH(&destination)
+	require.NoError(t, err)
+	for k, v := range expected {
+		assert.Equal(t, v, env[k])
+	}
+}
+
+func TestGetDestinationPath(t *testing.T) {
+	destination := config.DestinationConfig{
+		DestinationMixin: config.DestinationMixin{
+			Directory: &config.DestinationDirectory{
+				Path: "/foo",
+			},
+		},
+	}
+	require.NoError(t, destination.CheckAndSetDefaults())
+
+	path, err := GetDestinationPath(&destination)
+	require.NoError(t, err)
+	require.Equal(t, "/foo", path)
+}
+
+func TestGetIdentityTemplate(t *testing.T) {
+	destination := config.DestinationConfig{
+		DestinationMixin: config.DestinationMixin{
+			Directory: &config.DestinationDirectory{
+				Path: "/foo",
+			},
+		},
+	}
+	require.NoError(t, destination.CheckAndSetDefaults())
+
+	tpl, err := GetIdentityTemplate(&destination)
+	require.NoError(t, err)
+
+	// We don't particularly care where the file goes, but it does need to be
+	// set.
+	require.NotEmpty(t, tpl.FileName)
+}
+
+func TestGetTLSCATemplate(t *testing.T) {
+	destination := config.DestinationConfig{
+		DestinationMixin: config.DestinationMixin{
+			Directory: &config.DestinationDirectory{
+				Path: "/foo",
+			},
+		},
+	}
+	require.NoError(t, destination.CheckAndSetDefaults())
+
+	tpl, err := GetTLSCATemplate(&destination)
+	require.NoError(t, err)
+
+	// As above, the name is arbitrary but these do need to exist.
+	require.NotEmpty(t, tpl.HostCAPath)
+	require.NotEmpty(t, tpl.UserCAPath)
+	require.NotEmpty(t, tpl.DatabaseCAPath)
+}


### PR DESCRIPTION
Backport of #12687 for branch/v9

---

* Extend support for identity files in tsh

This enhances support for identity files in tsh, which previously only
worked for regular SSH access. The largest blocker for support is that
tsh uses profiles for all non-SSH resource access, and profiles have a
direct mapping to some on-disk resources. This patch works around this
in a few ways:
 * Virtual profiles: When an identity file is specified with `-i`, we
   use it to create an in-memory virtual profile using the cert as the
   root identity _and_ for every `RouteToDatabase` (and in the future,
   app) field contained in the cert.
 * Virtual profile paths: Certain profile operations require paths to
   valid certificates and other resources on disk, which may not exist
   inside the identity file.

   As the driving use-case for this change is integration with Machine
   ID, we can "cheat" and pass the correct paths to tsh via
   environment variables. A cooperating wrapper in `tbot` will execute
   `tsh` with appropriate flags and environment variables, which
   override tsh's usual certifiate paths. This allows commands like
   `tsh db connect ...` to work as expected.
 * Key stores: previously we used a `noLocalKeyStore{}` with which all
   lookups fail. This patch replaces it with an in-memory keystore if
   a client key is available.
 * Profile status: lastly, we add a new `StatusCurrentWithIdentity()`
   function to load virtual profiles where supported. Some commands
   are not supported in this PR (like `tsh app ...`), but others
   don't make sense to support (like cert reissuing).

   We might consider merging everything into the traditional
   `StatusCurrent()` when adding app support.

App access is still broken and will be addressed in a later change.

Partially fixes #11770

* Fix failing lint

* Add `tbot proxy` and `tbot db` wrapper commands

This adds new wrapper commands that leverage tsh for proxy and
database access.

It also adds a new `tshwrap` helper package which contains utilities
for locating the tsh executable, checking its version, and loading
all necessary data (certificates, destinations, etc) that will need
to be passed to tsh for wrapped commands to function.

* Fix failing unit test due to incorrect default IsVirtual profile flag

* Combine `StatusCurrentWithIdentity()` into `StatusCurrent()`

Additionally, log a warning when environment variable paths aren't
found.

* Fix virtual profile flag always being true

* Update lib/client/api.go

Co-authored-by: Krzysztof Skrzętnicki <krzysztof.skrzetnicki@goteleport.com>

* Address review feedback

* Use `tbot proxy` in generated `ssh_config`

* Add tests for mockable parts of our tsh integration

* Fix lints

* Clarify docstrings in CLIConf

* Tweak comment for clarity; fix typo in `onProxyCommand`

* Add missing copyright header

* Fix failing unit test and pass destination to `Describe()`

This fixes a failing unit test by making the description for
`ssh_config` match its behavior in practice. This necessitated
passing the destination to all templates, unfortunately.

* Add a few extra tests

* Apply suggestions from code review

Co-authored-by: Alan Parra <alan.parra@goteleport.com>

* Address another batch of review comments

* Comment tweaks

* Refactor tshwrap to remove the Runner interface.

* Apply suggestions from code review

Co-authored-by: Alan Parra <alan.parra@goteleport.com>

* Address review comments

Co-authored-by: Krzysztof Skrzętnicki <krzysztof.skrzetnicki@goteleport.com>
Co-authored-by: Alan Parra <alan.parra@goteleport.com>