### PR TITLE
Build tsh with static libfido2 for macOS

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -534,8 +534,10 @@ steps:
   - export RUST_HOME=$CARGO_HOME
   - export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH
   - cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
+  - build.assets/build-fido2-macos.sh build
+  - export PKG_CONFIG_PATH="$(build.assets/build-fido2-macos.sh pkg_config_path)"
   - rustup override set $RUST_VERSION
-  - make clean release OS=$OS ARCH=$ARCH TOUCHID=yes
+  - make clean release OS=$OS ARCH=$ARCH FIDO2=yes TOUCHID=yes
   environment:
     ARCH: amd64
     GOCACHE: /tmp/push-build-darwin-amd64/go/cache
@@ -2953,8 +2955,10 @@ steps:
   - export RUST_HOME=$CARGO_HOME
   - export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH
   - cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
+  - build.assets/build-fido2-macos.sh build
+  - export PKG_CONFIG_PATH="$(build.assets/build-fido2-macos.sh pkg_config_path)"
   - rustup override set $RUST_VERSION
-  - make clean release OS=$OS ARCH=$ARCH TOUCHID=yes
+  - make clean release OS=$OS ARCH=$ARCH FIDO2=yes TOUCHID=yes
   environment:
     ARCH: amd64
     GOCACHE: /tmp/build-darwin-amd64/go/cache
@@ -5388,6 +5392,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 350d7354fc9de834704c0158c259b0d5e4e372d38e628391b47ec7d32cf71715
+hmac: f40b6cd20e45e765bdd99047c27cf5dba8696c224e9b79b3000acc147055bdd9
 
 ...

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -33,7 +33,7 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 
 # Install libfido2.
 # Depends on libcbor, libssl-dev, zlib1g-dev and libudev.
-RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.10.0 && \
+RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.11.0 && \
     cd libfido2 && \
     CFLAGS=-pthread cmake \
         -DBUILD_EXAMPLES=OFF \
@@ -218,11 +218,11 @@ COPY --from=libfido2 /usr/local/lib/pkgconfig/ /usr/local/lib/pkgconfig/
 COPY --from=libfido2 \
     /usr/local/lib/libcbor.a \
     /usr/local/lib/libfido2.a \
-    /usr/local/lib/libfido2.so.1.10.0 \
+    /usr/local/lib/libfido2.so.1.11.0 \
     /usr/local/lib/libudev.a \
     /usr/local/lib/
 RUN cd /usr/local/lib && \
-    ln -s libfido2.so.1.10.0 libfido2.so.1 && \
+    ln -s libfido2.so.1.11.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
     ldconfig
 COPY pkgconfig/buildbox/ /

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -19,7 +19,7 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 
 # Instal openssl.
 # Pulled from source because repository versions are too old.
-RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1n && \
+RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1o && \
     cd openssl && \
     ./config --release && \
     make && \
@@ -39,7 +39,7 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 # Install libfido2.
 # Depends on libcbor, openssl, zlib-devel and libudev.
 # Linked so `make build/tsh` finds the library where it expects it.
-RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.10.0 && \
+RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.11.0 && \
     cd libfido2 && \
     cmake3 \
         -DBUILD_EXAMPLES=OFF \
@@ -125,7 +125,7 @@ COPY --from=libfido2 \
     /usr/local/lib64/libcrypto.a \
     /usr/local/lib64/libcrypto.so.1.1 \
     /usr/local/lib64/libfido2.a \
-    /usr/local/lib64/libfido2.so.1.10.0 \
+    /usr/local/lib64/libfido2.so.1.11.0 \
     /usr/local/lib64/libssl.a \
     /usr/local/lib64/libssl.so.1.1 \
     /usr/local/lib64/libudev.a \
@@ -133,7 +133,7 @@ COPY --from=libfido2 \
 RUN cd /usr/local/lib64 && \
 # Re-create usual lib64 links.
     ln -s libcrypto.so.1.1 libcrypto.so && \
-    ln -s libfido2.so.1.10.0 libfido2.so.1 && \
+    ln -s libfido2.so.1.11.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
     ln -s libssl.so.1.1 libssl.so && \
 # Update ld.

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -3,10 +3,10 @@
 # Builds libfido2 and dependencies, caching the resulting binaries in the local
 # filesystem.
 #
-# Run `build-fido2.sh build` to build libfido2 and its dependencies, at the
-# versions specified in the script.
-# Run `build-fido2.sh pkg_config_path` to print the path to the prior-built
-# libfido2-static.pc file.
+# Run `build-fido2-macos.sh build` to build libfido2 and its dependencies, at
+# the versions specified in the script.
+# Run `build-fido2-macos.sh pkg_config_path` to print the path to the
+# prior-built libfido2-static.pc file.
 #
 # Written mainly for macOS builders.
 set -eu

--- a/build.assets/build-fido2.sh
+++ b/build.assets/build-fido2.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+#
+# Builds libfido2 and dependencies, caching the resulting binaries in the local
+# filesystem.
+#
+# Run `build-fido2.sh build` to build libfido2 and its dependencies, at the
+# versions specified in the script.
+# Run `build-fido2.sh pkg_config_path` to print the path to the prior-built
+# libfido2-static.pc file.
+#
+# Written mainly for macOS builders.
+set -eu
+
+# Note: versions are the same as the corresponding git tags for each repo.
+readonly CBOR_VERSION=v0.9.0
+readonly CRYPTO_VERSION=OpenSSL_1_1_1o
+readonly FIDO2_VERSION=1.11.0
+
+readonly LIB_CACHE="$HOME/.teleport-fido2-cache"
+
+readonly PKGFILE_DIR="$LIB_CACHE/fido2-${FIDO2_VERSION}_cbor-${CBOR_VERSION}_crypto-${CRYPTO_VERSION}"
+
+fetch_and_build() {
+  local name="$1"      # eg, cbor
+  local version="$2"   # eg, v0.9.0
+  local url="$3"       # eg, https://github.com/...
+  local buildcmd="$4"  # eg, cbor_build, a bash function name
+  echo "$name: fetch and build" >&2
+
+  local tmp=''
+  tmp="$(mktemp -d)"
+  #shellcheck disable=SC2064  # Early expansion on purpose.
+  trap "rm -fr '$tmp'" exit
+
+  local fullname="$name-$version"
+  local install_path="$tmp/$fullname"
+
+  cd "$tmp"
+  git clone --depth=1 -b "$version" "$url"
+  cd "$(ls)"  # a single folder exists at this point
+  mkdir -p "$install_path"
+  eval "$buildcmd '$PWD' '$install_path'"
+
+  # Fix path in pkgconfig files.
+  local dest="$LIB_CACHE/$fullname"
+  find "$install_path" \
+    -name '*.pc' \
+    -exec sed -i '' "s@$install_path@$dest@g" {} +
+
+  # Check if another builder beat us. Builds _should_ be equivalent.
+  mkdir -p "$LIB_CACHE"
+  if [[ ! -d "$dest" ]]; then
+    echo "$name: moving $fullname to $dest" >&2
+    mv "$install_path" "$dest"
+  fi
+}
+
+cbor_build() {
+  local src="$1"
+  local dest="$2"
+  echo 'cbor: building' >&2
+  cd "$src"
+
+  cmake \
+    -DCBOR_CUSTOM_ALLOC=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$dest" \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DWITH_EXAMPLES=OFF \
+    -G "Unix Makefiles" \
+    .
+  make
+  make install
+}
+
+cbor_fetch_and_build() {
+  fetch_and_build \
+    cbor "$CBOR_VERSION" 'https://github.com/pjk/libcbor.git' cbor_build
+}
+
+crypto_build() {
+  local src="$1"
+  local dest="$2"
+  echo 'crypto: building' >&2
+  cd "$src"
+
+  ./config \
+    -mmacosx-version-min=10.12 \
+    --prefix="$dest" \
+    --openssldir="$dest/openssl@1.1" \
+    no-shared \
+    no-zlib
+  # Build and copy only what we need instead of 'make && make install'.
+  # It's a bit quicker.
+  make build_generated libcrypto.a libcrypto.pc
+  mkdir -p "$dest/"{include,lib/pkgconfig}
+  cp -r include/openssl "$dest/include/"
+  cp libcrypto.a "$dest/lib/"
+  cp libcrypto.pc "$dest/lib/pkgconfig"
+}
+
+crypto_fetch_and_build() {
+  fetch_and_build \
+    crypto "$CRYPTO_VERSION" 'https://github.com/openssl/openssl.git' \
+    crypto_build
+}
+
+fido2_build() {
+  local src="$1"
+  local dest="$2"
+  echo 'fido2: building' >&2
+  cd "$src"
+
+  export PKG_CONFIG_PATH="$LIB_CACHE/cbor-$CBOR_VERSION/lib/pkgconfig:$LIB_CACHE/crypto-$CRYPTO_VERSION/lib/pkgconfig"
+  cmake \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_MANPAGES=OFF \
+    -DBUILD_TOOLS=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$dest" \
+    -G "Unix Makefiles" \
+    .
+  make
+  make install
+}
+
+fido2_fetch_and_build() {
+  fetch_and_build \
+    fido2 "$FIDO2_VERSION" 'https://github.com/Yubico/libfido2.git' fido2_build
+}
+
+usage() {
+  echo "Usage: $0 build|pkg_config_path" >&2
+}
+
+build() {
+  local cbor_path="$LIB_CACHE/cbor-$CBOR_VERSION"
+  local crypto_path="$LIB_CACHE/crypto-$CRYPTO_VERSION"
+  local fido2_path="$LIB_CACHE/fido2-$FIDO2_VERSION"
+
+  if [[ ! -d "$cbor_path" ]]; then
+    cbor_fetch_and_build
+  fi
+
+  if [[ ! -d "$crypto_path" ]]; then
+    crypto_fetch_and_build
+  fi
+
+  if [[ ! -d "$fido2_path" ]]; then
+    fido2_fetch_and_build
+  fi
+
+  local pkgfile="$PKGFILE_DIR/libfido2-static.pc"
+  if [[ ! -f "$pkgfile" ]]; then
+    local tmp=''
+    tmp="$(mktemp)"  # file, not dir!
+    #shellcheck disable=SC2064  # Early expansion on purpose.
+    trap "rm -f '$tmp'" EXIT
+
+    # Write libfido2-static.pc to tmp.
+    local cbor="$LIB_CACHE/cbor-$CBOR_VERSION"
+    local crypto="$LIB_CACHE/crypto-$CRYPTO_VERSION"
+    local fido2="$LIB_CACHE/fido2-$FIDO2_VERSION"
+    cat >"$tmp" <<EOF
+prefix=$fido2
+exec_prefix=\${prefix}
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: libfido2
+Description: A FIDO2 library
+URL: https://github.com/yubico/libfido2
+Version: $FIDO2_VERSION
+Libs: -framework CoreFoundation -framework IOKit \${libdir}/libfido2.a $cbor/lib/libcbor.a $crypto/lib/libcrypto.a
+Cflags: -I\${includedir} -I$cbor/include -I$crypto/include
+EOF
+
+    # Move .pc file to expected path.
+    mkdir -p "$PKGFILE_DIR"
+    if [[ ! -f "$pkgfile" ]]; then
+      echo "fido2: creating $pkgfile" >&2
+      mv "$tmp" "$pkgfile"
+    fi
+  fi
+}
+
+main() {
+  if [[ $# -ne 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  case "$1" in
+    build)
+      build
+      ;;
+    pkg_config_path)
+      echo "$PKGFILE_DIR"
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/build.assets/build-fido2.sh
+++ b/build.assets/build-fido2.sh
@@ -28,7 +28,7 @@ fetch_and_build() {
   echo "$name: fetch and build" >&2
 
   local tmp=''
-  tmp="$(mktemp -d)"
+  tmp="$(mktemp -d "$LIB_CACHE/build.XXXXXX")"
   # Early expansion on purpose.
   #shellcheck disable=SC2064
   trap "rm -fr '$tmp'" exit

--- a/build.assets/build-fido2.sh
+++ b/build.assets/build-fido2.sh
@@ -29,7 +29,8 @@ fetch_and_build() {
 
   local tmp=''
   tmp="$(mktemp -d)"
-  #shellcheck disable=SC2064  # Early expansion on purpose.
+  # Early expansion on purpose.
+  #shellcheck disable=SC2064
   trap "rm -fr '$tmp'" exit
 
   local fullname="$name-$version"
@@ -154,7 +155,8 @@ build() {
   if [[ ! -f "$pkgfile" ]]; then
     local tmp=''
     tmp="$(mktemp)"  # file, not dir!
-    #shellcheck disable=SC2064  # Early expansion on purpose.
+    # Early expansion on purpose.
+    #shellcheck disable=SC2064
     trap "rm -f '$tmp'" EXIT
 
     # Write libfido2-static.pc to tmp.

--- a/build.assets/build-fido2.sh
+++ b/build.assets/build-fido2.sh
@@ -16,7 +16,7 @@ readonly CBOR_VERSION=v0.9.0
 readonly CRYPTO_VERSION=OpenSSL_1_1_1o
 readonly FIDO2_VERSION=1.11.0
 
-readonly LIB_CACHE="$HOME/.teleport-fido2-cache"
+readonly LIB_CACHE="/tmp/teleport-fido2-cache"
 
 readonly PKGFILE_DIR="$LIB_CACHE/fido2-${FIDO2_VERSION}_cbor-${CBOR_VERSION}_crypto-${CRYPTO_VERSION}"
 

--- a/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libfido2-static.pc
+++ b/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libfido2-static.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: libfido2
 Description: A FIDO2 library
 URL: https://github.com/yubico/libfido2
-Version: 1.10.0
+Version: 1.11.0
 Requires: libcrypto-static
 # libfido2, libcbor and libudev combined here for simplicity.
 Libs: ${libdir}/libfido2.a ${libdir}/libcbor.a ${libdir}/libudev.a -pthread

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -6,6 +6,6 @@ enginesdir=${libdir}/engines-1.1
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 1.1.1n
+Version: 1.1.1o
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libfido2-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libfido2-static.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: libfido2
 Description: A FIDO2 library
 URL: https://github.com/yubico/libfido2
-Version: 1.10.0
+Version: 1.11.0
 Requires: libcrypto-static
 # libfido2, libcbor and libudev combined here for simplicity.
 Libs: ${libdir}/libfido2.a ${libdir}/libcbor.a ${libdir}/libudev.a -pthread

--- a/dronegen/mac.go
+++ b/dronegen/mac.go
@@ -267,8 +267,8 @@ func darwinTagBuildCommands() []string {
 		`export RUST_HOME=$CARGO_HOME`,
 		`export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH`,
 		`cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport`,
-		`build.assets/build-fido2.sh build`,
-		`export PKG_CONFIG_PATH="$(build.assets/build-fido2.sh pkg_config_path)"`,
+		`build.assets/build-fido2-macos.sh build`,
+		`export PKG_CONFIG_PATH="$(build.assets/build-fido2-macos.sh pkg_config_path)"`,
 		`rustup override set $RUST_VERSION`,
 		`make clean release OS=$OS ARCH=$ARCH FIDO2=yes TOUCHID=yes`,
 	}

--- a/dronegen/mac.go
+++ b/dronegen/mac.go
@@ -267,8 +267,10 @@ func darwinTagBuildCommands() []string {
 		`export RUST_HOME=$CARGO_HOME`,
 		`export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH`,
 		`cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport`,
+		`build.assets/build-fido2.sh build`,
+		`export PKG_CONFIG_PATH="$(build.assets/build-fido2.sh pkg_config_path)"`,
 		`rustup override set $RUST_VERSION`,
-		`make clean release OS=$OS ARCH=$ARCH TOUCHID=yes`,
+		`make clean release OS=$OS ARCH=$ARCH FIDO2=yes TOUCHID=yes`,
 	}
 }
 


### PR DESCRIPTION
Add a script to build libfido2 (and its dependencies) on macOS and enable FIDO2 static builds.

I decided to build all dependencies instead of pulling from Homebrew for a few reasons:

1. There is no libcbor.a in a brew package
2. This captures library versions within the Teleport source code, allowing us to build binaries against different versions of libfido2 (and its dependencies).

I've also bumped libfido2 to 1.11.0. I've been running it locally and we are still pre-release, so it seems like a good time to do it. (See https://developers.yubico.com/libfido2/Release_Notes.html.)

#9160