### PR TITLE
Thread `context.Context` from tctl `main()` to subcommands

### DIFF
--- a/tool/tctl/common/access_command.go
+++ b/tool/tctl/common/access_command.go
@@ -59,9 +59,7 @@ func (c *AccessCommand) Initialize(app *kingpin.Application, config *service.Con
 }
 
 // TryRun attempts to run subcommands like "access ls".
-func (c *AccessCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
-
-	ctx := context.TODO()
+func (c *AccessCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.accessList.FullCommand():
 		access := datalog.NodeAccessRequest{Username: c.user, Login: c.login, Node: c.node, Namespace: c.namespace}

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -110,32 +110,32 @@ func (c *AccessRequestCommand) Initialize(app *kingpin.Application, config *serv
 }
 
 // TryRun takes the CLI command as an argument (like "access-request list") and executes it.
-func (c *AccessRequestCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+func (c *AccessRequestCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.requestList.FullCommand():
-		err = c.List(client)
+		err = c.List(ctx, client)
 	case c.requestGet.FullCommand():
-		err = c.Get(client)
+		err = c.Get(ctx, client)
 	case c.requestApprove.FullCommand():
-		err = c.Approve(client)
+		err = c.Approve(ctx, client)
 	case c.requestDeny.FullCommand():
-		err = c.Deny(client)
+		err = c.Deny(ctx, client)
 	case c.requestCreate.FullCommand():
-		err = c.Create(client)
+		err = c.Create(ctx, client)
 	case c.requestDelete.FullCommand():
-		err = c.Delete(client)
+		err = c.Delete(ctx, client)
 	case c.requestCaps.FullCommand():
-		err = c.Caps(client)
+		err = c.Caps(ctx, client)
 	case c.requestReview.FullCommand():
-		err = c.Review(client)
+		err = c.Review(ctx, client)
 	default:
 		return false, nil
 	}
 	return true, trace.Wrap(err)
 }
 
-func (c *AccessRequestCommand) List(client auth.ClientI) error {
-	reqs, err := client.GetAccessRequests(context.TODO(), types.AccessRequestFilter{})
+func (c *AccessRequestCommand) List(ctx context.Context, client auth.ClientI) error {
+	reqs, err := client.GetAccessRequests(ctx, types.AccessRequestFilter{})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -157,8 +157,7 @@ func (c *AccessRequestCommand) List(client auth.ClientI) error {
 	return nil
 }
 
-func (c *AccessRequestCommand) Get(client auth.ClientI) error {
-	ctx := context.TODO()
+func (c *AccessRequestCommand) Get(ctx context.Context, client auth.ClientI) error {
 	reqs := []types.AccessRequest{}
 	for _, reqID := range strings.Split(c.reqIDs, ",") {
 		req, err := client.GetAccessRequests(ctx, types.AccessRequestFilter{
@@ -213,8 +212,7 @@ func (c *AccessRequestCommand) splitRoles() []string {
 	return roles
 }
 
-func (c *AccessRequestCommand) Approve(client auth.ClientI) error {
-	ctx := context.TODO()
+func (c *AccessRequestCommand) Approve(ctx context.Context, client auth.ClientI) error {
 	if c.delegator != "" {
 		ctx = auth.WithDelegator(ctx, c.delegator)
 	}
@@ -236,8 +234,7 @@ func (c *AccessRequestCommand) Approve(client auth.ClientI) error {
 	return nil
 }
 
-func (c *AccessRequestCommand) Deny(client auth.ClientI) error {
-	ctx := context.TODO()
+func (c *AccessRequestCommand) Deny(ctx context.Context, client auth.ClientI) error {
 	if c.delegator != "" {
 		ctx = auth.WithDelegator(ctx, c.delegator)
 	}
@@ -258,7 +255,7 @@ func (c *AccessRequestCommand) Deny(client auth.ClientI) error {
 	return nil
 }
 
-func (c *AccessRequestCommand) Create(client auth.ClientI) error {
+func (c *AccessRequestCommand) Create(ctx context.Context, client auth.ClientI) error {
 	req, err := services.NewAccessRequest(c.user, c.splitRoles()...)
 	if err != nil {
 		return trace.Wrap(err)
@@ -272,15 +269,14 @@ func (c *AccessRequestCommand) Create(client auth.ClientI) error {
 		}
 		return trace.Wrap(printJSON(req, "request"))
 	}
-	if err := client.CreateAccessRequest(context.TODO(), req); err != nil {
+	if err := client.CreateAccessRequest(ctx, req); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf("%s\n", req.GetName())
 	return nil
 }
 
-func (c *AccessRequestCommand) Delete(client auth.ClientI) error {
-	ctx := context.TODO()
+func (c *AccessRequestCommand) Delete(ctx context.Context, client auth.ClientI) error {
 	var approvedTokens []string
 	for _, reqID := range strings.Split(c.reqIDs, ",") {
 		// Fetch the requests first to see if they were approved to provide the
@@ -301,7 +297,7 @@ func (c *AccessRequestCommand) Delete(client auth.ClientI) error {
 
 	if len(approvedTokens) == 0 || c.force {
 		for _, reqID := range strings.Split(c.reqIDs, ",") {
-			if err := client.DeleteAccessRequest(context.TODO(), reqID); err != nil {
+			if err := client.DeleteAccessRequest(ctx, reqID); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -320,8 +316,8 @@ func (c *AccessRequestCommand) Delete(client auth.ClientI) error {
 	return nil
 }
 
-func (c *AccessRequestCommand) Caps(client auth.ClientI) error {
-	caps, err := client.GetAccessCapabilities(context.TODO(), types.AccessCapabilitiesRequest{
+func (c *AccessRequestCommand) Caps(ctx context.Context, client auth.ClientI) error {
+	caps, err := client.GetAccessCapabilities(ctx, types.AccessCapabilitiesRequest{
 		User:               c.user,
 		RequestableRoles:   true,
 		SuggestedReviewers: true,
@@ -356,7 +352,7 @@ func (c *AccessRequestCommand) Caps(client auth.ClientI) error {
 	}
 }
 
-func (c *AccessRequestCommand) Review(client auth.ClientI) error {
+func (c *AccessRequestCommand) Review(ctx context.Context, client auth.ClientI) error {
 	if c.approve == c.deny {
 		return trace.BadParameter("must supply exactly one of '--approve' or '--deny'")
 	}
@@ -368,8 +364,6 @@ func (c *AccessRequestCommand) Review(client auth.ClientI) error {
 	case c.deny:
 		state = types.RequestState_DENIED
 	}
-
-	ctx := context.TODO()
 
 	req, err := client.SubmitAccessReview(ctx, types.AccessReviewSubmission{
 		RequestID: strings.Split(c.reqIDs, ",")[0],

--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -67,10 +67,10 @@ func (c *AppsCommand) Initialize(app *kingpin.Application, config *service.Confi
 }
 
 // TryRun attempts to run subcommands like "apps ls".
-func (c *AppsCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+func (c *AppsCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.appsList.FullCommand():
-		err = c.ListApps(client)
+		err = c.ListApps(ctx, client)
 	default:
 		return false, nil
 	}
@@ -79,9 +79,7 @@ func (c *AppsCommand) TryRun(cmd string, client auth.ClientI) (match bool, err e
 
 // ListApps prints the list of applications that have recently sent heartbeats
 // to the cluster.
-func (c *AppsCommand) ListApps(clt auth.ClientI) error {
-	ctx := context.TODO()
-
+func (c *AppsCommand) ListApps(ctx context.Context, clt auth.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -137,8 +137,7 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, config *service.Confi
 
 // TryRun takes the CLI command as an argument (like "auth gen") and executes it
 // or returns match=false if 'cmd' does not belong to it
-func (a *AuthCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
-	ctx := context.Background()
+func (a *AuthCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case a.authGenerate.FullCommand():
 		err = a.GenerateKeys(ctx)
@@ -311,12 +310,12 @@ func (a *AuthCommand) GenerateKeys(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = os.WriteFile(a.genPubPath, pubBytes, 0600)
+	err = os.WriteFile(a.genPubPath, pubBytes, 0o600)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	err = os.WriteFile(a.genPrivPath, privBytes, 0600)
+	err = os.WriteFile(a.genPrivPath, privBytes, 0o600)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -638,7 +637,7 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI auth.Clie
 		}
 		certUsage = proto.UserCertsRequest_App
 	case a.dbService != "":
-		server, err := getDatabaseServer(context.TODO(), clusterAPI, a.dbService)
+		server, err := getDatabaseServer(ctx, clusterAPI, a.dbService)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -729,7 +728,6 @@ func (a *AuthCommand) checkLeafCluster(clusterAPI auth.ClientI) error {
 	}
 
 	return trace.BadParameter("couldn't find leaf cluster named %q", a.leafCluster)
-
 }
 
 func (a *AuthCommand) checkKubeCluster(ctx context.Context, clusterAPI auth.ClientI) error {

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -67,10 +67,10 @@ func (c *DBCommand) Initialize(app *kingpin.Application, config *service.Config)
 }
 
 // TryRun attempts to run subcommands like "db ls".
-func (c *DBCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+func (c *DBCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.dbList.FullCommand():
-		err = c.ListDatabases(client)
+		err = c.ListDatabases(ctx, client)
 	default:
 		return false, nil
 	}
@@ -79,9 +79,7 @@ func (c *DBCommand) TryRun(cmd string, client auth.ClientI) (match bool, err err
 
 // ListDatabases prints the list of database proxies that have recently sent
 // heartbeats to the cluster.
-func (c *DBCommand) ListDatabases(clt auth.ClientI) error {
-	ctx := context.TODO()
-
+func (c *DBCommand) ListDatabases(ctx context.Context, clt auth.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/desktop_command.go
+++ b/tool/tctl/common/desktop_command.go
@@ -54,10 +54,10 @@ func (c *DesktopCommand) Initialize(app *kingpin.Application, config *service.Co
 }
 
 // TryRun attempts to run subcommands like "desktop ls".
-func (c *DesktopCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+func (c *DesktopCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.desktopList.FullCommand():
-		err = c.ListDesktop(client)
+		err = c.ListDesktop(ctx, client)
 	default:
 		return false, nil
 	}
@@ -66,8 +66,8 @@ func (c *DesktopCommand) TryRun(cmd string, client auth.ClientI) (match bool, er
 
 // ListDesktop prints the list of desktops that have recently sent heartbeats
 // to the cluster.
-func (c *DesktopCommand) ListDesktop(client auth.ClientI) error {
-	desktops, err := client.GetWindowsDesktops(context.TODO(), types.WindowsDesktopFilter{})
+func (c *DesktopCommand) ListDesktop(ctx context.Context, client auth.ClientI) error {
+	desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -75,7 +75,6 @@ func (c *DesktopCommand) ListDesktop(client auth.ClientI) error {
 		desktops: []windowsDesktopAndService{},
 		verbose:  c.verbose,
 	}
-	ctx := context.Background()
 	for _, desktop := range desktops {
 		ds, err := client.GetWindowsDesktopService(ctx, desktop.GetHostID())
 		if err != nil {

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -86,10 +86,11 @@ func runResourceCommand(t *testing.T, fc *config.FileConfig, args []string, opts
 		clientConfig.TLS.RootCAs = options.CertPool
 	}
 
-	client, err := authclient.Connect(context.Background(), clientConfig)
+	ctx := context.Background()
+	client, err := authclient.Connect(ctx, clientConfig)
 	require.NoError(t, err)
 
-	_, err = command.TryRun(selectedCmd, client)
+	_, err = command.TryRun(ctx, selectedCmd, client)
 	if err != nil {
 		return nil, err
 	}
@@ -126,10 +127,11 @@ func runTokensCommand(t *testing.T, fc *config.FileConfig, args []string, opts .
 		clientConfig.TLS.RootCAs = options.CertPool
 	}
 
-	client, err := authclient.Connect(context.Background(), clientConfig)
+	ctx := context.Background()
+	client, err := authclient.Connect(ctx, clientConfig)
 	require.NoError(t, err)
 
-	_, err = command.TryRun(selectedCmd, client)
+	_, err = command.TryRun(ctx, selectedCmd, client)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -53,10 +53,10 @@ func (c *KubeCommand) Initialize(app *kingpin.Application, config *service.Confi
 }
 
 // TryRun attempts to run subcommands like "kube ls".
-func (c *KubeCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+func (c *KubeCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.kubeList.FullCommand():
-		err = c.ListKube(client)
+		err = c.ListKube(ctx, client)
 	default:
 		return false, nil
 	}
@@ -65,8 +65,8 @@ func (c *KubeCommand) TryRun(cmd string, client auth.ClientI) (match bool, err e
 
 // ListKube prints the list of kube clusters that have recently sent heartbeats
 // to the cluster.
-func (c *KubeCommand) ListKube(client auth.ClientI) error {
-	kubes, err := client.GetKubeServices(context.TODO())
+func (c *KubeCommand) ListKube(ctx context.Context, client auth.ClientI) error {
+	kubes, err := client.GetKubeServices(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/lock_command.go
+++ b/tool/tctl/common/lock_command.go
@@ -57,8 +57,7 @@ func (c *LockCommand) Initialize(app *kingpin.Application, config *service.Confi
 }
 
 // TryRun attempts to run subcommands.
-func (c *LockCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
-	ctx := context.TODO()
+func (c *LockCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.mainCmd.FullCommand():
 		err = c.CreateLock(ctx, client)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -40,7 +40,7 @@ import (
 )
 
 // ResourceCreateHandler is the generic implementation of a resource creation handler
-type ResourceCreateHandler func(auth.ClientI, services.UnknownResource) error
+type ResourceCreateHandler func(context.Context, auth.ClientI, services.UnknownResource) error
 
 // ResourceKind is the string form of a resource, i.e. "oidc"
 type ResourceKind string
@@ -146,20 +146,20 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *service.
 
 // TryRun takes the CLI command as an argument (like "auth gen") and executes it
 // or returns match=false if 'cmd' does not belong to it
-func (rc *ResourceCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+func (rc *ResourceCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	// tctl get
 	case rc.getCmd.FullCommand():
-		err = rc.Get(client)
+		err = rc.Get(ctx, client)
 		// tctl create
 	case rc.createCmd.FullCommand():
-		err = rc.Create(client)
+		err = rc.Create(ctx, client)
 		// tctl rm
 	case rc.deleteCmd.FullCommand():
-		err = rc.Delete(client)
+		err = rc.Delete(ctx, client)
 		// tctl update
 	case rc.updateCmd.FullCommand():
-		err = rc.Update(client)
+		err = rc.Update(ctx, client)
 	default:
 		return false, nil
 	}
@@ -178,15 +178,15 @@ func (rc *ResourceCommand) GetRef() services.Ref {
 }
 
 // Get prints one or many resources of a certain type
-func (rc *ResourceCommand) Get(client auth.ClientI) error {
+func (rc *ResourceCommand) Get(ctx context.Context, client auth.ClientI) error {
 	if rc.refs.IsAll() {
-		return rc.GetAll(client)
+		return rc.GetAll(ctx, client)
 	}
 	if len(rc.refs) != 1 {
-		return rc.GetMany(client)
+		return rc.GetMany(ctx, client)
 	}
 	rc.ref = rc.refs[0]
-	collection, err := rc.getCollection(client)
+	collection, err := rc.getCollection(ctx, client)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -204,14 +204,14 @@ func (rc *ResourceCommand) Get(client auth.ClientI) error {
 	return trace.BadParameter("unsupported format")
 }
 
-func (rc *ResourceCommand) GetMany(client auth.ClientI) error {
+func (rc *ResourceCommand) GetMany(ctx context.Context, client auth.ClientI) error {
 	if rc.format != teleport.YAML {
 		return trace.BadParameter("mixed resource types only support YAML formatting")
 	}
 	var resources []types.Resource
 	for _, ref := range rc.refs {
 		rc.ref = ref
-		collection, err := rc.getCollection(client)
+		collection, err := rc.getCollection(ctx, client)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -223,7 +223,7 @@ func (rc *ResourceCommand) GetMany(client auth.ClientI) error {
 	return nil
 }
 
-func (rc *ResourceCommand) GetAll(client auth.ClientI) error {
+func (rc *ResourceCommand) GetAll(ctx context.Context, client auth.ClientI) error {
 	rc.withSecrets = true
 	allKinds := services.GetResourceMarshalerKinds()
 	allRefs := make([]services.Ref, 0, len(allKinds))
@@ -234,11 +234,11 @@ func (rc *ResourceCommand) GetAll(client auth.ClientI) error {
 		allRefs = append(allRefs, ref)
 	}
 	rc.refs = services.Refs(allRefs)
-	return rc.GetMany(client)
+	return rc.GetMany(ctx, client)
 }
 
 // Create updates or inserts one or many resources
-func (rc *ResourceCommand) Create(client auth.ClientI) (err error) {
+func (rc *ResourceCommand) Create(ctx context.Context, client auth.ClientI) (err error) {
 	var reader io.Reader
 	if rc.filename == "" {
 		reader = os.Stdin
@@ -277,7 +277,7 @@ func (rc *ResourceCommand) Create(client auth.ClientI) (err error) {
 		}
 		// only return in case of error, to create multiple resources
 		// in case if yaml spec is a list
-		if err := creator(client, raw); err != nil {
+		if err := creator(ctx, client, raw); err != nil {
 			if trace.IsAlreadyExists(err) {
 				return trace.Wrap(err, "use -f or --force flag to overwrite")
 			}
@@ -287,8 +287,7 @@ func (rc *ResourceCommand) Create(client auth.ClientI) (err error) {
 }
 
 // createTrustedCluster implements `tctl create cluster.yaml` command
-func (rc *ResourceCommand) createTrustedCluster(client auth.ClientI, raw services.UnknownResource) error {
-	ctx := context.TODO()
+func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	tc, err := services.UnmarshalTrustedCluster(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -326,7 +325,7 @@ func (rc *ResourceCommand) createTrustedCluster(client auth.ClientI, raw service
 }
 
 // createCertAuthority creates certificate authority
-func (rc *ResourceCommand) createCertAuthority(client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	certAuthority, err := services.UnmarshalCertAuthority(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -339,8 +338,7 @@ func (rc *ResourceCommand) createCertAuthority(client auth.ClientI, raw services
 }
 
 // createGithubConnector creates a Github connector
-func (rc *ResourceCommand) createGithubConnector(client auth.ClientI, raw services.UnknownResource) error {
-	ctx := context.TODO()
+func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	connector, err := services.UnmarshalGithubConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -364,8 +362,7 @@ func (rc *ResourceCommand) createGithubConnector(client auth.ClientI, raw servic
 }
 
 // createRole implements `tctl create role.yaml` command.
-func (rc *ResourceCommand) createRole(client auth.ClientI, raw services.UnknownResource) error {
-	ctx := context.TODO()
+func (rc *ResourceCommand) createRole(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	role, err := services.UnmarshalRole(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -397,7 +394,7 @@ func (rc *ResourceCommand) createRole(client auth.ClientI, raw services.UnknownR
 }
 
 // createUser implements `tctl create user.yaml` command.
-func (rc *ResourceCommand) createUser(client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createUser(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	user, err := services.UnmarshalUser(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -419,13 +416,13 @@ func (rc *ResourceCommand) createUser(client auth.ClientI, raw services.UnknownR
 		// This field should not be allowed to be overwritten.
 		user.SetCreatedBy(existingUser.GetCreatedBy())
 
-		if err := client.UpdateUser(context.TODO(), user); err != nil {
+		if err := client.UpdateUser(ctx, user); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("user %q has been updated\n", userName)
 
 	} else {
-		if err := client.CreateUser(context.TODO(), user); err != nil {
+		if err := client.CreateUser(ctx, user); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("user %q has been created\n", userName)
@@ -435,8 +432,7 @@ func (rc *ResourceCommand) createUser(client auth.ClientI, raw services.UnknownR
 }
 
 // createAuthPreference implements `tctl create cap.yaml` command.
-func (rc *ResourceCommand) createAuthPreference(client auth.ClientI, raw services.UnknownResource) error {
-	ctx := context.TODO()
+func (rc *ResourceCommand) createAuthPreference(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	newAuthPref, err := services.UnmarshalAuthPreference(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -458,9 +454,7 @@ func (rc *ResourceCommand) createAuthPreference(client auth.ClientI, raw service
 }
 
 // createClusterNetworkingConfig implements `tctl create netconfig.yaml` command.
-func (rc *ResourceCommand) createClusterNetworkingConfig(client auth.ClientI, raw services.UnknownResource) error {
-	ctx := context.TODO()
-
+func (rc *ResourceCommand) createClusterNetworkingConfig(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	newNetConfig, err := services.UnmarshalClusterNetworkingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -482,9 +476,7 @@ func (rc *ResourceCommand) createClusterNetworkingConfig(client auth.ClientI, ra
 }
 
 // createSessionRecordingConfig implements `tctl create recconfig.yaml` command.
-func (rc *ResourceCommand) createSessionRecordingConfig(client auth.ClientI, raw services.UnknownResource) error {
-	ctx := context.TODO()
-
+func (rc *ResourceCommand) createSessionRecordingConfig(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	newRecConfig, err := services.UnmarshalSessionRecordingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -506,8 +498,7 @@ func (rc *ResourceCommand) createSessionRecordingConfig(client auth.ClientI, raw
 }
 
 // createLock implements `tctl create lock.yaml` command.
-func (rc *ResourceCommand) createLock(client auth.ClientI, raw services.UnknownResource) error {
-	ctx := context.TODO()
+func (rc *ResourceCommand) createLock(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	lock, err := services.UnmarshalLock(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -533,9 +524,7 @@ func (rc *ResourceCommand) createLock(client auth.ClientI, raw services.UnknownR
 }
 
 // createNetworkRestrictions implements `tctl create net_restrict.yaml` command.
-func (rc *ResourceCommand) createNetworkRestrictions(client auth.ClientI, raw services.UnknownResource) error {
-	ctx := context.TODO()
-
+func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	newNetRestricts, err := services.UnmarshalNetworkRestrictions(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -548,17 +537,17 @@ func (rc *ResourceCommand) createNetworkRestrictions(client auth.ClientI, raw se
 	return nil
 }
 
-func (rc *ResourceCommand) createApp(client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createApp(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	app, err := services.UnmarshalApp(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := client.CreateApp(context.Background(), app); err != nil {
+	if err := client.CreateApp(ctx, app); err != nil {
 		if trace.IsAlreadyExists(err) {
 			if !rc.force {
 				return trace.AlreadyExists("application %q already exists", app.GetName())
 			}
-			if err := client.UpdateApp(context.Background(), app); err != nil {
+			if err := client.UpdateApp(ctx, app); err != nil {
 				return trace.Wrap(err)
 			}
 			fmt.Printf("application %q has been updated\n", app.GetName())
@@ -570,17 +559,17 @@ func (rc *ResourceCommand) createApp(client auth.ClientI, raw services.UnknownRe
 	return nil
 }
 
-func (rc *ResourceCommand) createDatabase(client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDatabase(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	database, err := services.UnmarshalDatabase(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := client.CreateDatabase(context.Background(), database); err != nil {
+	if err := client.CreateDatabase(ctx, database); err != nil {
 		if trace.IsAlreadyExists(err) {
 			if !rc.force {
 				return trace.AlreadyExists("database %q already exists", database.GetName())
 			}
-			if err := client.UpdateDatabase(context.Background(), database); err != nil {
+			if err := client.UpdateDatabase(ctx, database); err != nil {
 				return trace.Wrap(err)
 			}
 			fmt.Printf("database %q has been updated\n", database.GetName())
@@ -592,18 +581,18 @@ func (rc *ResourceCommand) createDatabase(client auth.ClientI, raw services.Unkn
 	return nil
 }
 
-func (rc *ResourceCommand) createToken(client auth.ClientI, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createToken(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
 	token, err := services.UnmarshalProvisionToken(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	err = client.UpsertToken(context.Background(), token)
+	err = client.UpsertToken(ctx, token)
 	return trace.Wrap(err)
 }
 
 // Delete deletes resource by name
-func (rc *ResourceCommand) Delete(client auth.ClientI) (err error) {
+func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err error) {
 	singletonResources := []string{
 		types.KindClusterAuthPreference,
 		types.KindClusterNetworkingConfig,
@@ -613,7 +602,6 @@ func (rc *ResourceCommand) Delete(client auth.ClientI) (err error) {
 		return trace.BadParameter("provide a full resource name to delete, for example:\n$ tctl rm cluster/east\n")
 	}
 
-	ctx := context.TODO()
 	switch rc.ref.Kind {
 	case types.KindNode:
 		if err = client.DeleteNode(ctx, apidefaults.Namespace, rc.ref.Name); err != nil {
@@ -846,7 +834,7 @@ func resetNetworkRestrictions(ctx context.Context, client auth.ClientI) error {
 }
 
 // Update updates select resource fields: expiry and labels
-func (rc *ResourceCommand) Update(clt auth.ClientI) error {
+func (rc *ResourceCommand) Update(ctx context.Context, clt auth.ClientI) error {
 	if rc.ref.Kind == "" || rc.ref.Name == "" {
 		return trace.BadParameter("provide a full resource name to update, for example:\n$ tctl update rc/remote --set-labels=env=prod\n")
 	}
@@ -873,8 +861,6 @@ func (rc *ResourceCommand) Update(clt auth.ClientI) error {
 		return trace.BadParameter("use at least one of --set-labels or --set-ttl")
 	}
 
-	// TODO: pass the context from CLI to terminate requests on Ctrl-C
-	ctx := context.TODO()
 	switch rc.ref.Kind {
 	case types.KindRemoteCluster:
 		cluster, err := clt.GetRemoteCluster(rc.ref.Name)
@@ -905,13 +891,11 @@ func (rc *ResourceCommand) IsForced() bool {
 }
 
 // getCollection lists all resources of a given type
-func (rc *ResourceCommand) getCollection(client auth.ClientI) (ResourceCollection, error) {
+func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.ClientI) (ResourceCollection, error) {
 	if rc.ref.Kind == "" {
 		return nil, trace.BadParameter("specify resource to list, e.g. 'tctl get roles'")
 	}
 
-	// TODO: pass the context from CLI to terminate requests on Ctrl-C
-	ctx := context.TODO()
 	switch rc.ref.Kind {
 	case types.KindUser:
 		if rc.ref.Name == "" {
@@ -968,7 +952,7 @@ func (rc *ResourceCommand) getCollection(client auth.ClientI) (ResourceCollectio
 		return &githubCollection{connectors}, nil
 	case types.KindReverseTunnel:
 		if rc.ref.Name == "" {
-			tunnels, err := client.GetReverseTunnels(context.Background())
+			tunnels, err := client.GetReverseTunnels(ctx)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/tool/tctl/common/status_command.go
+++ b/tool/tctl/common/status_command.go
@@ -45,10 +45,10 @@ func (c *StatusCommand) Initialize(app *kingpin.Application, config *service.Con
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *StatusCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+func (c *StatusCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.status.FullCommand():
-		err = c.Status(context.Background(), client)
+		err = c.Status(ctx, client)
 	default:
 		return false, nil
 	}
@@ -106,12 +106,14 @@ func (c *StatusCommand) Status(ctx context.Context, client auth.ClientI) error {
 					"has been completed.")
 			}
 			if c.config.Debug {
-				table.AddRow([]string{info,
+				table.AddRow([]string{
+					info,
 					fmt.Sprintf("%v, update_servers: %v, complete: %v",
 						rotation.String(),
 						rotation.Schedule.UpdateServers.Format(constants.HumanDateFormatSeconds),
 						rotation.Schedule.Standby.Format(constants.HumanDateFormatSeconds),
-					)})
+					),
+				})
 			} else {
 				table.AddRow([]string{info, rotation.String()})
 			}

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -126,14 +126,14 @@ func (c *TokensCommand) Initialize(app *kingpin.Application, config *service.Con
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *TokensCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+func (c *TokensCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.tokenAdd.FullCommand():
-		err = c.Add(client)
+		err = c.Add(ctx, client)
 	case c.tokenDel.FullCommand():
-		err = c.Del(client)
+		err = c.Del(ctx, client)
 	case c.tokenList.FullCommand():
-		err = c.List(client)
+		err = c.List(ctx, client)
 	default:
 		return false, nil
 	}
@@ -141,7 +141,7 @@ func (c *TokensCommand) TryRun(cmd string, client auth.ClientI) (match bool, err
 }
 
 // Add is called to execute "tokens add ..." command.
-func (c *TokensCommand) Add(client auth.ClientI) error {
+func (c *TokensCommand) Add(ctx context.Context, client auth.ClientI) error {
 	// Parse string to see if it's a type of role that Teleport supports.
 	roles, err := types.ParseTeleportRoles(c.tokenType)
 	if err != nil {
@@ -157,7 +157,7 @@ func (c *TokensCommand) Add(client auth.ClientI) error {
 	}
 
 	// Generate token.
-	token, err := client.GenerateToken(context.TODO(), auth.GenerateTokenRequest{
+	token, err := client.GenerateToken(ctx, auth.GenerateTokenRequest{
 		Roles:  roles,
 		TTL:    c.ttl,
 		Token:  c.value,
@@ -264,7 +264,7 @@ func (c *TokensCommand) Add(client auth.ClientI) error {
 	default:
 		authServer := authServers[0].GetAddr()
 
-		pingResponse, err := client.Ping(context.TODO())
+		pingResponse, err := client.Ping(ctx)
 		if err != nil {
 			log.Debugf("unnable to ping auth client: %s.", err.Error())
 		}
@@ -293,8 +293,7 @@ func (c *TokensCommand) Add(client auth.ClientI) error {
 }
 
 // Del is called to execute "tokens del ..." command.
-func (c *TokensCommand) Del(client auth.ClientI) error {
-	ctx := context.TODO()
+func (c *TokensCommand) Del(ctx context.Context, client auth.ClientI) error {
 	if c.value == "" {
 		return trace.Errorf("Need an argument: token")
 	}
@@ -306,8 +305,7 @@ func (c *TokensCommand) Del(client auth.ClientI) error {
 }
 
 // List is called to execute "tokens ls" command.
-func (c *TokensCommand) List(client auth.ClientI) error {
-	ctx := context.TODO()
+func (c *TokensCommand) List(ctx context.Context, client auth.ClientI) error {
 	tokens, err := client.GetTokens(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/top_command.go
+++ b/tool/tctl/common/top_command.go
@@ -62,14 +62,14 @@ func (c *TopCommand) Initialize(app *kingpin.Application, config *service.Config
 }
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
-func (c *TopCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+func (c *TopCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case c.top.FullCommand():
 		diagClient, err := roundtrip.NewClient(*c.diagURL, "")
 		if err != nil {
 			return true, trace.Wrap(err)
 		}
-		err = c.Top(diagClient)
+		err = c.Top(ctx, diagClient)
 		if trace.IsConnectionProblem(err) {
 			return true, trace.ConnectionProblem(err,
 				"[CLIENT] Could not connect to metrics service at %v. Is teleport running with --diag-addr=%v?", *c.diagURL, *c.diagURL)
@@ -81,14 +81,11 @@ func (c *TopCommand) TryRun(cmd string, client auth.ClientI) (match bool, err er
 }
 
 // Top is called to execute "status" CLI command.
-func (c *TopCommand) Top(client *roundtrip.Client) error {
+func (c *TopCommand) Top(ctx context.Context, client *roundtrip.Client) error {
 	if err := ui.Init(); err != nil {
 		return trace.Wrap(err)
 	}
 	defer ui.Close()
-
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
 
 	uiEvents := ui.PollEvents()
 	ticker := time.NewTicker(*c.refreshPeriod)
@@ -150,7 +147,7 @@ func (c *TopCommand) render(ctx context.Context, re Report, eventID string) erro
 		t.ColumnWidths = []int{10, 10, 10, 50000}
 		t.RowSeparator = false
 		t.Rows = [][]string{
-			[]string{"Count", "Req/Sec", "Range", "Key"},
+			{"Count", "Req/Sec", "Range", "Key"},
 		}
 		for _, req := range b.SortedTopRequests() {
 			t.Rows = append(t.Rows,
@@ -171,7 +168,7 @@ func (c *TopCommand) render(ctx context.Context, re Report, eventID string) erro
 		t.ColumnWidths = []int{10, 10, 10, 50000}
 		t.RowSeparator = false
 		t.Rows = [][]string{
-			[]string{"Count", "Req/Sec", "Avg Size", "Resource"},
+			{"Count", "Req/Sec", "Avg Size", "Resource"},
 		}
 		for _, event := range w.SortedTopEvents() {
 			t.Rows = append(t.Rows,
@@ -190,7 +187,7 @@ func (c *TopCommand) render(ctx context.Context, re Report, eventID string) erro
 		lc.Title = title
 		lc.TitleStyle = ui.NewStyle(ui.ColorCyan)
 		lc.Data = make([][]float64, 1)
-		//only get the most recent events to fill the graph
+		// only get the most recent events to fill the graph
 		lc.Data[0] = buf.Data((termWidth / 2) - 10)
 		lc.AxesColor = ui.ColorWhite
 		lc.LineColors[0] = ui.ColorGreen
@@ -205,11 +202,11 @@ func (c *TopCommand) render(ctx context.Context, re Report, eventID string) erro
 	t1.ColumnWidths = []int{30, 50000}
 	t1.RowSeparator = false
 	t1.Rows = [][]string{
-		[]string{"Interactive Sessions", humanize.FormatFloat("", re.Cluster.InteractiveSessions)},
-		[]string{"Cert Gen Active Requests", humanize.FormatFloat("", re.Cluster.GenerateRequests)},
-		[]string{"Cert Gen Requests/sec", humanize.FormatFloat("", re.Cluster.GenerateRequestsCount.GetFreq())},
-		[]string{"Cert Gen Throttled Requests/sec", humanize.FormatFloat("", re.Cluster.GenerateRequestsThrottledCount.GetFreq())},
-		[]string{"Auth Watcher Queue Size", humanize.FormatFloat("", re.Cache.QueueSize)},
+		{"Interactive Sessions", humanize.FormatFloat("", re.Cluster.InteractiveSessions)},
+		{"Cert Gen Active Requests", humanize.FormatFloat("", re.Cluster.GenerateRequests)},
+		{"Cert Gen Requests/sec", humanize.FormatFloat("", re.Cluster.GenerateRequestsCount.GetFreq())},
+		{"Cert Gen Throttled Requests/sec", humanize.FormatFloat("", re.Cluster.GenerateRequestsThrottledCount.GetFreq())},
+		{"Auth Watcher Queue Size", humanize.FormatFloat("", re.Cache.QueueSize)},
 	}
 	for _, rc := range re.Cluster.RemoteClusters {
 		t1.Rows = append(t1.Rows, []string{
@@ -223,11 +220,11 @@ func (c *TopCommand) render(ctx context.Context, re Report, eventID string) erro
 	t2.ColumnWidths = []int{30, 50000}
 	t2.RowSeparator = false
 	t2.Rows = [][]string{
-		[]string{"Start Time", re.Process.StartTime.Format(constants.HumanDateFormatSeconds)},
-		[]string{"Resident Memory Bytes", humanize.Bytes(uint64(re.Process.ResidentMemoryBytes))},
-		[]string{"Open File Descriptors", humanize.FormatFloat("", re.Process.OpenFDs)},
-		[]string{"CPU Seconds Total", humanize.FormatFloat("", re.Process.CPUSecondsTotal)},
-		[]string{"Max File Descriptors", humanize.FormatFloat("", re.Process.MaxFDs)},
+		{"Start Time", re.Process.StartTime.Format(constants.HumanDateFormatSeconds)},
+		{"Resident Memory Bytes", humanize.Bytes(uint64(re.Process.ResidentMemoryBytes))},
+		{"Open File Descriptors", humanize.FormatFloat("", re.Process.OpenFDs)},
+		{"CPU Seconds Total", humanize.FormatFloat("", re.Process.CPUSecondsTotal)},
+		{"Max File Descriptors", humanize.FormatFloat("", re.Process.MaxFDs)},
 	}
 
 	t3 := widgets.NewTable()
@@ -236,12 +233,12 @@ func (c *TopCommand) render(ctx context.Context, re Report, eventID string) erro
 	t3.ColumnWidths = []int{30, 50000}
 	t3.RowSeparator = false
 	t3.Rows = [][]string{
-		[]string{"Allocated Memory", humanize.Bytes(uint64(re.Go.AllocBytes))},
-		[]string{"Goroutines", humanize.FormatFloat("", re.Go.Goroutines)},
-		[]string{"Threads", humanize.FormatFloat("", re.Go.Threads)},
-		[]string{"Heap Objects", humanize.FormatFloat("", re.Go.HeapObjects)},
-		[]string{"Heap Allocated Memory", humanize.Bytes(uint64(re.Go.HeapAllocBytes))},
-		[]string{"Info", re.Go.Info},
+		{"Allocated Memory", humanize.Bytes(uint64(re.Go.AllocBytes))},
+		{"Goroutines", humanize.FormatFloat("", re.Go.Goroutines)},
+		{"Threads", humanize.FormatFloat("", re.Go.Threads)},
+		{"Heap Objects", humanize.FormatFloat("", re.Go.HeapObjects)},
+		{"Heap Allocated Memory", humanize.Bytes(uint64(re.Go.HeapAllocBytes))},
+		{"Info", re.Go.Info},
 	}
 
 	percentileTable := func(title string, hist Histogram) *widgets.Table {
@@ -251,7 +248,7 @@ func (c *TopCommand) render(ctx context.Context, re Report, eventID string) erro
 
 		if hist.Count == 0 {
 			t.Rows = [][]string{
-				[]string{"No data"},
+				{"No data"},
 			}
 			return t
 		}
@@ -259,7 +256,7 @@ func (c *TopCommand) render(ctx context.Context, re Report, eventID string) erro
 		t.ColumnWidths = []int{30, 50000}
 		t.RowSeparator = false
 		t.Rows = [][]string{
-			[]string{"Percentile", "Latency"},
+			{"Percentile", "Latency"},
 		}
 		for _, p := range hist.AsPercentiles() {
 			t.Rows = append(t.Rows, []string{
@@ -364,15 +361,15 @@ func (c *TopCommand) render(ctx context.Context, re Report, eventID string) erro
 }
 
 func (c *TopCommand) fetchAndGenerateReport(ctx context.Context, client *roundtrip.Client, prev *Report) (*Report, error) {
-	metrics, err := c.getPrometheusMetrics(client)
+	metrics, err := c.getPrometheusMetrics(ctx, client)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return generateReport(metrics, prev, *c.refreshPeriod)
 }
 
-func (c *TopCommand) getPrometheusMetrics(client *roundtrip.Client) (map[string]*dto.MetricFamily, error) {
-	re, err := client.Get(context.TODO(), client.Endpoint("metrics"), url.Values{})
+func (c *TopCommand) getPrometheusMetrics(ctx context.Context, client *roundtrip.Client) (map[string]*dto.MetricFamily, error) {
+	re, err := client.Get(ctx, client.Endpoint("metrics"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(trace.ConvertSystemError(err))
 	}
@@ -478,7 +475,7 @@ type GoStats struct {
 	HeapAllocBytes float64
 	// Number of bytes allocated and still in use.
 	AllocBytes float64
-	//HeapObjects is a number of allocated objects.
+	// HeapObjects is a number of allocated objects.
 	HeapObjects float64
 }
 

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -110,18 +110,18 @@ func (u *UserCommand) Initialize(app *kingpin.Application, config *service.Confi
 }
 
 // TryRun takes the CLI command as an argument (like "users add") and executes it.
-func (u *UserCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+func (u *UserCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
 	switch cmd {
 	case u.userAdd.FullCommand():
-		err = u.Add(client)
+		err = u.Add(ctx, client)
 	case u.userUpdate.FullCommand():
-		err = u.Update(client)
+		err = u.Update(ctx, client)
 	case u.userList.FullCommand():
-		err = u.List(client)
+		err = u.List(ctx, client)
 	case u.userDelete.FullCommand():
-		err = u.Delete(client)
+		err = u.Delete(ctx, client)
 	case u.userResetPassword.FullCommand():
-		err = u.ResetPassword(client)
+		err = u.ResetPassword(ctx, client)
 	default:
 		return false, nil
 	}
@@ -129,13 +129,13 @@ func (u *UserCommand) TryRun(cmd string, client auth.ClientI) (match bool, err e
 }
 
 // ResetPassword resets user password and generates a token to setup new password
-func (u *UserCommand) ResetPassword(client auth.ClientI) error {
+func (u *UserCommand) ResetPassword(ctx context.Context, client auth.ClientI) error {
 	req := auth.CreateUserTokenRequest{
 		Name: u.login,
 		TTL:  u.ttl,
 		Type: auth.UserTokenTypeResetPassword,
 	}
-	token, err := client.CreateResetPasswordToken(context.TODO(), req)
+	token, err := client.CreateResetPasswordToken(ctx, req)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,6 @@ func (u *UserCommand) PrintResetPasswordToken(token types.UserToken, format stri
 		format,
 		"User %q has been reset. Share this URL with the user to complete password reset, link is valid for %v:\n%v\n\n",
 	)
-
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -194,14 +193,14 @@ func (u *UserCommand) printResetPasswordToken(token types.UserToken, format stri
 
 // Add implements `tctl users add` for the enterprise edition. Unlike the OSS
 // version, this one requires --roles flag to be set
-func (u *UserCommand) Add(client auth.ClientI) error {
+func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 	u.createRoles = flattenSlice(u.createRoles)
 	u.allowedLogins = flattenSlice(u.allowedLogins)
 	u.allowedWindowsLogins = flattenSlice(u.allowedWindowsLogins)
 
 	// Validate roles (server does not do this yet).
 	for _, roleName := range u.createRoles {
-		if _, err := client.GetRole(context.TODO(), roleName); err != nil {
+		if _, err := client.GetRole(ctx, roleName); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -224,11 +223,11 @@ func (u *UserCommand) Add(client auth.ClientI) error {
 	user.SetTraits(traits)
 	user.SetRoles(u.createRoles)
 
-	if err := client.CreateUser(context.TODO(), user); err != nil {
+	if err := client.CreateUser(ctx, user); err != nil {
 		return trace.Wrap(err)
 	}
 
-	token, err := client.CreateResetPasswordToken(context.TODO(), auth.CreateUserTokenRequest{
+	token, err := client.CreateResetPasswordToken(ctx, auth.CreateUserTokenRequest{
 		Name: u.login,
 		TTL:  u.ttl,
 		Type: auth.UserTokenTypeResetPasswordInvite,
@@ -277,14 +276,14 @@ func printTokenAsText(token types.UserToken, messageFormat string) error {
 }
 
 // Update updates existing user
-func (u *UserCommand) Update(client auth.ClientI) error {
+func (u *UserCommand) Update(ctx context.Context, client auth.ClientI) error {
 	user, err := client.GetUser(u.login, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	roles := flattenSlice([]string{u.updateRoles})
 	for _, role := range roles {
-		if _, err := client.GetRole(context.TODO(), role); err != nil {
+		if _, err := client.GetRole(ctx, role); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -297,7 +296,7 @@ func (u *UserCommand) Update(client auth.ClientI) error {
 }
 
 // List prints all existing user accounts
-func (u *UserCommand) List(client auth.ClientI) error {
+func (u *UserCommand) List(ctx context.Context, client auth.ClientI) error {
 	users, err := client.GetUsers(false)
 	if err != nil {
 		return trace.Wrap(err)
@@ -326,9 +325,9 @@ func (u *UserCommand) List(client auth.ClientI) error {
 
 // Delete deletes teleport user(s). User IDs are passed as a comma-separated
 // list in UserCommand.login
-func (u *UserCommand) Delete(client auth.ClientI) error {
+func (u *UserCommand) Delete(ctx context.Context, client auth.ClientI) error {
 	for _, l := range strings.Split(u.login, ",") {
-		if err := client.DeleteUser(context.TODO(), l); err != nil {
+		if err := client.DeleteUser(ctx, l); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("User %q has been deleted\n", l)

--- a/tool/tctl/sso/configure/command.go
+++ b/tool/tctl/sso/configure/command.go
@@ -15,6 +15,7 @@
 package configure
 
 import (
+	"context"
 	"os"
 
 	"github.com/gravitational/teleport"
@@ -38,7 +39,7 @@ type SSOConfigureCommand struct {
 
 type AuthKindCommand struct {
 	Parsed bool
-	Run    func(clt auth.ClientI) error
+	Run    func(ctx context.Context, clt auth.ClientI) error
 }
 
 // Initialize allows a caller-defined command to plug itself into CLI
@@ -54,7 +55,7 @@ func (cmd *SSOConfigureCommand) Initialize(app *kingpin.Application, cfg *servic
 
 // TryRun is executed after the CLI parsing is done. The command must
 // determine if selectedCommand belongs to it and return match=true
-func (cmd *SSOConfigureCommand) TryRun(selectedCommand string, clt auth.ClientI) (match bool, err error) {
+func (cmd *SSOConfigureCommand) TryRun(ctx context.Context, selectedCommand string, clt auth.ClientI) (match bool, err error) {
 	for _, subCommand := range cmd.AuthCommands {
 		if subCommand.Parsed {
 			// the default tctl logging behaviour is to ignore all logs, unless --debug is present.
@@ -66,7 +67,7 @@ func (cmd *SSOConfigureCommand) TryRun(selectedCommand string, clt auth.ClientI)
 				cmd.Logger.Logger.SetOutput(os.Stderr)
 			}
 
-			return true, trace.Wrap(subCommand.Run(clt))
+			return true, trace.Wrap(subCommand.Run(ctx, clt))
 		}
 	}
 

--- a/tool/tctl/sso/configure/github.go
+++ b/tool/tctl/sso/configure/github.go
@@ -75,7 +75,7 @@ Examples:
   Generate the configuration and immediately test it using "tctl sso test" command.`)
 
 	preset := &AuthKindCommand{
-		Run: func(clt auth.ClientI) error { return ghRunFunc(cmd, &spec, gh, clt) },
+		Run: func(ctx context.Context, clt auth.ClientI) error { return ghRunFunc(ctx, cmd, &spec, gh, clt) },
 	}
 
 	sub.Action(func(ctx *kingpin.ParseContext) error {
@@ -86,8 +86,8 @@ Examples:
 	return preset
 }
 
-func ghRunFunc(cmd *SSOConfigureCommand, spec *types.GithubConnectorSpecV3, flags *ghExtraFlags, clt auth.ClientI) error {
-	if err := specCheckRoles(cmd.Logger, spec, flags.ignoreMissingRoles, clt); err != nil {
+func ghRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.GithubConnectorSpecV3, flags *ghExtraFlags, clt auth.ClientI) error {
+	if err := specCheckRoles(ctx, cmd.Logger, spec, flags.ignoreMissingRoles, clt); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -130,8 +130,8 @@ func ResolveCallbackURL(logger *logrus.Entry, clt auth.ClientI, fieldName string
 	return callbackURL
 }
 
-func specCheckRoles(logger *logrus.Entry, spec *types.GithubConnectorSpecV3, ignoreMissingRoles bool, clt auth.ClientI) error {
-	allRoles, err := clt.GetRoles(context.TODO())
+func specCheckRoles(ctx context.Context, logger *logrus.Entry, spec *types.GithubConnectorSpecV3, ignoreMissingRoles bool, clt auth.ClientI) error {
+	allRoles, err := clt.GetRoles(ctx)
 	if err != nil {
 		logger.WithError(err).Warn("unable to get roles list. Skipping teams-to-logins sanity checks.")
 		return nil

--- a/tool/tctl/sso/tester/command.go
+++ b/tool/tctl/sso/tester/command.go
@@ -92,7 +92,7 @@ func (cmd *SSOTestCommand) getSupportedKinds() []string {
 	return kinds
 }
 
-func (cmd *SSOTestCommand) ssoTestCommand(c auth.ClientI) error {
+func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c auth.ClientI) error {
 	reader := os.Stdin
 	if cmd.connectorFileName != "" {
 		f, err := utils.OpenFile(cmd.connectorFileName)
@@ -125,13 +125,13 @@ func (cmd *SSOTestCommand) ssoTestCommand(c auth.ClientI) error {
 		}
 
 		// note: loginErr is processed further down.
-		loginResponse, loginErr := cmd.runSSOLoginFlow(context.TODO(), raw.Kind, c, requestInfo.Config)
+		loginResponse, loginErr := cmd.runSSOLoginFlow(ctx, raw.Kind, c, requestInfo.Config)
 
 		if requestInfo.RequestCreateErr != nil {
 			return trace.BadParameter("Failed to create auth request. Check the auth connector definition for errors. Error: %v", requestInfo.RequestCreateErr)
 		}
 
-		info, infoErr := c.GetSSODiagnosticInfo(context.TODO(), raw.Kind, requestInfo.RequestID)
+		info, infoErr := c.GetSSODiagnosticInfo(ctx, raw.Kind, requestInfo.RequestID)
 
 		err = cmd.reportLoginResult(raw.Kind, info, infoErr, loginResponse, loginErr)
 		if err != nil {
@@ -142,9 +142,9 @@ func (cmd *SSOTestCommand) ssoTestCommand(c auth.ClientI) error {
 
 // TryRun is executed after the CLI parsing is done. The command must
 // determine if selectedCommand belongs to it and return match=true
-func (cmd *SSOTestCommand) TryRun(selectedCommand string, c auth.ClientI) (match bool, err error) {
+func (cmd *SSOTestCommand) TryRun(ctx context.Context, selectedCommand string, c auth.ClientI) (match bool, err error) {
 	if selectedCommand == cmd.ssoTestCmd.FullCommand() {
-		return true, cmd.ssoTestCommand(c)
+		return true, cmd.ssoTestCommand(ctx, c)
 	}
 	return false, nil
 }


### PR DESCRIPTION
Closes #12939 

Slight refactor to follow Go best practices, by creating a single new context in `main()` and passing this down to all sub commands. This tidies the codebase up (removing a plethora of random `context.Background()` and `context.TODO()`), and also means we can now allow users to cancel hung requests using `CTRL-C`.