### PR TITLE
[v9] Fix broken version check in tbot's `tshwrap` (#13034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 9.3.2
+
+This release of Teleport contains two bug fixes.
+
+* Fixed issue with Machine ID's `tsh` version check. [#13037](https://github.com/gravitational/teleport/pull/13037)
+* Fixed AWS related log spam in database agent when not running on AWS. [#12984](https://github.com/gravitational/teleport/pull/12984)
+
 ## 9.3.0
 
 This release of Teleport contains multiple improvements and bug fixes.

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=9.3.0
+VERSION=9.3.2
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/api/version.go
+++ b/api/version.go
@@ -3,7 +3,7 @@
 package api
 
 const (
-	Version = "9.3.0"
+	Version = "9.3.2"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-cluster
 apiVersion: v2
-version: "9.3.0"
-appVersion: "9.3.0"
+version: "9.3.2"
+appVersion: "9.3.2"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: "9.3.0"
-appVersion: "9.3.0"
+version: "9.3.2"
+appVersion: "9.3.2"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/tool/tbot/tshwrap/wrap.go
+++ b/tool/tbot/tshwrap/wrap.go
@@ -125,7 +125,7 @@ func (w *Wrapper) Exec(env map[string]string, args ...string) error {
 
 // GetTSHVersion queries the system tsh for its version.
 func GetTSHVersion(w *Wrapper) (*semver.Version, error) {
-	rawVersion, err := w.capture("version", "-f", "json")
+	rawVersion, err := w.capture(w.path, "version", "-f", "json")
 	if err != nil {
 		return nil, trace.Wrap(err, "querying tsh version")
 	}

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "9.3.0"
+	Version = "9.3.2"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Backport of #13034 for branch/v9.

---

`tshwrap` performs a tsh version check to ensure it has the functionality we need. Unfortunately, during a final refactoring before merging, we changed the function signature of `capture()` to require an explicit path to a `tsh` binary but in a way that was unfortunately not caught by the compiler. The previous syntax meant we just tried to execute the first argument, i.e. `version`, which is never what we want.

This PR correctly passes the tsh path to `capture()` to fix the version check.