### PR TITLE
Cloud customers should use port 443 when configuring agents

### DIFF
--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -89,7 +89,7 @@ $ sudo teleport app start \
   --auth-server=https://teleport.example.com:3080
 ```
 
-Change `https://teleport.example.com:3080` to the address and port of your Teleport Proxy Server. If you are a Teleport Cloud cluster, use your tenant's subdomain, e.g., `mytenant.teleport.sh`. 
+Change `https://teleport.example.com:3080` to the address and port of your Teleport Proxy Server. If you are a Teleport Cloud cluster, use port 443 of your tenant's subdomain, e.g., `mytenant.teleport.sh:443`.
 
 Make sure to update `--app-name` and `--app-uri` accordingly if you're using your own web application.
 

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -89,7 +89,7 @@ $ sudo teleport app start \
   --auth-server=https://teleport.example.com:3080
 ```
 
-Change `https://teleport.example.com:3080` to the address and port of your Teleport Proxy Server. If you are a Teleport Cloud cluster, use port 443 of your tenant's subdomain, e.g., `mytenant.teleport.sh:443`.
+Change `https://teleport.example.com:3080` to the address and port of your Teleport Proxy Server. If you are a Teleport Cloud customer, use port 443 of your tenant's subdomain, e.g., `mytenant.teleport.sh:443`.
 
 Make sure to update `--app-name` and `--app-uri` accordingly if you're using your own web application.
 

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -141,7 +141,7 @@ address of your Teleport Cloud tenant.
 $ teleport db start \
   --token=/tmp/token \
   --db-name=aurora \
-  --auth-server=mytenant.teleport.sh \
+  --auth-server=mytenant.teleport.sh:443 \
   --db-protocol=postgres \
   --db-uri=postgres-aurora-instance-1.abcdefghijklm.us-west-1.rds.amazonaws.com:5432 \
   --db-aws-region=us-west-1

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -108,7 +108,7 @@ endpoint.
   ```code
   $ teleport db start \
     --token=/tmp/token \
-    --auth-server=mytenant.teleport.sh \
+    --auth-server=mytenant.teleport.sh:443 \
     --name=azure-db \
     --protocol=postgres \
     --uri=example.postgres.database.azure.com:5321 \
@@ -121,7 +121,7 @@ endpoint.
   ```code
   $ teleport db start \
     --token=/tmp/token \
-    --auth-server=mytenant.teleport.sh \
+    --auth-server=mytenant.teleport.sh:443 \
     --name=azure-db \
     --protocol=mysql \
     --uri=example.mysql.database.azure.com:3306 \

--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -82,7 +82,7 @@ Start the Teleport Database Service, pointing the `--auth-server` flag at the ad
 ```code
 $ teleport db start \
   --token=/tmp/token \
-  --auth-server=mytenant.teleport.sh \
+  --auth-server=mytenant.teleport.sh:443 \
   --name=roach \
   --protocol=cockroachdb \
   --uri=roach.example.com:26257 \

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -109,7 +109,7 @@ On the node where you will run the Database Service, start Teleport, pointing th
 ```code
 $ teleport db start \
   --token=/tmp/token \
-  --auth-server=mytenant.teleport.sh \
+  --auth-server=mytenant.teleport.sh:443 \
   --name=mongodb-atlas \
   --protocol=mongodb \
   --uri=mongodb+srv://cluster0.abcde.mongodb.net \

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -84,7 +84,7 @@ address of your Teleport Cloud tenant:
 ```code
 $ teleport db start \
   --token=/tmp/token \
-  --auth-server=mytenant.teleport.sh \
+  --auth-server=mytenant.teleport.sh:443 \
   --name=example-mongo \
   --protocol=mongodb \
   --uri=mongo.example.com:27017 \

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -151,7 +151,7 @@ over a reverse tunnel.
 ```code
 $ teleport db start \
    --token=/tmp/token \
-   --auth-server=mytenant.teleport.sh \
+   --auth-server=mytenant.teleport.sh:443 \
    --name=test \
    --protocol=mysql \
    --uri=mysql.example.com:3306 \
@@ -189,7 +189,7 @@ $ teleport db configure create \
 $ teleport db configure create \
    -o file \
    --token=/tmp/token \
-   --proxy=mytenant.teleport.sh \
+   --proxy=mytenant.teleport.sh:443 \
    --name=test \
    --protocol=mysql \
    --uri=mysql.example.com:3306 \

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -64,7 +64,7 @@ $ teleport db configure create \
 ```code
 $ teleport db configure create \
    -o file \
-   --proxy=mytenant.teleport.sh:3080 \
+   --proxy=mytenant.teleport.sh:443 \
    --token=/tmp/token \
    --redshift-discovery=us-west-1
 ```

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -126,7 +126,7 @@ cluster over a reverse tunnel.
 ```code
 $ teleport db start \
    --token=/tmp/token \
-   --auth-server=mytenant.teleport.sh \
+   --auth-server=mytenant.teleport.sh:443 \
    --name=test \
    --protocol=postgres \
    --uri=postgres.example.com:5432 \
@@ -163,7 +163,7 @@ $ teleport db configure create \
 $ teleport db configure create \
    -o file \
    --token=/tmp/token \
-   --proxy=teleport.example.com:3080 \
+   --proxy=mytenant.teleport.sh:443 \
    --name=test \
    --protocol=postgres \
    --uri=postgres.example.com:5432 \

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -70,7 +70,7 @@ $ teleport db configure create \
 ```code
 $ teleport db configure create \
    -o file \
-   --proxy=mytenant.teleport.sh \
+   --proxy=mytenant.teleport.sh:443 \
    --token=/tmp/token \
    --rds-discovery=us-west-1
 ```

--- a/docs/pages/database-access/guides/redis-cluster.mdx
+++ b/docs/pages/database-access/guides/redis-cluster.mdx
@@ -95,7 +95,7 @@ address of your Teleport Cloud tenant:
 ```code
 $ teleport db start \
   --token=/tmp/token \
-  --auth-server=mytenant.teleport.sh \
+  --auth-server=mytenant.teleport.sh:443 \
   --name=example-redis \
   --protocol=redis \
   --uri=rediss://redis.example.com:6379?mode=cluster \

--- a/docs/pages/database-access/guides/redis.mdx
+++ b/docs/pages/database-access/guides/redis.mdx
@@ -95,7 +95,7 @@ address of your Teleport Cloud tenant:
 ```code
 $ teleport db start \
   --token=/tmp/token \
-  --auth-server=mytenant.teleport.sh \
+  --auth-server=mytenant.teleport.sh:443 \
   --name=example-redis \
   --protocol=redis \
   --uri=rediss://redis.example.com:6379 \

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -258,7 +258,7 @@ endpoint.
   ```code
   $ teleport db start \
     --token=/tmp/token \
-    --auth-server=mytenant.teleport.sh \
+    --auth-server=mytenant.teleport.sh:443 \
     --name=sqlserver \
     --protocol=sqlserver \
     --uri=sqlserver.example.com:1433 \

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -38,7 +38,7 @@ $ teleport db start \
 ```code
 $ teleport db start \
     --token=/path/to/token \
-    --auth-server=mytenant.teleport.sh:3080 \
+    --auth-server=mytenant.teleport.sh:443 \
     --name=example \
     --protocol=postgres \
     --uri=postgres.mytenant.teleport.sh:5432


### PR DESCRIPTION
Updating various docs to specify use of port 443 when setting up Teleport Agents.

When port is omitted, the agent goes into a retry loop as the default port (3025) is not available via a cloud tenant's subdomain.


```shell
$ sudo teleport db start --token=abcdefghijklmnopqrstuvwxyz012345 --auth-server=brendan.cloud.gravitational.io --name=pgdocker --protocol=postgres --uri=postgres.db.local:5432
INFO [PROC:1]    Connecting to the cluster brendan.cloud.gravitational.io with TLS client certificate. service/connect.go:164
ERRO [PROC:1]    Failed to resolve tunnel address Get "https://brendan.cloud.gravitational.io:3025/webapi/find": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) reversetunnel/transport.go:90
ERRO [PROC:1]    "Db failed to establish connection to cluster: Failed to connect to Auth Server directly or over tunnel, no methods remaining.\n\tGet \"https://teleport.cluster.local/v2/domain\": dial tcp 15.197.198.101:3025: i/o timeout, Get \"https://teleport.cluster.local/v2/domain\": Get \"https://brendan.cloud.gravitational.io:3025/webapi/find\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)." service/connect.go:86
ERRO [PROC:1]    Failed to resolve tunnel address Get "https://brendan.cloud.gravitational.io:3025/webapi/find": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) reversetunnel/transport.go:90
```
