### PR TITLE
Fix EC2 labels concurrent write bug

### DIFF
--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -411,8 +411,7 @@ func TestEC2Labels(t *testing.T) {
 }
 
 // TestEC2Hostname is an integration test which asserts that Teleport sets its
-// hostname if the EC2 tag `TeleportHostname` is available. This test must be
-// run on an instance with tag `TeleportHostname=fakehost.example.com`.
+// hostname if the EC2 tag `TeleportHostname` is available.
 func TestEC2Hostname(t *testing.T) {
 	teleportHostname := "fakehost.example.com"
 

--- a/lib/labels/ec2/ec2.go
+++ b/lib/labels/ec2/ec2.go
@@ -87,7 +87,11 @@ func New(ctx context.Context, c *Config) (*EC2, error) {
 func (l *EC2) Get() map[string]string {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
-	return l.labels
+	labels := make(map[string]string)
+	for k, v := range l.labels {
+		labels[k] = v
+	}
+	return labels
 }
 
 // Apply adds EC2 labels to the provided resource.


### PR DESCRIPTION
This PR fixes a bug in EC2 labels (#12593) involving concurrent writes to the labels map. This is fixed by making `EC2.Get()` return a copy instead of the actual label map.