### PR TITLE
[v7] Add a link from the older docs versions page

### DIFF
--- a/docs/pages/older-versions.mdx
+++ b/docs/pages/older-versions.mdx
@@ -1,0 +1,16 @@
+---
+title: Older Versions of the Teleport Documentation
+description: Links to older versions of the Teleport docs.
+h1: Older Versions of the Teleport Documentation
+layout: tocless-doc
+---
+
+Deprecated versions of the Teleport docs can be found at the GitHub links below:
+
+[Teleport 6.2](https://github.com/gravitational/teleport/tree/branch/v6.2) <br/>
+[Teleport 6.1](https://github.com/gravitational/teleport/tree/branch/v6.1) <br/>
+[Teleport 6.0](https://github.com/gravitational/teleport/tree/branch/v6.0) <br/>
+[Teleport 5](https://github.com/gravitational/teleport/tree/branch/5.0) <br/>
+[Teleport 4](https://github.com/gravitational/teleport/tree/branch/4.4) <br/>
+
+You can also [return to the main documentation site](../).


### PR DESCRIPTION
Backports #12838

If a reader uses the docs version picker to select "Older Versions",
they will navigate to a page where the current version is still
the version they had previously selected. This change adds a link to
the main docs site to make navigation easier.

This is a provisional solution to tide us over until we have a better
way to handle unsupported versions in our docs version picker.