### PR TITLE
Backport "Optionally provide ca_pin as a file path" (#12796) to v9

### DIFF
--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -137,7 +137,7 @@ func Register(params RegisterParams) (*proto.Certs, error) {
 	params.setDefaults()
 	// Read in the token. The token can either be passed in or come from a file
 	// on disk.
-	token, err := utils.ReadToken(params.Token)
+	token, err := utils.TryReadValueAsFile(params.Token)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -347,8 +347,8 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 
 	// Read in how nodes will validate the CA. A single empty string in the file
 	// conf should indicate no pins.
-	if len(fc.CAPin) > 1 || (len(fc.CAPin) == 1 && fc.CAPin[0] != "") {
-		cfg.CAPins = fc.CAPin
+	if err = cfg.ApplyCAPins(fc.CAPin); err != nil {
+		return trace.Wrap(err)
 	}
 
 	// Set diagnostic address
@@ -1833,8 +1833,8 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 	}
 
 	// Apply flags used for the node to validate the Auth Server.
-	if len(clf.CAPins) != 0 {
-		cfg.CAPins = clf.CAPins
+	if err = cfg.ApplyCAPins(clf.CAPins); err != nil {
+		return trace.Wrap(err)
 	}
 
 	// apply --listen-ip flag:

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -626,11 +626,28 @@ teleport:
 
 func TestApplyConfig(t *testing.T) {
 	tempDir := t.TempDir()
-	tokenPath := filepath.Join(tempDir, "small-config-token")
-	err := os.WriteFile(tokenPath, []byte("join-token"), 0644)
+	authTokenPath := filepath.Join(tempDir, "small-config-token")
+	err := os.WriteFile(authTokenPath, []byte("join-token"), 0o644)
 	require.NoError(t, err)
 
-	conf, err := ReadConfig(bytes.NewBufferString(fmt.Sprintf(SmallConfigString, tokenPath)))
+	caPinPath := filepath.Join(tempDir, "small-config-ca-pin")
+	err = os.WriteFile(caPinPath, []byte("ca-pin-from-file1\nca-pin-from-file2"), 0o644)
+	require.NoError(t, err)
+
+	staticTokenPath := filepath.Join(tempDir, "small-config-static-tokens")
+	err = os.WriteFile(staticTokenPath, []byte("token-from-file1\ntoken-from-file2"), 0o644)
+	require.NoError(t, err)
+
+	pkcs11LibPath := filepath.Join(tempDir, "fake-pkcs11-lib.so")
+	err = os.WriteFile(pkcs11LibPath, []byte("fake-pkcs11-lib"), 0o644)
+	require.NoError(t, err)
+
+	conf, err := ReadConfig(bytes.NewBufferString(fmt.Sprintf(
+		SmallConfigString,
+		authTokenPath,
+		caPinPath,
+		staticTokenPath,
+	)))
 	require.NoError(t, err)
 	require.NotNil(t, conf)
 	require.Equal(t, apiutils.Strings{"web3:443"}, conf.Proxy.PublicAddr)
@@ -644,6 +661,16 @@ func TestApplyConfig(t *testing.T) {
 		{
 			Token:   "xxx",
 			Roles:   types.SystemRoles([]types.SystemRole{"Proxy", "Node"}),
+			Expires: time.Unix(0, 0).UTC(),
+		},
+		{
+			Token:   "token-from-file1",
+			Roles:   types.SystemRoles([]types.SystemRole{"Node"}),
+			Expires: time.Unix(0, 0).UTC(),
+		},
+		{
+			Token:   "token-from-file2",
+			Roles:   types.SystemRoles([]types.SystemRole{"Node"}),
 			Expires: time.Unix(0, 0).UTC(),
 		},
 		{
@@ -720,7 +747,7 @@ SREzU8onbBsjMg9QDiSf5oJLKvd/Ren+zGY7
 	require.Equal(t, "example_token", cfg.Auth.KeyStore.TokenLabel)
 	require.Equal(t, 1, *cfg.Auth.KeyStore.SlotNumber)
 	require.Equal(t, "example_pin", cfg.Auth.KeyStore.Pin)
-	require.Empty(t, cfg.CAPins)
+	require.ElementsMatch(t, []string{"ca-pin-from-string", "ca-pin-from-file1", "ca-pin-from-file2"}, cfg.CAPins)
 }
 
 // TestApplyConfigNoneEnabled makes sure that if a section is not enabled,

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -309,6 +309,37 @@ func TestAuthenticationSection(t *testing.T) {
 	}
 }
 
+func TestAuthenticationConfig_Parse_StaticToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc  string
+		token string
+	}{
+		{desc: "file path on windows", token: `C:\path\to\some\file`},
+		{desc: "literal string", token: "some-literal-token"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			staticToken := StaticToken("Auth,Node,Proxy:" + tt.token)
+			provisionTokens, err := staticToken.Parse()
+			require.NoError(t, err)
+
+			require.Len(t, provisionTokens, 1)
+			provisionToken := provisionTokens[0]
+
+			want := types.ProvisionTokenV1{
+				Roles: []types.SystemRole{
+					types.RoleAuth, types.RoleNode, types.RoleProxy,
+				},
+				Token:   tt.token,
+				Expires: provisionToken.Expires,
+			}
+			require.Equal(t, provisionToken, want)
+		})
+	}
+}
+
 func TestAuthenticationConfig_Parse_nilU2F(t *testing.T) {
 	// An absent U2F section should be reflected as a nil U2F object.
 	// The config below is a valid config without U2F, but other than that we

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -106,13 +106,16 @@ teleport:
       average: 170
       burst: 171
   diag_addr: 127.0.0.1:3000
-  ca_pin: ""
+  ca_pin:
+    - ca-pin-from-string
+    - %v
 auth_service:
   enabled: yes
   listen_addr: 10.5.5.1:3025
   cluster_name: magadan
   tokens:
   - "proxy,node:xxx"
+  - "node:%v"
   - "auth:yyy"
   ca_key_params:
     pkcs11:

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -503,13 +503,13 @@ func TestMarshalYAML(t *testing.T) {
 }
 
 // TestReadToken tests reading token from file and as is
-func TestReadToken(t *testing.T) {
+func TestTryReadValueAsFile(t *testing.T) {
 	t.Parallel()
-	tok, err := ReadToken("token")
+	tok, err := TryReadValueAsFile("token")
 	require.Equal(t, "token", tok)
 	require.NoError(t, err)
 
-	_, err = ReadToken("/tmp/non-existent-token-for-teleport-tests-not-found")
+	_, err = TryReadValueAsFile("/tmp/non-existent-token-for-teleport-tests-not-found")
 	fixtures.AssertNotFound(t, err)
 
 	dir := t.TempDir()
@@ -517,7 +517,7 @@ func TestReadToken(t *testing.T) {
 	err = os.WriteFile(tokenPath, []byte("shmoken"), 0644)
 	require.NoError(t, err)
 
-	tok, err = ReadToken(tokenPath)
+	tok, err = TryReadValueAsFile(tokenPath)
 	require.NoError(t, err)
 	require.Equal(t, "shmoken", tok)
 }


### PR DESCRIPTION
Backport #12796 