### PR TITLE
[Search-based access requests] Nicer ResourceID strings

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -414,5 +414,15 @@ const (
 	BotGenerationLabel = "teleport.internal/bot-generation"
 )
 
-// ResourceKinds lists all Teleport resource kinds users can request access to.
-var ResourceKinds = []string{KindNode, KindDatabaseServer, KindAppServer, KindKubeService, KindWindowsDesktop}
+// RequestableResourceKinds lists all Teleport resource kinds users can request access to.
+var RequestableResourceKinds = []string{
+	KindNode,
+	KindKubeService,
+	KindKubernetesCluster,
+	KindDatabaseServer,
+	KindDatabase,
+	KindAppServer,
+	KindApp,
+	KindWindowsDesktopService,
+	KindWindowsDesktop,
+}

--- a/api/types/resource_ids_test.go
+++ b/api/types/resource_ids_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResourceIDs tests that ResourceIDs are correctly marshalled to and from
+// their string representation.
+func TestResourceIDs(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		in               []ResourceID
+		expected         string
+		expectParseError bool
+	}{
+		{
+			desc: "single id",
+			in: []ResourceID{{
+				ClusterName: "one",
+				Kind:        KindNode,
+				Name:        "uuid",
+			}},
+			expected: `["/one/node/uuid"]`,
+		},
+		{
+			desc: "multiple ids",
+			in: []ResourceID{{
+				ClusterName: "one",
+				Kind:        KindNode,
+				Name:        "uuid-1",
+			}, {
+				ClusterName: "two",
+				Kind:        KindDatabase,
+				Name:        "uuid-2",
+			}},
+			expected: `["/one/node/uuid-1","/two/db/uuid-2"]`,
+		},
+		{
+			desc: "no cluster name",
+			in: []ResourceID{{
+				ClusterName: "",
+				Kind:        KindNode,
+				Name:        "uuid",
+			}},
+			expected:         `["//node/uuid"]`,
+			expectParseError: true,
+		},
+		{
+			desc: "bad cluster name",
+			in: []ResourceID{{
+				ClusterName: "/,",
+				Kind:        KindNode,
+				Name:        "uuid",
+			}},
+			expected:         `["//,/node/uuid"]`,
+			expectParseError: true,
+		},
+		{
+			desc: "bad resource kind",
+			in: []ResourceID{{
+				ClusterName: "one",
+				Kind:        "not,/a,/kind",
+				Name:        "uuid",
+			}},
+			expected:         `["/one/not,/a,/kind/uuid"]`,
+			expectParseError: true,
+		},
+		{
+			// Any resource name is actually fine, test that the list parsing
+			// doesn't break.
+			desc: "bad resource name",
+			in: []ResourceID{{
+				ClusterName: "one",
+				Kind:        KindNode,
+				Name:        `really"--,bad resource\"\\"name`,
+			}},
+			expected: `["/one/node/really\"--,bad resource\\\"\\\\\"name"]`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			out, err := ResourceIDsToString(tc.in)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, out)
+
+			// Parse the ids from the string and make sure they match the
+			// original.
+			parsed, err := ResourceIDsFromString(out)
+			if tc.expectParseError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.in, parsed)
+		})
+	}
+}

--- a/tool/tsh/access_request.go
+++ b/tool/tsh/access_request.go
@@ -378,37 +378,35 @@ func onRequestSearch(cf *CLIConf) error {
 	}
 
 	rows := [][]string{}
-	resourceIDs := []types.ResourceID{}
+	var resourceIDs []string
 	for _, resource := range resources {
-		resourceIDs = append(resourceIDs, types.ResourceID{
+		resourceID := types.ResourceIDToString(types.ResourceID{
 			ClusterName: clusterName,
 			Kind:        resource.GetKind(),
 			Name:        resource.GetName(),
 		})
+		resourceIDs = append(resourceIDs, resourceID)
 		hostName := ""
 		if r, ok := resource.(interface{ GetHostname() string }); ok {
 			hostName = r.GetHostname()
 		}
 		rows = append(rows, []string{
-			resource.GetKind(),
+			resource.GetName(),
 			hostName,
 			sortedLabels(resource.GetAllLabels()),
-			resource.GetName(),
+			resourceID,
 		})
 	}
-	table := asciitable.MakeTableWithTruncatedColumn([]string{"Kind", "Hostname", "Labels", "ID"}, rows, "Labels")
+	table := asciitable.MakeTableWithTruncatedColumn([]string{"Name", "Hostname", "Labels", "Resource ID"}, rows, "Labels")
 	if _, err := table.AsBuffer().WriteTo(os.Stdout); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if len(resourceIDs) > 0 {
-		resourcesStr, err := types.ResourceIDsToString(resourceIDs)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+		resourcesStr := strings.Join(resourceIDs, " --resource ")
 		fmt.Fprintf(os.Stdout, `
 To request access to these resources, run
-> tsh request create --resources '%s' \
+> tsh request create --resource %s \
     --reason <request reason>
 
 `, resourcesStr)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -98,9 +98,8 @@ type CLIConf struct {
 	SuggestedReviewers string
 	// NoWait can be used with an access request to exit without waiting for a request resolution.
 	NoWait bool
-	// RequestedResourceIDs is a list of resources to request access to
-	// separated by commas.
-	RequestedResourceIDs string
+	// RequestedResourceIDs is a list of resources to request access to.
+	RequestedResourceIDs []string
 	// RequestID is an access request ID
 	RequestID string
 	// ReviewReason indicates the reason for an access review.
@@ -679,9 +678,7 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	reqCreate.Flag("reason", "Reason for requesting").StringVar(&cf.RequestReason)
 	reqCreate.Flag("reviewers", "Suggested reviewers").StringVar(&cf.SuggestedReviewers)
 	reqCreate.Flag("nowait", "Finish without waiting for request resolution").BoolVar(&cf.NoWait)
-	// TODO(nic): unhide this command when the rest of search-based access
-	// requests is implemented (#10887)
-	reqCreate.Flag("resources", "List of resources to request access to separated by commas").Hidden().StringVar(&cf.RequestedResourceIDs)
+	reqCreate.Flag("resource", "Resource ID to be requested").StringsVar(&cf.RequestedResourceIDs)
 
 	reqReview := req.Command("review", "Review an access request")
 	reqReview.Arg("request-id", "ID of target request").Required().StringVar(&cf.RequestID)
@@ -689,13 +686,11 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	reqReview.Flag("deny", "Review proposes denial").BoolVar(&cf.Deny)
 	reqReview.Flag("reason", "Review reason message").StringVar(&cf.ReviewReason)
 
-	// TODO(nic): unhide this command when the rest of search-based access
-	// requests is implemented (#10887)
-	reqSearch := req.Command("search", "Search for resources to request access to").Hidden()
-	reqSearch.Flag(
-		"kind",
-		fmt.Sprintf("Resource kind to search for (%s)", strings.Join(types.ResourceKinds, ", ")),
-	).Required().EnumVar(&cf.ResourceKind, types.ResourceKinds...)
+	reqSearch := req.Command("search", "Search for resources to request access to")
+	reqSearch.Flag("kind",
+		fmt.Sprintf("Resource kind to search for (%s)",
+			strings.Join(types.RequestableResourceKinds, ", ")),
+	).Required().EnumVar(&cf.ResourceKind, types.RequestableResourceKinds...)
 	reqSearch.Flag("search", searchHelp).StringVar(&cf.SearchKeywords)
 	reqSearch.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
 	reqSearch.Flag("labels", labelHelp).StringVar(&cf.UserHost)
@@ -1619,7 +1614,7 @@ func onListNodes(cf *CLIConf) error {
 }
 
 func executeAccessRequest(cf *CLIConf, tc *client.TeleportClient) error {
-	if cf.DesiredRoles == "" && cf.RequestID == "" && cf.RequestedResourceIDs == "" {
+	if cf.DesiredRoles == "" && cf.RequestID == "" && len(cf.RequestedResourceIDs) == 0 {
 		return trace.BadParameter("at least one role or resource or a request ID must be specified")
 	}
 	if cf.Username == "" {
@@ -1658,11 +1653,12 @@ func executeAccessRequest(cf *CLIConf, tc *client.TeleportClient) error {
 		roles := utils.SplitIdentifiers(cf.DesiredRoles)
 		reviewers := utils.SplitIdentifiers(cf.SuggestedReviewers)
 		requestedResourceIDs := []types.ResourceID{}
-		if cf.RequestedResourceIDs != "" {
-			requestedResourceIDs, err = types.ResourceIDsFromString(cf.RequestedResourceIDs)
+		for _, resourceIDString := range cf.RequestedResourceIDs {
+			resourceID, err := types.ResourceIDFromString(resourceIDString)
 			if err != nil {
 				return trace.Wrap(err)
 			}
+			requestedResourceIDs = append(requestedResourceIDs, resourceID)
 		}
 		req, err = services.NewAccessRequestWithResources(cf.Username, roles, requestedResourceIDs)
 		if err != nil {


### PR DESCRIPTION
This PR makes the string representation of `ResourceID`s used for search-based access requests shorter and much nicer to work with on the CLI.

The current work-in-progress implementation was just serializing them as a JSON list, here they have a custom representation `/cluster-name/resource-kind/resource-uuid`. These are easier to read and much easier to copy and paste.

It makes the search-request flow go from
```bash
Nics-MacBook-Pro:teletest nklaassen$ tsh request search --kind node --search one
Kind Hostname     Labels                    ID
---- ------------ ------------------------- ------------------------------------
node one-node     owner=db-admins,test=test bbb56211-7b54-4f9e-bee9-b68ea156be5f
node one-node-iot owner=db-admins,test=test cc03f3d4-a266-4637-86eb-5a44742600ca

To request access to these resources, run
> tsh request create --resources '[{"cluster":"cluster-one","kind":"node","name":"bbb56211-7b54-4f9e-bee9-b68ea156be5f"},{"cluster":"cluster-one","kind":"node","name":"cc03f3d4-a266-4637-86eb-5a44742600ca"}]' \
    --reason <request reason>

Nics-MacBook-Pro:teletest nklaassen$ tsh request create --resources '[{"cluster":"cluster-one","kind":"node","name":"bbb56211-7b54-4f9e-bee9-b68ea156be5f"},{"cluster":"cluster-one","kind":"node","name":"cc03f3d4-a266-4637-86eb-5a44742600ca"}]' \
    --reason "responding to incident"

```
to
```bash
$ tsh request search --kind node --search one
Name                                 Hostname     Labels                    Resource ID
------------------------------------ ------------ ------------------------- ------------------------------------------------------
bbb56211-7b54-4f9e-bee9-b68ea156be5f one-node     owner=db-admins,test=test /cluster-one/node/bbb56211-7b54-4f9e-bee9-b68ea156be5f
cc03f3d4-a266-4637-86eb-5a44742600ca one-node-iot owner=db-admins,test=test /cluster-one/node/cc03f3d4-a266-4637-86eb-5a44742600ca

To request access to these resources, run
> tsh request create --resource /cluster-one/node/bbb56211-7b54-4f9e-bee9-b68ea156be5f --resource /cluster-one/node/cc03f3d4-a266-4637-86eb-5a44742600ca \
    --reason <request reason>
$ tsh request create --resource /cluster-one/node/bbb56211-7b54-4f9e-bee9-b68ea156be5f --resource /cluster-one/node/cc03f3d4-a266-4637-86eb-5a44742600ca \
    --reason "responding to incident"

```

The UUIDs are still a bit long, but at least it's actually feasible to build up a request by copying from multiple searches