### PR TITLE
Add join-method flag to `teleport node configure`

### DIFF
--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -89,6 +89,25 @@ teleport:
     # auth_token: /var/lib/teleport/tokenjoin
     auth_token: xxxx-token-xxxx
 
+    # join_params are parameters to set when joining a cluster via
+    # EC2, IAM or a token.
+    #
+    # EC2 join method documentation:
+    # https://goteleport.com/docs/setup/guides/joining-nodes-aws-ec2/
+    # IAM join method documentation:
+    # https://goteleport.com/docs/setup/guides/joining-nodes-aws-iam/
+    join_params:
+        # join_method when set to "token", is equivalent to using auth_token.
+        join_method: "token"|"ec2"|"iam"
+        # When join_method is "token", token_name is either the
+        # token or the path to a file containing the token.
+        #
+        # If join_method is "iam" or "ec2", token_name will be will be
+        # the name of the joining token resource, e.g., "ec2-token" or
+        # "iam-token" as created in the Joining Nodes via EC2 or IAM
+        # guides.
+        token_name:  "token-name"
+
     # Optional CA pin of the auth server. This enables a more secure way of
     # adding new nodes to a cluster. See "Adding Nodes to the Cluster"
     # (https://goteleport.com/docs/admin-guide/#adding-nodes-to-the-cluster).

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -167,6 +167,8 @@ type SampleFlags struct {
 	AppURI string
 	// NodeLabels is list of labels in the format `foo=bar,baz=bax` to add to newly created nodes.
 	NodeLabels string
+	// JoinMethod is the method that will be used to join the cluster, either "token", "iam" or "ec2"
+	JoinMethod string
 }
 
 // MakeSampleFileConfig returns a sample config to start
@@ -198,7 +200,11 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 		g.DataDir = defaults.DataDir
 	}
 
-	g.AuthToken = flags.AuthToken
+	g.JoinParams = JoinParams{
+		TokenName: flags.AuthToken,
+		Method:    types.JoinMethod(flags.JoinMethod),
+	}
+
 	if flags.AuthServer != "" {
 		g.AuthServers = []string{flags.AuthServer}
 	}

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -717,10 +717,12 @@ func TestMakeSampleFileConfig(t *testing.T) {
 
 	t.Run("Token", func(t *testing.T) {
 		fc, err := MakeSampleFileConfig(SampleFlags{
-			AuthToken: "auth-token",
+			AuthToken:  "auth-token",
+			JoinMethod: "token",
 		})
 		require.NoError(t, err)
-		require.Equal(t, "auth-token", fc.AuthToken)
+		require.Equal(t, "auth-token", fc.JoinParams.TokenName)
+		require.Equal(t, types.JoinMethodToken, fc.JoinParams.Method)
 	})
 
 	t.Run("App name and URI", func(t *testing.T) {

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -318,6 +318,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dumpNodeConfigure.Flag("token", "Invitation token to register with an auth server.").StringVar(&dumpFlags.AuthToken)
 	dumpNodeConfigure.Flag("auth-server", "Address of the auth server.").StringVar(&dumpFlags.AuthServer)
 	dumpNodeConfigure.Flag("labels", "Comma-separated list of labels to add to newly created nodes ex) env=staging,cloud=aws.").StringVar(&dumpFlags.NodeLabels)
+	dumpNodeConfigure.Flag("join-method", "Method to use to join the cluster (token, iam, ec2)").Default("token").EnumVar(&dumpFlags.JoinMethod, "token", "iam", "ec2")
 
 	// parse CLI commands+flags:
 	utils.UpdateAppUsageTemplate(app, options.Args)


### PR DESCRIPTION
The join method flag will be used in #12410

This also documents the `join_method` configuration option int the
reference config.