### PR TITLE
Added debugging packages to Docker images

### DIFF
--- a/build.assets/charts/Dockerfile
+++ b/build.assets/charts/Dockerfile
@@ -5,11 +5,43 @@ FROM ubuntu:20.04
 # package is installed because the base Ubuntu image does not come with any
 # certificate authorities. libelf1 is a dependency introduced by Teleport 7.0.
 #
+# The below packages are provided for debug purposes. Installing them adds around
+#  six megabytes to the image size. The packages include the following commands:
+# * net-tools
+#   * netstat
+#   * ifconfig
+#   * ipmaddr
+#   * iptunnel
+#   * mii-tool
+#   * nameif
+#   * plipconfig
+#   * rarp
+#   * route
+#   * slattach
+#   * arp
+# * iputils-ping
+#   * ping
+#   * ping4
+#   * ping6
+# * inetutils-telnet
+#   * telnet
+# * netcat
+#   * netcat
+# * tcpdump
+#   * tcpdump
+# * busybox (see "busybox --list" for all provided utils)
+#   * less
+#   * nslookup
+#   * vi
+#   * wget
+
 # Note that /var/lib/apt/lists/* is cleaned up in the same RUN command as
 # "apt-get update" to reduce the size of the image.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ca-certificates dumb-init libelf1 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y net-tools iputils-ping inetutils-telnet netcat tcpdump busybox && \
+    busybox --install -s && \
     update-ca-certificates && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*

--- a/build.assets/charts/Dockerfile-fips
+++ b/build.assets/charts/Dockerfile-fips
@@ -5,11 +5,43 @@ FROM ubuntu:20.04
 # package is installed because the base Ubuntu image does not come with any
 # certificate authorities. libelf1 is a dependency introduced by Teleport 7.0.
 #
+# The below packages are provided for debug purposes. Installing them adds around
+#  six megabytes to the image size. The packages include the following commands:
+# * net-tools
+#   * netstat
+#   * ifconfig
+#   * ipmaddr
+#   * iptunnel
+#   * mii-tool
+#   * nameif
+#   * plipconfig
+#   * rarp
+#   * route
+#   * slattach
+#   * arp
+# * iputils-ping
+#   * ping
+#   * ping4
+#   * ping6
+# * inetutils-telnet
+#   * telnet
+# * netcat
+#   * netcat
+# * tcpdump
+#   * tcpdump
+# * busybox (see "busybox --list" for all provided utils)
+#   * less
+#   * nslookup
+#   * vi
+#   * wget
+#
 # Note that /var/lib/apt/lists/* is cleaned up in the same RUN command as
 # "apt-get update" to reduce the size of the image.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ca-certificates dumb-init libelf1 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y net-tools iputils-ping inetutils-telnet netcat tcpdump busybox && \
+    busybox --install -s && \
     update-ca-certificates && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Per issue #13116 this adds several packages/commands to the built container images for debugging purposes:
* net-tools
  * netstat
  * ifconfig
  * ipmaddr
  * iptunnel
  * mii-tool
  * nameif
  * plipconfig
  * rarp
  * route
  * slattach
  * arp
* iputils-ping
  * ping
  * ping4
  * ping6
* inetutils-telnet
  * telnet
* netcat
  * netcat
* tcpdump
  * tcpdump
* busybox (see "busybox --list" for all provided utils)
  * less
  * nslookup
  * vi
  * wget

These changes increase the image size by approximately 6 MB.