### PR TITLE
attempt to fix flaky TestProxyClientDisconnectDueToLockInForce

### DIFF
--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -293,9 +293,6 @@ func (w *Monitor) emitDisconnectEvent(reason string) error {
 
 func (w *Monitor) handleLockInForce(lockErr error) {
 	reason := lockErr.Error()
-	if err := w.emitDisconnectEvent(reason); err != nil {
-		w.Entry.WithError(err).Warn("Failed to emit audit event.")
-	}
 	if w.MessageWriter != nil {
 		if _, err := w.MessageWriter.WriteString(reason); err != nil {
 			w.Entry.WithError(err).Warn("Failed to send lock-in-force message.")
@@ -304,6 +301,9 @@ func (w *Monitor) handleLockInForce(lockErr error) {
 	w.Entry.Debugf("Disconnecting client: %v.", reason)
 	if err := w.Conn.Close(); err != nil {
 		w.Entry.WithError(err).Error("Failed to close connection.")
+	}
+	if err := w.emitDisconnectEvent(reason); err != nil {
+		w.Entry.WithError(err).Warn("Failed to emit audit event.")
 	}
 }
 


### PR DESCRIPTION
`TestProxyClientDisconnectDueToLockInForce` has failed on me a couple of times now, this is an attempt to fix the flakiness by waiting to emit the audit event until after the client has been disconnected.

The offending test lines are here https://github.com/gravitational/teleport/blob/6f73b82935956e51109bd9bd2a8379a7c2107ff7/lib/srv/db/proxy_test.go#L222-L224