### PR TITLE
dronegen/mac.go: Use `make print-version` for $VERSION

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -554,7 +554,8 @@ steps:
   - echo HOME=$${HOME}
   - export HOME=/Users/$(whoami)
   - export TOOLCHAIN_DIR=/tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains
-  - export VERSION=$(cat $WORKSPACE_DIR/go/.version.txt)
+  - export VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
+    print-version)
   - export NODE_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets
     print-node-version)
   - export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets
@@ -3010,7 +3011,8 @@ steps:
   - echo HOME=$${HOME}
   - export HOME=/Users/$(whoami)
   - export TOOLCHAIN_DIR=/tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains
-  - export VERSION=$(cat $WORKSPACE_DIR/go/.version.txt)
+  - export VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
+    print-version)
   - export NODE_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets
     print-node-version)
   - export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets
@@ -5606,6 +5608,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 8bb7ab736b95bbf06861653a21ab124a234c4beb3b297f986f508b92fa55b1d4
+hmac: 8ba01d8a4566bb36fc2375c5a6eb4e5ea9d6f5d638c0be44028397b3c1720668
 
 ...

--- a/dronegen/mac.go
+++ b/dronegen/mac.go
@@ -331,7 +331,7 @@ func darwinTagBuildCommands(b buildType, opts darwinBuildOptions) []string {
 		`echo HOME=$${HOME}`,
 		`export HOME=/Users/$(whoami)`,
 		`export TOOLCHAIN_DIR=` + perBuildToolchainsDir,
-		`export VERSION=$(cat $WORKSPACE_DIR/go/.version.txt)`,
+		`export VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport print-version)`,
 		`export NODE_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets print-node-version)`,
 		`export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets print-rust-version)`,
 		`export CARGO_HOME=` + perBuildCargoDir,


### PR DESCRIPTION
Fix for changes introduced in #13099.

`$WORKSPACE_DIR/go/.version.txt` is available only in tag pipelines, so
we can't read it in pipelines that run on pushes to master.

Instead, let's always use `make print-version`. It'll return the correct
value no matter what pipeline is used.

Running a test tag build to test if it works: https://drone.platform.teleport.sh/gravitational/teleport/12559/12/1 (edit: it works)