### PR TITLE
[v9] Document `tsh --mfa-mode` flag

### DIFF
--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -247,6 +247,11 @@ $ tsh ssh prod3.example.com
 # jerry@prod3.example.com >
 ```
 
+<Admonition title="Tip" type="tip">
+If you are using `tsh` in a constrained environment, you can tell it to use
+OTP by doing `tsh --mfa-mode=otp ssh prod3.example.com`.
+</Admonition>
+
 If per-session MFA was enabled cluster-wide, Jerry would be prompted for MFA
 even when logging into `dev1.example.com`.
 

--- a/docs/pages/setup/reference/cli.mdx
+++ b/docs/pages/setup/reference/cli.mdx
@@ -154,6 +154,7 @@ information about the cluster.
 | `--cert-format` | `file` | `file` or `openssh` | SSH certificate format |
 | `--insecure` | none | none | Do not verify server's certificate and host name. Use only in test environments |
 | `--auth` | `local` | any defined [authentication connector](./authentication.mdx) | Specify the type of authentication connector to use. |
+| `--mfa-mode` | auto | `auto` or `otp` | Preferred MFA method for `tsh`. Useful to force `otp` in constrained environments. |
 | `--skip-version-check` | none | none | Skip version checking between server and client. |
 | `-d, --debug` | none | none | Verbose logging to stdout |
 | `-J, --jumphost` | none | A jump host | SSH jumphost |
@@ -713,11 +714,11 @@ cluster. This can be done in three ways:
 Service signs an identity file when a user runs `tctl auth sign` or
 `tsh login --out=<output-path>`, and the user can include the path to the
 identity file in the `--identity` flag when running `tctl` commands.
-  
+
 When using the `--identity` flag, the user must provide the `--auth-server` flag
 with the address of an Auth Service or Proxy Service so `tctl` knows which
 cluster to authenticate to.
-  
+
 ### On the same host as the Teleport Auth Service
 
 If there is a Teleport configuration file on the host where `tctl` is run,
@@ -767,7 +768,7 @@ cluster. This can be done in two ways:
 Service signs an identity file when a user runs `tctl auth sign` or
 `tsh login --out=<output-path>`, and the user can include the path to the
 identity file in the `--identity` flag when running `tctl` commands.
-  
+
 When using the `--identity` flag, the user must alo provide the `--auth-server`
 flag with the address of an Auth Service or Proxy Service so `tctl` knows which
 cluster to authenticate to.


### PR DESCRIPTION
Document the `tsh --mfa-mode` flag added by #13212.

Doc changes made exclusively to v9, I'm bundling this with the soon-to-be passwordless docs for v10+.