### PR TITLE
Ignore Conditional Checks for Existing Items

### DIFF
--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -827,6 +827,12 @@ func (b *Backend) create(ctx context.Context, item backend.Item, mode int) error
 	_, err = b.svc.PutItemWithContext(ctx, &input)
 	err = convertError(err)
 	if err != nil {
+		// The conditional expression will fail for items that already exist.
+		// This is not an issue, so we override the error.
+		if mode == modeCreate && trace.IsCompareFailed(err) {
+			b.Debugf("Attempted to create a pre-existing key %q", item.Key)
+			return nil
+		}
 		return trace.Wrap(err)
 	}
 	return nil


### PR DESCRIPTION
We use a Conditional Check in DynamoDB for creates to ensure that an
item (specifically, the FullPath) doesn't exist ("attribute_not_exists")

This fails during startup for the following paths:
- teleport/cluster_configuration/name
- teleport/roles/editor/params
- teleport/roles/access/params
- teleport/roles/auditor/params

and periodically (every few minutes) for the following path:
- teleport/cloud/lock

For existing clusters these items already exist and don't need to be created.

This doesn't apply when the mode is to update. This is especially
important because these errors are impacting the
"backend_write_requests_failed_total" metric, which will throw off our
SLO calculations, in clusters where there is little activity the fact that we
attempt to create the lock every few minutes really throws off our success
ratio.

This change ignores such errors, returning nil. Though not explicitly defined 
in the Backend interface, I believe the intention that creating an existing item is not
an error. If this is not the case, the callers should be updated to check an item exists
first.

Signed-off-by: Michael McAllister <michael.mcallister@goteleport.com>