### PR TITLE
Linter fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,8 @@ linters-settings:
     include-go-root: true # check against stdlib
     packages-with-error-message:
     - io/ioutil: 'use "io" or "os" packages instead'
+    - github.com/siddontang/go/log: 'use "github.com/sirupsen/logrus" instead'
+    - github.com/siddontang/go-log/log: 'use "github.com/sirupsen/logrus" instead'
 
 output:
   uniq-by-line: false

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -34,8 +34,10 @@ import (
 
 // NewHostUsers initialize a new HostUsers object
 func NewHostUsers(ctx context.Context, storage *local.PresenceService) (HostUsers, error) {
-	backend, err := newHostUsersBackend()
-	if err != nil {
+	// newHostUsersBackend statically returns a valid backend or an error,
+	// resulting in a staticcheck linter error on darwin
+	backend, err := newHostUsersBackend() //nolint:staticcheck
+	if err != nil {                       //nolint:staticcheck
 		return nil, trace.Wrap(err)
 	}
 	cancelCtx, cancelFunc := context.WithCancel(ctx)

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -23,12 +23,13 @@ import (
 	"os/user"
 	"time"
 
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
-	"github.com/siddontang/go/log"
 )
 
 // NewHostUsers initialize a new HostUsers object

--- a/lib/srv/usermgmt_other.go
+++ b/lib/srv/usermgmt_other.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
+//nolint:staticcheck // intended to always return an error for non-linux builds
 func newHostUsersBackend() (HostUsersBackend, error) {
 	return nil, trace.NotImplemented("Host user creation management is only supported on linux")
 }

--- a/lib/utils/host/hostusers.go
+++ b/lib/utils/host/hostusers.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
-	"github.com/siddontang/go-log/log"
+	log "github.com/sirupsen/logrus"
 )
 
 // man GROUPADD(8), exit codes section


### PR DESCRIPTION
This fixes a recent linter warning that only appears on macOS builds, and blacklists `github.com/siddontang/go/log` recommending `github.com/sirupsen/logrus` instead.