### PR TITLE
Terraform reference: update provider's source

### DIFF
--- a/docs/pages/setup/reference/terraform-provider.mdx
+++ b/docs/pages/setup/reference/terraform-provider.mdx
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     teleport = {
       version = ">= (=teleport.version=)"
-      source  = "gravitational.com/teleport/teleport"
+      source  = "terraform.releases.teleport.dev/gravitational/teleport"
     }
   }
 }
@@ -31,18 +31,22 @@ terraform {
 
 The provider supports the following options:
 
-| Name                    | Type       | Description                                           | Environment Variable             |
-|-------------------------|------------|-------------------------------------------------------|----------------------------------|
-|                   `addr`|     string | Teleport auth or proxy address in "host:port" format. | `TF_TELEPORT_ADDR`               |
-|              `cert_path`|     string | Path to Teleport certificate file.                    | `TF_TELEPORT_CERT`               |
-|            `cert_base64`|     string | Teleport certificate as base64.                       | `TF_TELEPORT_CERT_BASE64`        |
-|     `identity_file_path`|     string | Path to Teleport identity file.                       | `TF_TELEPORT_IDENTITY_FILE_PATH` |
-|               `key_path`|     string | Path to Teleport key file.                            | `TF_TELEPORT_KEY`                |
-|             `key_base64`|     string | Teleport key as base64.                               | `TF_TELEPORT_KEY_BASE64`         |
-|            `profile_dir`|     string | Teleport profile path.                                | `TF_TELEPORT_PROFILE_PATH`       |
-|           `profile_name`|     string | Teleport profile name.                                | `TF_TELEPORT_PROFILE_NAME`       |
-|           `root_ca_path`|     string | Path to Teleport CA file.                             | `TF_TELEPORT_ROOT_CA`            |
-|         `root_ca_base64`|     string | Teleport CA as base64.                                | `TF_TELEPORT_ROOT_CA_BASE64`     |
+| Name                  | Type   | Description                                                                     | Environment Variable              |
+|-----------------------|--------|---------------------------------------------------------------------------------|-----------------------------------|
+| `addr`                | string | Teleport auth or proxy address in "host:port" format.                           | `TF_TELEPORT_ADDR`                |
+| `cert_path`           | string | Path to Teleport certificate file.                                              | `TF_TELEPORT_CERT`                |
+| `cert_base64`         | string | Teleport certificate as base64.                                                 | `TF_TELEPORT_CERT_BASE64`         |
+| `identity_file_path`  | string | Path to Teleport identity file.                                                 | `TF_TELEPORT_IDENTITY_FILE_PATH`  |
+| `key_path`            | string | Path to Teleport key file.                                                      | `TF_TELEPORT_KEY`                 |
+| `key_base64`          | string | Teleport key as base64.                                                         | `TF_TELEPORT_KEY_BASE64`          |
+| `profile_dir`         | string | Teleport profile path.                                                          | `TF_TELEPORT_PROFILE_PATH`        |
+| `profile_name`        | string | Teleport profile name.                                                          | `TF_TELEPORT_PROFILE_NAME`        |
+| `root_ca_path`        | string | Path to Teleport CA file.                                                       | `TF_TELEPORT_ROOT_CA`             |
+| `root_ca_base64`      | string | Teleport CA as base64.                                                          | `TF_TELEPORT_ROOT_CA_BASE64`      |
+| `retry_base_duration` | string | Base durantion between retries. [Format](https://pkg.go.dev/time#ParseDuration) | `TF_TELEPORT_RETRY_BASE_DURATION` |
+| `retry_cap_duration`  | string | Max duration between retries. [Format](https://pkg.go.dev/time#ParseDuration)   | `TF_TELEPORT_RETRY_CAP_DURATION`  |
+| `retry_max_tries`     | string | Max number of retries.                                                          | `TF_TELEPORT_RETRY_MAX_TRIES`     |
+
 
 You need to specify at least one of:
 
@@ -50,6 +54,8 @@ You need to specify at least one of:
 - `cert_base64`, `key_base64`,`root_ca_base64` and `addr` to connect using a base64-encoded key.
 - `identity_file_path` and `addr` to connect using identity file.
 - `profile_name` and `profile_dir` (both can be empty) and Teleport will try to connect using current profile from `~/.tsh`
+
+The `retry_*` values are used to retry the API calls to Teleport when the cache is stale.
 
 If more than one are provided, they will be tried in the order above until one succeeds.
 
@@ -85,7 +91,7 @@ Example:
 
 ```
 resource "teleport_user" "example" {
-  metadata {
+  metadata = {
     name        = "example"
     description = "Example Teleport User"
     expires     = "2022-10-12T07:20:50.3Z"
@@ -120,38 +126,46 @@ Example:
 
 ```
 resource "teleport_user" "example" {
-  spec {
+  metadata = {
+    name        = "example"
+  }
+  spec = {
     roles = ["example"]
 
-    oidc_identities {
-      connector_id = "oidc1.example.com"
-      username     = "example"
-    }
+    oidc_identities = [
+      {
+        connector_id = "oidc1.example.com"
+        username     = "example"
+      },
+      {
+        connector_id = "oidc2.example.com"
+        username     = "example"
+      }
+    ]
 
-    oidc_identities {
-      connector_id = "oidc2.example.com"
-      username     = "example"
-    }
-
-    traits {
-      key   = "trait1"
+    traits = {
+      key   = ["trait1"]
       value = ["example", "test"]
     }
 
-    traits {
-      key   = "trait2"
+    traits = {
+      key   = ["trait2"]
       value = ["foo", "bar"]
     }
 
-    github_identities {
-      connector_id = "github.com"
-      username     = "example"
-    }
+    github_identities = [
+      {
+        connector_id = "github.com"
+        username     = "example"
+      }
+    ]
 
-    saml_identities {
-      connector_id = "saml.example.com"
-      username     = "example"
-    }
+    saml_identities = [
+      {
+        connector_id = "saml.example.com"
+        username     = "example"
+      }
+    ]
   }
 }
 ```


### PR DESCRIPTION
This PR updates the Terraform provider's source to match our registry
It also update some syntax changes when Terraform version reached 0.12

There are some fields missing, mostly new ones
As a follow up for this one, I created the following issue:
https://github.com/gravitational/teleport-plugins/issues/576

Fixes #13256