### PR TITLE
Add sudo to the Dockerfile

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -94,6 +94,7 @@ RUN apt-get update -y --fix-missing && \
         pkg-config \
         shellcheck \
         softhsm2 \
+        sudo \
         tree \
         unzip \
         zip \


### PR DESCRIPTION
`visudo` is used in sudoers provisioning integration tests (#12061)