### PR TITLE
Fix listener flakiness in tbot tests

### DIFF
--- a/lib/tbot/configtemplate_test.go
+++ b/lib/tbot/configtemplate_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/testhelpers"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,11 +81,11 @@ func validateTemplate(t *testing.T, tplI config.Template, dest destination.Desti
 // TestTemplateRendering performs a full renewal and ensures all expected
 // default config templates are present.
 func TestDefaultTemplateRendering(t *testing.T) {
-	utils.InitLogger(utils.LoggingForDaemon, logrus.DebugLevel)
+	t.Parallel()
 
 	// Make a new auth server.
-	fc := testhelpers.DefaultConfig(t)
-	_ = testhelpers.MakeAndRunTestAuthServer(t, fc)
+	fc, fds := testhelpers.DefaultConfig(t)
+	_ = testhelpers.MakeAndRunTestAuthServer(t, fc, fds)
 	rootClient := testhelpers.MakeDefaultAuthClient(t, fc)
 
 	// Make and join a new bot instance.

--- a/lib/tbot/identity_test.go
+++ b/lib/tbot/identity_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestLoadEmptyIdentity(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	dest := config.DestinationDirectory{
 		Path: dir,

--- a/lib/tbot/renew_test.go
+++ b/lib/tbot/renew_test.go
@@ -34,9 +34,11 @@ import (
 
 // TestOnboardViaToken ensures a bot can join using token auth.
 func TestOnboardViaToken(t *testing.T) {
+	t.Parallel()
+
 	// Make a new auth server.
-	fc := testhelpers.DefaultConfig(t)
-	_ = testhelpers.MakeAndRunTestAuthServer(t, fc)
+	fc, fds := testhelpers.DefaultConfig(t)
+	_ = testhelpers.MakeAndRunTestAuthServer(t, fc, fds)
 	rootClient := testhelpers.MakeDefaultAuthClient(t, fc)
 
 	// Make and join a new bot instance.
@@ -61,8 +63,10 @@ func TestOnboardViaToken(t *testing.T) {
 }
 
 func TestDatabaseRequest(t *testing.T) {
+	t.Parallel()
+
 	// Make a new auth server.
-	fc := testhelpers.DefaultConfig(t)
+	fc, fds := testhelpers.DefaultConfig(t)
 	fc.Databases.Databases = []*libconfig.Database{
 		{
 			Name:     "foo",
@@ -73,7 +77,7 @@ func TestDatabaseRequest(t *testing.T) {
 			},
 		},
 	}
-	_ = testhelpers.MakeAndRunTestAuthServer(t, fc)
+	_ = testhelpers.MakeAndRunTestAuthServer(t, fc, fds)
 	rootClient := testhelpers.MakeDefaultAuthClient(t, fc)
 
 	// Wait for the database to become available. Sometimes this takes a bit


### PR DESCRIPTION
I got a failed CI run because a `tbot` test got an "address already in use" error on a listener: `tbot` tests pick ports by opening a listener on `:0` and then reading the socket's local address, then they close the listener - which essentially picks a random number for a port that's not in use _at the time of the check_, but not later and not between different picks of the same test run.

This PR fixes this by opening listeners on `:0` and feeding them as imported file descriptors with the appropriate tag, because passing `127.0.0.1:0` as a `listen_addr` to Teleport itself doesn't really work and would require too many changes to make it work.

`tctl` tests are also guilty of the same thing, and integration tests (among other sins) end up picking ports at random from an in-memory list, which ends up clobbering listeners if one attempts to run two instances of the integration tests at the same time. If this approach ends up working well, it can be replicated for both the `tctl` tests and the integration tests.