### PR TITLE
Fix request review time for tctl and tsh

### DIFF
--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -370,8 +370,8 @@ func (c *AccessRequestCommand) Review(ctx context.Context, client auth.ClientI) 
 		Review: types.AccessReview{
 			Author:        c.user,
 			ProposedState: state,
-			Created:       time.Now(),
 			Reason:        c.reason,
+			Created:       time.Now(),
 		},
 	})
 	if err != nil {

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -369,7 +369,9 @@ func (c *AccessRequestCommand) Review(ctx context.Context, client auth.ClientI) 
 		RequestID: strings.Split(c.reqIDs, ",")[0],
 		Review: types.AccessReview{
 			Author:        c.user,
-			ProposedState: state,
+      ProposedState: state,
+			Created:       time.Now(),
+      Reason:        c.reason,
 		},
 	})
 	if err != nil {

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -369,9 +369,9 @@ func (c *AccessRequestCommand) Review(ctx context.Context, client auth.ClientI) 
 		RequestID: strings.Split(c.reqIDs, ",")[0],
 		Review: types.AccessReview{
 			Author:        c.user,
-      ProposedState: state,
+			ProposedState: state,
 			Created:       time.Now(),
-      Reason:        c.reason,
+			Reason:        c.reason,
 		},
 	})
 	if err != nil {

--- a/tool/tsh/access_request.go
+++ b/tool/tsh/access_request.go
@@ -312,7 +312,7 @@ func onRequestReview(cf *CLIConf) error {
 				Author:        cf.Username,
 				ProposedState: state,
 				Reason:        cf.ReviewReason,
-        Created:       time.Now(),
+				Created:       time.Now(),
 			},
 		})
 		return trace.Wrap(err)

--- a/tool/tsh/access_request.go
+++ b/tool/tsh/access_request.go
@@ -312,6 +312,7 @@ func onRequestReview(cf *CLIConf) error {
 				Author:        cf.Username,
 				ProposedState: state,
 				Reason:        cf.ReviewReason,
+        Created:       time.Now(),
 			},
 		})
 		return trace.Wrap(err)


### PR DESCRIPTION
Related: https://github.com/gravitational/teleport/issues/9863

When approving a request through the Web UI, users would see the proper 'approved' timestamp due to having a `Created:` key [present in the access review param.](https://github.com/gravitational/teleport.e/blob/3ca592556f0df98b6b9efff476c4824562efc14f/lib/web/access_request.go#L170) 

This key was missing in the review params for `tctl` and `tsh`. 

NOTE: This is not (and can not be) a retroactive fix due to the approval being a timestamp present in the db blob. It will only work for approvals created after this fix. 