### PR TITLE
Implement write and read for directory sharing

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -469,7 +469,6 @@ func (c *Client) start() {
 				if c.cfg.AllowDirectorySharing {
 
 					var readData *C.uint8_t
-
 					if m.ReadDataLength > 0 {
 						readData = (*C.uint8_t)(unsafe.Pointer(&m.ReadData[0]))
 					} else {
@@ -676,8 +675,9 @@ func (c *Client) sharedDirectoryReadRequest(req tdp.SharedDirectoryReadRequest) 
 			c.cfg.Log.Errorf("failed to send SharedDirectoryReadRequest: %v", err)
 			return C.ErrCodeFailure
 		}
+		return C.ErrCodeSuccess
 	}
-	return C.ErrCodeSuccess
+	return C.ErrCodeFailure
 }
 
 //export tdp_sd_write_request
@@ -699,8 +699,9 @@ func (c *Client) sharedDirectoryWriteRequest(req tdp.SharedDirectoryWriteRequest
 			c.cfg.Log.Errorf("failed to send SharedDirectoryWriteRequest: %v", err)
 			return C.ErrCodeFailure
 		}
+		return C.ErrCodeSuccess
 	}
-	return C.ErrCodeSuccess
+	return C.ErrCodeFailure
 }
 
 // Wait blocks until the client disconnects and runs the cleanup.

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -465,6 +465,38 @@ func (c *Client) start() {
 						return
 					}
 				}
+			case tdp.SharedDirectoryReadResponse:
+				if c.cfg.AllowDirectorySharing {
+
+					var readData *C.uint8_t
+
+					if m.ReadDataLength > 0 {
+						readData = (*C.uint8_t)(unsafe.Pointer(&m.ReadData[0]))
+					} else {
+						readData = (*C.uint8_t)(unsafe.Pointer(&m.ReadData))
+					}
+
+					if errCode := C.handle_tdp_sd_read_response(c.rustClient, C.CGOSharedDirectoryReadResponse{
+						completion_id:    C.uint32_t(m.CompletionID),
+						err_code:         m.ErrCode,
+						read_data_length: C.uint32_t(m.ReadDataLength),
+						read_data:        readData,
+					}); errCode != C.ErrCodeSuccess {
+						c.cfg.Log.Errorf("SharedDirectoryReadResponse failed: %v", errCode)
+						return
+					}
+				}
+			case tdp.SharedDirectoryWriteResponse:
+				if c.cfg.AllowDirectorySharing {
+					if errCode := C.handle_tdp_sd_write_response(c.rustClient, C.CGOSharedDirectoryWriteResponse{
+						completion_id: C.uint32_t(m.CompletionID),
+						err_code:      m.ErrCode,
+						bytes_written: C.uint32_t(m.BytesWritten),
+					}); errCode != C.ErrCodeSuccess {
+						c.cfg.Log.Errorf("SharedDirectoryWriteResponse failed: %v", errCode)
+						return
+					}
+				}
 			default:
 				c.cfg.Log.Warningf("Skipping unimplemented TDP message type %T", msg)
 			}
@@ -620,6 +652,51 @@ func (c *Client) sharedDirectoryListRequest(req tdp.SharedDirectoryListRequest) 
 	if c.cfg.AllowDirectorySharing {
 		if err := c.cfg.Conn.OutputMessage(req); err != nil {
 			c.cfg.Log.Errorf("failed to send SharedDirectoryAcknowledge: %v", err)
+			return C.ErrCodeFailure
+		}
+	}
+	return C.ErrCodeSuccess
+}
+
+//export tdp_sd_read_request
+func tdp_sd_read_request(handle C.uintptr_t, req *C.CGOSharedDirectoryReadRequest) C.CGOErrCode {
+	return cgo.Handle(handle).Value().(*Client).sharedDirectoryReadRequest(tdp.SharedDirectoryReadRequest{
+		CompletionID: uint32(req.completion_id),
+		DirectoryID:  uint32(req.directory_id),
+		Path:         C.GoString(req.path),
+		PathLength:   uint32(req.path_length),
+		Offset:       uint64(req.offset),
+		Length:       uint32(req.length),
+	})
+}
+
+func (c *Client) sharedDirectoryReadRequest(req tdp.SharedDirectoryReadRequest) C.CGOErrCode {
+	if c.cfg.AllowDirectorySharing {
+		if err := c.cfg.Conn.OutputMessage(req); err != nil {
+			c.cfg.Log.Errorf("failed to send SharedDirectoryReadRequest: %v", err)
+			return C.ErrCodeFailure
+		}
+	}
+	return C.ErrCodeSuccess
+}
+
+//export tdp_sd_write_request
+func tdp_sd_write_request(handle C.uintptr_t, req *C.CGOSharedDirectoryWriteRequest) C.CGOErrCode {
+	return cgo.Handle(handle).Value().(*Client).sharedDirectoryWriteRequest(tdp.SharedDirectoryWriteRequest{
+		CompletionID:    uint32(req.completion_id),
+		DirectoryID:     uint32(req.directory_id),
+		Offset:          uint64(req.offset),
+		PathLength:      uint32(req.path_length),
+		Path:            C.GoString(req.path),
+		WriteDataLength: uint32(req.write_data_length),
+		WriteData:       C.GoBytes(unsafe.Pointer(req.write_data), C.int(req.write_data_length)),
+	})
+}
+
+func (c *Client) sharedDirectoryWriteRequest(req tdp.SharedDirectoryWriteRequest) C.CGOErrCode {
+	if c.cfg.AllowDirectorySharing {
+		if err := c.cfg.Conn.OutputMessage(req); err != nil {
+			c.cfg.Log.Errorf("failed to send SharedDirectoryWriteRequest: %v", err)
 			return C.ErrCodeFailure
 		}
 	}

--- a/lib/srv/desktop/rdp/rdpclient/librdprs.h
+++ b/lib/srv/desktop/rdp/rdpclient/librdprs.h
@@ -128,6 +128,21 @@ typedef struct CGOSharedDirectoryListResponse {
   struct CGOFileSystemObject *fso_list;
 } CGOSharedDirectoryListResponse;
 
+typedef struct CGOSharedDirectoryReadResponse {
+  uint32_t completion_id;
+  enum TdpErrCode err_code;
+  uint32_t read_data_length;
+  uint8_t *read_data;
+} CGOSharedDirectoryReadResponse;
+
+typedef struct SharedDirectoryWriteResponse {
+  uint32_t completion_id;
+  enum TdpErrCode err_code;
+  uint32_t bytes_written;
+} SharedDirectoryWriteResponse;
+
+typedef struct SharedDirectoryWriteResponse CGOSharedDirectoryWriteResponse;
+
 /**
  * CGOMousePointerEvent is a CGO-compatible version of PointerEvent that we pass back to Go.
  * PointerEvent is a mouse move or click update from the user.
@@ -190,6 +205,25 @@ typedef struct CGOSharedDirectoryCreateRequest {
 typedef struct CGOSharedDirectoryInfoRequest CGOSharedDirectoryDeleteRequest;
 
 typedef struct CGOSharedDirectoryInfoRequest CGOSharedDirectoryListRequest;
+
+typedef struct CGOSharedDirectoryReadRequest {
+  uint32_t completion_id;
+  uint32_t directory_id;
+  uint32_t path_length;
+  const char *path;
+  uint64_t offset;
+  uint32_t length;
+} CGOSharedDirectoryReadRequest;
+
+typedef struct CGOSharedDirectoryWriteRequest {
+  uint32_t completion_id;
+  uint32_t directory_id;
+  uint64_t offset;
+  uint32_t path_length;
+  const char *path;
+  uint32_t write_data_length;
+  uint8_t *write_data;
+} CGOSharedDirectoryWriteRequest;
 
 void init(void);
 
@@ -316,6 +350,28 @@ enum CGOErrCode handle_tdp_sd_list_response(struct Client *client_ptr,
                                             struct CGOSharedDirectoryListResponse res);
 
 /**
+ * handle_tdp_sd_read_response handles a TDP Shared Directory Read Response
+ * message
+ *
+ * # Safety
+ *
+ * client_ptr must be a valid pointer
+ */
+enum CGOErrCode handle_tdp_sd_read_response(struct Client *client_ptr,
+                                            struct CGOSharedDirectoryReadResponse res);
+
+/**
+ * handle_tdp_sd_write_response handles a TDP Shared Directory Write Response
+ * message
+ *
+ * # Safety
+ *
+ * client_ptr must be a valid pointer
+ */
+enum CGOErrCode handle_tdp_sd_write_response(struct Client *client_ptr,
+                                             CGOSharedDirectoryWriteResponse res);
+
+/**
  * `read_rdp_output` reads incoming RDP bitmap frames from client at client_ref and forwards them to
  * handle_bitmap.
  *
@@ -378,3 +434,9 @@ extern enum CGOErrCode tdp_sd_delete_request(uintptr_t client_ref,
 
 extern enum CGOErrCode tdp_sd_list_request(uintptr_t client_ref,
                                            CGOSharedDirectoryListRequest *req);
+
+extern enum CGOErrCode tdp_sd_read_request(uintptr_t client_ref,
+                                           struct CGOSharedDirectoryReadRequest *req);
+
+extern enum CGOErrCode tdp_sd_write_request(uintptr_t client_ref,
+                                            struct CGOSharedDirectoryWriteRequest *req);

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -406,7 +406,7 @@ fn connect_rdp_inner(
                             completion_id: req.completion_id,
                             directory_id: req.directory_id,
                             path: c_string.as_ptr(),
-                            path_length: req.path_length,
+                            path_length: req.path.len() as u32,
                             offset: req.offset,
                             length: req.length,
                         },
@@ -441,15 +441,15 @@ fn connect_rdp_inner(
                             directory_id: req.directory_id,
                             offset: req.offset,
                             path: c_string.as_ptr(),
-                            path_length: req.path_length,
-                            write_data_length: req.write_data_length,
-                            write_data: req.write_data,
+                            path_length: req.path.len() as u32,
+                            write_data_length: req.write_data.len() as u32,
+                            write_data: req.write_data.as_ptr() as *mut u8,
                         },
                     );
 
                     if err != CGOErrCode::ErrCodeSuccess {
                         return Err(RdpError::TryError(String::from(
-                            "call to tdp_sd_read_request failed",
+                            "call to tdp_sd_write_failed",
                         )));
                     }
                 }
@@ -1346,11 +1346,8 @@ pub struct SharedDirectoryWriteRequest {
     completion_id: u32,
     directory_id: u32,
     offset: u64,
-    path_length: u32,
     path: String,
-    // write_data: Vec<u8>,
-    write_data_length: u32,
-    write_data: *mut u8,
+    write_data: Vec<u8>,
 }
 
 #[derive(Debug)]
@@ -1370,7 +1367,6 @@ pub struct SharedDirectoryReadRequest {
     completion_id: u32,
     directory_id: u32,
     path: String,
-    path_length: u32,
     offset: u64,
     length: u32,
 }

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -395,6 +395,75 @@ fn connect_rdp_inner(
         }
     });
 
+    let tdp_sd_read_request = Box::new(move |req: SharedDirectoryReadRequest| -> RdpResult<()> {
+        debug!("sending: {:?}", req);
+        match CString::new(req.path.clone()) {
+            Ok(c_string) => {
+                unsafe {
+                    let err = tdp_sd_read_request(
+                        go_ref,
+                        &mut CGOSharedDirectoryReadRequest {
+                            completion_id: req.completion_id,
+                            directory_id: req.directory_id,
+                            path: c_string.as_ptr(),
+                            path_length: req.path_length,
+                            offset: req.offset,
+                            length: req.length,
+                        },
+                    );
+
+                    if err != CGOErrCode::ErrCodeSuccess {
+                        return Err(RdpError::TryError(String::from(
+                            "call to tdp_sd_read_request failed",
+                        )));
+                    }
+                }
+                Ok(())
+            }
+            Err(_) => {
+                return Err(RdpError::TryError(format!(
+                    "path contained characters that couldn't be converted to a C string: {}",
+                    req.path
+                )));
+            }
+        }
+    });
+
+    let tdp_sd_write_request = Box::new(move |req: SharedDirectoryWriteRequest| -> RdpResult<()> {
+        debug!("sending: {:?}", req);
+        match CString::new(req.path.clone()) {
+            Ok(c_string) => {
+                unsafe {
+                    let err = tdp_sd_write_request(
+                        go_ref,
+                        &mut CGOSharedDirectoryWriteRequest {
+                            completion_id: req.completion_id,
+                            directory_id: req.directory_id,
+                            offset: req.offset,
+                            path: c_string.as_ptr(),
+                            path_length: req.path_length,
+                            write_data_length: req.write_data_length,
+                            write_data: req.write_data,
+                        },
+                    );
+
+                    if err != CGOErrCode::ErrCodeSuccess {
+                        return Err(RdpError::TryError(String::from(
+                            "call to tdp_sd_read_request failed",
+                        )));
+                    }
+                }
+                Ok(())
+            }
+            Err(_) => {
+                return Err(RdpError::TryError(format!(
+                    "path contained characters that couldn't be converted to a C string: {}",
+                    req.path
+                )));
+            }
+        }
+    });
+
     // Client for the "rdpdr" channel - smartcard emulation and drive redirection.
     let rdpdr = rdpdr::Client::new(rdpdr::Config {
         cert_der: params.cert_der,
@@ -406,6 +475,8 @@ fn connect_rdp_inner(
         tdp_sd_create_request,
         tdp_sd_delete_request,
         tdp_sd_list_request,
+        tdp_sd_read_request,
+        tdp_sd_write_request,
     });
 
     // Client for the "cliprdr" channel - clipboard sharing.
@@ -515,6 +586,20 @@ impl<S: Read + Write> RdpClient<S> {
         res: SharedDirectoryListResponse,
     ) -> RdpResult<()> {
         self.rdpdr.handle_tdp_sd_list_response(res, &mut self.mcs)
+    }
+
+    pub fn handle_tdp_sd_read_response(
+        &mut self,
+        res: SharedDirectoryReadResponse,
+    ) -> RdpResult<()> {
+        self.rdpdr.handle_tdp_sd_read_response(res, &mut self.mcs)
+    }
+
+    pub fn handle_tdp_sd_write_response(
+        &mut self,
+        res: SharedDirectoryWriteResponse,
+    ) -> RdpResult<()> {
+        self.rdpdr.handle_tdp_sd_write_response(res, &mut self.mcs)
     }
 
     pub fn shutdown(&mut self) -> RdpResult<()> {
@@ -809,6 +894,63 @@ pub unsafe extern "C" fn handle_tdp_sd_list_response(
         Ok(()) => CGOErrCode::ErrCodeSuccess,
         Err(e) => {
             error!("failed to handle Shared Directory Create Response: {:?}", e);
+            CGOErrCode::ErrCodeFailure
+        }
+    }
+}
+
+/// handle_tdp_sd_read_response handles a TDP Shared Directory Read Response
+/// message
+///
+/// # Safety
+///
+/// client_ptr must be a valid pointer
+#[no_mangle]
+pub unsafe extern "C" fn handle_tdp_sd_read_response(
+    client_ptr: *mut Client,
+    res: CGOSharedDirectoryReadResponse,
+) -> CGOErrCode {
+    let client = match Client::from_ptr(client_ptr) {
+        Ok(client) => client,
+        Err(cgo_error) => {
+            return cgo_error;
+        }
+    };
+
+    let mut rdp_client = client.rdp_client.lock().unwrap();
+    match rdp_client.handle_tdp_sd_read_response(SharedDirectoryReadResponse::from(res)) {
+        Ok(()) => CGOErrCode::ErrCodeSuccess,
+        Err(e) => {
+            error!("failed to handle Shared Directory Read Response: {:?}", e);
+            CGOErrCode::ErrCodeFailure
+        }
+    }
+}
+
+/// handle_tdp_sd_write_response handles a TDP Shared Directory Write Response
+/// message
+///
+/// # Safety
+///
+/// client_ptr must be a valid pointer
+#[no_mangle]
+pub unsafe extern "C" fn handle_tdp_sd_write_response(
+    client_ptr: *mut Client,
+    res: CGOSharedDirectoryWriteResponse,
+) -> CGOErrCode {
+    let client = match Client::from_ptr(client_ptr) {
+        Ok(client) => client,
+        Err(cgo_error) => {
+            return cgo_error;
+        }
+    };
+
+    let mut rdp_client = client.rdp_client.lock().unwrap();
+
+    match rdp_client.handle_tdp_sd_write_response(res) {
+        Ok(()) => CGOErrCode::ErrCodeSuccess,
+        Err(e) => {
+            error!("failed to handle Shared Directory Write Response: {:?}", e);
             CGOErrCode::ErrCodeFailure
         }
     }
@@ -1199,6 +1341,89 @@ pub enum TdpErrCode {
     AE = 3,
 }
 
+#[derive(Debug, Clone)]
+pub struct SharedDirectoryWriteRequest {
+    completion_id: u32,
+    directory_id: u32,
+    offset: u64,
+    path_length: u32,
+    path: String,
+    // write_data: Vec<u8>,
+    write_data_length: u32,
+    write_data: *mut u8,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct CGOSharedDirectoryWriteRequest {
+    pub completion_id: u32,
+    pub directory_id: u32,
+    pub offset: u64,
+    pub path_length: u32,
+    pub path: *const c_char,
+    pub write_data_length: u32,
+    pub write_data: *mut u8,
+}
+
+#[derive(Debug)]
+pub struct SharedDirectoryReadRequest {
+    completion_id: u32,
+    directory_id: u32,
+    path: String,
+    path_length: u32,
+    offset: u64,
+    length: u32,
+}
+
+#[repr(C)]
+pub struct CGOSharedDirectoryReadRequest {
+    pub completion_id: u32,
+    pub directory_id: u32,
+    pub path_length: u32,
+    pub path: *const c_char,
+    pub offset: u64,
+    pub length: u32,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct SharedDirectoryReadResponse {
+    pub completion_id: u32,
+    pub err_code: TdpErrCode,
+    pub read_data: Vec<u8>,
+}
+
+impl From<CGOSharedDirectoryReadResponse> for SharedDirectoryReadResponse {
+    fn from(cgo_response: CGOSharedDirectoryReadResponse) -> SharedDirectoryReadResponse {
+        unsafe {
+            SharedDirectoryReadResponse {
+                completion_id: cgo_response.completion_id,
+                err_code: cgo_response.err_code,
+                read_data: from_go_array(cgo_response.read_data, cgo_response.read_data_length),
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct CGOSharedDirectoryReadResponse {
+    pub completion_id: u32,
+    pub err_code: TdpErrCode,
+    pub read_data_length: u32,
+    pub read_data: *mut u8,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct SharedDirectoryWriteResponse {
+    pub completion_id: u32,
+    pub err_code: TdpErrCode,
+    pub bytes_written: u32,
+}
+
+pub type CGOSharedDirectoryWriteResponse = SharedDirectoryWriteResponse;
+
 #[derive(Debug)]
 pub struct SharedDirectoryCreateRequest {
     completion_id: u32,
@@ -1287,6 +1512,14 @@ extern "C" {
     fn tdp_sd_list_request(
         client_ref: usize,
         req: *mut CGOSharedDirectoryListRequest,
+    ) -> CGOErrCode;
+    fn tdp_sd_read_request(
+        client_ref: usize,
+        req: *mut CGOSharedDirectoryReadRequest,
+    ) -> CGOErrCode;
+    fn tdp_sd_write_request(
+        client_ref: usize,
+        req: *mut CGOSharedDirectoryWriteRequest,
     ) -> CGOErrCode;
 }
 

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/consts.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/consts.rs
@@ -14,6 +14,8 @@
 
 pub const CHANNEL_NAME: &str = "rdpdr";
 
+pub const DIRECTORY_SHARE_CLIENT_NAME: &str = "teleport";
+
 // Each redirected device requires a unique ID.
 pub const SCARD_DEVICE_ID: u32 = 1;
 

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/mod.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/mod.rs
@@ -48,6 +48,8 @@ use std::io::{Read, Seek, SeekFrom, Write};
 
 pub use consts::CHANNEL_NAME;
 
+use std::ffi::CString;
+
 /// Client implements a device redirection (RDPDR) client, as defined in
 /// https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-RDPEFS/%5bMS-RDPEFS%5d.pdf
 ///
@@ -141,17 +143,7 @@ impl Client {
             }
             let responses = match header.packet_id {
                 PacketId::PAKID_CORE_SERVER_ANNOUNCE => {
-                    let client_name_request = ClientNameRequest::new(
-                        ClientNameRequestUnicodeFlag::Ascii,
-                        DIRECTORY_SHARE_CLIENT_NAME.to_string(),
-                    );
-                    let mut client_name_response = self.add_headers_and_chunkify(
-                        PacketId::PAKID_CORE_CLIENT_NAME,
-                        client_name_request.encode()?,
-                    )?;
-                    let mut resp = self.handle_server_announce(&mut payload)?;
-                    resp.append(&mut client_name_response);
-                    resp
+                    self.handle_server_announce(&mut payload)?
                 }
                 PacketId::PAKID_CORE_SERVER_CAPABILITY => {
                     self.handle_server_capability(&mut payload)?
@@ -189,8 +181,20 @@ impl Client {
 
         let resp = ClientAnnounceReply::new(req);
         debug!("sending RDP {:?}", resp);
-        let resp =
+
+        let mut resp =
             self.add_headers_and_chunkify(PacketId::PAKID_CORE_CLIENTID_CONFIRM, resp.encode()?)?;
+
+        let client_name_request = ClientNameRequest::new(
+            ClientNameRequestUnicodeFlag::Ascii,
+            CString::new(DIRECTORY_SHARE_CLIENT_NAME.to_string()).unwrap(),
+        );
+
+        let mut client_name_response = self.add_headers_and_chunkify(
+            PacketId::PAKID_CORE_CLIENT_NAME,
+            client_name_request.encode()?,
+        )?;
+        resp.append(&mut client_name_response);
 
         Ok(resp)
     }
@@ -702,8 +706,17 @@ impl Client {
                         buffer,
                     )
                 }
+                FileSystemInformationClassLevel::FileFsAttributeInformation => {
+                    let buffer = Some(FileSystemInformationClass::FileFsAttributeInformation(
+                        FileFsAttributeInformation::new(),
+                    ));
+                    self.prep_query_vol_info_response(
+                        &rdp_req.device_io_request,
+                        NTSTATUS::STATUS_SUCCESS,
+                        buffer,
+                    )
+                }
                 FileSystemInformationClassLevel::FileFsSizeInformation
-                | FileSystemInformationClassLevel::FileFsAttributeInformation
                 | FileSystemInformationClassLevel::FileFsFullSizeInformation
                 | FileSystemInformationClassLevel::FileFsDeviceInformation => {
                     return Err(not_implemented_error(&format!(
@@ -736,12 +749,7 @@ impl Client {
         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L268
         let rdp_req = DeviceReadRequest::decode(device_io_request, payload)?;
         debug!("received RDP: {:?}", rdp_req);
-
-        if let Some(file) = self.file_cache.remove(rdp_req.device_io_request.file_id) {
-            self.tdp_sd_read(rdp_req, file)
-        } else {
-            self.prep_read_response(rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL, vec![])
-        }
+        self.tdp_sd_read(rdp_req)
     }
 
     fn process_irp_write(
@@ -751,12 +759,7 @@ impl Client {
     ) -> RdpResult<Vec<Vec<u8>>> {
         let rdp_req = DeviceWriteRequest::decode(device_io_request, payload)?;
         debug!("received RDP: {:?}", rdp_req);
-
-        if let Some(file) = self.file_cache.remove(rdp_req.device_io_request.file_id) {
-            self.tdp_sd_write(rdp_req, file)
-        } else {
-            self.prep_write_response(rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL, 0)
-        }
+        self.tdp_sd_write(rdp_req)
     }
 
     fn process_irp_set_information(
@@ -766,9 +769,22 @@ impl Client {
     ) -> RdpResult<Vec<Vec<u8>>> {
         let rdp_req = ServerDriveSetInformationRequest::decode(device_io_request, payload)?;
 
-        // TODO(LKozlowski): handle it?
-        let resp = ClientDriveSetInformationResponse::new(&rdp_req, NTSTATUS::STATUS_SUCCESS);
-        debug!("replying with: {:?}", resp);
+        let resp = match rdp_req.file_information_class_level {
+            FileInformationClassLevel::FileBasicInformation
+            | FileInformationClassLevel::FileEndOfFileInformation
+            | FileInformationClassLevel::FileAllocationInformation
+            | FileInformationClassLevel::FileDispositionInformation => {
+                ClientDriveSetInformationResponse::new(&rdp_req, NTSTATUS::STATUS_SUCCESS)
+            }
+            _ => {
+                return Err(not_implemented_error(&format!(
+                    "support for ServerDriveSetInformationRequest with fs_info_class_lvl = {:?} is not implemented",
+                    rdp_req.file_information_class_level
+                )));
+            }
+        };
+
+        debug!("sending RDP: {:?}", resp);
         let resp = self
             .add_headers_and_chunkify(PacketId::PAKID_CORE_DEVICE_IOCOMPLETION, resp.encode()?)?;
         Ok(resp)
@@ -968,7 +984,7 @@ impl Client {
         io_status: NTSTATUS,
     ) -> RdpResult<Vec<Vec<u8>>> {
         let resp = DeviceCloseResponse::new(req, io_status);
-        debug!("replying with: {:?}", resp);
+        debug!("sending RDP: {:?}", resp);
         let resp = self
             .add_headers_and_chunkify(PacketId::PAKID_CORE_DEVICE_IOCOMPLETION, resp.encode()?)?;
         Ok(resp)
@@ -1094,7 +1110,7 @@ impl Client {
         data: Vec<u8>,
     ) -> RdpResult<Vec<Vec<u8>>> {
         let resp = DeviceReadResponse::new(&req, io_status, data);
-        debug!("replying with: {:?}", resp);
+        debug!("sending RDP: {:?}", resp);
         let resp = self
             .add_headers_and_chunkify(PacketId::PAKID_CORE_DEVICE_IOCOMPLETION, resp.encode()?)?;
         Ok(resp)
@@ -1102,12 +1118,12 @@ impl Client {
 
     fn prep_write_response(
         &self,
-        req: DeviceWriteRequest,
+        req: DeviceIoRequest,
         io_status: NTSTATUS,
         length: u32,
     ) -> RdpResult<Vec<Vec<u8>>> {
         let resp = DeviceWriteResponse::new(&req, io_status, length);
-        debug!("replying with: {:?}", resp);
+        debug!("sending RDP: {:?}", resp);
         let resp = self
             .add_headers_and_chunkify(PacketId::PAKID_CORE_DEVICE_IOCOMPLETION, resp.encode()?)?;
         Ok(resp)
@@ -1204,78 +1220,83 @@ impl Client {
         Ok(vec![])
     }
 
-    fn tdp_sd_read(
-        &mut self,
-        rdp_req: DeviceReadRequest,
-        file: FileCacheObject,
-    ) -> RdpResult<Vec<Vec<u8>>> {
-        let path_length = file.path.len() as u32;
+    fn tdp_sd_read(&mut self, rdp_req: DeviceReadRequest) -> RdpResult<Vec<Vec<u8>>> {
+        if let Some(file) = self.file_cache.get(rdp_req.device_io_request.file_id) {
+            let tdp_req = SharedDirectoryReadRequest {
+                completion_id: rdp_req.device_io_request.completion_id,
+                directory_id: rdp_req.device_io_request.device_id,
+                path: file.path.clone(),
+                length: rdp_req.length,
+                offset: rdp_req.offset,
+            };
+            (self.tdp_sd_read_request)(tdp_req)?;
 
-        let tdp_req = SharedDirectoryReadRequest {
-            completion_id: rdp_req.device_io_request.completion_id,
-            directory_id: rdp_req.device_io_request.device_id,
-            path: file.path,
-            path_length,
-            length: rdp_req.length,
-            offset: rdp_req.offset,
-        };
-        (self.tdp_sd_read_request)(tdp_req)?;
-
-        self.pending_sd_read_resp_handlers.insert(
-            rdp_req.device_io_request.completion_id,
-            Box::new(
-                move |cli: &mut Self,
-                      res: SharedDirectoryReadResponse|
-                      -> RdpResult<Vec<Vec<u8>>> {
-                    match res.err_code {
-                        TdpErrCode::Nil => {
-                            cli.prep_read_response(rdp_req, NTSTATUS::STATUS_SUCCESS, res.read_data)
+            self.pending_sd_read_resp_handlers.insert(
+                rdp_req.device_io_request.completion_id,
+                Box::new(
+                    move |cli: &mut Self,
+                          res: SharedDirectoryReadResponse|
+                          -> RdpResult<Vec<Vec<u8>>> {
+                        match res.err_code {
+                            TdpErrCode::Nil => cli.prep_read_response(
+                                rdp_req,
+                                NTSTATUS::STATUS_SUCCESS,
+                                res.read_data,
+                            ),
+                            _ => cli.prep_read_response(
+                                rdp_req,
+                                NTSTATUS::STATUS_UNSUCCESSFUL,
+                                vec![],
+                            ),
                         }
-                        _ => cli.prep_read_response(rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL, vec![]),
-                    }
-                },
-            ),
-        );
+                    },
+                ),
+            );
 
-        Ok(vec![])
+            Ok(vec![])
+        } else {
+            self.prep_read_response(rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL, vec![])
+        }
     }
 
-    fn tdp_sd_write(
-        &mut self,
-        rdp_req: DeviceWriteRequest,
-        file: FileCacheObject,
-    ) -> RdpResult<Vec<Vec<u8>>> {
-        let path_length = file.path.len() as u32;
-        let tdp_req = SharedDirectoryWriteRequest {
-            completion_id: rdp_req.device_io_request.completion_id,
-            directory_id: rdp_req.device_io_request.device_id,
-            path: file.path,
-            path_length,
-            offset: rdp_req.offset,
-            write_data_length: rdp_req.write_data.len() as u32,
-            write_data: rdp_req.write_data.as_ptr() as _,
-        };
-        (self.tdp_sd_write_request)(tdp_req)?;
+    fn tdp_sd_write(&mut self, rdp_req: DeviceWriteRequest) -> RdpResult<Vec<Vec<u8>>> {
+        if let Some(file) = self.file_cache.get(rdp_req.device_io_request.file_id) {
+            let tdp_req = SharedDirectoryWriteRequest {
+                completion_id: rdp_req.device_io_request.completion_id,
+                directory_id: rdp_req.device_io_request.device_id,
+                path: file.path.clone(),
+                offset: rdp_req.offset,
+                write_data: rdp_req.write_data,
+            };
+            (self.tdp_sd_write_request)(tdp_req)?;
 
-        self.pending_sd_write_resp_handlers.insert(
-            rdp_req.device_io_request.completion_id,
-            Box::new(
-                move |cli: &mut Self,
-                      res: SharedDirectoryWriteResponse|
-                      -> RdpResult<Vec<Vec<u8>>> {
-                    match res.err_code {
-                        TdpErrCode::Nil => cli.prep_write_response(
-                            rdp_req,
-                            NTSTATUS::STATUS_SUCCESS,
-                            res.bytes_written,
-                        ),
-                        _ => cli.prep_write_response(rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL, 0),
-                    }
-                },
-            ),
-        );
+            let device_io_request = rdp_req.device_io_request;
+            self.pending_sd_write_resp_handlers.insert(
+                device_io_request.completion_id,
+                Box::new(
+                    move |cli: &mut Self,
+                          res: SharedDirectoryWriteResponse|
+                          -> RdpResult<Vec<Vec<u8>>> {
+                        match res.err_code {
+                            TdpErrCode::Nil => cli.prep_write_response(
+                                device_io_request,
+                                NTSTATUS::STATUS_SUCCESS,
+                                res.bytes_written,
+                            ),
+                            _ => cli.prep_write_response(
+                                device_io_request,
+                                NTSTATUS::STATUS_UNSUCCESSFUL,
+                                0,
+                            ),
+                        }
+                    },
+                ),
+            );
 
-        Ok(vec![])
+            Ok(vec![])
+        } else {
+            self.prep_write_response(rdp_req.device_io_request, NTSTATUS::STATUS_UNSUCCESSFUL, 0)
+        }
     }
 
     /// add_headers_and_chunkify takes an encoded PDU ready to be sent over a virtual channel (payload),
@@ -1841,11 +1862,11 @@ enum ClientNameRequestUnicodeFlag {
 #[allow(dead_code)]
 pub struct ClientNameRequest {
     unicode_flag: ClientNameRequestUnicodeFlag,
-    computer_name: String,
+    computer_name: CString,
 }
 
 impl ClientNameRequest {
-    fn new(unicode_flag: ClientNameRequestUnicodeFlag, computer_name: String) -> Self {
+    fn new(unicode_flag: ClientNameRequestUnicodeFlag, computer_name: CString) -> Self {
         Self {
             unicode_flag,
             computer_name,
@@ -1859,11 +1880,16 @@ impl ClientNameRequest {
         w.write_u32::<LittleEndian>(0x0)?;
 
         let computer_name_data = match self.unicode_flag {
-            ClientNameRequestUnicodeFlag::Ascii => self.computer_name.as_bytes().to_vec(),
-            ClientNameRequestUnicodeFlag::Unicode => util::to_utf8(&self.computer_name),
+            ClientNameRequestUnicodeFlag::Ascii => self.computer_name.to_bytes_with_nul().to_vec(),
+            ClientNameRequestUnicodeFlag::Unicode => util::to_unicode(
+                self.computer_name
+                    .as_c_str()
+                    .to_str()
+                    .map_err(|err| RdpError::TryError(err.to_string()))?,
+                true,
+            ),
         };
 
-        // let computer_name_data = util::to_utf8(&self.computer_name);
         w.write_u32::<LittleEndian>(computer_name_data.len() as u32)?;
         w.extend_from_slice(&computer_name_data);
         Ok(w)
@@ -2195,6 +2221,10 @@ enum FileInformationClass {
     FileBothDirectoryInformation(FileBothDirectoryInformation),
     FileAttributeTagInformation(FileAttributeTagInformation),
     FileFullDirectoryInformation(FileFullDirectoryInformation),
+    FileEndOfFileInformation(FileEndOfFileInformation),
+    FileDispositionInformation(FileDispositionInformation),
+    FileRenameInformation(FileRenameInformation),
+    FileAllocationInformation(FileAllocationInformation),
 }
 
 #[allow(dead_code)]
@@ -2206,6 +2236,61 @@ impl FileInformationClass {
             Self::FileBothDirectoryInformation(file_info_class) => file_info_class.encode(),
             Self::FileAttributeTagInformation(file_info_class) => file_info_class.encode(),
             Self::FileFullDirectoryInformation(file_info_class) => file_info_class.encode(),
+            Self::FileEndOfFileInformation(file_info_class) => file_info_class.encode(),
+            Self::FileDispositionInformation(file_info_class) => file_info_class.encode(),
+            Self::FileRenameInformation(file_info_class) => file_info_class.encode(),
+            Self::FileAllocationInformation(file_info_class) => file_info_class.encode(),
+        }
+    }
+
+    fn decode(
+        file_information_class_level: &FileInformationClassLevel,
+        payload: &mut Payload,
+    ) -> RdpResult<Self> {
+        match file_information_class_level {
+            FileInformationClassLevel::FileBasicInformation => Ok(
+                FileInformationClass::FileBasicInformation(FileBasicInformation::decode(payload)?),
+            ),
+            FileInformationClassLevel::FileEndOfFileInformation => {
+                Ok(FileInformationClass::FileEndOfFileInformation(
+                    FileEndOfFileInformation::decode(payload)?,
+                ))
+            }
+            FileInformationClassLevel::FileDispositionInformation => {
+                Ok(FileInformationClass::FileDispositionInformation(
+                    FileDispositionInformation::decode(payload)?,
+                ))
+            }
+            FileInformationClassLevel::FileRenameInformation => {
+                Ok(FileInformationClass::FileRenameInformation(
+                    FileRenameInformation::decode(payload)?,
+                ))
+            }
+            FileInformationClassLevel::FileAllocationInformation => {
+                Ok(FileInformationClass::FileAllocationInformation(
+                    FileAllocationInformation::decode(payload)?,
+                ))
+            }
+            _ => {
+                return Err(invalid_data_error(&format!(
+                    "decode invalid FileInformationClassLevel: {:?}",
+                    file_information_class_level
+                )))
+            }
+        }
+    }
+
+    fn size(&self) -> u32 {
+        match self {
+            Self::FileBasicInformation(file_info_class) => file_info_class.size(),
+            Self::FileStandardInformation(file_info_class) => file_info_class.size(),
+            Self::FileBothDirectoryInformation(file_info_class) => file_info_class.size(),
+            Self::FileAttributeTagInformation(file_info_class) => file_info_class.size(),
+            Self::FileFullDirectoryInformation(file_info_class) => file_info_class.size(),
+            Self::FileEndOfFileInformation(file_info_class) => file_info_class.size(),
+            Self::FileDispositionInformation(file_info_class) => file_info_class.size(),
+            Self::FileRenameInformation(file_info_class) => file_info_class.size(),
+            Self::FileAllocationInformation(file_info_class) => file_info_class.size(),
         }
     }
 }
@@ -2229,6 +2314,8 @@ struct FileBasicInformation {
 const FILE_BASIC_INFORMATION_SIZE: u32 = (4 * 8) + 4;
 
 impl FileBasicInformation {
+    const BASE_SIZE: u32 = (4 * 8) + 4;
+
     fn encode(&self) -> RdpResult<Vec<u8>> {
         let mut w = vec![];
         w.write_i64::<LittleEndian>(self.creation_time)?;
@@ -2237,6 +2324,27 @@ impl FileBasicInformation {
         w.write_i64::<LittleEndian>(self.change_time)?;
         w.write_u32::<LittleEndian>(self.file_attributes.bits())?;
         Ok(w)
+    }
+
+    fn decode(payload: &mut Payload) -> RdpResult<Self> {
+        let creation_time = payload.read_i64::<LittleEndian>()?;
+        let last_access_time = payload.read_i64::<LittleEndian>()?;
+        let last_write_time = payload.read_i64::<LittleEndian>()?;
+        let change_time = payload.read_i64::<LittleEndian>()?;
+        let file_attributes = flags::FileAttributes::from_bits(payload.read_u32::<LittleEndian>()?)
+            .ok_or_else(|| invalid_data_error("invalid flags in FileBasicInformation decode"))?;
+
+        Ok(Self {
+            creation_time,
+            last_access_time,
+            last_write_time,
+            change_time,
+            file_attributes,
+        })
+    }
+
+    fn size(&self) -> u32 {
+        Self::BASE_SIZE
     }
 }
 
@@ -2275,6 +2383,8 @@ struct FileStandardInformation {
 }
 
 impl FileStandardInformation {
+    const BASE_SIZE: u32 = (2 * 8) + 4 + 2;
+
     fn encode(&self) -> RdpResult<Vec<u8>> {
         let mut w = vec![];
         w.write_i64::<LittleEndian>(self.allocation_size)?;
@@ -2283,6 +2393,10 @@ impl FileStandardInformation {
         w.write_u8(Boolean::to_u8(&self.delete_pending).unwrap())?;
         w.write_u8(Boolean::to_u8(&self.directory).unwrap())?;
         Ok(w)
+    }
+
+    fn size(&self) -> u32 {
+        Self::BASE_SIZE
     }
 }
 
@@ -2298,11 +2412,18 @@ struct FileAttributeTagInformation {
 }
 
 impl FileAttributeTagInformation {
+    // 2 i64's + 1 u32 + 2 Boolean (u8) = (2 * 8) + 4 + 2
+    const BASE_SIZE: u32 = (2 * 8) + 4 + 2;
+
     fn encode(&self) -> RdpResult<Vec<u8>> {
         let mut w = vec![];
         w.write_u32::<LittleEndian>(self.file_attributes.bits())?;
         w.write_u32::<LittleEndian>(self.reparse_tag)?;
         Ok(w)
+    }
+
+    fn size(&self) -> u32 {
+        Self::BASE_SIZE
     }
 }
 
@@ -2311,7 +2432,7 @@ const FILE_ATTRIBUTE_TAG_INFO_SIZE: u32 = 8;
 
 /// 2.1.8 Boolean
 /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/8ce7b38c-d3cc-415d-ab39-944000ea77ff
-#[derive(Debug, ToPrimitive)]
+#[derive(Debug, FromPrimitive, ToPrimitive)]
 #[repr(u8)]
 enum Boolean {
     True = 1,
@@ -2340,13 +2461,13 @@ struct FileBothDirectoryInformation {
     file_name: String,
 }
 
-/// Base size of the FileBothDirectoryInformation, not accounting for variably sized file_name.
-/// Note that file_name's size should be calculated as if it were a Unicode string.
-/// 5 u32's (including FileAttributesFlags) + 6 i64's + 1 i8 + 24 bytes
-const FILE_BOTH_DIRECTORY_INFORMATION_BASE_SIZE: u32 = (5 * 4) + (6 * 8) + 1 + 24; // 93
-
 #[allow(dead_code)]
 impl FileBothDirectoryInformation {
+    /// Base size of the FileBothDirectoryInformation, not accounting for variably sized file_name.
+    /// Note that file_name's size should be calculated as if it were a Unicode string.
+    /// 5 u32's (including FileAttributesFlags) + 6 i64's + 1 i8 + 24 bytes
+    const BASE_SIZE: u32 = (5 * 4) + (6 * 8) + 1 + 24; // 93
+
     fn new(
         creation_time: i64,
         last_access_time: i64,
@@ -2414,12 +2535,11 @@ impl FileBothDirectoryInformation {
             fso.name()?,
         ))
     }
-}
 
-/// Base size of the FileFullDirectoryInformation, not accounting for variably sized file_name.
-/// Note that file_name's size should be calculated as if it were a Unicode string.
-/// 4 u32's (including FileAttributesFlags) + 6 i64's
-const FILE_FULL_DIRECTORY_INFORMATION_BASE_SIZE: u32 = (5 * 4) + (6 * 8); // 68
+    fn size(&self) -> u32 {
+        Self::BASE_SIZE + self.file_name_length
+    }
+}
 
 /// 2.4.14 FileFullDirectoryInformation
 /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/e8d926d1-3a22-4654-be9c-58317a85540b
@@ -2440,6 +2560,11 @@ struct FileFullDirectoryInformation {
 }
 
 impl FileFullDirectoryInformation {
+    /// Base size of the FileFullDirectoryInformation, not accounting for variably sized file_name.
+    /// Note that file_name's size should be calculated as if it were a Unicode string.
+    /// 4 u32's (including FileAttributesFlags) + 6 i64's
+    const BASE_SIZE: u32 = (5 * 4) + (6 * 8); // 68
+
     fn new(
         creation_time: i64,
         last_access_time: i64,
@@ -2501,6 +2626,134 @@ impl FileFullDirectoryInformation {
             file_attributes,
             fso.name()?,
         ))
+    }
+
+    fn size(&self) -> u32 {
+        Self::BASE_SIZE + self.file_name_length
+    }
+}
+
+// 2.4.13 FileEndOfFileInformation
+// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/75241cca-3167-472f-8058-a52d77c6bb17
+#[derive(Debug)]
+struct FileEndOfFileInformation {
+    end_of_file: i64,
+}
+
+impl FileEndOfFileInformation {
+    const BASE_SIZE: u32 = 4;
+
+    fn encode(&self) -> RdpResult<Vec<u8>> {
+        let mut w = vec![];
+        w.write_i64::<LittleEndian>(self.end_of_file)?;
+        Ok(w)
+    }
+
+    fn decode(payload: &mut Payload) -> RdpResult<Self> {
+        let end_of_file = payload.read_i64::<LittleEndian>()?;
+        Ok(Self { end_of_file })
+    }
+
+    fn size(&self) -> u32 {
+        Self::BASE_SIZE
+    }
+}
+
+// 2.4.11 FileDispositionInformation
+// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/12c3dd1c-14f6-4229-9d29-75fb2cb392f6
+#[derive(Debug)]
+struct FileDispositionInformation {
+    delete_pending: u8,
+}
+
+impl FileDispositionInformation {
+    const BASE_SIZE: u32 = 1;
+
+    fn encode(&self) -> RdpResult<Vec<u8>> {
+        let mut w = vec![];
+        w.write_u8(self.delete_pending)?;
+        Ok(w)
+    }
+
+    fn decode(payload: &mut Payload) -> RdpResult<Self> {
+        let delete_pending = payload.read_u8()?;
+        Ok(Self { delete_pending })
+    }
+
+    fn size(&self) -> u32 {
+        Self::BASE_SIZE
+    }
+}
+
+// 2.4.37 FileRenameInformation
+// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/1d2673a8-8fb9-4868-920a-775ccaa30cf8
+#[derive(Debug)]
+struct FileRenameInformation {
+    replace_if_exists: Boolean,
+    file_name: String,
+}
+
+impl FileRenameInformation {
+    const BASE_SIZE: u32 = 1 + 1 + 4;
+
+    fn encode(&self) -> RdpResult<Vec<u8>> {
+        // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L709
+        // https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/3668ae46-1df5-4656-b481-763877428bcb
+        // This matches the FreeRDP implementation rather than Microsoft specification
+        let mut w = vec![];
+        w.write_u8(Boolean::to_u8(&self.replace_if_exists).unwrap())?;
+        // RootDirectory. For network operations, this value MUST be zero.
+        w.write_u8(0)?;
+        w.write_u32::<LittleEndian>(self.file_name.len() as u32)?;
+        w.extend_from_slice(&util::to_unicode(&self.file_name, false));
+        Ok(w)
+    }
+
+    fn decode(payload: &mut Payload) -> RdpResult<Self> {
+        let replace_if_exists = payload.read_u8()?;
+        // RootDirectory
+        payload.read_u8()?;
+
+        let file_name_length = payload.read_u32::<LittleEndian>()?;
+        let mut file_name = vec![0u8; file_name_length as usize];
+        payload.read_exact(&mut file_name)?;
+        let file_name = util::from_unicode(file_name)?;
+
+        Ok(Self {
+            replace_if_exists: Boolean::from_u8(replace_if_exists).unwrap(),
+            file_name,
+        })
+    }
+
+    fn size(&self) -> u32 {
+        Self::BASE_SIZE + self.file_name.len() as u32
+    }
+}
+
+// 2.4.4 FileAllocationInformation
+// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/0201c69b-50db-412d-bab3-dd97aeede13b
+#[derive(Debug)]
+struct FileAllocationInformation {
+    allocation_size: i64,
+}
+
+impl FileAllocationInformation {
+    const BASE_SIZE: u32 = 4;
+
+    fn encode(&self) -> RdpResult<Vec<u8>> {
+        let mut w = vec![];
+        w.write_i64::<LittleEndian>(self.allocation_size)?;
+        Ok(w)
+    }
+
+    fn decode(payload: &mut Payload) -> RdpResult<Self> {
+        let allocation_size = payload.read_i64::<LittleEndian>()?;
+
+        Ok(Self { allocation_size })
+    }
+
+    fn size(&self) -> u32 {
+        Self::BASE_SIZE
     }
 }
 
@@ -3049,8 +3302,7 @@ pub struct DeviceWriteResponse {
 }
 
 impl DeviceWriteResponse {
-    fn new(device_read_request: &DeviceWriteRequest, io_status: NTSTATUS, length: u32) -> Self {
-        let device_io_request = &device_read_request.device_io_request;
+    fn new(device_io_request: &DeviceIoRequest, io_status: NTSTATUS, length: u32) -> Self {
         Self {
             device_io_reply: DeviceIoResponse::new(
                 device_io_request,
@@ -3087,7 +3339,7 @@ impl ClientDriveSetInformationResponse {
                 &device_read_request.device_io_request,
                 NTSTATUS::to_u32(&io_status).unwrap(),
             ),
-            length: device_read_request.set_buffer.len() as u32,
+            length: device_read_request.set_buffer.size() as u32,
         }
     }
 
@@ -3109,8 +3361,7 @@ struct ServerDriveSetInformationRequest {
     /// The MajorFunction field in the DR_DEVICE_IOREQUEST header MUST be set to IRP_MJ_SET_INFORMATION.
     device_io_request: DeviceIoRequest,
     file_information_class_level: FileInformationClassLevel,
-    /// TODO(LKozlowski): change to enum?
-    set_buffer: Vec<u8>,
+    set_buffer: FileInformationClass,
 }
 
 impl ServerDriveSetInformationRequest {
@@ -3119,29 +3370,28 @@ impl ServerDriveSetInformationRequest {
             FileInformationClassLevel::from_u32(payload.read_u32::<LittleEndian>()?)
                 .ok_or_else(|| invalid_data_error("failed to read FileInformationClassLevel"))?;
 
-        let valid_levels = vec![
-            FileInformationClassLevel::FileBasicInformation,
-            FileInformationClassLevel::FileEndOfFileInformation,
-            FileInformationClassLevel::FileDispositionInformation,
-            FileInformationClassLevel::FileRenameInformation,
-            FileInformationClassLevel::FileAllocationInformation,
-        ];
+        match file_information_class_level {
+            FileInformationClassLevel::FileBasicInformation
+            | FileInformationClassLevel::FileEndOfFileInformation
+            | FileInformationClassLevel::FileDispositionInformation
+            | FileInformationClassLevel::FileRenameInformation
+            | FileInformationClassLevel::FileAllocationInformation => {}
+            _ => {
+                return Err(invalid_data_error(&format!(
+                    "read invalid FileInformationClassLevel: {:?}",
+                    file_information_class_level
+                )))
+            }
+        };
 
-        if !valid_levels.contains(&file_information_class_level) {
-            return Err(invalid_data_error(&format!(
-                "read invalid FileInformationClassLevel: {:?}, expected one of {:?}",
-                file_information_class_level, valid_levels,
-            )));
-        }
-
-        let length = payload.read_u32::<LittleEndian>()?;
+        // length, u32
+        payload.seek(SeekFrom::Current(4))?;
 
         // There is a padding of 24 bytes between offset and write data so we
         // must ignore it
         payload.seek(SeekFrom::Current(24))?;
 
-        let mut set_buffer = vec![0; length as usize];
-        payload.read_exact(&mut set_buffer)?;
+        let set_buffer = FileInformationClass::decode(&file_information_class_level, payload)?;
 
         Ok(Self {
             device_io_request,
@@ -3280,10 +3530,10 @@ impl ClientDriveQueryDirectoryResponse {
         let length = match buffer {
             Some(ref fs_information_class) => match fs_information_class {
                 FileInformationClass::FileBothDirectoryInformation(fs_info_class) => {
-                    FILE_BOTH_DIRECTORY_INFORMATION_BASE_SIZE + fs_info_class.file_name_length
+                    fs_info_class.size()
                 }
                 FileInformationClass::FileFullDirectoryInformation(fs_info_class) => {
-                    FILE_FULL_DIRECTORY_INFORMATION_BASE_SIZE + fs_info_class.file_name_length
+                    fs_info_class.size()
                 }
                 // TODO(isaiah): add support for FileDirectoryInformation and FileNamesInformation
                 // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L794

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/mod.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/mod.rs
@@ -19,13 +19,14 @@ mod scard;
 use crate::errors::{
     invalid_data_error, not_implemented_error, try_error, NTSTATUS_OK, SPECIAL_NO_RESPONSE,
 };
-use crate::util;
 use crate::vchan;
+use crate::util;
 use crate::{
     FileSystemObject, FileType, Payload, SharedDirectoryAcknowledge, SharedDirectoryCreateRequest,
     SharedDirectoryCreateResponse, SharedDirectoryDeleteRequest, SharedDirectoryDeleteResponse,
-    SharedDirectoryInfoRequest, SharedDirectoryInfoResponse, SharedDirectoryListRequest,
-    SharedDirectoryListResponse, TdpErrCode,
+    SharedDirectoryInfoRequest, SharedDirectoryInfoResponse, SharedDirectoryReadRequest, SharedDirectoryReadResponse, SharedDirectoryWriteRequest, SharedDirectoryWriteResponse,
+    SharedDirectoryListRequest, SharedDirectoryListResponse,
+    TdpErrCode,
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -43,7 +44,7 @@ use rdp::model::error::Error as RdpError;
 use rdp::model::error::*;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
-use std::io::{Read, Write};
+use std::io::{Read, Write, Seek, SeekFrom};
 
 pub use consts::CHANNEL_NAME;
 
@@ -67,12 +68,16 @@ pub struct Client {
     tdp_sd_create_request: SharedDirectoryCreateRequestSender,
     tdp_sd_delete_request: SharedDirectoryDeleteRequestSender,
     tdp_sd_list_request: SharedDirectoryListRequestSender,
+    tdp_sd_read_request: SharedDirectoryReadRequestSender,
+    tdp_sd_write_request: SharedDirectoryWriteRequestSender,
 
     // CompletionId-indexed maps of handlers for tdp messages coming from the browser client.
     pending_sd_info_resp_handlers: HashMap<u32, SharedDirectoryInfoResponseHandler>,
     pending_sd_create_resp_handlers: HashMap<u32, SharedDirectoryCreateResponseHandler>,
     pending_sd_delete_resp_handlers: HashMap<u32, SharedDirectoryDeleteResponseHandler>,
     pending_sd_list_resp_handlers: HashMap<u32, SharedDirectoryListResponseHandler>,
+    pending_sd_read_resp_handlers: HashMap<u32, SharedDirectoryReadResponseHandler>,
+    pending_sd_write_resp_handlers: HashMap<u32, SharedDirectoryWriteResponseHandler>,
 }
 
 pub struct Config {
@@ -86,6 +91,8 @@ pub struct Config {
     pub tdp_sd_create_request: SharedDirectoryCreateRequestSender,
     pub tdp_sd_delete_request: SharedDirectoryDeleteRequestSender,
     pub tdp_sd_list_request: SharedDirectoryListRequestSender,
+    pub tdp_sd_read_request: SharedDirectoryReadRequestSender,
+    pub tdp_sd_write_request: SharedDirectoryWriteRequestSender,
 }
 
 impl Client {
@@ -109,11 +116,15 @@ impl Client {
             tdp_sd_create_request: cfg.tdp_sd_create_request,
             tdp_sd_delete_request: cfg.tdp_sd_delete_request,
             tdp_sd_list_request: cfg.tdp_sd_list_request,
+            tdp_sd_read_request: cfg.tdp_sd_read_request,
+            tdp_sd_write_request: cfg.tdp_sd_write_request,
 
             pending_sd_info_resp_handlers: HashMap::new(),
             pending_sd_create_resp_handlers: HashMap::new(),
             pending_sd_delete_resp_handlers: HashMap::new(),
             pending_sd_list_resp_handlers: HashMap::new(),
+            pending_sd_read_resp_handlers: HashMap::new(),
+            pending_sd_write_resp_handlers: HashMap::new(),
         }
     }
     /// Reads raw RDP messages sent on the rdpdr virtual channel and replies as necessary.
@@ -275,6 +286,8 @@ impl Client {
             MajorFunction::IRP_MJ_QUERY_VOLUME_INFORMATION => {
                 self.process_irp_query_volume_information(device_io_request, payload)
             }
+            MajorFunction::IRP_MJ_READ => self.process_irp_read(device_io_request, payload),
+            MajorFunction::IRP_MJ_WRITE => self.process_irp_write(device_io_request, payload),
             _ => Err(invalid_data_error(&format!(
                 // TODO(isaiah): send back a not implemented response(?)
                 "got unsupported major_function in DeviceIoRequest: {:?}",
@@ -702,6 +715,37 @@ impl Client {
         }
     }
 
+    fn process_irp_read(
+        &mut self,
+        device_io_request: DeviceIoRequest,
+        payload: &mut Payload,
+    ) -> RdpResult<Vec<Vec<u8>>> {
+        // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L268
+        let rdp_req = DeviceReadRequest::decode(device_io_request, payload)?;
+        debug!("received RDP: {:?}", rdp_req);
+
+        if let Some(file) = self.file_cache.remove(rdp_req.device_io_request.file_id) {
+            self.tdp_sd_read(rdp_req, file)
+        } else {
+            self.prep_read_response(rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL, vec![])
+        }
+    }
+
+    fn process_irp_write(
+        &mut self,
+        device_io_request: DeviceIoRequest,
+        payload: &mut Payload,
+    ) -> RdpResult<Vec<Vec<u8>>> {
+        let rdp_req = DeviceWriteRequest::decode(device_io_request, payload)?;
+        debug!("received RDP: {:?}", rdp_req);
+
+        if let Some(file) = self.file_cache.remove(rdp_req.device_io_request.file_id) {
+            self.tdp_sd_write(rdp_req, file)
+        } else {
+            self.prep_write_response(rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL, 0)
+        }
+    }
+
     pub fn write_client_device_list_announce<S: Read + Write>(
         &mut self,
         req: ClientDeviceListAnnounce,
@@ -815,6 +859,55 @@ impl Client {
             )));
         }
     }
+
+    pub fn handle_tdp_sd_read_response<S: Read + Write>(
+        &mut self,
+        res: SharedDirectoryReadResponse,
+        mcs: &mut mcs::Client<S>,
+    ) -> RdpResult<()> {
+        debug!("received TDP: {:?}", res);
+        if let Some(tdp_resp_handler) = self
+            .pending_sd_read_resp_handlers
+            .remove(&res.completion_id)
+        {
+            let rdp_responses = tdp_resp_handler(self, res)?;
+            let chan = &CHANNEL_NAME.to_string();
+            for resp in rdp_responses {
+                mcs.write(chan, resp)?;
+            }
+            Ok(())
+        } else {
+            return Err(try_error(&format!(
+                "received invalid completion id: {}",
+                res.completion_id
+            )));
+        }
+    }
+
+    pub fn handle_tdp_sd_write_response<S: Read + Write>(
+        &mut self,
+        res: SharedDirectoryWriteResponse,
+        mcs: &mut mcs::Client<S>,
+    ) -> RdpResult<()> {
+        debug!("received TDP: {:?}", res);
+        if let Some(tdp_resp_handler) = self
+            .pending_sd_write_resp_handlers
+            .remove(&res.completion_id)
+        {
+            let rdp_responses = tdp_resp_handler(self, res)?;
+            let chan = &CHANNEL_NAME.to_string();
+            for resp in rdp_responses {
+                mcs.write(chan, resp)?;
+            }
+            Ok(())
+        } else {
+            return Err(try_error(&format!(
+                "received invalid completion id: {}",
+                res.completion_id
+            )));
+        }
+    }
+
 
     fn prep_device_create_response(
         &mut self,
@@ -967,6 +1060,32 @@ impl Client {
         Ok(resp)
     }
 
+    fn prep_read_response(
+        &self,
+        req: DeviceReadRequest,
+        io_status: NTSTATUS,
+        data: Vec<u8>,
+    ) -> RdpResult<Vec<Vec<u8>>> {
+        let resp = DeviceReadResponse::new(&req, io_status, data);
+        debug!("replying with: {:?}", resp);
+        let resp = self
+            .add_headers_and_chunkify(PacketId::PAKID_CORE_DEVICE_IOCOMPLETION, resp.encode()?)?;
+        Ok(resp)
+    }
+
+    fn prep_write_response(
+        &self,
+        req: DeviceWriteRequest,
+        io_status: NTSTATUS,
+        length: u32,
+    ) -> RdpResult<Vec<Vec<u8>>> {
+        let resp = DeviceWriteResponse::new(&req, io_status, length);
+        debug!("replying with: {:?}", resp);
+        let resp = self
+            .add_headers_and_chunkify(PacketId::PAKID_CORE_DEVICE_IOCOMPLETION, resp.encode()?)?;
+        Ok(resp)
+    }
+
     /// Helper function for sending a TDP SharedDirectoryCreateRequest based on an
     /// RDP DeviceCreateRequest and handling the TDP SharedDirectoryCreateResponse.
     fn tdp_sd_create(
@@ -1055,6 +1174,78 @@ impl Client {
                 },
             ),
         );
+        Ok(vec![])
+    }
+
+    fn tdp_sd_read(
+        &mut self,
+        rdp_req: DeviceReadRequest,
+        file: FileCacheObject,
+    ) -> RdpResult<Vec<Vec<u8>>> {
+        let path_length = file.path.len() as u32;
+
+        let tdp_req = SharedDirectoryReadRequest {
+            completion_id: rdp_req.device_io_request.completion_id,
+            directory_id: rdp_req.device_io_request.device_id,
+            path: file.path,
+            path_length,
+            length: rdp_req.length,
+            offset: rdp_req.offset,
+        };
+        (self.tdp_sd_read_request)(tdp_req)?;
+
+        self.pending_sd_read_resp_handlers.insert(
+            rdp_req.device_io_request.completion_id,
+            Box::new(
+                move |cli: &mut Self,
+                      res: SharedDirectoryReadResponse|
+                      -> RdpResult<Vec<Vec<u8>>> {
+                    match res.err_code {
+                        TdpErrCode::Nil => {
+                            cli.prep_read_response(rdp_req, NTSTATUS::STATUS_SUCCESS, res.read_data)
+                        }
+                        _ => cli.prep_read_response(rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL, vec![]),
+                    }
+                },
+            ),
+        );
+
+        Ok(vec![])
+    }
+
+    fn tdp_sd_write(
+        &mut self,
+        rdp_req: DeviceWriteRequest,
+        file: FileCacheObject,
+    ) -> RdpResult<Vec<Vec<u8>>> {
+        let path_length = file.path.len() as u32;
+        let tdp_req = SharedDirectoryWriteRequest {
+            completion_id: rdp_req.device_io_request.completion_id,
+            directory_id: rdp_req.device_io_request.device_id,
+            path: file.path,
+            path_length,
+            offset: rdp_req.offset,
+            write_data_length: rdp_req.write_data.len() as u32,
+            write_data: rdp_req.write_data.as_ptr() as _,
+        };
+        (self.tdp_sd_write_request)(tdp_req)?;
+
+        self.pending_sd_write_resp_handlers.insert(
+            rdp_req.device_io_request.completion_id,
+            Box::new(
+                move |cli: &mut Self,
+                      res: SharedDirectoryWriteResponse|
+                      -> RdpResult<Vec<Vec<u8>>> {
+                    match res.err_code {
+                        TdpErrCode::Nil => {
+                            cli.prep_write_response(rdp_req, NTSTATUS::STATUS_SUCCESS, res.bytes_written)
+                        }
+                        _ => cli.prep_write_response(rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL, 0),
+                    }
+                },
+            ),
+        );
+
         Ok(vec![])
     }
 
@@ -2675,15 +2866,15 @@ impl ServerDriveNotifyChangeDirectoryRequest {
 
 /// 2.2.1.4.3 Device Read Request (DR_READ_REQ)
 /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/3192516d-36a6-47c5-987a-55c214aa0441
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
-struct DeviceReadRequest {
+pub struct DeviceReadRequest {
     /// The MajorFunction field in this header MUST be set to IRP_MJ_READ.
-    device_io_request: DeviceIoRequest,
+    pub device_io_request: DeviceIoRequest,
     /// This field specifies the maximum number of bytes to be read from the device.
-    length: u32,
+    pub length: u32,
     /// This field specifies the file offset where the read operation is performed.
-    offset: u64,
+    pub offset: u64,
     // Padding (20 bytes):  An array of 20 bytes. Reserved. This field can be set to any value and MUST be ignored.
 }
 
@@ -2738,6 +2929,78 @@ impl DeviceReadResponse {
         Ok(w)
     }
 }
+
+/// 2.2.1.4.4 Device Write Request (DR_WRITE_REQ)
+/// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/2e25f0aa-a4ce-4ff3-ad62-ab6098280a3a
+#[derive(Debug, Clone)]
+pub struct DeviceWriteRequest {
+    /// The MajorFunction field in this header MUST be set to IRP_MJ_WRITE.
+    pub device_io_request: DeviceIoRequest,
+    /// Number of bytes in the write_data field.
+    pub length: u32,
+    /// File offset at which the data must be written.
+    pub offset: u64,
+    /// Data to be written on the target device.
+    pub write_data: Vec<u8>,
+}
+
+impl DeviceWriteRequest {
+    fn decode(device_io_request: DeviceIoRequest, payload: &mut Payload) -> RdpResult<Self> {
+        let length = payload.read_u32::<LittleEndian>()?;
+        let offset = payload.read_u64::<LittleEndian>()?;
+
+        // There is a padding of 20 bytes between offset and write data so we
+        // must ignore it
+        payload.seek(SeekFrom::Current(20))?;
+
+        let mut write_data = vec![0; length as usize];
+        payload.read_exact(&mut write_data)?;
+
+        Ok(Self {
+            device_io_request,
+            length,
+            offset,
+            write_data,
+        })
+    }
+}
+
+/// 2.2.1.5.4 Device Write Response (DR_WRITE_RSP)
+/// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/58160a47-2379-4c4a-a99d-24a1a666c02a
+#[derive(Debug)]
+pub struct DeviceWriteResponse {
+    /// The CompletionId field of this header MUST match a Device I/O Request (section 2.2.1.4) message that had the MajorFunction field set to IRP_MJ_WRITE.
+    device_io_reply: DeviceIoResponse,
+    /// Number of bytes written in response to the write request. 
+    length: u32,
+}
+
+impl DeviceWriteResponse {
+    fn new(
+        device_read_request: &DeviceWriteRequest,
+        io_status: NTSTATUS,
+        length: u32,
+    ) -> Self {
+        let device_io_request = &device_read_request.device_io_request;
+        Self {
+            device_io_reply: DeviceIoResponse::new(
+                device_io_request,
+                NTSTATUS::to_u32(&io_status).unwrap(),
+            ),
+            length,
+        }
+    }
+
+    fn encode(&self) -> RdpResult<Vec<u8>> {
+        let mut w = vec![];
+        w.extend_from_slice(&self.device_io_reply.encode()?);
+        w.write_u32::<LittleEndian>(self.length)?;
+        // 1 byte padding
+        w.write_u32::<LittleEndian>(0)?;
+        Ok(w)
+    }
+}
+
 
 /// 2.2.3.3.10 Server Drive Query Directory Request (DR_DRIVE_QUERY_DIRECTORY_REQ)
 /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/458019d2-5d5a-4fd4-92ef-8c05f8d7acb1
@@ -3057,6 +3320,8 @@ type SharedDirectoryCreateRequestSender =
 type SharedDirectoryDeleteRequestSender =
     Box<dyn Fn(SharedDirectoryDeleteRequest) -> RdpResult<()>>;
 type SharedDirectoryListRequestSender = Box<dyn Fn(SharedDirectoryListRequest) -> RdpResult<()>>;
+type SharedDirectoryReadRequestSender = Box<dyn Fn(SharedDirectoryReadRequest) -> RdpResult<()>>;
+type SharedDirectoryWriteRequestSender = Box<dyn Fn(SharedDirectoryWriteRequest) -> RdpResult<()>>;
 
 type SharedDirectoryInfoResponseHandler =
     Box<dyn FnOnce(&mut Client, SharedDirectoryInfoResponse) -> RdpResult<Vec<Vec<u8>>>>;
@@ -3066,3 +3331,7 @@ type SharedDirectoryDeleteResponseHandler =
     Box<dyn FnOnce(&mut Client, SharedDirectoryDeleteResponse) -> RdpResult<Vec<Vec<u8>>>>;
 type SharedDirectoryListResponseHandler =
     Box<dyn FnOnce(&mut Client, SharedDirectoryListResponse) -> RdpResult<Vec<Vec<u8>>>>;
+type SharedDirectoryReadResponseHandler =
+    Box<dyn FnOnce(&mut Client, SharedDirectoryReadResponse) -> RdpResult<Vec<Vec<u8>>>>;
+type SharedDirectoryWriteResponseHandler =
+    Box<dyn FnOnce(&mut Client, SharedDirectoryWriteResponse) -> RdpResult<Vec<Vec<u8>>>>;

--- a/lib/srv/desktop/tdp/proto.go
+++ b/lib/srv/desktop/tdp/proto.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"image"
 	"image/png"
 	"io"
@@ -65,6 +66,10 @@ const (
 	TypeSharedDirectoryDeleteResponse = MessageType(18)
 	TypeSharedDirectoryListRequest    = MessageType(25)
 	TypeSharedDirectoryListResponse   = MessageType(26)
+	TypeSharedDirectoryReadRequest    = MessageType(19)
+	TypeSharedDirectoryReadResponse   = MessageType(20)
+	TypeSharedDirectoryWriteRequest   = MessageType(21)
+	TypeSharedDirectoryWriteResponse  = MessageType(22)
 )
 
 // Message is a Go representation of a desktop protocol message.
@@ -137,6 +142,14 @@ func decode(in peekReader) (Message, error) {
 		return decodeSharedDirectoryListRequest(in)
 	case TypeSharedDirectoryListResponse:
 		return decodeSharedDirectoryListResponse(in)
+	case TypeSharedDirectoryReadRequest:
+		return decodeSharedDirectoryReadRequest(in)
+	case TypeSharedDirectoryReadResponse:
+		return decodeSharedDirectoryReadResponse(in)
+	case TypeSharedDirectoryWriteRequest:
+		return decodeSharedDirectoryWriteRequest(in)
+	case TypeSharedDirectoryWriteResponse:
+		return decodeSharedDirectoryWriteResponse(in)
 	default:
 		return nil, trace.BadParameter("unsupported desktop protocol message type %d", t)
 	}
@@ -1100,6 +1113,252 @@ func decodeSharedDirectoryListResponse(in peekReader) (SharedDirectoryListRespon
 		ErrCode:      errCode,
 		FsoList:      fsoList,
 	}, nil
+}
+
+type SharedDirectoryReadRequest struct {
+	CompletionID uint32
+	DirectoryID  uint32
+	Path         string
+	PathLength   uint32
+	Offset       uint64
+	Length       uint32
+}
+
+func (s SharedDirectoryReadRequest) Encode() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	buf.WriteByte(byte(TypeSharedDirectoryReadRequest))
+	binary.Write(buf, binary.BigEndian, s.CompletionID)
+	binary.Write(buf, binary.BigEndian, s.DirectoryID)
+	// binary.Write(buf, binary.BigEndian, s.PathLength)
+	if err := encodeString(buf, s.Path); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	binary.Write(buf, binary.BigEndian, s.Offset)
+	binary.Write(buf, binary.BigEndian, s.Length)
+
+	return buf.Bytes(), nil
+}
+
+func decodeSharedDirectoryReadRequest(in peekReader) (SharedDirectoryReadRequest, error) {
+	t, err := in.ReadByte()
+	if err != nil {
+		return SharedDirectoryReadRequest{}, trace.Wrap(err)
+	}
+	if t != byte(TypeSharedDirectoryReadRequest) {
+		return SharedDirectoryReadRequest{}, trace.BadParameter("got message type %v, expected TypeSharedDirectoryReadRequest(%v)", t, TypeSharedDirectoryReadRequest)
+	}
+
+	var completionId, directoryId, pathLength, length uint32
+	var offset uint64
+
+	err = binary.Read(in, binary.BigEndian, &completionId)
+	if err != nil {
+		return SharedDirectoryReadRequest{}, trace.Wrap(err)
+	}
+
+	err = binary.Read(in, binary.BigEndian, &directoryId)
+	if err != nil {
+		return SharedDirectoryReadRequest{}, trace.Wrap(err)
+	}
+
+	path, err := decodeString(in, tdpMaxPathLength)
+	if err != nil {
+		return SharedDirectoryReadRequest{}, trace.Wrap(err)
+	}
+
+	err = binary.Read(in, binary.BigEndian, &pathLength)
+	if err != nil {
+		return SharedDirectoryReadRequest{}, trace.Wrap(err)
+	}
+
+	err = binary.Read(in, binary.BigEndian, &offset)
+	if err != nil {
+		return SharedDirectoryReadRequest{}, trace.Wrap(err)
+	}
+
+	err = binary.Read(in, binary.BigEndian, &length)
+	if err != nil {
+		return SharedDirectoryReadRequest{}, trace.Wrap(err)
+	}
+
+	return SharedDirectoryReadRequest{
+		CompletionID: completionId,
+		DirectoryID:  directoryId,
+		Path:         path,
+		PathLength:   pathLength,
+		Offset:       offset,
+		Length:       length,
+	}, nil
+}
+
+type SharedDirectoryReadResponse struct {
+	CompletionID   uint32
+	ErrCode        uint32
+	ReadDataLength uint32
+	ReadData       []byte
+}
+
+func (s SharedDirectoryReadResponse) Encode() ([]byte, error) {
+	fmt.Println("SharedDirectoryReadResponse: Encode")
+	buf := new(bytes.Buffer)
+	buf.WriteByte(byte(TypeSharedDirectoryReadResponse))
+	binary.Write(buf, binary.BigEndian, s)
+	return buf.Bytes(), nil
+}
+
+func decodeSharedDirectoryReadResponse(in peekReader) (SharedDirectoryReadResponse, error) {
+	t, err := in.ReadByte()
+	if err != nil {
+		return SharedDirectoryReadResponse{}, trace.Wrap(err)
+	}
+	if t != byte(TypeSharedDirectoryReadResponse) {
+		return SharedDirectoryReadResponse{}, trace.BadParameter("got message type %v, expected TypeSharedDirectoryReadResponse(%v)", t, TypeSharedDirectoryReadResponse)
+	}
+
+	var completionId, errorCode, readDataLength uint32
+
+	err = binary.Read(in, binary.BigEndian, &completionId)
+	if err != nil {
+		return SharedDirectoryReadResponse{}, trace.Wrap(err)
+	}
+
+	err = binary.Read(in, binary.BigEndian, &errorCode)
+	if err != nil {
+		return SharedDirectoryReadResponse{}, trace.Wrap(err)
+	}
+
+	err = binary.Read(in, binary.BigEndian, &readDataLength)
+	if err != nil {
+		return SharedDirectoryReadResponse{}, trace.Wrap(err)
+	}
+
+	readData := make([]byte, int(readDataLength))
+	if _, err := io.ReadFull(in, readData); err != nil {
+		return SharedDirectoryReadResponse{}, trace.Wrap(err)
+	}
+
+	return SharedDirectoryReadResponse{
+		CompletionID:   completionId,
+		ErrCode:        errorCode,
+		ReadDataLength: readDataLength,
+		ReadData:       readData,
+	}, nil
+}
+
+type SharedDirectoryWriteResponse struct {
+	CompletionID uint32
+	ErrCode      uint32
+	BytesWritten uint32
+}
+
+func (s SharedDirectoryWriteResponse) Encode() ([]byte, error) {
+	fmt.Println("SharedDirectoryWriteResponse: Encode")
+	buf := new(bytes.Buffer)
+	buf.WriteByte(byte(TypeSharedDirectoryWriteResponse))
+	binary.Write(buf, binary.BigEndian, s)
+	return buf.Bytes(), nil
+}
+
+func decodeSharedDirectoryWriteResponse(in peekReader) (SharedDirectoryWriteResponse, error) {
+	t, err := in.ReadByte()
+	if err != nil {
+		return SharedDirectoryWriteResponse{}, trace.Wrap(err)
+	}
+	if t != byte(TypeSharedDirectoryWriteResponse) {
+		return SharedDirectoryWriteResponse{}, trace.BadParameter("got message type %v, expected SharedDirectoryWriteResponse(%v)", t, TypeSharedDirectoryWriteResponse)
+	}
+
+	var res SharedDirectoryWriteResponse
+	err = binary.Read(in, binary.BigEndian, &res)
+	return res, err
+}
+
+type SharedDirectoryWriteRequest struct {
+	CompletionID    uint32
+	DirectoryID     uint32
+	Offset          uint64
+	Path            string
+	PathLength      uint32
+	WriteDataLength uint32
+	WriteData       []byte
+}
+
+func (s SharedDirectoryWriteRequest) Encode() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	buf.WriteByte(byte(TypeSharedDirectoryWriteRequest))
+	binary.Write(buf, binary.BigEndian, s.CompletionID)
+	binary.Write(buf, binary.BigEndian, s.DirectoryID)
+	binary.Write(buf, binary.BigEndian, s.Offset)
+	if err := encodeString(buf, s.Path); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	binary.Write(buf, binary.BigEndian, s.WriteDataLength)
+	if _, err := io.WriteString(buf, string(s.WriteData)); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return buf.Bytes(), nil
+
+}
+
+func decodeSharedDirectoryWriteRequest(in peekReader) (SharedDirectoryWriteRequest, error) {
+	t, err := in.ReadByte()
+	if err != nil {
+		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
+	}
+	if t != byte(TypeSharedDirectoryWriteRequest) {
+		return SharedDirectoryWriteRequest{}, trace.BadParameter("got message type %v, expected TypeSharedDirectoryWriteRequest(%v)", t, TypeSharedDirectoryWriteRequest)
+	}
+
+	var completionId, directoryId, pathLength, writeDataLength uint32
+	var offset uint64
+
+	err = binary.Read(in, binary.BigEndian, &completionId)
+	if err != nil {
+		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
+	}
+
+	err = binary.Read(in, binary.BigEndian, &directoryId)
+	if err != nil {
+		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
+	}
+
+	err = binary.Read(in, binary.BigEndian, &offset)
+	if err != nil {
+		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
+	}
+
+	path, err := decodeString(in, tdpMaxPathLength)
+	if err != nil {
+		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
+	}
+
+	err = binary.Read(in, binary.BigEndian, &pathLength)
+	if err != nil {
+		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
+	}
+
+	err = binary.Read(in, binary.BigEndian, &writeDataLength)
+	if err != nil {
+		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
+	}
+
+	writeData := make([]byte, int(writeDataLength))
+	if _, err := io.ReadFull(in, writeData); err != nil {
+		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
+	}
+
+	return SharedDirectoryWriteRequest{
+		CompletionID:    completionId,
+		DirectoryID:     directoryId,
+		Path:            path,
+		PathLength:      pathLength,
+		Offset:          offset,
+		WriteDataLength: writeDataLength,
+		WriteData:       writeData,
+	}, nil
+
 }
 
 // encodeString encodes strings for TDP. Strings are encoded as UTF-8 with


### PR DESCRIPTION
Implements these major functions:
- IRP_MJ_READ
- IRP_MJ_WRITE
- IRP_MJ_SET_INFORMATION

Also, I've added client name and set it to `teleport` so from now it will display it correctly rather than displaying random unicode characters. However, I'm not sure if this is the name we want to use as a client name. We should discuss it.