### PR TITLE
Add prominent scope links to the Enterprise intro

### DIFF
--- a/docs/pages/enterprise/introduction.mdx
+++ b/docs/pages/enterprise/introduction.mdx
@@ -7,8 +7,31 @@ h1: Teleport Enterprise
 Teleport Enterprise is a commercial product built around Teleport's open source
 core.
 
-For those that want to jump right in, you can play with the
-[Getting Started Guide for Teleport Enterprise](getting-started.mdx/?scope=enterprise).
+<TileSet>
+<Tile
+title="Get started with Teleport Enterprise"
+href="./getting-started.mdx/?scope=enterprise"
+icon="building"
+>
+
+Learn how to deploy a Teleport Enterprise cluster.
+
+</Tile>
+<ScopedBlock scope={["oss", "cloud"]}>
+<Tile 
+title="Read the docs as a Teleport Enterprise user" 
+icon="building" 
+href="./introduction.mdx/?scope=enterprise">
+</Tile>
+</ScopedBlock>
+<ScopedBlock scope={["oss", "enterprise"]}>
+<Tile 
+title="Read the docs as a Teleport Cloud user" 
+icon="cloud" 
+href="./introduction.mdx/?scope=cloud">
+</Tile>
+</ScopedBlock>
+</TileSet>
 
 The table below gives a quick overview of the benefits of Teleport Enterprise.
 

--- a/docs/pages/enterprise/introduction.mdx
+++ b/docs/pages/enterprise/introduction.mdx
@@ -4,8 +4,10 @@ description: Introduction to features and benefits of using Teleport Enterprise.
 h1: Teleport Enterprise
 ---
 
-Teleport Enterprise is a commercial product built around Teleport's open source
-core.
+Teleport Enterprise is a self-hosted deployment of Teleport that allows
+organizations to achieve the most stringent standards of security and
+compliance. We offer Teleport Enterprise as a commercial product built around
+Teleport's open source core.
 
 <TileSet>
 <Tile
@@ -17,21 +19,16 @@ icon="building"
 Learn how to deploy a Teleport Enterprise cluster.
 
 </Tile>
-<ScopedBlock scope={["oss", "cloud"]}>
-<Tile 
-title="Read the docs as a Teleport Enterprise user" 
-icon="building" 
-href="./introduction.mdx/?scope=enterprise">
-</Tile>
-</ScopedBlock>
-<ScopedBlock scope={["oss", "enterprise"]}>
-<Tile 
-title="Read the docs as a Teleport Cloud user" 
-icon="cloud" 
-href="./introduction.mdx/?scope=cloud">
-</Tile>
-</ScopedBlock>
 </TileSet>
+
+<Notice type="tip">
+
+You can also read about
+[Teleport Cloud](../cloud/introduction.mdx/?scope=cloud), a fully managed
+deployment of the Teleport Auth Service and Proxy Service that makes it easier
+to control access to your infrastructure.
+
+</Notice>
 
 The table below gives a quick overview of the benefits of Teleport Enterprise.
 


### PR DESCRIPTION
Readers were confused as to why the Teleport Enterprise section of
the docs was missing content if the "oss" scope was selected. I have
added a scope link to make it clearer for OSS users that they need to
change scope.