### PR TITLE
Add Enterprise info to the Installation page

### DIFF
--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,3 +1,4 @@
+<ScopedBlock scope={["oss", "cloud"]}>
 <Tabs>
     <TabItem label="Debian/Ubuntu (DEB)">
         ```code
@@ -63,3 +64,41 @@
   </TabItem>
 
 </Tabs>
+</ScopedBlock>
+<ScopedBlock scope={["enterprise"]}>
+
+Visit the [Downloads Page](https://dashboard.gravitational.com/web/downloads) in
+the customer portal and select the URL for your package of choice.
+
+Next, use the appropriate commands for your environment to install your package.
+
+For example, use the following commands to install Teleport on a machine with an
+x86-64 chip via tarball:
+
+
+```code
+$ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
+# <checksum> <filename>
+$ curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
+$ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
+# Verify that the checksums match
+$ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
+$ cd teleport
+$ sudo ./install
+```
+
+For FedRAMP/FIPS-compliant installations of Teleport Enterprise, package URLs
+will be slightly different:
+
+```code
+$ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz.sha256
+# <checksum> <filename>
+$ curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
+$ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
+# Verify that the checksums match
+$ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
+$ cd teleport
+$ sudo ./install
+```
+
+</ScopedBlock>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -40,8 +40,18 @@ All installations include `teleport`, `tsh`, `tctl`, and `tbot`.
 
 (!docs/pages/includes/install-linux.mdx!)
 
+<ScopedBlock scope="oss">
+
 Check the [Downloads](https://goteleport.com/download/) page for the most
 up-to-date information.
+
+</ScopedBlock>
+<ScopedBlock scope="cloud">
+
+Check the [Downloads](./cloud/downloads.mdx) page for the most
+up-to-date information.
+
+</ScopedBlock>
 
 ## Docker
 
@@ -102,6 +112,7 @@ chart.
 
 ## macOS
 
+<ScopedBlock scope={["oss", "cloud"]}>
 <Tabs>
   <TabItem label="Installer">
 
@@ -215,6 +226,30 @@ chart.
   </TabItem>
 
 </Tabs>
+</ScopedBlock>
+<ScopedBlock scope="enterprise">
+  You can download one of the following .pkg installers for macOS:
+
+  |Link|Binaries|
+  |-|-|
+  |[`teleport-ent-(=teleport.version=).pkg`](https://get.gravitational.com/teleport-ent-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`|
+  |[`tsh-(=teleport.version=).pkg`](https://get.gravitational.com/tsh-(=teleport.version=).pkg)|`tsh`|
+
+  You can also fetch an installer via the command line: 
+
+  ```code
+  $ curl -O https://get.gravitational.com/teleport-ent-(=teleport.version=).pkg
+  # Installs on Macintosh HD
+  $ sudo installer -pkg teleport-ent-(=teleport.version=).pkg -target / 
+  # Password:
+  # installer: Package name is teleport-ent-(=teleport.version=)
+  # installer: Upgrading at base path /
+  # installer: The upgrade was successful.
+  $ which teleport
+  # /usr/local/bin/teleport
+  ```
+
+</ScopedBlock>
 
 ## Windows (tsh client only)
 


### PR DESCRIPTION
Fixes #12924

The Linux and MacOS sections of the Installation page only included
instructions for the OSS edition of Teleport. This change adds
Enterprise instructions to prevent Enterprise users from downloading
the wrong Teleport edition.

This also changes the install-linux partial to accommodate Enterprise
customers.