### PR TITLE
Remove uneeded GitHub mapping length check

### DIFF
--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -307,14 +307,7 @@ func (a *Server) validateGithubAuthCallback(ctx context.Context, diagCtx *ssoDia
 		return nil, trace.Wrap(err, "Failed to get Github connector and client.")
 	}
 	diagCtx.info.GithubTeamsToLogins = connector.GetTeamsToLogins()
-	logger.Debugf("Connector %q teams to logins: %v", connector.GetName(), connector.GetTeamsToLogins())
-
-	if len(connector.GetTeamsToLogins()) == 0 {
-		logger.Warnf("Github connector %q has empty teams_to_logins mapping, cannot populate claims.",
-			connector.GetName())
-		return nil, trace.BadParameter(
-			"connector %q has empty teams_to_logins mapping", connector.GetName())
-	}
+	logger.Debugf("Connector %q teams to logins: %v, roles: %v", connector.GetName(), connector.GetTeamsToLogins(), connector.GetTeamsToRoles())
 
 	// exchange the authorization code received by the callback for an access token
 	token, err := client.RequestToken(oauth2.GrantTypeAuthCode, code)


### PR DESCRIPTION
Previously, the GitHub callback handler checked that the connector had any `teams_to_logins` mappings. This check became invalid with https://github.com/gravitational/teleport/pull/13296. After taking a look, this check seems uneeded as we already prevent creating connectors with no `teams_to_logins` *or* `teams_to_roles` mappings, making this check useless. This check is applied in `GitHubConnector.CheckAndSetDefaults` which means we can't actually get to this point with an invalid connector like this.