### PR TITLE
Update docs bash blocks to code

### DIFF
--- a/docs/pages/enterprise/fedramp.mdx
+++ b/docs/pages/enterprise/fedramp.mdx
@@ -49,7 +49,7 @@ Enterprise FIPS Binary.
 
 After downloading the binary tarball, run:
 
-```bsh
+```code
 $ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
 $ cd teleport-ent
 $ sudo ./install
@@ -124,7 +124,7 @@ proxy_service:
 Next, download the systemd service unit file from the [examples directory](https://github.com/gravitational/teleport/tree/master/examples/systemd/fips)
 on GitHub and save it as `/etc/systemd/system/teleport.service` on both servers.
 
-```bsh
+```code
 # run this on both servers:
 $ sudo systemctl daemon-reload
 $ sudo systemctl enable teleport

--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -72,7 +72,7 @@ if you don't want to install Teleport Enterprise binaries straight away.
 To start using Teleport Enterprise, you will need to Download the binaries and the license file from the [customer portal](https://dashboard.gravitational.com/web/login).
 After downloading the binary tarball, run:
 
-```bsh
+```code
 $ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-ent
 ```
@@ -94,7 +94,7 @@ and save it as `/var/lib/teleport/license.pem` on the auth server.
 Next, download the systemd service unit file from [examples directory](https://github.com/gravitational/teleport/tree/master/examples/systemd)
 on GitHub and save it as `/etc/systemd/system/teleport.service` on both servers.
 
-```bsh
+```code
 # run this on both servers:
 $ sudo systemctl daemon-reload
 $ sudo systemctl enable teleport
@@ -137,7 +137,7 @@ ssh_service:
 
 Start the Teleport service and confirm the service has started. After it has started you can get the Certificate Authority (CA) pin that has been generated.
 
-```bsh
+```code
 $ sudo systemctl start teleport
 # confirm Teleport started
 $ sudo systemctl status teleport
@@ -174,7 +174,7 @@ proxy_service:
 
 ## Start Node service
 
-```bsh
+```code
 # run this on node server:
 $ sudo systemctl start teleport
 # Confirm node has started successfully and connected
@@ -190,7 +190,7 @@ You can use `netstat -lptne` to review the port that Teleport is
 listening on  on [TCP/IP ports](../setup/reference/networking.mdx#ports). On *auth.example.com*, it should
 look something like this:
 
-```bsh
+```code
 $ auth.example.com ~: sudo netstat -lptne
 Active Internet connections (only servers)
 Proto Recv-Q Send-Q Local Address   State       User       PID/Program name
@@ -203,7 +203,7 @@ tcp6       0      0 :::3023         LISTEN      0          337/teleport
 
 and *node.example.com* should look something like this:
 
-```bsh
+```code
 $ node.example.com ~: sudo netstat -lptne
 Active Internet connections (only servers)
 Proto Recv-Q Send-Q Local Address   State       User       PID/Program name
@@ -255,13 +255,13 @@ allow:
 
 Then send it back into Teleport:
 
-```bsh
+```code
 $ sudo tctl create -f role.yaml
 ```
 
 Now, lets create a new Teleport user "joe" with "access" role:
 
-```bsh
+```code
 $ sudo tctl users add --roles=access --logins=joe,ubuntu,ec2-user joe
 
 Signup token has been created and is valid for 1 hours. Share this URL with the user:
@@ -276,14 +276,14 @@ which is available for both Android and iPhone.
 
 To update user's roles, dump the user resource into a file:
 
-```bsh
+```code
 $ sudo tctl get users/joe > joe.yaml
 ```
 
 Edit the YAML file and update the "roles" array.
 Then, re-insert it back:
 
-```bsh
+```code
 $ sudo tctl create -f joe.yaml
 ```
 
@@ -296,7 +296,7 @@ a Single Sign-On (SSO) mechanism.
 But first, lets see how Joe can log into the Teleport cluster. He can do this
 on his client laptop:
 
-```bsh
+```code
 $ tsh --proxy=auth.example.com --insecure login --user=joe
 ```
 
@@ -324,7 +324,7 @@ store it in `~/.tsh/keys/<proxy>` directory.
 
 With a certificate in place, Joe can now interact with the Teleport cluster:
 
-```bsh
+```code
 # SSH into any host behind the proxy (Unix user 'joe' should already exist on the node):
 $ tsh ssh joe@node.example.com
 

--- a/docs/pages/enterprise/sso.mdx
+++ b/docs/pages/enterprise/sso.mdx
@@ -57,7 +57,7 @@ organization's Single Sign-On (SSO) provider.
 
 Users need to execute the following command login in the CLI or login using UI:
 
-```bsh
+```code
 # this command will automatically open the default web browser and take a user
 # through the login process with an SSO provider:
 $ tsh login --proxy=proxy.example.com --auth=github
@@ -218,7 +218,7 @@ as described in the [Resources Reference](../setup/reference/resources.mdx).
 If multiple authentication connectors exist, the clients must supply a
 connector name to `tsh login` via `--auth` argument:
 
-```bsh
+```code
 # use "okta" SAML connector:
 $ tsh --proxy=proxy.example.com login --auth=okta
 

--- a/docs/pages/enterprise/sso/adfs.mdx
+++ b/docs/pages/enterprise/sso/adfs.mdx
@@ -158,7 +158,7 @@ to the *"admin"* role. Groups with the value *"users"* is being mapped to the
 
 For the last step, you'll need to export the signing key:
 
-```bsh
+```code
 $ tctl saml export adfs
 ```
 
@@ -171,7 +171,7 @@ certificates.
 The Web UI will now contain a new button: "Login with MS Active Directory". The CLI is
 the same as before:
 
-```bsh
+```code
 $ tsh --proxy=proxy.example.com login
 ```
 

--- a/docs/pages/enterprise/sso/gitlab.mdx
+++ b/docs/pages/enterprise/sso/gitlab.mdx
@@ -103,7 +103,7 @@ version: v2
 
 Create the connector using `tctl` tool:
 
-```bsh
+```code
 $ tctl create oidc-connector.yaml
 ```
 
@@ -154,7 +154,7 @@ spec:
 
 Create both roles on the auth server:
 
-```bsh
+```code
 $ tctl create admin.yaml
 $ tctl create dev.yaml
 ```
@@ -164,7 +164,7 @@ $ tctl create dev.yaml
 The Web UI will now contain a new button: "Login with GitLab". The CLI is
 the same as before:
 
-```bsh
+```code
 $ tsh --proxy=teleport.example.com login
 ```
 

--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -148,7 +148,7 @@ spec:
 
 Create both roles:
 
-```bsh
+```code
 $ tctl create role-admin.yaml
 $ tctl create role-dev.yaml
 ```

--- a/docs/pages/enterprise/sso/okta.mdx
+++ b/docs/pages/enterprise/sso/okta.mdx
@@ -112,7 +112,7 @@ Now, create a SAML connector [resource](../../setup/reference/resources.mdx):
 
 Create the connector using `tctl` tool:
 
-```bsh
+```code
 $ tctl create okta-connector.yaml
 ```
 
@@ -145,7 +145,7 @@ spec:
 
 We'll use tctl to create this role on the auth server:
 
-```bsh
+```code
 $ tctl create dev.yaml
 ```
 
@@ -154,7 +154,7 @@ $ tctl create dev.yaml
 The Web UI will now contain a new button: "Login with Okta". The CLI is
 the same as before:
 
-```bsh
+```code
 $ tsh login --proxy=proxy.example.com --auth=okta
 ```
 

--- a/docs/pages/enterprise/sso/one-login.mdx
+++ b/docs/pages/enterprise/sso/one-login.mdx
@@ -117,7 +117,7 @@ To fill in the fields, open `SSO` tab:
 
 Create the connector using `tctl` tool:
 
-```bsh
+```code
 $ tctl create onelogin-connector.yaml
 ```
 
@@ -147,7 +147,7 @@ spec:
 
 **Notice:** Replace `ubuntu` with linux login available on your servers!
 
-```bsh
+```code
 $ tctl create dev.yaml
 ```
 
@@ -156,7 +156,7 @@ $ tctl create dev.yaml
 The Web UI will now contain a new button: "Login with OneLogin". The CLI is
 the same as before:
 
-```bsh
+```code
 $ tsh --proxy=proxy.example.com login
 ```
 


### PR DESCRIPTION
We had previously updated all `bash` to `code`.  These are the remaining items that are using `bsh`. Switching to `code` allows for things like individual copy lines and copies without the `$`.