### PR TITLE
Fix CLI reference for the tsh --ttl flag

### DIFF
--- a/docs/pages/setup/reference/cli.mdx
+++ b/docs/pages/setup/reference/cli.mdx
@@ -147,14 +147,14 @@ information about the cluster.
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `-l, --login` | none | an identity name | the login identity that the Teleport User should use |
-| `--proxy` | none | `host:https_port[,ssh_proxy_port]` | set SSH proxy address |
-| `--user` | `$USER` | none | the Teleport User name |
-| `--ttl` | none | relative duration like 5s, 2m, or 3h | set time to live for a SSH session, session ttl unrestricted if unset {/* TODO Check this */} |
+| `-l, --login` | none | an identity name | The login identity that the Teleport user will use |
+| `--proxy` | none | `host:https_port[,ssh_proxy_port]` | Teleport Proxy Service address |
+| `--user` | `$USER` | none | The Teleport username |
+| `--ttl` | `720` (12 hours) | integer | Number of minutes a certificate issued for the `tsh` user will be valid for |
 | `-i, --identity` | none | **string** filepath | Identity file |
 | `--cert-format` | `file` | `file` or `openssh` | SSH certificate format |
-| `--insecure` | none | none | Do not verify server's certificate and host name. Use only in test environments |
-| `--auth` | `local` | any defined [authentication connector](./authentication.mdx) | Specify the type of authentication connector to use. |
+| `--insecure` | none | none | Do not verify the server's certificate and host name. Use only in test environments. |
+| `--auth` | `local` | Any defined [authentication connector](./authentication.mdx) | Specify the type of authentication connector to use. |
 | `--skip-version-check` | none | none | Skip version checking between server and client. |
 | `-d, --debug` | none | none | Verbose logging to stdout |
 | `-J, --jumphost` | none | A jump host | SSH jumphost |


### PR DESCRIPTION
The value of the --ttl flag for tsh commands was incorrectly stated to
be a duration. Instead, it is an integer indicating a number of minutes.
The default is 12 hours.

Also does some minor copy-editing on the tsh global flags.