### PR TITLE
wip: add openssh servers and show them in teleport

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -104,6 +104,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *service.
 		types.KindApp:                     rc.createApp,
 		types.KindDatabase:                rc.createDatabase,
 		types.KindToken:                   rc.createToken,
+		types.KindNode:                    rc.createNode,
 	}
 	rc.config = config
 
@@ -589,6 +590,16 @@ func (rc *ResourceCommand) createToken(ctx context.Context, client auth.ClientI,
 	}
 
 	err = client.UpsertToken(ctx, token)
+	return trace.Wrap(err)
+}
+
+func (rc *ResourceCommand) createNode(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+	token, err := services.UnmarshalServer(raw.Raw, types.KindNode)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = client.UpsertNode(ctx, token)
 	return trace.Wrap(err)
 }
 


### PR DESCRIPTION
Allow manually creating nodes with `tctl` , 

issues:
- RBAC isnt working properly for access -- the node wont be shown however manually sshing to a node will work
  -  `tsh ssh user@host.ip` will work regardless of what RBAC rules would indicate
- access via hostname doesnt work: `tsh user@hostname` results in an error
```
ERROR: access denied to alex connecting to suse on cluster localhost
```


example creation: 
```
tctl create ./node.yaml
```
```yaml
kind: node
sub_kind: agentless
metadata:
  labels:
    env: openssh
  name: "192.168.122.24:22"
spec:
  addr: 192.168.122.24:22
  public_addr: 192.168.122.24:22  
  hostname: suse
  version: 10.0.0-dev
version: v2
```
