### PR TITLE
Add more general information to our SSO guide

### DIFF
--- a/docs/pages/enterprise/sso.mdx
+++ b/docs/pages/enterprise/sso.mdx
@@ -4,11 +4,15 @@ description: How to set up single sign-on (SSO) for SSH using Teleport
 h1: Single Sign-On (SSO) for SSH
 ---
 
-Users of the Enterprise edition of Teleport can log in to servers, Kubernetes
-clusters, databases, web applications, and Windows desktops through their
-organization's Single Sign-On (SSO) provider.
+Teleport users can log in to servers, Kubernetes clusters, databases, web
+applications, and Windows desktops through their organization's Single Sign-On
+(SSO) provider.
 
 <TileSet>
+  <Tile icon="bolt" title="GitHub" href="../setup/admin/github-sso.mdx">
+    Configure GitHub SSO for SSH, Kubernetes, databases, desktops and web
+    apps.
+  </Tile>
   <Tile icon="bolt" title="Azure Active Directory (AD)" href="./sso/azuread.mdx">
     Configure Azure Active Directory SSO for SSH, Kubernetes, databases, desktops and web apps.
   </Tile>
@@ -32,9 +36,149 @@ organization's Single Sign-On (SSO) provider.
   </Tile>
 </TileSet>
 
-## How does SSO work?
+## How Teleport uses SSO
 
-Execute the following command to log in to your Teleport cluster using the CLI.
+You can register your Teleport cluster as an application with your SSO provider.
+When a user signs in to Teleport, your SSO provider will execute its own
+authentication flow, then send an HTTP request to your Teleport cluster to
+indicate that authentication has completed.
+
+Teleport authenticates users to your infrastructure by issuing short-lived
+certificates. After a user completes an SSO authentication flow, Teleport issues
+a short-lived certificate to the user. Teleport also creates a temporary `user`
+resource on the Auth Service backend.
+
+### Temporary `user` resources
+
+After a user completes an SSO authentication flow, Teleport creates a temporary
+`user` resource for the user.
+
+When a user signs in to Teleport with `tsh login`, they can configure the TTL of
+the `user` Teleport creates. Teleport enforces a limit of 30 hours (the default
+is 12 hours).
+  
+In the Teleport audit log, you will see an event of type `user.create` with
+information about the temporary user.
+
+<Details title="How can I inspect a temporary user resource?">
+
+You can inspect the temporary `user` resource created via your SSO integration
+by using the `tctl` command:
+
+
+<ScopedBlock scope={["oss", "enterprise"]}>
+
+```code
+# Log in to your cluster with tsh so you can use tctl remotely
+$ tsh login --proxy=proxy.example.com --user=myuser
+$ tctl get users
+```
+
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
+
+```code
+# Log in to your cluster with tsh so you can use tctl remotely
+$ tsh login --proxy=mytenant.teleport.sh --user=myuser
+$ tctl get users
+```
+</ScopedBlock>
+
+Here is an example of a temporary `user` resource created when the GitHub user
+`myuser` signed in to GitHub to authenticate to Teleport. This resource
+expires 12 hours after creation. The `created_by` field indicates that the
+resource was created by Teleport's GitHub SSO integration:
+
+```yaml
+kind: user
+metadata:
+  expires: "2022-06-15T04:02:34.586688054Z"
+  id: 0000000000000000000
+  name: myuser
+spec:
+  created_by:
+    connector:
+      id: github
+      identity: myuser
+      type: github
+    time: "2022-06-14T16:02:34.586688441Z"
+    user:
+      name: system
+  expires: "0001-01-01T00:00:00Z"
+  github_identities:
+  - connector_id: github
+    username: myuser
+  roles:
+  - editor
+  - access
+  - auditor
+  status:
+    is_locked: false
+    lock_expires: "0001-01-01T00:00:00Z"
+    locked_time: "0001-01-01T00:00:00Z"
+    recovery_attempt_lock_expires: "0001-01-01T00:00:00Z"
+  traits:
+    github_teams:
+    - my-team
+    kubernetes_groups: null
+    kubernetes_users: null
+    logins:
+    - root
+version: v2
+```
+
+</Details>
+
+### Certificates for SSO users
+
+Along with creating a temporary `user` resource, Teleport issues an X.509
+certificate to a successfully authenticated SSO user. The certificate's
+`Subject` field contains the same information defined in the temporary `user`
+resource. This enables Teleport to enforce RBAC rules for the authenticated user
+when they access resources in your cluster.
+
+For example, this is a `Subject` field for a certificate that Teleport issued
+for the GitHub user `myuser`, who signed in to a Teleport cluster via the GitHub
+SSO integration:
+
+```
+Subject: L=myuser/street=teleport.example.com/postalCode={"github_teams":["my-team"],"kubernetes_groups":null,"kubernetes_users":null,"logins":["root"]}, O=access, O=editor, O=auditor, CN=myuser/1.3.9999.1.7=teleport.example.com
+```
+
+The user belongs to the GitHub team `my-team`, which this Teleport cluster maps
+to the `access`, `editor`, and `auditor` roles in Teleport. (Read the guide for
+your SSO provider to determine how to configure role mapping.)
+
+<Details title="Inspecting your certificate subject">
+
+To inspect the contents of a certificate issued for your user after you sign in to Teleport via 
+SSO, run the following commands:
+
+```code
+$ TELEPORT_CLUSTER=<your cluster>
+$ SSO_USER=<your username within your SSO provider>
+$ openssl x509 -text -in ~/.tsh/keys/${CLUSTER}/${SSO_USER}-x509.pem | grep "Subject:"
+```
+
+</Details>
+
+### Multiple SSO providers
+
+Since Teleport creates temporary users and issues short-lived certificates when
+a user authenticates via SSO, it is straightforward to integrate Teleport with
+multiple SSO providers. Besides the temporary `user` resource, no persistent
+backend data in Teleport is tied to a user's account with the SSO provider. 
+
+This also means that if one SSO provider becomes unavailable, the end user only
+needs to choose another SSO provider when signing in to Teleport. While the
+user may be locked out of their account with the first SSO provider, signing in
+via the second provider is sufficient for Teleport to issue a new certificate
+and grant the user access to your infrastructure.
+
+## Logging in via SSO
+
+Users can log in to Teleport via your SSO provider by executing a command
+similar to the following, using the `--auth` flag to specify the provider:
 
 ```code
 # This command will automatically open the default web browser and take a user
@@ -58,37 +202,56 @@ add SSH cert to an SSH agent if there's one running.
 ## Configuring SSO
 
 Teleport works with SSO providers by relying on the concept of an
-**authentication connector**. An authentication connector is a plugin that
-controls how a user logs in and which group they belong to.
+**authentication connector**. An authentication connector is a configuration
+resource that controls how SSO users log in to Teleport—and which Teleport roles
+they will assume once they do.
+
+This means that you can apply fine-grained RBAC policies to your Teleport
+cluster without needing to change the solution you use for on– and offboarding
+users.
 
 ### Supported connectors
 
 The following authentication connectors are supported:
 
-- `local` connector type uses the built-in user database. This database can be
-  manipulated by the `tctl users` command.
-- `saml` connector type uses the [SAML protocol](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language)
-  to authenticate users and query their group membership.
-- `oidc` connector type uses the [OpenID Connect protocol](https://en.wikipedia.org/wiki/OpenID_Connect)
-  to authenticate users and query their group membership.
+<ScopedBlock scope={["cloud", "enterprise"]}>
+
+|Type|Description|
+|---|---|
+|None|If no authentication connector is created, Teleport will use local authentication based user information stored in the Auth Service backend. You can manage user data via the `tctl users` command. |
+|`saml`| The SAML connector type uses the [SAML protocol](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language) to authenticate users and query their group membership.|
+|`oidc`| The OIDC connector type uses the [OpenID Connect protocol](https://en.wikipedia.org/wiki/OpenID_Connect) to authenticate users and query their group membership.|
+|`github`| The GitHub connector uses GitHub SSO to authenticate users and query their group membership.|
+
+</ScopedBlock>
+<ScopedBlock scope={["oss"]}>
+
+|Type|Description|
+|---|---|
+|None|If no authentication connector is created, Teleport will use local authentication based user information stored in the Auth Service backend. You can manage user data via the `tctl users` command. |
+|`github`| The GitHub connector uses GitHub SSO to authenticate users and query their group membership.|
+
+</ScopedBlock>
 
 ### Creating an authentication connector
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 Before you can create an authentication connector, you must enable
 authentication via that connector's protocol.
 
 To set the default authentication type as `saml` or `oidc`, <ScopedBlock
-scope={["oss", "enterprise"]}>either modify your Auth Service configuration file
+scope={["enterprise"]}>either modify your Auth Service configuration file
 or </ScopedBlock>create a `cluster_auth_preference` resource.
 
 <Tabs>
-  <TabItem label="Static Config (Self-Hosted)" scope={["oss", "enterprise"]}>
+  <TabItem label="Static Config (Self-Hosted)" scope={["enterprise"]}>
  Update `/etc/teleport.yaml` in the `auth_service` section and restart the `teleport` daemon.
   ```yaml
   auth_service:
     authentication:
-      # Set as saml or oidc
-      type: saml|oidc
+      # Set as saml, oidc, or github
+      type: saml|oidc|github
   ```
   </TabItem>
   <TabItem scope={["cloud"]} label="Dynamic Resources (All Editions)">
@@ -99,14 +262,14 @@ or </ScopedBlock>create a `cluster_auth_preference` resource.
     name: cluster-auth-preference
   spec:
     authentication:
-      # set as saml or oidc
-      type: saml|oidc
+      # Set as saml, oidc, or github
+      type: saml|oidc|github
   version: v2
   ```
 
   Create the resource:
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
+  <ScopedBlock scope={["enterprise"]}>
 
   ```code
   # Log in to your cluster with tsh so you can run tctl commands.
@@ -128,6 +291,29 @@ or </ScopedBlock>create a `cluster_auth_preference` resource.
   </TabItem>
 </Tabs>
 
+</ScopedBlock>
+
+<ScopedBlock scope="oss">
+
+Next, define an authentication connector. Create a file called `connector.yaml`
+with the following content:
+
+```yaml
+kind: cluster_auth_preference
+metadata:
+  name: cluster-auth-preference
+spec:
+  type: github
+  webauthn:
+    # Replace with the address of your Teleport cluster
+    rp_id: 'example.teleport.sh'
+version: v2
+
+```
+
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud", "enterprise"]}>
 
 Next, define an authentication connector. Create a file called `connector.yaml`
 based on one of the following examples.
@@ -159,7 +345,8 @@ spec:
      - { name: "group", value: "^ssh_admin_(.*)$", roles: ["admin-$1"] }
 
   entity_descriptor: |
-    <paste SAML XML contents here>```
+    <paste SAML XML contents here>
+```
 
 </TabItem>
 <TabItem label="OneLogin">
@@ -197,14 +384,31 @@ spec:
 ```
 
 </TabItem>
-</Tabs>
+<TabItem label="GitHub">
 
+```yaml
+kind: cluster_auth_preference
+metadata:
+  name: cluster-auth-preference
+spec:
+  type: github
+  webauthn:
+    # Replace with the address of your Teleport cluster
+    rp_id: 'example.teleport.sh'
+version: v2
+
+```
+
+</TabItem>
+</Tabs>
 
 You may use `entity_descriptor_url`, in lieu of `entity_descriptor`, to fetch
 the entity descriptor from your IDP. 
 
 We recommend "pinning" the entity descriptor by including the XML rather than
 fetching from a URL.
+
+</ScopedBlock>
 
 Create the connector: 
 
@@ -234,6 +438,8 @@ spec:
       '*': '*'
 ```
 
+<ScopedBlock scope={["cloud", "enterprise"]}>
+
 ### Provider-Specific Workarounds
 
 Certain SSO providers may require or benefit from changes to Teleport's SSO
@@ -251,13 +457,22 @@ values to match your identity provider:
 
 At this time, the `spec.provider` field should not be set for any other identity providers.
 
-## Working with External Email Identity
+</ScopedBlock>
+
+## Working with an external email identity
 
 Along with sending groups, an SSO provider will also provide a user's email address.
 In many organizations, the username that a person uses to log in to a system is the
-same as the first part of their email address, the "local" part. For example, `dave.smith@acme.com` might log in with the username `dave.smith`. Teleport provides an easy way to extract the first part of an email address so it can be used as a username. This is the `{{email.local}}` function.
+same as the first part of their email address, the "local" part. 
 
-If the email claim from the identity provider (which can be accessed via `{{external.email}}`) is sent and contains an email address, you can extract the "local" part of the email address before the @ sign like this: `{{email.local(external.email)}}`
+For example, `dave.smith@example.com` might log in with the username `dave.smith`.
+Teleport provides an easy way to extract the first part of an email address so
+it can be used as a username. This is the `{{email.local}}` function.
+
+If the email claim from the identity provider (which can be accessed via
+`{{external.email}}`) is sent and contains an email address, you can extract the
+"local" part of the email address before the @ sign like this:
+`{{email.local(external.email)}}`
 
 Here's how this looks in a Teleport role:
 
@@ -276,12 +491,13 @@ spec:
       '*': '*'
 ```
 
-## Multiple SSO Providers
+## Working with multiple SSO providers
 
-Teleport can also support multiple connectors, i.e. a Teleport administrator
-can define and create multiple connector resources using `tctl create` as shown above.
+Teleport can also support multiple connectors. For example, a Teleport
+administrator can define and create multiple connector resources using
+`tctl create` as shown above.
 
-To see all configured connectors, execute this on the auth server:
+To see all configured connectors, execute this command on the Auth Server:
 
 ```code
 $ tctl get connectors
@@ -309,7 +525,10 @@ SAML and OIDC types:
 - [SSH Authentication with ADFS](./sso/adfs.mdx)
 - [SSH Authentication with OAuth2 / OpenID Connect](./sso/oidc.mdx)
 
-## SSO Customization
+## SSO customization
+
+Use the `display` field in an authentication connector to control the appearance
+of SSO buttons in the Teleport Web UI.
 
 | Provider | YAML | Example |
 | - | - | - |

--- a/docs/pages/enterprise/sso.mdx
+++ b/docs/pages/enterprise/sso.mdx
@@ -45,8 +45,8 @@ indicate that authentication has completed.
 
 Teleport authenticates users to your infrastructure by issuing short-lived
 certificates. After a user completes an SSO authentication flow, Teleport issues
-a short-lived certificate to the user. Teleport also creates a temporary `user`
-resource on the Auth Service backend.
+a short-lived certificate to the user. Teleport also creates a temporary user on
+the Auth Service backend.
 
 ### Temporary `user` resources
 
@@ -62,7 +62,7 @@ information about the temporary user.
 
 <Details title="How can I inspect a temporary user resource?">
 
-You can inspect the temporary `user` resource created via your SSO integration
+You can inspect a temporary `user` resource created via your SSO integration
 by using the `tctl` command:
 
 
@@ -71,7 +71,7 @@ by using the `tctl` command:
 ```code
 # Log in to your cluster with tsh so you can use tctl remotely
 $ tsh login --proxy=proxy.example.com --user=myuser
-$ tctl get users
+$ tctl get users/<username>
 ```
 
 </ScopedBlock>
@@ -131,15 +131,19 @@ version: v2
 
 ### Certificates for SSO users
 
-Along with creating a temporary `user` resource, Teleport issues an X.509
-certificate to a successfully authenticated SSO user. The certificate's
-`Subject` field contains the same information defined in the temporary `user`
-resource. This enables Teleport to enforce RBAC rules for the authenticated user
-when they access resources in your cluster.
+Along with creating a temporary user, Teleport issues SSH and X.509 certificates
+to a successfully authenticated SSO user's machine. This enables SSO users to
+authenticate to your cluster without Teleport needing to create a permanent
+record of them.
 
-For example, this is a `Subject` field for a certificate that Teleport issued
-for the GitHub user `myuser`, who signed in to a Teleport cluster via the GitHub
-SSO integration:
+In the X.509 certificate, for example, the `Subject` field contains the same
+information defined in the temporary `user` resource. This enables Teleport to
+enforce RBAC rules for the authenticated user when they access resources in your
+cluster.
+
+This is a `Subject` field for a certificate that Teleport issued for the GitHub
+user `myuser`, who signed in to a Teleport cluster via the GitHub SSO
+integration:
 
 ```
 Subject: L=myuser/street=teleport.example.com/postalCode={"github_teams":["my-team"],"kubernetes_groups":null,"kubernetes_users":null,"logins":["root"]}, O=access, O=editor, O=auditor, CN=myuser/1.3.9999.1.7=teleport.example.com
@@ -151,13 +155,20 @@ your SSO provider to determine how to configure role mapping.)
 
 <Details title="Inspecting your certificate subject">
 
-To inspect the contents of a certificate issued for your user after you sign in to Teleport via 
-SSO, run the following commands:
+To inspect the contents of an X.509 certificate issued for your user after you
+sign in to Teleport via SSO, run the following commands:
 
 ```code
 $ TELEPORT_CLUSTER=<your cluster>
 $ SSO_USER=<your username within your SSO provider>
-$ openssl x509 -text -in ~/.tsh/keys/${CLUSTER}/${SSO_USER}-x509.pem | grep "Subject:"
+$ openssl x509 -text -in ~/.tsh/keys/${TELEPORT_CLUSTER}/${SSO_USER}-x509.pem | grep "Subject:"
+```
+
+You can inspect an SSH certificate issued for your Teleport user with the
+following command:
+
+```code
+$ ssh-keygen -L -f ~/.tsh/keys/${TELEPORT_CLUSTER}/${SSO_USER}-ssh/${TELEPORT_CLUSTER}-cert.pub
 ```
 
 </Details>
@@ -174,6 +185,10 @@ needs to choose another SSO provider when signing in to Teleport. While the
 user may be locked out of their account with the first SSO provider, signing in
 via the second provider is sufficient for Teleport to issue a new certificate
 and grant the user access to your infrastructure.
+
+Note that if the username of an SSO user already belongs to a user registered
+locally with the Auth Service (i.e., created via `tctl users add`), the SSO
+login will fail.
 
 ## Logging in via SSO
 


### PR DESCRIPTION
Fixes #13347

To help users adopt our SSO integrations, I have added some general
information to our SSO guide about how Teleport uses SSO integrations
to authenticate users. This should clarify what is taking place in
Teleport when a user authenticates via SSO and--especially--explain how
Teleport can work with multiple IdPs.

Because this information applies to all SSO integrations, including
GitHub, I have also edited this page to accommodate OSS users in
addition to Cloud and Enterprise users, including mentioning the
GitHub connector for users of all editions.

Eventually, we can think about moving this guide (and potentially other
SSO guides) outside of the "Enterprise" section.