### PR TITLE
Use `make release-windows` on Drone, make it similar to `make release`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4585,7 +4585,7 @@ steps:
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
   - echo -n "$WINDOWS_SIGNING_CERT" | base64 -d > windows-signing-cert.pfx
-  - make -C build.assets release-amd64
+  - make -C build.assets release-windows
   - rm -f windows-signing-cert.pfx
   environment:
     ARCH: amd64
@@ -5614,6 +5614,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 5acd82e991fc974378ec84b0265df412875f0c349000a6c92720b39287639ac8
+hmac: 9d5d0eb18f94215e5b4ecb03dadf936696789e776df1e31aa93aeb5719d60531
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -411,15 +411,15 @@ release-centos7-fips:
 .PHONY:release-windows
 release-windows: buildbox
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX) \
-		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=windows
+		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=windows RUNTIME=$(GOLANG_VERSION) REPRODUCIBLE=yes
 
 #
-# Create a Windows Teleport package using the build container.
+# Create an unsigned Windows Teleport package using the build container.
 #
 .PHONY:release-windows-unsigned
 release-windows-unsigned: buildbox
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX) \
-		/usr/bin/make release-windows-unsigned -e ADDFLAGS="$(ADDFLAGS)" OS=windows
+		/usr/bin/make release-windows-unsigned -e ADDFLAGS="$(ADDFLAGS)" OS=windows RUNTIME=$(GOLANG_VERSION) REPRODUCIBLE=yes
 
 #
 # Run docs tester to detect problems.

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -203,9 +203,16 @@ func releaseMakefileTarget(b buildType) string {
 	if b.fips {
 		makefileTarget += "-fips"
 	}
-	if b.os == "windows" && b.windowsUnsigned {
-		makefileTarget = "release-windows-unsigned"
+
+	// Override Windows targets.
+	if b.os == "windows" {
+		if b.windowsUnsigned {
+			makefileTarget = "release-windows-unsigned"
+		} else {
+			makefileTarget = "release-windows"
+		}
 	}
+
 	return makefileTarget
 }
 


### PR DESCRIPTION
Switch from `make release-amd64` to `make release-windows` in Drone builds, making release builds similar to "regular" builds (that already use `make release-windows-unsigned`).

Fixes current woes caused by FIDO2=yes in Windows release builds. (Note that ARCH is implied by the build.)