### PR TITLE
[v9] Update docs self-hosted version to 9.3.6

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -962,14 +962,14 @@
       "min_version": "3.6"
     },
     "teleport": {
-      "version": "9.3.4",
+      "version": "9.3.6",
       "golang": "1.17",
       "plugin": {
-        "version": "9.3.4"
+        "version": "9.3.6"
       },
       "helm_repo_url": "https://charts.releases.teleport.dev",
-      "latest_oss_docker_image": "quay.io/gravitational/teleport:9.3.4",
-      "latest_ent_docker_image": "quay.io/gravitational/teleport-ent:9.3.4"
+      "latest_oss_docker_image": "quay.io/gravitational/teleport:9.3.6",
+      "latest_ent_docker_image": "quay.io/gravitational/teleport-ent:9.3.6"
     }
   },
   "redirects": [


### PR DESCRIPTION
Update branch v9 docs for self-hosted to 9.3.6