### PR TITLE
Dont log `teleport-service` group not found, down grade macos warning to debug

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -995,7 +995,7 @@ func applySSHConfig(fc *FileConfig, cfg *service.Config) (err error) {
 	if fc.SSH.DisableCreateHostUser || runtime.GOOS != constants.LinuxOS {
 		cfg.SSH.DisableCreateHostUser = true
 		if runtime.GOOS != constants.LinuxOS {
-			log.Warnln("Disabling host user creation as this feature is only available on Linux")
+			log.Debugln("Disabling host user creation as this feature is only available on Linux")
 		}
 	}
 	if fc.SSH.PAM != nil {

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -273,6 +273,10 @@ func (u *HostUserManagement) DeleteAllUsers() error {
 	}
 	teleportGroup, err := u.backend.LookupGroup(types.TeleportServiceGroup)
 	if err != nil {
+		if errors.Is(err, user.UnknownGroupError(types.TeleportServiceGroup)) {
+			log.Debugf("'teleport-service' group not found, not deleting users")
+			return nil
+		}
 		return trace.Wrap(err)
 	}
 	var errs []error

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -241,4 +241,11 @@ func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 	require.NoError(t, err)
 
 	require.ElementsMatch(t, remainingUsers, resultingUsers)
+
+	users = HostUserManagement{
+		backend: newTestUserMgmt(),
+		storage: pres,
+	}
+	// teleport-system group doesnt exist, DeleteAllUsers will return nil, instead of erroring
+	require.NoError(t, users.DeleteAllUsers())
 }


### PR DESCRIPTION
Fix for #13546 

Debug log the error, should only come up if a temporary user has not yet been created.

Also downgrade logging that host user creation is disabled on macos at every run to a debugline