### PR TITLE
use editor instead of admin in tctl usage example

### DIFF
--- a/tool/tctl/common/usage.go
+++ b/tool/tctl/common/usage.go
@@ -30,10 +30,10 @@ const (
 
 Examples:
 
-  > tctl users add --roles=admin,dba joe
+  > tctl users add --roles=editor,dba joe
 
-  This creates a Teleport account 'joe' who will assume the roles 'admin' and 'dba'
-  To see the permissions of 'admin' role, execute 'tctl get role/admin'
+  This creates a Teleport account 'joe' who will assume the roles 'editor' and 'dba'
+  To see the permissions of 'editor' role, execute 'tctl get role/editor'
 `
 
 	AddNodeHelp = `Notes:


### PR DESCRIPTION
Fix for part 2 of https://github.com/gravitational/teleport/issues/13340#issuecomment-1156904160

New output:
```
λ tctl users add --help
usage: tctl users add --roles=ROLES [<flags>] <account>
....

Examples:

  > tctl users add --roles=editor,dba joe

  This creates a Teleport account 'joe' who will assume the roles 'editor' and 'dba'
  To see the permissions of 'editor' role, execute 'tctl get role/editor'
```