### PR TITLE
Support configuration `teleport.join_params.join_method` "token"

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2126,10 +2126,10 @@ func applyTokenConfig(fc *FileConfig, cfg *service.Config) error {
 		}
 		cfg.Token = fc.JoinParams.TokenName
 		switch fc.JoinParams.Method {
-		case types.JoinMethodEC2, types.JoinMethodIAM:
+		case types.JoinMethodEC2, types.JoinMethodIAM, types.JoinMethodToken:
 			cfg.JoinMethod = fc.JoinParams.Method
 		default:
-			return trace.BadParameter(`unknown value for join_params.method: %q, expected one of %v`, fc.JoinParams.Method, []types.JoinMethod{types.JoinMethodEC2, types.JoinMethodIAM})
+			return trace.BadParameter(`unknown value for join_params.method: %q, expected one of %v`, fc.JoinParams.Method, []types.JoinMethod{types.JoinMethodEC2, types.JoinMethodIAM, types.JoinMethodToken})
 		}
 	}
 	return nil

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2124,7 +2124,10 @@ func applyTokenConfig(fc *FileConfig, cfg *service.Config) error {
 		if cfg.Token != "" {
 			return trace.BadParameter("only one of auth_token or join_params should be set")
 		}
-		cfg.Token = fc.JoinParams.TokenName
+		_, err := cfg.ApplyToken(fc.JoinParams.TokenName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		switch fc.JoinParams.Method {
 		case types.JoinMethodEC2, types.JoinMethodIAM, types.JoinMethodToken:
 			cfg.JoinMethod = fc.JoinParams.Method

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -514,9 +514,13 @@ func (l *Log) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Global is 'teleport' (global) section of the config file
 type Global struct {
-	NodeName    string           `yaml:"nodename,omitempty"`
-	DataDir     string           `yaml:"data_dir,omitempty"`
-	PIDFile     string           `yaml:"pid_file,omitempty"`
+	NodeName string `yaml:"nodename,omitempty"`
+	DataDir  string `yaml:"data_dir,omitempty"`
+	PIDFile  string `yaml:"pid_file,omitempty"`
+
+	// AuthToken is the old way of configuring the token to be used by the
+	// node to join the Teleport cluster. `JoinParams.TokenName` should be
+	// used instead with `JoinParams.JoinMethod = types.JoinMethodToken`.
 	AuthToken   string           `yaml:"auth_token,omitempty"`
 	JoinParams  JoinParams       `yaml:"join_params,omitempty"`
 	AuthServers []string         `yaml:"auth_servers,omitempty"`

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -197,9 +197,13 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 		g.DataDir = defaults.DataDir
 	}
 
+	joinMethod := flags.JoinMethod
+	if joinMethod == "" && flags.AuthToken != "" {
+		joinMethod = string(types.JoinMethodToken)
+	}
 	g.JoinParams = JoinParams{
 		TokenName: flags.AuthToken,
-		Method:    types.JoinMethod(flags.JoinMethod),
+		Method:    types.JoinMethod(joinMethod),
 	}
 
 	if flags.AuthServer != "" {

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -126,7 +126,6 @@ func TestAuthSection(t *testing.T) {
 			desc: "Web idle timeout",
 			mutate: func(cfg cfgMap) {
 				cfg["auth_service"].(cfgMap)["web_idle_timeout"] = "10m"
-
 			},
 			expectError:          require.NoError,
 			expectWebIdleTimeout: requireEqual(types.Duration(10 * time.Minute)),
@@ -134,7 +133,6 @@ func TestAuthSection(t *testing.T) {
 			desc: "Web idle timeout (invalid)",
 			mutate: func(cfg cfgMap) {
 				cfg["auth_service"].(cfgMap)["web_idle_timeout"] = "potato"
-
 			},
 			expectError: require.Error,
 		},
@@ -465,7 +463,6 @@ func TestSSHSection(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestX11Config(t *testing.T) {
@@ -490,7 +487,8 @@ func TestX11Config(t *testing.T) {
 				}
 			},
 			expectX11Config: &x11.ServerConfig{},
-		}, {
+		},
+		{
 			desc: "x11 enabled",
 			mutate: func(cfg cfgMap) {
 				cfg["ssh_service"].(cfgMap)["x11"] = cfgMap{
@@ -517,7 +515,8 @@ func TestX11Config(t *testing.T) {
 				DisplayOffset: 100,
 				MaxDisplay:    100 + x11.DefaultMaxDisplays,
 			},
-		}, {
+		},
+		{
 			desc: "display offset value capped",
 			mutate: func(cfg cfgMap) {
 				cfg["ssh_service"].(cfgMap)["x11"] = cfgMap{
@@ -545,7 +544,8 @@ func TestX11Config(t *testing.T) {
 				DisplayOffset: x11.DefaultDisplayOffset,
 				MaxDisplay:    100,
 			},
-		}, {
+		},
+		{
 			desc: "max display value capped",
 			mutate: func(cfg cfgMap) {
 				cfg["ssh_service"].(cfgMap)["x11"] = cfgMap{
@@ -558,7 +558,8 @@ func TestX11Config(t *testing.T) {
 				DisplayOffset: x11.DefaultDisplayOffset,
 				MaxDisplay:    x11.MaxDisplayNumber,
 			},
-		}, {
+		},
+		{
 			desc: "max display smaller than display offset",
 			mutate: func(cfg cfgMap) {
 				cfg["ssh_service"].(cfgMap)["x11"] = cfgMap{
@@ -720,6 +721,15 @@ func TestMakeSampleFileConfig(t *testing.T) {
 		fc, err := MakeSampleFileConfig(SampleFlags{
 			AuthToken:  "auth-token",
 			JoinMethod: "token",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "auth-token", fc.JoinParams.TokenName)
+		require.Equal(t, types.JoinMethodToken, fc.JoinParams.Method)
+	})
+
+	t.Run("Token, method not specified", func(t *testing.T) {
+		fc, err := MakeSampleFileConfig(SampleFlags{
+			AuthToken: "auth-token",
 		})
 		require.NoError(t, err)
 		require.Equal(t, "auth-token", fc.JoinParams.TokenName)


### PR DESCRIPTION
Closes #13558 