### PR TITLE
Only heartbeat a proxyID superset at the keepalive interval

### DIFF
--- a/lib/services/compare.go
+++ b/lib/services/compare.go
@@ -17,14 +17,14 @@ limitations under the License.
 package services
 
 import (
-	"github.com/gravitational/teleport/api/types"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 // CompareResources compares two resources by all significant fields.
-func CompareResources(resA, resB types.Resource) int {
+func CompareResources(resA, resB types.Resource) CompareResult {
 	equal := cmp.Equal(resA, resB,
 		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
 		cmpopts.IgnoreFields(types.DatabaseV3{}, "Status"),

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -21,27 +21,29 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/gravitational/trace"
 )
+
+type CompareResult int
 
 const (
 	// Equal means two objects are equal
-	Equal = iota
+	Equal CompareResult = iota
 	// OnlyTimestampsDifferent is true when only timestamps are different
-	OnlyTimestampsDifferent = iota
+	OnlyTimestampsDifferent
 	// Different means that some fields are different
-	Different = iota
+	Different
 )
 
 // CompareServers compares two provided servers.
-func CompareServers(a, b types.Resource) int {
+func CompareServers(a, b types.Resource) CompareResult {
 	if serverA, ok := a.(types.Server); ok {
 		if serverB, ok := b.(types.Server); ok {
 			return compareServers(serverA, serverB)
@@ -65,7 +67,7 @@ func CompareServers(a, b types.Resource) int {
 	return Different
 }
 
-func compareServers(a, b types.Server) int {
+func compareServers(a, b types.Server) CompareResult {
 	if a.GetKind() != b.GetKind() {
 		return Different
 	}
@@ -116,7 +118,7 @@ func compareServers(a, b types.Server) int {
 	return Equal
 }
 
-func compareApplicationServers(a, b types.AppServer) int {
+func compareApplicationServers(a, b types.AppServer) CompareResult {
 	if a.GetKind() != b.GetKind() {
 		return Different
 	}
@@ -146,7 +148,7 @@ func compareApplicationServers(a, b types.AppServer) int {
 	return Equal
 }
 
-func compareDatabaseServers(a, b types.DatabaseServer) int {
+func compareDatabaseServers(a, b types.DatabaseServer) CompareResult {
 	if a.GetKind() != b.GetKind() {
 		return Different
 	}
@@ -176,7 +178,7 @@ func compareDatabaseServers(a, b types.DatabaseServer) int {
 	return Equal
 }
 
-func compareWindowsDesktopServices(a, b types.WindowsDesktopService) int {
+func compareWindowsDesktopServices(a, b types.WindowsDesktopService) CompareResult {
 	if a.GetKind() != b.GetKind() {
 		return Different
 	}

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -40,6 +40,8 @@ const (
 	OnlyTimestampsDifferent
 	// Different means that some fields are different
 	Different
+	// ProxyReachabilityDifferent means that the ProxyIDs are different
+	ProxyReachabilityDifferent
 )
 
 // CompareServers compares two provided servers.
@@ -109,6 +111,11 @@ func compareServers(a, b types.Server) CompareResult {
 		return Different
 	}
 	if !cmp.Equal(a.GetProxyIDs(), b.GetProxyIDs()) {
+		if len(b.GetProxyIDs()) > len(a.GetProxyIDs()) && len(a.GetProxyIDs()) > 0 {
+			if utils.StringSliceSubset(b.GetProxyIDs(), a.GetProxyIDs()) == nil {
+				return ProxyReachabilityDifferent
+			}
+		}
 		return Different
 	}
 	// OnlyTimestampsDifferent check must be after all Different checks.

--- a/lib/services/servers_test.go
+++ b/lib/services/servers_test.go
@@ -21,14 +21,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/check.v1"
+
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/check.v1"
 )
 
 type ServerSuite struct {
@@ -219,7 +219,7 @@ func TestOnlyTimestampsDifferent(t *testing.T) {
 		desc   string
 		a      types.Resource
 		b      types.Resource
-		expect int
+		expect CompareResult
 	}{
 		{
 			desc: "Kube cluster change returns Different",

--- a/lib/srv/heartbeatv2.go
+++ b/lib/srv/heartbeatv2.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
@@ -29,9 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/interval"
-
-	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 )
 
 // SSHServerHeartbeatConfig configures the HeartbeatV2 for an ssh server.
@@ -409,7 +409,8 @@ func (h *sshServerHeartbeatV2) Poll() (changed bool) {
 	if h.prev == nil {
 		return true
 	}
-	return services.CompareServers(h.getServer(), h.prev) == services.Different
+	result := services.CompareServers(h.prev, h.getServer())
+	return result == services.Different || result == services.ProxyReachabilityDifferent
 }
 
 func (h *sshServerHeartbeatV2) FallbackAnnounce(ctx context.Context) (ok bool) {

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -34,14 +34,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/modules"
-
-	"github.com/google/uuid"
-	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 )
 
 // WriteContextCloser provides close method with context
@@ -506,9 +506,9 @@ func PrintVersion() {
 
 // StringSliceSubset returns true if b is a subset of a.
 func StringSliceSubset(a []string, b []string) error {
-	aset := make(map[string]bool)
+	aset := make(map[string]struct{})
 	for _, v := range a {
-		aset[v] = true
+		aset[v] = struct{}{}
 	}
 
 	for _, v := range b {


### PR DESCRIPTION
Temporarily parked until an actual load problem occurs in a real deployment and not in a synthetic load test.

The strategy employed in daac36f seems to be successful in reducing a portion of the heartbeats while still allowing for some diagnostics and zero sacrifice in reachability. Further reductions in heartbeats could be done if we delayed heartbeats as long as the intersection between the previous list and the current list was nonempty, to the temporary detriment of reachability.