### PR TITLE
Update roles sample in ent getting started

### DIFF
--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -218,8 +218,11 @@ metadata:
 spec:
   allow:
     # The logins array defines the OS/UNIX logins a user is allowed to use
-    # for accessing Nodes in the Teleport cluster.
-    # Using the variable internal.logins allows including user logins
+    # for accessing Nodes in the Teleport cluster. The internal.logins variable 
+    # allows populating from a Teleport DB user's logins traits which could 
+    # include user logins like root, ec2-user,ubuntu and debian. That variable 
+    # also populates logins from a root Teleport Cluster in Trusted Clusters.
+  Using the variable internal.logins allows including user logins
     # from the user's traits and logins from a root cluster in Trusted Clusters.    
     logins: ['{{internal.logins}}', root]
     # List of Node labels a user will be allowed to SSH into

--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -217,7 +217,8 @@ metadata:
   name: access-sample
 spec:
   allow:
-    # The logins array defines the OS/UNIX logins a user is allowed to use.
+    # The logins array defines the OS/UNIX logins a user is allowed to use
+    # for accessing Nodes in the Teleport cluster.
     # Using the variable internal.logins allows including user logins
     # from the user's traits and logins from a root cluster in Trusted Clusters.    
     logins: ['{{internal.logins}}', root]

--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -222,7 +222,7 @@ spec:
     # Using the variable internal.logins allows including user logins
     # from the user's traits and logins from a root cluster in Trusted Clusters.    
     logins: ['{{internal.logins}}', root]
-    # List of node labels a user will be allowed to ssh to
+    # List of Node labels a user will be allowed to SSH into
     node_labels:
       '*': '*'
     # List of allowed Teleport resources for the user

--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -216,16 +216,21 @@ kind: role
 metadata:
   name: access-sample
 spec:
-  # This example defines a typical role. It allows listing all resources
-  # with typical developer credentials.
   allow:
+    # The logins array defines the OS/UNIX logins a user is allowed to use.
+    # Using the variable internal.logins allows including user logins
+    # from the user's traits and logins from a root cluster in Trusted Clusters.    
     logins: ['{{internal.logins}}', root]
+    # List of node labels a user will be allowed to ssh to
     node_labels:
       '*': '*'
+    # List of allowed Teleport resources for the user
     rules:
+    # User can view the event log details
     - resources:
       - event
       verbs: [list, read]
+    # User is allowed to view their own session recordings
     - resources:
       - session
       verbs: [list, read]

--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -214,12 +214,23 @@ role only allows SSH logins as `root@host`.
 ```yaml
 kind: role
 metadata:
-  name: access
+  name: access-sample
 spec:
+  # This example defines a typical role. It allows listing all resources
+  # with typical developer credentials.
   allow:
-    logins:
-    - '{{internal.logins}}'
-    - root
+    logins: ['{{internal.logins}}', root]
+    node_labels:
+      '*': '*'
+    rules:
+    - resources:
+      - event
+      verbs: [list, read]
+    - resources:
+      - session
+      verbs: [list, read]
+      where: contains(session.participants, user.metadata.name)
+version: v5
 ```
 
 You probably want to replace "root" with something else. Let's assume there will
@@ -229,7 +240,9 @@ to look like this:
 
 ```yaml
 allow:
-   logins: [admin]
+    logins: [admin]
+    node_labels:
+      '*': '*'
 ```
 
 <Admonition
@@ -248,7 +261,7 @@ $ sudo tctl create -f role.yaml
 Now, lets create a new Teleport user "joe" with "access" role:
 
 ```code
-$ sudo tctl users add --roles=access --logins=joe,ubuntu,ec2-user joe
+$ sudo tctl users add --roles=access-sample --logins=joe,ubuntu,ec2-user joe
 
 Signup token has been created and is valid for 1 hours. Share this URL with the user:
 https://auth.example.com:3080/web/newuser/22e3acb6a0c2cde22f13bdc879ff9d2a

--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -220,7 +220,8 @@ spec:
     # The logins array defines the OS/UNIX logins a user is allowed to use
     # for accessing Nodes in the Teleport cluster. The internal.logins variable 
     # allows populating from a Teleport DB user's logins traits which could 
-    # include user logins like root, ec2-user,ubuntu and debian. That variable 
+    # include user logins like root, ec2-user,ubuntu and debian. You then
+    # don't need to keep changing the role for each user. That variable 
     # also populates logins from a root Teleport Cluster in Trusted Clusters.
   Using the variable internal.logins allows including user logins
     # from the user's traits and logins from a root cluster in Trusted Clusters.    


### PR DESCRIPTION
The existing example was overwriting the OOTB `access` and also prevented seeing nodes and session replays.