### PR TITLE
Fix CentOS 7 builds after upgrading prost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1039,7 +1039,7 @@ endif
 .PHONY: pkg
 pkg:
 	mkdir -p $(BUILDDIR)/
-	cp ./build.assets/build-package.sh $(BUILDDIR)/
+	cp ./build.assets/build-package.sh ./build.assets/build-common.sh $(BUILDDIR)/
 	chmod +x $(BUILDDIR)/build-package.sh
 	# arch and runtime are currently ignored on OS X
 	# we pass them through for consistency - they will be dropped by the build script
@@ -1057,7 +1057,7 @@ pkg-tsh:
 .PHONY: rpm
 rpm:
 	mkdir -p $(BUILDDIR)/
-	cp ./build.assets/build-package.sh $(BUILDDIR)/
+	cp ./build.assets/build-package.sh ./build.assets/build-common.sh $(BUILDDIR)/
 	chmod +x $(BUILDDIR)/build-package.sh
 	cp -a ./build.assets/rpm $(BUILDDIR)/
 	cp -a ./build.assets/rpm-sign $(BUILDDIR)/
@@ -1073,7 +1073,7 @@ rpm-unsigned:
 .PHONY: deb
 deb:
 	mkdir -p $(BUILDDIR)/
-	cp ./build.assets/build-package.sh $(BUILDDIR)/
+	cp ./build.assets/build-package.sh ./build.assets/build-common.sh $(BUILDDIR)/
 	chmod +x $(BUILDDIR)/build-package.sh
 	cd $(BUILDDIR) && ./build-package.sh -t oss -v $(VERSION) -p deb -a $(ARCH) $(RUNTIME_SECTION) $(TARBALL_PATH_SECTION)
 	if [ -f e/Makefile ]; then $(MAKE) -C e deb; fi

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -166,6 +166,8 @@ RUN (curl -L https://github.com/bats-core/bats-core/archive/v1.2.1.tar.gz | tar 
 ARG PROTOC_VER
 ARG GOGO_PROTO_TAG
 ENV GOGOPROTO_ROOT ${GOPATH}/src/github.com/gogo/protobuf
+
+# Tell prost to use the system protoc instead of building it from source
 ENV PROTOC_NO_VENDOR true
 ENV PROTOC /usr/local/bin/protoc
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -85,9 +85,9 @@ RUN yum groupinstall -y 'Development Tools' && \
 # Use just created devtool image with newer GCC and Cmake
 FROM centos-devtoolset as clang10
 
-# Compile Clang 10.0.1 from source. It is needed to create BPF files. 
+# Compile Clang 10.0.1 from source. It is needed to create BPF files.
 # Centos 7 doesn't provide it as a package unfortunately.
-# LLVM_INCLUDE_BENCHMARKS must be off, otherwise compilation fails, 
+# LLVM_INCLUDE_BENCHMARKS must be off, otherwise compilation fails,
 # CLANG_BUILD_TOOLS must be on, it builds clang binary,
 # LLVM_BUILD_TOOLS must be on, it builds llvm-strip binary.
 # the rest is disabled to speedup the compilation.
@@ -176,6 +176,21 @@ ENV GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="/opt/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
+ARG BUILDARCH
+
+# Install protoc (for prost, a roletester dependency)
+ARG PROTOC_VER
+RUN (export PROTOC_TARBALL=protoc-${PROTOC_VER}-linux-$(if [ "$BUILDARCH" = "amd64" ]; then echo "x86_64"; else echo "aarch_64"; fi).zip && \
+     curl -L -o /tmp/${PROTOC_TARBALL} https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VER}/${PROTOC_TARBALL} && \
+     cd /tmp && unzip /tmp/${PROTOC_TARBALL} -d /usr/local && \
+     chmod -R a+r /usr/local/include/google/protobuf && \
+     chmod -R a+xr /usr/local/bin/protoc && \
+     rm /tmp/${PROTOC_TARBALL})
+
+# Tell prost to use the system protoc instead of building it from source
+ENV PROTOC_NO_VENDOR true
+ENV PROTOC /usr/local/bin/protoc
+
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install
@@ -231,7 +246,7 @@ COPY --from=clang10 /opt/llvm /opt/llvm/
 ENV PATH=/opt/llvm/bin:${PATH}
 
 # Copy libbpf into the final image.
-COPY --from=libbpf /opt/libbpf/usr /usr 
+COPY --from=libbpf /opt/libbpf/usr /usr
 
 USER ci
 VOLUME ["/go/src/github.com/gravitational/teleport"]

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -5,7 +5,6 @@ ENV LANGUAGE=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LC_CTYPE=en_US.UTF-8
 
-ARG RUST_VERSION
 ARG BORINGCRYPTO_RUNTIME
 ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
 
@@ -38,32 +37,16 @@ RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/
     chmod a-w / && \
     /opt/go/bin/go version
 
-# Install PAM module and policies for testing.
-COPY pam/ /opt/pam_teleport/
-RUN make -C /opt/pam_teleport install
-
-# Install Rust.
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=$RUST_VERSION
-
-RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
-    mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
-
-RUN chmod a-w /
-
-USER ci
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
-    rustup --version && \
-    cargo --version && \
-    rustc --version && \
-    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy && \
-    cargo install cbindgen
-
 ENV GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="/opt/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
+# Install PAM module and policies for testing.
+COPY pam/ /opt/pam_teleport/
+RUN make -C /opt/pam_teleport install
+
+RUN chmod a-w /
+
+USER ci
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -62,6 +62,9 @@ RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.
     chmod a+w /go && \
     chmod a+w /var/lib && \
     chmod a-w /
+ENV GOPATH="/go" \
+    GOROOT="/opt/go" \
+    PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
 # Install libbpf
 ARG LIBBPF_VERSION
@@ -69,10 +72,6 @@ RUN mkdir -p /opt && cd /opt && curl -L https://github.com/gravitational/libbpf/
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make && \
     make install
-
-ENV GOPATH="/go" \
-    GOROOT="/opt/go" \
-    PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -158,8 +158,10 @@ buildbox-centos7:
 	docker build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
+		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
+		--build-arg PROTOC_VER=$(PROTOC_VER) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--cache-from $(BUILDBOX_CENTOS7) \
 		--tag $(BUILDBOX_CENTOS7) -f Dockerfile-centos7 .


### PR DESCRIPTION
Recent Rust dependency upgrades include a newer version of prost.
This new version no longer ships embedded protoc binaries, and
instead tries to build protoc from source. This would require us
to install cmake on our buildboxes. We want to avoid this and
instead leverage the version of protoc already installed.

This change was made to the standard buildbox, but the CentOS 7
buildbox was missed.

Additionally, I noticed that Rust was installed in
Dockerfile-centos7-fips, but not in Dockerfile-fips, which means
the FIPS binaries have different functionality depending on which
version you use. To correct this, I removed Rust from the CentOS 7
FIPS builds (since the Rust features are not FIPS compliant anyway).