### PR TITLE
Changing instructions to reflect correct tag

### DIFF
--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -161,5 +161,5 @@ Please note:
   - When proxying an on-prem database, it must be configured with Teleport CA
     and key pair issued by "tctl auth sign --format=db" command.
   - When proxying an AWS RDS or Aurora database, the region must also be
-    specified with --db-aws-region flag.
+    specified with --aws-region flag.
 `))


### PR DESCRIPTION
--db-aws-region does nothing. It should be --aws-region to reflect the latest nomenclature. this is also out of data for a few docs but I figure this is the most urgent change.