### PR TITLE
Serialize HSM tests

### DIFF
--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -341,7 +341,6 @@ func liteBackendConfig(t *testing.T) *backend.Config {
 
 // Tests a single CA rotation with a single HSM auth server
 func TestHSMRotation(t *testing.T) {
-	t.Parallel()
 	if os.Getenv("SOFTHSM2_PATH") == "" {
 		t.Skip("Skipping test as SOFTHSM2_PATH is not set")
 	}
@@ -407,7 +406,6 @@ func TestHSMRotation(t *testing.T) {
 
 // Tests multiple CA rotations and rollbacks with 2 HSM auth servers in an HA configuration
 func TestHSMDualAuthRotation(t *testing.T) {
-	t.Parallel()
 	if os.Getenv("TELEPORT_ETCD_TEST") == "" || os.Getenv("SOFTHSM2_PATH") == "" {
 		t.Skip("Skipping test as either etcd or SoftHSM2 is not enabled")
 	}
@@ -696,7 +694,6 @@ func TestHSMDualAuthRotation(t *testing.T) {
 
 // Tests a dual-auth server migration from raw keys to HSM keys
 func TestHSMMigrate(t *testing.T) {
-	t.Parallel()
 	if os.Getenv("TELEPORT_ETCD_TEST") == "" || os.Getenv("SOFTHSM2_PATH") == "" {
 		t.Skip("Skipping test as either etcd or SoftHSM2 is not enabled")
 	}


### PR DESCRIPTION
I'm observing `libsofthsm2` becoming very slow and returning flaky results on certain APIs, especially when running these tests in parallel. Unfortunately `libsofthsm2` is extremely slow as soon as you have more than a very small number of keys at once (multiple seconds to generate a new keypair).

Parallelizing these tests seems to give us a modest speedup, but I'm worried it has made them all flakier. When running them in parallel with all other integration tests, I'm not sure the speedup actually makes a difference, so I'm considering serializing these again to improve stability.

Opening this draft PR to see if it affects overall runtime of our integration tests.

EDIT:
https://console.cloud.google.com/cloud-build/builds/bf368bfd-a788-4a6f-aaa2-bd6792e5bdd9?project=ci-account
Integration tests passed on this in 21:48, all other passing integration test runs right now seem to take 21:30-25 minutes, usually 23-24.

The total time for all HSM tests is 2:30. These DO still run in parallel with all other integration tests, because they are in their own package. They only run serially with each other.
```
pass (in 149.91s): github.com/gravitational/teleport/integration/hsm
```

Fixes https://github.com/gravitational/teleport/issues/13599
Fixes #13635