### PR TITLE
Deflake TestGRPCErrorWrapping

### DIFF
--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -587,5 +587,5 @@ func mustFindFailedNodeLoginAttempt(t *testing.T, av []apievents.AuditEvent, nod
 			return
 		}
 	}
-	t.Error("failed to find AuthAttemptFailureCode event")
+	t.Errorf("failed to find AuthAttemptFailureCode event (0/%d events matched)", len(av))
 }


### PR DESCRIPTION
This test would occaisonally fail with:

    === RUN   TestGRPCErrorWrapping
         grpc_test.go:125:
            	Error Trace:	grpc_test.go:125
            	Error:      	Received unexpected error:
            	            	EOF
            	Test:       	TestGRPCErrorWrapping

According to the GPRC docs
(https://pkg.go.dev/google.golang.org/grpc#section-readme)
io.EOF indicates that the server closed the stream and
that "the status of the stream may be discovered using ReadMsg."

Since the test is ultimately attempting to assert that the error
from Recv() is properly wrapped in an "already exists" error, we
tolerate the io.EOF on Send() and continue to check the error from
Recv().

I've run with this change for about 150K iterations and haven't seen
a failure. Prior to this change we would get a few failures per 10K
iterations.