### PR TITLE
Fix issues fround with automatic host user creation from test plan

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -151,6 +151,9 @@ func (u *HostUserManagement) CreateUser(name string, ui *services.HostUsersInfo)
 		}
 		systemGroup, err := u.backend.LookupGroup(types.TeleportServiceGroup)
 		if err != nil {
+			if errors.Is(err, user.UnknownGroupError(types.TeleportServiceGroup)) {
+				return nil, nil, trace.AlreadyExists("User %q already exists, however no users are currently managed by teleport", name)
+			}
 			return nil, nil, trace.Wrap(err)
 		}
 		var found bool


### PR DESCRIPTION
Fix for #13662  by returning an AleadyExists error when the user already exists but the teleport-service group does not yet exist.