### PR TITLE
helm: Add CA Pinning Support 

### DIFF
--- a/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
@@ -438,6 +438,34 @@ See [this link for information on Community Docker image versions](../../setup/g
   </TabItem>
 </Tabs>
 
+## `caPin`
+
+| Type | Default value |
+| - | - |
+| `list` | `[]` |
+
+When `caPin` is set, the Teleport pod will use its values to check the
+Auth Service's identity when first joining a cluster. This enables a more secure
+way of adding new Teleport instances to a cluster. See
+["Adding Nodes to the Cluster"](../admin/adding-nodes.mdx).
+
+Each list element can be the pin itself (recommended, works out of the box),
+or a path to a file containing the pin. For the latter it is your
+responsibility to mount the file using [`extraVolumes`](#extraVolumes).
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  caPin: ["sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"]
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set caPin[0]="sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
+  ```
+  </TabItem>
+</Tabs>
+
 ## `insecureSkipProxyTLSVerify`
 
 | Type | Default value |

--- a/examples/chart/teleport-kube-agent/.lint/ca-pin.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/ca-pin.yaml
@@ -1,0 +1,5 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube
+kubeClusterName: test-kube-cluster
+caPin: ["sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"]

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -22,6 +22,9 @@ data:
     teleport:
       auth_token: "/etc/teleport-secrets/auth-token"
       auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
+      {{- if .Values.caPin }}
+      ca_pin: {{- toYaml .Values.caPin | nindent 8 }}
+      {{- end }}
       log:
         severity: {{ $logLevel }}
         output: {{ .Values.log.output }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -312,6 +312,43 @@ matches snapshot for backwards-compatibility.yaml:
     metadata:
       name: RELEASE-NAME
       namespace: NAMESPACE
+matches snapshot for ca-pin.yaml:
+  1: |
+    apiVersion: v1
+    data:
+      teleport.yaml: |
+        teleport:
+          auth_token: "/etc/teleport-secrets/auth-token"
+          auth_servers: ["proxy.example.com:3080"]
+          ca_pin:
+            - sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1
+          log:
+            severity: INFO
+            output: stderr
+            format:
+              output: text
+              extra_fields: ["timestamp","level","component","caller"]
+
+        kubernetes_service:
+          enabled: true
+          kube_cluster_name: test-kube-cluster
+
+        app_service:
+          enabled: false
+
+        db_service:
+          enabled: false
+
+        auth_service:
+          enabled: false
+        ssh_service:
+          enabled: false
+        proxy_service:
+          enabled: false
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for db.yaml:
   1: |
     apiVersion: v1

--- a/examples/chart/teleport-kube-agent/tests/config_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/config_test.yaml
@@ -70,6 +70,16 @@ tests:
           of: ConfigMap
       - matchSnapshot: {}
 
+  - it: matches snapshot for ca-pin.yaml
+    values:
+      - ../.lint/ca-pin.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot: {}
+
   - it: does not generate a config for clusterrole.yaml
     values:
       - ../.lint/clusterrole.yaml

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -143,6 +143,14 @@
             "type": "string",
             "default": ""
         },
+        "caPin": {
+            "$id": "#/properties/caPin",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
+        },
         "insecureSkipProxyTLSVerify": {
             "$id": "#/properties/insecureSkipProxyTLSVerify",
             "type": "boolean",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -76,6 +76,15 @@ databaseResources: []
 
 # Version of teleport image, if different from appVersion in Chart.yaml.
 teleportVersionOverride: ""
+
+# Optional CA pins of the auth server. This enables a more secure way of
+# adding new nodes to a cluster. See "Adding Nodes to the Cluster"
+# (https://goteleport.com/docs/admin-guide/#adding-nodes-to-the-cluster).
+# Each list element can be the pin itself (recommended), or a path to a file
+# containing the pin. For the latter it is your responsibility to mount
+# the file, using extraVolumes.
+caPin: []
+
 # When set to true, the agent will skip the verification of proxy TLS
 # certificate.
 insecureSkipProxyTLSVerify: false


### PR DESCRIPTION
Fixes #13580 by adding an additional `caPin` field allowing the user to set the `ca_pin` config field.