### PR TITLE
bumps `RotateTrustedClusters` timeout from 30 to 60 sec

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4273,7 +4273,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 			}
 
 			return false
-		}, 30*time.Second, 250*time.Millisecond, "failed to converge to phase %q", phase)
+		}, 60*time.Second, 250*time.Millisecond, "failed to converge to phase %q", phase)
 	}
 
 	waitForPhase(types.RotationPhaseInit)


### PR DESCRIPTION
All of the failures documented in https://github.com/gravitational/teleport/issues/13569 appear to be run-of-the-mill timeout failures. Presuming there's been a recent increase in this failure, the hypothesis in https://github.com/gravitational/teleport/issues/13568#issuecomment-1159479944 could be the underlying cause. Until that's investigated, bumping the timeout may give us more successful integration test runs.