### PR TITLE
[v8] Remove outdated Ansible guide link

### DIFF
--- a/docs/pages/server-access/guides.mdx
+++ b/docs/pages/server-access/guides.mdx
@@ -8,9 +8,6 @@ layout: tocless-doc
   <Tile icon="server" title="Using Teleport with PAM" href="./guides/ssh-pam.mdx">
     How to configure Teleport SSH with PAM (Pluggable Authentication Modules).
   </Tile>
-  <Tile icon="server" title="Using Teleport with Ansible" href="./guides/ansible.mdx">
-    How to configure Teleport SSH with Ansible.
-  </Tile>
   <Tile icon="server" title="OpenSSH Guide" href="./guides/openssh.mdx">
     How to use Teleport on legacy systems with OpenSSH and sshd.
   </Tile>


### PR DESCRIPTION
Backport #12767 to branch/v8