### PR TITLE
Correct terminology from SSHAddr to ListenAddr for Auth server

### DIFF
--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -103,12 +103,12 @@ func newAuthConfig(t *testing.T, clock clockwork.Clock) *service.Config {
 
 	config := service.MakeDefaultConfig()
 	config.DataDir = t.TempDir()
-	config.Auth.SSHAddr.Addr = net.JoinHostPort(Host, helpers.NewPortStr())
+	config.Auth.ListenAddr.Addr = net.JoinHostPort(Host, helpers.NewPortStr())
 	config.Auth.ClusterName, err = services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
 		ClusterName: "testcluster",
 	})
 	require.NoError(t, err)
-	config.AuthServers = append(config.AuthServers, config.Auth.SSHAddr)
+	config.AuthServers = append(config.AuthServers, config.Auth.ListenAddr)
 	config.Auth.StorageConfig = storageConfig
 	config.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 	config.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
@@ -162,7 +162,7 @@ func TestEC2NodeJoin(t *testing.T) {
 		types.ProvisionTokenSpecV2{
 			Roles: []types.SystemRole{types.RoleNode},
 			Allow: []*types.TokenRule{
-				&types.TokenRule{
+				{
 					AWSAccount: iid.AccountID,
 					AWSRegions: []string{iid.Region},
 				},
@@ -192,7 +192,7 @@ func TestEC2NodeJoin(t *testing.T) {
 	require.Empty(t, nodes)
 
 	// create and start the node
-	nodeConfig := newNodeConfig(t, authConfig.Auth.SSHAddr, tokenName, types.JoinMethodEC2)
+	nodeConfig := newNodeConfig(t, authConfig.Auth.ListenAddr, tokenName, types.JoinMethodEC2)
 	nodeSvc, err := service.NewTeleport(nodeConfig)
 	require.NoError(t, err)
 	require.NoError(t, nodeSvc.Start())
@@ -234,7 +234,7 @@ func TestIAMNodeJoin(t *testing.T) {
 		types.ProvisionTokenSpecV2{
 			Roles: []types.SystemRole{types.RoleNode, types.RoleProxy},
 			Allow: []*types.TokenRule{
-				&types.TokenRule{
+				{
 					AWSAccount: *id.Account,
 				},
 			},
@@ -252,7 +252,7 @@ func TestIAMNodeJoin(t *testing.T) {
 
 	// create and start the proxy, will use the IAM method to join by connecting
 	// directly to the auth server
-	proxyConfig := newProxyConfig(t, authConfig.Auth.SSHAddr, tokenName, types.JoinMethodIAM)
+	proxyConfig := newProxyConfig(t, authConfig.Auth.ListenAddr, tokenName, types.JoinMethodIAM)
 	proxySvc, err := service.NewTeleport(proxyConfig)
 	require.NoError(t, err)
 	require.NoError(t, proxySvc.Start())
@@ -331,8 +331,8 @@ func TestEC2Labels(t *testing.T) {
 	tconf.Proxy.Enabled = true
 	tconf.Proxy.DisableWebInterface = true
 	tconf.Auth.StorageConfig = storageConfig
-	tconf.Auth.SSHAddr.Addr = net.JoinHostPort(Host, helpers.NewPortStr())
-	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.SSHAddr)
+	tconf.Auth.ListenAddr.Addr = net.JoinHostPort(Host, helpers.NewPortStr())
+	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.ListenAddr)
 
 	tconf.SSH.Enabled = true
 	tconf.SSH.Addr.Addr = net.JoinHostPort(Host, helpers.NewPortStr())
@@ -434,8 +434,8 @@ func TestEC2Hostname(t *testing.T) {
 	tconf.Proxy.Enabled = true
 	tconf.Proxy.DisableWebInterface = true
 	tconf.Auth.StorageConfig = storageConfig
-	tconf.Auth.SSHAddr.Addr = net.JoinHostPort(Host, helpers.NewPortStr())
-	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.SSHAddr)
+	tconf.Auth.ListenAddr.Addr = net.JoinHostPort(Host, helpers.NewPortStr())
+	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.ListenAddr)
 
 	tconf.SSH.Enabled = true
 	tconf.SSH.Addr.Addr = net.JoinHostPort(Host, helpers.NewPortStr())

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -461,7 +461,7 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 			Addr:        Host,
 		},
 	}
-	tconf.Auth.SSHAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortAuth())
+	tconf.Auth.ListenAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortAuth())
 	tconf.Auth.PublicAddrs = []utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
@@ -507,7 +507,7 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 			tconf.Proxy.MongoAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortMongo())
 		}
 	}
-	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.SSHAddr)
+	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.ListenAddr)
 	tconf.Auth.StorageConfig = backend.Config{
 		Type:   lite.GetName(),
 		Params: backend.Params{"path": dataDir + string(os.PathListSeparator) + defaults.BackendDir, "poll_stream_period": 50 * time.Millisecond},

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -208,8 +208,8 @@ func (t *teleportService) waitForPhaseChange(ctx context.Context) error {
 	return nil
 }
 
-func (t *teleportService) AuthSSHAddr(testingT *testing.T) utils.NetAddr {
-	addr, err := t.process.AuthSSHAddr()
+func (t *teleportService) AuthAddr(testingT *testing.T) utils.NetAddr {
+	addr, err := t.process.AuthAddr()
 	require.NoError(testingT, err)
 
 	return *addr
@@ -253,7 +253,7 @@ func newHSMAuthConfig(ctx context.Context, t *testing.T, storageConfig *backend.
 	config.ClientTimeout = time.Second
 	config.ShutdownTimeout = time.Minute
 	config.DataDir = t.TempDir()
-	config.Auth.SSHAddr.Addr = net.JoinHostPort(hostName, "0")
+	config.Auth.ListenAddr.Addr = net.JoinHostPort(hostName, "0")
 	config.Auth.PublicAddrs = []utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
@@ -264,7 +264,7 @@ func newHSMAuthConfig(ctx context.Context, t *testing.T, storageConfig *backend.
 		ClusterName: "testcluster",
 	})
 	require.NoError(t, err)
-	config.AuthServers = append(config.AuthServers, config.Auth.SSHAddr)
+	config.AuthServers = append(config.AuthServers, config.Auth.ListenAddr)
 	config.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
 		StaticTokens: []types.ProvisionTokenV1{
 			{
@@ -363,7 +363,7 @@ func TestHSMRotation(t *testing.T) {
 
 	// start a proxy to make sure it can get creds at each stage of rotation
 	log.Debug("TestHSMRotation: starting proxy")
-	proxy := newTeleportService(t, newProxyConfig(ctx, t, auth1.AuthSSHAddr(t), log), "proxy")
+	proxy := newTeleportService(t, newProxyConfig(ctx, t, auth1.AuthAddr(t), log), "proxy")
 	require.NoError(t, proxy.waitForStart(ctx))
 	teleportServices = append(teleportServices, proxy)
 
@@ -434,7 +434,7 @@ func TestHSMDualAuthRotation(t *testing.T) {
 	lb, err := utils.NewLoadBalancer(
 		ctx,
 		*utils.MustParseAddr(net.JoinHostPort(hostName, "0")),
-		auth1.AuthSSHAddr(t),
+		auth1.AuthAddr(t),
 	)
 	require.NoError(t, err)
 	require.NoError(t, lb.Listen())
@@ -467,7 +467,7 @@ func TestHSMDualAuthRotation(t *testing.T) {
 		require.NoError(t, err)
 		tlsConfig, err := identity.TLSConfig(nil)
 		require.NoError(t, err)
-		authAddrs := []utils.NetAddr{auth2.AuthSSHAddr(t)}
+		authAddrs := []utils.NetAddr{auth2.AuthAddr(t)}
 		clt, err := auth.NewClient(client.Config{
 			Addrs: utils.NetAddrsToStrings(authAddrs),
 			Credentials: []client.Credentials{
@@ -536,7 +536,7 @@ func TestHSMDualAuthRotation(t *testing.T) {
 	}
 
 	// Safe to send traffic to new auth server now that a full rotation has been completed.
-	lb.AddBackend(auth2.AuthSSHAddr(t))
+	lb.AddBackend(auth2.AuthAddr(t))
 
 	// load balanced client shoud work with either backend
 	getAdminClient = func() *auth.Client {
@@ -721,8 +721,8 @@ func TestHSMMigrate(t *testing.T) {
 	lb, err := utils.NewLoadBalancer(
 		ctx,
 		*utils.MustParseAddr(net.JoinHostPort(hostName, "0")),
-		auth1.AuthSSHAddr(t),
-		auth2.AuthSSHAddr(t),
+		auth1.AuthAddr(t),
+		auth2.AuthAddr(t),
 	)
 	require.NoError(t, err)
 	require.NoError(t, lb.Listen())
@@ -743,7 +743,7 @@ func TestHSMMigrate(t *testing.T) {
 		require.NoError(t, err)
 		tlsConfig, err := identity.TLSConfig(nil)
 		require.NoError(t, err)
-		authAddrs := []utils.NetAddr{auth2.AuthSSHAddr(t)}
+		authAddrs := []utils.NetAddr{auth2.AuthAddr(t)}
 		clt, err := auth.NewClient(client.Config{
 			Addrs: utils.NetAddrsToStrings(authAddrs),
 			Credentials: []client.Credentials{
@@ -763,7 +763,7 @@ func TestHSMMigrate(t *testing.T) {
 	require.NoError(t, testClient(clt))
 
 	// Phase 1: migrate auth1 to HSM
-	lb.RemoveBackend(auth1.AuthSSHAddr(t))
+	lb.RemoveBackend(auth1.AuthAddr(t))
 	auth1.process.Close()
 	require.NoError(t, auth1.waitForShutdown(ctx))
 	auth1Config.Auth.KeyStore = keystore.SetupSoftHSMTest(t)
@@ -827,10 +827,10 @@ func TestHSMMigrate(t *testing.T) {
 	}
 
 	// Safe to send traffic to new auth1 again
-	lb.AddBackend(auth1.AuthSSHAddr(t))
+	lb.AddBackend(auth1.AuthAddr(t))
 
 	// Phase 2: migrate auth2 to HSM
-	lb.RemoveBackend(auth2.AuthSSHAddr(t))
+	lb.RemoveBackend(auth2.AuthAddr(t))
 	auth2.process.Close()
 	require.NoError(t, auth2.waitForShutdown(ctx))
 	auth2Config.Auth.KeyStore = keystore.SetupSoftHSMTest(t)
@@ -855,6 +855,6 @@ func TestHSMMigrate(t *testing.T) {
 	}
 
 	// Safe to send traffic to new auth2 again
-	lb.AddBackend(auth2.AuthSSHAddr(t))
+	lb.AddBackend(auth2.AuthAddr(t))
 	require.NoError(t, testClient(clt))
 }

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -289,13 +289,13 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	})
 	require.NoError(t, err)
 	cfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(cfg.DataDir, defaults.BackendDir)}
-	cfg.Auth.SSHAddr = randomAddr
+	cfg.Auth.ListenAddr = randomAddr
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = false
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	authProcess := startAndWait(t, cfg, service.AuthTLSReady)
 	t.Cleanup(func() { authProcess.Close() })
-	authAddr, err := authProcess.AuthSSHAddr()
+	authAddr, err := authProcess.AuthAddr()
 	require.NoError(t, err)
 
 	// Use the same clock on AuthServer, it doesn't appear to cascade from

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -538,7 +538,7 @@ func applyAuthConfig(fc *FileConfig, cfg *service.Config) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		cfg.Auth.SSHAddr = *addr
+		cfg.Auth.ListenAddr = *addr
 		cfg.AuthServers = append(cfg.AuthServers, *addr)
 	}
 	for _, t := range fc.Auth.ReverseTunnels {
@@ -1962,7 +1962,7 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 
 	// auth_servers not configured, but the 'auth' is enabled (auth is on localhost)?
 	if len(cfg.AuthServers) == 0 && cfg.Auth.Enabled {
-		cfg.AuthServers = append(cfg.AuthServers, cfg.Auth.SSHAddr)
+		cfg.AuthServers = append(cfg.AuthServers, cfg.Auth.ListenAddr)
 	}
 
 	// add data_dir to the backend config:
@@ -2069,8 +2069,8 @@ func isCmdLabelSpec(spec string) (types.CommandLabel, error) {
 // a given IP
 func applyListenIP(ip net.IP, cfg *service.Config) {
 	listeningAddresses := []*utils.NetAddr{
-		&cfg.Auth.SSHAddr,
-		&cfg.Auth.SSHAddr,
+		&cfg.Auth.ListenAddr,
+		&cfg.Auth.ListenAddr,
 		&cfg.Proxy.SSHAddr,
 		&cfg.Proxy.WebAddr,
 		&cfg.SSH.Addr,

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -291,7 +291,7 @@ func makeSampleSSHConfig(conf *service.Config, flags SampleFlags, enabled bool) 
 func makeSampleAuthConfig(conf *service.Config, flags SampleFlags, enabled bool) Auth {
 	var a Auth
 	if enabled {
-		a.ListenAddress = conf.Auth.SSHAddr.Addr
+		a.ListenAddress = conf.Auth.ListenAddr.Addr
 		a.ClusterName = ClusterName(flags.ClusterName)
 		a.EnabledFlag = "yes"
 

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -512,8 +512,8 @@ type AuthConfig struct {
 	// EnableProxyProtocol enables proxy protocol support
 	EnableProxyProtocol bool
 
-	// SSHAddr is the listening address of SSH tunnel to HTTP service
-	SSHAddr utils.NetAddr
+	// ListenAddr is the listening address of the auth service
+	ListenAddr utils.NetAddr
 
 	// Authorities is a set of trusted certificate authorities
 	// that will be added by this auth server on the first start
@@ -1262,7 +1262,7 @@ func ApplyDefaults(cfg *Config) {
 
 	// Auth service defaults.
 	cfg.Auth.Enabled = true
-	cfg.Auth.SSHAddr = *defaults.AuthListenAddr()
+	cfg.Auth.ListenAddr = *defaults.AuthListenAddr()
 	cfg.Auth.StorageConfig.Type = lite.GetName()
 	cfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(cfg.DataDir, defaults.BackendDir)}
 	cfg.Auth.StaticTokens = types.DefaultStaticTokens()

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -74,7 +74,7 @@ func TestDefaultConfig(t *testing.T) {
 
 	// auth section
 	auth := config.Auth
-	require.Equal(t, auth.SSHAddr, localAuthAddr)
+	require.Equal(t, auth.ListenAddr, localAuthAddr)
 	require.Equal(t, auth.Limiter.MaxConnections, int64(defaults.LimiterMaxConnections))
 	require.Equal(t, auth.Limiter.MaxNumberOfUsers, defaults.LimiterMaxConcurrentUsers)
 	require.Equal(t, config.Auth.StorageConfig.Type, lite.GetName())

--- a/lib/service/listeners.go
+++ b/lib/service/listeners.go
@@ -28,7 +28,7 @@ import (
 type listenerType string
 
 var (
-	listenerAuthSSH    = listenerType(teleport.ComponentAuth)
+	listenerAuth       = listenerType(teleport.ComponentAuth)
 	listenerNodeSSH    = listenerType(teleport.ComponentNode)
 	listenerProxySSH   = listenerType(teleport.Component(teleport.ComponentProxy, "ssh"))
 	listenerDiagnostic = listenerType(teleport.ComponentDiagnostic)
@@ -47,9 +47,9 @@ var (
 	listenerWindowsDesktop    = listenerType(teleport.ComponentWindowsDesktop)
 )
 
-// AuthSSHAddr returns auth server SSH endpoint, if configured and started.
-func (process *TeleportProcess) AuthSSHAddr() (*utils.NetAddr, error) {
-	return process.registeredListenerAddr(listenerAuthSSH)
+// AuthAddr returns auth server endpoint, if configured and started.
+func (process *TeleportProcess) AuthAddr() (*utils.NetAddr, error) {
+	return process.registeredListenerAddr(listenerAuth)
 }
 
 // NodeSSHAddr returns the node SSH endpoint, if configured and started.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -907,12 +907,12 @@ func NewTeleport(cfg *Config, opts ...NewTeleportOption) (*TeleportProcess, erro
 	// if user started auth and another service (without providing the auth address for
 	// that service, the address of the in-process auth will be used
 	if process.Config.Auth.Enabled && len(process.Config.AuthServers) == 0 {
-		process.Config.AuthServers = []utils.NetAddr{process.Config.Auth.SSHAddr}
+		process.Config.AuthServers = []utils.NetAddr{process.Config.Auth.ListenAddr}
 	}
 
 	if len(process.Config.AuthServers) != 0 && process.Config.AuthServers[0].Port(0) == 0 {
 		// port appears undefined, attempt early listener creation so that we can get the real port
-		listener, err := process.importOrCreateListener(listenerAuthSSH, process.Config.Auth.SSHAddr.Addr)
+		listener, err := process.importOrCreateListener(listenerAuth, process.Config.Auth.ListenAddr.Addr)
 		if err == nil {
 			process.Config.AuthServers = []utils.NetAddr{utils.FromAddr(listener.Addr())}
 		}
@@ -1605,14 +1605,13 @@ func (process *TeleportProcess) initAuthService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	// auth server listens on SSH and TLS, reusing the same socket
-	listener, err := process.importOrCreateListener(listenerAuthSSH, cfg.Auth.SSHAddr.Addr)
+	listener, err := process.importOrCreateListener(listenerAuth, cfg.Auth.ListenAddr.Addr)
 	if err != nil {
-		log.Errorf("PID: %v Failed to bind to address %v: %v, exiting.", os.Getpid(), cfg.Auth.SSHAddr.Addr, err)
+		log.Errorf("PID: %v Failed to bind to address %v: %v, exiting.", os.Getpid(), cfg.Auth.ListenAddr.Addr, err)
 		return trace.Wrap(err)
 	}
 
-	// use listener addr instead of cfg.Auth.SSHAddr in order to support
+	// use listener addr instead of cfg.Auth.ListenAddr in order to support
 	// binding to a random port (e.g. `127.0.0.1:0`).
 	authAddr := listener.Addr().String()
 
@@ -1621,6 +1620,8 @@ func (process *TeleportProcess) initAuthService() error {
 	if cfg.Auth.EnableProxyProtocol {
 		log.Infof("Starting Auth service with PROXY protocol support.")
 	}
+
+	// use multiplexer to leverage support for proxy protocol.
 	mux, err := multiplexer.New(multiplexer.Config{
 		EnableProxyProtocol: cfg.Auth.EnableProxyProtocol,
 		Listener:            listener,

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -98,7 +98,7 @@ func TestMonitor(t *testing.T) {
 	cfg.AuthServers = []utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}}
 	cfg.Auth.Enabled = true
 	cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
-	cfg.Auth.SSHAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
+	cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = false
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
@@ -657,7 +657,7 @@ func TestTeleportProcessAuthVersionCheck(t *testing.T) {
 	authCfg.Auth.StaticTokens = staticTokens
 	authCfg.Auth.StorageConfig.Type = lite.GetName()
 	authCfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(authCfg.DataDir, defaults.BackendDir)}
-	authCfg.Auth.SSHAddr = listenAddr
+	authCfg.Auth.ListenAddr = listenAddr
 	authCfg.Proxy.Enabled = false
 	authCfg.SSH.Enabled = false
 

--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -39,7 +39,7 @@ import (
 // from lib/service/listeners.go
 // TODO(espadolini): have the constants exported
 const (
-	listenerAuthSSH     = "auth"
+	listenerAuth        = "auth"
 	listenerProxySSH    = "proxy:ssh"
 	listenerProxyWeb    = "proxy:web"
 	listenerProxyTunnel = "proxy:tunnel"
@@ -74,7 +74,7 @@ func DefaultConfig(t *testing.T) (*config.FileConfig, []service.FileDescriptor) 
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: newListener(t, listenerAuthSSH, &fds),
+				ListenAddress: newListener(t, listenerAuth, &fds),
 			},
 		},
 	}

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -564,13 +564,13 @@ func TestSSHAccessRequest(t *testing.T) {
 	user, err := user.Current()
 	require.NoError(t, err)
 	traits := map[string][]string{
-		teleport.TraitLogins: []string{user.Username},
+		teleport.TraitLogins: {user.Username},
 	}
 	alice.SetTraits(traits)
 
 	rootAuth, rootProxy := makeTestServers(t, withBootstrap(requester, nodeAccessRole, connector, alice))
 
-	authAddr, err := rootAuth.AuthSSHAddr()
+	authAddr, err := rootAuth.AuthAddr()
 	require.NoError(t, err)
 
 	proxyAddr, err := rootProxy.ProxyWebAddr()
@@ -1682,7 +1682,7 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	require.NoError(t, err)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = true
-	cfg.Auth.SSHAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}
+	cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}
 	cfg.Proxy.Enabled = false
 	cfg.Log = utils.NewLoggerForTests()
 
@@ -1710,7 +1710,7 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 		t.Fatal("auth server didn't start after 30s")
 	}
 
-	authAddr, err := auth.AuthSSHAddr()
+	authAddr, err := auth.AuthAddr()
 	require.NoError(t, err)
 
 	// Set up a test proxy service.


### PR DESCRIPTION
It looks like at one point in history, the Auth server accepted SSH connections, and later TLS connections were added and eventually support for SSH connections to the Auth server were removed (please correct me if I'm wrong, I'm just going off git blame and what's in front of me).

This means that throughout the codebase, the listener/address for the Auth server is referred to as `ListenerAuthSSH`, `AuthSSHAddr` or `SSHAddr`. This seems misleading and was confusing to me, as I was expecting to find somewhere where it handled a SSH connection.

This PR renames references to SSH in the context of the auth server listener to be more generic. I had considered changing referneces to SSH to TLS or similar, but, given that the auth server opens no other listeners this extra detail seems redundant. I'd be more than happy to use `AuthTLS` if others feel that is more appropriate.