### PR TITLE
[v9] Refine the organization of /docs/getting-started

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -24,21 +24,7 @@
             {
               "title": "Docker Compose",
               "slug": "/getting-started/docker-compose/",
-              "forScopes": ["oss"]
-            },
-            {
-              "title": "DigitalOcean",
-              "slug": "/getting-started/digitalocean/"
-            },
-            {
-              "title": "Local Kubernetes Lab",
-              "slug": "/getting-started/local-kubernetes/",
-              "forScopes": ["oss"]
-            },
-            {
-              "title": "Kubernetes Cluster",
-              "slug": "/getting-started/kubernetes-cluster/",
-              "forScopes": ["oss", "enterprise"]
+              "forScopes": "oss"
             }
           ]
         },
@@ -117,7 +103,13 @@
             {
               "title": "IBM",
               "slug": "/setup/deployments/ibm/",
-              "forScopes": ["oss", "enterprise"]
+              "forScopes": ["oss", "enterprise"],
+              "slug": "/setup/deployments/ibm/"
+            },
+            {
+              "title": "Digital Ocean",
+              "forScopes": "oss",
+              "slug": "/setup/deployments/digitalocean/"
             }
           ]
         },
@@ -1261,6 +1253,11 @@
     {
       "source": "/docs/kubernetes-access/getting-started/local/",
       "destination": "/docs/getting-started/local-kubernetes/",
+      "permanent": true
+    },
+    {
+      "source": "/getting-started/digitalocean/",
+      "destination": "/setup/deployments/digitalocean/",
       "permanent": true
     }
   ]

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -40,15 +40,6 @@ Host your own Teleport deployment.
   Linux server.
 
   </Tile>
-  <Tile
-  icon="stack"
-  title="Teleport on DigitalOcean"
-  href="./getting-started/digitalocean.mdx/"
-  >
-
-  Use our DigitalOcean 1-Click App to quickly spin up Teleport on a droplet.
-    
-  </Tile>
   <Tile 
   icon="kubernetes"
   title="Kubernetes"

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -26,7 +26,7 @@ Quickly see how Teleport works in one of our demo environments.
   <Tile icon="integrations" title="Docker Compose Lab" href="./getting-started/docker-compose.mdx">
     Try Teleport locally using Docker Compose.
   </Tile>
-    <Tile icon="kubernetes" title="Kubernetes Lab" href="./kubernetes-access/getting-started/local.mdx">
+    <Tile icon="kubernetes" title="Kubernetes Lab" href="./getting-started/local-kubernetes.mdx">
     See how Teleport runs on Kubernetes with this local lab.
   </Tile>
 </TileSet>

--- a/docs/pages/setup/deployments.mdx
+++ b/docs/pages/setup/deployments.mdx
@@ -7,14 +7,28 @@ layout: tocless-doc
 These guides show you how to set up a full self-hosted Teleport deployment on
 the platform of your choice.
 
-<ul>
-  <li>
-    [AWS Terraform](./deployments/aws-terraform.mdx). Deploy HA Teleport with Terraform Provider on AWS.
-  </li>
-  <li>
-    [GCP](./deployments/gcp.mdx). Deploy HA Teleport on GCP.
-  </li>
-  <li>
-    [IBM Cloud](./deployments/ibm.mdx). Deploy HA Teleport on IBM cloud.
-  </li>
-</ul>
+<TileSet>
+  <Tile
+  title="DigitalOcean"
+  href="./deployments/digitalocean/"
+  >
+
+    Use our DigitalOcean 1-Click App to quickly spin up Teleport on a droplet.
+    
+  </Tile>
+  <Tile href="./deployments/aws-terraform.mdx" title="AWS Terraform">
+
+    Deploy HA Teleport with Terraform Provider on AWS.
+
+  </Tile>
+  <Tile href="./deployments/gcp.mdx" title="GCP">
+
+    Deploy HA Teleport on GCP.
+
+  </Tile>
+  <Tile href="./deployments/ibm.mdx" title="IBM Cloud">
+
+    Deploy HA Teleport on IBM cloud.
+
+  </Tile>
+</TileSet>

--- a/docs/pages/setup/deployments/digitalocean.mdx
+++ b/docs/pages/setup/deployments/digitalocean.mdx
@@ -9,7 +9,7 @@ DigitalOcean with the Teleport 1-Click Droplet app.
 
 <Notice type="tip">
 
-If you are looking for a manual installation, refer to our [Linux installation guide](./linux-server.mdx). 
+If you are looking for a manual installation, refer to our [Linux installation guide](../../getting-started/linux-server.mdx). 
 
 </Notice>
 
@@ -23,19 +23,19 @@ If you are looking for a manual installation, refer to our [Linux installation g
 Head over to the Teleport page on [DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps/teleport) and click the “Create a Droplet” button:
 
 <Figure align="left" bordered caption="Teleport 1-Click droplet page">
-  ![Teleport 1-Click droplet page](../../img/quickstart/digitalocean/1click-droplet-page.png)
+  ![Teleport 1-Click droplet page](../../../img/quickstart/digitalocean/1click-droplet-page.png)
 </Figure>
 
 
 Once you click the button, DigitalOcean redirects you to the control panel to configure resources for the Teleport droplet. This step is similar to how you create a regular [droplet in DigitalOcean](https://docs.digitalocean.com/products/droplets/how-to/create/). Teleport is very lightweight, and if you are just trying out Teleport, you can select the $5 droplet. Make sure you select "SSH keys" as the SSH authentication method as it is more secure than a password.
 <Figure align="left" bordered caption="Create a droplet">
-  ![Create a droplet](../../img/quickstart/digitalocean/create-droplet.png)
+  ![Create a droplet](../../../img/quickstart/digitalocean/create-droplet.png)
 </Figure>
 
 It will take a few minutes before our newly created Teleport droplet is ready. Once the droplet is ready, configure your FQDN with the public IP address of the droplet as an IP address for the `A` record of your domain name. 
 For example, refer to the image below; we use the domain name `example.com`. The resulting domain we are using as an FQDN is `tele.example.com`, pointing to our Teleport droplet's public IP `192.168.200.200`.
 <Figure align="left" bordered caption="Configure DNS">
-  ![Configure DNS](../../img/quickstart/digitalocean/fqdn.png)
+  ![Configure DNS](../../../img/quickstart/digitalocean/fqdn.png)
 </Figure>
 
 ## Step 2/3. Configure Teleport
@@ -82,14 +82,14 @@ Open the link copied in the previous step in the browser to complete the setup p
 1. Scan the QR code with your two-factor authentication app (e.g., Google Authenticator)
 2. Set a password and enter the TOTP code generated from the two-factor authentication app.
 <Figure align="left" bordered caption="Set up user">
-  ![Set up user](../../img/quickstart/digitalocean/setup-user.png)
+  ![Set up user](../../../img/quickstart/digitalocean/setup-user.png)
 </Figure>
 
 
 Once you set up a password and provide a valid TOTP code, the user setup process will be complete, and you will be redirected to Teleport Web UI:
 
 <Figure align="left" bordered caption="Teleport Web UI">
-  ![Teleport Web UI](../../img/quickstart/digitalocean/webui.png)
+  ![Teleport Web UI](../../../img/quickstart/digitalocean/webui.png)
 </Figure>
 
 
@@ -97,23 +97,23 @@ Congrats! You've completed setting up Teleport.
 
 ## Next steps
 Finally, you are a step closer to managing secure access to your infrastructure hosted in DigitalOcean.
-Teleport lets you enable [certificate-based authentication for SSH](../server-access/getting-started.mdx) access. If you want to protect public access to internal applications such as GitLab or Grafana, check out our getting started guide on [Application Access](../application-access/getting-started.mdx).  
+Teleport lets you enable [certificate-based authentication for SSH](../../server-access/getting-started.mdx) access. If you want to protect public access to internal applications such as GitLab or Grafana, check out our getting started guide on [Application Access](../../application-access/getting-started.mdx).  
 
 You can also secure access to databases, DigitalOcean Marketplace apps, and Kubernetes clusters using Teleport. Below are the links to get started further:
 <TileSet>
-  <Tile icon="server" title="Server Access" href="../server-access/getting-started.mdx">
+  <Tile icon="server" title="Server Access" href="../../server-access/getting-started.mdx">
     Single Sign-On, short-lived certificates, and audit for SSH servers.
   </Tile>
-  <Tile icon="window" title="Application Access" href="../application-access/getting-started.mdx">
+  <Tile icon="window" title="Application Access" href="../../application-access/getting-started.mdx">
     Secure access to internal dashboards and web applications.
   </Tile>
-  <Tile icon="kubernetes" title="Kubernetes Access" href="../kubernetes-access/getting-started.mdx">
+  <Tile icon="kubernetes" title="Kubernetes Access" href="../../kubernetes-access/getting-started.mdx">
     Single Sign-On, audit and unified access for Kubernetes clusters.
   </Tile>
-  <Tile icon="database" title="Database Access" href="../database-access/getting-started.mdx">
+  <Tile icon="database" title="Database Access" href="../../database-access/getting-started.mdx">
     Secure access to PostgreSQL, MySQL and MongoDB databases.
   </Tile>
-  <Tile icon="desktop" title="Desktop Access" href="../desktop-access/getting-started.mdx">
+  <Tile icon="desktop" title="Desktop Access" href="../../desktop-access/getting-started.mdx">
     Secure access to Windows Server.
   </Tile>
 </TileSet>


### PR DESCRIPTION
Backports #12923

Fixes #12921

This removes the DigitalOcean link on the /docs/getting-started page
and moves the DigitalOcean guide into /docs/setup/deployments, which is
a more appropriate home. Now, the "Deploy to production" section of
/docs/getting-started only includes links to the Getting Started
guide for the Open Source, Cloud, and Enterprise editions, making it
clearer to users that there are three editions and that we have separate
content for each one.

This also changes the href of the Teleport Cloud link on the Getting
Started page to /cloud/getting-started/?scope=cloud to be
consistent with the other links, which direct users to guides.