### PR TITLE
[v8] Add Enterprise info to the Installation page

### DIFF
--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -254,6 +254,7 @@ Install `tsh` on your local machine:
     ```
 
     <Admonition type="note">
+
       The Teleport package in Homebrew is not maintained by Teleport and we can't
       guarantee its reliability or security. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=mac).
 
@@ -261,6 +262,7 @@ Install `tsh` on your local machine:
       `tctl` are compatible with the versions you run server-side. Homebrew usually
       ships the latest release of Teleport, which may be incompatible with older
       versions. See our [compatibility policy](../setup/operations/upgrading.mdx#component-compatibility) for details.
+
     </Admonition>
   </TabItem>
 

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,3 +1,4 @@
+<ScopedBlock scope={["oss", "cloud"]}>
 <Tabs>
     <TabItem label="Debian/Ubuntu (DEB)">
         ```code
@@ -61,5 +62,42 @@
         $ sudo ./install
         ```
   </TabItem>
-
 </Tabs>
+</ScopedBlock>
+<ScopedBlock scope={["enterprise"]}>
+
+Visit the [Downloads Page](https://dashboard.gravitational.com/web/downloads) in
+the customer portal and select the URL for your package of choice.
+
+Next, use the appropriate commands for your environment to install your package.
+
+For example, use the following commands to install Teleport on a machine with an
+x86-64 chip via tarball:
+
+
+```code
+$ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
+# <checksum> <filename>
+$ curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
+$ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
+# Verify that the checksums match
+$ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
+$ cd teleport
+$ sudo ./install
+```
+
+For FedRAMP/FIPS-compliant installations of Teleport Enterprise, package URLs
+will be slightly different:
+
+```code
+$ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz.sha256
+# <checksum> <filename>
+$ curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
+$ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
+# Verify that the checksums match
+$ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
+$ cd teleport
+$ sudo ./install
+```
+
+</ScopedBlock>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -101,6 +101,7 @@ chart.
 
 ## macOS
 
+<ScopedBlock scope={["oss", "cloud"]}>
 <Tabs>
   <TabItem label="Installer">
 
@@ -214,6 +215,30 @@ chart.
   </TabItem>
 
 </Tabs>
+</ScopedBlock>
+<ScopedBlock scope="enterprise">
+  You can download one of the following .pkg installers for macOS:
+
+  |Link|Binaries|
+  |-|-|
+  |[`teleport-ent-(=teleport.version=).pkg`](https://get.gravitational.com/teleport-ent-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`|
+  |[`tsh-(=teleport.version=).pkg`](https://get.gravitational.com/tsh-(=teleport.version=).pkg)|`tsh`|
+
+  You can also fetch an installer via the command line: 
+
+  ```code
+  $ curl -O https://get.gravitational.com/teleport-ent-(=teleport.version=).pkg
+  # Installs on Macintosh HD
+  $ sudo installer -pkg teleport-ent-(=teleport.version=).pkg -target / 
+  # Password:
+  # installer: Package name is teleport-ent-(=teleport.version=)
+  # installer: Upgrading at base path /
+  # installer: The upgrade was successful.
+  $ which teleport
+  # /usr/local/bin/teleport
+  ```
+
+</ScopedBlock>
 
 ## Windows (tsh client only)
 


### PR DESCRIPTION
Backports #13447

Fixes #12924

The Linux and MacOS sections of the Installation page only included
instructions for the OSS edition of Teleport. This change adds
Enterprise instructions to prevent Enterprise users from downloading
the wrong Teleport edition.

This also changes the install-linux partial to accommodate Enterprise
customers.