### PR TITLE
[v9] ensure timestamps on request reviews

### DIFF
--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -19,6 +19,7 @@ package services
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -279,6 +280,11 @@ func ApplyAccessReview(req types.AccessRequest, rev types.AccessReview, author t
 	tids, err := collectReviewThresholdIndexes(req, rev, author)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	// set a review created time if not already set
+	if rev.Created.IsZero() {
+		rev.Created = time.Now()
 	}
 
 	// set threshold indexes and store the review


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/13395
Accidentally closed the last pull request when fixing a commit merge instead of rebase.