### PR TITLE
Add AWS matchers to the ssh_service section of the fileconf

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1044,6 +1044,16 @@ func applySSHConfig(fc *FileConfig, cfg *service.Config) (err error) {
 		return trace.Wrap(err)
 	}
 
+	for _, matcher := range fc.SSH.AWSMatchers {
+		cfg.SSH.AWSMatchers = append(cfg.SSH.AWSMatchers,
+			services.AWSMatcher{
+				Types:       matcher.Types,
+				Regions:     matcher.Regions,
+				Tags:        matcher.Tags,
+				SSMDocument: matcher.SSMDocument,
+			})
+	}
+
 	return nil
 }
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -987,6 +987,9 @@ type SSH struct {
 	// DisableCreateHostUser disables automatic user provisioning on this
 	// SSH node.
 	DisableCreateHostUser bool `yaml:"disable_create_host_user,omitempty"`
+
+	// AWSMatchers are used to match EC2 instances
+	AWSMatchers []AWSMatcher `yaml:"aws,omitempty"`
 }
 
 // AllowTCPForwarding checks whether the config file allows TCP forwarding or not.
@@ -1173,6 +1176,9 @@ type AWSMatcher struct {
 	Regions []string `yaml:"regions,omitempty"`
 	// Tags are AWS tags to match.
 	Tags map[string]apiutils.Strings `yaml:"tags,omitempty"`
+	// SSMDocument is the ssm command document to execute for EC2
+	// installation
+	SSMDocument string `yaml:"ssm_command_document"`
 }
 
 // Database represents a single database proxied by the service.

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -599,6 +599,9 @@ type SSHConfig struct {
 	// DisableCreateHostUser disables automatic user provisioning on this
 	// SSH node.
 	DisableCreateHostUser bool
+
+	// AWSMatchers are used to match EC2 instances for auto enrollment.
+	AWSMatchers []services.AWSMatcher
 }
 
 // KubeConfig specifies configuration for kubernetes service

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2292,6 +2292,7 @@ func (process *TeleportProcess) initSSH() error {
 			regular.SetCreateHostUser(!cfg.SSH.DisableCreateHostUser),
 			regular.SetStoragePresenceService(storagePresence),
 			regular.SetInventoryControlHandle(process.inventoryHandle),
+			regular.SetAWSMatchers(cfg.SSH.AWSMatchers),
 		)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -37,6 +37,9 @@ type AWSMatcher struct {
 	Regions []string
 	// Tags are AWS tags to match.
 	Tags types.Labels
+	// SSMDocument is the SSM document used to execute the
+	// installation script
+	SSMDocument string
 }
 
 // MatchResourceLabels returns true if any of the provided selectors matches the provided database.
@@ -227,4 +230,6 @@ const (
 	AWSMatcherElastiCache = "elasticache"
 	// AWSMatcherMemoryDB is the AWS matcher type for MemoryDB databases.
 	AWSMatcherMemoryDB = "memorydb"
+	// AWSMatcherEC2 is the AWS matcher type for EC2 instances.
+	AWSMatcherEC2 = "ec2"
 )

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -214,6 +214,8 @@ type Server struct {
 
 	// users is used to start the automatic user deletion loop
 	users srv.HostUsers
+	// awsMatchers are used to match EC2 instances
+	awsMatchers []services.AWSMatcher
 }
 
 // GetClock returns server clock implementation
@@ -654,6 +656,14 @@ func SetConnectedProxyGetter(getter *reversetunnel.ConnectedProxyGetter) ServerO
 func SetInventoryControlHandle(handle inventory.DownstreamHandle) ServerOption {
 	return func(s *Server) error {
 		s.inventoryHandle = handle
+		return nil
+	}
+}
+
+// SetAWSMatchers sets the matchers used for matching EC2 instances
+func SetAWSMatchers(matchers []services.AWSMatcher) ServerOption {
+	return func(s *Server) error {
+		s.awsMatchers = matchers
 		return nil
 	}
 }


### PR DESCRIPTION
Adds an `aws` section to the fileconf so the below options may be supported (required by #12410) :

```yaml
ssh_service:
  aws:
    - types: ["ec2"]
      regions: ["us-west-2"]
      tags:
        "discover_teleport": "yes"
      ssm_command_document: "awsinstallerdoc"
```