### PR TITLE
Trace ssh requests

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -16,7 +16,9 @@ require (
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.7.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.7.0
+	go.opentelemetry.io/otel/sdk v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
+	go.opentelemetry.io/proto/otlp v0.16.0
 	golang.org/x/crypto v0.0.0-20220126234351-aa10faf2a1f8
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	google.golang.org/grpc v1.46.0

--- a/api/observability/tracing/option.go
+++ b/api/observability/tracing/option.go
@@ -1,0 +1,73 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// Option applies an option value for a Config.
+type Option interface {
+	apply(*Config)
+}
+
+// Config stores tracing related properties to customize
+// creating Tracers and extracting TraceContext
+type Config struct {
+	TracerProvider    oteltrace.TracerProvider
+	TextMapPropagator propagation.TextMapPropagator
+}
+
+// NewConfig returns a Config configured with all the passed Option.
+func NewConfig(opts []Option) *Config {
+	c := &Config{
+		TracerProvider:    otel.GetTracerProvider(),
+		TextMapPropagator: otel.GetTextMapPropagator(),
+	}
+	for _, o := range opts {
+		o.apply(c)
+	}
+	return c
+}
+
+type tracerProviderOption struct{ tp oteltrace.TracerProvider }
+
+func (o tracerProviderOption) apply(c *Config) {
+	if o.tp != nil {
+		c.TracerProvider = o.tp
+	}
+}
+
+// WithTracerProvider returns an Option to use the trace.TracerProvider when
+// creating a trace.Tracer.
+func WithTracerProvider(tp oteltrace.TracerProvider) Option {
+	return tracerProviderOption{tp: tp}
+}
+
+type propagatorOption struct{ p propagation.TextMapPropagator }
+
+func (o propagatorOption) apply(c *Config) {
+	if o.p != nil {
+		c.TextMapPropagator = o.p
+	}
+}
+
+// WithTextMapPropagator returns an Option to use the propagation.TextMapPropagator when extracting
+// and injecting trace context.
+func WithTextMapPropagator(p propagation.TextMapPropagator) Option {
+	return propagatorOption{p: p}
+}

--- a/api/observability/tracing/ssh/agent/forward.go
+++ b/api/observability/tracing/ssh/agent/forward.go
@@ -1,0 +1,31 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package agent
+
+import (
+	"context"
+	"errors"
+
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
+)
+
+// RequestAgentForwarding sets up agent forwarding for the session.
+// ForwardToAgent or ForwardToRemote should be called to route
+// the authentication requests.
+//
+// This is a forked version of golang.org/x/crypto/ssh/agent
+// that wraps payloads sent across the underlying session in an
+// Envelope, which allows us to provide tracing context to
+// the server processing forwarding requests.
+func RequestAgentForwarding(ctx context.Context, session *tracessh.Session) error {
+	ok, err := session.SendRequest(ctx, "auth-agent-req@openssh.com", true, nil)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("forwarding request denied")
+	}
+	return nil
+}

--- a/api/observability/tracing/ssh/session.go
+++ b/api/observability/tracing/ssh/session.go
@@ -1,0 +1,736 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/crypto/ssh"
+)
+
+// A Session represents a connection to a remote command or shell.
+//
+// This is a forked version of golang.org/x/crypto/ssh.Session
+// that wraps payloads sent across the underlying channel in an
+// Envelope, which allows us to provide tracing context to
+// the server processing the requests.
+type Session struct {
+	// Stdin specifies the remote process's standard input.
+	// If Stdin is nil, the remote process reads from an empty
+	// bytes.Buffer.
+	Stdin io.Reader
+
+	// Stdout and Stderr specify the remote process's standard
+	// output and error.
+	//
+	// If either is nil, Run connects the corresponding file
+	// descriptor to an instance of io.Discard. There is a
+	// fixed amount of buffering that is shared for the two streams.
+	// If either blocks it may eventually cause the remote
+	// command to block.
+	Stdout io.Writer
+	Stderr io.Writer
+
+	ch        *Channel // the channel backing this session
+	started   bool     // true once Start, Run or Shell is invoked.
+	copyFuncs []func() error
+	errors    chan error // one send per copyFunc
+
+	// true if pipe method is active
+	stdinpipe, stdoutpipe, stderrpipe bool
+
+	// stdinPipeWriter is non-nil if StdinPipe has not been called
+	// and Stdin was specified by the user; it is the write end of
+	// a pipe connecting Session.Stdin to the stdin channel.
+	stdinPipeWriter io.WriteCloser
+
+	exitStatus chan error
+
+	// tracer specifies the Tracer to be used to start spans for any
+	// operations performed on this Session.
+	tracer oteltrace.Tracer
+	// tracingSupported indicates whether the server is capable
+	// of receiving a tracing Envelope.
+	tracingSupported bool
+}
+
+// SendRequest sends an out-of-band channel request on the SSH channel
+// underlying the session.
+func (s *Session) SendRequest(ctx context.Context, name string, wantReply bool, payload []byte) (bool, error) {
+	ctx, span := s.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.SendRequest/%s", name),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("SendRequest"),
+			semconv.RPCSystemKey.String("ssh"),
+			attribute.Bool("want_reply", wantReply),
+		),
+	)
+	defer span.End()
+
+	ok, err := s.ch.SendRequest(ctx, name, wantReply, payload)
+	return ok, trace.Wrap(err)
+}
+
+func (s *Session) Close() error {
+	return trace.Wrap(s.ch.Close())
+}
+
+// RFC 4254 Section 6.4.
+type setenvRequest struct {
+	Name  string
+	Value string
+}
+
+// Setenv sets an environment variable that will be applied to any
+// command executed by Shell or Run.
+func (s *Session) Setenv(ctx context.Context, name, value string) error {
+	ctx, span := s.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.Setenv/%s", name),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("SendRequest"),
+			semconv.RPCSystemKey.String("ssh"),
+		),
+	)
+	defer span.End()
+
+	msg := setenvRequest{
+		Name:  name,
+		Value: value,
+	}
+	ok, err := s.ch.SendRequest(ctx, "env", true, ssh.Marshal(&msg))
+	if err == nil && !ok {
+		err = errors.New("ssh: setenv failed")
+	}
+	return trace.Wrap(err)
+}
+
+// RFC 4254 Section 6.2.
+type ptyRequestMsg struct {
+	Term     string
+	Columns  uint32
+	Rows     uint32
+	Width    uint32
+	Height   uint32
+	Modelist string
+}
+
+// POSIX terminal mode flags as listed in RFC 4254 Section 8.
+const (
+	ttyOpEnd = 0
+)
+
+// RequestPty requests the association of a pty with the session on the remote host.
+func (s *Session) RequestPty(ctx context.Context, term string, h, w int, termmodes ssh.TerminalModes) error {
+	ctx, span := s.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.RequestPty/%s", term),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("SendRequest"),
+			semconv.RPCSystemKey.String("ssh"),
+			attribute.Int("width", w),
+			attribute.Int("height", h),
+		),
+	)
+	defer span.End()
+
+	var tm []byte
+	for k, v := range termmodes {
+		kv := struct {
+			Key byte
+			Val uint32
+		}{k, v}
+
+		tm = append(tm, ssh.Marshal(&kv)...)
+	}
+	tm = append(tm, ttyOpEnd)
+	req := ptyRequestMsg{
+		Term:     term,
+		Columns:  uint32(w),
+		Rows:     uint32(h),
+		Width:    uint32(w * 8),
+		Height:   uint32(h * 8),
+		Modelist: string(tm),
+	}
+	ok, err := s.ch.SendRequest(ctx, "pty-req", true, ssh.Marshal(&req))
+	if err == nil && !ok {
+		err = errors.New("ssh: pty-req failed")
+	}
+	return trace.Wrap(err)
+}
+
+// RFC 4254 Section 6.5.
+type subsystemRequestMsg struct {
+	Subsystem string
+}
+
+// RequestSubsystem requests the association of a subsystem with the session on the remote host.
+// A subsystem is a predefined command that runs in the background when the ssh session is initiated
+func (s *Session) RequestSubsystem(ctx context.Context, subsystem string) error {
+	ctx, span := s.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.RequestSubsystem/%s", subsystem),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("RequestSubsystem"),
+			semconv.RPCSystemKey.String("ssh"),
+		),
+	)
+	defer span.End()
+
+	msg := subsystemRequestMsg{
+		Subsystem: subsystem,
+	}
+
+	ok, err := s.ch.SendRequest(ctx, "subsystem", true, ssh.Marshal(&msg))
+	if err == nil && !ok {
+		err = errors.New("ssh: subsystem request failed")
+	}
+	return trace.Wrap(err)
+}
+
+// RFC 4254 Section 6.7.
+type ptyWindowChangeMsg struct {
+	Columns uint32
+	Rows    uint32
+	Width   uint32
+	Height  uint32
+}
+
+// WindowChange informs the remote host about a terminal window dimension change to h rows and w columns.
+func (s *Session) WindowChange(ctx context.Context, h, w int) error {
+	ctx, span := s.tracer.Start(
+		ctx,
+		"ssh.WindowChange",
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("WindowChange"),
+			semconv.RPCSystemKey.String("ssh"),
+			attribute.Int("height", h),
+			attribute.Int("width", w),
+		),
+	)
+	defer span.End()
+
+	req := ptyWindowChangeMsg{
+		Columns: uint32(w),
+		Rows:    uint32(h),
+		Width:   uint32(w * 8),
+		Height:  uint32(h * 8),
+	}
+	_, err := s.ch.SendRequest(ctx, "window-change", false, ssh.Marshal(&req))
+	return trace.Wrap(err)
+}
+
+// RFC 4254 Section 6.9.
+type signalMsg struct {
+	Signal string
+}
+
+// Signal sends the given signal to the remote process.
+// sig is one of the SIG* constants.
+func (s *Session) Signal(ctx context.Context, sig ssh.Signal) error {
+	ctx, span := s.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.Signal/%s", sig),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("Signal"),
+			semconv.RPCSystemKey.String("ssh"),
+		),
+	)
+	defer span.End()
+
+	msg := signalMsg{
+		Signal: string(sig),
+	}
+
+	_, err := s.ch.SendRequest(ctx, "signal", false, ssh.Marshal(&msg))
+	return trace.Wrap(err)
+}
+
+// RFC 4254 Section 6.5.
+type execMsg struct {
+	Command string
+}
+
+// Start runs cmd on the remote host. Typically, the remote
+// server passes cmd to the shell for interpretation.
+// A Session only accepts one call to Run, Start or Shell.
+func (s *Session) Start(ctx context.Context, cmd string) error {
+	ctx, span := s.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.Start/%s", stripCommandName(cmd)),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("Start"),
+			semconv.RPCSystemKey.String("ssh"),
+		),
+	)
+	defer span.End()
+
+	if s.started {
+		return trace.Wrap(errors.New("ssh: session already started"))
+	}
+	msg := execMsg{
+		Command: cmd,
+	}
+
+	ok, err := s.ch.SendRequest(ctx, "exec", true, ssh.Marshal(&msg))
+	if err == nil && !ok {
+		err = fmt.Errorf("ssh: command %v failed", cmd)
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(s.start())
+}
+
+// stripCommandName attempts to extract only the command
+// name from the provided cmd which may contain a command
+// and arguments. This prevents any potentially sensitive
+// information being included in a trace.
+func stripCommandName(cmd string) string {
+	return strings.SplitN(cmd, " ", 2)[0]
+}
+
+// Run runs cmd on the remote host. Typically, the remote
+// server passes cmd to the shell for interpretation.
+// A Session only accepts one call to Run, Start, Shell, Output,
+// or CombinedOutput.
+//
+// The returned error is nil if the command runs, has no problems
+// copying stdin, stdout, and stderr, and exits with a zero exit
+// status.
+//
+// If the remote server does not send an exit status, an error of type
+// *ExitMissingError is returned. If the command completes
+// unsuccessfully or is interrupted by a signal, the error is of type
+// *ExitError. Other error types may be returned for I/O problems.
+func (s *Session) Run(ctx context.Context, cmd string) error {
+	ctx, span := s.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.Run/%s", stripCommandName(cmd)),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("Run"),
+			semconv.RPCSystemKey.String("ssh"),
+		),
+	)
+	defer span.End()
+
+	err := s.Start(ctx, cmd)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(s.Wait())
+}
+
+// Output runs cmd on the remote host and returns its standard output.
+func (s *Session) Output(ctx context.Context, cmd string) ([]byte, error) {
+	ctx, span := s.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.Output/%s", stripCommandName(cmd)),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("Output"),
+			semconv.RPCSystemKey.String("ssh"),
+		),
+	)
+	defer span.End()
+
+	if s.Stdout != nil {
+		return nil, trace.Wrap(errors.New("ssh: Stdout already set"))
+	}
+	var b bytes.Buffer
+	s.Stdout = &b
+	err := s.Run(ctx, cmd)
+	return b.Bytes(), trace.Wrap(err)
+}
+
+type singleWriter struct {
+	b  bytes.Buffer
+	mu sync.Mutex
+}
+
+func (w *singleWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.Write(p)
+}
+
+// CombinedOutput runs cmd on the remote host and returns its combined
+// standard output and standard error.
+func (s *Session) CombinedOutput(ctx context.Context, cmd string) ([]byte, error) {
+	ctx, span := s.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.CombinedOutput/%s", stripCommandName(cmd)),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("CombinedOutput"),
+			semconv.RPCSystemKey.String("ssh"),
+		),
+	)
+	defer span.End()
+
+	if s.Stdout != nil {
+		return nil, trace.Wrap(errors.New("ssh: Stdout already set"))
+	}
+	if s.Stderr != nil {
+		return nil, trace.Wrap(errors.New("ssh: Stderr already set"))
+	}
+	var b singleWriter
+	s.Stdout = &b
+	s.Stderr = &b
+	err := s.Run(ctx, cmd)
+	return b.b.Bytes(), trace.Wrap(err)
+}
+
+// Shell starts a login shell on the remote host. A Session only
+// accepts one call to Run, Start, Shell, Output, or CombinedOutput.
+func (s *Session) Shell(ctx context.Context) error {
+	ctx, span := s.tracer.Start(
+		ctx,
+		"ssh.Shell",
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Session"),
+			semconv.RPCMethodKey.String("Shell"),
+			semconv.RPCSystemKey.String("ssh"),
+		),
+	)
+	defer span.End()
+
+	if s.started {
+		return trace.Wrap(errors.New("ssh: session already started"))
+	}
+
+	ok, err := s.ch.SendRequest(ctx, "shell", true, nil)
+	if err == nil && !ok {
+		return trace.Wrap(errors.New("ssh: could not start shell"))
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(s.start())
+}
+
+func (s *Session) start() error {
+	s.started = true
+
+	type F func(*Session)
+	for _, setupFd := range []F{(*Session).stdin, (*Session).stdout, (*Session).stderr} {
+		setupFd(s)
+	}
+
+	s.errors = make(chan error, len(s.copyFuncs))
+	for _, fn := range s.copyFuncs {
+		go func(fn func() error) {
+			s.errors <- fn()
+		}(fn)
+	}
+	return nil
+}
+
+// Wait waits for the remote command to exit.
+//
+// The returned error is nil if the command runs, has no problems
+// copying stdin, stdout, and stderr, and exits with a zero exit
+// status.
+//
+// If the remote server does not send an exit status, an error of type
+// *ExitMissingError is returned. If the command completes
+// unsuccessfully or is interrupted by a signal, the error is of type
+// *ExitError. Other error types may be returned for I/O problems.
+func (s *Session) Wait() error {
+	if !s.started {
+		return trace.Wrap(errors.New("ssh: session not started"))
+	}
+	waitErr := <-s.exitStatus
+
+	if s.stdinPipeWriter != nil {
+		s.stdinPipeWriter.Close()
+	}
+	var copyError error
+	for range s.copyFuncs {
+		if err := <-s.errors; err != nil && copyError == nil {
+			copyError = err
+		}
+	}
+	if waitErr != nil {
+		return trace.Wrap(waitErr)
+	}
+	return trace.Wrap(copyError)
+}
+
+var signals = map[ssh.Signal]int{
+	ssh.SIGABRT: 6,
+	ssh.SIGALRM: 14,
+	ssh.SIGFPE:  8,
+	ssh.SIGHUP:  1,
+	ssh.SIGILL:  4,
+	ssh.SIGINT:  2,
+	ssh.SIGKILL: 9,
+	ssh.SIGPIPE: 13,
+	ssh.SIGQUIT: 3,
+	ssh.SIGSEGV: 11,
+	ssh.SIGTERM: 15,
+}
+
+func (s *Session) wait(reqs <-chan *ssh.Request) error {
+	wm := Waitmsg{status: -1}
+	// Wait for msg channel to be closed before returning.
+	for msg := range reqs {
+		switch msg.Type {
+		case "exit-status":
+			wm.status = int(binary.BigEndian.Uint32(msg.Payload))
+		case "exit-signal":
+			var sigval struct {
+				Signal     string
+				CoreDumped bool
+				Error      string
+				Lang       string
+			}
+			if err := ssh.Unmarshal(msg.Payload, &sigval); err != nil {
+				return trace.Wrap(err)
+			}
+
+			// Must sanitize strings?
+			wm.signal = sigval.Signal
+			wm.msg = sigval.Error
+			wm.lang = sigval.Lang
+		default:
+			// This handles keepalives and matches
+			// OpenSSH's behaviour.
+			if msg.WantReply {
+				msg.Reply(false, nil)
+			}
+		}
+	}
+	if wm.status == 0 {
+		return nil
+	}
+	if wm.status == -1 {
+		// exit-status was never sent from server
+		if wm.signal == "" {
+			// signal was not sent either.  RFC 4254
+			// section 6.10 recommends against this
+			// behavior, but it is allowed, so we let
+			// clients handle it.
+			return &ExitMissingError{}
+		}
+		wm.status = 128
+		if _, ok := signals[ssh.Signal(wm.signal)]; ok {
+			wm.status += signals[ssh.Signal(wm.signal)]
+		}
+	}
+
+	return &ExitError{wm}
+}
+
+// ExitMissingError is returned if a session is torn down cleanly, but
+// the server sends no confirmation of the exit status.
+type ExitMissingError struct{}
+
+func (e *ExitMissingError) Error() string {
+	return "wait: remote command exited without exit status or exit signal"
+}
+
+func (s *Session) stdin() {
+	if s.stdinpipe {
+		return
+	}
+	var stdin io.Reader
+	if s.Stdin == nil {
+		stdin = new(bytes.Buffer)
+	} else {
+		r, w := io.Pipe()
+		go func() {
+			_, err := io.Copy(w, s.Stdin)
+			w.CloseWithError(err)
+		}()
+		stdin, s.stdinPipeWriter = r, w
+	}
+	s.copyFuncs = append(s.copyFuncs, func() error {
+		_, err := io.Copy(s.ch, stdin)
+		if err1 := s.ch.CloseWrite(); err == nil && err1 != io.EOF {
+			err = err1
+		}
+		return err
+	})
+}
+
+func (s *Session) stdout() {
+	if s.stdoutpipe {
+		return
+	}
+	if s.Stdout == nil {
+		s.Stdout = io.Discard
+	}
+	s.copyFuncs = append(s.copyFuncs, func() error {
+		_, err := io.Copy(s.Stdout, s.ch)
+		return err
+	})
+}
+
+func (s *Session) stderr() {
+	if s.stderrpipe {
+		return
+	}
+	if s.Stderr == nil {
+		s.Stderr = io.Discard
+	}
+	s.copyFuncs = append(s.copyFuncs, func() error {
+		_, err := io.Copy(s.Stderr, s.ch.Stderr())
+		return err
+	})
+}
+
+// sessionStdin reroutes Close to CloseWrite.
+type sessionStdin struct {
+	io.Writer
+	ch *Channel
+}
+
+func (s *sessionStdin) Close() error {
+	return trace.Wrap(s.ch.CloseWrite())
+}
+
+// StdinPipe returns a pipe that will be connected to the
+// remote command's standard input when the command starts.
+func (s *Session) StdinPipe() (io.WriteCloser, error) {
+	if s.Stdin != nil {
+		return nil, trace.Wrap(errors.New("ssh: Stdin already set"))
+	}
+	if s.started {
+		return nil, trace.Wrap(errors.New("ssh: StdinPipe after process started"))
+	}
+	s.stdinpipe = true
+	return &sessionStdin{s.ch, s.ch}, nil
+}
+
+// StdoutPipe returns a pipe that will be connected to the
+// remote command's standard output when the command starts.
+// There is a fixed amount of buffering that is shared between
+// stdout and stderr streams. If the StdoutPipe reader is
+// not serviced fast enough it may eventually cause the
+// remote command to block.
+func (s *Session) StdoutPipe() (io.Reader, error) {
+	if s.Stdout != nil {
+		return nil, trace.Wrap(errors.New("ssh: Stdout already set"))
+	}
+	if s.started {
+		return nil, trace.Wrap(errors.New("ssh: StdoutPipe after process started"))
+	}
+	s.stdoutpipe = true
+	return s.ch, nil
+}
+
+// StderrPipe returns a pipe that will be connected to the
+// remote command's standard error when the command starts.
+// There is a fixed amount of buffering that is shared between
+// stdout and stderr streams. If the StderrPipe reader is
+// not serviced fast enough it may eventually cause the
+// remote command to block.
+func (s *Session) StderrPipe() (io.Reader, error) {
+	if s.Stderr != nil {
+		return nil, trace.Wrap(errors.New("ssh: Stderr already set"))
+	}
+	if s.started {
+		return nil, trace.Wrap(errors.New("ssh: StderrPipe after process started"))
+	}
+	s.stderrpipe = true
+	return s.ch.Stderr(), nil
+}
+
+// newSession returns a new interactive session on the remote host.
+func newSession(ch *Channel, reqs <-chan *ssh.Request, tracingSupported bool, tracer oteltrace.Tracer) (*Session, error) {
+	s := &Session{
+		ch:               ch,
+		tracingSupported: tracingSupported,
+		tracer:           tracer,
+	}
+	s.exitStatus = make(chan error, 1)
+	go func() {
+		s.exitStatus <- s.wait(reqs)
+	}()
+
+	return s, nil
+}
+
+// An ExitError reports unsuccessful completion of a remote command.
+type ExitError struct {
+	Waitmsg
+}
+
+func (e *ExitError) Error() string {
+	return e.Waitmsg.String()
+}
+
+// Waitmsg stores the information about an exited remote command
+// as reported by Wait.
+type Waitmsg struct {
+	status int
+	signal string
+	msg    string
+	lang   string
+}
+
+// ExitStatus returns the exit status of the remote command.
+func (w Waitmsg) ExitStatus() int {
+	return w.status
+}
+
+// Signal returns the exit signal of the remote command if
+// it was terminated violently.
+func (w Waitmsg) Signal() string {
+	return w.signal
+}
+
+// Msg returns the exit message given by the remote command
+func (w Waitmsg) Msg() string {
+	return w.msg
+}
+
+// Lang returns the language tag. See RFC 3066
+func (w Waitmsg) Lang() string {
+	return w.lang
+}
+
+func (w Waitmsg) String() string {
+	str := fmt.Sprintf("Process exited with status %v", w.status)
+	if w.signal != "" {
+		str += fmt.Sprintf(" from signal %v", w.signal)
+	}
+	if w.msg != "" {
+		str += fmt.Sprintf(". Reason was: %v", w.msg)
+	}
+	return str
+}

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -17,62 +17,397 @@ package ssh
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"time"
 
+	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ssh"
 )
 
 const (
-	// TracingRequest is sent by clients to server to pass along tracing context.
-	TracingRequest = "tracing@goteleport.com"
+	// TracingChannel is a SSH channel used to indicate that servers support tracing.
+	TracingChannel = "tracing"
+
+	// instrumentationName is the name of this instrumentation package.
+	instrumentationName = "otelssh"
 )
+
+// ContextFromRequest extracts any tracing data provided via an Envelope
+// in the ssh.Request payload. If the payload contains an Envelope, then
+// the context returned will have tracing data populated from the remote
+// tracing context and the ssh.Request payload will be replaced with the
+// original payload from the client.
+func ContextFromRequest(req *ssh.Request) context.Context {
+	ctx := context.Background()
+	var envelope Envelope
+	if err := json.Unmarshal(req.Payload, &envelope); err == nil {
+		ctx = tracing.WithPropagationContext(ctx, envelope.PropagationContext)
+		req.Payload = envelope.Payload
+	}
+
+	return ctx
+}
+
+// ContextFromNewChannel extracts any tracing data provided via an Envelope
+// in the ssh.NewChannel ExtraData. If the ExtraData contains an Envelope, then
+// the context returned will have tracing data populated from the remote
+// tracing context and the ssh.NewChannel wrapped in a TraceCh so that the
+// original ExtraData from the client is exposed instead of the Envelope
+// payload.
+func ContextFromNewChannel(nch ssh.NewChannel) (context.Context, ssh.NewChannel) {
+	ch := NewTraceCh(nch)
+	ctx := tracing.WithPropagationContext(context.Background(), ch.Envelope.PropagationContext)
+
+	return ctx, ch
+}
 
 // Client is a wrapper around ssh.Client that adds tracing support.
 type Client struct {
 	*ssh.Client
+	tracer           oteltrace.Tracer
+	cfg              *tracing.Config
+	tracingSupported bool
+	rejectedError    error
 }
 
 // NewClient creates a new Client.
-func NewClient(c ssh.Conn, chans <-chan ssh.NewChannel, reqs <-chan *ssh.Request) *Client {
-	return &Client{Client: ssh.NewClient(c, chans, reqs)}
+//
+// The server being connected to is probed to determine if it supports
+// ssh tracing. This is done by attempting to open a TracingChannel channel.
+// If the channel is successfully opened then all payloads delivered to the
+// server will be wrapped in an Envelope with tracing context. All Session
+// and Channel created from the returned Client will honor the clients view
+// of whether they should provide tracing context.
+//
+// Note: a channel is used instead of a global request in order prevent blocking
+// forever in the event that the connection is rejected. In that case, the server
+// doesn't service any global requests and writes the error to the first opened
+// channel.
+func NewClient(c ssh.Conn, chans <-chan ssh.NewChannel, reqs <-chan *ssh.Request, opts ...tracing.Option) *Client {
+	cfg := tracing.NewConfig(opts)
+	clt := &Client{
+		Client: ssh.NewClient(c, chans, reqs),
+		tracer: cfg.TracerProvider.Tracer(
+			instrumentationName,
+			oteltrace.WithInstrumentationVersion(api.Version),
+		),
+		cfg: cfg,
+	}
+
+	// Check if the server supports tracing
+	ch, _, err := clt.Client.OpenChannel(TracingChannel, nil)
+	if err != nil {
+		var openError *ssh.OpenChannelError
+		if errors.As(err, &openError) {
+			switch openError.Reason {
+			case ssh.Prohibited:
+				// prohibited errors due to locks and session control are expected by callers of NewSession
+				clt.rejectedError = err
+			default:
+			}
+
+			return clt
+		}
+
+		return clt
+	}
+
+	_ = ch.Close()
+	clt.tracingSupported = true
+
+	return clt
 }
 
-// NewSession creates a new SSH session that is passed tracing context so that spans may be correlated
-// properly over the ssh connection.
-func (c *Client) NewSession(ctx context.Context) (*ssh.Session, error) {
-	session, err := c.Client.NewSession()
+// DialContext initiates a connection to the addr from the remote host.
+// The resulting connection has a zero LocalAddr() and RemoteAddr().
+func (c *Client) DialContext(ctx context.Context, n, addr string) (net.Conn, error) {
+	_, span := c.tracer.Start(
+		ctx,
+		"ssh.Dial",
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			append(
+				peerAttr(c.Conn.RemoteAddr()),
+				attribute.String("network", n),
+				attribute.String("address", addr),
+				semconv.RPCServiceKey.String("ssh.Client"),
+				semconv.RPCMethodKey.String("SendRequest"),
+				semconv.RPCSystemKey.String("ssh"),
+			)...,
+		),
+	)
+	defer span.End()
+
+	conn, err := c.Client.Dial(n, addr)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	span := oteltrace.SpanFromContext(ctx)
-	if !span.IsRecording() {
-		return session, nil
-	}
+	return conn, nil
+}
 
-	traceCtx := tracing.PropagationContextFromContext(ctx)
-	if len(traceCtx) == 0 {
-		return session, nil
-	}
+// SendRequest sends a global request, and returns the
+// reply. If tracing is enabled, the provided payload
+// is wrapped in an Envelope to forward any tracing context.
+func (c *Client) SendRequest(ctx context.Context, name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	ctx, span := c.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.GlobalRequest/%s", name),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			append(
+				peerAttr(c.Conn.RemoteAddr()),
+				attribute.Bool("want_reply", wantReply),
+				semconv.RPCServiceKey.String("ssh.Client"),
+				semconv.RPCMethodKey.String("SendRequest"),
+				semconv.RPCSystemKey.String("ssh"),
+			)...,
+		),
+	)
+	defer span.End()
 
-	payload, err := json.Marshal(traceCtx)
+	ok, resp, err := c.Client.SendRequest(name, wantReply, wrapPayload(ctx, c.tracingSupported, c.cfg.TextMapPropagator, payload))
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+
+	return ok, resp, err
+}
+
+// OpenChannel tries to open a channel. If tracing is enabled,
+// the provided payload is wrapped in an Envelope to forward
+// any tracing context.
+func (c *Client) OpenChannel(ctx context.Context, name string, data []byte) (*Channel, <-chan *ssh.Request, error) {
+	ctx, span := c.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.OpenChannel/%s", name),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			append(
+				peerAttr(c.Conn.RemoteAddr()),
+				semconv.RPCServiceKey.String("ssh.Client"),
+				semconv.RPCMethodKey.String("OpenChannel"),
+				semconv.RPCSystemKey.String("ssh"),
+			)...,
+		),
+	)
+	defer span.End()
+
+	ch, reqs, err := c.Client.OpenChannel(name, wrapPayload(ctx, c.tracingSupported, c.cfg.TextMapPropagator, data))
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+
+	return &Channel{
+		Channel:          ch,
+		tracingSupported: c.tracingSupported,
+		tracer:           c.tracer,
+		cfg:              c.cfg,
+	}, reqs, err
+}
+
+// NewSession creates a new Session.
+func (c *Client) NewSession(ctx context.Context) (*Session, error) {
+	ctx, span := c.tracer.Start(
+		ctx,
+		"ssh.NewSession",
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			append(
+				peerAttr(c.Conn.RemoteAddr()),
+				semconv.RPCServiceKey.String("ssh.Client"),
+				semconv.RPCMethodKey.String("NewSession"),
+				semconv.RPCSystemKey.String("ssh"),
+			)...,
+		),
+	)
+	defer span.End()
+
+	ch, in, err := c.OpenChannel(ctx, "session", nil)
+	if err != nil {
+		// An EOF here means that the server closed our connection. In
+		// the event that the rejectedError was populated when opening the
+		// TracingChannel channel, the connection was prohibited due to a lock or
+		// session control. Callers to NewSession are expecting to receive
+		// the reason the session was rejected, so we need to propagate the
+		// rejectedError here instead of returning the EOF.
+		if errors.Is(err, io.EOF) && c.rejectedError != nil {
+			return nil, trace.Wrap(c.rejectedError)
+		}
+
 		return nil, trace.Wrap(err)
 	}
 
-	if _, err := session.SendRequest(TracingRequest, false, payload); err != nil {
-		return nil, trace.Wrap(err)
+	return newSession(ch, in, c.tracingSupported, c.tracer)
+}
+
+// Channel is a wrapper around ssh.Channel that adds tracing support.
+type Channel struct {
+	ssh.Channel
+	tracingSupported bool
+	cfg              *tracing.Config
+	tracer           oteltrace.Tracer
+}
+
+// NewChannel creates a new Channel.
+func NewChannel(ch ssh.Channel, opts ...tracing.Option) *Channel {
+	cfg := tracing.NewConfig(opts)
+
+	return &Channel{
+		Channel: ch,
+		cfg:     cfg,
+		tracer: cfg.TracerProvider.Tracer(
+			instrumentationName,
+			oteltrace.WithInstrumentationVersion(api.Version),
+		),
+	}
+}
+
+// SendRequest sends a global request, and returns the
+// reply. If tracing is enabled, the provided payload
+// is wrapped in an Envelope to forward any tracing context.
+func (c *Channel) SendRequest(ctx context.Context, name string, wantReply bool, payload []byte) (bool, error) {
+	ctx, span := c.tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.ChannelRequest/%s", name),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Channel"),
+			semconv.RPCMethodKey.String("SendRequest"),
+			semconv.RPCSystemKey.String("ssh"),
+		),
+	)
+	defer span.End()
+
+	ok, err := c.Channel.SendRequest(name, wantReply, wrapPayload(ctx, c.tracingSupported, c.cfg.TextMapPropagator, payload))
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
 	}
 
-	return session, nil
+	return ok, err
+}
+
+// ServerConn is a wrapper around ssh.ServerConn
+// that adds tracing support.
+type ServerConn struct {
+	Options []tracing.Option
+	*ssh.ServerConn
+}
+
+// NewServerConn creates a new ServerConn.
+func NewServerConn(conn net.Conn, config *ssh.ServerConfig, opts ...tracing.Option) (*ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request, error) {
+	sconn, chans, reqs, err := ssh.NewServerConn(conn, config)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+
+	serverConn := &ServerConn{
+		Options:    opts,
+		ServerConn: sconn,
+	}
+
+	return serverConn, chans, reqs, nil
+}
+
+// SendRequest sends a global request, and returns the
+// reply. If tracing is enabled, the provided payload
+// is wrapped in an Envelope to forward any tracing context.
+func (s *ServerConn) SendRequest(ctx context.Context, name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	cfg := tracing.NewConfig(s.Options)
+	tracer := cfg.TracerProvider.Tracer(
+		instrumentationName,
+		oteltrace.WithInstrumentationVersion(api.Version),
+	)
+
+	ctx, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.SeverRequest/%s", name),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			append(
+				peerAttr(s.Conn.RemoteAddr()),
+				semconv.RPCServiceKey.String("ssh.ServerConn"),
+				semconv.RPCMethodKey.String("SendRequest"),
+				semconv.RPCSystemKey.String("ssh"),
+			)...,
+		),
+	)
+	defer span.End()
+
+	ok, resp, err := s.Conn.SendRequest(name, wantReply, wrapPayload(ctx, true, cfg.TextMapPropagator, payload))
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+
+	return ok, resp, err
+}
+
+// OpenChannel tries to open a channel. If tracing is enabled,
+// the provided payload is wrapped in an Envelope to forward
+// any tracing context.
+func (s *ServerConn) OpenChannel(ctx context.Context, name string, data []byte) (*Channel, <-chan *ssh.Request, error) {
+	cfg := tracing.NewConfig(s.Options)
+	tracer := cfg.TracerProvider.Tracer(
+		instrumentationName,
+		oteltrace.WithInstrumentationVersion(api.Version),
+	)
+
+	ctx, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.OpenChannel/%s", name),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			append(
+				peerAttr(s.Conn.RemoteAddr()),
+				semconv.RPCServiceKey.String("ssh.ServerConn"),
+				semconv.RPCMethodKey.String("OpenChannel"),
+				semconv.RPCSystemKey.String("ssh"),
+			)...,
+		),
+	)
+	defer span.End()
+
+	ch, reqs, err := s.Conn.OpenChannel(name, wrapPayload(ctx, true, cfg.TextMapPropagator, data))
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+
+	return NewChannel(ch), reqs, err
+}
+
+// Dial starts a client connection to the given SSH server. It is a
+// convenience function that connects to the given network address,
+// initiates the SSH handshake, and then sets up a Client.  For access
+// to incoming channels and requests, use net.Dial with NewClientConn
+// instead.
+func Dial(ctx context.Context, network, addr string, config *ssh.ClientConfig) (*Client, error) {
+	conn, err := net.DialTimeout(network, addr, config.Timeout)
+	if err != nil {
+		return nil, err
+	}
+	c, chans, reqs, err := NewClientConn(ctx, conn, addr, config)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(c, chans, reqs), nil
 }
 
 // NewClientConn creates a new SSH client connection that is passed tracing context so that spans may be correlated
@@ -118,4 +453,106 @@ func NewClientConnWithDeadline(ctx context.Context, conn net.Conn, addr string, 
 		}
 	}
 	return NewClient(c, chans, reqs), nil
+}
+
+// peerAttr returns attributes about the peer address.
+func peerAttr(addr net.Addr) []attribute.KeyValue {
+	host, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return nil
+	}
+
+	if host == "" {
+		host = "127.0.0.1"
+	}
+
+	return []attribute.KeyValue{
+		semconv.NetPeerIPKey.String(host),
+		semconv.NetPeerPortKey.String(port),
+	}
+}
+
+// Envelope wraps the payload of all ssh messages with
+// tracing context. Any servers that reply to a TracingChannel
+// will attempt to parse the Envelope for all received requests and
+// ensure that the original payload is provided to the handlers.
+type Envelope struct {
+	PropagationContext tracing.PropagationContext
+	Payload            []byte
+}
+
+// createEnvelope wraps the provided payload with a tracing envelope
+// that is used to propagate trace context .
+func createEnvelope(ctx context.Context, propagator propagation.TextMapPropagator, payload []byte) Envelope {
+	envelope := Envelope{
+		Payload: payload,
+	}
+
+	span := oteltrace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return envelope
+	}
+
+	traceCtx := tracing.PropagationContextFromContext(ctx, tracing.WithTextMapPropagator(propagator))
+	if len(traceCtx) == 0 {
+		return envelope
+	}
+
+	envelope.PropagationContext = traceCtx
+
+	return envelope
+}
+
+// wrapPayload wraps the provided payload within an envelope if tracing is
+// enabled and there is any tracing information to propagate. Otherwise, the
+// original payload is returned
+func wrapPayload(ctx context.Context, supported bool, propagator propagation.TextMapPropagator, payload []byte) []byte {
+	if !supported {
+		return payload
+	}
+
+	envelope := createEnvelope(ctx, propagator, payload)
+	if len(envelope.PropagationContext) == 0 {
+		return payload
+	}
+
+	wrappedPayload, err := json.Marshal(envelope)
+	if err == nil {
+		return wrappedPayload
+	}
+
+	return payload
+}
+
+// NewCh is a wrapper around ssh.NewChannel that allows an
+// Envelope to be provided to new channels.
+type NewCh struct {
+	ssh.NewChannel
+	Envelope Envelope
+}
+
+// NewTraceCh creates a new NewCh
+//
+// The provided ssh.NewChannel will have any Envelope provided
+// via ExtraData extracted so that the original payload can be
+// provided to callers of NewCh.ExtraData.
+func NewTraceCh(nch ssh.NewChannel) *NewCh {
+	ch := &NewCh{
+		NewChannel: nch,
+	}
+
+	var envelope Envelope
+	if err := json.Unmarshal(nch.ExtraData(), &envelope); err == nil {
+		ch.Envelope = envelope
+	} else {
+		ch.Envelope.Payload = nch.ExtraData()
+	}
+
+	return ch
+}
+
+// ExtraData returns the arbitrary payload for this channel, as supplied
+// by the client. This data is specific to the channel type.
+func (n NewCh) ExtraData() []byte {
+	return n.Envelope.Payload
 }

--- a/api/observability/tracing/ssh/ssh_test.go
+++ b/api/observability/tracing/ssh/ssh_test.go
@@ -1,0 +1,447 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssh
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/subtle"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/observability/tracing"
+)
+
+const testPayload = "test"
+
+type server struct {
+	listener net.Listener
+	config   *ssh.ServerConfig
+	handler  func(*ssh.ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request)
+
+	cSigner ssh.Signer
+	hSigner ssh.Signer
+}
+
+func (s *server) Run(errC chan error) {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if !errors.Is(err, net.ErrClosed) {
+				errC <- err
+			}
+			return
+		}
+
+		go func() {
+			sconn, chans, reqs, err := ssh.NewServerConn(conn, s.config)
+			if err != nil {
+				errC <- err
+				return
+			}
+			s.handler(sconn, chans, reqs)
+		}()
+	}
+}
+
+func (s *server) Stop() error {
+	return s.listener.Close()
+}
+
+func generateSigner(t *testing.T) ssh.Signer {
+	private, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(private),
+	}
+
+	privatePEM := pem.EncodeToMemory(block)
+	signer, err := ssh.ParsePrivateKey(privatePEM)
+	require.NoError(t, err)
+
+	return signer
+}
+
+func (s *server) GetClient(t *testing.T) (ssh.Conn, <-chan ssh.NewChannel, <-chan *ssh.Request) {
+	conn, err := net.Dial("tcp", s.listener.Addr().String())
+	require.NoError(t, err)
+
+	sconn, nc, r, err := ssh.NewClientConn(conn, "", &ssh.ClientConfig{
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(s.cSigner)},
+		HostKeyCallback: ssh.FixedHostKey(s.hSigner.PublicKey()),
+	})
+	require.NoError(t, err)
+
+	return sconn, nc, r
+}
+
+func newServer(t *testing.T, handler func(*ssh.ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request)) *server {
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	cSigner := generateSigner(t)
+	hSigner := generateSigner(t)
+
+	config := &ssh.ServerConfig{
+		NoClientAuth: true,
+	}
+	config.AddHostKey(hSigner)
+
+	srv := &server{
+		listener: listener,
+		config:   config,
+		handler:  handler,
+		cSigner:  cSigner,
+		hSigner:  hSigner,
+	}
+
+	return srv
+}
+
+type handler struct {
+	tracingSupported bool
+	errChan          chan error
+	ctx              context.Context
+}
+
+func (h handler) handle(sconn *ssh.ServerConn, chans <-chan ssh.NewChannel, reqs <-chan *ssh.Request) {
+	for {
+		select {
+		case <-h.ctx.Done():
+			return
+		case req := <-reqs:
+			if req == nil {
+				return
+			}
+
+			h.requestHandler(req)
+
+		case ch := <-chans:
+			if ch == nil {
+				return
+			}
+
+			h.channelHandler(ch)
+		}
+	}
+}
+
+func (h handler) requestHandler(req *ssh.Request) {
+	switch {
+	case req.Type == TracingChannel && h.tracingSupported:
+		if err := req.Reply(true, nil); err != nil {
+			h.errChan <- err
+		}
+	case req.Type == "test":
+		defer func() {
+			if req.WantReply {
+				if err := req.Reply(true, nil); err != nil {
+					h.errChan <- err
+				}
+			}
+		}()
+
+		switch h.tracingSupported {
+		case false:
+			if subtle.ConstantTimeCompare(req.Payload, []byte(testPayload)) != 1 {
+				h.errChan <- errors.New("payload mismatch")
+			}
+		case true:
+			var envelope Envelope
+			if err := json.Unmarshal(req.Payload, &envelope); err != nil {
+				h.errChan <- trace.Wrap(err, "failed to unmarshal envelope")
+				return
+			}
+			if len(envelope.PropagationContext) <= 0 {
+				h.errChan <- errors.New("empty propagation context")
+				return
+			}
+			if subtle.ConstantTimeCompare(envelope.Payload, []byte(testPayload)) != 1 {
+				h.errChan <- errors.New("payload mismatch")
+				return
+			}
+		}
+	default:
+		if err := req.Reply(false, nil); err != nil {
+			h.errChan <- err
+		}
+	}
+}
+
+func (h handler) channelHandler(ch ssh.NewChannel) {
+	switch ch.ChannelType() {
+	case TracingChannel:
+		switch h.tracingSupported {
+		case false:
+			if err := ch.Reject(ssh.UnknownChannelType, "unknown channel type"); err != nil {
+				h.errChan <- trace.Wrap(err, "failed to reject channel")
+			}
+		case true:
+			ch.Accept()
+			return
+		}
+	case "session":
+		switch h.tracingSupported {
+		case false:
+			if subtle.ConstantTimeCompare(ch.ExtraData(), []byte(testPayload)) == 1 {
+				h.errChan <- errors.New("payload mismatch")
+			}
+		case true:
+			var envelope Envelope
+			if err := json.Unmarshal(ch.ExtraData(), &envelope); err != nil {
+				h.errChan <- trace.Wrap(err, "failed to unmarshal envelope")
+				ch.Accept()
+				return
+			}
+			if len(envelope.PropagationContext) <= 0 {
+				h.errChan <- errors.New("empty propagation context")
+				ch.Accept()
+				return
+			}
+			if len(envelope.Payload) > 0 {
+				h.errChan <- errors.New("payload mismatch")
+				ch.Accept()
+				return
+			}
+		}
+		_, chReqs, err := ch.Accept()
+		if err != nil {
+			h.errChan <- trace.Wrap(err, "failed to accept channel")
+			return
+		}
+
+		go func() {
+			for {
+				select {
+				case <-h.ctx.Done():
+					return
+				case req := <-chReqs:
+					switch req.Type {
+					case "subsystem":
+						h.subsystemHandler(req)
+					}
+				}
+			}
+		}()
+	default:
+		if err := ch.Reject(ssh.UnknownChannelType, "unknown channel type"); err != nil {
+			h.errChan <- trace.Wrap(err, "failed to reject channel")
+		}
+	}
+}
+
+func (h handler) subsystemHandler(req *ssh.Request) {
+	defer func() {
+		if req.WantReply {
+			if err := req.Reply(true, nil); err != nil {
+				h.errChan <- err
+			}
+		}
+	}()
+	switch h.tracingSupported {
+	case false:
+		var msg subsystemRequestMsg
+		if err := ssh.Unmarshal(req.Payload, &msg); err != nil {
+			h.errChan <- trace.Wrap(err, "failed to unmarshal payload")
+			return
+		}
+
+		if msg.Subsystem != "test" {
+			h.errChan <- errors.New("received wrong subsystem")
+		}
+	case true:
+		var envelope Envelope
+		if err := json.Unmarshal(req.Payload, &envelope); err != nil {
+			h.errChan <- trace.Wrap(err, "failed to unmarshal envelope")
+			return
+		}
+		if len(envelope.PropagationContext) <= 0 {
+			h.errChan <- errors.New("empty propagation context")
+			return
+		}
+
+		var msg subsystemRequestMsg
+		if err := ssh.Unmarshal(envelope.Payload, &msg); err != nil {
+			h.errChan <- trace.Wrap(err, "failed to unmarshal payload")
+			return
+		}
+		if msg.Subsystem != "test" {
+			h.errChan <- errors.New("received wrong subsystem")
+			return
+		}
+	default:
+		if err := req.Reply(false, nil); err != nil {
+			h.errChan <- err
+		}
+	}
+}
+
+func TestClient(t *testing.T) {
+	cases := []struct {
+		name             string
+		tracingSupported bool
+	}{
+		{
+			name:             "server supports tracing",
+			tracingSupported: true,
+		},
+		{
+			name:             "server does not support tracing",
+			tracingSupported: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			errChan := make(chan error, 5)
+
+			handler := handler{
+				tracingSupported: tt.tracingSupported,
+				errChan:          errChan,
+				ctx:              ctx,
+			}
+
+			srv := newServer(t, handler.handle)
+			go srv.Run(errChan)
+
+			tp := sdktrace.NewTracerProvider()
+			conn, chans, reqs := srv.GetClient(t)
+			client := NewClient(
+				conn,
+				chans,
+				reqs,
+				tracing.WithTracerProvider(tp),
+				tracing.WithTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})),
+			)
+			require.Equal(t, handler.tracingSupported, client.tracingSupported)
+
+			ctx, span := tp.Tracer("test").Start(context.Background(), "test")
+			t.Cleanup(func() { span.End() })
+
+			ok, resp, err := client.SendRequest(ctx, "test", true, []byte("test"))
+			span.End()
+			require.True(t, ok)
+			require.Empty(t, resp)
+			require.NoError(t, err)
+
+			select {
+			case err := <-errChan:
+				require.NoError(t, err)
+			default:
+			}
+
+			session, err := client.NewSession(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, session)
+
+			select {
+			case err := <-errChan:
+				require.NoError(t, err)
+			default:
+			}
+
+			require.NoError(t, session.RequestSubsystem(ctx, "test"))
+
+			select {
+			case err := <-errChan:
+				require.NoError(t, err)
+			default:
+			}
+		})
+	}
+}
+
+func TestWrapPayload(t *testing.T) {
+	testPayload := []byte("test")
+
+	nonRecordingCtx, nonRecordingSpan := otel.GetTracerProvider().Tracer("non-recording").Start(context.Background(), "test")
+	nonRecordingSpan.End()
+
+	emptyCtx, emptySpan := sdktrace.NewTracerProvider().Tracer("empty-trace-context").Start(context.Background(), "test")
+	t.Cleanup(func() { emptySpan.End() })
+
+	recordingCtx, recordingSpan := sdktrace.NewTracerProvider().Tracer("recording").Start(context.Background(), "test")
+	t.Cleanup(func() { recordingSpan.End() })
+	cases := []struct {
+		name             string
+		ctx              context.Context
+		supported        bool
+		propagator       propagation.TextMapPropagator
+		payloadAssertion require.ComparisonAssertionFunc
+	}{
+		{
+			name:             "unsupported returns provided payload",
+			ctx:              recordingCtx,
+			payloadAssertion: require.Equal,
+		},
+		{
+
+			name:             "non-recording spans aren't propagated",
+			supported:        true,
+			ctx:              nonRecordingCtx,
+			payloadAssertion: require.Equal,
+		},
+		{
+			name:             "empty trace context is not propagated",
+			supported:        true,
+			ctx:              emptyCtx,
+			payloadAssertion: require.Equal,
+		},
+		{
+			name:       "recording spans are propagated",
+			supported:  true,
+			ctx:        recordingCtx,
+			propagator: propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}),
+			payloadAssertion: func(t require.TestingT, i interface{}, i2 interface{}, i3 ...interface{}) {
+				payload, ok := i2.([]byte)
+				require.True(t, ok)
+
+				require.NotEqual(t, testPayload, payload)
+
+				var envelope Envelope
+				require.NoError(t, json.Unmarshal(payload, &envelope))
+				require.Equal(t, testPayload, envelope.Payload)
+				require.NotEmpty(t, envelope.PropagationContext)
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.propagator == nil {
+				tt.propagator = otel.GetTextMapPropagator()
+			}
+			payload := wrapPayload(tt.ctx, tt.supported, tt.propagator, testPayload)
+			tt.payloadAssertion(t, testPayload, payload)
+		})
+	}
+}

--- a/api/observability/tracing/tracing.go
+++ b/api/observability/tracing/tracing.go
@@ -17,7 +17,6 @@ package tracing
 import (
 	"context"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 )
 
@@ -26,14 +25,14 @@ type PropagationContext map[string]string
 
 // PropagationContextFromContext creates a PropagationContext from the given context.Context. If the context
 // does not contain any tracing information, the PropagationContext will be empty.
-func PropagationContextFromContext(ctx context.Context) PropagationContext {
+func PropagationContextFromContext(ctx context.Context, opts ...Option) PropagationContext {
 	carrier := propagation.MapCarrier{}
-	otel.GetTextMapPropagator().Inject(ctx, &carrier)
+	NewConfig(opts).TextMapPropagator.Inject(ctx, &carrier)
 	return PropagationContext(carrier)
 }
 
 // WithPropagationContext injects any tracing information from the given PropagationContext into the
 // given context.Context.
-func WithPropagationContext(ctx context.Context, pc PropagationContext) context.Context {
-	return otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(pc))
+func WithPropagationContext(ctx context.Context, pc PropagationContext, opts ...Option) context.Context {
+	return NewConfig(opts).TextMapPropagator.Extract(ctx, propagation.MapCarrier(pc))
 }

--- a/api/utils/sshutils/chconn.go
+++ b/api/utils/sshutils/chconn.go
@@ -30,17 +30,17 @@ import (
 
 // NewChConn returns a new net.Conn implemented over
 // SSH channel
-func NewChConn(conn ssh.Conn, ch ssh.Channel) *ChConn {
+func NewChConn(conn Conn, ch ssh.Channel) *ChConn {
 	return newChConn(conn, ch, false)
 }
 
 // NewExclusiveChConn returns a new net.Conn implemented over
 // SSH channel, whenever this connection closes
-func NewExclusiveChConn(conn ssh.Conn, ch ssh.Channel) *ChConn {
+func NewExclusiveChConn(conn Conn, ch ssh.Channel) *ChConn {
 	return newChConn(conn, ch, true)
 }
 
-func newChConn(conn ssh.Conn, ch ssh.Channel, exclusive bool) *ChConn {
+func newChConn(conn Conn, ch ssh.Channel, exclusive bool) *ChConn {
 	reader, writer := net.Pipe()
 	c := &ChConn{
 		Channel:   ch,
@@ -68,7 +68,7 @@ type ChConn struct {
 	mu sync.Mutex
 
 	ssh.Channel
-	conn ssh.Conn
+	conn Conn
 	// exclusive indicates that whenever this channel connection
 	// is getting closed, the underlying connection is closed as well
 	exclusive bool

--- a/api/utils/sshutils/conn.go
+++ b/api/utils/sshutils/conn.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
@@ -28,6 +29,14 @@ import (
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 )
+
+type Conn interface {
+	io.Closer
+	// RemoteAddr returns the remote address for this connection.
+	RemoteAddr() net.Addr
+	// LocalAddr returns the local address for this connection.
+	LocalAddr() net.Addr
+}
 
 // ConnectProxyTransport opens a channel over the remote tunnel and connects
 // to the requested host.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4517,8 +4517,8 @@ func testWindowChange(t *testing.T, suite *integrationTestSuite) {
 		cl.Stdin = personB
 
 		// Change the size of the window immediately after it is created.
-		cl.OnShellCreated = func(s *ssh.Session, c *tracessh.Client, terminal io.ReadWriteCloser) (exit bool, err error) {
-			err = s.WindowChange(48, 160)
+		cl.OnShellCreated = func(s *tracessh.Session, c *tracessh.Client, terminal io.ReadWriteCloser) (exit bool, err error) {
+			err = s.WindowChange(context.Background(), 48, 160)
 			if err != nil {
 				return true, trace.Wrap(err)
 			}

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -62,7 +62,8 @@ func (s *ClientTestSuite) SetUpSuite(c *check.C) {
 func (s *ClientTestSuite) TestNewSession(c *check.C) {
 	nc := &NodeClient{
 		Namespace: "blue",
-		Tracer:    tracing.NoopProvider().Tracer("test"),
+		Provider:  tracing.NoopProvider(),
+		tracer:    tracing.NoopProvider().Tracer("test"),
 	}
 
 	ctx := context.Background()
@@ -195,7 +196,8 @@ func (s *ClientTestSuite) TestListenAndForwardCancel(c *check.C) {
 				Conn: &fakeSSHConn{},
 			},
 		},
-		Tracer: tracing.NoopProvider().Tracer("test"),
+		Provider: tracing.NoopProvider(),
+		tracer:   tracing.NoopProvider().Tracer("test"),
 	}
 
 	// Create two anchors. An "accept" anchor that unblocks once the listener has

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -29,6 +29,8 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
+	traceagent "github.com/gravitational/teleport/api/observability/tracing/ssh/agent"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client/escape"
 	"github.com/gravitational/teleport/lib/client/terminal"
@@ -188,7 +190,7 @@ func (ns *NodeSession) NodeClient() *NodeClient {
 	return ns.nodeClient
 }
 
-func (ns *NodeSession) regularSession(ctx context.Context, callback func(s *ssh.Session) error) error {
+func (ns *NodeSession) regularSession(ctx context.Context, callback func(s *tracessh.Session) error) error {
 	session, err := ns.createServerSession(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -199,9 +201,9 @@ func (ns *NodeSession) regularSession(ctx context.Context, callback func(s *ssh.
 	return trace.Wrap(callback(session))
 }
 
-type interactiveCallback func(serverSession *ssh.Session, shell io.ReadWriteCloser) error
+type interactiveCallback func(serverSession *tracessh.Session, shell io.ReadWriteCloser) error
 
-func (ns *NodeSession) createServerSession(ctx context.Context) (*ssh.Session, error) {
+func (ns *NodeSession) createServerSession(ctx context.Context) (*tracessh.Session, error) {
 	sess, err := ns.nodeClient.Client.NewSession(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -218,7 +220,7 @@ func (ns *NodeSession) createServerSession(ctx context.Context) (*ssh.Session, e
 	evarsToPass := []string{"LANG", "LANGUAGE"}
 	for _, evar := range evarsToPass {
 		if value := os.Getenv(evar); value != "" {
-			err = sess.Setenv(evar, value)
+			err = sess.Setenv(ctx, evar, value)
 			if err != nil {
 				log.Warn(err)
 			}
@@ -226,7 +228,7 @@ func (ns *NodeSession) createServerSession(ctx context.Context) (*ssh.Session, e
 	}
 	// pass environment variables set by client
 	for key, val := range ns.env {
-		err = sess.Setenv(key, val)
+		err = sess.Setenv(ctx, key, val)
 		if err != nil {
 			log.Warn(err)
 		}
@@ -243,7 +245,7 @@ func (ns *NodeSession) createServerSession(ctx context.Context) (*ssh.Session, e
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		err = agent.RequestAgentForwarding(sess)
+		err = traceagent.RequestAgentForwarding(ctx, sess)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -282,7 +284,7 @@ func (ns *NodeSession) interactiveSession(ctx context.Context, mode types.Sessio
 		return trace.Wrap(err)
 	}
 	// allocate terminal on the server:
-	remoteTerm, err := ns.allocateTerminal(termType, sess)
+	remoteTerm, err := ns.allocateTerminal(ctx, termType, sess)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -305,7 +307,7 @@ func (ns *NodeSession) interactiveSession(ctx context.Context, mode types.Sessio
 
 	// start piping input into the remote shell and pipe the output from
 	// the remote shell into stdout:
-	ns.pipeInOut(remoteTerm, mode, sess)
+	ns.pipeInOut(ctx, remoteTerm, mode, sess)
 
 	// wait for the session to end
 	<-ns.closer.C
@@ -316,7 +318,7 @@ func (ns *NodeSession) interactiveSession(ctx context.Context, mode types.Sessio
 }
 
 // allocateTerminal creates (allocates) a server-side terminal for this session.
-func (ns *NodeSession) allocateTerminal(termType string, s *ssh.Session) (io.ReadWriteCloser, error) {
+func (ns *NodeSession) allocateTerminal(ctx context.Context, termType string, s *tracessh.Session) (io.ReadWriteCloser, error) {
 	var err error
 
 	// read the size of the terminal window:
@@ -333,7 +335,9 @@ func (ns *NodeSession) allocateTerminal(termType string, s *ssh.Session) (io.Rea
 	}
 
 	// ... and request a server-side terminal of the same size:
-	err = s.RequestPty(termType,
+	err = s.RequestPty(
+		ctx,
+		termType,
 		height,
 		width,
 		ssh.TerminalModes{})
@@ -353,7 +357,7 @@ func (ns *NodeSession) allocateTerminal(termType string, s *ssh.Session) (io.Rea
 		return nil, trace.Wrap(err)
 	}
 	if ns.terminal.IsAttached() {
-		go ns.updateTerminalSize(s)
+		go ns.updateTerminalSize(ctx, s)
 	}
 	go func() {
 		if _, err := io.Copy(os.Stderr, stderr); err != nil {
@@ -369,7 +373,7 @@ func (ns *NodeSession) allocateTerminal(termType string, s *ssh.Session) (io.Rea
 	), nil
 }
 
-func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
+func (ns *NodeSession) updateTerminalSize(ctx context.Context, s *tracessh.Session) {
 	terminalEvents := ns.terminal.Subscribe()
 
 	lastWidth, lastHeight, err := ns.terminal.Size()
@@ -410,6 +414,7 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 
 			// Send the "window-change" request over the channel.
 			_, err = s.SendRequest(
+				ctx,
 				sshutils.WindowChangeRequest,
 				false,
 				ssh.Marshal(sshutils.WinChangeReqParams{
@@ -475,13 +480,13 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 
 // runShell executes user's shell on the remote node under an interactive session
 func (ns *NodeSession) runShell(ctx context.Context, mode types.SessionParticipantMode, beforeStart func(io.Writer), callback ShellCreatedCallback) error {
-	return ns.interactiveSession(ctx, mode, func(s *ssh.Session, shell io.ReadWriteCloser) error {
+	return ns.interactiveSession(ctx, mode, func(s *tracessh.Session, shell io.ReadWriteCloser) error {
 		if beforeStart != nil {
 			beforeStart(s.Stdout)
 		}
 
 		// start the shell on the server:
-		if err := s.Shell(); err != nil {
+		if err := s.Shell(ctx); err != nil {
 			return trace.Wrap(err)
 		}
 		// call the client-supplied callback
@@ -511,8 +516,8 @@ func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionPartici
 	// keyboard based signals will be propogated to the TTY on the server which is
 	// where all signal handling will occur.
 	if interactive {
-		return ns.interactiveSession(ctx, mode, func(s *ssh.Session, term io.ReadWriteCloser) error {
-			err := s.Start(strings.Join(cmd, " "))
+		return ns.interactiveSession(ctx, mode, func(s *tracessh.Session, term io.ReadWriteCloser) error {
+			err := s.Start(ctx, strings.Join(cmd, " "))
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -538,13 +543,13 @@ func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionPartici
 	// Unfortunately at the moment the Go SSH library Teleport uses does not
 	// support sending SSH_MSG_DISCONNECT. Instead we close the SSH channel and
 	// SSH client, and try and exit as gracefully as possible.
-	return ns.regularSession(ctx, func(s *ssh.Session) error {
+	return ns.regularSession(ctx, func(s *tracessh.Session) error {
 		var err error
 
 		runContext, cancel := context.WithCancel(ctx)
 		go func() {
 			defer cancel()
-			err = s.Run(strings.Join(cmd, " "))
+			err = s.Run(ctx, strings.Join(cmd, " "))
 		}()
 
 		select {
@@ -672,7 +677,7 @@ func handlePeerControls(term *terminal.Terminal, remoteStdin io.Writer) {
 
 // pipeInOut launches two goroutines: one to pipe the local input into the remote shell,
 // and another to pipe the output of the remote shell into the local output
-func (ns *NodeSession) pipeInOut(shell io.ReadWriteCloser, mode types.SessionParticipantMode, sess *ssh.Session) {
+func (ns *NodeSession) pipeInOut(ctx context.Context, shell io.ReadWriteCloser, mode types.SessionParticipantMode, sess *tracessh.Session) {
 	// copy from the remote shell to the local output
 	go func() {
 		defer ns.closer.Close()
@@ -688,7 +693,7 @@ func (ns *NodeSession) pipeInOut(shell io.ReadWriteCloser, mode types.SessionPar
 			defer ns.closer.Close()
 
 			handleNonPeerControls(mode, ns.terminal, func() {
-				_, err := sess.SendRequest(teleport.ForceTerminateRequest, true, nil)
+				_, err := sess.SendRequest(ctx, teleport.ForceTerminateRequest, true, nil)
 				if err != nil {
 					fmt.Printf("\n\rError while sending force termination request: %v\n\r", err.Error())
 				}

--- a/lib/client/x11_session.go
+++ b/lib/client/x11_session.go
@@ -21,8 +21,10 @@ import (
 	"os"
 	"time"
 
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
+
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 )
@@ -30,7 +32,7 @@ import (
 // handleX11Forwarding handles X11 channel requests for the given server session.
 // If X11 forwarding is not requested by the client, or it is rejected by the server,
 // then X11 channel requests will be rejected.
-func (ns *NodeSession) handleX11Forwarding(ctx context.Context, sess *ssh.Session) error {
+func (ns *NodeSession) handleX11Forwarding(ctx context.Context, sess *tracessh.Session) error {
 	if !ns.nodeClient.TC.EnableX11Forwarding {
 		return ns.rejectX11Channels(ctx)
 	}
@@ -54,7 +56,7 @@ func (ns *NodeSession) handleX11Forwarding(ctx context.Context, sess *ssh.Sessio
 		return trace.Wrap(err)
 	}
 
-	if err := x11.RequestForwarding(sess, ns.spoofedXAuthEntry); err != nil {
+	if err := x11.RequestForwarding(ctx, sess, ns.spoofedXAuthEntry); err != nil {
 		// Notify the user that x11 forwarding request failed regardless of debug level
 		log.Print("X11 forwarding request failed")
 		log.WithError(err).Debug("X11 forwarding request error")
@@ -126,7 +128,7 @@ func (ns *NodeSession) setXAuthData(ctx context.Context, display x11.Display) er
 }
 
 // serveX11Channels serves incoming X11 channels by starting X11 forwarding with the session.
-func (ns *NodeSession) serveX11Channels(ctx context.Context, sess *ssh.Session) error {
+func (ns *NodeSession) serveX11Channels(ctx context.Context, sess *tracessh.Session) error {
 	err := x11.ServeChannelRequests(ctx, ns.nodeClient.Client.Client, func(ctx context.Context, nch ssh.NewChannel) {
 		if !ns.x11RefuseTime.IsZero() && time.Now().After(ns.x11RefuseTime) {
 			nch.Reject(ssh.Prohibited, "rejected X11 channel request after ForwardX11Timeout")

--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
+	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -35,8 +37,8 @@ import (
 )
 
 type mockSSHClient struct {
-	MockSendRequest       func(name string, wantReply bool, payload []byte) (bool, []byte, error)
-	MockOpenChannel       func(name string, data []byte) (ssh.Channel, <-chan *ssh.Request, error)
+	MockSendRequest       func(ctx context.Context, name string, wantReply bool, payload []byte) (bool, []byte, error)
+	MockOpenChannel       func(ctx context.Context, name string, data []byte) (*tracessh.Channel, <-chan *ssh.Request, error)
 	MockClose             func() error
 	MockReply             func(*ssh.Request, bool, []byte) error
 	MockPrincipals        []string
@@ -56,16 +58,16 @@ func (m *mockSSHClient) RemoteAddr() net.Addr { return nil }
 
 func (m *mockSSHClient) LocalAddr() net.Addr { return nil }
 
-func (m *mockSSHClient) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+func (m *mockSSHClient) SendRequest(ctx context.Context, name string, wantReply bool, payload []byte) (bool, []byte, error) {
 	if m.MockSendRequest != nil {
-		return m.MockSendRequest(name, wantReply, payload)
+		return m.MockSendRequest(ctx, name, wantReply, payload)
 	}
 	return false, nil, trace.NotImplemented("")
 }
 
-func (m *mockSSHClient) OpenChannel(name string, data []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+func (m *mockSSHClient) OpenChannel(ctx context.Context, name string, data []byte) (*tracessh.Channel, <-chan *ssh.Request, error) {
 	if m.MockOpenChannel != nil {
-		return m.MockOpenChannel(name, data)
+		return m.MockOpenChannel(ctx, name, data)
 	}
 	return nil, nil, trace.NotImplemented("")
 }
@@ -134,7 +136,7 @@ type mockAgentInjection struct {
 	client SSHClient
 }
 
-func (m *mockAgentInjection) transport(context.Context, ssh.Channel, <-chan *ssh.Request, ssh.Conn) *transport {
+func (m *mockAgentInjection) transport(context.Context, ssh.Channel, <-chan *ssh.Request, sshutils.Conn) *transport {
 	return &transport{}
 }
 
@@ -264,20 +266,26 @@ func TestAgentStart(t *testing.T) {
 		}
 	}()
 
-	client.MockOpenChannel = func(name string, data []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	client.MockOpenChannel = func(ctx context.Context, name string, data []byte) (*tracessh.Channel, <-chan *ssh.Request, error) {
 		// Block until the version request is handled to ensure we handle
 		// global requests during startup.
 		<-waitForVersion
 
 		openChannels++
 		assert.Equal(t, name, chanHeartbeat, "Unexpected channel opened during startup.")
-		return &mockSSHChannel{MockSendRequest: func(name string, wantReply bool, payload []byte) (bool, error) {
-			sentPings++
+		return tracessh.NewChannel(
+				&mockSSHChannel{
+					MockSendRequest: func(name string, wantReply bool, payload []byte) (bool, error) {
+						sentPings++
 
-			assert.Equal(t, name, "ping", "Unexpected request name.")
-			assert.False(t, wantReply, "Expected no reply wanted.")
-			return true, nil
-		}}, make(<-chan *ssh.Request), nil
+						assert.Equal(t, name, "ping", "Unexpected request name.")
+						assert.False(t, wantReply, "Expected no reply wanted.")
+						return true, nil
+					},
+				},
+			),
+			make(<-chan *ssh.Request),
+			nil
 	}
 
 	versionReplies := 0

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
@@ -541,7 +542,7 @@ func (p *AgentPool) getVersion(ctx context.Context) (string, error) {
 }
 
 // transport creates a new transport instance.
-func (p *AgentPool) transport(ctx context.Context, channel ssh.Channel, requests <-chan *ssh.Request, conn ssh.Conn) *transport {
+func (p *AgentPool) transport(ctx context.Context, channel ssh.Channel, requests <-chan *ssh.Request, conn sshutils.Conn) *transport {
 	return &transport{
 		closeContext:        ctx,
 		component:           p.Component,

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -292,6 +292,7 @@ func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 		Emitter:         s.srv.Config.Emitter,
 		ParentContext:   s.srv.Context,
 		LockWatcher:     s.srv.LockWatcher,
+		TracerProvider:  s.srv.TracerProvider,
 	}
 	remoteServer, err := forward.New(serverConfig)
 	if err != nil {

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -765,6 +765,7 @@ func (s *remoteSite) dialWithAgent(params DialParams) (net.Conn, error) {
 		Emitter:         s.srv.Config.Emitter,
 		ParentContext:   s.srv.Context,
 		LockWatcher:     s.srv.LockWatcher,
+		TracerProvider:  s.srv.TracerProvider,
 	}
 	remoteServer, err := forward.New(serverConfig)
 	if err != nil {

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -155,7 +155,7 @@ type transport struct {
 	kubeDialAddr utils.NetAddr
 
 	// sconn is a SSH connection to the remote host. Used for dial back nodes.
-	sconn ssh.Conn
+	sconn sshutils.Conn
 
 	// reverseTunnelServer holds all reverse tunnel connections.
 	reverseTunnelServer Server

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1108,7 +1108,7 @@ func (process *TeleportProcess) newClientThroughTunnel(authServers []utils.NetAd
 
 	// Check connectivity to cluster. If the request fails, unwrap the error to
 	// get the underlying error.
-	_, err = clt.GetDomainName(context.TODO())
+	_, err = clt.GetDomainName(process.ExitContext())
 	if err != nil {
 		if err2 := clt.Close(); err2 != nil {
 			process.log.WithError(err2).Warn("Failed to close Auth Server tunnel client.")

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2285,6 +2285,7 @@ func (process *TeleportProcess) initSSH() error {
 			regular.SetCreateHostUser(!cfg.SSH.DisableCreateHostUser),
 			regular.SetStoragePresenceService(storagePresence),
 			regular.SetInventoryControlHandle(process.inventoryHandle),
+			regular.SetTracerProvider(process.TracingProvider),
 		)
 		if err != nil {
 			return trace.Wrap(err)
@@ -3331,6 +3332,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				CertAuthorityWatcher:          caWatcher,
 				CircuitBreakerConfig:          process.Config.CircuitBreakerConfig,
 				LocalAuthAddresses:            utils.NetAddrsToStrings(process.Config.AuthServers),
+				TracerProvider:                process.TracingProvider,
 			})
 		if err != nil {
 			return trace.Wrap(err)
@@ -3497,6 +3499,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		regular.SetEmitter(streamEmitter),
 		regular.SetLockWatcher(lockWatcher),
 		regular.SetNodeWatcher(nodeWatcher),
+		regular.SetTracerProvider(process.TracingProvider),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -24,9 +24,8 @@ import (
 	"strconv"
 	"time"
 
-	"golang.org/x/crypto/ssh"
-
 	"github.com/gravitational/teleport"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
@@ -36,12 +35,12 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 
-	"github.com/gravitational/trace"
-
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 )
 
 var (
@@ -109,7 +108,7 @@ func NewAuthHandlers(config *AuthHandlerConfig) (*AuthHandlers, error) {
 
 // CreateIdentityContext returns an IdentityContext populated with information
 // about the logged in user on the connection.
-func (h *AuthHandlers) CreateIdentityContext(sconn *ssh.ServerConn) (IdentityContext, error) {
+func (h *AuthHandlers) CreateIdentityContext(sconn *tracessh.ServerConn) (IdentityContext, error) {
 	identity := IdentityContext{
 		TeleportUser: sconn.Permissions.Extensions[utils.CertTeleportUser],
 		Login:        sconn.User(),

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -290,7 +290,7 @@ type ServerContext struct {
 
 	// RemoteSession holds a SSH session to a remote server. Only used by the
 	// recording proxy.
-	RemoteSession *ssh.Session
+	RemoteSession *tracessh.Session
 
 	// clientLastActive records the last time there was activity from the client
 	clientLastActive time.Time
@@ -630,7 +630,7 @@ func (c *ServerContext) getSession() *session {
 }
 
 // OpenXServerListener opens a new XServer unix listener.
-func (c *ServerContext) OpenXServerListener(x11Req x11.ForwardRequestPayload, displayOffset, maxDisplays int) error {
+func (c *ServerContext) OpenXServerListener(ctx context.Context, x11Req x11.ForwardRequestPayload, displayOffset, maxDisplays int) error {
 	l, display, err := x11.OpenNewXServerListener(displayOffset, maxDisplays, x11Req.ScreenNumber)
 	if err != nil {
 		return trace.Wrap(err)
@@ -688,7 +688,7 @@ func (c *ServerContext) OpenXServerListener(x11Req x11.ForwardRequestPayload, di
 					return
 				}
 
-				xchan, sin, err := c.ServerConn.OpenChannel(sshutils.X11ChannelRequest, x11ChannelReqPayload)
+				xchan, sin, err := c.ServerConn.OpenChannel(ctx, sshutils.X11ChannelRequest, x11ChannelReqPayload)
 				if err != nil {
 					c.Logger.WithError(err).Debug("Failed to open a new X11 channel")
 					return

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -18,6 +18,7 @@ package srv
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -28,9 +29,8 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/crypto/ssh"
-
 	"github.com/gravitational/teleport"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/events"
@@ -38,6 +38,7 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 )
 
 const (
@@ -68,7 +69,7 @@ type Exec interface {
 	SetCommand(string)
 
 	// Start will start the execution of the command.
-	Start(channel ssh.Channel) (*ExecResult, error)
+	Start(ctx context.Context, channel ssh.Channel) (*ExecResult, error)
 
 	// Wait will block while the command executes.
 	Wait() *ExecResult
@@ -135,7 +136,7 @@ func (e *localExec) SetCommand(command string) {
 
 // Start launches the given command returns (nil, nil) if successful.
 // ExecResult is only used to communicate an error while launching.
-func (e *localExec) Start(channel ssh.Channel) (*ExecResult, error) {
+func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult, error) {
 	// Parse the command to see if it is scp.
 	err := e.transformSecureCopy()
 	if err != nil {
@@ -286,7 +287,7 @@ func waitForContinue(contfd *os.File) error {
 // remoteExec is used to run an "exec" SSH request and return the result.
 type remoteExec struct {
 	command string
-	session *ssh.Session
+	session *tracessh.Session
 	ctx     *ServerContext
 }
 
@@ -307,7 +308,7 @@ func (e *remoteExec) SetCommand(command string) {
 
 // Start launches the given command returns (nil, nil) if successful.
 // ExecResult is only used to communicate an error while launching.
-func (e *remoteExec) Start(ch ssh.Channel) (*ExecResult, error) {
+func (e *remoteExec) Start(ctx context.Context, ch ssh.Channel) (*ExecResult, error) {
 	// hook up stdout/err the channel so the user can interact with the command
 	e.session.Stdout = ch
 	e.session.Stderr = ch.Stderr()
@@ -324,7 +325,7 @@ func (e *remoteExec) Start(ch ssh.Channel) (*ExecResult, error) {
 		inputWriter.Close()
 	}()
 
-	err = e.session.Start(e.command)
+	err = e.session.Start(ctx, e.command)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -20,15 +20,14 @@ import (
 	"context"
 	"io"
 
-	"golang.org/x/crypto/ssh"
-
 	"github.com/gravitational/teleport"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/srv"
-	"github.com/gravitational/trace"
 
+	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 )
 
 // remoteSubsystem is a subsystem that executes on a remote node.
@@ -77,7 +76,7 @@ func (r *remoteSubsystem) Start(ctx context.Context, channel ssh.Channel) error 
 
 	// request the subsystem from the remote node. if successful, the user can
 	// interact with the remote subsystem with stdin, stdout, and stderr.
-	err = session.RequestSubsystem(r.subsytemName)
+	err = session.RequestSubsystem(ctx, r.subsytemName)
 	if err != nil {
 		// emit an event to the audit log with the reason remote execution failed
 		r.emitAuditEvent(err)

--- a/lib/srv/keepalive_test.go
+++ b/lib/srv/keepalive_test.go
@@ -127,7 +127,7 @@ type testRequestSender struct {
 	reply bool
 }
 
-func (n *testRequestSender) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+func (n *testRequestSender) SendRequest(ctx context.Context, name string, wantReply bool, payload []byte) (bool, []byte, error) {
 	atomic.AddInt64(&n.count, 1)
 	if n.reply == false {
 		return false, nil, trace.BadParameter("no reply")

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/gravitational/teleport"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/types"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
@@ -40,6 +41,7 @@ import (
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
+
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
@@ -63,7 +65,9 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 	scx := &ServerContext{
 		Entry: logrus.NewEntry(logrus.StandardLogger()),
 		ConnectionContext: &sshutils.ConnectionContext{
-			ServerConn: &ssh.ServerConn{Conn: sshConn},
+			ServerConn: &tracessh.ServerConn{
+				ServerConn: &ssh.ServerConn{Conn: sshConn},
+			},
 		},
 		env:                    make(map[string]string),
 		SessionRecordingConfig: types.DefaultSessionRecordingConfig(),

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/observability/tracing"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
@@ -227,7 +228,7 @@ func (t *proxySubsys) String() string {
 
 // Start is called by Golang's ssh when it needs to engage this sybsystem (typically to establish
 // a mapping connection between a client & remote node we're proxying to)
-func (t *proxySubsys) Start(ctx context.Context, sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) error {
+func (t *proxySubsys) Start(ctx context.Context, sconn *tracessh.ServerConn, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) error {
 	// once we start the connection, update logger to include component fields
 	t.log = logrus.WithFields(logrus.Fields{
 		trace.Component: teleport.ComponentSubsystemProxy,

--- a/lib/srv/regular/sites.go
+++ b/lib/srv/regular/sites.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"encoding/json"
 
-	"golang.org/x/crypto/ssh"
-
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv"
 
 	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
 )
 
 // proxySubsys is an SSH subsystem for easy proxyneling through proxy server
@@ -51,7 +51,7 @@ func (t *proxySitesSubsys) Wait() error {
 
 // Start serves a request for "proxysites" custom SSH subsystem. It builds an array of
 // service.Site structures, and writes it serialized as JSON back to the SSH client
-func (t *proxySitesSubsys) Start(ctx context.Context, sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) error {
+func (t *proxySitesSubsys) Start(ctx context.Context, sconn *tracessh.ServerConn, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) error {
 	log.Debugf("proxysites.start(%v)", serverContext)
 	remoteSites, err := t.srv.tunnelWithAccessChecker(serverContext).GetSites()
 	if err != nil {

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -33,14 +33,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport/api/breaker"
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
-
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
+	traceagent "github.com/gravitational/teleport/api/observability/tracing/ssh/agent"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
@@ -59,10 +58,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 // teleportTestUser is additional user used for tests
@@ -91,7 +91,7 @@ type sshInfo struct {
 	srvAddress     string
 	srvPort        string
 	srvHostPort    string
-	clt            *ssh.Client
+	clt            *tracessh.Client
 	cltConfig      *ssh.ClientConfig
 	assertCltClose require.ErrorAssertionFunc
 }
@@ -229,7 +229,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 		HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", sshSrv.Addr(), cltConfig)
+	client, err := tracessh.Dial(ctx, "tcp", sshSrvAddress, cltConfig)
 	require.NoError(t, err)
 
 	f := &sshTestFixture{
@@ -250,7 +250,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 	}
 
 	t.Cleanup(func() { f.ssh.assertCltClose(t, client.Close()) })
-	require.NoError(t, agent.ForwardToAgent(client, keyring))
+	require.NoError(t, agent.ForwardToAgent(client.Client, keyring))
 	return f
 }
 
@@ -324,7 +324,7 @@ func TestInactivityTimeout(t *testing.T) {
 	// so change the assertion on closing the client to expect it to fail
 	f.ssh.assertCltClose = require.Error
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(context.Background())
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -364,7 +364,7 @@ func TestLockInForce(t *testing.T) {
 	// so change the assertion on closing the client to expect it to fail.
 	f.ssh.assertCltClose = require.Error
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 
 	stderr, err := se.StderrPipe()
@@ -400,14 +400,14 @@ func TestLockInForce(t *testing.T) {
 	require.Equal(t, lockInForceMsg, string(text))
 
 	// As long as the lock is in force, new sessions cannot be opened.
-	newClient, err := ssh.Dial("tcp", f.ssh.srvAddress, f.ssh.cltConfig)
+	newClient, err := tracessh.Dial(ctx, "tcp", f.ssh.srvAddress, f.ssh.cltConfig)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		// The client is expected to be closed by the lock monitor therefore expect
 		// an error on this second attempt.
 		require.Error(t, newClient.Close())
 	})
-	_, err = newClient.NewSession()
+	_, err = newClient.NewSession(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), lockInForceMsg)
 
@@ -443,7 +443,7 @@ func TestDirectTCPIP(t *testing.T) {
 	httpClient := http.Client{
 		Transport: &http.Transport{
 			Dial: func(network string, addr string) (net.Conn, error) {
-				return f.ssh.clt.Dial("tcp", u.Host)
+				return f.ssh.clt.DialContext(context.Background(), "tcp", u.Host)
 			},
 		},
 	}
@@ -515,16 +515,16 @@ func TestAgentForwardPermission(t *testing.T) {
 	err = f.testSrv.Auth().SetSessionRecordingConfig(ctx, recConfig)
 	require.NoError(t, err)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { se.Close() })
 
 	// to interoperate with OpenSSH, requests for agent forwarding always succeed.
 	// however that does not mean the users agent will actually be forwarded.
-	require.NoError(t, agent.RequestAgentForwarding(se))
+	require.NoError(t, traceagent.RequestAgentForwarding(ctx, se))
 
 	// the output of env, we should not see SSH_AUTH_SOCK in the output
-	output, err := se.Output("env")
+	output, err := se.Output(ctx, "env")
 	require.NoError(t, err)
 	require.NotContains(t, string(output), "SSH_AUTH_SOCK")
 }
@@ -548,18 +548,18 @@ func TestMaxSessions(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := int64(0); i < maxSessions; i++ {
-		se, err := f.ssh.clt.NewSession()
+		se, err := f.ssh.clt.NewSession(ctx)
 		require.NoError(t, err)
 		defer se.Close()
 	}
 
-	_, err = f.ssh.clt.NewSession()
+	_, err = f.ssh.clt.NewSession(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "too many session channels")
 
 	// verify that max sessions does not affect max connections.
 	for i := int64(0); i <= maxSessions; i++ {
-		clt, err := ssh.Dial("tcp", f.ssh.srv.Addr(), f.ssh.cltConfig)
+		clt, err := tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), f.ssh.cltConfig)
 		require.NoError(t, err)
 		require.NoError(t, clt.Close())
 	}
@@ -571,18 +571,19 @@ func TestMaxSessions(t *testing.T) {
 // command and send the command to then launch through a pipe.
 func TestExecLongCommand(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 	f := newFixture(t)
 
 	// Get the path to where the "echo" command is on disk.
 	echoPath, err := exec.LookPath("echo")
 	require.NoError(t, err)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 	defer se.Close()
 
 	// Write a message that larger than the maximum pipe size.
-	_, err = se.Output(fmt.Sprintf("%v %v", echoPath, strings.Repeat("a", maxPipeSize)))
+	_, err = se.Output(ctx, fmt.Sprintf("%v %v", echoPath, strings.Repeat("a", maxPipeSize)))
 	require.NoError(t, err)
 }
 
@@ -590,15 +591,16 @@ func TestExecLongCommand(t *testing.T) {
 // sets ServerContext session.
 func TestOpenExecSessionSetsSession(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 	f := newFixture(t)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 	defer se.Close()
 
 	// This will trigger an exec request, which will start a non-interactive session,
 	// which then triggers setting env for SSH_SESSION_ID.
-	output, err := se.Output("env")
+	output, err := se.Output(ctx, "env")
 	require.NoError(t, err)
 	require.Contains(t, string(output), teleport.SSHSessionID)
 }
@@ -627,11 +629,11 @@ func TestAgentForward(t *testing.T) {
 	err = f.testSrv.Auth().SetSessionRecordingConfig(ctx, recConfig)
 	require.NoError(t, err)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { se.Close() })
 
-	err = agent.RequestAgentForwarding(se)
+	err = traceagent.RequestAgentForwarding(ctx, se)
 	require.NoError(t, err)
 
 	// prepare to send virtual "keyboard input" into the shell:
@@ -640,7 +642,7 @@ func TestAgentForward(t *testing.T) {
 	t.Cleanup(func() { keyboard.Close() })
 
 	// start interactive SSH session (new shell):
-	err = se.Shell()
+	err = se.Shell(ctx)
 	require.NoError(t, err)
 
 	// create a temp file to collect the shell output into:
@@ -677,7 +679,7 @@ func TestAgentForward(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	client, err := tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	err = client.Close()
 	require.NoError(t, err)
@@ -746,7 +748,7 @@ func TestX11Forward(t *testing.T) {
 	// concurrent X11 sessions.
 	serverDisplay := x11EchoSession(ctx, t, f.ssh.clt)
 
-	client2, err := ssh.Dial("tcp", f.ssh.srv.Addr(), f.ssh.cltConfig)
+	client2, err := tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), f.ssh.cltConfig)
 	require.NoError(t, err)
 	serverDisplay2 := x11EchoSession(ctx, t, client2)
 
@@ -779,8 +781,8 @@ func TestX11Forward(t *testing.T) {
 // x11EchoSession creates a new ssh session and handles x11 forwarding for the session,
 // echoing XServer requests received back to the client. Returns the Display opened on the
 // session, which is set in $DISPLAY.
-func x11EchoSession(ctx context.Context, t *testing.T, clt *ssh.Client) x11.Display {
-	se, err := clt.NewSession()
+func x11EchoSession(ctx context.Context, t *testing.T, clt *tracessh.Client) x11.Display {
+	se, err := clt.NewSession(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { se.Close() })
 
@@ -803,7 +805,7 @@ func x11EchoSession(ctx context.Context, t *testing.T, clt *ssh.Client) x11.Disp
 
 	// Handle any x11 channel requests received from the server
 	// and start x11 forwarding to the client display.
-	err = x11.ServeChannelRequests(ctx, clt, func(ctx context.Context, nch ssh.NewChannel) {
+	err = x11.ServeChannelRequests(ctx, clt.Client, func(ctx context.Context, nch ssh.NewChannel) {
 		sch, sin, err := nch.Accept()
 		require.NoError(t, err)
 		defer sch.Close()
@@ -829,7 +831,7 @@ func x11EchoSession(ctx context.Context, t *testing.T, clt *ssh.Client) x11.Disp
 	// Client requests x11 forwarding for the server session.
 	clientXAuthEntry, err := x11.NewFakeXAuthEntry(x11.Display{})
 	require.NoError(t, err)
-	err = x11.RequestForwarding(se, clientXAuthEntry)
+	err = x11.RequestForwarding(ctx, se, clientXAuthEntry)
 	require.NoError(t, err)
 
 	// prepare to send virtual "keyboard input" into the shell:
@@ -837,7 +839,7 @@ func x11EchoSession(ctx context.Context, t *testing.T, clt *ssh.Client) x11.Disp
 	require.NoError(t, err)
 
 	// start interactive SSH session with x11 forwarding enabled (new shell):
-	err = se.Shell()
+	err = se.Shell(ctx)
 	require.NoError(t, err)
 
 	// create a temp file to collect the shell output into:
@@ -890,6 +892,7 @@ func x11EchoRequest(t *testing.T, serverDisplay x11.Display) {
 
 func TestAllowedUsers(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 	f := newFixture(t)
 
 	up, err := newUpack(f.testSrv, f.user, []string{f.user}, wildcardAllow)
@@ -901,7 +904,7 @@ func TestAllowedUsers(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	client, err := tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	require.NoError(t, client.Close())
 
@@ -915,12 +918,13 @@ func TestAllowedUsers(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	_, err = ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	_, err = tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), sshConfig)
 	require.Error(t, err)
 }
 
 func TestAllowedLabels(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 	f := newFixture(t)
 
 	tests := []struct {
@@ -965,7 +969,7 @@ func TestAllowedLabels(t *testing.T) {
 				HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 			}
 
-			_, err = ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+			_, err = tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), sshConfig)
 			if tt.outError {
 				require.Error(t, err)
 			} else {
@@ -990,26 +994,28 @@ func TestKeyAlgorithms(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	_, err = ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	_, err = tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), sshConfig)
 	require.Error(t, err)
 }
 
 func TestInvalidSessionID(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 	f := newFixture(t)
 
-	session, err := f.ssh.clt.NewSession()
+	session, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 
-	err = session.Setenv(sshutils.SessionEnvVar, "foo")
+	err = session.Setenv(ctx, sshutils.SessionEnvVar, "foo")
 	require.NoError(t, err)
 
-	err = session.Shell()
+	err = session.Shell(ctx)
 	require.Error(t, err)
 }
 
 func TestSessionHijack(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 	_, err := user.Lookup(teleportTestUser)
 	if err != nil {
 		t.Skipf("user %v is not found, skipping test", teleportTestUser)
@@ -1028,22 +1034,22 @@ func TestSessionHijack(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	client, err := tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	defer func() {
 		err := client.Close()
 		require.NoError(t, err)
 	}()
 
-	se, err := client.NewSession()
+	se, err := client.NewSession(ctx)
 	require.NoError(t, err)
 	defer se.Close()
 
 	firstSessionID := string(sess.NewID())
-	err = se.Setenv(sshutils.SessionEnvVar, firstSessionID)
+	err = se.Setenv(ctx, sshutils.SessionEnvVar, firstSessionID)
 	require.NoError(t, err)
 
-	err = se.Shell()
+	err = se.Shell(ctx)
 	require.NoError(t, err)
 
 	// user 2 does not have s.user as a listed principal
@@ -1056,33 +1062,34 @@ func TestSessionHijack(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client2, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig2)
+	client2, err := tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), sshConfig2)
 	require.NoError(t, err)
 	defer func() {
 		err := client2.Close()
 		require.NoError(t, err)
 	}()
 
-	se2, err := client2.NewSession()
+	se2, err := client2.NewSession(ctx)
 	require.NoError(t, err)
 	defer se2.Close()
 
-	err = se2.Setenv(sshutils.SessionEnvVar, firstSessionID)
+	err = se2.Setenv(ctx, sshutils.SessionEnvVar, firstSessionID)
 	require.NoError(t, err)
 
 	// attempt to hijack, should return error
-	err = se2.Shell()
+	err = se2.Shell(ctx)
 	require.Error(t, err)
 }
 
 // testClient dials targetAddr via proxyAddr and executes 2+3 command
 func testClient(t *testing.T, f *sshTestFixture, proxyAddr, targetAddr, remoteAddr string, sshConfig *ssh.ClientConfig) {
+	ctx := context.Background()
 	// Connect to node using registered address
-	client, err := ssh.Dial("tcp", proxyAddr, sshConfig)
+	client, err := tracessh.Dial(ctx, "tcp", proxyAddr, sshConfig)
 	require.NoError(t, err)
 	defer client.Close()
 
-	se, err := client.NewSession()
+	se, err := client.NewSession(ctx)
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -1093,7 +1100,7 @@ func testClient(t *testing.T, f *sshTestFixture, proxyAddr, targetAddr, remoteAd
 	require.NoError(t, err)
 
 	// Request opening TCP connection to the remote host
-	require.NoError(t, se.RequestSubsystem(fmt.Sprintf("proxy:%v", targetAddr)))
+	require.NoError(t, se.RequestSubsystem(ctx, fmt.Sprintf("proxy:%v", targetAddr)))
 
 	local, err := utils.ParseAddr("tcp://" + proxyAddr)
 	require.NoError(t, err)
@@ -1111,21 +1118,21 @@ func testClient(t *testing.T, f *sshTestFixture, proxyAddr, targetAddr, remoteAd
 	defer pipeNetConn.Close()
 
 	// Open SSH connection via TCP
-	conn, chans, reqs, err := ssh.NewClientConn(pipeNetConn,
+	conn, chans, reqs, err := tracessh.NewClientConn(ctx, pipeNetConn,
 		f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	defer conn.Close()
 
 	// using this connection as regular SSH
-	client2 := ssh.NewClient(conn, chans, reqs)
+	client2 := tracessh.NewClient(conn, chans, reqs)
 	require.NoError(t, err)
 	defer client2.Close()
 
-	se2, err := client2.NewSession()
+	se2, err := client2.NewSession(ctx)
 	require.NoError(t, err)
 	defer se2.Close()
 
-	out, err := se2.Output("echo hello")
+	out, err := se2.Output(ctx, "echo hello")
 	require.NoError(t, err)
 
 	require.Equal(t, "hello\n", string(out))
@@ -1347,37 +1354,37 @@ func TestProxyDirectAccess(t *testing.T) {
 // TestPTY requests PTY for an interactive session
 func TestPTY(t *testing.T) {
 	t.Parallel()
-
+	ctx := context.Background()
 	f := newFixture(t)
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 	defer se.Close()
 
 	// request PTY with valid size
-	require.NoError(t, se.RequestPty("xterm", 30, 30, ssh.TerminalModes{}))
+	require.NoError(t, se.RequestPty(ctx, "xterm", 30, 30, ssh.TerminalModes{}))
 
 	// request PTY with invalid size, should still work (selects defaults)
-	require.NoError(t, se.RequestPty("xterm", 0, 0, ssh.TerminalModes{}))
+	require.NoError(t, se.RequestPty(ctx, "xterm", 0, 0, ssh.TerminalModes{}))
 }
 
 // TestEnv requests setting environment variables. (We are currently ignoring these requests)
 func TestEnv(t *testing.T) {
 	t.Parallel()
-
+	ctx := context.Background()
 	f := newFixture(t)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 	defer se.Close()
 
-	require.NoError(t, se.Setenv("HOME", "/"))
+	require.NoError(t, se.Setenv(ctx, "HOME", "/"))
 }
 
 // TestNoAuth tries to log in with no auth methods and should be rejected
 func TestNoAuth(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
-	_, err := ssh.Dial("tcp", f.ssh.srv.Addr(), &ssh.ClientConfig{})
+	_, err := tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), &ssh.ClientConfig{})
 	require.Error(t, err)
 }
 
@@ -1395,19 +1402,20 @@ func TestPasswordAuth(t *testing.T) {
 
 func TestClientDisconnect(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 	f := newFixture(t)
 	config := &ssh.ClientConfig{
 		User:            f.user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(f.up.certSigner)},
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
-	clt, err := ssh.Dial("tcp", f.ssh.srv.Addr(), config)
+	clt, err := tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), config)
 	require.NoError(t, err)
 	require.NotNil(t, clt)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
-	require.NoError(t, se.Shell())
+	require.NoError(t, se.Shell(ctx))
 	require.NoError(t, clt.Close())
 }
 
@@ -1471,24 +1479,24 @@ func TestLimiter(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	clt0, err := ssh.Dial("tcp", srv.Addr(), config)
+	clt0, err := tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.NoError(t, err)
 	require.NotNil(t, clt0)
 
-	se0, err := clt0.NewSession()
+	se0, err := clt0.NewSession(ctx)
 	require.NoError(t, err)
-	require.NoError(t, se0.Shell())
+	require.NoError(t, se0.Shell(ctx))
 
 	// current connections = 2
-	clt, err := ssh.Dial("tcp", srv.Addr(), config)
+	clt, err := tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.NotNil(t, clt)
 	require.NoError(t, err)
-	se, err := clt.NewSession()
+	se, err := clt.NewSession(ctx)
 	require.NoError(t, err)
-	require.NoError(t, se.Shell())
+	require.NoError(t, se.Shell(ctx))
 
 	// current connections = 3
-	_, err = ssh.Dial("tcp", srv.Addr(), config)
+	_, err = tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.Error(t, err)
 
 	require.NoError(t, se.Close())
@@ -1496,15 +1504,15 @@ func TestLimiter(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// current connections = 2
-	clt, err = ssh.Dial("tcp", srv.Addr(), config)
+	clt, err = tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.NotNil(t, clt)
 	require.NoError(t, err)
-	se, err = clt.NewSession()
+	se, err = clt.NewSession(ctx)
 	require.NoError(t, err)
-	require.NoError(t, se.Shell())
+	require.NoError(t, se.Shell(ctx))
 
 	// current connections = 3
-	_, err = ssh.Dial("tcp", srv.Addr(), config)
+	_, err = tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.Error(t, err)
 
 	require.NoError(t, se.Close())
@@ -1513,10 +1521,10 @@ func TestLimiter(t *testing.T) {
 
 	// current connections = 2
 	// requests rate should exceed now
-	clt, err = ssh.Dial("tcp", srv.Addr(), config)
+	clt, err = tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.NotNil(t, clt)
 	require.NoError(t, err)
-	_, err = clt.NewSession()
+	_, err = clt.NewSession(ctx)
 	require.Error(t, err)
 
 	clt.Close()
@@ -1528,7 +1536,7 @@ func TestLimiter(t *testing.T) {
 func TestServerAliveInterval(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
-	ok, _, err := f.ssh.clt.SendRequest(teleport.KeepAliveReqType, true, nil)
+	ok, _, err := f.ssh.clt.SendRequest(context.Background(), teleport.KeepAliveReqType, true, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 }
@@ -1550,7 +1558,7 @@ func TestGlobalRequestRecordingProxy(t *testing.T) {
 
 	// send the request again, we have cluster config and when we parse the
 	// response, it should be false because recording is occurring at the node.
-	ok, responseBytes, err := f.ssh.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
+	ok, responseBytes, err := f.ssh.clt.SendRequest(ctx, teleport.RecordingProxyReqType, true, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	response, err := strconv.ParseBool(string(responseBytes))
@@ -1568,7 +1576,7 @@ func TestGlobalRequestRecordingProxy(t *testing.T) {
 	// send request again, now that we have cluster config and it's set to record
 	// at the proxy, we should return true and when we parse the payload it should
 	// also be true
-	ok, responseBytes, err = f.ssh.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
+	ok, responseBytes, err = f.ssh.clt.SendRequest(ctx, teleport.RecordingProxyReqType, true, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	response, err = strconv.ParseBool(string(responseBytes))
@@ -1587,12 +1595,12 @@ type rawNode struct {
 }
 
 // accept an incoming connection and perform a basic ssh handshake
-func (r *rawNode) accept() (*ssh.ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request, error) {
+func (r *rawNode) accept() (*tracessh.ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request, error) {
 	netConn, err := r.listener.Accept()
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)
 	}
-	srvConn, chs, reqs, err := ssh.NewServerConn(netConn, &r.cfg)
+	srvConn, chs, reqs, err := tracessh.NewServerConn(netConn, &r.cfg)
 	if err != nil {
 		netConn.Close()
 		return nil, nil, nil, trace.Wrap(err)
@@ -1659,74 +1667,77 @@ func newRawNode(t *testing.T, authSrv *auth.Server) *rawNode {
 	}
 }
 
-// startX11EchoServer starts a fake node which, for each incoming SSH connection, accepts an
-// X11 forwarding request and then dials a single X11 channel which echoes all bytes written
-// to it.  Used to verify the behavior of X11 forwarding in recording proxies. Returns a
-// node and an error channel that can be monitored for asynchronous failures.
-func startX11EchoServer(ctx context.Context, t *testing.T, authSrv *auth.Server) (*rawNode, <-chan error) {
-	node := newRawNode(t, authSrv)
-
-	sessionMain := func(ctx context.Context, conn *ssh.ServerConn, chs <-chan ssh.NewChannel) error {
-		defer conn.Close()
-
-		// expect client to open a session channel
-		var nch ssh.NewChannel
-		select {
-		case nch = <-chs:
-		case <-time.After(time.Second * 3):
-			return trace.LimitExceeded("Timeout waiting for session channel")
-		case <-ctx.Done():
-			return nil
-		}
-		if nch.ChannelType() != teleport.ChanSession {
-			return trace.BadParameter("Unexpected channel type: %q", nch.ChannelType())
-		}
-
-		sch, creqs, err := nch.Accept()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer sch.Close()
-
-		// expect client to send an X11 forwarding request
-		var req *ssh.Request
-		select {
-		case req = <-creqs:
-		case <-time.After(time.Second * 3):
-			return trace.LimitExceeded("Timeout waiting for X11 forwarding request")
-		case <-ctx.Done():
-			return nil
-		}
-
-		if req.Type != sshutils.X11ForwardRequest {
-			return trace.BadParameter("Unexpected request type %q", req.Type)
-		}
-
-		if err = req.Reply(true, nil); err != nil {
-			return trace.Wrap(err)
-		}
-
-		// start a fake X11 channel
-		xch, _, err := conn.OpenChannel(sshutils.X11ChannelRequest, nil)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer xch.Close()
-
-		// echo all bytes back across the X11 channel
-		_, err = io.Copy(xch, xch)
-		if err == nil {
-			xch.CloseWrite()
-		} else {
-			log.Errorf("X11 channel error: %v", err)
-		}
-
+// x11Handler handles requests received by the x11 echo server
+func x11Handler(ctx context.Context, conn *tracessh.ServerConn, chs <-chan ssh.NewChannel) error {
+	// expect client to open a session channel
+	var nch ssh.NewChannel
+	select {
+	case nch = <-chs:
+	case <-time.After(time.Second * 3):
+		return trace.LimitExceeded("Timeout waiting for session channel")
+	case <-ctx.Done():
 		return nil
 	}
 
-	errorCh := make(chan error, 1)
+	if nch.ChannelType() == tracessh.TracingChannel {
+		nch.Reject(ssh.UnknownChannelType, "")
+		return x11Handler(ctx, conn, chs)
+	}
 
-	nodeMain := func() {
+	if nch.ChannelType() != teleport.ChanSession {
+		return trace.BadParameter("Unexpected channel type: %q", nch.ChannelType())
+	}
+
+	sch, creqs, err := nch.Accept()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer sch.Close()
+
+	// expect client to send an X11 forwarding request
+	var req *ssh.Request
+	select {
+	case req = <-creqs:
+	case <-time.After(time.Second * 3):
+		return trace.LimitExceeded("Timeout waiting for X11 forwarding request")
+	case <-ctx.Done():
+		return nil
+	}
+
+	if req.Type != sshutils.X11ForwardRequest {
+		return trace.BadParameter("Unexpected request type %q", req.Type)
+	}
+
+	if err = req.Reply(true, nil); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// start a fake X11 channel
+	xch, _, err := conn.OpenChannel(ctx, sshutils.X11ChannelRequest, nil)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer xch.Close()
+
+	// echo all bytes back across the X11 channel
+	_, err = io.Copy(xch, xch)
+	if err == nil {
+		xch.CloseWrite()
+	} else {
+		log.Errorf("X11 channel error: %v", err)
+	}
+
+	return nil
+}
+
+// startX11EchoServer starts a fake node which, for each incoming SSH connection, accepts an
+// X11 forwarding request and then dials a single X11 channel which echoes all bytes written
+// to it. Used to verify the behavior of X11 forwarding in recording proxies. Returns a
+// node and an error channel that can be monitored for asynchronous failures.
+func startX11EchoServer(ctx context.Context, t *testing.T, authSrv *auth.Server) (*rawNode, <-chan error) {
+	node := newRawNode(t, authSrv)
+	errorCh := make(chan error, 1)
+	go func() {
 		for {
 			conn, chs, _, err := node.accept()
 			if err != nil {
@@ -1734,14 +1745,13 @@ func startX11EchoServer(ctx context.Context, t *testing.T, authSrv *auth.Server)
 				return
 			}
 			go func() {
-				if err := sessionMain(ctx, conn, chs); err != nil {
+				if err := x11Handler(ctx, conn, chs); err != nil {
 					errorCh <- err
 				}
+				conn.Close()
 			}()
 		}
-	}
-
-	go nodeMain()
+	}()
 
 	return node, errorCh
 }
@@ -1752,7 +1762,7 @@ func startX11EchoServer(ctx context.Context, t *testing.T, authSrv *auth.Server)
 func startGatheringErrors(ctx context.Context, errCh <-chan error) <-chan []error {
 	doneGathering := make(chan []error)
 	go func() {
-		errors := []error{}
+		var errors []error
 		for {
 			select {
 			case err := <-errCh:
@@ -1800,7 +1810,7 @@ func TestX11ProxySupport(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify that the proxy is in recording mode
-	ok, responseBytes, err := f.ssh.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
+	ok, responseBytes, err := f.ssh.clt.SendRequest(ctx, teleport.RecordingProxyReqType, true, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	response, err := strconv.ParseBool(string(responseBytes))
@@ -1820,22 +1830,16 @@ func TestX11ProxySupport(t *testing.T) {
 	// here rather than directly below the context creation
 	defer x11Cancel()
 
-	// Create a direct TCP/IP connection from proxy to our X11 test server.
-	netConn, err := f.ssh.clt.Dial("tcp", node.addr)
-	require.NoError(t, err)
-	defer netConn.Close()
-
 	// make an insecure version of our client config (this test is only about X11 forwarding,
 	// so we don't bother to verify recording proxy key generation here).
 	cltConfig := *f.ssh.cltConfig
 	cltConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 
-	// Perform ssh handshake and setup client for X11 test server.
-	cltConn, chs, reqs, err := ssh.NewClientConn(netConn, node.addr, &cltConfig)
+	// dial X11 test server and get a client.
+	clt, err := tracessh.Dial(ctx, "tcp", node.addr, &cltConfig)
 	require.NoError(t, err)
-	clt := ssh.NewClient(cltConn, chs, reqs)
 
-	sess, err := clt.NewSession()
+	sess, err := clt.NewSession(ctx)
 	require.NoError(t, err)
 
 	// register X11 channel handler before requesting forwarding to avoid races
@@ -1843,7 +1847,7 @@ func TestX11ProxySupport(t *testing.T) {
 	require.NotNil(t, xchs)
 
 	// Send an X11 forwarding request to the server
-	ok, err = sess.SendRequest(sshutils.X11ForwardRequest, true, nil)
+	ok, err = sess.SendRequest(ctx, sshutils.X11ForwardRequest, true, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 
@@ -1954,12 +1958,12 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	// Connect SSH client to proxy
-	client, err := ssh.Dial("tcp", proxy.Addr(), sshConfig)
+	client, err := tracessh.Dial(ctx, "tcp", proxy.Addr(), sshConfig)
 
 	require.NoError(t, err)
 	defer client.Close()
 
-	se, err := client.NewSession()
+	se, err := client.NewSession(ctx)
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -1971,11 +1975,11 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 
 	// Request the PuTTY-specific "simple@putty.projects.tartarus.org" channel type
 	// This request should be ignored, and the connection should remain open.
-	_, err = se.SendRequest(sshutils.PuTTYSimpleRequest, false, []byte{})
+	_, err = se.SendRequest(ctx, sshutils.PuTTYSimpleRequest, false, []byte{})
 	require.NoError(t, err)
 
 	// Request proxy subsystem routing TCP connection to the remote host
-	require.NoError(t, se.RequestSubsystem(fmt.Sprintf("proxy:%v", f.ssh.srvAddress)))
+	require.NoError(t, se.RequestSubsystem(ctx, fmt.Sprintf("proxy:%v", f.ssh.srvAddress)))
 
 	local, err := utils.ParseAddr("tcp://" + proxy.Addr())
 	require.NoError(t, err)
@@ -1993,21 +1997,21 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	defer pipeNetConn.Close()
 
 	// Open SSH connection via proxy subsystem's TCP tunnel
-	conn, chans, reqs, err := ssh.NewClientConn(pipeNetConn,
+	conn, chans, reqs, err := tracessh.NewClientConn(ctx, pipeNetConn,
 		f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	defer conn.Close()
 
 	// Run commands over this connection like regular SSH
-	client2 := ssh.NewClient(conn, chans, reqs)
+	client2 := tracessh.NewClient(conn, chans, reqs)
 	require.NoError(t, err)
 	defer client2.Close()
 
-	se2, err := client2.NewSession()
+	se2, err := client2.NewSession(ctx)
 	require.NoError(t, err)
 	defer se2.Close()
 
-	out, err := se2.Output("echo hello again")
+	out, err := se2.Output(ctx, "echo hello again")
 	require.NoError(t, err)
 
 	require.Equal(t, "hello again\n", string(out))

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
@@ -211,12 +212,12 @@ func (s *SessionRegistry) tryCreateHostUser(ctx *ServerContext) (*user.User, err
 }
 
 // OpenSession either joins an existing session or starts a new session.
-func (s *SessionRegistry) OpenSession(ch ssh.Channel, ctx *ServerContext) error {
-	session := ctx.getSession()
+func (s *SessionRegistry) OpenSession(ctx context.Context, ch ssh.Channel, scx *ServerContext) error {
+	session := scx.getSession()
 	if session != nil {
-		ctx.Infof("Joining existing session %v.", session.id)
+		scx.Infof("Joining existing session %v.", session.id)
 
-		mode := types.SessionParticipantMode(ctx.env[teleport.EnvSSHJoinMode])
+		mode := types.SessionParticipantMode(scx.env[teleport.EnvSSHJoinMode])
 		switch mode {
 		case types.SessionModeratorMode, types.SessionObserverMode:
 		default:
@@ -228,7 +229,7 @@ func (s *SessionRegistry) OpenSession(ch ssh.Channel, ctx *ServerContext) error 
 		}
 
 		// Update the in-memory data structure that a party member has joined.
-		_, err := session.join(ch, ctx, mode)
+		_, err := session.join(ctx, ch, scx, mode)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -236,33 +237,33 @@ func (s *SessionRegistry) OpenSession(ch ssh.Channel, ctx *ServerContext) error 
 		return nil
 	}
 
-	if ctx.JoinOnly {
+	if scx.JoinOnly {
 		return trace.AccessDenied("join-only mode was used to create this connection but attempted to create a new session.")
 	}
 
 	// session not found? need to create one. start by getting/generating an ID for it
-	sid, found := ctx.GetEnv(sshutils.SessionEnvVar)
+	sid, found := scx.GetEnv(sshutils.SessionEnvVar)
 	if !found {
 		sid = string(rsession.NewID())
-		ctx.SetEnv(sshutils.SessionEnvVar, sid)
+		scx.SetEnv(sshutils.SessionEnvVar, sid)
 	}
 	// This logic allows concurrent request to create a new session
 	// to fail, what is ok because we should never have this condition
-	sess, err := newSession(rsession.ID(sid), s, ctx)
+	sess, err := newSession(rsession.ID(sid), s, scx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ctx.setSession(sess)
+	scx.setSession(sess)
 	s.addSession(sess)
-	ctx.Infof("Creating (interactive) session %v.", sid)
+	scx.Infof("Creating (interactive) session %v.", sid)
 
-	tempUser, err := s.tryCreateHostUser(ctx)
+	tempUser, err := s.tryCreateHostUser(scx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	// Start an interactive session (TTY attached). Close the session if an error
 	// occurs, otherwise it will be closed by the callee.
-	if err := sess.startInteractive(ch, ctx, tempUser); err != nil {
+	if err := sess.startInteractive(ctx, ch, scx, tempUser); err != nil {
 		sess.Close()
 		return trace.Wrap(err)
 	}
@@ -270,18 +271,18 @@ func (s *SessionRegistry) OpenSession(ch ssh.Channel, ctx *ServerContext) error 
 }
 
 // OpenExecSession opens an non-interactive exec session.
-func (s *SessionRegistry) OpenExecSession(channel ssh.Channel, ctx *ServerContext) error {
+func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
 	// Create a new session ID. These sessions can not be joined so no point in
 	// looking for an exisiting one.
 	sessionID := rsession.NewID()
 
 	// This logic allows concurrent request to create a new session
 	// to fail, what is ok because we should never have this condition.
-	sess, err := newSession(sessionID, s, ctx)
+	sess, err := newSession(sessionID, s, scx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ctx.Infof("Creating (exec) session %v.", sessionID)
+	scx.Infof("Creating (exec) session %v.", sessionID)
 
 	canStart, _, err := sess.checkIfStart()
 	if err != nil {
@@ -294,14 +295,14 @@ func (s *SessionRegistry) OpenExecSession(channel ssh.Channel, ctx *ServerContex
 
 	// Start a non-interactive session (TTY attached). Close the session if an error
 	// occurs, otherwise it will be closed by the callee.
-	ctx.setSession(sess)
+	scx.setSession(sess)
 
-	tempUser, err := s.tryCreateHostUser(ctx)
+	tempUser, err := s.tryCreateHostUser(scx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	err = sess.startExec(channel, ctx, tempUser)
+	err = sess.startExec(ctx, channel, scx, tempUser)
 	if err != nil {
 		sess.Close()
 		return trace.Wrap(err)
@@ -342,8 +343,8 @@ func (s *SessionRegistry) GetTerminalSize(sessionID string) (*term.Winsize, erro
 // NotifyWinChange is called to notify all members in the party that the PTY
 // size has changed. The notification is sent as a global SSH request and it
 // is the responsibility of the client to update it's window size upon receipt.
-func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *ServerContext) error {
-	session := ctx.getSession()
+func (s *SessionRegistry) NotifyWinChange(ctx context.Context, params rsession.TerminalParams, scx *ServerContext) error {
+	session := scx.getSession()
 	if session == nil {
 		s.log.Debug("Unable to update window size, no session found in context.")
 		return nil
@@ -355,19 +356,19 @@ func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *S
 		Metadata: apievents.Metadata{
 			Type:        events.ResizeEvent,
 			Code:        events.TerminalResizeCode,
-			ClusterName: ctx.ClusterName,
+			ClusterName: scx.ClusterName,
 		},
 		ServerMetadata: apievents.ServerMetadata{
-			ServerID:        ctx.srv.HostUUID(),
-			ServerLabels:    ctx.srv.GetInfo().GetAllLabels(),
+			ServerID:        scx.srv.HostUUID(),
+			ServerLabels:    scx.srv.GetInfo().GetAllLabels(),
 			ServerNamespace: s.Srv.GetNamespace(),
 			ServerHostname:  s.Srv.GetInfo().GetHostname(),
-			ServerAddr:      ctx.ServerConn.LocalAddr().String(),
+			ServerAddr:      scx.ServerConn.LocalAddr().String(),
 		},
 		SessionMetadata: apievents.SessionMetadata{
 			SessionID: string(sid),
 		},
-		UserMetadata: ctx.Identity.GetUserMetadata(),
+		UserMetadata: scx.Identity.GetUserMetadata(),
 		TerminalSize: params.Serialize(),
 	}
 
@@ -378,7 +379,7 @@ func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *S
 	}
 
 	// Update the size of the server side PTY.
-	err := session.term.SetWinSize(params)
+	err := session.term.SetWinSize(ctx, params)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -386,7 +387,7 @@ func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *S
 	// If sessions are being recorded at the proxy, sessions can not be shared.
 	// In that situation, PTY size information does not need to be propagated
 	// back to all clients and we can return right away.
-	if services.IsRecordAtProxy(ctx.SessionRecordingConfig.GetMode()) {
+	if services.IsRecordAtProxy(scx.SessionRecordingConfig.GetMode()) {
 		return nil
 	}
 
@@ -395,7 +396,7 @@ func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *S
 	// OpenSSH clients will ignore this and not update their own local PTY.
 	for _, p := range session.getParties() {
 		// Don't send the window change notification back to the originator.
-		if p.ctx.ID() == ctx.ID() {
+		if p.ctx.ID() == scx.ID() {
 			continue
 		}
 
@@ -406,7 +407,7 @@ func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *S
 		}
 
 		// Send the message as a global request.
-		_, _, err = p.sconn.SendRequest(teleport.SessionEvent, false, eventPayload)
+		_, _, err = p.sconn.SendRequest(ctx, teleport.SessionEvent, false, eventPayload)
 		if err != nil {
 			s.log.Warnf("Unable to resize event to %v: %v.", p.sconn.RemoteAddr(), err)
 			continue
@@ -661,7 +662,7 @@ func (s *session) Stop() {
 		if err := s.term.Close(); err != nil {
 			s.log.WithError(err).Debug("Failed to close the shell")
 		}
-		if err := s.term.Kill(); err != nil {
+		if err := s.term.Kill(context.TODO()); err != nil {
 			s.log.WithError(err).Debug("Failed to kill the shell")
 		}
 	}
@@ -766,35 +767,35 @@ func (s *session) emitSessionStartEvent(ctx *ServerContext) {
 // emitSessionJoinEvent emits a session join event to both the Audit Log as
 // well as sending a "x-teleport-event" global request on the SSH connection.
 // Must be called under session Lock.
-func (s *session) emitSessionJoinEvent(ctx *ServerContext) {
+func (s *session) emitSessionJoinEvent(ctx context.Context, scx *ServerContext) {
 	sessionJoinEvent := &apievents.SessionJoin{
 		Metadata: apievents.Metadata{
 			Type:        events.SessionJoinEvent,
 			Code:        events.SessionJoinCode,
-			ClusterName: ctx.ClusterName,
+			ClusterName: scx.ClusterName,
 		},
 		ServerMetadata: apievents.ServerMetadata{
-			ServerID:        ctx.srv.HostUUID(),
-			ServerLabels:    ctx.srv.GetInfo().GetAllLabels(),
+			ServerID:        scx.srv.HostUUID(),
+			ServerLabels:    scx.srv.GetInfo().GetAllLabels(),
 			ServerNamespace: s.getNamespace(),
 			ServerHostname:  s.getHostname(),
-			ServerAddr:      ctx.ServerConn.LocalAddr().String(),
+			ServerAddr:      scx.ServerConn.LocalAddr().String(),
 		},
 		SessionMetadata: apievents.SessionMetadata{
-			SessionID: string(ctx.SessionID()),
+			SessionID: string(scx.SessionID()),
 		},
-		UserMetadata: ctx.Identity.GetUserMetadata(),
+		UserMetadata: scx.Identity.GetUserMetadata(),
 		ConnectionMetadata: apievents.ConnectionMetadata{
-			RemoteAddr: ctx.ServerConn.RemoteAddr().String(),
+			RemoteAddr: scx.ServerConn.RemoteAddr().String(),
 		},
 	}
 	// Local address only makes sense for non-tunnel nodes.
-	if !ctx.srv.UseTunnel() {
-		sessionJoinEvent.ConnectionMetadata.LocalAddr = ctx.ServerConn.LocalAddr().String()
+	if !scx.srv.UseTunnel() {
+		sessionJoinEvent.ConnectionMetadata.LocalAddr = scx.ServerConn.LocalAddr().String()
 	}
 
 	// Emit session join event to Audit Log.
-	if err := s.emitAuditEvent(ctx.srv.Context(), sessionJoinEvent); err != nil {
+	if err := s.emitAuditEvent(scx.srv.Context(), sessionJoinEvent); err != nil {
 		s.log.WithError(err).Warn("Failed to emit session join event.")
 	}
 
@@ -806,7 +807,7 @@ func (s *session) emitSessionJoinEvent(ctx *ServerContext) {
 			s.log.Warnf("Unable to marshal %v for %v: %v.", events.SessionJoinEvent, p.sconn.RemoteAddr(), err)
 			continue
 		}
-		_, _, err = p.sconn.SendRequest(teleport.SessionEvent, false, eventPayload)
+		_, _, err = p.sconn.SendRequest(ctx, teleport.SessionEvent, false, eventPayload)
 		if err != nil {
 			s.log.Warnf("Unable to send %v to %v: %v.", events.SessionJoinEvent, p.sconn.RemoteAddr(), err)
 			continue
@@ -818,28 +819,28 @@ func (s *session) emitSessionJoinEvent(ctx *ServerContext) {
 // emitSessionLeaveEvent emits a session leave event to both the Audit Log as
 // well as sending a "x-teleport-event" global request on the SSH connection.
 // Must be called under session Lock.
-func (s *session) emitSessionLeaveEvent(ctx *ServerContext) {
+func (s *session) emitSessionLeaveEvent(scx *ServerContext) {
 	sessionLeaveEvent := &apievents.SessionLeave{
 		Metadata: apievents.Metadata{
 			Type:        events.SessionLeaveEvent,
 			Code:        events.SessionLeaveCode,
-			ClusterName: ctx.ClusterName,
+			ClusterName: scx.ClusterName,
 		},
 		ServerMetadata: apievents.ServerMetadata{
-			ServerID:        ctx.srv.HostUUID(),
-			ServerLabels:    ctx.srv.GetInfo().GetAllLabels(),
+			ServerID:        scx.srv.HostUUID(),
+			ServerLabels:    scx.srv.GetInfo().GetAllLabels(),
 			ServerNamespace: s.getNamespace(),
 			ServerHostname:  s.getHostname(),
-			ServerAddr:      ctx.ServerConn.LocalAddr().String(),
+			ServerAddr:      scx.ServerConn.LocalAddr().String(),
 		},
 		SessionMetadata: apievents.SessionMetadata{
 			SessionID: string(s.id),
 		},
-		UserMetadata: ctx.Identity.GetUserMetadata(),
+		UserMetadata: scx.Identity.GetUserMetadata(),
 	}
 
 	// Emit session leave event to Audit Log.
-	if err := s.emitAuditEvent(ctx.srv.Context(), sessionLeaveEvent); err != nil {
+	if err := s.emitAuditEvent(scx.srv.Context(), sessionLeaveEvent); err != nil {
 		s.log.WithError(err).Warn("Failed to emit session leave event.")
 	}
 
@@ -851,7 +852,7 @@ func (s *session) emitSessionLeaveEvent(ctx *ServerContext) {
 			s.log.Warnf("Unable to marshal %v for %v: %v.", events.SessionLeaveEvent, p.sconn.RemoteAddr(), err)
 			continue
 		}
-		_, _, err = p.sconn.SendRequest(teleport.SessionEvent, false, eventPayload)
+		_, _, err = p.sconn.SendRequest(scx.srv.Context(), teleport.SessionEvent, false, eventPayload)
 		if err != nil {
 			// The party's connection may already be closed, in which case we expect an EOF
 			if !trace.IsEOF(err) {
@@ -1022,23 +1023,23 @@ func (s *session) launch(ctx *ServerContext) error {
 
 // startInteractive starts a new interactive process (or a shell) in the
 // current session.
-func (s *session) startInteractive(ch ssh.Channel, ctx *ServerContext, tempUser *user.User) error {
+func (s *session) startInteractive(ctx context.Context, ch ssh.Channel, scx *ServerContext, tempUser *user.User) error {
 	inReader, inWriter := io.Pipe()
 	s.inWriter = inWriter
 	s.io.AddReader("reader", inReader)
-	s.io.AddWriter(sessionRecorderID, utils.WriteCloserWithContext(ctx.srv.Context(), s.Recorder()))
+	s.io.AddWriter(sessionRecorderID, utils.WriteCloserWithContext(scx.srv.Context(), s.Recorder()))
 	s.BroadcastMessage("Creating session with ID: %v...", s.id)
 	s.BroadcastMessage(SessionControlsInfoBroadcast)
 
-	if err := s.startTerminal(ctx); err != nil {
+	if err := s.startTerminal(ctx, scx); err != nil {
 		return trace.Wrap(err)
 	}
 
 	// Emit a session.start event for the interactive session.
-	s.emitSessionStartEvent(ctx)
+	s.emitSessionStartEvent(scx)
 
 	// create a new "party" (connected client) and launch/join the session.
-	p := newParty(s, types.SessionPeerMode, ch, ctx)
+	p := newParty(s, types.SessionPeerMode, ch, scx)
 	if err := s.addParty(p, types.SessionPeerMode); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1046,31 +1047,31 @@ func (s *session) startInteractive(ch ssh.Channel, ctx *ServerContext, tempUser 
 	// Open a BPF recording session. If BPF was not configured, not available,
 	// or running in a recording proxy, OpenSession is a NOP.
 	sessionContext := &bpf.SessionContext{
-		Context:   ctx.srv.Context(),
+		Context:   scx.srv.Context(),
 		PID:       s.term.PID(),
 		Emitter:   s.Recorder(),
-		Namespace: ctx.srv.GetNamespace(),
+		Namespace: scx.srv.GetNamespace(),
 		SessionID: s.id.String(),
-		ServerID:  ctx.srv.HostUUID(),
-		Login:     ctx.Identity.Login,
-		User:      ctx.Identity.TeleportUser,
-		Events:    ctx.Identity.AccessChecker.EnhancedRecordingSet(),
+		ServerID:  scx.srv.HostUUID(),
+		Login:     scx.Identity.Login,
+		User:      scx.Identity.TeleportUser,
+		Events:    scx.Identity.AccessChecker.EnhancedRecordingSet(),
 	}
 
-	if cgroupID, err := ctx.srv.GetBPF().OpenSession(sessionContext); err != nil {
-		ctx.Errorf("Failed to open enhanced recording (interactive) session: %v: %v.", s.id, err)
+	if cgroupID, err := scx.srv.GetBPF().OpenSession(sessionContext); err != nil {
+		scx.Errorf("Failed to open enhanced recording (interactive) session: %v: %v.", s.id, err)
 		return trace.Wrap(err)
 	} else if cgroupID > 0 {
 		// If a cgroup ID was assigned then enhanced session recording was enabled.
 		s.setHasEnhancedRecording(true)
-		ctx.srv.GetRestrictedSessionManager().OpenSession(sessionContext, cgroupID)
+		scx.srv.GetRestrictedSessionManager().OpenSession(sessionContext, cgroupID)
 		go func() {
 			// Close the BPF recording session once the session is closed
 			<-s.stopC
-			ctx.srv.GetRestrictedSessionManager().CloseSession(sessionContext, cgroupID)
-			err = ctx.srv.GetBPF().CloseSession(sessionContext)
+			scx.srv.GetRestrictedSessionManager().CloseSession(sessionContext, cgroupID)
+			err = scx.srv.GetBPF().CloseSession(sessionContext)
 			if err != nil {
-				ctx.Errorf("Failed to close enhanced recording (interactive) session: %v: %v.", s.id, err)
+				scx.Errorf("Failed to close enhanced recording (interactive) session: %v: %v.", s.id, err)
 			}
 		}()
 	}
@@ -1079,10 +1080,10 @@ func (s *session) startInteractive(ch ssh.Channel, ctx *ServerContext, tempUser 
 		return trace.Wrap(err)
 	}
 
-	ctx.Debug("Waiting for continue signal")
+	scx.Debug("Waiting for continue signal")
 
 	if tempUser != nil {
-		sessionUser, err := user.Lookup(ctx.Identity.Login)
+		sessionUser, err := user.Lookup(scx.Identity.Login)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1095,30 +1096,30 @@ func (s *session) startInteractive(ch ssh.Channel, ctx *ServerContext, tempUser 
 	// Process has been placed in a cgroup, continue execution.
 	s.term.Continue()
 
-	ctx.Debug("Got continue signal")
+	scx.Debug("Got continue signal")
 
 	// Start a heartbeat that marks this session as active with current members
 	// of party in the backend.
-	go s.heartbeat(ctx)
+	go s.heartbeat(scx)
 	return nil
 }
 
-func (s *session) startTerminal(ctx *ServerContext) error {
+func (s *session) startTerminal(ctx context.Context, scx *ServerContext) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	// allocate a terminal or take the one previously allocated via a
 	// separate "allocate TTY" SSH request
 	var err error
-	if s.term = ctx.GetTerm(); s.term != nil {
-		ctx.SetTerm(nil)
-	} else if s.term, err = NewTerminal(ctx); err != nil {
-		ctx.Infof("Unable to allocate new terminal: %v", err)
+	if s.term = scx.GetTerm(); s.term != nil {
+		scx.SetTerm(nil)
+	} else if s.term, err = NewTerminal(scx); err != nil {
+		scx.Infof("Unable to allocate new terminal: %v", err)
 		return trace.Wrap(err)
 	}
 
-	if err := s.term.Run(); err != nil {
-		ctx.Errorf("Unable to run shell command: %v.", err)
+	if err := s.term.Run(ctx); err != nil {
+		scx.Errorf("Unable to run shell command: %v.", err)
 		return trace.ConvertSystemError(err)
 	}
 
@@ -1197,49 +1198,49 @@ func newEventOnlyRecorder(s *session, ctx *ServerContext) (events.StreamWriter, 
 	return rec, nil
 }
 
-func (s *session) startExec(channel ssh.Channel, ctx *ServerContext, tempUser *user.User) error {
+func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *ServerContext, tempUser *user.User) error {
 	// Emit a session.start event for the exec session.
-	s.emitSessionStartEvent(ctx)
+	s.emitSessionStartEvent(scx)
 
 	// Start execution. If the program failed to start, send that result back.
 	// Note this is a partial start. Teleport will have re-exec'ed itself and
 	// wait until it's been placed in a cgroup and told to continue.
-	result, err := ctx.ExecRequest.Start(channel)
+	result, err := scx.ExecRequest.Start(ctx, channel)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	if result != nil {
-		ctx.Debugf("Exec request (%v) result: %v.", ctx.ExecRequest, result)
-		ctx.SendExecResult(*result)
+		scx.Debugf("Exec request (%v) result: %v.", scx.ExecRequest, result)
+		scx.SendExecResult(*result)
 	}
 
 	// Open a BPF recording session. If BPF was not configured, not available,
 	// or running in a recording proxy, OpenSession is a NOP.
 	sessionContext := &bpf.SessionContext{
-		Context:   ctx.srv.Context(),
-		PID:       ctx.ExecRequest.PID(),
+		Context:   scx.srv.Context(),
+		PID:       scx.ExecRequest.PID(),
 		Emitter:   s.Recorder(),
-		Namespace: ctx.srv.GetNamespace(),
+		Namespace: scx.srv.GetNamespace(),
 		SessionID: string(s.id),
-		ServerID:  ctx.srv.HostUUID(),
-		Login:     ctx.Identity.Login,
-		User:      ctx.Identity.TeleportUser,
-		Events:    ctx.Identity.AccessChecker.EnhancedRecordingSet(),
+		ServerID:  scx.srv.HostUUID(),
+		Login:     scx.Identity.Login,
+		User:      scx.Identity.TeleportUser,
+		Events:    scx.Identity.AccessChecker.EnhancedRecordingSet(),
 	}
-	cgroupID, err := ctx.srv.GetBPF().OpenSession(sessionContext)
+	cgroupID, err := scx.srv.GetBPF().OpenSession(sessionContext)
 	if err != nil {
-		ctx.Errorf("Failed to open enhanced recording (exec) session: %v: %v.", ctx.ExecRequest.GetCommand(), err)
+		scx.Errorf("Failed to open enhanced recording (exec) session: %v: %v.", scx.ExecRequest.GetCommand(), err)
 		return trace.Wrap(err)
 	}
 
 	// If a cgroup ID was assigned then enhanced session recording was enabled.
 	if cgroupID > 0 {
 		s.setHasEnhancedRecording(true)
-		ctx.srv.GetRestrictedSessionManager().OpenSession(sessionContext, cgroupID)
+		scx.srv.GetRestrictedSessionManager().OpenSession(sessionContext, cgroupID)
 	}
 
 	if tempUser != nil {
-		sessionUser, err := user.Lookup(ctx.Identity.Login)
+		sessionUser, err := user.Lookup(scx.Identity.Login)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1250,26 +1251,26 @@ func (s *session) startExec(channel ssh.Channel, ctx *ServerContext, tempUser *u
 	}
 
 	// Process has been placed in a cgroup, continue execution.
-	ctx.ExecRequest.Continue()
+	scx.ExecRequest.Continue()
 
 	// Process is running, wait for it to stop.
 	go func() {
-		result = ctx.ExecRequest.Wait()
+		result = scx.ExecRequest.Wait()
 		if result != nil {
-			ctx.SendExecResult(*result)
+			scx.SendExecResult(*result)
 		}
 
 		// Wait a little bit to let all events filter through before closing the
 		// BPF session so everything can be recorded.
 		time.Sleep(2 * time.Second)
 
-		ctx.srv.GetRestrictedSessionManager().CloseSession(sessionContext, cgroupID)
+		scx.srv.GetRestrictedSessionManager().CloseSession(sessionContext, cgroupID)
 
 		// Close the BPF recording session. If BPF was not configured, not available,
 		// or running in a recording proxy, this is simply a NOP.
-		err = ctx.srv.GetBPF().CloseSession(sessionContext)
+		err = scx.srv.GetBPF().CloseSession(sessionContext)
 		if err != nil {
-			ctx.Errorf("Failed to close enhanced recording (exec) session: %v: %v.", s.id, err)
+			scx.Errorf("Failed to close enhanced recording (exec) session: %v: %v.", s.id, err)
 		}
 
 		s.emitSessionEndEvent()
@@ -1634,11 +1635,11 @@ func (s *session) addParty(p *party, mode types.SessionParticipantMode) error {
 	return nil
 }
 
-func (s *session) join(ch ssh.Channel, ctx *ServerContext, mode types.SessionParticipantMode) (*party, error) {
-	if ctx.Identity.TeleportUser != s.initiator {
+func (s *session) join(ctx context.Context, ch ssh.Channel, scx *ServerContext, mode types.SessionParticipantMode) (*party, error) {
+	if scx.Identity.TeleportUser != s.initiator {
 		accessContext := auth.SessionAccessContext{
-			Username: ctx.Identity.TeleportUser,
-			Roles:    ctx.Identity.AccessChecker.Roles(),
+			Username: scx.Identity.TeleportUser,
+			Roles:    scx.Identity.AccessChecker.Roles(),
 		}
 
 		modes := s.access.CanJoin(accessContext)
@@ -1654,14 +1655,14 @@ func (s *session) join(ch ssh.Channel, ctx *ServerContext, mode types.SessionPar
 		}
 	}
 
-	p := newParty(s, mode, ch, ctx)
+	p := newParty(s, mode, ch, scx)
 	if err := s.addParty(p, mode); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Emit session join event to both the Audit Log as well as over the
 	// "x-teleport-event" channel in the SSH connection.
-	s.emitSessionJoinEvent(p.ctx)
+	s.emitSessionJoinEvent(ctx, p.ctx)
 
 	return p, nil
 }
@@ -1685,7 +1686,7 @@ type party struct {
 	site       string
 	id         rsession.ID
 	s          *session
-	sconn      *ssh.ServerConn
+	sconn      *tracessh.ServerConn
 	ch         ssh.Channel
 	ctx        *ServerContext
 	lastActive time.Time

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -459,7 +459,7 @@ func testJoinSession(t *testing.T, reg *SessionRegistry, sess *session) {
 		io.ReadAll(sshChanOpen)
 	}()
 
-	err := reg.OpenSession(sshChanOpen, scx)
+	err := reg.OpenSession(context.Background(), sshChanOpen, scx)
 	require.NoError(t, err)
 }
 
@@ -559,7 +559,7 @@ func testOpenSession(t *testing.T, reg *SessionRegistry, roleSet services.RoleSe
 		io.ReadAll(sshChanOpen)
 	}()
 
-	err := reg.OpenSession(sshChanOpen, scx)
+	err := reg.OpenSession(context.Background(), sshChanOpen, scx)
 	require.NoError(t, err)
 
 	require.NotNil(t, scx.session)

--- a/lib/srv/subsystem.go
+++ b/lib/srv/subsystem.go
@@ -20,6 +20,8 @@ import (
 	"context"
 
 	"golang.org/x/crypto/ssh"
+
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 )
 
 // SubsystemResult is a result of execution of the subsystem.
@@ -35,7 +37,7 @@ type SubsystemResult struct {
 // in the context of the session.
 type Subsystem interface {
 	// Start starts subsystem
-	Start(context.Context, *ssh.ServerConn, ssh.Channel, *ssh.Request, *ServerContext) error
+	Start(context.Context, *tracessh.ServerConn, ssh.Channel, *ssh.Request, *ServerContext) error
 
 	// Wait is returned by subsystem when it's completed
 	Wait() error

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -17,6 +17,7 @@ limitations under the License.
 package srv
 
 import (
+	"context"
 	"io"
 	"os"
 	"os/exec"
@@ -25,18 +26,17 @@ import (
 	"sync"
 	"syscall"
 
-	"golang.org/x/crypto/ssh"
-
 	"github.com/gravitational/teleport"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
 
+	"github.com/gravitational/trace"
 	"github.com/kr/pty"
 	"github.com/moby/term"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
 )
 
 // LookupUser is used to mock the value returned by user.Lookup(string).
@@ -54,7 +54,7 @@ type Terminal interface {
 	AddParty(delta int)
 
 	// Run will run the terminal.
-	Run() error
+	Run(ctx context.Context) error
 
 	// Wait will block until the terminal is complete.
 	Wait() (*ExecResult, error)
@@ -64,7 +64,7 @@ type Terminal interface {
 	Continue()
 
 	// Kill will force kill the terminal.
-	Kill() error
+	Kill(ctx context.Context) error
 
 	// PTY returns the PTY backing the terminal.
 	PTY() io.ReadWriter
@@ -82,7 +82,7 @@ type Terminal interface {
 	GetWinSize() (*term.Winsize, error)
 
 	// SetWinSize sets the window size of the terminal.
-	SetWinSize(params rsession.TerminalParams) error
+	SetWinSize(ctx context.Context, params rsession.TerminalParams) error
 
 	// GetTerminalParams is a fast call to get cached terminal parameters
 	// and avoid extra system call.
@@ -169,7 +169,7 @@ func (t *terminal) AddParty(delta int) {
 }
 
 // Run will run the terminal.
-func (t *terminal) Run() error {
+func (t *terminal) Run(context.Context) error {
 	var err error
 	defer t.closeTTY()
 
@@ -229,7 +229,7 @@ func (t *terminal) Continue() {
 }
 
 // Kill will force kill the terminal.
-func (t *terminal) Kill() error {
+func (t *terminal) Kill(context.Context) error {
 	if t.cmd != nil && t.cmd.Process != nil {
 		if err := t.cmd.Process.Kill(); err != nil {
 			if err.Error() != "os: process already finished" {
@@ -314,7 +314,7 @@ func (t *terminal) GetWinSize() (*term.Winsize, error) {
 }
 
 // SetWinSize sets the window size of the terminal.
-func (t *terminal) SetWinSize(params rsession.TerminalParams) error {
+func (t *terminal) SetWinSize(ctx context.Context, params rsession.TerminalParams) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.pty == nil {
@@ -417,7 +417,7 @@ type remoteTerminal struct {
 
 	ctx *ServerContext
 
-	session   *ssh.Session
+	session   *tracessh.Session
 	params    rsession.TerminalParams
 	termModes ssh.TerminalModes
 	ptyBuffer *ptyBuffer
@@ -458,9 +458,9 @@ func (b *ptyBuffer) Write(p []byte) (n int, err error) {
 	return b.w.Write(p)
 }
 
-func (t *remoteTerminal) Run() error {
-	// prepare the remote remote session by setting environment variables
-	t.prepareRemoteSession(t.session, t.ctx)
+func (t *remoteTerminal) Run(ctx context.Context) error {
+	// prepare the remote session by setting environment variables
+	t.prepareRemoteSession(ctx, t.session, t.ctx)
 
 	// combine stdout and stderr
 	stdout, err := t.session.StdoutPipe()
@@ -484,7 +484,7 @@ func (t *remoteTerminal) Run() error {
 		t.termType = defaultTerm
 	}
 
-	if err := t.session.RequestPty(t.termType, t.params.H, t.params.W, t.termModes); err != nil {
+	if err := t.session.RequestPty(ctx, t.termType, t.params.H, t.params.W, t.termModes); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -492,7 +492,7 @@ func (t *remoteTerminal) Run() error {
 	if t.ctx.ExecRequest.GetCommand() != "" {
 		t.log.Debugf("Running exec request within a PTY")
 
-		if err := t.session.Start(t.ctx.ExecRequest.GetCommand()); err != nil {
+		if err := t.session.Start(ctx, t.ctx.ExecRequest.GetCommand()); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -501,7 +501,7 @@ func (t *remoteTerminal) Run() error {
 
 	// we want an interactive shell
 	t.log.Debugf("Requesting an interactive terminal of type %v", t.termType)
-	if err := t.session.Shell(); err != nil {
+	if err := t.session.Shell(ctx); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -532,8 +532,8 @@ func (t *remoteTerminal) Wait() (*ExecResult, error) {
 // Continue does nothing for remote command execution.
 func (t *remoteTerminal) Continue() {}
 
-func (t *remoteTerminal) Kill() error {
-	err := t.session.Signal(ssh.SIGKILL)
+func (t *remoteTerminal) Kill(ctx context.Context) error {
+	err := t.session.Signal(ctx, ssh.SIGKILL)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -575,11 +575,11 @@ func (t *remoteTerminal) GetWinSize() (*term.Winsize, error) {
 	return t.params.Winsize(), nil
 }
 
-func (t *remoteTerminal) SetWinSize(params rsession.TerminalParams) error {
+func (t *remoteTerminal) SetWinSize(ctx context.Context, params rsession.TerminalParams) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	err := t.windowChange(params.W, params.H)
+	err := t.windowChange(ctx, params.W, params.H)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -611,7 +611,7 @@ func (t *remoteTerminal) SetTerminalModes(termModes ssh.TerminalModes) {
 	t.termModes = termModes
 }
 
-func (t *remoteTerminal) windowChange(w int, h int) error {
+func (t *remoteTerminal) windowChange(ctx context.Context, w int, h int) error {
 	type windowChangeRequest struct {
 		W   uint32
 		H   uint32
@@ -624,22 +624,22 @@ func (t *remoteTerminal) windowChange(w int, h int) error {
 		Wpx: uint32(w * 8),
 		Hpx: uint32(h * 8),
 	}
-	_, err := t.session.SendRequest(sshutils.WindowChangeRequest, false, ssh.Marshal(&req))
+	_, err := t.session.SendRequest(ctx, sshutils.WindowChangeRequest, false, ssh.Marshal(&req))
 	return err
 }
 
 // prepareRemoteSession prepares the more session for execution.
-func (t *remoteTerminal) prepareRemoteSession(session *ssh.Session, ctx *ServerContext) {
+func (t *remoteTerminal) prepareRemoteSession(ctx context.Context, session *tracessh.Session, scx *ServerContext) {
 	envs := map[string]string{
-		teleport.SSHTeleportUser:        ctx.Identity.TeleportUser,
-		teleport.SSHSessionWebproxyAddr: ctx.ProxyPublicAddress(),
-		teleport.SSHTeleportHostUUID:    ctx.srv.ID(),
-		teleport.SSHTeleportClusterName: ctx.ClusterName,
-		teleport.SSHSessionID:           string(ctx.SessionID()),
+		teleport.SSHTeleportUser:        scx.Identity.TeleportUser,
+		teleport.SSHSessionWebproxyAddr: scx.ProxyPublicAddress(),
+		teleport.SSHTeleportHostUUID:    scx.srv.ID(),
+		teleport.SSHTeleportClusterName: scx.ClusterName,
+		teleport.SSHSessionID:           string(scx.SessionID()),
 	}
 
 	for k, v := range envs {
-		if err := session.Setenv(k, v); err != nil {
+		if err := session.Setenv(ctx, k, v); err != nil {
 			t.log.Debugf("Unable to set environment variable: %v: %v", k, v)
 		}
 	}

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -17,13 +17,14 @@ limitations under the License.
 package srv
 
 import (
+	"context"
 	"encoding/json"
-
-	"golang.org/x/crypto/ssh"
 
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
+
 	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
 )
 
 // TermHandlers are common terminal handling functions used by both the
@@ -35,28 +36,28 @@ type TermHandlers struct {
 // HandleExec handles requests of type "exec" which can execute with or
 // without a TTY. Result of execution is propagated back on the ExecResult
 // channel of the context.
-func (t *TermHandlers) HandleExec(ch ssh.Channel, req *ssh.Request, ctx *ServerContext) error {
+func (t *TermHandlers) HandleExec(ctx context.Context, ch ssh.Channel, req *ssh.Request, scx *ServerContext) error {
 	// Save the request within the context.
-	ctx.request = req
+	scx.request = req
 
 	// Parse the exec request and store it in the context.
-	_, err := parseExecRequest(req, ctx)
+	_, err := parseExecRequest(req, scx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// If a terminal was previously allocated for this command, run command in
 	// an interactive session. Otherwise run it in an exec session.
-	if ctx.GetTerm() != nil {
-		return t.SessionRegistry.OpenSession(ch, ctx)
+	if scx.GetTerm() != nil {
+		return t.SessionRegistry.OpenSession(ctx, ch, scx)
 	}
-	return t.SessionRegistry.OpenExecSession(ch, ctx)
+	return t.SessionRegistry.OpenExecSession(ctx, ch, scx)
 }
 
 // HandlePTYReq handles requests of type "pty-req" which allocate a TTY for
 // "exec" or "shell" requests. The "pty-req" includes the size of the TTY as
 // well as the terminal type requested.
-func (t *TermHandlers) HandlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *ServerContext) error {
+func (t *TermHandlers) HandlePTYReq(ctx context.Context, ch ssh.Channel, req *ssh.Request, scx *ServerContext) error {
 	// parse and extract the requested window size of the pty
 	ptyRequest, err := parsePTYReq(req)
 	if err != nil {
@@ -72,28 +73,28 @@ func (t *TermHandlers) HandlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *Serve
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ctx.Debugf("Requested terminal %q of size %v", ptyRequest.Env, *params)
+	scx.Debugf("Requested terminal %q of size %v", ptyRequest.Env, *params)
 
 	// get an existing terminal or create a new one
-	term := ctx.GetTerm()
+	term := scx.GetTerm()
 	if term == nil {
 		// a regular or forwarding terminal will be allocated
-		term, err = NewTerminal(ctx)
+		term, err = NewTerminal(scx)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		ctx.SetTerm(term)
-		ctx.termAllocated = true
+		scx.SetTerm(term)
+		scx.termAllocated = true
 	}
-	if err := term.SetWinSize(*params); err != nil {
-		ctx.Errorf("Failed setting window size: %v", err)
+	if err := term.SetWinSize(ctx, *params); err != nil {
+		scx.Errorf("Failed setting window size: %v", err)
 	}
 	term.SetTermType(ptyRequest.Env)
 	term.SetTerminalModes(termModes)
 
 	// update the session
-	if err := t.SessionRegistry.NotifyWinChange(*params, ctx); err != nil {
-		ctx.Errorf("Unable to update session: %v", err)
+	if err := t.SessionRegistry.NotifyWinChange(ctx, *params, scx); err != nil {
+		scx.Errorf("Unable to update session: %v", err)
 	}
 
 	return nil
@@ -101,18 +102,18 @@ func (t *TermHandlers) HandlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *Serve
 
 // HandleShell handles requests of type "shell" which request a interactive
 // shell be created within a TTY.
-func (t *TermHandlers) HandleShell(ch ssh.Channel, req *ssh.Request, ctx *ServerContext) error {
+func (t *TermHandlers) HandleShell(ctx context.Context, ch ssh.Channel, req *ssh.Request, scx *ServerContext) error {
 	var err error
 
 	// Save the request within the context.
-	ctx.request = req
+	scx.request = req
 
 	// Creating an empty exec request implies a interactive shell was requested.
-	ctx.ExecRequest, err = NewExecRequest(ctx, "")
+	scx.ExecRequest, err = NewExecRequest(scx, "")
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := t.SessionRegistry.OpenSession(ch, ctx); err != nil {
+	if err := t.SessionRegistry.OpenSession(ctx, ch, scx); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -122,7 +123,7 @@ func (t *TermHandlers) HandleShell(ch ssh.Channel, req *ssh.Request, ctx *Server
 // HandleWinChange handles requests of type "window-change" which update the
 // size of the PTY running on the server and update any other members in the
 // party.
-func (t *TermHandlers) HandleWinChange(ch ssh.Channel, req *ssh.Request, ctx *ServerContext) error {
+func (t *TermHandlers) HandleWinChange(ctx context.Context, ch ssh.Channel, req *ssh.Request, scx *ServerContext) error {
 	params, err := parseWinChange(req)
 	if err != nil {
 		return trace.Wrap(err)
@@ -130,7 +131,7 @@ func (t *TermHandlers) HandleWinChange(ch ssh.Channel, req *ssh.Request, ctx *Se
 
 	// Update any other members in the party that the window size has changed
 	// and to update their terminal windows accordingly.
-	err = t.SessionRegistry.NotifyWinChange(*params, ctx)
+	err = t.SessionRegistry.NotifyWinChange(ctx, *params, scx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/sshutils/forward.go
+++ b/lib/sshutils/forward.go
@@ -24,12 +24,12 @@ import (
 // RequestForwarder represents a resource capable of sending
 // an ssh request such as an ssh.Channel or ssh.Session.
 type RequestForwarder interface {
-	SendRequest(name string, wantReply bool, payload []byte) (bool, error)
+	SendRequest(ctx context.Context, name string, wantReply bool, payload []byte) (bool, error)
 }
 
 // ForwardRequest is a helper for forwarding a request across a session or channel.
-func ForwardRequest(sender RequestForwarder, req *ssh.Request) (bool, error) {
-	reply, err := sender.SendRequest(req.Type, req.WantReply, req.Payload)
+func ForwardRequest(ctx context.Context, sender RequestForwarder, req *ssh.Request) (bool, error) {
+	reply, err := sender.SendRequest(ctx, req.Type, req.WantReply, req.Payload)
 	if err != nil || !req.WantReply {
 		return reply, trace.Wrap(err)
 	}
@@ -48,7 +48,7 @@ func ForwardRequests(ctx context.Context, sin <-chan *ssh.Request, sender Reques
 			}
 			switch sreq.Type {
 			case WindowChangeRequest:
-				if _, err := ForwardRequest(sender, sreq); err != nil {
+				if _, err := ForwardRequest(ctx, sender, sreq); err != nil {
 					return trace.Wrap(err)
 				}
 			default:

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -31,10 +32,14 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/observability/tracing"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
@@ -86,6 +91,14 @@ type Server struct {
 	// fips means Teleport started in a FedRAMP/FIPS 140-2 compliant
 	// configuration.
 	fips bool
+
+	// tracerProvider is used to create tracers capable
+	// of starting spans.
+	tracerProvider oteltrace.TracerProvider
+
+	// tracer is used to create spans for any ssh messages
+	// received by this server
+	tracer oteltrace.Tracer
 }
 
 const (
@@ -139,6 +152,14 @@ func SetInsecureSkipHostValidation() ServerOption {
 	}
 }
 
+// SetTracerProvider sets the tracer provider for the server.
+func SetTracerProvider(provider oteltrace.TracerProvider) ServerOption {
+	return func(s *Server) error {
+		s.tracerProvider = provider
+		return nil
+	}
+}
+
 func NewServer(
 	component string,
 	a utils.NetAddr,
@@ -176,6 +197,13 @@ func NewServer(
 	if s.shutdownPollPeriod == 0 {
 		s.shutdownPollPeriod = defaults.ShutdownPollPeriod
 	}
+
+	if s.tracerProvider == nil {
+		s.tracerProvider = otel.GetTracerProvider()
+	}
+
+	s.tracer = s.tracerProvider.Tracer("ssh", oteltrace.WithInstrumentationVersion(teleport.Version))
+
 	err = s.checkArguments(a, h, hostSigners, ah)
 	if err != nil {
 		return nil, err
@@ -415,7 +443,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	// payload structure which will be populated only when/if this connection
 	// comes from another Teleport proxy):
 	wrappedConn := wrapConnection(wconn, s.log)
-	sconn, chans, reqs, err := ssh.NewServerConn(wrappedConn, &s.cfg)
+	sconn, chans, reqs, err := tracessh.NewServerConn(wrappedConn, &s.cfg, tracing.WithTracerProvider(s.tracerProvider))
 	if err != nil {
 		conn.SetDeadline(time.Time{})
 		return
@@ -497,8 +525,26 @@ func (s *Server) HandleConnection(conn net.Conn) {
 				return
 			}
 			s.log.Debugf("Received out-of-band request: %+v.", req)
+
+			reqCtx := tracessh.ContextFromRequest(req)
+			ctx, span := s.tracer.Start(
+				oteltrace.ContextWithRemoteSpanContext(ctx, oteltrace.SpanContextFromContext(reqCtx)),
+				fmt.Sprintf("ssh.GlobalRequest/%s", req.Type),
+				oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+				oteltrace.WithAttributes(
+					semconv.RPCServiceKey.String("ssh.Server"),
+					semconv.RPCMethodKey.String("GlobalRequest"),
+					semconv.RPCSystemKey.String("ssh"),
+				),
+			)
+
 			if s.reqHandler != nil {
-				go s.reqHandler.HandleRequest(ctx, req)
+				go func(span oteltrace.Span) {
+					defer span.End()
+					s.reqHandler.HandleRequest(ctx, req)
+				}(span)
+			} else {
+				span.End()
 			}
 			// handle channels:
 		case nch := <-chans:
@@ -506,11 +552,44 @@ func (s *Server) HandleConnection(conn net.Conn) {
 				connClosed()
 				return
 			}
-			go s.newChanHandler.HandleNewChan(ctx, ccx, nch)
+
+			// This is a request from clients to determine if tracing is enabled.
+			// Handle here so that we always alert clients that we can handle tracing envelopes.
+			if nch.ChannelType() == tracessh.TracingChannel {
+				ch, _, err := nch.Accept()
+				if err != nil {
+					if err := nch.Reject(ssh.ConnectionFailed, err.Error()); err != nil {
+						s.log.Warnf("Unable to reject %q channel: %v", nch.ChannelType(), err)
+					}
+					continue
+				}
+
+				if err := ch.Close(); err != nil {
+					s.log.Warnf("Unable to close %q channel: %v", nch.ChannelType(), err)
+				}
+				continue
+			}
+
+			chanCtx, nch := tracessh.ContextFromNewChannel(nch)
+			ctx, span := s.tracer.Start(
+				oteltrace.ContextWithRemoteSpanContext(ctx, oteltrace.SpanContextFromContext(chanCtx)),
+				fmt.Sprintf("ssh.OpenChannel/%s", nch.ChannelType()),
+				oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+				oteltrace.WithAttributes(
+					semconv.RPCServiceKey.String("ssh.Server"),
+					semconv.RPCMethodKey.String("OpenChannel"),
+					semconv.RPCSystemKey.String("ssh"),
+				),
+			)
+
+			go func(span oteltrace.Span) {
+				defer span.End()
+				s.newChanHandler.HandleNewChan(ctx, ccx, nch)
+			}(span)
 			// send keepalive pings to the clients
 		case <-keepAliveTick.C:
 			const wantReply = true
-			_, _, err = sconn.SendRequest(teleport.KeepAliveReqType, wantReply, keepAlivePayload[:])
+			_, _, err = sconn.SendRequest(ctx, teleport.KeepAliveReqType, wantReply, keepAlivePayload[:])
 			if err != nil {
 				s.log.Errorf("Failed sending keepalive request: %v", err)
 			}

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -167,9 +167,9 @@ type TerminalHandler struct {
 	hostUUID string
 
 	// sshSession holds the "shell" SSH channel to the node.
-	sshSession *ssh.Session
+	sshSession *tracessh.Session
 
-	// terminalContext is used to signal when the terminal sesson is closing.
+	// terminalContext is used to signal when the terminal session is closing.
 	terminalContext context.Context
 
 	// terminalCancel is used to signal when the terminal session is closing.
@@ -349,9 +349,9 @@ func (t *TerminalHandler) makeClient(ws *websocket.Conn, r *http.Request) (*clie
 	// Save the *ssh.Session after the shell has been created. The session is
 	// used to update all other parties window size to that of the web client and
 	// to allow future window changes.
-	tc.OnShellCreated = func(s *ssh.Session, c *tracessh.Client, _ io.ReadWriteCloser) (bool, error) {
+	tc.OnShellCreated = func(s *tracessh.Session, c *tracessh.Client, _ io.ReadWriteCloser) (bool, error) {
 		t.sshSession = s
-		t.windowChange(&t.params.Term)
+		t.windowChange(r.Context(), &t.params.Term)
 
 		return false, nil
 	}
@@ -547,12 +547,13 @@ func (t *TerminalHandler) streamEvents(ws *websocket.Conn, tc *client.TeleportCl
 
 // windowChange is called when the browser window is resized. It sends a
 // "window-change" channel request to the server.
-func (t *TerminalHandler) windowChange(params *session.TerminalParams) {
+func (t *TerminalHandler) windowChange(ctx context.Context, params *session.TerminalParams) {
 	if t.sshSession == nil {
 		return
 	}
 
 	_, err := t.sshSession.SendRequest(
+		ctx,
 		sshutils.WindowChangeRequest,
 		false,
 		ssh.Marshal(sshutils.WinChangeReqParams{
@@ -701,7 +702,7 @@ func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error
 
 		// Send the window change request in a goroutine so reads are not blocked
 		// by network connectivity issues.
-		go t.windowChange(params)
+		go t.windowChange(context.TODO(), params)
 
 		return 0, nil
 	default:

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -70,6 +70,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
@@ -2684,7 +2685,7 @@ func makeClientForProxy(cf *CLIConf, proxy string, useProfileLogin bool) (*clien
 	c := client.MakeDefaultConfig()
 	c.Host = cf.UserHost
 	if cf.TracingProvider == nil {
-		cf.TracingProvider = tracing.NoopProvider()
+		cf.TracingProvider = otel.GetTracerProvider()
 	}
 	c.Tracer = cf.TracingProvider.Tracer(teleport.ComponentTSH)
 


### PR DESCRIPTION
Add wrappers for ssh.Client, ssh.Session, ssh.Channel, ssh.ServerConn,
and ssh.NewCh that pass tracing context along with all ssh messages.
In order to maintain backwards compatibility the ssh.Client wrapper
tries to open a TracingChannel when constructed. Any servers that
don't support tracing will reject the unknown channel. The client
will only provide tracing context to servers which do NOT reject
the TracingChannel request.

In order to include pass tracing context along all ssh payloads
are wrapped in an envelope that includes the original payload
AND any trace context. Servers now try to unmarshal all payloads
into an envelope when processing messages. If there is an envelope
provided, a new span will be created and the original payload will
be pass along to handlers.

Part of #12241