### PR TITLE
[helm] Include Teleport version in Kubernetes agent labels

### DIFF
--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -90,10 +90,11 @@ data:
   {{- else }}
       kube_cluster_name: {{ .Values.clusterName }}
   {{- end }}
-  {{- if .Values.labels }}
       labels:
-    {{- toYaml .Values.labels | nindent 8 }}
-  {{- end }}
+        version: "{{ if .Values.teleportVersionOverride }}{{ .Values.teleportVersionOverride }}{{ else }}{{ .Chart.Version }}{{ end }}"
+      {{- if .Values.labels }}
+        {{- toYaml .Values.labels | nindent 8 }}
+      {{- end }}
     proxy_service:
       public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
   {{- if not .Values.proxyListenerMode }}

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -33,9 +33,11 @@ data:
       {{- if or (contains "kube" (.Values.roles | toString)) (empty .Values.roles) }}
       enabled: true
       kube_cluster_name: {{ required "kubeClusterName is required in chart values when kube role is enabled, see README" .Values.kubeClusterName }}
-        {{- if .Values.labels }}
-      labels: {{- toYaml .Values.labels | nindent 8 }}
-        {{- end }}
+      labels:
+        version: "{{ if .Values.teleportVersionOverride }}{{ .Values.teleportVersionOverride }}{{ else }}{{ .Chart.Version }}{{ end }}"
+      {{- if .Values.labels }}
+        {{- toYaml .Values.labels | nindent 8 }}
+      {{- end }}
       {{- else }}
       enabled: false
       {{- end }}


### PR DESCRIPTION
Partial fix for including Teleport version in Kubernetes agent labels as described in https://github.com/gravitational/teleport/issues/10465

Would also like to see Teleport version automatically included in agent labels for other agent types (SSH node agents, Desktop access, Database access, etc.)