### PR TITLE
pass and preserve a path parameter during the app authentication

### DIFF
--- a/lib/web/app/fragment.go
+++ b/lib/web/app/fragment.go
@@ -57,6 +57,7 @@ func (h *Handler) handleFragment(w http.ResponseWriter, r *http.Request, p httpr
 				clusterName: q.Get("cluster"),
 				publicAddr:  q.Get("addr"),
 				awsRole:     q.Get("awsrole"),
+				path:        q.Get("path"),
 				stateToken:  stateToken,
 			}
 			return h.redirectToLauncher(w, r, urlParams)

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -337,7 +337,7 @@ func HasName(r *http.Request, proxyPublicAddrs []utils.NetAddr) (string, bool) {
 	u := url.URL{
 		Scheme: "https",
 		Host:   proxyPublicAddrs[0].String(),
-		Path:   fmt.Sprintf("/web/launch/%v", raddr.Host()),
+		Path:   fmt.Sprintf("/web/launch/%v?path=%v", raddr.Host(), r.URL),
 	}
 	return u.String(), true
 }

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -337,7 +337,7 @@ func HasName(r *http.Request, proxyPublicAddrs []utils.NetAddr) (string, bool) {
 	u := url.URL{
 		Scheme: "https",
 		Host:   proxyPublicAddrs[0].String(),
-		Path:   fmt.Sprintf("/web/launch/%v?path=%v", raddr.Host(), r.URL),
+		Path:   fmt.Sprintf("/web/launch/%v?path=%v", raddr.Host(), r.URL.Path),
 	}
 	return u.String(), true
 }

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -103,6 +103,42 @@ func TestAuthPOST(t *testing.T) {
 	}
 }
 
+func TestHasName(t *testing.T) {
+	for _, test := range []struct {
+		desc        string
+		addrs       []string
+		reqHost     string
+		reqURL      string
+		expectedURL string
+		hasName     bool
+	}{
+		{
+			desc:        "NOK - invalid host",
+			addrs:       []string{"proxy.com"},
+			reqURL:      "badurl.com",
+			expectedURL: "",
+			hasName:     false,
+		},
+		{
+			desc:        "OK - adds path",
+			addrs:       []string{"proxy.com"},
+			reqURL:      "https://app1.proxy.com/foo",
+			expectedURL: "https://proxy.com/web/launch/app1.proxy.com%3Fpath=/foo",
+			hasName:     true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, test.reqURL, nil)
+			require.NoError(t, err)
+
+			addrs := utils.MustParseAddrList(test.addrs...)
+			u, ok := HasName(req, addrs)
+			require.Equal(t, test.expectedURL, u)
+			require.Equal(t, test.hasName, ok)
+		})
+	}
+}
+
 func TestMatchApplicationServers(t *testing.T) {
 	clusterName := "test-cluster"
 	publicAddr := "app.example.com"

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -126,6 +126,13 @@ func TestHasName(t *testing.T) {
 			expectedURL: "https://proxy.com/web/launch/app1.proxy.com%3Fpath=/foo",
 			hasName:     true,
 		},
+		{
+			desc:        "OK - adds root path",
+			addrs:       []string{"proxy.com"},
+			reqURL:      "https://app1.proxy.com/",
+			expectedURL: "https://proxy.com/web/launch/app1.proxy.com%3Fpath=/",
+			hasName:     true,
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, test.reqURL, nil)

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -90,6 +90,9 @@ func (h *Handler) redirectToLauncher(w http.ResponseWriter, r *http.Request, p l
 	if p.awsRole != "" {
 		urlQuery.Add("awsrole", p.awsRole)
 	}
+	if p.path != "" {
+		urlQuery.Add("path", p.path)
+	}
 
 	u := url.URL{
 		Scheme:   "https",
@@ -106,6 +109,7 @@ type launcherURLParams struct {
 	publicAddr  string
 	stateToken  string
 	awsRole     string
+	path        string
 }
 
 // makeRouterHandler creates a httprouter.Handle.

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -77,8 +77,13 @@ const js = `
           body: JSON.stringify(data),
         }).then(response => {
           if (response.ok) {
+            try {
+                window.location.replace(url.origin + path);
+            } catch (error) {
+                // in case of malformed url, return to origin
+                window.location.replace(url.origin)
+            }
             // redirect to the target path and remove current URL from history (back button)
-            window.location.replace(path || "/");
           }
         });
       })();

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -51,10 +51,10 @@ const js = `
     <title>Teleport Redirection Service</title>
     <script nonce="%v">
       (function() {
-        var url = new URL(window.location)
-        var params = new URLSearchParams(url.search)
+        var url = new URL(window.location);
+        var params = new URLSearchParams(url.search);
         var searchParts = window.location.search.split('=');
-        var stateValue = params.get("state")
+        var stateValue = params.get("state");
         var path = params.get("path")
         if (!stateValue) {
           return;
@@ -78,7 +78,7 @@ const js = `
         }).then(response => {
           if (response.ok) {
             // redirect to the target path and remove current URL from history (back button)
-            window.location.replace(path || "/")
+            window.location.replace(path || "/");
           }
         });
       })();

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -55,7 +55,7 @@ const js = `
         var params = new URLSearchParams(url.search);
         var searchParts = window.location.search.split('=');
         var stateValue = params.get("state");
-        var path = params.get("path")
+        var path = params.get("path");
         if (!stateValue) {
           return;
         }

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -51,8 +51,12 @@ const js = `
     <title>Teleport Redirection Service</title>
     <script nonce="%v">
       (function() {
+        var url = new URL(window.location)
+        var params = new URLSearchParams(url.search)
         var searchParts = window.location.search.split('=');
-        if (searchParts.length !== 2 || searchParts[0] !== '?state') {
+        var stateValue = params.get("state")
+        var path = params.get("path")
+        if (!stateValue) {
           return;
         }
         var hashParts = window.location.hash.split('=');
@@ -60,7 +64,7 @@ const js = `
           return;
         }
         const data = {
-          state_value: searchParts[1],
+          state_value: stateValue,
           cookie_value: hashParts[1],
         };
         fetch('/x-teleport-auth', {
@@ -73,8 +77,8 @@ const js = `
           body: JSON.stringify(data),
         }).then(response => {
           if (response.ok) {
-            // redirect to the root and remove current URL from history (back button)
-            window.location.replace('/');
+            // redirect to the target path and remove current URL from history (back button)
+            window.location.replace(path || "/")
           }
         });
       })();

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -78,7 +78,10 @@ const js = `
         }).then(response => {
           if (response.ok) {
             try {
-                window.location.replace(url.origin + path);
+              if (path.charAt(0) !== "/") {
+                throw "malformed url"
+              }
+              window.location.replace(url.origin + path);
             } catch (error) {
                 // in case of malformed url, return to origin
                 window.location.replace(url.origin)

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -78,10 +78,8 @@ const js = `
         }).then(response => {
           if (response.ok) {
             try {
-              if (path.charAt(0) !== "/") {
-                throw "malformed url"
-              }
-              window.location.replace(url.origin + path);
+              var redirectUrl = new URL(path, url.origin)
+              window.location.replace(redirectUrl.toString());
             } catch (error) {
                 // in case of malformed url, return to origin
                 window.location.replace(url.origin)


### PR DESCRIPTION
I left some detailed info in the [webapps PR](https://github.com/gravitational/webapps/pull/913) with some reproduction steps

This would add the requested path as a parameter to the redirect_uri during app access, which would only exist from a bookmarked or shared link since our dashboard links to root anyway.  This is where the problem arises, when a path is included in a request but the user is unauthenticated, the requested path is lost during the (many) redirects that happen during the authentication process.

Including this query parameter in the final javascript code in the redirection service will keep the path preserved. 

Also, cleaned up the state value params to not be hard coded to retrieve from a specific index and instead uses standard getters with URLSearchParams