### PR TITLE
[v10] Fix AWS credentials format in IBM guide

### DIFF
--- a/docs/pages/setup/deployments/ibm.mdx
+++ b/docs/pages/setup/deployments/ibm.mdx
@@ -168,8 +168,8 @@ Save these settings to `~/.aws/credentials`
 ```yaml
 # Example keys from example service account to be saved into ~/.aws/credentials
 [default]
-access_key_id="e668d66374e141668e3432443bc879e"
-secret_access_key="d8762b57f61d5dd524ccd49c7d44861ceafdsfds37d05836"
+aws_access_key_id="e668d66374e141668e3432443bc879e"
+aws_secret_access_key="d8762b57f61d5dd524ccd49c7d44861ceafdsfds37d05836"
 ```
 
 Example `/etc/teleport.yaml`


### PR DESCRIPTION
Backport #13830 to branch/v10