### PR TITLE
Add an AWS EC2 instance fetcher

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -328,6 +328,4 @@ const (
 	// https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html
 	// Used for filtering instances for automatic EC2 discovery
 	AWSInstanceStateName = "instance-state-name"
-	// AWSVPCID is used to filter AWS describe-instances output by vpc
-	AWSVPCID = "vpc-id"
 )

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -321,11 +321,3 @@ const (
 	// allowed AWS role ARNs.
 	TraitAWSRoleARNs = "aws_role_arns"
 )
-
-const (
-	// AWSInstanceStateName represents the state of the AWS EC2
-	// instance - (pending | running | shutting-down | terminated | stopping | stopped )
-	// https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html
-	// Used for filtering instances for automatic EC2 discovery
-	AWSInstanceStateName = "instance-state-name"
-)

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -321,3 +321,13 @@ const (
 	// allowed AWS role ARNs.
 	TraitAWSRoleARNs = "aws_role_arns"
 )
+
+const (
+	// AWSInstanceStateName represents the state of the AWS EC2
+	// instance - (pending | running | shutting-down | terminated | stopping | stopped )
+	// https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html
+	// Used for filtering instances for automatic EC2 discovery
+	AWSInstanceStateName = "instance-state-name"
+	// AWSVPCID is used to filter AWS describe-instances output by vpc
+	AWSVPCID = "vpc-id"
+)

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -659,6 +659,11 @@ const (
 	DatabaseTypeMemoryDB = "memorydb"
 )
 
+// GetServerName returns the GCP database project and instance as "<project-id>:<instance-id>".
+func (gcp GCPCloudSQL) GetServerName() string {
+	return fmt.Sprintf("%s:%s", gcp.ProjectID, gcp.InstanceID)
+}
+
 // DeduplicateDatabases deduplicates databases by name.
 func DeduplicateDatabases(databases []Database) (result []Database) {
 	seen := make(map[string]struct{})

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1060,10 +1060,14 @@ func applySSHConfig(fc *FileConfig, cfg *service.Config) (err error) {
 	for _, matcher := range fc.SSH.AWSMatchers {
 		cfg.SSH.AWSMatchers = append(cfg.SSH.AWSMatchers,
 			services.AWSMatcher{
-				Types:       matcher.Types,
-				Regions:     matcher.Regions,
-				Tags:        matcher.Tags,
-				SSMDocument: matcher.SSMDocument,
+				Types:   matcher.Types,
+				Regions: matcher.Regions,
+				Tags:    matcher.Tags,
+				Params: services.InstallerParams{
+					JoinMethod: matcher.InstallParams.JoinParams.Method,
+					JoinToken:  matcher.InstallParams.JoinParams.TokenName,
+				},
+				SSM: &services.AWSSSM{Document: matcher.SSM.Document},
 			})
 	}
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1060,9 +1060,9 @@ func applySSHConfig(fc *FileConfig, cfg *service.Config) (err error) {
 	for _, matcher := range fc.SSH.AWSMatchers {
 		cfg.SSH.AWSMatchers = append(cfg.SSH.AWSMatchers,
 			services.AWSMatcher{
-				Types:   matcher.Types,
-				Regions: matcher.Regions,
-				Tags:    matcher.Tags,
+				Types:   matcher.Matcher.Types,
+				Regions: matcher.Matcher.Regions,
+				Tags:    matcher.Matcher.Tags,
 				Params: services.InstallerParams{
 					JoinMethod: matcher.InstallParams.JoinParams.Method,
 					JoinToken:  matcher.InstallParams.JoinParams.TokenName,

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1067,7 +1067,7 @@ func applySSHConfig(fc *FileConfig, cfg *service.Config) (err error) {
 					JoinMethod: matcher.InstallParams.JoinParams.Method,
 					JoinToken:  matcher.InstallParams.JoinParams.TokenName,
 				},
-				SSM: &services.AWSSSM{Document: matcher.SSM.Document},
+				SSM: &services.AWSSSM{DocumentName: matcher.SSM.DocumentName},
 			})
 	}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -336,6 +336,24 @@ func TestConfigReading(t *testing.T) {
 			},
 			Labels:   Labels,
 			Commands: CommandLabels,
+			AWSMatchers: []AWSEC2Matcher{
+				{
+					Matcher: AWSMatcher{
+						Types:   []string{"ec2"},
+						Regions: []string{"us-west-1", "us-east-1"},
+						Tags: map[string]apiutils.Strings{
+							"a": {"b"},
+						},
+					},
+					InstallParams: &InstallParams{
+						JoinParams: JoinParams{
+							TokenName: "aws-discovery-iam-token",
+							Method:    "iam",
+						},
+					},
+					SSM: AWSSSM{DocumentName: "TeleportDiscoveryInstaller"},
+				},
+			},
 		},
 		Proxy: Proxy{
 			Service: Service{
@@ -1161,7 +1179,8 @@ func checkStaticConfig(t *testing.T, conf *FileConfig) {
 			{Name: "hostname", Command: []string{"/bin/hostname"}, Period: 10 * time.Millisecond},
 			{Name: "date", Command: []string{"/bin/date"}, Period: 20 * time.Millisecond},
 		},
-		PublicAddr: apiutils.Strings{"luna3:22"},
+		PublicAddr:  apiutils.Strings{"luna3:22"},
+		AWSMatchers: []AWSEC2Matcher{},
 	}, cmp.AllowUnexported(Service{})))
 
 	require.True(t, conf.Auth.Configured())
@@ -1264,6 +1283,14 @@ func makeConfigFixture() string {
 	conf.SSH.ListenAddress = "tcp://ssh"
 	conf.SSH.Labels = Labels
 	conf.SSH.Commands = CommandLabels
+	conf.SSH.AWSMatchers = []AWSEC2Matcher{
+		{
+			Matcher: AWSMatcher{Types: []string{"ec2"},
+				Regions: []string{"us-west-1", "us-east-1"},
+				Tags:    map[string]apiutils.Strings{"a": {"b"}},
+			},
+		},
+	}
 
 	// proxy-service:
 	conf.Proxy.EnabledFlag = "yes"

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -460,8 +460,8 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 			}
 		}
 
-		if matcher.SSM.Document == "" {
-			matcher.SSM.Document = defaults.AWSInstallerDocument
+		if matcher.SSM.DocumentName == "" {
+			matcher.SSM.DocumentName = defaults.AWSInstallerDocument
 		}
 		matchers = append(matchers, matcher)
 	}
@@ -1229,9 +1229,9 @@ type InstallParams struct {
 
 // AWSSSM provides options to use when executing SSM documents
 type AWSSSM struct {
-	// Document is the name of the document to use when executing an
+	// DocumentName is the name of the document to use when executing an
 	// SSM command
-	Document string `yaml:"document,omitempty"`
+	DocumentName string `yaml:"document_name,omitempty"`
 }
 
 // Database represents a single database proxied by the service.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -437,7 +437,7 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 		}
 	}
 
-	matchers := make([]AWSMatcher, 0, len(conf.SSH.AWSMatchers))
+	matchers := make([]AWSEC2Matcher, 0, len(conf.SSH.AWSMatchers))
 
 	for _, matcher := range conf.SSH.AWSMatchers {
 		if matcher.InstallParams == nil {
@@ -1027,7 +1027,7 @@ type SSH struct {
 	DisableCreateHostUser bool `yaml:"disable_create_host_user,omitempty"`
 
 	// AWSMatchers are used to match EC2 instances
-	AWSMatchers []AWSMatcher `yaml:"aws,omitempty"`
+	AWSMatchers []AWSEC2Matcher `yaml:"aws,omitempty"`
 }
 
 // AllowTCPForwarding checks whether the config file allows TCP forwarding or not.
@@ -1214,6 +1214,12 @@ type AWSMatcher struct {
 	Regions []string `yaml:"regions,omitempty"`
 	// Tags are AWS tags to match.
 	Tags map[string]apiutils.Strings `yaml:"tags,omitempty"`
+}
+
+// AWSEC2Matcher matches EC2 instances
+type AWSEC2Matcher struct {
+	// Matcher is used to match EC2 instances based on tags
+	Matcher AWSMatcher `yaml:",inline"`
 	// InstallParams sets the join method when installing on
 	// discovered EC2 nodes
 	InstallParams *InstallParams `yaml:"install,omitempty"`

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -437,6 +437,37 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 		}
 	}
 
+	matchers := make([]AWSMatcher, 0, len(conf.SSH.AWSMatchers))
+
+	for _, matcher := range conf.SSH.AWSMatchers {
+		if matcher.InstallParams == nil {
+			matcher.InstallParams = &InstallParams{
+				JoinParams: JoinParams{
+					TokenName: defaults.IAMInviteTokenName,
+					Method:    types.JoinMethodIAM,
+				},
+			}
+		} else {
+			method := matcher.InstallParams.JoinParams.Method
+			if method == "" {
+				matcher.InstallParams.JoinParams.Method = types.JoinMethodIAM
+			} else if method != types.JoinMethodIAM {
+				return trace.BadParameter("only IAM joining is supported for EC2 auto-discovery")
+			}
+			token := matcher.InstallParams.JoinParams.TokenName
+			if token == "" {
+				matcher.InstallParams.JoinParams.TokenName = defaults.IAMInviteTokenName
+			}
+		}
+
+		if matcher.SSM.Document == "" {
+			matcher.SSM.Document = defaults.AWSInstallerDocument
+		}
+		matchers = append(matchers, matcher)
+	}
+
+	conf.SSH.AWSMatchers = matchers
+
 	return nil
 }
 
@@ -1183,9 +1214,24 @@ type AWSMatcher struct {
 	Regions []string `yaml:"regions,omitempty"`
 	// Tags are AWS tags to match.
 	Tags map[string]apiutils.Strings `yaml:"tags,omitempty"`
-	// SSMDocument is the ssm command document to execute for EC2
-	// installation
-	SSMDocument string `yaml:"ssm_command_document"`
+	// InstallParams sets the join method when installing on
+	// discovered EC2 nodes
+	InstallParams *InstallParams `yaml:"install,omitempty"`
+	// SSM provides options to use when sending a document command to
+	// an EC2 node
+	SSM AWSSSM `yaml:"ssm,omitempty"`
+}
+
+// InstallParams sets join method to use on discovered nodes
+type InstallParams struct {
+	JoinParams JoinParams `yaml:"join_params,omitempty"`
+}
+
+// AWSSSM provides options to use when executing SSM documents
+type AWSSSM struct {
+	// Document is the name of the document to use when executing an
+	// SSM command
+	Document string `yaml:"document,omitempty"`
 }
 
 // Database represents a single database proxied by the service.

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -468,7 +468,7 @@ func TestSSHSection(t *testing.T) {
 		expectError               require.ErrorAssertionFunc
 		expectEnabled             require.BoolAssertionFunc
 		expectAllowsTCPForwarding require.BoolAssertionFunc
-		expectedAWSSection        []AWSMatcher
+		expectedAWSSection        []AWSEC2Matcher
 	}{
 		{
 			desc:                      "default",
@@ -529,12 +529,14 @@ func TestSSHSection(t *testing.T) {
 					},
 				}
 			},
-			expectedAWSSection: []AWSMatcher{
+			expectedAWSSection: []AWSEC2Matcher{
 				{
-					Types:   []string{"ec2"},
-					Regions: []string{"eu-central-1"},
-					Tags: map[string]apiutils.Strings{
-						"discover_teleport": []string{"yes"},
+					Matcher: AWSMatcher{
+						Types:   []string{"ec2"},
+						Regions: []string{"eu-central-1"},
+						Tags: map[string]apiutils.Strings{
+							"discover_teleport": []string{"yes"},
+						},
 					},
 					InstallParams: &InstallParams{
 						JoinParams: JoinParams{
@@ -564,17 +566,19 @@ func TestSSHSection(t *testing.T) {
 							},
 						},
 						"ssm": cfgMap{
-							"document": "hello_document",
+							"document_name": "hello_document",
 						},
 					},
 				}
 			},
-			expectedAWSSection: []AWSMatcher{
+			expectedAWSSection: []AWSEC2Matcher{
 				{
-					Types:   []string{"ec2"},
-					Regions: []string{"eu-central-1"},
-					Tags: map[string]apiutils.Strings{
-						"discover_teleport": []string{"yes"},
+					Matcher: AWSMatcher{
+						Types:   []string{"ec2"},
+						Regions: []string{"eu-central-1"},
+						Tags: map[string]apiutils.Strings{
+							"discover_teleport": []string{"yes"},
+						},
 					},
 					InstallParams: &InstallParams{
 						JoinParams: JoinParams{
@@ -618,7 +622,7 @@ func TestSSHSection(t *testing.T) {
 					},
 				}
 			},
-			expectedAWSSection: []AWSMatcher{
+			expectedAWSSection: []AWSEC2Matcher{
 				{
 					SSM: AWSSSM{
 						DocumentName: defaults.AWSInstallerDocument,

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -468,6 +468,7 @@ func TestSSHSection(t *testing.T) {
 		expectError               require.ErrorAssertionFunc
 		expectEnabled             require.BoolAssertionFunc
 		expectAllowsTCPForwarding require.BoolAssertionFunc
+		expectedAWSSection        []AWSMatcher
 	}{
 		{
 			desc:                      "default",
@@ -513,6 +514,123 @@ func TestSSHSection(t *testing.T) {
 				cfg["ssh_service"].(cfgMap)["port_forwarding"] = "banana"
 			},
 			expectError: require.Error,
+		}, {
+			desc:        "AWS section is filled with defaults",
+			expectError: require.NoError,
+			mutate: func(cfg cfgMap) {
+				cfg["ssh_service"].(cfgMap)["enabled"] = "yes"
+				cfg["ssh_service"].(cfgMap)["aws"] = []cfgMap{
+					{
+						"types":   []string{"ec2"},
+						"regions": []string{"eu-central-1"},
+						"tags": cfgMap{
+							"discover_teleport": "yes",
+						},
+					},
+				}
+			},
+			expectedAWSSection: []AWSMatcher{
+				{
+					Types:   []string{"ec2"},
+					Regions: []string{"eu-central-1"},
+					Tags: map[string]apiutils.Strings{
+						"discover_teleport": []string{"yes"},
+					},
+					InstallParams: &InstallParams{
+						JoinParams: JoinParams{
+							TokenName: defaults.IAMInviteTokenName,
+							Method:    types.JoinMethodIAM,
+						},
+					},
+					SSM: AWSSSM{Document: defaults.AWSInstallerDocument},
+				},
+			},
+		}, {
+			desc:        "AWS section is filled with custom configs",
+			expectError: require.NoError,
+			mutate: func(cfg cfgMap) {
+				cfg["ssh_service"].(cfgMap)["enabled"] = "yes"
+				cfg["ssh_service"].(cfgMap)["aws"] = []cfgMap{
+					{
+						"types":   []string{"ec2"},
+						"regions": []string{"eu-central-1"},
+						"tags": cfgMap{
+							"discover_teleport": "yes",
+						},
+						"install": cfgMap{
+							"join_params": cfgMap{
+								"token_name": "hello-iam-a-token",
+								"method":     "iam",
+							},
+						},
+						"ssm": cfgMap{
+							"document": "hello_document",
+						},
+					},
+				}
+			},
+			expectedAWSSection: []AWSMatcher{
+				{
+					Types:   []string{"ec2"},
+					Regions: []string{"eu-central-1"},
+					Tags: map[string]apiutils.Strings{
+						"discover_teleport": []string{"yes"},
+					},
+					InstallParams: &InstallParams{
+						JoinParams: JoinParams{
+							TokenName: "hello-iam-a-token",
+							Method:    types.JoinMethodIAM,
+						},
+					},
+					SSM: AWSSSM{Document: "hello_document"},
+				},
+			},
+		}, {
+			desc:        "AWS section is filled with invalid join method",
+			expectError: require.Error,
+			mutate: func(cfg cfgMap) {
+				cfg["ssh_service"].(cfgMap)["enabled"] = "yes"
+				cfg["ssh_service"].(cfgMap)["aws"] = []cfgMap{
+					{
+						"install": cfgMap{
+							"join_params": cfgMap{
+								"token_name": "hello-iam-a-token",
+								"method":     "token",
+							},
+						},
+					},
+				}
+			},
+			expectedAWSSection: nil,
+		},
+		{
+			desc:        "AWS section is filled with no token",
+			expectError: require.NoError,
+			mutate: func(cfg cfgMap) {
+				cfg["ssh_service"].(cfgMap)["enabled"] = "yes"
+				cfg["ssh_service"].(cfgMap)["aws"] = []cfgMap{
+					{
+						"install": cfgMap{
+							"join_params": cfgMap{
+								"method": "iam",
+							},
+						},
+					},
+				}
+			},
+			expectedAWSSection: []AWSMatcher{
+				{
+					SSM: AWSSSM{
+						Document: defaults.AWSInstallerDocument,
+					},
+					InstallParams: &InstallParams{
+						JoinParams: JoinParams{
+							TokenName: defaults.IAMInviteTokenName,
+							Method:    types.JoinMethodIAM,
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -529,6 +647,10 @@ func TestSSHSection(t *testing.T) {
 
 			if testCase.expectAllowsTCPForwarding != nil {
 				testCase.expectAllowsTCPForwarding(t, cfg.SSH.AllowTCPForwarding())
+			}
+
+			if testCase.expectedAWSSection != nil {
+				require.Equal(t, testCase.expectedAWSSection, cfg.SSH.AWSMatchers)
 			}
 		})
 	}

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -542,7 +542,7 @@ func TestSSHSection(t *testing.T) {
 							Method:    types.JoinMethodIAM,
 						},
 					},
-					SSM: AWSSSM{Document: defaults.AWSInstallerDocument},
+					SSM: AWSSSM{DocumentName: defaults.AWSInstallerDocument},
 				},
 			},
 		}, {
@@ -582,7 +582,7 @@ func TestSSHSection(t *testing.T) {
 							Method:    types.JoinMethodIAM,
 						},
 					},
-					SSM: AWSSSM{Document: "hello_document"},
+					SSM: AWSSSM{DocumentName: "hello_document"},
 				},
 			},
 		}, {
@@ -621,7 +621,7 @@ func TestSSHSection(t *testing.T) {
 			expectedAWSSection: []AWSMatcher{
 				{
 					SSM: AWSSSM{
-						Document: defaults.AWSInstallerDocument,
+						DocumentName: defaults.AWSInstallerDocument,
 					},
 					InstallParams: &InstallParams{
 						JoinParams: JoinParams{

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -804,3 +804,12 @@ func SearchSessionRange(clock clockwork.Clock, fromUTC, toUTC string) (from time
 	}
 	return from, to, nil
 }
+
+const (
+	// AWSInstallerDocument is the name of the default AWS document
+	// that will be called when executing the SSM command.
+	AWSInstallerDocument = "TeleportDiscoveryInstaller"
+	// IAMInviteTokenName is the name of the default Teleport IAM
+	// token to use when templating the script to be executed.
+	IAMInviteTokenName = "aws-discovery-iam-token"
+)

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -29,6 +29,21 @@ type ResourceMatcher struct {
 	Labels types.Labels
 }
 
+// AWSSSM provides options to use when executing SSM documents
+type AWSSSM struct {
+	// Document is the name of the document to use when executing an
+	// SSM command
+	Document string
+}
+
+// InstallerParams are passed to the AWS SSM document
+type InstallerParams struct {
+	// JoinMethod is the method to use when joining the cluster
+	JoinMethod types.JoinMethod
+	// JoinToken is the token to use when joining the cluster
+	JoinToken string
+}
+
 // AWSMatcher matches AWS databases.
 type AWSMatcher struct {
 	// Types are AWS database types to match, "rds" or "redshift".
@@ -37,9 +52,11 @@ type AWSMatcher struct {
 	Regions []string
 	// Tags are AWS tags to match.
 	Tags types.Labels
-	// SSMDocument is the SSM document used to execute the
-	// installation script
-	SSMDocument string
+	// Params are passed to AWS when executing the SSM document
+	Params InstallerParams
+	// SSM provides options to use when sending a document command to
+	// an EC2 node
+	SSM *AWSSSM
 }
 
 // MatchResourceLabels returns true if any of the provided selectors matches the provided database.

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -31,9 +31,9 @@ type ResourceMatcher struct {
 
 // AWSSSM provides options to use when executing SSM documents
 type AWSSSM struct {
-	// Document is the name of the document to use when executing an
+	// DocumentName is the name of the document to use when executing an
 	// SSM command
-	Document string
+	DocumentName string
 }
 
 // InstallerParams are passed to the AWS SSM document

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
+	clients "github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -1859,7 +1860,7 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t *testing.T, p a
 	// Create test database auth tokens generator.
 	testAuth, err := newTestAuth(common.AuthConfig{
 		AuthClient: c.authClient,
-		Clients:    &common.TestCloudClients{},
+		Clients:    &clients.TestCloudClients{},
 		Clock:      c.clock,
 	})
 	require.NoError(t, err)
@@ -1901,7 +1902,7 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t *testing.T, p a
 		},
 		OnReconcile: p.OnReconcile,
 		LockWatcher: lockWatcher,
-		CloudClients: &common.TestCloudClients{
+		CloudClients: &clients.TestCloudClients{
 			STS:            &cloud.STSMock{},
 			RDS:            &cloud.RDSMock{},
 			Redshift:       &cloud.RedshiftMock{},

--- a/lib/srv/db/cloud/aws.go
+++ b/lib/srv/db/cloud/aws.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
-	"github.com/gravitational/teleport/lib/srv/db/common"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -37,7 +37,7 @@ import (
 // awsConfig is the config for the client that configures IAM for AWS databases.
 type awsConfig struct {
 	// clients is an interface for creating AWS clients.
-	clients common.CloudClients
+	clients cloud.Clients
 	// identity is AWS identity this database agent is running as.
 	identity awslib.Identity
 	// database is the database instance to configure.

--- a/lib/srv/db/cloud/gcp.go
+++ b/lib/srv/db/cloud/gcp.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/trace"
 )
@@ -27,8 +28,8 @@ import (
 // GetGCPRequireSSL requests settings for the project/instance in session from GCP
 // and returns true when the instance requires SSL. An access denied error is
 // returned when an unauthorized error is returned from GCP.
-func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient common.GCPSQLAdminClient) (requireSSL bool, err error) {
-	dbi, err := gcpClient.GetDatabaseInstance(ctx, sessionCtx)
+func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient cloud.GCPSQLAdminClient) (requireSSL bool, err error) {
+	dbi, err := gcpClient.GetDatabaseInstance(ctx, sessionCtx.Database)
 	if err != nil {
 		err = common.ConvertError(err)
 		if trace.IsAccessDenied(err) {
@@ -39,9 +40,9 @@ func GetGCPRequireSSL(ctx context.Context, sessionCtx *common.Session, gcpClient
 Make sure Teleport db service has "Cloud SQL Admin" GCP IAM role,
 or "cloudsql.instances.get" IAM permission.`, err)
 		}
-		return false, trace.Wrap(err, "Failed to get Cloud SQL instance information for %q.", common.GCPServerName(sessionCtx))
+		return false, trace.Wrap(err, "Failed to get Cloud SQL instance information for %q.", sessionCtx.Database.GetGCP().GetServerName())
 	} else if dbi.Settings == nil || dbi.Settings.IpConfiguration == nil {
-		return false, trace.BadParameter("Failed to find Cloud SQL settings for %q. GCP returned %+v.", common.GCPServerName(sessionCtx), dbi)
+		return false, trace.BadParameter("Failed to find Cloud SQL settings for %q. GCP returned %+v.", sessionCtx.Database.GetGCP().GetServerName(), dbi)
 	}
 	return dbi.Settings.IpConfiguration.RequireSsl, nil
 }
@@ -49,8 +50,8 @@ or "cloudsql.instances.get" IAM permission.`, err)
 // AppendGCPClientCert calls the GCP API to generate an ephemeral certificate
 // and adds it to the TLS config. An access denied error is returned when the
 // generate call fails.
-func AppendGCPClientCert(ctx context.Context, sessionCtx *common.Session, gcpClient common.GCPSQLAdminClient, tlsConfig *tls.Config) error {
-	cert, err := gcpClient.GenerateEphemeralCert(ctx, sessionCtx)
+func AppendGCPClientCert(ctx context.Context, sessionCtx *common.Session, gcpClient cloud.GCPSQLAdminClient, tlsConfig *tls.Config) error {
+	cert, err := gcpClient.GenerateEphemeralCert(ctx, sessionCtx.Database, sessionCtx.Identity)
 	if err != nil {
 		err = common.ConvertError(err)
 		if trace.IsAccessDenied(err) {
@@ -61,7 +62,7 @@ func AppendGCPClientCert(ctx context.Context, sessionCtx *common.Session, gcpCli
 Make sure Teleport db service has "Cloud SQL Admin" GCP IAM role,
 or "cloudsql.sslCerts.createEphemeral" IAM permission.`, err)
 		}
-		return trace.Wrap(err, "Failed to generate GCP ephemeral client certificate for %q.", common.GCPServerName(sessionCtx))
+		return trace.Wrap(err, "Failed to generate GCP ephemeral client certificate for %q.", sessionCtx.Database.GetGCP().GetServerName())
 	}
 	tlsConfig.Certificates = []tls.Certificate{*cert}
 	return nil

--- a/lib/srv/db/cloud/iam.go
+++ b/lib/srv/db/cloud/iam.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/cloud"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -44,7 +44,7 @@ type IAMConfig struct {
 	// AccessPoint is a caching client connected to the Auth Server.
 	AccessPoint auth.DatabaseAccessPoint
 	// Clients is an interface for retrieving cloud clients.
-	Clients common.CloudClients
+	Clients cloud.Clients
 	// HostID is the host identified where this agent is running.
 	// DELETE IN 11.0.
 	HostID string
@@ -61,7 +61,7 @@ func (c *IAMConfig) Check() error {
 		return trace.BadParameter("missing AccessPoint")
 	}
 	if c.Clients == nil {
-		c.Clients = common.NewCloudClients()
+		c.Clients = cloud.NewClients()
 	}
 	if c.HostID == "" {
 		return trace.BadParameter("missing HostID")

--- a/lib/srv/db/cloud/meta.go
+++ b/lib/srv/db/cloud/meta.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 
@@ -41,13 +42,13 @@ import (
 // MetadataConfig is the cloud metadata service config.
 type MetadataConfig struct {
 	// Clients is an interface for retrieving cloud clients.
-	Clients common.CloudClients
+	Clients cloud.Clients
 }
 
 // Check validates the metadata service config.
 func (c *MetadataConfig) Check() error {
 	if c.Clients == nil {
-		c.Clients = common.NewCloudClients()
+		c.Clients = cloud.NewClients()
 	}
 	return nil
 }

--- a/lib/srv/db/cloud/meta_test.go
+++ b/lib/srv/db/cloud/meta_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/srv/db/common"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -102,7 +102,7 @@ func TestAWSMetadata(t *testing.T) {
 
 	// Create metadata fetcher.
 	metadata, err := NewMetadata(MetadataConfig{
-		Clients: &common.TestCloudClients{
+		Clients: &cloud.TestCloudClients{
 			RDS:         rds,
 			Redshift:    redshift,
 			ElastiCache: elasticache,
@@ -263,7 +263,7 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 
 	// Create metadata fetcher.
 	metadata, err := NewMetadata(MetadataConfig{
-		Clients: &common.TestCloudClients{
+		Clients: &cloud.TestCloudClients{
 			RDS:      rds,
 			Redshift: redshift,
 		},

--- a/lib/srv/db/cloud/mocks.go
+++ b/lib/srv/db/cloud/mocks.go
@@ -35,7 +35,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/redshift/redshiftiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
-	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/trace"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
@@ -361,15 +362,15 @@ type GCPSQLAdminClientMock struct {
 	EphemeralCert *tls.Certificate
 }
 
-func (g *GCPSQLAdminClientMock) UpdateUser(ctx context.Context, sessionCtx *common.Session, user *sqladmin.User) error {
+func (g *GCPSQLAdminClientMock) UpdateUser(ctx context.Context, db types.Database, dbUser string, user *sqladmin.User) error {
 	return nil
 }
 
-func (g *GCPSQLAdminClientMock) GetDatabaseInstance(ctx context.Context, sessionCtx *common.Session) (*sqladmin.DatabaseInstance, error) {
+func (g *GCPSQLAdminClientMock) GetDatabaseInstance(ctx context.Context, db types.Database) (*sqladmin.DatabaseInstance, error) {
 	return g.DatabaseInstance, nil
 }
 
-func (g *GCPSQLAdminClientMock) GenerateEphemeralCert(ctx context.Context, sessionCtx *common.Session) (*tls.Certificate, error) {
+func (g *GCPSQLAdminClientMock) GenerateEphemeralCert(ctx context.Context, db types.Database, identity tlsca.Identity) (*tls.Certificate, error) {
 	return g.EphemeralCert, nil
 }
 

--- a/lib/srv/db/cloud/users/helpers.go
+++ b/lib/srv/db/cloud/users/helpers.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/secrets"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -152,7 +152,7 @@ func genRandomPassword(length int) (string, error) {
 }
 
 // newSecretStore create a new secrets store helper for provided database.
-func newSecretStore(database types.Database, clients common.CloudClients) (secrets.Secrets, error) {
+func newSecretStore(database types.Database, clients cloud.Clients) (secrets.Secrets, error) {
 	secretStoreConfig := database.GetSecretStore()
 
 	client, err := clients.GetAWSSecretsManagerClient(database.GetAWS().Region)

--- a/lib/srv/db/cloud/users/users.go
+++ b/lib/srv/db/cloud/users/users.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/interval"
 
@@ -32,7 +32,7 @@ import (
 // Config is the config for users service.
 type Config struct {
 	// Clients is an interface for retrieving cloud clients.
-	Clients common.CloudClients
+	Clients cloud.Clients
 	// Clock is used to control time.
 	Clock clockwork.Clock
 	// Interval is the interval between user updates. Interval is also used as
@@ -50,7 +50,7 @@ func (c *Config) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing UpdateMeta")
 	}
 	if c.Clients == nil {
-		c.Clients = common.NewCloudClients()
+		c.Clients = cloud.NewClients()
 	}
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()

--- a/lib/srv/db/cloud/users/users_test.go
+++ b/lib/srv/db/cloud/users/users_test.go
@@ -29,10 +29,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	clients "github.com/gravitational/teleport/lib/cloud"
 	libaws "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/cloud"
-	"github.com/gravitational/teleport/lib/srv/db/common"
 	libsecrets "github.com/gravitational/teleport/lib/srv/db/secrets"
 	"github.com/gravitational/trace"
 )
@@ -72,7 +72,7 @@ func TestUsers(t *testing.T) {
 	db6 := mustCreateMemoryDBDatabase(t, "db6", "acl1")
 
 	users, err := NewUsers(Config{
-		Clients: &common.TestCloudClients{
+		Clients: &clients.TestCloudClients{
 			ElastiCache:    ecMock,
 			MemoryDB:       mdbMock,
 			SecretsManager: smMock,

--- a/lib/srv/db/cloud/watchers/watcher_test.go
+++ b/lib/srv/db/cloud/watchers/watcher_test.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/api/types"
+	clients "github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/cloud"
-	"github.com/gravitational/teleport/lib/srv/db/common"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -96,7 +96,7 @@ func TestWatcher(t *testing.T) {
 	tests := []struct {
 		name              string
 		awsMatchers       []services.AWSMatcher
-		clients           common.CloudClients
+		clients           clients.Clients
 		expectedDatabases types.Databases
 	}{
 		{
@@ -113,7 +113,7 @@ func TestWatcher(t *testing.T) {
 					Tags:    types.Labels{"env": []string{"dev"}},
 				},
 			},
-			clients: &common.TestCloudClients{
+			clients: &clients.TestCloudClients{
 				RDSPerRegion: map[string]rdsiface.RDSAPI{
 					"us-east-1": &cloud.RDSMock{
 						DBInstances: []*rds.DBInstance{rdsInstance1, rdsInstance3},
@@ -134,7 +134,7 @@ func TestWatcher(t *testing.T) {
 				Regions: []string{"us-east-1"},
 				Tags:    types.Labels{"*": []string{"*"}},
 			}},
-			clients: &common.TestCloudClients{
+			clients: &clients.TestCloudClients{
 				RDSPerRegion: map[string]rdsiface.RDSAPI{
 					"us-east-1": &cloud.RDSMock{
 						DBClusters: []*rds.DBCluster{auroraCluster1, auroraClusterUnsupported},
@@ -150,7 +150,7 @@ func TestWatcher(t *testing.T) {
 				Regions: []string{"us-east-1"},
 				Tags:    types.Labels{"*": []string{"*"}},
 			}},
-			clients: &common.TestCloudClients{
+			clients: &clients.TestCloudClients{
 				RDS: &cloud.RDSMock{
 					DBInstances: []*rds.DBInstance{rdsInstance1, rdsInstanceUnavailable, rdsInstanceUnknownStatus},
 					DBClusters:  []*rds.DBCluster{auroraCluster1, auroraClusterUnavailable, auroraClusterUnknownStatus},
@@ -165,7 +165,7 @@ func TestWatcher(t *testing.T) {
 				Regions: []string{"ca-central-1", "us-west-1", "us-east-1"},
 				Tags:    types.Labels{"*": []string{"*"}},
 			}},
-			clients: &common.TestCloudClients{
+			clients: &clients.TestCloudClients{
 				RDSPerRegion: map[string]rdsiface.RDSAPI{
 					"ca-central-1": &cloud.RDSMockUnauth{},
 					"us-west-1": &cloud.RDSMockByDBType{
@@ -189,7 +189,7 @@ func TestWatcher(t *testing.T) {
 					Tags:    types.Labels{"env": []string{"prod"}},
 				},
 			},
-			clients: &common.TestCloudClients{
+			clients: &clients.TestCloudClients{
 				Redshift: &cloud.RedshiftMock{
 					Clusters: []*redshift.Cluster{redshiftUse1Prod, redshiftUse1Dev},
 				},
@@ -205,7 +205,7 @@ func TestWatcher(t *testing.T) {
 					Tags:    types.Labels{"*": []string{"*"}},
 				},
 			},
-			clients: &common.TestCloudClients{
+			clients: &clients.TestCloudClients{
 				Redshift: &cloud.RedshiftMock{
 					Clusters: []*redshift.Cluster{redshiftUse1Prod, redshiftUse1Unavailable, redshiftUse1UnknownStatus},
 				},
@@ -221,7 +221,7 @@ func TestWatcher(t *testing.T) {
 					Tags:    types.Labels{"env": []string{"prod", "qa"}},
 				},
 			},
-			clients: &common.TestCloudClients{
+			clients: &clients.TestCloudClients{
 				ElastiCache: &cloud.ElastiCacheMock{
 					ReplicationGroups: []*elasticache.ReplicationGroup{
 						elasticacheProd, // labels match
@@ -244,7 +244,7 @@ func TestWatcher(t *testing.T) {
 					Tags:    types.Labels{"env": []string{"prod"}},
 				},
 			},
-			clients: &common.TestCloudClients{
+			clients: &clients.TestCloudClients{
 				MemoryDB: &cloud.MemoryDBMock{
 					Clusters: []*memorydb.Cluster{
 						memorydbProd, // labels match
@@ -271,7 +271,7 @@ func TestWatcher(t *testing.T) {
 					Tags:    types.Labels{"env": []string{"prod"}},
 				},
 			},
-			clients: &common.TestCloudClients{
+			clients: &clients.TestCloudClients{
 				RDS: &cloud.RDSMock{
 					DBClusters: []*rds.DBCluster{auroraCluster1},
 				},

--- a/lib/srv/db/common/engines.go
+++ b/lib/srv/db/common/engines.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/cloud"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -72,7 +73,7 @@ type EngineConfig struct {
 	// AuthClient is the cluster auth server client.
 	AuthClient *auth.Client
 	// CloudClients provides access to cloud API clients.
-	CloudClients CloudClients
+	CloudClients cloud.Clients
 	// Context is the database server close context.
 	Context context.Context
 	// Clock is the clock interface.

--- a/lib/srv/db/common/engines_test.go
+++ b/lib/srv/db/common/engines_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/cloud"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -37,7 +38,7 @@ func TestRegisterEngine(t *testing.T) {
 		Auth:         &testAuth{},
 		Audit:        &testAudit{},
 		AuthClient:   &auth.Client{},
-		CloudClients: NewCloudClients(),
+		CloudClients: cloud.NewClients(),
 	}
 
 	// No engine is registered initially.

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	clients "github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/labels"
@@ -104,7 +105,7 @@ type Config struct {
 	// LockWatcher is a lock watcher.
 	LockWatcher *services.LockWatcher
 	// CloudClients creates cloud API clients.
-	CloudClients common.CloudClients
+	CloudClients clients.Clients
 	// CloudMeta fetches cloud metadata for cloud hosted databases.
 	CloudMeta *cloud.Metadata
 	// CloudIAM configures IAM for cloud hosted databases.
@@ -173,7 +174,7 @@ func (c *Config) CheckAndSetDefaults(ctx context.Context) (err error) {
 		return trace.BadParameter("missing LockWatcher")
 	}
 	if c.CloudClients == nil {
-		c.CloudClients = common.NewCloudClients()
+		c.CloudClients = clients.NewClients()
 	}
 	if c.CloudMeta == nil {
 		c.CloudMeta, err = cloud.NewMetadata(cloud.MetadataConfig{

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -655,6 +655,7 @@ func SetTracerProvider(provider oteltrace.TracerProvider) ServerOption {
 	}
 }
 
+// SetCloudClients returns a server option that sets cloud API clients
 func SetCloudClients(clients cloud.Clients) ServerOption {
 	return func(s *Server) error {
 		s.clients = clients
@@ -788,7 +789,7 @@ func New(addr utils.NetAddr,
 			s.clients = cloud.NewClients()
 		}
 
-		s.cloudWatcher, err = server.NewCloudServerWatcher(s.ctx, s.awsMatchers, s.clients)
+		s.cloudWatcher, err = server.NewCloudWatcher(s.ctx, s.awsMatchers, s.clients)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -39,6 +39,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/inventory"
@@ -51,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/teleport/lib/srv/server"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
 	"github.com/gravitational/teleport/lib/teleagent"
@@ -214,8 +216,14 @@ type Server struct {
 
 	// users is used to start the automatic user deletion loop
 	users srv.HostUsers
+
+	// cloudWatcher periodically retrieves cloud resources, currently
+	// only EC2
+	cloudWatcher *server.Watcher
 	// awsMatchers are used to match EC2 instances
 	awsMatchers []services.AWSMatcher
+	// clients is used to retrieve clients used for AWS EC2 discovery
+	clients cloud.Clients
 
 	// tracerProvider is used to create tracers capable
 	// of starting spans.
@@ -647,6 +655,13 @@ func SetTracerProvider(provider oteltrace.TracerProvider) ServerOption {
 	}
 }
 
+func SetCloudClients(clients cloud.Clients) ServerOption {
+	return func(s *Server) error {
+		s.clients = clients
+		return nil
+	}
+}
+
 // New returns an unstarted server
 func New(addr utils.NetAddr,
 	hostname string,
@@ -766,6 +781,17 @@ func New(addr utils.NetAddr,
 	// common term handlers
 	s.termHandlers = &srv.TermHandlers{
 		SessionRegistry: s.reg,
+	}
+
+	if len(s.awsMatchers) != 0 {
+		if s.clients == nil {
+			s.clients = cloud.NewClients()
+		}
+
+		s.cloudWatcher, err = server.NewCloudServerWatcher(s.ctx, s.awsMatchers, s.clients)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	server, err := sshutils.NewServer(

--- a/lib/srv/server/cloudwatcher.go
+++ b/lib/srv/server/cloudwatcher.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+// EC2Instances contains information required to send SSM commands to EC2 instances
+type EC2Instances struct {
+	// Region is the AWS region where the instances are located.
+	Region string
+	// Document is the SSM document that should be executed on the EC2
+	// instances.
+	Document string
+	// Parameters are parameters passed to the SSM document.
+	Parameters map[string]string
+	// AccountID is the AWS account the instances belong to.
+	AccountID string
+	// Instances is a list of discovered EC2 instances
+	Instances []*ec2.Instance
+}
+
+type Watcher struct {
+	// InstancesC can be used to consume newly discovered EC2 instances
+	InstancesC chan EC2Instances
+
+	fetchers      []*ec2InstanceFetcher
+	fetchInterval time.Duration
+	ctx           context.Context
+	cancel        context.CancelFunc
+}
+
+func (w *Watcher) Run() {
+	ticker := time.NewTicker(w.fetchInterval)
+	defer ticker.Stop()
+	for {
+		for _, fetcher := range w.fetchers {
+			inst, err := fetcher.GetEC2Instances(w.ctx)
+			if err != nil {
+				log.WithError(err).Error("Failed to fetch EC2 instances")
+				continue
+			}
+			if inst == nil {
+				continue
+			}
+			select {
+			case w.InstancesC <- *inst:
+			case <-w.ctx.Done():
+			}
+		}
+		select {
+		case <-ticker.C:
+			continue
+		case <-w.ctx.Done():
+			return
+		}
+	}
+}
+
+func (w *Watcher) Stop() {
+	w.cancel()
+}
+
+func NewCloudServerWatcher(ctx context.Context, matchers []services.AWSMatcher, clients cloud.Clients) (*Watcher, error) {
+	cancelCtx, cancelFn := context.WithCancel(ctx)
+	watcher := Watcher{
+		fetchers:      []*ec2InstanceFetcher{},
+		ctx:           cancelCtx,
+		cancel:        cancelFn,
+		fetchInterval: time.Minute,
+		InstancesC:    make(chan EC2Instances),
+	}
+	for _, matcher := range matchers {
+		for _, region := range matcher.Regions {
+			cl, err := clients.GetAWSEC2Client(region)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			fetcher := newEC2InstanceFetcher(ec2FetcherConfig{
+				Matcher:   matcher,
+				Region:    region,
+				Document:  matcher.SSM.Document,
+				EC2Client: cl,
+				Labels:    matcher.Tags,
+			})
+			watcher.fetchers = append(watcher.fetchers, fetcher)
+		}
+	}
+	return &watcher, nil
+}
+
+type ec2FetcherConfig struct {
+	Matcher   services.AWSMatcher
+	Region    string
+	Document  string
+	EC2Client ec2iface.EC2API
+	Labels    types.Labels
+	VPC       string
+}
+
+type ec2InstanceFetcher struct {
+	Filters    []*ec2.Filter
+	EC2        ec2iface.EC2API
+	Region     string
+	Document   string
+	Parameters map[string]string
+}
+
+func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
+	tagFilters := []*ec2.Filter{&ec2.Filter{
+		Name:   aws.String(constants.AWSInstanceStateName),
+		Values: aws.StringSlice([]string{ec2.InstanceStateNameRunning}),
+	}}
+	if cfg.VPC != "" {
+		tagFilters = append(tagFilters, &ec2.Filter{
+			Name:   aws.String(constants.AWSInstanceStateName),
+			Values: aws.StringSlice([]string{cfg.VPC}),
+		})
+	}
+
+	for key, val := range cfg.Labels {
+		tagFilters = append(tagFilters, &ec2.Filter{
+			Name:   aws.String("tag:" + key),
+			Values: aws.StringSlice(val),
+		})
+	}
+	fetcherConfig := ec2InstanceFetcher{
+		EC2:      cfg.EC2Client,
+		Filters:  tagFilters,
+		Region:   cfg.Region,
+		Document: cfg.Document,
+		Parameters: map[string]string{
+			"token": cfg.Matcher.Params.JoinToken,
+		},
+	}
+	return &fetcherConfig
+}
+
+func (f *ec2InstanceFetcher) GetEC2Instances(ctx context.Context) (*EC2Instances, error) {
+	var instances []*ec2.Instance
+	var accountID string
+	err := f.EC2.DescribeInstancesPagesWithContext(ctx, &ec2.DescribeInstancesInput{
+		Filters: f.Filters,
+	},
+		func(dio *ec2.DescribeInstancesOutput, b bool) bool {
+			for _, res := range dio.Reservations {
+				if accountID == "" {
+					accountID = aws.StringValue(res.OwnerId)
+				}
+				instances = append(instances, res.Instances...)
+			}
+			return true
+		})
+
+	if err != nil {
+		return nil, common.ConvertError(err)
+	}
+
+	if len(instances) == 0 {
+		return nil, nil
+	}
+
+	return &EC2Instances{
+		AccountID:  accountID,
+		Region:     f.Region,
+		Document:   f.Document,
+		Instances:  instances,
+		Parameters: f.Parameters,
+	}, nil
+}

--- a/lib/srv/server/cloudwatcher_test.go
+++ b/lib/srv/server/cloudwatcher_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/stretchr/testify/require"
+)
+
+type mockClients struct {
+	cloud.Clients
+
+	ec2Client *mockEC2Client
+}
+
+func (c *mockClients) GetAWSEC2Client(region string) (ec2iface.EC2API, error) {
+	return c.ec2Client, nil
+}
+
+type mockEC2Client struct {
+	ec2iface.EC2API
+	output *ec2.DescribeInstancesOutput
+}
+
+func (m *mockEC2Client) DescribeInstancesPagesWithContext(
+	ctx context.Context, input *ec2.DescribeInstancesInput,
+	f func(dio *ec2.DescribeInstancesOutput, b bool) bool, opts ...request.Option) error {
+	f(m.output, true)
+	return nil
+}
+
+func TestEC2Watcher(t *testing.T) {
+	clients := mockClients{
+		ec2Client: &mockEC2Client{},
+	}
+	matchers := []services.AWSMatcher{
+		{
+			Types:   []string{"EC2"},
+			Regions: []string{"us-west-2"},
+			Tags:    map[string]utils.Strings{"teleport": {"yes"}},
+		},
+		{
+			Types:   []string{"EC2"},
+			Regions: []string{"us-west-2"},
+			Tags:    map[string]utils.Strings{"env": {"dev"}},
+		},
+	}
+	ctx := context.Background()
+
+	present := ec2.Instance{
+		InstanceId: aws.String("instance-present"),
+		Tags: []*ec2.Tag{{
+			Key:   aws.String("teleport"),
+			Value: aws.String("yes"),
+		}},
+		State: &ec2.InstanceState{
+			Name: aws.String(ec2.InstanceStateNameRunning),
+		},
+	}
+	presentOther := ec2.Instance{
+		InstanceId: aws.String("instance-present-2"),
+		Tags: []*ec2.Tag{{
+			Key:   aws.String("env"),
+			Value: aws.String("dev"),
+		}},
+		State: &ec2.InstanceState{
+			Name: aws.String(ec2.InstanceStateNameRunning),
+		},
+	}
+
+	output := ec2.DescribeInstancesOutput{
+		Reservations: []*ec2.Reservation{{
+			Instances: []*ec2.Instance{
+				&present,
+				&presentOther,
+				{
+					InstanceId: aws.String("instance-absent"),
+					Tags: []*ec2.Tag{{
+						Key:   aws.String("env"),
+						Value: aws.String("prod"),
+					}},
+					State: &ec2.InstanceState{
+						Name: aws.String(ec2.InstanceStateNameRunning),
+					},
+				},
+				{
+					InstanceId: aws.String("instance-absent-3"),
+					Tags: []*ec2.Tag{{
+						Key:   aws.String("env"),
+						Value: aws.String("prod"),
+					}, {
+						Key:   aws.String("teleport"),
+						Value: aws.String("yes"),
+					}},
+					State: &ec2.InstanceState{
+						Name: aws.String(ec2.InstanceStateNamePending),
+					},
+				},
+			},
+		}},
+	}
+	clients.ec2Client.output = &output
+	watcher, err := NewCloudServerWatcher(ctx, matchers, &clients)
+	require.NoError(t, err)
+
+	go watcher.Run()
+
+	result := <-watcher.InstancesC
+	require.Equal(t, EC2Instances{
+		Region:    "us-west-2",
+		Instances: []*ec2.Instance{&present},
+	}, result)
+	result = <-watcher.InstancesC
+	require.Equal(t, EC2Instances{
+		Region:    "us-west-2",
+		Instances: []*ec2.Instance{&presentOther},
+	}, result)
+}

--- a/lib/srv/server/cloudwatcher_test.go
+++ b/lib/srv/server/cloudwatcher_test.go
@@ -123,7 +123,7 @@ func TestEC2Watcher(t *testing.T) {
 		}},
 	}
 	clients.ec2Client.output = &output
-	watcher, err := NewCloudServerWatcher(ctx, matchers, &clients)
+	watcher, err := NewCloudWatcher(ctx, matchers, &clients)
 	require.NoError(t, err)
 
 	go watcher.Run()


### PR DESCRIPTION
This adds a fetcher for ec2 instances as well as a watcher to periodically fetch them.

Requires IAM permissions:  `iam:DescribeInstances`

Depends on #13787 
Part of #12410 