### PR TITLE
lib/services/role CurrentUserRoleGetter: Fix comment

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -743,7 +743,7 @@ func FetchRoles(roleNames []string, access RoleGetter, traits map[string][]strin
 	return NewRoleSet(roles...), nil
 }
 
-// CurrentUserRoleGetter limits the interface of auth.ClientI to methods needed by FetchClusterRoles.
+// CurrentUserRoleGetter limits the interface of auth.ClientI to methods needed by FetchAllClusterRoles.
 type CurrentUserRoleGetter interface {
 	GetCurrentUser(context.Context) (types.User, error)
 	RoleGetter


### PR DESCRIPTION
Pointed out by @GavinFrazar under my PR (https://github.com/gravitational/teleport/pull/13877#discussion_r907604663). The comment refers to a function that I since renamed.

Just before finishing my work yesterday I got too excited by seeing the CI pass for that PR. I went ahead and merged it only to realize that I had set its base to another PR (#13625).

To avoid making even more mess I created this PR which I'm going to backport to v10 too after #13625 gets in.