### PR TITLE
[v10] Drop `v` from macOS tsh installer version number

### DIFF
--- a/build.assets/build-pkg-tsh.sh
+++ b/build.assets/build-pkg-tsh.sh
@@ -130,7 +130,8 @@ password created by APPLE_USERNAME"
     "$target"
 
   # Prepare and sign the installer package.
-  target="$tmp/tsh-v$TELEPORT_VERSION.pkg" # switches from app to pkg
+  # Note that the installer does __NOT__ have a `v` in the version number.
+  target="$tmp/tsh-$TELEPORT_VERSION.pkg" # switches from app to pkg
   pkgbuild \
     --root "$tmp/root/" \
     --identifier "$TSH_BUNDLEID" \


### PR DESCRIPTION
Drop the `v` from the tsh installer version number, which was inadvertently changed by #12751. Makes the installer reappear as a download option in Houston.

Note that the final .app name still has the `v`. Ie:

* tsh-10.0.0-dev.pkg (installer)
* tsh-10.0.0-dev.pkg.sha256 (installer hash)
* tsh-v10.0.0-dev.app (Application package)

Backport #13896 to branch/v10