### PR TITLE
Handle SHA1 certificates in ssh proxy command

### DIFF
--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/profile"
@@ -212,6 +213,8 @@ func sshProxy(tc *libclient.TeleportClient, params sshProxyParams) error {
 
 	args := []string{
 		"-A",
+		// TODO: remove once we finish deprecating SHA1
+		"-o", fmt.Sprintf("PubkeyAcceptedKeyTypes=+%s", ssh.CertAlgoRSAv01),
 		"-o", fmt.Sprintf("UserKnownHostsFile=%s", knownHostsPath),
 		"-p", params.proxyPort,
 		params.proxyHost,


### PR DESCRIPTION
This PR adds `-o PubkeyAcceptedKeyTypes=+ssh-rsa-cert-v01@openssh.com` to the `ssh` call in `tsh proxy ssh`. This fixes ssh compatibility for newer ssh clients which do not support this deprecated key type.

See https://github.com/gravitational/teleport/pull/11178 for more background

Side note: It would also be nice if we provided `-o IdentityFile` and `-o CertificateFile`, rather than expecting the user's `~/.ssh/config` to provide them.