### PR TITLE
[v8] backport #10020 (CertAuthority watcher filtering)

### DIFF
--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -723,3 +723,46 @@ func (k *JWTKeyPair) CheckAndSetDefaults() error {
 	}
 	return nil
 }
+
+type CertAuthorityFilter map[CertAuthType]string
+
+func (f CertAuthorityFilter) IsEmpty() bool {
+	return len(f) == 0
+}
+
+// Match checks if a given CA matches this filter.
+func (f CertAuthorityFilter) Match(ca CertAuthority) bool {
+	if len(f) == 0 {
+		return true
+	}
+
+	return f[ca.GetType()] == Wildcard || f[ca.GetType()] == ca.GetClusterName()
+}
+
+// IntoMap makes this filter into a map for use as the Filter in a WatchKind.
+func (f CertAuthorityFilter) IntoMap() map[string]string {
+	if len(f) == 0 {
+		return nil
+	}
+
+	m := make(map[string]string, len(f))
+	for caType, name := range f {
+		m[string(caType)] = name
+	}
+	return m
+}
+
+// FromMap converts the provided map into this filter.
+func (f *CertAuthorityFilter) FromMap(m map[string]string) {
+	if len(m) == 0 {
+		*f = nil
+		return
+	}
+
+	*f = make(CertAuthorityFilter, len(m))
+	// there's not a lot of value in rejecting unknown values from the filter
+	for key, val := range m {
+		(*f)[CertAuthType(key)] = val
+	}
+
+}

--- a/api/types/events.go
+++ b/api/types/events.go
@@ -152,11 +152,20 @@ func (kind WatchKind) Matches(e Event) (bool, error) {
 				return false, trace.Wrap(err)
 			}
 			return target.Match(res), nil
+		case CertAuthority:
+			var filter CertAuthorityFilter
+			filter.FromMap(kind.Filter)
+			return filter.Match(res), nil
 		default:
-			return false, trace.BadParameter("unfilterable resource type %T", e.Resource)
+			// we don't know about this filter, let the event through
 		}
 	}
 	return true, nil
+}
+
+// IsTrivial returns true iff the WatchKind only specifies a Kind but no other field.
+func (kind WatchKind) IsTrivial() bool {
+	return kind.SubKind == "" && kind.Name == "" && !kind.LoadSecrets && len(kind.Filter) == 0
 }
 
 // Events returns new events interface

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -318,6 +318,12 @@ func (g *GRPCServer) WatchEvents(watch *proto.Watch, stream proto.AuthService_Wa
 	for _, kind := range watch.Kinds {
 		servicesWatch.Kinds = append(servicesWatch.Kinds, proto.ToWatchKind(kind))
 	}
+
+	if clusterName, err := auth.GetClusterName(); err == nil {
+		// we might want to enforce a filter for older clients in certain conditions
+		maybeFilterCertAuthorityWatches(stream.Context(), clusterName.GetClusterName(), auth.Checker.RoleNames(), &servicesWatch)
+	}
+
 	watcher, err := auth.NewWatcher(stream.Context(), servicesWatch)
 	if err != nil {
 		return trace.Wrap(err)
@@ -354,6 +360,60 @@ func (g *GRPCServer) WatchEvents(watch *proto.Watch, stream proto.AuthService_Wa
 		}
 	}
 }
+
+// maybeFilterCertAuthorityWatches will add filters to the CertAuthority
+// WatchKinds in the watch if the client is authenticated as just a `Node` with
+// no other roles and if the client is older than the cutoff version, and if the
+// WatchKind for KindCertAuthority is trivial, i.e. it's a WatchKind{Kind:
+// KindCertAuthority} with no other fields set. In any other case we will assume
+// that the client knows what it's doing and the cache watcher will still send
+// everything.
+//
+// DELETE IN 10.0, no supported clients should require this at that point
+func maybeFilterCertAuthorityWatches(ctx context.Context, clusterName string, roleNames []string, watch *types.Watch) {
+	if len(roleNames) != 1 || roleNames[0] != string(types.RoleNode) {
+		return
+	}
+
+	clientVersionString, ok := metadata.ClientVersionFromContext(ctx)
+	if !ok {
+		log.Debug("no client version found in grpc context")
+		return
+	}
+
+	clientVersion, err := semver.NewVersion(clientVersionString)
+	if err != nil {
+		log.WithError(err).Debugf("couldn't parse client version %q", clientVersionString)
+		return
+	}
+
+	// we treat the entire previous major version as "old" for this version
+	// check, even if there might have been backports; compliant clients will
+	// supply their own filter anyway
+	if !clientVersion.LessThan(certAuthorityFilterVersionCutoff) {
+		return
+	}
+
+	for i, k := range watch.Kinds {
+		if k.Kind != types.KindCertAuthority || !k.IsTrivial() {
+			continue
+		}
+
+		log.Debugf("Injecting filter for CertAuthority watch for Node-only watcher with version %v", clientVersion)
+		watch.Kinds[i].Filter = NodeCertAuthorityFilter(clusterName).IntoMap()
+	}
+}
+
+func NodeCertAuthorityFilter(clusterName string) types.CertAuthorityFilter {
+	return types.CertAuthorityFilter{
+		types.HostCA: clusterName,
+		types.UserCA: types.Wildcard,
+	}
+}
+
+// certAuthorityFilterVersionCutoff is the version starting from which we stop
+// injecting filters for CertAuthority watches in maybeFilterCertAuthorityWatches.
+var certAuthorityFilterVersionCutoff = *semver.New("9.0.0")
 
 // resourceLabel returns the label for the provided types.Event
 func resourceLabel(event types.Event) string {

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -52,7 +52,9 @@ func setupCollections(c *Cache, watches []types.WatchKind) (map[resourceKind]col
 			if c.Trust == nil {
 				return nil, trace.BadParameter("missing parameter Trust")
 			}
-			collections[resourceKind] = &certAuthority{watch: watch, Cache: c}
+			var filter types.CertAuthorityFilter
+			filter.FromMap(watch.Filter)
+			collections[resourceKind] = &certAuthority{Cache: c, watch: watch, filter: filter}
 		case types.KindStaticTokens:
 			if c.ClusterConfig == nil {
 				return nil, trace.BadParameter("missing parameter ClusterConfig")
@@ -786,6 +788,8 @@ func (c *namespace) watchKind() types.WatchKind {
 type certAuthority struct {
 	*Cache
 	watch types.WatchKind
+	// filter extracted from watch.Filter, to avoid rebuilding it on every event
+	filter types.CertAuthorityFilter
 }
 
 // erase erases all data in the collection
@@ -846,6 +850,19 @@ func (c *certAuthority) fetchCertAuthorities(ctx context.Context, caType types.C
 		}
 		return nil, trace.Wrap(err)
 	}
+
+	// this can be removed once we get the ability to fetch CAs with a filter,
+	// but it should be harmless, and it could be kept as additional safety
+	if !c.filter.IsEmpty() {
+		filteredCAs := make([]types.CertAuthority, 0, len(authorities))
+		for _, ca := range authorities {
+			if c.filter.Match(ca) {
+				filteredCAs = append(filteredCAs, ca)
+			}
+		}
+		authorities = filteredCAs
+	}
+
 	return func(ctx context.Context) error {
 		if err := c.trustCache.DeleteAllCertAuthorities(caType); err != nil {
 			if !trace.IsNotFound(err) {
@@ -881,6 +898,9 @@ func (c *certAuthority) processEvent(ctx context.Context, event types.Event) err
 		resource, ok := event.Resource.(types.CertAuthority)
 		if !ok {
 			return trace.BadParameter("unexpected type %T", event.Resource)
+		}
+		if !c.filter.Match(resource) {
+			return nil
 		}
 		if err := c.trustCache.UpsertCertAuthority(resource); err != nil {
 			return trace.Wrap(err)

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -552,7 +552,7 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 				process.log.Debugf("Skipping event %v for %v", event.Type, event.Resource.GetName())
 				continue
 			}
-			if ca.GetType() != types.HostCA && ca.GetClusterName() != conn.ClientIdentity.ClusterName {
+			if ca.GetType() != types.HostCA || ca.GetClusterName() != conn.ClientIdentity.ClusterName {
 				process.log.Debugf("Skipping event for %v %v", ca.GetType(), ca.GetClusterName())
 				continue
 			}

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -73,6 +73,17 @@ func (s *CA) UpsertCertAuthority(ca types.CertAuthority) error {
 	if err := services.ValidateCertAuthority(ca); err != nil {
 		return trace.Wrap(err)
 	}
+
+	// try to skip writes that would have no effect
+	if existing, err := s.GetCertAuthority(context.TODO(), types.CertAuthID{
+		Type:       ca.GetType(),
+		DomainName: ca.GetClusterName(),
+	}, true); err == nil {
+		if services.CertAuthoritiesEquivalent(existing, ca) {
+			return nil
+		}
+	}
+
 	value, err := services.MarshalCertAuthority(ca)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Backport of #10020, including similar changes to the v7 backport (gravitational/teleport-private#107, #10744).