### PR TITLE
[v9] Remove duplicate parties in kube and ssh session trackers.

### DIFF
--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -1065,16 +1065,11 @@ func getRolesByName(forwarder *Forwarder, roleNames []string) ([]types.Role, err
 // on an interval until the session tracker is closed.
 func (s *session) trackSession(p *party, policySet []*types.SessionTrackerPolicySet) error {
 	trackerSpec := types.SessionTrackerSpecV1{
-		SessionID:   s.id.String(),
-		Kind:        string(types.KubernetesSessionKind),
-		State:       types.SessionState_SessionStatePending,
-		Hostname:    s.podName,
-		ClusterName: s.ctx.teleportCluster.name,
-		Participants: []types.Participant{{
-			ID:         p.ID.String(),
-			User:       p.Ctx.User.GetName(),
-			LastActive: time.Now().UTC(),
-		}},
+		SessionID:         s.id.String(),
+		Kind:              string(types.KubernetesSessionKind),
+		State:             types.SessionState_SessionStatePending,
+		Hostname:          s.podName,
+		ClusterName:       s.ctx.teleportCluster.name,
 		KubernetesCluster: s.ctx.kubeCluster,
 		HostUser:          p.Ctx.User.GetName(),
 		HostPolicies:      policySet,


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/13753 to branch/v9