### PR TITLE
Prefix sudoers lines with the user that is logging in instead of requiring a trait be templated.

### DIFF
--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -195,7 +195,7 @@ func TestRootHostUsers(t *testing.T) {
 		})
 		_, closer, err := users.CreateUser(testuser,
 			&services.HostUsersInfo{
-				Sudoers: []string{"root ALL=(ALL) ALL"},
+				Sudoers: []string{"ALL=(ALL) ALL"},
 			})
 		require.NoError(t, err)
 		_, err = os.Stat(sudoersPath(testuser, uuid))

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -19,6 +19,7 @@ package srv
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os/user"
 	"strings"
@@ -218,8 +219,11 @@ func (u *HostUserManagement) CreateUser(name string, ui *services.HostUsersInfo)
 		backend:  u.backend,
 	}
 	if len(ui.Sudoers) != 0 {
-		contents := []byte(strings.Join(ui.Sudoers, "\n") + "\n")
-		err := u.backend.WriteSudoersFile(name, contents)
+		var sudoers strings.Builder
+		for _, entry := range ui.Sudoers {
+			sudoers.WriteString(fmt.Sprintf("%s %s\n", name, entry))
+		}
+		err := u.backend.WriteSudoersFile(name, []byte(sudoers.String()))
 		if err != nil {
 			return tempUser, closer, trace.Wrap(err)
 		}

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -112,7 +112,7 @@ func (tm *testHostUserBackend) RemoveSudoersFile(user string) error {
 
 // CheckSudoers implements HostUsersBackend
 func (*testHostUserBackend) CheckSudoers(contents []byte) error {
-	if string(contents) == "valid" {
+	if strings.Contains(string(contents), "validsudoers") {
 		return nil
 	}
 	return errors.New("invalid")
@@ -184,12 +184,12 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 
 	_, closer, err := users.CreateUser("bob", &services.HostUsersInfo{
 		Groups:  []string{"hello", "sudo"},
-		Sudoers: []string{"valid"},
+		Sudoers: []string{"validsudoers"},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, closer)
 
-	require.Equal(t, map[string]string{"bob": "valid"}, backend.sudoers)
+	require.Equal(t, map[string]string{"bob": "bob validsudoers"}, backend.sudoers)
 
 	require.NoError(t, closer.Close())
 	require.Empty(t, backend.sudoers)


### PR DESCRIPTION
Instead of doing

```
{{internal.logins}} ALL=(ALL) ALL
```

this line can be
```
ALL=(ALL) ALL
```
and this line will be prefixed the user that is logging in.
