### PR TITLE
[v9] remove extra `handle.Delete()`

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -452,8 +452,7 @@ func (c *Client) handleRemoteCopy(data []byte) C.CGOErrCode {
 // and frees the Rust client.
 func (c *Client) close() {
 	c.closeOnce.Do(func() {
-		c.handle.Delete()
-
+		// Close the RDP client
 		if err := C.close_rdp(c.rustClient); err != C.ErrCodeSuccess {
 			c.cfg.Log.Warningf("failed to close the RDP client")
 		}


### PR DESCRIPTION
I made a mistake somewhere during a backport and allowed an extra call to `c.handle.Delete()` to slip into `c.close()`, meaning that any time a user closes a desktop session window in v9, Teleport panics. This fixes it.