### PR TITLE
[v10] don't precompute keys on peripheral agents

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -155,6 +155,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		}
 	}
 	if cfg.KeyStoreConfig.RSAKeyPairSource == nil {
+		native.PrecomputeKeys()
 		cfg.KeyStoreConfig.RSAKeyPairSource = native.GenerateKeyPair
 	}
 	if cfg.KeyStoreConfig.HostUUID == "" {

--- a/lib/auth/native/native_test.go
+++ b/lib/auth/native/native_test.go
@@ -35,6 +35,18 @@ import (
 	"gopkg.in/check.v1"
 )
 
+// TestPrecomputeMode verifies that package enters precompute mode when
+// PrecomputeKeys is called.
+func TestPrecomputeMode(t *testing.T) {
+	PrecomputeKeys()
+
+	select {
+	case <-precomputedKeys:
+	case <-time.After(time.Second * 10):
+		t.Fatal("Key precompute routine failed to start.")
+	}
+}
+
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
 	os.Exit(m.Run())

--- a/lib/reversetunnel/cache.go
+++ b/lib/reversetunnel/cache.go
@@ -46,6 +46,7 @@ type certificateCache struct {
 // newHostCertificateCache creates a shared host certificate cache that is
 // used by the forwarding server.
 func newHostCertificateCache(keygen sshca.Authority, authClient auth.ClientI) (*certificateCache, error) {
+	native.PrecomputeKeys() // ensure native package is set to precompute keys
 	cache, err := ttlmap.New(defaults.HostCertCacheSize)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -718,6 +718,13 @@ func NewTeleport(cfg *Config, opts ...NewTeleportOption) (*TeleportProcess, erro
 	}
 	var err error
 
+	// auth and proxy benefit from precomputing keys since they can experience spikes in key
+	// generation due to web session creation and recorded session creation respectively.
+	// for all other agents precomputing keys consumes excess resources.
+	if cfg.Auth.Enabled || cfg.Proxy.Enabled {
+		native.PrecomputeKeys()
+	}
+
 	// Before we do anything reset the SIGINT handler back to the default.
 	system.ResetInterruptSignalHandler()
 


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/14021