### PR TITLE
Update passwordless RFDs with current FIDO2 flows

### DIFF
--- a/rfd/0040-webauthn-support.md
+++ b/rfd/0040-webauthn-support.md
@@ -9,6 +9,8 @@ state: implemented
 
 Provide WebAuthn support for Teleport, both server- and client-side.
 
+WebAuthn is available since Teleport 8.
+
 ## Why
 
 (Quoting issue [#6478](https://github.com/gravitational/teleport/issues/6478).)
@@ -40,35 +42,35 @@ to the server with the signed challenge. Assuming all is well this completes the
 registration process.
 
 ```
-                          Registration flow                     
-                                                                
+                          Registration flow
+
      ┌──────┐                       ┌──────┐            ┌──────┐
      │Device│                       │Client│            │Server│
      └──┬───┘                       └──┬───┘            └──┬───┘
-        │                              │ BeginRegistration │    
-        │                              │ ──────────────────>    
-        │                              │                   │    
-        │                              │ CredentialCreation│    
-        │                              │ <──────────────────    
-        │                              │                   │    
-        │ navigator.credential.create()│                   │    
-        │ <─────────────────────────────                   │    
-        │                              │                   │    
-        │          Credential          │                   │    
-        │ ─────────────────────────────>                   │    
-        │                              │                   │    
-        │                              │ FinishRegistration│    
-        │                              │ ──────────────────>    
-        │                              │                   │    
-        │                              │  success/failure  │    
-        │                              │ <──────────────────    
+        │                              │ BeginRegistration │
+        │                              │ ──────────────────>
+        │                              │                   │
+        │                              │ CredentialCreation│
+        │                              │ <──────────────────
+        │                              │                   │
+        │ navigator.credential.create()│                   │
+        │ <─────────────────────────────                   │
+        │                              │                   │
+        │          Credential          │                   │
+        │ ─────────────────────────────>                   │
+        │                              │                   │
+        │                              │ FinishRegistration│
+        │                              │ ──────────────────>
+        │                              │                   │
+        │                              │  success/failure  │
+        │                              │ <──────────────────
      ┌──┴───┐                       ┌──┴───┐            ┌──┴───┐
      │Device│                       │Client│            │Server│
      └──────┘                       └──────┘            └──────┘
 ```
 
 Authentication (also referred simply as Login) follows a similar "challenge ->
-sign -> verify" protocol. In simple terms, the client requests a 
+sign -> verify" protocol. In simple terms, the client requests a
 [CredentialAssertion](https://pkg.go.dev/github.com/duo-labs/webauthn/protocol#CredentialAssertion)
 from the server, signs it by calling
 [navigartor.credentials.get()](https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/get),
@@ -407,58 +409,58 @@ that the viability of it has been established.
 This is the current flow of the login API:
 
 ```
-                                                      U2F login                                                  
-                                                                                                                 
-          ┌─┐                                                                                                    
-          ║"│                                                                                                    
-          └┬┘                                                                                                    
-          ┌┼┐                                                                                                    
+                                                      U2F login
+
+          ┌─┐
+          ║"│
+          └┬┘
+          ┌┼┐
            │                ┌───┐                             ┌─────┐                                      ┌────┐
           ┌┴┐               │tsh│                             │proxy│                                      │auth│
       codingllama           └─┬─┘                             └──┬──┘                                      └─┬──┘
-           │   $ tsh login    │                                  │                                           │   
-           │─────────────────>│                                  │                                           │   
-           │                  │                                  │                                           │   
-           │                  │  POST /webapi/u2f/signrequest    │                                           │   
-           │                  │─────────────────────────────────>│                                           │   
-           │                  │                                  │                                           │   
-           │                  │                                  │    POST /v2/u2f/users/codingllama/sign    │   
-           │                  │                                  │───────────────────────────────────────────>   
-           │                  │                                  │                                           │   
-           │                  │                                  │     lib.auth.MFAAuthenticateChallenge     │   
-           │                  │                                  │<───────────────────────────────────────────   
-           │                  │                                  │                                           │   
-           │                  │lib.auth.MFAAuthenticateChallenge │                                           │   
-           │                  │<─────────────────────────────────│                                           │   
-           │                  │                                  │                                           │   
-           │tap security key  │                                  │                                           │   
-           │<─────────────────│                                  │                                           │   
-           │                  │                                  │                                           │   
-           ────┐              │                                  │                                           │   
-               │ *taps*       │                                  │                                           │   
-           <───┘              │                                  │                                           │   
-           │                  │                                  │                                           │   
-           │                  │     POST /webapi/u2f/certs       │                                           │   
-           │                  │─────────────────────────────────>│                                           │   
-           │                  │                                  │                                           │   
-           │                  │                                  │POST /v2/users/codingllama/ssh/authenticate│   
-           │                  │                                  │───────────────────────────────────────────>   
-           │                  │                                  │                                           │   
-           │                  │                                  │         lib.auth.SSHLoginResponse         │   
-           │                  │                                  │<───────────────────────────────────────────   
-           │                  │                                  │                                           │   
-           │                  │    lib.auth.SSHLoginResponse     │                                           │   
-           │                  │<─────────────────────────────────│                                           │   
-           │                  │                                  │                                           │   
-           │      done        │                                  │                                           │   
-           │<─────────────────│                                  │                                           │   
+           │   $ tsh login    │                                  │                                           │
+           │─────────────────>│                                  │                                           │
+           │                  │                                  │                                           │
+           │                  │  POST /webapi/u2f/signrequest    │                                           │
+           │                  │─────────────────────────────────>│                                           │
+           │                  │                                  │                                           │
+           │                  │                                  │    POST /v2/u2f/users/codingllama/sign    │
+           │                  │                                  │───────────────────────────────────────────>
+           │                  │                                  │                                           │
+           │                  │                                  │     lib.auth.MFAAuthenticateChallenge     │
+           │                  │                                  │<───────────────────────────────────────────
+           │                  │                                  │                                           │
+           │                  │lib.auth.MFAAuthenticateChallenge │                                           │
+           │                  │<─────────────────────────────────│                                           │
+           │                  │                                  │                                           │
+           │tap security key  │                                  │                                           │
+           │<─────────────────│                                  │                                           │
+           │                  │                                  │                                           │
+           ────┐              │                                  │                                           │
+               │ *taps*       │                                  │                                           │
+           <───┘              │                                  │                                           │
+           │                  │                                  │                                           │
+           │                  │     POST /webapi/u2f/certs       │                                           │
+           │                  │─────────────────────────────────>│                                           │
+           │                  │                                  │                                           │
+           │                  │                                  │POST /v2/users/codingllama/ssh/authenticate│
+           │                  │                                  │───────────────────────────────────────────>
+           │                  │                                  │                                           │
+           │                  │                                  │         lib.auth.SSHLoginResponse         │
+           │                  │                                  │<───────────────────────────────────────────
+           │                  │                                  │                                           │
+           │                  │    lib.auth.SSHLoginResponse     │                                           │
+           │                  │<─────────────────────────────────│                                           │
+           │                  │                                  │                                           │
+           │      done        │                                  │                                           │
+           │<─────────────────│                                  │                                           │
       codingllama           ┌─┴─┐                             ┌──┴──┐                                      ┌─┴──┐
           ┌─┐               │tsh│                             │proxy│                                      │auth│
           ║"│               └───┘                             └─────┘                                      └────┘
-          └┬┘                                                                                                    
-          ┌┼┐                                                                                                    
-           │                                                                                                     
-          ┌┴┐                                                                                                    
+          └┬┘
+          ┌┼┐
+           │
+          ┌┴┐
 ```
 
 The proposed changes are twofold:

--- a/rfd/0052-passwordless.md
+++ b/rfd/0052-passwordless.md
@@ -24,6 +24,8 @@ documents for client-side aspects of the design:
 * [Passwordless for FIDO2 clients][passwordless fido2]
 * [Passwordless for macOS CLI][passwordless macos] (aka Touch ID)
 
+Passwordless is available as a preview in Teleport 10.
+
 ## Why
 
 Passwords are a pain for users and a liability for both users and service

--- a/rfd/0052-passwordless.md
+++ b/rfd/0052-passwordless.md
@@ -124,51 +124,43 @@ necessary until we can be sure that passwords are ripe for full removal.
 A passwordless login flow is exemplified below:
 
 ```
-                                     Passwordless login
+                                    Passwordless login
 
-                                   ┌─┐
-                                   ║"│
-                                   └┬┘
-                                   ┌┼┐
-     ┌─────────────┐                │                                        ┌────────┐
-     │authenticator│               ┌┴┐                                       │Teleport│
-     └──────┬──────┘              user                                       └───┬────┘
-            │                      │       1. CreateAuthenticateChallenge()      │
-            │                      │ ────────────────────────────────────────────>
-            │                      │                                             │
-            │                      │                1.1. challenge               │
-            │                      │ <────────────────────────────────────────────
-            │                      │                                             │
-            │ 2. list credentials  │                                             │
-            │<──────────────────────                                             │
-            │                      │                                             │
-            │                      │                                             │
-            │──────────────────────>                                             │
-            │                      │                                             │
-            │2.1. choose credential│                                             │
-            │<──────────────────────                                             │
-            │                      │                                             │
-            │                      │                                             │
-            │──────────────────────>                                             │
-            │                      │                                             │
-            │ 2.2. sign challenge  │                                             │
-            │<──────────────────────                                             │
-            │                      │                                             │
-            │2.3. signed challenge │                                             │
-            │──────────────────────>                                             │
-            │                      │                                             │
-            │                      │ 3. Authenticate(userHandle, signedChallenge)│
-            │                      │ ────────────────────────────────────────────>
-            │                      │                                             │
-            │                      │   3.1. signed certificates or web session   │
-            │                      │ <────────────────────────────────────────────
-     ┌──────┴──────┐              user                                       ┌───┴────┐
-     │authenticator│               ┌─┐                                       │Teleport│
-     └─────────────┘               ║"│                                       └────────┘
-                                   └┬┘
-                                   ┌┼┐
-                                    │
-                                   ┌┴┐
+                                  ┌─┐
+                                  ║"│
+                                  └┬┘
+                                  ┌┼┐
+     ┌─────────────┐               │                                        ┌────────┐
+     │authenticator│              ┌┴┐                                       │Teleport│
+     └──────┬──────┘             user                                       └───┬────┘
+            │                     │       1. CreateAuthenticateChallenge()      │
+            │                     │ ────────────────────────────────────────────>
+            │                     │                                             │
+            │                     │                1.1. challenge               │
+            │                     │ <────────────────────────────────────────────
+            │                     │                                             │
+            │  2. sign challenge  │                                             │
+            │<─────────────────────                                             │
+            │                     │                                             │
+            │2.1. signed challenge│                                             │
+            │─────────────────────>                                             │
+            │                     │                                             │
+            │                     │────┐                                        │
+            │                     │    │ 2.2. choose credential                 │
+            │                     │<───┘                                        │
+            │                     │                                             │
+            │                     │ 3. Authenticate(userHandle, signedChallenge)│
+            │                     │ ────────────────────────────────────────────>
+            │                     │                                             │
+            │                     │   3.1. signed certificates or web session   │
+            │                     │ <────────────────────────────────────────────
+     ┌──────┴──────┐             user                                       ┌───┴────┐
+     │authenticator│              ┌─┐                                       │Teleport│
+     └─────────────┘              ║"│                                       └────────┘
+                                  └┬┘
+                                  ┌┼┐
+                                   │
+                                  ┌┴┐
 ```
 
 Authentication looks similar to our well-known challenge/response protocols,
@@ -186,6 +178,9 @@ the [cluster settings](#cluster-settings) section for our take on this).
 In regards to authenticator interactions (2), it is important to note that the
 user may have multiple credentials attached to an
 [RPID](https://www.w3.org/TR/webauthn-2/#rp-id) (Relying Party ID) / Teleport.
+Authenticators are capable of returning multiple assertions, one for each
+applicable credential, thus allowing the user to pick the desired credential for
+login.
 
 Finally, in the last step of the authentication (3) we require the WebAuthn
 [user handle](
@@ -403,6 +398,10 @@ message AddMFADeviceRequestInit {
 
 #### Device restrictions
 
+UPDATE 2022-06: Device restrictions are not present in the passwordless preview,
+as various Touch ID implementations aren't capable of more than
+self-attestation.
+
 Passwordless device restrictions can be attained through [attestation](
 https://github.com/gravitational/teleport/blob/master/rfd/0040-webauthn-support.md#attestation).
 
@@ -597,12 +596,9 @@ participant "Teleport" as server
 user -> server: 1. CreateAuthenticateChallenge()
 server -> user: 1.1. challenge
 
-user -> authenticator: 2. list credentials
-authenticator -> user
-user -> authenticator: 2.1. choose credential
-authenticator -> user
-user -> authenticator: 2.2. sign challenge
-authenticator -> user: 2.3. signed challenge
+user -> authenticator: 2. sign challenge
+authenticator -> user: 2.1. signed challenge
+user -> user: 2.2. choose credential
 
 user -> server: 3. Authenticate(userHandle, signedChallenge)
 server -> user: 3.1. signed certificates or web session

--- a/rfd/0053-passwordless-fido2.md
+++ b/rfd/0053-passwordless-fido2.md
@@ -14,6 +14,8 @@ covered by accompanying designs.
 
 This is a part of the [Passwordless RFD][passwordless rfd].
 
+Passwordless is available as a preview in Teleport 10.
+
 ## Why
 
 See the [Passwordless RFD][passwordless rfd].

--- a/rfd/0053-passwordless-fido2.md
+++ b/rfd/0053-passwordless-fido2.md
@@ -148,17 +148,10 @@ CLI-native passwordless relies on
 interaction with FIDO2 resident keys. (The official Go wrapper is
 [github.com/keys-pub/go-libfido2](https://github.com/keys-pub/go-libfido2/).)
 
-One of the issues for passwordless interaction is that the client (`tsh`) gets
-no information about registered credentials. The usual tactic of attempting an
-assertion on all hardware keys falls short, as an authenticator may hold
-multiple keys for the same Relying Party - in this case, the authenticator picks
-the account, not the user!
-
-The solution is similar to the one used by browsers - we make all hardware keys
-blink and ask the user to choose the desired key by touching it. Authentication
-proceeds by enumerating the credentials from that key and letting the user,
-again, pick the desired one. (See libfido2's [examples/select.c](
-https://github.com/Yubico/libfido2/blob/master/examples/select.c).)
+The solution provides a UX similar to the one seen in browsers: we request
+assertions of all hardware keys, making them blink. The user then chooses the
+desired key by touching it. If there are multiple resulting assertions, we then
+ask the user to choose the desired credential.
 
 Authentication diagram below:
 
@@ -169,106 +162,83 @@ Authentication diagram below:
                                 ║"│
                                 └┬┘
                                 ┌┼┐
-     ┌─────────────┐             │                   ┌───┐                                       ┌────────┐
-     │authenticator│            ┌┴┐                  │tsh│                                       │Teleport│
-     └──────┬──────┘           user                  └─┬─┘                                       └───┬────┘
-            │                   │       tsh login      │                                             │
-            │                   │ ─────────────────────>                                             │
-            │                   │                      │                                             │
-            │                   │                      │        CreateAuthenticateChallenge()        │
-            │                   │                      │        (no user or password informed)       │
-            │                   │                      │ ────────────────────────────────────────────>
-            │                   │                      │                                             │
-            │                   │                      │                  challenge                  │
-            │                   │                      │ <────────────────────────────────────────────
-            │                   │                      │                                             │
-            │          wait for touch (1)              │                                             │
-            │          (all authenticators)            │                                             │
-            │<─────────────────────────────────────────│                                             │
-            │                   │                      │                                             │
-            │                   │ choose authenticator?│                                             │
-            │                   │ <─────────────────────                                             │
-            │                   │                      │                                             │
-            │      *taps*       │                      │                                             │
-            │<──────────────────│                      │                                             │
-            │                   │                      │                                             │
-            │                 touched                  │                                             │
-            │─────────────────────────────────────────>│                                             │
-            │                   │                      │                                             │
-            │                   │    enter PIN? (2)    │                                             │
-            │                   │ <─────────────────────                                             │
-            │                   │                      │                                             │
-            │                   │     *enters PIN*     │                                             │
-            │                   │ ─────────────────────>                                             │
-            │                   │                      │                                             │
-            │       Credentials(RPID, pin) (3)         │                                             │
-            │<─────────────────────────────────────────│                                             │
-            │                   │                      │                                             │
-            │        authenticator credentials         │                                             │
-            │        (includes user handle)            │                                             │
-            │─────────────────────────────────────────>│                                             │
-            │                   │                      │                                             │
-            │                   │  choose credential?  │                                             │
-            │                   │ <─────────────────────                                             │
-            │                   │                      │                                             │
-            │                   │       *chooses*      │                                             │
-            │                   │ ─────────────────────>                                             │
-            │                   │                      │                                             │
-            │   Assertion (4)   │                      │                                             │
-            │   (RPID, challenge, credential, pin)     │                                             │
-            │<─────────────────────────────────────────│                                             │
-            │                   │                      │                                             │
-            │                   │  tap authenticator?  │                                             │
-            │                   │ <─────────────────────                                             │
-            │                   │                      │                                             │
-            │      *taps*       │                      │                                             │
-            │<──────────────────│                      │                                             │
-            │                   │                      │                                             │
-            │            signed challenge              │                                             │
-            │─────────────────────────────────────────>│                                             │
-            │                   │                      │                                             │
-            │                   │                      │ AuthenticateSSH(userHandle, signedChallenge)│
-            │                   │                      │ ────────────────────────────────────────────>
-            │                   │                      │                                             │
-            │                   │                      │               SSH credentials               │
-            │                   │                      │ <────────────────────────────────────────────
-            │                   │                      │                                             │
-            │                   │          ok          │                                             │
-            │                   │ <─────────────────────                                             │
-     ┌──────┴──────┐           user                  ┌─┴─┐                                       ┌───┴────┐
-     │authenticator│            ┌─┐                  │tsh│                                       │Teleport│
-     └─────────────┘            ║"│                  └───┘                                       └────────┘
+     ┌─────────────┐             │                    ┌───┐                                       ┌────────┐
+     │authenticator│            ┌┴┐                   │tsh│                                       │Teleport│
+     └──────┬──────┘           user                   └─┬─┘                                       └───┬────┘
+            │                   │       tsh login       │                                             │
+            │                   │ ──────────────────────>                                             │
+            │                   │                       │                                             │
+            │                   │                       │        CreateAuthenticateChallenge()        │
+            │                   │                       │        (no user or password informed)       │
+            │                   │                       │ ────────────────────────────────────────────>
+            │                   │                       │                                             │
+            │                   │                       │                  challenge                  │
+            │                   │                       │ <────────────────────────────────────────────
+            │                   │                       │                                             │
+            │     get_assertion(challenge, "") (1)      │                                             │
+            │     (all authenticators)                  │                                             │
+            │<──────────────────────────────────────────│                                             │
+            │                   │                       │                                             │
+            │                   │ choose authenticator? │                                             │
+            │                   │ <──────────────────────                                             │
+            │                   │                       │                                             │
+            │      *taps*       │                       │                                             │
+            │<──────────────────│                       │                                             │
+            │                   │                       │                                             │
+            │                assertions                 │                                             │
+            │──────────────────────────────────────────>│                                             │
+            │                   │                       │                                             │
+            │                   │     enter PIN? (2)    │                                             │
+            │                   │ <──────────────────────                                             │
+            │                   │                       │                                             │
+            │                   │      *enters PIN*     │                                             │
+            │                   │ ──────────────────────>                                             │
+            │                   │                       │                                             │
+            │    get_assertion(challenge, pin) (3)      │                                             │
+            │<──────────────────────────────────────────│                                             │
+            │                   │                       │                                             │
+            │                   │   tap authenticator?  │                                             │
+            │                   │ <──────────────────────                                             │
+            │                   │                       │                                             │
+            │      *taps*       │                       │                                             │
+            │<──────────────────│                       │                                             │
+            │                   │                       │                                             │
+            │                assertions                 │                                             │
+            │──────────────────────────────────────────>│                                             │
+            │                   │                       │                                             │
+            │                   │ choose credential? (4)│                                             │
+            │                   │ <──────────────────────                                             │
+            │                   │                       │                                             │
+            │                   │       *chooses*       │                                             │
+            │                   │ ──────────────────────>                                             │
+            │                   │                       │                                             │
+            │                   │                       │ AuthenticateSSH(userHandle, signedChallenge)│
+            │                   │                       │ ────────────────────────────────────────────>
+            │                   │                       │                                             │
+            │                   │                       │               SSH credentials               │
+            │                   │                       │ <────────────────────────────────────────────
+            │                   │                       │                                             │
+            │                   │           ok          │                                             │
+            │                   │ <──────────────────────                                             │
+     ┌──────┴──────┐           user                   ┌─┴─┐                                       ┌───┴────┐
+     │authenticator│            ┌─┐                   │tsh│                                       │Teleport│
+     └─────────────┘            ║"│                   └───┘                                       └────────┘
                                 └┬┘
                                 ┌┼┐
                                  │
                                 ┌┴┐
 ```
 
-(As a side note, it's interesting to note the differences in interaction between
-Web and `tsh` and how it may provide clues as to how browsers work.)
+(1) is the assertion step explained above, requiring one touch from the user to
+choose the desired authenticator. Biometric capable authenticators skip directly
+to step (4), as PINs aren't required.
 
-(1) is the "key selection" step explained above, requiring one touch\* from the
-user to choose the desired authenticator.
+(2) and (3) are necessary for PIN-based authenticators. The first assertion
+fails due to lack of PIN, requiring the second assertion.
 
-(2) is the PIN-entering step. For biometric authenticators, we can "merge" steps
-(1), (2) and (3) by using [Credentials](
-https://github.com/keys-pub/go-libfido2/blob/9246c0bee502c5f2c2495557f07fa5f45da8cd1c/fido2.go#L770)
-as the method to choose the authenticator. This technique requires one user
-touch/verification and avoids the need for PINs with biometric authenticators.
-
-(3) is when we enumerate resident keys for the {authenticator, RPID} pair. We
-can skip user interaction if only a single key exists.
-
-(4) is the assertion step, where the authenticator signs the challenge. This
-step requires a final touch/verification from the user.
-
-\* currently go-libfido2 doesn't expose operations equivalent to
-[fido_dev_touch_begin](https://developers.yubico.com/libfido2/Manuals/fido_dev_get_touch_begin.html)/[
-fido_dev_touch_status](https://developers.yubico.com/libfido2/Manuals/fido_dev_get_touch_status.html),
-but we can make do by attempting an [Assertion](
-https://github.com/keys-pub/go-libfido2/blob/9246c0bee502c5f2c2495557f07fa5f45da8cd1c/fido2.go#L639).
-(We could fork it and add it ourselves; I have a local patch that does just
-that, but I'd rather keep light on forking if possible.)
+(4) is the credential picker step. It's skipped if there is only one resulting
+assertion, or if the user already picked a credential through other means (such
+as `tsh login --user=mylogin`).
 
 #### libfido2 and Teleport
 
@@ -466,23 +436,21 @@ user -> tsh: tsh login
 tsh -> server: CreateAuthenticateChallenge()\n(no user or password informed)
 server -> tsh: challenge
 
-tsh -> authenticator: wait for touch (1)\n(all authenticators)
+tsh -> authenticator: get_assertion(challenge, "") (1)\n(all authenticators)
 tsh -> user: choose authenticator?
 user -> authenticator: *taps*
-authenticator -> tsh: touched
+authenticator -> tsh: assertions
 
 tsh -> user: enter PIN? (2)
 user -> tsh: *enters PIN*
 
-tsh -> authenticator: Credentials(RPID, pin) (3)
-authenticator -> tsh: authenticator credentials\n(includes user handle)
-tsh -> user: choose credential?
-user -> tsh: *chooses*
-
-tsh -> authenticator: Assertion (4)\n(RPID, challenge, credential, pin)
+tsh -> authenticator: get_assertion(challenge, pin) (3)
 tsh -> user: tap authenticator?
 user -> authenticator: *taps*
-authenticator -> tsh: signed challenge
+authenticator -> tsh: assertions
+
+tsh -> user: choose credential? (4)
+user -> tsh: *chooses*
 
 tsh -> server: AuthenticateSSH(userHandle, signedChallenge)
 server -> tsh: SSH credentials

--- a/rfd/0054-passwordless-macos.md
+++ b/rfd/0054-passwordless-macos.md
@@ -11,6 +11,8 @@ Passwordless features for native macOS CLIs, aka Touch ID support for CLI/`tsh`.
 
 This is a part of the [Passwordless RFD][passwordless rfd].
 
+Passwordless is available as a preview in Teleport 10.
+
 ## Why
 
 Native, non-browser macOS clients lack support for Touch ID. This RFD explores


### PR DESCRIPTION
Update FIDO2 authn flows for `tsh` and clear the implication that authenticators are only capable of returning a single assertion.