### PR TITLE
Use CentOS 7 for building release binaries

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5614,6 +5614,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 36cb56689a9f2dc75b3adeb626cb64db2d728dd2c1060bc86d34401ad28e6e8f
+hmac: b662295f3a64d55f5b446997e0a822dc840da2aa35ede16d24282c9951168228
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,7 @@ steps:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-amd64
+  - make -C build.assets release-amd64-centos7
   environment:
     ARCH: amd64
     GID: "1000"
@@ -299,7 +299,7 @@ steps:
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
   - export VERSION=$(cat /go/.version.txt)
-  - make -C build.assets release-amd64-fips
+  - make -C build.assets release-amd64-centos7-fips
   environment:
     ARCH: amd64
     FIPS: "yes"
@@ -1464,7 +1464,7 @@ steps:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-amd64
+  - make -C build.assets release-amd64-centos7
   environment:
     ARCH: amd64
     GID: "1000"
@@ -1619,7 +1619,7 @@ steps:
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
   - export VERSION=$(cat /go/.version.txt)
-  - make -C build.assets release-amd64-fips
+  - make -C build.assets release-amd64-centos7-fips
   environment:
     ARCH: amd64
     FIPS: "yes"

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ RS_BPF_BUILDDIR := lib/restrictedsession/bytecode
 CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
 	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
 
-CGOFLAG = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic -lbpf -lelf -lz -Wl,-Bdynamic"
+CGOFLAG = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic -l:libbpf.a -l:libelf.a -l:libz.a -Wl,-Bdynamic -Wl,--as-needed -static-libgcc"
 CGOFLAG_TSH = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic -lelf -lz -Wl,-Bdynamic"
 endif
 endif
@@ -213,6 +213,8 @@ CLANG_FORMAT_STYLE = '{ColumnLimit: 100, IndentWidth: 4, Language: Proto}'
 .PHONY: all
 all: version
 	@echo "---> Building OSS binaries."
+	gcc --version
+	@gcc --version
 	$(MAKE) $(BINARIES)
 
 # By making these 3 targets below (tsh, tctl and teleport) PHONY we are solving
@@ -362,6 +364,7 @@ release-arm64:
 #
 .PHONY:
 release-unix: clean full
+	gcc --version
 	@echo "---> Creating OSS release archive."
 	mkdir teleport
 	cp -rf $(BUILDDIR)/* \

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ PWD ?= `pwd`
 TELEPORT_DEBUG ?= no
 GITTAG=v$(VERSION)
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
-CGOFLAG ?= CGO_ENABLED=1
-CGOFLAG_TSH ?= CGO_ENABLED=1
+CGOFLAG ?= CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--as-needed -static-libgcc"
+CGOFLAG_TSH ?= CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--as-needed -static-libgcc"
 # Windows requires extra parameters to cross-compile with CGO.
 ifeq ("$(OS)","windows")
 ARCH ?= amd64
@@ -115,8 +115,8 @@ RS_BPF_BUILDDIR := lib/restrictedsession/bytecode
 CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
 	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
 
-CGOFLAG = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic -l:libbpf.a -l:libelf.a -l:libz.a -Wl,-Bdynamic -Wl,--as-needed -static-libgcc"
-CGOFLAG_TSH = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic -lelf -lz -Wl,-Bdynamic"
+CGOFLAG = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic -lbpf -lelf -lz -Wl,-Bdynamic -Wl,--as-needed -static-libgcc"
+CGOFLAG_TSH = CGO_ENABLED=1
 endif
 endif
 endif
@@ -213,8 +213,6 @@ CLANG_FORMAT_STYLE = '{ColumnLimit: 100, IndentWidth: 4, Language: Proto}'
 .PHONY: all
 all: version
 	@echo "---> Building OSS binaries."
-	gcc --version
-	@gcc --version
 	$(MAKE) $(BINARIES)
 
 # By making these 3 targets below (tsh, tctl and teleport) PHONY we are solving
@@ -364,7 +362,6 @@ release-arm64:
 #
 .PHONY:
 release-unix: clean full
-	gcc --version
 	@echo "---> Creating OSS release archive."
 	mkdir teleport
 	cp -rf $(BUILDDIR)/* \

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ endif
 
 ifeq ("$(OS)","linux")
 # Link static version of libgcc to reduce system dependencies.
-CGOFLAG ?= CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--as-needed -static-libgcc"
-CGOFLAG_TSH ?= CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--as-needed -static-libgcc"
+CGOFLAG ?= CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--as-needed"
+CGOFLAG_TSH ?= CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--as-needed"
 # ARM builds need to specify the correct C compiler
 ifeq ("$(ARCH)","arm")
 CGOFLAG = CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc
@@ -118,7 +118,7 @@ RS_BPF_BUILDDIR := lib/restrictedsession/bytecode
 CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
 	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
 
-CGOFLAG = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic -lbpf -lelf -lz -Wl,-Bdynamic -Wl,--as-needed -static-libgcc"
+CGOFLAG = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic -lbpf -lelf -lz -Wl,-Bdynamic -Wl,--as-needed"
 CGOFLAG_TSH = CGO_ENABLED=1
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ PWD ?= `pwd`
 TELEPORT_DEBUG ?= no
 GITTAG=v$(VERSION)
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
-CGOFLAG ?= CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--as-needed -static-libgcc"
-CGOFLAG_TSH ?= CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--as-needed -static-libgcc"
+CGOFLAG ?= CGO_ENABLED=1
+CGOFLAG_TSH ?= CGO_ENABLED=1
 # Windows requires extra parameters to cross-compile with CGO.
 ifeq ("$(OS)","windows")
 ARCH ?= amd64
@@ -45,6 +45,9 @@ CGOFLAG_TSH = $(CGOFLAG)
 endif
 
 ifeq ("$(OS)","linux")
+# Link static version of libgcc to reduce system dependencies.
+CGOFLAG ?= CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--as-needed -static-libgcc"
+CGOFLAG_TSH ?= CGO_ENABLED=1 CGO_LDFLAGS="-Wl,--as-needed -static-libgcc"
 # ARM builds need to specify the correct C compiler
 ifeq ("$(ARCH)","arm")
 CGOFLAG = CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -70,14 +70,10 @@ RUN yum groupinstall -y 'Development Tools' && \
     # required by libbpf
     devtoolset-11-make \
     # required by libbpf
-    elfutils-libelf-devel \
-    # required by libbpf
     elfutils-libelf-devel-static \
     git \
     # required by libbpf, Clang
     scl-utils \
-    # required by libbpf
-    zlib-devel \
     # required by libbpf
     zlib-static && \
     yum clean all
@@ -109,9 +105,14 @@ RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home
     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 RUN yum groupinstall -y 'Development Tools' && \
+    yum install -y epel-release && \
+    yum update -y && \
+    yum -y install centos-release-scl-rh && \
     yum install -y \
-    # required by libbpf
-    elfutils-libelf-devel \
+    #required by libbpf, Clang
+    centos-release-scl \
+    # required by libbpf and Clang
+    devtoolset-11-* \
     # required by libbpf
     elfutils-libelf-devel-static \
     git \
@@ -124,10 +125,13 @@ RUN yum groupinstall -y 'Development Tools' && \
     which \
     zip \
     # required by libbpf
-    zlib-devel \
-    # required by libbpf
     zlib-static && \
     yum clean all
+
+#RUN echo "source scl_source enable devtoolset-11" >> /etc/profile
+RUN echo "source /opt/rh/devtoolset-11/enable" >> /etc/profile
+
+ENV PROMPT_COMMAND=". /etc/profile"
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -141,7 +141,7 @@ RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLA
     /opt/go/bin/go version
 ENV GOPATH="/go" \
     GOROOT="/opt/go" \
-    PATH="/opt/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
+    PATH="/opt/llvm/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
 ARG BUILDARCH
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -5,10 +5,10 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
     yum update -y && \
     yum install -y \
-    cmake3 \
-    git \
-    libudev-devel \
-    zlib-devel && \
+        cmake3 \
+        git \
+        libudev-devel \
+        zlib-devel && \
     yum clean all
 
 # Install libudev-zero.
@@ -30,10 +30,10 @@ RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1o && \
 RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
     cd libcbor && \
     cmake3 \
-    -DCBOR_CUSTOM_ALLOC=ON \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-    -DWITH_EXAMPLES=OFF . && \
+        -DCBOR_CUSTOM_ALLOC=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DWITH_EXAMPLES=OFF . && \
     make && \
     make install
 
@@ -43,13 +43,13 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.11.0 && \
     cd libfido2 && \
     cmake3 \
-    -DBUILD_EXAMPLES=OFF \
-    -DBUILD_MANPAGES=OFF \
-    -DBUILD_TOOLS=OFF \
-    -DCMAKE_BUILD_TYPE=Release . && \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_MANPAGES=OFF \
+        -DBUILD_TOOLS=OFF \
+        -DCMAKE_BUILD_TYPE=Release . && \
     make && \
     make install && \
-    # Update ld.
+# Update ld.
     echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
     ldconfig
 
@@ -114,22 +114,21 @@ RUN yum groupinstall -y 'Development Tools' && \
     pam-devel \
     perl-IPC-Cmd \
     tree \
-    # used in our Makefile
+    # used by our Makefile
     which \
     zip \
     # required by libbpf
     zlib-static && \
     yum clean all
 
-#RUN echo "source scl_source enable devtoolset-11" >> /etc/profile
+# Add devtoolset to /etc/profile to enable it when logging in.
 RUN echo "source /opt/rh/devtoolset-11/enable" >> /etc/profile
-#ENV PROMPT_COMMAND=". /etc/profile"
-
+# Enable devtoolset for docker build.
 SHELL [ "/usr/bin/scl", "enable", "devtoolset-11"]
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
-    cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
+     cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # Install Go.
 RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-amd64.tar.gz | tar xz && \
@@ -182,12 +181,12 @@ COPY --from=libfido2 \
     /usr/local/lib64/libudev.a \
     /usr/local/lib64/
 RUN cd /usr/local/lib64 && \
-    # Re-create usual lib64 links.
+# Re-create usual lib64 links.
     ln -s libcrypto.so.1.1 libcrypto.so && \
     ln -s libfido2.so.1.11.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
     ln -s libssl.so.1.1 libssl.so && \
-    # Update ld.
+# Update ld.
     echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
     ldconfig
 COPY pkgconfig/centos7/ /
@@ -201,5 +200,6 @@ COPY --from=libbpf /opt/libbpf/usr /usr
 
 USER ci
 VOLUME ["/go/src/github.com/gravitational/teleport"]
+# Add login option to bash, so startup scripts like /etc/profile are being loaded.
 ENTRYPOINT [ "/bin/bash", "-l", "-c"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -95,7 +95,7 @@ ARG RUST_VERSION
 ARG UID
 ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
-    mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
+     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
@@ -120,11 +120,6 @@ RUN yum groupinstall -y 'Development Tools' && \
     # required by libbpf
     zlib-static && \
     yum clean all
-
-# Add devtoolset to /etc/profile to enable it when logging in.
-RUN echo "source /opt/rh/devtoolset-11/enable" >> /etc/profile
-# Enable devtoolset for docker build.
-SHELL [ "/usr/bin/scl", "enable", "devtoolset-11"]
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
@@ -200,6 +195,4 @@ COPY --from=libbpf /opt/libbpf/usr /usr
 
 USER ci
 VOLUME ["/go/src/github.com/gravitational/teleport"]
-# Add login option to bash, so startup scripts like /etc/profile are being loaded.
-ENTRYPOINT [ "/bin/bash", "-l", "-c"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -53,7 +53,7 @@ RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.11.0 && \
     echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
     ldconfig
 
-FROM centos:7 AS centos-devtoolset
+FROM centos:7 AS libbpf
 
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
@@ -61,25 +61,18 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum update -y && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
-    # required by libbpf, Clang
+    # required by libbpf
     centos-release-scl \
-    # required by Clang/LLVM
-    cmake3 \
-    # required by libbpf and Clang
+    # required by libbpf
     devtoolset-11-gcc* \
     # required by libbpf
     devtoolset-11-make \
     # required by libbpf
     elfutils-libelf-devel-static \
     git \
-    # required by libbpf, Clang
-    scl-utils \
     # required by libbpf
-    zlib-static && \
+    scl-utils \
     yum clean all
-
-# Use just created devtools image with never GCC
-FROM centos-devtoolset as libbpf
 
 # Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
 # BUILD_STATIC_ONLY disables libbpf.so build as we don't need it.
@@ -109,9 +102,9 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum update -y && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
-    #required by libbpf, Clang
+    #required by libbpf
     centos-release-scl \
-    # required by libbpf and Clang
+    # required by libbpf
     devtoolset-11-* \
     # required by libbpf
     elfutils-libelf-devel-static \
@@ -121,7 +114,7 @@ RUN yum groupinstall -y 'Development Tools' && \
     pam-devel \
     perl-IPC-Cmd \
     tree \
-    # used by our Makefile
+    # used in our Makefile
     which \
     zip \
     # required by libbpf
@@ -130,8 +123,9 @@ RUN yum groupinstall -y 'Development Tools' && \
 
 #RUN echo "source scl_source enable devtoolset-11" >> /etc/profile
 RUN echo "source /opt/rh/devtoolset-11/enable" >> /etc/profile
+#ENV PROMPT_COMMAND=". /etc/profile"
 
-ENV PROMPT_COMMAND=". /etc/profile"
+SHELL [ "/usr/bin/scl", "enable", "devtoolset-11"]
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
@@ -207,4 +201,5 @@ COPY --from=libbpf /opt/libbpf/usr /usr
 
 USER ci
 VOLUME ["/go/src/github.com/gravitational/teleport"]
+ENTRYPOINT [ "/bin/bash", "-l", "-c"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -5,10 +5,10 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
     yum update -y && \
     yum install -y \
-        cmake3 \
-        git \
-        libudev-devel \
-        zlib-devel && \
+    cmake3 \
+    git \
+    libudev-devel \
+    zlib-devel && \
     yum clean all
 
 # Install libudev-zero.
@@ -30,10 +30,10 @@ RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1o && \
 RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
     cd libcbor && \
     cmake3 \
-        -DCBOR_CUSTOM_ALLOC=ON \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-        -DWITH_EXAMPLES=OFF . && \
+    -DCBOR_CUSTOM_ALLOC=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DWITH_EXAMPLES=OFF . && \
     make && \
     make install
 
@@ -43,15 +43,55 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.11.0 && \
     cd libfido2 && \
     cmake3 \
-        -DBUILD_EXAMPLES=OFF \
-        -DBUILD_MANPAGES=OFF \
-        -DBUILD_TOOLS=OFF \
-        -DCMAKE_BUILD_TYPE=Release . && \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_MANPAGES=OFF \
+    -DBUILD_TOOLS=OFF \
+    -DCMAKE_BUILD_TYPE=Release . && \
     make && \
     make install && \
-# Update ld.
+    # Update ld.
     echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
     ldconfig
+
+FROM centos:7 AS centos-devtoolset
+
+# Install required dependencies.
+RUN yum groupinstall -y 'Development Tools' && \
+    yum install -y epel-release && \
+    yum update -y && \
+    yum -y install centos-release-scl-rh && \
+    yum install -y \
+    # required by libbpf, Clang
+    centos-release-scl \
+    # required by Clang/LLVM
+    cmake3 \
+    # required by libbpf and Clang
+    devtoolset-11-gcc* \
+    # required by libbpf
+    devtoolset-11-make \
+    # required by libbpf
+    elfutils-libelf-devel \
+    # required by libbpf
+    elfutils-libelf-devel-static \
+    git \
+    # required by libbpf, Clang
+    scl-utils \
+    # required by libbpf
+    zlib-devel \
+    # required by libbpf
+    zlib-static && \
+    yum clean all
+
+# Use just created devtools image with never GCC
+FROM centos-devtoolset as libbpf
+
+# Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
+# BUILD_STATIC_ONLY disables libbpf.so build as we don't need it.
+ARG LIBBPF_VERSION
+RUN mkdir -p /opt && cd /opt && \
+    curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+    cd /opt/libbpf-${LIBBPF_VERSION}/src && \
+    scl enable devtoolset-11 "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
 
 FROM centos:7 AS buildbox
 
@@ -66,24 +106,32 @@ ARG RUST_VERSION
 ARG UID
 ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
-     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
+    mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y \
-        git \
-        net-tools \
-        # required by Teleport PAM support
-        pam-devel \
-        perl-IPC-Cmd \
-        tree \
-        # used by our Makefile
-        which \
-        zip \
+    # required by libbpf
+    elfutils-libelf-devel \
+    # required by libbpf
+    elfutils-libelf-devel-static \
+    git \
+    net-tools \
+    # required by Teleport PAM support
+    pam-devel \
+    perl-IPC-Cmd \
+    tree \
+    # used by our Makefile
+    which \
+    zip \
+    # required by libbpf
+    zlib-devel \
+    # required by libbpf
+    zlib-static && \
     yum clean all
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
-     cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
+    cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # Install Go.
 RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-amd64.tar.gz | tar xz && \
@@ -136,16 +184,22 @@ COPY --from=libfido2 \
     /usr/local/lib64/libudev.a \
     /usr/local/lib64/
 RUN cd /usr/local/lib64 && \
-# Re-create usual lib64 links.
+    # Re-create usual lib64 links.
     ln -s libcrypto.so.1.1 libcrypto.so && \
     ln -s libfido2.so.1.11.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
     ln -s libssl.so.1.1 libssl.so && \
-# Update ld.
+    # Update ld.
     echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
     ldconfig
 COPY pkgconfig/centos7/ /
 ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
+
+# Download pre-built CentOS 7 assets with clang needed to build BPF tools.
+RUN cd / && curl -L https://s3.amazonaws.com/clientbuilds.gravitational.io/go/centos7-assets.tar.gz | tar -xz
+
+# Copy libbpf into the final image.
+COPY --from=libbpf /opt/libbpf/usr /usr
 
 USER ci
 VOLUME ["/go/src/github.com/gravitational/teleport"]

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -59,25 +59,11 @@ RUN git clone --branch llvmorg-10.0.1 --depth=1 https://github.com/llvm/llvm-pro
     cd ../.. && \
     rm -rf llvm-project
 
-# Use just created devtools image with never GCC
-FROM centos-devtoolset as libbpf
-
-# Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
-# BUILD_STATIC_ONLY disables libbpf.so build as we don't need it.
-ARG LIBBPF_VERSION
-RUN mkdir -p /opt && cd /opt && \
-    curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
-    cd /opt/libbpf-${LIBBPF_VERSION}/src && \
-    scl enable devtoolset-11 "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
-
 FROM centos:7 AS assetbox
 
 # Copy Clang into the final image.
 COPY --from=clang10 /opt/llvm /opt/llvm/
 ENV PATH=/opt/llvm/bin:${PATH}
-
-# Copy libbpf into the final image.
-COPY --from=libbpf /opt/libbpf/usr /usr
 
 # Create the archive and copy it to the host.
 RUN tar -czvf centos7-assets.tar.gz /opt

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -1,0 +1,83 @@
+FROM centos:7 AS centos-devtoolset
+
+# Install required dependencies.
+RUN yum groupinstall -y 'Development Tools' && \
+    yum install -y epel-release && \
+    yum update -y && \
+    yum -y install centos-release-scl-rh && \
+    yum install -y \
+        # required by libbpf, Clang
+        centos-release-scl \
+        # required by Clang/LLVM
+        cmake3 \
+        # required by libbpf and Clang
+        devtoolset-11-gcc* \
+        # required by libbpf
+        devtoolset-11-make \
+        # required by libbpf
+        elfutils-libelf-devel \
+        # required by libbpf
+        elfutils-libelf-devel-static \
+        git \
+        # required by libbpf, Clang
+        scl-utils \
+        # required by libbpf
+        zlib-devel \
+        # required by libbpf
+        zlib-static && \
+    yum clean all
+
+# Use just created devtool image with newer GCC and Cmake
+FROM centos-devtoolset as clang10
+
+# Compile Clang 10.0.1 from source. It is needed to create BPF files.
+# Centos 7 doesn't provide it as a package unfortunately.
+# LLVM_INCLUDE_BENCHMARKS must be off, otherwise compilation fails,
+# CLANG_BUILD_TOOLS must be on, it builds clang binary,
+# LLVM_BUILD_TOOLS must be on, it builds llvm-strip binary.
+# the rest is disabled to speedup the compilation.
+RUN git clone --branch llvmorg-10.0.1 --depth=1 https://github.com/llvm/llvm-project.git && \
+    cd llvm-project/ && \
+    mkdir build && cd build/ && \
+    scl enable devtoolset-11 'bash -c "cmake3 \
+    -DCLANG_BUILD_TOOLS=ON \
+    -DCLANG_ENABLE_ARCMT=OFF \
+    -DCLANG_ENABLE_STATIC_ANALYZER=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/opt/llvm \
+    -DLLVM_BUILD_TOOLS=ON \
+    -DLLVM_BUILD_UTILS=OFF \
+    -DLLVM_ENABLE_BINDINGS=OFF \
+    -DLLVM_ENABLE_PROJECTS=clang \
+    -DLLVM_INCLUDE_BENCHMARKS=OFF \
+    -DLLVM_INCLUDE_GO_TESTS=OFF \
+    -DLLVM_INCLUDE_TESTS=OFF \
+    -DLLVM_TOOL_LLI_BUILD=OFF \
+    -G \"Unix Makefiles\" ../llvm && \
+    make -j6 &&  \
+    make install"' && \
+    cd ../.. && \
+    rm -rf llvm-project
+
+# Use just created devtools image with never GCC
+FROM centos-devtoolset as libbpf
+
+# Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
+# BUILD_STATIC_ONLY disables libbpf.so build as we don't need it.
+ARG LIBBPF_VERSION
+RUN mkdir -p /opt && cd /opt && \
+    curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+    cd /opt/libbpf-${LIBBPF_VERSION}/src && \
+    scl enable devtoolset-11 "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
+
+FROM centos:7 AS assetbox
+
+# Copy Clang into the final image.
+COPY --from=clang10 /opt/llvm /opt/llvm/
+ENV PATH=/opt/llvm/bin:${PATH}
+
+# Copy libbpf into the final image.
+COPY --from=libbpf /opt/libbpf/usr /usr
+
+# Create the archive and copy it to the host.
+RUN tar -czvf centos7-assets.tar.gz /opt

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -1,3 +1,32 @@
+FROM centos:7 AS libbpf
+
+# Install required dependencies.
+RUN yum groupinstall -y 'Development Tools' && \
+    yum install -y epel-release && \
+    yum update -y && \
+    yum -y install centos-release-scl-rh && \
+    yum install -y \
+    # required by libbpf
+    centos-release-scl \
+    # required by libbpf
+    devtoolset-11-gcc* \
+    # required by libbpf
+    devtoolset-11-make \
+    # required by libbpf
+    elfutils-libelf-devel-static \
+    git \
+    # required by libbpf
+    scl-utils \
+    yum clean all
+
+# Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
+# BUILD_STATIC_ONLY disables libbpf.so build as we don't need it.
+ARG LIBBPF_VERSION
+RUN mkdir -p /opt && cd /opt && \
+    curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+    cd /opt/libbpf-${LIBBPF_VERSION}/src && \
+    scl enable devtoolset-11 "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
+
 FROM centos:7
 
 ENV LANGUAGE=en_US.UTF-8 \
@@ -13,9 +42,28 @@ ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
-# Install dev tools (make, etc) and a Perl package needed to build OpenSSL.
-RUN yum groupinstall -y "Development Tools"
-RUN yum install -y pam-devel net-tools tree git zip libatomic perl-IPC-Cmd && \
+RUN yum groupinstall -y 'Development Tools' && \
+    yum install -y epel-release && \
+    yum update -y && \
+    yum -y install centos-release-scl-rh && \
+    yum install -y \
+    #required by libbpf
+    centos-release-scl \
+    # required by libbpf
+    devtoolset-11-* \
+    # required by libbpf
+    elfutils-libelf-devel-static \
+    git \
+    net-tools \
+    # required by Teleport PAM support
+    pam-devel \
+    perl-IPC-Cmd \
+    tree \
+    # used by our Makefile
+    which \
+    zip \
+    # required by libbpf
+    zlib-static && \
     yum clean all
 
 # Install etcd.
@@ -39,13 +87,19 @@ RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/
 
 ENV GOPATH="/go" \
     GOROOT="/opt/go" \
-    PATH="/opt/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
+    PATH="/opt/llvm/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install
 
 RUN chmod a-w /
+
+# Download pre-built CentOS 7 assets with clang needed to build BPF tools.
+RUN cd / && curl -L https://s3.amazonaws.com/clientbuilds.gravitational.io/go/centos7-assets.tar.gz | tar -xz
+
+# Copy libbpf into the final image.
+COPY --from=libbpf /opt/libbpf/usr /usr
 
 USER ci
 VOLUME ["/go/src/github.com/gravitational/teleport"]

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -395,8 +395,8 @@ release-fips: buildbox-fips
 #
 .PHONY:release-centos7
 release-centos7: buildbox-centos7
-	docker run $(DOCKERFLAGS) -i $(NOROOT) -e PROMPT_COMMAND=". /etc/profile" $(BUILDBOX_CENTOS7) \
-		bash -c ". /etc/profile && /usr/bin/make release -e ADDFLAGS=\"$(ADDFLAGS)\" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) REPRODUCIBLE=no"
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
+		 /usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) REPRODUCIBLE=no
 
 #
 # Create a Teleport FIPS package for CentOS 7 using the build container.

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -395,8 +395,8 @@ release-fips: buildbox-fips
 #
 .PHONY:release-centos7
 release-centos7: buildbox-centos7
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
-		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) REPRODUCIBLE=no
+	docker run $(DOCKERFLAGS) -i $(NOROOT) -e PROMPT_COMMAND=". /etc/profile" $(BUILDBOX_CENTOS7) \
+		bash -c ". /etc/profile && /usr/bin/make release -e ADDFLAGS=\"$(ADDFLAGS)\" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) REPRODUCIBLE=no"
 
 #
 # Create a Teleport FIPS package for CentOS 7 using the build container.

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -462,3 +462,11 @@ print-node-version:
 .PHONY:print-buildbox-version
 print-buildbox-version:
 	@echo $(BUILDBOX_VERSION)
+
+#
+# Build CentOS 7 assets such as clang.
+#
+.PHONY:build-centos7-assets
+build-centos7-assets:
+	docker build --build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) -t buildbox-centos7-assets -f Dockerfile-centos7-assets .
+	docker run -v $$(pwd):/centos7.assets -it buildbox-centos7-assets cp /centos7-assets.tar.gz /centos7.assets

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -177,6 +177,7 @@ buildbox-centos7-fips:
 		--build-arg GID=$(GID) \
 		--build-arg BORINGCRYPTO_RUNTIME=$(BORINGCRYPTO_RUNTIME) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
+		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--cache-from $(BUILDBOX_CENTOS7_FIPS) \
 		--tag $(BUILDBOX_CENTOS7_FIPS) -f Dockerfile-centos7-fips .
 
@@ -396,7 +397,7 @@ release-fips: buildbox-fips
 .PHONY:release-centos7
 release-centos7: buildbox-centos7
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
-		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) REPRODUCIBLE=no
+		/usr/bin/scl enable devtoolset-11 'make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) REPRODUCIBLE=no'
 
 #
 # Create a Teleport FIPS package for CentOS 7 using the build container.
@@ -405,7 +406,7 @@ release-centos7: buildbox-centos7
 .PHONY:release-centos7-fips
 release-centos7-fips:
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
-		/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=no
+		/usr/bin/scl enable devtoolset-11 '/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=no'
 
 #
 # Create a Windows Teleport package using the build container.

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -396,7 +396,7 @@ release-fips: buildbox-fips
 .PHONY:release-centos7
 release-centos7: buildbox-centos7
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
-		 /usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) REPRODUCIBLE=no
+		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) REPRODUCIBLE=no
 
 #
 # Create a Teleport FIPS package for CentOS 7 using the build container.

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -197,7 +197,8 @@ func dockerVolumeRefs(v ...volumeRef) []volumeRef {
 // releaseMakefileTarget gets the correct Makefile target for a given arch/fips/centos combo
 func releaseMakefileTarget(b buildType) string {
 	makefileTarget := fmt.Sprintf("release-%s", b.arch)
-	if b.centos7 {
+	// All x86_64 binaries are built on CentOS 7 now for better glibc compatibility.
+	if b.centos7 || b.arch == "amd64" {
 		makefileTarget += "-centos7"
 	}
 	if b.fips {


### PR DESCRIPTION
This PR adds BPF supports in CentOS 7 Docker images and switches to building Teleport on CenOS 7 to increase the glibc compatibility.

Teleport binary only has these dependencies
```
$ ldd teleport
	linux-vdso.so.1 (0x00007ffe9335b000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fed1e6b7000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fed1e6b2000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fed1e5cb000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fed1e5ab000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fed1e200000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fed1e6cf000)
```