### PR TITLE
teleterm_test.go: Make sure daemon has started before stopping it

### DIFF
--- a/lib/teleterm/teleterm_test.go
+++ b/lib/teleterm/teleterm_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gravitational/teleport/lib/teleterm"
 
@@ -41,7 +42,11 @@ func TestStart(t *testing.T) {
 	}()
 
 	defer func() {
-		cancel() // Stop the server.
+		// Make sure Start() is called.
+		time.Sleep(time.Millisecond * 500)
+
+		// Stop the server.
+		cancel()
 		require.NoError(t, <-wait)
 	}()
 


### PR DESCRIPTION
Fixes #13999.

That instance of a flaky tests has thrown "grpc: the server has been stopped". It seems [this error](https://github.com/grpc/grpc-go/blob/v1.46.0/server.go#L708-L710) is thrown by google.golang.org/grpc [only when `Server.Serve` is called after `Server.Stop`](
https://github.com/grpc/grpc-go/blob/v1.46.0/server.go#L737-L746).

`teleterm.Start` is written in a way that makes it possible for `apiServer.Stop` to be called after `apiServer.Serve` and `apiServer` is just a thin wrapper over that gRPC server.

I don't know if it's possible to orchestrate this code in a way which guarantees that `Stop` is called after `Serve`. `Serve` blocks until the server is stopped. But from what I can see, even in grpc-go tests [they resorted to calling `time.Sleep`](https://github.com/grpc/grpc-go/blob/v1.46.0/server_test.go#L66-L84) so that's what I'm going to do in our tests as well.