### PR TITLE
Use a getter/setter for reading the token value from the config

### DIFF
--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -83,12 +83,12 @@ teleport:
     # PID file for Teleport process
     #pid_file: /var/run/teleport.pid
 
-    # Invitation token or file path containing token used to join a cluster. It
-    # is not used on subsequent starts.
+    # The invitation token or an absolute path to a file containing the token used 
+    # to join a cluster. It is not used on subsequent starts.
+    # If using a file, it only needs to exist when teleport is first ran
     #
     # File path example:
     # auth_token: /var/lib/teleport/tokenjoin
-    # If using a file, it only needs to exist when teleport is first ran
     auth_token: xxxx-token-xxxx
 
     # join_params are parameters to set when joining a cluster via

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -85,7 +85,7 @@ teleport:
 
     # The invitation token or an absolute path to a file containing the token used 
     # to join a cluster. It is not used on subsequent starts.
-    # If using a file, it only needs to exist when teleport is first ran
+    # If using a file, it only needs to exist when teleport is first ran.
     #
     # File path example:
     # auth_token: /var/lib/teleport/tokenjoin

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -88,6 +88,7 @@ teleport:
     #
     # File path example:
     # auth_token: /var/lib/teleport/tokenjoin
+    # If using a file, it only needs to exist when teleport is first ran
     auth_token: xxxx-token-xxxx
 
     # join_params are parameters to set when joining a cluster via

--- a/integration/app_integration_test.go
+++ b/integration/app_integration_test.go
@@ -1501,7 +1501,7 @@ func (p *pack) startRootAppServers(t *testing.T, count int, extraApps []service.
 		raConf.Console = nil
 		raConf.Log = log
 		raConf.DataDir = t.TempDir()
-		raConf.Token = "static-token-value"
+		raConf.StoreToken("static-token-value")
 		raConf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -1635,7 +1635,7 @@ func (p *pack) startLeafAppServers(t *testing.T, count int, extraApps []service.
 		laConf.Console = nil
 		laConf.Log = log
 		laConf.DataDir = t.TempDir()
-		laConf.Token = "static-token-value"
+		laConf.StoreToken("static-token-value")
 		laConf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",

--- a/integration/app_integration_test.go
+++ b/integration/app_integration_test.go
@@ -1501,7 +1501,7 @@ func (p *pack) startRootAppServers(t *testing.T, count int, extraApps []service.
 		raConf.Console = nil
 		raConf.Log = log
 		raConf.DataDir = t.TempDir()
-		raConf.StoreToken("static-token-value")
+		raConf.SetToken("static-token-value")
 		raConf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -1635,7 +1635,7 @@ func (p *pack) startLeafAppServers(t *testing.T, count int, extraApps []service.
 		laConf.Console = nil
 		laConf.Log = log
 		laConf.DataDir = t.TempDir()
-		laConf.StoreToken("static-token-value")
+		laConf.SetToken("static-token-value")
 		laConf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",

--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -1103,7 +1103,7 @@ func setupDatabaseTest(t *testing.T, options ...testOptionFunc) *databasePack {
 	}
 	rdConf := service.MakeDefaultConfig()
 	rdConf.DataDir = t.TempDir()
-	rdConf.Token = "static-token-value"
+	rdConf.StoreToken("static-token-value")
 	rdConf.AuthServers = []utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
@@ -1141,7 +1141,7 @@ func setupDatabaseTest(t *testing.T, options ...testOptionFunc) *databasePack {
 	}
 	ldConf := service.MakeDefaultConfig()
 	ldConf.DataDir = t.TempDir()
-	ldConf.Token = "static-token-value"
+	ldConf.StoreToken("static-token-value")
 	ldConf.AuthServers = []utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
@@ -1303,7 +1303,7 @@ type databaseAgentStartParams struct {
 func (p *databasePack) startRootDatabaseAgent(t *testing.T, params databaseAgentStartParams) (*service.TeleportProcess, *auth.Client) {
 	conf := service.MakeDefaultConfig()
 	conf.DataDir = t.TempDir()
-	conf.Token = "static-token-value"
+	congf.StoreToken("static-token-value")
 	conf.DiagnosticAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerDiagnostic, &conf.FileDescriptors))
 	conf.AuthServers = []utils.NetAddr{
 		{

--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -1103,7 +1103,7 @@ func setupDatabaseTest(t *testing.T, options ...testOptionFunc) *databasePack {
 	}
 	rdConf := service.MakeDefaultConfig()
 	rdConf.DataDir = t.TempDir()
-	rdConf.StoreToken("static-token-value")
+	rdConf.SetToken("static-token-value")
 	rdConf.AuthServers = []utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
@@ -1141,7 +1141,7 @@ func setupDatabaseTest(t *testing.T, options ...testOptionFunc) *databasePack {
 	}
 	ldConf := service.MakeDefaultConfig()
 	ldConf.DataDir = t.TempDir()
-	ldConf.StoreToken("static-token-value")
+	ldConf.SetToken("static-token-value")
 	ldConf.AuthServers = []utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
@@ -1303,7 +1303,7 @@ type databaseAgentStartParams struct {
 func (p *databasePack) startRootDatabaseAgent(t *testing.T, params databaseAgentStartParams) (*service.TeleportProcess, *auth.Client) {
 	conf := service.MakeDefaultConfig()
 	conf.DataDir = t.TempDir()
-	congf.StoreToken("static-token-value")
+	conf.SetToken("static-token-value")
 	conf.DiagnosticAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerDiagnostic, &conf.FileDescriptors))
 	conf.AuthServers = []utils.NetAddr{
 		{

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -56,7 +56,7 @@ func newSilentLogger() utils.Logger {
 
 func newNodeConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, joinMethod types.JoinMethod) *service.Config {
 	config := service.MakeDefaultConfig()
-	config.StoreToken(tokenName)
+	config.SetToken(tokenName)
 	config.JoinMethod = joinMethod
 	config.SSH.Enabled = true
 	config.SSH.Addr.Addr = helpers.NewListener(t, service.ListenerNodeSSH, &config.FileDescriptors)
@@ -72,7 +72,7 @@ func newNodeConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, joinM
 func newProxyConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, joinMethod types.JoinMethod) *service.Config {
 	config := service.MakeDefaultConfig()
 	config.Version = defaults.TeleportConfigVersionV2
-	config.StoreToken(tokenName)
+	config.SetToken(tokenName)
 	config.JoinMethod = joinMethod
 	config.SSH.Enabled = false
 	config.Auth.Enabled = false

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -56,7 +56,7 @@ func newSilentLogger() utils.Logger {
 
 func newNodeConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, joinMethod types.JoinMethod) *service.Config {
 	config := service.MakeDefaultConfig()
-	config.Token = tokenName
+	config.StoreToken(tokenName)
 	config.JoinMethod = joinMethod
 	config.SSH.Enabled = true
 	config.SSH.Addr.Addr = helpers.NewListener(t, service.ListenerNodeSSH, &config.FileDescriptors)
@@ -72,7 +72,7 @@ func newNodeConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, joinM
 func newProxyConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, joinMethod types.JoinMethod) *service.Config {
 	config := service.MakeDefaultConfig()
 	config.Version = defaults.TeleportConfigVersionV2
-	config.Token = tokenName
+	config.StoreToken(tokenName)
 	config.JoinMethod = joinMethod
 	config.SSH.Enabled = false
 	config.Auth.Enabled = false

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -620,7 +620,7 @@ func (i *TeleInstance) startNode(tconf *service.Config, authPort string) (*servi
 
 	authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
 	tconf.AuthServers = append(tconf.AuthServers, *authServer)
-	tconf.Token = "token"
+	tconf.StoreToken("token")
 	tconf.UploadEventsC = i.UploadEventsC
 	tconf.CachePolicy = service.CachePolicy{
 		Enabled: true,
@@ -677,7 +677,7 @@ func (i *TeleInstance) StartApp(conf *service.Config) (*service.TeleportProcess,
 			Addr:        i.Web,
 		},
 	}
-	conf.Token = "token"
+	conf.StoreToken("token")
 	conf.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
@@ -729,7 +729,7 @@ func (i *TeleInstance) StartApps(configs []*service.Config) ([]*service.Teleport
 					Addr:        i.Web,
 				},
 			}
-			cfg.Token = "token"
+			cfg.StoreToken("token")
 			cfg.UploadEventsC = i.UploadEventsC
 			cfg.Auth.Enabled = false
 			cfg.Proxy.Enabled = false
@@ -793,7 +793,7 @@ func (i *TeleInstance) StartDatabase(conf *service.Config) (*service.TeleportPro
 			Addr:        i.Web,
 		},
 	}
-	conf.Token = "token"
+	conf.StoreToken("token")
 	conf.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
@@ -856,7 +856,7 @@ func (i *TeleInstance) StartKube(t *testing.T, conf *service.Config, clusterName
 			Addr:        i.Web,
 		},
 	}
-	conf.Token = "token"
+	conf.StoreToken("token")
 	conf.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
@@ -904,7 +904,7 @@ func (i *TeleInstance) StartNodeAndProxy(t *testing.T, name string) (sshPort, we
 	tconf.Log = i.Log
 	authServer := utils.MustParseAddr(i.Auth)
 	tconf.AuthServers = append(tconf.AuthServers, *authServer)
-	tconf.Token = "token"
+	tconf.StoreToken("token")
 	tconf.HostUUID = name
 	tconf.Hostname = name
 	tconf.UploadEventsC = i.UploadEventsC
@@ -997,7 +997,7 @@ func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnel.Server, error)
 	tconf.UploadEventsC = i.UploadEventsC
 	tconf.HostUUID = cfg.Name
 	tconf.Hostname = cfg.Name
-	tconf.Token = "token"
+	tconf.StoreToken("token")
 
 	tconf.Auth.Enabled = false
 

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -620,7 +620,7 @@ func (i *TeleInstance) startNode(tconf *service.Config, authPort string) (*servi
 
 	authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
 	tconf.AuthServers = append(tconf.AuthServers, *authServer)
-	tconf.StoreToken("token")
+	tconf.SetToken("token")
 	tconf.UploadEventsC = i.UploadEventsC
 	tconf.CachePolicy = service.CachePolicy{
 		Enabled: true,
@@ -677,7 +677,7 @@ func (i *TeleInstance) StartApp(conf *service.Config) (*service.TeleportProcess,
 			Addr:        i.Web,
 		},
 	}
-	conf.StoreToken("token")
+	conf.SetToken("token")
 	conf.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
@@ -729,7 +729,7 @@ func (i *TeleInstance) StartApps(configs []*service.Config) ([]*service.Teleport
 					Addr:        i.Web,
 				},
 			}
-			cfg.StoreToken("token")
+			cfg.SetToken("token")
 			cfg.UploadEventsC = i.UploadEventsC
 			cfg.Auth.Enabled = false
 			cfg.Proxy.Enabled = false
@@ -793,7 +793,7 @@ func (i *TeleInstance) StartDatabase(conf *service.Config) (*service.TeleportPro
 			Addr:        i.Web,
 		},
 	}
-	conf.StoreToken("token")
+	conf.SetToken("token")
 	conf.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
@@ -856,7 +856,7 @@ func (i *TeleInstance) StartKube(t *testing.T, conf *service.Config, clusterName
 			Addr:        i.Web,
 		},
 	}
-	conf.StoreToken("token")
+	conf.SetToken("token")
 	conf.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
@@ -904,7 +904,7 @@ func (i *TeleInstance) StartNodeAndProxy(t *testing.T, name string) (sshPort, we
 	tconf.Log = i.Log
 	authServer := utils.MustParseAddr(i.Auth)
 	tconf.AuthServers = append(tconf.AuthServers, *authServer)
-	tconf.StoreToken("token")
+	tconf.SetToken("token")
 	tconf.HostUUID = name
 	tconf.Hostname = name
 	tconf.UploadEventsC = i.UploadEventsC
@@ -997,7 +997,7 @@ func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnel.Server, error)
 	tconf.UploadEventsC = i.UploadEventsC
 	tconf.HostUUID = cfg.Name
 	tconf.Hostname = cfg.Name
-	tconf.StoreToken("token")
+	tconf.SetToken("token")
 
 	tconf.Auth.Enabled = false
 

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -278,7 +278,7 @@ func newProxyConfig(ctx context.Context, t *testing.T, authAddr utils.NetAddr, l
 
 	config := service.MakeDefaultConfig()
 	config.PollingPeriod = 1 * time.Second
-	config.StoreToken("foo")
+	config.SetToken("foo")
 	config.SSH.Enabled = false
 	config.Auth.Enabled = false
 	config.Proxy.Enabled = true

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -278,7 +278,7 @@ func newProxyConfig(ctx context.Context, t *testing.T, authAddr utils.NetAddr, l
 
 	config := service.MakeDefaultConfig()
 	config.PollingPeriod = 1 * time.Second
-	config.Token = "foo"
+	config.StoreToken("foo")
 	config.SSH.Enabled = false
 	config.Auth.Enabled = false
 	config.Proxy.Enabled = true

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -718,7 +718,7 @@ func (s *integrationTestSuite) newTeleportIoT(t *testing.T, logins []string) *he
 	nodeConfig := func() *service.Config {
 		tconf := s.defaultServiceConfig()
 		tconf.Hostname = Host
-		tconf.StoreToken("token")
+		tconf.SetToken("token")
 		tconf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -1088,7 +1088,7 @@ func testCustomReverseTunnel(t *testing.T, suite *integrationTestSuite) {
 	// Create a Teleport instance with a Node.
 	nodeConf := suite.defaultServiceConfig()
 	nodeConf.Hostname = Host
-	nodeConf.StoreToken("token")
+	nodeConf.SetToken("token")
 	nodeConf.Auth.Enabled = false
 	nodeConf.Proxy.Enabled = false
 	nodeConf.SSH.Enabled = true
@@ -2742,7 +2742,7 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 	nodeConfig := func() *service.Config {
 		tconf := suite.defaultServiceConfig()
 		tconf.Hostname = tunnelNodeHostname
-		tconf.StoreToken("token")
+		tconf.SetToken("token")
 		tconf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -3142,7 +3142,7 @@ func testReverseTunnelCollapse(t *testing.T, suite *integrationTestSuite) {
 	nodeConfig := func() *service.Config {
 		tconf := suite.defaultServiceConfig()
 		tconf.Hostname = "cluster-main-node"
-		tconf.StoreToken("token")
+		tconf.SetToken("token")
 		tconf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -3278,7 +3278,7 @@ func testDiscoveryNode(t *testing.T, suite *integrationTestSuite) {
 	nodeConfig := func() *service.Config {
 		tconf := suite.defaultServiceConfig()
 		tconf.Hostname = "cluster-main-node"
-		tconf.StoreToken("token")
+		tconf.SetToken("token")
 		tconf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -6430,7 +6430,7 @@ func testListResourcesAcrossClusters(t *testing.T, suite *integrationTestSuite) 
 			conf.Proxy.Enabled = false
 
 			conf.DataDir = t.TempDir()
-			conf.StoreToken("token")
+			conf.SetToken("token")
 			conf.UploadEventsC = i.UploadEventsC
 			conf.AuthServers = []utils.NetAddr{
 				*utils.MustParseAddr(net.JoinHostPort(i.Hostname, helpers.PortStr(t, i.Web))),

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -718,7 +718,7 @@ func (s *integrationTestSuite) newTeleportIoT(t *testing.T, logins []string) *he
 	nodeConfig := func() *service.Config {
 		tconf := s.defaultServiceConfig()
 		tconf.Hostname = Host
-		tconf.Token = "token"
+		tconf.StoreToken("token")
 		tconf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -1088,7 +1088,7 @@ func testCustomReverseTunnel(t *testing.T, suite *integrationTestSuite) {
 	// Create a Teleport instance with a Node.
 	nodeConf := suite.defaultServiceConfig()
 	nodeConf.Hostname = Host
-	nodeConf.Token = "token"
+	nodeConf.StoreToken("token")
 	nodeConf.Auth.Enabled = false
 	nodeConf.Proxy.Enabled = false
 	nodeConf.SSH.Enabled = true
@@ -2742,7 +2742,7 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 	nodeConfig := func() *service.Config {
 		tconf := suite.defaultServiceConfig()
 		tconf.Hostname = tunnelNodeHostname
-		tconf.Token = "token"
+		tconf.StoreToken("token")
 		tconf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -3142,7 +3142,7 @@ func testReverseTunnelCollapse(t *testing.T, suite *integrationTestSuite) {
 	nodeConfig := func() *service.Config {
 		tconf := suite.defaultServiceConfig()
 		tconf.Hostname = "cluster-main-node"
-		tconf.Token = "token"
+		tconf.StoreToken("token")
 		tconf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -3278,7 +3278,7 @@ func testDiscoveryNode(t *testing.T, suite *integrationTestSuite) {
 	nodeConfig := func() *service.Config {
 		tconf := suite.defaultServiceConfig()
 		tconf.Hostname = "cluster-main-node"
-		tconf.Token = "token"
+		tconf.StoreToken("token")
 		tconf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -6430,7 +6430,7 @@ func testListResourcesAcrossClusters(t *testing.T, suite *integrationTestSuite) 
 			conf.Proxy.Enabled = false
 
 			conf.DataDir = t.TempDir()
-			conf.Token = "token"
+			conf.StoreToken("token")
 			conf.UploadEventsC = i.UploadEventsC
 			conf.AuthServers = []utils.NetAddr{
 				*utils.MustParseAddr(net.JoinHostPort(i.Hostname, helpers.PortStr(t, i.Web))),

--- a/integration/proxy_helpers_test.go
+++ b/integration/proxy_helpers_test.go
@@ -171,7 +171,7 @@ func (p *ProxySuite) addNodeToLeafCluster(t *testing.T, tunnelNodeHostname strin
 		tconf.Console = nil
 		tconf.Log = utils.NewLoggerForTests()
 		tconf.Hostname = tunnelNodeHostname
-		tconf.Token = "token"
+		tconf.StoreToken("token")
 		tconf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -499,7 +499,7 @@ func mustStartALPNLocalProxy(t *testing.T, addr string, protocol alpncommon.Prot
 func makeNodeConfig(nodeName, authAddr string) *service.Config {
 	nodeConfig := service.MakeDefaultConfig()
 	nodeConfig.Hostname = nodeName
-	nodeConfig.Token = "token"
+	nodeConfig.StoreToken("token")
 	nodeConfig.AuthServers = []utils.NetAddr{
 		{
 			AddrNetwork: "tcp",

--- a/integration/proxy_helpers_test.go
+++ b/integration/proxy_helpers_test.go
@@ -171,7 +171,7 @@ func (p *ProxySuite) addNodeToLeafCluster(t *testing.T, tunnelNodeHostname strin
 		tconf.Console = nil
 		tconf.Log = utils.NewLoggerForTests()
 		tconf.Hostname = tunnelNodeHostname
-		tconf.StoreToken("token")
+		tconf.SetToken("token")
 		tconf.AuthServers = []utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
@@ -499,7 +499,7 @@ func mustStartALPNLocalProxy(t *testing.T, addr string, protocol alpncommon.Prot
 func makeNodeConfig(nodeName, authAddr string) *service.Config {
 	nodeConfig := service.MakeDefaultConfig()
 	nodeConfig.Hostname = nodeName
-	nodeConfig.StoreToken("token")
+	nodeConfig.SetToken("token")
 	nodeConfig.AuthServers = []utils.NetAddr{
 		{
 			AddrNetwork: "tcp",

--- a/integration/proxy_tunnel_strategy_test.go
+++ b/integration/proxy_tunnel_strategy_test.go
@@ -329,7 +329,7 @@ func (p *proxyTunnelStrategy) makeProxy(t *testing.T) {
 
 	conf := service.MakeDefaultConfig()
 	conf.AuthServers = append(conf.AuthServers, *authAddr)
-	conf.StoreToken("token")
+	conf.SetToken("token")
 	conf.DataDir = t.TempDir()
 
 	conf.Auth.Enabled = false
@@ -373,7 +373,7 @@ func (p *proxyTunnelStrategy) makeNode(t *testing.T) {
 
 	conf := service.MakeDefaultConfig()
 	conf.AuthServers = append(conf.AuthServers, utils.FromAddr(p.lb.Addr()))
-	conf.StoreToken("token")
+	conf.SetToken("token")
 	conf.DataDir = t.TempDir()
 
 	conf.Auth.Enabled = false
@@ -409,7 +409,7 @@ func (p *proxyTunnelStrategy) makeDatabase(t *testing.T) {
 
 	conf := service.MakeDefaultConfig()
 	conf.AuthServers = append(conf.AuthServers, utils.FromAddr(p.lb.Addr()))
-	conf.StoreToken("token")
+	conf.SetToken("token")
 	conf.DataDir = t.TempDir()
 
 	conf.Auth.Enabled = false

--- a/integration/proxy_tunnel_strategy_test.go
+++ b/integration/proxy_tunnel_strategy_test.go
@@ -329,7 +329,7 @@ func (p *proxyTunnelStrategy) makeProxy(t *testing.T) {
 
 	conf := service.MakeDefaultConfig()
 	conf.AuthServers = append(conf.AuthServers, *authAddr)
-	conf.Token = "token"
+	conf.StoreToken("token")
 	conf.DataDir = t.TempDir()
 
 	conf.Auth.Enabled = false
@@ -373,7 +373,7 @@ func (p *proxyTunnelStrategy) makeNode(t *testing.T) {
 
 	conf := service.MakeDefaultConfig()
 	conf.AuthServers = append(conf.AuthServers, utils.FromAddr(p.lb.Addr()))
-	conf.Token = "token"
+	conf.StoreToken("token")
 	conf.DataDir = t.TempDir()
 
 	conf.Auth.Enabled = false
@@ -409,7 +409,7 @@ func (p *proxyTunnelStrategy) makeDatabase(t *testing.T) {
 
 	conf := service.MakeDefaultConfig()
 	conf.AuthServers = append(conf.AuthServers, utils.FromAddr(p.lb.Addr()))
-	conf.Token = "token"
+	conf.StoreToken("token")
 	conf.DataDir = t.TempDir()
 
 	conf.Auth.Enabled = false

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -448,7 +448,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	cfg = service.MakeDefaultConfig()
 	cfg.DataDir = t.TempDir()
 	cfg.Hostname = "localhost"
-	cfg.StoreToken(staticToken)
+	cfg.SetToken(staticToken)
 	cfg.Clock = clock
 	cfg.Console = console
 	cfg.Log = logger

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -448,7 +448,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	cfg = service.MakeDefaultConfig()
 	cfg.DataDir = t.TempDir()
 	cfg.Hostname = "localhost"
-	cfg.Token = staticToken
+	cfg.StoreToken(staticToken)
 	cfg.Clock = clock
 	cfg.Console = console
 	cfg.Log = logger

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1955,10 +1955,8 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 		cfg.PIDFile = clf.PIDFile
 	}
 
-	// apply --token flag:
-	if _, err := cfg.ApplyToken(clf.AuthToken); err != nil {
-		return trace.Wrap(err)
-	}
+	// store the value of the --token flag:
+	cfg.StoreToken(clf.AuthToken)
 
 	// Apply flags used for the node to validate the Auth Server.
 	if err = cfg.ApplyCAPins(clf.CAPins); err != nil {
@@ -2145,17 +2143,18 @@ func splitRoles(roles string) []string {
 func applyTokenConfig(fc *FileConfig, cfg *service.Config) error {
 	if fc.AuthToken != "" {
 		cfg.JoinMethod = types.JoinMethodToken
-		_, err := cfg.ApplyToken(fc.AuthToken)
-		return trace.Wrap(err)
+		cfg.StoreToken(fc.AuthToken)
+
+		return nil
 	}
+
 	if fc.JoinParams != (JoinParams{}) {
-		if cfg.Token != "" {
+		if !cfg.HasTokenValue() {
 			return trace.BadParameter("only one of auth_token or join_params should be set")
 		}
-		_, err := cfg.ApplyToken(fc.JoinParams.TokenName)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+
+		cfg.StoreToken(fc.JoinParams.TokenName)
+
 		switch fc.JoinParams.Method {
 		case types.JoinMethodEC2, types.JoinMethodIAM, types.JoinMethodToken:
 			cfg.JoinMethod = fc.JoinParams.Method

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1955,8 +1955,10 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 		cfg.PIDFile = clf.PIDFile
 	}
 
-	// store the value of the --token flag:
-	cfg.StoreToken(clf.AuthToken)
+	if clf.AuthToken != "" {
+		// store the value of the --token flag:
+		cfg.StoreToken(clf.AuthToken)
+	}
 
 	// Apply flags used for the node to validate the Auth Server.
 	if err = cfg.ApplyCAPins(clf.CAPins); err != nil {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1957,7 +1957,7 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 
 	if clf.AuthToken != "" {
 		// store the value of the --token flag:
-		cfg.StoreToken(clf.AuthToken)
+		cfg.SetToken(clf.AuthToken)
 	}
 
 	// Apply flags used for the node to validate the Auth Server.
@@ -2145,17 +2145,17 @@ func splitRoles(roles string) []string {
 func applyTokenConfig(fc *FileConfig, cfg *service.Config) error {
 	if fc.AuthToken != "" {
 		cfg.JoinMethod = types.JoinMethodToken
-		cfg.StoreToken(fc.AuthToken)
+		cfg.SetToken(fc.AuthToken)
 
 		return nil
 	}
 
 	if fc.JoinParams != (JoinParams{}) {
-		if !cfg.HasTokenValue() {
+		if !cfg.HasToken() {
 			return trace.BadParameter("only one of auth_token or join_params should be set")
 		}
 
-		cfg.StoreToken(fc.JoinParams.TokenName)
+		cfg.SetToken(fc.JoinParams.TokenName)
 
 		switch fc.JoinParams.Method {
 		case types.JoinMethodEC2, types.JoinMethodIAM, types.JoinMethodToken:

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -664,7 +664,8 @@ func TestApplyConfig(t *testing.T) {
 	err = ApplyFileConfig(conf, cfg)
 	require.NoError(t, err)
 
-	require.Equal(t, "join-token", cfg.Token)
+	token, _ := cfg.GetToken()
+	require.Equal(t, "join-token", token)
 	require.Equal(t, types.ProvisionTokensFromV1([]types.ProvisionTokenV1{
 		{
 			Token:   "xxx",

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -664,7 +664,9 @@ func TestApplyConfig(t *testing.T) {
 	err = ApplyFileConfig(conf, cfg)
 	require.NoError(t, err)
 
-	token, _ := cfg.Token()
+	token, err := cfg.Token()
+	require.NoError(t, err)
+
 	require.Equal(t, "join-token", token)
 	require.Equal(t, types.ProvisionTokensFromV1([]types.ProvisionTokenV1{
 		{

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -664,7 +664,7 @@ func TestApplyConfig(t *testing.T) {
 	err = ApplyFileConfig(conf, cfg)
 	require.NoError(t, err)
 
-	token, _ := cfg.GetToken()
+	token, _ := cfg.Token()
 	require.Equal(t, "join-token", token)
 	require.Equal(t, types.ProvisionTokensFromV1([]types.ProvisionTokenV1{
 		{

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -264,11 +264,11 @@ type Config struct {
 	// that contains the token
 	//
 	// This is private to avoid external packages reading the value - the value should be obtained
-	// using GetToken
+	// using Token()
 	token string
 }
 
-// GetToken returns token needed to join the auth server
+// Token returns token needed to join the auth server
 //
 // If the value stored points to a file, it will attempt to read the token value from the file
 // and return an error if it wasn't successful
@@ -282,7 +282,7 @@ func (cfg *Config) Token() (string, error) {
 	return token, nil
 }
 
-// StoreToken stores the value for --token or auth_token in the config
+// SetToken stores the value for --token or auth_token in the config
 //
 // In the case of the token value pointing to a file, this allows us to
 // fetch the value of the token when it's needed (when connecting for the first time)
@@ -293,7 +293,7 @@ func (cfg *Config) SetToken(token string) {
 	cfg.token = token
 }
 
-// HasTokenValue gives the ability to check if there has been a token value stored
+// HasToken gives the ability to check if there has been a token value stored
 // in the config
 func (cfg *Config) HasToken() bool {
 	return cfg.token != ""

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -273,6 +273,7 @@ type Config struct {
 // If the value stored points to a file, it will attempt to read the token value from the file
 // and return an error if it wasn't successful
 // If the value stored doesn't point to a file, it'll return the value stored
+// If the token hasn't been set, an empty string will be returned
 func (cfg *Config) Token() (string, error) {
 	token, err := utils.TryReadValueAsFile(cfg.token)
 	if err != nil {
@@ -284,11 +285,7 @@ func (cfg *Config) Token() (string, error) {
 
 // SetToken stores the value for --token or auth_token in the config
 //
-// In the case of the token value pointing to a file, this allows us to
-// fetch the value of the token when it's needed (when connecting for the first time)
-// instead of trying to read the file every time that teleport is launched.
-// This means we can allow temporary token files that are removed after teleport has
-// successfully connected the first time.
+// This can be either the token or an absolute path to a file containing the token.
 func (cfg *Config) SetToken(token string) {
 	cfg.token = token
 }

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -273,7 +273,7 @@ type Config struct {
 // If the value stored points to a file, it will attempt to read the token value from the file
 // and return an error if it wasn't successful
 // If the value stored doesn't point to a file, it'll return the value stored
-func (cfg *Config) GetToken() (string, error) {
+func (cfg *Config) Token() (string, error) {
 	token, err := utils.TryReadValueAsFile(cfg.token)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -289,13 +289,13 @@ func (cfg *Config) GetToken() (string, error) {
 // instead of trying to read the file every time that teleport is launched.
 // This means we can allow temporary token files that are removed after teleport has
 // successfully connected the first time.
-func (cfg *Config) StoreToken(token string) {
+func (cfg *Config) SetToken(token string) {
 	cfg.token = token
 }
 
 // HasTokenValue gives the ability to check if there has been a token value stored
 // in the config
-func (cfg *Config) HasTokenValue() bool {
+func (cfg *Config) HasToken() bool {
 	return cfg.token != ""
 }
 

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -571,7 +571,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 		}
 	} else {
 		// Auth server is remote, so we need a provisioning token.
-		if !process.Config.HasTokenValue() {
+		if !process.Config.HasToken() {
 			return nil, trace.BadParameter("%v must join a cluster and needs a provisioning token", role)
 		}
 
@@ -582,7 +582,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 			return nil, trace.Wrap(err)
 		}
 
-		token, err := process.Config.GetToken()
+		token, err := process.Config.Token()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -571,7 +571,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 		}
 	} else {
 		// Auth server is remote, so we need a provisioning token.
-		if process.Config.Token == "" {
+		if !process.Config.HasTokenValue() {
 			return nil, trace.BadParameter("%v must join a cluster and needs a provisioning token", role)
 		}
 
@@ -582,8 +582,13 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 			return nil, trace.Wrap(err)
 		}
 
+		token, err := process.Config.GetToken()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
 		certs, err := auth.Register(auth.RegisterParams{
-			Token:                process.Config.Token,
+			Token:                token,
 			ID:                   id,
 			Servers:              process.Config.AuthServers,
 			AdditionalPrincipals: additionalPrincipals,

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -627,7 +627,7 @@ func TestTeleportProcessAuthVersionCheck(t *testing.T) {
 	nodeCfg := MakeDefaultConfig()
 	nodeCfg.AuthServers = []utils.NetAddr{listenAddr}
 	nodeCfg.DataDir = t.TempDir()
-	nodeCfg.StoreToken(token)
+	nodeCfg.SetToken(token)
 	nodeCfg.Auth.Enabled = false
 	nodeCfg.Proxy.Enabled = false
 	nodeCfg.SSH.Enabled = true

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -627,7 +627,7 @@ func TestTeleportProcessAuthVersionCheck(t *testing.T) {
 	nodeCfg := MakeDefaultConfig()
 	nodeCfg.AuthServers = []utils.NetAddr{listenAddr}
 	nodeCfg.DataDir = t.TempDir()
-	nodeCfg.Token = token
+	nodeCfg.StoreToken(token)
 	nodeCfg.Auth.Enabled = false
 	nodeCfg.Proxy.Enabled = false
 	nodeCfg.SSH.Enabled = true

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -124,7 +124,9 @@ func TestTeleportMain(t *testing.T) {
 		require.False(t, conf.Proxy.Enabled)
 		require.Equal(t, log.DebugLevel, conf.Log.GetLevel())
 		require.Equal(t, "hvostongo.example.org", conf.Hostname)
-		require.Equal(t, "xxxyyy", conf.Token)
+
+		token, _ := conf.GetToken()
+		require.Equal(t, "xxxyyy", token)
 		require.Equal(t, "10.5.5.5", conf.AdvertiseIP)
 		require.Equal(t, map[string]string{"a": "a1", "b": "b1"}, conf.SSH.Labels)
 	})

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -125,7 +125,8 @@ func TestTeleportMain(t *testing.T) {
 		require.Equal(t, log.DebugLevel, conf.Log.GetLevel())
 		require.Equal(t, "hvostongo.example.org", conf.Hostname)
 
-		token, _ := conf.Token()
+		token, err := conf.Token()
+		require.NoError(t, err)
 		require.Equal(t, "xxxyyy", token)
 		require.Equal(t, "10.5.5.5", conf.AdvertiseIP)
 		require.Equal(t, map[string]string{"a": "a1", "b": "b1"}, conf.SSH.Labels)

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -125,7 +125,7 @@ func TestTeleportMain(t *testing.T) {
 		require.Equal(t, log.DebugLevel, conf.Log.GetLevel())
 		require.Equal(t, "hvostongo.example.org", conf.Hostname)
 
-		token, _ := conf.GetToken()
+		token, _ := conf.Token()
 		require.Equal(t, "xxxyyy", token)
 		require.Equal(t, "10.5.5.5", conf.AdvertiseIP)
 		require.Equal(t, map[string]string{"a": "a1", "b": "b1"}, conf.SSH.Labels)

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -313,7 +313,9 @@ func makeTestDatabaseServer(t *testing.T, auth *service.TeleportProcess, proxy *
 
 	cfg.AuthServers = []utils.NetAddr{*proxyAddr}
 
-	token, _ := proxy.Config.Token()
+	token, err := proxy.Config.Token()
+	require.NoError(t, err)
+
 	cfg.SetToken(token)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = false

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -312,7 +312,9 @@ func makeTestDatabaseServer(t *testing.T, auth *service.TeleportProcess, proxy *
 	require.NoError(t, err)
 
 	cfg.AuthServers = []utils.NetAddr{*proxyAddr}
-	cfg.Token = proxy.Config.Token
+
+	token, _ := proxy.Config.GetToken()
+	cfg.StoreToken(token)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = false
 	cfg.Databases.Enabled = true

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -313,8 +313,8 @@ func makeTestDatabaseServer(t *testing.T, auth *service.TeleportProcess, proxy *
 
 	cfg.AuthServers = []utils.NetAddr{*proxyAddr}
 
-	token, _ := proxy.Config.GetToken()
-	cfg.StoreToken(token)
+	token, _ := proxy.Config.Token()
+	cfg.SetToken(token)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = false
 	cfg.Databases.Enabled = true

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -1937,7 +1937,7 @@ func makeTestSSHNode(t *testing.T, authAddr *utils.NetAddr, opts ...testServerOp
 	cfg.DataDir = t.TempDir()
 
 	cfg.AuthServers = []utils.NetAddr{*authAddr}
-	cfg.Token = staticToken
+	cfg.StoreToken(staticToken)
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = true
@@ -2028,7 +2028,7 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	cfg.DataDir = t.TempDir()
 
 	cfg.AuthServers = []utils.NetAddr{*authAddr}
-	cfg.Token = staticToken
+	cfg.StoreToken(staticToken)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = true

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -1937,7 +1937,7 @@ func makeTestSSHNode(t *testing.T, authAddr *utils.NetAddr, opts ...testServerOp
 	cfg.DataDir = t.TempDir()
 
 	cfg.AuthServers = []utils.NetAddr{*authAddr}
-	cfg.StoreToken(staticToken)
+	cfg.SetToken(staticToken)
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = true
@@ -2028,7 +2028,7 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	cfg.DataDir = t.TempDir()
 
 	cfg.AuthServers = []utils.NetAddr{*authAddr}
-	cfg.StoreToken(staticToken)
+	cfg.SetToken(staticToken)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = true


### PR DESCRIPTION
This allows us to only try and read the value when the node is connecting for the first time, meaning we won't get an error if the file that contained the token has been deleted since the first time teleport was started.

This would fix https://github.com/gravitational/teleport/issues/13605.

This preserves the error message if the file doesn't exist, we just will throw it a bit later (first time connection instead of when creating the config)

<img width="606" alt="image" src="https://user-images.githubusercontent.com/7922109/177177030-f6756d1b-34c5-4dae-9343-569c169bc1a1.png">
