### PR TITLE
Wait for application servers tunnel connection before integration tests

### DIFF
--- a/integration/app_integration_test.go
+++ b/integration/app_integration_test.go
@@ -1488,10 +1488,10 @@ func (p *pack) startRootAppServers(t *testing.T, count int, extraApps []service.
 
 	for _, appServer := range servers {
 		srv := appServer
-		waitAppServerTunnel(t, p.rootCluster.Tunnel, p.rootAppClusterName, srv.Config.HostUUID)
 		t.Cleanup(func() {
 			require.NoError(t, srv.Close())
 		})
+		waitAppServerTunnel(t, p.rootCluster.Tunnel, p.rootAppClusterName, srv.Config.HostUUID)
 	}
 
 	return servers
@@ -1603,10 +1603,10 @@ func (p *pack) startLeafAppServers(t *testing.T, count int, extraApps []service.
 
 	for _, appServer := range servers {
 		srv := appServer
-		waitAppServerTunnel(t, p.rootCluster.Tunnel, p.leafAppClusterName, srv.Config.HostUUID)
 		t.Cleanup(func() {
 			require.NoError(t, srv.Close())
 		})
+		waitAppServerTunnel(t, p.rootCluster.Tunnel, p.leafAppClusterName, srv.Config.HostUUID)
 	}
 
 	return servers

--- a/integration/app_integration_test.go
+++ b/integration/app_integration_test.go
@@ -1488,6 +1488,7 @@ func (p *pack) startRootAppServers(t *testing.T, count int, extraApps []service.
 
 	for _, appServer := range servers {
 		srv := appServer
+		waitAppServerTunnel(t, p.rootCluster.Tunnel, p.rootAppClusterName, srv.Config.HostUUID)
 		t.Cleanup(func() {
 			require.NoError(t, srv.Close())
 		})
@@ -1602,6 +1603,7 @@ func (p *pack) startLeafAppServers(t *testing.T, count int, extraApps []service.
 
 	for _, appServer := range servers {
 		srv := appServer
+		waitAppServerTunnel(t, p.rootCluster.Tunnel, p.leafAppClusterName, srv.Config.HostUUID)
 		t.Cleanup(func() {
 			require.NoError(t, srv.Close())
 		})

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3284,7 +3284,7 @@ func waitAppServerTunnel(t *testing.T, tunnel reversetunnel.Server, clusterName,
 			return false
 		}
 
-		conn.Close()
+		require.NoError(t, conn.Close())
 		return true
 	}, 10*time.Second, time.Second)
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3268,7 +3268,7 @@ func waitForTunnelConnections(t *testing.T, authServer *auth.Server, clusterName
 	require.Len(t, conns, expectedCount)
 }
 
-// waitAppServerTunnel waits for application server tunnel conenctions.
+// waitAppServerTunnel waits for application server tunnel connections.
 func waitAppServerTunnel(t *testing.T, tunnel reversetunnel.Server, clusterName, serverUUID string) {
 	cluster, err := tunnel.GetSite(clusterName)
 	require.NoError(t, err)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3270,6 +3270,7 @@ func waitForTunnelConnections(t *testing.T, authServer *auth.Server, clusterName
 
 // waitAppServerTunnel waits for application server tunnel connections.
 func waitAppServerTunnel(t *testing.T, tunnel reversetunnel.Server, clusterName, serverUUID string) {
+	t.Helper()
 	cluster, err := tunnel.GetSite(clusterName)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Related to #13568

Some errors in the `TestAppAccess/TestAppServersHA` integration tests are related to the application servers' reverse tunnel not being available, causing the proxy to fail [when matching applications](https://github.com/gravitational/teleport/blob/master/lib/web/app/session.go#L67-L77). In those scenarios, the API returns a `302` error indicating an authentication failure.

The new `waitAppServerTunnel` (called for each app server started) will try to establish a connection to the application ([using the same logic as the proxy](https://github.com/gravitational/teleport/blob/master/lib/web/app/transport.go#L232-L250)).