### PR TITLE
Change tbot to allow reading the token from a file

### DIFF
--- a/docs/pages/machine-id/reference/cli.mdx
+++ b/docs/pages/machine-id/reference/cli.mdx
@@ -41,7 +41,7 @@ $ tbot start \
 | `-d/--debug`         | Enable verbose logging to stderr.                                                              |
 | `-c/--config`        | Path to a configuration file. Defaults to `/etc/tbot.yaml` if unspecified.                     |
 | `-a/--auth-server`   | Address of the Teleport Auth Server (On-Prem installs) or Teleport Cloud tenant.       |
-| `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect. Can also be the path to a file containing the token. |
+| `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect. Can also be an absolute path to a file containing the token. |
 | `--ca-pin`           | CA pin to validate the Teleport Auth Server; used on first connect.                            |
 | `--data-dir`         | Directory to store internal bot data. Access to this directory should be limited.              |
 | `--destination-dir`  | Directory to write short-lived machine certificates.                                           |

--- a/docs/pages/machine-id/reference/cli.mdx
+++ b/docs/pages/machine-id/reference/cli.mdx
@@ -39,9 +39,9 @@ $ tbot start \
 | Flag                 | Description                                                                                    |
 |----------------------|------------------------------------------------------------------------------------------------|
 | `-d/--debug`         | Enable verbose logging to stderr.                                                              |
-| `-c/--config`        | Path to a configuration file.                                                                  |
-| `-a/--auth-server`   | Address of the Teleport Auth Server (on-prem installs) or Teleport Cloud tenant.               |
-| `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect.                   |
+| `-c/--config`        | Path to a configuration file. Defaults to `/etc/tbot.yaml` if unspecified.                     |
+| `-a/--auth-server`   | Address of the Teleport Auth Server (On-Prem installs) or Teleport Cloud tenant.       |
+| `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect. Can also be the path to a file containing the token. |
 | `--ca-pin`           | CA pin to validate the Teleport Auth Server; used on first connect.                            |
 | `--data-dir`         | Directory to store internal bot data. Access to this directory should be limited.              |
 | `--destination-dir`  | Directory to write short-lived machine certificates.                                           |

--- a/docs/pages/machine-id/reference/cli.mdx
+++ b/docs/pages/machine-id/reference/cli.mdx
@@ -39,8 +39,8 @@ $ tbot start \
 | Flag                 | Description                                                                                    |
 |----------------------|------------------------------------------------------------------------------------------------|
 | `-d/--debug`         | Enable verbose logging to stderr.                                                              |
-| `-c/--config`        | Path to a configuration file. Defaults to `/etc/tbot.yaml` if unspecified.                     |
-| `-a/--auth-server`   | Address of the Teleport Auth Server (On-Prem installs) or Teleport Cloud tenant.       |
+| `-c/--config`        | Path to a configuration file.                                                                  |
+| `-a/--auth-server`   | Address of the Teleport Auth Server (on-prem installs) or Teleport Cloud tenant.               |
 | `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect. Can also be an absolute path to a file containing the token. |
 | `--ca-pin`           | CA pin to validate the Teleport Auth Server; used on first connect.                            |
 | `--data-dir`         | Directory to store internal bot data. Access to this directory should be limited.              |

--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -30,6 +30,9 @@ onboarding:
     join_method: "token"
 
     # Token used to join the cluster. (only required for join_method: token)
+    # This can also be a path to a file containing the token
+    # The token can live in a temporary file that's deleted after first launched, 
+    # but if tbot has to re-authenticate with the auth server, it will fail
     token: "00000000000000000000000000000000"
 
     # CA Path used to validate the identity of the Teleport Auth Server on first connect.

--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -30,9 +30,13 @@ onboarding:
     join_method: "token"
 
     # Token used to join the cluster. (only required for join_method: token)
-    # This can also be a path to a file containing the token
+    #
+    # This can also be an absolute path to a file containing the token.
     # The token can live in a temporary file that's deleted after first launched, 
-    # but if tbot has to re-authenticate with the auth server, it will fail
+    # but if tbot has to re-authenticate with the auth server, it will fail.
+    # 
+    # File path example:
+    # token: /var/lib/teleport/tokenjoin
     token: "00000000000000000000000000000000"
 
     # CA Path used to validate the identity of the Teleport Auth Server on first connect.

--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -32,8 +32,8 @@ onboarding:
     # Token used to join the cluster. (only required for join_method: token)
     #
     # This can also be an absolute path to a file containing the token.
-    # The token can live in a temporary file that's deleted after first launched, 
-    # but if tbot has to re-authenticate with the auth server, it will fail.
+    # The token can live in a temporary file that's deleted after tbot is first launched, 
+    # but if tbot has to re-authenticate with the Auth Service, it will fail.
     # 
     # File path example:
     # token: /var/lib/teleport/tokenjoin

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -145,12 +145,12 @@ type CLIConf struct {
 
 // OnboardingConfig contains values only required on first connect.
 type OnboardingConfig struct {
-	// token is either the token needed to join the auth server, or a path pointing to a file
+	// Token is either the token needed to join the auth server, or a path pointing to a file
 	// that contains the token
 	//
-	// This is private to avoid external packages reading the value - the value should be obtained
-	// using GetToken
-	token string `yaml:"token"`
+	// You should use GetToken instead - this has to be an accessible property for YAML unmarshalling
+	// to work correctly, but this could be a path instead of a token
+	Token string `yaml:"token"`
 
 	// CAPath is an optional path to a CA certificate.
 	CAPath string `yaml:"ca_path"`
@@ -167,7 +167,7 @@ type OnboardingConfig struct {
 // HasTokenValue gives the ability to check if there has been a token value stored
 // in the config
 func (conf *OnboardingConfig) HasTokenValue() bool {
-	return conf.token != ""
+	return conf.Token != ""
 }
 
 // StoreToken stores the value for --token or auth_token in the config
@@ -178,7 +178,7 @@ func (conf *OnboardingConfig) HasTokenValue() bool {
 // This means we can allow temporary token files that are removed after teleport has
 // successfully connected the first time.
 func (conf *OnboardingConfig) StoreToken(token string) {
-	conf.token = token
+	conf.Token = token
 }
 
 // GetToken returns token needed to join the auth server
@@ -187,9 +187,9 @@ func (conf *OnboardingConfig) StoreToken(token string) {
 // and return an error if it wasn't successful
 // If the value stored doesn't point to a file, it'll return the value stored
 func (conf *OnboardingConfig) GetToken() (string, error) {
-	fmt.Println("token", conf.token)
+	fmt.Println("token", conf.Token)
 
-	token, err := utils.TryReadValueAsFile(conf.token)
+	token, err := utils.TryReadValueAsFile(conf.Token)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -150,7 +150,7 @@ type OnboardingConfig struct {
 	//
 	// You should use GetToken instead - this has to be an accessible property for YAML unmarshalling
 	// to work correctly, but this could be a path instead of a token
-	Token string `yaml:"token"`
+	TokenValue string `yaml:"token"`
 
 	// CAPath is an optional path to a CA certificate.
 	CAPath string `yaml:"ca_path"`
@@ -167,7 +167,7 @@ type OnboardingConfig struct {
 // HasTokenValue gives the ability to check if there has been a token value stored
 // in the config
 func (conf *OnboardingConfig) HasTokenValue() bool {
-	return conf.Token != ""
+	return conf.TokenValue != ""
 }
 
 // StoreToken stores the value for --token or auth_token in the config
@@ -178,7 +178,7 @@ func (conf *OnboardingConfig) HasTokenValue() bool {
 // This means we can allow temporary token files that are removed after teleport has
 // successfully connected the first time.
 func (conf *OnboardingConfig) StoreToken(token string) {
-	conf.Token = token
+	conf.TokenValue = token
 }
 
 // GetToken returns token needed to join the auth server
@@ -187,7 +187,7 @@ func (conf *OnboardingConfig) StoreToken(token string) {
 // and return an error if it wasn't successful
 // If the value stored doesn't point to a file, it'll return the value stored
 func (conf *OnboardingConfig) GetToken() (string, error) {
-	token, err := utils.TryReadValueAsFile(conf.Token)
+	token, err := utils.TryReadValueAsFile(conf.TokenValue)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -187,8 +187,6 @@ func (conf *OnboardingConfig) StoreToken(token string) {
 // and return an error if it wasn't successful
 // If the value stored doesn't point to a file, it'll return the value stored
 func (conf *OnboardingConfig) GetToken() (string, error) {
-	fmt.Println("token", conf.Token)
-
 	token, err := utils.TryReadValueAsFile(conf.Token)
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -148,7 +148,7 @@ type OnboardingConfig struct {
 	// TokenValue is either the token needed to join the auth server, or a path pointing to a file
 	// that contains the token
 	//
-	// You should use GetToken instead - this has to be an accessible property for YAML unmarshalling
+	// You should use Token() instead - this has to be an accessible property for YAML unmarshalling
 	// to work correctly, but this could be a path instead of a token
 	TokenValue string `yaml:"token"`
 
@@ -164,29 +164,29 @@ type OnboardingConfig struct {
 	JoinMethod types.JoinMethod `yaml:"join_method"`
 }
 
-// HasTokenValue gives the ability to check if there has been a token value stored
+// HasToken gives the ability to check if there has been a token value stored
 // in the config
-func (conf *OnboardingConfig) HasTokenValue() bool {
+func (conf *OnboardingConfig) HasToken() bool {
 	return conf.TokenValue != ""
 }
 
-// StoreToken stores the value for --token or auth_token in the config
+// SetToken stores the value for --token or auth_token in the config
 //
 // In the case of the token value pointing to a file, this allows us to
 // fetch the value of the token when it's needed (when connecting for the first time)
 // instead of trying to read the file every time that teleport is launched.
 // This means we can allow temporary token files that are removed after teleport has
 // successfully connected the first time.
-func (conf *OnboardingConfig) StoreToken(token string) {
+func (conf *OnboardingConfig) SetToken(token string) {
 	conf.TokenValue = token
 }
 
-// GetToken returns token needed to join the auth server
+// Token returns token needed to join the auth server
 //
 // If the value stored points to a file, it will attempt to read the token value from the file
 // and return an error if it wasn't successful
 // If the value stored doesn't point to a file, it'll return the value stored
-func (conf *OnboardingConfig) GetToken() (string, error) {
+func (conf *OnboardingConfig) Token() (string, error) {
 	token, err := utils.TryReadValueAsFile(conf.TokenValue)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -366,7 +366,7 @@ func FromCLIConf(cf *CLIConf) (*BotConfig, error) {
 	// merging)
 	if cf.Token != "" || len(cf.CAPins) > 0 || !isJoinMethodDefault(cf.JoinMethod) {
 		onboarding := config.Onboarding
-		if onboarding != nil && (onboarding.HasTokenValue() || onboarding.CAPath != "" || len(onboarding.CAPins) > 0) || !isJoinMethodDefault(cf.JoinMethod) {
+		if onboarding != nil && (onboarding.HasToken() || onboarding.CAPath != "" || len(onboarding.CAPins) > 0) || !isJoinMethodDefault(cf.JoinMethod) {
 			// To be safe, warn about possible confusion.
 			log.Warnf("CLI parameters are overriding onboarding config from %s", cf.ConfigPath)
 		}
@@ -376,7 +376,7 @@ func FromCLIConf(cf *CLIConf) (*BotConfig, error) {
 			JoinMethod: types.JoinMethod(cf.JoinMethod),
 		}
 
-		config.Onboarding.StoreToken(cf.Token)
+		config.Onboarding.SetToken(cf.Token)
 	}
 
 	if err := config.CheckAndSetDefaults(); err != nil {

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -148,7 +148,7 @@ type OnboardingConfig struct {
 	// TokenValue is either the token needed to join the auth server, or a path pointing to a file
 	// that contains the token
 	//
-	// You should use Token() instead - this has to be an accessible property for YAML unmarshalling
+	// You should use Token() instead - this has to be an exported field for YAML unmarshalling
 	// to work correctly, but this could be a path instead of a token
 	TokenValue string `yaml:"token"`
 

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -145,7 +145,7 @@ type CLIConf struct {
 
 // OnboardingConfig contains values only required on first connect.
 type OnboardingConfig struct {
-	// Token is either the token needed to join the auth server, or a path pointing to a file
+	// TokenValue is either the token needed to join the auth server, or a path pointing to a file
 	// that contains the token
 	//
 	// You should use GetToken instead - this has to be an accessible property for YAML unmarshalling

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -94,7 +94,8 @@ func TestConfigCLIOnlySample(t *testing.T) {
 }
 
 func TestConfigFile(t *testing.T) {
-	cfg, err := ReadConfig(strings.NewReader(exampleConfigFile))
+	configData := fmt.Sprintf(exampleConfigFile, "foo")
+	cfg, err := ReadConfig(strings.NewReader(configData))
 	require.NoError(t, err)
 
 	require.Equal(t, "auth.example.com", cfg.AuthServer)
@@ -135,7 +136,7 @@ func TestLoadTokenFromFile(t *testing.T) {
 	tokenFile := filepath.Join(tokenDir, "token")
 	require.NoError(t, os.WriteFile(tokenFile, []byte("xxxyyy"), 0660))
 
-	configData := fmt.Sprintf(exampleConfigFileWithTokenInFile, tokenFile)
+	configData := fmt.Sprintf(exampleConfigFile, tokenFile)
 	cfg, err := ReadConfig(strings.NewReader(configData))
 	require.NoError(t, err)
 
@@ -189,23 +190,6 @@ func TestParseSSHVersion(t *testing.T) {
 }
 
 const exampleConfigFile = `
-auth_server: auth.example.com
-renewal_interval: 5m
-onboarding:
-  token: foo
-  ca_pins:
-    - sha256:abc123
-storage:
-  memory: {}
-destinations:
-  - directory:
-      path: /tmp/foo
-    configs:
-      - ssh_client:
-          proxy_port: 1234
-`
-
-const exampleConfigFileWithTokenInFile = `
 auth_server: auth.example.com
 renewal_interval: 5m
 onboarding:

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -61,7 +61,9 @@ func TestConfigCLIOnlySample(t *testing.T) {
 	require.Equal(t, cf.AuthServer, cfg.AuthServer)
 
 	require.NotNil(t, cfg.Onboarding)
-	require.Equal(t, cf.Token, cfg.Onboarding.Token)
+
+	token, _ := cfg.Onboarding.GetToken()
+	require.Equal(t, cf.Token, token)
 	require.Equal(t, cf.CAPins, cfg.Onboarding.CAPins)
 
 	// Storage is still default
@@ -96,7 +98,9 @@ func TestConfigFile(t *testing.T) {
 	require.Equal(t, time.Minute*5, cfg.RenewalInterval)
 
 	require.NotNil(t, cfg.Onboarding)
-	require.Equal(t, "foo", cfg.Onboarding.Token)
+
+	token, _ := cfg.Onboarding.GetToken()
+	require.Equal(t, "foo", token)
 	require.ElementsMatch(t, []string{"sha256:abc123"}, cfg.Onboarding.CAPins)
 
 	storage, err := cfg.Storage.GetDestination()

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -65,7 +65,7 @@ func TestConfigCLIOnlySample(t *testing.T) {
 
 	require.NotNil(t, cfg.Onboarding)
 
-	token, _ := cfg.Onboarding.GetToken()
+	token, _ := cfg.Onboarding.Token()
 	require.Equal(t, cf.Token, token)
 	require.Equal(t, cf.CAPins, cfg.Onboarding.CAPins)
 
@@ -103,7 +103,7 @@ func TestConfigFile(t *testing.T) {
 
 	require.NotNil(t, cfg.Onboarding)
 
-	token, _ := cfg.Onboarding.GetToken()
+	token, _ := cfg.Onboarding.Token()
 	require.Equal(t, "foo", token)
 	require.ElementsMatch(t, []string{"sha256:abc123"}, cfg.Onboarding.CAPins)
 
@@ -140,7 +140,7 @@ func TestLoadTokenFromFile(t *testing.T) {
 	cfg, err := ReadConfig(strings.NewReader(configData))
 	require.NoError(t, err)
 
-	token, err := cfg.Onboarding.GetToken()
+	token, err := cfg.Onboarding.Token()
 	require.NoError(t, err)
 	require.Equal(t, token, "xxxyyy")
 }

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -65,7 +65,8 @@ func TestConfigCLIOnlySample(t *testing.T) {
 
 	require.NotNil(t, cfg.Onboarding)
 
-	token, _ := cfg.Onboarding.Token()
+	token, err := cfg.Onboarding.Token()
+	require.NoError(t, err)
 	require.Equal(t, cf.Token, token)
 	require.Equal(t, cf.CAPins, cfg.Onboarding.CAPins)
 
@@ -103,7 +104,8 @@ func TestConfigFile(t *testing.T) {
 
 	require.NotNil(t, cfg.Onboarding)
 
-	token, _ := cfg.Onboarding.Token()
+	token, err := cfg.Onboarding.Token()
+	require.NoError(t, err)
 	require.Equal(t, "foo", token)
 	require.ElementsMatch(t, []string{"sha256:abc123"}, cfg.Onboarding.CAPins)
 

--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -337,7 +337,7 @@ func (b *Bot) getIdentityFromToken() (*identity.Identity, error) {
 	if b.cfg.Onboarding == nil {
 		return nil, trace.BadParameter("onboarding config required via CLI or YAML")
 	}
-	if !b.cfg.Onboarding.HasTokenValue() {
+	if !b.cfg.Onboarding.HasToken() {
 		return nil, trace.BadParameter("unable to start: no token present")
 	}
 	addr, err := utils.ParseAddr(b.cfg.AuthServer)
@@ -352,7 +352,7 @@ func (b *Bot) getIdentityFromToken() (*identity.Identity, error) {
 
 	b.log.Info("Attempting to generate new identity from token")
 
-	token, err := b.cfg.Onboarding.GetToken()
+	token, err := b.cfg.Onboarding.Token()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -337,7 +337,7 @@ func (b *Bot) getIdentityFromToken() (*identity.Identity, error) {
 	if b.cfg.Onboarding == nil {
 		return nil, trace.BadParameter("onboarding config required via CLI or YAML")
 	}
-	if b.cfg.Onboarding.Token == "" {
+	if !b.cfg.Onboarding.HasTokenValue() {
 		return nil, trace.BadParameter("unable to start: no token present")
 	}
 	addr, err := utils.ParseAddr(b.cfg.AuthServer)
@@ -351,8 +351,14 @@ func (b *Bot) getIdentityFromToken() (*identity.Identity, error) {
 	}
 
 	b.log.Info("Attempting to generate new identity from token")
+
+	token, err := b.cfg.Onboarding.GetToken()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	params := auth.RegisterParams{
-		Token: b.cfg.Onboarding.Token,
+		Token: token,
 		ID: auth.IdentityID{
 			Role: types.RoleBot,
 		},

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -158,7 +158,7 @@ func (b *Bot) initialize(ctx context.Context) error {
 				fetchNewIdentity = hasTokenChanged(ident.TokenHashBytes, configTokenHashBytes)
 			} else {
 				// we failed to get the token, we'll continue on trying to use the existing identity
-				b.log.Errorf("There was an error loading the token: %s", err)
+				b.log.WithError(err).Error("There was an error loading the token")
 
 				fetchNewIdentity = false
 

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -158,7 +158,11 @@ func (b *Bot) initialize(ctx context.Context) error {
 				fetchNewIdentity = hasTokenChanged(ident.TokenHashBytes, configTokenHashBytes)
 			} else {
 				// we failed to get the token, we'll continue on trying to use the existing identity
+				b.log.Errorf("There was an error loading the token: %s", err)
+
 				fetchNewIdentity = false
+
+				b.log.Info("Using the last good identity")
 			}
 		}
 

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -149,9 +149,9 @@ func (b *Bot) initialize(ctx context.Context) error {
 	// First, attempt to load an identity from storage.
 	ident, err := identity.LoadIdentity(dest, identity.BotKinds()...)
 	if err == nil {
-		if b.cfg.Onboarding != nil && b.cfg.Onboarding.HasTokenValue() {
+		if b.cfg.Onboarding != nil && b.cfg.Onboarding.HasToken() {
 			// try to grab the token to see if it's changed, as we'll need to fetch a new identity if it has
-			if token, err := b.cfg.Onboarding.GetToken(); err == nil {
+			if token, err := b.cfg.Onboarding.Token(); err == nil {
 				sha := sha256.Sum256([]byte(token))
 				configTokenHashBytes := []byte(hex.EncodeToString(sha[:]))
 

--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -259,7 +259,7 @@ func MakeMemoryBotConfig(t *testing.T, fc *config.FileConfig, botParams *proto.C
 		},
 	}
 
-	cfg.Onboarding.StoreToken(botParams.TokenID)
+	cfg.Onboarding.SetToken(botParams.TokenID)
 
 	require.NoError(t, cfg.CheckAndSetDefaults())
 

--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -244,7 +244,6 @@ func MakeMemoryBotConfig(t *testing.T, fc *config.FileConfig, botParams *proto.C
 		AuthServer: authCfg.AuthServers[0].String(),
 		Onboarding: &botconfig.OnboardingConfig{
 			JoinMethod: botParams.JoinMethod,
-			Token:      botParams.TokenID,
 		},
 		Storage: &botconfig.StorageConfig{
 			DestinationMixin: botconfig.DestinationMixin{
@@ -259,6 +258,9 @@ func MakeMemoryBotConfig(t *testing.T, fc *config.FileConfig, botParams *proto.C
 			},
 		},
 	}
+
+	cfg.Onboarding.StoreToken(botParams.TokenID)
+
 	require.NoError(t, cfg.CheckAndSetDefaults())
 
 	return cfg


### PR DESCRIPTION
This changes tbot's configuration to access the token via a getter/setter instead of a direct property, to allow us to fetch the token (possibly reading it from a file) when we need it instead of when the configuration is created.

This also changes the identity fetching logic, to try and read the token when there is an identity present but not error, allowing for the token file to have been deleted between restarts. If it can read the token, it'll check to see if it has changed and refetch the identity if so.

This would close https://github.com/gravitational/teleport/issues/13574.