### PR TITLE
added v7 to deprecated list

### DIFF
--- a/docs/pages/older-versions.mdx
+++ b/docs/pages/older-versions.mdx
@@ -7,6 +7,7 @@ layout: tocless-doc
 
 Deprecated versions of the Teleport docs can be found at the GitHub links below:
 
+[Teleport 7.0](https://github.com/gravitational/teleport/tree/branch/v7) <br/>
 [Teleport 6.2](https://github.com/gravitational/teleport/tree/branch/v6.2) <br/>
 [Teleport 6.1](https://github.com/gravitational/teleport/tree/branch/v6.1) <br/>
 [Teleport 6.0](https://github.com/gravitational/teleport/tree/branch/v6.0) <br/>


### PR DESCRIPTION
some context: https://github.com/gravitational/docs/pull/90