### PR TITLE
SSH request tracing

### DIFF
--- a/api/observability/tracing/option.go
+++ b/api/observability/tracing/option.go
@@ -1,0 +1,73 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// Option applies an option value for a Config.
+type Option interface {
+	apply(*Config)
+}
+
+// Config stores tracing related properties to customize
+// creating Tracers and extracting TraceContext
+type Config struct {
+	TracerProvider    oteltrace.TracerProvider
+	TextMapPropagator propagation.TextMapPropagator
+}
+
+// NewConfig returns a Config configured with all the passed Option.
+func NewConfig(opts []Option) *Config {
+	c := &Config{
+		TracerProvider:    otel.GetTracerProvider(),
+		TextMapPropagator: otel.GetTextMapPropagator(),
+	}
+	for _, o := range opts {
+		o.apply(c)
+	}
+	return c
+}
+
+type tracerProviderOption struct{ tp oteltrace.TracerProvider }
+
+func (o tracerProviderOption) apply(c *Config) {
+	if o.tp != nil {
+		c.TracerProvider = o.tp
+	}
+}
+
+// WithTracerProvider returns an Option to use the trace.TracerProvider when
+// creating a trace.Tracer.
+func WithTracerProvider(tp oteltrace.TracerProvider) Option {
+	return tracerProviderOption{tp: tp}
+}
+
+type propagatorOption struct{ p propagation.TextMapPropagator }
+
+func (o propagatorOption) apply(c *Config) {
+	if o.p != nil {
+		c.TextMapPropagator = o.p
+	}
+}
+
+// WithTextMapPropagator returns an Option to use the propagation.TextMapPropagator when extracting
+// and injecting trace context.
+func WithTextMapPropagator(p propagation.TextMapPropagator) Option {
+	return propagatorOption{p: p}
+}

--- a/api/observability/tracing/ssh/channel.go
+++ b/api/observability/tracing/ssh/channel.go
@@ -1,0 +1,106 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/observability/tracing"
+)
+
+// Channel is a wrapper around ssh.Channel that adds tracing support.
+type Channel struct {
+	ssh.Channel
+	tracingSupported bool
+	opts             []tracing.Option
+}
+
+// NewTraceChannel creates a new Channel.
+func NewTraceChannel(ch ssh.Channel, opts ...tracing.Option) *Channel {
+	return &Channel{
+		Channel: ch,
+		opts:    opts,
+	}
+}
+
+// SendRequest sends a global request, and returns the
+// reply. If tracing is enabled, the provided payload
+// is wrapped in an Envelope to forward any tracing context.
+func (c *Channel) SendRequest(ctx context.Context, name string, wantReply bool, payload []byte) (bool, error) {
+	config := tracing.NewConfig(c.opts)
+	tracer := config.TracerProvider.Tracer(instrumentationName)
+
+	ctx, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.ChannelRequest/%s", name),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String("ssh.Channel"),
+			semconv.RPCMethodKey.String("SendRequest"),
+			semconv.RPCSystemKey.String("ssh"),
+		),
+	)
+	defer span.End()
+
+	ok, err := c.Channel.SendRequest(name, wantReply, wrapPayload(ctx, c.tracingSupported, config.TextMapPropagator, payload))
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+
+	return ok, err
+}
+
+// NewChannel is a wrapper around ssh.NewChannel that allows an
+// Envelope to be provided to new channels.
+type NewChannel struct {
+	ssh.NewChannel
+	Envelope Envelope
+}
+
+// NewTraceNewChannel wraps the ssh.NewChannel in a new NewChannel
+//
+// The provided ssh.NewChannel will have any Envelope provided
+// via ExtraData extracted so that the original payload can be
+// provided to callers of NewCh.ExtraData.
+func NewTraceNewChannel(nch ssh.NewChannel) *NewChannel {
+	ch := &NewChannel{
+		NewChannel: nch,
+	}
+
+	data := nch.ExtraData()
+
+	var envelope Envelope
+	if err := json.Unmarshal(data, &envelope); err == nil {
+		ch.Envelope = envelope
+	} else {
+		ch.Envelope.Payload = data
+	}
+
+	return ch
+}
+
+// ExtraData returns the arbitrary payload for this channel, as supplied
+// by the client. This data is specific to the channel type.
+func (n NewChannel) ExtraData() []byte {
+	return n.Envelope.Payload
+}

--- a/api/observability/tracing/ssh/channel.go
+++ b/api/observability/tracing/ssh/channel.go
@@ -30,7 +30,7 @@ import (
 // Channel is a wrapper around ssh.Channel that adds tracing support.
 type Channel struct {
 	ssh.Channel
-	tracingSupported bool
+	tracingSupported tracingCapability
 	opts             []tracing.Option
 }
 

--- a/api/observability/tracing/ssh/client.go
+++ b/api/observability/tracing/ssh/client.go
@@ -1,0 +1,210 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/gravitational/trace"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/observability/tracing"
+)
+
+// Client is a wrapper around ssh.Client that adds tracing support.
+type Client struct {
+	*ssh.Client
+	opts             []tracing.Option
+	tracingSupported bool
+	rejectedError    error
+}
+
+// NewClient creates a new Client.
+//
+// The server being connected to is probed to determine if it supports
+// ssh tracing. This is done by attempting to open a TracingChannel channel.
+// If the channel is successfully opened then all payloads delivered to the
+// server will be wrapped in an Envelope with tracing context. All Session
+// and Channel created from the returned Client will honor the clients view
+// of whether they should provide tracing context.
+//
+// Note: a channel is used instead of a global request in order prevent blocking
+// forever in the event that the connection is rejected. In that case, the server
+// doesn't service any global requests and writes the error to the first opened
+// channel.
+func NewClient(c ssh.Conn, chans <-chan ssh.NewChannel, reqs <-chan *ssh.Request, opts ...tracing.Option) *Client {
+	clt := &Client{
+		Client: ssh.NewClient(c, chans, reqs),
+		opts:   opts,
+	}
+
+	// Check if the server supports tracing
+	ch, _, err := clt.Client.OpenChannel(TracingChannel, nil)
+	if err != nil {
+		var openError *ssh.OpenChannelError
+		if errors.As(err, &openError) {
+			switch openError.Reason {
+			case ssh.Prohibited:
+				// prohibited errors due to locks and session control are expected by callers of NewSession
+				clt.rejectedError = err
+			default:
+			}
+
+			return clt
+		}
+
+		return clt
+	}
+
+	_ = ch.Close()
+	clt.tracingSupported = true
+
+	return clt
+}
+
+// DialContext initiates a connection to the addr from the remote host.
+// The resulting connection has a zero LocalAddr() and RemoteAddr().
+func (c *Client) DialContext(ctx context.Context, n, addr string) (net.Conn, error) {
+	tracer := tracing.NewConfig(c.opts).TracerProvider.Tracer(instrumentationName)
+
+	_, span := tracer.Start(
+		ctx,
+		"ssh.DialContext",
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			append(
+				peerAttr(c.Conn.RemoteAddr()),
+				attribute.String("network", n),
+				attribute.String("address", addr),
+				semconv.RPCServiceKey.String("ssh.Client"),
+				semconv.RPCMethodKey.String("Dial"),
+				semconv.RPCSystemKey.String("ssh"),
+			)...,
+		),
+	)
+	defer span.End()
+
+	conn, err := c.Client.Dial(n, addr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return conn, nil
+}
+
+// SendRequest sends a global request, and returns the
+// reply. If tracing is enabled, the provided payload
+// is wrapped in an Envelope to forward any tracing context.
+func (c *Client) SendRequest(ctx context.Context, name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	config := tracing.NewConfig(c.opts)
+	tracer := config.TracerProvider.Tracer(instrumentationName)
+
+	ctx, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.GlobalRequest/%s", name),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			append(
+				peerAttr(c.Conn.RemoteAddr()),
+				attribute.Bool("want_reply", wantReply),
+				semconv.RPCServiceKey.String("ssh.Client"),
+				semconv.RPCMethodKey.String("SendRequest"),
+				semconv.RPCSystemKey.String("ssh"),
+			)...,
+		),
+	)
+	defer span.End()
+
+	ok, resp, err := c.Client.SendRequest(name, wantReply, wrapPayload(ctx, c.tracingSupported, config.TextMapPropagator, payload))
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+
+	return ok, resp, err
+}
+
+// OpenChannel tries to open a channel. If tracing is enabled,
+// the provided payload is wrapped in an Envelope to forward
+// any tracing context.
+func (c *Client) OpenChannel(ctx context.Context, name string, data []byte) (*Channel, <-chan *ssh.Request, error) {
+	config := tracing.NewConfig(c.opts)
+	tracer := config.TracerProvider.Tracer(instrumentationName)
+	ctx, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("ssh.OpenChannel/%s", name),
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			append(
+				peerAttr(c.Conn.RemoteAddr()),
+				semconv.RPCServiceKey.String("ssh.Client"),
+				semconv.RPCMethodKey.String("OpenChannel"),
+				semconv.RPCSystemKey.String("ssh"),
+			)...,
+		),
+	)
+	defer span.End()
+
+	ch, reqs, err := c.Client.OpenChannel(name, wrapPayload(ctx, c.tracingSupported, config.TextMapPropagator, data))
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+
+	return &Channel{
+		Channel: ch,
+		opts:    c.opts,
+	}, reqs, err
+}
+
+// NewSession creates a new SSH session that is passed tracing context
+// so that spans may be correlated properly over the ssh connection.
+func (c *Client) NewSession(ctx context.Context) (*ssh.Session, error) {
+	tracer := tracing.NewConfig(c.opts).TracerProvider.Tracer(instrumentationName)
+
+	_, span := tracer.Start(
+		ctx,
+		"ssh.NewSession",
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			append(
+				peerAttr(c.Conn.RemoteAddr()),
+				semconv.RPCServiceKey.String("ssh.Client"),
+				semconv.RPCMethodKey.String("NewSession"),
+				semconv.RPCSystemKey.String("ssh"),
+			)...,
+		),
+	)
+	defer span.End()
+
+	// If the TracingChannel was rejected when the client was created,
+	// the connection was prohibited due to a lock or session control.
+	// Callers to NewSession are expecting to receive the reason the session
+	// was rejected, so we need to propagate the rejectedError here.
+	if c.rejectedError != nil {
+		return nil, trace.Wrap(c.rejectedError)
+	}
+
+	session, err := c.Client.NewSession()
+
+	return session, trace.Wrap(err)
+}

--- a/api/observability/tracing/ssh/client_test.go
+++ b/api/observability/tracing/ssh/client_test.go
@@ -1,0 +1,253 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestIsTracingSupported(t *testing.T) {
+
+	rejected := &ssh.OpenChannelError{
+		Reason:  ssh.Prohibited,
+		Message: "rejected!",
+	}
+
+	unknown := &ssh.OpenChannelError{
+		Reason:  ssh.UnknownChannelType,
+		Message: "unknown!",
+	}
+
+	cases := []struct {
+		name               string
+		channelErr         *ssh.OpenChannelError
+		expectedCapability tracingCapability
+		errAssertion       require.ErrorAssertionFunc
+	}{
+		{
+			name:               "rejected",
+			channelErr:         rejected,
+			expectedCapability: tracingUnknown,
+			errAssertion: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Equal(t, rejected.Error(), err.Error())
+			},
+		},
+		{
+			name:               "unknown",
+			channelErr:         unknown,
+			expectedCapability: tracingUnsupported,
+			errAssertion:       require.NoError,
+		},
+		{
+			name:               "supported",
+			channelErr:         nil,
+			expectedCapability: tracingSupported,
+			errAssertion:       require.NoError,
+		},
+		{
+			name: "other error",
+			channelErr: &ssh.OpenChannelError{
+				Reason:  ssh.ConnectionFailed,
+				Message: "",
+			},
+			expectedCapability: tracingUnknown,
+			errAssertion:       require.NoError,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			errChan := make(chan error, 5)
+
+			srv := newServer(t, func(conn *ssh.ServerConn, channels <-chan ssh.NewChannel, requests <-chan *ssh.Request) {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+
+					case ch := <-channels:
+						if ch == nil {
+							return
+						}
+
+						if tt.channelErr != nil {
+							if err := ch.Reject(tt.channelErr.Reason, tt.channelErr.Message); err != nil {
+								errChan <- trace.Wrap(err, "failed to reject channel")
+							}
+							return
+						}
+
+						_, _, err := ch.Accept()
+						if err != nil {
+							errChan <- trace.Wrap(err, "failed to accept channel")
+							return
+						}
+					}
+				}
+			})
+
+			go srv.Run(errChan)
+
+			conn, chans, reqs := srv.GetClient(t)
+			client := ssh.NewClient(conn, chans, reqs)
+
+			capabaility, err := isTracingSupported(client)
+			require.Equal(t, tt.expectedCapability, capabaility)
+			tt.errAssertion(t, err)
+
+			select {
+			case err := <-errChan:
+				require.NoError(t, err)
+			default:
+			}
+		})
+	}
+}
+
+func TestNewSession(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	errChan := make(chan error, 5)
+
+	first := ssh.OpenChannelError{
+		Reason:  ssh.Prohibited,
+		Message: "first attempt",
+	}
+
+	second := ssh.OpenChannelError{
+		Reason:  ssh.ConnectionFailed,
+		Message: "second attempt",
+	}
+
+	srv := newServer(t, func(conn *ssh.ServerConn, channels <-chan ssh.NewChannel, requests <-chan *ssh.Request) {
+		for i := 0; ; i++ {
+			select {
+			case <-ctx.Done():
+				return
+
+			case ch := <-channels:
+				switch {
+				case ch == nil:
+					return
+				case ch.ChannelType() == "session":
+					_, _, err := ch.Accept()
+					if err != nil {
+						errChan <- trace.Wrap(err, "failed to accept session channel")
+						return
+					}
+				case i == 0:
+					if err := ch.Reject(first.Reason, first.Message); err != nil {
+						errChan <- err
+						return
+					}
+				case i == 1:
+					if err := ch.Reject(second.Reason, second.Message); err != nil {
+						errChan <- err
+						return
+					}
+				case i > 2:
+					if _, _, err := ch.Accept(); err != nil {
+						errChan <- err
+						return
+					}
+				default:
+					if err := ch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unexpected channel %d", i)); err != nil {
+						errChan <- err
+						return
+					}
+				}
+			}
+		}
+	})
+
+	go srv.Run(errChan)
+
+	cases := []struct {
+		name          string
+		assertionFunc func(t *testing.T, clt *Client, session *ssh.Session, err error)
+	}{
+		{
+			name: "session prohibited",
+			assertionFunc: func(t *testing.T, clt *Client, sess *ssh.Session, err error) {
+				// creating a new session should return any errors captured when creating the client
+				// and not actually probe the server
+				require.Error(t, err)
+				require.Equal(t, trace.Unwrap(err).Error(), first.Error())
+				require.Nil(t, sess)
+				require.Nil(t, clt.rejectedError)
+				require.Equal(t, clt.capability, tracingUnknown)
+			},
+		},
+		{
+			name: "other failure to open tracing channel",
+			assertionFunc: func(t *testing.T, clt *Client, sess *ssh.Session, err error) {
+				// this time through we should probe the server without getting a prohibited error,
+				// but things still failed, so we shouldn't know the capability
+				require.NoError(t, err)
+				require.NotNil(t, sess)
+				require.NoError(t, clt.rejectedError)
+				require.Equal(t, clt.capability, tracingUnknown)
+				require.NoError(t, sess.Close())
+			},
+		},
+		{
+			name: "active session",
+			assertionFunc: func(t *testing.T, clt *Client, sess *ssh.Session, err error) {
+				// all is good now, we should have an active session
+				require.NoError(t, err)
+				require.NotNil(t, sess)
+				require.NoError(t, clt.rejectedError)
+				require.Equal(t, clt.capability, tracingSupported)
+				require.NoError(t, sess.Close())
+			},
+		},
+	}
+
+	// check tracing status after first capability probe from creating the client
+	conn, chans, reqs := srv.GetClient(t)
+	client := NewClient(conn, chans, reqs)
+	require.Error(t, client.rejectedError)
+	require.Equal(t, client.rejectedError.Error(), first.Error())
+	require.Equal(t, client.capability, tracingUnknown)
+
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+	default:
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			sess, err := client.NewSession(ctx)
+			tt.assertionFunc(t, client, sess, err)
+
+			select {
+			case err := <-errChan:
+				require.NoError(t, err)
+			default:
+			}
+		})
+	}
+}

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -191,8 +191,8 @@ func createEnvelope(ctx context.Context, propagator propagation.TextMapPropagato
 // wrapPayload wraps the provided payload within an envelope if tracing is
 // enabled and there is any tracing information to propagate. Otherwise, the
 // original payload is returned
-func wrapPayload(ctx context.Context, supported bool, propagator propagation.TextMapPropagator, payload []byte) []byte {
-	if !supported {
+func wrapPayload(ctx context.Context, supported tracingCapability, propagator propagation.TextMapPropagator, payload []byte) []byte {
+	if supported != tracingSupported {
 		return payload
 	}
 

--- a/api/observability/tracing/ssh/ssh_test.go
+++ b/api/observability/tracing/ssh/ssh_test.go
@@ -121,6 +121,8 @@ func newServer(t *testing.T, handler func(*ssh.ServerConn, <-chan ssh.NewChannel
 		hSigner:  hSigner,
 	}
 
+	t.Cleanup(func() { require.NoError(t, srv.Stop()) })
+
 	return srv
 }
 

--- a/api/observability/tracing/ssh/ssh_test.go
+++ b/api/observability/tracing/ssh/ssh_test.go
@@ -1,0 +1,409 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssh
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/subtle"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/observability/tracing"
+)
+
+const testPayload = "test"
+
+type server struct {
+	listener net.Listener
+	config   *ssh.ServerConfig
+	handler  func(*ssh.ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request)
+
+	cSigner ssh.Signer
+	hSigner ssh.Signer
+}
+
+func (s *server) Run(errC chan error) {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if !errors.Is(err, net.ErrClosed) {
+				errC <- err
+			}
+			return
+		}
+
+		go func() {
+			sconn, chans, reqs, err := ssh.NewServerConn(conn, s.config)
+			if err != nil {
+				errC <- err
+				return
+			}
+			s.handler(sconn, chans, reqs)
+		}()
+	}
+}
+
+func (s *server) Stop() error {
+	return s.listener.Close()
+}
+
+func generateSigner(t *testing.T) ssh.Signer {
+	private, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(private),
+	}
+
+	privatePEM := pem.EncodeToMemory(block)
+	signer, err := ssh.ParsePrivateKey(privatePEM)
+	require.NoError(t, err)
+
+	return signer
+}
+
+func (s *server) GetClient(t *testing.T) (ssh.Conn, <-chan ssh.NewChannel, <-chan *ssh.Request) {
+	conn, err := net.Dial("tcp", s.listener.Addr().String())
+	require.NoError(t, err)
+
+	sconn, nc, r, err := ssh.NewClientConn(conn, "", &ssh.ClientConfig{
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(s.cSigner)},
+		HostKeyCallback: ssh.FixedHostKey(s.hSigner.PublicKey()),
+	})
+	require.NoError(t, err)
+
+	return sconn, nc, r
+}
+
+func newServer(t *testing.T, handler func(*ssh.ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request)) *server {
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	cSigner := generateSigner(t)
+	hSigner := generateSigner(t)
+
+	config := &ssh.ServerConfig{
+		NoClientAuth: true,
+	}
+	config.AddHostKey(hSigner)
+
+	srv := &server{
+		listener: listener,
+		config:   config,
+		handler:  handler,
+		cSigner:  cSigner,
+		hSigner:  hSigner,
+	}
+
+	return srv
+}
+
+type handler struct {
+	tracingSupported bool
+	errChan          chan error
+	ctx              context.Context
+}
+
+func (h handler) handle(sconn *ssh.ServerConn, chans <-chan ssh.NewChannel, reqs <-chan *ssh.Request) {
+	for {
+		select {
+		case <-h.ctx.Done():
+			return
+		case req := <-reqs:
+			if req == nil {
+				return
+			}
+
+			h.requestHandler(req)
+
+		case ch := <-chans:
+			if ch == nil {
+				return
+			}
+
+			h.channelHandler(ch)
+		}
+	}
+}
+
+func (h handler) requestHandler(req *ssh.Request) {
+	switch {
+	case req.Type == TracingChannel && h.tracingSupported:
+		if err := req.Reply(true, nil); err != nil {
+			h.errChan <- err
+		}
+	case req.Type == "test":
+		defer func() {
+			if req.WantReply {
+				if err := req.Reply(true, nil); err != nil {
+					h.errChan <- err
+				}
+			}
+		}()
+
+		switch h.tracingSupported {
+		case false:
+			if subtle.ConstantTimeCompare(req.Payload, []byte(testPayload)) != 1 {
+				h.errChan <- errors.New("payload mismatch")
+			}
+		case true:
+			var envelope Envelope
+			if err := json.Unmarshal(req.Payload, &envelope); err != nil {
+				h.errChan <- trace.Wrap(err, "failed to unmarshal envelope")
+				return
+			}
+			if len(envelope.PropagationContext) <= 0 {
+				h.errChan <- errors.New("empty propagation context")
+				return
+			}
+			if subtle.ConstantTimeCompare(envelope.Payload, []byte(testPayload)) != 1 {
+				h.errChan <- errors.New("payload mismatch")
+				return
+			}
+		}
+	default:
+		if err := req.Reply(false, nil); err != nil {
+			h.errChan <- err
+		}
+	}
+}
+
+func (h handler) channelHandler(ch ssh.NewChannel) {
+	switch ch.ChannelType() {
+	case TracingChannel:
+		switch h.tracingSupported {
+		case false:
+			if err := ch.Reject(ssh.UnknownChannelType, "unknown channel type"); err != nil {
+				h.errChan <- trace.Wrap(err, "failed to reject channel")
+			}
+		case true:
+			ch.Accept()
+			return
+		}
+	case "session":
+		// TODO(tross): add tracing checks when session tracing lands
+		if subtle.ConstantTimeCompare(ch.ExtraData(), []byte(testPayload)) == 1 {
+			h.errChan <- errors.New("payload mismatch")
+		}
+
+		_, chReqs, err := ch.Accept()
+		if err != nil {
+			h.errChan <- trace.Wrap(err, "failed to accept channel")
+			return
+		}
+
+		go func() {
+			for {
+				select {
+				case <-h.ctx.Done():
+					return
+				case req := <-chReqs:
+					switch req.Type {
+					case "subsystem":
+						h.subsystemHandler(req)
+					}
+				}
+			}
+		}()
+	default:
+		if err := ch.Reject(ssh.UnknownChannelType, "unknown channel type"); err != nil {
+			h.errChan <- trace.Wrap(err, "failed to reject channel")
+		}
+	}
+}
+
+type subsystemRequestMsg struct {
+	Subsystem string
+}
+
+func (h handler) subsystemHandler(req *ssh.Request) {
+	defer func() {
+		if req.WantReply {
+			if err := req.Reply(true, nil); err != nil {
+				h.errChan <- err
+			}
+		}
+	}()
+
+	// TODO(tross): add tracing checks when session tracing lands
+
+	var msg subsystemRequestMsg
+	if err := ssh.Unmarshal(req.Payload, &msg); err != nil {
+		h.errChan <- trace.Wrap(err, "failed to unmarshal payload")
+		return
+	}
+
+	if msg.Subsystem != "test" {
+		h.errChan <- errors.New("received wrong subsystem")
+	}
+}
+
+func TestClient(t *testing.T) {
+	cases := []struct {
+		name             string
+		tracingSupported bool
+	}{
+		{
+			name:             "server supports tracing",
+			tracingSupported: true,
+		},
+		{
+			name:             "server does not support tracing",
+			tracingSupported: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			errChan := make(chan error, 5)
+
+			handler := handler{
+				tracingSupported: tt.tracingSupported,
+				errChan:          errChan,
+				ctx:              ctx,
+			}
+
+			srv := newServer(t, handler.handle)
+			go srv.Run(errChan)
+
+			tp := sdktrace.NewTracerProvider()
+			conn, chans, reqs := srv.GetClient(t)
+			client := NewClient(
+				conn,
+				chans,
+				reqs,
+				tracing.WithTracerProvider(tp),
+				tracing.WithTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})),
+			)
+			require.Equal(t, handler.tracingSupported, client.tracingSupported)
+
+			ctx, span := tp.Tracer("test").Start(context.Background(), "test")
+			t.Cleanup(func() { span.End() })
+
+			ok, resp, err := client.SendRequest(ctx, "test", true, []byte("test"))
+			span.End()
+			require.True(t, ok)
+			require.Empty(t, resp)
+			require.NoError(t, err)
+
+			select {
+			case err := <-errChan:
+				require.NoError(t, err)
+			default:
+			}
+
+			session, err := client.NewSession(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, session)
+
+			select {
+			case err := <-errChan:
+				require.NoError(t, err)
+			default:
+			}
+
+			require.NoError(t, session.RequestSubsystem("test"))
+
+			select {
+			case err := <-errChan:
+				require.NoError(t, err)
+			default:
+			}
+		})
+	}
+}
+
+func TestWrapPayload(t *testing.T) {
+	testPayload := []byte("test")
+
+	nonRecordingCtx, nonRecordingSpan := otel.GetTracerProvider().Tracer("non-recording").Start(context.Background(), "test")
+	nonRecordingSpan.End()
+
+	emptyCtx, emptySpan := sdktrace.NewTracerProvider().Tracer("empty-trace-context").Start(context.Background(), "test")
+	t.Cleanup(func() { emptySpan.End() })
+
+	recordingCtx, recordingSpan := sdktrace.NewTracerProvider().Tracer("recording").Start(context.Background(), "test")
+	t.Cleanup(func() { recordingSpan.End() })
+	cases := []struct {
+		name             string
+		ctx              context.Context
+		supported        bool
+		propagator       propagation.TextMapPropagator
+		payloadAssertion require.ComparisonAssertionFunc
+	}{
+		{
+			name:             "unsupported returns provided payload",
+			ctx:              recordingCtx,
+			payloadAssertion: require.Equal,
+		},
+		{
+
+			name:             "non-recording spans aren't propagated",
+			supported:        true,
+			ctx:              nonRecordingCtx,
+			payloadAssertion: require.Equal,
+		},
+		{
+			name:             "empty trace context is not propagated",
+			supported:        true,
+			ctx:              emptyCtx,
+			payloadAssertion: require.Equal,
+		},
+		{
+			name:       "recording spans are propagated",
+			supported:  true,
+			ctx:        recordingCtx,
+			propagator: propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}),
+			payloadAssertion: func(t require.TestingT, i interface{}, i2 interface{}, i3 ...interface{}) {
+				payload, ok := i2.([]byte)
+				require.True(t, ok)
+
+				require.NotEqual(t, testPayload, payload)
+
+				var envelope Envelope
+				require.NoError(t, json.Unmarshal(payload, &envelope))
+				require.Equal(t, testPayload, envelope.Payload)
+				require.NotEmpty(t, envelope.PropagationContext)
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.propagator == nil {
+				tt.propagator = otel.GetTextMapPropagator()
+			}
+			payload := wrapPayload(tt.ctx, tt.supported, tt.propagator, testPayload)
+			tt.payloadAssertion(t, testPayload, payload)
+		})
+	}
+}

--- a/api/observability/tracing/ssh/ssh_test.go
+++ b/api/observability/tracing/ssh/ssh_test.go
@@ -309,8 +309,6 @@ func TestClient(t *testing.T) {
 			require.Equal(t, handler.tracingSupported, client.capability)
 
 			ctx, span := tp.Tracer("test").Start(context.Background(), "test")
-			t.Cleanup(func() { span.End() })
-
 			ok, resp, err := client.SendRequest(ctx, "test", true, []byte("test"))
 			span.End()
 			require.True(t, ok)

--- a/api/observability/tracing/tracing.go
+++ b/api/observability/tracing/tracing.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // PropagationContext contains tracing information to be passed across service boundaries
@@ -26,14 +27,19 @@ type PropagationContext map[string]string
 
 // PropagationContextFromContext creates a PropagationContext from the given context.Context. If the context
 // does not contain any tracing information, the PropagationContext will be empty.
-func PropagationContextFromContext(ctx context.Context) PropagationContext {
+func PropagationContextFromContext(ctx context.Context, opts ...Option) PropagationContext {
 	carrier := propagation.MapCarrier{}
-	otel.GetTextMapPropagator().Inject(ctx, &carrier)
+	NewConfig(opts).TextMapPropagator.Inject(ctx, &carrier)
 	return PropagationContext(carrier)
 }
 
 // WithPropagationContext injects any tracing information from the given PropagationContext into the
 // given context.Context.
-func WithPropagationContext(ctx context.Context, pc PropagationContext) context.Context {
-	return otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(pc))
+func WithPropagationContext(ctx context.Context, pc PropagationContext, opts ...Option) context.Context {
+	return NewConfig(opts).TextMapPropagator.Extract(ctx, propagation.MapCarrier(pc))
+}
+
+// DefaultProvider returns the global default TracerProvider.
+func DefaultProvider() oteltrace.TracerProvider {
+	return otel.GetTracerProvider()
 }

--- a/api/utils/sshutils/chconn.go
+++ b/api/utils/sshutils/chconn.go
@@ -28,19 +28,27 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+type Conn interface {
+	io.Closer
+	// RemoteAddr returns the remote address for this connection.
+	RemoteAddr() net.Addr
+	// LocalAddr returns the local address for this connection.
+	LocalAddr() net.Addr
+}
+
 // NewChConn returns a new net.Conn implemented over
 // SSH channel
-func NewChConn(conn ssh.Conn, ch ssh.Channel) *ChConn {
+func NewChConn(conn Conn, ch ssh.Channel) *ChConn {
 	return newChConn(conn, ch, false)
 }
 
 // NewExclusiveChConn returns a new net.Conn implemented over
 // SSH channel, whenever this connection closes
-func NewExclusiveChConn(conn ssh.Conn, ch ssh.Channel) *ChConn {
+func NewExclusiveChConn(conn Conn, ch ssh.Channel) *ChConn {
 	return newChConn(conn, ch, true)
 }
 
-func newChConn(conn ssh.Conn, ch ssh.Channel, exclusive bool) *ChConn {
+func newChConn(conn Conn, ch ssh.Channel, exclusive bool) *ChConn {
 	reader, writer := net.Pipe()
 	c := &ChConn{
 		Channel:   ch,
@@ -68,7 +76,7 @@ type ChConn struct {
 	mu sync.Mutex
 
 	ssh.Channel
-	conn ssh.Conn
+	conn Conn
 	// exclusive indicates that whenever this channel connection
 	// is getting closed, the underlying connection is closed as well
 	exclusive bool

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
@@ -543,7 +544,7 @@ func (p *AgentPool) getVersion(ctx context.Context) (string, error) {
 }
 
 // transport creates a new transport instance.
-func (p *AgentPool) transport(ctx context.Context, channel ssh.Channel, requests <-chan *ssh.Request, conn ssh.Conn) *transport {
+func (p *AgentPool) transport(ctx context.Context, channel ssh.Channel, requests <-chan *ssh.Request, conn sshutils.Conn) *transport {
 	return &transport{
 		closeContext:        ctx,
 		component:           p.Component,

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -162,7 +162,7 @@ type transport struct {
 	kubeDialAddr utils.NetAddr
 
 	// sconn is a SSH connection to the remote host. Used for dial back nodes.
-	sconn ssh.Conn
+	sconn sshutils.Conn
 
 	// reverseTunnelServer holds all reverse tunnel connections.
 	reverseTunnelServer Server

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -26,10 +26,9 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
-	"github.com/gravitational/trace"
-
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/observability/tracing"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -47,8 +46,11 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // Server is a forwarding server. Server is used to create a single in-memory
@@ -157,6 +159,10 @@ type Server struct {
 
 	// lockWatcher is the server's lock watcher.
 	lockWatcher *services.LockWatcher
+
+	// tracerProvider is used to create tracers capable
+	// of starting spans.
+	tracerProvider oteltrace.TracerProvider
 }
 
 // ServerConfig is the configuration needed to create an instance of a Server.
@@ -209,6 +215,10 @@ type ServerConfig struct {
 
 	// LockWatcher is a lock watcher.
 	LockWatcher *services.LockWatcher
+
+	// TracerProvider is used to create tracers capable
+	// of starting spans.
+	TracerProvider oteltrace.TracerProvider
 }
 
 // CheckDefaults makes sure all required parameters are passed in.
@@ -245,6 +255,9 @@ func (s *ServerConfig) CheckDefaults() error {
 	}
 	if s.LockWatcher == nil {
 		return trace.BadParameter("missing parameter LockWatcher")
+	}
+	if s.TracerProvider == nil {
+		s.TracerProvider = tracing.DefaultProvider()
 	}
 	return nil
 }
@@ -290,6 +303,7 @@ func New(c ServerConfig) (*Server, error) {
 		StreamEmitter:   c.Emitter,
 		parentContext:   c.ParentContext,
 		lockWatcher:     c.LockWatcher,
+		tracerProvider:  c.TracerProvider,
 	}
 
 	// Set the ciphers, KEX, and MACs that the in-memory server will send to the
@@ -538,7 +552,7 @@ func (s *Server) Serve() {
 	go srv.StartKeepAliveLoop(srv.KeepAliveParams{
 		Conns: []srv.RequestSender{
 			s.sconn,
-			s.remoteClient,
+			s.remoteClient.Client,
 		},
 		Interval:     netConfig.GetKeepAliveInterval(),
 		MaxCount:     netConfig.GetKeepAliveCountMax(),
@@ -624,17 +638,47 @@ func (s *Server) handleConnection(ctx context.Context, chans <-chan ssh.NewChann
 	for {
 		select {
 		// Global out-of-band requests.
-		case newRequest := <-reqs:
-			if newRequest == nil {
+		case req := <-reqs:
+			if req == nil {
 				return
 			}
-			go s.handleGlobalRequest(newRequest)
+			reqCtx := tracessh.ContextFromRequest(req)
+			ctx, span := s.tracerProvider.Tracer("ssh").Start(
+				oteltrace.ContextWithRemoteSpanContext(ctx, oteltrace.SpanContextFromContext(reqCtx)),
+				fmt.Sprintf("ssh.Forward.GlobalRequest/%s", req.Type),
+				oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+				oteltrace.WithAttributes(
+					semconv.RPCServiceKey.String("ssh.ForwardServer"),
+					semconv.RPCMethodKey.String("GlobalRequest"),
+					semconv.RPCSystemKey.String("ssh"),
+				),
+			)
+
+			go func(span oteltrace.Span) {
+				defer span.End()
+				s.handleGlobalRequest(ctx, req)
+			}(span)
 		// Channel requests.
-		case newChannel := <-chans:
-			if newChannel == nil {
+		case nch := <-chans:
+			if nch == nil {
 				return
 			}
-			go s.handleChannel(ctx, newChannel)
+			chanCtx, nch := tracessh.ContextFromNewChannel(nch)
+			ctx, span := s.tracerProvider.Tracer("ssh").Start(
+				oteltrace.ContextWithRemoteSpanContext(ctx, oteltrace.SpanContextFromContext(chanCtx)),
+				fmt.Sprintf("ssh.Forward.OpenChannel/%s", nch.ChannelType()),
+				oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+				oteltrace.WithAttributes(
+					semconv.RPCServiceKey.String("ssh.ForwardServer"),
+					semconv.RPCMethodKey.String("OpenChannel"),
+					semconv.RPCSystemKey.String("ssh"),
+				),
+			)
+
+			go func(span oteltrace.Span) {
+				defer span.End()
+				s.handleChannel(ctx, nch)
+			}(span)
 		// If the server is closing (either the heartbeat failed or Close() was
 		// called, exit out of the connection handler loop.
 		case <-ctx.Done():
@@ -653,7 +697,7 @@ func (s *Server) rejectChannel(chans <-chan ssh.NewChannel, errMessage string) {
 	}
 }
 
-func (s *Server) handleGlobalRequest(req *ssh.Request) {
+func (s *Server) handleGlobalRequest(ctx context.Context, req *ssh.Request) {
 	// Version requests are internal Teleport requests, they should not be
 	// forwarded to the remote server.
 	if req.Type == teleport.VersionRequest {
@@ -664,7 +708,7 @@ func (s *Server) handleGlobalRequest(req *ssh.Request) {
 		return
 	}
 
-	ok, payload, err := s.remoteClient.SendRequest(req.Type, req.WantReply, req.Payload)
+	ok, payload, err := s.remoteClient.SendRequest(ctx, req.Type, req.WantReply, req.Payload)
 	if err != nil {
 		s.log.Warnf("Failed to forward global request %v: %v", req.Type, err)
 		return
@@ -682,6 +726,22 @@ func (s *Server) handleChannel(ctx context.Context, nch ssh.NewChannel) {
 	channelType := nch.ChannelType()
 
 	switch channelType {
+	// Channels of type "tracing-request" are sent to determine if ssh tracing envelopes
+	// are supported. Accepting the channel indicates to clients that they may wrap their
+	// ssh payload with tracing context.
+	case tracessh.TracingChannel:
+		ch, _, err := nch.Accept()
+		if err != nil {
+			if err := nch.Reject(ssh.ConnectionFailed, err.Error()); err != nil {
+				s.log.Warnf("Unable to reject %q channel: %v", nch.ChannelType(), err)
+			}
+			return
+		}
+
+		if err := ch.Close(); err != nil {
+			s.log.Warnf("Unable to close %q channel: %v", nch.ChannelType(), err)
+		}
+		return
 	// Channels of type "session" handle requests that are involved in running
 	// commands on a server, subsystem requests, and agent forwarding.
 	case teleport.ChanSession:
@@ -742,7 +802,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ch ssh.Channel, r
 	defer s.log.Debugf("Completing direct-tcpip request from %v to %v in context %v.", scx.SrcAddr, scx.DstAddr, scx.ID())
 
 	// Create "direct-tcpip" channel from the remote host to the target host.
-	conn, err := s.remoteClient.Dial("tcp", scx.DstAddr)
+	conn, err := s.remoteClient.DialContext(ctx, "tcp", scx.DstAddr)
 	if err != nil {
 		scx.Infof("Failed to connect to: %v: %v", scx.DstAddr, err)
 		return
@@ -880,8 +940,22 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 				scx.Debugf("Client %v disconnected", s.sconn.RemoteAddr())
 				return
 			}
+
+			reqCtx := tracessh.ContextFromRequest(req)
+			ctx, span := s.tracerProvider.Tracer("ssh").Start(
+				oteltrace.ContextWithRemoteSpanContext(ctx, oteltrace.SpanContextFromContext(reqCtx)),
+				fmt.Sprintf("ssh.Forward.SessionRequest/%s", req.Type),
+				oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+				oteltrace.WithAttributes(
+					semconv.RPCServiceKey.String("ssh.ForwardServer"),
+					semconv.RPCMethodKey.String("SessionRequest"),
+					semconv.RPCSystemKey.String("ssh"),
+				),
+			)
+
 			if err := s.dispatch(ctx, ch, req, scx); err != nil {
 				s.replyError(ch, req, err)
+				span.End()
 				return
 			}
 			if req.WantReply {
@@ -889,6 +963,7 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 					scx.Errorf("failed sending OK response on %q request: %v", req.Type, err)
 				}
 			}
+			span.End()
 		case result := <-scx.ExecResultCh:
 			scx.Debugf("Exec request (%q) complete: %v", result.Command, result.Code)
 

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -732,8 +732,9 @@ func (s *Server) handleChannel(ctx context.Context, nch ssh.NewChannel) {
 	case tracessh.TracingChannel:
 		ch, _, err := nch.Accept()
 		if err != nil {
-			if err := nch.Reject(ssh.ConnectionFailed, err.Error()); err != nil {
-				s.log.Warnf("Unable to reject %q channel: %v", nch.ChannelType(), err)
+			s.log.Warnf("Unable to accept channel: %v", err)
+			if err := nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err)); err != nil {
+				s.log.Warnf("Failed to reject channel: %v", err)
 			}
 			return
 		}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -188,7 +188,7 @@ type Server struct {
 	// utmpPath is the path to the user accounting database.
 	utmpPath string
 
-	// wtmpPath is the path to the user accounting log.
+	// wtmpPath is the path to the user accounting s.Logger.
 	wtmpPath string
 
 	// allowTCPForwarding indicates whether the ssh server is allowed to offer
@@ -820,7 +820,7 @@ func New(addr utils.NetAddr,
 
 	var heartbeat srv.HeartbeatI
 	if heartbeatMode == srv.HeartbeatModeNode && s.inventoryHandle != nil {
-		log.Info("debug -> starting control-stream based heartbeat.")
+		s.Logger.Info("debug -> starting control-stream based heartbeat.")
 		heartbeat, err = srv.NewSSHServerHeartbeat(srv.SSHServerHeartbeatConfig{
 			InventoryHandle: s.inventoryHandle,
 			GetServer:       s.getServerInfo,
@@ -828,7 +828,7 @@ func New(addr utils.NetAddr,
 			OnHeartbeat:     s.onHeartbeat,
 		})
 	} else {
-		log.Info("debug -> starting legacy heartbeat.")
+		s.Logger.Info("debug -> starting legacy heartbeat.")
 		heartbeat, err = srv.NewHeartbeat(srv.HeartbeatConfig{
 			Mode:            heartbeatMode,
 			Context:         ctx,
@@ -919,7 +919,7 @@ func (s *Server) AdvertiseAddr() string {
 	_, port, _ := net.SplitHostPort(listenAddr)
 	ahost, aport, err := utils.ParseAdvertiseAddr(advertiseAddr.String())
 	if err != nil {
-		log.Warningf("Failed to parse advertise address %q, %v, using default value %q.", advertiseAddr, err, listenAddr)
+		s.Logger.Warningf("Failed to parse advertise address %q, %v, using default value %q.", advertiseAddr, err, listenAddr)
 		return listenAddr
 	}
 	if aport == "" {
@@ -995,7 +995,7 @@ func (s *Server) getServerInfo() *types.ServerV2 {
 		rotation, err := s.getRotation(s.getRole())
 		if err != nil {
 			if !trace.IsNotFound(err) {
-				log.Warningf("Failed to get rotation state: %v", err)
+				s.Logger.Warningf("Failed to get rotation state: %v", err)
 			}
 		} else {
 			server.SetRotation(*rotation)
@@ -1067,10 +1067,10 @@ func (s *Server) HandleRequest(ctx context.Context, r *ssh.Request) {
 	default:
 		if r.WantReply {
 			if err := r.Reply(false, nil); err != nil {
-				log.Warnf("Failed to reply to %q request: %v", r.Type, err)
+				s.Logger.Warnf("Failed to reply to %q request: %v", r.Type, err)
 			}
 		}
-		log.Debugf("Discarding %q global request: %+v", r.Type, r)
+		s.Logger.Debugf("Discarding %q global request: %+v", r.Type, r)
 	}
 }
 
@@ -1112,7 +1112,7 @@ func (s *Server) HandleNewConn(ctx context.Context, ccx *sshutils.ConnectionCont
 	if lockErr := s.lockWatcher.CheckLockInForce(lockingMode, lockTargets...); lockErr != nil {
 		event.Reason = lockErr.Error()
 		if err := s.EmitAuditEvent(s.ctx, event); err != nil {
-			log.WithError(err).Warn("Failed to emit session reject event.")
+			s.Logger.WithError(err).Warn("Failed to emit session reject event.")
 		}
 		return ctx, trace.Wrap(lockErr)
 	}
@@ -1151,7 +1151,7 @@ func (s *Server) HandleNewConn(ctx context.Context, ccx *sshutils.ConnectionCont
 			event.Reason = events.SessionRejectedEvent
 			event.Maximum = maxConnections
 			if err := s.EmitAuditEvent(s.ctx, event); err != nil {
-				log.WithError(err).Warn("Failed to emit session reject event.")
+				s.Logger.WithError(err).Warn("Failed to emit session reject event.")
 			}
 			err = trace.AccessDenied("too many concurrent ssh connections for user %q (max=%d)",
 				identityContext.TeleportUser,
@@ -1191,13 +1191,14 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 		case tracessh.TracingChannel:
 			ch, _, err := nch.Accept()
 			if err != nil {
-				if err := nch.Reject(ssh.ConnectionFailed, err.Error()); err != nil {
-					log.Warnf("Unable to reject %q channel: %v", nch.ChannelType(), err)
+				s.Logger.Warnf("Unable to accept channel: %v", err)
+				if err := nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err)); err != nil {
+					s.Logger.Warnf("Failed to reject channel: %v", err)
 				}
 				return
 			}
 			if err := ch.Close(); err != nil {
-				log.Warnf("Unable to close %q channel: %v", nch.ChannelType(), err)
+				s.Logger.Warnf("Unable to close %q channel: %v", nch.ChannelType(), err)
 			}
 			return
 		// Channels of type "direct-tcpip", for proxies, it's equivalent
@@ -1205,13 +1206,13 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 		case teleport.ChanDirectTCPIP:
 			req, err := sshutils.ParseDirectTCPIPReq(nch.ExtraData())
 			if err != nil {
-				log.Errorf("Failed to parse request data: %v, err: %v.", string(nch.ExtraData()), err)
+				s.Logger.Errorf("Failed to parse request data: %v, err: %v.", string(nch.ExtraData()), err)
 				rejectChannel(nch, ssh.UnknownChannelType, "failed to parse direct-tcpip request")
 				return
 			}
 			ch, _, err := nch.Accept()
 			if err != nil {
-				log.Warnf("Unable to accept channel: %v.", err)
+				s.Logger.Warnf("Unable to accept channel: %v.", err)
 				rejectChannel(nch, ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 				return
 			}
@@ -1223,7 +1224,7 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 		case teleport.ChanSession:
 			ch, requests, err := nch.Accept()
 			if err != nil {
-				log.Warnf("Unable to accept channel: %v.", err)
+				s.Logger.Warnf("Unable to accept channel: %v.", err)
 				rejectChannel(nch, ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 				return
 			}
@@ -1243,13 +1244,13 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 		ch, _, err := nch.Accept()
 		if err != nil {
 			if err := nch.Reject(ssh.ConnectionFailed, err.Error()); err != nil {
-				log.Warnf("Unable to reject %q channel: %v", nch.ChannelType(), err)
+				s.Logger.Warnf("Unable to reject %q channel: %v", nch.ChannelType(), err)
 			}
 			return
 		}
 
 		if err := ch.Close(); err != nil {
-			log.Warnf("Unable to close %q channel: %v", nch.ChannelType(), err)
+			s.Logger.Warnf("Unable to close %q channel: %v", nch.ChannelType(), err)
 		}
 		return
 	// Channels of type "session" handle requests that are involved in running
@@ -1278,7 +1279,7 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 					Reason:  events.SessionRejectedReasonMaxSessions,
 					Maximum: max,
 				}); err != nil {
-					log.WithError(err).Warn("Failed to emit session reject event.")
+					s.Logger.WithError(err).Warn("Failed to emit session reject event.")
 				}
 				rejectChannel(nch, ssh.Prohibited, fmt.Sprintf("too many session channels for user %q (max=%d)", identityContext.TeleportUser, max))
 				return
@@ -1287,7 +1288,7 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 		}
 		ch, requests, err := nch.Accept()
 		if err != nil {
-			log.Warnf("Unable to accept channel: %v.", err)
+			s.Logger.Warnf("Unable to accept channel: %v.", err)
 			rejectChannel(nch, ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 			if decr != nil {
 				decr()
@@ -1304,13 +1305,13 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 	case teleport.ChanDirectTCPIP:
 		req, err := sshutils.ParseDirectTCPIPReq(nch.ExtraData())
 		if err != nil {
-			log.Errorf("Failed to parse request data: %v, err: %v.", string(nch.ExtraData()), err)
+			s.Logger.Errorf("Failed to parse request data: %v, err: %v.", string(nch.ExtraData()), err)
 			rejectChannel(nch, ssh.UnknownChannelType, "failed to parse direct-tcpip request")
 			return
 		}
 		ch, _, err := nch.Accept()
 		if err != nil {
-			log.Warnf("Unable to accept channel: %v.", err)
+			s.Logger.Warnf("Unable to accept channel: %v.", err)
 			rejectChannel(nch, ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 			return
 		}
@@ -1355,10 +1356,10 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 	// forwarding is complete.
 	ctx, scx, err := srv.NewServerContext(ctx, ccx, s, identityContext)
 	if err != nil {
-		log.WithError(err).Error("Unable to create connection context.")
+		s.Logger.WithError(err).Error("Unable to create connection context.")
 		writeStderr(channel, "Unable to create connection context.")
 		if err := channel.Close(); err != nil {
-			log.WithError(err).Warn("Failed to close channel.")
+			s.Logger.WithError(err).Warn("Failed to close channel.")
 		}
 		return
 	}
@@ -1396,13 +1397,13 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 	// parent and child.
 	pr, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Errorf("Failed to setup stdout pipe: %v", err)
+		s.Logger.Errorf("Failed to setup stdout pipe: %v", err)
 		writeStderr(channel, err.Error())
 		return
 	}
 	pw, err := cmd.StdinPipe()
 	if err != nil {
-		log.Errorf("Failed to setup stdin pipe: %v", err)
+		s.Logger.Errorf("Failed to setup stdin pipe: %v", err)
 		writeStderr(channel, err.Error())
 		return
 	}
@@ -1441,7 +1442,7 @@ Loop:
 		select {
 		case err := <-errorCh:
 			if err != nil && err != io.EOF {
-				log.Warnf("Connection problem in \"direct-tcpip\" channel: %v %T.", trace.DebugReport(err), err)
+				s.Logger.Warnf("Connection problem in \"direct-tcpip\" channel: %v %T.", trace.DebugReport(err), err)
 			}
 		case <-ctx.Done():
 			break Loop
@@ -1471,7 +1472,7 @@ Loop:
 			Success: true,
 		},
 	}); err != nil {
-		log.WithError(err).Warn("Failed to emit port forward event.")
+		s.Logger.WithError(err).Warn("Failed to emit port forward event.")
 	}
 }
 
@@ -1481,7 +1482,7 @@ Loop:
 func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.ConnectionContext, identityContext srv.IdentityContext, ch ssh.Channel, in <-chan *ssh.Request) {
 	netConfig, err := s.GetAccessPoint().GetClusterNetworkingConfig(ctx)
 	if err != nil {
-		log.Errorf("Unable to fetch cluster networking config: %v.", err)
+		s.Logger.Errorf("Unable to fetch cluster networking config: %v.", err)
 		writeStderr(ch, "Unable to fetch cluster networking configuration.")
 		return
 	}
@@ -1493,10 +1494,10 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 		cfg.MessageWriter = &stderrWriter{channel: ch}
 	})
 	if err != nil {
-		log.WithError(err).Error("Unable to create connection context.")
+		s.Logger.WithError(err).Error("Unable to create connection context.")
 		writeStderr(ch, "Unable to create connection context.")
 		if err := ch.Close(); err != nil {
-			log.WithError(err).Warn("Failed to close channel.")
+			s.Logger.WithError(err).Warn("Failed to close channel.")
 		}
 		return
 	}
@@ -1569,7 +1570,7 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 			}
 			if req.WantReply {
 				if err := req.Reply(true, nil); err != nil {
-					log.Warnf("Failed to reply to %q request: %v", req.Type, err)
+					s.Logger.Warnf("Failed to reply to %q request: %v", req.Type, err)
 				}
 			}
 			span.End()
@@ -1585,7 +1586,7 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 
 			return
 		case <-ctx.Done():
-			log.Debugf("Closing session due to cancellation.")
+			s.Logger.Debugf("Closing session due to cancellation.")
 			return
 		}
 	}
@@ -1612,7 +1613,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			// recording proxy mode.
 			err := s.handleAgentForwardProxy(req, serverContext)
 			if err != nil {
-				log.Warn(err)
+				s.Logger.Warn(err)
 			}
 			return nil
 		case sshutils.PuTTYSimpleRequest:
@@ -1620,7 +1621,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			// as a proxy to indicate that it's in "simple" node and won't be requesting any other channels.
 			// As we don't support this request, we ignore it.
 			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
-			log.Debugf("%v: deliberately ignoring request for '%v' channel", s.Component(), sshutils.PuTTYSimpleRequest)
+			s.Logger.Debugf("%v: deliberately ignoring request for '%v' channel", s.Component(), sshutils.PuTTYSimpleRequest)
 			return nil
 		default:
 			return trace.BadParameter(
@@ -1660,7 +1661,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			// processing requests.
 			err := s.handleAgentForwardNode(req, serverContext)
 			if err != nil {
-				log.Warn(err)
+				s.Logger.Warn(err)
 			}
 			return nil
 		default:
@@ -1702,7 +1703,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		// processing requests.
 		err := s.handleAgentForwardNode(req, serverContext)
 		if err != nil {
-			log.Warn(err)
+			s.Logger.Warn(err)
 		}
 		return nil
 	default:
@@ -1787,12 +1788,12 @@ func (s *Server) handleX11Forward(ch ssh.Channel, req *ssh.Request, ctx *srv.Ser
 		}
 		if trace.IsAccessDenied(err) {
 			// denied X11 requests are ok from a protocol perspective so we
-			// don't return them, just reply over ssh and emit the audit log.
+			// don't return them, just reply over ssh and emit the audit s.Logger.
 			s.replyError(ch, req, err)
 			err = nil
 		}
 		if err := s.EmitAuditEvent(s.ctx, event); err != nil {
-			log.WithError(err).Warn("Failed to emit x11-forward event.")
+			s.Logger.WithError(err).Warn("Failed to emit x11-forward event.")
 		}
 	}()
 
@@ -1837,7 +1838,7 @@ func (s *Server) handleSubsystem(ctx context.Context, ch ssh.Channel, req *ssh.R
 	}
 	go func() {
 		err := sb.Wait()
-		log.Debugf("Subsystem %v finished with result: %v.", sb, err)
+		s.Logger.Debugf("Subsystem %v finished with result: %v.", sb, err)
 		serverContext.SendSubsystemResult(srv.SubsystemResult{Err: trace.Wrap(err)})
 	}()
 	return nil
@@ -1857,18 +1858,18 @@ func (s *Server) handleEnv(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerCont
 
 // handleKeepAlive accepts and replies to keepalive@openssh.com requests.
 func (s *Server) handleKeepAlive(req *ssh.Request) {
-	log.Debugf("Received %q: WantReply: %v", req.Type, req.WantReply)
+	s.Logger.Debugf("Received %q: WantReply: %v", req.Type, req.WantReply)
 
 	// only reply if the sender actually wants a response
 	if req.WantReply {
 		err := req.Reply(true, nil)
 		if err != nil {
-			log.Warnf("Unable to reply to %q request: %v", req.Type, err)
+			s.Logger.Warnf("Unable to reply to %q request: %v", req.Type, err)
 			return
 		}
 	}
 
-	log.Debugf("Replied to %q", req.Type)
+	s.Logger.Debugf("Replied to %q", req.Type)
 }
 
 // handleRecordingProxy responds to global out-of-band with a bool which
@@ -1876,7 +1877,7 @@ func (s *Server) handleKeepAlive(req *ssh.Request) {
 func (s *Server) handleRecordingProxy(req *ssh.Request) {
 	var recordingProxy bool
 
-	log.Debugf("Global request (%v, %v) received", req.Type, req.WantReply)
+	s.Logger.Debugf("Global request (%v, %v) received", req.Type, req.WantReply)
 
 	if req.WantReply {
 		// get the cluster config, if we can't get it, reply false
@@ -1884,7 +1885,7 @@ func (s *Server) handleRecordingProxy(req *ssh.Request) {
 		if err != nil {
 			err := req.Reply(false, nil)
 			if err != nil {
-				log.Warnf("Unable to respond to global request (%v, %v): %v", req.Type, req.WantReply, err)
+				s.Logger.Warnf("Unable to respond to global request (%v, %v): %v", req.Type, req.WantReply, err)
 			}
 			return
 		}
@@ -1894,19 +1895,19 @@ func (s *Server) handleRecordingProxy(req *ssh.Request) {
 		recordingProxy = services.IsRecordAtProxy(recConfig.GetMode())
 		err = req.Reply(true, []byte(strconv.FormatBool(recordingProxy)))
 		if err != nil {
-			log.Warnf("Unable to respond to global request (%v, %v): %v: %v", req.Type, req.WantReply, recordingProxy, err)
+			s.Logger.Warnf("Unable to respond to global request (%v, %v): %v: %v", req.Type, req.WantReply, recordingProxy, err)
 			return
 		}
 	}
 
-	log.Debugf("Replied to global request (%v, %v): %v", req.Type, req.WantReply, recordingProxy)
+	s.Logger.Debugf("Replied to global request (%v, %v): %v", req.Type, req.WantReply, recordingProxy)
 }
 
 // handleVersionRequest replies with the Teleport version of the server.
 func (s *Server) handleVersionRequest(req *ssh.Request) {
 	err := req.Reply(true, []byte(teleport.Version))
 	if err != nil {
-		log.Debugf("Failed to reply to version request: %v.", err)
+		s.Logger.Debugf("Failed to reply to version request: %v.", err)
 	}
 }
 
@@ -1916,10 +1917,10 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 	// session request is complete.
 	ctx, scx, err := srv.NewServerContext(ctx, ccx, s, identityContext)
 	if err != nil {
-		log.WithError(err).Error("Unable to create connection context.")
+		s.Logger.WithError(err).Error("Unable to create connection context.")
 		writeStderr(ch, "Unable to create connection context.")
 		if err := ch.Close(); err != nil {
-			log.WithError(err).Warn("Failed to close channel.")
+			s.Logger.WithError(err).Warn("Failed to close channel.")
 		}
 		return
 	}
@@ -1931,7 +1932,7 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 
 	recConfig, err := s.GetAccessPoint().GetSessionRecordingConfig(ctx)
 	if err != nil {
-		log.Errorf("Unable to fetch session recording config: %v.", err)
+		s.Logger.Errorf("Unable to fetch session recording config: %v.", err)
 		writeStderr(ch, "Unable to fetch session recording configuration.")
 		return
 	}
@@ -1964,7 +1965,7 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 	if services.IsRecordAtProxy(recConfig.GetMode()) {
 		err = s.handleAgentForwardProxy(&ssh.Request{}, scx)
 		if err != nil {
-			log.Warningf("Failed to request agent in recording mode: %v", err)
+			s.Logger.Warningf("Failed to request agent in recording mode: %v", err)
 			writeStderr(ch, "Failed to request agent")
 			return
 		}
@@ -1972,7 +1973,7 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 
 	netConfig, err := s.GetAccessPoint().GetClusterNetworkingConfig(ctx)
 	if err != nil {
-		log.Errorf("Unable to fetch cluster networking config: %v.", err)
+		s.Logger.Errorf("Unable to fetch cluster networking config: %v.", err)
 		writeStderr(ch, "Unable to fetch cluster networking configuration.")
 		return
 	}
@@ -1995,13 +1996,13 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 		port: fmt.Sprintf("%v", req.Port),
 	})
 	if err != nil {
-		log.Errorf("Unable instantiate proxy subsystem: %v.", err)
+		s.Logger.Errorf("Unable instantiate proxy subsystem: %v.", err)
 		writeStderr(ch, "Unable to instantiate proxy subsystem.")
 		return
 	}
 
 	if err := subsys.Start(ctx, scx.ServerConn, ch, &ssh.Request{}, scx); err != nil {
-		log.Errorf("Unable to start proxy subsystem: %v.", err)
+		s.Logger.Errorf("Unable to start proxy subsystem: %v.", err)
 		writeStderr(ch, "Unable to start proxy subsystem.")
 		return
 	}
@@ -2010,7 +2011,7 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 	go func() {
 		defer close(wch)
 		if err := subsys.Wait(); err != nil {
-			log.Errorf("Proxy subsystem failed: %v.", err)
+			s.Logger.Errorf("Proxy subsystem failed: %v.", err)
 			writeStderr(ch, "Proxy subsystem failed.")
 		}
 	}()
@@ -2021,7 +2022,7 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 }
 
 func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
-	log.Error(err)
+	s.Logger.Error(err)
 	// Terminate the error with a newline when writing to remote channel's
 	// stderr so the output does not mix with the rest of the output if the remote
 	// side is not doing additional formatting for extended data.
@@ -2030,7 +2031,7 @@ func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
 	writeStderr(ch, message)
 	if req.WantReply {
 		if err := req.Reply(false, []byte(message)); err != nil {
-			log.Warnf("Failed to reply to %q request: %v", req.Type, err)
+			s.Logger.Warnf("Failed to reply to %q request: %v", req.Type, err)
 		}
 	}
 }

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -33,15 +33,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport/api/breaker"
 	"github.com/mailgun/timetools"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
@@ -92,7 +93,7 @@ type sshInfo struct {
 	srvAddress     string
 	srvPort        string
 	srvHostPort    string
-	clt            *ssh.Client
+	clt            *tracessh.Client
 	cltConfig      *ssh.ClientConfig
 	assertCltClose require.ErrorAssertionFunc
 }
@@ -247,7 +248,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 		HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", sshSrv.Addr(), cltConfig)
+	client, err := tracessh.Dial(ctx, "tcp", sshSrv.Addr(), cltConfig)
 	require.NoError(t, err)
 
 	f := &sshTestFixture{
@@ -268,7 +269,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 	}
 
 	t.Cleanup(func() { f.ssh.assertCltClose(t, client.Close()) })
-	require.NoError(t, agent.ForwardToAgent(client, keyring))
+	require.NoError(t, agent.ForwardToAgent(client.Client, keyring))
 	return f
 }
 
@@ -342,7 +343,7 @@ func TestInactivityTimeout(t *testing.T) {
 	// so change the assertion on closing the client to expect it to fail
 	f.ssh.assertCltClose = require.Error
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(context.Background())
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -382,7 +383,7 @@ func TestLockInForce(t *testing.T) {
 	// so change the assertion on closing the client to expect it to fail.
 	f.ssh.assertCltClose = require.Error
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 
 	stderr, err := se.StderrPipe()
@@ -418,23 +419,23 @@ func TestLockInForce(t *testing.T) {
 	require.Equal(t, lockInForceMsg, string(text))
 
 	// As long as the lock is in force, new sessions cannot be opened.
-	newClient, err := ssh.Dial("tcp", f.ssh.srvAddress, f.ssh.cltConfig)
+	newClient, err := tracessh.Dial(ctx, "tcp", f.ssh.srvAddress, f.ssh.cltConfig)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		// The client is expected to be closed by the lock monitor therefore expect
 		// an error on this second attempt.
 		require.Error(t, newClient.Close())
 	})
-	_, err = newClient.NewSession()
+	_, err = newClient.NewSession(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), lockInForceMsg)
 
 	// Once the lock is lifted, new sessions should go through without error.
 	require.NoError(t, f.testSrv.Auth().DeleteLock(ctx, "test-lock"))
-	newClient2, err := ssh.Dial("tcp", f.ssh.srvAddress, f.ssh.cltConfig)
+	newClient2, err := tracessh.Dial(ctx, "tcp", f.ssh.srvAddress, f.ssh.cltConfig)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, newClient2.Close()) })
-	_, err = newClient2.NewSession()
+	_, err = newClient2.NewSession(context.Background())
 	require.NoError(t, err)
 }
 
@@ -461,7 +462,7 @@ func TestDirectTCPIP(t *testing.T) {
 	httpClient := http.Client{
 		Transport: &http.Transport{
 			Dial: func(network string, addr string) (net.Conn, error) {
-				return f.ssh.clt.Dial("tcp", u.Host)
+				return f.ssh.clt.DialContext(context.Background(), "tcp", u.Host)
 			},
 		},
 	}
@@ -524,7 +525,7 @@ func TestAgentForwardPermission(t *testing.T) {
 	role.SetOptions(roleOptions)
 	require.NoError(t, f.testSrv.Auth().UpsertRole(ctx, role))
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { se.Close() })
 
@@ -557,18 +558,18 @@ func TestMaxSessions(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := int64(0); i < maxSessions; i++ {
-		se, err := f.ssh.clt.NewSession()
+		se, err := f.ssh.clt.NewSession(ctx)
 		require.NoError(t, err)
 		defer se.Close()
 	}
 
-	_, err = f.ssh.clt.NewSession()
+	_, err = f.ssh.clt.NewSession(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "too many session channels")
 
 	// verify that max sessions does not affect max connections.
 	for i := int64(0); i <= maxSessions; i++ {
-		clt, err := ssh.Dial("tcp", f.ssh.srv.Addr(), f.ssh.cltConfig)
+		clt, err := tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), f.ssh.cltConfig)
 		require.NoError(t, err)
 		require.NoError(t, clt.Close())
 	}
@@ -586,7 +587,7 @@ func TestExecLongCommand(t *testing.T) {
 	echoPath, err := exec.LookPath("echo")
 	require.NoError(t, err)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(context.Background())
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -601,7 +602,7 @@ func TestOpenExecSessionSetsSession(t *testing.T) {
 	t.Parallel()
 	f := newFixtureWithoutDiskBasedLogging(t)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(context.Background())
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -627,7 +628,7 @@ func TestAgentForward(t *testing.T) {
 	err = f.testSrv.Auth().UpsertRole(ctx, role)
 	require.NoError(t, err)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { se.Close() })
 
@@ -677,7 +678,7 @@ func TestAgentForward(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	client, err := tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	err = client.Close()
 	require.NoError(t, err)
@@ -737,7 +738,7 @@ func TestX11Forward(t *testing.T) {
 	// concurrent X11 sessions.
 	serverDisplay := x11EchoSession(ctx, t, f.ssh.clt)
 
-	client2, err := ssh.Dial("tcp", f.ssh.srv.Addr(), f.ssh.cltConfig)
+	client2, err := tracessh.Dial(ctx, "tcp", f.ssh.srv.Addr(), f.ssh.cltConfig)
 	require.NoError(t, err)
 	serverDisplay2 := x11EchoSession(ctx, t, client2)
 
@@ -770,8 +771,8 @@ func TestX11Forward(t *testing.T) {
 // x11EchoSession creates a new ssh session and handles x11 forwarding for the session,
 // echoing XServer requests received back to the client. Returns the Display opened on the
 // session, which is set in $DISPLAY.
-func x11EchoSession(ctx context.Context, t *testing.T, clt *ssh.Client) x11.Display {
-	se, err := clt.NewSession()
+func x11EchoSession(ctx context.Context, t *testing.T, clt *tracessh.Client) x11.Display {
+	se, err := clt.NewSession(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(func() { se.Close() })
 
@@ -794,7 +795,7 @@ func x11EchoSession(ctx context.Context, t *testing.T, clt *ssh.Client) x11.Disp
 
 	// Handle any x11 channel requests received from the server
 	// and start x11 forwarding to the client display.
-	err = x11.ServeChannelRequests(ctx, clt, func(ctx context.Context, nch ssh.NewChannel) {
+	err = x11.ServeChannelRequests(ctx, clt.Client, func(ctx context.Context, nch ssh.NewChannel) {
 		sch, sin, err := nch.Accept()
 		require.NoError(t, err)
 		defer sch.Close()
@@ -892,7 +893,7 @@ func TestAllowedUsers(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	client, err := tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	require.NoError(t, client.Close())
 
@@ -906,7 +907,7 @@ func TestAllowedUsers(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	_, err = ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	_, err = tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), sshConfig)
 	require.Error(t, err)
 }
 
@@ -956,7 +957,7 @@ func TestAllowedLabels(t *testing.T) {
 				HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 			}
 
-			_, err = ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+			_, err = tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), sshConfig)
 			if tt.outError {
 				require.Error(t, err)
 			} else {
@@ -981,7 +982,7 @@ func TestKeyAlgorithms(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	_, err = ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	_, err = tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), sshConfig)
 	require.Error(t, err)
 }
 
@@ -989,7 +990,7 @@ func TestInvalidSessionID(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
 
-	session, err := f.ssh.clt.NewSession()
+	session, err := f.ssh.clt.NewSession(context.Background())
 	require.NoError(t, err)
 
 	err = session.Setenv(sshutils.SessionEnvVar, "foo")
@@ -1019,14 +1020,14 @@ func TestSessionHijack(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	client, err := tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	defer func() {
 		err := client.Close()
 		require.NoError(t, err)
 	}()
 
-	se, err := client.NewSession()
+	se, err := client.NewSession(context.Background())
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -1047,14 +1048,14 @@ func TestSessionHijack(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client2, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig2)
+	client2, err := tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), sshConfig2)
 	require.NoError(t, err)
 	defer func() {
 		err := client2.Close()
 		require.NoError(t, err)
 	}()
 
-	se2, err := client2.NewSession()
+	se2, err := client2.NewSession(context.Background())
 	require.NoError(t, err)
 	defer se2.Close()
 
@@ -1069,11 +1070,11 @@ func TestSessionHijack(t *testing.T) {
 // testClient dials targetAddr via proxyAddr and executes 2+3 command
 func testClient(t *testing.T, f *sshTestFixture, proxyAddr, targetAddr, remoteAddr string, sshConfig *ssh.ClientConfig) {
 	// Connect to node using registered address
-	client, err := ssh.Dial("tcp", proxyAddr, sshConfig)
+	client, err := tracessh.Dial(context.Background(), "tcp", proxyAddr, sshConfig)
 	require.NoError(t, err)
 	defer client.Close()
 
-	se, err := client.NewSession()
+	se, err := client.NewSession(context.Background())
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -1102,17 +1103,21 @@ func testClient(t *testing.T, f *sshTestFixture, proxyAddr, targetAddr, remoteAd
 	defer pipeNetConn.Close()
 
 	// Open SSH connection via TCP
-	conn, chans, reqs, err := ssh.NewClientConn(pipeNetConn,
-		f.ssh.srv.Addr(), sshConfig)
+	conn, chans, reqs, err := tracessh.NewClientConn(
+		context.Background(),
+		pipeNetConn,
+		f.ssh.srv.Addr(),
+		sshConfig,
+	)
 	require.NoError(t, err)
 	defer conn.Close()
 
 	// using this connection as regular SSH
-	client2 := ssh.NewClient(conn, chans, reqs)
+	client2 := tracessh.NewClient(conn, chans, reqs)
 	require.NoError(t, err)
 	defer client2.Close()
 
-	se2, err := client2.NewSession()
+	se2, err := client2.NewSession(context.Background())
 	require.NoError(t, err)
 	defer se2.Close()
 
@@ -1340,7 +1345,7 @@ func TestPTY(t *testing.T) {
 
 	f := newFixture(t)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(context.Background())
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -1357,7 +1362,7 @@ func TestEnv(t *testing.T) {
 
 	f := newFixture(t)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(context.Background())
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -1368,7 +1373,7 @@ func TestEnv(t *testing.T) {
 func TestNoAuth(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
-	_, err := ssh.Dial("tcp", f.ssh.srv.Addr(), &ssh.ClientConfig{})
+	_, err := tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), &ssh.ClientConfig{})
 	require.Error(t, err)
 }
 
@@ -1380,7 +1385,7 @@ func TestPasswordAuth(t *testing.T) {
 		Auth:            []ssh.AuthMethod{ssh.Password("")},
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
-	_, err := ssh.Dial("tcp", f.ssh.srv.Addr(), config)
+	_, err := tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), config)
 	require.Error(t, err)
 }
 
@@ -1393,11 +1398,11 @@ func TestClientDisconnect(t *testing.T) {
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(f.up.certSigner)},
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
-	clt, err := ssh.Dial("tcp", f.ssh.srv.Addr(), config)
+	clt, err := tracessh.Dial(context.Background(), "tcp", f.ssh.srv.Addr(), config)
 	require.NoError(t, err)
 	require.NotNil(t, clt)
 
-	se, err := f.ssh.clt.NewSession()
+	se, err := f.ssh.clt.NewSession(context.Background())
 	require.NoError(t, err)
 	require.NoError(t, se.Shell())
 	require.NoError(t, clt.Close())
@@ -1493,24 +1498,24 @@ func TestLimiter(t *testing.T) {
 		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	clt0, err := ssh.Dial("tcp", srv.Addr(), config)
+	clt0, err := tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.NoError(t, err)
 	require.NotNil(t, clt0)
 
-	se0, err := clt0.NewSession()
+	se0, err := clt0.NewSession(ctx)
 	require.NoError(t, err)
 	require.NoError(t, se0.Shell())
 
 	// current connections = 1
-	clt, err := ssh.Dial("tcp", srv.Addr(), config)
+	clt, err := tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.NoError(t, err)
 	require.NotNil(t, clt)
-	se, err := clt.NewSession()
+	se, err := clt.NewSession(ctx)
 	require.NoError(t, err)
 	require.NoError(t, se.Shell())
 
 	// current connections = 2
-	_, err = ssh.Dial("tcp", srv.Addr(), config)
+	_, err = tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.Error(t, err)
 
 	require.NoError(t, se.Close())
@@ -1521,15 +1526,15 @@ func TestLimiter(t *testing.T) {
 	require.Eventually(t, getWaitForNumberOfConnsFunc(t, limiter, "127.0.0.1", 1), time.Second*10, time.Millisecond*100)
 
 	// current connections = 1
-	clt, err = ssh.Dial("tcp", srv.Addr(), config)
+	clt, err = tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.NoError(t, err)
 	require.NotNil(t, clt)
-	se, err = clt.NewSession()
+	se, err = clt.NewSession(ctx)
 	require.NoError(t, err)
 	require.NoError(t, se.Shell())
 
 	// current connections = 2
-	_, err = ssh.Dial("tcp", srv.Addr(), config)
+	_, err = tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.Error(t, err)
 
 	require.NoError(t, se.Close())
@@ -1541,10 +1546,10 @@ func TestLimiter(t *testing.T) {
 
 	// current connections = 1
 	// requests rate should exceed now
-	clt, err = ssh.Dial("tcp", srv.Addr(), config)
+	clt, err = tracessh.Dial(ctx, "tcp", srv.Addr(), config)
 	require.NoError(t, err)
 	require.NotNil(t, clt)
-	_, err = clt.NewSession()
+	_, err = clt.NewSession(ctx)
 	require.Error(t, err)
 
 	clt.Close()
@@ -1556,7 +1561,7 @@ func TestLimiter(t *testing.T) {
 func TestServerAliveInterval(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
-	ok, _, err := f.ssh.clt.SendRequest(teleport.KeepAliveReqType, true, nil)
+	ok, _, err := f.ssh.clt.SendRequest(context.Background(), teleport.KeepAliveReqType, true, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 }
@@ -1578,7 +1583,7 @@ func TestGlobalRequestRecordingProxy(t *testing.T) {
 
 	// send the request again, we have cluster config and when we parse the
 	// response, it should be false because recording is occurring at the node.
-	ok, responseBytes, err := f.ssh.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
+	ok, responseBytes, err := f.ssh.clt.SendRequest(ctx, teleport.RecordingProxyReqType, true, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	response, err := strconv.ParseBool(string(responseBytes))
@@ -1596,7 +1601,7 @@ func TestGlobalRequestRecordingProxy(t *testing.T) {
 	// send request again, now that we have cluster config and it's set to record
 	// at the proxy, we should return true and when we parse the payload it should
 	// also be true
-	ok, responseBytes, err = f.ssh.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
+	ok, responseBytes, err = f.ssh.clt.SendRequest(ctx, teleport.RecordingProxyReqType, true, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	response, err = strconv.ParseBool(string(responseBytes))
@@ -1691,70 +1696,77 @@ func newRawNode(t *testing.T, authSrv *auth.Server) *rawNode {
 // X11 forwarding request and then dials a single X11 channel which echoes all bytes written
 // to it.  Used to verify the behavior of X11 forwarding in recording proxies. Returns a
 // node and an error channel that can be monitored for asynchronous failures.
-func startX11EchoServer(ctx context.Context, t *testing.T, authSrv *auth.Server) (*rawNode, <-chan error) {
-	node := newRawNode(t, authSrv)
-
-	sessionMain := func(ctx context.Context, conn *ssh.ServerConn, chs <-chan ssh.NewChannel) error {
-		defer conn.Close()
-
-		// expect client to open a session channel
-		var nch ssh.NewChannel
-		select {
-		case nch = <-chs:
-		case <-time.After(time.Second * 3):
-			return trace.LimitExceeded("Timeout waiting for session channel")
-		case <-ctx.Done():
-			return nil
-		}
-		if nch.ChannelType() != teleport.ChanSession {
-			return trace.BadParameter("Unexpected channel type: %q", nch.ChannelType())
-		}
-
-		sch, creqs, err := nch.Accept()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer sch.Close()
-
-		// expect client to send an X11 forwarding request
-		var req *ssh.Request
-		select {
-		case req = <-creqs:
-		case <-time.After(time.Second * 3):
-			return trace.LimitExceeded("Timeout waiting for X11 forwarding request")
-		case <-ctx.Done():
-			return nil
-		}
-
-		if req.Type != sshutils.X11ForwardRequest {
-			return trace.BadParameter("Unexpected request type %q", req.Type)
-		}
-
-		if err = req.Reply(true, nil); err != nil {
-			return trace.Wrap(err)
-		}
-
-		// start a fake X11 channel
-		xch, _, err := conn.OpenChannel(sshutils.X11ChannelRequest, nil)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		defer xch.Close()
-
-		// echo all bytes back across the X11 channel
-		_, err = io.Copy(xch, xch)
-		if err == nil {
-			xch.CloseWrite()
-		} else {
-			log.Errorf("X11 channel error: %v", err)
-		}
-
+// x11Handler handles requests received by the x11 echo server
+func x11Handler(ctx context.Context, conn *ssh.ServerConn, chs <-chan ssh.NewChannel) error {
+	// expect client to open a session channel
+	var nch ssh.NewChannel
+	select {
+	case nch = <-chs:
+	case <-time.After(time.Second * 3):
+		return trace.LimitExceeded("Timeout waiting for session channel")
+	case <-ctx.Done():
 		return nil
 	}
 
-	errorCh := make(chan error, 1)
+	if nch.ChannelType() == tracessh.TracingChannel {
+		nch.Reject(ssh.UnknownChannelType, "")
+		return x11Handler(ctx, conn, chs)
+	}
 
-	nodeMain := func() {
+	if nch.ChannelType() != teleport.ChanSession {
+		return trace.BadParameter("Unexpected channel type: %q", nch.ChannelType())
+	}
+
+	sch, creqs, err := nch.Accept()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer sch.Close()
+
+	// expect client to send an X11 forwarding request
+	var req *ssh.Request
+	select {
+	case req = <-creqs:
+	case <-time.After(time.Second * 3):
+		return trace.LimitExceeded("Timeout waiting for X11 forwarding request")
+	case <-ctx.Done():
+		return nil
+	}
+
+	if req.Type != sshutils.X11ForwardRequest {
+		return trace.BadParameter("Unexpected request type %q", req.Type)
+	}
+
+	if err = req.Reply(true, nil); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// start a fake X11 channel
+	xch, _, err := conn.OpenChannel(sshutils.X11ChannelRequest, nil)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer xch.Close()
+
+	// echo all bytes back across the X11 channel
+	_, err = io.Copy(xch, xch)
+	if err == nil {
+		xch.CloseWrite()
+	} else {
+		log.Errorf("X11 channel error: %v", err)
+	}
+
+	return nil
+}
+
+// startX11EchoServer starts a fake node which, for each incoming SSH connection, accepts an
+// X11 forwarding request and then dials a single X11 channel which echoes all bytes written
+// to it. Used to verify the behavior of X11 forwarding in recording proxies. Returns a
+// node and an error channel that can be monitored for asynchronous failures.
+func startX11EchoServer(ctx context.Context, t *testing.T, authSrv *auth.Server) (*rawNode, <-chan error) {
+	node := newRawNode(t, authSrv)
+	errorCh := make(chan error, 1)
+	go func() {
 		for {
 			conn, chs, _, err := node.accept()
 			if err != nil {
@@ -1762,14 +1774,13 @@ func startX11EchoServer(ctx context.Context, t *testing.T, authSrv *auth.Server)
 				return
 			}
 			go func() {
-				if err := sessionMain(ctx, conn, chs); err != nil {
+				if err := x11Handler(ctx, conn, chs); err != nil {
 					errorCh <- err
 				}
+				conn.Close()
 			}()
 		}
-	}
-
-	go nodeMain()
+	}()
 
 	return node, errorCh
 }
@@ -1828,7 +1839,7 @@ func TestX11ProxySupport(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify that the proxy is in recording mode
-	ok, responseBytes, err := f.ssh.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
+	ok, responseBytes, err := f.ssh.clt.SendRequest(ctx, teleport.RecordingProxyReqType, true, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	response, err := strconv.ParseBool(string(responseBytes))
@@ -1849,7 +1860,7 @@ func TestX11ProxySupport(t *testing.T) {
 	defer x11Cancel()
 
 	// Create a direct TCP/IP connection from proxy to our X11 test server.
-	netConn, err := f.ssh.clt.Dial("tcp", node.addr)
+	netConn, err := f.ssh.clt.DialContext(x11Ctx, "tcp", node.addr)
 	require.NoError(t, err)
 	defer netConn.Close()
 
@@ -1859,11 +1870,11 @@ func TestX11ProxySupport(t *testing.T) {
 	cltConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 
 	// Perform ssh handshake and setup client for X11 test server.
-	cltConn, chs, reqs, err := ssh.NewClientConn(netConn, node.addr, &cltConfig)
+	cltConn, chs, reqs, err := tracessh.NewClientConn(ctx, netConn, node.addr, &cltConfig)
 	require.NoError(t, err)
-	clt := ssh.NewClient(cltConn, chs, reqs)
+	clt := tracessh.NewClient(cltConn, chs, reqs)
 
-	sess, err := clt.NewSession()
+	sess, err := clt.NewSession(ctx)
 	require.NoError(t, err)
 
 	// register X11 channel handler before requesting forwarding to avoid races
@@ -1982,12 +1993,12 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	// Connect SSH client to proxy
-	client, err := ssh.Dial("tcp", proxy.Addr(), sshConfig)
+	client, err := tracessh.Dial(ctx, "tcp", proxy.Addr(), sshConfig)
 
 	require.NoError(t, err)
 	defer client.Close()
 
-	se, err := client.NewSession()
+	se, err := client.NewSession(ctx)
 	require.NoError(t, err)
 	defer se.Close()
 
@@ -2021,17 +2032,17 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	defer pipeNetConn.Close()
 
 	// Open SSH connection via proxy subsystem's TCP tunnel
-	conn, chans, reqs, err := ssh.NewClientConn(pipeNetConn,
+	conn, chans, reqs, err := tracessh.NewClientConn(ctx, pipeNetConn,
 		f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	defer conn.Close()
 
 	// Run commands over this connection like regular SSH
-	client2 := ssh.NewClient(conn, chans, reqs)
+	client2 := tracessh.NewClient(conn, chans, reqs)
 	require.NoError(t, err)
 	defer client2.Close()
 
-	se2, err := client2.NewSession()
+	se2, err := client2.NewSession(ctx)
 	require.NoError(t, err)
 	defer se2.Close()
 

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -551,8 +551,9 @@ func (s *Server) HandleConnection(conn net.Conn) {
 			if nch.ChannelType() == tracessh.TracingChannel {
 				ch, _, err := nch.Accept()
 				if err != nil {
-					if err := nch.Reject(ssh.ConnectionFailed, err.Error()); err != nil {
-						s.log.Warnf("Unable to reject %q channel: %v", nch.ChannelType(), err)
+					s.log.Warnf("Unable to accept channel: %v", err)
+					if err := nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err)); err != nil {
+						s.log.Warnf("Failed to reject channel: %v", err)
 					}
 					continue
 				}


### PR DESCRIPTION
Add tracing support for ssh global requests and  channels. Wrappers
for `ssh.Client`, `ssh.Channel`, and `ssh.NewChannel` provide a
mechanism for tracing context to be propagated via a `context.Context`.

In order to maintain backwards compatibility the ssh.Client wrapper
tries to open a TracingChannel when constructed. Any servers that
don't support tracing will reject the unknown channel. The client
will only provide tracing context to servers which do NOT reject
the TracingChannel request.

In order to include pass tracing context along all ssh payloads
are wrapped in an Envelope that includes the original payload
AND any tracing context. Servers now try to unmarshal all payloads
into said Envelope when processing messages. If there is an Envelope
provided, a new span will be created and the original payload will
be pass along to handlers.

Part of #12241