### PR TITLE
[v10] docs: remove duplicate code block of DB configure

### DIFF
--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -70,7 +70,7 @@ $ teleport db configure create \
 ```code
 $ teleport db configure create \
    -o file \
-   --proxy=mytenant.teleport.sh \
+   --proxy=mytenant.teleport.sh:443 \
    --token=/tmp/token \
    --rds-discovery=us-west-1
 ```


### PR DESCRIPTION
The documentation for DB access had a duplicate code block to configure and generate the database configurations which causes confusion.