### PR TITLE
WebAPI: return user traits

### DIFF
--- a/api/types/user.go
+++ b/api/types/user.go
@@ -44,6 +44,20 @@ type User interface {
 	SetLocalAuth(auth *LocalAuthSecrets)
 	// GetRoles returns a list of roles assigned to user
 	GetRoles() []string
+	// GetLogins gets the list of server logins/principals for the user
+	GetLogins() []string
+	// GetDBUsers gets the list of DB Users for the user
+	GetDBUsers() []string
+	// GetDBNames gets the list of DB Names for the user
+	GetDBNames() []string
+	// GetKubeUsers gets the list of Kubernetes Users for the user
+	GetKubeUsers() []string
+	// GetKubeGroups gets the list of Kubernetes Groups for the user
+	GetKubeGroups() []string
+	// GetWindowsLogins gets the list of Windows Logins for the user
+	GetWindowsLogins() []string
+	// GetAWSRoleARNs gets the list of AWS role ARNs for the user
+	GetAWSRoleARNs() []string
 	// String returns user
 	String() string
 	// GetStatus return user login status
@@ -307,6 +321,48 @@ func (u *UserV2) AddRole(name string) {
 		}
 	}
 	u.Spec.Roles = append(u.Spec.Roles, name)
+}
+
+func (u UserV2) getTrait(trait string) []string {
+	if u.Spec.Traits == nil {
+		return []string{}
+	}
+	return u.Spec.Traits[trait]
+}
+
+// GetLogins gets the list of server logins/principals for the user
+func (u UserV2) GetLogins() []string {
+	return u.getTrait(constants.TraitLogins)
+}
+
+// GetDBUsers gets the list of DB Users for the user
+func (u UserV2) GetDBUsers() []string {
+	return u.getTrait(constants.TraitDBUsers)
+}
+
+// GetDBNames gets the list of DB Names for the user
+func (u UserV2) GetDBNames() []string {
+	return u.getTrait(constants.TraitDBNames)
+}
+
+// GetKubeUsers gets the list of Kubernetes Users for the user
+func (u UserV2) GetKubeUsers() []string {
+	return u.getTrait(constants.TraitKubeUsers)
+}
+
+// GetKubeGroups gets the list of Kubernetes Groups for the user
+func (u UserV2) GetKubeGroups() []string {
+	return u.getTrait(constants.TraitKubeGroups)
+}
+
+// GetWindowsLogins gets the list of Windows Logins for the user
+func (u UserV2) GetWindowsLogins() []string {
+	return u.getTrait(constants.TraitWindowsLogins)
+}
+
+// GetAWSRoleARNs gets the list of AWS role ARNs for the user
+func (u UserV2) GetAWSRoleARNs() []string {
+	return u.getTrait(constants.TraitAWSRoleARNs)
 }
 
 func (u *UserV2) String() string {

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -46,10 +46,10 @@ type User interface {
 	GetRoles() []string
 	// GetLogins gets the list of server logins/principals for the user
 	GetLogins() []string
-	// GetDBUsers gets the list of DB Users for the user
-	GetDBUsers() []string
-	// GetDBNames gets the list of DB Names for the user
-	GetDBNames() []string
+	// GetDatabaseUsers gets the list of Database Users for the user
+	GetDatabaseUsers() []string
+	// GetDatabaseNames gets the list of Database Names for the user
+	GetDatabaseNames() []string
 	// GetKubeUsers gets the list of Kubernetes Users for the user
 	GetKubeUsers() []string
 	// GetKubeGroups gets the list of Kubernetes Groups for the user
@@ -74,10 +74,10 @@ type User interface {
 	AddRole(name string)
 	// SetLogins sets a list of server logins/principals for user
 	SetLogins(logins []string)
-	// SetDBUsers sets a list of DB Users for user
-	SetDBUsers(dbUsers []string)
-	// SetDBNames sets a list of DB Names for user
-	SetDBNames(dbNames []string)
+	// SetDatabaseUsers sets a list of Database Users for user
+	SetDatabaseUsers(databaseUsers []string)
+	// SetDatabaseNames sets a list of Database Names for user
+	SetDatabaseNames(databaseNames []string)
 	// SetKubeUsers sets a list of Kubernetes Users for user
 	SetKubeUsers(kubeUsers []string)
 	// SetKubeGroups sets a list of Kubernetes Groups for user
@@ -248,14 +248,14 @@ func (u *UserV2) SetLogins(logins []string) {
 	u.setTrait(constants.TraitLogins, logins)
 }
 
-// SetDBUsers sets the DBUsers trait for the user
-func (u *UserV2) SetDBUsers(dbUsers []string) {
-	u.setTrait(constants.TraitDBUsers, dbUsers)
+// SetDatabaseUsers sets the DatabaseUsers trait for the user
+func (u *UserV2) SetDatabaseUsers(databaseUsers []string) {
+	u.setTrait(constants.TraitDBUsers, databaseUsers)
 }
 
-// SetDBNames sets the DBNames trait for the user
-func (u *UserV2) SetDBNames(dbNames []string) {
-	u.setTrait(constants.TraitDBNames, dbNames)
+// SetDatabaseNames sets the DatabaseNames trait for the user
+func (u *UserV2) SetDatabaseNames(databaseNames []string) {
+	u.setTrait(constants.TraitDBNames, databaseNames)
 }
 
 // SetKubeUsers sets the KubeUsers trait for the user
@@ -335,13 +335,13 @@ func (u UserV2) GetLogins() []string {
 	return u.getTrait(constants.TraitLogins)
 }
 
-// GetDBUsers gets the list of DB Users for the user
-func (u UserV2) GetDBUsers() []string {
+// GetDatabaseUsers gets the list of DB Users for the user
+func (u UserV2) GetDatabaseUsers() []string {
 	return u.getTrait(constants.TraitDBUsers)
 }
 
-// GetDBNames gets the list of DB Names for the user
-func (u UserV2) GetDBNames() []string {
+// GetDatabaseNames gets the list of DB Names for the user
+func (u UserV2) GetDatabaseNames() []string {
 	return u.getTrait(constants.TraitDBNames)
 }
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -149,6 +149,7 @@ func RoleForUser(u types.User) types.Role {
 				types.NewRule(types.KindDatabase, RW()),
 				types.NewRule(types.KindLock, RW()),
 				types.NewRule(types.KindToken, RW()),
+				types.NewRule(types.KindUser, RW()),
 			},
 			JoinSessions: []*types.SessionJoinPolicy{
 				{

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -149,7 +149,6 @@ func RoleForUser(u types.User) types.Role {
 				types.NewRule(types.KindDatabase, RW()),
 				types.NewRule(types.KindLock, RW()),
 				types.NewRule(types.KindToken, RW()),
-				types.NewRule(types.KindUser, RW()),
 			},
 			JoinSessions: []*types.SessionJoinPolicy{
 				{

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -317,6 +317,8 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 	h.DELETE("/webapi/users/:username", h.WithAuth(h.deleteUserHandle))
 
 	// We have an overlap route here, please see godoc of handleGetUserOrResetToken
+	//h.GET("/webapi/users/:username", h.WithAuth(h.getUserHandle))
+	//h.GET("/webapi/users/password/token/:token", httplib.MakeHandler(h.getResetPasswordTokenHandle))
 	h.GET("/webapi/users/*wildcard", h.handleGetUserOrResetToken)
 
 	h.PUT("/webapi/users/password/token", httplib.WithCSRFProtection(h.changeUserAuthentication))
@@ -572,9 +574,6 @@ func (h *Handler) getUserStatus(w http.ResponseWriter, r *http.Request, _ httpro
 // Using `GET /webapi/users/:username` invalidates the `GET /webapi/users/password/token/:token` route
 // An alternative would be using the resource's singular name `GET /webapi/user/:username` but it invalidates the `GET /webapi/user/status` route
 // So, instead we'll use `GET /webapi/users/*wildcard`, parse the path/params and call the appropriate handler
-
-//h.GET("/webapi/users/:username", h.WithAuth(h.getUserHandle))
-//h.GET("/webapi/users/password/token/:token", httplib.MakeHandler(h.getResetPasswordTokenHandle))
 func (h *Handler) handleGetUserOrResetToken(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	// do we have multiple path fields or just one
 	relativePath := p.ByName("wildcard")

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -316,7 +316,9 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 	h.GET("/webapi/users", h.WithAuth(h.getUsersHandle))
 	h.DELETE("/webapi/users/:username", h.WithAuth(h.deleteUserHandle))
 
-	h.GET("/webapi/users/password/token/:token", httplib.MakeHandler(h.getResetPasswordTokenHandle))
+	// We have an overlap route here, please see godoc of handleGetUserOrResetToken
+	h.GET("/webapi/users/*wildcard", h.handleGetUserOrResetToken)
+
 	h.PUT("/webapi/users/password/token", httplib.WithCSRFProtection(h.changeUserAuthentication))
 	h.PUT("/webapi/users/password", h.WithAuth(h.changePassword))
 	h.POST("/webapi/users/password/token", h.WithAuth(h.createResetPasswordToken))
@@ -561,6 +563,52 @@ func (h *Handler) Close() error {
 
 func (h *Handler) getUserStatus(w http.ResponseWriter, r *http.Request, _ httprouter.Params, c *SessionContext) (interface{}, error) {
 	return OK(), nil
+}
+
+// handleGetUserOrResetToken has two handlers:
+// - read user
+// - return reset password token
+// It has two because the expected route for reading a user overlaps with an already existing one
+// Using `GET /webapi/users/:username` invalidates the `GET /webapi/users/password/token/:token` route
+// An alternative would be using the resource's singular name `GET /webapi/user/:username` but it invalidates the `GET /webapi/user/status` route
+// So, instead we'll use `GET /webapi/users/*wildcard`, parse the path/params and call the appropriate handler
+
+//h.GET("/webapi/users/:username", h.WithAuth(h.getUserHandle))
+//h.GET("/webapi/users/password/token/:token", httplib.MakeHandler(h.getResetPasswordTokenHandle))
+func (h *Handler) handleGetUserOrResetToken(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+	// do we have multiple path fields or just one
+	relativePath := p.ByName("wildcard")
+	relativePath = strings.TrimPrefix(relativePath, "/") // relativePath might start with "/", removing it helps reasoning
+	pathFields := strings.Split(relativePath, "/")
+
+	params := httprouter.Params{}
+
+	handleFunc := httplib.MakeHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
+		http.NotFound(w, r)
+		return nil, nil
+	})
+
+	// having one means we have an username
+	if len(pathFields) == 1 {
+		params = httprouter.Params{httprouter.Param{
+			Key:   "username",
+			Value: pathFields[0],
+		}}
+
+		handleFunc = h.WithAuth(h.getUserHandle)
+	}
+
+	// if we have exactly 3 and they look like /password/token/:token
+	if len(pathFields) == 3 && pathFields[0] == "password" && pathFields[1] == "token" && pathFields[2] != "" {
+		params = httprouter.Params{httprouter.Param{
+			Key:   "token",
+			Value: pathFields[2],
+		}}
+
+		handleFunc = httplib.MakeHandler(h.getResetPasswordTokenHandle)
+	}
+
+	handleFunc(w, r, params)
 }
 
 // getUserContext returns user context

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3320,6 +3320,14 @@ func TestGetUserOrResetToken(t *testing.T) {
 
 	pack := env.proxies[0].authPack(t, "foo")
 
+	// the default roles of foo don't have users read but we need it on our tests
+	fooRole, err := env.server.Auth().GetRole(ctx, "user:foo")
+	require.NoError(t, err)
+	fooAllowRules := fooRole.GetRules(types.Allow)
+	fooAllowRules = append(fooAllowRules, types.NewRule(types.KindUser, services.RO()))
+	fooRole.SetRules(types.Allow, fooAllowRules)
+	require.NoError(t, env.server.Auth().UpsertRole(ctx, fooRole))
+
 	resp, err := pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "users", username), url.Values{})
 	require.NoError(t, err)
 	require.Contains(t, string(resp.Bytes()), "login1")

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3300,6 +3300,38 @@ func TestParseSSORequestParams(t *testing.T) {
 	}
 }
 
+func TestGetUserOrResetToken(t *testing.T) {
+	env := newWebPack(t, 1)
+	ctx := context.Background()
+	username := "someuser"
+
+	// Create a username.
+	teleUser, err := types.NewUser(username)
+	require.NoError(t, err)
+	teleUser.SetLogins([]string{"login1"})
+	require.NoError(t, env.server.Auth().CreateUser(ctx, teleUser))
+
+	// Create a reset password token and secrets.
+	resetToken, err := env.server.Auth().CreateResetPasswordToken(ctx, auth.CreateUserTokenRequest{
+		Name: username,
+		Type: auth.UserTokenTypeResetPasswordInvite,
+	})
+	require.NoError(t, err)
+
+	pack := env.proxies[0].authPack(t, "foo")
+
+	resp, err := pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "users", username), url.Values{})
+	require.NoError(t, err)
+	require.Contains(t, string(resp.Bytes()), "login1")
+
+	resp, err = pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "users", "password", "token", resetToken.GetName()), url.Values{})
+	require.NoError(t, err)
+	require.Equal(t, resp.Code(), http.StatusOK)
+
+	_, err = pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "users", "password", "notToken", resetToken.GetName()), url.Values{})
+	require.True(t, trace.IsNotFound(err))
+}
+
 type authProviderMock struct {
 	server types.ServerV2
 }

--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -36,10 +36,10 @@ type User struct {
 	UserListEntry
 	// Logins is the list of Logins Trait for the user
 	Logins []string `json:"logins,omitempty"`
-	// DBUsers is the list of DBUsers Trait for the user
-	DBUsers []string `json:"db_users,omitempty"`
-	// DBNames is the list of DBNames Trait for the user
-	DBNames []string `json:"db_names,omitempty"`
+	// DatabaseUsers is the list of DatabaseUsers Trait for the user
+	DatabaseUsers []string `json:"database_users,omitempty"`
+	// DatabaseNames is the list of DatabaseNames Trait for the user
+	DatabaseNames []string `json:"database_names,omitempty"`
 	// KubeUsers is the list of KubeUsers Trait for the user
 	KubeUsers []string `json:"kube_users,omitempty"`
 	// KubeGroups is the list of KubeGroups Trait for the user
@@ -79,8 +79,8 @@ func NewUser(teleUser types.User) (*User, error) {
 	return &User{
 		UserListEntry: *userListEntry,
 		Logins:        teleUser.GetLogins(),
-		DBUsers:       teleUser.GetDBUsers(),
-		DBNames:       teleUser.GetDBNames(),
+		DatabaseUsers: teleUser.GetDatabaseUsers(),
+		DatabaseNames: teleUser.GetDatabaseNames(),
 		KubeUsers:     teleUser.GetKubeUsers(),
 		KubeGroups:    teleUser.GetKubeGroups(),
 		WindowsLogins: teleUser.GetWindowsLogins(),

--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -21,8 +21,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// User contains data needed by the web UI to display locally saved users.
-type User struct {
+type UserListEntry struct {
 	// Name is the user name.
 	Name string `json:"name"`
 	// Roles is the list of roles user belongs to.
@@ -32,8 +31,26 @@ type User struct {
 	AuthType string `json:"authType"`
 }
 
-// NewUser creates UI user object
-func NewUser(teleUser types.User) (*User, error) {
+// User contains data needed by the web UI to display locally saved users.
+type User struct {
+	UserListEntry
+	// Logins is the list of Logins Trait for the user
+	Logins []string `json:"logins,omitempty"`
+	// DBUsers is the list of DBUsers Trait for the user
+	DBUsers []string `json:"db_users,omitempty"`
+	// DBNames is the list of DBNames Trait for the user
+	DBNames []string `json:"db_names,omitempty"`
+	// KubeUsers is the list of KubeUsers Trait for the user
+	KubeUsers []string `json:"kube_users,omitempty"`
+	// KubeGroups is the list of KubeGroups Trait for the user
+	KubeGroups []string `json:"kube_groups,omitempty"`
+	// WindowsLogins is the list of WindowsLogins Trait for the user
+	WindowsLogins []string `json:"windows_logins,omitempty"`
+	// AWSRoleARNs is the list of AWSRoleARNs Trait for the user
+	AWSRoleARNs []string `json:"aws_role_ar_ns,omitempty"`
+}
+
+func NewUserListEntry(teleUser types.User) (*UserListEntry, error) {
 	if teleUser == nil {
 		return nil, trace.BadParameter("missing teleUser")
 	}
@@ -43,9 +60,30 @@ func NewUser(teleUser types.User) (*User, error) {
 		authType = teleUser.GetCreatedBy().Connector.Type
 	}
 
-	return &User{
+	return &UserListEntry{
 		Name:     teleUser.GetName(),
 		Roles:    teleUser.GetRoles(),
 		AuthType: authType,
+	}, nil
+}
+
+// NewUser creates UI user object
+func NewUser(teleUser types.User) (*User, error) {
+	// NewUserListEntry checks for a nil teleUser, no need to check for it here
+
+	userListEntry, err := NewUserListEntry(teleUser)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &User{
+		UserListEntry: *userListEntry,
+		Logins:        teleUser.GetLogins(),
+		DBUsers:       teleUser.GetDBUsers(),
+		DBNames:       teleUser.GetDBNames(),
+		KubeUsers:     teleUser.GetKubeUsers(),
+		KubeGroups:    teleUser.GetKubeGroups(),
+		WindowsLogins: teleUser.GetWindowsLogins(),
+		AWSRoleARNs:   teleUser.GetAWSRoleARNs(),
 	}, nil
 }

--- a/lib/web/users.go
+++ b/lib/web/users.go
@@ -127,7 +127,7 @@ func updateUserTraits(req *saveUserRequest, user types.User) {
 		user.SetDatabaseUsers(*req.DatabaseUsers)
 	}
 	if req.DatabaseNames != nil {
-		user.SetDatabaseNames(*req.DatabaseUsers)
+		user.SetDatabaseNames(*req.DatabaseNames)
 	}
 	if req.KubeUsers != nil {
 		user.SetKubeUsers(*req.KubeUsers)

--- a/lib/web/users.go
+++ b/lib/web/users.go
@@ -59,6 +59,19 @@ func (h *Handler) getUsersHandle(w http.ResponseWriter, r *http.Request, params 
 	return getUsers(clt)
 }
 
+func (h *Handler) getUserHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	username := params.ByName("username")
+	if username == "" {
+		return nil, trace.BadParameter("missing username")
+	}
+
+	return getUser(username, clt)
+}
+
 func (h *Handler) deleteUserHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
 	clt, err := ctx.GetClient()
 	if err != nil {
@@ -156,15 +169,15 @@ func updateUser(r *http.Request, m userAPIGetter, createdBy string) (*ui.User, e
 	return ui.NewUser(user)
 }
 
-func getUsers(m userAPIGetter) ([]ui.User, error) {
+func getUsers(m userAPIGetter) ([]ui.UserListEntry, error) {
 	users, err := m.GetUsers(false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	var uiUsers []ui.User
+	var uiUsers []ui.UserListEntry
 	for _, u := range users {
-		uiuser, err := ui.NewUser(u)
+		uiuser, err := ui.NewUserListEntry(u)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -172,6 +185,20 @@ func getUsers(m userAPIGetter) ([]ui.User, error) {
 	}
 
 	return uiUsers, nil
+}
+
+func getUser(username string, m userAPIGetter) (*ui.User, error) {
+	user, err := m.GetUser(username, false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	uiUser, err := ui.NewUser(user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return uiUser, nil
 }
 
 func deleteUser(r *http.Request, params httprouter.Params, m userAPIGetter, user string) error {

--- a/lib/web/users.go
+++ b/lib/web/users.go
@@ -123,11 +123,11 @@ func updateUserTraits(req *saveUserRequest, user types.User) {
 	if req.Logins != nil {
 		user.SetLogins(*req.Logins)
 	}
-	if req.DBUsers != nil {
-		user.SetDBUsers(*req.DBUsers)
+	if req.DatabaseUsers != nil {
+		user.SetDatabaseUsers(*req.DatabaseUsers)
 	}
-	if req.DBNames != nil {
-		user.SetDBNames(*req.DBNames)
+	if req.DatabaseNames != nil {
+		user.SetDatabaseNames(*req.DatabaseUsers)
 	}
 	if req.KubeUsers != nil {
 		user.SetKubeUsers(*req.KubeUsers)
@@ -284,8 +284,8 @@ type saveUserRequest struct {
 	Name          string    `json:"name"`
 	Roles         []string  `json:"roles"`
 	Logins        *[]string `json:"logins,omitempty"`
-	DBUsers       *[]string `json:"db_users,omitempty"`
-	DBNames       *[]string `json:"db_names,omitempty"`
+	DatabaseUsers *[]string `json:"database_users,omitempty"`
+	DatabaseNames *[]string `json:"database_names,omitempty"`
 	KubeUsers     *[]string `json:"kube_users,omitempty"`
 	KubeGroups    *[]string `json:"kube_groups,omitempty"`
 	WindowsLogins *[]string `json:"windows_logins,omitempty"`

--- a/lib/web/users_test.go
+++ b/lib/web/users_test.go
@@ -243,6 +243,18 @@ func TestUpdateUser_setTraits(t *testing.T) {
 
 			// Other fields dont't change
 			require.ElementsMatch(t, user.GetRoles(), defaultRoles)
+
+			// We can read back the user traits
+			uiUser, err := getUser(tt.name, m)
+			require.NoError(t, err)
+
+			require.ElementsMatch(t, uiUser.Logins, tt.expectedTraits[constants.TraitLogins])
+			require.ElementsMatch(t, uiUser.DBUsers, tt.expectedTraits[constants.TraitDBUsers])
+			require.ElementsMatch(t, uiUser.DBNames, tt.expectedTraits[constants.TraitDBNames])
+			require.ElementsMatch(t, uiUser.KubeUsers, tt.expectedTraits[constants.TraitKubeUsers])
+			require.ElementsMatch(t, uiUser.KubeGroups, tt.expectedTraits[constants.TraitKubeGroups])
+			require.ElementsMatch(t, uiUser.WindowsLogins, tt.expectedTraits[constants.TraitWindowsLogins])
+			require.ElementsMatch(t, uiUser.AWSRoleARNs, tt.expectedTraits[constants.TraitAWSRoleARNs])
 		})
 	}
 }

--- a/lib/web/users_test.go
+++ b/lib/web/users_test.go
@@ -141,11 +141,11 @@ func TestUpdateUser_setTraits(t *testing.T) {
 		{
 			name: "DB",
 			updateReq: saveUserRequest{
-				Name:    "setdb",
-				Roles:   defaultRoles,
-				Logins:  &defaultLogins,
-				DBUsers: &[]string{"dbuser1", "dbuser2"},
-				DBNames: &[]string{"dbname1", "dbname2"},
+				Name:          "setdb",
+				Roles:         defaultRoles,
+				Logins:        &defaultLogins,
+				DatabaseUsers: &[]string{"dbuser1", "dbuser2"},
+				DatabaseNames: &[]string{"dbname1", "dbname2"},
 			},
 			expectedTraits: map[string][]string{
 				constants.TraitDBUsers: {"dbuser1", "dbuser2"},
@@ -249,8 +249,8 @@ func TestUpdateUser_setTraits(t *testing.T) {
 			require.NoError(t, err)
 
 			require.ElementsMatch(t, uiUser.Logins, tt.expectedTraits[constants.TraitLogins])
-			require.ElementsMatch(t, uiUser.DBUsers, tt.expectedTraits[constants.TraitDBUsers])
-			require.ElementsMatch(t, uiUser.DBNames, tt.expectedTraits[constants.TraitDBNames])
+			require.ElementsMatch(t, uiUser.DatabaseUsers, tt.expectedTraits[constants.TraitDBUsers])
+			require.ElementsMatch(t, uiUser.DatabaseNames, tt.expectedTraits[constants.TraitDBNames])
 			require.ElementsMatch(t, uiUser.KubeUsers, tt.expectedTraits[constants.TraitKubeUsers])
 			require.ElementsMatch(t, uiUser.KubeGroups, tt.expectedTraits[constants.TraitKubeGroups])
 			require.ElementsMatch(t, uiUser.WindowsLogins, tt.expectedTraits[constants.TraitWindowsLogins])


### PR DESCRIPTION
Web API only returns Roles when listing Users

With this PR, we'll also return their traits.
This is a follow up of
https://github.com/gravitational/teleport/pull/14076

The following traits are returned:
- Logins
- DB Users
- DB Names
- Kube Users
- Kube Groups
- Windows Logins
- AWS Role ARNs

# Demo

**Create**
`curl 'https://localhost:8443/v1/webapi/users' --data-raw '{"name":"NewUser","roles":["access"],"logins":["login1"]}'  ...`
```json
{
  "name": "NewUser",
  "roles": [
    "access"
  ],
  "logins": [
    "login1"
  ],
  "authType": "local"
}
```

**Update**
`curl 'https://localhost:8443/v1/webapi/users' -X 'PUT' --data-raw '{"name":"NewUser","roles":["access","auditor"],"windows_logins":["notadmin"]}' ...`

```json
{
  "name": "NewUser",
  "roles": [
    "access",
    "auditor"
  ],
  "logins": [
    "login1"
  ],
  "windows_logins": [
    "notadmin"
  ],
  "authType": "local"
}
```

**Read**
`curl 'https://localhost:8443/v1/webapi/users/NewUser' ...`

```json
{
  "name": "NewUser",
  "roles": [
    "access",
    "auditor"
  ],
  "authType": "local",
  "logins": [
    "login1"
  ],
  "windows_logins": [
    "notadmin"
  ]
}
```