### PR TITLE
[v9] Revert spurious debug code left in #14044

### DIFF
--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -504,17 +504,9 @@ func (s *remoteSite) watchCertAuthorities(remoteWatcher *services.CertAuthorityW
 		}
 		ca, err := s.localAccessPoint.GetCertAuthority(s.ctx, caID, false)
 		if err != nil {
-			s.WithError(err).Debugf("failed to get local cert authority %v", caID)
 			return trace.Wrap(err, "failed to get local cert authority")
 		}
-		errors := 0
-	retry:
 		if err := s.remoteClient.RotateExternalCertAuthority(s.ctx, ca); err != nil {
-			s.WithError(err).Debugf("failed to push local cert authority %v", caID)
-			errors++
-			if trace.IsCompareFailed(err) && errors < 5 {
-				goto retry
-			}
 			return trace.Wrap(err, "failed to push local cert authority")
 		}
 		s.Debugf("Pushed local cert authority %v", caID.String())

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -17,9 +17,6 @@ package local
 import (
 	"context"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/sirupsen/logrus"
-
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
@@ -125,7 +122,6 @@ func (s *CA) CompareAndSwapCertAuthority(new, expected types.CertAuthority) erro
 	}
 
 	if !services.CertAuthoritiesEquivalent(actual, expected) {
-		logrus.Debugf("CAS failed: %q", cmp.Diff(actual, expected))
 		return trace.CompareFailed("cluster %v settings have been updated, try again", new.GetName())
 	}
 


### PR DESCRIPTION
This reverts commit 73086eabb27e9e7c3bd35f01a16a78d7b4ab929a.