### PR TITLE
Refactor tests under services package

### DIFF
--- a/lib/services/license_test.go
+++ b/lib/services/license_test.go
@@ -17,20 +17,20 @@ limitations under the License.
 package services
 
 import (
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/fixtures"
+	"fmt"
+	"testing"
 
-	"gopkg.in/check.v1"
+	"github.com/gravitational/teleport/api/types"
 
 	"github.com/gravitational/trace"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
-type LicenseSuite struct {
-}
+func TestLicenseUnmarshal(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&LicenseSuite{})
-
-func (l *LicenseSuite) TestUnmarshal(c *check.C) {
 	type testCase struct {
 		description string
 		input       string
@@ -103,18 +103,18 @@ func (l *LicenseSuite) TestUnmarshal(c *check.C) {
 		},
 	}
 	for _, tc := range testCases {
-		comment := check.Commentf("test case %q", tc.description)
+		comment := fmt.Sprintf("test case %q", tc.description)
 		out, err := UnmarshalLicense([]byte(tc.input))
 		if tc.err == nil {
-			c.Assert(err, check.IsNil, comment)
-			fixtures.DeepCompare(c, tc.expected, out)
+			require.NoError(t, err, comment)
+			require.Empty(t, cmp.Diff(tc.expected, out))
 			data, err := MarshalLicense(out)
-			c.Assert(err, check.IsNil, comment)
+			require.NoError(t, err, comment)
 			out2, err := UnmarshalLicense(data)
-			c.Assert(err, check.IsNil, comment)
-			fixtures.DeepCompare(c, tc.expected, out2)
+			require.NoError(t, err, comment)
+			require.Empty(t, cmp.Diff(tc.expected, out2))
 		} else {
-			c.Assert(err, check.FitsTypeOf, tc.err, comment)
+			require.IsType(t, err, tc.err, comment)
 		}
 	}
 }

--- a/lib/services/local/desktops_test.go
+++ b/lib/services/local/desktops_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/backend/lite"
+	"github.com/gravitational/teleport/lib/backend/memory"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
@@ -32,15 +32,17 @@ import (
 
 func TestListWindowsDesktops(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	liteBackend, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:  t.TempDir(),
-		Clock: clockwork.NewFakeClock(),
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
 	})
 	require.NoError(t, err)
 
-	service := NewWindowsDesktopService(liteBackend)
+	service := NewWindowsDesktopService(bk)
 
 	// Initially we expect no desktops.
 	out, err := service.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
@@ -111,15 +113,17 @@ func TestListWindowsDesktops(t *testing.T) {
 
 func TestListWindowsDesktops_Filters(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	liteBackend, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:  t.TempDir(),
-		Clock: clockwork.NewFakeClock(),
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
 	})
 	require.NoError(t, err)
 
-	service := NewWindowsDesktopService(liteBackend)
+	service := NewWindowsDesktopService(bk)
 
 	// Upsert some windows desktops.
 

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -27,124 +27,85 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jonboulle/clockwork"
-	"gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { check.TestingT(t) }
+func TestUserResource(t *testing.T) {
+	t.Parallel()
 
-type ResourceSuite struct {
-	bk backend.Backend
+	tt := setupServicesContext(context.Background(), t)
+	runUserResourceTest(t, tt, false)
 }
 
-var _ = check.Suite(&ResourceSuite{})
+func TestUserResourceWithSecrets(t *testing.T) {
+	t.Parallel()
 
-func (r *ResourceSuite) SetUpTest(c *check.C) {
-	var err error
-
-	clock := clockwork.NewFakeClockAt(time.Now())
-
-	r.bk, err = memory.New(memory.Config{
-		Context: context.Background(),
-		Clock:   clock,
-	})
-	c.Assert(err, check.IsNil)
+	tt := setupServicesContext(context.Background(), t)
+	runUserResourceTest(t, tt, true)
 }
 
-func (r *ResourceSuite) TearDownTest(c *check.C) {
-	c.Assert(r.bk.Close(), check.IsNil)
-}
+func runUserResourceTest(t *testing.T, tt *servicesContext, withSecrets bool) {
+	expiry := tt.bk.Clock().Now().Add(time.Minute)
 
-func (r *ResourceSuite) dumpResources(c *check.C) []types.Resource {
-	startKey := []byte("/")
-	endKey := backend.RangeEnd(startKey)
-	result, err := r.bk.GetRange(context.TODO(), startKey, endKey, 0)
-	c.Assert(err, check.IsNil)
-	resources, err := ItemsToResources(result.Items...)
-	c.Assert(err, check.IsNil)
-	return resources
-}
+	alice := newUserTestCase(t, "alice", nil, withSecrets, expiry)
+	bob := newUserTestCase(t, "bob", nil, withSecrets, expiry)
 
-func (r *ResourceSuite) runCreationChecks(c *check.C, resources ...types.Resource) {
-	for _, rsc := range resources {
-		switch r := rsc.(type) {
-		case types.User:
-			c.Logf("Creating User: %+v", r)
-		default:
-		}
-	}
-	err := CreateResources(context.TODO(), r.bk, resources...)
-	c.Assert(err, check.IsNil)
-	dump := r.dumpResources(c)
-Outer:
-	for _, exp := range resources {
-		for _, got := range dump {
-			if got.GetKind() == exp.GetKind() && got.GetName() == exp.GetName() && got.Expiry() == exp.Expiry() {
-				continue Outer
-			}
-		}
-		c.Errorf("Missing expected resource kind=%s,name=%s,expiry=%v", exp.GetKind(), exp.GetName(), exp.Expiry().String())
-	}
-}
-
-func (r *ResourceSuite) TestUserResource(c *check.C) {
-	r.runUserResourceTest(c, false)
-}
-
-func (r *ResourceSuite) TestUserResourceWithSecrets(c *check.C) {
-	r.runUserResourceTest(c, true)
-}
-
-func (r *ResourceSuite) runUserResourceTest(c *check.C, withSecrets bool) {
-	expiry := r.bk.Clock().Now().Add(time.Minute)
-
-	alice := newUserTestCase(c, "alice", nil, withSecrets, expiry)
-	bob := newUserTestCase(c, "bob", nil, withSecrets, expiry)
 	// Check basic dynamic item creation
-	r.runCreationChecks(c, alice, bob)
+	runCreationChecks(t, tt, alice, bob)
+
 	// Check that dynamically created item is compatible with service
-	s := NewIdentityService(r.bk)
+	s := NewIdentityService(tt.bk)
 	b, err := s.GetUser("bob", withSecrets)
-	c.Assert(err, check.IsNil)
-	c.Assert(services.UsersEquals(bob, b), check.Equals, true, check.Commentf("dynamically inserted user does not match"))
+	require.NoError(t, err)
+	require.Equal(t, services.UsersEquals(bob, b), true, "dynamically inserted user does not match")
 	allUsers, err := s.GetUsers(withSecrets)
-	c.Assert(err, check.IsNil)
-	c.Assert(len(allUsers), check.Equals, 2, check.Commentf("expected exactly two users"))
+	require.NoError(t, err)
+	require.Equal(t, len(allUsers), 2, "expected exactly two users")
 	for _, user := range allUsers {
 		switch user.GetName() {
 		case "alice":
-			c.Assert(services.UsersEquals(alice, user), check.Equals, true, check.Commentf("alice does not match"))
+			require.Equal(t, services.UsersEquals(alice, user), true, "alice does not match")
 		case "bob":
-			c.Assert(services.UsersEquals(bob, user), check.Equals, true, check.Commentf("bob does not match"))
+			require.Equal(t, services.UsersEquals(bob, user), true, "bob does not match")
 		default:
-			c.Errorf("Unexpected user %q", user.GetName())
+			t.Errorf("Unexpected user %q", user.GetName())
 		}
 	}
 
 	// Advance the clock to let the users to expire.
-	r.bk.Clock().(clockwork.FakeClock).Advance(2 * time.Minute)
+	tt.bk.Clock().(clockwork.FakeClock).Advance(2 * time.Minute)
 	allUsers, err = s.GetUsers(withSecrets)
-	c.Assert(err, check.IsNil)
-	c.Assert(len(allUsers), check.Equals, 0, check.Commentf("expected all users to expire"))
+	require.NoError(t, err)
+	require.Equal(t, len(allUsers), 0, "expected all users to expire")
 }
 
-func (r *ResourceSuite) TestCertAuthorityResource(c *check.C) {
+func TestCertAuthorityResource(t *testing.T) {
+	t.Parallel()
+
+	tt := setupServicesContext(context.Background(), t)
+
 	userCA := suite.NewTestCA(types.UserCA, "example.com")
 	hostCA := suite.NewTestCA(types.HostCA, "example.com")
+
 	// Check basic dynamic item creation
-	r.runCreationChecks(c, userCA, hostCA)
+	runCreationChecks(t, tt, userCA, hostCA)
+
 	// Check that dynamically created item is compatible with service
-	s := NewCAService(r.bk)
+	s := NewCAService(tt.bk)
 	err := s.CompareAndSwapCertAuthority(userCA, userCA)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 }
 
-func (r *ResourceSuite) TestTrustedClusterResource(c *check.C) {
+func TestTrustedClusterResource(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
+	tt := setupServicesContext(ctx, t)
+
 	foo, err := types.NewTrustedCluster("foo", types.TrustedClusterSpecV2{
 		Enabled:              true,
 		Roles:                []string{"bar", "baz"},
@@ -152,7 +113,7 @@ func (r *ResourceSuite) TestTrustedClusterResource(c *check.C) {
 		ProxyAddress:         "quux",
 		ReverseTunnelAddress: "quuz",
 	})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	bar, err := types.NewTrustedCluster("bar", types.TrustedClusterSpecV2{
 		Enabled:              false,
@@ -161,19 +122,24 @@ func (r *ResourceSuite) TestTrustedClusterResource(c *check.C) {
 		ProxyAddress:         "quuz",
 		ReverseTunnelAddress: "corge",
 	})
-	c.Assert(err, check.IsNil)
-	// Check basic dynamic item creation
-	r.runCreationChecks(c, foo, bar)
+	require.NoError(t, err)
 
-	s := NewPresenceService(r.bk)
+	// Check basic dynamic item creation
+	runCreationChecks(t, tt, foo, bar)
+
+	s := NewPresenceService(tt.bk)
 	_, err = s.GetTrustedCluster(ctx, "foo")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	_, err = s.GetTrustedCluster(ctx, "bar")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 }
 
-func (r *ResourceSuite) TestGithubConnectorResource(c *check.C) {
+func TestGithubConnectorResource(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
+	tt := setupServicesContext(ctx, t)
+
 	connector := &types.GithubConnectorV3{
 		Kind:    types.KindGithubConnector,
 		Version: types.V3,
@@ -196,28 +162,29 @@ func (r *ResourceSuite) TestGithubConnectorResource(c *check.C) {
 			},
 		},
 	}
-	// Check basic dynamic item creation
-	r.runCreationChecks(c, connector)
 
-	s := NewIdentityService(r.bk)
+	// Check basic dynamic item creation
+	runCreationChecks(t, tt, connector)
+
+	s := NewIdentityService(tt.bk)
 	_, err := s.GetGithubConnector(ctx, "github", true)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 }
 
-func localAuthSecretsTestCase(c *check.C) types.LocalAuthSecrets {
+func localAuthSecretsTestCase(t *testing.T) types.LocalAuthSecrets {
 	var auth types.LocalAuthSecrets
 	var err error
 	auth.PasswordHash, err = bcrypt.GenerateFromPassword([]byte("insecure"), bcrypt.MinCost)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	dev, err := services.NewTOTPDevice("otp", base32.StdEncoding.EncodeToString([]byte("abc123")), time.Now())
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	auth.MFA = append(auth.MFA, dev)
 
 	return auth
 }
 
-func newUserTestCase(c *check.C, name string, roles []string, withSecrets bool, expires time.Time) types.User {
+func newUserTestCase(t *testing.T, name string, roles []string, withSecrets bool, expires time.Time) types.User {
 	user := types.UserV2{
 		Kind:    types.KindUser,
 		Version: types.V2,
@@ -231,8 +198,40 @@ func newUserTestCase(c *check.C, name string, roles []string, withSecrets bool, 
 		},
 	}
 	if withSecrets {
-		auth := localAuthSecretsTestCase(c)
+		auth := localAuthSecretsTestCase(t)
 		user.SetLocalAuth(&auth)
 	}
 	return &user
+}
+
+func dumpResources(t *testing.T, tt *servicesContext) []types.Resource {
+	startKey := []byte("/")
+	endKey := backend.RangeEnd(startKey)
+	result, err := tt.bk.GetRange(context.TODO(), startKey, endKey, 0)
+	require.NoError(t, err)
+	resources, err := ItemsToResources(result.Items...)
+	require.NoError(t, err)
+	return resources
+}
+
+func runCreationChecks(t *testing.T, tt *servicesContext, resources ...types.Resource) {
+	for _, rsc := range resources {
+		switch r := rsc.(type) {
+		case types.User:
+			t.Logf("Creating User: %+v", r)
+		default:
+		}
+	}
+	err := CreateResources(context.TODO(), tt.bk, resources...)
+	require.NoError(t, err)
+	dump := dumpResources(t, tt)
+Outer:
+	for _, exp := range resources {
+		for _, got := range dump {
+			if got.GetKind() == exp.GetKind() && got.GetName() == exp.GetName() && got.Expiry() == exp.Expiry() {
+				continue Outer
+			}
+		}
+		t.Errorf("Missing expected resource kind=%s,name=%s,expiry=%v", exp.GetKind(), exp.GetName(), exp.Expiry().String())
+	}
 }

--- a/lib/services/map_test.go
+++ b/lib/services/map_test.go
@@ -17,19 +17,20 @@ limitations under the License.
 package services
 
 import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/trace"
 )
 
-type RoleMapSuite struct{}
+func TestRoleParsing(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&RoleMapSuite{})
-
-func (s *RoleMapSuite) TestRoleParsing(c *check.C) {
 	testCases := []struct {
 		roleMap types.RoleMap
 		err     error
@@ -64,18 +65,20 @@ func (s *RoleMapSuite) TestRoleParsing(c *check.C) {
 	}
 
 	for i, tc := range testCases {
-		comment := check.Commentf("test case '%v'", i)
+		comment := fmt.Sprintf("test case '%v'", i)
 		_, err := parseRoleMap(tc.roleMap)
 		if tc.err != nil {
-			c.Assert(err, check.NotNil, comment)
-			c.Assert(err, check.FitsTypeOf, tc.err)
+			require.NotNilf(t, err, comment)
+			require.IsTypef(t, err, tc.err, comment)
 		} else {
-			c.Assert(err, check.IsNil)
+			require.NoError(t, err)
 		}
 	}
 }
 
-func (s *RoleMapSuite) TestRoleMap(c *check.C) {
+func TestRoleMap(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		remote  []string
 		local   []string
@@ -183,14 +186,14 @@ func (s *RoleMapSuite) TestRoleMap(c *check.C) {
 	}
 
 	for _, tc := range testCases {
-		comment := check.Commentf("test case '%v'", tc.name)
+		comment := fmt.Sprintf("test case '%v'", tc.name)
 		local, err := MapRoles(tc.roleMap, tc.remote)
 		if tc.err != nil {
-			c.Assert(err, check.NotNil, comment)
-			c.Assert(err, check.FitsTypeOf, tc.err)
+			require.NotNilf(t, err, comment)
+			require.IsTypef(t, err, tc.err, comment)
 		} else {
-			c.Assert(err, check.IsNil, comment)
-			c.Assert(local, check.DeepEquals, tc.local, comment)
+			require.NoError(t, err, comment)
+			require.Empty(t, cmp.Diff(local, tc.local), comment)
 		}
 	}
 }

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -23,36 +23,36 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/check.v1"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
-type SAMLSuite struct{}
+func TestParseFromMetadata(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&SAMLSuite{})
-
-func (s *SAMLSuite) TestParseFromMetadata(c *check.C) {
 	input := fixtures.SAMLOktaConnectorV2
 
 	decoder := kyaml.NewYAMLOrJSONDecoder(strings.NewReader(input), defaults.LookaheadBufSize)
 	var raw UnknownResource
 	err := decoder.Decode(&raw)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	oc, err := UnmarshalSAMLConnector(raw.Raw)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	err = ValidateSAMLConnector(oc)
-	c.Assert(err, check.IsNil)
-	c.Assert(oc.GetIssuer(), check.Equals, "http://www.okta.com/exkafftca6RqPVgyZ0h7")
-	c.Assert(oc.GetSSO(), check.Equals, "https://dev-813354.oktapreview.com/app/gravitationaldev813354_teleportsaml_1/exkafftca6RqPVgyZ0h7/sso/saml")
-	c.Assert(oc.GetAssertionConsumerService(), check.Equals, "https://localhost:3080/v1/webapi/saml/acs")
-	c.Assert(oc.GetAudience(), check.Equals, "https://localhost:3080/v1/webapi/saml/acs")
-	c.Assert(oc.GetSigningKeyPair(), check.NotNil)
-	c.Assert(oc.GetAttributes(), check.DeepEquals, []string{"groups"})
+	require.NoError(t, err)
+	require.Equal(t, oc.GetIssuer(), "http://www.okta.com/exkafftca6RqPVgyZ0h7")
+	require.Equal(t, oc.GetSSO(), "https://dev-813354.oktapreview.com/app/gravitationaldev813354_teleportsaml_1/exkafftca6RqPVgyZ0h7/sso/saml")
+	require.Equal(t, oc.GetAssertionConsumerService(), "https://localhost:3080/v1/webapi/saml/acs")
+	require.Equal(t, oc.GetAudience(), "https://localhost:3080/v1/webapi/saml/acs")
+	require.NotNil(t, oc.GetSigningKeyPair())
+	require.Empty(t, cmp.Diff(oc.GetAttributes(), []string{"groups"}))
 }
 
 func TestCheckSAMLEntityDescriptor(t *testing.T) {
+	t.Parallel()
+
 	input := fixtures.SAMLOktaConnectorV2
 
 	decoder := kyaml.NewYAMLOrJSONDecoder(strings.NewReader(input), defaults.LookaheadBufSize)

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -23,12 +23,10 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/check.v1"
 )
 
 func TestMain(m *testing.M) {
@@ -36,57 +34,56 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-type ServicesSuite struct {
-}
-
-func TestServices(t *testing.T) { check.TestingT(t) }
-
-var _ = check.Suite(&ServicesSuite{})
-
 // TestOptions tests command options operations
-func (s *ServicesSuite) TestOptions(c *check.C) {
+func TestOptions(t *testing.T) {
+	t.Parallel()
+
 	// test empty scenario
 	out := AddOptions(nil)
-	c.Assert(out, check.HasLen, 0)
+	require.Len(t, out, 0)
 
 	// make sure original option list is not affected
 	in := []MarshalOption{}
 	out = AddOptions(in, WithResourceID(1))
-	c.Assert(out, check.HasLen, 1)
-	c.Assert(in, check.HasLen, 0)
+	require.Len(t, out, 1)
+	require.Len(t, in, 0)
 	cfg, err := CollectOptions(out)
-	c.Assert(err, check.IsNil)
-	c.Assert(cfg.ID, check.Equals, int64(1))
+	require.NoError(t, err)
+	require.Equal(t, cfg.ID, int64(1))
 
 	// Add a couple of other parameters
 	out = AddOptions(in, WithResourceID(2), WithVersion(types.V2))
-	c.Assert(out, check.HasLen, 2)
-	c.Assert(in, check.HasLen, 0)
+	require.Len(t, out, 2)
+	require.Len(t, in, 0)
 	cfg, err = CollectOptions(out)
-	c.Assert(err, check.IsNil)
-	c.Assert(cfg.ID, check.Equals, int64(2))
-	c.Assert(cfg.Version, check.Equals, types.V2)
+	require.NoError(t, err)
+	require.Equal(t, cfg.ID, int64(2))
+	require.Equal(t, cfg.Version, types.V2)
 }
 
 // TestCommandLabels tests command labels
-func (s *ServicesSuite) TestCommandLabels(c *check.C) {
+func TestCommandLabels(t *testing.T) {
+	t.Parallel()
+
 	var l CommandLabels
 	out := l.Clone()
-	c.Assert(out, check.HasLen, 0)
+	require.Len(t, out, 0)
 
 	label := &types.CommandLabelV2{Command: []string{"ls", "-l"}, Period: types.Duration(time.Second)}
 	l = CommandLabels{"a": label}
 	out = l.Clone()
 
-	c.Assert(out, check.HasLen, 1)
-	fixtures.DeepCompare(c, out["a"], label)
+	require.Len(t, out, 1)
+	require.Empty(t, cmp.Diff(out["a"], label))
 
 	// make sure it's not a shallow copy
 	label.Command[0] = "/bin/ls"
-	c.Assert(label.Command[0], check.Not(check.Equals), out["a"].GetCommand())
+	require.NotEqual(t, label.Command[0], out["a"].GetCommand())
 }
 
 func TestLabelKeyValidation(t *testing.T) {
+	t.Parallel()
+
 	tts := []struct {
 		label string
 		ok    bool
@@ -107,6 +104,7 @@ func TestLabelKeyValidation(t *testing.T) {
 
 func TestServerDeepCopy(t *testing.T) {
 	t.Parallel()
+
 	// setup
 	now := time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC)
 	expires := now.Add(1 * time.Hour)

--- a/lib/services/usertoken_test.go
+++ b/lib/services/usertoken_test.go
@@ -13,25 +13,26 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package services
 
 import (
+	"fmt"
+	"testing"
 	"time"
-
-	"gopkg.in/check.v1"
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/fixtures"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
-type UserTokenSuite struct{}
+func TestUserTokenUnmarshal(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&UserTokenSuite{})
-
-func (r *UserTokenSuite) TestUnmarshal(c *check.C) {
 	created, err := time.Parse(time.RFC3339, "2020-01-14T18:52:39.523076855Z")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	type testCase struct {
 		description string
@@ -73,14 +74,14 @@ func (r *UserTokenSuite) TestUnmarshal(c *check.C) {
 	}
 
 	for _, tc := range testCases {
-		comment := check.Commentf("test case %q", tc.description)
+		comment := fmt.Sprintf("test case %q", tc.description)
 		out, err := UnmarshalUserToken([]byte(tc.input))
-		c.Assert(err, check.IsNil, comment)
-		fixtures.DeepCompare(c, tc.expected, out)
+		require.NoError(t, err, comment)
+		require.Empty(t, cmp.Diff(tc.expected, out))
 		data, err := MarshalUserToken(out)
-		c.Assert(err, check.IsNil, comment)
+		require.NoError(t, err, comment)
 		out2, err := UnmarshalUserToken(data)
-		c.Assert(err, check.IsNil, comment)
-		fixtures.DeepCompare(c, tc.expected, out2)
+		require.NoError(t, err, comment)
+		require.Empty(t, cmp.Diff(tc.expected, out2))
 	}
 }

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -35,7 +35,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
-	"github.com/gravitational/teleport/lib/backend/lite"
+	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/services"
@@ -103,11 +103,13 @@ func TestResourceWatcher_Backoff(t *testing.T) {
 
 func TestProxyWatcher(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	bk, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:             t.TempDir(),
-		PollStreamPeriod: 200 * time.Millisecond,
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
 	})
 	require.NoError(t, err)
 
@@ -194,13 +196,13 @@ func newProxyServer(t *testing.T, name, addr string) types.Server {
 
 func TestLockWatcher(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
-	bk, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:             t.TempDir(),
-		PollStreamPeriod: 200 * time.Millisecond,
-		Clock:            clock,
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
 	})
 	require.NoError(t, err)
 
@@ -299,13 +301,13 @@ func TestLockWatcher(t *testing.T) {
 
 func TestLockWatcherSubscribeWithEmptyTarget(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
-	bk, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:             t.TempDir(),
-		PollStreamPeriod: 200 * time.Millisecond,
-		Clock:            clock,
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
 	})
 	require.NoError(t, err)
 
@@ -376,13 +378,13 @@ func TestLockWatcherSubscribeWithEmptyTarget(t *testing.T) {
 
 func TestLockWatcherStale(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
-	bk, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:             t.TempDir(),
-		PollStreamPeriod: 200 * time.Millisecond,
-		Clock:            clock,
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
 	})
 	require.NoError(t, err)
 
@@ -522,11 +524,13 @@ func resourceDiff(res1, res2 types.Resource) string {
 // and dispatches updates to database resources.
 func TestDatabaseWatcher(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	bk, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:             t.TempDir(),
-		PollStreamPeriod: 200 * time.Millisecond,
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
 	})
 	require.NoError(t, err)
 
@@ -619,11 +623,13 @@ func newDatabase(t *testing.T, name string) types.Database {
 // and dispatches updates.
 func TestAppWatcher(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	bk, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:             t.TempDir(),
-		PollStreamPeriod: 200 * time.Millisecond,
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
 	})
 	require.NoError(t, err)
 
@@ -713,13 +719,13 @@ func newApp(t *testing.T, name string) types.Application {
 
 func TestCertAuthorityWatcher(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
-	bk, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:             t.TempDir(),
-		PollStreamPeriod: 200 * time.Millisecond,
-		Clock:            clock,
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
 	})
 	require.NoError(t, err)
 
@@ -855,11 +861,13 @@ func newCertAuthority(t *testing.T, name string, caType types.CertAuthType) type
 
 func TestNodeWatcher(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	bk, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:             t.TempDir(),
-		PollStreamPeriod: 200 * time.Millisecond,
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
 	})
 	require.NoError(t, err)
 

--- a/lib/services/wrappers_test.go
+++ b/lib/services/wrappers_test.go
@@ -20,31 +20,26 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"gopkg.in/check.v1"
-
 	"github.com/gravitational/teleport/api/types/wrappers"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
-type WrappersSuite struct{}
-
-var _ = check.Suite(&WrappersSuite{})
-
-func TestWrappers(t *testing.T) { check.TestingT(t) }
-
-func (w *WrappersSuite) TestUnmarshalBackwards(c *check.C) {
+func TestUnmarshalBackwards(t *testing.T) {
 	var traits wrappers.Traits
 
 	// Attempt to unmarshal protobuf encoded data.
 	protoBytes := "0a120a066c6f67696e7312080a06666f6f6261720a150a116b756265726e657465735f67726f7570731200"
 	data, err := hex.DecodeString(protoBytes)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	err = wrappers.UnmarshalTraits(data, &traits)
-	c.Assert(err, check.IsNil)
-	c.Assert(traits["logins"], check.DeepEquals, []string{"foobar"})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(traits["logins"], []string{"foobar"}))
 
 	// Attempt to unmarshal JSON encoded data.
 	jsonBytes := `{"logins": ["foobar"]}`
 	err = wrappers.UnmarshalTraits([]byte(jsonBytes), &traits)
-	c.Assert(err, check.IsNil)
-	c.Assert(traits["logins"], check.DeepEquals, []string{"foobar"})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(traits["logins"], []string{"foobar"}))
 }


### PR DESCRIPTION
Refactored all tests under `lib/services/suite` to use testify instead of `gocheck`.

----

Used the following `gofmt` rewrite rules to automate most of the refactoring.

```
gofmt -r 'c.Assert(a, check.NotNil) -> require.NotNil(t, a)' -w *_test.go   
gofmt -r 'c.Assert(a, check.NotNil, b) -> require.NotNilf(t, a, b)' -w *_test.go   
gofmt -r 'c.Assert(a, check.FitsTypeOf, b) -> require.IsTypef(t, a, b)' -w *_test.go   
gofmt -r 'c.Assert(a, check.IsNil) -> require.NoError(t, a)' -w *_test.go   
gofmt -r 'c.Assert(a, check.IsNil, d) -> require.NoError(t, a, d)' -w *_test.go   
gofmt -r 'c.Assert(a, check.Equals, b) -> require.Equal(t, a, b)' -w *_test.go
gofmt -r 'c.Assert(a, check.HasLen, b) -> require.Len(t, a, b)' -w *_test.go
gofmt -r 'c.Assert(a, check.DeepEquals, b) -> require.Empty(t, cmp.Diff(a, b))' -w *_test.go
gofmt -r 'c.Assert(a, check.DeepEquals, b, d) -> require.Empty(t, cmp.Diff(a, b), d)' -w *_test.go
gofmt -r 'c.Assert(a, check.Equals, b, d) -> require.Equal(t, a, b, d)' -w *_test.go
gofmt -r 'c.Assert(a, check.ErrorMatches, b) -> require.ErrorContains(t, err, b)' -w *_test.go
gofmt -r 'check.Commentf(a, b) -> fmt.Sprintf(a, b)' -w *_test.go
gofmt -r 'fixtures.DeepCompare(c, a, b) -> require.Empty(t, cmp.Diff(a, b))' -w *_test.go
gofmt -r 'fixtures.ExpectNotFound(c, a) -> require.True(t, trace.IsNotFound(a))' -w *_test.go
gofmt -r 'fixtures.ExpectBadParameter(c, a) -> require.True(t, trace.IsBadParameter(a))' -w *_test.go
gofmt -r 'fixtures.ExpectAlreadyExists(c, a) -> require.True(t, trace.IsAlreadyExists(a))' -w *_test.go
gofmt -r 'fixtures.ExpectLimitExceeded(c, a) -> require.True(t, trace.IsLimitExceeded(a))' -w *_test.go
gofmt -r 'fixtures.ExpectConnectionProblem(c, a) -> require.True(t, trace.IsConnectionProblem(a))' -w *_test.go
gofmt -r 'fixtures.ExpectAccessDenied(c, a) -> require.True(t, trace.IsAccessDenied(a))' -w *_test.go
gofmt -r 'c.Errorf(a) -> t.Errorf(a)' -w *_test.go
gofmt -r 'c.Errorf(a, b) -> t.Errorf(a, b)' -w *_test.go
gofmt -r 'c.Fatalf(a) -> t.Fatalf(a)' -w *_test.go
gofmt -r 'c.Fatalf(a, b) -> t.Fatalf(a, b)' -w *_test.go
```