### PR TITLE
Expands GCB integration test timeout to 35m

### DIFF
--- a/.cloudbuild/ci/integration-tests.yaml
+++ b/.cloudbuild/ci/integration-tests.yaml
@@ -26,7 +26,7 @@ steps:
           -build "$BUILD_ID"                    \
           -key-secret "$_GITHUB_DEPLOY_KEY_SRC" \
           -a "test-logs/*.json"
-    # The actual makefile timeout is 30m. We add the 5 minute buffer here to
+    # The actual makefile timeout is 30m. We add the 10 minute buffer here to
     # allow for setup and teardown time, reports to be saved, etc, if the
     # underlying tests time out.
     timeout: 40m

--- a/.cloudbuild/ci/integration-tests.yaml
+++ b/.cloudbuild/ci/integration-tests.yaml
@@ -1,4 +1,4 @@
-timeout: 25m
+timeout: 35m
 
 options:
   pool:
@@ -26,4 +26,6 @@ steps:
           -build "$BUILD_ID"                    \
           -key-secret "$_GITHUB_DEPLOY_KEY_SRC" \
           -a "test-logs/*.json"
-    timeout: 25m
+    # The actual makefile timeout is 30m. We add the 5 minute buffer here to 
+    # allow for reports to be saved, etc, if the underlying tests time out.
+    timeout: 35m

--- a/.cloudbuild/ci/integration-tests.yaml
+++ b/.cloudbuild/ci/integration-tests.yaml
@@ -1,4 +1,4 @@
-timeout: 35m
+timeout: 40m
 
 options:
   pool:
@@ -26,6 +26,7 @@ steps:
           -build "$BUILD_ID"                    \
           -key-secret "$_GITHUB_DEPLOY_KEY_SRC" \
           -a "test-logs/*.json"
-    # The actual makefile timeout is 30m. We add the 5 minute buffer here to 
-    # allow for reports to be saved, etc, if the underlying tests time out.
-    timeout: 35m
+    # The actual makefile timeout is 30m. We add the 5 minute buffer here to
+    # allow for setup and teardown time, reports to be saved, etc, if the
+    # underlying tests time out.
+    timeout: 40m


### PR DESCRIPTION
Keeps the underlying 30m timeout used in `go test`, but adds the extra 5
minutes to allow for error reporting to complete should `go test` time
out.