### PR TITLE
10.0.0 Post-release 1: Update docs versions for 10.0.0

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -791,16 +791,16 @@
         {
           "title": "Access Requests",
           "slug": "/enterprise/workflow/",
-		  "entries": [
-			{
-			  "title": "Resource Access Requests",
-			  "slug": "/enterprise/workflow/resource-requests/"
-			},
-			{
-			  "title": "Role Access Requests",
-			  "slug": "/enterprise/workflow/role-requests/"
-			}
-		  ]
+          "entries": [
+            {
+              "title": "Resource Access Requests",
+              "slug": "/enterprise/workflow/resource-requests/"
+            },
+            {
+              "title": "Role Access Requests",
+              "slug": "/enterprise/workflow/role-requests/"
+            }
+          ]
         },
         {
           "title": "FedRAMP",
@@ -910,7 +910,7 @@
     }
   ],
   "variables": {
-    "version": "7.0",
+    "version": "10.0",
     "terraform": {
       "version": "1.0.0"
     },
@@ -929,7 +929,7 @@
       "last_report": "April 12th, 2021"
     },
     "cloud": {
-      "version": "8.3.4",
+      "version": "9.3.8",
       "sla": {
         "monthly_percentage": "99.5%",
         "monthly_downtime": "3 hours 40 minutes"
@@ -958,14 +958,14 @@
       "min_version": "3.6"
     },
     "teleport": {
-      "version": "9.0.4",
-      "golang": "1.17",
+      "version": "10.0.0",
+      "golang": "1.18",
       "plugin": {
-        "version": "9.0.4"
+        "version": "10.0.0"
       },
       "helm_repo_url": "https://charts.releases.teleport.dev",
-      "latest_oss_docker_image": "quay.io/gravitational/teleport:9.1.2",
-      "latest_ent_docker_image": "quay.io/gravitational/teleport-ent:9.1.2"
+      "latest_oss_docker_image": "quay.io/gravitational/teleport:10.0.0",
+      "latest_ent_docker_image": "quay.io/gravitational/teleport-ent:10.0.0"
     }
   },
   "redirects": [


### PR DESCRIPTION
Will merge after other 10.0 post-release steps. Refs https://github.com/gravitational/teleport/issues/13341.