### PR TITLE
fix in-memory control stream

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -743,19 +743,7 @@ func (a *ServerWithRoles) RegisterInventoryControlStream(ics client.UpstreamInve
 
 	upstreamHello.Services = filteredServices
 
-	// send downstream hello (note: in theory we could send hellos simultaneously to slightly
-	// improve perf, but there is a potential benefit to having the downstream hello serve
-	// double-duty as an indicator of successful auth).
-	downstreamHello := proto.DownstreamInventoryHello{
-		Version:  teleport.Version,
-		ServerID: a.authServer.ServerID,
-	}
-	if err := ics.Send(a.CloseContext(), downstreamHello); err != nil {
-		return trace.Wrap(err)
-	}
-
-	a.authServer.RegisterInventoryControlStream(ics, upstreamHello)
-	return nil
+	return a.authServer.RegisterInventoryControlStream(ics, upstreamHello)
 }
 
 func (a *ServerWithRoles) GetInventoryStatus(ctx context.Context, req proto.InventoryStatusRequest) (proto.InventoryStatusSummary, error) {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1184,22 +1184,7 @@ func (process *TeleportProcess) makeInventoryControlStreamWhenReady(ctx context.
 func (process *TeleportProcess) makeInventoryControlStream(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
 	// if local auth exists, create an in-memory control stream
 	if auth := process.getLocalAuth(); auth != nil {
-		upstream, downstream := client.InventoryControlStreamPipe()
-		go func() {
-			select {
-			case msg := <-upstream.Recv():
-				hello, ok := msg.(proto.UpstreamInventoryHello)
-				if !ok {
-					upstream.CloseWithError(trace.BadParameter("expected upstream hello, got: %T", msg))
-					return
-				}
-				auth.RegisterInventoryControlStream(upstream, hello)
-			case <-upstream.Done():
-			case <-auth.CloseContext().Done():
-				upstream.Close()
-			}
-		}()
-		return downstream, nil
+		return auth.MakeLocalInventoryControlStream(), nil
 	}
 
 	// fallback to using the instance client


### PR DESCRIPTION
Fixes hello message exchange for in-memory control stream registration and adds test coverage to ensure that in-memory registration behaves equivalent to normal registration.

Fixes an issue that was causing teleport instances running both auth and node service to emit TeleportDegraded events.