### PR TITLE
Fix Kubernetes Access nav sidebar section

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -394,21 +394,7 @@
         },
         {
           "title": "Getting Started",
-          "slug": "/kubernetes-access/getting-started/",
-          "entries": [
-            {
-              "title": "Local Demo Cluster",
-              "slug": "/kubernetes-access/getting-started/local/"
-            },
-            {
-              "title": "Cluster",
-              "slug": "/kubernetes-access/getting-started/cluster/"
-            },
-            {
-              "title": "Agent",
-              "slug": "/kubernetes-access/getting-started/agent/"
-            }
-          ]
+          "slug": "/kubernetes-access/getting-started/"
         },
         {
           "title": "Guides",


### PR DESCRIPTION
The changes in #13068 moved pages in the Kubernetes Access section that
did not relate to Kubernetes Access into more appropriate sections of
the docs. This meant converting
`/docs/kubernetes-access/getting-started` into a guide, rather than a
section, since only one page within the previous `getting-started`
section had to do with Kubernetes Access.

However, this change left the nav sidebar for the Getting Started
section unchanged. The current change deletes the sidebar entries to
prevent confusion.