### PR TITLE
Fix Deadlock on session registry close

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -525,8 +525,8 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 		return trace.BadParameter("invalid session id")
 	}
 
-	// update ctx with the session if it exists
-	if sess, found := reg.findSession(*id); found {
+	// update ctx with the session if it exists and is still active
+	if sess, found := reg.findSession(*id); found && !sess.isStopped() {
 		c.session = sess
 		c.Logger.Debugf("Will join session %v for SSH connection %v.", c.session.id, c.ServerConn.RemoteAddr())
 	} else {

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -525,8 +525,8 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 		return trace.BadParameter("invalid session id")
 	}
 
-	// update ctx with the session if it exists and is still active
-	if sess, found := reg.findSession(*id); found && !sess.isStopped() {
+	// update ctx with the session if it exists
+	if sess, found := reg.findSession(*id); found {
 		c.session = sess
 		c.Logger.Debugf("Will join session %v for SSH connection %v.", c.session.id, c.ServerConn.RemoteAddr())
 	} else {

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -652,10 +652,6 @@ func (s *session) Stop() {
 	// close io copy loops
 	s.io.Close()
 
-	// remove session from server context to prevent new requests
-	// from attempting to join the session during cleanup
-	s.scx.setSession(nil)
-
 	// Close and kill terminal
 	if s.term != nil {
 		if err := s.term.Close(); err != nil {
@@ -1386,6 +1382,7 @@ func (s *session) removePartyUnderLock(p *party) error {
 	return nil
 }
 
+// isStopped does not need to be called under sessionLock
 func (s *session) isStopped() bool {
 	select {
 	case <-s.stopC:

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -210,10 +210,10 @@ func (s *SessionRegistry) tryCreateHostUser(ctx *ServerContext) (*user.User, err
 	return tempUser, nil
 }
 
-// OpenSession either joins an existing session or starts a new session.
+// OpenSession either joins an existing active session or starts a new session.
 func (s *SessionRegistry) OpenSession(ch ssh.Channel, ctx *ServerContext) error {
 	session := ctx.getSession()
-	if session != nil {
+	if session != nil && !session.isStopped() {
 		ctx.Infof("Joining existing session %v.", session.id)
 
 		mode := types.SessionParticipantMode(ctx.env[teleport.EnvSSHJoinMode])


### PR DESCRIPTION
Removes a deadlock caused by https://github.com/gravitational/teleport/pull/12889 and replaces it with a safer check to avoid the race condition of a session being joined during its shutdown process.