### PR TITLE
Refactor tests under `util` package.

### DIFF
--- a/lib/utils/addr_test.go
+++ b/lib/utils/addr_test.go
@@ -17,131 +17,147 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"net"
 	"strings"
+	"testing"
 
-	. "gopkg.in/check.v1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
-type AddrTestSuite struct {
-}
+func TestParseHostPort(t *testing.T) {
+	t.Parallel()
 
-var _ = Suite(&AddrTestSuite{})
-
-func (s *AddrTestSuite) TestParseHostPort(c *C) {
 	// success
 	addr, err := ParseHostPortAddr("localhost:22", -1)
-	c.Assert(err, IsNil)
-	c.Assert(addr.AddrNetwork, Equals, "tcp")
-	c.Assert(addr.Addr, Equals, "localhost:22")
+	require.NoError(t, err)
+	require.Equal(t, addr.AddrNetwork, "tcp")
+	require.Equal(t, addr.Addr, "localhost:22")
 
 	// scheme + existing port
 	addr, err = ParseHostPortAddr("https://localhost", 443)
-	c.Assert(err, IsNil)
-	c.Assert(addr.AddrNetwork, Equals, "https")
-	c.Assert(addr.Addr, Equals, "localhost:443")
+	require.NoError(t, err)
+	require.Equal(t, addr.AddrNetwork, "https")
+	require.Equal(t, addr.Addr, "localhost:443")
 
 	// success
 	addr, err = ParseHostPortAddr("localhost", 1111)
-	c.Assert(err, IsNil)
-	c.Assert(addr.AddrNetwork, Equals, "tcp")
-	c.Assert(addr.Addr, Equals, "localhost:1111")
+	require.NoError(t, err)
+	require.Equal(t, addr.AddrNetwork, "tcp")
+	require.Equal(t, addr.Addr, "localhost:1111")
 
 	// missing port
 	addr, err = ParseHostPortAddr("localhost", -1)
-	c.Assert(err, NotNil)
-	c.Assert(addr, IsNil)
+	require.Error(t, err)
+	require.Nil(t, addr)
 
 	// scheme + missing port
 	_, err = ParseHostPortAddr("https://localhost", -1)
-	c.Assert(err, NotNil)
+	require.NotNil(t, err)
 }
 
-func (s *AddrTestSuite) TestEmpty(c *C) {
+func TestEmpty(t *testing.T) {
+	t.Parallel()
+
 	var a NetAddr
-	c.Assert(a.IsEmpty(), Equals, true)
+	require.Equal(t, a.IsEmpty(), true)
 }
 
-func (s *AddrTestSuite) TestParse(c *C) {
+func TestParse(t *testing.T) {
+	t.Parallel()
+
 	addr, err := ParseAddr("tcp://one:25/path")
-	c.Assert(err, IsNil)
-	c.Assert(addr, NotNil)
-	c.Assert(addr.Addr, Equals, "one:25")
-	c.Assert(addr.Path, Equals, "/path")
-	c.Assert(addr.FullAddress(), Equals, "tcp://one:25")
-	c.Assert(addr.IsEmpty(), Equals, false)
-	c.Assert(addr.Host(), Equals, "one")
-	c.Assert(addr.Port(0), Equals, 25)
+	require.NoError(t, err)
+	require.NotNil(t, addr)
+	require.Equal(t, addr.Addr, "one:25")
+	require.Equal(t, addr.Path, "/path")
+	require.Equal(t, addr.FullAddress(), "tcp://one:25")
+	require.Equal(t, addr.IsEmpty(), false)
+	require.Equal(t, addr.Host(), "one")
+	require.Equal(t, addr.Port(0), 25)
 }
 
-func (s *AddrTestSuite) TestParseIPV6(c *C) {
+func TestParseIPV6(t *testing.T) {
+	t.Parallel()
+
 	addr, err := ParseAddr("[::1]:49870")
-	c.Assert(err, IsNil)
-	c.Assert(addr, NotNil)
-	c.Assert(addr.Addr, Equals, "[::1]:49870")
-	c.Assert(addr.Path, Equals, "")
-	c.Assert(addr.FullAddress(), Equals, "tcp://[::1]:49870")
-	c.Assert(addr.IsEmpty(), Equals, false)
-	c.Assert(addr.Host(), Equals, "::1")
-	c.Assert(addr.Port(0), Equals, 49870)
+	require.NoError(t, err)
+	require.NotNil(t, addr)
+	require.Equal(t, addr.Addr, "[::1]:49870")
+	require.Equal(t, addr.Path, "")
+	require.Equal(t, addr.FullAddress(), "tcp://[::1]:49870")
+	require.Equal(t, addr.IsEmpty(), false)
+	require.Equal(t, addr.Host(), "::1")
+	require.Equal(t, addr.Port(0), 49870)
 
 	// Just square brackets is also valid
 	addr, err = ParseAddr("[::1]")
-	c.Assert(err, IsNil)
-	c.Assert(addr, NotNil)
-	c.Assert(addr.Addr, Equals, "[::1]")
-	c.Assert(addr.Host(), Equals, "::1")
+	require.NoError(t, err)
+	require.NotNil(t, addr)
+	require.Equal(t, addr.Addr, "[::1]")
+	require.Equal(t, addr.Host(), "::1")
 }
 
-func (s *AddrTestSuite) TestParseEmptyPort(c *C) {
+func TestParseEmptyPort(t *testing.T) {
+	t.Parallel()
+
 	addr, err := ParseAddr("one")
-	c.Assert(err, IsNil)
-	c.Assert(addr, NotNil)
-	c.Assert(addr.Addr, Equals, "one")
-	c.Assert(addr.Path, Equals, "")
-	c.Assert(addr.FullAddress(), Equals, "tcp://one")
-	c.Assert(addr.IsEmpty(), Equals, false)
-	c.Assert(addr.Host(), Equals, "one")
-	c.Assert(addr.Port(443), Equals, 443)
+	require.NoError(t, err)
+	require.NotNil(t, addr)
+	require.Equal(t, addr.Addr, "one")
+	require.Equal(t, addr.Path, "")
+	require.Equal(t, addr.FullAddress(), "tcp://one")
+	require.Equal(t, addr.IsEmpty(), false)
+	require.Equal(t, addr.Host(), "one")
+	require.Equal(t, addr.Port(443), 443)
 }
 
-func (s *AddrTestSuite) TestParseHTTP(c *C) {
+func TestParseHTTP(t *testing.T) {
+	t.Parallel()
+
 	addr, err := ParseAddr("http://one:25/path")
-	c.Assert(err, IsNil)
-	c.Assert(addr, NotNil)
-	c.Assert(addr.Addr, Equals, "one:25")
-	c.Assert(addr.Path, Equals, "/path")
-	c.Assert(addr.FullAddress(), Equals, "http://one:25")
-	c.Assert(addr.IsEmpty(), Equals, false)
+	require.NoError(t, err)
+	require.NotNil(t, addr)
+	require.Equal(t, addr.Addr, "one:25")
+	require.Equal(t, addr.Path, "/path")
+	require.Equal(t, addr.FullAddress(), "http://one:25")
+	require.Equal(t, addr.IsEmpty(), false)
 }
 
-func (s *AddrTestSuite) TestParseDefaults(c *C) {
+func TestParseDefaults(t *testing.T) {
+	t.Parallel()
+
 	addr, err := ParseAddr("host:25")
-	c.Assert(err, IsNil)
-	c.Assert(addr, NotNil)
-	c.Assert(addr.Addr, Equals, "host:25")
-	c.Assert(addr.FullAddress(), Equals, "tcp://host:25")
-	c.Assert(addr.IsEmpty(), Equals, false)
+	require.NoError(t, err)
+	require.NotNil(t, addr)
+	require.Equal(t, addr.Addr, "host:25")
+	require.Equal(t, addr.FullAddress(), "tcp://host:25")
+	require.Equal(t, addr.IsEmpty(), false)
 }
 
-func (s *AddrTestSuite) TestReplaceLocalhost(c *C) {
+func TestReplaceLocalhost(t *testing.T) {
+	t.Parallel()
+
 	var result string
 	result = ReplaceLocalhost("10.10.1.1", "192.168.1.100:399")
-	c.Assert(result, Equals, "10.10.1.1")
+	require.Equal(t, result, "10.10.1.1")
 	result = ReplaceLocalhost("10.10.1.1:22", "192.168.1.100:399")
-	c.Assert(result, Equals, "10.10.1.1:22")
+	require.Equal(t, result, "10.10.1.1:22")
 	result = ReplaceLocalhost("127.0.0.1:22", "192.168.1.100:399")
-	c.Assert(result, Equals, "192.168.1.100:22")
+	require.Equal(t, result, "192.168.1.100:22")
 	result = ReplaceLocalhost("0.0.0.0:22", "192.168.1.100:399")
-	c.Assert(result, Equals, "192.168.1.100:22")
+	require.Equal(t, result, "192.168.1.100:22")
 	result = ReplaceLocalhost("[::]:22", "192.168.1.100:399")
-	c.Assert(result, Equals, "192.168.1.100:22")
+	require.Equal(t, result, "192.168.1.100:22")
 	result = ReplaceLocalhost("[::]:22", "[1::1]:399")
-	c.Assert(result, Equals, "[1::1]:22")
+	require.Equal(t, result, "[1::1]:22")
 }
 
-func (s *AddrTestSuite) TestLocalAddrs(c *C) {
+func TestLocalAddrs(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		in       string
 		expected bool
@@ -155,13 +171,15 @@ func (s *AddrTestSuite) TestLocalAddrs(c *C) {
 	}
 	for i, testCase := range testCases {
 		addr, err := ParseAddr(testCase.in)
-		c.Assert(err, IsNil)
-		c.Assert(addr.IsLocal(), Equals, testCase.expected,
-			Commentf("test case %v, %v should be local(%v)", i, testCase.in, testCase.expected))
+		require.NoError(t, err)
+		require.Equalf(t, addr.IsLocal(), testCase.expected,
+			fmt.Sprintf("test case %v, %v should be local(%v)", i, testCase.in, testCase.expected))
 	}
 }
 
-func (s *AddrTestSuite) TestGuessesIPAddress(c *C) {
+func TestGuessesIPAddress(t *testing.T) {
+	t.Parallel()
+
 	var testCases = []struct {
 		addrs    []net.Addr
 		expected net.IP
@@ -233,11 +251,13 @@ func (s *AddrTestSuite) TestGuessesIPAddress(c *C) {
 	}
 	for _, testCase := range testCases {
 		ip := guessHostIP(testCase.addrs)
-		c.Assert(ip, DeepEquals, testCase.expected, Commentf(testCase.comment))
+		require.Empty(t, cmp.Diff(ip, testCase.expected), fmt.Sprintf(testCase.comment))
 	}
 }
 
-func (s *AddrTestSuite) TestMarshal(c *C) {
+func TestMarshal(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		in       *NetAddr
 		expected string
@@ -250,13 +270,15 @@ func (s *AddrTestSuite) TestMarshal(c *C) {
 
 	for i, testCase := range testCases {
 		bytes, err := yaml.Marshal(testCase.in)
-		c.Assert(err, IsNil)
-		c.Assert(strings.TrimSpace(string(bytes)), Equals, testCase.expected,
-			Commentf("test case %v, %v should be marshaled to: %v", i, testCase.in, testCase.expected))
+		require.NoError(t, err)
+		require.Equalf(t, strings.TrimSpace(string(bytes)), testCase.expected,
+			fmt.Sprintf("test case %v, %v should be marshaled to: %v", i, testCase.in, testCase.expected))
 	}
 }
 
-func (s *AddrTestSuite) TestUnmarshal(c *C) {
+func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		in       string
 		expected *NetAddr
@@ -269,13 +291,16 @@ func (s *AddrTestSuite) TestUnmarshal(c *C) {
 	for i, testCase := range testCases {
 		addr := &NetAddr{}
 		err := yaml.Unmarshal([]byte(testCase.in), addr)
-		c.Assert(err, IsNil)
-		c.Assert(addr, DeepEquals, testCase.expected,
-			Commentf("test case %v, %v should be unmarshalled to: %v", i, testCase.in, testCase.expected))
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(addr, testCase.expected),
+			fmt.Sprintf("test case %v, %v should be unmarshalled to: %v", i, testCase.in, testCase.expected))
+
 	}
 }
 
-func (s *AddrTestSuite) TestParseMultiple(c *C) {
+func TestParseMultiple(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		in  []string
 		out []NetAddr
@@ -295,7 +320,7 @@ func (s *AddrTestSuite) TestParseMultiple(c *C) {
 	}
 	for _, test := range tests {
 		parsed, err := ParseAddrs(test.in)
-		c.Assert(err, IsNil)
-		c.Assert(parsed, DeepEquals, test.out)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(parsed, test.out))
 	}
 }

--- a/lib/utils/anonymizer_test.go
+++ b/lib/utils/anonymizer_test.go
@@ -17,25 +17,26 @@ limitations under the License.
 package utils
 
 import (
+	"testing"
+
 	"github.com/gravitational/trace"
-	"gopkg.in/check.v1"
+
+	"github.com/stretchr/testify/require"
 )
 
-type AnonymizerSuite struct{}
+func TestHMACAnonymizer(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&AnonymizerSuite{})
-
-func (s *AnonymizerSuite) TestHMACAnonymizer(c *check.C) {
 	a, err := NewHMACAnonymizer(" ")
-	c.Assert(err, check.FitsTypeOf, trace.BadParameter(""))
-	c.Assert(a, check.IsNil)
+	require.IsType(t, err, trace.BadParameter(""))
+	require.Nil(t, a)
 
 	a, err = NewHMACAnonymizer("key")
-	c.Assert(err, check.IsNil)
-	c.Assert(a, check.NotNil)
+	require.NoError(t, err)
+	require.NotNil(t, a)
 
 	data := "secret"
 	result := a.Anonymize([]byte(data))
-	c.Assert(result, check.Not(check.Equals), "")
-	c.Assert(result, check.Not(check.Equals), data)
+	require.NotEqual(t, result, "")
+	require.NotEqual(t, result, data)
 }

--- a/lib/utils/certs_test.go
+++ b/lib/utils/certs_test.go
@@ -18,28 +18,37 @@ package utils
 
 import (
 	"os"
+	"runtime"
+	"testing"
+
+	"github.com/gravitational/teleport/api/constants"
 
 	"github.com/gravitational/trace"
 
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
-type CertsSuite struct{}
+func TestRejectsInvalidPEMData(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&CertsSuite{})
-
-func (s *CertsSuite) TestRejectsInvalidPEMData(c *check.C) {
 	_, err := ReadCertificateChain([]byte("no data"))
-	c.Assert(trace.Unwrap(err), check.FitsTypeOf, &trace.NotFoundError{})
+	require.IsType(t, trace.Unwrap(err), &trace.NotFoundError{})
 }
 
-func (s *CertsSuite) TestRejectsSelfSignedCertificate(c *check.C) {
+func TestRejectsSelfSignedCertificate(t *testing.T) {
+	t.Parallel()
+
 	certificateChainBytes, err := os.ReadFile("../../fixtures/certs/ca.pem")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	certificateChain, err := ReadCertificateChain(certificateChainBytes)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	err = VerifyCertificateChain(certificateChain)
-	c.Assert(err, check.ErrorMatches, "x509: certificate signed by unknown authority")
+	switch runtime.GOOS {
+	case constants.DarwinOS:
+		require.ErrorContains(t, err, "certificate is not standards compliant")
+	default:
+		require.ErrorContains(t, err, "x509: certificate signed by unknown authority")
+	}
 }

--- a/lib/utils/chconn_test.go
+++ b/lib/utils/chconn_test.go
@@ -35,6 +35,8 @@ import (
 // TestChConn validates that reads from the channel connection can be
 // canceled by setting a read deadline.
 func TestChConn(t *testing.T) {
+	t.Parallel()
+
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { listener.Close() })

--- a/lib/utils/circular_buffer_test.go
+++ b/lib/utils/circular_buffer_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestNewCircularBuffer(t *testing.T) {
+	t.Parallel()
+
 	buff, err := NewCircularBuffer(-1)
 	require.Error(t, err)
 	require.Nil(t, buff)
@@ -36,6 +38,8 @@ func TestNewCircularBuffer(t *testing.T) {
 }
 
 func TestCircularBuffer_Data(t *testing.T) {
+	t.Parallel()
+
 	buff, err := NewCircularBuffer(5)
 	require.NoError(t, err)
 

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestUserMessageFromError(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("Enable after https://drone.gravitational.io/gravitational/teleport/3517 is merged.")
 	tests := []struct {
 		comment   string
@@ -62,6 +64,8 @@ func TestUserMessageFromError(t *testing.T) {
 // Regressions test - Consolef used to panic when component name was longer
 // than 8 bytes.
 func TestConsolefLongComponent(t *testing.T) {
+	t.Parallel()
+
 	require.NotPanics(t, func() {
 		component := strings.Repeat("na ", 10) + "batman!"
 		Consolef(io.Discard, logrus.New(), component, "test message")
@@ -70,6 +74,8 @@ func TestConsolefLongComponent(t *testing.T) {
 
 // TestEscapeControl tests escape control
 func TestEscapeControl(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		in  string
 		out string
@@ -95,6 +101,8 @@ func TestEscapeControl(t *testing.T) {
 
 // TestAllowNewlines tests escape control that allows newlines
 func TestAllowNewlines(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		in  string
 		out string

--- a/lib/utils/distro_test.go
+++ b/lib/utils/distro_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestOSRelease(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name     string
 		in       string

--- a/lib/utils/environment_test.go
+++ b/lib/utils/environment_test.go
@@ -17,15 +17,15 @@ package utils
 
 import (
 	"os"
+	"testing"
 
-	"gopkg.in/check.v1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
-type EnvironmentSuite struct{}
+func TestReadEnvironmentFile(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&EnvironmentSuite{})
-
-func (s *EnvironmentSuite) TestReadEnvironmentFile(c *check.C) {
 	// contents of environment file
 	rawenv := []byte(`
 foo=bar
@@ -40,17 +40,17 @@ foo=
 
 	// create a temp file with an environment in it
 	f, err := os.CreateTemp("", "teleport-environment-")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	_, err = f.Write(rawenv)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	err = f.Close()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// read in the temp file
 	env, err := ReadEnvironmentFile(f.Name())
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// check we parsed it correctly
-	c.Assert(env, check.DeepEquals, []string{"foo=bar", "foo=bar=baz", "foo="})
+	require.Empty(t, cmp.Diff(env, []string{"foo=bar", "foo=bar=baz", "foo="}))
 }

--- a/lib/utils/fields_test.go
+++ b/lib/utils/fields_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestFields(t *testing.T) {
 	t.Parallel()
+
 	now := time.Now().Round(time.Minute)
 
 	sliceString := []string{"test", "string", "slice"}

--- a/lib/utils/fncache_test.go
+++ b/lib/utils/fncache_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestFnCache_New(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		desc      string
 		config    FnCacheConfig
@@ -56,6 +58,8 @@ func TestFnCache_New(t *testing.T) {
 
 // TestFnCacheSanity runs basic FnCache test cases.
 func TestFnCacheSanity(t *testing.T) {
+	t.Parallel()
+
 	tts := []struct {
 		ttl   time.Duration
 		delay time.Duration
@@ -151,6 +155,8 @@ func testFnCacheSimple(t *testing.T, ttl time.Duration, delay time.Duration) {
 // in-progress loading continues, and the entry is correctly updated, even if the call to Get
 // which happened to trigger the load needs to be unblocked early.
 func TestFnCacheCancellation(t *testing.T) {
+	t.Parallel()
+
 	const timeout = time.Millisecond * 10
 
 	cache, err := NewFnCache(FnCacheConfig{TTL: time.Minute})
@@ -185,6 +191,8 @@ func TestFnCacheCancellation(t *testing.T) {
 }
 
 func TestFnCacheContext(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cache, err := NewFnCache(FnCacheConfig{
 		TTL:     time.Minute,

--- a/lib/utils/grpc_test.go
+++ b/lib/utils/grpc_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestChainUnaryServerInterceptors(t *testing.T) {
+	t.Parallel()
+
 	handler := func(context.Context, interface{}) (interface{}, error) { return "resp", fmt.Errorf("error") }
 
 	interceptors := []grpc.UnaryServerInterceptor{}
@@ -55,6 +57,8 @@ func TestChainUnaryServerInterceptors(t *testing.T) {
 }
 
 func TestChainStreamServerInterceptors(t *testing.T) {
+	t.Parallel()
+
 	handler := func(interface{}, grpc.ServerStream) error { return fmt.Errorf("handler") }
 
 	interceptors := []grpc.StreamServerInterceptor{}
@@ -90,6 +94,8 @@ func (s *service) BidirectionalStreamingEcho(stream pb.Echo_BidirectionalStreami
 // TestGRPCErrorWrapping tests the error wrapping capability of the client
 // and server unary and stream interceptors
 func TestGRPCErrorWrapping(t *testing.T) {
+	t.Parallel()
+
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 

--- a/lib/utils/jsontools_test.go
+++ b/lib/utils/jsontools_test.go
@@ -28,6 +28,8 @@ import (
 // backends don't sort map keys for performance reasons, which can make
 // operations that depend on the byte ordering fail (e.g. CompareAndSwap).
 func TestMarshalMapConsistency(t *testing.T) {
+	t.Parallel()
+
 	value := map[string]string{
 		types.TeleportNamespace + "/foo": "1234",
 		types.TeleportNamespace + "/bar": "5678",

--- a/lib/utils/kernel_test.go
+++ b/lib/utils/kernel_test.go
@@ -18,18 +18,17 @@ package utils
 
 import (
 	"strings"
+	"testing"
 
 	"github.com/coreos/go-semver/semver"
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
-
-type KernelSuite struct{}
-
-var _ = check.Suite(&KernelSuite{})
 
 // TestKernelVersion checks that version strings for various distributions
 // can be parsed correctly.
-func (s *KernelSuite) TestKernelVersion(c *check.C) {
+func TestKernelVersion(t *testing.T) {
+	t.Parallel()
+
 	var tests = []struct {
 		inRelease  string
 		inMin      string
@@ -76,15 +75,15 @@ func (s *KernelSuite) TestKernelVersion(c *check.C) {
 	for _, tt := range tests {
 		// Check the version is parsed correctly.
 		version, err := kernelVersion(strings.NewReader(tt.inRelease))
-		c.Assert(err, check.IsNil)
-		c.Assert(version.String(), check.Equals, tt.outRelease)
+		require.NoError(t, err)
+		require.Equal(t, version.String(), tt.outRelease)
 
 		// Check that version comparisons work.
 		min, err := semver.NewVersion(tt.inMin)
-		c.Assert(err, check.IsNil)
+		require.NoError(t, err)
 		max, err := semver.NewVersion(tt.inMax)
-		c.Assert(err, check.IsNil)
-		c.Assert(version.LessThan(*max), check.Equals, true)
-		c.Assert(version.LessThan(*min), check.Equals, false)
+		require.NoError(t, err)
+		require.Equal(t, version.LessThan(*max), true)
+		require.Equal(t, version.LessThan(*min), false)
 	}
 }

--- a/lib/utils/linking_test.go
+++ b/lib/utils/linking_test.go
@@ -18,16 +18,14 @@ package utils
 
 import (
 	"net/http"
+	"testing"
 
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
-type WebLinksSuite struct {
-}
+func TestWebLinks(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&WebLinksSuite{})
-
-func (s *WebLinksSuite) TestWebLinks(c *check.C) {
 	var tests = []struct {
 		inResponse *http.Response
 		outNext    string
@@ -84,9 +82,9 @@ func (s *WebLinksSuite) TestWebLinks(c *check.C) {
 
 	for _, tt := range tests {
 		wls := ParseWebLinks(tt.inResponse)
-		c.Assert(wls.NextPage, check.Equals, tt.outNext)
-		c.Assert(wls.PrevPage, check.Equals, tt.outPrev)
-		c.Assert(wls.FirstPage, check.Equals, tt.outFirst)
-		c.Assert(wls.LastPage, check.Equals, tt.outLast)
+		require.Equal(t, wls.NextPage, tt.outNext)
+		require.Equal(t, wls.PrevPage, tt.outPrev)
+		require.Equal(t, wls.FirstPage, tt.outFirst)
+		require.Equal(t, wls.LastPage, tt.outLast)
 	}
 }

--- a/lib/utils/loadbalancer_test.go
+++ b/lib/utils/loadbalancer_test.go
@@ -23,36 +23,36 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"testing"
 
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
 var randomLocalAddr = *MustParseAddr("127.0.0.1:0")
 
-type LBSuite struct {
-}
+func TestSingleBackendLB(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&LBSuite{})
-
-func (s *LBSuite) TestSingleBackendLB(c *check.C) {
 	backend1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "backend 1")
 	}))
 	defer backend1.Close()
 
 	lb, err := NewLoadBalancer(context.TODO(), randomLocalAddr, urlToNetAddr(backend1.URL))
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	err = lb.Listen()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	go lb.Serve()
 	defer lb.Close()
 
 	out, err := Roundtrip(lb.Addr().String())
-	c.Assert(err, check.IsNil)
-	c.Assert(out, check.Equals, "backend 1")
+	require.NoError(t, err)
+	require.Equal(t, out, "backend 1")
 }
 
-func (s *LBSuite) TestTwoBackendsLB(c *check.C) {
+func TestTwoBackendsLB(t *testing.T) {
+	t.Parallel()
+
 	backend1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "backend 1")
 	}))
@@ -66,28 +66,30 @@ func (s *LBSuite) TestTwoBackendsLB(c *check.C) {
 	backend1Addr, backend2Addr := urlToNetAddr(backend1.URL), urlToNetAddr(backend2.URL)
 
 	lb, err := NewLoadBalancer(context.TODO(), randomLocalAddr)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	err = lb.Listen()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	go lb.Serve()
 	defer lb.Close()
 
 	// no endpoints
 	_, err = Roundtrip(lb.Addr().String())
-	c.Assert(err, check.NotNil)
+	require.NotNil(t, err)
 
 	lb.AddBackend(backend1Addr)
 	out, err := Roundtrip(lb.Addr().String())
-	c.Assert(err, check.IsNil)
-	c.Assert(out, check.Equals, "backend 1")
+	require.NoError(t, err)
+	require.Equal(t, out, "backend 1")
 
 	lb.AddBackend(backend2Addr)
 	out, err = Roundtrip(lb.Addr().String())
-	c.Assert(err, check.IsNil)
-	c.Assert(out, check.Equals, "backend 2")
+	require.NoError(t, err)
+	require.Equal(t, out, "backend 2")
 }
 
-func (s *LBSuite) TestOneFailingBackend(c *check.C) {
+func TestOneFailingBackend(t *testing.T) {
+	t.Parallel()
+
 	backend1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "backend 1")
 	}))
@@ -101,9 +103,9 @@ func (s *LBSuite) TestOneFailingBackend(c *check.C) {
 	backend1Addr, backend2Addr := urlToNetAddr(backend1.URL), urlToNetAddr(backend2.URL)
 
 	lb, err := NewLoadBalancer(context.TODO(), randomLocalAddr)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	err = lb.Listen()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	go lb.Serve()
 	defer lb.Close()
 
@@ -111,33 +113,35 @@ func (s *LBSuite) TestOneFailingBackend(c *check.C) {
 	lb.AddBackend(backend2Addr)
 
 	out, err := Roundtrip(lb.Addr().String())
-	c.Assert(err, check.IsNil)
-	c.Assert(out, check.Equals, "backend 1")
+	require.NoError(t, err)
+	require.Equal(t, out, "backend 1")
 
 	_, err = Roundtrip(lb.Addr().String())
-	c.Assert(err, check.NotNil)
+	require.NotNil(t, err)
 
 	out, err = Roundtrip(lb.Addr().String())
-	c.Assert(err, check.IsNil)
-	c.Assert(out, check.Equals, "backend 1")
+	require.NoError(t, err)
+	require.Equal(t, out, "backend 1")
 }
 
-func (s *LBSuite) TestClose(c *check.C) {
+func TestClose(t *testing.T) {
+	t.Parallel()
+
 	backend1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "backend 1")
 	}))
 	defer backend1.Close()
 
 	lb, err := NewLoadBalancer(context.TODO(), randomLocalAddr, urlToNetAddr(backend1.URL))
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	err = lb.Listen()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	go lb.Serve()
 	defer lb.Close()
 
 	out, err := Roundtrip(lb.Addr().String())
-	c.Assert(err, check.IsNil)
-	c.Assert(out, check.Equals, "backend 1")
+	require.NoError(t, err)
+	require.Equal(t, out, "backend 1")
 
 	lb.Close()
 	// second close works
@@ -147,10 +151,12 @@ func (s *LBSuite) TestClose(c *check.C) {
 
 	// requests are failing
 	out, err = Roundtrip(lb.Addr().String())
-	c.Assert(err, check.NotNil, check.Commentf("output: %s, err: %v", out, err))
+	require.NotNilf(t, err, fmt.Sprintf("output: %s, err: %v", out, err))
 }
 
-func (s *LBSuite) TestDropConnections(c *check.C) {
+func TestDropConnections(t *testing.T) {
+	t.Parallel()
+
 	backend1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "backend 1")
 	}))
@@ -158,30 +164,30 @@ func (s *LBSuite) TestDropConnections(c *check.C) {
 
 	backendAddr := urlToNetAddr(backend1.URL)
 	lb, err := NewLoadBalancer(context.TODO(), randomLocalAddr, backendAddr)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	err = lb.Listen()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	go lb.Serve()
 	defer lb.Close()
 
 	conn, err := net.Dial("tcp", lb.Addr().String())
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	defer conn.Close()
 
 	out, err := RoundtripWithConn(conn)
-	c.Assert(err, check.IsNil)
-	c.Assert(out, check.Equals, "backend 1")
+	require.NoError(t, err)
+	require.Equal(t, out, "backend 1")
 
 	// to make sure multiple requests work on the same wire
 	out, err = RoundtripWithConn(conn)
-	c.Assert(err, check.IsNil)
-	c.Assert(out, check.Equals, "backend 1")
+	require.NoError(t, err)
+	require.Equal(t, out, "backend 1")
 
 	// removing backend results in dropped connection to this backend
 	err = lb.RemoveBackend(backendAddr)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	_, err = RoundtripWithConn(conn)
-	c.Assert(err, check.NotNil)
+	require.NotNil(t, err)
 }
 
 func urlToNetAddr(u string) NetAddr {

--- a/lib/utils/proxyjump_test.go
+++ b/lib/utils/proxyjump_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestProxyJumpParsing(t *testing.T) {
+	t.Parallel()
+
 	type tc struct {
 		in  string
 		out []JumpHost

--- a/lib/utils/retry_test.go
+++ b/lib/utils/retry_test.go
@@ -25,6 +25,7 @@ import (
 
 func Test_LinearRetryMax(t *testing.T) {
 	t.Parallel()
+
 	cases := []struct {
 		desc              string
 		config            LinearConfig

--- a/lib/utils/slice_test.go
+++ b/lib/utils/slice_test.go
@@ -22,6 +22,8 @@ import (
 
 // TestSlice tests sync pool holding slices - SliceSyncPool
 func TestSlice(t *testing.T) {
+	t.Parallel()
+
 	pool := NewSliceSyncPool(1024)
 	// having a loop is not a guarantee that the same slice
 	// will be reused, but a good enough bet

--- a/lib/utils/timed_counter_test.go
+++ b/lib/utils/timed_counter_test.go
@@ -23,17 +23,23 @@ import (
 )
 
 func TestTimedCounterReturnsZeroOnConstruction(t *testing.T) {
+	t.Parallel()
+
 	uut := NewTimedCounter(clockwork.NewFakeClock(), time.Second)
 	require.Zero(t, uut.Count())
 }
 
 func TestTimedCounterIncrement(t *testing.T) {
+	t.Parallel()
+
 	clock := clockwork.NewFakeClock()
 	uut := NewTimedCounter(clock, time.Second)
 	require.Equal(t, uut.Increment(), 1)
 }
 
 func TestTimedCounterExpiresEvents(t *testing.T) {
+	t.Parallel()
+
 	// Given a counter with a 10-second cutoff, primed with events at 1 second
 	// intervals
 	clock := clockwork.NewFakeClock()
@@ -72,6 +78,8 @@ func TestTimedCounterExpiresEvents(t *testing.T) {
 }
 
 func TestTimedCounterIncrementExpiresValues(t *testing.T) {
+	t.Parallel()
+
 	// Given a counter with a 10-second cutoff, primed with 5 events at 1-
 	// second intervals
 	clock := clockwork.NewFakeClock()

--- a/lib/utils/unpack_test.go
+++ b/lib/utils/unpack_test.go
@@ -18,15 +18,15 @@ package utils
 
 import (
 	"archive/tar"
+	"fmt"
+	"testing"
 
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
-type UnpackSuite struct{}
+func TestSanitizeTarPath(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&UnpackSuite{})
-
-func (s *UnpackSuite) TestSanitizeTarPath(c *check.C) {
 	cases := []struct {
 		header      *tar.Header
 		expectError bool
@@ -140,8 +140,8 @@ func (s *UnpackSuite) TestSanitizeTarPath(c *check.C) {
 	}
 
 	for _, tt := range cases {
-		comment := check.Commentf("Name: %v LinkName: %v", tt.header.Name, tt.header.Linkname)
+		comment := fmt.Sprintf("Name: %v LinkName: %v", tt.header.Name, tt.header.Linkname)
 		err := sanitizeTarPath(tt.header, "/tmp")
-		c.Assert(err != nil, check.Equals, tt.expectError, comment)
+		require.Equal(t, err != nil, tt.expectError, comment)
 	}
 }

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -42,6 +42,7 @@ func TestMain(m *testing.M) {
 // TestLinear tests retry logic
 func TestLinear(t *testing.T) {
 	t.Parallel()
+
 	r, err := NewLinear(LinearConfig{
 		Step: time.Second,
 		Max:  3 * time.Second,
@@ -61,8 +62,9 @@ func TestLinear(t *testing.T) {
 }
 
 func TestHostUUIDIdempotent(t *testing.T) {
-	// call twice, get same result
 	t.Parallel()
+
+	// call twice, get same result
 	dir := t.TempDir()
 	id, err := ReadOrMakeHostUUID(dir)
 	require.Len(t, id, 36)
@@ -73,8 +75,9 @@ func TestHostUUIDIdempotent(t *testing.T) {
 }
 
 func TestHostUUIDBadLocation(t *testing.T) {
-	// call with a read-only dir, make sure to get an error
 	t.Parallel()
+
+	// call with a read-only dir, make sure to get an error
 	id, err := ReadOrMakeHostUUID("/bad-location")
 	require.Equal(t, id, "")
 	require.Error(t, err)
@@ -82,8 +85,9 @@ func TestHostUUIDBadLocation(t *testing.T) {
 }
 
 func TestHostUUIDIgnoreWhitespace(t *testing.T) {
-	// newlines are getting ignored
 	t.Parallel()
+
+	// newlines are getting ignored
 	dir := t.TempDir()
 	id := fmt.Sprintf("%s\n", uuid.NewString())
 	err := os.WriteFile(filepath.Join(dir, HostUUIDFile), []byte(id), 0666)
@@ -94,8 +98,9 @@ func TestHostUUIDIgnoreWhitespace(t *testing.T) {
 }
 
 func TestHostUUIDRegenerateEmpty(t *testing.T) {
-	// empty UUID in file is regenerated
 	t.Parallel()
+
+	// empty UUID in file is regenerated
 	dir := t.TempDir()
 	err := os.WriteFile(filepath.Join(dir, HostUUIDFile), nil, 0666)
 	require.NoError(t, err)
@@ -105,6 +110,8 @@ func TestHostUUIDRegenerateEmpty(t *testing.T) {
 }
 
 func TestSelfSignedCert(t *testing.T) {
+	t.Parallel()
+
 	creds, err := GenerateSelfSignedCert([]string{"example.com"})
 	require.NoError(t, err)
 	require.NotNil(t, creds)
@@ -114,6 +121,7 @@ func TestSelfSignedCert(t *testing.T) {
 
 func TestRandomDuration(t *testing.T) {
 	t.Parallel()
+
 	expectedMin := time.Duration(0)
 	expectedMax := time.Second * 10
 	for i := 0; i < 50; i++ {
@@ -125,6 +133,7 @@ func TestRandomDuration(t *testing.T) {
 
 func TestRemoveFromSlice(t *testing.T) {
 	t.Parallel()
+
 	tests := []struct {
 		name     string
 		slice    []string
@@ -147,6 +156,7 @@ func TestRemoveFromSlice(t *testing.T) {
 // TestVersions tests versions compatibility checking
 func TestVersions(t *testing.T) {
 	t.Parallel()
+
 	type tc struct {
 		info      string
 		client    string
@@ -177,6 +187,7 @@ func TestVersions(t *testing.T) {
 // TestClickableURL tests clickable URL conversions
 func TestClickableURL(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		info string
 		in   string
@@ -199,6 +210,7 @@ func TestClickableURL(t *testing.T) {
 // TestParseAdvertiseAddr tests parsing of advertise address
 func TestParseAdvertiseAddr(t *testing.T) {
 	t.Parallel()
+
 	type tc struct {
 		info string
 		in   string
@@ -242,6 +254,7 @@ func TestParseAdvertiseAddr(t *testing.T) {
 // with regular expression compatible value
 func TestGlobToRegexp(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		comment string
 		in      string
@@ -279,6 +292,7 @@ func TestGlobToRegexp(t *testing.T) {
 // TestReplaceRegexp tests regexp-style replacement of values
 func TestReplaceRegexp(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		comment string
 		expr    string
@@ -381,6 +395,7 @@ func TestReplaceRegexp(t *testing.T) {
 // TestContainsExpansion tests whether string contains expansion value
 func TestContainsExpansion(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		comment  string
 		val      string
@@ -428,6 +443,7 @@ func TestContainsExpansion(t *testing.T) {
 // TestMarshalYAML tests marshal/unmarshal of elements
 func TestMarshalYAML(t *testing.T) {
 	t.Parallel()
+
 	type kv struct {
 		Key string
 	}
@@ -485,6 +501,7 @@ func TestMarshalYAML(t *testing.T) {
 // TestReadToken tests reading token from file and as is
 func TestTryReadValueAsFile(t *testing.T) {
 	t.Parallel()
+
 	tok, err := TryReadValueAsFile("token")
 	require.Equal(t, "token", tok)
 	require.NoError(t, err)
@@ -504,6 +521,8 @@ func TestTryReadValueAsFile(t *testing.T) {
 
 // TestStringsSet makes sure that nil slice returns empty set (less error prone)
 func TestStringsSet(t *testing.T) {
+	t.Parallel()
+
 	out := StringsSet(nil)
 	require.Len(t, out, 0)
 	require.NotNil(t, out)
@@ -512,6 +531,7 @@ func TestStringsSet(t *testing.T) {
 // TestRepeatReader tests repeat reader
 func TestRepeatReader(t *testing.T) {
 	t.Parallel()
+
 	type tc struct {
 		name     string
 		repeat   byte
@@ -549,6 +569,7 @@ func TestRepeatReader(t *testing.T) {
 
 func TestReadAtMost(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		name  string
 		limit int64

--- a/lib/utils/ver_test.go
+++ b/lib/utils/ver_test.go
@@ -1,20 +1,17 @@
 /*
+Copyright 2022 Gravitational, Inc.
 
- Copyright 2022 Gravitational, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
 
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-
-
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package utils
@@ -22,6 +19,8 @@ package utils
 import "testing"
 
 func TestMinVerWithoutPreRelease(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name           string
 		currentVersion string

--- a/lib/utils/writer_test.go
+++ b/lib/utils/writer_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestCaptureNBytesWriter(t *testing.T) {
+	t.Parallel()
+
 	data := []byte("abcdef")
 	w := NewCaptureNBytesWriter(10)
 


### PR DESCRIPTION
Refactored all tests under `lib/util` to use testify instead of `gocheck`.

----

Used the following `gofmt` rewrite rules to automate most of the refactoring.

```
gofmt -r 'c.Assert(a, check.NotNil) -> require.NotNil(t, a)' -w *_test.go   
gofmt -r 'c.Assert(a, check.NotNil, b) -> require.NotNilf(t, a, b)' -w *_test.go   
gofmt -r 'c.Assert(a, check.FitsTypeOf, b) -> require.IsTypef(t, a, b)' -w *_test.go   
gofmt -r 'c.Assert(a, check.IsNil) -> require.NoError(t, a)' -w *_test.go   
gofmt -r 'c.Assert(a, check.IsNil, d) -> require.NoError(t, a, d)' -w *_test.go   
gofmt -r 'c.Assert(a, check.Equals, b) -> require.Equal(t, a, b)' -w *_test.go
gofmt -r 'c.Assert(a, check.HasLen, b) -> require.Len(t, a, b)' -w *_test.go
gofmt -r 'c.Assert(a, check.DeepEquals, b) -> require.Empty(t, cmp.Diff(a, b))' -w *_test.go
gofmt -r 'c.Assert(a, check.DeepEquals, b, d) -> require.Empty(t, cmp.Diff(a, b), d)' -w *_test.go
gofmt -r 'c.Assert(a, check.Equals, b, d) -> require.Equal(t, a, b, d)' -w *_test.go
gofmt -r 'c.Assert(a, check.ErrorMatches, b) -> require.ErrorContains(t, err, b)' -w *_test.go
gofmt -r 'check.Commentf(a, b) -> fmt.Sprintf(a, b)' -w *_test.go
gofmt -r 'fixtures.DeepCompare(c, a, b) -> require.Empty(t, cmp.Diff(a, b))' -w *_test.go
gofmt -r 'fixtures.ExpectNotFound(c, a) -> require.True(t, trace.IsNotFound(a))' -w *_test.go
gofmt -r 'fixtures.ExpectBadParameter(c, a) -> require.True(t, trace.IsBadParameter(a))' -w *_test.go
gofmt -r 'fixtures.ExpectAlreadyExists(c, a) -> require.True(t, trace.IsAlreadyExists(a))' -w *_test.go
gofmt -r 'fixtures.ExpectLimitExceeded(c, a) -> require.True(t, trace.IsLimitExceeded(a))' -w *_test.go
gofmt -r 'fixtures.ExpectConnectionProblem(c, a) -> require.True(t, trace.IsConnectionProblem(a))' -w *_test.go
gofmt -r 'fixtures.ExpectAccessDenied(c, a) -> require.True(t, trace.IsAccessDenied(a))' -w *_test.go
gofmt -r 'c.Errorf(a) -> t.Errorf(a)' -w *_test.go
gofmt -r 'c.Errorf(a, b) -> t.Errorf(a, b)' -w *_test.go
gofmt -r 'c.Fatalf(a) -> t.Fatalf(a)' -w *_test.go
gofmt -r 'c.Fatalf(a, b) -> t.Fatalf(a, b)' -w *_test.go
```