### PR TITLE
Refactor tests under `srv` package.

### DIFF
--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -37,6 +37,7 @@ import (
 // it as an argument. Otherwise it will run tests as normal.
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
+
 	// If the test is re-executing itself, execute the command that comes over
 	// the pipe.
 	if IsReexec() {

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -33,6 +33,8 @@ import (
 // TestEmitExecAuditEvent make sure the full command and exit code for a
 // command is always recorded.
 func TestEmitExecAuditEvent(t *testing.T) {
+	t.Parallel()
+
 	srv := newMockServer(t)
 	scx := newExecServerContext(t, srv)
 
@@ -97,6 +99,8 @@ func TestEmitExecAuditEvent(t *testing.T) {
 }
 
 func TestLoginDefsParser(t *testing.T) {
+	t.Parallel()
+
 	expectedEnvSuPath := "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/bar"
 	expectedSuPath := "PATH=/usr/local/bin:/usr/bin:/bin:/foo"
 

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -33,6 +33,8 @@ import (
 
 // TestHeartbeatKeepAlive tests keep alive cycle used for nodes and apps.
 func TestHeartbeatKeepAlive(t *testing.T) {
+	t.Parallel()
+
 	var tests = []struct {
 		name       string
 		mode       HeartbeatMode
@@ -211,6 +213,7 @@ func TestHeartbeatKeepAlive(t *testing.T) {
 // TestHeartbeatAnnounce tests announce cycles used for proxies and auth servers
 func TestHeartbeatAnnounce(t *testing.T) {
 	t.Parallel()
+
 	tests := []struct {
 		mode HeartbeatMode
 		kind string

--- a/lib/srv/heartbeatv2_test.go
+++ b/lib/srv/heartbeatv2_test.go
@@ -18,6 +18,7 @@ package srv
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -28,7 +29,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/inventory"
 
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -132,7 +132,7 @@ func newFakeHeartbeatDriver(t *testing.T) *fakeHeartbeatDriver {
 		// test need to run longer.
 		select {
 		case <-ctx.Done():
-			return nil, trace.Errorf("context canceled while waiting for next control stream")
+			return nil, fmt.Errorf("context canceled while waiting for next control stream")
 		case stream := <-streamC:
 			return stream, nil
 		}

--- a/lib/srv/keepalive_test.go
+++ b/lib/srv/keepalive_test.go
@@ -24,16 +24,12 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
-type KeepAliveSuite struct{}
+func TestServerClose(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&KeepAliveSuite{})
-
-func TestSrv(t *testing.T) { check.TestingT(t) }
-
-func (s *KeepAliveSuite) TestServerClose(c *check.C) {
 	doneCh := make(chan bool, 1)
 	closeContext, closeCancel := context.WithCancel(context.Background())
 
@@ -57,7 +53,7 @@ func (s *KeepAliveSuite) TestServerClose(c *check.C) {
 
 	// Wait for a keep-alive to be sent.
 	err := waitForRequests(requestSender, 1)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// Close the context (server), should cause the loop to stop as well.
 	closeCancel()
@@ -65,12 +61,14 @@ func (s *KeepAliveSuite) TestServerClose(c *check.C) {
 	// Wait 1 second for the keep-alive loop to stop, or return an error.
 	select {
 	case <-time.After(1 * time.Second):
-		c.Fatalf("Timeout waiting for keep-alive loop to stop.")
+		t.Fatalf("Timeout waiting for keep-alive loop to stop.")
 	case <-doneCh:
 	}
 }
 
-func (s *KeepAliveSuite) TestLoopClose(c *check.C) {
+func TestLoopClose(t *testing.T) {
+	t.Parallel()
+
 	doneCh := make(chan bool, 1)
 	closeContext, closeCancel := context.WithCancel(context.Background())
 
@@ -94,12 +92,12 @@ func (s *KeepAliveSuite) TestLoopClose(c *check.C) {
 
 	// Wait for a keep-alive to be sent.
 	err := waitForRequests(requestSender, 1)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// Wait 1 second for the keep-alive loop to stop, or return an error.
 	select {
 	case <-time.After(1 * time.Second):
-		c.Fatalf("Timeout waiting for keep-alive loop to stop.")
+		t.Fatalf("Timeout waiting for keep-alive loop to stop.")
 	case <-doneCh:
 	}
 }

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -57,6 +57,7 @@ func newTestMonitor(ctx context.Context, t *testing.T, asrv *auth.TestAuthServer
 
 func TestMonitorLockInForce(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 	asrv, err := auth.NewTestAuthServer(auth.TestAuthServerConfig{
 		Dir:   t.TempDir(),
@@ -93,6 +94,7 @@ func TestMonitorLockInForce(t *testing.T) {
 
 func TestMonitorStaleLocks(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 	asrv, err := auth.NewTestAuthServer(auth.TestAuthServerConfig{
 		Dir:   t.TempDir(),
@@ -166,6 +168,7 @@ func (t *mockActivityTracker) UpdateClientActivity() {}
 // is already before time.Now
 func TestMonitorDisconnectExpiredCertBeforeTimeNow(t *testing.T) {
 	t.Parallel()
+
 	clock := clockwork.NewRealClock()
 
 	certExpirationTime := clock.Now().Add(-1 * time.Second)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1339,6 +1339,7 @@ func TestPTY(t *testing.T) {
 	t.Parallel()
 
 	f := newFixture(t)
+
 	se, err := f.ssh.clt.NewSession()
 	require.NoError(t, err)
 	defer se.Close()

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -40,6 +40,8 @@ import (
 )
 
 func TestParseAccessRequestIDs(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		input     string
 		comment   string
@@ -82,6 +84,8 @@ func TestParseAccessRequestIDs(t *testing.T) {
 }
 
 func TestSession_newRecorder(t *testing.T) {
+	t.Parallel()
+
 	proxyRecording, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
 		Mode: types.RecordAtProxy,
 	})
@@ -303,6 +307,8 @@ func TestSession_newRecorder(t *testing.T) {
 }
 
 func TestSession_emitAuditEvent(t *testing.T) {
+	t.Parallel()
+
 	logger := logrus.WithFields(logrus.Fields{
 		trace.Component: teleport.ComponentAuth,
 	})
@@ -377,6 +383,8 @@ func TestInteractiveSession(t *testing.T) {
 // TestParties tests the party mechanisms within an interactive session,
 // including party leave, party disconnect, and empty session lingerAndDie.
 func TestParties(t *testing.T) {
+	t.Parallel()
+
 	srv := newMockServer(t)
 	srv.component = teleport.ComponentNode
 
@@ -464,6 +472,8 @@ func testJoinSession(t *testing.T, reg *SessionRegistry, sess *session) {
 }
 
 func TestSessionRecordingModes(t *testing.T) {
+	t.Parallel()
+
 	for _, tt := range []struct {
 		desc                 string
 		sessionRecordingMode constants.SessionRecordingMode

--- a/lib/srv/sessiontracker_test.go
+++ b/lib/srv/sessiontracker_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestSessionTracker(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -148,7 +148,7 @@ func newLocalTerminal(ctx *ServerContext) (*terminal, error) {
 	// Open PTY and corresponding TTY.
 	t.pty, t.tty, err = pty.Open()
 	if err != nil {
-		log.Warnf("Could not start PTY %v", err)
+		log.Warnf("Could not start PTY: %v", err)
 		return nil, err
 	}
 

--- a/lib/srv/term_test.go
+++ b/lib/srv/term_test.go
@@ -19,18 +19,16 @@ package srv
 import (
 	"os"
 	"os/user"
+	"testing"
 
 	"github.com/gravitational/trace"
 
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
-type TermSuite struct {
-}
+func TestGetOwner(t *testing.T) {
+	t.Parallel()
 
-var _ = check.Suite(&TermSuite{})
-
-func (s *TermSuite) TestGetOwner(c *check.C) {
 	tests := []struct {
 		inUserLookup  LookupUser
 		inGroupLookup LookupGroup
@@ -74,10 +72,10 @@ func (s *TermSuite) TestGetOwner(c *check.C) {
 
 	for _, tt := range tests {
 		uid, gid, mode, err := getOwner("", tt.inUserLookup, tt.inGroupLookup)
-		c.Assert(err, check.IsNil)
+		require.NoError(t, err)
 
-		c.Assert(uid, check.Equals, tt.outUID)
-		c.Assert(gid, check.Equals, tt.outGID)
-		c.Assert(mode, check.Equals, tt.outMode)
+		require.Equal(t, tt.outUID, uid)
+		require.Equal(t, tt.outGID, gid)
+		require.Equal(t, tt.outMode, mode)
 	}
 }

--- a/lib/srv/termmanager_test.go
+++ b/lib/srv/termmanager_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestCTRLCPassthrough(t *testing.T) {
+	t.Parallel()
+
 	m := NewTermManager()
 	m.On()
 	r, w := io.Pipe()
@@ -39,6 +41,8 @@ func TestCTRLCPassthrough(t *testing.T) {
 }
 
 func TestCTRLCCapture(t *testing.T) {
+	t.Parallel()
+
 	m := NewTermManager()
 	r, w := io.Pipe()
 	m.AddReader("foo", r)
@@ -52,6 +56,8 @@ func TestCTRLCCapture(t *testing.T) {
 }
 
 func TestHistoryKept(t *testing.T) {
+	t.Parallel()
+
 	m := NewTermManager()
 	m.On()
 
@@ -73,6 +79,8 @@ func TestHistoryKept(t *testing.T) {
 }
 
 func TestBufferedKept(t *testing.T) {
+	t.Parallel()
+
 	m := NewTermManager()
 
 	data := make([]byte, 20000)
@@ -90,6 +98,7 @@ func TestBufferedKept(t *testing.T) {
 
 func TestNoReadWhenOff(t *testing.T) {
 	t.Parallel()
+
 	m := NewTermManager()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 	defer cancel()

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -133,6 +133,7 @@ var _ HostUsersBackend = &testHostUserBackend{}
 
 func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 	t.Parallel()
+
 	backend := newTestUserMgmt()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
@@ -173,6 +174,7 @@ func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 
 func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 	t.Parallel()
+
 	backend := newTestUserMgmt()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
@@ -219,6 +221,7 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 
 func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 	t.Parallel()
+
 	type userAndGroups struct {
 		user   string
 		groups []string


### PR DESCRIPTION
Refactored all tests under `lib/srv` to use testify instead of `gocheck`.