### PR TITLE
Change EC2 discovery matchers in the fileconfig to include a configuration section

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1044,14 +1044,17 @@ func applySSHConfig(fc *FileConfig, cfg *service.Config) (err error) {
 		return trace.Wrap(err)
 	}
 
-	for _, matcher := range fc.SSH.AWSMatchers {
-		cfg.SSH.AWSMatchers = append(cfg.SSH.AWSMatchers,
-			services.AWSMatcher{
-				Types:       matcher.Types,
-				Regions:     matcher.Regions,
-				Tags:        matcher.Tags,
-				SSMDocument: matcher.SSMDocument,
-			})
+	if fc.SSH.AWSMatchers != nil {
+		cfg.SSH.AWSInviteToken = fc.SSH.AWSMatchers.InviteToken
+		for _, matcher := range fc.SSH.AWSMatchers.AWSMatchers {
+			cfg.SSH.AWSMatchers = append(cfg.SSH.AWSMatchers,
+				services.AWSMatcher{
+					Types:       matcher.Types,
+					Regions:     matcher.Regions,
+					Tags:        matcher.Tags,
+					SSMDocument: matcher.SSMDocument,
+				})
+		}
 	}
 
 	return nil

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -996,7 +996,7 @@ type SSH struct {
 	DisableCreateHostUser bool `yaml:"disable_create_host_user,omitempty"`
 
 	// AWSMatchers are used to match EC2 instances
-	AWSMatchers []AWSMatcher `yaml:"aws,omitempty"`
+	AWSMatchers *AWSMatcherConf `yaml:"aws,omitempty"`
 }
 
 // AllowTCPForwarding checks whether the config file allows TCP forwarding or not.
@@ -1174,9 +1174,9 @@ type ResourceMatcher struct {
 	Labels map[string]apiutils.Strings `yaml:"labels,omitempty"`
 }
 
-// AWSMatcher matches AWS databases.
+// AWSMatcher matches AWS databases and EC2 instances.
 type AWSMatcher struct {
-	// Types are AWS database types to match, "rds", "redshift", "elasticache",
+	// Types are AWS service types to match, "ec2", "rds", "redshift", "elasticache",
 	// or "memorydb".
 	Types []string `yaml:"types,omitempty"`
 	// Regions are AWS regions to query for databases.
@@ -1186,6 +1186,15 @@ type AWSMatcher struct {
 	// SSMDocument is the ssm command document to execute for EC2
 	// installation
 	SSMDocument string `yaml:"ssm_command_document"`
+}
+
+// AWSMatcherConf is used to configure and set aws matchers.
+type AWSMatcherConf struct {
+	// InviteToken is the token to use when generating the teleport
+	// install script.
+	InviteToken string `yaml:"invite_token,omitempty"`
+	// AWSMatchers matches AWS databases and EC2 instances.
+	AWSMatchers []AWSMatcher `yaml:"matchers,omitempty"`
 }
 
 // Database represents a single database proxied by the service.

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -399,6 +399,7 @@ func TestSSHSection(t *testing.T) {
 		expectError               require.ErrorAssertionFunc
 		expectEnabled             require.BoolAssertionFunc
 		expectAllowsTCPForwarding require.BoolAssertionFunc
+		expectedAWSSection        *AWSMatcherConf
 	}{
 		{
 			desc:                      "default",
@@ -444,6 +445,39 @@ func TestSSHSection(t *testing.T) {
 				cfg["ssh_service"].(cfgMap)["port_forwarding"] = "banana"
 			},
 			expectError: require.Error,
+		}, {
+			desc:        "AWS section is filled",
+			expectError: require.NoError,
+			mutate: func(cfg cfgMap) {
+				cfg["ssh_service"].(cfgMap)["enabled"] = "yes"
+				cfg["ssh_service"].(cfgMap)["aws"] =
+					cfgMap{
+						"invite_token": "invite-token",
+						"matchers": []cfgMap{
+							{
+								"types":   []string{"ec2"},
+								"regions": []string{"eu-central-1"},
+								"tags": cfgMap{
+									"discover_teleport": "yes",
+								},
+								"ssm_command_document": "ssm-document",
+							},
+						},
+					}
+			},
+			expectedAWSSection: &AWSMatcherConf{
+				InviteToken: "invite-token",
+				AWSMatchers: []AWSMatcher{
+					{
+						Types:   []string{"ec2"},
+						Regions: []string{"eu-central-1"},
+						Tags: map[string]apiutils.Strings{
+							"discover_teleport": []string{"yes"},
+						},
+						SSMDocument: "ssm-document",
+					},
+				},
+			},
 		},
 	}
 
@@ -461,8 +495,16 @@ func TestSSHSection(t *testing.T) {
 			if testCase.expectAllowsTCPForwarding != nil {
 				testCase.expectAllowsTCPForwarding(t, cfg.SSH.AllowTCPForwarding())
 			}
+
+			if testCase.expectedAWSSection != nil {
+				require.Equal(t, testCase.expectedAWSSection, cfg.SSH.AWSMatchers)
+			}
 		})
 	}
+}
+
+func TestSSHSection_AWSMatchers(t *testing.T) {
+
 }
 
 func TestX11Config(t *testing.T) {

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -602,6 +602,9 @@ type SSHConfig struct {
 	// SSH node.
 	DisableCreateHostUser bool
 
+	//AWSInviteToken is used to set the token in the default installer script
+	AWSInviteToken string
+
 	// AWSMatchers are used to match EC2 instances for auto enrollment.
 	AWSMatchers []services.AWSMatcher
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2277,7 +2277,7 @@ func (process *TeleportProcess) initSSH() error {
 			regular.SetCreateHostUser(!cfg.SSH.DisableCreateHostUser),
 			regular.SetStoragePresenceService(storagePresence),
 			regular.SetInventoryControlHandle(process.inventoryHandle),
-			regular.SetAWSMatchers(cfg.SSH.AWSMatchers),
+			regular.SetAWSMatchers(cfg.SSH.AWSMatchers, cfg.SSH.AWSInviteToken),
 		)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -214,8 +214,11 @@ type Server struct {
 
 	// users is used to start the automatic user deletion loop
 	users srv.HostUsers
+
 	// awsMatchers are used to match EC2 instances
 	awsMatchers []services.AWSMatcher
+	// awsInviteToken used to fill the default installer script
+	awsInviteToken string
 }
 
 // GetClock returns server clock implementation
@@ -661,9 +664,10 @@ func SetInventoryControlHandle(handle inventory.DownstreamHandle) ServerOption {
 }
 
 // SetAWSMatchers sets the matchers used for matching EC2 instances
-func SetAWSMatchers(matchers []services.AWSMatcher) ServerOption {
+func SetAWSMatchers(matchers []services.AWSMatcher, token string) ServerOption {
 	return func(s *Server) error {
 		s.awsMatchers = matchers
+		s.awsInviteToken = token
 		return nil
 	}
 }


### PR DESCRIPTION
Updated the RFD to account for this

Changes the SSH config matchers section from this: 
```yaml
ssh_service:
  enabled: "yes"
  aws:
  - types: ["ec2"]
    regions: ["us-west-1"]
    tags:
      "teleport": "yes" # aws tags to match
    ssm_command_document: ssm_command_document_name
```

To this:
```yaml
ssh_service:
  enabled: "yes"
  aws:
    invite_token: "iam-token-name"
    matchers:
    - types: ["ec2"]
      regions: ["us-west-1"]
      tags:
        "teleport": "yes" # aws tags to match
      ssm_command_document: ssm_command_document_name
```
