### PR TITLE
[v10] Retry UV failures and correctly handle single accounts

### DIFF
--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -205,11 +205,8 @@ func fido2Login(
 		return nil, "", trace.Wrap(err)
 	}
 
-	// Trust the assertion user if present, otherwise go with the requested user.
+	// Trust the assertion user if present, otherwise say nothing.
 	actualUser := assertionResp.User.Name
-	if actualUser == "" {
-		actualUser = user
-	}
 
 	return &proto.MFAAuthenticateResponse{
 		Response: &proto.MFAAuthenticateResponse_Webauthn{
@@ -255,8 +252,12 @@ func pickAssertion(
 	case l == 0:
 		return nil, errors.New("authenticator returned empty assertions")
 
-	// MFA or single credential (no explicit user).
-	case !passwordless, l == 1 && user == "":
+	// MFA or single account.
+	// Note that authenticators don't return the user name, display name or icon
+	// for a single account per RP.
+	// See the authenticatorGetAssertion response, user member (0x04):
+	// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorgetassertion-response-structure
+	case !passwordless, l == 1:
 		return assertions[0], nil
 
 	// Explicit user required. First occurrence wins.

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -472,7 +472,7 @@ func TestFIDO2Login(t *testing.T) {
 				assert.Equal(t, pin3.credentials[0].ID, resp.RawId, "RawId mismatch (want %q resident credential)", alpacaName)
 				assert.Equal(t, alpacaID, resp.Response.UserHandle, "UserHandle mismatch (want %q)", alpacaName)
 			},
-			wantUser: alpacaName,
+			wantUser: "", // single account response
 		},
 		{
 			name:  "passwordless biometric (llama)",
@@ -529,7 +529,7 @@ func TestFIDO2Login(t *testing.T) {
 				assert.Equal(t, pin3.credentials[0].ID, resp.RawId, "RawId mismatch (want %q resident credential)", alpacaName)
 				assert.Equal(t, alpacaID, resp.Response.UserHandle, "UserHandle mismatch (want %q)", alpacaName)
 			},
-			wantUser: alpacaName,
+			wantUser: "", // single account response
 		},
 		{
 			name:  "passwordless multi-choice credential picker",
@@ -661,6 +661,147 @@ func TestFIDO2Login(t *testing.T) {
 		})
 		t.Run(test.name+"/nonMetered", func(t *testing.T) {
 			runTest(t, test.fido2.withNonMeteredLocations())
+		})
+	}
+}
+
+func TestFIDO2Login_retryUVFailures(t *testing.T) {
+	resetFIDO2AfterTests(t)
+
+	const user = "llama"
+	pin1 := mustNewFIDO2Device("/pin1", "supersecretpinllama", &libfido2.DeviceInfo{
+		Options: pinOpts,
+	}, &libfido2.Credential{
+		ID: []byte{1, 1, 1, 1, 1},
+		User: libfido2.User{
+			ID:   []byte{1, 1, 1, 1, 2},
+			Name: user,
+		},
+	})
+	pin1.failUV = true // fail UV regardless of PIN
+
+	f2 := newFakeFIDO2(pin1).withNonMeteredLocations()
+	f2.setCallbacks()
+
+	const rpID = "example.com"
+	const origin = "https://example.com"
+	ctx := context.Background()
+	assertion := &wanlib.CredentialAssertion{
+		Response: protocol.PublicKeyCredentialRequestOptions{
+			Challenge:        []byte{1, 2, 3, 4, 5}, // arbitrary
+			RelyingPartyID:   rpID,
+			UserVerification: protocol.VerificationRequired,
+		},
+	}
+
+	pin1.setUP()
+	_, _, err := wancli.FIDO2Login(ctx, origin, assertion, pin1 /* prompt */, nil /* opts */)
+	require.NoError(t, err, "FIDO2Login failed UV retry")
+}
+
+func TestFIDO2Login_singleResidentCredential(t *testing.T) {
+	resetFIDO2AfterTests(t)
+
+	const user1Name = "llama"
+	const user2Name = "alpaca"
+	user1ID := []byte{1, 1, 1, 1, 1}
+	user2ID := []byte{1, 1, 1, 1, 2}
+
+	oneCredential := mustNewFIDO2Device("/bio1", "supersecretBIO1pin", &libfido2.DeviceInfo{
+		Options: bioOpts,
+	}, &libfido2.Credential{
+		ID: []byte{1, 1, 1, 1, 1},
+		User: libfido2.User{
+			ID:   user1ID,
+			Name: user1Name,
+		},
+	})
+	manyCredentials := mustNewFIDO2Device("/bio2", "supersecretBIO2pin", &libfido2.DeviceInfo{
+		Options: bioOpts,
+	},
+		&libfido2.Credential{
+			ID: user1ID,
+			User: libfido2.User{
+				ID:   user1ID,
+				Name: user1Name,
+			},
+		},
+		&libfido2.Credential{
+			ID: user2ID,
+			User: libfido2.User{
+				ID:   user2ID,
+				Name: user2Name,
+			},
+		})
+
+	f2 := newFakeFIDO2(oneCredential, manyCredentials).withNonMeteredLocations()
+	f2.setCallbacks()
+
+	const rpID = "example.com"
+	const origin = "https://example.com"
+	ctx := context.Background()
+	assertion := &wanlib.CredentialAssertion{
+		Response: protocol.PublicKeyCredentialRequestOptions{
+			Challenge:        []byte{1, 2, 3, 4, 5}, // arbitrary
+			RelyingPartyID:   rpID,
+			UserVerification: protocol.VerificationRequired,
+		},
+	}
+
+	tests := []struct {
+		name       string
+		up         func()
+		prompt     wancli.LoginPrompt
+		opts       *wancli.LoginOpts
+		wantUserID []byte
+		// Actual user is empty for all single account cases.
+		// Authenticators don't return the data.
+		wantUser string
+	}{
+		{
+			name:       "single credential with empty user",
+			up:         oneCredential.setUP,
+			prompt:     oneCredential,
+			wantUserID: user1ID,
+		},
+		{
+			name:   "single credential with correct user",
+			up:     oneCredential.setUP,
+			prompt: oneCredential,
+			opts: &wancli.LoginOpts{
+				User: user1Name, // happens to match
+			},
+			wantUserID: user1ID,
+		},
+		{
+			name:   "single credential with ignored user",
+			up:     oneCredential.setUP,
+			prompt: oneCredential,
+			opts: &wancli.LoginOpts{
+				User: user2Name, // ignored, we just can't know
+			},
+			wantUserID: user1ID,
+		},
+		{
+			name:   "multi credentials",
+			up:     manyCredentials.setUP,
+			prompt: manyCredentials,
+			opts: &wancli.LoginOpts{
+				User: user2Name, // respected, authenticator returns the data
+			},
+			wantUserID: user2ID,
+			wantUser:   user2Name,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.up()
+
+			resp, gotUser, err := wancli.FIDO2Login(ctx, origin, assertion, test.prompt, test.opts)
+			require.NoError(t, err, "FIDO2Login failed")
+			gotUserID := resp.GetWebauthn().GetResponse().GetUserHandle()
+			assert.Equal(t, test.wantUserID, gotUserID, "FIDO2Login user ID mismatch")
+			assert.Equal(t, test.wantUser, gotUser, "FIDO2Login user mismatch")
 		})
 	}
 }
@@ -1439,6 +1580,10 @@ func (f *fakeFIDO2) NewDevice(path string) (wancli.FIDODevice, error) {
 type fakeFIDO2Device struct {
 	simplePicker
 
+	// Set to true to cause "unsupported option" UV errors, regardless of other
+	// conditions.
+	failUV bool
+
 	path        string
 	info        *libfido2.DeviceInfo
 	pin         string
@@ -1614,6 +1759,10 @@ func (f *fakeFIDO2Device) Assertion(
 	// Validate UV.
 	switch {
 	case opts.UV == "": // OK, actually works as false.
+	case opts.UV == libfido2.True && f.failUV:
+		// Emulate UV failures, as seen in some devices regardless of other
+		// settings.
+		return nil, libfido2.ErrUnsupportedOption
 	case opts.UV == libfido2.True && f.isBio(): // OK.
 	case opts.UV == libfido2.True && f.hasClientPin() && pin != "": // OK, doubles as UV.
 	default: // Anything else is invalid, including libfido2.False.
@@ -1685,10 +1834,20 @@ func (f *fakeFIDO2Device) Assertion(
 		}
 	}
 
-	if len(assertions) == 0 {
+	switch len(assertions) {
+	case 0:
 		return nil, libfido2.ErrNoCredentials
+	case 1:
+		// Remove user name / display name / icon.
+		// See the authenticatorGetAssertion response structure, user member (0x04):
+		// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorgetassertion-response-structure
+		assertions[0].User.Name = ""
+		assertions[0].User.DisplayName = ""
+		assertions[0].User.Icon = ""
+		return assertions, nil
+	default:
+		return assertions, nil
 	}
-	return assertions, nil
 }
 
 func (f *fakeFIDO2Device) validatePIN(pin string) error {


### PR DESCRIPTION
Address the following FIDO2 issues:

1. Retry assertions without UV if UV=true if the PIN is set
2. Correctly handle single account responses from authenticators

1 happens in the wild and the fix is confirmed. The fix is based in the fact that the authenticator will set the UV bit in the resulting assertion when the PIN is present, regardless of us asking for it. We do need the UV bit to clear server-side validation, that haven't changed.

2 was a misunderstanding on my part; the spec doesn't require authenticators to return user names for single account responses, which they effectively don't. In practical terms we are unable to guarantee the `--user` flag for single account scenarios, but not failing seems better than failing. See the [authenticatorGetAssertion response][1], user member.

[1]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorgetassertion-response-structure

Backport #14198 to branch/v10