### PR TITLE
Refactor tests under `secret` package

### DIFF
--- a/lib/secret/secret_test.go
+++ b/lib/secret/secret_test.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/teleport/lib/utils"
-
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -31,88 +31,82 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestSecret(t *testing.T) { check.TestingT(t) }
-
-type SecretSuite struct{}
-
-var _ = check.Suite(&SecretSuite{})
-
 // TestKey checks a various key operations like new key generation and parsing.
-func (s *SecretSuite) TestKey(c *check.C) {
+func TestKey(t *testing.T) {
 	// Keys should be 32-bytes.
 	key, err := NewKey()
-	c.Assert(err, check.IsNil)
-	c.Assert(key, check.HasLen, 32)
+	require.NoError(t, err)
+	require.Len(t, key, 32)
 
 	// ParseKey should be able to load and key and use it to Open something
 	// sealed by the original key.
 	ciphertext, err := key.Seal([]byte("hello, world"))
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	pkey, err := ParseKey([]byte(key.String()))
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	plaintext, err := pkey.Open(ciphertext)
-	c.Assert(err, check.IsNil)
-	c.Assert(plaintext, check.DeepEquals, []byte("hello, world"))
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(plaintext, []byte("hello, world")))
 
 	// NewKey should always return a new key.
 	key1, err := NewKey()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	key2, err := NewKey()
-	c.Assert(err, check.IsNil)
-	c.Assert(key1, check.Not(check.DeepEquals), key2)
+	require.NoError(t, err)
+	require.NotEmpty(t, cmp.Diff(key1, key2))
 }
 
 // TestSeal makes sure calling Seal on the same data with the same key
 // results in different ciphertexts and nonces.
-func (s *SecretSuite) TestSeal(c *check.C) {
+func TestSeal(t *testing.T) {
 	key, err := NewKey()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	plaintext := []byte("hello, world")
 
 	ciphertext1, err := key.Seal(plaintext)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	var data1 sealedData
 	err = json.Unmarshal(ciphertext1, &data1)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	ciphertext2, err := key.Seal(plaintext)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	var data2 sealedData
 	err = json.Unmarshal(ciphertext2, &data2)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// Ciphertext and nonce for the same plaintext should be different each time
 	// Seal is called.
-	c.Assert(data1.Ciphertext, check.Not(check.DeepEquals), data2.Ciphertext)
-	c.Assert(data1.Nonce, check.Not(check.DeepEquals), data2.Nonce)
+	require.NotEmpty(t, cmp.Diff(data1.Ciphertext, data2.Ciphertext))
+	require.NotEmpty(t, cmp.Diff(data1.Nonce, data2.Nonce))
 
 	// The plaintext for both should be the same and match the original.
 	plaintext1, err := key.Open(ciphertext1)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	plaintext2, err := key.Open(ciphertext2)
-	c.Assert(err, check.IsNil)
-	c.Assert(plaintext, check.DeepEquals, plaintext1)
-	c.Assert(plaintext, check.DeepEquals, plaintext2)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(plaintext, plaintext1))
+	require.Empty(t, cmp.Diff(plaintext, plaintext2))
 }
 
 // TestOpen makes sure data that was sealed with a key can only be opened
 // with the same key.
-func (s *SecretSuite) TestOpen(c *check.C) {
+func TestOpen(t *testing.T) {
 	key1, err := NewKey()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	ciphertext, err := key1.Seal([]byte("hello, world"))
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// Trying to call Open with a different key should always fail.
 	key2, err := NewKey()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	_, err = key2.Open(ciphertext)
-	c.Assert(err, check.NotNil)
+	require.Error(t, err)
 
 	// Calling Open with the same key should work.
 	plaintext, err := key1.Open(ciphertext)
-	c.Assert(err, check.IsNil)
-	c.Assert(plaintext, check.DeepEquals, []byte("hello, world"))
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(plaintext, []byte("hello, world")))
 }


### PR DESCRIPTION
Refactored all tests under `lib/secret` to use testify instead of gocheck.