### PR TITLE
Fix TTL file config not working in tbot

### DIFF
--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -66,7 +66,7 @@ func Run(args []string, stdout io.Writer) error {
 	startCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
 	startCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)
 	startCmd.Flag("destination-dir", "Directory to write short-lived machine certificates.").StringVar(&cf.DestinationDir)
-	startCmd.Flag("certificate-ttl", "TTL of short-lived machine certificates.").Default("60m").DurationVar(&cf.CertificateTTL)
+	startCmd.Flag("certificate-ttl", "TTL of short-lived machine certificates.").DurationVar(&cf.CertificateTTL)
 	startCmd.Flag("renewal-interval", "Interval at which short-lived certificates are renewed; must be less than the certificate TTL.").DurationVar(&cf.RenewalInterval)
 	startCmd.Flag("join-method", "Method to use to join the cluster, can be \"token\" or \"iam\".").Default(config.DefaultJoinMethod).EnumVar(&cf.JoinMethod, "token", "iam")
 	startCmd.Flag("oneshot", "If set, quit after the first renewal.").BoolVar(&cf.Oneshot)


### PR DESCRIPTION
Closes #14318

For the main `tbot` run, we do not use the kingpin default behaviour. We instead apply the file config, and then apply any command line values where they have a non zero value. I'm not sure this is the best behaviour, but it works for now.

Here, an erroneous `.Default()` had slipped in, and was therefore overriding the value in the file config. 