### PR TITLE
Deflake TestIgnorePuTTYSimpleChannel

### DIFF
--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1909,7 +1909,7 @@ func TestX11ProxySupport(t *testing.T) {
 func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	t.Parallel()
 
-	f := newFixture(t)
+	f := newFixtureWithoutDiskBasedLogging(t)
 	ctx := context.Background()
 
 	listener, _ := mustListen(t)


### PR DESCRIPTION
Yet another test where we need to disable the filesessions
uploader.

Fixes #14368