### PR TITLE
only build url if path param exists

### DIFF
--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -78,6 +78,7 @@ const js = `
         }).then(response => {
           if (response.ok) {
             try {
+              // if a path parameter was passed through the redirect, append that path to the target url
               if (path) {
                 var redirectUrl = new URL(path, url.origin)
                 window.location.replace(redirectUrl.toString());
@@ -88,7 +89,6 @@ const js = `
                 // in case of malformed url, return to origin
                 window.location.replace(url.origin)
             }
-            // redirect to the target path and remove current URL from history (back button)
           }
         });
       })();

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -78,8 +78,12 @@ const js = `
         }).then(response => {
           if (response.ok) {
             try {
-              var redirectUrl = new URL(path, url.origin)
-              window.location.replace(redirectUrl.toString());
+              if (path) {
+                var redirectUrl = new URL(path, url.origin)
+                window.location.replace(redirectUrl.toString());
+              } else {
+                window.location.replace(url.origin);
+              }
             } catch (error) {
                 // in case of malformed url, return to origin
                 window.location.replace(url.origin)


### PR DESCRIPTION
A fix for the issue some customers are having where they are forwarded to `app.example.com/null`.
The problem is caused by creating a URL with a `null` path. It _should_ always be present, but I think the linking of the proper changes from the webapps repo was done incorrectly (by me). Investing that.

This fix will make sure that, if no path parameter was passed, we return to origin instead of `/null`