### PR TITLE
[v8] Fix  "tsh db ls --cluster cluster" to use the correct cluster name

### DIFF
--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -73,7 +73,7 @@ func onListDatabases(cf *CLIConf) error {
 
 	var roleSet services.RoleSet
 	if isRoleSetRequiredForShowDatabases(cf) {
-		roleSet, err = fetchRoleSetForCluster(cf.Context, profile, proxy, profile.Cluster)
+		roleSet, err = fetchRoleSetForCluster(cf.Context, profile, proxy, tc.SiteName)
 		if err != nil {
 			log.Debugf("Failed to fetch user roles: %v.", err)
 		}
@@ -84,7 +84,8 @@ func onListDatabases(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	showDatabases(cf.SiteName, databases, activeDatabases, roleSet, cf.Verbose)
+	sort.Sort(types.Databases(databases))
+	showDatabases(cf.Stdout(), cf.SiteName, databases, activeDatabases, roleSet, cf.Verbose)
 	return nil
 }
 

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/pem"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -105,6 +107,65 @@ func TestDatabaseLogin(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, certs, 1)
 	require.Len(t, keys, 1)
+}
+
+func TestListDatabase(t *testing.T) {
+	lib.SetInsecureDevMode(true)
+	defer lib.SetInsecureDevMode(false)
+
+	tshHome := t.TempDir()
+	t.Setenv(types.HomeEnvVar, tshHome)
+
+	s := newTestSuite(t,
+		withRootConfigFunc(func(cfg *service.Config) {
+			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+			cfg.Databases.Enabled = true
+			cfg.Databases.Databases = []service.Database{{
+				Name:     "root-postgres",
+				Protocol: defaults.ProtocolPostgres,
+				URI:      "localhost:5432",
+			}}
+		}),
+		withLeafCluster(),
+		withLeafConfigFunc(func(cfg *service.Config) {
+			cfg.Databases.Enabled = true
+			cfg.Databases.Databases = []service.Database{{
+				Name:     "leaf-postgres",
+				Protocol: defaults.ProtocolPostgres,
+				URI:      "localhost:5432",
+			}}
+		}),
+	)
+
+	mustLogin(t, s)
+
+	captureStdout := new(bytes.Buffer)
+	err := Run([]string{
+		"db",
+		"ls",
+		"--insecure",
+		"--debug",
+	}, func(cf *CLIConf) error {
+		cf.overrideStdout = io.MultiWriter(os.Stdout, captureStdout)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Contains(t, captureStdout.String(), "root-postgres")
+
+	captureStdout.Reset()
+	err = Run([]string{
+		"db",
+		"ls",
+		"--cluster",
+		"leaf1",
+		"--insecure",
+		"--debug",
+	}, func(cf *CLIConf) error {
+		cf.overrideStdout = io.MultiWriter(os.Stdout, captureStdout)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Contains(t, captureStdout.String(), "leaf-postgres")
 }
 
 func TestFormatDatabaseListCommand(t *testing.T) {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1579,7 +1579,7 @@ func getUsersForDb(database types.Database, roleSet services.RoleSet) string {
 	return fmt.Sprintf("%v, except: %v", allowed, denied)
 }
 
-func showDatabases(clusterFlag string, databases []types.Database, active []tlsca.RouteToDatabase, roleSet services.RoleSet, verbose bool) {
+func showDatabases(w io.Writer, clusterFlag string, databases []types.Database, active []tlsca.RouteToDatabase, roleSet services.RoleSet, verbose bool) {
 	if verbose {
 		t := asciitable.MakeTable([]string{"Name", "Description", "Protocol", "Type", "URI", "Allowed Users", "Labels", "Connect", "Expires"})
 		for _, database := range databases {
@@ -1604,7 +1604,7 @@ func showDatabases(clusterFlag string, databases []types.Database, active []tlsc
 				database.Expiry().Format(constants.HumanDateFormatSeconds),
 			})
 		}
-		fmt.Println(t.AsBuffer().String())
+		fmt.Fprintln(w, t.AsBuffer().String())
 	} else {
 		var rows [][]string
 		for _, database := range databases {
@@ -1625,7 +1625,7 @@ func showDatabases(clusterFlag string, databases []types.Database, active []tlsc
 			})
 		}
 		t := makeTableWithTruncatedColumn([]string{"Name", "Description", "Allowed Users", "Labels", "Connect"}, rows, "Labels")
-		fmt.Println(t.AsBuffer().String())
+		fmt.Fprintln(w, t.AsBuffer().String())
 	}
 }
 

--- a/tool/tsh/tsh_helper_test.go
+++ b/tool/tsh/tsh_helper_test.go
@@ -228,7 +228,21 @@ func runTeleport(t *testing.T, cfg *service.Config) *service.TeleportProcess {
 		require.NoError(t, process.Close())
 		require.NoError(t, process.Wait())
 	})
-	waitForEvents(t, process, service.ProxyWebServerReady, service.NodeSSHReady)
+
+	serviceReadyEvents := []string{
+		service.ProxyWebServerReady,
+		service.NodeSSHReady,
+	}
+	if cfg.Databases.Enabled {
+		serviceReadyEvents = append(serviceReadyEvents, service.DatabasesReady)
+	}
+	waitForEvents(t, process, serviceReadyEvents...)
+
+	if cfg.Databases.Enabled {
+		for _, database := range cfg.Databases.Databases {
+			waitForDatabase(t, process, database)
+		}
+	}
 	return process
 }
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/14334 to branch/v8