### PR TITLE
improve semaphore retries and tests

### DIFF
--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -52,7 +52,7 @@ type backendItemToResourceFunc func(item backend.Item) (types.ResourceWithLabels
 func NewPresenceService(b backend.Backend) *PresenceService {
 	return &PresenceService{
 		log:     logrus.WithFields(logrus.Fields{trace.Component: "Presence"}),
-		jitter:  utils.NewJitter(),
+		jitter:  utils.NewFullJitter(),
 		Backend: b,
 	}
 }
@@ -689,10 +689,10 @@ func (s *PresenceService) DeleteAllRemoteClusters() error {
 }
 
 // this combination of backoff parameters leads to worst-case total time spent
-// in backoff between 1200ms and 2400ms depending on jitter.  tests are in
+// in backoff between 1ms and 2000ms depending on jitter.  tests are in
 // place to verify that this is sufficient to resolve a 20-lease contention
 // event, which is worse than should ever occur in practice.
-const baseBackoff = time.Millisecond * 300
+const baseBackoff = time.Millisecond * 400
 const leaseRetryAttempts int64 = 6
 
 // AcquireSemaphore attempts to acquire the specified semaphore.  AcquireSemaphore will automatically handle

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -85,6 +85,26 @@ func NewSeventhJitter() Jitter {
 	}
 }
 
+// NewFullJitter builds a new jitter on the range (0,n]. Most use-cases
+// are better served by a jitter with a meaningful minimum value, but if
+// the *only* purpose of the jitter is to spread out retries to the greatest
+// extent possible (e.g. when retrying a CompareAndSwap operation), a full jitter
+// may be appropriate.
+func NewFullJitter() Jitter {
+	var mu sync.Mutex
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return func(d time.Duration) time.Duration {
+		// values less than 1 cause rng to panic, and some logic
+		// relies on treating zero duration as non-blocking case.
+		if d < 1 {
+			return 0
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		return time.Duration(1) + time.Duration(rng.Int63n(int64(d)))
+	}
+}
+
 // Retry is an interface that provides retry logic
 type Retry interface {
 	// Reset resets retry state


### PR DESCRIPTION
This PR, in combination with https://github.com/gravitational/teleport/pull/14187 (recently merged) should reduce the flakiness observed in https://github.com/gravitational/teleport/issues/13570.

The main improvement made here is to change semaphore operations to occur across a broader range of retry times (full jitter versus half jitter).  Since the backoff in these retries are purely about spreading out retry attempts (as opposed to waiting for load to drop off or for some bad state to be resolved), there is no benefit to having a minimum threshold for the backoff.  It is difficult to replicate the failures seen in CI, but this change noticeably improves performance which should translate to a reduced sensitivity to the resource constrained environment that tests are run in.