### PR TITLE
Fix Resource Request approvals

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2546,35 +2546,11 @@ func (a *Server) NewWatcher(ctx context.Context, watch types.Watch) (types.Watch
 	return a.GetCache().NewWatcher(ctx, watch)
 }
 
-func (a *Server) pruneResourceRequestRoles(ctx context.Context, req types.AccessRequest) error {
-	clusterName, err := a.GetClusterName()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	user, err := a.GetUser(req.GetUser(), false /* withSecrets */)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return trace.Wrap(services.PruneResourceRequestRoles(
-		ctx,
-		req,
-		a.GetCache(),
-		clusterName.GetClusterName(),
-		user.GetTraits(),
-	))
-}
-
 func (a *Server) CreateAccessRequest(ctx context.Context, req types.AccessRequest) error {
 	if err := services.ValidateAccessRequestForUser(ctx, a, req,
 		// if request is in state pending, variable expansion must be applied
 		services.ExpandVars(req.GetState().IsPending()),
 	); err != nil {
-		return trace.Wrap(err)
-	}
-
-	if err := a.pruneResourceRequestRoles(ctx, req); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -1395,6 +1395,9 @@ func TestPruneRequestRoles(t *testing.T) {
 
 			require.ElementsMatch(t, tc.expectRoles, req.GetRoles(),
 				"Pruned roles %v don't match expected roles %v", req.GetRoles(), tc.expectRoles)
+			require.Len(t, req.GetRoleThresholdMapping(), len(req.GetRoles()),
+				"Length of rtm does not match number of roles. rtm: %v roles %v",
+				req.GetRoleThresholdMapping(), req.GetRoles())
 		})
 	}
 }

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -40,6 +40,7 @@ type mockGetter struct {
 	dbServers   map[string]types.DatabaseServer
 	appServers  map[string]types.AppServer
 	desktops    map[string]types.WindowsDesktop
+	clusterName string
 }
 
 // user inserts a new user with the specified roles and returns the username.
@@ -111,6 +112,13 @@ func (m *mockGetter) ListResources(ctx context.Context, req proto.ListResourcesR
 		}
 	}
 	return resp, nil
+}
+
+func (m *mockGetter) GetClusterName(opts ...MarshalOption) (types.ClusterName, error) {
+	return types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: m.clusterName,
+		ClusterID:   "testid",
+	})
 }
 
 // TestReviewThresholds tests various review threshold scenarios
@@ -1017,8 +1025,9 @@ func TestRolesForResourceRequest(t *testing.T) {
 			}
 
 			g := &mockGetter{
-				roles: roles,
-				users: users,
+				roles:       roles,
+				users:       users,
+				clusterName: "my-cluster",
 			}
 
 			req, err := types.NewAccessRequestWithResources(
@@ -1042,6 +1051,8 @@ func TestRolesForResourceRequest(t *testing.T) {
 func TestPruneRequestRoles(t *testing.T) {
 	ctx := context.Background()
 
+	clusterName := "my-cluster"
+
 	g := &mockGetter{
 		roles:       make(map[string]types.Role),
 		users:       make(map[string]types.User),
@@ -1050,6 +1061,7 @@ func TestPruneRequestRoles(t *testing.T) {
 		dbServers:   make(map[string]types.DatabaseServer),
 		appServers:  make(map[string]types.AppServer),
 		desktops:    make(map[string]types.WindowsDesktop),
+		clusterName: clusterName,
 	}
 
 	// set up test roles
@@ -1201,8 +1213,6 @@ func TestPruneRequestRoles(t *testing.T) {
 	})
 	require.NoError(t, err)
 	g.desktops[desktop.GetName()] = desktop
-
-	clusterName := "my-cluster"
 
 	testCases := []struct {
 		desc               string
@@ -1384,9 +1394,6 @@ func TestPruneRequestRoles(t *testing.T) {
 			req.SetLoginHint(tc.loginHint)
 
 			err = ValidateAccessRequestForUser(ctx, g, req, ExpandVars(true))
-			require.NoError(t, err)
-
-			err = PruneResourceRequestRoles(ctx, req, g, clusterName, g.users[user].GetTraits())
 			if tc.expectError {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
Resource Request approvals from the web UI are currently broken in the case where:
1. The user has multiple `search_as_roles` available.
2. 1 or more of the available `search_as_roles` do not grant access to the requested resources, and are thus not included in the request.

In this case, the error `role subselection is not yet supported in reviews, try omitting role list` will be displayed to the reviewer when they try to approve the request.

This error is caused by the list of requested roles and the "Role Threshold Mapping" (rtm) in the request resource becoming out of sync with the list of requested roles. This is demonstrated by the first commit in this PR which adds a broken test.

This bug happens because "pruning" the list of roles to request for a resource access request is currently performed in a separate step. The fix here is to do the pruning inline with the original request variable expansion, before the rtm is calculated.