### PR TITLE
Fix Resource Requests for Desktops

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2858,30 +2858,9 @@ type ResourcePageFunc func(next []types.ResourceWithLabels) (stop bool, err erro
 // IterateResourcePages can be used to iterate over pages of resources.
 func (a *Server) IterateResourcePages(ctx context.Context, req proto.ListResourcesRequest, f ResourcePageFunc) (*types.ListResourcesResponse, error) {
 	for {
-		var resp *types.ListResourcesResponse
-		switch {
-		case req.ResourceType == types.KindWindowsDesktop:
-			wResp, err := a.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
-				WindowsDesktopFilter: req.WindowsDesktopFilter,
-				Limit:                int(req.Limit),
-				StartKey:             req.StartKey,
-				PredicateExpression:  req.PredicateExpression,
-				Labels:               req.Labels,
-				SearchKeywords:       req.SearchKeywords,
-			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			resp = &types.ListResourcesResponse{
-				Resources: types.WindowsDesktops(wResp.Desktops).AsResources(),
-				NextKey:   wResp.NextKey,
-			}
-		default:
-			dResp, err := a.ListResources(ctx, req)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			resp = dResp
+		resp, err := a.ListResources(ctx, req)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
 		stop, err := f(resp.Resources)
@@ -3185,6 +3164,26 @@ func (a *Server) GetDatabase(ctx context.Context, name string) (types.Database, 
 
 // ListResources returns paginated resources depending on the resource type..
 func (a *Server) ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+	// Because WindowsDesktopService does not contain the desktop resources,
+	// this is not implemented at the cache level and requires the workaround
+	// here in order to support KindWindowsDesktop for ListResources.
+	if req.ResourceType == types.KindWindowsDesktop {
+		wResp, err := a.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
+			WindowsDesktopFilter: req.WindowsDesktopFilter,
+			Limit:                int(req.Limit),
+			StartKey:             req.StartKey,
+			PredicateExpression:  req.PredicateExpression,
+			Labels:               req.Labels,
+			SearchKeywords:       req.SearchKeywords,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &types.ListResourcesResponse{
+			Resources: types.WindowsDesktops(wResp.Desktops).AsResources(),
+			NextKey:   wResp.NextKey,
+		}, nil
+	}
 	return a.GetCache().ListResources(ctx, req)
 }
 

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -2088,6 +2088,17 @@ func TestListResources(t *testing.T) {
 			require.Empty(t, resp.NextKey)
 			require.Empty(t, resp.TotalCount)
 
+			// ListResources should also work when called on auth directly
+			resp, err = srv.Auth().ListResources(ctx, proto.ListResourcesRequest{
+				ResourceType: test.resourceType,
+				Namespace:    apidefaults.Namespace,
+				Limit:        100,
+			})
+			require.NoError(t, err)
+			require.Len(t, resp.Resources, 2)
+			require.Empty(t, resp.NextKey)
+			require.Empty(t, resp.TotalCount)
+
 			// Test types.KindKubernetesCluster
 			if test.resourceType == types.KindKubeService {
 				test.resourceType = types.KindKubernetesCluster


### PR DESCRIPTION
Currently `KindWindowsDesktop` is only supported by the `ListResources` implementation of `*ServerWithRoles` but not `*Server` and not at the cache layer.

It is only supported by a hack currently in `(*Server).IterateResourcePages` which calls `ListWindowsDesktops` for this case, instead of `ListResources`. This breaks Resource Access Requests which tries to call `ListResources` through the `Server` rather than `ServerWithRoles`.

The fix here is simply to move the hack down a level into `(*Server).ListResources`. It would be nice to support all the same resource kinds for all implementations of `ListResources`, but many technical tradeoffs were made here and making such a broad change seems out of scope for this bugfix.

The existing tests for the access request validator mock the `ListResources` implementation assuming that it works for windows desktops, unfortunately that was not the case. Catching this would require a large integration test which would need to set up an auth server and a windows desktop service, I'm not sure it's worthwhile to implement that right now, I have tested this fix manually.