### PR TITLE
Require user interaction to find Touch ID credentials

### DIFF
--- a/lib/auth/touchid/api_other.go
+++ b/lib/auth/touchid/api_other.go
@@ -25,15 +25,27 @@ func (noopNative) Diag() (*DiagResult, error) {
 	return &DiagResult{}, nil
 }
 
+type noopAuthContext struct{}
+
+func (noopAuthContext) Close() {}
+
+func (noopNative) NewAuthContext() AuthContext {
+	return noopAuthContext{}
+}
+
 func (noopNative) Register(rpID, user string, userHandle []byte) (*CredentialInfo, error) {
 	return nil, ErrNotAvailable
 }
 
-func (noopNative) Authenticate(credentialID string, digest []byte) ([]byte, error) {
+func (noopNative) Authenticate(actx AuthContext, credentialID string, digest []byte) ([]byte, error) {
 	return nil, ErrNotAvailable
 }
 
-func (noopNative) FindCredentials(rpID, user string) ([]CredentialInfo, error) {
+func (noopNative) HasCredentials(rpID, user string) (bool, error) {
+	return false, ErrNotAvailable
+}
+
+func (noopNative) FindCredentials(actx AuthContext, rpID, user string) ([]CredentialInfo, error) {
 	return nil, ErrNotAvailable
 }
 

--- a/lib/auth/touchid/authenticate.m
+++ b/lib/auth/touchid/authenticate.m
@@ -22,8 +22,10 @@
 #import <Security/Security.h>
 
 #include "common.h"
+#include "context.h"
 
-int Authenticate(AuthenticateRequest req, char **sigB64Out, char **errOut) {
+int Authenticate(AuthContext *actx, AuthenticateRequest req, char **sigB64Out,
+                 char **errOut) {
   NSData *appLabel = [NSData dataWithBytes:req.app_label
                                     length:strlen(req.app_label)];
   NSDictionary *query = @{
@@ -32,7 +34,10 @@ int Authenticate(AuthenticateRequest req, char **sigB64Out, char **errOut) {
     (id)kSecMatchLimit : (id)kSecMatchLimitOne,
     (id)kSecReturnRef : @YES,
     (id)kSecAttrApplicationLabel : appLabel,
+    // ctx takes effect in the SecKeyCreateSignature call below.
+    (id)kSecUseAuthenticationContext : (id)GetLAContextFromAuth(actx),
   };
+
   SecKeyRef privateKey = NULL;
   OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query,
                                         (CFTypeRef *)&privateKey);

--- a/lib/auth/touchid/context.h
+++ b/lib/auth/touchid/context.h
@@ -1,0 +1,34 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONTEXT_H_
+#define CONTEXT_H_
+
+#import <LocalAuthentication/LocalAuthentication.h>
+
+// AuthContext is an optional, shared authentication context.
+// Allows reusing a single authentication prompt/gesture between different
+// functions, provided the functions are invoked in a short time interval.
+typedef struct AuthContext {
+  LAContext *la_ctx;
+} AuthContext;
+
+// GetLAContextFromAuth gets the LAContext from ctx, or returns a new LAContext
+// instance.
+LAContext *GetLAContextFromAuth(AuthContext *ctx);
+
+// AuthContextClose releases resources held by ctx.
+void AuthContextClose(AuthContext *ctx);
+
+#endif // CONTEXT_H_

--- a/lib/auth/touchid/context.m
+++ b/lib/auth/touchid/context.m
@@ -1,3 +1,6 @@
+//go:build touchid
+// +build touchid
+
 // Copyright 2022 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,25 +15,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTHENTICATE_H_
-#define AUTHENTICATE_H_
-
-#include <stddef.h>
-
 #include "context.h"
-#include "credential_info.h"
 
-typedef struct AuthenticateRequest {
-  const char *app_label;
-  const char *digest;
-  size_t digest_len;
-} AuthenticateRequest;
+#import <LocalAuthentication/LocalAuthentication.h>
 
-// Authenticate finds the key specified by app_label and signs the digest using
-// it. The digest is expected to be in SHA256.
-// Authenticate requires user interaction.
-// Returns zero if successful, non-zero otherwise.
-int Authenticate(AuthContext *actx, AuthenticateRequest req, char **sigB64Out,
-                 char **errOut);
+LAContext *GetLAContextFromAuth(AuthContext *ctx) {
+  if (ctx == NULL) {
+    return [[LAContext alloc] init];
+  }
+  if (ctx->la_ctx == NULL) {
+    ctx->la_ctx = [[LAContext alloc] init];
+    ctx->la_ctx.touchIDAuthenticationAllowableReuseDuration = 10; // seconds
+  }
+  return ctx->la_ctx;
+}
 
-#endif // AUTHENTICATE_H_
+void AuthContextClose(AuthContext *ctx) {
+  if (ctx == NULL) {
+    return;
+  }
+  ctx->la_ctx = NULL;
+}

--- a/lib/auth/touchid/credential_info.h
+++ b/lib/auth/touchid/credential_info.h
@@ -19,25 +19,25 @@
 typedef struct CredentialInfo {
   // label is the label for the Keychain entry.
   // In practice, the label is a combination of RPID and username.
-  const char *label;
+  char *label;
 
   // app_label is the application label for the Keychain entry.
   // In practice, the app_label is the credential ID.
-  const char *app_label;
+  char *app_label;
 
   // app_tag is the application tag for the Keychain entry.
   // In practice, the app_tag is the WebAuthn user handle.
-  const char *app_tag;
+  char *app_tag;
 
   // pub_key_b64 is the public key representation, encoded as a standard base64
   // string.
   // Refer to
   // https://developer.apple.com/documentation/security/1643698-seckeycopyexternalrepresentation?language=objc.
-  const char *pub_key_b64;
+  char *pub_key_b64;
 
   // creation_date in ISO 8601 format.
   // Only present when reading existing credentials.
-  const char *creation_date;
+  char *creation_date;
 } CredentialInfo;
 
 #endif // CREDENTIAL_INFO_H_

--- a/lib/auth/touchid/credentials.h
+++ b/lib/auth/touchid/credentials.h
@@ -27,6 +27,12 @@ typedef struct LabelFilter {
   const char *value;
 } LabelFilter;
 
+// HasCredentials returns 1 if at least one known credential matches the filter,
+// otherwise it behaves like FindCredentials (zero means no credentials,
+// negative means failure / OSStatus).
+// Does not require user interaction.
+int HasCredentials(LabelFilter filter);
+
 // FindCredentials finds all credentials matching a certain label filter.
 // Returns the numbers of credentials assigned to the infos array, or negative
 // on failure (typically an OSStatus code). The caller is expected to free infos

--- a/lib/auth/touchid/credentials.h
+++ b/lib/auth/touchid/credentials.h
@@ -15,6 +15,7 @@
 #ifndef CREDENTIALS_H_
 #define CREDENTIALS_H_
 
+#include "context.h"
 #include "credential_info.h"
 
 // LabelFilterKind is a way to filter by label.
@@ -30,8 +31,9 @@ typedef struct LabelFilter {
 // Returns the numbers of credentials assigned to the infos array, or negative
 // on failure (typically an OSStatus code). The caller is expected to free infos
 // (and their contents!).
-// User interaction is not required.
-int FindCredentials(LabelFilter filter, CredentialInfo **infosOut);
+// Requires user interaction.
+int FindCredentials(AuthContext *actx, const char *reason, LabelFilter filter,
+                    CredentialInfo **infosOut, char **errOut);
 
 // ListCredentials finds all registered credentials.
 // Returns the numbers of credentials assigned to the infos array, or negative


### PR DESCRIPTION
Require user interaction to find credentials, as a preparation for the Touch ID credential picker. No user-visible changes are introduced in this PR, even though program behavior is slightly different.

To avoid double-prompting users during Touch ID authentication we have to set a grace period in the underlying LAContext and share it between functions. Note that FindCredentials (native) uses the LAContext explicitly, whereas Authenticate (native) uses it through the SecItemCopyMatching query dictionary.

A new HasCredentials check is introduced so we keep the current behavior of failing without user interaction if no Touch ID keys are present. This is necessary to keep the `tsh` UX smooth.

#13901