### PR TITLE
Make the Fluentd guide more usable

### DIFF
--- a/docs/pages/management/guides/fluentd.mdx
+++ b/docs/pages/management/guides/fluentd.mdx
@@ -45,6 +45,10 @@ from Teleport's events API, and forwards them to Fluentd.
   $ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
   ```
 
+  We currently only build the event handler plugin for amd64 machines. If your
+  macOS machine uses Apple silicon, you will need to [install
+  Rosetta](https://support.apple.com/en-us/HT211861) before you can run the
+  event handler plugin. You can also build from source.
   </TabItem>
 
   <TabItem label="Docker">
@@ -57,6 +61,21 @@ from Teleport's events API, and forwards them to Fluentd.
   ```code
   $ helm repo add teleport https://charts.releases.teleport.dev/
   ```
+  </TabItem>
+  <TabItem label="From Source">
+  Ensure that you have Docker installed and running.
+
+  Run the following commands to build the plugin:
+
+  ```code
+  $ git clone https://github.com/gravitational/teleport-plugins.git --depth 1
+  $ cd teleport-plugins/event-handler/build.assets
+  $ make build
+  ```
+
+  You can find the compiled binary within your clone of the `teleport-plugins`
+  repo, with the file path, `event-handler/build/teleport-event-handler`.
+
   </TabItem>
 </Tabs>
 

--- a/docs/pages/management/guides/fluentd.mdx
+++ b/docs/pages/management/guides/fluentd.mdx
@@ -38,11 +38,13 @@ from Teleport's events API, and forwards them to Fluentd.
   ```
   </TabItem>
 
-  <TabItem label="MacOS">
+  <TabItem label="macOS">
+
   ```code
   $ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
-  $ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
   ```
+
   </TabItem>
 
   <TabItem label="Docker">

--- a/docs/pages/management/guides/fluentd.mdx
+++ b/docs/pages/management/guides/fluentd.mdx
@@ -63,6 +63,16 @@ from Teleport's events API, and forwards them to Fluentd.
 ## Step 2/6. Configure the plugin
 
 <Tabs>
+<TabItem scope={["cloud"]} label="Teleport Cloud">
+
+Run the `configure` command to generate a sample configuration. Replace
+`mytenant.teleport.sh` with the DNS name of your Teleport Cloud tenant:
+
+```code
+$ ./teleport-event-handler configure . mytenant.teleport.sh
+```
+
+</TabItem>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Run the `configure` command to generate a sample configuration. Replace
@@ -71,16 +81,6 @@ Service:
 
 ```code
 $ ./teleport-event-handler configure . teleport.example.com:443
-```
-
-</TabItem>
-<TabItem scope={["cloud"]} label="Teleport Cloud">
-
-Run the `configure` command to generate a sample configuration. Replace
-`mytenant.teleport.sh` with the DNS name of your Teleport Cloud tenant:
-
-```code
-$ ./teleport-event-handler configure . mytenant.teleport.sh
 ```
 
 </TabItem>


### PR DESCRIPTION
- Fix a mismatch between archive names in the two commands within the
  "MacOS" tab in Step 1
- Fix the name of the identity file resulting from `tctl auth sign` in
  the accompanying text.