### PR TITLE
Support GitHub organization wide roles

### DIFF
--- a/api/types/github.go
+++ b/api/types/github.go
@@ -258,11 +258,13 @@ func (c *GithubConnectorV3) MapClaims(claims GithubClaims) ([]string, []string, 
 			continue
 		}
 		for _, team := range teams {
-			// see if the user belongs to this team
-			if team == mapping.Team {
+			// see if the user belongs to this team or if there is a catch-all
+			// config for the organization
+			if team == mapping.Team || mapping.Team == "*" {
 				roles = append(roles, mapping.Logins...)
 				kubeGroups = append(kubeGroups, mapping.KubeGroups...)
 				kubeUsers = append(kubeUsers, mapping.KubeUsers...)
+				break
 			}
 		}
 	}
@@ -273,9 +275,11 @@ func (c *GithubConnectorV3) MapClaims(claims GithubClaims) ([]string, []string, 
 			continue
 		}
 		for _, team := range teams {
-			// see if the user belongs to this team
-			if team == mapping.Team {
+			// see if the user belongs to this team or if there is a catch-all
+			// config for the organization
+			if team == mapping.Team || mapping.Team == "*" {
 				roles = append(roles, mapping.Roles...)
+				break
 			}
 		}
 	}

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -8825,7 +8825,7 @@ var xxx_messageInfo_GithubClaims proto.InternalMessageInfo
 type TeamMapping struct {
 	// Organization is a Github organization a user belongs to.
 	Organization string `protobuf:"bytes,1,opt,name=Organization,proto3" json:"organization"`
-	// Team is a team within the organization a user belongs to.
+	// Team is a team within the organization a user belongs to or '*' to match all users in the organization regardless of teams.
 	Team string `protobuf:"bytes,2,opt,name=Team,proto3" json:"team"`
 	// Logins is a list of allowed logins for this org/team.
 	Logins []string `protobuf:"bytes,3,rep,name=Logins,proto3" json:"logins,omitempty"`
@@ -8875,7 +8875,7 @@ var xxx_messageInfo_TeamMapping proto.InternalMessageInfo
 type TeamRolesMapping struct {
 	// Organization is a Github organization a user belongs to.
 	Organization string `protobuf:"bytes,1,opt,name=Organization,proto3" json:"organization"`
-	// Team is a team within the organization a user belongs to.
+	// Team is a team within the organization a user belongs to or '*' to match all users in the organization regardless of teams.
 	Team string `protobuf:"bytes,2,opt,name=Team,proto3" json:"team"`
 	// Roles is a list of allowed logins for this org/team.
 	Roles                []string `protobuf:"bytes,3,rep,name=Roles,proto3" json:"roles,omitempty"`


### PR DESCRIPTION
This change adds support for setting `team` to `'*'` in the GitHub connector's `teams_to_roles`/`teams_to_logins` config. This has the effect of assigning the given roles to all users in the specified organization, regardless of their membership in any teams.

This implements the proposition from #14418 