### PR TITLE
[v10] Fail `app_service` start on invalid configuration (#14325)

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4118,9 +4118,16 @@ func (process *TeleportProcess) initApps() {
 		if tunnelAddrResolver == nil {
 			tunnelAddrResolver = process.singleProcessModeResolver(resp.GetProxyListenerMode())
 
+			// run the resolver. this will check configuration for errors.
+			_, err := tunnelAddrResolver(process.ExitContext())
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
 			// Block and wait for all dependencies to start before starting.
 			log.Debugf("Waiting for application service dependencies to start.")
 			process.waitForAppDepend()
+			log.Debugf("Application service dependencies have started, continuing.")
 		}
 
 		// Start uploader that will scan a path on disk and upload completed


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/14325
---
`app_service` supports two modes: one in which the single process runs `app_service`, `auth` and `proxy`, and the second in which the connection to auth server is done via proxy: it must be able to create a reverse tunnel.

Currently, if we cannot create a reverse tunnel, the `singleProcessModeResolver` is used, but we are not checking the configuration before waiting for all components to come online. If the configuration is invalid, they never will.

This change calls `singleProcessModeResolver` to force the (already existing) check before entering the wait.

Parent: #13969.