### PR TITLE
Use v5 roles in CreateRole

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -941,7 +941,7 @@ type clt interface {
 
 // CreateRole creates a role without assigning any users. Used in tests.
 func CreateRole(ctx context.Context, clt clt, name string, spec types.RoleSpecV5) (types.Role, error) {
-	role, err := types.NewRoleV3(name, spec)
+	role, err := types.NewRole(name, spec)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Trying to eliminate our use of V3 roles. This should have no functional effect.

One step towards https://github.com/gravitational/teleport/issues/14345