### PR TITLE
[v7] backport of #12661 (proxy initiated agent reconnects)

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -154,6 +154,8 @@ type Agent struct {
 	log         log.FieldLogger
 	ctx         context.Context
 	cancel      context.CancelFunc
+	claimCtx    context.Context
+	claimCancel context.CancelFunc
 	authMethods []ssh.AuthMethod
 	// state is the state of this agent
 	state string
@@ -170,10 +172,13 @@ func NewAgent(cfg AgentConfig) (*Agent, error) {
 		return nil, trace.Wrap(err)
 	}
 	ctx, cancel := context.WithCancel(cfg.Context)
+	claimCtx, claimCancel := context.WithCancel(ctx)
 	a := &Agent{
 		AgentConfig: cfg,
 		ctx:         ctx,
 		cancel:      cancel,
+		claimCtx:    claimCtx,
+		claimCancel: claimCancel,
 		authMethods: []ssh.AuthMethod{ssh.PublicKeys(cfg.Signer)},
 		state:       agentStateConnecting,
 		log:         cfg.Log,
@@ -320,6 +325,17 @@ func (a *Agent) handleGlobalRequests(ctx context.Context, requestCh <-chan *ssh.
 					a.log.Debugf("Failed to reply to %v request: %v.", r.Type, err)
 					continue
 				}
+			case reconnectRequest:
+				a.log.Debug("Received reconnect advisory request from proxy.")
+				if r.WantReply {
+					err := r.Reply(true, nil)
+					if err != nil {
+						a.log.Debugf("Failed to reply to %v request: %v.", r.Type, err)
+					}
+				}
+
+				a.claimCancel()
+				a.Lease.Release()
 			default:
 				// This handles keep-alive messages and matches the behaviour of OpenSSH.
 				err := r.Reply(false, nil)
@@ -345,6 +361,7 @@ func (a *Agent) handleGlobalRequests(ctx context.Context, requestCh <-chan *ssh.
 func (a *Agent) run() {
 	defer a.setState(agentStateDisconnected)
 	defer a.Lease.Release()
+	defer a.claimCancel()
 
 	a.setState(agentStateConnecting)
 
@@ -369,40 +386,36 @@ func (a *Agent) run() {
 		"remote-addr": remote,
 	}).Info("Connected.")
 
-	// wrap up remaining business logic in closure for easy
-	// conditional execution.
-	doWork := func() {
-		a.log.Debugf("Agent connected to proxy: %v.", a.getPrincipalsList())
-		a.setState(agentStateConnected)
-		// Notify waiters that the agent has connected.
-		if a.EventsC != nil {
-			select {
-			case a.EventsC <- ConnectedEvent:
-			case <-a.ctx.Done():
-				a.log.Debug("Context is closing.")
-				return
-			default:
-			}
-		}
-
-		// A connection has been established start - processing requests. Note that
-		// this function blocks while the connection is up. It will unblock when
-		// the connection is closed either due to intermittent connectivity issues
-		// or permanent loss of a proxy.
-		err = a.processRequests(conn)
-		if err != nil {
-			a.log.Warnf("Unable to continue processioning requests: %v.", err)
-			return
-		}
-	}
 	// if Tracker was provided, then the agent shouldn't continue unless
 	// no other agents hold a claim.
 	if a.Tracker != nil {
-		if !a.Tracker.WithProxy(doWork, a.getPrincipalsList()...) {
+		if ok := a.Tracker.ClaimContext(a.claimCtx, a.getPrincipalsList()...); !ok {
 			a.log.Debugf("Proxy already held by other agent: %v, releasing.", a.getPrincipalsList())
+			return
 		}
-	} else {
-		doWork()
+	}
+
+	a.log.Debugf("Agent connected to proxy: %v.", a.getPrincipalsList())
+	a.setState(agentStateConnected)
+	// Notify waiters that the agent has connected.
+	if a.EventsC != nil {
+		select {
+		case a.EventsC <- ConnectedEvent:
+		case <-a.ctx.Done():
+			a.log.Debug("Context is closing.")
+			return
+		default:
+		}
+	}
+
+	// A connection has been established start - processing requests. Note that
+	// this function blocks while the connection is up. It will unblock when
+	// the connection is closed either due to intermittent connectivity issues
+	// or permanent loss of a proxy.
+	err = a.processRequests(conn)
+	if err != nil {
+		a.log.Warnf("Unable to continue processioning requests: %v.", err)
+		return
 	}
 }
 
@@ -538,6 +551,7 @@ const (
 	chanHeartbeat    = "teleport-heartbeat"
 	chanDiscovery    = "teleport-discovery"
 	chanDiscoveryReq = "discovery"
+	reconnectRequest = "reconnect@goteleport.com"
 )
 
 const (

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -125,7 +125,10 @@ type Server interface {
 	Start() error
 	// Close closes server's operations immediately
 	Close() error
-	// Shutdown performs graceful server shutdown
+	// DrainConnections closes listeners and begins draining connections without
+	// closing open connections.
+	DrainConnections(context.Context) error
+	// Shutdown performs graceful server shutdown closing open connections.
 	Shutdown(context.Context) error
 	// Wait waits for server to close all outstanding operations
 	Wait()

--- a/lib/reversetunnel/conn.go
+++ b/lib/reversetunnel/conn.go
@@ -23,15 +23,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
-
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 )
 
 // connKey is a key used to identify tunnel connections. It contains the UUID
@@ -140,7 +139,6 @@ func (c *remoteConn) Close() error {
 	}
 
 	return nil
-
 }
 
 // OpenChannel will open a SSH channel to the remote side.
@@ -245,4 +243,8 @@ func (c *remoteConn) sendDiscoveryRequest(req discoveryRequest) error {
 	}
 
 	return nil
+}
+
+func (c *remoteConn) adviseReconnect() {
+	c.sconn.SendRequest(reconnectRequest, true, nil)
 }

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -217,6 +217,18 @@ func (s *localSite) IsClosed() bool { return false }
 // Close always returns nil because a localSite isn't closed.
 func (s *localSite) Close() error { return nil }
 
+func (s *localSite) adviseReconnect() {
+	s.remoteConnsMtx.Lock()
+	defer s.remoteConnsMtx.Unlock()
+
+	for _, conns := range s.remoteConns {
+		for _, conn := range conns {
+			s.log.Debugf("Sending reconnect: %s", conn.nodeID)
+			go conn.adviseReconnect()
+		}
+	}
+}
+
 func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 	if params.GetUserAgent == nil {
 		return nil, trace.BadParameter("user agent getter missing")

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -266,6 +266,15 @@ func (s *remoteSite) addConn(conn net.Conn, sconn ssh.Conn) (*remoteConn, error)
 	return rconn, nil
 }
 
+func (s *remoteSite) adviseReconnect() {
+	s.RLock()
+	defer s.RUnlock()
+	for _, conn := range s.connections {
+		s.Debugf("Sending reconnect: %s", conn.nodeID)
+		go conn.adviseReconnect()
+	}
+}
+
 func (s *remoteSite) GetStatus() string {
 	connInfo, err := s.getLastConnInfo()
 	if err != nil {

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -577,6 +577,28 @@ func (s *server) Close() error {
 	return s.srv.Close()
 }
 
+// DrainConnections closes the listener and sends reconnects to connected agents without
+// closing open connections.
+func (s *server) DrainConnections(ctx context.Context) error {
+	// Ensure listener is closed before sending reconnects.
+	err := s.srv.Close()
+	s.srv.Wait(ctx)
+
+	s.RLock()
+	defer s.RUnlock()
+	for _, site := range s.localSites {
+		s.log.Debugf("Advising reconnect to local site: %s", site.GetName())
+		site.adviseReconnect()
+	}
+
+	for _, site := range s.remoteSites {
+		s.log.Debugf("Advising reconnect to remote site: %s", site.GetName())
+		site.adviseReconnect()
+	}
+
+	return trace.Wrap(err)
+}
+
 func (s *server) Shutdown(ctx context.Context) error {
 	err := s.srv.Shutdown(ctx)
 	s.proxyWatcher.Close()

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2976,6 +2976,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		} else {
 			log.Infof("Shutting down gracefully.")
 			ctx := payloadContext(payload, log)
+			if tsrv != nil {
+				warnOnErr(tsrv.DrainConnections(ctx), log)
+			}
 			warnOnErr(sshProxy.Shutdown(ctx), log)
 			if tsrv != nil {
 				warnOnErr(tsrv.Shutdown(ctx), log)


### PR DESCRIPTION
Minimal backport of #12661, to avoid having to pull in the entirety of the proxy peering agentpool changes.