### PR TITLE
Try to fix flaky TestAccessMongoDB

### DIFF
--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -97,6 +97,11 @@ func PrecomputeKeys() {
 	})
 }
 
+// PrecomputeKeysCount return current number of pre-computed keys.
+func PrecomputeKeysCount() int {
+	return len(precomputedKeys)
+}
+
 // GenerateKeyPair returns fresh priv/pub keypair, takes about 300ms to execute in a worst case.
 // This will pull from a precomputed cache of ready to use keys if PrecomputeKeys was enabled.
 func GenerateKeyPair() ([]byte, []byte, error) {

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -813,6 +814,13 @@ func TestAccessMongoDB(t *testing.T) {
 
 						// Create user/role with the requested permissions.
 						testCtx.createUserAndRole(ctx, t, test.user, test.role, test.allowDbUsers, test.allowDbNames)
+
+						// Mongo driver establish servers connection to the upstream mongo server
+						// To decrease the deal during dialing Mongo TestServer by Engine wait for
+						// PrecomputeKeys.
+						require.Eventually(t, func() bool {
+							return native.PrecomputeKeysCount() > 3
+						}, time.Minute, time.Second, "failed to wait for pre-computed keys ")
 
 						// Try to connect to the database as this user.
 						mongoClient, err := testCtx.mongoClient(ctx, test.user, "mongo", test.dbUser, clientOpt.opts)


### PR DESCRIPTION
### What

Mongo Driver establishes severals connection to the Mongo Server where the connection time depends on `getClientCert` where for each new connection the `GenerateKeyPair` function is called. 
Depending on env load the `GenerateKeyPair` call can take more 4s: 

```
[724af] ###################  engine.connect 1 [690ns]
[724af] --------------------------->  getTopologyOptions start [600ns]
[724af] --------------------------->  getTopologyOptions 1 [36.281µs]
[724af] --------------------------->  getTopologyOptions 2 [96.572µs]
[724af] --------------------------->  getTopologyOptions 3 [136.412µs]
[724af] ------------------------------->  getConnectionOptions start [840ns]
[724af] ------------------------------->  getConnectionOptions stage1 [39.26µs]
------> [487a5] [TUNNELSRV2] Server.handleConnection stage6: 164.754832ms
------------> [487a5] e.HandleConnection [730ns]
[724af] ---------------------------------->  GetTLSConfig start [500ns]
[724af] ---------------------------------->  stage3  [813.969µs]
[724af] ------------------------------------->  getTLSConfigVerifyFull start [220ns]
[724af] *--------------------------------------->  getClientCert start [420ns]
[724af] *--------------------------------------->  getClientCert end [3.126131424s]
// Trace for second connection
[724af] ------------------------------------->  getTLSConfigVerifyFull end [3.131561459s]
[724af] ---------------------------------->  GetTLSConfig end [3.13245186s]
[724af] ------------------------------->  getConnectionOptions stage2 [3.132566242s]
[724af] ------------------------------->  getConnectionOptions stage4 [3.132601232s]
[724af] ------------------------------->  getConnectionOptions end [3.132643622s]
[724af] --------------------------->  getTopologyOptions 4 [3.132853436s]
[724af] --------------------------->  getTopologyOptions end [3.132887606s]
[724af] ###################  engine.connect 2 [3.132950346s]
[724af] ###################  engine.connect 3 [3.133040117s]
[724af] ###################  engine.connect 4 [3.13329676s]
```
