### PR TITLE
Add RBAC instructions for DB tctl auth sign

### DIFF
--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -158,6 +158,66 @@ $ tctl auth sign --format=db --host=host1,localhost,127.0.0.1 --out=db --ttl=219
 | `--out` | Name prefix for output files. |
 | `--ttl` | Certificate validity period. |
 
+<Details title="Setting up RBAC for signing database certificates">
+
+The `tctl` user must have permissions to impersonate the Teleport Database
+Service user, `Db`, in order to generate a signed database certificate. To add
+these impersonation privileges to your Teleport user, run the following
+commands.
+
+First, define a role that can impersonate the `Db` user. Add the following
+content to a file called `db-impersonator.yaml`:
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: db-impersonator
+spec:
+  options:
+  allow:
+    impersonate:
+      users: ['Db']
+      roles: ['Db']
+```
+
+Create the fole:
+
+```code
+$ tctl create -f db-impersonator.yaml
+```
+
+Retrieve your Teleport user's dynamic configuration resource so you can add the
+`db-impersonator` role:
+
+```code
+$ TELEPORT_USER=<your user>
+$ tctl get user/${TELEPORT_USER?} > myuser.yaml
+```
+
+Edit `myuser.yaml` to add the `db-impersonator` role:
+
+```diff
+spec:
+   - access
+   - auditor
+   - editor
++  - db-impersonator
+   status:
+     is_locked: false
+```
+
+Update your user:
+
+```code
+$ tctl create -f myuser.yaml
+```
+
+Log out of your Teleport cluster and log in again. You will now be able to run
+`tctl auth sign` for database-specific certificate formats.
+
+</Details>
+
 (!docs/pages/includes/database-access/ttl-note.mdx!)
 
 ## tctl db ls

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -161,7 +161,7 @@ $ tctl auth sign --format=db --host=host1,localhost,127.0.0.1 --out=db --ttl=219
 <Details title="Setting up RBAC for signing database certificates">
 
 The `tctl` user must have permissions to impersonate the Teleport Database
-Service user, `Db`, in order to generate a signed database certificate. To add
+Service role, `Db`, in order to generate a signed database certificate. To add
 these impersonation privileges to your Teleport user, run the following
 commands.
 


### PR DESCRIPTION
Fixes #13768

Add a `Details` box to the `tctl auth sign` entry in the Database Access
CLI reference explaining how to set up your user's Teleport roles in
order to enable running `tctl auth sign` for database-specific
certificate formats.