### PR TITLE
Improve cluster ID is required error

### DIFF
--- a/api/types/clustername.go
+++ b/api/types/clustername.go
@@ -151,7 +151,7 @@ func (c *ClusterNameV2) CheckAndSetDefaults() error {
 		return trace.BadParameter("cluster name is required")
 	}
 	if c.Spec.ClusterID == "" {
-		return trace.BadParameter("cluster ID is required")
+		return trace.BadParameter("cluster ID is required - this error may also occur if you are using a newer version of tsh than the cluster supports or if you followed the wrong upgrade path when upgrading the cluster")
 	}
 	return nil
 }


### PR DESCRIPTION
This slightly improves the cluster ID is required error that commonly occurs when you're using a newer version of the tsh client than the cluster supports.  For example, a v8 tsh client with a v7 cluster.  

This error may also occur in other situations, for example, if you followed the wrong upgrade path when upgrading the cluster.  (upgrading from v6 to v8 directly)

This error has caused confusion with customers and employees (using both Cloud and Core) for a good while now and I'd like to improve it.  Any further changes to word this better / make it more accurate are welcome.