### PR TITLE
Add regression test for "tsh db ls" performance issue

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -393,6 +393,8 @@ type Config struct {
 
 	// Tracer is the tracer to create spans with
 	Tracer oteltrace.Tracer
+	// TracerProvider is the optional provider to create tracers.
+	TracerProvider oteltrace.TracerProvider
 }
 
 // CachePolicy defines cache policy for local clients
@@ -1423,7 +1425,11 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 	c.Namespace = types.ProcessNamespace(c.Namespace)
 
 	if c.Tracer == nil {
-		c.Tracer = tracing.NoopProvider().Tracer(teleport.ComponentTeleport)
+		if c.TracerProvider != nil {
+			c.Tracer = c.TracerProvider.Tracer(teleport.ComponentTeleport)
+		} else {
+			c.Tracer = tracing.NoopProvider().Tracer(teleport.ComponentTeleport)
+		}
 	}
 
 	tc = &TeleportClient{

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1163,6 +1163,7 @@ func (proxy *ProxyClient) ConnectToAuthServiceThroughALPNSNIProxy(ctx context.Co
 		},
 		ALPNSNIAuthDialClusterName: clusterName,
 		CircuitBreakerConfig:       breaker.NoopBreakerConfig(),
+		TracerProvider:             proxy.teleportClient.TracerProvider,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1231,6 +1232,7 @@ func (proxy *ProxyClient) ConnectToCluster(ctx context.Context, clusterName stri
 				client.LoadTLS(proxy.teleportClient.TLS),
 			},
 			CircuitBreakerConfig: breaker.NoopBreakerConfig(),
+			TracerProvider:       proxy.teleportClient.TracerProvider,
 		})
 	}
 
@@ -1250,6 +1252,7 @@ func (proxy *ProxyClient) ConnectToCluster(ctx context.Context, clusterName stri
 			client.LoadTLS(tlsConfig),
 		},
 		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
+		TracerProvider:       proxy.teleportClient.TracerProvider,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/tsh/tsh_helper_test.go
+++ b/tool/tsh/tsh_helper_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/stretchr/testify/require"
 
@@ -365,4 +366,21 @@ func (h traceHelper) countClientSpans(spanNamePrefixes ...string) int {
 		}
 	}
 	return count
+}
+
+func (h traceHelper) printClientSpans(t *testing.T) {
+	h.ForceFlush(h.ctx)
+
+	for _, span := range h.exporter.GetSpans() {
+		data, err := yaml.Marshal(span)
+		require.NoError(t, err)
+		t.Logf("client span %v\n%v\n", span.Name, string(data))
+	}
+}
+
+func (h traceHelper) teleportClientSpanName(name string) string {
+	return fmt.Sprintf("%v/%v", "teleportClient", name)
+}
+func (h traceHelper) authServiceSpanName(name string) string {
+	return fmt.Sprintf("%v/%v", "proto.AuthService", name)
 }


### PR DESCRIPTION
Related issue
- #14075

I tried a few different ways to make a regression test for this scenario. I don't want to stress the CI system too much. Or if using some manual delays here and there, it may become another flaky test.

I end up creating a test that utilizes the tracing capabilities to count outgoing API calls.

The drawback with this approach is that it will not capture all scenarios that degrade the `tsh` performance (e.g. a single API that takes very long, or tsh using lots of CPU). 

Please also leave me suggestions if you have some other approaches. I am happy to try those out. Thanks!