### PR TITLE
Fix finding `pam_appl.h` on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,12 @@ FIPS_MESSAGE := "with FIPS support"
 RELEASE = teleport-$(GITTAG)-$(OS)-$(ARCH)-fips-bin
 endif
 
+ifeq ("$(OS)","darwin")
+SDKROOT ?= $(shell xcrun --show-sdk-path)
+endif
 # PAM support will only be built into Teleport if headers exist at build time.
 PAM_MESSAGE := "without PAM support"
-ifneq ("$(wildcard /usr/include/security/pam_appl.h)","")
+ifneq ("$(wildcard $(SDKROOT)/usr/include/security/pam_appl.h)","")
 PAM_TAG := pam
 PAM_MESSAGE := "with PAM support"
 else


### PR DESCRIPTION
`pam_appl.h` can be found in the SDK on macOS, so let's check there if
required.
