### PR TITLE
[v8] pin cbindgen to 0.24.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ ifeq ("$(with_rdpclient)", "yes")
 .PHONY: rdpclient
 rdpclient:
 	cargo build --manifest-path=lib/srv/desktop/rdp/rdpclient/Cargo.toml --release $(CARGO_TARGET)
-	cargo install cbindgen
+	cargo install --locked --version 0.24.3 cbindgen
 	cbindgen --quiet --crate rdp-client --output lib/srv/desktop/rdp/rdpclient/librdprs.h --lang c lib/srv/desktop/rdp/rdpclient/
 else
 .PHONY: rdpclient

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -153,7 +153,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
     rustup target add i686-unknown-linux-gnu && \
     rustup target add arm-unknown-linux-gnueabihf && \
     rustup target add aarch64-unknown-linux-gnu && \
-    cargo install cbindgen
+    cargo install --locked --version 0.24.3 cbindgen
 
 USER root
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -50,7 +50,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
     cargo --version && \
     rustc --version && \
     rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy && \
-    cargo install cbindgen
+    cargo install --locked --version 0.24.3 cbindgen
 
 ENV GOPATH="/go" \
     GOROOT="/opt/go" \

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -59,7 +59,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
     cargo --version && \
     rustc --version && \
     rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy && \
-    cargo install cbindgen
+    cargo install --locked --version 0.24.3 cbindgen
 
 ENV GOPATH="/go" \
     GOROOT="/opt/go" \


### PR DESCRIPTION
A dependency of `cbindgen`, `os_str_bytes`, had a minor version bump from 6.1.0 to 6.2.0 that brought the MSRV to 1.57.0 while our buildbox for v8 has 1.56.1, preventing it from being installed. This PR pins the version of `cbindgen` to the current version and makes `cargo install` use the dependencies of `cbindgen` from when it was published (the `--locked` option), which work fine with rust 1.56.1.