### PR TITLE
Backport ""Update docs for new APT repos"" (#12959) into branch/v8

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -637,6 +637,7 @@
       "dbeaver_min_ver": "8.0.3"
     },
     "teleport": {
+      "major_version": "8",
       "version": "8.3.1",
       "golang": "1.17",
       "plugin": {

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -5,10 +5,17 @@
         # Download Teleport's PGP public key
         $ sudo curl https://deb.releases.teleport.dev/teleport-pubkey.asc \
           -o /usr/share/keyrings/teleport-archive-keyring.asc
-        # Add the Teleport APT repository
-        $ cat<<EOF>/etc/apt/sources.list.d/teleport.list
-        deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://deb.releases.teleport.dev/ stable main
-        EOF
+        # Source variables about OS version
+        $ source /etc/os-release
+        # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
+        # file for each major (breaking) release of Teleport.
+        # Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
+        # and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
+        # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-apt-repos/main.go#L26
+        $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+          https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
+        | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
+
         $ sudo apt-get update
         $ sudo apt-get install teleport
         ```
@@ -62,6 +69,24 @@
         $ sudo ./install
         ```
   </TabItem>
+
+  <TabItem label="Debian/Ubuntu Legacy (DEB)">
+        ```code
+        # Using this APT repo may result in breaking upgrades upon "apt upgrade" as all major versions will be
+        # published under the same component. We recommend following the instructions in the
+        # "Debian/Ubuntu (DEB)" tab instead.
+        # Download Teleport's PGP public key
+        $ sudo curl https://deb.releases.teleport.dev/teleport-pubkey.asc \
+          -o /usr/share/keyrings/teleport-archive-keyring.asc
+        # Add the Teleport APT repository
+        $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://deb.releases.teleport.dev/ stable main" \
+        | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
+
+        $ sudo apt-get update
+        $ sudo apt-get install teleport
+        ```
+  </TabItem>
+
 </Tabs>
 </ScopedBlock>
 <ScopedBlock scope={["enterprise"]}>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -39,6 +39,22 @@ All installations include `teleport`, `tsh`, `tctl`, and `tbot`.
 
 (!docs/pages/includes/install-linux.mdx!)
 
+<Details 
+title="Using APT for versions prior to Teleport 10?" 
+scopeOnly={false}
+>
+
+If you've previously installed Teleport via the APT
+repo at `https://deb.releases.teleport.dev/`, you can upgrade by
+re-running the "Debian/Ubuntu (DEB)" install instructions above.
+
+We will also continue to maintain the legacy APT repo at
+`https://deb.releases.teleport.dev/` for the foreseeable future.
+
+</Details>
+
+<ScopedBlock scope="oss">
+
 Check the [Downloads](https://goteleport.com/download/) page for the most
 up-to-date information.
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -53,8 +53,6 @@ We will also continue to maintain the legacy APT repo at
 
 </Details>
 
-<ScopedBlock scope="oss">
-
 Check the [Downloads](https://goteleport.com/download/) page for the most
 up-to-date information.
 


### PR DESCRIPTION
Base PR: #12959

Source PR description:

"Update the APT install command to point to the new APT repos as a part of RFD 0058.

Related PR: https://github.com/gravitational/teleport/pull/10746

This is my first doc PR so I'm not sure that I did everything right. Do I need to run a static site generator of some kind? Also, is there anything special I need to do because I added a variable to `config.json`?"