### PR TITLE
[v8] Fix tctl instructions in DB Access guides

### DIFF
--- a/docs/pages/includes/database-access/start-auth-proxy.mdx
+++ b/docs/pages/includes/database-access/start-auth-proxy.mdx
@@ -46,11 +46,7 @@ If you do not have a Teleport Cloud account, use our [signup form](/signup) to
 get started. Teleport Cloud manages instances of the Proxy Service and Auth
 Service, and automatically issues and renews the required TLS certificate.
 
-You must log into your cluster before you can run `tctl` commands.
-```code
-$ tsh login --proxy=mytenant.teleport.sh
-$ tctl status
-```
 </TabItem>
 </Tabs>
 
+(!docs/pages/includes/tctl.mdx!)


### PR DESCRIPTION
Backports #13760

Fixes #13688

Database Access guides instruct the user to log in to their cluster
and test their tctl connection before installing the Auth/Proxy, which
can cause confusion.

This change fixes this by:

- Editing start-auth-proxy.mdx to include tctl.mdx, and removing the
  text telling all users to run tctl commands on their Auth Service
  host.