### PR TITLE
[v9] Fix tctl instructions in DB Access guides

### DIFF
--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -37,8 +37,6 @@ release.
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/3. Set up Aurora
 
 In order to allow Teleport connections to an Aurora instance, the instance needs

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -44,8 +44,6 @@ This guide will help you to:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/4. Install and configure Teleport
 
 ### Set up the Teleport Auth and Proxy Services

--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -36,8 +36,6 @@ This guide will help you to:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/3. Install and configure Teleport
 
 ### Set up the Teleport Auth and Proxy Services

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -27,8 +27,6 @@ In this guide you will:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/3. Configure Teleport
 
 ### Set up the Teleport Auth and Proxy services

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -32,8 +32,6 @@ In this guide you will:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/3. Install and configure Teleport
 
 ### Set up the Teleport Auth and Proxy services

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -26,8 +26,6 @@ This guide will help you to:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/5. Create a service account for the Teleport Database Service
 
 Teleport uses one-time passwords to authenticate with Cloud SQL MySQL. To be

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -26,8 +26,6 @@ This guide will help you to:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/4. Set up the Teleport Auth and Proxy Services
 
 Teleport Database Access for MySQL is available starting from Teleport version

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -25,8 +25,6 @@ This guide will help you to:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/7. Enable Cloud SQL IAM authentication
 
 Teleport uses [IAM database authentication](https://cloud.google.com/sql/docs/postgres/authentication)

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -27,8 +27,6 @@ This guide will help you to:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/6. Install Teleport
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -25,8 +25,6 @@ This guide will help you to:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/5. Set up the Teleport Auth and Proxy services
 
 Teleport Database Access for PostgreSQL is available starting from the `6.0`

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -37,8 +37,6 @@ This guide will help you to:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/7. Install Teleport
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)

--- a/docs/pages/database-access/guides/redis-cluster.mdx
+++ b/docs/pages/database-access/guides/redis-cluster.mdx
@@ -42,8 +42,6 @@ This guide will help you to:
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 <Admonition type="note" title="Note">
   Redis `7.0` and RESP3 (REdis Serialization Protocol) are currently not supported.
 </Admonition>

--- a/docs/pages/database-access/guides/redis.mdx
+++ b/docs/pages/database-access/guides/redis.mdx
@@ -32,8 +32,17 @@ This guide will help you to:
 ## Prerequisites
 
 - Teleport version `9.0` or newer.
+
 - Redis version `6.0` or newer.
-- `redis-cli` installed and added to your system's `PATH` environment variable.
+
+- `redis-cli` version `6.2` or newer installed and added to your system's `PATH` environment variable.
+
+- A host where you will run the Teleport Database Service. Teleport version 9.0
+  or newer must be installed.
+
+  See [Installation](../../installation.mdx) for details.
+
+(!docs/pages/includes/user-client-prereqs.mdx!)
 
 <Admonition type="note" title="Note">
   Redis `7.0` and RESP3 (REdis Serialization Protocol) are currently not supported.

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -45,8 +45,6 @@ Directory authentication.
 
 (!docs/pages/includes/user-client-prereqs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
 ## Step 1/7. Set up the Teleport Auth and Proxy
 
 (!docs/pages/includes/database-access/start-auth-proxy.mdx!)

--- a/docs/pages/includes/database-access/start-auth-proxy.mdx
+++ b/docs/pages/includes/database-access/start-auth-proxy.mdx
@@ -43,20 +43,13 @@ Next, start the Teleport Auth and Proxy Services:
 $ sudo teleport start
 ```
 
-You will run subsequent `tctl` commands on the host where you started the Auth
-and Proxy Services.
-
 </TabItem> 
 <TabItem label="Teleport Cloud" scope={["cloud"]}> 
 If you do not have a Teleport Cloud account, use our [signup form](https://goteleport.com/signup/) to
 get started. Teleport Cloud manages instances of the Proxy Service and Auth
 Service, and automatically issues and renews the required TLS certificate.
 
-You must log in to your cluster before you can run `tctl` commands.
-```code
-$ tsh login --proxy=mytenant.teleport.sh
-$ tctl status
-```
 </TabItem>
 </Tabs>
 
+(!docs/pages/includes/tctl.mdx!)


### PR DESCRIPTION
Backports #13760

Fixes #13688

Database Access guides instruct the user to log in to their cluster
and test their tctl connection before installing the Auth/Proxy, which
can cause confusion.

This change fixes this by:

- Editing start-auth-proxy.mdx to include tctl.mdx, and removing the
  text telling all users to run tctl commands on their Auth Service
  host.

- Removing tctl.mdx from the Prerequisites sections of DB Access
  guides.