### PR TITLE
Allow setting public addresses in `teleport-cluster` chart

### DIFF
--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -221,6 +221,108 @@ When `publicAddress` is not set, the address used is [`clusterName`](#clusterNam
   </TabItem>
 </Tabs>
 
+## `kubePublicAddress`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `""` | no | `proxy_service.kube_public_addr` | ❌ |
+
+`kubePublicAddress` controls the advertised address for the Kubernetes proxy.
+This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
+
+When `kubePublicAddress` is not set, the address is inferred from [`publicAddress`](#publicAddress) if set,
+else [`clusterName`](#clusterName) is used. Default port is 3026.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  kubePublicAddress: loadbalancer.example.com:3026
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set kubePublicAddress=loadbalancer.example.com:3026
+  ```
+  </TabItem>
+</Tabs>
+
+## `mongoPublicAddress`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `""` | no | `proxy_service.mongo_public_addr` | ❌ |
+
+`mongoPublicAddress` controls the advertised address to postgres clients.
+This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
+requires [`separateMongoListener`](#separatePostgresListener) enabled.
+
+When `mongoPublicAddress` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
+Default port is 27017.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  mongoPublicAddress: 'loadbalancer.example.com:27017'
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set mongoPublicAddress='loadbalancer.example.com:27017'
+  ```
+  </TabItem>
+</Tabs>
+
+## `mysqlPublicAddress`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `""` | no | `proxy_service.mysql_public_addr` | ❌ |
+
+`mysqlPublicAddress` controls the advertised address for the MySQL proxy.
+This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
+
+When `mysqlPublicAddress` is not set, the address is inferred from [`publicAddress`](#publicAddress) if set,
+else [`clusterName`](#clusterName) is used. Default port is 3026.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  mysqlPublicAddress: loadbalancer.example.com:3026
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set mysqlPublicAddress=loadbalancer.example.com:3026
+  ```
+  </TabItem>
+</Tabs>
+
+
+## `postgresPublicAddress`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `""` | no | `proxy_service.postgres_public_addr` | ❌ |
+
+`postgresPublicAddress` controls the advertised address to postgres clients.
+This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
+requires [`separatePostgresListener`](#separatePostgresListener) enabled.
+
+When `postgresPublicAddress` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
+Default port is 5432.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  postgresPublicAddress: 'loadbalancer.example.com:5432'
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set postgresPublicAddress='loadbalancer.example.com:5432'
+  ```
+  </TabItem>
+</Tabs>
 
 ## `sshPublicAddress`
 
@@ -268,58 +370,6 @@ else [`clusterName`](#clusterName) is used. Default port is 3024.
   <TabItem label="--set">
   ```code
   $ --set tunnelPublicAddress='loadbalancer.example.com:3024'
-  ```
-  </TabItem>
-</Tabs>
-
-## `postgresPublicAddress`
-
-| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
-| - | - | - | - | - |
-| `string` | `""` | no | `proxy_service.postgres_public_addr` | ❌ |
-
-`postgresPublicAddress` controls the advertised address to postgres clients.
-This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
-requires [`separatePostgresListener`](#separatePostgresListener) enabled.
-
-When `postgresPublicAddress` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
-Default port is 5432.
-
-<Tabs>
-  <TabItem label="values.yaml">
-  ```yaml
-  postgresPublicAddress: 'loadbalancer.example.com:5432'
-  ```
-  </TabItem>
-  <TabItem label="--set">
-  ```code
-  $ --set postgresPublicAddress='loadbalancer.example.com:5432'
-  ```
-  </TabItem>
-</Tabs>
-
-## `mongoPublicAddress`
-
-| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
-| - | - | - | - | - |
-| `string` | `""` | no | `proxy_service.mongo_public_addr` | ❌ |
-
-`mongoPublicAddress` controls the advertised address to postgres clients.
-This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
-requires [`separateMongoListener`](#separatePostgresListener) enabled.
-
-When `mongoPublicAddress` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
-Default port is 27017.
-
-<Tabs>
-  <TabItem label="values.yaml">
-  ```yaml
-  mongoPublicAddress: 'loadbalancer.example.com:27017'
-  ```
-  </TabItem>
-  <TabItem label="--set">
-  ```code
-  $ --set mongoPublicAddress='loadbalancer.example.com:27017'
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -287,12 +287,12 @@ else [`clusterName`](#clusterName) is used. Default port is 3026.
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  mysqlPublicAddress: loadbalancer.example.com:3026
+  mysqlPublicAddress: loadbalancer.example.com:3036
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set mysqlPublicAddress=loadbalancer.example.com:3026
+  $ --set mysqlPublicAddress=loadbalancer.example.com:3036
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -282,7 +282,7 @@ Default port is 27017.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
 When `mysqlPublicAddr` is not set, the address is inferred from [`publicAddr`](#publicAddr) if set,
-else [`clusterName`](#clusterName) is used. Default port is 3026.
+else [`clusterName`](#clusterName) is used. Default port is 3036.
 
 <Tabs>
   <TabItem label="values.yaml">

--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -198,178 +198,178 @@ These settings will not apply if [`proxyListenerMode`](#proxylistenermode) is se
   </TabItem>
 </Tabs>
 
-## `publicAddress`
+## `publicAddr`
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
 | `string` | `""` | no | `proxy_service.public_addr` | ❌ |
 
-`publicAddress` controls the advertised address for TLS connections.
+`publicAddr` controls the advertised address for TLS connections.
 
-When `publicAddress` is not set, the address used is [`clusterName`](#clusterName) on port 443.
+When `publicAddr` is not set, the address used is [`clusterName`](#clusterName) on port 443.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  publicAddress: loadbalancer.example.com:443
+  publicAddr: loadbalancer.example.com:443
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set publicAddress=loadbalancer.example.com:443
+  $ --set publicAddr=loadbalancer.example.com:443
   ```
   </TabItem>
 </Tabs>
 
-## `kubePublicAddress`
+## `kubePublicAddr`
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
 | `string` | `""` | no | `proxy_service.kube_public_addr` | ❌ |
 
-`kubePublicAddress` controls the advertised address for the Kubernetes proxy.
+`kubePublicAddr` controls the advertised address for the Kubernetes proxy.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
-When `kubePublicAddress` is not set, the address is inferred from [`publicAddress`](#publicAddress) if set,
+When `kubePublicAddr` is not set, the address is inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3026.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  kubePublicAddress: loadbalancer.example.com:3026
+  kubePublicAddr: loadbalancer.example.com:3026
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set kubePublicAddress=loadbalancer.example.com:3026
+  $ --set kubePublicAddr=loadbalancer.example.com:3026
   ```
   </TabItem>
 </Tabs>
 
-## `mongoPublicAddress`
+## `mongoPublicAddr`
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
 | `string` | `""` | no | `proxy_service.mongo_public_addr` | ❌ |
 
-`mongoPublicAddress` controls the advertised address to postgres clients.
+`mongoPublicAddr` controls the advertised address to postgres clients.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
 requires [`separateMongoListener`](#separatePostgresListener) enabled.
 
-When `mongoPublicAddress` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
+When `mongoPublicAddr` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
 Default port is 27017.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  mongoPublicAddress: 'loadbalancer.example.com:27017'
+  mongoPublicAddr: 'loadbalancer.example.com:27017'
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set mongoPublicAddress='loadbalancer.example.com:27017'
+  $ --set mongoPublicAddr='loadbalancer.example.com:27017'
   ```
   </TabItem>
 </Tabs>
 
-## `mysqlPublicAddress`
+## `mysqlPublicAddr`
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
 | `string` | `""` | no | `proxy_service.mysql_public_addr` | ❌ |
 
-`mysqlPublicAddress` controls the advertised address for the MySQL proxy.
+`mysqlPublicAddr` controls the advertised address for the MySQL proxy.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
-When `mysqlPublicAddress` is not set, the address is inferred from [`publicAddress`](#publicAddress) if set,
+When `mysqlPublicAddr` is not set, the address is inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3026.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  mysqlPublicAddress: loadbalancer.example.com:3036
+  mysqlPublicAddr: loadbalancer.example.com:3036
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set mysqlPublicAddress=loadbalancer.example.com:3036
+  $ --set mysqlPublicAddr=loadbalancer.example.com:3036
   ```
   </TabItem>
 </Tabs>
 
 
-## `postgresPublicAddress`
+## `postgresPublicAddr`
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
 | `string` | `""` | no | `proxy_service.postgres_public_addr` | ❌ |
 
-`postgresPublicAddress` controls the advertised address to postgres clients.
+`postgresPublicAddr` controls the advertised address to postgres clients.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
 requires [`separatePostgresListener`](#separatePostgresListener) enabled.
 
-When `postgresPublicAddress` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
+When `postgresPublicAddr` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
 Default port is 5432.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  postgresPublicAddress: 'loadbalancer.example.com:5432'
+  postgresPublicAddr: 'loadbalancer.example.com:5432'
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set postgresPublicAddress='loadbalancer.example.com:5432'
+  $ --set postgresPublicAddr='loadbalancer.example.com:5432'
   ```
   </TabItem>
 </Tabs>
 
-## `sshPublicAddress`
+## `sshPublicAddr`
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
 | `string` | `""` | no | `proxy_service.ssh_public_addr` | ❌ |
 
-`sshPublicAddress` controls the advertised address for SSH clients.
+`sshPublicAddr` controls the advertised address for SSH clients.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
-When `sshPublicAddress` is not set, the address is inferred from [`publicAddress`](#publicAddress) if set,
+hen `sshPublicAddr` is not set, the address is inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3023.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  sshPublicAddress: loadbalancer.example.com:3023
+  sshPublicAddr: loadbalancer.example.com:3023
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set sshPublicAddress=loadbalancer.example.com:3023
+  $ --set sshPublicAddr=loadbalancer.example.com:3023
   ```
   </TabItem>
 </Tabs>
 
-## `tunnelPublicAddress`
+## `tunnelPublicAddr`
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
 | `string` | `""` | no | `proxy_service.tunnel_public_addr` | ❌ |
 
-`tunnelPublicAddress` controls the advertised address to trusted clusters or nodes joining via node-tunneling.
+`tunnelPublicAddr` controls the advertised address to trusted clusters or nodes joining via node-tunneling.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
-When `tunnelPublicAddress` is not set, the address is inferred from [`publicAddress`](#publicAddress) if set,
+When `tunnelPublicAddr` is not set, the address is inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3024.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  tunnelPublicAddress: 'loadbalancer.example.com:3024'
+  tunnelPublicAddr: 'loadbalancer.example.com:3024'
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set tunnelPublicAddress='loadbalancer.example.com:3024'
+  $ --set tunnelPublicAddr='loadbalancer.example.com:3024'
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -198,6 +198,132 @@ These settings will not apply if [`proxyListenerMode`](#proxylistenermode) is se
   </TabItem>
 </Tabs>
 
+## `publicAddress`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `""` | no | `proxy_service.public_addr` | ❌ |
+
+`publicAddress` controls the advertised address for TLS connections.
+
+When `publicAddress` is not set, the address used is [`clusterName`](#clusterName) on port 443.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  publicAddress: loadbalancer.example.com:443
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set publicAddress=loadbalancer.example.com:443
+  ```
+  </TabItem>
+</Tabs>
+
+
+## `sshPublicAddress`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `""` | no | `proxy_service.ssh_public_addr` | ❌ |
+
+`sshPublicAddress` controls the advertised address for SSH clients.
+This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
+
+When `sshPublicAddress` is not set, the address is inferred from [`publicAddress`](#publicAddress) if set,
+else [`clusterName`](#clusterName) is used. Default port is 3023.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  sshPublicAddress: loadbalancer.example.com:3023
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set sshPublicAddress=loadbalancer.example.com:3023
+  ```
+  </TabItem>
+</Tabs>
+
+## `tunnelPublicAddress`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `""` | no | `proxy_service.tunnel_public_addr` | ❌ |
+
+`tunnelPublicAddress` controls the advertised address to trusted clusters or nodes joining via node-tunneling.
+This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
+
+When `tunnelPublicAddress` is not set, the address is inferred from [`publicAddress`](#publicAddress) if set,
+else [`clusterName`](#clusterName) is used. Default port is 3024.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  tunnelPublicAddress: 'loadbalancer.example.com:3024'
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set tunnelPublicAddress='loadbalancer.example.com:3024'
+  ```
+  </TabItem>
+</Tabs>
+
+## `postgresPublicAddress`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `""` | no | `proxy_service.postgres_public_addr` | ❌ |
+
+`postgresPublicAddress` controls the advertised address to postgres clients.
+This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
+requires [`separatePostgresListener`](#separatePostgresListener) enabled.
+
+When `postgresPublicAddress` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
+Default port is 5432.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  postgresPublicAddress: 'loadbalancer.example.com:5432'
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set postgresPublicAddress='loadbalancer.example.com:5432'
+  ```
+  </TabItem>
+</Tabs>
+
+## `mongoPublicAddress`
+
+| Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
+| - | - | - | - | - |
+| `string` | `""` | no | `proxy_service.mongo_public_addr` | ❌ |
+
+`mongoPublicAddress` controls the advertised address to postgres clients.
+This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
+requires [`separateMongoListener`](#separatePostgresListener) enabled.
+
+When `mongoPublicAddress` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
+Default port is 27017.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  mongoPublicAddress: 'loadbalancer.example.com:27017'
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set mongoPublicAddress='loadbalancer.example.com:27017'
+  ```
+  </TabItem>
+</Tabs>
+
 ## `enterprise`
 
 | Type | Default value | Can be used in `custom` mode? |

--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -202,21 +202,21 @@ These settings will not apply if [`proxyListenerMode`](#proxylistenermode) is se
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
-| `string` | `""` | no | `proxy_service.public_addr` | ❌ |
+| `list[string]` | `[]` | no | `proxy_service.public_addr` | ❌ |
 
-`publicAddr` controls the advertised address for TLS connections.
+`publicAddr` controls the advertised addresses for TLS connections.
 
 When `publicAddr` is not set, the address used is [`clusterName`](#clusterName) on port 443.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  publicAddr: loadbalancer.example.com:443
+  publicAddr: ["loadbalancer.example.com:443"]
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set publicAddr=loadbalancer.example.com:443
+  $ --set publicAddr[0]=loadbalancer.example.com:443
   ```
   </TabItem>
 </Tabs>
@@ -225,23 +225,23 @@ When `publicAddr` is not set, the address used is [`clusterName`](#clusterName) 
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
-| `string` | `""` | no | `proxy_service.kube_public_addr` | ❌ |
+| `list[string]` | `[]` | no | `proxy_service.kube_public_addr` | ❌ |
 
-`kubePublicAddr` controls the advertised address for the Kubernetes proxy.
+`kubePublicAddr` controls the advertised addresses for the Kubernetes proxy.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
-When `kubePublicAddr` is not set, the address is inferred from [`publicAddr`](#publicAddr) if set,
+When `kubePublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3026.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  kubePublicAddr: loadbalancer.example.com:3026
+  kubePublicAddr: ["loadbalancer.example.com:3026"]
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set kubePublicAddr=loadbalancer.example.com:3026
+  $ --set kubePublicAddr[0]=loadbalancer.example.com:3026
   ```
   </TabItem>
 </Tabs>
@@ -250,24 +250,24 @@ else [`clusterName`](#clusterName) is used. Default port is 3026.
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
-| `string` | `""` | no | `proxy_service.mongo_public_addr` | ❌ |
+| `list[string]` | `[]` | no | `proxy_service.mongo_public_addr` | ❌ |
 
-`mongoPublicAddr` controls the advertised address to postgres clients.
+`mongoPublicAddr` controls the advertised addresses to postgres clients.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
 requires [`separateMongoListener`](#separatePostgresListener) enabled.
 
-When `mongoPublicAddr` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
+When `mongoPublicAddr` is not set, the addresses are inferred from [`clusterName`](#clusterName) is used.
 Default port is 27017.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  mongoPublicAddr: 'loadbalancer.example.com:27017'
+  mongoPublicAddr: ["loadbalancer.example.com:27017"]
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set mongoPublicAddr='loadbalancer.example.com:27017'
+  $ --set mongoPublicAddr[0]=loadbalancer.example.com:27017
   ```
   </TabItem>
 </Tabs>
@@ -276,23 +276,23 @@ Default port is 27017.
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
-| `string` | `""` | no | `proxy_service.mysql_public_addr` | ❌ |
+| `list[string]` | `[]` | no | `proxy_service.mysql_public_addr` | ❌ |
 
-`mysqlPublicAddr` controls the advertised address for the MySQL proxy.
+`mysqlPublicAddr` controls the advertised addresses for the MySQL proxy.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
-When `mysqlPublicAddr` is not set, the address is inferred from [`publicAddr`](#publicAddr) if set,
+When `mysqlPublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3036.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  mysqlPublicAddr: loadbalancer.example.com:3036
+  mysqlPublicAddr: ["loadbalancer.example.com:3036"]
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set mysqlPublicAddr=loadbalancer.example.com:3036
+  $ --set mysqlPublicAddr[0]=loadbalancer.example.com:3036
   ```
   </TabItem>
 </Tabs>
@@ -302,24 +302,24 @@ else [`clusterName`](#clusterName) is used. Default port is 3036.
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
-| `string` | `""` | no | `proxy_service.postgres_public_addr` | ❌ |
+| `list[string]` | `[]` | no | `proxy_service.postgres_public_addr` | ❌ |
 
-`postgresPublicAddr` controls the advertised address to postgres clients.
+`postgresPublicAddr` controls the advertised addresses to postgres clients.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
 requires [`separatePostgresListener`](#separatePostgresListener) enabled.
 
-When `postgresPublicAddr` is not set, the address is inferred from [`clusterName`](#clusterName) is used.
-Default port is 5432.
+When `postgresPublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,
+else [`clusterName`](#clusterName) is used. Default port is 5432.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  postgresPublicAddr: 'loadbalancer.example.com:5432'
+  postgresPublicAddr: ["loadbalancer.example.com:5432"]
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set postgresPublicAddr='loadbalancer.example.com:5432'
+  $ --set postgresPublicAddr[0]=loadbalancer.example.com:5432
   ```
   </TabItem>
 </Tabs>
@@ -328,23 +328,23 @@ Default port is 5432.
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
-| `string` | `""` | no | `proxy_service.ssh_public_addr` | ❌ |
+| `list[string]` | `[]` | no | `proxy_service.ssh_public_addr` | ❌ |
 
-`sshPublicAddr` controls the advertised address for SSH clients.
+`sshPublicAddr` controls the advertised addresses for SSH clients.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
-hen `sshPublicAddr` is not set, the address is inferred from [`publicAddr`](#publicAddr) if set,
+hen `sshPublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3023.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  sshPublicAddr: loadbalancer.example.com:3023
+  sshPublicAddr: ["loadbalancer.example.com:3023"]
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set sshPublicAddr=loadbalancer.example.com:3023
+  $ --set sshPublicAddr[0]=loadbalancer.example.com:3023
   ```
   </TabItem>
 </Tabs>
@@ -353,23 +353,23 @@ else [`clusterName`](#clusterName) is used. Default port is 3023.
 
 | Type | Default value | Required? | `teleport.yaml` equivalent | Can be used in `custom` mode? |
 | - | - | - | - | - |
-| `string` | `""` | no | `proxy_service.tunnel_public_addr` | ❌ |
+| `list[string]` | `[]` | no | `proxy_service.tunnel_public_addr` | ❌ |
 
-`tunnelPublicAddr` controls the advertised address to trusted clusters or nodes joining via node-tunneling.
+`tunnelPublicAddr` controls the advertised addresses to trusted clusters or nodes joining via node-tunneling.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
-When `tunnelPublicAddr` is not set, the address is inferred from [`publicAddr`](#publicAddr) if set,
+When `tunnelPublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3024.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  tunnelPublicAddr: 'loadbalancer.example.com:3024'
+  tunnelPublicAddr: ["loadbalancer.example.com:3024"]
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set tunnelPublicAddr='loadbalancer.example.com:3024'
+  $ --set tunnelPublicAddr[0]=loadbalancer.example.com:3024
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -330,7 +330,7 @@ else [`clusterName`](#clusterName) is used. Default port is 5432.
 | - | - | - | - | - |
 | `list[string]` | `[]` | no | `proxy_service.ssh_public_addr` | ❌ |
 
-`sshPublicAddr` controls the advertised addresses for SSH clients.
+`sshPublicAddr` controls the advertised addresses for SSH clients. This is also used by the `tsh` client.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
 hen `sshPublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,

--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -252,7 +252,7 @@ else [`clusterName`](#clusterName) is used. Default port is 3026.
 | - | - | - | - | - |
 | `list[string]` | `[]` | no | `proxy_service.mongo_public_addr` | ❌ |
 
-`mongoPublicAddr` controls the advertised addresses to postgres clients.
+`mongoPublicAddr` controls the advertised addresses to MongoDB clients.
 This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex` and
 requires [`separateMongoListener`](#separatePostgresListener) enabled.
 

--- a/examples/chart/teleport-cluster/.lint/public-addresses.yaml
+++ b/examples/chart/teleport-cluster/.lint/public-addresses.yaml
@@ -1,11 +1,11 @@
 clusterName: helm-lint
-publicAddress: "loadbalancer.example.com:443"
-sshPublicAddress: "loadbalancer.example.com:3023"
-tunnelPublicAddress: "loadbalancer.example.com:3024"
-postgresPublicAddress: "loadbalancer.example.com:5432"
-mongoPublicAddress: "loadbalancer.example.com:27017"
-mysqlPublicAddress: "loadbalancer.example.com:3036"
-kubePublicAddress: "loadbalancer.example.com:3026"
+publicAddr: "loadbalancer.example.com:443"
+sshPublicAddr: "loadbalancer.example.com:3023"
+tunnelPublicAddr: "loadbalancer.example.com:3024"
+postgresPublicAddr: "loadbalancer.example.com:5432"
+mongoPublicAddr: "loadbalancer.example.com:27017"
+mysqlPublicAddr: "loadbalancer.example.com:3036"
+kubePublicAddr: "loadbalancer.example.com:3026"
 
 separatePostgresListener: true
 separateMongoListener: true

--- a/examples/chart/teleport-cluster/.lint/public-addresses.yaml
+++ b/examples/chart/teleport-cluster/.lint/public-addresses.yaml
@@ -4,6 +4,8 @@ sshPublicAddress: "loadbalancer.example.com:3023"
 tunnelPublicAddress: "loadbalancer.example.com:3024"
 postgresPublicAddress: "loadbalancer.example.com:5432"
 mongoPublicAddress: "loadbalancer.example.com:27017"
+mysqlPublicAddress: "loadbalancer.example.com:3026"
+kubePublicAddress: "loadbalancer.example.com:3026"
 
 separatePostgresListener: true
 separateMongoListener: true

--- a/examples/chart/teleport-cluster/.lint/public-addresses.yaml
+++ b/examples/chart/teleport-cluster/.lint/public-addresses.yaml
@@ -4,7 +4,7 @@ sshPublicAddress: "loadbalancer.example.com:3023"
 tunnelPublicAddress: "loadbalancer.example.com:3024"
 postgresPublicAddress: "loadbalancer.example.com:5432"
 mongoPublicAddress: "loadbalancer.example.com:27017"
-mysqlPublicAddress: "loadbalancer.example.com:3026"
+mysqlPublicAddress: "loadbalancer.example.com:3036"
 kubePublicAddress: "loadbalancer.example.com:3026"
 
 separatePostgresListener: true

--- a/examples/chart/teleport-cluster/.lint/public-addresses.yaml
+++ b/examples/chart/teleport-cluster/.lint/public-addresses.yaml
@@ -1,0 +1,9 @@
+clusterName: helm-lint
+publicAddress: "loadbalancer.example.com:443"
+sshPublicAddress: "loadbalancer.example.com:3023"
+tunnelPublicAddress: "loadbalancer.example.com:3024"
+postgresPublicAddress: "loadbalancer.example.com:5432"
+mongoPublicAddress: "loadbalancer.example.com:27017"
+
+separatePostgresListener: true
+separateMongoListener: true

--- a/examples/chart/teleport-cluster/.lint/public-addresses.yaml
+++ b/examples/chart/teleport-cluster/.lint/public-addresses.yaml
@@ -1,11 +1,11 @@
 clusterName: helm-lint
-publicAddr: "loadbalancer.example.com:443"
-sshPublicAddr: "loadbalancer.example.com:3023"
-tunnelPublicAddr: "loadbalancer.example.com:3024"
-postgresPublicAddr: "loadbalancer.example.com:5432"
-mongoPublicAddr: "loadbalancer.example.com:27017"
-mysqlPublicAddr: "loadbalancer.example.com:3036"
-kubePublicAddr: "loadbalancer.example.com:3026"
+publicAddr: ["loadbalancer.example.com:443"]
+sshPublicAddr: ["loadbalancer.example.com:3023"]
+tunnelPublicAddr: ["loadbalancer.example.com:3024"]
+postgresPublicAddr: ["loadbalancer.example.com:5432"]
+mongoPublicAddr: ["loadbalancer.example.com:27017"]
+mysqlPublicAddr: ["loadbalancer.example.com:3036"]
+kubePublicAddr: ["loadbalancer.example.com:3026"]
 
 separatePostgresListener: true
 separateMongoListener: true

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -95,38 +95,38 @@ data:
     {{- toYaml .Values.labels | nindent 8 }}
   {{- end }}
     proxy_service:
-  {{- if .Values.publicAddress }}
-      public_addr: '{{ .Values.publicAddress }}'
+  {{- if .Values.publicAddr }}
+      public_addr: '{{ .Values.publicAddr }}'
   {{- else }}
       public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
   {{- end }}
-  {{- if .Values.sshPublicAddress }}
-      ssh_public_addr: '{{ .Values.sshPublicAddress }}'
+  {{- if .Values.sshPublicAddr }}
+      ssh_public_addr: '{{ .Values.sshPublicAddr }}'
   {{- end }}
-  {{- if .Values.tunnelPublicAddress }}
-      tunnel_public_addr: '{{ .Values.tunnelPublicAddress }}'
+  {{- if .Values.tunnelPublicAddr }}
+      tunnel_public_addr: '{{ .Values.tunnelPublicAddr }}'
   {{- end }}
   {{- if not .Values.proxyListenerMode }}
       kube_listen_addr: 0.0.0.0:3026
-    {{- if .Values.kubePublicAddress }}
-      kube_public_addr: '{{ .Values.kubePublicAddress }}'
+    {{- if .Values.kubePublicAddr }}
+      kube_public_addr: '{{ .Values.kubePublicAddr }}'
     {{- end }}
       mysql_listen_addr: 0.0.0.0:3036
-    {{- if .Values.mysqlPublicAddress }}
-      mysql_public_addr: '{{ .Values.mysqlPublicAddress }}'
+    {{- if .Values.mysqlPublicAddr }}
+      mysql_public_addr: '{{ .Values.mysqlPublicAddr }}'
     {{- end }}
     {{- if .Values.separatePostgresListener }}
       postgres_listen_addr: 0.0.0.0:5432
-      {{- if .Values.postgresPublicAddress }}
-      postgres_public_addr: '{{ .Values.postgresPublicAddress }}'
+      {{- if .Values.postgresPublicAddr }}
+      postgres_public_addr: '{{ .Values.postgresPublicAddr }}'
       {{- else }}
       postgres_public_addr: {{ .Values.clusterName }}:5432
       {{- end }}
     {{- end }}
     {{- if .Values.separateMongoListener }}
       mongo_listen_addr: 0.0.0.0:27017
-      {{- if .Values.mongoPublicAddress }}
-      mongo_public_addr: '{{ .Values.mongoPublicAddress }}'
+      {{- if .Values.mongoPublicAddr }}
+      mongo_public_addr: '{{ .Values.mongoPublicAddr }}'
       {{- else }}
       mongo_public_addr: {{ .Values.clusterName }}:27017
       {{- end }}

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -108,7 +108,13 @@ data:
   {{- end }}
   {{- if not .Values.proxyListenerMode }}
       kube_listen_addr: 0.0.0.0:3026
+    {{- if .Values.kubePublicAddress }}
+      kube_public_addr: '{{ .Values.kubePublicAddress }}'
+    {{- end }}
       mysql_listen_addr: 0.0.0.0:3036
+    {{- if .Values.mysqlPublicAddress }}
+      mysql_public_addr: '{{ .Values.mysqlPublicAddress }}'
+    {{- end }}
     {{- if .Values.separatePostgresListener }}
       postgres_listen_addr: 0.0.0.0:5432
       {{- if .Values.postgresPublicAddress }}

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -95,17 +95,35 @@ data:
     {{- toYaml .Values.labels | nindent 8 }}
   {{- end }}
     proxy_service:
+  {{- if .Values.publicAddress }}
+      public_addr: '{{ .Values.publicAddress }}'
+  {{- else }}
       public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
+  {{- end }}
+  {{- if .Values.sshPublicAddress }}
+      ssh_public_addr: '{{ .Values.sshPublicAddress }}'
+  {{- end }}
+  {{- if .Values.tunnelPublicAddress }}
+      tunnel_public_addr: '{{ .Values.tunnelPublicAddress }}'
+  {{- end }}
   {{- if not .Values.proxyListenerMode }}
       kube_listen_addr: 0.0.0.0:3026
       mysql_listen_addr: 0.0.0.0:3036
     {{- if .Values.separatePostgresListener }}
       postgres_listen_addr: 0.0.0.0:5432
+      {{- if .Values.postgresPublicAddress }}
+      postgres_public_addr: '{{ .Values.postgresPublicAddress }}'
+      {{- else }}
       postgres_public_addr: {{ .Values.clusterName }}:5432
+      {{- end }}
     {{- end }}
     {{- if .Values.separateMongoListener }}
       mongo_listen_addr: 0.0.0.0:27017
+      {{- if .Values.mongoPublicAddress }}
+      mongo_public_addr: '{{ .Values.mongoPublicAddress }}'
+      {{- else }}
       mongo_public_addr: {{ .Values.clusterName }}:27017
+      {{- end }}
     {{- end }}
   {{- end }}
       enabled: true

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -96,29 +96,29 @@ data:
   {{- end }}
     proxy_service:
   {{- if .Values.publicAddr }}
-      public_addr: '{{ .Values.publicAddr }}'
+      public_addr: {{ .Values.publicAddr }}
   {{- else }}
       public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
   {{- end }}
   {{- if .Values.sshPublicAddr }}
-      ssh_public_addr: '{{ .Values.sshPublicAddr }}'
+      ssh_public_addr: {{ .Values.sshPublicAddr }}
   {{- end }}
   {{- if .Values.tunnelPublicAddr }}
-      tunnel_public_addr: '{{ .Values.tunnelPublicAddr }}'
+      tunnel_public_addr: {{ .Values.tunnelPublicAddr }}
   {{- end }}
   {{- if not .Values.proxyListenerMode }}
       kube_listen_addr: 0.0.0.0:3026
     {{- if .Values.kubePublicAddr }}
-      kube_public_addr: '{{ .Values.kubePublicAddr }}'
+      kube_public_addr: {{ .Values.kubePublicAddr }}
     {{- end }}
       mysql_listen_addr: 0.0.0.0:3036
     {{- if .Values.mysqlPublicAddr }}
-      mysql_public_addr: '{{ .Values.mysqlPublicAddr }}'
+      mysql_public_addr: {{ .Values.mysqlPublicAddr }}
     {{- end }}
     {{- if .Values.separatePostgresListener }}
       postgres_listen_addr: 0.0.0.0:5432
       {{- if .Values.postgresPublicAddr }}
-      postgres_public_addr: '{{ .Values.postgresPublicAddr }}'
+      postgres_public_addr: {{ .Values.postgresPublicAddr }}
       {{- else }}
       postgres_public_addr: {{ .Values.clusterName }}:5432
       {{- end }}
@@ -126,7 +126,7 @@ data:
     {{- if .Values.separateMongoListener }}
       mongo_listen_addr: 0.0.0.0:27017
       {{- if .Values.mongoPublicAddr }}
-      mongo_public_addr: '{{ .Values.mongoPublicAddr }}'
+      mongo_public_addr: {{ .Values.mongoPublicAddr }}
       {{- else }}
       mongo_public_addr: {{ .Values.clusterName }}:27017
       {{- end }}

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -96,29 +96,29 @@ data:
   {{- end }}
     proxy_service:
   {{- if .Values.publicAddr }}
-      public_addr: {{ .Values.publicAddr }}
+      public_addr: {{- toYaml .Values.publicAddr | nindent 8 }}
   {{- else }}
       public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
   {{- end }}
   {{- if .Values.sshPublicAddr }}
-      ssh_public_addr: {{ .Values.sshPublicAddr }}
+      ssh_public_addr: {{- toYaml .Values.sshPublicAddr | nindent 8 }}
   {{- end }}
   {{- if .Values.tunnelPublicAddr }}
-      tunnel_public_addr: {{ .Values.tunnelPublicAddr }}
+      tunnel_public_addr: {{- toYaml .Values.tunnelPublicAddr | nindent 8 }}
   {{- end }}
   {{- if not .Values.proxyListenerMode }}
       kube_listen_addr: 0.0.0.0:3026
     {{- if .Values.kubePublicAddr }}
-      kube_public_addr: {{ .Values.kubePublicAddr }}
+      kube_public_addr: {{- toYaml .Values.kubePublicAddr | nindent 8 }}
     {{- end }}
       mysql_listen_addr: 0.0.0.0:3036
     {{- if .Values.mysqlPublicAddr }}
-      mysql_public_addr: {{ .Values.mysqlPublicAddr }}
+      mysql_public_addr: {{- toYaml .Values.mysqlPublicAddr | nindent 8 }}
     {{- end }}
     {{- if .Values.separatePostgresListener }}
       postgres_listen_addr: 0.0.0.0:5432
       {{- if .Values.postgresPublicAddr }}
-      postgres_public_addr: {{ .Values.postgresPublicAddr }}
+      postgres_public_addr: {{- toYaml .Values.postgresPublicAddr | nindent 8 }}
       {{- else }}
       postgres_public_addr: {{ .Values.clusterName }}:5432
       {{- end }}
@@ -126,7 +126,7 @@ data:
     {{- if .Values.separateMongoListener }}
       mongo_listen_addr: 0.0.0.0:27017
       {{- if .Values.mongoPublicAddr }}
-      mongo_public_addr: {{ .Values.mongoPublicAddr }}
+      mongo_public_addr: {{- toYaml .Values.mongoPublicAddr | nindent 8 }}
       {{- else }}
       mongo_public_addr: {{ .Values.clusterName }}:27017
       {{- end }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
@@ -878,6 +878,45 @@ matches snapshot for proxy-listener-mode.yaml:
     metadata:
       name: RELEASE-NAME
       namespace: NAMESPACE
+matches snapshot for public-addresses.yaml:
+  1: |
+    apiVersion: v1
+    data:
+      teleport.yaml: |-
+        teleport:
+          log:
+            severity: INFO
+            output: stderr
+            format:
+              output: text
+              extra_fields: ["timestamp","level","component","caller"]
+        auth_service:
+          enabled: true
+          cluster_name: helm-lint
+          authentication:
+            type: local
+            second_factor: otp
+        kubernetes_service:
+          enabled: true
+          listen_addr: 0.0.0.0:3027
+          kube_cluster_name: helm-lint
+        proxy_service:
+          public_addr: 'loadbalancer.example.com:443'
+          ssh_public_addr: 'loadbalancer.example.com:3023'
+          tunnel_public_addr: 'loadbalancer.example.com:3024'
+          kube_listen_addr: 0.0.0.0:3026
+          mysql_listen_addr: 0.0.0.0:3036
+          postgres_listen_addr: 0.0.0.0:5432
+          postgres_public_addr: 'loadbalancer.example.com:5432'
+          mongo_listen_addr: 0.0.0.0:27017
+          mongo_public_addr: 'loadbalancer.example.com:27017'
+          enabled: true
+        ssh_service:
+          enabled: false
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for resources.yaml:
   1: |
     apiVersion: v1

--- a/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
@@ -907,7 +907,7 @@ matches snapshot for public-addresses.yaml:
           kube_listen_addr: 0.0.0.0:3026
           kube_public_addr: 'loadbalancer.example.com:3026'
           mysql_listen_addr: 0.0.0.0:3036
-          mysql_public_addr: 'loadbalancer.example.com:3026'
+          mysql_public_addr: 'loadbalancer.example.com:3036'
           postgres_listen_addr: 0.0.0.0:5432
           postgres_public_addr: 'loadbalancer.example.com:5432'
           mongo_listen_addr: 0.0.0.0:27017

--- a/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
@@ -905,7 +905,9 @@ matches snapshot for public-addresses.yaml:
           ssh_public_addr: 'loadbalancer.example.com:3023'
           tunnel_public_addr: 'loadbalancer.example.com:3024'
           kube_listen_addr: 0.0.0.0:3026
+          kube_public_addr: 'loadbalancer.example.com:3026'
           mysql_listen_addr: 0.0.0.0:3036
+          mysql_public_addr: 'loadbalancer.example.com:3026'
           postgres_listen_addr: 0.0.0.0:5432
           postgres_public_addr: 'loadbalancer.example.com:5432'
           mongo_listen_addr: 0.0.0.0:27017

--- a/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
@@ -901,17 +901,17 @@ matches snapshot for public-addresses.yaml:
           listen_addr: 0.0.0.0:3027
           kube_cluster_name: helm-lint
         proxy_service:
-          public_addr: 'loadbalancer.example.com:443'
-          ssh_public_addr: 'loadbalancer.example.com:3023'
-          tunnel_public_addr: 'loadbalancer.example.com:3024'
+          public_addr: loadbalancer.example.com:443
+          ssh_public_addr: loadbalancer.example.com:3023
+          tunnel_public_addr: loadbalancer.example.com:3024
           kube_listen_addr: 0.0.0.0:3026
-          kube_public_addr: 'loadbalancer.example.com:3026'
+          kube_public_addr: loadbalancer.example.com:3026
           mysql_listen_addr: 0.0.0.0:3036
-          mysql_public_addr: 'loadbalancer.example.com:3036'
+          mysql_public_addr: loadbalancer.example.com:3036
           postgres_listen_addr: 0.0.0.0:5432
-          postgres_public_addr: 'loadbalancer.example.com:5432'
+          postgres_public_addr: loadbalancer.example.com:5432
           mongo_listen_addr: 0.0.0.0:27017
-          mongo_public_addr: 'loadbalancer.example.com:27017'
+          mongo_public_addr: loadbalancer.example.com:27017
           enabled: true
         ssh_service:
           enabled: false

--- a/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/config_test.yaml.snap
@@ -901,17 +901,24 @@ matches snapshot for public-addresses.yaml:
           listen_addr: 0.0.0.0:3027
           kube_cluster_name: helm-lint
         proxy_service:
-          public_addr: loadbalancer.example.com:443
-          ssh_public_addr: loadbalancer.example.com:3023
-          tunnel_public_addr: loadbalancer.example.com:3024
+          public_addr:
+            - loadbalancer.example.com:443
+          ssh_public_addr:
+            - loadbalancer.example.com:3023
+          tunnel_public_addr:
+            - loadbalancer.example.com:3024
           kube_listen_addr: 0.0.0.0:3026
-          kube_public_addr: loadbalancer.example.com:3026
+          kube_public_addr:
+            - loadbalancer.example.com:3026
           mysql_listen_addr: 0.0.0.0:3036
-          mysql_public_addr: loadbalancer.example.com:3036
+          mysql_public_addr:
+            - loadbalancer.example.com:3036
           postgres_listen_addr: 0.0.0.0:5432
-          postgres_public_addr: loadbalancer.example.com:5432
+          postgres_public_addr:
+            - loadbalancer.example.com:5432
           mongo_listen_addr: 0.0.0.0:27017
-          mongo_public_addr: loadbalancer.example.com:27017
+          mongo_public_addr:
+            - loadbalancer.example.com:27017
           enabled: true
         ssh_service:
           enabled: false

--- a/examples/chart/teleport-cluster/tests/config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/config_test.yaml
@@ -299,6 +299,16 @@ tests:
           of: ConfigMap
       - matchSnapshot: {}
 
+  - it: matches snapshot for public-addresses.yaml
+    values:
+      - ../.lint/public-addresses.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot: {}
+
   - it: matches snapshot for standalone-customsize.yaml
     values:
       - ../.lint/standalone-customsize.yaml

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -79,6 +79,31 @@
             "type": "boolean",
             "default": false
         },
+        "publicAddress": {
+            "$id": "#/properties/publicAddress",
+            "type": "string",
+            "default": ""
+        },
+        "sshPublicAddress": {
+            "$id": "#/properties/sshPublicAddress",
+            "type": "string",
+            "default": ""
+        },
+        "tunnelPublicAddress": {
+            "$id": "#/properties/tunnelPublicAddress",
+            "type": "string",
+            "default": ""
+        },
+        "postgresPublicAddress": {
+            "$id": "#/properties/postgresPublicAddress",
+            "type": "string",
+            "default": ""
+        },
+        "mongoPublicAddress": {
+            "$id": "#/properties/mongoPublicAddress",
+            "type": "string",
+            "default": ""
+        },
         "teleportVersionOverride": {
             "$id": "#/properties/teleportVersionOverride",
             "type": "string",

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -84,13 +84,18 @@
             "type": "string",
             "default": ""
         },
-        "sshPublicAddress": {
-            "$id": "#/properties/sshPublicAddress",
+        "kubePublicAddress": {
+            "$id": "#/properties/kubePublicAddress",
             "type": "string",
             "default": ""
         },
-        "tunnelPublicAddress": {
-            "$id": "#/properties/tunnelPublicAddress",
+        "mongoPublicAddress": {
+            "$id": "#/properties/mongoPublicAddress",
+            "type": "string",
+            "default": ""
+        },
+        "mysqlPublicAddress": {
+            "$id": "#/properties/mysqlPublicAddress",
             "type": "string",
             "default": ""
         },
@@ -99,8 +104,13 @@
             "type": "string",
             "default": ""
         },
-        "mongoPublicAddress": {
-            "$id": "#/properties/mongoPublicAddress",
+        "sshPublicAddress": {
+            "$id": "#/properties/sshPublicAddress",
+            "type": "string",
+            "default": ""
+        },
+        "tunnelPublicAddress": {
+            "$id": "#/properties/tunnelPublicAddress",
             "type": "string",
             "default": ""
         },

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -79,38 +79,38 @@
             "type": "boolean",
             "default": false
         },
-        "publicAddress": {
-            "$id": "#/properties/publicAddress",
+        "publicAddr": {
+            "$id": "#/properties/publicAddr",
             "type": "string",
             "default": ""
         },
-        "kubePublicAddress": {
-            "$id": "#/properties/kubePublicAddress",
+        "kubePublicAddr": {
+            "$id": "#/properties/kubePublicAddr",
             "type": "string",
             "default": ""
         },
-        "mongoPublicAddress": {
-            "$id": "#/properties/mongoPublicAddress",
+        "mongoPublicAddr": {
+            "$id": "#/properties/mongoPublicAddr",
             "type": "string",
             "default": ""
         },
-        "mysqlPublicAddress": {
-            "$id": "#/properties/mysqlPublicAddress",
+        "mysqlPublicAddr": {
+            "$id": "#/properties/mysqlPublicAddr",
             "type": "string",
             "default": ""
         },
-        "postgresPublicAddress": {
-            "$id": "#/properties/postgresPublicAddress",
+        "postgresPublicAddr": {
+            "$id": "#/properties/postgresPublicAddr",
             "type": "string",
             "default": ""
         },
-        "sshPublicAddress": {
-            "$id": "#/properties/sshPublicAddress",
+        "sshPublicAddr": {
+            "$id": "#/properties/sshPublicAddr",
             "type": "string",
             "default": ""
         },
-        "tunnelPublicAddress": {
-            "$id": "#/properties/tunnelPublicAddress",
+        "tunnelPublicAddr": {
+            "$id": "#/properties/tunnelPublicAddr",
             "type": "string",
             "default": ""
         },

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -81,38 +81,59 @@
         },
         "publicAddr": {
             "$id": "#/properties/publicAddr",
-            "type": "string",
-            "default": ""
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
         },
         "kubePublicAddr": {
             "$id": "#/properties/kubePublicAddr",
-            "type": "string",
-            "default": ""
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
         },
         "mongoPublicAddr": {
             "$id": "#/properties/mongoPublicAddr",
-            "type": "string",
-            "default": ""
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
         },
         "mysqlPublicAddr": {
             "$id": "#/properties/mysqlPublicAddr",
-            "type": "string",
-            "default": ""
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
         },
         "postgresPublicAddr": {
             "$id": "#/properties/postgresPublicAddr",
-            "type": "string",
-            "default": ""
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
         },
         "sshPublicAddr": {
             "$id": "#/properties/sshPublicAddr",
-            "type": "string",
-            "default": ""
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
         },
         "tunnelPublicAddr": {
             "$id": "#/properties/tunnelPublicAddr",
-            "type": "string",
-            "default": ""
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
         },
         "teleportVersionOverride": {
             "$id": "#/properties/teleportVersionOverride",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -38,25 +38,25 @@ separatePostgresListener: false
 separateMongoListener: false
 
 # Public cluster address, including port. Defaults to `clusterName` on 443 port.
-publicAddress: ""
-# Public cluster kube address, including port. Defaults to `publicAddress` on 3026 port.
+publicAddr: ""
+# Public cluster kube address, including port. Defaults to `publicAddr` on 3026 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
-kubePublicAddress: ""
-# Public cluster mongo listener address, including port. Defaults to `publicAddress` on 27017 port.
+kubePublicAddr: ""
+# Public cluster mongo listener address, including port. Defaults to `publicAddr` on 27017 port.
 # Only used when `proxyListenerMode` is not 'multiplex' and `separateMongoListener` is true.
-mongoPublicAddress: ""
-# Public cluster MySQL address, including port. Defaults to `publicAddress` on 3036 port.
+mongoPublicAddr: ""
+# Public cluster MySQL address, including port. Defaults to `publicAddr` on 3036 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
-mysqlPublicAddress: ""
-# Public cluster postgres listener address, including port. Defaults to `publicAddress` on 5432 port.
+mysqlPublicAddr: ""
+# Public cluster postgres listener address, including port. Defaults to `publicAddr` on 5432 port.
 # Only used when `proxyListenerMode` is not 'multiplex' and `separatePostgresListener` is true.
-postgresPublicAddress: ""
-# Public cluster SSH address, including port. Defaults to `publicAddress` on 3023 port.
+postgresPublicAddr: ""
+# Public cluster SSH address, including port. Defaults to `publicAddr` on 3023 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
-sshPublicAddress: ""
-# Public cluster tunnel SSH address, including port. Defaults to `publicAddress` on 3024 port.
+sshPublicAddr: ""
+# Public cluster tunnel SSH address, including port. Defaults to `publicAddr` on 3024 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
-tunnelPublicAddress: ""
+tunnelPublicAddr: ""
 
 # ACME is a protocol for getting Web X.509 certificates
 # Note: ACME can only be used for single-instance clusters. It is not suitable for use in HA configurations.

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -45,7 +45,7 @@ kubePublicAddress: ""
 # Public cluster mongo listener address, including port. Defaults to `publicAddress` on 27017 port.
 # Only used when `proxyListenerMode` is not 'multiplex' and `separateMongoListener` is true.
 mongoPublicAddress: ""
-# Public cluster MySQL address, including port. Defaults to `publicAddress` on 3026 port.
+# Public cluster MySQL address, including port. Defaults to `publicAddress` on 3036 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
 mysqlPublicAddress: ""
 # Public cluster postgres listener address, including port. Defaults to `publicAddress` on 5432 port.

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -37,6 +37,21 @@ proxyListenerMode: ""
 separatePostgresListener: false
 separateMongoListener: false
 
+# Public cluster address, including port. Defaults to `clusterName` on 443 port.
+publicAddress: ""
+# Public cluster SSH address, including port. Defaults to `publicAddress` on 3023 port.
+# Only used when `proxyListenerMode` is not 'multiplex'.
+sshPublicAddress: ""
+# Public cluster tunnel SSH address, including port. Defaults to `publicAddress` on 3024 port.
+# Only used when `proxyListenerMode` is not 'multiplex'.
+tunnelPublicAddress: ""
+# Public cluster postgres listener address, including port. Defaults to `publicAddress` on 5432 port.
+# Only used when `proxyListenerMode` is not 'multiplex' and `separatePostgresListener` is true.
+postgresPublicAddress: ""
+# Public cluster mongo listener address, including port. Defaults to `publicAddress` on 27017 port.
+# Only used when `proxyListenerMode` is not 'multiplex' and `separateMongoListener` is true.
+mongoPublicAddress: ""
+
 # ACME is a protocol for getting Web X.509 certificates
 # Note: ACME can only be used for single-instance clusters. It is not suitable for use in HA configurations.
 # For HA configurations, see either the "highAvailability.certManager" or "tls" values.

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -37,6 +37,7 @@ proxyListenerMode: ""
 separatePostgresListener: false
 separateMongoListener: false
 
+# Do not set any of these values unless you explicitly need to. Teleport always uses the cluster name by default.
 # Public cluster address, including port. Defaults to `clusterName` on 443 port.
 publicAddr: ""
 # Public cluster kube address, including port. Defaults to `publicAddr` on 3026 port.

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -39,18 +39,24 @@ separateMongoListener: false
 
 # Public cluster address, including port. Defaults to `clusterName` on 443 port.
 publicAddress: ""
+# Public cluster kube address, including port. Defaults to `publicAddress` on 3026 port.
+# Only used when `proxyListenerMode` is not 'multiplex'.
+kubePublicAddress: ""
+# Public cluster mongo listener address, including port. Defaults to `publicAddress` on 27017 port.
+# Only used when `proxyListenerMode` is not 'multiplex' and `separateMongoListener` is true.
+mongoPublicAddress: ""
+# Public cluster MySQL address, including port. Defaults to `publicAddress` on 3026 port.
+# Only used when `proxyListenerMode` is not 'multiplex'.
+mysqlPublicAddress: ""
+# Public cluster postgres listener address, including port. Defaults to `publicAddress` on 5432 port.
+# Only used when `proxyListenerMode` is not 'multiplex' and `separatePostgresListener` is true.
+postgresPublicAddress: ""
 # Public cluster SSH address, including port. Defaults to `publicAddress` on 3023 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
 sshPublicAddress: ""
 # Public cluster tunnel SSH address, including port. Defaults to `publicAddress` on 3024 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
 tunnelPublicAddress: ""
-# Public cluster postgres listener address, including port. Defaults to `publicAddress` on 5432 port.
-# Only used when `proxyListenerMode` is not 'multiplex' and `separatePostgresListener` is true.
-postgresPublicAddress: ""
-# Public cluster mongo listener address, including port. Defaults to `publicAddress` on 27017 port.
-# Only used when `proxyListenerMode` is not 'multiplex' and `separateMongoListener` is true.
-mongoPublicAddress: ""
 
 # ACME is a protocol for getting Web X.509 certificates
 # Note: ACME can only be used for single-instance clusters. It is not suitable for use in HA configurations.

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -38,26 +38,26 @@ separatePostgresListener: false
 separateMongoListener: false
 
 # Do not set any of these values unless you explicitly need to. Teleport always uses the cluster name by default.
-# Public cluster address, including port. Defaults to `clusterName` on 443 port.
-publicAddr: ""
-# Public cluster kube address, including port. Defaults to `publicAddr` on 3026 port.
+# Public cluster addresses, including port. Defaults to `clusterName` on 443 port.
+publicAddr: []
+# Public cluster kube addresses, including port. Defaults to `publicAddr` on 3026 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
-kubePublicAddr: ""
-# Public cluster mongo listener address, including port. Defaults to `publicAddr` on 27017 port.
+kubePublicAddr: []
+# Public cluster mongo listener addresses, including port. Defaults to `publicAddr` on 27017 port.
 # Only used when `proxyListenerMode` is not 'multiplex' and `separateMongoListener` is true.
-mongoPublicAddr: ""
-# Public cluster MySQL address, including port. Defaults to `publicAddr` on 3036 port.
+mongoPublicAddr: []
+# Public cluster MySQL addresses, including port. Defaults to `publicAddr` on 3036 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
-mysqlPublicAddr: ""
-# Public cluster postgres listener address, including port. Defaults to `publicAddr` on 5432 port.
+mysqlPublicAddr: []
+# Public cluster postgres listener addresses, including port. Defaults to `publicAddr` on 5432 port.
 # Only used when `proxyListenerMode` is not 'multiplex' and `separatePostgresListener` is true.
-postgresPublicAddr: ""
-# Public cluster SSH address, including port. Defaults to `publicAddr` on 3023 port.
+postgresPublicAddr: []
+# Public cluster SSH addresses, including port. Defaults to `publicAddr` on 3023 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
-sshPublicAddr: ""
-# Public cluster tunnel SSH address, including port. Defaults to `publicAddr` on 3024 port.
+sshPublicAddr: []
+# Public cluster tunnel SSH addresses, including port. Defaults to `publicAddr` on 3024 port.
 # Only used when `proxyListenerMode` is not 'multiplex'.
-tunnelPublicAddr: ""
+tunnelPublicAddr: []
 
 # ACME is a protocol for getting Web X.509 certificates
 # Note: ACME can only be used for single-instance clusters. It is not suitable for use in HA configurations.


### PR DESCRIPTION
Fixes #14309 

This PR adds the following values controlling public addresses in teleport.yaml

```
publicAddress
sshPublicAddress
tunnelPublicAddress
postgresPublicAddress
mongoPublicAddress
kubePublicAddr
```

When not set, either the chart or teleport will default to `clusterName`. After this PR `clusterName` can be something else than the cluster public address.