### PR TITLE
cleanup proxy connect calls

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1648,7 +1648,7 @@ func (tc *TeleportClient) ReissueUserCerts(ctx context.Context, cachePolicy Cert
 // (according to RBAC), IssueCertsWithMFA will:
 // - for SSH certs, return the existing Key from the keystore.
 // - for TLS certs, fall back to ReissueUserCerts.
-func (tc *TeleportClient) IssueUserCertsWithMFA(ctx context.Context, params ReissueParams) (*Key, error) {
+func (tc *TeleportClient) IssueUserCertsWithMFA(ctx context.Context, pc *ProxyClient, params ReissueParams) (*Key, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/IssueUserCertsWithMFA",
@@ -1656,13 +1656,7 @@ func (tc *TeleportClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 	)
 	defer span.End()
 
-	proxyClient, err := tc.ConnectToProxy(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer proxyClient.Close()
-
-	return proxyClient.IssueUserCertsWithMFA(
+	return pc.IssueUserCertsWithMFA(
 		ctx, params,
 		func(ctx context.Context, proxyAddr string, c *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
 			return tc.PromptMFAChallenge(ctx, proxyAddr, c, nil /* applyOpts */)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2534,7 +2534,7 @@ func (tc *TeleportClient) DeleteAppSession(ctx context.Context, sessionID string
 }
 
 // ListDatabaseServersWithFilters returns all registered database proxy servers.
-func (tc *TeleportClient) ListDatabaseServersWithFilters(ctx context.Context, customFilter *proto.ListResourcesRequest) ([]types.DatabaseServer, error) {
+func (tc *TeleportClient) ListDatabaseServersWithFilters(ctx context.Context, pc *ProxyClient, customFilter *proto.ListResourcesRequest) ([]types.DatabaseServer, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/ListDatabaseServersWithFilters",
@@ -2542,18 +2542,12 @@ func (tc *TeleportClient) ListDatabaseServersWithFilters(ctx context.Context, cu
 	)
 	defer span.End()
 
-	proxyClient, err := tc.ConnectToProxy(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer proxyClient.Close()
-
 	filter := customFilter
 	if filter == nil {
 		filter = tc.DefaultResourceFilter()
 	}
 
-	servers, err := proxyClient.FindDatabaseServersByFilters(ctx, *filter)
+	servers, err := pc.FindDatabaseServersByFilters(ctx, *filter)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2590,7 +2584,7 @@ func (tc *TeleportClient) listDatabaseServersWithFiltersAllClusters(ctx context.
 }
 
 // ListDatabases returns all registered databases.
-func (tc *TeleportClient) ListDatabases(ctx context.Context, customFilter *proto.ListResourcesRequest) ([]types.Database, error) {
+func (tc *TeleportClient) ListDatabases(ctx context.Context, pc *ProxyClient, customFilter *proto.ListResourcesRequest) ([]types.Database, error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/ListDatabases",
@@ -2598,7 +2592,7 @@ func (tc *TeleportClient) ListDatabases(ctx context.Context, customFilter *proto
 	)
 	defer span.End()
 
-	servers, err := tc.ListDatabaseServersWithFilters(ctx, customFilter)
+	servers, err := tc.ListDatabaseServersWithFilters(ctx, pc, customFilter)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -645,6 +645,14 @@ func prepareLocalProxyOptions(arg *localProxyConfig) (localProxyOpts, error) {
 
 	// To set correct MySQL server version DB proxy needs additional protocol.
 	if !arg.localProxyTunnel && arg.routeToDatabase.Protocol == defaults.ProtocolMySQL {
+		if arg.database == nil {
+			var err error
+			arg.database, err = getDatabase(arg.cliConf, arg.teleportClient, arg.routeToDatabase.ServiceName)
+			if err != nil {
+				return localProxyOpts{}, trace.Wrap(err)
+			}
+		}
+
 		mysqlServerVersionProto := mySQLVersionToProto(arg.database)
 		if mysqlServerVersionProto != "" {
 			opts.protocols = append(opts.protocols, common.Protocol(mysqlServerVersionProto))

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -244,7 +244,11 @@ func onDatabaseLogin(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	pc, err := tc.ConnectToProxy(cf.Context)
+	var pc *client.ProxyClient
+	err = client.RetryWithRelogin(cf.Context, tc, func() error {
+		pc, err = tc.ConnectToProxy(cf.Context)
+		return trace.Wrap(err)
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -300,7 +304,7 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, pc *client.ProxyClien
 	} else {
 		var key *client.Key
 		if err = client.RetryWithRelogin(cf.Context, tc, func() error {
-			key, err = tc.IssueUserCertsWithMFA(cf.Context, client.ReissueParams{
+			key, err = tc.IssueUserCertsWithMFA(cf.Context, pc, client.ReissueParams{
 				RouteToCluster: tc.SiteName,
 				RouteToDatabase: proto.RouteToDatabase{
 					ServiceName: dbRoute.ServiceName,
@@ -675,7 +679,11 @@ func onDatabaseConnect(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	pc, err := tc.ConnectToProxy(cf.Context)
+	var pc *client.ProxyClient
+	err = client.RetryWithRelogin(cf.Context, tc, func() error {
+		pc, err = tc.ConnectToProxy(cf.Context)
+		return trace.Wrap(err)
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -598,6 +598,7 @@ func prepareLocalProxyOptions(cf *CLIConf, tc *client.TeleportClient, profile *c
 	// cli arguments directly.
 	localProxyTunnel := cf.LocalProxyTunnel
 	if dbProtocol == defaults.ProtocolSnowflake {
+		// Snowflake only works in the local tunnel mode.
 		localProxyTunnel = true
 	}
 

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -155,8 +155,12 @@ func (c *kubeJoinCommand) run(cf *CLIConf) error {
 			log.Debugf("Re-using existing TLS cert for kubernetes cluster %q", kubeCluster)
 		} else {
 			err = client.RetryWithRelogin(cf.Context, tc, func() error {
-				var err error
-				k, err = tc.IssueUserCertsWithMFA(cf.Context, client.ReissueParams{
+				pc, err := tc.ConnectToProxy(cf.Context)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				defer pc.Close()
+				k, err = tc.IssueUserCertsWithMFA(cf.Context, pc, client.ReissueParams{
 					RouteToCluster:    cluster,
 					KubernetesCluster: kubeCluster,
 				})
@@ -601,8 +605,12 @@ func (c *kubeCredentialsCommand) run(cf *CLIConf) error {
 
 	log.Debugf("Requesting TLS cert for kubernetes cluster %q", c.kubeCluster)
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
-		var err error
-		k, err = tc.IssueUserCertsWithMFA(cf.Context, client.ReissueParams{
+		pc, err := tc.ConnectToProxy(cf.Context)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer pc.Close()
+		k, err = tc.IssueUserCertsWithMFA(cf.Context, pc, client.ReissueParams{
 			RouteToCluster:    c.teleportCluster,
 			KubernetesCluster: c.kubeCluster,
 		})

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -359,6 +359,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 		teleportClient:   client,
 		profile:          profile,
 		routeToDatabase:  routeToDatabase,
+		database:         db,
 		listener:         listener,
 		localProxyTunnel: cf.LocalProxyTunnel,
 	})

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -316,11 +316,18 @@ func onProxyCommandDB(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	routeToDatabase, db, err := getDatabaseInfo(cf, client, cf.DatabaseService)
+	pc, err := client.ConnectToProxy(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := maybeDatabaseLogin(cf, client, profile, routeToDatabase, db); err != nil {
+	defer pc.Close()
+
+	routeToDatabase, db, err := getDatabaseInfo(cf, client, pc, cf.DatabaseService)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := maybeDatabaseLogin(cf, client, pc, profile, routeToDatabase, db); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -354,15 +354,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 		}
 	}()
 
-	proxyOpts, err := prepareLocalProxyOptions(&localProxyConfig{
-		cliConf:          cf,
-		teleportClient:   client,
-		profile:          profile,
-		routeToDatabase:  routeToDatabase,
-		database:         db,
-		listener:         listener,
-		localProxyTunnel: cf.LocalProxyTunnel,
-	})
+	proxyOpts, err := prepareLocalProxyOptions(cf, client, profile, db, listener)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR targets another open PR to keep the requested change review manageable.

This PR reduces the number of calls to `ConnectToProxy` for `tsh db login/connect` by passing a connected `ProxyClient` down as an argument to functions that need it. Previously, there were unnecessary proxy connections established in:
* `getDatabase`
* `databaseLogin` via the new `checkRoute` function.
* `needDatabaseRelogin` (for `tsh db connect` only)
* `IssueUserCertsWithMFA`