### PR TITLE
Cancel context in DB tests

### DIFF
--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -80,7 +80,7 @@ func TestMain(m *testing.M) {
 // on the configured RBAC rules.
 func TestAccessPostgres(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
@@ -186,7 +186,7 @@ func TestAccessPostgres(t *testing.T) {
 // on the configured RBAC rules.
 func TestAccessMySQL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -268,7 +268,7 @@ func TestAccessMySQL(t *testing.T) {
 // on the configured RBAC rules.
 func TestAccessRedis(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
@@ -325,7 +325,7 @@ func TestAccessRedis(t *testing.T) {
 			testCtx.createUserAndRole(ctx, t, test.user, test.role, test.allowDbUsers, []string{types.Wildcard})
 
 			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(func() { cancel() })
+			t.Cleanup(cancel)
 
 			// Try to connect to the database as this user.
 			redisClient, err := testCtx.redisClient(ctx, test.user, "redis", test.dbUser)
@@ -353,7 +353,7 @@ func TestAccessRedis(t *testing.T) {
 // client handshake messages.
 func TestMySQLBadHandshake(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -408,7 +408,7 @@ func TestMySQLBadHandshake(t *testing.T) {
 // TestAccessMySQLChangeUser verifies that COM_CHANGE_USER command is rejected.
 func TestAccessMySQLChangeUser(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -446,7 +446,7 @@ func TestAccessMySQLChangeUser(t *testing.T) {
 
 func TestMySQLCloseConnection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -474,7 +474,7 @@ func TestMySQLCloseConnection(t *testing.T) {
 // TestAccessRedisAUTHDefaultCmd checks if empty user can log in to Redis as default.
 func TestAccessRedisAUTHDefaultCmd(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis", redis.TestServerPassword("123")))
 	go testCtx.startHandlingConnections()
@@ -501,7 +501,7 @@ func TestAccessRedisAUTHDefaultCmd(t *testing.T) {
 // TestAccessRedisAUTHCmd checks if AUTH command is verified against Teleport RBAC before is sent to Redis.
 func TestAccessRedisAUTHCmd(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
@@ -525,7 +525,7 @@ func TestAccessRedisAUTHCmd(t *testing.T) {
 // wire packets sent by the MySQL server.
 func TestAccessMySQLServerPacket(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -550,7 +550,7 @@ func TestAccessMySQLServerPacket(t *testing.T) {
 // databases with an ephemeral client certificate.
 func TestGCPRequireSSL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	user := "alice"
 	testCtx := setupTestContext(ctx, t)
@@ -628,7 +628,7 @@ func newTestSQLServerEngine(ec common.EngineConfig) common.Engine {
 // TestAccessSQLServer verifies access scenarios to a SQL Server database.
 func TestAccessSQLServer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSQLServer("sqlserver"))
 	go testCtx.startHandlingConnections()
@@ -817,7 +817,7 @@ func TestAccessMongoDB(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	// Execute each scenario on both modern and legacy Mongo servers
 	// to make sure legacy messages are also subject to RBAC.
@@ -828,7 +828,7 @@ func TestAccessMongoDB(t *testing.T) {
 
 			for _, serverOpt := range serverOpts {
 				setupCtx, cancel := context.WithCancel(ctx)
-				t.Cleanup(func() { cancel() })
+				t.Cleanup(cancel)
 
 				testCtx := setupTestContext(setupCtx, t, withSelfHostedMongo("mongo", serverOpt.opts...))
 				go testCtx.startHandlingConnections()
@@ -840,7 +840,7 @@ func TestAccessMongoDB(t *testing.T) {
 						t.Parallel()
 
 						ctx, cancel := context.WithCancel(ctx)
-						t.Cleanup(func() { cancel() })
+						t.Cleanup(cancel)
 
 						// Create user/role with the requested permissions.
 						testCtx.createUserAndRole(ctx, t, test.user, test.role, test.allowDbUsers, test.allowDbNames)
@@ -884,7 +884,7 @@ func TestAccessDisabled(t *testing.T) {
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
@@ -907,7 +907,7 @@ func TestAccessDisabled(t *testing.T) {
 // susceptible to malicious database name injections.
 func TestPostgresInjectionDatabase(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
@@ -936,7 +936,7 @@ func TestPostgresInjectionDatabase(t *testing.T) {
 // susceptible to malicious user name injections.
 func TestPostgresInjectionUser(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
@@ -966,7 +966,7 @@ func TestPostgresInjectionUser(t *testing.T) {
 
 func TestRedisGetSet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
@@ -1025,7 +1025,7 @@ func TestRedisPubSub(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(func() { cancel() })
+			t.Cleanup(cancel)
 
 			testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 			go testCtx.startHandlingConnections()
@@ -1085,7 +1085,7 @@ func TestRedisPubSub(t *testing.T) {
 
 func TestRedisPipeline(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
@@ -1137,7 +1137,7 @@ func TestRedisPipeline(t *testing.T) {
 
 func TestRedisTransaction(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
@@ -1229,7 +1229,7 @@ func TestRedisTransaction(t *testing.T) {
 
 func TestRedisNil(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -79,7 +79,9 @@ func TestMain(m *testing.M) {
 // TestAccessPostgres verifies access scenarios to a Postgres database based
 // on the configured RBAC rules.
 func TestAccessPostgres(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
 
@@ -183,7 +185,9 @@ func TestAccessPostgres(t *testing.T) {
 // TestAccessMySQL verifies access scenarios to a MySQL database based
 // on the configured RBAC rules.
 func TestAccessMySQL(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -263,7 +267,9 @@ func TestAccessMySQL(t *testing.T) {
 // TestAccessRedis verifies access scenarios to a Redis database based
 // on the configured RBAC rules.
 func TestAccessRedis(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
 
@@ -318,7 +324,8 @@ func TestAccessRedis(t *testing.T) {
 			// Create user/role with the requested permissions.
 			testCtx.createUserAndRole(ctx, t, test.user, test.role, test.allowDbUsers, []string{types.Wildcard})
 
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(func() { cancel() })
 			// Try to connect to the database as this user.
 			redisClient, err := testCtx.redisClient(ctx, test.user, "redis", test.dbUser)
 			if test.err != "" {
@@ -344,7 +351,9 @@ func TestAccessRedis(t *testing.T) {
 // TestMySQLBadHandshake verifies MySQL proxy can gracefully handle truncated
 // client handshake messages.
 func TestMySQLBadHandshake(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -397,7 +406,9 @@ func TestMySQLBadHandshake(t *testing.T) {
 
 // TestAccessMySQLChangeUser verifies that COM_CHANGE_USER command is rejected.
 func TestAccessMySQLChangeUser(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -433,7 +444,9 @@ func TestAccessMySQLChangeUser(t *testing.T) {
 }
 
 func TestMySQLCloseConnection(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -459,7 +472,9 @@ func TestMySQLCloseConnection(t *testing.T) {
 
 // TestAccessRedisAUTHDefaultCmd checks if empty user can log in to Redis as default.
 func TestAccessRedisAUTHDefaultCmd(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis", redis.TestServerPassword("123")))
 	go testCtx.startHandlingConnections()
 
@@ -484,7 +499,9 @@ func TestAccessRedisAUTHDefaultCmd(t *testing.T) {
 
 // TestAccessRedisAUTHCmd checks if AUTH command is verified against Teleport RBAC before is sent to Redis.
 func TestAccessRedisAUTHCmd(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
 
@@ -506,7 +523,8 @@ func TestAccessRedisAUTHCmd(t *testing.T) {
 // TestAccessMySQLServerPacket verifies some edge-cases related to reading
 // wire packets sent by the MySQL server.
 func TestAccessMySQLServerPacket(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -529,7 +547,8 @@ func TestAccessMySQLServerPacket(t *testing.T) {
 // TestGCPRequireSSL tests connecting to GCP Cloud SQL Postgres and MySQL
 // databases with an ephemeral client certificate.
 func TestGCPRequireSSL(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
 	user := "alice"
 	testCtx := setupTestContext(ctx, t)
 	testCtx.createUserAndRole(ctx, t, user, "admin", []string{types.Wildcard}, []string{types.Wildcard})
@@ -605,7 +624,9 @@ func newTestSQLServerEngine(ec common.EngineConfig) common.Engine {
 
 // TestAccessSQLServer verifies access scenarios to a SQL Server database.
 func TestAccessSQLServer(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSQLServer("sqlserver"))
 	go testCtx.startHandlingConnections()
 
@@ -675,8 +696,6 @@ func TestAccessSQLServer(t *testing.T) {
 // TestAccessMongoDB verifies access scenarios to a MongoDB database based
 // on the configured RBAC rules.
 func TestAccessMongoDB(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		desc         string
 		user         string
@@ -794,6 +813,9 @@ func TestAccessMongoDB(t *testing.T) {
 		},
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	// Execute each scenario on both modern and legacy Mongo servers
 	// to make sure legacy messages are also subject to RBAC.
 	for _, test := range tests {
@@ -802,7 +824,10 @@ func TestAccessMongoDB(t *testing.T) {
 			t.Parallel()
 
 			for _, serverOpt := range serverOpts {
-				testCtx := setupTestContext(ctx, t, withSelfHostedMongo("mongo", serverOpt.opts...))
+				setupCtx, cancel := context.WithCancel(ctx)
+				t.Cleanup(func() { cancel() })
+
+				testCtx := setupTestContext(setupCtx, t, withSelfHostedMongo("mongo", serverOpt.opts...))
 				go testCtx.startHandlingConnections()
 
 				for _, clientOpt := range clientOpts {
@@ -810,6 +835,9 @@ func TestAccessMongoDB(t *testing.T) {
 
 					t.Run(fmt.Sprintf("%v/%v", serverOpt.name, clientOpt.name), func(t *testing.T) {
 						t.Parallel()
+
+						ctx, cancel := context.WithCancel(ctx)
+						t.Cleanup(func() { cancel() })
 
 						// Create user/role with the requested permissions.
 						testCtx.createUserAndRole(ctx, t, test.user, test.role, test.allowDbUsers, test.allowDbNames)
@@ -852,7 +880,9 @@ func TestAccessDisabled(t *testing.T) {
 		},
 	})
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
 
@@ -873,7 +903,9 @@ func TestAccessDisabled(t *testing.T) {
 // TestPostgresInjectionDatabase makes sure Postgres connection is not
 // susceptible to malicious database name injections.
 func TestPostgresInjectionDatabase(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
 
@@ -900,7 +932,9 @@ func TestPostgresInjectionDatabase(t *testing.T) {
 // TestPostgresInjectionUser makes sure Postgres connection is not
 // susceptible to malicious user name injections.
 func TestPostgresInjectionUser(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
 
@@ -928,7 +962,9 @@ func TestPostgresInjectionUser(t *testing.T) {
 }
 
 func TestRedisGetSet(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
 
@@ -985,7 +1021,9 @@ func TestRedisPubSub(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(func() { cancel() })
+
 			testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 			go testCtx.startHandlingConnections()
 
@@ -1043,7 +1081,9 @@ func TestRedisPubSub(t *testing.T) {
 }
 
 func TestRedisPipeline(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
 
@@ -1093,7 +1133,9 @@ func TestRedisPipeline(t *testing.T) {
 }
 
 func TestRedisTransaction(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
 
@@ -1183,7 +1225,9 @@ func TestRedisTransaction(t *testing.T) {
 }
 
 func TestRedisNil(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
 

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -326,6 +326,7 @@ func TestAccessRedis(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(func() { cancel() })
+
 			// Try to connect to the database as this user.
 			redisClient, err := testCtx.redisClient(ctx, test.user, "redis", test.dbUser)
 			if test.err != "" {
@@ -525,6 +526,7 @@ func TestAccessRedisAUTHCmd(t *testing.T) {
 func TestAccessMySQLServerPacket(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -549,6 +551,7 @@ func TestAccessMySQLServerPacket(t *testing.T) {
 func TestGCPRequireSSL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() { cancel() })
+
 	user := "alice"
 	testCtx := setupTestContext(ctx, t)
 	testCtx.createUserAndRole(ctx, t, user, "admin", []string{types.Wildcard}, []string{types.Wildcard})

--- a/lib/srv/db/audit_test.go
+++ b/lib/srv/db/audit_test.go
@@ -34,7 +34,7 @@ import (
 // connections.
 func TestAuditPostgres(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
@@ -82,7 +82,7 @@ func TestAuditPostgres(t *testing.T) {
 // connections.
 func TestAuditMySQL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -114,7 +114,7 @@ func TestAuditMySQL(t *testing.T) {
 // connections.
 func TestAuditMongo(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMongo("mongo"))
 	go testCtx.startHandlingConnections()
@@ -149,7 +149,7 @@ func TestAuditMongo(t *testing.T) {
 
 func TestAuditRedis(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
@@ -192,7 +192,7 @@ func TestAuditRedis(t *testing.T) {
 // connections.
 func TestAuditSQLServer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSQLServer("sqlserver"))
 	go testCtx.startHandlingConnections()

--- a/lib/srv/db/audit_test.go
+++ b/lib/srv/db/audit_test.go
@@ -33,7 +33,9 @@ import (
 // TestAuditPostgres verifies proper audit events are emitted for Postgres
 // connections.
 func TestAuditPostgres(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
 
@@ -79,7 +81,9 @@ func TestAuditPostgres(t *testing.T) {
 // TestAuditMySQL verifies proper audit events are emitted for MySQL
 // connections.
 func TestAuditMySQL(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -109,7 +113,9 @@ func TestAuditMySQL(t *testing.T) {
 // TestAuditMongo verifies proper audit events are emitted for MongoDB
 // connections.
 func TestAuditMongo(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMongo("mongo"))
 	go testCtx.startHandlingConnections()
 
@@ -142,7 +148,9 @@ func TestAuditMongo(t *testing.T) {
 }
 
 func TestAuditRedis(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
 
@@ -183,7 +191,9 @@ func TestAuditRedis(t *testing.T) {
 // TestAuditSQLServer verifies proper audit events are emitted for SQLServer
 // connections.
 func TestAuditSQLServer(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSQLServer("sqlserver"))
 	go testCtx.startHandlingConnections()
 
@@ -204,7 +214,7 @@ func TestAuditSQLServer(t *testing.T) {
 
 		requireEvent(t, testCtx, libevents.DatabaseSessionStartCode)
 
-		err = conn.Ping(context.Background())
+		err = conn.Ping(ctx)
 		require.NoError(t, err)
 		requireEvent(t, testCtx, libevents.DatabaseSessionQueryCode)
 

--- a/lib/srv/db/auth_test.go
+++ b/lib/srv/db/auth_test.go
@@ -40,7 +40,9 @@ import (
 // TestAuthTokens verifies that proper IAM auth tokens are used when connecting
 // to cloud databases such as RDS, Redshift, Cloud SQL.
 func TestAuthTokens(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t,
 		withRDSPostgres("postgres-rds-correct-token", rdsAuthToken),
 		withRDSPostgres("postgres-rds-incorrect-token", "qwe123"),
@@ -225,7 +227,8 @@ func TestDBCertSigning(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
 
 	privateKey, _, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)

--- a/lib/srv/db/auth_test.go
+++ b/lib/srv/db/auth_test.go
@@ -41,7 +41,7 @@ import (
 // to cloud databases such as RDS, Redshift, Cloud SQL.
 func TestAuthTokens(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t,
 		withRDSPostgres("postgres-rds-correct-token", rdsAuthToken),
@@ -228,7 +228,7 @@ func TestDBCertSigning(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	privateKey, _, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)

--- a/lib/srv/db/ca_test.go
+++ b/lib/srv/db/ca_test.go
@@ -34,7 +34,7 @@ import (
 // TestInitCACert verifies automatic download of root certs for cloud databases.
 func TestInitCACert(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t)
 
@@ -169,7 +169,7 @@ func TestInitCACert(t *testing.T) {
 // it was already downloaded before.
 func TestInitCACertCaching(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t)
 
@@ -433,7 +433,7 @@ func TestTLSConfiguration(t *testing.T) {
 				dbType := dbType
 				t.Run(dbType, func(t *testing.T) {
 					ctx, cancel := context.WithCancel(context.Background())
-					t.Cleanup(func() { cancel() })
+					t.Cleanup(cancel)
 
 					cfg := &setupTLSTestCfg{
 						commonName: tt.commonName,

--- a/lib/srv/db/ca_test.go
+++ b/lib/srv/db/ca_test.go
@@ -166,7 +166,9 @@ func TestInitCACert(t *testing.T) {
 // TestInitCACertCaching verifies root certificate is not re-downloaded if
 // it was already downloaded before.
 func TestInitCACertCaching(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t)
 
 	rds, err := types.NewDatabaseV3(types.Metadata{
@@ -428,7 +430,9 @@ func TestTLSConfiguration(t *testing.T) {
 			} {
 				dbType := dbType
 				t.Run(dbType, func(t *testing.T) {
-					ctx := context.Background()
+					ctx, cancel := context.WithCancel(context.Background())
+					t.Cleanup(func() { cancel() })
+
 					cfg := &setupTLSTestCfg{
 						commonName: tt.commonName,
 						serverName: tt.serverName,

--- a/lib/srv/db/ca_test.go
+++ b/lib/srv/db/ca_test.go
@@ -33,7 +33,9 @@ import (
 
 // TestInitCACert verifies automatic download of root certs for cloud databases.
 func TestInitCACert(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t)
 
 	selfHosted, err := types.NewDatabaseV3(types.Metadata{

--- a/lib/srv/db/cloud/meta_test.go
+++ b/lib/srv/db/cloud/meta_test.go
@@ -235,7 +235,9 @@ func TestAWSMetadata(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			database, err := types.NewDatabaseV3(types.Metadata{
@@ -292,7 +294,9 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			database, err := types.NewDatabaseV3(types.Metadata{

--- a/lib/srv/db/cloud/meta_test.go
+++ b/lib/srv/db/cloud/meta_test.go
@@ -236,7 +236,7 @@ func TestAWSMetadata(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -295,7 +295,7 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/lib/srv/db/cloud/users/user_test.go
+++ b/lib/srv/db/cloud/users/user_test.go
@@ -32,7 +32,9 @@ import (
 func TestBaseUser(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	clock := clockwork.NewFakeClock()
 	mockCloudResource := newMockCloudResource()
 

--- a/lib/srv/db/cloud/users/user_test.go
+++ b/lib/srv/db/cloud/users/user_test.go
@@ -33,7 +33,7 @@ func TestBaseUser(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	clock := clockwork.NewFakeClock()
 	mockCloudResource := newMockCloudResource()

--- a/lib/srv/db/cloud/watchers/watcher_test.go
+++ b/lib/srv/db/cloud/watchers/watcher_test.go
@@ -40,7 +40,8 @@ import (
 
 // TestWatcher tests cloud databases watcher.
 func TestWatcher(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
 
 	rdsInstance1, rdsDatabase1 := makeRDSInstance(t, "instance-1", "us-east-1", map[string]string{"env": "prod"})
 	rdsInstance2, _ := makeRDSInstance(t, "instance-2", "us-east-2", map[string]string{"env": "prod"})

--- a/lib/srv/db/cloud/watchers/watcher_test.go
+++ b/lib/srv/db/cloud/watchers/watcher_test.go
@@ -41,7 +41,7 @@ import (
 // TestWatcher tests cloud databases watcher.
 func TestWatcher(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	rdsInstance1, rdsDatabase1 := makeRDSInstance(t, "instance-1", "us-east-1", map[string]string{"env": "prod"})
 	rdsInstance2, _ := makeRDSInstance(t, "instance-2", "us-east-2", map[string]string{"env": "prod"})

--- a/lib/srv/db/ha_test.go
+++ b/lib/srv/db/ha_test.go
@@ -33,7 +33,7 @@ import (
 // TestHA tests scenario with multiple database services proxying the same database.
 func TestHA(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t)
 	go testCtx.startProxy()

--- a/lib/srv/db/ha_test.go
+++ b/lib/srv/db/ha_test.go
@@ -32,7 +32,9 @@ import (
 
 // TestHA tests scenario with multiple database services proxying the same database.
 func TestHA(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t)
 	go testCtx.startProxy()
 

--- a/lib/srv/db/local_proxy_test.go
+++ b/lib/srv/db/local_proxy_test.go
@@ -32,7 +32,7 @@ import (
 // through the local authenticated ALPN proxy.
 func TestLocalProxyPostgres(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
@@ -60,7 +60,7 @@ func TestLocalProxyPostgres(t *testing.T) {
 // through the local authenticated ALPN proxy.
 func TestLocalProxyMySQL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -87,7 +87,7 @@ func TestLocalProxyMySQL(t *testing.T) {
 // through the local authenticated ALPN proxy.
 func TestLocalProxyMongoDB(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMongo("mongo"))
 	go testCtx.startHandlingConnections()
@@ -114,7 +114,7 @@ func TestLocalProxyMongoDB(t *testing.T) {
 // through the local authenticated ALPN proxy.
 func TestLocalProxyRedis(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()

--- a/lib/srv/db/local_proxy_test.go
+++ b/lib/srv/db/local_proxy_test.go
@@ -31,7 +31,9 @@ import (
 // TestLocalProxyPostgres verifies connecting to a Postgres database
 // through the local authenticated ALPN proxy.
 func TestLocalProxyPostgres(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
 
@@ -57,7 +59,9 @@ func TestLocalProxyPostgres(t *testing.T) {
 // TestLocalProxyMySQL verifies connecting to a MySQL database
 // through the local authenticated ALPN proxy.
 func TestLocalProxyMySQL(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -82,7 +86,9 @@ func TestLocalProxyMySQL(t *testing.T) {
 // TestLocalProxyMongoDB verifies connecting to a MongoDB database
 // through the local authenticated ALPN proxy.
 func TestLocalProxyMongoDB(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMongo("mongo"))
 	go testCtx.startHandlingConnections()
 
@@ -107,7 +113,9 @@ func TestLocalProxyMongoDB(t *testing.T) {
 // TestLocalProxyRedis verifies connecting to a Redis database
 // through the local authenticated ALPN proxy.
 func TestLocalProxyRedis(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
 

--- a/lib/srv/db/mysql/engine_test.go
+++ b/lib/srv/db/mysql/engine_test.go
@@ -120,7 +120,7 @@ func TestFetchMySQLVersion(t *testing.T) {
 
 			srvAddr := fakeMySQL.Addr().String()
 			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(func() { cancel() })
+			t.Cleanup(cancel)
 
 			version, err := FetchMySQLVersion(ctx, &types.DatabaseV3{
 				Spec: types.DatabaseSpecV3{

--- a/lib/srv/db/mysql/engine_test.go
+++ b/lib/srv/db/mysql/engine_test.go
@@ -119,7 +119,8 @@ func TestFetchMySQLVersion(t *testing.T) {
 			}()
 
 			srvAddr := fakeMySQL.Addr().String()
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(func() { cancel() })
 
 			version, err := FetchMySQLVersion(ctx, &types.DatabaseV3{
 				Spec: types.DatabaseSpecV3{

--- a/lib/srv/db/proxy_test.go
+++ b/lib/srv/db/proxy_test.go
@@ -36,7 +36,7 @@ import (
 // line.
 func TestProxyProtocolPostgres(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
@@ -65,7 +65,7 @@ func TestProxyProtocolPostgres(t *testing.T) {
 // line.
 func TestProxyProtocolMySQL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -94,7 +94,7 @@ func TestProxyProtocolMySQL(t *testing.T) {
 // line.
 func TestProxyProtocolMongo(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMongo("mongo"))
 	go testCtx.startHandlingConnections()
@@ -120,7 +120,7 @@ func TestProxyProtocolMongo(t *testing.T) {
 
 func TestProxyProtocolRedis(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
@@ -158,7 +158,7 @@ func TestProxyClientDisconnectDueToIdleConnection(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -187,7 +187,7 @@ func TestProxyClientDisconnectDueToCertExpiration(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -212,7 +212,7 @@ func TestProxyClientDisconnectDueToCertExpiration(t *testing.T) {
 // disconnected when there is a matching lock in force.
 func TestProxyClientDisconnectDueToLockInForce(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
@@ -254,7 +254,7 @@ func setConfigClientIdleTimoutAndDisconnectExpiredCert(ctx context.Context, t *t
 
 func TestExtractMySQLVersion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql", mysql.WithServerVersion("8.0.25")))
 	go testCtx.startHandlingConnections()

--- a/lib/srv/db/proxy_test.go
+++ b/lib/srv/db/proxy_test.go
@@ -35,7 +35,9 @@ import (
 // Postgres database when Teleport is running behind a proxy that sends a proxy
 // line.
 func TestProxyProtocolPostgres(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
 	go testCtx.startHandlingConnections()
 
@@ -62,7 +64,9 @@ func TestProxyProtocolPostgres(t *testing.T) {
 // MySQL database when Teleport is running behind a proxy that sends a proxy
 // line.
 func TestProxyProtocolMySQL(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -89,7 +93,9 @@ func TestProxyProtocolMySQL(t *testing.T) {
 // Mongo database when Teleport is running behind a proxy that sends a proxy
 // line.
 func TestProxyProtocolMongo(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMongo("mongo"))
 	go testCtx.startHandlingConnections()
 
@@ -113,7 +119,9 @@ func TestProxyProtocolMongo(t *testing.T) {
 }
 
 func TestProxyProtocolRedis(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
 	go testCtx.startHandlingConnections()
 
@@ -149,7 +157,9 @@ func TestProxyClientDisconnectDueToIdleConnection(t *testing.T) {
 		connMonitorDisconnectTimeBuff = time.Second * 5
 	)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -176,7 +186,9 @@ func TestProxyClientDisconnectDueToCertExpiration(t *testing.T) {
 		ttlClientCert = time.Hour
 	)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -199,7 +211,9 @@ func TestProxyClientDisconnectDueToCertExpiration(t *testing.T) {
 // TestProxyClientDisconnectDueToLockInForce ensures that clients will be
 // disconnected when there is a matching lock in force.
 func TestProxyClientDisconnectDueToLockInForce(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
 	go testCtx.startHandlingConnections()
 
@@ -239,7 +253,9 @@ func setConfigClientIdleTimoutAndDisconnectExpiredCert(ctx context.Context, t *t
 }
 
 func TestExtractMySQLVersion(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql", mysql.WithServerVersion("8.0.25")))
 	go testCtx.startHandlingConnections()
 

--- a/lib/srv/db/proxyserver_test.go
+++ b/lib/srv/db/proxyserver_test.go
@@ -36,7 +36,9 @@ func TestProxyConnectionLimiting(t *testing.T) {
 		connLimitNumber = 3 // Arbitrary number
 	)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t,
 		withSelfHostedPostgres("postgres"),
 		withSelfHostedMySQL("mysql"))
@@ -138,7 +140,9 @@ func TestProxyRateLimiting(t *testing.T) {
 		connLimitNumber = 20 // Should be enough to hit the connection limit.
 	)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t,
 		withSelfHostedPostgres("postgres"),
 		withSelfHostedMySQL("mysql"),
@@ -244,7 +248,9 @@ func TestProxyRateLimiting(t *testing.T) {
 }
 
 func TestProxyMySQLVersion(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t,
 		withSelfHostedMySQL("mysql", mysql.WithServerVersion("8.0.12")),
 	)

--- a/lib/srv/db/proxyserver_test.go
+++ b/lib/srv/db/proxyserver_test.go
@@ -37,7 +37,7 @@ func TestProxyConnectionLimiting(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t,
 		withSelfHostedPostgres("postgres"),
@@ -141,7 +141,7 @@ func TestProxyRateLimiting(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t,
 		withSelfHostedPostgres("postgres"),
@@ -249,7 +249,7 @@ func TestProxyRateLimiting(t *testing.T) {
 
 func TestProxyMySQLVersion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t,
 		withSelfHostedMySQL("mysql", mysql.WithServerVersion("8.0.12")),

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -37,7 +37,7 @@ import (
 // dynamic labels and heartbeats its presence to the auth server.
 func TestDatabaseServerStart(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t,
 		withSelfHostedPostgres("postgres"),
@@ -80,7 +80,7 @@ func TestDatabaseServerLimiting(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	allowDbUsers := []string{types.Wildcard}
 	allowDbNames := []string{types.Wildcard}
@@ -187,7 +187,7 @@ func TestDatabaseServerLimiting(t *testing.T) {
 
 func TestHeartbeatEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	dbOne, err := types.NewDatabaseV3(types.Metadata{
 		Name: "dbOne",

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -36,7 +36,9 @@ import (
 // TestDatabaseServerStart validates that started database server updates its
 // dynamic labels and heartbeats its presence to the auth server.
 func TestDatabaseServerStart(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t,
 		withSelfHostedPostgres("postgres"),
 		withSelfHostedMySQL("mysql"),
@@ -77,7 +79,9 @@ func TestDatabaseServerLimiting(t *testing.T) {
 		connLimit = int64(5) // Arbitrary number
 	)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	allowDbUsers := []string{types.Wildcard}
 	allowDbNames := []string{types.Wildcard}
 
@@ -182,7 +186,8 @@ func TestDatabaseServerLimiting(t *testing.T) {
 }
 
 func TestHeartbeatEvents(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
 
 	dbOne, err := types.NewDatabaseV3(types.Metadata{
 		Name: "dbOne",

--- a/lib/srv/db/snowflake_test.go
+++ b/lib/srv/db/snowflake_test.go
@@ -74,7 +74,7 @@ func newTestSnowflakeEngine(ec common.EngineConfig) common.Engine {
 
 func TestAccessSnowflake(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSnowflake("snowflake"))
 	go testCtx.startHandlingConnections()
@@ -190,7 +190,7 @@ func TestAccessSnowflake(t *testing.T) {
 
 func TestAuditSnowflake(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSnowflake("snowflake"))
 	go testCtx.startHandlingConnections()
@@ -253,7 +253,7 @@ func TestAuditSnowflake(t *testing.T) {
 
 func TestTokenRefresh(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSnowflake("snowflake", snowflake.TestForceTokenRefresh()))
 	go testCtx.startHandlingConnections()
@@ -283,7 +283,7 @@ func TestTokenRefresh(t *testing.T) {
 
 func TestTokenSession(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t, withSnowflake("snowflake"))
 	go testCtx.startHandlingConnections()

--- a/lib/srv/db/snowflake_test.go
+++ b/lib/srv/db/snowflake_test.go
@@ -73,7 +73,9 @@ func newTestSnowflakeEngine(ec common.EngineConfig) common.Engine {
 }
 
 func TestAccessSnowflake(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSnowflake("snowflake"))
 	go testCtx.startHandlingConnections()
 
@@ -187,7 +189,9 @@ func TestAccessSnowflake(t *testing.T) {
 }
 
 func TestAuditSnowflake(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSnowflake("snowflake"))
 	go testCtx.startHandlingConnections()
 
@@ -248,7 +252,9 @@ func TestAuditSnowflake(t *testing.T) {
 }
 
 func TestTokenRefresh(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSnowflake("snowflake", snowflake.TestForceTokenRefresh()))
 	go testCtx.startHandlingConnections()
 
@@ -276,7 +282,9 @@ func TestTokenRefresh(t *testing.T) {
 }
 
 func TestTokenSession(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
 	testCtx := setupTestContext(ctx, t, withSnowflake("snowflake"))
 	go testCtx.startHandlingConnections()
 

--- a/lib/srv/db/watcher_test.go
+++ b/lib/srv/db/watcher_test.go
@@ -35,7 +35,7 @@ import (
 // changes to database resources.
 func TestWatcher(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t)
 
@@ -128,7 +128,7 @@ func TestWatcher(t *testing.T) {
 // evaluated for the dynamic registered resources.
 func TestWatcherCloudDynamicResource(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
+	t.Cleanup(cancel)
 
 	testCtx := setupTestContext(ctx, t)
 


### PR DESCRIPTION
Test in DB package (and probably not only) almost never cancel `context` at the end of tests which leads to goroutine leaks. This PR adds cancelation to all? context in the DB test package.