### PR TITLE
POC TLS Routing behind ALB

### DIFF
--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -134,6 +135,9 @@ func NewHTTPClient(cfg client.Config, tls *tls.Config, params ...roundtrip.Clien
 			return nil, trace.BadParameter("no addresses to dial")
 		}
 		contextDialer := client.NewDialer(cfg.KeepAlivePeriod, cfg.DialTimeout)
+		if env := os.Getenv("ALB_TEST"); env != "" {
+			contextDialer = client.NewDialer2(cfg.KeepAlivePeriod, cfg.DialTimeout)
+		}
 		dialer = client.ContextDialerFunc(func(ctx context.Context, network, _ string) (conn net.Conn, err error) {
 			for _, addr := range cfg.Addrs {
 				conn, err = contextDialer.DialContext(ctx, network, addr)

--- a/lib/reversetunnel/agent_dialer.go
+++ b/lib/reversetunnel/agent_dialer.go
@@ -49,7 +49,7 @@ func (d *agentDialer) DialContext(ctx context.Context, addr utils.NetAddr) (SSHC
 	for _, authMethod := range d.authMethods {
 		// Create a dialer (that respects HTTP proxies) and connect to remote host.
 		dialer := proxy.DialerFromEnvironment(addr.Addr, d.options...)
-		pconn, err := dialer.DialTimeout(ctx, addr.AddrNetwork, addr.Addr, apidefaults.DefaultDialTimeout)
+		pconn, err := dialer.DialTimeout(ctx, addr.AddrNetwork, addr.Addr, apidefaults.DefaultDialTimeout*1000)
 		if err != nil {
 			d.log.WithError(err).Debugf("Failed to dial %s.", addr.Addr)
 			continue

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -472,6 +473,12 @@ func (p *AgentPool) newAgent(ctx context.Context, tracker *track.Tracker, lease 
 	if p.runtimeConfig.useALPNRouting() {
 		tlsConfig := &tls.Config{
 			NextProtos: []string{string(alpncommon.ProtocolReverseTunnel)},
+		}
+		if v := os.Getenv("ALB_TEST_TUNNEL"); v != "" {
+			tlsConfig = &tls.Config{
+				NextProtos: []string{string(alpncommon.ProtocolReverseTunnel + "-http")},
+			}
+
 		}
 
 		if p.runtimeConfig.useReverseTunnelV2() {

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/teleagent"
 )
 
@@ -141,6 +142,7 @@ type Server interface {
 	Wait()
 	// GetProxyPeerClient returns the proxy peer client
 	GetProxyPeerClient() *proxy.Client
+	GetServer() *sshutils.Server
 }
 
 const (

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -84,6 +84,7 @@ type server struct {
 
 	// srv is the "base class" i.e. the underlying SSH server
 	srv     *sshutils.Server
+	SRV     *sshutils.Server
 	limiter *limiter.Limiter
 
 	// remoteSites is the list of connected remote clusters
@@ -345,6 +346,7 @@ func NewServer(cfg Config) (Server, error) {
 		return nil, err
 	}
 	srv.srv = s
+	srv.SRV = s
 	go srv.periodicFunctions()
 	return srv, nil
 }
@@ -379,6 +381,10 @@ func (s *server) disconnectClusters() error {
 		}
 	}
 	return nil
+}
+
+func (s *server) GetServer() *sshutils.Server {
+	return s.SRV
 }
 
 func (s *server) periodicFunctions() {

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -17,6 +17,8 @@ limitations under the License.
 package service
 
 import (
+	"context"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
@@ -73,6 +75,12 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	pingResp, err := conn.Client.Ping(context.Background())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	pingResp = pingResp
 
 	tunnelAddrResolver := conn.TunnelProxyResolver()
 	if tunnelAddrResolver == nil {

--- a/lib/srv/alpnproxy/common/protocols.go
+++ b/lib/srv/alpnproxy/common/protocols.go
@@ -91,6 +91,8 @@ var SupportedProtocols = []Protocol{
 	ProtocolProxySSH,
 	ProtocolReverseTunnel,
 	ProtocolAuth,
+	"teleport-proxy-ssh-http",
+	"teleport-reversetunnel-http",
 }
 
 // ProtocolsToString converts the list of Protocols to the list of strings.


### PR DESCRIPTION
## How:

1) start Teleport proxy and auth service behind ALB: 
  `teleport start -c alb-teleprot-config.yaml`

2) start db agent that will connect to auth service and tunnel service behind ALB. 
   `ALB_TEST_TUNNEL=true teleport start -c db-agent.yaml`

3) interact with teleport cluster behind ALB: 
   `ALB_TEST=true tsh login --proxy=teleport.example.com:3080 --user=marek`
   `ALB_TEST=true tsh db connect --db-user=marek mysql02`
