### PR TITLE
[v8] Correct Node/agent naming and usage

### DIFF
--- a/docs/pages/access-controls/faq.mdx
+++ b/docs/pages/access-controls/faq.mdx
@@ -11,4 +11,4 @@ description: Frequently asked questions about Teleport RBAC
 
 **Q:** Can I use node-level RBAC with OpenSSH servers?
 
-**A:** No. OpenSSH servers running `sshd` can't label themselves. This is a factor in deciding to run the Teleport Node service instead.
+**A:** No. OpenSSH servers running `sshd` can't label themselves. This is a factor in deciding to run the Teleport Node Service instead.

--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -29,7 +29,7 @@ A lock can target the following objects or attributes:
 - a Teleport [RBAC](../reference.mdx) role by the role's name
 - an MFA device by the device's UUID
 - an OS/UNIX login
-- a Teleport node by the node's UUID (effectively unregistering it from the
+- a Teleport Node by the Node's UUID (effectively unregistering it from the
   cluster)
 - a Windows desktop by the desktop's name
 - an [Access Request](../../enterprise/workflow/index.mdx) by UUID
@@ -185,7 +185,7 @@ Deleting a lock will allow new sessions or host connections.
 
 ## Next steps: Locking modes
 
-If a Teleport node or Proxy Service cannot properly synchronize its local lock
+If a Teleport Node or Proxy Service cannot properly synchronize its local lock
 view with the backend, there is a decision to be made about whether to rely on
 the last known locks. This decision strategy is encoded as one of the two modes:
 - `strict` mode causes all interactions to be terminated when the locks are not

--- a/docs/pages/api/getting-started.mdx
+++ b/docs/pages/api/getting-started.mdx
@@ -6,7 +6,7 @@ description: Get started working with the Teleport API programmatically using Go
 # Getting Started
 
 In this getting started guide we will use the Teleport API Go client to connect
-to a Teleport Node configured as an Auth Server.
+to a Teleport Auth Service.
 
 Here are the steps we'll walkthrough:
 

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -52,7 +52,7 @@ your platform from our
 
 ### Generate a token
 
-A join token is required to authorize a Teleport Application Service agent to
+A join token is required to authorize a Teleport Application Service instance to
 join the cluster. Generate a short-lived join token and save it, for example,
 in `/tmp/token` on your Teleport Application Service host:
 

--- a/docs/pages/application-access/guides/aws-console.mdx
+++ b/docs/pages/application-access/guides/aws-console.mdx
@@ -20,15 +20,16 @@ This guide will explain how to:
 ## Prerequisites
 
 - A running Teleport cluster, either self hosted or in Teleport Cloud.
-- A Teleport Node with Application Access enabled. Follow the [Getting Started](../getting-started.mdx)
-  or [Connecting Apps](./connecting-apps.mdx) guides to get it running.
+- A host running the `teleport` daemon with Application Access enabled. Follow
+  the [Getting Started](../getting-started.mdx) or
+  [Connecting Apps](./connecting-apps.mdx) guides to get it running.
 - IAM permissions in the AWS account you want to connect.
 - AWS EC2 or other instance where you can assign a IAM Security Role for the Teleport Agent.
 - `aws` command line interface (CLI) tool in PATH. [Installing or updating the latest version of the AWS CLI
 ](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
 
 <Admonition type="note">
-If using the Teleport agent deployed in AWS EKS, you cannot use Helm chart
+If using Teleport deployed in AWS EKS, you cannot use Helm chart
 annotations to specify the IAM permissions;
 you must associate the policy with the cluster role for the worker nodes.
 Otherwise, you will receive "400 Bad Request" errors from AWS.
@@ -245,7 +246,7 @@ federated login and the name of your assumed IAM role:
 Note that your federated login session is marked with your Teleport username.
 
 <Admonition type="note" title="Session Duration">
-    If the Teleport agent is running with [temporary security credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html),
+    If Teleport is running with [temporary security credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html),
     the management console session will be limited to a maximum of one hour.
 </Admonition>
 

--- a/docs/pages/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/application-access/guides/dynamic-registration.mdx
@@ -82,8 +82,8 @@ $ tctl create app.yaml
 
 
 After the resource has been created, it will appear among the list of available
-apps (in `tsh app ls` or UI) as long as at least one application agent picks it
-up according to its label selectors.
+apps (in `tsh app ls` or UI) as long as at least one Application Service
+instance picks it up according to its label selectors.
 
 To update an existing application resource, run:
 

--- a/docs/pages/architecture/tls-routing.mdx
+++ b/docs/pages/architecture/tls-routing.mdx
@@ -90,10 +90,10 @@ how it's configured.
 
 ## Reverse tunnels
 
-Reverse tunnel agents for Teleport node, application and database services, as
-well as for trusted clusters, open a TLS tunnel to the cluster's proxy with
-`teleport-reversetunnel` ALPN protocol and then dials SSH over it establishing
-the reverse tunnel connection.
+Reverse tunnel workers within the Teleport Node, Application and Database
+Services, as well as for Trusted Clusters, open a TLS tunnel to the cluster's
+Proxy Service with the `teleport-reversetunnel` ALPN protocol. The workers then
+dial SSH over the tunnel, establishing a secure connection.
 
 ## Kubernetes
 

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -110,7 +110,7 @@ achieve that:
 
   ![Created identity](../../../img/database-access/guides/azure/created-identity@2x.png)
 
-  Next, navigate to the Azure VM that will run your Database Service agent and
+  Next, navigate to the Azure VM that will run your Database Service instance and
   add the identity you've just created to it:
 
   ![VM identity](../../../img/database-access/guides/azure/vm-identity@2x.png)

--- a/docs/pages/database-access/guides/dynamic-registration.mdx
+++ b/docs/pages/database-access/guides/dynamic-registration.mdx
@@ -69,8 +69,8 @@ $ tctl create database.yaml
 (!docs/pages/includes/tctl.mdx!)
 
 After the resource has been created, it will appear among the list of available
-databases (in `tsh db ls` or UI) as long as at least one database agent picks
-it up according to its label selectors.
+databases (in `tsh db ls` or UI) as long as at least one Database Service
+instance picks it up according to its label selectors.
 
 To update an existing database resource, run:
 

--- a/docs/pages/database-access/guides/ha.mdx
+++ b/docs/pages/database-access/guides/ha.mdx
@@ -41,33 +41,33 @@ $ tsh db login postgres
 $ tsh db connect postgres
 ```
 
-When connecting, Teleport will randomly pick the service to connect through to
-provide some load balancing. If the selected agent is down (e.g. in case of AZ
-outage), Teleport will try to connect via other agents.
+When connecting, Teleport will randomly pick the Database Service instance to
+connect through to provide some load balancing. If the selected instance is down
+(e.g. in case of AZ outage), Teleport will try to connect via other instances.
 
 ## Separate replicas
 
-With separate replicas, each Database Service agent proxying the database
+With separate replicas, each Database Service instance proxying the database
 assigns it a different name. This allows you to explicitly pick the agent
 you want to connect to the database over:
 
 ```yaml
-# Database service agent #1.
+# Database service instance #1.
 db_service:
   enabled: "yes"
   databases:
-  # Note the name is different than agent #2 but URI is the same.
+  # Note the name is different than instance #2 but the URI is the same.
   - name: "postgres-us-east-1a"
     protocol: "postgres"
     uri: "postgres.example.com:5432"
 ```
 
 ```yaml
-# Database service agent #2.
+# Database service instance #2.
 db_service:
   enabled: "yes"
   databases:
-  # Note the name is different than agent #1 but URI is the same.
+  # Note the name is different than instance #1 but the URI is the same.
   - name: "postgres-us-east-1b"
     protocol: "postgres"
     uri: "postgres.example.com:5432"

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -99,7 +99,7 @@ Assign it the "Service Account Token Creator" role:
 
 <Admonition type="note" title="Service account permissions">
   "Service Account Token Creator", "Cloud SQL Viewer", and "Cloud SQL Admin"
-  IAM roles include more permissions than the database agent needs. To further
+  IAM roles include more permissions than the Database Service needs. To further
   restrict the service account, you can create a role that includes only the
   following permissions:
   ```ini

--- a/docs/pages/database-access/reference/audit.mdx
+++ b/docs/pages/database-access/reference/audit.mdx
@@ -24,7 +24,7 @@ Successful connection event:
   "ei": 0, // Event index within the session.
   "event": "db.session.start", // Event name.
   "namespace": "default", // Event namespace, always "default".
-  "server_id": "05ff66c9-a948-42f4-af0e-a1b6ba62561e", // Database service agent host ID.
+  "server_id": "05ff66c9-a948-42f4-af0e-a1b6ba62561e", // Database Service host ID.
   "sid": "63b6fa11-cd44-477b-911a-602b75ab13b5", // Unique database session ID.
   "success": true, // Indicates successful connection.
   "time": "2021-04-27T23:00:26.014Z", // Event timestamp.
@@ -49,7 +49,7 @@ Access denied event:
   "event": "db.session.start", // Event name.
   "message": "access to database denied", // Detailed error message.
   "namespace": "default", // Event namespace, always "default".
-  "server_id": "05ff66c9-a948-42f4-af0e-a1b6ba62561e", // Database service agent host ID.
+  "server_id": "05ff66c9-a948-42f4-af0e-a1b6ba62561e", // Database Service host ID.
   "sid": "d18388e5-cc7c-4624-b22b-d36db60d0c50", // Unique database session ID.
   "success": false, // Indicates unsuccessful connection.
   "time": "2021-04-27T23:03:05.226Z", // Event timestamp.

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -19,7 +19,7 @@ Database Access, including:
 
 ## teleport db start
 
-Starts Teleport Database Service agent.
+Starts Teleport Database Service.
 
 <ScopedBlock scope={["oss", "enterprise"]}>
 

--- a/docs/pages/enterprise/fedramp.mdx
+++ b/docs/pages/enterprise/fedramp.mdx
@@ -90,7 +90,8 @@ ssh_service:
 
 ### Teleport Node
 
-Save the following configuration file as `/etc/teleport.yaml` on the node server.
+Save the following configuration file as `/etc/teleport.yaml` on the Node
+Service host:
 
 ```yaml
 teleport:

--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -9,7 +9,7 @@ This guide shows you how to get up and running with Teleport Enterprise.
 There are three types of services Teleport can run:
 
 - **Auth Service** stores user accounts and provides authentication and
-  authorization for every agent and every user in a cluster.
+  authorization for every resource service and every user in a cluster.
 - **Proxy Service** routes client connection requests to the appropriate agent
   and serves a Web UI that can also be used to access resources.
 - **Agents** provide access to resources including SSH servers, Kubernetes

--- a/docs/pages/enterprise/sso.mdx
+++ b/docs/pages/enterprise/sso.mdx
@@ -116,7 +116,7 @@ spec:
 - You may use `entity_descriptor_url`, in lieu of `entity_descriptor`, to fetch the entity descriptor from
   your IDP. Though, we recommend "pinning" the entity descriptor by including the XML rather than fetching from a URL.
 
-### User Logins
+### User logins
 
 Often it is required to restrict SSO users to their unique UNIX logins when they
 connect to Teleport nodes. To support this:

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -13,10 +13,29 @@ the stability of Teleport from a security perspective.
 
 ## Can Teleport be deployed in agentless mode?
 
-Yes. Teleport can be deployed with a tiny footprint as an authentication
-gateway/proxy and you can keep your existing SSH servers on Teleport Nodes. But
-some innovating Teleport features, such as cluster introspection, will not be
-available unless the Teleport SSH daemon is present on all cluster Nodes.
+Yes. 
+
+With Teleport in agentless mode, you can easily control access to SSH servers,
+Kubernetes clusters, desktops, databases, and internal applications without running any
+additional software on your servers. Agentless mode supports session recordings
+and audit logs for deep understanding into user behavior.
+
+For capabilities such as kernel-level logging and user provisioning,
+we recommend Teleport as a drop in replacement for OpenSSH. Since Teleport
+replaces the OpenSSH agent while preserving OpenSSH's functionality, you get
+more functionality without a net addition of an agent on your system.
+
+Here are details about running each of Teleport's resource services in agentless
+mode. All resource services except for the Node/SSH Service act as proxies for
+client traffic:
+
+|Service|Supports agent mode|Supports agentless mode|Notes|
+|---|---|---|---|
+|[Application Service](./application-access/introduction.mdx)|&#10004;|&#10004;|Proxies HTTP requests to a user-configured list of applications, which can run on the same host as the `teleport` daemon or at a remote endpoint.|
+|[Database Service](./database-access/introduction.mdx)|&#10004;|&#10004;|Proxies database-specific protocol traffic to a user-configured list of databases, which can run on the same host as the `teleport` daemon or at a remote endpoint.|
+|[Kubernetes Service](./kubernetes-access/introduction.mdx)|&#10006;|&#10004;|Proxies client traffic to the API server of a registered Kubernetes cluster.|
+|[Node/SSH Service](./server-access/introduction.mdx)|&#10004;|&#10004;|You can configure OpenSSH clients and servers to trust Teleport's CA. See our [OpenSSH guide](./server-access/guides/openssh.mdx).<br/><br/>For full functionality, you can run the Node Service, which implements SSH, on each server in your infrastructure.|
+|[Windows Desktop Service](./desktop-access/introduction.mdx)|&#10006;|&#10004;|Proxies RDP traffic from client browsers to remote Windows servers.|
 
 ## Can I use OpenSSH with a Teleport cluster?
 

--- a/docs/pages/getting-started/docker-compose.mdx
+++ b/docs/pages/getting-started/docker-compose.mdx
@@ -94,7 +94,7 @@ Teleport is a bastion server for your OpenSSH hosts. SSH into OpenSSH server and
 $ ssh root@mars.openssh.teleport
 ```
 
-You can also run ansible on Teleport nodes and OpenSSH servers:
+You can also run Ansible on Teleport Nodes and OpenSSH servers:
 
 ```code
 # From term container
@@ -161,7 +161,7 @@ as a bastion server:
 Host *.openssh.teleport
     ProxyCommand ssh -o "ForwardAgent yes" -p 3023 proxy.luna.teleport -s proxy:%h:22
 
-# Hosts without openssh suffix are Teleport nodes listening on port 3022
+# Hosts without openssh suffix are Teleport Nodes listening on port 3022
 Host *.teleport !proxy.luna.teleport
     ProxyCommand ssh -o "ForwardAgent yes" -p 3023 proxy.luna.teleport -s proxy:%h:3022
 ```

--- a/docs/pages/getting-started/local-kubernetes.mdx
+++ b/docs/pages/getting-started/local-kubernetes.mdx
@@ -178,9 +178,9 @@ from a certificate authority like Let's Encrypt.
 
 ### Configure DNS
 
-For the Proxy Service to communicate with end-users and Teleport Nodes, it needs
-a domain name that is resolvable both inside and outside your Kubernetes
-cluster.
+For the Proxy Service to communicate with end-users and Teleport resource
+services, it needs a domain name that is resolvable both inside and outside your
+Kubernetes cluster.
 
 Production Teleport deployments achieve this by either using a registered domain
 name or an internal DNS infrastructure. For this demonstration, we will

--- a/docs/pages/includes/permission-warning.mdx
+++ b/docs/pages/includes/permission-warning.mdx
@@ -13,9 +13,10 @@
   - Follow the "Principle of Least Privilege" (PoLP). Don't give users
     permissive roles when giving them more restrictive roles will do instead.
     For example, assign users the built-in `access,editor` roles.
-  - When joining a Teleport agent to a cluster, save the invitation token to a
-    file. Otherwise, the token will be visible when examining the `teleport`
-    command that started the agent, e.g., via the `history` command on a
-    compromised system.
+  - When joining a Teleport resource service (e.g., the Database Service or
+    Application Service) to a cluster, save the invitation token to a file.
+    Otherwise, the token will be visible when examining the `teleport` command
+    that started the agent, e.g., via the `history` command on a compromised
+    system.
 
 </Details>

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -223,7 +223,7 @@ Label each cluster with key-value pairs describing the cluster:
 <Tabs>
   <TabItem label="Helm">
     ```code
-    # Install or upgrade the agent or cluster and set labels:
+    # Install or upgrade Teleport and set labels:
     $ helm upgrade teleport-agent teleport-kube-agent --set kubeClusterName={CLUSTER?}\
       --set proxyAddr=${PROXY?} --set authToken=${TOKEN?} --create-namespace --namespace=teleport-agent\
       --set labels.env=prod --set labels.region=us-west-1

--- a/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
+++ b/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
@@ -32,8 +32,8 @@ Teleport can act as an access plane for multiple Kubernetes clusters.
 
 We will assume that the domain of your Teleport cluster is `tele.example.com`.
 
-Let's start a lightweight agent in another Kubernetes cluster `cookie` and
-connect it to `tele.example.com`.
+Let's start the Teleport Kubernetes Service in another Kubernetes cluster,
+`cookie`, and connect it to `tele.example.com`.
 
 We will need a join token from `tele.example.com`:
 
@@ -84,8 +84,8 @@ Teleport can act as an access plane for multiple Kubernetes clusters.
 
 We will assume that the domain of your Teleport cluster is `mytenant.teleport.sh`.
 
-Let's start a lightweight agent in another Kubernetes cluster `cookie` and
-connect it to `mytenant.teleport.sh`.
+Let's start the Teleport Kubernetes Service in another Kubernetes cluster,
+`cookie`, and connect it to `tele.example.com`.
 
 We will need a join token from `mytenant.teleport.sh`:
 

--- a/docs/pages/setup/deployments/aws-terraform.mdx
+++ b/docs/pages/setup/deployments/aws-terraform.mdx
@@ -519,7 +519,7 @@ $ tsh ssh root@ip-172-31-11-69-ec2-internal
   You are using LetsEncrypt if your `use_acm` variable is set to `"false"`.
 </Admonition>
 
-#### Auth service
+#### Auth Service
 
 ```code
 $ systemctl status teleport-auth.service
@@ -534,7 +534,7 @@ $ systemctl status teleport-auth.service
 # Mar 05 18:04:39 ip-172-31-0-196.ec2.internal /usr/bin/teleport[3766]: INFO [CA]        Generating TLS certificate {0x3767920 0xc00155d200 CN=teleport-admin,O=admin,POSTALCODE={\"kubernetes_groups\":null\,\"logins\":null},STREET=,L=root 2020-03-06 06:04:39.844777551 +0000 UTC []}. common_name:teleport-admin dns_name...
 ```
 
-You can get detailed logs for the Teleport auth servers using the `journalctl` command:
+You can get detailed logs for the Teleport Auth Service using the `journalctl` command:
 
 ```code
 $ journalctl -u teleport-auth.service
@@ -551,7 +551,7 @@ $ aws ec2 describe-instances --filters "Name=tag:TeleportCluster,Values=${TF_VAR
 
 You can run `tctl` commands on **any** of the auth instances connected to your cluster, however.
 
-#### Proxy service
+#### Proxy Service
 
 ```code
 $ systemctl status teleport-proxy.service
@@ -567,7 +567,7 @@ $ systemctl status teleport-proxy.service
 # Mar 05 20:58:50 ip-172-31-2-109.ec2.internal /usr/bin/teleport[4514]: ERRO             read tcp 172.31.2.109:3023->172.31.2.143:38011: read: connection reset by peer
 ```
 
-You can get detailed logs for the Teleport proxy service using the `journalctl` command:
+You can get detailed logs for the Teleport Proxy Service using the `journalctl` command:
 
 ```code
 $ journalctl -u teleport-proxy.service
@@ -582,7 +582,7 @@ $ aws ec2 describe-instances --filters "Name=tag:TeleportCluster,Values=${TF_VAR
 # 172.31.3.215
 ```
 
-#### Node service
+#### Node Service
 
 ```code
 $ systemctl status teleport-node.service
@@ -598,7 +598,7 @@ $ systemctl status teleport-node.service
 # Mar 05 17:18:25 ip-172-31-11-69.ec2.internal /usr/bin/teleport[4456]: INFO [AUDIT:1]   Setting directory /var/lib/teleport/log/upload/sessions owner...o:1639
 ```
 
-You can get detailed logs for the Teleport node service using the `journalctl` command:
+You can get detailed logs for the Teleport Node Service using the `journalctl` command:
 
 ```code
 $ journalctl -u teleport-node.service
@@ -612,7 +612,7 @@ $ journalctl -u teleport-node.service
 
 When using ACM, the service name for the proxy is different (`teleport-proxy-acm.service` vs `teleport-proxy.service`).
 
-#### Auth service
+#### Auth Service
 
 ```code
 $ systemctl status teleport-auth.service
@@ -627,7 +627,7 @@ $ systemctl status teleport-auth.service
 # Mar 05 18:04:39 ip-172-31-0-196.ec2.internal /usr/bin/teleport[3766]: INFO [CA]        Generating TLS certificate {0x3767920 0xc00155d200 CN=teleport-admin,O=admin,POSTALCODE={\"kubernetes_groups\":null\,\"logins\":null},STREET=,L=root 2020-03-06 06:04:39.844777551 +0000 UTC []}. common_name:teleport-admin dns_name...
 ```
 
-You can get detailed logs for the Teleport auth server using the `journalctl` command:
+You can get detailed logs for the Teleport Auth Service using the `journalctl` command:
 
 ```code
 $ journalctl -u teleport-auth.service
@@ -644,7 +644,7 @@ $ aws ec2 describe-instances --filters "Name=tag:TeleportCluster,Values=${TF_VAR
 
 You can run `tctl` commands on **any** of the auth instances connected to your cluster, however.
 
-#### Proxy service (ACM)
+#### Proxy Service (ACM)
 
 ```code
 $ systemctl status teleport-proxy-acm.service
@@ -660,7 +660,7 @@ $ systemctl status teleport-proxy-acm.service
 # Mar 05 20:58:50 ip-172-31-2-109.ec2.internal /usr/bin/teleport[4514]: ERRO             read tcp 172.31.2.109:3023->172.31.2.143:38011: read: connection reset by peer
 ```
 
-You can get detailed logs for the Teleport proxy service using the `journalctl` command:
+You can get detailed logs for the Teleport Proxy Service using the `journalctl` command:
 
 ```code
 $ journalctl -u teleport-proxy-acm.service
@@ -675,7 +675,7 @@ $ aws ec2 describe-instances --filters "Name=tag:TeleportCluster,Values=${TF_VAR
 # 172.31.3.215
 ```
 
-#### Node service
+#### Node Service
 
 ```code
 $ systemctl status teleport-node.service
@@ -691,7 +691,7 @@ $ systemctl status teleport-node.service
 # Mar 05 17:18:25 ip-172-31-11-69.ec2.internal /usr/bin/teleport[4456]: INFO [AUDIT:1]   Setting directory /var/lib/teleport/log/upload/sessions owner...o:1639
 ```
 
-You can get detailed logs for the Teleport node service using the `journalctl` command:
+You can get detailed logs for the Teleport Node Service using the `journalctl` command:
 
 ```code
 $ journalctl -u teleport-node.service
@@ -720,7 +720,7 @@ $ aws ssm get-parameter --region ${TF_VAR_region} --name "/teleport/${TF_VAR_clu
 
 You should use this so that nodes can validate the auth server's identity when joining your cluster.
 
-### Getting the node join token
+### Getting the Node join token
 
 You can use this command to get a join token for your Teleport cluster:
 
@@ -731,26 +731,26 @@ $ aws ssm get-parameter --region ${TF_VAR_region} --name "/teleport/${TF_VAR_clu
 
 You can also generate a Node join token using `tctl tokens add --type=node` [as detailed here in our admin guide](../admin/adding-nodes.mdx).
 
-### Joining nodes via the Teleport auth server
+### Joining Nodes via the Teleport Auth Service
 
-To join Teleport nodes in the same VPC via the auth server, you can find the hostname for the auth load balancer with
-this command:
+To join Teleport Nodes in the same VPC via the Auth Service, you can find the
+hostname for the Auth Service load balancer with this command:
 
 ```code
 $ aws elbv2 describe-load-balancers --names "${TF_VAR_cluster_name}-auth" --query "LoadBalancers[*].DNSName" --output text
 # example-cluster-auth-c5b0fc2764ee015b.elb.us-east-1.amazonaws.com
 ```
 
-With this method, the nodes should be configured like so:
+With this method, the Nodes should be configured like so:
 
 ```yaml
 auth_servers:
   - example-cluster-auth-c5b0fc2764ee015b.elb.us-east-1.amazonaws.com:3025
 ```
 
-### Joining nodes via Teleport IoT/node tunneling
+### Joining Nodes via Teleport IoT/Node tunneling
 
-To join Teleport nodes from outside the same VPC, you will either need to investigate VPC peering/gateways (out of scope
+To join Teleport Nodes from outside the same VPC, you will either need to investigate VPC peering/gateways (out of scope
 for this document) or join your nodes using [Teleport's node tunneling](../admin/adding-nodes.mdx) functionality.
 
 With this method, you can join the nodes using the public facing proxy address - `teleport.example.com:443` for our
@@ -761,9 +761,9 @@ auth_servers:
   - teleport.example.com:443
 ```
 
-### Trusted clusters
+### Trusted Clusters
 
-To add a trusted cluster, you'll need the hostname of the proxy load balancer. You can get it using this command:
+To add a Trusted Cluster, you'll need the hostname of the proxy load balancer. You can get it using this command:
 
 ```code
 $ aws elbv2 describe-load-balancers --names "${TF_VAR_cluster_name}-proxy" --query "LoadBalancers[*].DNSName" --output text

--- a/docs/pages/setup/deployments/gcp.mdx
+++ b/docs/pages/setup/deployments/gcp.mdx
@@ -198,9 +198,9 @@ proxy_service:
   enabled: false
 ```
 
-**3. Setup Teleport Nodes**
+**3. Set up Teleport Nodes**
 
-Save the following configuration file as `/etc/teleport.yaml` on the node:
+Save the following configuration file as `/etc/teleport.yaml` on the Node:
 
 ```yaml
 teleport:

--- a/docs/pages/setup/helm-deployments/digitalocean.mdx
+++ b/docs/pages/setup/helm-deployments/digitalocean.mdx
@@ -10,7 +10,7 @@ on a DigitalOcean Kubernetes cluster. These services are fully managed in
 Teleport Cloud.
 
 Instead, Teleport Cloud users should consult the following guide, which shows
-you how to connect a Teleport Kubernetes Service agent to an existing Teleport
+you how to connect a Teleport Kubernetes Service instance to an existing Teleport
 cluster:
 
 <TileSet>

--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -5,8 +5,8 @@ description: Values that can be set using the teleport-cluster Helm chart
 
 The `teleport-cluster` Helm chart deploys the `teleport` daemon on Kubernetes.
 You can use our preset configurations to deploy the Auth Service and Proxy
-Service, or a custom configuration to deploy agent services such as the Teleport
-Kubernetes Service or Database Service.
+Service, or a custom configuration to deploy resource services such as the
+Teleport Kubernetes Service or Database Service.
 
 You can
 [browse the source on GitHub](https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-cluster).

--- a/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
@@ -3,8 +3,8 @@ title: teleport-kube-agent Chart Reference
 description: Values that can be set using the teleport-kube-agent Helm chart
 ---
 
-The `teleport-kube-agent` Helm chart is used to configure a Teleport agent that
-runs in a remote Kubernetes cluster and joins back to a Teleport cluster to
+The `teleport-kube-agent` Helm chart is used to configure a Teleport instance
+that runs in a remote Kubernetes cluster and joins back to a Teleport cluster to
 provide access to services running there.
 
 You can [browse the source on GitHub](https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-kube-agent).
@@ -65,7 +65,7 @@ If you specify a role here, you may also need to specify some other settings whi
 | - | - | - |
 | `string` | `nil` | Yes |
 
-`authToken` provides a Teleport join token which will be used to join the Teleport agent to a Teleport cluster.
+`authToken` provides a Teleport join token which will be used to join the Teleport instance to a Teleport cluster.
 
 This value **must** be provided for the chart to work. The token that you use must also be valid for every Teleport service that you
 are trying to add with the `teleport-kube-agent` chart. Here are a few examples:
@@ -86,7 +86,7 @@ are trying to add with the `teleport-kube-agent` chart. Here are a few examples:
   You cannot reuse the same static token and specify a different set of services.
 </Admonition>
 
-If you do not have the correct services (Teleport refers to these internally as `Roles`) assigned to your join token, the Teleport agent will
+If you do not have the correct services (Teleport refers to these internally as `Roles`) assigned to your join token, the Teleport instance will
 fail to join the Teleport cluster.
 
 <Tabs>
@@ -199,7 +199,7 @@ You can specify multiple apps by adding additional list elements.
 </Admonition>
 
 <Admonition type="note" title="IAM roles">
-  For AWS database auto-discovery to work, your agent pods will need to use a role which has appropriate IAM permissions as per the [database documentation](../../database-access/guides/rds.mdx#create-iam-policy-for-teleport).
+  For AWS database auto-discovery to work, your Database Service pods will need to use a role which has appropriate IAM permissions as per the [database documentation](../../database-access/guides/rds.mdx#create-iam-policy-for-teleport).
 
   After configuring a role, you can use an `eks.amazonaws.com/role-arn` annotation with the `annotations.serviceAccount` value to associate it with the service account and grant permissions:
 
@@ -363,10 +363,10 @@ See [this link for information on Community Docker image versions](../../setup/g
 | - | - |
 | `bool` | `false` |
 
-When `insecureSkipProxyTLSVerify` is set to `true`, the agent will skip the verification of the TLS certificate presented by the Teleport
-proxy server specified using [`proxyAddr`](#proxyaddr).
+When `insecureSkipProxyTLSVerify` is set to `true`, the Teleport instance will skip the verification of the TLS certificate presented by the Teleport
+Proxy Service specified using [`proxyAddr`](#proxyaddr).
 
-This can be used for joining a Teleport agent to a Teleport cluster which does not have valid TLS certificates for testing.
+This can be used for joining a Teleport instance to a Teleport cluster which does not have valid TLS certificates for testing.
 
 <Tabs>
   <TabItem label="values.yaml">
@@ -484,7 +484,7 @@ These labels can then be used with Teleport's RBAC policies to define access rul
 | - | - |
 | `bool` | `false` |
 
-Enables the creation of a Kubernetes persistent volume to hold Teleport agent state.
+Enables the creation of a Kubernetes persistent volume to hold Teleport instance state.
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
 
@@ -606,7 +606,7 @@ A list of secrets containing authorization tokens which can be optionally used t
 
 `highAvailability.replicaCount` can be used to set the number of replicas used in the deployment.
 
-Set to a number higher than `1` for a high availability mode where multiple Teleport agent pods will be deployed.
+Set to a number higher than `1` for a high availability mode where multiple Teleport pods will be deployed.
 
 <Admonition type="tip" title="Sizing guidelines">
   As a rough guide, we recommend configuring one replica per distinct availability zone where your cluster has worker nodes.
@@ -980,7 +980,8 @@ Kubernetes affinity to set for pod assignments.
 | - | - |
 | `object` | `{}` |
 
-`nodeSelector` can be used to add a map of key-value pairs to constrain the nodes the agent pods will run on.
+`nodeSelector` can be used to add a map of key-value pairs to constrain the
+nodes that Teleport pods will run on.
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)
 

--- a/docs/pages/setup/operations/tls-routing.mdx
+++ b/docs/pages/setup/operations/tls-routing.mdx
@@ -63,7 +63,7 @@ or your enterprise portal and follow the standard [upgrade procedure](./upgradin
 Make sure to upgrade both root and leaf clusters as well as `tsh` client.
 
 Pre-8.0 cluster configurations are fully backwards compatible with TLS routing.
-Existing trusted cluster and reverse tunnel agent connections won't be affected.
+Existing Trusted Cluster and reverse tunnel connections won't be affected.
 
 ## Step 2/7. Enable proxy multiplexing
 

--- a/docs/pages/setup/operations/upgrading.mdx
+++ b/docs/pages/setup/operations/upgrading.mdx
@@ -32,10 +32,10 @@ command, where `mytenant` is the name of your Teleport Cloud tenant:
 $ curl -s https://mytenant.teleport.sh/webapi/ping | jq '.server_version'
 ```
 
-Read the following rules to ensure that your Teleport Nodes are compatible with
-the Teleport Auth and Proxy Services. You should check the version of the Auth
-and Proxy Services regularly to make sure that your Teleport Nodes are
-compatible.
+Read the following rules to ensure that your Teleport resource services (e.g.,
+the SSH Service and Database Service) are compatible with the Teleport Auth and
+Proxy Services. You should check the version of the Auth and Proxy Services
+regularly to make sure that your Teleport resource services are compatible.
 
 </Details>
 
@@ -66,7 +66,8 @@ When upgrading a single Teleport cluster:
    perform necessary migrations.
 2. Upgrade Proxy Service instances. These are stateless and can be upgraded in
    any sequence or at the same time.
-3. Finally, upgrade your Teleport Nodes in any sequence or at the same time.
+3. Finally, upgrade your Teleport resource services in any sequence or at the
+   same time.
 
 <Admonition
   type="warning"
@@ -90,7 +91,8 @@ When upgrading multiple clusters:
 <TabItem scope={["cloud"]} label="Teleport Cloud">
 
 The Teleport Auth Service and Proxy Service are upgraded automatically. When
-upgrading Nodes, you may upgrade in any sequence or at the same time.
+upgrading resource services, you may upgrade in any sequence or at the same
+time.
 
 When upgrading multiple clusters:
 

--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -404,8 +404,8 @@ that as shown above. To configure Teleport to use DynamoDB:
   section of `teleport.yaml` as shown below.
 - Deploy several auth servers connected to DynamoDB storage back-end.
 - Deploy several proxy nodes.
-- Make sure that all Teleport nodes have `auth_servers` configuration setting
-  populated with the auth servers.
+- Make sure that all Teleport resource services have the `auth_servers` configuration setting
+  populated with the addresses of your cluster's Auth Service instances.
 
 ```yaml
 teleport:
@@ -598,9 +598,10 @@ Firestore:
   section of `teleport.yaml` as shown below.
 - Deploy several auth servers connected to Firestore storage back-end.
 - Deploy several proxy nodes.
-- Make sure that all Teleport nodes have `auth_servers` configuration setting
-  populated with the auth servers or use a load balancer for the auth servers in
-  high availability mode.
+- Make sure that all Teleport resource services have the `auth_servers`
+  configuration setting populated with the addresses of your cluster's Auth
+  Service instances or use a load balancer for Auth Service instances in high
+  availability mode.
 
 ```yaml
 teleport:

--- a/docs/pages/setup/reference/cli.mdx
+++ b/docs/pages/setup/reference/cli.mdx
@@ -1417,7 +1417,7 @@ tctl access ls [--user <user> | --login <login> | --node <hostname>][<flags>]
 | - | - | - | - |
 | `--user` | none | existing user | Teleport user name |
 | `--login` | none | user login | Teleport user login |
-| `--node` | none | existing hostname | Teleport node hostname |
+| `--node` | none | existing hostname | Teleport Node hostname |
 | `--namespace` | default | existing namespace | Teleport namespace |
 
 #### Examples

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -45,7 +45,8 @@ By default, it is stored in `/etc/teleport.yaml`.
   enable you to roll back to the previous configuration if you need to.
 
 - Teleport Cloud manages the Auth Service and Proxy Service for you. Your
-  Teleport Nodes should include the following configuration options to avoid
+  Teleport resource services (e.g., the Application Service and Database
+  Service) should include the following configuration options to avoid
   unintended effects:
 
   ```yaml
@@ -91,8 +92,8 @@ teleport:
     # (https://goteleport.com/docs/admin-guide/#adding-nodes-to-the-cluster).
     ca_pin: "sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
 
-    # When running in multi-homed or NATed environments Teleport nodes need
-    # to know which IP it will be reachable at by other nodes
+    # When running in multi-homed or NATed environments Teleport Nodes need
+    # to know which IP it will be reachable at by other Nodes.
     #
     # This value can be specified as FQDN e.g. host.example.com
     advertise_ip: 10.1.0.5
@@ -365,7 +366,7 @@ auth_service:
         # (https://goteleport.com/docs/access-controls/guides/locking/#locking-mode).
         locking_mode: best_effort
 
-    # IP and the port to bind to. Other Teleport nodes will be connecting to
+    # IP and the port to bind to. Other Teleport Nodes will be connecting to
     # this port (AKA "Auth API" or "Cluster API") to validate client
     # certificates
     listen_addr: 0.0.0.0:3025
@@ -534,7 +535,7 @@ ssh_service:
     # "tsh ssh -X".
     #
     # X11 forwarding will only work if the server has the "xauth" binary
-    # installed and the Teleport node can open Unix sockets.
+    # installed and the Teleport Node can open Unix sockets.
     # e.g. "$TEMP/.X11-unix/X[display_number]."
     x11:
       # no by default

--- a/docs/pages/setup/reference/terraform-provider.mdx
+++ b/docs/pages/setup/reference/terraform-provider.mdx
@@ -264,7 +264,8 @@ Options specify session, connection and auditing permissions of the role.
 
 ## teleport_provision_token
 
-Provision tokens authenticate teleport nodes and proxies when they first join the cluster.
+Provision tokens authenticate Teleport resource services and Proxy Service
+instances when they first join the cluster.
 
 **metadata**
 


### PR DESCRIPTION
Backports #13840

Fixes #10976

This change helps to remedy two issues with the documentation:

- Much of the documentation was written when Teleport's services
  consisted of the Auth Service, Proxy Service, and Nodes/SSH Service.
  There are some places in the docs where a reader can mistake the
  Node Service to mean "any resource service."

- Users often associate the term "agent" with a daemon that must run on
  every host in their infrastructure, and usage of this term can make
  Teleport seem more resource intensive than it actually is.

This change corrects mentions of "Node" that stand in for "any service
that access resources in your infrastructure" to account for Teleport's
other resource services. It also replaces mentions of the term "agent"
with "instance," the name of a resource service, or simply "Teleport."

Also edits the "agentless" question in the FAQ to include more detailed
information about each of Teleport's resource services.

This change also does some light copy-editing to correct the
capitalization of service names. It doesn't aim to be comprehensive,
though, since the main purpose of this change is to fix potentially
misleading mentions of "Node" and "agents".

Finally, this change deletes the production.mdx guide, as there is
no way to access this guide due to redirects. This guide includes
some outdated usage of "Nodes".