### PR TITLE
fix some context cancel races

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2849,10 +2849,12 @@ func (tc *TeleportClient) ConnectToProxy(ctx context.Context) (*ProxyClient, err
 	var proxyClient *ProxyClient
 
 	// Use a channel to signal when a response is returned from connectToProxy.
-	connectDone := make(chan struct {
-		*ProxyClient
-		error
-	})
+	type doneMsg struct {
+		client *ProxyClient
+		err    error
+	}
+
+	connectDone := make(chan doneMsg)
 	go func() {
 		proxyClient, err = tc.connectToProxy(ctx)
 		connectDone <- struct {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2848,8 +2848,7 @@ func (tc *TeleportClient) ConnectToProxy(ctx context.Context) (*ProxyClient, err
 	var err error
 	var proxyClient *ProxyClient
 
-	// Use a channel to signal when a response is
-	// returned from connectToProxy.
+	// Use a channel to signal when a response is returned from connectToProxy.
 	connectDone := make(chan struct {
 		*ProxyClient
 		error

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -553,8 +553,7 @@ func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionPartici
 
 		runDone := make(chan error)
 		go func() {
-			err = s.Run(strings.Join(cmd, " "))
-			runDone <- err
+			runDone <- s.Run(strings.Join(cmd, " "))
 		}()
 
 		select {

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -549,8 +549,6 @@ func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionPartici
 	// support sending SSH_MSG_DISCONNECT. Instead we close the SSH channel and
 	// SSH client, and try and exit as gracefully as possible.
 	return ns.regularSession(ctx, func(s *ssh.Session) error {
-		var err error
-
 		runDone := make(chan error)
 		go func() {
 			runDone <- s.Run(strings.Join(cmd, " "))
@@ -563,7 +561,7 @@ func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionPartici
 		// The passed in context timed out. This is often due to the user hitting
 		// Ctrl-C.
 		case <-ctx.Done():
-			err = s.Close()
+			err := s.Close()
 			if err != nil {
 				log.Debugf("Unable to close SSH channel: %v", err)
 			}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1921,6 +1921,7 @@ func (f *Forwarder) serializedRequestClientCreds(authContext authContext) (*tls.
 	// cancel == nil means that another request is in progress, so simply wait until
 	// it finishes or fails
 	f.log.Debugf("Another request is in progress for %v, waiting until it gets completed.", authContext)
+	// REVIEW(gavin) potential race here because ctx may be derived from f.ctx in `f.getOrCreateRequestContext`
 	select {
 	case <-ctx.Done():
 		c := f.getClientCreds(authContext)

--- a/lib/kube/proxy/remotecommand.go
+++ b/lib/kube/proxy/remotecommand.go
@@ -357,7 +357,7 @@ WaitForStreams:
 		case <-expired:
 			return nil, trace.BadParameter("timed out waiting for client to create streams")
 		case <-connContext.Done():
-			return nil, trace.BadParameter("onnectoin has dropped, exiting")
+			return nil, trace.BadParameter("connection has dropped, exiting")
 		}
 	}
 

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -576,6 +576,9 @@ func (s *remoteSite) watchCertAuthorities(remoteWatcher *services.CertAuthorityW
 
 	s.Debugf("Watching for cert authority changes.")
 	for {
+		// REVIEW(gavin): potential race here. localWatch and remoteWatch derive from
+		// s.ctx. So if s.ctx is cancelled, any one of these branches can be selected
+		// at random.
 		select {
 		case <-s.ctx.Done():
 			s.WithError(s.ctx.Err()).Debug("Context is closing.")


### PR DESCRIPTION
This PR fixes some context cancellation races I found.

For context (pun intended):
When `context.WithCancel` is called, a new context is created with a cancel function. This is the "child" context, and the "parent" is the context passed to `context.WithCancel`. If the parent context is cancelled, then so is the child. Here is an example of the race:

```go
package main

import (
	"context"
	"fmt"
)

func main() {
	for i := 0; i < 10; i++ {
		parentCtx, cancelParent := context.WithCancel(context.Background())
		childCtx, cancelChild := context.WithCancel(parentCtx)
		go func() {
			defer cancelChild()
			// mock for a long running process that doesnt finish before parent is cancelled
			for {
			}
		}()
		cancelParent()
		// select will choose from multiple ready cases at random, since cancelling parentCtx cancels the child as well.
		select {
		case <-parentCtx.Done():
			fmt.Println("parent cancelled")
		case <-childCtx.Done():
			fmt.Println("child cancelled")
		}
	}
}
```

output:
```fish
> go run main.go                                                                                                                                                                                             (base) 
child cancelled
child cancelled
child cancelled
child cancelled
parent cancelled
child cancelled
child cancelled
parent cancelled
parent cancelled
parent cancelled
```

I fixed two places where we have this race condition. In other places I also added review comments inline where I believe the race condition is possible.