### PR TITLE
Allow dynamic libfido2 builds via Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,12 +159,15 @@ LIBFIDO2_TEST_TAG := libfido2
 endif
 
 # Build tsh against libfido2?
-# Only build if FIDO2=yes, each platform we support must make this decision
-# explicitly.
+# FIDO2=yes and FIDO2=static enable static libfido2 builds.
+# FIDO2=dynamic enables dynamic libfido2 builds.
 LIBFIDO2_MESSAGE := without libfido2
-ifeq ("$(FIDO2)", "yes")
+ifneq (, $(filter $(FIDO2), yes static))
 LIBFIDO2_MESSAGE := with libfido2
 LIBFIDO2_BUILD_TAG := libfido2 libfido2static
+else ifeq ("$(FIDO2)", "dynamic")
+LIBFIDO2_MESSAGE := with libfido2
+LIBFIDO2_BUILD_TAG := libfido2
 endif
 
 # Enable Touch ID builds?


### PR DESCRIPTION
Allow dynamic libfido2 builds via `make full FIDO2=dynamic`.

The behavior of `FIDO2=yes` remains unchanged (it does static builds). For completeness, I've added `FIDO2=static` as an alias for "yes".

This allows dynamic builds in environments where that makes sense. For example, it is trivial to change the [Homebrew formula][1] to depend on `libfido2` and do `make full FIDO2=dynamic` after this change.

[1]: https://github.com/Homebrew/homebrew-core/blob/4379fb3a04ca8ee6cc110e6d3af68602a0bd0c99/Formula/teleport.rb#L43