### PR TITLE
Make dir before trying to open config file on `teleport configure --output=/some/dir`

### DIFF
--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -587,7 +587,7 @@ func dumpConfigFile(outputURI, contents, comment string) (string, error) {
 				return "", trace.Wrap(err, "permission denied creating directory %s", configDir)
 			}
 
-			return "", trace.Wrap(err, "error creating config file directory")
+			return "", trace.Wrap(err, "error creating config file directory %s", configDir)
 		}
 
 		f, err := os.OpenFile(uri.Path, os.O_RDWR|os.O_CREATE|os.O_EXCL, teleport.FileMaskOwnerOnly)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -577,6 +578,18 @@ func dumpConfigFile(outputURI, contents, comment string) (string, error) {
 		if !filepath.IsAbs(uri.Path) {
 			return "", trace.BadParameter("please use absolute path for file %v", uri.Path)
 		}
+
+		configDir := path.Dir(outputURI)
+		err := os.MkdirAll(configDir, 0755)
+		err = trace.ConvertSystemError(err)
+		if err != nil {
+			if trace.IsAccessDenied(err) {
+				return "", trace.Wrap(err, "permission denied creating directory %s", configDir)
+			}
+
+			return "", trace.Wrap(err, "error creating config file directory")
+		}
+
 		f, err := os.OpenFile(uri.Path, os.O_RDWR|os.O_CREATE|os.O_EXCL, teleport.FileMaskOwnerOnly)
 		err = trace.ConvertSystemError(err)
 		if err != nil {

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -171,6 +172,39 @@ func TestConfigure(t *testing.T) {
 		err := flags.CheckAndSetDefaults()
 		require.NoError(t, err)
 	})
+}
+
+func TestDumpConfigFile(t *testing.T) {
+	tt := []struct {
+		name      string
+		outputURI string
+		contents  string
+		comment   string
+		shouldErr bool
+	}{
+		{
+			name:      "errors on relative path",
+			shouldErr: true,
+			outputURI: "../",
+		},
+		{
+			name:      "doesn't error on unexisting config path",
+			shouldErr: false,
+			outputURI: fmt.Sprintf("%s/unexisting/dir/%s", t.TempDir(), "config.yaml"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := dumpConfigFile(tc.outputURI, tc.contents, tc.comment)
+			if tc.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.outputURI, r)
+			}
+		})
+	}
 }
 
 const configData = `

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -180,29 +180,24 @@ func TestDumpConfigFile(t *testing.T) {
 		outputURI string
 		contents  string
 		comment   string
-		shouldErr bool
+		assert    require.ErrorAssertionFunc
 	}{
 		{
 			name:      "errors on relative path",
-			shouldErr: true,
+			assert:    require.Error,
 			outputURI: "../",
 		},
 		{
 			name:      "doesn't error on unexisting config path",
-			shouldErr: false,
+			assert:    require.NoError,
 			outputURI: fmt.Sprintf("%s/unexisting/dir/%s", t.TempDir(), "config.yaml"),
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			r, err := dumpConfigFile(tc.outputURI, tc.contents, tc.comment)
-			if tc.shouldErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tc.outputURI, r)
-			}
+			_, err := dumpConfigFile(tc.outputURI, tc.contents, tc.comment)
+			tc.assert(t, err)
 		})
 	}
 }


### PR DESCRIPTION
This PR makes `teleport configure` create the directory of the output file before trying to open the file.

Running `teleport configure` with an `--output` flag containing a path that doesn't exist is causing an error:

```
$ teleport configure --output=/tmp/i/do/not/exist/node_config.yaml --roles=node
ERROR: open /tmp/i/do/not/exist/node_config.yaml: no such file or directory
```

After this change:

```
$ teleport configure --output=/tmp/i/do/not/exist/node_config.yaml --roles=node
Wrote config to file "/tmp/i/do/not/exist/node_config.yaml". Now you can start the server. Happy Teleporting!


$ ll /tmp/i/do/not/exist/
total 16
drwxr-xr-x 2 matheus matheus 4096 jul 20 09:55 ./
drwxr-xr-x 3 matheus matheus 4096 jul 20 09:50 ../
-rw------- 1 matheus matheus  369 jul 20 09:50 node_config.yaml
```

Output when the user does not have permission to write on the path:

```
$ ll | grep rootdir
drwxr-xr-x  2 root    root      4096 jul 20 10:21 rootdir/

$ teleport configure --output=/tmp/rootdir/i/do/not/exist/config.yaml --roles=node
ERROR: permission denied creating directory /tmp/rootdir/i/do/not/exist
mkdir /tmp/rootdir/i: permission denied
```

___

Note that this is not related to checking if the data dir is empty, as this was failing before the check. Behavior when the config is created but the `data-dir` does not exist:


```
$ ./build/teleport configure --output=/tmp/i/do/not/exist/config_.yaml --roles=node --data-dir=/tmp/another/unexisting/path
Wrote config to file "/tmp/i/do/not/exist/config_.yaml". Now you can start the server. Happy Teleporting!
```

And when `data-dir` cannot be read:

```
$ teleport configure --output=/tmp/i/do/not/exist/node_config3.yaml --roles=node
Could not check the contents of /var/lib/teleport: open /var/lib/teleport: permission denied
The data directory may contain existing cluster state.
Wrote config to file "/tmp/i/do/not/exist/node_config3.yaml". Now you can start the server. Happy Teleporting!
```