### PR TITLE
Ccooper/add proxy ls auth ls 12965

### DIFF
--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -83,8 +83,6 @@ type AuthCommand struct {
 	authSign     *kingpin.CmdClause
 	authRotate   *kingpin.CmdClause
 	authLS       *kingpin.CmdClause
-
-	stdout io.Writer
 }
 
 // Initialize allows TokenCommand to plug itself into the CLI parser
@@ -141,9 +139,6 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, config *service.Confi
 	a.authLS = auth.Command("ls", "List connected auth servers")
 	a.authLS.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(teleport.YAML).StringVar(&a.format)
 
-	if a.stdout == nil {
-		a.stdout = os.Stdout
-	}
 }
 
 // TryRun takes the CLI command as an argument (like "auth gen") and executes it
@@ -425,11 +420,11 @@ func (a *AuthCommand) ListAuthServers(ctx context.Context, clusterAPI auth.Clien
 
 	switch a.format {
 	case teleport.Text:
-		return sc.writeText(a.stdout)
+		return sc.writeText(os.Stdout)
 	case teleport.YAML:
-		return writeYAML(sc, a.stdout)
+		return writeYAML(sc, os.Stdout)
 	case teleport.JSON:
-		return writeJSON(sc, a.stdout)
+		return writeJSON(sc, os.Stdout)
 	}
 
 	return nil

--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -1,18 +1,17 @@
-/*
-Copyright 2022 Gravitational, Inc.
+// Copyright 2022 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package common
 
 import (
@@ -20,7 +19,7 @@ import (
 	"github.com/gravitational/teleport/tool/tctl/sso/tester"
 )
 
-// Commads returns the set of commands that are to oss and ent
+// Commands returns the set of commands that are to oss and ent
 // variants of tctl.
 func Commands() []CLICommand {
 	return []CLICommand{
@@ -40,6 +39,7 @@ func Commands() []CLICommand {
 		&InventoryCommand{},
 		&RecordingsCommand{},
 		&AlertCommand{},
+		&ProxyCommand{},
 	}
 }
 

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"context"
+	"github.com/gravitational/kingpin"
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/trace"
+	"io"
+	"os"
+)
+
+// ProxyCommand returns information about connected proxies
+type ProxyCommand struct {
+	config *service.Config
+	lsCmd  *kingpin.CmdClause
+
+	format string
+
+	stdout io.Writer
+}
+
+// Initialize creates the proxy command and subcommands
+func (p *ProxyCommand) Initialize(app *kingpin.Application, config *service.Config) {
+	p.config = config
+
+	auth := app.Command("proxy", "Operations with information for cluster proxies").Hidden()
+	p.lsCmd = auth.Command("ls", "List connected auth servers")
+	p.lsCmd.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(teleport.YAML).StringVar(&p.format)
+
+	if p.stdout == nil {
+		p.stdout = os.Stdout
+	}
+}
+
+// ListProxies prints currently connected proxies
+func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI auth.ClientI) error {
+	proxies, err := clusterAPI.GetProxies()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	sc := &serverCollection{proxies, false}
+
+	switch p.format {
+	case teleport.Text:
+		return sc.writeText(p.stdout)
+	case teleport.YAML:
+		return writeYAML(sc, p.stdout)
+	case teleport.JSON:
+		return writeJSON(sc, p.stdout)
+	}
+
+	return nil
+}
+
+// TryRun runs the proxy command
+func (p *ProxyCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+	switch cmd {
+	case p.lsCmd.FullCommand():
+		err = p.ListProxies(ctx, client)
+		return false, nil
+	}
+	return true, trace.Wrap(err)
+}

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -1,14 +1,29 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (
 	"context"
+	"io"
+	"os"
+
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/trace"
-	"io"
-	"os"
 )
 
 // ProxyCommand returns information about connected proxies
@@ -25,8 +40,8 @@ type ProxyCommand struct {
 func (p *ProxyCommand) Initialize(app *kingpin.Application, config *service.Config) {
 	p.config = config
 
-	auth := app.Command("proxy", "Operations with information for cluster proxies").Hidden()
-	p.lsCmd = auth.Command("ls", "List connected auth servers")
+	authCommand := app.Command("proxy", "Operations with information for cluster proxies").Hidden()
+	p.lsCmd = authCommand.Command("ls", "List connected auth servers")
 	p.lsCmd.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(teleport.YAML).StringVar(&p.format)
 
 	if p.stdout == nil {
@@ -60,6 +75,10 @@ func (p *ProxyCommand) TryRun(ctx context.Context, cmd string, client auth.Clien
 	switch cmd {
 	case p.lsCmd.FullCommand():
 		err = p.ListProxies(ctx, client)
+		if err != nil {
+			return false, err
+		}
+	default:
 		return false, nil
 	}
 	return true, trace.Wrap(err)

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -16,7 +16,6 @@ package common
 
 import (
 	"context"
-	"io"
 	"os"
 
 	"github.com/gravitational/teleport"
@@ -33,8 +32,6 @@ type ProxyCommand struct {
 	lsCmd  *kingpin.CmdClause
 
 	format string
-
-	stdout io.Writer
 }
 
 // Initialize creates the proxy command and subcommands
@@ -45,9 +42,6 @@ func (p *ProxyCommand) Initialize(app *kingpin.Application, config *service.Conf
 	p.lsCmd = authCommand.Command("ls", "List connected auth servers")
 	p.lsCmd.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(teleport.YAML).StringVar(&p.format)
 
-	if p.stdout == nil {
-		p.stdout = os.Stdout
-	}
 }
 
 // ListProxies prints currently connected proxies
@@ -61,11 +55,11 @@ func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI auth.ClientI)
 
 	switch p.format {
 	case teleport.Text:
-		return sc.writeText(p.stdout)
+		return sc.writeText(os.Stdout)
 	case teleport.YAML:
-		return writeYAML(sc, p.stdout)
+		return writeYAML(sc, os.Stdout)
 	case teleport.JSON:
-		return writeJSON(sc, p.stdout)
+		return writeJSON(sc, os.Stdout)
 	}
 
 	return nil

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -75,9 +75,6 @@ func (p *ProxyCommand) TryRun(ctx context.Context, cmd string, client auth.Clien
 	switch cmd {
 	case p.lsCmd.FullCommand():
 		err = p.ListProxies(ctx, client)
-		if err != nil {
-			return false, err
-		}
 	default:
 		return false, nil
 	}

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -19,11 +19,12 @@ import (
 	"io"
 	"os"
 
-	"github.com/gravitational/kingpin"
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/service"
+
 	"github.com/gravitational/trace"
+	"github.com/gravitational/kingpin"
 )
 
 // ProxyCommand returns information about connected proxies

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -22,8 +22,8 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/service"
 
-	"github.com/gravitational/trace"
 	"github.com/gravitational/kingpin"
+	"github.com/gravitational/trace"
 )
 
 // ProxyCommand returns information about connected proxies

--- a/tool/tctl/common/proxy_command_test.go
+++ b/tool/tctl/common/proxy_command_test.go
@@ -1,0 +1,1 @@
+package common

--- a/tool/tctl/common/proxy_command_test.go
+++ b/tool/tctl/common/proxy_command_test.go
@@ -1,1 +1,0 @@
-package common

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -1,18 +1,16 @@
-/*
-Copyright 2017 Gravitational, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2017 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package main
 


### PR DESCRIPTION
Adds `tcl proxy ls` and `tcl auth ls` commands. Implements #12965

Example output:

```
tctl proxy ls
./tctl proxy ls
kind: proxy
metadata:
  expires: "2022-09-07T13:31:28.531837238Z"
  id: 1662556888532240040
  name: 38c0176c-4e9b-4dcb-ac06-7409a8d74b13
spec:
  addr: 127.0.0.1:443
  hostname: cerebro
  public_addr: cerebro.alistanis.github.beta.tailscale.net:443
  rotation:
    current_id: ""
    last_rotated: "0001-01-01T00:00:00Z"
    schedule:
      standby: "0001-01-01T00:00:00Z"
      update_clients: "0001-01-01T00:00:00Z"
      update_servers: "0001-01-01T00:00:00Z"
    started: "0001-01-01T00:00:00Z"
  version: 9.3.2
version: v2
kind: proxy
metadata:
  expires: "2022-09-07T13:31:28.531837238Z"
  id: 1662556888532240040
  name: 38c0176c-4e9b-4dcb-ac06-7409a8d74b13
spec:
  addr: 127.0.0.1:443
  hostname: hephaestus
  public_addr: hephaestus.alistanis.github.beta.tailscale.net:443
  rotation:
    current_id: ""
    last_rotated: "0001-01-01T00:00:00Z"
    schedule:
      standby: "0001-01-01T00:00:00Z"
      update_clients: "0001-01-01T00:00:00Z"
      update_servers: "0001-01-01T00:00:00Z"
    started: "0001-01-01T00:00:00Z"
  version: 9.3.2
version: v2

```

```
tcl auth ls
kind: auth_server
metadata:
  expires: "2022-09-07T13:31:01.470720987Z"
  id: 1662556861470757487
  name: 38c0176c-4e9b-4dcb-ac06-7409a8d74b13
spec:
  addr: 172.31.10.175:3025
  hostname: cerebro
  rotation:
    current_id: ""
    last_rotated: "0001-01-01T00:00:00Z"
    schedule:
      standby: "0001-01-01T00:00:00Z"
      update_clients: "0001-01-01T00:00:00Z"
      update_servers: "0001-01-01T00:00:00Z"
    started: "0001-01-01T00:00:00Z"
  version: 9.3.2
version: v2
```