### PR TITLE
[v8] Add Enterprise instructions to Helm guides.

### DIFF
--- a/docs/pages/getting-started/kubernetes-cluster.mdx
+++ b/docs/pages/getting-started/kubernetes-cluster.mdx
@@ -61,11 +61,12 @@ Let's start with a single-pod Teleport using persistent volume as a backend.
     # Create a namespace for a deployment.
     $ kubectl create namespace teleport-cluster-ent
 
-    # Set kubectl context to the namespace to save some typing
+    # Set the kubectl context to the namespace to save some typing
     $ kubectl config set-context --current --namespace=teleport-cluster-ent
 
-    # Get a license from Teleport and create a secret "license" in the namespace teleport-cluster-ent
-    $ kubectl -n teleport-cluster-ent create secret generic license --from-file=license.pem
+    # Get a license from Teleport and create a secret called "license" in the
+    # namespace you created
+    $ kubectl create secret generic license --from-file=license.pem
 
     # Install Teleport
     $ helm install teleport-cluster teleport/teleport-cluster --namespace=teleport-cluster-ent \

--- a/docs/pages/setup/helm-deployments/aws.mdx
+++ b/docs/pages/setup/helm-deployments/aws.mdx
@@ -305,64 +305,77 @@ Replace `arn:aws:acm:us-east-1:1234567890:certificate/12345678-43c7-4dd1-a2f6-c4
 
 ## Step 5/7. Set values to configure the cluster
 
-There are two different ways to configure the `teleport-cluster` Helm chart to use `aws` mode - using a `values.yaml` file, or using `--set`
-on the command line.
+<ScopedBlock scope="enterprise">
 
-We recommend using a `values.yaml` file as it can be easily kept in source control.
+Before you can install Teleport in your Kubernetes cluster, you will need to
+create a secret that contains your Teleport license information.
 
-The `--set` CLI method is more appropriate for quick test deployments.
+Download your Teleport Enterprise license from the
+[Customer Portal](https://dashboard.gravitational.com/web/login) and save it to
+a file called `license.pem`.
 
-<Tabs>
-  <TabItem label="Using values.yaml">
-  Create an `aws-values.yaml` file and write the values you've chosen above to it:
+Create a secret from your license file. Teleport will automatically discover
+this secret as long as your file is named `license.pem`.
 
-  ```yaml
-  chartMode: aws
-  clusterName: teleport.example.com                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
-  aws:
-    region: us-west-2                               # AWS region
-    backendTable: teleport-helm-backend             # DynamoDB table to use for the Teleport backend
-    auditLogTable: teleport-helm-events             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
-    auditLogMirrorToStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
-    sessionRecordingBucket: teleport-helm-sessions  # S3 bucket to use for Teleport session recordings
-    backups: true                                   # Whether or not to turn on DynamoDB backups
-  highAvailability:
-    replicaCount: 2                                 # Number of replicas to configure
-    certManager:
-      enabled: true                                 # Enable cert-manager support to get TLS certificates
-      issuerName: letsencrypt-production            # Name of the cert-manager Issuer to use (as configured above)
-  ```
+```code
+$ kubectl -n teleport create secret generic license --from-file=license.pem
+```
 
-  Install the chart with the values from your `aws-values.yaml` file using this command:
+</ScopedBlock>
 
-  ```code
-  $ helm install teleport teleport/teleport-cluster \
-    --create-namespace \
-    --namespace teleport \
-    -f aws-values.yaml
-  ```
+Next, configure the `teleport-cluster` Helm chart to use the `aws` mode. Create
+a file called `aws-values.yaml` and write the values you've chosen above to it:
 
-  </TabItem>
-  <TabItem label="Using --set via CLI">
-  Install the chart using this command, replacing the placeholders with the values you've chosen above:
+<ScopedBlock scope={["oss", "cloud"]}>
 
-  ```code
-  $ helm install teleport teleport/teleport-cluster \
-    --create-namespace \
-    --namespace teleport \
-    --set chartMode=aws \
-    --set clusterName=teleport.example.com                                `# Name of your cluster. Use the FQDN you intend to configure in DNS below.` \
-    --set aws.region=us-west-2                                            `# AWS region` \
-    --set aws.backendTable=teleport-helm-backend                          `# DynamoDB table to use for the Teleport backend` \
-    --set aws.backups=true                                                `# Whether or not to turn on DynamoDB backups` \
-    --set aws.auditLogTable=teleport-helm-events                          `# DynamoDB table to use for the Teleport audit log (must be different to the backend table)` \
-    --set aws.sessionRecordingBucket=teleport-helm-sessions               `# S3 bucket to use for Teleport session recordings` \
-    --set highAvailability.replicaCount=2                                 `# Number of replicas to configure` \
-    --set highAvailability.certManager.enabled=true                       `# Enable cert-manager support to get TLS certificates` \
-    --set highAvailability.certManager.issuerName=letsencrypt-production  `# Name of the cert-manager Issuer to use`
-  ```
-  </TabItem>
-</Tabs>
+```yaml
+chartMode: aws
+clusterName: teleport.example.com                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
+aws:
+  region: us-west-2                               # AWS region
+  backendTable: teleport-helm-backend             # DynamoDB table to use for the Teleport backend
+  auditLogTable: teleport-helm-events             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
+  auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
+  sessionRecordingBucket: teleport-helm-sessions  # S3 bucket to use for Teleport session recordings
+  backups: true                                   # Whether or not to turn on DynamoDB backups
+highAvailability:
+  replicaCount: 2                                 # Number of replicas to configure
+  certManager:
+    enabled: true                                 # Enable cert-manager support to get TLS certificates
+    issuerName: letsencrypt-production            # Name of the cert-manager Issuer to use (as configured above)
+```
+
+</ScopedBlock>
+<ScopedBlock scope={["enterprise"]}>
+
+```yaml
+chartMode: aws
+clusterName: teleport.example.com                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
+aws:
+  region: us-west-2                               # AWS region
+  backendTable: teleport-helm-backend             # DynamoDB table to use for the Teleport backend
+  auditLogTable: teleport-helm-events             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
+  auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
+  sessionRecordingBucket: teleport-helm-sessions  # S3 bucket to use for Teleport session recordings
+  backups: true                                   # Whether or not to turn on DynamoDB backups
+highAvailability:
+  replicaCount: 2                                 # Number of replicas to configure
+  certManager:
+    enabled: true                                 # Enable cert-manager support to get TLS certificates
+    issuerName: letsencrypt-production            # Name of the cert-manager Issuer to use (as configured above)
+enterprise: true                                  # Indicate that this is a Teleport Enterprise deployment
+```
+
+</ScopedBlock>
+
+Install the chart with the values from your `aws-values.yaml` file using this command:
+
+```code
+$ helm install teleport teleport/teleport-cluster \
+  --create-namespace \
+  --namespace teleport \
+  -f aws-values.yaml
+```
 
 <Admonition type="note">
   You cannot change the `clusterName` after the cluster is configured, so make sure you choose wisely. You should use the fully-qualified domain name that you'll use for external access to your Teleport cluster.

--- a/docs/pages/setup/helm-deployments/custom.mdx
+++ b/docs/pages/setup/helm-deployments/custom.mdx
@@ -65,7 +65,8 @@ EOF
   You can skip this step if you already have a `teleport.yaml` file locally that you'd like to use.
 </Admonition>
 
-You can create the namespace for the config and add the `teleport.yaml` from your local disk like this:
+Create the namespace for the config and add the `teleport.yaml` from your local
+disk:
 
 ```code
 $ kubectl create namespace teleport
@@ -84,14 +85,47 @@ $ kubectl --namespace teleport create configmap teleport --from-file=teleport.ya
   ```
 </Admonition>
 
-After the `ConfigMap` has been created, you can deploy the Helm chart into a Kubernetes cluster with a command like this:
+<ScopedBlock scope="enterprise">
+
+Before you can install Teleport in your Kubernetes cluster, you will need to
+create a secret that contains your Teleport license information.
+
+Download your Teleport Enterprise license from the
+[Customer Portal](https://dashboard.gravitational.com/web/login) and save it to
+a file called `license.pem`.
+
+Create a secret from your license file. Teleport will automatically discover
+this secret as long as your file is named `license.pem`.
+
+```code
+$ kubectl -n teleport create secret generic license --from-file=license.pem
+```
+
+</ScopedBlock>
+
+After the `ConfigMap` has been created<ScopedBlock scope="enterprise"> and you
+have deployed the secret containing your license file</ScopedBlock>, you can
+deploy the Helm chart into a Kubernetes cluster with a command like this:
+
+<ScopedBlock scope={["oss", "cloud"]}>
 
 ```code
 $ helm install teleport teleport/teleport-cluster \
-  --create-namespace \
   --namespace teleport \
   --set chartMode=custom
 ```
+
+</ScopedBlock>
+<ScopedBlock scope={["enterprise"]}>
+
+```code
+$ helm install teleport teleport/teleport-cluster \
+  --namespace teleport \
+  --set chartMode=custom \
+  --set enterprise=true
+```
+
+</ScopedBlock>
 
 <Admonition type="warning">
   Most settings from `values.yaml` will not be applied in `custom` mode.

--- a/docs/pages/setup/helm-deployments/gcp.mdx
+++ b/docs/pages/setup/helm-deployments/gcp.mdx
@@ -273,6 +273,24 @@ $ kubectl --namespace teleport create -f gcp-issuer.yaml
 
 ## Step 5/7. Set values to configure the cluster
 
+<ScopedBlock scope="enterprise">
+
+Before you can install Teleport in your Kubernetes cluster, you will need to
+create a secret that contains your Teleport license information.
+
+Download your Teleport Enterprise license from the
+[Customer Portal](https://dashboard.gravitational.com/web/login) and save it to
+a file called `license.pem`.
+
+Create a secret from your license file. Teleport will automatically discover
+this secret as long as your file is named `license.pem`.
+
+```code
+$ kubectl -n teleport create secret generic license --from-file=license.pem
+```
+
+</ScopedBlock>
+
 <Admonition type="note">
   If you are installing Teleport in a brand new GCP project, make sure you have enabled the
   [Cloud Firestore API](https://console.cloud.google.com/apis/api/firestore.googleapis.com/overview)
@@ -281,62 +299,58 @@ $ kubectl --namespace teleport create -f gcp-issuer.yaml
   in your project before continuing.
 </Admonition>
 
-There are two different ways to configure the `teleport-cluster` Helm chart to use `gcp` mode - using a `values.yaml` file or using `--set`
-on the command line.
+Next, configure the `teleport-cluster` Helm chart to use the `gcp` mode. Create a
+file called `gcp-values.yaml` file and write the values you've chosen above to
+it:
 
-We recommend using a `values.yaml` file as it can be easily kept in source control.
+<ScopedBlock scope={["oss", "cloud"]}>
 
-The `--set` CLI method is more appropriate for quick test deployments.
+```yaml
+chartMode: gcp
+clusterName: teleport.example.com                 # Name of your cluster. Use the FQDN you intend to configure in DNS below
+gcp:
+  projectId: gcpproj-123456                       # Google Cloud project ID
+  backendTable: teleport-helm-backend             # Firestore collection to use for the Teleport backend
+  auditLogTable: teleport-helm-events             # Firestore collection to use for the Teleport audit log (must be different to the backend collection)
+  auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
+  sessionRecordingBucket: teleport-helm-sessions  # Google Cloud Storage bucket to use for Teleport session recordings
+highAvailability:
+  replicaCount: 2                                 # Number of replicas to configure
+  certManager:
+    enabled: true                                 # Enable cert-manager support to get TLS certificates
+    issuerName: letsencrypt-production            # Name of the cert-manager Issuer to use (as configured above)
+```
 
-<Tabs>
-  <TabItem label="Using values.yaml">
-  Create a `gcp-values.yaml` file and write the values you've chosen above to it:
+</ScopedBlock>
+<ScopedBlock scope={["enterprise"]}>
 
-  ```yaml
-  chartMode: gcp
-  clusterName: teleport.example.com                 # Name of your cluster. Use the FQDN you intend to configure in DNS below
-  gcp:
-    projectId: gcpproj-123456                       # Google Cloud project ID
-    backendTable: teleport-helm-backend             # Firestore collection to use for the Teleport backend
-    auditLogTable: teleport-helm-events             # Firestore collection to use for the Teleport audit log (must be different to the backend collection)
-    auditLogMirrorToStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
-    sessionRecordingBucket: teleport-helm-sessions  # Google Cloud Storage bucket to use for Teleport session recordings
-  highAvailability:
-    replicaCount: 2                                 # Number of replicas to configure
-    certManager:
-      enabled: true                                 # Enable cert-manager support to get TLS certificates
-      issuerName: letsencrypt-production            # Name of the cert-manager Issuer to use (as configured above)
-  ```
+```yaml
+chartMode: gcp
+clusterName: teleport.example.com                 # Name of your cluster. Use the FQDN you intend to configure in DNS below
+gcp:
+  projectId: gcpproj-123456                       # Google Cloud project ID
+  backendTable: teleport-helm-backend             # Firestore collection to use for the Teleport backend
+  auditLogTable: teleport-helm-events             # Firestore collection to use for the Teleport audit log (must be different to the backend collection)
+  auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
+  sessionRecordingBucket: teleport-helm-sessions  # Google Cloud Storage bucket to use for Teleport session recordings
+highAvailability:
+  replicaCount: 2                                 # Number of replicas to configure
+  certManager:
+    enabled: true                                 # Enable cert-manager support to get TLS certificates
+    issuerName: letsencrypt-production            # Name of the cert-manager Issuer to use (as configured above)
+enterprise: true                                  # Indicate that this is a Teleport Enterprise deployment
+```
 
-  Install the chart with the values from your `gcp-values.yaml` file using this command:
+</ScopedBlock>
 
-  ```code
-  $ helm install teleport teleport/teleport-cluster \
-    --create-namespace \
-    --namespace teleport \
-    -f gcp-values.yaml
-  ```
+Install the chart with the values from your `gcp-values.yaml` file using this command:
 
-  </TabItem>
-  <TabItem label="Using --set via CLI">
-  Install the chart using this command, replacing the placeholders with the values you've chosen above:
-
-  ```code
-  $ helm install teleport teleport/teleport-cluster \
-    --create-namespace \
-    --namespace teleport \
-    --set chartMode=gcp \
-    --set clusterName=teleport.example.com                                `# Name of your cluster. Use the FQDN you intend to configure in DNS below` \
-    --set gcp.projectId=gcpproj-123456                                    `# GCP project ID` \
-    --set gcp.backendTable=teleport-helm-backend                          `# Firestore collection to use for the Teleport backend` \
-    --set gcp.auditLogTable=teleport-helm-events                          `# Firestore collection to use for the Teleport audit log (must be different to the backend collection)` \
-    --set gcp.sessionRecordingBucket=teleport-helm-sessions               `# Google Cloud storage bucket to use for Teleport session recordings` \
-    --set highAvailability.replicaCount=2                                 `# Number of replicas to configure` \
-    --set highAvailability.certManager.enabled=true                       `# Enable cert-manager support to get TLS certificates` \
-    --set highAvailability.certManager.issuerName=letsencrypt-production  `# Name of the cert-manager Issuer to use`
-  ```
-  </TabItem>
-</Tabs>
+```code
+$ helm install teleport teleport/teleport-cluster \
+  --create-namespace \
+  --namespace teleport \
+  -f gcp-values.yaml
+```
 
 <Admonition type="note">
   You cannot change the `clusterName` after the cluster is configured, so make sure you choose wisely. We recommend using the fully-qualified domain name that you'll use for external access to your Teleport cluster.


### PR DESCRIPTION
Backports #12770

* Add Enterprise instructions to Helm guides.

Fixes #10787

- Add ScopedBlocks to include instructions for Enterprise users
- The Enterprise instructions affected the examples of values files. To
  simplify these guides, I removed the tabs related to using --set in
  the AWS and GCP guides. Since the `helm install` commands using
  `--set` are very long, and we recommend using a values file anyway,
  I thought it would make sense to remove the `--set` instructions.

* Respond to PR feedback

- Remove redundant namespace commands/flags.
- Move an Admonition related to the "kubectl create configmap"
  command after that command in the Custom teleport-cluster Helm chart
  guide.