### PR TITLE
Validate token for node join script

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1532,8 +1532,12 @@ func (a *ServerWithRoles) GetTokens(ctx context.Context) ([]types.ProvisionToken
 }
 
 func (a *ServerWithRoles) GetToken(ctx context.Context, token string) (types.ProvisionToken, error) {
-	if err := a.action(apidefaults.Namespace, types.KindToken, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+	// The Proxy has permission to look up tokens by name in order to validate
+	// attempts to use the node join script.
+	if isProxy := a.hasBuiltinRole(types.RoleProxy); !isProxy {
+		if err := a.action(apidefaults.Namespace, types.KindToken, types.VerbRead); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return a.authServer.GetToken(ctx, token)
 }

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -18,6 +18,7 @@ package web
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 )
 
 func TestCreateNodeJoinToken(t *testing.T) {
+	t.Parallel()
 	m := &mockedNodeAPIGetter{}
 	m.mockGenerateToken = func(ctx context.Context, req *proto.GenerateTokenRequest) (string, error) {
 		return "some-token-id", nil
@@ -47,6 +49,7 @@ func TestCreateNodeJoinToken(t *testing.T) {
 }
 
 func TestGenerateIAMTokenName(t *testing.T) {
+	t.Parallel()
 	rule1 := types.TokenRule{
 		AWSAccount: "100000000000",
 		AWSARN:     "arn:aws:iam:1",
@@ -84,6 +87,7 @@ func TestGenerateIAMTokenName(t *testing.T) {
 }
 
 func TestSortRules(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		name     string
 		rules    []*types.TokenRule
@@ -277,81 +281,126 @@ func TestSortRules(t *testing.T) {
 	}
 }
 
+func toHex(s string) string { return hex.EncodeToString([]byte(s)) }
+
 func TestGetNodeJoinScript(t *testing.T) {
-	m := &mockedNodeAPIGetter{}
-	m.mockGetProxyServers = func() ([]types.Server, error) {
-		var s types.ServerV2
-		s.SetPublicAddr("test-host:12345678")
+	validToken := "f18da1c9f6630a51e8daf121e7451daa"
+	validIAMToken := "valid-iam-token"
 
-		return []types.Server{&s}, nil
-	}
-	m.mockGetClusterCACert = func(ctx context.Context) (*proto.GetClusterCACertResponse, error) {
-		fakeBytes := []byte(fixtures.SigningCertPEM)
-		return &proto.GetClusterCACertResponse{TLSCA: fakeBytes}, nil
-	}
+	m := &mockedNodeAPIGetter{
+		mockGetProxyServers: func() ([]types.Server, error) {
+			var s types.ServerV2
+			s.SetPublicAddr("test-host:12345678")
 
-	nilTokenLength := scriptSettings{
-		token: "",
-	}
-
-	shortTokenLength := scriptSettings{
-		token: "f18da1c9f6630a51e8daf121e7451d",
-	}
-
-	testTokenID := "f18da1c9f6630a51e8daf121e7451daa"
-	validTokenLength := scriptSettings{
-		token: testTokenID,
-	}
-
-	// Test zero-value initialization.
-	script, err := getJoinScript(scriptSettings{}, m)
-	require.Empty(t, script)
-	require.True(t, trace.IsBadParameter(err))
-
-	// Test bad token lengths.
-	script, err = getJoinScript(nilTokenLength, m)
-	require.Empty(t, script)
-	require.True(t, trace.IsBadParameter(err))
-
-	script, err = getJoinScript(shortTokenLength, m)
-	require.Empty(t, script)
-	require.True(t, trace.IsBadParameter(err))
-
-	// Test valid token format.
-	script, err = getJoinScript(validTokenLength, m)
-	require.NoError(t, err)
-
-	require.Contains(t, script, testTokenID)
-	require.Contains(t, script, "test-host")
-	require.Contains(t, script, "12345678")
-	require.Contains(t, script, "sha256:")
-	require.NotContains(t, script, "JOIN_METHOD=\"iam\"")
-
-	// Test iam method script
-	iamToken := scriptSettings{
-		token:      "token length doesnt matter in this case",
-		joinMethod: string(types.JoinMethodIAM),
+			return []types.Server{&s}, nil
+		},
+		mockGetClusterCACert: func(context.Context) (*proto.GetClusterCACertResponse, error) {
+			fakeBytes := []byte(fixtures.SigningCertPEM)
+			return &proto.GetClusterCACertResponse{TLSCA: fakeBytes}, nil
+		},
+		mockGetToken: func(_ context.Context, token string) (types.ProvisionToken, error) {
+			if token == validToken || token == validIAMToken {
+				return &types.ProvisionTokenV2{
+					Metadata: types.Metadata{
+						Name: token,
+					},
+				}, nil
+			}
+			return nil, trace.NotFound("token does not exist")
+		},
 	}
 
-	script, err = getJoinScript(iamToken, m)
-	require.NoError(t, err)
-	require.Contains(t, script, "JOIN_METHOD=\"iam\"")
+	for _, test := range []struct {
+		desc            string
+		settings        scriptSettings
+		errAssert       require.ErrorAssertionFunc
+		extraAssertions func(script string)
+	}{
+		{
+			desc:      "zero value",
+			settings:  scriptSettings{},
+			errAssert: require.Error,
+		},
+		{
+			desc:      "short token length",
+			settings:  scriptSettings{token: toHex("f18da1c9f6630a51e8daf121e7451d")},
+			errAssert: require.Error,
+		},
+		{
+			desc:      "valid length but does not exist",
+			settings:  scriptSettings{token: toHex("xxxxxxx9f6630a51e8daf121exxxxxxx")},
+			errAssert: require.Error,
+		},
+		{
+			desc:      "valid",
+			settings:  scriptSettings{token: validToken},
+			errAssert: require.NoError,
+			extraAssertions: func(script string) {
+				require.Contains(t, script, validToken)
+				require.Contains(t, script, "test-host")
+				require.Contains(t, script, "12345678")
+				require.Contains(t, script, "sha256:")
+				require.NotContains(t, script, "JOIN_METHOD='iam'")
+			},
+		},
+		{
+			desc: "invalid IAM",
+			settings: scriptSettings{
+				token:      toHex("invalid-iam-token"),
+				joinMethod: string(types.JoinMethodIAM),
+			},
+			errAssert: require.Error,
+		},
+		{
+			desc: "valid iam",
+			settings: scriptSettings{
+				token:      validIAMToken,
+				joinMethod: string(types.JoinMethodIAM),
+			},
+			errAssert: require.NoError,
+			extraAssertions: func(script string) {
+				require.Contains(t, script, "JOIN_METHOD='iam'")
+			},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			script, err := getJoinScript(context.Background(), test.settings, m)
+			test.errAssert(t, err)
+			if err != nil {
+				require.Empty(t, script)
+			}
+
+			if test.extraAssertions != nil {
+				test.extraAssertions(script)
+			}
+		})
+	}
 }
 
 func TestGetAppJoinScript(t *testing.T) {
-	m := &mockedNodeAPIGetter{}
-	m.mockGetProxyServers = func() ([]types.Server, error) {
-		var s types.ServerV2
-		s.SetPublicAddr("test-host:12345678")
-
-		return []types.Server{&s}, nil
-	}
-	m.mockGetClusterCACert = func(ctx context.Context) (*proto.GetClusterCACertResponse, error) {
-		fakeBytes := []byte(fixtures.SigningCertPEM)
-		return &proto.GetClusterCACertResponse{TLSCA: fakeBytes}, nil
-	}
-
 	testTokenID := "f18da1c9f6630a51e8daf121e7451daa"
+	m := &mockedNodeAPIGetter{
+		mockGetToken: func(_ context.Context, token string) (types.ProvisionToken, error) {
+			if token == testTokenID {
+				return &types.ProvisionTokenV2{
+					Metadata: types.Metadata{
+						Name: token,
+					},
+				}, nil
+			}
+			return nil, trace.NotFound("token does not exist")
+		},
+		mockGetProxyServers: func() ([]types.Server, error) {
+			var s types.ServerV2
+			s.SetPublicAddr("test-host:12345678")
+
+			return []types.Server{&s}, nil
+		},
+		mockGetClusterCACert: func(context.Context) (*proto.GetClusterCACertResponse, error) {
+			fakeBytes := []byte(fixtures.SigningCertPEM)
+			return &proto.GetClusterCACertResponse{TLSCA: fakeBytes}, nil
+		},
+	}
 	badAppName := scriptSettings{
 		token:          testTokenID,
 		appInstallMode: true,
@@ -367,11 +416,11 @@ func TestGetAppJoinScript(t *testing.T) {
 	}
 
 	// Test invalid app data.
-	script, err := getJoinScript(badAppName, m)
+	script, err := getJoinScript(context.Background(), badAppName, m)
 	require.Empty(t, script)
 	require.True(t, trace.IsBadParameter(err))
 
-	script, err = getJoinScript(badAppURI, m)
+	script, err = getJoinScript(context.Background(), badAppURI, m)
 	require.Empty(t, script)
 	require.True(t, trace.IsBadParameter(err))
 
@@ -500,7 +549,7 @@ func TestGetAppJoinScript(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			script, err = getJoinScript(tc.settings, m)
+			script, err = getJoinScript(context.Background(), tc.settings, m)
 			if tc.shouldError {
 				require.NotNil(t, err)
 				require.Equal(t, script, "")
@@ -622,6 +671,7 @@ type mockedNodeAPIGetter struct {
 	mockGenerateToken    func(ctx context.Context, req *proto.GenerateTokenRequest) (string, error)
 	mockGetProxyServers  func() ([]types.Server, error)
 	mockGetClusterCACert func(ctx context.Context) (*proto.GetClusterCACertResponse, error)
+	mockGetToken         func(ctx context.Context, token string) (types.ProvisionToken, error)
 }
 
 func (m *mockedNodeAPIGetter) GenerateToken(ctx context.Context, req *proto.GenerateTokenRequest) (string, error) {
@@ -646,4 +696,11 @@ func (m *mockedNodeAPIGetter) GetClusterCACert(ctx context.Context) (*proto.GetC
 	}
 
 	return nil, trace.NotImplemented("mockGetClusterCACert not implemented")
+}
+
+func (m *mockedNodeAPIGetter) GetToken(ctx context.Context, token string) (types.ProvisionToken, error) {
+	if m.mockGetToken != nil {
+		return m.mockGetToken(ctx, token)
+	}
+	return nil, trace.NotImplemented("mockGetToken not implemented")
 }

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -35,25 +35,22 @@ INTERACTIVE=false
 
 # the default value of each variable is a templatable Go value so that it can
 # optionally be replaced by the server before the script is served up
-TELEPORT_VERSION="{{.version}}"
-TARGET_HOSTNAME="{{.hostname}}"
-TARGET_PORT="{{.port}}"
-JOIN_TOKEN="{{.token}}"
-JOIN_METHOD="{{.joinMethod}}"
+TELEPORT_VERSION='{{.version}}'
+TARGET_HOSTNAME='{{.hostname}}'
+TARGET_PORT='{{.port}}'
+JOIN_TOKEN='{{.token}}'
+JOIN_METHOD='{{.joinMethod}}'
 JOIN_METHOD_FLAG=""
 [ ! -z "$JOIN_METHOD" ] && JOIN_METHOD_FLAG="--join-method ${JOIN_METHOD}"
-# When all stanza generators have been updated to use the new 
+# When all stanza generators have been updated to use the new
 # `teleport <service> configure` commands CA_PIN_HASHES can be removed along
 # with the script passing it in in `join_tokens.go`.
-CA_PIN_HASHES="{{.caPinsOld}}"
-CA_PINS="{{.caPins}}"
+CA_PIN_HASHES='{{.caPinsOld}}'
+CA_PINS='{{.caPins}}'
 ARG_CA_PIN_HASHES=""
-APP_INSTALL_MODE="{{.appInstallMode}}"
-APP_NAME="{{.appName}}"
-APP_URI="{{.appURI}}"
-NODE_LABELS="{{.nodeLabels}}"
-LABELS_FLAG=""
-[ ! -z "$NODE_LABELS" ] && LABELS_FLAG="--labels ${NODE_LABELS}"
+APP_INSTALL_MODE='{{.appInstallMode}}'
+APP_NAME='{{.appName}}'
+APP_URI='{{.appURI}}'
 
 # usage message
 # shellcheck disable=SC2086
@@ -442,7 +439,6 @@ install_teleport_node_config() {
       ${JOIN_METHOD_FLAG} \
       --ca-pin ${CA_PINS} \
       --auth-server ${TARGET_HOSTNAME}:${TARGET_PORT} \
-      ${LABELS_FLAG} \
       --output ${TELEPORT_CONFIG_PATH}
 }
 # checks whether the given host is running MacOS


### PR DESCRIPTION
The token value is provided via the HTTP request
and fed into the node join script. This could allow an attacker
to generate a node-join script with malicious code included.

Fix this by validating that tokens are valid and exist in the backend.

Additionally, we recently added the ability to specify labels via the
node-labels query parameter, which is also user-controlled. Since this
functionality was never integrated in the UI, we remove it here and
will add an alternative implementation in the future.

Lastly, use single quotes in the script to prevent expansion.

Fixes gravitational/teleport-private#153