### PR TITLE
[v8] Better error message on ping parse error.

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -207,7 +207,7 @@ func Ping(cfg *Config) (*PingResponse, error) {
 	}
 	pr := &PingResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(pr); err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "cannot parse server response; is %q a Teleport server?", "https://"+cfg.ProxyAddr)
 	}
 
 	return pr, nil


### PR DESCRIPTION
Backport #14700 to branch/v8

---

Before:
```
$ tsh login --proxy=teleport.sh
ERROR: invalid character '<' looking for beginning of value
```

After:
```
$ tsh login --proxy=teleport.sh
ERROR: cannot parse server response; is "https://teleport.sh:443" a Teleport server?
invalid character '<' looking for beginning of value
```

Ref: #8345.