### PR TITLE
[v9] backport #14239 (sqlite options docs)

### DIFF
--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -699,3 +699,52 @@ $ psql -d postgres
 postgres=# CREATE DATABASE teleport;
 postgres=# GRANT ALL PRIVILEGES ON DATABASE teleport TO dbuser;
 ```
+
+## SQLite
+
+The Auth Service uses the SQLite backend when no `type` is specified in the
+storage section in the Teleport configuration file, or when `type` is set to
+`sqlite` or `dir`. The SQLite backend is not designed for high throughput and
+it's not capable of serving the needs of Teleport's High Availability configurations.
+
+If you are planning to use SQLite as your backend, scale your cluster slowly and
+monitor the number of warning messages in the Auth Service's logs that say
+`SLOW TRANSACTION`, as that's a sign that the cluster has outgrown the capabilities
+of the SQLite backend.
+
+As a stopgap measure until it's possible to migrate the cluster to use a
+HA-capable backend, you can configure the SQLite backend to reduce the amount of
+disk synchronization, in exchange for less resilience against system crashes or
+power loss. For an explanation on what the options mean, see [the official
+SQLite docs](https://www.sqlite.org/pragma.html#pragma_synchronous). No matter
+the configuration, we recommend you take regular backups of your cluster state.
+
+To reduce disk synchronization:
+```yaml
+teleport:
+  storage:
+    type: sqlite
+    sync: NORMAL
+```
+
+To disable disk synchronization altogether:
+```yaml
+teleport:
+  storage:
+    type: sqlite
+    sync: "OFF"
+```
+
+When running on a filesystem that supports file locks (i.e. a local filesystem,
+not a networked one) it's possible to also configure the SQLite database to use
+Write-Ahead Logging (see [the official docs on WAL
+mode](https://www.sqlite.org/wal.html)) for significantly improved performance
+without sacrificing reliability:
+
+```yaml
+teleport:
+  storage:
+    type: sqlite
+    sync: NORMAL
+    journal: WAL
+```

--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -735,7 +735,7 @@ teleport:
     sync: "OFF"
 ```
 
-When running on a filesystem that supports file locks (i.e. a local filesystem,
+Starting from version 9.0.4, when running on a filesystem that supports file locks (i.e. a local filesystem,
 not a networked one) it's possible to also configure the SQLite database to use
 Write-Ahead Logging (see [the official docs on WAL
 mode](https://www.sqlite.org/wal.html)) for significantly improved performance

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -157,9 +157,9 @@ teleport:
     # (https://goteleport.com/docs/admin-guide/#high-availability) to learn how
     # to configure DynamoDB, S3, etcd, and other highly available back-ends.
     storage:
-        # By default teleport uses the `data_dir` directory on a local
-        # filesystem
-        type: dir
+        # By default teleport uses a SQLite database in the `data_dir`
+        # directory on a local filesystem
+        type: sqlite
 
         # List of locations where the audit log events will be stored. By
         # default, they are stored in `/var/lib/teleport/log`.
@@ -176,7 +176,23 @@ teleport:
         # (https://goteleport.com/docs/admin-guide/#using-amazon-s3).
         audit_sessions_uri: 's3://example.com/path/to/bucket?region=us-east-1'
 
-        # DynamoDB Specific Section
+        # SQLite-specific section:
+
+        # The default path is the `backend` directory in the `data_dir`
+        path: /var/lib/teleport/backend/
+        # SQLite's `synchronous` pragma, can be set to `"OFF"` for improved
+        # write performance in exchange for reliability against system crashes
+        # (see https://www.sqlite.org/pragma.html#pragma_synchronous).
+        sync: FULL
+        # SQLite's `journal_mode` pragma, by default it doesn't change the mode from
+        # the SQLite default (DELETE unless the database file is using WAL mode).
+        # For improved performance without sacrificing reliability it's possible to
+        # set `journal` to `WAL` and `sync` to `NORMAL`, but only when using a filesystem
+        # that supports locks (see https://www.sqlite.org/pragma.html#pragma_journal_mode).
+        #journal: DELETE
+
+        # DynamoDB-specific section:
+
         # continuous_backups is used to enable continuous backups.
         continuous_backups: [true|false]
 


### PR DESCRIPTION
Backport #14239 to branch/v9 with a version warning

---

This PR adds some description of parameters of the `sqlite` backend that were previously undocumented, and adds some advice on what to do about poor performance when using SQLite as a backend (the infamous `SLOW TRANSACTION` log spam) after the changes in #11387.