### PR TITLE
Refactor `services.AccessInfo`

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1145,7 +1145,8 @@ func TestGenerateUserCertWithCertExtension(t *testing.T) {
 	err = p.a.UpsertRole(ctx, role)
 	require.NoError(t, err)
 
-	accessInfo, err := services.AccessInfoFromUser(user, p.a)
+	accessInfo := services.AccessInfoFromUser(user)
+	accessChecker, err := services.NewAccessChecker(accessInfo, p.clusterName.GetClusterName(), p.a)
 	require.NoError(t, err)
 
 	keygen := testauthority.New()
@@ -1153,7 +1154,7 @@ func TestGenerateUserCertWithCertExtension(t *testing.T) {
 	require.NoError(t, err)
 	certReq := certRequest{
 		user:      user,
-		checker:   services.NewAccessChecker(accessInfo, p.clusterName.GetClusterName()),
+		checker:   accessChecker,
 		publicKey: pub,
 	}
 	certs, err := p.a.generateUserCert(certReq)
@@ -1175,7 +1176,8 @@ func TestGenerateUserCertWithLocks(t *testing.T) {
 
 	user, _, err := CreateUserAndRole(p.a, "test-user", []string{})
 	require.NoError(t, err)
-	accessInfo, err := services.AccessInfoFromUser(user, p.a)
+	accessInfo := services.AccessInfoFromUser(user)
+	accessChecker, err := services.NewAccessChecker(accessInfo, p.clusterName.GetClusterName(), p.a)
 	require.NoError(t, err)
 	mfaID := "test-mfa-id"
 	requestID := "test-access-request"
@@ -1184,7 +1186,7 @@ func TestGenerateUserCertWithLocks(t *testing.T) {
 	require.NoError(t, err)
 	certReq := certRequest{
 		user:           user,
-		checker:        services.NewAccessChecker(accessInfo, p.clusterName.GetClusterName()),
+		checker:        accessChecker,
 		mfaVerified:    mfaID,
 		publicKey:      pub,
 		activeRequests: services.RequestIDs{AccessRequests: []string{requestID}},

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2269,12 +2269,11 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	checker := services.NewAccessChecker(&services.AccessInfo{
+	checker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
 		Roles:              roleSet.RoleNames(),
 		Traits:             traits,
 		AllowedResourceIDs: allowedResourceIDs,
-		RoleSet:            roleSet,
-	}, clusterName.GetClusterName())
+	}, clusterName.GetClusterName(), roleSet)
 
 	switch {
 	case a.hasBuiltinRole(types.RoleAdmin):

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -488,15 +488,15 @@ func (s *Server) generateInitialBotCerts(ctx context.Context, username string, p
 	}
 
 	// Inherit the user's roles and traits verbatim.
-	accessInfo, err := services.AccessInfoFromUser(user, s)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	accessInfo := services.AccessInfoFromUser(user)
 	clusterName, err := s.GetClusterName()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	checker := services.NewAccessChecker(accessInfo, clusterName.GetClusterName())
+	checker, err := services.NewAccessChecker(accessInfo, clusterName.GetClusterName(), s)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	// renewable cert request must include a generation
 	var generation uint64

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -357,11 +357,11 @@ func (a *TestAuthServer) GenerateUserCert(key []byte, username string, ttl time.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessInfo, err := services.AccessInfoFromUser(user, a.AuthServer)
+	accessInfo := services.AccessInfoFromUser(user)
+	checker, err := services.NewAccessChecker(accessInfo, a.ClusterName, a.AuthServer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	checker := services.NewAccessChecker(accessInfo, a.ClusterName)
 	certs, err := a.AuthServer.generateUserCert(certRequest{
 		user:          user,
 		ttl:           ttl,
@@ -415,11 +415,11 @@ func generateCertificate(authServer *Server, identity TestIdentity) ([]byte, []b
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-		accessInfo, err := services.AccessInfoFromUser(user, authServer)
+		accessInfo := services.AccessInfoFromUser(user)
+		checker, err := services.NewAccessChecker(accessInfo, clusterName.GetClusterName(), authServer)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-		checker := services.NewAccessChecker(accessInfo, clusterName.GetClusterName())
 		if identity.TTL == 0 {
 			identity.TTL = time.Hour
 		}

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -460,11 +460,11 @@ func (s *Server) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginRespo
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessInfo, err := services.AccessInfoFromUser(user, s)
+	accessInfo := services.AccessInfoFromUser(user)
+	checker, err := services.NewAccessChecker(accessInfo, clusterName.GetClusterName(), s)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	checker := services.NewAccessChecker(accessInfo, clusterName.GetClusterName())
 
 	// Return the host CA for this cluster only.
 	authority, err := s.GetCertAuthority(ctx, types.CertAuthID{

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -480,9 +480,9 @@ func TestAuthenticate(t *testing.T) {
 			require.NoError(t, err)
 			authCtx := auth.Context{
 				User: user,
-				Checker: services.NewAccessChecker(&services.AccessInfo{
-					RoleSet: roles,
-				}, "local"),
+				Checker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+					Roles: roles.RoleNames(),
+				}, "local", roles),
 				Identity: auth.WrapIdentity(tlsca.Identity{
 					RouteToCluster:    tt.routeToCluster,
 					KubernetesCluster: tt.kubernetesCluster,

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -76,7 +76,8 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 			Certificate:  cert,
 			// roles do not actually exist in mock backend, just need a non-nil
 			// access checker to avoid panic
-			AccessChecker: services.NewAccessChecker(&services.AccessInfo{RoleSet: roleSet}, clusterName),
+			AccessChecker: services.NewAccessCheckerWithRoleSet(
+				&services.AccessInfo{Roles: roleSet.RoleNames()}, clusterName, roleSet),
 		},
 		cancelContext: ctx,
 		cancel:        cancel,

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -205,20 +205,20 @@ func TestSession_newRecorder(t *testing.T) {
 					component: teleport.ComponentNode,
 				},
 				Identity: IdentityContext{
-					AccessChecker: services.NewAccessChecker(&services.AccessInfo{
-						RoleSet: services.RoleSet{
-							&types.RoleV5{
-								Metadata: types.Metadata{Name: "dev", Namespace: apidefaults.Namespace},
-								Spec: types.RoleSpecV5{
-									Options: types.RoleOptions{
-										RecordSession: &types.RecordSession{
-											SSH: constants.SessionRecordingModeStrict,
-										},
+					AccessChecker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+						Roles: []string{"dev"},
+					}, "test", services.RoleSet{
+						&types.RoleV5{
+							Metadata: types.Metadata{Name: "dev", Namespace: apidefaults.Namespace},
+							Spec: types.RoleSpecV5{
+								Options: types.RoleOptions{
+									RecordSession: &types.RecordSession{
+										SSH: constants.SessionRecordingModeStrict,
 									},
 								},
 							},
 						},
-					}, "test"),
+					}),
 				},
 			},
 			errAssertion: require.Error,
@@ -244,20 +244,20 @@ func TestSession_newRecorder(t *testing.T) {
 					component: teleport.ComponentNode,
 				},
 				Identity: IdentityContext{
-					AccessChecker: services.NewAccessChecker(&services.AccessInfo{
-						RoleSet: services.RoleSet{
-							&types.RoleV5{
-								Metadata: types.Metadata{Name: "dev", Namespace: apidefaults.Namespace},
-								Spec: types.RoleSpecV5{
-									Options: types.RoleOptions{
-										RecordSession: &types.RecordSession{
-											SSH: constants.SessionRecordingModeBestEffort,
-										},
+					AccessChecker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+						Roles: []string{"dev"},
+					}, "test", services.RoleSet{
+						&types.RoleV5{
+							Metadata: types.Metadata{Name: "dev", Namespace: apidefaults.Namespace},
+							Spec: types.RoleSpecV5{
+								Options: types.RoleOptions{
+									RecordSession: &types.RecordSession{
+										SSH: constants.SessionRecordingModeBestEffort,
 									},
 								},
 							},
 						},
-					}, "test"),
+					}),
 				},
 			},
 			errAssertion: require.NoError,

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -345,7 +345,7 @@ func (c *SessionContext) GetUserAccessChecker() (services.AccessChecker, error) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessInfo, err := services.AccessInfoFromLocalCertificate(cert, c.unsafeCachedAuthClient)
+	accessInfo, err := services.AccessInfoFromLocalCertificate(cert)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -353,7 +353,11 @@ func (c *SessionContext) GetUserAccessChecker() (services.AccessChecker, error) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return services.NewAccessChecker(accessInfo, clusterName.GetClusterName()), nil
+	accessChecker, err := services.NewAccessChecker(accessInfo, clusterName.GetClusterName(), c.unsafeCachedAuthClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return accessChecker, nil
 }
 
 // GetProxyListenerMode returns cluster proxy listener mode form cluster networking config.


### PR DESCRIPTION
This is a fairly mechanical refactor of `services.AccessInfo`, here's the diff of the full type:

```diff
// AccessInfo hold information about an identity necessary to check whether that
// identity has access to cluster resources. This info can come from a user or
// host SSH certificate, TLS certificate, or user information stored in the
// backend.
type AccessInfo struct {
	// Roles is the list of cluster local roles for the identity.
	Roles []string
	// Traits is the set of traits for the identity.
	Traits wrappers.Traits
	// AllowedResourceIDs is the list of resource IDs the identity is allowed to
	// access. A nil or empty list indicates that no resource-specific
	// access restrictions should be applied. Used for resource access
	// requests.
	AllowedResourceIDs []types.ResourceID
-	// RoleSet holds the fetched and parsed roles from Roles.
-	RoleSet RoleSet
}
```

My original idea for this type was to separate gathering the state necessary for a `services.AccessChecker` and actually creating the type. I'm making this change for three reasons:
1. Having `Roles` and `RoleSet` in the type is redundant.
2. `AccessInfo` can be useful as a simple struct for passing the necessary information to determine access rules for an identity: roles, traits, and allowed resource IDs.
3. I want to use this type in another PR ([link](https://github.com/gravitational/teleport/pull/14766)) without having to fetch all the roles to build a `RoleSet`.

Instead of fetching the full roles in `AccessInfoFrom(Local|Remote)(Identity|Certificate)` they are new fetched in just one place: `NewAccessChecker`. For break-glass scenarios where we already have the `RoleSet` and should not be fetching roles (builtin roles aren't in the backend), there is now `NewAccessCheckerWithRoleSet`.