### PR TITLE
[v10] Allow to override db name using AWS tag.

### DIFF
--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -822,7 +822,7 @@ const (
 	// labelVPCID is the label key containing the VPC ID.
 	labelVPCID = "vpc-id"
 	// labelTeleportDBName is the label key containing the database name override.
-	labelTeleportDBName = "teleport.dev/database-name"
+	labelTeleportDBName = types.TeleportNamespace + "/database-name"
 )
 
 const (

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -118,6 +118,16 @@ func UnmarshalDatabase(data []byte, opts ...MarshalOption) (types.Database, erro
 	return nil, trace.BadParameter("unsupported database resource version %q", h.Version)
 }
 
+// newDatabase is a wrapper around types.NewDatabaseV3 that additionally applies tag-based name override.
+// For database types we don't want to override the entire name; if this is desired, caller will pass
+// suffixes to append to the database name.
+func newDatabase(suffix string, meta types.Metadata, spec types.DatabaseSpecV3) (types.Database, error) {
+	if override, found := meta.Labels[labelTeleportDBName]; found && override != "" {
+		meta.Name = override + suffix
+	}
+	return types.NewDatabaseV3(meta, spec)
+}
+
 // NewDatabaseFromRDSInstance creates a database resource from an RDS instance.
 func NewDatabaseFromRDSInstance(instance *rds.DBInstance) (types.Database, error) {
 	endpoint := instance.Endpoint
@@ -128,7 +138,8 @@ func NewDatabaseFromRDSInstance(instance *rds.DBInstance) (types.Database, error
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return types.NewDatabaseV3(types.Metadata{
+
+	return newDatabase("", types.Metadata{
 		Name:        aws.StringValue(instance.DBInstanceIdentifier),
 		Description: fmt.Sprintf("RDS instance in %v", metadata.Region),
 		Labels:      labelsFromRDSInstance(instance, metadata),
@@ -145,7 +156,7 @@ func NewDatabaseFromRDSCluster(cluster *rds.DBCluster) (types.Database, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return types.NewDatabaseV3(types.Metadata{
+	return newDatabase("", types.Metadata{
 		Name:        aws.StringValue(cluster.DBClusterIdentifier),
 		Description: fmt.Sprintf("Aurora cluster in %v", metadata.Region),
 		Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypePrimary),
@@ -162,7 +173,7 @@ func NewDatabaseFromRDSClusterReaderEndpoint(cluster *rds.DBCluster) (types.Data
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return types.NewDatabaseV3(types.Metadata{
+	return newDatabase(fmt.Sprintf("-%v", string(RDSEndpointTypeReader)), types.Metadata{
 		Name:        fmt.Sprintf("%v-%v", aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeReader)),
 		Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeReader)),
 		Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeReader),
@@ -191,7 +202,7 @@ func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster) (types.Da
 			continue
 		}
 
-		database, err := types.NewDatabaseV3(types.Metadata{
+		database, err := newDatabase(fmt.Sprintf("-%v-%v", string(RDSEndpointTypeCustom), endpointName), types.Metadata{
 			Name:        fmt.Sprintf("%v-%v-%v", aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeCustom), endpointName),
 			Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeCustom)),
 			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeCustom),
@@ -230,7 +241,7 @@ func NewDatabaseFromRedshiftCluster(cluster *redshift.Cluster) (types.Database, 
 		return nil, trace.Wrap(err)
 	}
 
-	return types.NewDatabaseV3(types.Metadata{
+	return newDatabase("", types.Metadata{
 		Name:        aws.StringValue(cluster.ClusterIdentifier),
 		Description: fmt.Sprintf("Redshift cluster in %v", metadata.Region),
 		Labels:      labelsFromRedshiftCluster(cluster, metadata),
@@ -283,11 +294,13 @@ func newElastiCacheDatabase(cluster *elasticache.ReplicationGroup, endpoint *ela
 	}
 
 	name := aws.StringValue(cluster.ReplicationGroupId)
+	suffix := ""
 	if endpointType == awsutils.ElastiCacheReaderEndpoint {
 		name = fmt.Sprintf("%s-%s", name, endpointType)
+		suffix = fmt.Sprintf("-%s", endpointType)
 	}
 
-	return types.NewDatabaseV3(types.Metadata{
+	return newDatabase(suffix, types.Metadata{
 		Name:        name,
 		Description: fmt.Sprintf("ElastiCache cluster in %v (%v endpoint)", metadata.Region, endpointType),
 		Labels:      labelsFromMetaAndEndpointType(metadata, endpointType, extraLabels),
@@ -308,7 +321,7 @@ func NewDatabaseFromMemoryDBCluster(cluster *memorydb.Cluster, extraLabels map[s
 		return nil, trace.Wrap(err)
 	}
 
-	return types.NewDatabaseV3(types.Metadata{
+	return newDatabase("", types.Metadata{
 		Name:        aws.StringValue(cluster.Name),
 		Description: fmt.Sprintf("MemoryDB cluster in %v", metadata.Region),
 		Labels:      labelsFromMetaAndEndpointType(metadata, endpointType, extraLabels),
@@ -808,6 +821,8 @@ const (
 	labelEndpointType = "endpoint-type"
 	// labelVPCID is the label key containing the VPC ID.
 	labelVPCID = "vpc-id"
+	// labelTeleportDBName is the label key containing the database name override.
+	labelTeleportDBName = "teleport-db-name"
 )
 
 const (

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -118,14 +118,20 @@ func UnmarshalDatabase(data []byte, opts ...MarshalOption) (types.Database, erro
 	return nil, trace.BadParameter("unsupported database resource version %q", h.Version)
 }
 
-// newDatabase is a wrapper around types.NewDatabaseV3 that additionally applies tag-based name override.
-// For some database types we don't want to override the entire name; if this is desired, caller will pass
-// suffix to be appended to the database name.
-func newDatabase(suffix string, meta types.Metadata, spec types.DatabaseSpecV3) (types.Database, error) {
+// setDBName modifies the types.Metadata argument in place, setting the database name.
+// The name is calculated based on nameParts arguments which are joined by hyphens "-".
+// If the DB name override label is present (labelTeleportDBName), it will replace the *first* name part.
+func setDBName(meta types.Metadata, firstNamePart string, extraNameParts ...string) types.Metadata {
+	nameParts := append([]string{firstNamePart}, extraNameParts...)
+
+	// apply override
 	if override, found := meta.Labels[labelTeleportDBName]; found && override != "" {
-		meta.Name = override + suffix
+		nameParts[0] = override
 	}
-	return types.NewDatabaseV3(meta, spec)
+
+	meta.Name = strings.Join(nameParts, "-")
+
+	return meta
 }
 
 // NewDatabaseFromRDSInstance creates a database resource from an RDS instance.
@@ -139,15 +145,16 @@ func NewDatabaseFromRDSInstance(instance *rds.DBInstance) (types.Database, error
 		return nil, trace.Wrap(err)
 	}
 
-	return newDatabase("", types.Metadata{
-		Name:        aws.StringValue(instance.DBInstanceIdentifier),
-		Description: fmt.Sprintf("RDS instance in %v", metadata.Region),
-		Labels:      labelsFromRDSInstance(instance, metadata),
-	}, types.DatabaseSpecV3{
-		Protocol: engineToProtocol(aws.StringValue(instance.Engine)),
-		URI:      fmt.Sprintf("%v:%v", aws.StringValue(endpoint.Address), aws.Int64Value(endpoint.Port)),
-		AWS:      *metadata,
-	})
+	return types.NewDatabaseV3(
+		setDBName(types.Metadata{
+			Description: fmt.Sprintf("RDS instance in %v", metadata.Region),
+			Labels:      labelsFromRDSInstance(instance, metadata),
+		}, aws.StringValue(instance.DBInstanceIdentifier)),
+		types.DatabaseSpecV3{
+			Protocol: engineToProtocol(aws.StringValue(instance.Engine)),
+			URI:      fmt.Sprintf("%v:%v", aws.StringValue(endpoint.Address), aws.Int64Value(endpoint.Port)),
+			AWS:      *metadata,
+		})
 }
 
 // NewDatabaseFromRDSCluster creates a database resource from an RDS cluster (Aurora).
@@ -156,15 +163,16 @@ func NewDatabaseFromRDSCluster(cluster *rds.DBCluster) (types.Database, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return newDatabase("", types.Metadata{
-		Name:        aws.StringValue(cluster.DBClusterIdentifier),
-		Description: fmt.Sprintf("Aurora cluster in %v", metadata.Region),
-		Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypePrimary),
-	}, types.DatabaseSpecV3{
-		Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
-		URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.Endpoint), aws.Int64Value(cluster.Port)),
-		AWS:      *metadata,
-	})
+	return types.NewDatabaseV3(
+		setDBName(types.Metadata{
+			Description: fmt.Sprintf("Aurora cluster in %v", metadata.Region),
+			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypePrimary),
+		}, aws.StringValue(cluster.DBClusterIdentifier)),
+		types.DatabaseSpecV3{
+			Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
+			URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.Endpoint), aws.Int64Value(cluster.Port)),
+			AWS:      *metadata,
+		})
 }
 
 // NewDatabaseFromRDSClusterReaderEndpoint creates a database resource from an RDS cluster reader endpoint (Aurora).
@@ -173,15 +181,16 @@ func NewDatabaseFromRDSClusterReaderEndpoint(cluster *rds.DBCluster) (types.Data
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return newDatabase(fmt.Sprintf("-%v", string(RDSEndpointTypeReader)), types.Metadata{
-		Name:        fmt.Sprintf("%v-%v", aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeReader)),
-		Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeReader)),
-		Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeReader),
-	}, types.DatabaseSpecV3{
-		Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
-		URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.ReaderEndpoint), aws.Int64Value(cluster.Port)),
-		AWS:      *metadata,
-	})
+	return types.NewDatabaseV3(
+		setDBName(types.Metadata{
+			Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeReader)),
+			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeReader),
+		}, aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeReader)),
+		types.DatabaseSpecV3{
+			Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
+			URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.ReaderEndpoint), aws.Int64Value(cluster.Port)),
+			AWS:      *metadata,
+		})
 }
 
 // NewDatabasesFromRDSClusterCustomEndpoints creates database resources from RDS cluster custom endpoints (Aurora).
@@ -202,21 +211,22 @@ func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster) (types.Da
 			continue
 		}
 
-		database, err := newDatabase(fmt.Sprintf("-%v-%v", string(RDSEndpointTypeCustom), endpointName), types.Metadata{
-			Name:        fmt.Sprintf("%v-%v-%v", aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeCustom), endpointName),
-			Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeCustom)),
-			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeCustom),
-		}, types.DatabaseSpecV3{
-			Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
-			URI:      fmt.Sprintf("%v:%v", aws.StringValue(endpoint), aws.Int64Value(cluster.Port)),
-			AWS:      *metadata,
+		database, err := types.NewDatabaseV3(
+			setDBName(types.Metadata{
+				Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeCustom)),
+				Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeCustom),
+			}, aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeCustom), endpointName),
+			types.DatabaseSpecV3{
+				Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
+				URI:      fmt.Sprintf("%v:%v", aws.StringValue(endpoint), aws.Int64Value(cluster.Port)),
+				AWS:      *metadata,
 
-			// Aurora instances update their certificates upon restart, and thus custom endpoint SAN may not be available right
-			// away. Using primary endpoint instead as server name since it's always available.
-			TLS: types.DatabaseTLS{
-				ServerName: aws.StringValue(cluster.Endpoint),
-			},
-		})
+				// Aurora instances update their certificates upon restart, and thus custom endpoint SAN may not be available right
+				// away. Using primary endpoint instead as server name since it's always available.
+				TLS: types.DatabaseTLS{
+					ServerName: aws.StringValue(cluster.Endpoint),
+				},
+			})
 		if err != nil {
 			errors = append(errors, trace.Wrap(err))
 			continue
@@ -241,15 +251,16 @@ func NewDatabaseFromRedshiftCluster(cluster *redshift.Cluster) (types.Database, 
 		return nil, trace.Wrap(err)
 	}
 
-	return newDatabase("", types.Metadata{
-		Name:        aws.StringValue(cluster.ClusterIdentifier),
-		Description: fmt.Sprintf("Redshift cluster in %v", metadata.Region),
-		Labels:      labelsFromRedshiftCluster(cluster, metadata),
-	}, types.DatabaseSpecV3{
-		Protocol: defaults.ProtocolPostgres,
-		URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.Endpoint.Address), aws.Int64Value(cluster.Endpoint.Port)),
-		AWS:      *metadata,
-	})
+	return types.NewDatabaseV3(
+		setDBName(types.Metadata{
+			Description: fmt.Sprintf("Redshift cluster in %v", metadata.Region),
+			Labels:      labelsFromRedshiftCluster(cluster, metadata),
+		}, aws.StringValue(cluster.ClusterIdentifier)),
+		types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolPostgres,
+			URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.Endpoint.Address), aws.Int64Value(cluster.Endpoint.Port)),
+			AWS:      *metadata,
+		})
 }
 
 // NewDatabaseFromElastiCacheConfigurationEndpoint creates a database resource
@@ -293,18 +304,15 @@ func newElastiCacheDatabase(cluster *elasticache.ReplicationGroup, endpoint *ela
 		return nil, trace.Wrap(err)
 	}
 
-	name := aws.StringValue(cluster.ReplicationGroupId)
-	suffix := ""
+	suffix := make([]string, 0)
 	if endpointType == awsutils.ElastiCacheReaderEndpoint {
-		name = fmt.Sprintf("%s-%s", name, endpointType)
-		suffix = fmt.Sprintf("-%s", endpointType)
+		suffix = []string{endpointType}
 	}
 
-	return newDatabase(suffix, types.Metadata{
-		Name:        name,
+	return types.NewDatabaseV3(setDBName(types.Metadata{
 		Description: fmt.Sprintf("ElastiCache cluster in %v (%v endpoint)", metadata.Region, endpointType),
 		Labels:      labelsFromMetaAndEndpointType(metadata, endpointType, extraLabels),
-	}, types.DatabaseSpecV3{
+	}, aws.StringValue(cluster.ReplicationGroupId), suffix...), types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolRedis,
 		URI:      fmt.Sprintf("%v:%v", aws.StringValue(endpoint.Address), aws.Int64Value(endpoint.Port)),
 		AWS:      *metadata,
@@ -321,15 +329,16 @@ func NewDatabaseFromMemoryDBCluster(cluster *memorydb.Cluster, extraLabels map[s
 		return nil, trace.Wrap(err)
 	}
 
-	return newDatabase("", types.Metadata{
-		Name:        aws.StringValue(cluster.Name),
-		Description: fmt.Sprintf("MemoryDB cluster in %v", metadata.Region),
-		Labels:      labelsFromMetaAndEndpointType(metadata, endpointType, extraLabels),
-	}, types.DatabaseSpecV3{
-		Protocol: defaults.ProtocolRedis,
-		URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.ClusterEndpoint.Address), aws.Int64Value(cluster.ClusterEndpoint.Port)),
-		AWS:      *metadata,
-	})
+	return types.NewDatabaseV3(
+		setDBName(types.Metadata{
+			Description: fmt.Sprintf("MemoryDB cluster in %v", metadata.Region),
+			Labels:      labelsFromMetaAndEndpointType(metadata, endpointType, extraLabels),
+		}, aws.StringValue(cluster.Name)),
+		types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolRedis,
+			URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.ClusterEndpoint.Address), aws.Int64Value(cluster.ClusterEndpoint.Port)),
+			AWS:      *metadata,
+		})
 }
 
 // MetadataFromRDSInstance creates AWS metadata from the provided RDS instance.

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -822,7 +822,7 @@ const (
 	// labelVPCID is the label key containing the VPC ID.
 	labelVPCID = "vpc-id"
 	// labelTeleportDBName is the label key containing the database name override.
-	labelTeleportDBName = "teleport-db-name"
+	labelTeleportDBName = "teleport.dev/database-name"
 )
 
 const (

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -119,8 +119,8 @@ func UnmarshalDatabase(data []byte, opts ...MarshalOption) (types.Database, erro
 }
 
 // newDatabase is a wrapper around types.NewDatabaseV3 that additionally applies tag-based name override.
-// For database types we don't want to override the entire name; if this is desired, caller will pass
-// suffixes to append to the database name.
+// For some database types we don't want to override the entire name; if this is desired, caller will pass
+// suffix to be appended to the database name.
 func newDatabase(suffix string, meta types.Metadata, spec types.DatabaseSpecV3) (types.Database, error) {
 	if override, found := meta.Labels[labelTeleportDBName]; found && override != "" {
 		meta.Name = override + suffix

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -339,7 +339,7 @@ func TestDatabaseFromRDSCluster(t *testing.T) {
 	})
 }
 
-// TestDatabaseFromRDSClusterNameOverride tests converting an RDS cluster to a database resource with overriden name.
+// TestDatabaseFromRDSClusterNameOverride tests converting an RDS cluster to a database resource with overridden name.
 func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
 	cluster := &rds.DBCluster{
 		DBClusterArn:                     aws.String("arn:aws:rds:us-east-1:1234567890:cluster:cluster-1"),

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -23,12 +23,13 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/types"
 	awsutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -130,6 +131,58 @@ func TestDatabaseFromRDSInstance(t *testing.T) {
 			labelEngineVersion: "13.0",
 			labelEndpointType:  "instance",
 			"key":              "val",
+		},
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolPostgres,
+		URI:      "localhost:5432",
+		AWS: types.AWS{
+			AccountID: "1234567890",
+			Region:    "us-west-1",
+			RDS: types.RDS{
+				InstanceID: "instance-1",
+				ClusterID:  "cluster-1",
+				ResourceID: "resource-1",
+				IAMAuth:    true,
+			},
+		},
+	})
+	require.NoError(t, err)
+	actual, err := NewDatabaseFromRDSInstance(instance)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+// TestDatabaseFromRDSInstance tests converting an RDS instance to a database resource.
+func TestDatabaseFromRDSInstanceNameOverride(t *testing.T) {
+	instance := &rds.DBInstance{
+		DBInstanceArn:                    aws.String("arn:aws:rds:us-west-1:1234567890:db:instance-1"),
+		DBInstanceIdentifier:             aws.String("instance-1"),
+		DBClusterIdentifier:              aws.String("cluster-1"),
+		DbiResourceId:                    aws.String("resource-1"),
+		IAMDatabaseAuthenticationEnabled: aws.Bool(true),
+		Engine:                           aws.String(RDSEnginePostgres),
+		EngineVersion:                    aws.String("13.0"),
+		Endpoint: &rds.Endpoint{
+			Address: aws.String("localhost"),
+			Port:    aws.Int64(5432),
+		},
+		TagList: []*rds.Tag{
+			{Key: aws.String("key"), Value: aws.String("val")},
+			{Key: aws.String(labelTeleportDBName), Value: aws.String("override-1")},
+		},
+	}
+	expected, err := types.NewDatabaseV3(types.Metadata{
+		Name:        "override-1",
+		Description: "RDS instance in us-west-1",
+		Labels: map[string]string{
+			types.OriginLabel:   types.OriginCloud,
+			labelAccountID:      "1234567890",
+			labelRegion:         "us-west-1",
+			labelEngine:         RDSEnginePostgres,
+			labelEngineVersion:  "13.0",
+			labelEndpointType:   "instance",
+			labelTeleportDBName: "override-1",
+			"key":               "val",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
@@ -258,6 +311,144 @@ func TestDatabaseFromRDSCluster(t *testing.T) {
 
 		expectedMyEndpoint2, err := types.NewDatabaseV3(types.Metadata{
 			Name:        "cluster-1-custom-myendpoint2",
+			Description: "Aurora cluster in us-east-1 (custom endpoint)",
+			Labels:      expectedLabels,
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolMySQL,
+			URI:      "myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com:3306",
+			AWS:      expectedAWS,
+			TLS: types.DatabaseTLS{
+				ServerName: "localhost",
+			},
+		})
+		require.NoError(t, err)
+
+		databases, err := NewDatabasesFromRDSClusterCustomEndpoints(cluster)
+		require.NoError(t, err)
+		require.Equal(t, types.Databases{expectedMyEndpoint1, expectedMyEndpoint2}, databases)
+	})
+
+	t.Run("bad custom endpoints ", func(t *testing.T) {
+		badCluster := *cluster
+		badCluster.CustomEndpoints = []*string{
+			aws.String("badendpoint1"),
+			aws.String("badendpoint2"),
+		}
+		_, err := NewDatabasesFromRDSClusterCustomEndpoints(&badCluster)
+		require.Error(t, err)
+	})
+}
+
+// TestDatabaseFromRDSClusterNameOverride tests converting an RDS cluster to a database resource with overriden name.
+func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
+	cluster := &rds.DBCluster{
+		DBClusterArn:                     aws.String("arn:aws:rds:us-east-1:1234567890:cluster:cluster-1"),
+		DBClusterIdentifier:              aws.String("cluster-1"),
+		DbClusterResourceId:              aws.String("resource-1"),
+		IAMDatabaseAuthenticationEnabled: aws.Bool(true),
+		Engine:                           aws.String(RDSEngineAuroraMySQL),
+		EngineVersion:                    aws.String("8.0.0"),
+		Endpoint:                         aws.String("localhost"),
+		ReaderEndpoint:                   aws.String("reader.host"),
+		Port:                             aws.Int64(3306),
+		CustomEndpoints: []*string{
+			aws.String("myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com"),
+			aws.String("myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com"),
+		},
+		TagList: []*rds.Tag{
+			{Key: aws.String("key"), Value: aws.String("val")},
+			{Key: aws.String(labelTeleportDBName), Value: aws.String("mycluster-2")},
+		},
+	}
+
+	expectedAWS := types.AWS{
+		AccountID: "1234567890",
+		Region:    "us-east-1",
+		RDS: types.RDS{
+			ClusterID:  "cluster-1",
+			ResourceID: "resource-1",
+			IAMAuth:    true,
+		},
+	}
+
+	t.Run("primary", func(t *testing.T) {
+		expected, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "mycluster-2",
+			Description: "Aurora cluster in us-east-1",
+			Labels: map[string]string{
+				types.OriginLabel:   types.OriginCloud,
+				labelAccountID:      "1234567890",
+				labelRegion:         "us-east-1",
+				labelEngine:         RDSEngineAuroraMySQL,
+				labelEngineVersion:  "8.0.0",
+				labelEndpointType:   "primary",
+				labelTeleportDBName: "mycluster-2",
+				"key":               "val",
+			},
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolMySQL,
+			URI:      "localhost:3306",
+			AWS:      expectedAWS,
+		})
+		require.NoError(t, err)
+		actual, err := NewDatabaseFromRDSCluster(cluster)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("reader", func(t *testing.T) {
+		expected, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "mycluster-2-reader",
+			Description: "Aurora cluster in us-east-1 (reader endpoint)",
+			Labels: map[string]string{
+				types.OriginLabel:   types.OriginCloud,
+				labelAccountID:      "1234567890",
+				labelRegion:         "us-east-1",
+				labelEngine:         RDSEngineAuroraMySQL,
+				labelEngineVersion:  "8.0.0",
+				labelEndpointType:   "reader",
+				labelTeleportDBName: "mycluster-2",
+				"key":               "val",
+			},
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolMySQL,
+			URI:      "reader.host:3306",
+			AWS:      expectedAWS,
+		})
+		require.NoError(t, err)
+		actual, err := NewDatabaseFromRDSClusterReaderEndpoint(cluster)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("custom endpoints", func(t *testing.T) {
+		expectedLabels := map[string]string{
+			types.OriginLabel:   types.OriginCloud,
+			labelAccountID:      "1234567890",
+			labelRegion:         "us-east-1",
+			labelEngine:         RDSEngineAuroraMySQL,
+			labelEngineVersion:  "8.0.0",
+			labelEndpointType:   "custom",
+			labelTeleportDBName: "mycluster-2",
+			"key":               "val",
+		}
+
+		expectedMyEndpoint1, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "mycluster-2-custom-myendpoint1",
+			Description: "Aurora cluster in us-east-1 (custom endpoint)",
+			Labels:      expectedLabels,
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolMySQL,
+			URI:      "myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com:3306",
+			AWS:      expectedAWS,
+			TLS: types.DatabaseTLS{
+				ServerName: "localhost",
+			},
+		})
+		require.NoError(t, err)
+
+		expectedMyEndpoint2, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "mycluster-2-custom-myendpoint2",
 			Description: "Aurora cluster in us-east-1 (custom endpoint)",
 			Labels:      expectedLabels,
 		}, types.DatabaseSpecV3{
@@ -480,6 +671,59 @@ func TestDatabaseFromRedshiftCluster(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
+	t.Run("success with name override", func(t *testing.T) {
+		cluster := &redshift.Cluster{
+			ClusterIdentifier:   aws.String("mycluster"),
+			ClusterNamespaceArn: aws.String("arn:aws:redshift:us-east-1:1234567890:namespace:u-u-i-d"),
+			Endpoint: &redshift.Endpoint{
+				Address: aws.String("localhost"),
+				Port:    aws.Int64(5439),
+			},
+			Tags: []*redshift.Tag{
+				{
+					Key:   aws.String("key"),
+					Value: aws.String("val"),
+				},
+				{
+					Key:   aws.String("elasticbeanstalk:environment-id"),
+					Value: aws.String("id"),
+				},
+				{
+					Key:   aws.String(labelTeleportDBName),
+					Value: aws.String("mycluster-override-2"),
+				},
+			},
+		}
+		expected, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "mycluster-override-2",
+			Description: "Redshift cluster in us-east-1",
+			Labels: map[string]string{
+				types.OriginLabel:                 types.OriginCloud,
+				labelAccountID:                    "1234567890",
+				labelRegion:                       "us-east-1",
+				labelTeleportDBName:               "mycluster-override-2",
+				"key":                             "val",
+				"elasticbeanstalk:environment-id": "id",
+			},
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolPostgres,
+			URI:      "localhost:5439",
+			AWS: types.AWS{
+				AccountID: "1234567890",
+				Region:    "us-east-1",
+				Redshift: types.Redshift{
+					ClusterID: "mycluster",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+
+		actual, err := NewDatabaseFromRedshiftCluster(cluster)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+
 	t.Run("missing endpoint", func(t *testing.T) {
 		_, err := NewDatabaseFromRedshiftCluster(&redshift.Cluster{
 			ClusterIdentifier: aws.String("still-creating"),
@@ -537,6 +781,80 @@ func TestDatabaseFromElastiCacheConfigurationEndpoint(t *testing.T) {
 			labelRegion:       "us-east-1",
 			labelEndpointType: "configuration",
 			"key":             "value",
+		},
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolRedis,
+		URI:      "configuration.localhost:6379",
+		AWS: types.AWS{
+			AccountID: "1234567890",
+			Region:    "us-east-1",
+			ElastiCache: types.ElastiCache{
+				ReplicationGroupID:       "my-cluster",
+				UserGroupIDs:             []string{"my-user-group"},
+				TransitEncryptionEnabled: true,
+				EndpointType:             awsutils.ElastiCacheConfigurationEndpoint,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	actual, err := NewDatabaseFromElastiCacheConfigurationEndpoint(cluster, extraLabels)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestDatabaseFromElastiCacheConfigurationEndpointNameOverride(t *testing.T) {
+	cluster := &elasticache.ReplicationGroup{
+		ARN:                      aws.String("arn:aws:elasticache:us-east-1:1234567890:replicationgroup:my-cluster"),
+		ReplicationGroupId:       aws.String("my-cluster"),
+		Status:                   aws.String("available"),
+		TransitEncryptionEnabled: aws.Bool(true),
+		ClusterEnabled:           aws.Bool(true),
+		ConfigurationEndpoint: &elasticache.Endpoint{
+			Address: aws.String("configuration.localhost"),
+			Port:    aws.Int64(6379),
+		},
+		UserGroupIds: []*string{aws.String("my-user-group")},
+		NodeGroups: []*elasticache.NodeGroup{
+			{
+				NodeGroupId: aws.String("0001"),
+				NodeGroupMembers: []*elasticache.NodeGroupMember{
+					{
+						CacheClusterId: aws.String("my-cluster-0001-001"),
+					},
+					{
+						CacheClusterId: aws.String("my-cluster-0001-002"),
+					},
+				},
+			},
+			{
+				NodeGroupId: aws.String("0002"),
+				NodeGroupMembers: []*elasticache.NodeGroupMember{
+					{
+						CacheClusterId: aws.String("my-cluster-0002-001"),
+					},
+					{
+						CacheClusterId: aws.String("my-cluster-0002-002"),
+					},
+				},
+			},
+		},
+	}
+	extraLabels := map[string]string{
+		labelTeleportDBName: "my-override-cluster-2",
+		"key":               "value",
+	}
+
+	expected, err := types.NewDatabaseV3(types.Metadata{
+		Name:        "my-override-cluster-2",
+		Description: "ElastiCache cluster in us-east-1 (configuration endpoint)",
+		Labels: map[string]string{
+			types.OriginLabel:   types.OriginCloud,
+			labelAccountID:      "1234567890",
+			labelRegion:         "us-east-1",
+			labelEndpointType:   "configuration",
+			labelTeleportDBName: "my-override-cluster-2",
+			"key":               "value",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolRedis,
@@ -640,6 +958,92 @@ func TestDatabaseFromElastiCacheNodeGroups(t *testing.T) {
 	require.Equal(t, types.Databases{expectedPrimary, expectedReader}, actual)
 }
 
+func TestDatabaseFromElastiCacheNodeGroupsNameOverride(t *testing.T) {
+	cluster := &elasticache.ReplicationGroup{
+		ARN:                      aws.String("arn:aws:elasticache:us-east-1:1234567890:replicationgroup:my-cluster"),
+		ReplicationGroupId:       aws.String("my-cluster"),
+		Status:                   aws.String("available"),
+		TransitEncryptionEnabled: aws.Bool(true),
+		ClusterEnabled:           aws.Bool(false),
+		UserGroupIds:             []*string{aws.String("my-user-group")},
+		NodeGroups: []*elasticache.NodeGroup{
+			{
+				NodeGroupId: aws.String("0001"),
+				PrimaryEndpoint: &elasticache.Endpoint{
+					Address: aws.String("primary.localhost"),
+					Port:    aws.Int64(6379),
+				},
+				ReaderEndpoint: &elasticache.Endpoint{
+					Address: aws.String("reader.localhost"),
+					Port:    aws.Int64(6379),
+				},
+			},
+		},
+	}
+	extraLabels := map[string]string{
+		labelTeleportDBName: "my-override-cluster-2",
+		"key":               "value",
+	}
+
+	expectedPrimary, err := types.NewDatabaseV3(types.Metadata{
+		Name:        "my-override-cluster-2",
+		Description: "ElastiCache cluster in us-east-1 (primary endpoint)",
+		Labels: map[string]string{
+			types.OriginLabel:   types.OriginCloud,
+			labelAccountID:      "1234567890",
+			labelRegion:         "us-east-1",
+			labelEndpointType:   "primary",
+			labelTeleportDBName: "my-override-cluster-2",
+			"key":               "value",
+		},
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolRedis,
+		URI:      "primary.localhost:6379",
+		AWS: types.AWS{
+			AccountID: "1234567890",
+			Region:    "us-east-1",
+			ElastiCache: types.ElastiCache{
+				ReplicationGroupID:       "my-cluster",
+				UserGroupIDs:             []string{"my-user-group"},
+				TransitEncryptionEnabled: true,
+				EndpointType:             awsutils.ElastiCachePrimaryEndpoint,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	expectedReader, err := types.NewDatabaseV3(types.Metadata{
+		Name:        "my-override-cluster-2-reader",
+		Description: "ElastiCache cluster in us-east-1 (reader endpoint)",
+		Labels: map[string]string{
+			types.OriginLabel:   types.OriginCloud,
+			labelAccountID:      "1234567890",
+			labelRegion:         "us-east-1",
+			labelEndpointType:   "reader",
+			labelTeleportDBName: "my-override-cluster-2",
+			"key":               "value",
+		},
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolRedis,
+		URI:      "reader.localhost:6379",
+		AWS: types.AWS{
+			AccountID: "1234567890",
+			Region:    "us-east-1",
+			ElastiCache: types.ElastiCache{
+				ReplicationGroupID:       "my-cluster",
+				UserGroupIDs:             []string{"my-user-group"},
+				TransitEncryptionEnabled: true,
+				EndpointType:             awsutils.ElastiCacheReaderEndpoint,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	actual, err := NewDatabasesFromElastiCacheNodeGroups(cluster, extraLabels)
+	require.NoError(t, err)
+	require.Equal(t, types.Databases{expectedPrimary, expectedReader}, actual)
+}
+
 func TestDatabaseFromMemoryDBCluster(t *testing.T) {
 	cluster := &memorydb.Cluster{
 		ARN:        aws.String("arn:aws:memorydb:us-east-1:1234567890:cluster:my-cluster"),
@@ -663,6 +1067,55 @@ func TestDatabaseFromMemoryDBCluster(t *testing.T) {
 			labelRegion:       "us-east-1",
 			labelEndpointType: "cluster",
 			"key":             "value",
+		},
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolRedis,
+		URI:      "memorydb.localhost:6379",
+		AWS: types.AWS{
+			AccountID: "1234567890",
+			Region:    "us-east-1",
+			MemoryDB: types.MemoryDB{
+				ClusterName:  "my-cluster",
+				ACLName:      "my-user-group",
+				TLSEnabled:   true,
+				EndpointType: awsutils.MemoryDBClusterEndpoint,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	actual, err := NewDatabaseFromMemoryDBCluster(cluster, extraLabels)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestDatabaseFromMemoryDBClusterNameOverride(t *testing.T) {
+	cluster := &memorydb.Cluster{
+		ARN:        aws.String("arn:aws:memorydb:us-east-1:1234567890:cluster:my-cluster"),
+		Name:       aws.String("my-cluster"),
+		Status:     aws.String("available"),
+		TLSEnabled: aws.Bool(true),
+		ACLName:    aws.String("my-user-group"),
+		ClusterEndpoint: &memorydb.Endpoint{
+			Address: aws.String("memorydb.localhost"),
+			Port:    aws.Int64(6379),
+		},
+	}
+	extraLabels := map[string]string{
+		labelTeleportDBName: "override-1",
+		"key":               "value",
+	}
+
+	expected, err := types.NewDatabaseV3(types.Metadata{
+		Name:        "override-1",
+		Description: "MemoryDB cluster in us-east-1",
+		Labels: map[string]string{
+			types.OriginLabel:   types.OriginCloud,
+			labelAccountID:      "1234567890",
+			labelRegion:         "us-east-1",
+			labelEndpointType:   "cluster",
+			labelTeleportDBName: "override-1",
+			"key":               "value",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolRedis,
@@ -853,6 +1306,60 @@ func TestGetLabelEngineVersion(t *testing.T) {
 			if got := GetMySQLEngineVersion(tt.labels); got != tt.want {
 				t.Errorf("GetMySQLEngineVersion() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_newDatabase(t *testing.T) {
+	mkDb := func(meta types.Metadata, spec types.DatabaseSpecV3) *types.DatabaseV3 {
+		db, err := types.NewDatabaseV3(meta, spec)
+		require.NoError(t, err)
+		return db
+	}
+
+	tests := []struct {
+		name   string
+		suffix string
+		meta   types.Metadata
+		spec   types.DatabaseSpecV3
+		want   types.Database
+	}{
+		{
+			name: "no override",
+			meta: types.Metadata{Name: "my-cluster", Labels: map[string]string{}},
+			spec: types.DatabaseSpecV3{Protocol: defaults.ProtocolRedis, URI: "localhost:6379"},
+			want: mkDb(types.Metadata{Name: "my-cluster", Labels: map[string]string{}},
+				types.DatabaseSpecV3{Protocol: defaults.ProtocolRedis, URI: "localhost:6379"}),
+		},
+		{
+			name: "no override, no labels",
+			meta: types.Metadata{Name: "my-cluster"},
+			spec: types.DatabaseSpecV3{Protocol: defaults.ProtocolRedis, URI: "localhost:6379"},
+			want: mkDb(types.Metadata{Name: "my-cluster"},
+				types.DatabaseSpecV3{Protocol: defaults.ProtocolRedis, URI: "localhost:6379"}),
+		},
+		{
+			name: "override, no suffix",
+			meta: types.Metadata{Name: "my-cluster", Labels: map[string]string{labelTeleportDBName: "ov-clust-2"}},
+			spec: types.DatabaseSpecV3{Protocol: defaults.ProtocolRedis, URI: "localhost:6379"},
+			want: mkDb(types.Metadata{Name: "ov-clust-2", Labels: map[string]string{labelTeleportDBName: "ov-clust-2"}},
+				types.DatabaseSpecV3{Protocol: defaults.ProtocolRedis, URI: "localhost:6379"}),
+		},
+		{
+			name:   "override with suffix",
+			suffix: "-stuff",
+			meta:   types.Metadata{Name: "my-cluster", Labels: map[string]string{labelTeleportDBName: "ov-clust-2"}},
+			spec:   types.DatabaseSpecV3{Protocol: defaults.ProtocolRedis, URI: "localhost:6379"},
+			want: mkDb(types.Metadata{Name: "ov-clust-2-stuff", Labels: map[string]string{labelTeleportDBName: "ov-clust-2"}},
+				types.DatabaseSpecV3{Protocol: defaults.ProtocolRedis, URI: "localhost:6379"}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newDatabase(tt.suffix, tt.meta, tt.spec)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Backport #14740 to branch/v10

---

* If `teleport.dev/database-name` tag is present, it will override automatic DB name.
* If a single AWS DB maps to several Teleport DB entries, the override will become part of the name.

Among other things, this change makes it possible to pick a different name in case there are multiple dbs with the same name present.