### PR TITLE
Add a version to the role in the GitHub CA guide

### DIFF
--- a/docs/pages/setup/guides/ssh-key-extensions.mdx
+++ b/docs/pages/setup/guides/ssh-key-extensions.mdx
@@ -48,6 +48,7 @@ Create or update a role to include the `cert_extensions` option. The value of `n
 
 ```yaml
 kind: role
+version: v5
 metadata:
   name: developer
 spec:


### PR DESCRIPTION
The version was missing, which was causing issues for users.