### PR TITLE
[v9] Allow to override db name using AWS tag.

### DIFF
--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -115,6 +115,22 @@ func UnmarshalDatabase(data []byte, opts ...MarshalOption) (types.Database, erro
 	return nil, trace.BadParameter("unsupported database resource version %q", h.Version)
 }
 
+// setDBName modifies the types.Metadata argument in place, setting the database name.
+// The name is calculated based on nameParts arguments which are joined by hyphens "-".
+// If the DB name override label is present (labelTeleportDBName), it will replace the *first* name part.
+func setDBName(meta types.Metadata, firstNamePart string, extraNameParts ...string) types.Metadata {
+	nameParts := append([]string{firstNamePart}, extraNameParts...)
+
+	// apply override
+	if override, found := meta.Labels[labelTeleportDBName]; found && override != "" {
+		nameParts[0] = override
+	}
+
+	meta.Name = strings.Join(nameParts, "-")
+
+	return meta
+}
+
 // NewDatabaseFromRDSInstance creates a database resource from an RDS instance.
 func NewDatabaseFromRDSInstance(instance *rds.DBInstance) (types.Database, error) {
 	endpoint := instance.Endpoint
@@ -125,15 +141,17 @@ func NewDatabaseFromRDSInstance(instance *rds.DBInstance) (types.Database, error
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return types.NewDatabaseV3(types.Metadata{
-		Name:        aws.StringValue(instance.DBInstanceIdentifier),
-		Description: fmt.Sprintf("RDS instance in %v", metadata.Region),
-		Labels:      labelsFromRDSInstance(instance, metadata),
-	}, types.DatabaseSpecV3{
-		Protocol: engineToProtocol(aws.StringValue(instance.Engine)),
-		URI:      fmt.Sprintf("%v:%v", aws.StringValue(endpoint.Address), aws.Int64Value(endpoint.Port)),
-		AWS:      *metadata,
-	})
+
+	return types.NewDatabaseV3(
+		setDBName(types.Metadata{
+			Description: fmt.Sprintf("RDS instance in %v", metadata.Region),
+			Labels:      labelsFromRDSInstance(instance, metadata),
+		}, aws.StringValue(instance.DBInstanceIdentifier)),
+		types.DatabaseSpecV3{
+			Protocol: engineToProtocol(aws.StringValue(instance.Engine)),
+			URI:      fmt.Sprintf("%v:%v", aws.StringValue(endpoint.Address), aws.Int64Value(endpoint.Port)),
+			AWS:      *metadata,
+		})
 }
 
 // NewDatabaseFromRDSCluster creates a database resource from an RDS cluster (Aurora).
@@ -142,15 +160,16 @@ func NewDatabaseFromRDSCluster(cluster *rds.DBCluster) (types.Database, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return types.NewDatabaseV3(types.Metadata{
-		Name:        aws.StringValue(cluster.DBClusterIdentifier),
-		Description: fmt.Sprintf("Aurora cluster in %v", metadata.Region),
-		Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypePrimary),
-	}, types.DatabaseSpecV3{
-		Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
-		URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.Endpoint), aws.Int64Value(cluster.Port)),
-		AWS:      *metadata,
-	})
+	return types.NewDatabaseV3(
+		setDBName(types.Metadata{
+			Description: fmt.Sprintf("Aurora cluster in %v", metadata.Region),
+			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypePrimary),
+		}, aws.StringValue(cluster.DBClusterIdentifier)),
+		types.DatabaseSpecV3{
+			Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
+			URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.Endpoint), aws.Int64Value(cluster.Port)),
+			AWS:      *metadata,
+		})
 }
 
 // NewDatabaseFromRDSClusterReaderEndpoint creates a database resource from an RDS cluster reader endpoint (Aurora).
@@ -159,15 +178,16 @@ func NewDatabaseFromRDSClusterReaderEndpoint(cluster *rds.DBCluster) (types.Data
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return types.NewDatabaseV3(types.Metadata{
-		Name:        fmt.Sprintf("%v-%v", aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeReader)),
-		Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeReader)),
-		Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeReader),
-	}, types.DatabaseSpecV3{
-		Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
-		URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.ReaderEndpoint), aws.Int64Value(cluster.Port)),
-		AWS:      *metadata,
-	})
+	return types.NewDatabaseV3(
+		setDBName(types.Metadata{
+			Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeReader)),
+			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeReader),
+		}, aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeReader)),
+		types.DatabaseSpecV3{
+			Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
+			URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.ReaderEndpoint), aws.Int64Value(cluster.Port)),
+			AWS:      *metadata,
+		})
 }
 
 // NewDatabasesFromRDSClusterCustomEndpoints creates database resources from RDS cluster custom endpoints (Aurora).
@@ -186,21 +206,22 @@ func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster) (types.Da
 			continue
 		}
 
-		database, err := types.NewDatabaseV3(types.Metadata{
-			Name:        fmt.Sprintf("%v-%v-%v", aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeCustom), endpointName),
-			Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeCustom)),
-			Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeCustom),
-		}, types.DatabaseSpecV3{
-			Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
-			URI:      fmt.Sprintf("%v:%v", aws.StringValue(endpoint), aws.Int64Value(cluster.Port)),
-			AWS:      *metadata,
+		database, err := types.NewDatabaseV3(
+			setDBName(types.Metadata{
+				Description: fmt.Sprintf("Aurora cluster in %v (%v endpoint)", metadata.Region, string(RDSEndpointTypeCustom)),
+				Labels:      labelsFromRDSCluster(cluster, metadata, RDSEndpointTypeCustom),
+			}, aws.StringValue(cluster.DBClusterIdentifier), string(RDSEndpointTypeCustom), endpointName),
+			types.DatabaseSpecV3{
+				Protocol: engineToProtocol(aws.StringValue(cluster.Engine)),
+				URI:      fmt.Sprintf("%v:%v", aws.StringValue(endpoint), aws.Int64Value(cluster.Port)),
+				AWS:      *metadata,
 
-			// Aurora instances update their certificates upon restart, and thus custom endpoint SAN may not be available right
-			// away. Using primary endpoint instead as server name since it's always available.
-			TLS: types.DatabaseTLS{
-				ServerName: aws.StringValue(cluster.Endpoint),
-			},
-		})
+				// Aurora instances update their certificates upon restart, and thus custom endpoint SAN may not be available right
+				// away. Using primary endpoint instead as server name since it's always available.
+				TLS: types.DatabaseTLS{
+					ServerName: aws.StringValue(cluster.Endpoint),
+				},
+			})
 		if err != nil {
 			errors = append(errors, trace.Wrap(err))
 			continue
@@ -225,15 +246,16 @@ func NewDatabaseFromRedshiftCluster(cluster *redshift.Cluster) (types.Database, 
 		return nil, trace.Wrap(err)
 	}
 
-	return types.NewDatabaseV3(types.Metadata{
-		Name:        aws.StringValue(cluster.ClusterIdentifier),
-		Description: fmt.Sprintf("Redshift cluster in %v", metadata.Region),
-		Labels:      labelsFromRedshiftCluster(cluster, metadata),
-	}, types.DatabaseSpecV3{
-		Protocol: defaults.ProtocolPostgres,
-		URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.Endpoint.Address), aws.Int64Value(cluster.Endpoint.Port)),
-		AWS:      *metadata,
-	})
+	return types.NewDatabaseV3(
+		setDBName(types.Metadata{
+			Description: fmt.Sprintf("Redshift cluster in %v", metadata.Region),
+			Labels:      labelsFromRedshiftCluster(cluster, metadata),
+		}, aws.StringValue(cluster.ClusterIdentifier)),
+		types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolPostgres,
+			URI:      fmt.Sprintf("%v:%v", aws.StringValue(cluster.Endpoint.Address), aws.Int64Value(cluster.Endpoint.Port)),
+			AWS:      *metadata,
+		})
 }
 
 // MetadataFromRDSInstance creates AWS metadata from the provided RDS instance.
@@ -569,6 +591,8 @@ const (
 const (
 	// rdsEndpointSuffix is the RDS/Aurora endpoint suffix.
 	rdsEndpointSuffix = ".rds.amazonaws.com"
+	// labelTeleportDBName is the label key containing the database name override.
+	labelTeleportDBName = types.TeleportNamespace + "/database-name"
 )
 
 const (

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -23,11 +23,12 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -127,6 +128,58 @@ func TestDatabaseFromRDSInstance(t *testing.T) {
 			labelEngineVersion: "13.0",
 			labelEndpointType:  "instance",
 			"key":              "val",
+		},
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolPostgres,
+		URI:      "localhost:5432",
+		AWS: types.AWS{
+			AccountID: "1234567890",
+			Region:    "us-west-1",
+			RDS: types.RDS{
+				InstanceID: "instance-1",
+				ClusterID:  "cluster-1",
+				ResourceID: "resource-1",
+				IAMAuth:    true,
+			},
+		},
+	})
+	require.NoError(t, err)
+	actual, err := NewDatabaseFromRDSInstance(instance)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+// TestDatabaseFromRDSInstance tests converting an RDS instance to a database resource.
+func TestDatabaseFromRDSInstanceNameOverride(t *testing.T) {
+	instance := &rds.DBInstance{
+		DBInstanceArn:                    aws.String("arn:aws:rds:us-west-1:1234567890:db:instance-1"),
+		DBInstanceIdentifier:             aws.String("instance-1"),
+		DBClusterIdentifier:              aws.String("cluster-1"),
+		DbiResourceId:                    aws.String("resource-1"),
+		IAMDatabaseAuthenticationEnabled: aws.Bool(true),
+		Engine:                           aws.String(RDSEnginePostgres),
+		EngineVersion:                    aws.String("13.0"),
+		Endpoint: &rds.Endpoint{
+			Address: aws.String("localhost"),
+			Port:    aws.Int64(5432),
+		},
+		TagList: []*rds.Tag{
+			{Key: aws.String("key"), Value: aws.String("val")},
+			{Key: aws.String(labelTeleportDBName), Value: aws.String("override-1")},
+		},
+	}
+	expected, err := types.NewDatabaseV3(types.Metadata{
+		Name:        "override-1",
+		Description: "RDS instance in us-west-1",
+		Labels: map[string]string{
+			types.OriginLabel:   types.OriginCloud,
+			labelAccountID:      "1234567890",
+			labelRegion:         "us-west-1",
+			labelEngine:         RDSEnginePostgres,
+			labelEngineVersion:  "13.0",
+			labelEndpointType:   "instance",
+			labelTeleportDBName: "override-1",
+			"key":               "val",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
@@ -287,6 +340,144 @@ func TestParseRDSCustomEndpoint(t *testing.T) {
 	name, err := parseRDSCustomEndpoint("custom-endpoint.cluster-custom-example.ca-central-1.rds.amazonaws.com")
 	require.NoError(t, err)
 	require.Equal(t, "custom-endpoint", name)
+}
+
+// TestDatabaseFromRDSClusterNameOverride tests converting an RDS cluster to a database resource with overridden name.
+func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
+	cluster := &rds.DBCluster{
+		DBClusterArn:                     aws.String("arn:aws:rds:us-east-1:1234567890:cluster:cluster-1"),
+		DBClusterIdentifier:              aws.String("cluster-1"),
+		DbClusterResourceId:              aws.String("resource-1"),
+		IAMDatabaseAuthenticationEnabled: aws.Bool(true),
+		Engine:                           aws.String(RDSEngineAuroraMySQL),
+		EngineVersion:                    aws.String("8.0.0"),
+		Endpoint:                         aws.String("localhost"),
+		ReaderEndpoint:                   aws.String("reader.host"),
+		Port:                             aws.Int64(3306),
+		CustomEndpoints: []*string{
+			aws.String("myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com"),
+			aws.String("myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com"),
+		},
+		TagList: []*rds.Tag{
+			{Key: aws.String("key"), Value: aws.String("val")},
+			{Key: aws.String(labelTeleportDBName), Value: aws.String("mycluster-2")},
+		},
+	}
+
+	expectedAWS := types.AWS{
+		AccountID: "1234567890",
+		Region:    "us-east-1",
+		RDS: types.RDS{
+			ClusterID:  "cluster-1",
+			ResourceID: "resource-1",
+			IAMAuth:    true,
+		},
+	}
+
+	t.Run("primary", func(t *testing.T) {
+		expected, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "mycluster-2",
+			Description: "Aurora cluster in us-east-1",
+			Labels: map[string]string{
+				types.OriginLabel:   types.OriginCloud,
+				labelAccountID:      "1234567890",
+				labelRegion:         "us-east-1",
+				labelEngine:         RDSEngineAuroraMySQL,
+				labelEngineVersion:  "8.0.0",
+				labelEndpointType:   "primary",
+				labelTeleportDBName: "mycluster-2",
+				"key":               "val",
+			},
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolMySQL,
+			URI:      "localhost:3306",
+			AWS:      expectedAWS,
+		})
+		require.NoError(t, err)
+		actual, err := NewDatabaseFromRDSCluster(cluster)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("reader", func(t *testing.T) {
+		expected, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "mycluster-2-reader",
+			Description: "Aurora cluster in us-east-1 (reader endpoint)",
+			Labels: map[string]string{
+				types.OriginLabel:   types.OriginCloud,
+				labelAccountID:      "1234567890",
+				labelRegion:         "us-east-1",
+				labelEngine:         RDSEngineAuroraMySQL,
+				labelEngineVersion:  "8.0.0",
+				labelEndpointType:   "reader",
+				labelTeleportDBName: "mycluster-2",
+				"key":               "val",
+			},
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolMySQL,
+			URI:      "reader.host:3306",
+			AWS:      expectedAWS,
+		})
+		require.NoError(t, err)
+		actual, err := NewDatabaseFromRDSClusterReaderEndpoint(cluster)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("custom endpoints", func(t *testing.T) {
+		expectedLabels := map[string]string{
+			types.OriginLabel:   types.OriginCloud,
+			labelAccountID:      "1234567890",
+			labelRegion:         "us-east-1",
+			labelEngine:         RDSEngineAuroraMySQL,
+			labelEngineVersion:  "8.0.0",
+			labelEndpointType:   "custom",
+			labelTeleportDBName: "mycluster-2",
+			"key":               "val",
+		}
+
+		expectedMyEndpoint1, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "mycluster-2-custom-myendpoint1",
+			Description: "Aurora cluster in us-east-1 (custom endpoint)",
+			Labels:      expectedLabels,
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolMySQL,
+			URI:      "myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com:3306",
+			AWS:      expectedAWS,
+			TLS: types.DatabaseTLS{
+				ServerName: "localhost",
+			},
+		})
+		require.NoError(t, err)
+
+		expectedMyEndpoint2, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "mycluster-2-custom-myendpoint2",
+			Description: "Aurora cluster in us-east-1 (custom endpoint)",
+			Labels:      expectedLabels,
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolMySQL,
+			URI:      "myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com:3306",
+			AWS:      expectedAWS,
+			TLS: types.DatabaseTLS{
+				ServerName: "localhost",
+			},
+		})
+		require.NoError(t, err)
+
+		databases, err := NewDatabasesFromRDSClusterCustomEndpoints(cluster)
+		require.NoError(t, err)
+		require.Equal(t, types.Databases{expectedMyEndpoint1, expectedMyEndpoint2}, databases)
+	})
+
+	t.Run("bad custom endpoints ", func(t *testing.T) {
+		badCluster := *cluster
+		badCluster.CustomEndpoints = []*string{
+			aws.String("badendpoint1"),
+			aws.String("badendpoint2"),
+		}
+		_, err := NewDatabasesFromRDSClusterCustomEndpoints(&badCluster)
+		require.Error(t, err)
+	})
 }
 
 func TestAuroraMySQLVersion(t *testing.T) {
@@ -483,6 +674,59 @@ func TestDatabaseFromRedshiftCluster(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
+	t.Run("success with name override", func(t *testing.T) {
+		cluster := &redshift.Cluster{
+			ClusterIdentifier:   aws.String("mycluster"),
+			ClusterNamespaceArn: aws.String("arn:aws:redshift:us-east-1:1234567890:namespace:u-u-i-d"),
+			Endpoint: &redshift.Endpoint{
+				Address: aws.String("localhost"),
+				Port:    aws.Int64(5439),
+			},
+			Tags: []*redshift.Tag{
+				{
+					Key:   aws.String("key"),
+					Value: aws.String("val"),
+				},
+				{
+					Key:   aws.String("elasticbeanstalk:environment-id"),
+					Value: aws.String("id"),
+				},
+				{
+					Key:   aws.String(labelTeleportDBName),
+					Value: aws.String("mycluster-override-2"),
+				},
+			},
+		}
+		expected, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "mycluster-override-2",
+			Description: "Redshift cluster in us-east-1",
+			Labels: map[string]string{
+				types.OriginLabel:                 types.OriginCloud,
+				labelAccountID:                    "1234567890",
+				labelRegion:                       "us-east-1",
+				labelTeleportDBName:               "mycluster-override-2",
+				"key":                             "val",
+				"elasticbeanstalk:environment-id": "id",
+			},
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolPostgres,
+			URI:      "localhost:5439",
+			AWS: types.AWS{
+				AccountID: "1234567890",
+				Region:    "us-east-1",
+				Redshift: types.Redshift{
+					ClusterID: "mycluster",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+
+		actual, err := NewDatabaseFromRedshiftCluster(cluster)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+
 	t.Run("missing endpoint", func(t *testing.T) {
 		_, err := NewDatabaseFromRedshiftCluster(&redshift.Cluster{
 			ClusterIdentifier: aws.String("still-creating"),
@@ -531,6 +775,51 @@ func TestGetLabelEngineVersion(t *testing.T) {
 			if got := GetMySQLEngineVersion(tt.labels); got != tt.want {
 				t.Errorf("GetMySQLEngineVersion() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_setDBName(t *testing.T) {
+	tests := []struct {
+		name           string
+		meta           types.Metadata
+		firstNamePart  string
+		extraNameParts []string
+		want           types.Metadata
+	}{
+		{
+			name:           "no override, one part name",
+			meta:           types.Metadata{},
+			firstNamePart:  "foo",
+			extraNameParts: nil,
+			want:           types.Metadata{Name: "foo"},
+		},
+		{
+			name:           "no override, multi part name",
+			meta:           types.Metadata{},
+			firstNamePart:  "foo",
+			extraNameParts: []string{"bar", "baz"},
+			want:           types.Metadata{Name: "foo-bar-baz"},
+		},
+		{
+			name:           "override, one part name",
+			meta:           types.Metadata{Labels: map[string]string{labelTeleportDBName: "gizmo"}},
+			firstNamePart:  "foo",
+			extraNameParts: nil,
+			want:           types.Metadata{Name: "gizmo", Labels: map[string]string{labelTeleportDBName: "gizmo"}},
+		},
+		{
+			name:           "override, multi part name",
+			meta:           types.Metadata{Labels: map[string]string{labelTeleportDBName: "gizmo"}},
+			firstNamePart:  "foo",
+			extraNameParts: []string{"bar", "baz"},
+			want:           types.Metadata{Name: "gizmo-bar-baz", Labels: map[string]string{labelTeleportDBName: "gizmo"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := setDBName(tt.meta, tt.firstNamePart, tt.extraNameParts...)
+			require.Equal(t, tt.want, result)
 		})
 	}
 }


### PR DESCRIPTION
Backport #14740 to branch/v9

---

* If `teleport.dev/database-name` tag is present, it will override automatic DB name.
* If a single AWS DB maps to several Teleport DB entries, the override will become part of the name.

Among other things, this change makes it possible to pick a different name in case there are multiple dbs with the same name present.