### PR TITLE
[v10] Ensure that the WindowsDesktopReady event is emitted

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -1754,6 +1754,20 @@ func enableKubernetesService(t *testing.T, config *service.Config) {
 	require.NoError(t, enableKube(config, "teleport-cluster"))
 }
 
+func enableDesktopService(config *service.Config) {
+	// This config won't actually work, because there is no LDAP server,
+	// but it's enough to force desktop service to run.
+	config.WindowsDesktop.Enabled = true
+	config.WindowsDesktop.ListenAddr = *utils.MustParseAddr("127.0.0.1:0")
+	config.WindowsDesktop.Discovery.BaseDN = ""
+	config.WindowsDesktop.LDAP = service.LDAPConfig{
+		Domain:             "example.com",
+		Addr:               "127.0.0.1:636",
+		Username:           "test",
+		InsecureSkipVerify: true,
+	}
+}
+
 func enableKube(config *service.Config, clusterName string) error {
 	kubeConfigPath := config.Kube.KubeconfigPath
 	if kubeConfigPath == "" {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3933,9 +3933,9 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	config, err := teleport.GenerateConfig(t, nil, tconf)
 	require.NoError(t, err)
 
-	// Enable Kubernetes service to test issue where the `KubernetesReady` event was not properly propagated
-	// and in the case where Kube service was enabled cert rotation flow was broken.
+	// Enable Kubernetes/Desktop services to test that the ready event is propagated.
 	enableKubernetesService(t, config)
+	enableDesktopService(config)
 
 	serviceC := make(chan *service.TeleportProcess, 20)
 

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -253,6 +253,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 				"Windows desktop service %s:%s is starting on %v.",
 				teleport.Version, teleport.Gitref, listener.Addr())
 		}
+		process.BroadcastEvent(Event{Name: WindowsDesktopReady, Payload: nil})
 		err := srv.Serve(listener)
 		if err != nil {
 			if err == http.ErrServerClosed {


### PR DESCRIPTION
When desktop access is enabled, the TeleportReady event will not
be emitted until the WindowsDesktopReadyEvent is emitted, and it
turns out we have *never* emitted a WindowsDesktopReadyEvent.

This is likely due to desktop access being copied from kube access
since the very beginning. The same issue was recently fixed for
kube access in #9418.

Backports #14804 