### PR TITLE
Add calls to action for Teleport Cloud

### DIFF
--- a/docs/pages/getting-started/kubernetes-cluster.mdx
+++ b/docs/pages/getting-started/kubernetes-cluster.mdx
@@ -21,6 +21,8 @@ While completing this guide, you will deploy a single Teleport pod running the A
 If you are already running Teleport on another platform, you can use your existing Teleport deployment to access your Kubernetes cluster. [Follow our guide](../kubernetes-access/getting-started.mdx) to connect your Kubernetes cluster to Teleport.
 </Admonition>
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Follow along with our video guide
 
 <iframe

--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -25,6 +25,8 @@ We will run the following Teleport services:
 
 (!docs/pages/includes/permission-warning.mdx!)
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Prerequisites
 
 - A Linux machine with only port `443` open to ingress traffic. You must be able

--- a/docs/pages/includes/cloud/call-to-action.mdx
+++ b/docs/pages/includes/cloud/call-to-action.mdx
@@ -1,0 +1,12 @@
+<Notice 
+type="tip" 
+scope={["oss", "enterprise"]} 
+>
+
+Teleport Cloud takes care of this setup for you so you can provide secure access
+to your infrastructure right away.
+
+Get started with a [free trial](https://goteleport.com/signup?source=docs) of
+Teleport Cloud.
+
+</Notice>

--- a/docs/pages/setup/deployments/aws-terraform.mdx
+++ b/docs/pages/setup/deployments/aws-terraform.mdx
@@ -7,6 +7,8 @@ h1: Running Teleport Enterprise in High Availability mode on AWS
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to manage the resulting Teleport deployment.
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Prerequisites
 
 Our code requires Terraform 0.12+. You can [download Terraform here](https://www.terraform.io/downloads.html). We will assume that you have

--- a/docs/pages/setup/deployments/digitalocean.mdx
+++ b/docs/pages/setup/deployments/digitalocean.mdx
@@ -13,6 +13,8 @@ If you are looking for a manual installation, refer to our [Linux installation g
 
 </Notice>
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Prerequisites
 - A Fully Qualified Domain Name (FQDN).
 - A two-factor authenticator app (e.g., [Google Authenticator](https://www.google.com/landing/2step/)).

--- a/docs/pages/setup/deployments/gcp.mdx
+++ b/docs/pages/setup/deployments/gcp.mdx
@@ -20,6 +20,8 @@ We have split this guide into:
 - [GCP Teleport Introduction](#gcp-teleport-introduction)
 - [GCP Quickstart](#gcp-quickstart)
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Teleport on GCP FAQ
 
 ### Why would you want to use Teleport with GCP?

--- a/docs/pages/setup/deployments/ibm.mdx
+++ b/docs/pages/setup/deployments/ibm.mdx
@@ -19,6 +19,8 @@ We have split this guide into:
 - [Teleport on IBM FAQ](#teleport-on-ibm-cloud-faq)
 - [IBM Teleport Introduction](#ibm-teleport-introduction)
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Teleport on IBM Cloud FAQ
 
 ### Why would you want to use Teleport with IBM Cloud?

--- a/docs/pages/setup/helm-deployments/aws.mdx
+++ b/docs/pages/setup/helm-deployments/aws.mdx
@@ -12,6 +12,8 @@ using Teleport Helm charts and AWS products (DynamoDB and S3).
 
 </ScopedBlock>
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Prerequisites
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/setup/helm-deployments/digitalocean.mdx
+++ b/docs/pages/setup/helm-deployments/digitalocean.mdx
@@ -28,6 +28,8 @@ icon="kubernetes"
 This guide will show you how to get started with Teleport on DigitalOcean
 Kubernetes.
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Prerequisites
 
 - DigitalOcean account.

--- a/docs/pages/setup/helm-deployments/gcp.mdx
+++ b/docs/pages/setup/helm-deployments/gcp.mdx
@@ -12,6 +12,8 @@ using Teleport Helm charts and Google Cloud Platform products (Firestore and Goo
 
 </ScopedBlock>
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Prerequisites
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/setup/operations/backup-restore.mdx
+++ b/docs/pages/setup/operations/backup-restore.mdx
@@ -5,6 +5,8 @@ description: How to back up and restore your Teleport cluster state.
 This guide explains the components of your Teleport deployment that must be
 backed up and lays out our recommended approach for performing backups.
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## What you should back up
 
 ### Teleport services

--- a/docs/pages/setup/operations/scaling.mdx
+++ b/docs/pages/setup/operations/scaling.mdx
@@ -13,6 +13,8 @@ automatically.
 
 </ScopedBlock>
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Prerequisites
 
 - Teleport v(=teleport.version=) Open Source or Enterprise.

--- a/docs/pages/setup/operations/upgrading.mdx
+++ b/docs/pages/setup/operations/upgrading.mdx
@@ -6,6 +6,8 @@ description: How to upgrade Teleport components
 In this guide, we will show you how to upgrade all of the components in your
 Teleport cluster.
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Production releases
 
 <Notice type="warning">

--- a/docs/pages/setup/reference/backends.mdx
+++ b/docs/pages/setup/reference/backends.mdx
@@ -38,6 +38,8 @@ If High Availability cannot be provided by the infrastructure (perhaps you're
 running Teleport on a bare metal cluster), you can still configure Teleport to
 run in a highly available fashion.
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 ## Auth Server State
 
 To run multiple instances of Teleport Auth Server, you must switch to a High Availability secrets back-end first. Also, you must tell each node in a cluster that there is more than one auth server available. There are two ways to do this:


### PR DESCRIPTION
Fixes #14517

- Add a partial that briefly explains the value of Teleport Cloud for
  use in guides that Teleport Cloud renders unnecessary. The partial
  includes a signup link with the "source=docs" param so we can gauge
  the effectiveness of these calls to action.
- Add the partial to guides for setting up and managing the Auth/Proxy
  Services.