### PR TITLE
[v9] Handle `"true"` being passed for the `email_verified` OIDC claim

### DIFF
--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -323,7 +323,7 @@ func checkEmailVerifiedClaim(claims jose.Claims) error {
 			return nil
 		}
 
-		return trace.BadParameter("unable to parse oidc claim: %q, must be set to either 'true' or 'false'", claimName)
+		return trace.BadParameter("unable to parse oidc claim: %q, must be either 'true' or 'false', got '%s'", claimName, emailVerified)
 	}
 
 	data, ok := claims[claimName]

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -315,8 +315,15 @@ func checkEmailVerifiedClaim(claims jose.Claims) error {
 	unverifiedErr := trace.AccessDenied("email not verified by OIDC provider")
 
 	emailVerified, hasEmailVerifiedClaim, _ := claims.StringClaim(claimName)
-	if hasEmailVerifiedClaim && emailVerified == "false" {
-		return unverifiedErr
+	if hasEmailVerifiedClaim {
+		if emailVerified == "false" {
+			return unverifiedErr
+		}
+		if emailVerified == "true" {
+			return nil
+		}
+
+		return trace.BadParameter("unable to parse oidc claim: %q, must be set to either 'true' or 'false'", claimName)
 	}
 
 	data, ok := claims[claimName]

--- a/lib/auth/oidc_test.go
+++ b/lib/auth/oidc_test.go
@@ -509,3 +509,50 @@ func TestOIDCGoogle(t *testing.T) {
 		require.ElementsMatch(t, testCase.filtered, groups)
 	}
 }
+
+func TestEmailVerifiedClaim(t *testing.T) {
+	tests := []struct {
+		claims        map[string]interface{}
+		expectedError string
+	}{
+		{
+			claims: map[string]interface{}{
+				"email_verified": "true",
+			},
+			expectedError: "",
+		},
+		{
+			claims: map[string]interface{}{
+				"email_verified": "false",
+			},
+			expectedError: "email not verified by OIDC provider",
+		},
+		{
+			claims: map[string]interface{}{
+				"email_verified": false,
+			},
+			expectedError: "email not verified by OIDC provider",
+		},
+		{
+			claims: map[string]interface{}{
+				"email_verified": true,
+			},
+			expectedError: "",
+		},
+		{
+			claims: map[string]interface{}{
+				"email_verified": "random_value",
+			},
+			expectedError: "unable to parse oidc claim: \"email_verified\", must be either 'true' or 'false', got 'random_value'",
+		},
+	}
+
+	for _, test := range tests {
+		err := checkEmailVerifiedClaim(test.claims)
+		if test.expectedError == "" {
+			require.NoError(t, err)
+		} else {
+			require.ErrorContains(t, err, test.expectedError)
+		}
+	}
+}


### PR DESCRIPTION
Backport #14854 to branch/v9