### PR TITLE
Rename `teleport.dev/database-name` to `teleport.dev/database_name` to match convention.

### DIFF
--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -832,7 +832,7 @@ const (
 	// labelVPCID is the label key containing the VPC ID.
 	labelVPCID = "vpc-id"
 	// labelTeleportDBName is the label key containing the database name override.
-	labelTeleportDBName = types.TeleportNamespace + "/database-name"
+	labelTeleportDBName = types.TeleportNamespace + "/database_name"
 )
 
 const (


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/14740 the support for tag-based database name override was added. This PR renames the tag `teleport.dev/database-name` to `teleport.dev/database_name` to match existing naming convention.