### PR TITLE
Firestore: Err Not Found if doc was already deleted

### DIFF
--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -497,7 +497,7 @@ func (b *Backend) Delete(ctx context.Context, key []byte) error {
 	if !doc.Exists() {
 		return trace.NotFound("key %s does not exist", string(key))
 	}
-	_, err = docRef.Delete(ctx)
+	_, err = docRef.Delete(ctx, firestore.Exists)
 	if err != nil {
 		return ConvertGRPCError(err)
 	}

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -488,19 +488,16 @@ func (b *Backend) Delete(ctx context.Context, key []byte) error {
 	if len(key) == 0 {
 		return trace.BadParameter("missing parameter key")
 	}
+
 	docRef := b.svc.Collection(b.CollectionName).Doc(b.keyToDocumentID(key))
-	doc, err := docRef.Get(ctx)
-	if err != nil {
+	if _, err := docRef.Delete(ctx, firestore.Exists); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return trace.NotFound("key %s does not exist", string(key))
+		}
+
 		return ConvertGRPCError(err)
 	}
 
-	if !doc.Exists() {
-		return trace.NotFound("key %s does not exist", string(key))
-	}
-	_, err = docRef.Delete(ctx, firestore.Exists)
-	if err != nil {
-		return ConvertGRPCError(err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
Most of the backends implementation we have return an error when the
item does not exist.
This allow us to make stronger assumptions when dealing with possible
concurrent issues.

**dynamo** ✅
https://github.com/gravitational/teleport/blob/0c48cefef211ff5c6841f025cebfb8eb1407e04e/lib/backend/dynamo/dynamodbbk.go#L855
AWS docs state that we receive a ResourceNotFoundException if the item does not exist
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteItem.html#API_DeleteItem_Errors

**InMemory** ✅
https://github.com/gravitational/teleport/blob/02b4f8575f5f0bc305a37c89b58e4469c2662921/lib/backend/memory/memory.go#L277
Protected by a lock

**SQLite** ✅
https://github.com/gravitational/teleport/blob/e9fb1e84e25546e1728e71c750a0ae2a5ddaf30c/lib/backend/lite/lite.go#L822

**etcd** ✅
https://github.com/gravitational/teleport/blob/02b4f8575f5f0bc305a37c89b58e4469c2662921/lib/backend/etcdbk/etcd.go#L717
It checks if the total deleted is 0, if so, returns Err NotFound

**Postgres** ✅
https://github.com/gravitational/teleport/blob/06fef2abf13b8a741f12065413d6930fcc20d582/lib/backend/postgres/tx.go#L155
This fails when doing the `Scan` call if the record does not exist

---

Firestore does not give us such guarantee.
https://pkg.go.dev/cloud.google.com/go/firestore#DocumentRef.Delete

> Delete deletes the document. If the document doesn't exist, it does nothing and returns no error

Between the Get and Delete calls we can have another execution unit
doing a Delete. We would not receive an error if that happens.

We can fix this by passing a PreCondition to the Delete call:
`firestore.Exists`.
This ensures we receive an error if, at the deletion moment, the doc was
already deleted.

It's hard to do a proper test that validates we are safe from
concurrency issues, because we must keep the Get call in order to call
the `doc.Delete()`
I did validate this with a dummy project locally.

If you have an idea on how to better validate this behavior please let
me know.