### PR TITLE
[v10] Rename `teleport.dev/database-name` to `teleport.dev/database_name` to match convention.

### DIFF
--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -831,7 +831,7 @@ const (
 	// labelVPCID is the label key containing the VPC ID.
 	labelVPCID = "vpc-id"
 	// labelTeleportDBName is the label key containing the database name override.
-	labelTeleportDBName = types.TeleportNamespace + "/database-name"
+	labelTeleportDBName = types.TeleportNamespace + "/database_name"
 )
 
 const (


### PR DESCRIPTION
Backport #14922 to branch/v10