### PR TITLE
[v9] Rename `teleport.dev/database-name` to `teleport.dev/database_name` to match convention.

### DIFF
--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -592,7 +592,7 @@ const (
 	// rdsEndpointSuffix is the RDS/Aurora endpoint suffix.
 	rdsEndpointSuffix = ".rds.amazonaws.com"
 	// labelTeleportDBName is the label key containing the database name override.
-	labelTeleportDBName = types.TeleportNamespace + "/database-name"
+	labelTeleportDBName = types.TeleportNamespace + "/database_name"
 )
 
 const (


### PR DESCRIPTION
Backport #14922 to branch/v9