### PR TITLE
[v8] Rename `teleport.dev/database-name` to `teleport.dev/database_name` to match convention.

### DIFF
--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -468,7 +468,7 @@ const (
 	// rdsEndpointSuffix is the RDS/Aurora endpoint suffix.
 	rdsEndpointSuffix = ".rds.amazonaws.com"
 	// labelTeleportDBName is the label key containing the database name override.
-	labelTeleportDBName = "teleport.dev/database-name"
+	labelTeleportDBName = "teleport.dev/database_name"
 )
 
 const (


### PR DESCRIPTION
Backport #14922 to branch/v8