### PR TITLE
Fix Token creation TTL regression

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2016,12 +2016,11 @@ func (a *Server) CreateWebSession(ctx context.Context, user string) (types.WebSe
 
 // GenerateToken generates multi-purpose authentication token.
 func (a *Server) GenerateToken(ctx context.Context, req *proto.GenerateTokenRequest) (string, error) {
-	expires := a.clock.Now().UTC()
+	ttl := defaults.ProvisioningTokenTTL
 	if req.TTL != 0 {
-		expires = expires.Add(req.TTL.Get())
-	} else {
-		expires = expires.Add(defaults.ProvisioningTokenTTL)
+		ttl = req.TTL.Get()
 	}
+	expires := a.clock.Now().UTC().Add(ttl)
 
 	if req.Token == "" {
 		token, err := utils.CryptoRandomHex(TokenLenBytes)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2018,9 +2018,9 @@ func (a *Server) CreateWebSession(ctx context.Context, user string) (types.WebSe
 func (a *Server) GenerateToken(ctx context.Context, req *proto.GenerateTokenRequest) (string, error) {
 	expires := a.clock.Now().UTC()
 	if req.TTL != 0 {
-		expires.Add(req.TTL.Get())
+		expires = expires.Add(req.TTL.Get())
 	} else {
-		expires.Add(defaults.ProvisioningTokenTTL)
+		expires = expires.Add(defaults.ProvisioningTokenTTL)
 	}
 
 	if req.Token == "" {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -591,7 +591,7 @@ func TestTokensCRUD(t *testing.T) {
 	require.NoError(t, err)
 	token, err := s.a.GetToken(ctx, tokenName)
 	require.NoError(t, err)
-	actualTTL := token.Expiry().Sub(time.Now())
+	actualTTL := time.Until(token.Expiry())
 	diff := actualTTL - desiredTTL
 	require.True(
 		t,

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -566,7 +566,9 @@ func TestTokensCRUD(t *testing.T) {
 	require.Empty(t, btokens, 0)
 
 	// generate persistent token
-	tokenName, err := s.a.GenerateToken(ctx, &proto.GenerateTokenRequest{Roles: types.SystemRoles{types.RoleNode}})
+	tokenName, err := s.a.GenerateToken(ctx, &proto.GenerateTokenRequest{
+		Roles: types.SystemRoles{types.RoleNode},
+	})
 	require.NoError(t, err)
 	require.Len(t, tokenName, 2*TokenLenBytes)
 	tokens, err := s.a.GetTokens(ctx)
@@ -580,9 +582,31 @@ func TestTokensCRUD(t *testing.T) {
 	require.True(t, roles.Include(types.RoleNode))
 	require.False(t, roles.Include(types.RoleProxy))
 
+	// generate persistent token with defined TTL
+	desiredTTL := 6 * time.Hour
+	tokenName, err = s.a.GenerateToken(ctx, &proto.GenerateTokenRequest{
+		Roles: types.SystemRoles{types.RoleNode},
+		TTL:   proto.Duration(desiredTTL),
+	})
+	require.NoError(t, err)
+	token, err := s.a.GetToken(ctx, tokenName)
+	require.NoError(t, err)
+	actualTTL := token.Expiry().Sub(time.Now())
+	diff := actualTTL - desiredTTL
+	require.True(
+		t,
+		diff <= time.Minute && diff >= (-1*time.Minute),
+		"Token TTL should be within one minute of the desired TTL",
+	)
+
+	require.NoError(t, s.a.DeleteToken(ctx, tokenName))
+
 	// generate predefined token
 	customToken := "custom-token"
-	tokenName, err = s.a.GenerateToken(ctx, &proto.GenerateTokenRequest{Roles: types.SystemRoles{types.RoleNode}, Token: customToken})
+	tokenName, err = s.a.GenerateToken(ctx, &proto.GenerateTokenRequest{
+		Roles: types.SystemRoles{types.RoleNode},
+		Token: customToken,
+	})
 	require.NoError(t, err)
 	require.Equal(t, tokenName, customToken)
 


### PR DESCRIPTION
Closes #14916 

`time.Time.Add` takes a value receiver rather than a pointer receiver, so we need to assign the returned value back to `expires`. This could have resulted in tokens being produced that would've expired immediately, but lower level logic in `tokenToItem` was detecting this short expiry and defaulting to `ProvisioningTokenTTL`.

Introduces a test to ensure we don't regress on this again.