### PR TITLE
Refactor `Supervisor.WaitForEvent`

### DIFF
--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -193,18 +193,14 @@ func (p *databasePack) testRotateTrustedCluster(t *testing.T) {
 	}, false)
 	require.NoError(t, err)
 
-	rotationPhases := []string{types.RotationPhaseInit, types.RotationPhaseUpdateClients,
-		types.RotationPhaseUpdateServers, types.RotationPhaseStandby}
+	rotationPhases := []string{
+		types.RotationPhaseInit, types.RotationPhaseUpdateClients,
+		types.RotationPhaseUpdateServers, types.RotationPhaseStandby,
+	}
 
 	waitForEvent := func(process *service.TeleportProcess, event string) {
-		eventC := make(chan service.Event, 1)
-		process.WaitForEvent(context.TODO(), event, eventC)
-		select {
-		case <-eventC:
-
-		case <-time.After(20 * time.Second):
-			t.Fatalf("timeout waiting for service to broadcast event %s", event)
-		}
+		_, err := process.WaitForEventTimeout(20*time.Second, event)
+		require.NoError(t, err, "timeout waiting for service to broadcast event %s", event)
 	}
 
 	for _, phase := range rotationPhases {
@@ -381,7 +377,6 @@ func (p *databasePack) testMySQLRootCluster(t *testing.T) {
 	// Disconnect.
 	err = client.Close()
 	require.NoError(t, err)
-
 }
 
 // testMySQLLeafCluster tests a scenario where a user connects
@@ -523,7 +518,6 @@ func (p *databasePack) testMongoLeafCluster(t *testing.T) {
 	// Disconnect.
 	err = client.Disconnect(context.Background())
 	require.NoError(t, err)
-
 }
 
 // TestRootLeafIdleTimeout tests idle client connection termination by proxy and DB services in
@@ -992,8 +986,7 @@ func setupDatabaseTest(t *testing.T, options ...testOptionFunc) *databasePack {
 	privateKey, publicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
 
-	//TODO(tcsc): Refactor the test database setup such that it does
-	//            not use NewPortStr(),
+	// TODO(tcsc): Refactor the test database setup such that it does not use NewPortStr()
 	p := &databasePack{
 		clock: opts.clock,
 		root: databaseClusterPack{

--- a/integration/helpers/internal.go
+++ b/integration/helpers/internal.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport/lib/service"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
+
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func nullImpersonationCheck(context.Context, string, authztypes.SelfSubjectAccessReviewInterface) error {
@@ -29,12 +30,6 @@ func nullImpersonationCheck(context.Context, string, authztypes.SelfSubjectAcces
 }
 
 func StartAndWait(process *service.TeleportProcess, expectedEvents []string) ([]service.Event, error) {
-	// register to listen for all ready events on the broadcast channel
-	broadcastCh := make(chan service.Event)
-	for _, eventName := range expectedEvents {
-		process.WaitForEvent(context.TODO(), eventName, broadcastCh)
-	}
-
 	// start the process
 	err := process.Start()
 	if err != nil {
@@ -43,17 +38,18 @@ func StartAndWait(process *service.TeleportProcess, expectedEvents []string) ([]
 
 	// wait for all events to arrive or a timeout. if all the expected events
 	// from above are not received, this instance will not start
-	receivedEvents := []service.Event{}
-	timeoutCh := time.After(10 * time.Second)
-
-	for idx := 0; idx < len(expectedEvents); idx++ {
-		select {
-		case e := <-broadcastCh:
-			receivedEvents = append(receivedEvents, e)
-		case <-timeoutCh:
-			return nil, trace.BadParameter("timed out, only %v/%v events received. received: %v, expected: %v",
-				len(receivedEvents), len(expectedEvents), receivedEvents, expectedEvents)
+	receivedEvents := make([]service.Event, 0, len(expectedEvents))
+	ctx, cancel := context.WithTimeout(process.ExitContext(), 10*time.Second)
+	defer cancel()
+	for _, eventName := range expectedEvents {
+		if event, err := process.WaitForEvent(ctx, eventName); err == nil {
+			receivedEvents = append(receivedEvents, event)
 		}
+	}
+
+	if len(receivedEvents) < len(expectedEvents) {
+		return nil, trace.BadParameter("timed out, only %v/%v events received. received: %v, expected: %v",
+			len(receivedEvents), len(expectedEvents), receivedEvents, expectedEvents)
 	}
 
 	// Not all services follow a non-blocking Start/Wait pattern. This means a

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3128,15 +3128,8 @@ func testReverseTunnelCollapse(t *testing.T, suite *integrationTestSuite) {
 	require.Error(t, err)
 
 	// wait for the node to reach a degraded state
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	t.Cleanup(cancel)
-	eventC := make(chan service.Event)
-	node.WaitForEvent(ctx, service.TeleportDegradedEvent, eventC)
-	select {
-	case <-eventC:
-	case <-ctx.Done():
-		t.Fatal("timed out waiting for node to become degraded")
-	}
+	_, err = node.WaitForEventTimeout(5*time.Minute, service.TeleportDegradedEvent)
+	require.NoError(t, err, "timed out waiting for node to become degraded")
 
 	// start the proxy again and ensure the tunnel is re-established
 	proxyTunnel, err = main.StartProxy(proxyConfig)
@@ -4518,14 +4511,10 @@ func (s *integrationTestSuite) rotationConfig(disableWebService bool) *service.C
 
 // waitForProcessEvent waits for process event to occur or timeout
 func waitForProcessEvent(svc *service.TeleportProcess, event string, timeout time.Duration) error {
-	eventC := make(chan service.Event, 1)
-	svc.WaitForEvent(context.TODO(), event, eventC)
-	select {
-	case <-eventC:
-		return nil
-	case <-time.After(timeout):
+	if _, err := svc.WaitForEventTimeout(timeout, event); err != nil {
 		return trace.BadParameter("timeout waiting for service to broadcast event %v", event)
 	}
+	return nil
 }
 
 // waitForProcessStart is waiting for the process to start
@@ -4555,12 +4544,7 @@ func waitForReload(serviceC chan *service.TeleportProcess, old *service.Teleport
 		return nil, trace.BadParameter("timeout waiting for service to start")
 	}
 
-	eventC := make(chan service.Event, 1)
-	svc.WaitForEvent(context.TODO(), service.TeleportReadyEvent, eventC)
-	select {
-	case <-eventC:
-
-	case <-time.After(20 * time.Second):
+	if _, err := svc.WaitForEventTimeout(20*time.Second, service.TeleportReadyEvent); err != nil {
 		dumpGoroutineProfile()
 		return nil, trace.BadParameter("timeout waiting for service to broadcast ready status")
 	}

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -43,25 +43,12 @@ func (process *TeleportProcess) initWindowsDesktopService() {
 	})
 	process.registerWithAuthServer(types.RoleWindowsDesktop, WindowsDesktopIdentityEvent)
 	process.RegisterCriticalFunc("windows_desktop.init", func() error {
-		eventsC := make(chan Event)
-		process.WaitForEvent(process.ExitContext(), WindowsDesktopIdentityEvent, eventsC)
-
-		var event Event
-		select {
-		case event = <-eventsC:
-			log.Debugf("Received event %q.", event.Name)
-		case <-process.ExitContext().Done():
-			log.Debug("Process is exiting.")
-			return nil
+		conn, err := process.waitForConnector(WindowsDesktopIdentityEvent, log)
+		if conn == nil {
+			return trace.Wrap(err)
 		}
 
-		conn, ok := (event.Payload).(*Connector)
-		if !ok {
-			return trace.BadParameter("unsupported connector type: %T", event.Payload)
-		}
-
-		err := process.initWindowsDesktopServiceRegistered(log, conn)
-		if err != nil {
+		if err := process.initWindowsDesktopServiceRegistered(log, conn); err != nil {
 			warnOnErr(conn.Close(), log)
 			return trace.Wrap(err)
 		}

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 	"sync"
-
-	"github.com/gravitational/teleport"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
 )
 
 // Supervisor implements the simple service logic - registering
@@ -65,14 +66,20 @@ type Supervisor interface {
 	// subscribed parties.
 	BroadcastEvent(Event)
 
-	// WaitForEvent arranges for eventC to receive events with the specified name if
-	// none was broadcasted already; if the event was already broadcasted, eventC
-	// will only receive the latest value immediately.
-	WaitForEvent(ctx context.Context, name string, eventC chan<- Event)
+	// WaitForEvent waits for one event with the specified name (returns the
+	// latest such event if at least one has been broadcasted already, ignoring
+	// the context). Returns an error if the context is canceled before an event
+	// is received.
+	WaitForEvent(ctx context.Context, name string) (Event, error)
+
+	// WaitForEventTimeout waits for one event with the specified name (returns the
+	// latest such event if at least one has been broadcasted already). Returns
+	// an error if the timeout triggers before an event is received.
+	WaitForEventTimeout(timeout time.Duration, name string) (Event, error)
 
 	// ListenForEvents arranges for eventC to receive events with the specified
 	// name; if the event was already broadcasted, eventC will receive the latest
-	// value immediately.
+	// value immediately. The broadcasting will stop when the context is done.
 	ListenForEvents(ctx context.Context, name string, eventC chan<- Event)
 
 	// RegisterEventMapping registers event mapping -
@@ -413,25 +420,36 @@ func (s *LocalSupervisor) RegisterEventMapping(m EventMapping) {
 	s.eventMappings = append(s.eventMappings, m)
 }
 
-// WaitForEvent arranges for eventC to receive events with the specified name if
-// none was broadcasted already; if the event was already broadcasted, eventC
-// will only receive the latest value immediately.
-func (s *LocalSupervisor) WaitForEvent(ctx context.Context, name string, eventC chan<- Event) {
+func (s *LocalSupervisor) WaitForEvent(ctx context.Context, name string) (Event, error) {
 	s.Lock()
-	defer s.Unlock()
 
-	waiter := &waiter{eventC: eventC, context: ctx}
-	event, ok := s.events[name]
-	if ok {
-		go waiter.notify(event)
-		return
+	if event, ok := s.events[name]; ok {
+		s.Unlock()
+		return event, nil
 	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	eventC := make(chan Event)
+	waiter := &waiter{eventC: eventC, context: ctx}
 	s.eventWaiters[name] = append(s.eventWaiters[name], waiter)
+	s.Unlock()
+
+	select {
+	case event := <-eventC:
+		return event, nil
+	case <-ctx.Done():
+		return Event{}, trace.Wrap(ctx.Err())
+	}
 }
 
-// ListenForEvents arranges for eventC to receive events with the specified
-// name; if the event was already broadcasted, eventC will receive the latest
-// value immediately.
+func (s *LocalSupervisor) WaitForEventTimeout(timeout time.Duration, name string) (Event, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return s.WaitForEvent(ctx, name)
+}
+
 func (s *LocalSupervisor) ListenForEvents(ctx context.Context, name string, eventC chan<- Event) {
 	s.Lock()
 	defer s.Unlock()

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/config"
@@ -29,8 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/testhelpers"
 	"github.com/gravitational/teleport/lib/utils"
 	libutils "github.com/gravitational/teleport/lib/utils"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 )
 
 func rotate(
@@ -86,15 +87,10 @@ func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *test
 	}
 
 	// Ensure the service starts correctly the first time before proceeding
-	eventCh := make(chan service.Event, 1)
-	svc.WaitForEvent(svc.ExitContext(), service.TeleportReadyEvent, eventCh)
-	select {
-	case <-eventCh:
-	case <-time.After(30 * time.Second):
-		// in reality, the auth server should start *much* sooner than this.  we use a very large
-		// timeout here because this isn't the kind of problem that this test is meant to catch.
-		t.Fatal("auth server didn't start after 30s")
-	}
+	_, err := svc.WaitForEventTimeout(30*time.Second, service.TeleportReadyEvent)
+	// in reality, the auth server should start *much* sooner than this.  we use a very large
+	// timeout here because this isn't the kind of problem that this test is meant to catch.
+	require.NoError(t, err, "auth server didn't start after 30s")
 
 	// Tracks the latest instance of the Teleport service through reloads
 	activeSvc := svc

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -28,6 +28,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -39,9 +42,6 @@ import (
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
-
-	"github.com/gravitational/trace"
-	"github.com/stretchr/testify/require"
 )
 
 // TestDatabaseLogin verifies "tsh db login" command.
@@ -289,7 +289,7 @@ func TestDBInfoHasChanged(t *testing.T) {
 			require.NoError(t, err)
 
 			certPath := filepath.Join(t.TempDir(), "mongo_db_cert.pem")
-			require.NoError(t, os.WriteFile(certPath, certBytes, 0600))
+			require.NoError(t, os.WriteFile(certPath, certBytes, 0o600))
 
 			cliConf := &CLIConf{DatabaseUser: tc.databaseUserName, DatabaseName: tc.databaseName}
 			got, err := dbInfoHasChanged(cliConf, certPath)
@@ -328,13 +328,8 @@ func makeTestDatabaseServer(t *testing.T, auth *service.TeleportProcess, proxy *
 	})
 
 	// Wait for database agent to start.
-	eventCh := make(chan service.Event, 1)
-	db.WaitForEvent(db.ExitContext(), service.DatabasesReady, eventCh)
-	select {
-	case <-eventCh:
-	case <-time.After(10 * time.Second):
-		t.Fatal("database server didn't start after 10s")
-	}
+	_, err = db.WaitForEventTimeout(10*time.Second, service.DatabasesReady)
+	require.NoError(t, err, "database server didn't start after 10s")
 
 	// Wait for all databases to register to avoid races.
 	for _, database := range dbs {

--- a/tool/tsh/tsh_helper_test.go
+++ b/tool/tsh/tsh_helper_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport/api/breaker"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/breaker"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/config"
@@ -262,15 +262,8 @@ func localListenerAddr() string {
 
 func waitForEvents(t *testing.T, svc service.Supervisor, events ...string) {
 	for _, event := range events {
-		eventCh := make(chan service.Event, 1)
-		svc.WaitForEvent(svc.ExitContext(), event, eventCh)
-		select {
-		case <-eventCh:
-		case <-time.After(30 * time.Second):
-			// in reality, the auth server should start *much* sooner than this.  we use a very large
-			// timeout here because this isn't the kind of problem that this test is meant to catch.
-			t.Fatalf("service server didn't receved %v event after 30s", event)
-		}
+		_, err := svc.WaitForEventTimeout(30*time.Second, event)
+		require.NoError(t, err, "service server didn't receved %v event after 30s", event)
 	}
 }
 

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -32,6 +32,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghodss/yaml"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	otlp "go.opentelemetry.io/proto/otlp/trace/v1"
+	"go.uber.org/atomic"
+	"golang.org/x/crypto/ssh"
+	yamlv2 "gopkg.in/yaml.v2"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/constants"
@@ -55,14 +63,6 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/prompt"
-
-	"github.com/ghodss/yaml"
-	"github.com/gravitational/trace"
-	"github.com/stretchr/testify/require"
-	otlp "go.opentelemetry.io/proto/otlp/trace/v1"
-	"go.uber.org/atomic"
-	"golang.org/x/crypto/ssh"
-	yamlv2 "gopkg.in/yaml.v2"
 )
 
 const (
@@ -239,7 +239,7 @@ func TestAlias(t *testing.T) {
 			config := &TshConfig{Aliases: tt.aliases}
 			configBytes, err := yamlv2.Marshal(config)
 			require.NoError(t, err)
-			err = os.WriteFile(filepath.Join(tmpHomePath, "tsh_global.yaml"), configBytes, 0777)
+			err = os.WriteFile(filepath.Join(tmpHomePath, "tsh_global.yaml"), configBytes, 0o777)
 			require.NoError(t, err)
 
 			// run command
@@ -1942,13 +1942,8 @@ func makeTestSSHNode(t *testing.T, authAddr *utils.NetAddr, opts ...testServerOp
 	})
 
 	// Wait for node to become ready.
-	eventCh := make(chan service.Event, 1)
-	node.WaitForEvent(node.ExitContext(), service.NodeSSHReady, eventCh)
-	select {
-	case <-eventCh:
-	case <-time.After(10 * time.Second):
-		t.Fatal("node didn't start after 10s")
-	}
+	node.WaitForEventTimeout(10*time.Second, service.NodeSSHReady)
+	require.NoError(t, err, "node didn't start after 10s")
 
 	return node
 }
@@ -2000,15 +1995,10 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	})
 
 	// Wait for proxy to become ready.
-	eventCh := make(chan service.Event, 1)
-	auth.WaitForEvent(auth.ExitContext(), service.AuthTLSReady, eventCh)
-	select {
-	case <-eventCh:
-	case <-time.After(30 * time.Second):
-		// in reality, the auth server should start *much* sooner than this.  we use a very large
-		// timeout here because this isn't the kind of problem that this test is meant to catch.
-		t.Fatal("auth server didn't start after 30s")
-	}
+	_, err = auth.WaitForEventTimeout(30*time.Second, service.AuthTLSReady)
+	// in reality, the auth server should start *much* sooner than this.  we use a very large
+	// timeout here because this isn't the kind of problem that this test is meant to catch.
+	require.NoError(t, err, "auth server didn't start after 30s")
 
 	authAddr, err := auth.AuthAddr()
 	require.NoError(t, err)
@@ -2040,12 +2030,8 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	})
 
 	// Wait for proxy to become ready.
-	proxy.WaitForEvent(proxy.ExitContext(), service.ProxyWebServerReady, eventCh)
-	select {
-	case <-eventCh:
-	case <-time.After(10 * time.Second):
-		t.Fatal("proxy web server didn't start after 10s")
-	}
+	_, err = proxy.WaitForEventTimeout(10*time.Second, service.ProxyWebServerReady)
+	require.NoError(t, err, "proxy web server didn't start after 10s")
 
 	return auth, proxy
 }


### PR DESCRIPTION
`WaitForEvent` used to pull double duty as both the "fetch one event" function and the "subscribe to events" function. After #11802 we've had a `ListenForEvents` that did the latter, so there's no real reason to pass supervisor events through a channel anymore.

In addition, this fixes a couple of leaks in `(*TeleportProcess).WaitForSignals`. Resources will still be held in the fanout mechanism for each `WaitForEvent` until either a new event with the same name occurs, or the process exits, but nothing should be leaked after the `TeleportProcess` exits.