### PR TITLE
[v9] Validate token for node join script

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1439,8 +1439,12 @@ func (a *ServerWithRoles) GetTokens(ctx context.Context, opts ...services.Marsha
 }
 
 func (a *ServerWithRoles) GetToken(ctx context.Context, token string) (types.ProvisionToken, error) {
-	if err := a.action(apidefaults.Namespace, types.KindToken, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+	// The Proxy has permission to look up tokens by name in order to validate
+	// attempts to use the node join script.
+	if isProxy := a.hasBuiltinRole(types.RoleProxy); !isProxy {
+		if err := a.action(apidefaults.Namespace, types.KindToken, types.VerbRead); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return a.authServer.GetToken(ctx, token)
 }

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -154,7 +154,7 @@ func (h *Handler) getNodeJoinScriptHandle(w http.ResponseWriter, r *http.Request
 		joinMethod:     r.URL.Query().Get("method"),
 	}
 
-	script, err := getJoinScript(settings, h.GetProxyClient())
+	script, err := getJoinScript(r.Context(), settings, h.GetProxyClient())
 	if err != nil {
 		log.WithError(err).Info("Failed to return the node install script.")
 		w.Write(scripts.ErrorBashScript)
@@ -195,7 +195,7 @@ func (h *Handler) getAppJoinScriptHandle(w http.ResponseWriter, r *http.Request,
 		appURI:         uri,
 	}
 
-	script, err := getJoinScript(settings, h.GetProxyClient())
+	script, err := getJoinScript(r.Context(), settings, h.GetProxyClient())
 	if err != nil {
 		log.WithError(err).Info("Failed to return the app install script.")
 		w.Write(scripts.ErrorBashScript)
@@ -228,21 +228,27 @@ func createJoinToken(ctx context.Context, m nodeAPIGetter, roles types.SystemRol
 	}, nil
 }
 
-func getJoinScript(settings scriptSettings, m nodeAPIGetter) (string, error) {
-	// Skip decoding validation for IAM tokens since they are generated with a different method
-	if settings.joinMethod != string(types.JoinMethodIAM) {
-		// This token does not need to be validated against the backend because it's not used to
-		// reveal any sensitive information. However, we still need to perform a simple input
-		// validation check by verifying that the token was auto-generated.
-		// Auto-generated tokens must be encoded and must have an expected length.
+func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter) (string, error) {
+	switch types.JoinMethod(settings.joinMethod) {
+	case types.JoinMethodUnspecified, types.JoinMethodToken:
 		decodedToken, err := hex.DecodeString(settings.token)
 		if err != nil {
 			return "", trace.Wrap(err)
 		}
-
 		if len(decodedToken) != auth.TokenLenBytes {
-			return "", trace.BadParameter("invalid token length")
+			return "", trace.BadParameter("invalid token %q", decodedToken)
 		}
+
+	case types.JoinMethodIAM:
+	default:
+		return "", trace.BadParameter("join method %q is not supported via script", settings.joinMethod)
+	}
+
+	// The provided token can be attacker controlled, so we must validate
+	// it with the backend before using it to generate the script.
+	_, err := m.GetToken(ctx, settings.token)
+	if err != nil {
+		return "", trace.BadParameter("invalid token")
 	}
 
 	// Get hostname and port from proxy server address.
@@ -274,9 +280,9 @@ func getJoinScript(settings scriptSettings, m nodeAPIGetter) (string, error) {
 	var buf bytes.Buffer
 	// If app install mode is requested but parameters are blank for some reason,
 	// we need to return an error.
-	if settings.appInstallMode == true {
+	if settings.appInstallMode {
 		if errs := validation.IsDNS1035Label(settings.appName); len(errs) > 0 {
-			return "", trace.BadParameter("appName %q must be a valid DNS subdomain: https://gravitational.com/teleport/docs/application-access/#application-name", settings.appName)
+			return "", trace.BadParameter("appName %q must be a valid DNS subdomain: https://goteleport.com/docs/application-access/guides/connecting-apps/#application-name", settings.appName)
 		}
 		if !appURIPattern.MatchString(settings.appURI) {
 			return "", trace.BadParameter("appURI %q contains invalid characters", settings.appURI)
@@ -346,15 +352,17 @@ func isSameRuleSet(r1 []*types.TokenRule, r2 []*types.TokenRule) bool {
 }
 
 type nodeAPIGetter interface {
-	// GenerateToken creates a special provisioning token for a new SSH server
-	// that is valid for ttl period seconds.
+	// GenerateToken creates a special provisioning token for a new SSH server.
 	//
 	// This token is used by SSH server to authenticate with Auth server
-	// and get signed certificate and private key from the auth server.
+	// and get a signed certificate.
 	//
 	// If token is not supplied, it will be auto generated and returned.
 	// If TTL is not supplied, token will be valid until removed.
 	GenerateToken(ctx context.Context, req auth.GenerateTokenRequest) (string, error)
+
+	// GetToken looks up a provisioning token.
+	GetToken(ctx context.Context, token string) (types.ProvisionToken, error)
 
 	// GetClusterCACert returns the CAs for the local cluster without signing keys.
 	GetClusterCACert() (*auth.LocalCAResponse, error)

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -18,6 +18,7 @@ package web
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 )
 
 func TestCreateNodeJoinToken(t *testing.T) {
+	t.Parallel()
 	m := &mockedNodeAPIGetter{}
 	m.mockGenerateToken = func(ctx context.Context, req auth.GenerateTokenRequest) (string, error) {
 		return "some-token-id", nil
@@ -47,6 +49,7 @@ func TestCreateNodeJoinToken(t *testing.T) {
 }
 
 func TestGenerateIAMTokenName(t *testing.T) {
+	t.Parallel()
 	rule1 := types.TokenRule{
 		AWSAccount: "100000000000",
 		AWSARN:     "arn:aws:iam:1",
@@ -84,6 +87,7 @@ func TestGenerateIAMTokenName(t *testing.T) {
 }
 
 func TestSortRules(t *testing.T) {
+	t.Parallel()
 	tt := []struct {
 		name     string
 		rules    []*types.TokenRule
@@ -277,81 +281,126 @@ func TestSortRules(t *testing.T) {
 	}
 }
 
+func toHex(s string) string { return hex.EncodeToString([]byte(s)) }
+
 func TestGetNodeJoinScript(t *testing.T) {
-	m := &mockedNodeAPIGetter{}
-	m.mockGetProxyServers = func() ([]types.Server, error) {
-		var s types.ServerV2
-		s.SetPublicAddr("test-host:12345678")
+	validToken := "f18da1c9f6630a51e8daf121e7451daa"
+	validIAMToken := "valid-iam-token"
 
-		return []types.Server{&s}, nil
-	}
-	m.mockGetClusterCACert = func() (*auth.LocalCAResponse, error) {
-		fakeBytes := []byte(fixtures.SigningCertPEM)
-		return &auth.LocalCAResponse{TLSCA: fakeBytes}, nil
-	}
+	m := &mockedNodeAPIGetter{
+		mockGetProxyServers: func() ([]types.Server, error) {
+			var s types.ServerV2
+			s.SetPublicAddr("test-host:12345678")
 
-	nilTokenLength := scriptSettings{
-		token: "",
-	}
-
-	shortTokenLength := scriptSettings{
-		token: "f18da1c9f6630a51e8daf121e7451d",
-	}
-
-	testTokenID := "f18da1c9f6630a51e8daf121e7451daa"
-	validTokenLength := scriptSettings{
-		token: testTokenID,
-	}
-
-	// Test zero-value initialization.
-	script, err := getJoinScript(scriptSettings{}, m)
-	require.Empty(t, script)
-	require.True(t, trace.IsBadParameter(err))
-
-	// Test bad token lengths.
-	script, err = getJoinScript(nilTokenLength, m)
-	require.Empty(t, script)
-	require.True(t, trace.IsBadParameter(err))
-
-	script, err = getJoinScript(shortTokenLength, m)
-	require.Empty(t, script)
-	require.True(t, trace.IsBadParameter(err))
-
-	// Test valid token format.
-	script, err = getJoinScript(validTokenLength, m)
-	require.NoError(t, err)
-
-	require.Contains(t, script, testTokenID)
-	require.Contains(t, script, "test-host")
-	require.Contains(t, script, "12345678")
-	require.Contains(t, script, "sha256:")
-	require.NotContains(t, script, "JOIN_METHOD=\"iam\"")
-
-	// Test iam method script
-	iamToken := scriptSettings{
-		token:      "token length doesnt matter in this case",
-		joinMethod: string(types.JoinMethodIAM),
+			return []types.Server{&s}, nil
+		},
+		mockGetClusterCACert: func() (*auth.LocalCAResponse, error) {
+			fakeBytes := []byte(fixtures.SigningCertPEM)
+			return &auth.LocalCAResponse{TLSCA: fakeBytes}, nil
+		},
+		mockGetToken: func(_ context.Context, token string) (types.ProvisionToken, error) {
+			if token == validToken || token == validIAMToken {
+				return &types.ProvisionTokenV2{
+					Metadata: types.Metadata{
+						Name: token,
+					},
+				}, nil
+			}
+			return nil, trace.NotFound("token does not exist")
+		},
 	}
 
-	script, err = getJoinScript(iamToken, m)
-	require.NoError(t, err)
-	require.Contains(t, script, "JOIN_METHOD=\"iam\"")
+	for _, test := range []struct {
+		desc            string
+		settings        scriptSettings
+		errAssert       require.ErrorAssertionFunc
+		extraAssertions func(script string)
+	}{
+		{
+			desc:      "zero value",
+			settings:  scriptSettings{},
+			errAssert: require.Error,
+		},
+		{
+			desc:      "short token length",
+			settings:  scriptSettings{token: toHex("f18da1c9f6630a51e8daf121e7451d")},
+			errAssert: require.Error,
+		},
+		{
+			desc:      "valid length but does not exist",
+			settings:  scriptSettings{token: toHex("xxxxxxx9f6630a51e8daf121exxxxxxx")},
+			errAssert: require.Error,
+		},
+		{
+			desc:      "valid",
+			settings:  scriptSettings{token: validToken},
+			errAssert: require.NoError,
+			extraAssertions: func(script string) {
+				require.Contains(t, script, validToken)
+				require.Contains(t, script, "test-host")
+				require.Contains(t, script, "12345678")
+				require.Contains(t, script, "sha256:")
+				require.NotContains(t, script, "JOIN_METHOD='iam'")
+			},
+		},
+		{
+			desc: "invalid IAM",
+			settings: scriptSettings{
+				token:      toHex("invalid-iam-token"),
+				joinMethod: string(types.JoinMethodIAM),
+			},
+			errAssert: require.Error,
+		},
+		{
+			desc: "valid iam",
+			settings: scriptSettings{
+				token:      validIAMToken,
+				joinMethod: string(types.JoinMethodIAM),
+			},
+			errAssert: require.NoError,
+			extraAssertions: func(script string) {
+				require.Contains(t, script, "JOIN_METHOD='iam'")
+			},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			script, err := getJoinScript(context.Background(), test.settings, m)
+			test.errAssert(t, err)
+			if err != nil {
+				require.Empty(t, script)
+			}
+
+			if test.extraAssertions != nil {
+				test.extraAssertions(script)
+			}
+		})
+	}
 }
 
 func TestGetAppJoinScript(t *testing.T) {
-	m := &mockedNodeAPIGetter{}
-	m.mockGetProxyServers = func() ([]types.Server, error) {
-		var s types.ServerV2
-		s.SetPublicAddr("test-host:12345678")
-
-		return []types.Server{&s}, nil
-	}
-	m.mockGetClusterCACert = func() (*auth.LocalCAResponse, error) {
-		fakeBytes := []byte(fixtures.SigningCertPEM)
-		return &auth.LocalCAResponse{TLSCA: fakeBytes}, nil
-	}
-
 	testTokenID := "f18da1c9f6630a51e8daf121e7451daa"
+	m := &mockedNodeAPIGetter{
+		mockGetToken: func(_ context.Context, token string) (types.ProvisionToken, error) {
+			if token == testTokenID {
+				return &types.ProvisionTokenV2{
+					Metadata: types.Metadata{
+						Name: token,
+					},
+				}, nil
+			}
+			return nil, trace.NotFound("token does not exist")
+		},
+		mockGetProxyServers: func() ([]types.Server, error) {
+			var s types.ServerV2
+			s.SetPublicAddr("test-host:12345678")
+
+			return []types.Server{&s}, nil
+		},
+		mockGetClusterCACert: func() (*auth.LocalCAResponse, error) {
+			fakeBytes := []byte(fixtures.SigningCertPEM)
+			return &auth.LocalCAResponse{TLSCA: fakeBytes}, nil
+		},
+	}
 	badAppName := scriptSettings{
 		token:          testTokenID,
 		appInstallMode: true,
@@ -367,11 +416,11 @@ func TestGetAppJoinScript(t *testing.T) {
 	}
 
 	// Test invalid app data.
-	script, err := getJoinScript(badAppName, m)
+	script, err := getJoinScript(context.Background(), badAppName, m)
 	require.Empty(t, script)
 	require.True(t, trace.IsBadParameter(err))
 
-	script, err = getJoinScript(badAppURI, m)
+	script, err = getJoinScript(context.Background(), badAppURI, m)
 	require.Empty(t, script)
 	require.True(t, trace.IsBadParameter(err))
 
@@ -500,7 +549,7 @@ func TestGetAppJoinScript(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			script, err = getJoinScript(tc.settings, m)
+			script, err = getJoinScript(context.Background(), tc.settings, m)
 			if tc.shouldError {
 				require.NotNil(t, err)
 				require.Equal(t, script, "")
@@ -622,6 +671,7 @@ type mockedNodeAPIGetter struct {
 	mockGenerateToken    func(ctx context.Context, req auth.GenerateTokenRequest) (string, error)
 	mockGetProxyServers  func() ([]types.Server, error)
 	mockGetClusterCACert func() (*auth.LocalCAResponse, error)
+	mockGetToken         func(ctx context.Context, token string) (types.ProvisionToken, error)
 }
 
 func (m *mockedNodeAPIGetter) GenerateToken(ctx context.Context, req auth.GenerateTokenRequest) (string, error) {
@@ -646,4 +696,11 @@ func (m *mockedNodeAPIGetter) GetClusterCACert() (*auth.LocalCAResponse, error) 
 	}
 
 	return nil, trace.NotImplemented("mockGetClusterCACert not implemented")
+}
+
+func (m *mockedNodeAPIGetter) GetToken(ctx context.Context, token string) (types.ProvisionToken, error) {
+	if m.mockGetToken != nil {
+		return m.mockGetToken(ctx, token)
+	}
+	return nil, trace.NotImplemented("mockGetToken not implemented")
 }

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -80,16 +80,16 @@ INTERACTIVE=false
 
 # the default value of each variable is a templatable Go value so that it can
 # optionally be replaced by the server before the script is served up
-TELEPORT_VERSION="{{.version}}"
-TARGET_HOSTNAME="{{.hostname}}"
-TARGET_PORT="{{.port}}"
-JOIN_TOKEN="{{.token}}"
-JOIN_METHOD="{{.joinMethod}}"
-CA_PIN_HASHES="{{.caPins}}"
+TELEPORT_VERSION='{{.version}}'
+TARGET_HOSTNAME='{{.hostname}}'
+TARGET_PORT='{{.port}}'
+JOIN_TOKEN='{{.token}}'
+JOIN_METHOD='{{.joinMethod}}'
+CA_PIN_HASHES='{{.caPins}}'
 ARG_CA_PIN_HASHES=""
-APP_INSTALL_MODE="{{.appInstallMode}}"
-APP_NAME="{{.appName}}"
-APP_URI="{{.appURI}}"
+APP_INSTALL_MODE='{{.appInstallMode}}'
+APP_NAME='{{.appName}}'
+APP_URI='{{.appURI}}'
 
 # usage message
 # shellcheck disable=SC2086
@@ -494,14 +494,14 @@ proxy_service:
 EOF
 }
 # get the auth section of a node config
-get_node_auth_config() { 
-    if [[ ${JOIN_METHOD} == "iam" ]]; then 
+get_node_auth_config() {
+    if [[ ${JOIN_METHOD} == "iam" ]]; then
         echo "join_params:
     token_name: ${JOIN_TOKEN}
     method: iam
-"; 
-    else 
-        echo "auth_token: ${JOIN_TOKEN}"; fi 
+";
+    else
+        echo "auth_token: ${JOIN_TOKEN}"; fi
 }
 # checks whether the given host is running MacOS
 is_macos_host() { if [[ ${OSTYPE} == "darwin"* ]]; then return 0; else return 1; fi }


### PR DESCRIPTION
The token value is provided via the HTTP request
and fed into the node join script. This could allow an attacker
to generate a node-join script with malicious code included.

Fix this by validating that tokens are valid and exist in the backend.

Additionally, we recently added the ability to specify labels via the
node-labels query parameter, which is also user-controlled. Since this
functionality was never integrated in the UI, we remove it here and
will add an alternative implementation in the future.

Also use single quotes in script to prevent expansion

Backports #14726