### PR TITLE
Clarify Touch ID support doesn't require Touch Bar

### DIFF
--- a/docs/pages/access-controls/guides/passwordless.mdx
+++ b/docs/pages/access-controls/guides/passwordless.mdx
@@ -203,7 +203,7 @@ If you are having trouble with Touch ID, make sure that you are using the latest
 standalone version of `tsh`. [Download the macOS tsh installer](
 ../../installation.mdx#macos).
 
-Touch ID support requires Macs with the Touch Bar and Secure Enclave. It also
+Touch ID support requires Macs with a Touch ID sensor and Secure Enclave. It also
 requires macOS >= 10.13 (macOS High Sierra).
 
 You can run the `tsh touchid diag` command to verify requirements. A capable


### PR DESCRIPTION
Tested on M1 Mac without Touch Bar but with Magic Keyboard with Touch ID.  Signed standalone installer passes diag:

```
 % tsh touchid diag
Has compile support? true
Has signature? true
Has entitlements? true
Passed LAPolicy test? true
Passed Secure Enclave test? true
Touch ID enabled? true
```