### PR TITLE
Passwordless user type clarification

### DIFF
--- a/docs/pages/access-controls/guides/passwordless.mdx
+++ b/docs/pages/access-controls/guides/passwordless.mdx
@@ -9,7 +9,8 @@ videoBanner: GA37qqB6Lmk
 </Admonition>
 
 Passwordless takes advantage of WebAuthn to provide passwordless and
-usernameless authentication for Teleport.
+usernameless authentication for Teleport.  Teleport [local users](../../setup/admin/users.mdx) are the only initial 
+supported user types for passwordless authentication.
 
 ## Prerequisites
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -135,7 +135,7 @@ chart.
   |Link|Binaries|
   |-|-|
   |[`teleport-(=teleport.version=).pkg`](https://get.gravitational.com/teleport-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`|
-  |[`tsh-(=teleport.version=).pkg`](https://get.gravitational.com/tsh-(=teleport.version=).pkg)|`tsh`|
+  |[`tsh-(=teleport.version=).pkg`](https://get.gravitational.com/tsh-(=teleport.version=).pkg) (signed)|`tsh`|
 
   You can also fetch an installer via the command line: 
 


### PR DESCRIPTION
Provide clarification on user types supported

Mark tsh download package provided by Teleport as signed.  Matches language on downloads page and instructions from Passwordless page.