### PR TITLE
Update to use 443 port for google oidc inline example

### DIFF
--- a/examples/resources/gworkspace-connector-inline.yaml
+++ b/examples/resources/gworkspace-connector-inline.yaml
@@ -10,7 +10,7 @@ spec:
   - claim: groups
     roles:
     - access
-    value: teleport-developers@example.com
+    value: <teleport-developers@example.com>
   client_id: <GOOGLE_WORKSPACE_CLIENT_ID>.apps.googleusercontent.com
   client_secret: <OAUTH_CLIENT_SECRET>
   display: Google
@@ -29,7 +29,7 @@ spec:
      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/teleport-service-account%40access-304316.iam.gserviceaccount.com"
     }
   issuer_url: https://accounts.google.com
-  redirect_url: https://<cluster-url>:3080/v1/webapi/oidc/callback
+  redirect_url: https://<cluster-url>:443/v1/webapi/oidc/callback
   scope:
   - openid
   - email


### PR DESCRIPTION
Having `3080` for the Teleport Cloud example causes confusion.