### PR TITLE
Remove requirement for `listen_addr` when proxy mode is `multiplex`

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -597,6 +597,11 @@ func KubeProxyListenAddr() *utils.NetAddr {
 	return makeAddr(BindIP, KubeListenPort)
 }
 
+// WindowsDesktopProxyListenAddr returns the default listening address for the Desktop Proxy service
+func WindowsDesktopProxyListenAddr() *utils.NetAddr {
+	return makeAddr(BindIP, WindowsDesktopListenPort)
+}
+
 // ProxyWebListenAddr returns the default listening address for the Web-based SSH Proxy service
 func ProxyWebListenAddr() *utils.NetAddr {
 	return makeAddr(BindIP, HTTPListenPort)

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -101,8 +101,8 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 	case useTunnel && !cfg.WindowsDesktop.ListenAddr.IsEmpty():
 		return trace.BadParameter("either set windows_desktop_service.listen_addr if this process can be reached from a teleport proxy or point teleport.auth_servers to a proxy to dial out, but don't set both")
 	case !useTunnel && cfg.WindowsDesktop.ListenAddr.IsEmpty():
-		return trace.BadParameter("set windows_desktop_service.listen_addr if this process can be reached from a teleport proxy or point teleport.auth_servers to a proxy to dial out")
-
+		cfg.WindowsDesktop.ListenAddr = *defaults.WindowsDesktopProxyListenAddr()
+		fallthrough
 	// Start a local listener and let proxies dial in.
 	case !useTunnel && !cfg.WindowsDesktop.ListenAddr.IsEmpty():
 		log.Info("Using local listener and registering directly with auth server")


### PR DESCRIPTION
Removes the requirement for Kubernetes/Desktop services to specify listen_addr when running with multiplex proxy

Closes #12375