### PR TITLE
[v10] Use IP as `LocalAddress` when gateway is created on Windows for SQL Server

### DIFF
--- a/lib/teleterm/gateway/config.go
+++ b/lib/teleterm/gateway/config.go
@@ -72,8 +72,8 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.LocalAddress == "" {
-		// due to SQL Server Management Studio behavior, it can't connect to address like localhost:12345,
-		// we have to use IP, like 127.0.0.1:12345
+		// Due to SQL Server Management Studio behavior, it can't connect to address like localhost:12345,
+		// we have to use IP, like 127.0.0.1:12345.
 		if runtime.GOOS == constants.WindowsOS && c.Protocol == defaults.ProtocolSQLServer {
 			c.LocalAddress = "127.0.0.1"
 		} else {

--- a/lib/teleterm/gateway/config.go
+++ b/lib/teleterm/gateway/config.go
@@ -17,11 +17,14 @@ limitations under the License.
 package gateway
 
 import (
-	"github.com/google/uuid"
-	"github.com/gravitational/teleport/lib/teleterm/api/uri"
+	"runtime"
 
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/trace"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -69,7 +72,13 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.LocalAddress == "" {
-		c.LocalAddress = "localhost"
+		// due to SQL Server Management Studio behavior, it can't connect to address like localhost:12345,
+		// we have to use IP, like 127.0.0.1:12345
+		if runtime.GOOS == constants.WindowsOS && c.Protocol == defaults.ProtocolSQLServer {
+			c.LocalAddress = "127.0.0.1"
+		} else {
+			c.LocalAddress = "localhost"
+		}
 	}
 
 	if c.LocalPort == "" {

--- a/lib/teleterm/gateway/config.go
+++ b/lib/teleterm/gateway/config.go
@@ -72,12 +72,10 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.LocalAddress == "" {
-		// Due to SQL Server Management Studio behavior, it can't connect to address like localhost:12345,
-		// we have to use IP, like 127.0.0.1:12345.
+		c.LocalAddress = "localhost"
+		// SQL Server Management Studio won't connect to localhost:12345, so use 127.0.0.1:12345 instead.
 		if runtime.GOOS == constants.WindowsOS && c.Protocol == defaults.ProtocolSQLServer {
 			c.LocalAddress = "127.0.0.1"
-		} else {
-			c.LocalAddress = "localhost"
 		}
 	}
 


### PR DESCRIPTION
Backport #14930 to branch/v10