### PR TITLE
[v10] Make tsh installer non relocatable and drop version from app

### DIFF
--- a/build.assets/build-pkg-tsh.sh
+++ b/build.assets/build-pkg-tsh.sh
@@ -10,6 +10,20 @@ usage() {
   log "Usage: $0 -t oss|eng -v version [-s tarball_directory] [-n]"
 }
 
+# make_non_relocatable_plist changes the default component plist of the $root
+# package to non-relocatable.
+# This makes install paths consistent, which also facilitates pathing in
+# pre/postscripts.
+# Creates component_plist.
+# See `man pkgbuild` for reference.
+make_non_relocatable_plist() {
+  local root="$1"
+  local component_plist="$2"
+
+  pkgbuild --analyze --root "$root" "$component_plist"
+  plutil -replace BundleIsRelocatable -bool NO "$component_plist"
+}
+
 main() {
   local buildassets=''
   buildassets="$(dirname "$0")"
@@ -109,13 +123,9 @@ password created by APPLE_USERNAME"
   # We only care about the 'tsh' file for the script.
   tar xzf "$tarname" -C "$tmp"
 
-  # Copy and edit scripts, then write the correct VERSION variable.
-  cp -r "$buildassets/macos/scripts" "$tmp/"
-  sed -i '' "s/VERSION=''/VERSION='-v$TELEPORT_VERSION'/g" "$tmp/scripts"/*
-
   # Prepare app shell.
   local skel="$buildassets/macos/$TSH_SKELETON"
-  local target="$tmp/root/tsh-v$TELEPORT_VERSION.app"
+  local target="$tmp/root/tsh.app"
   cp -r "$skel/tsh.app" "$target"
   mkdir -p "$target/Contents/MacOS/"
   cp "$tmp"/teleport*/tsh "$target/Contents/MacOS/"
@@ -132,13 +142,19 @@ password created by APPLE_USERNAME"
   # Prepare and sign the installer package.
   # Note that the installer does __NOT__ have a `v` in the version number.
   target="$tmp/tsh-$TELEPORT_VERSION.pkg" # switches from app to pkg
+  local pkg_root="$tmp/root"
+  local pkg_component_plist="$tmp/tsh-component.plist"
+  local pkg_scripts="$buildassets/macos/scripts"
+  make_non_relocatable_plist "$pkg_root" "$pkg_component_plist"
   pkgbuild \
-    --root "$tmp/root/" \
+    --root "$pkg_root" \
+    --component-plist "$pkg_component_plist" \
     --identifier "$TSH_BUNDLEID" \
     --version "v$TELEPORT_VERSION" \
     --install-location /Applications \
-    --scripts "$tmp/scripts" \
+    --scripts "$pkg_scripts" \
     "$target.unsigned"
+
   $DRY_RUN_PREFIX productsign \
     --sign "$DEVELOPER_ID_INSTALLER" \
     --timestamp \

--- a/build.assets/macos/scripts/postinstall
+++ b/build.assets/macos/scripts/postinstall
@@ -1,10 +1,6 @@
 #!/bin/sh
 set -eu
 
-# VERSION is dynamically updated when the installer is created.
-# Includes "-v" after edit, eg: "-v1.2.3".
-VERSION=''
-
 main() {
   BIN=/usr/local/bin/
   [ ! -d "$BIN" ] && mkdir -p "$BIN"
@@ -17,7 +13,7 @@ main() {
 
   # Link package to $BIN.
   rm -f "$BIN/tsh"  # in case link exists
-  ln -s "/Applications/tsh$VERSION.app/Contents/MacOS/tsh" "$BIN/tsh"
+  ln -s "/Applications/tsh.app/Contents/MacOS/tsh" "$BIN/tsh"
 }
 
 main "$@"


### PR DESCRIPTION
This is a twofold change with the aim of reducing possible pains with the tsh
installer.

- Dropping the version number from "tsh.app" makes it more alike other apps
  (including Connect)
- Making the installer non-relocatable makes it easy to reason about (and
  ensures our postinstall script is correct!)

A relocatable installer will look for the app in places other the specified
install path, according to the bundle ID. This means that if the user moves or
renames the app, the installer will overwrite it no matter where it is. It also
means our path assumptions can be wrong.

Note that the installer itself is still numbered, so it won't break Houston or
change the downloads page.

Backport #15018 to branch/v10