### PR TITLE
[v9] Check manifest before attempting to push docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -953,7 +953,11 @@ image-ci: clean docker-binaries
 
 .PHONY: publish-ci
 publish-ci: image-ci
-	docker push $(DOCKER_IMAGE_STAGING):$(VERSION)
+	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $(DOCKER_IMAGE_STAGING):$(VERSION) 2>&1 >/dev/null; then\
+		echo "$(DOCKER_IMAGE_STAGING):$(VERSION) already exists. ";     \
+	else                                                                \
+		docker push $(DOCKER_IMAGE_STAGING):$(VERSION);                 \
+	fi
 	if [ -f e/Makefile ]; then $(MAKE) -C e publish-ci; fi
 
 .PHONY: print-version


### PR DESCRIPTION
Backport of #15093

## Testing
```bash
➜  teleport git:(logan/reentrable-docker-push-amazon-ecr) ✗ export DOCKER_IMAGE_STAGING=146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:10.1.2
➜  teleport git:(logan/reentrable-docker-push-amazon-ecr) ✗ if docker manifest inspect ${DOCKER_IMAGE_STAGING} 2>&1 >/dev/null; then echo "Image already exists"; else echo "Push new image"; fi
no such manifest: 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:10.1.2
Push new image
➜  teleport git:(logan/reentrable-docker-push-amazon-ecr) ✗ export DOCKER_IMAGE_STAGING=146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:10.1.1
➜  teleport git:(logan/reentrable-docker-push-amazon-ecr) ✗ if docker manifest inspect ${DOCKER_IMAGE_STAGING} 2>&1 >/dev/null; then echo "Image already exists"; else echo "Push new image"; fi
Image already exists
```

Test drone build showing success despite existing images. https://drone.platform.teleport.sh/gravitational/teleport/14211