### PR TITLE
Fix cert renewal for new ASG instances

### DIFF
--- a/assets/aws/files/bin/teleport-all-pre-start
+++ b/assets/aws/files/bin/teleport-all-pre-start
@@ -15,4 +15,4 @@ if [[ "${USE_LETSENCRYPT}" != "true" ]]; then
 fi
 
 # copy certificates into place
-/bin/aws s3 sync s3://${TELEPORT_S3_BUCKET}/live/${TELEPORT_DOMAIN_NAME} /var/lib/teleport
+/bin/aws s3 sync --exact-timestamps s3://${TELEPORT_S3_BUCKET}/live/${TELEPORT_DOMAIN_NAME} /var/lib/teleport

--- a/assets/aws/files/bin/teleport-get-cert
+++ b/assets/aws/files/bin/teleport-get-cert
@@ -27,4 +27,4 @@ echo "No certs/keys found in ${TELEPORT_S3_BUCKET}. Going to request certificate
 /usr/local/bin/certbot certonly -n --agree-tos --email ${TELEPORT_DOMAIN_ADMIN_EMAIL} --dns-route53 -d "${TELEPORT_DOMAIN_NAME}" -d "*.${TELEPORT_DOMAIN_NAME}"
 echo "Got wildcard certificate for ${TELEPORT_DOMAIN_NAME}. Syncing to S3."
 
-aws s3 sync /etc/letsencrypt/ s3://${TELEPORT_S3_BUCKET} --sse=AES256
+aws s3 sync --exact-timestamps /etc/letsencrypt/ s3://${TELEPORT_S3_BUCKET} --sse=AES256

--- a/assets/aws/files/bin/teleport-renew-cert
+++ b/assets/aws/files/bin/teleport-renew-cert
@@ -14,6 +14,27 @@ if [ ! -f /etc/teleport.d/role.auth ] && [ ! -f /etc/teleport.d/role.all ]; then
     exit 0
 fi
 
+# Fetching certbot state
+aws s3 sync --exact-timestamps "s3://${TELEPORT_S3_BUCKET}" /etc/letsencrypt/ --sse=AES256
+
+# s3 does not support symlinks, we have to create them after the sync, else certbot will fail.
+# live/ symlinks point to the latest archive/<domain>/<object>XX.pem where XX is incremented at each cert-renewal.
+# The last iteration is retrieved by listing all fullchains, sorting them by iteration (this is not alphabetical order
+# because fullchain10.pem should be greater than fullchain2.pem). We finally strip the id from the filename.
+ARCHIVE_NUMBER="$(
+  find "/etc/letsencrypt/archive/${TELEPORT_DOMAIN_NAME}/" -iname "fullchain*.pem" \
+  | sort -V \
+  | tail -n 1 \
+  | sed 's@.\+fullchain\([[:digit:]]\+\)\.pem@\1@'
+  )"
+
+PEM_FILES="cert chain fullchain privkey"
+
+for PEM_FILE in $PEM_FILES; do
+  rm "/etc/letsencrypt/live/${TELEPORT_DOMAIN_NAME}/${PEM_FILE}.pem"
+  ln -sf "/etc/letsencrypt/archive/${TELEPORT_DOMAIN_NAME}/${PEM_FILE}${ARCHIVE_NUMBER}.pem" "/etc/letsencrypt/live/${TELEPORT_DOMAIN_NAME}/${PEM_FILE}.pem"
+done
+
 # This is called periodically, if renewal is successful
 # certs are uploaded to the S3 Bucket
 /usr/local/bin/certbot renew --deploy-hook=/usr/local/bin/teleport-upload-cert

--- a/assets/aws/files/bin/teleport-upload-cert
+++ b/assets/aws/files/bin/teleport-upload-cert
@@ -7,4 +7,4 @@ set -x
 # Source variables from user-data
 . /etc/teleport.d/conf
 
-aws s3 sync /etc/letsencrypt/ s3://${TELEPORT_S3_BUCKET} --sse=AES256
+aws s3 sync --exact-timestamps /etc/letsencrypt/ s3://${TELEPORT_S3_BUCKET} --sse=AES256

--- a/docs/pages/setup/deployments/aws-terraform.mdx
+++ b/docs/pages/setup/deployments/aws-terraform.mdx
@@ -11,14 +11,14 @@ and describe how to manage the resulting Teleport deployment.
 
 ## Prerequisites
 
-Our code requires Terraform 0.12+. You can [download Terraform here](https://www.terraform.io/downloads.html). We will assume that you have
+Our code requires Terraform 0.13+. You can [download Terraform here](https://www.terraform.io/downloads.html). We will assume that you have
 `terraform` installed and available on your path.
 
 ```code
 $ which terraform
 /usr/local/bin/terraform
 $ terraform version
-Terraform v0.12.20
+Terraform v1.2.6
 ```
 
 You will also require the `aws` command line tool. This is available in Ubuntu/Debian/Fedora/CentOS and MacOS Homebrew

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -68,16 +68,16 @@ export TF_VAR_route53_domain="cluster.example.com"
 
 # Set to true to add a wildcard subdomain entry to point to the proxy, e.g. *.cluster.example.com
 # This is used to enable Teleport Application Access
-TF_VAR_add_wildcard_route53_record ?= true
+export TF_VAR_add_wildcard_route53_record="true"
 
 # Enable adding MongoDB listeners in Teleport proxy, load balancer ports and security groups
-TF_VAR_enable_mongodb_listener ?= true
+export TF_VAR_enable_mongodb_listener="true"
 
 # Enable adding MySQL listeners in Teleport proxy, load balancer ports and security groups
-TF_VAR_enable_mysql_listener ?= true
+export TF_VAR_enable_mysql_listener="true"
 
 # Enable adding Postgres listeners in Teleport proxy, load balancer ports and security groups
-TF_VAR_enable_postgres_listener ?= true
+export TF_VAR_enable_postgres_listener="true"
 
 # (optional) If using ACM, set an additional DNS alias which will be added pointing to the NLB. This can
 # be used with clients like kubectl which should target a DNS record. This will also add the DNS name to the

--- a/examples/aws/terraform/ha-autoscale-cluster/provider.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/provider.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13"
+  required_version = ">= 0.13, < 2.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/aws/terraform/starter-cluster/README.md
+++ b/examples/aws/terraform/starter-cluster/README.md
@@ -97,16 +97,16 @@ TF_VAR_route53_domain ?="cluster.example.com"
 
 # Set to true to add a wildcard subdomain entry to point to the proxy, e.g. *.cluster.example.com
 # This is used to enable Teleport Application Access
-TF_VAR_add_wildcard_route53_record ?= true
+export TF_VAR_add_wildcard_route53_record="true"
 
 # Enable adding MongoDB listeners in Teleport proxy, load balancer ports and security groups
-TF_VAR_enable_mongodb_listener ?= true
+export TF_VAR_enable_mongodb_listener="true"
 
 # Enable adding MySQL listeners in Teleport proxy, load balancer ports and security groups
-TF_VAR_enable_mysql_listener ?= true
+export TF_VAR_enable_mysql_listener="true"
 
 # Enable adding Postgres listeners in Teleport proxy, load balancer ports and security groups
-TF_VAR_enable_postgres_listener ?= true
+export TF_VAR_enable_postgres_listener="true"
 
 # Bucket name to store encrypted LetsEncrypt certificates.
 TF_VAR_s3_bucket_name ?="teleport.example.com"


### PR DESCRIPTION
Fixes #3610 
Fixes #15087 (plus a couple of typos in README).

I went for the suggested solution: sync certbot's state before renewing.

Certbot expects symlinks but S3 does not support them. We have to create them by hand, but doing it before the sync as suggested in the issue did not work. Hence the flow: sync, delete files, create symlink.

I also added `--extact-timestamps` on most S3 syncs even if technically needed in a single place because default behaviour is terrible in our situation (`aws s3 sync` compares sizes only to detect changes, we are dealing with fixed-size crypto material).

Note: Those scripts are not linted and most variable interpolations are unsafe. I tried not to introduce more issues than there was already. At some point we might want to `shellcheck` them.