### PR TITLE
Update fpm docker image and publish to ECR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1039,7 +1039,7 @@ steps:
     commands:
       - apk --update --no-cache add curl
       # get Dockerfiles
-      - curl -Ls -o /go/build/Dockerfile-fpm https://raw.githubusercontent.com/gravitational/teleport/${DRONE_SOURCE_BRANCH:-master}/build.assets/Dockerfile-fpm
+      - curl -Ls -o /go/build/Dockerfile-fpm https://raw.githubusercontent.com/gravitational/teleport/${DRONE_SOURCE_BRANCH:-logan/add-fpm-drone}/build.assets/Dockerfile-fpm
 
   - name: Build and push fpm image
     image: docker
@@ -6409,6 +6409,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: e948b57797c50b1691f64e550dcbfa13b0e697badb56b33d877d9c7ceb4e04b0
+hmac: 93a08f396bd1ab7812b3b9c45a73f9eb1663d64410a3b81a5b5520e83691c10f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1027,6 +1027,9 @@ clone:
 steps:
   - name: Wait for docker
     image: docker
+    volumes:
+      - name: dockersock
+        path: /var/run
     commands:
     - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
 
@@ -6406,6 +6409,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: df3726eac463f7682076a9be714bd0cfb0b022dc6ba2c048ebbf100bb3eac14d
+hmac: e948b57797c50b1691f64e550dcbfa13b0e697badb56b33d877d9c7ceb4e04b0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6406,6 +6406,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: 333d58503087a6737fc405d20d89b086c0237b61611fa917ecd85aac36b49ac6
+hmac: df3726eac463f7682076a9be714bd0cfb0b022dc6ba2c048ebbf100bb3eac14d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1038,6 +1038,7 @@ steps:
     environment:
     commands:
       - apk --update --no-cache add curl
+      - mkdir -p /go/build
       # get Dockerfiles
       - curl -Ls -o /go/build/Dockerfile-fpm https://raw.githubusercontent.com/gravitational/teleport/${DRONE_SOURCE_BRANCH:-logan/add-fpm-drone}/build.assets/Dockerfile-fpm
 
@@ -6409,6 +6410,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: 93a08f396bd1ab7812b3b9c45a73f9eb1663d64410a3b81a5b5520e83691c10f
+hmac: 1e4acf5eb683737a16cfc74a7f39f71efb306f5ca10a9edeed13563deda1a7a1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1006,6 +1006,87 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+---
+kind: pipeline
+type: kubernetes
+name: teleport-docker-fpm
+
+trigger:
+  cron:
+    - teleport-docker-fpm
+  repo:
+    include:
+      - gravitational/teleport
+
+workspace:
+  path: /go
+
+clone:
+  disable: false
+
+steps:
+  - name: Wait for docker
+    image: docker
+    commands:
+    - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+
+  - name: Set up Dockerfile
+    image: docker:git
+    environment:
+    commands:
+      - apk --update --no-cache add curl
+      # get Dockerfiles
+      - curl -Ls -o /go/build/Dockerfile-fpm https://raw.githubusercontent.com/gravitational/teleport/${DRONE_SOURCE_BRANCH:-master}/build.assets/Dockerfile-fpm
+
+  - name: Build and push fpm image
+    image: docker
+    environment:
+      OS: linux
+      ARCH: amd64
+      STAGING_AWS_ACCESS_KEY_ID:
+        from_secret: STAGING_FPM_DRONE_USER_ECR_KEY
+      STAGING_AWS_SECRET_ACCESS_KEY:
+        from_secret: STAGING_FPM_DRONE_USER_ECR_SECRET
+      PROD_AWS_ACCESS_KEY_ID:
+        from_secret: PRODUCTION_FPM_DRONE_USER_ECR_KEY
+      PROD_AWS_SECRET_ACCESS_KEY:
+        from_secret: PRODUCTION_FPM_DRONE_USER_ECR_SECRET
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache aws-cli
+      - export CURRENT_DATE=$(date '+%Y%m%d%H%M')
+      - export STAGING_FPM_IMAGE_NAME="146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/fpm:$CURRENT_DATE"
+      - export PRODUCTION_FPM_IMAGE_NAME="public.ecr.aws/gravitational/fpm"
+      # Authenticate to staging registry
+      - export AWS_ACCESS_KEY_ID="$STAGING_AWS_ACCESS_KEY_ID"
+      - export AWS_SECRET_ACCESS_KEY="$STAGING_AWS_SECRET_ACCESS_KEY"
+      - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
+      # Build and push debian image
+      - docker build -t $STAGING_FPM_IMAGE_NAME -f /go/build/Dockerfile-fpm /go/build
+      - docker push $STAGING_FPM_IMAGE_NAME
+      # Authenticate to production registry
+      - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
+      - export AWS_ACCESS_KEY_ID="$PROD_AWS_ACCESS_KEY_ID"
+      - export AWS_SECRET_ACCESS_KEY="$PROD_AWS_SECRET_ACCESS_KEY"
+      - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin public.ecr.aws
+      # Retag images
+      - docker tag $STAGING_FPM_IMAGE_NAME $PRODUCTION_FPM_IMAGE_NAME
+      # Promote to production registry
+      - docker push $PRODUCTION_FPM_IMAGE_NAME
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
 
 ---
 kind: pipeline
@@ -6325,6 +6406,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: 8ece36469050311a0d0aa6f30e51f0b66e6e60614447b519ee037ecb21b13832
+hmac: 333d58503087a6737fc405d20d89b086c0237b61611fa917ecd85aac36b49ac6
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
 VERSION=11.0.0-dev
+
 DOCKER_IMAGE_OPERATOR_CI ?= quay.io/gravitational/teleport-operator-ci
 DOCKER_IMAGE_QUAY ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_ECR ?= public.ecr.aws/gravitational/teleport

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
 VERSION=11.0.0-dev
-
 DOCKER_IMAGE_OPERATOR_CI ?= quay.io/gravitational/teleport-operator-ci
 DOCKER_IMAGE_QUAY ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_ECR ?= public.ecr.aws/gravitational/teleport

--- a/build.assets/Dockerfile-fpm
+++ b/build.assets/Dockerfile-fpm
@@ -1,0 +1,29 @@
+FROM ubuntu:18.04 as minimal-base
+# Runtime deps. Build deps go in the build or test containers
+WORKDIR /src
+
+RUN apt-get update \
+	&& apt-get -y dist-upgrade \
+	&& apt-get install --no-install-recommends -y \
+	ruby rubygems rubygems-integration \
+	bsdtar \
+	cpio \
+	debsigs \
+	pacman \
+	rpm  \
+	squashfs-tools \
+	xz-utils \
+	zip \
+    gcc \
+    make \
+    ruby-dev \
+    libc-dev \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& apt-get clean
+RUN adduser fpm 
+
+ENV GEM_PATH /fpm
+ENV PATH "/fpm/bin:${PATH}"
+RUN gem install --no-ri --no-rdoc --install-dir=/fpm fpm
+
+ENTRYPOINT ["/fpm/bin/fpm"]

--- a/build.assets/Dockerfile-fpm
+++ b/build.assets/Dockerfile-fpm
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as minimal-base
+FROM ubuntu:18.04
 # Runtime deps. Build deps go in the build or test containers
 WORKDIR /src
 
@@ -14,10 +14,10 @@ RUN apt-get update \
 	squashfs-tools \
 	xz-utils \
 	zip \
-    gcc \
-    make \
-    ruby-dev \
-    libc-dev \
+  gcc \
+  make \
+  ruby-dev \
+  libc-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& apt-get clean
 RUN adduser fpm 

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -59,6 +59,8 @@ RUNTIME="$r"
 TARBALL_DIRECTORY="$s"
 GNUPG_DIR=${GNUPG_DIR:-/tmp/gnupg}
 
+DOCKER_IMAGE="public.ecr.aws/gravitational/fpm
+
 # linux package configuration
 LINUX_BINARY_DIR=/usr/local/bin
 LINUX_SYSTEMD_DIR=/lib/systemd/system
@@ -118,13 +120,6 @@ else
     # if arch isn't set for other package types, throw an error
     if [[ "${ARCH}" == "" ]]; then
         usage
-    fi
-
-    # set docker image appropriately
-    if [[ "${PACKAGE_TYPE}" == "deb" ]]; then
-        DOCKER_IMAGE="quay.io/gravitational/fpm-debian:8"
-    elif [[ "${PACKAGE_TYPE}" == "rpm" ]]; then
-        DOCKER_IMAGE="quay.io/gravitational/fpm-centos:8"
     fi
 fi
 
@@ -326,7 +321,6 @@ else
 
     # build for other platforms
     docker run -v ${PACKAGE_TEMPDIR}:/src --rm ${EXTRA_DOCKER_OPTIONS} ${DOCKER_IMAGE} \
-        fpm \
         --input-type dir \
         --output-type ${PACKAGE_TYPE} \
         --name ${RPM_NAME} \

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -59,7 +59,7 @@ RUNTIME="$r"
 TARBALL_DIRECTORY="$s"
 GNUPG_DIR=${GNUPG_DIR:-/tmp/gnupg}
 
-DOCKER_IMAGE="public.ecr.aws/gravitational/fpm
+DOCKER_IMAGE="public.ecr.aws/gravitational/fpm"
 
 # linux package configuration
 LINUX_BINARY_DIR=/usr/local/bin


### PR DESCRIPTION
This PR is a part of RFD 73 Public Image RFD. The fpm images say they haven't been modified in ~2 years but are still used whenever a new tag is created. This PR will update the base image daily in order to keep the base packages up to date. 

The PR also updates the base image used in `build-package.sh` to use the amazon ECR image. 

## Open Questions
* Is it necessary for fpm to be run from a centos container for rpms, and a debian container for deb packages? 
* Should I limit the scope of this PR to just update to use Amazon ECR and not add a pipeline for keeping the fpm image up-to-date. 

## Testing
* Cronjob - https://drone.platform.teleport.sh/gravitational/teleport/14312/1/5
* Git tag - https://drone.platform.teleport.sh/gravitational/teleport/14367
