### PR TITLE
Don't reset eventID to 0 when out of events in the Postgres backend

### DIFF
--- a/lib/backend/postgres/tx.go
+++ b/lib/backend/postgres/tx.go
@@ -207,7 +207,7 @@ func (tx *pgTx) GetEvents(fromEventID int64, limit int) sqlbk.Events {
 		return events
 	}
 
-	var lastEventID int64
+	lastEventID := fromEventID
 	var backendEvents []backend.Event
 	for rows.Next() {
 		var event backend.Event


### PR DESCRIPTION
The Postgres backend resets its event fetching cursor to 0 whenever it reaches the end of the `event` table, to then fetch all the events again on the next polling iteration. This PR makes it so that we stay at whatever the last fetched event was.