### PR TITLE
Detect M1/M2 ARM CPUs when using the install script

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -634,8 +634,8 @@ elif [[ "${OSTYPE}" == "darwin"* ]]; then
     TELEPORT_BINARY_TYPE="darwin"
     ARCH=$(uname -m)
     log "Detected host: ${OSTYPE}, using Teleport binary type ${TELEPORT_BINARY_TYPE}"
-    if [[ ${ARCH} == "aarch64" ]]; then
-        TELEPORT_ARCH="aarch64"
+    if [[ ${ARCH} == "aarch64" || ${ARCH} == "arm64" ]]; then
+        TELEPORT_ARCH="arm64"
         log_important "Error: detected ${ARCH} but Teleport doesn't build binaries for this architecture yet, exiting"
         exit 1
     elif [[ ${ARCH} == "x86_64" ]]; then


### PR DESCRIPTION
The `install.sh` used for automatic installation of teleport was checking for `aarch64` when trying to detect ARM CPUs in Darwin.

However, the actual string we should be comparing to is `arm64` because that's the output of `uname -m`
Other places also use the string `arm64` such as the Golang tooling.

This is not a big deal for now because we don't support M1/M2 CPUs yet
This only changes the output message from
```
---> Error: unsupported architecture from uname -m: arm64
```
to
```
---> Error: detected arm64 but Teleport doesn't build binaries for this architecture yet, exiting
```