### PR TITLE
Use `waitForError` instead of `require.Eventually` in SessionRecordingModes integration tests

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -936,16 +936,10 @@ func testSessionRecordingModes(t *testing.T, suite *integrationTestSuite) {
 		return term, errCh
 	}
 
+	// waitSessionTermination wait until the errCh returns something and assert
+	// it with the provided function.
 	waitSessionTermination := func(t *testing.T, errCh chan error, errorAssertion require.ErrorAssertionFunc) {
-		require.Eventually(t, func() bool {
-			select {
-			case err := <-errCh:
-				errorAssertion(t, err)
-				return true
-			default:
-				return false
-			}
-		}, 10*time.Second, 500*time.Millisecond)
+		errorAssertion(t, waitForError(errCh, 10*time.Second))
 	}
 
 	// enableDiskFailure changes the OpenFileFunc on filesession package. The


### PR DESCRIPTION
Closes #15097. After some tests, it seemed that the `require.Eventually` loop wasn't consuming the `errCh` message, even when it was available. The `waitForError` function works differently than the previous solution, using a context to determine the channel receive timeout.

Before the change:
```
$ go test ./integration/ -race -count=1 -run TestIntegrations/SessionRecordingModes/StrictMode/BeforeStartFailure
...logs...
--- FAIL: TestIntegrations (11.01s)
    --- FAIL: TestIntegrations/SessionRecordingModes (11.00s)
        --- FAIL: TestIntegrations/SessionRecordingModes/StrictMode (10.01s)
            --- FAIL: TestIntegrations/SessionRecordingModes/StrictMode/BeforeStartFailure (10.00s)
                integration_test.go:940:
                        Error Trace:    integration_test.go:940
                                                                integration_test.go:1001
                        Error:          Condition never satisfied
                        Test:           TestIntegrations/SessionRecordingModes/StrictMode/BeforeStartFailure
FAIL
FAIL    github.com/gravitational/teleport/integration   12.141s
FAIL
```

And, after:
```
$ go test ./integration/ -race -count=10 -run TestIntegrations/SessionRecordingModes/StrictMode/BeforeStartFailure
ok      github.com/gravitational/teleport/integration   110.100s
```