### PR TITLE
forScopes changed to array

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -24,7 +24,7 @@
             {
               "title": "Docker Compose",
               "slug": "/getting-started/docker-compose/",
-              "forScopes": "oss"
+              "forScopes": ["oss"]
             }
           ]
         },
@@ -108,7 +108,7 @@
             },
             {
               "title": "Digital Ocean",
-              "forScopes": "oss",
+              "forScopes": ["oss"],
               "slug": "/setup/deployments/digitalocean/"
             }
           ]


### PR DESCRIPTION
Updating forScopes to an array of one instead of string to try and fix this docs build issue. https://vercel.com/gravitational/docs/DmXzTPBsqcxKE9d4KrYMnB1mbFUT

This _shouldn't_ be a problem according to [the types](https://github.com/gravitational/docs/blob/fcd53fbcc7ab51bab49c12b8090dc2516328c4f3/layouts/DocsPage/types.ts#L25) but this page specifically is failing. 