### PR TITLE
Update teleport-operator to use amazon ECR for staging registry. 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5074,10 +5074,6 @@ steps:
       GOPATH: /go
       OS: linux
       ARCH: amd64
-      QUAY_USERNAME:
-        from_secret: QUAYIO_DOCKER_USERNAME
-      QUAY_PASSWORD:
-        from_secret: QUAYIO_DOCKER_PASSWORD
       AWS_ACCESS_KEY_ID:
         from_secret: STAGING_TELEPORT_DRONE_USER_ECR_KEY
       AWS_SECRET_ACCESS_KEY:
@@ -5088,7 +5084,6 @@ steps:
     commands:
       - apk add --no-cache make bash aws-cli
       - chown -R $UID:$GID /go
-      - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
       - aws ecr get-login-password --region us-west-2 | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
       - cd /go/src/github.com/gravitational/teleport
       - make image-ci publish-ci
@@ -5765,6 +5760,7 @@ steps:
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$${VERSION}
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$${VERSION}
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$${VERSION}-fips
+  - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$${VERSION}
   - echo "---> Tagging images for $${VERSION}"
   - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$${VERSION}
     public.ecr.aws/gravitational/teleport:$${VERSION}
@@ -5772,6 +5768,8 @@ steps:
     public.ecr.aws/gravitational/teleport-ent:$${VERSION}
   - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$${VERSION}-fips
     public.ecr.aws/gravitational/teleport-ent:$${VERSION}-fips
+  - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$${VERSION}
+    public.ecr.aws/gravitational/teleport-operator:$${VERSION}
   - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
@@ -5779,6 +5777,7 @@ steps:
   - docker push public.ecr.aws/gravitational/teleport:$${VERSION}
   - docker push public.ecr.aws/gravitational/teleport-ent:$${VERSION}
   - docker push public.ecr.aws/gravitational/teleport-ent:$${VERSION}-fips
+  - docker push public.ecr.aws/gravitational/teleport-operator:$${VERSION}
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
@@ -5802,7 +5801,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/promote.go:82
+# Generated at dronegen/promote.go:85
 ################################################
 
 kind: pipeline
@@ -5842,14 +5841,13 @@ steps:
   commands:
   - apk add --no-cache aws-cli
   - export VERSION=${DRONE_TAG##v}
-  - docker login -u="$STAGING_QUAY_USERNAME" -p="$STAGING_QUAY_PASSWORD" quay.io
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
   - echo "---> Pulling images for $${VERSION}"
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$${VERSION}
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$${VERSION}
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$${VERSION}-fips
-  - docker pull quay.io/gravitational/teleport-operator-ci:$${VERSION}
+  - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$${VERSION}
   - echo "---> Tagging images for $${VERSION}"
   - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$${VERSION}
     quay.io/gravitational/teleport:$${VERSION}
@@ -5857,8 +5855,8 @@ steps:
     quay.io/gravitational/teleport-ent:$${VERSION}
   - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$${VERSION}-fips
     quay.io/gravitational/teleport-ent:$${VERSION}-fips
-  - docker tag quay.io/gravitational/teleport-operator-ci:$${VERSION} quay.io/gravitational/teleport-operator:$${VERSION}
-  - docker logout quay.io
+  - docker tag 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$${VERSION}
+    quay.io/gravitational/teleport-operator:$${VERSION}
   - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
   - echo "---> Pushing images for $${VERSION}"
@@ -5875,10 +5873,6 @@ steps:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
       from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-    STAGING_QUAY_PASSWORD:
-      from_secret: QUAYIO_DOCKER_PASSWORD
-    STAGING_QUAY_USERNAME:
-      from_secret: QUAYIO_DOCKER_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
@@ -6371,6 +6365,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: 1ac2bbbd3ecc42e83a2d1ef49e5db1c4e4b35567603f9dc9aa231bba79bf0d51
+hmac: 435e18755866e12d1b6cc018ea75e457c1d6aa4054cdce89f0ffeac9119841f4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6365,6 +6365,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: 435e18755866e12d1b6cc018ea75e457c1d6aa4054cdce89f0ffeac9119841f4
+hmac: 8ece36469050311a0d0aa6f30e51f0b66e6e60614447b519ee037ecb21b13832
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6365,6 +6365,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: 8ece36469050311a0d0aa6f30e51f0b66e6e60614447b519ee037ecb21b13832
+hmac: 435e18755866e12d1b6cc018ea75e457c1d6aa4054cdce89f0ffeac9119841f4
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -1029,7 +1029,11 @@ image-operator-ci:
 
 .PHONY: publish-operator-ci
 publish-operator-ci: image-operator-ci
-	docker push $(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)
+	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION) 2>&1 >/dev/null; then\
+		echo "$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION) already exists. ";     \
+	else                                                                         \
+		docker push $(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION);                 \
+	fi
 
 .PHONY: print-version
 print-version:

--- a/Makefile
+++ b/Makefile
@@ -1013,26 +1013,31 @@ image-ci: clean docker-binaries
 	cd $(BUILDDIR) && docker build --no-cache . -t $(DOCKER_IMAGE_STAGING):$(VERSION)
 	if [ -f e/Makefile ]; then $(MAKE) -C e image-ci; fi
 
+
+# DOCKER_CLI_EXPERIMENTAL=enabled is set to allow inspecting the manifest for present images.
+# https://docs.docker.com/engine/reference/commandline/cli/#experimental-features
 .PHONY: publish-ci
 publish-ci: image-ci
-	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $(DOCKER_IMAGE_STAGING):$(VERSION) 2>&1 >/dev/null; then\
+	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$(DOCKER_IMAGE_STAGING):$(VERSION)" 2>&1 >/dev/null; then\
 		echo "$(DOCKER_IMAGE_STAGING):$(VERSION) already exists. ";     \
 	else                                                                \
-		docker push $(DOCKER_IMAGE_STAGING):$(VERSION);                 \
+		docker push "$(DOCKER_IMAGE_STAGING):$(VERSION)"";                 \
 	fi
 	if [ -f e/Makefile ]; then $(MAKE) -C e publish-ci; fi
 
 # Docker image build for Teleport Operator
 .PHONY: image-operator-ci
 image-operator-ci:
-	make -C operator docker-build IMG=$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)
+	make -C operator docker-build IMG="$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)"
 
+# DOCKER_CLI_EXPERIMENTAL=enabled is set to allow inspecting the manifest for present images.
+# https://docs.docker.com/engine/reference/commandline/cli/#experimental-features
 .PHONY: publish-operator-ci
 publish-operator-ci: image-operator-ci
-	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION) 2>&1 >/dev/null; then\
-		echo "$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION) already exists. ";     \
-	else                                                                         \
-		docker push $(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION);                 \
+	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)"" >/dev/null 2>&1; then \
+		echo "$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION) already exists. ";                                                         \
+	else                                                                                                                             \
+		docker push "$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)";                                                                   \
 	fi
 
 .PHONY: print-version

--- a/Makefile
+++ b/Makefile
@@ -1034,7 +1034,7 @@ image-operator-ci:
 # https://docs.docker.com/engine/reference/commandline/cli/#experimental-features
 .PHONY: publish-operator-ci
 publish-operator-ci: image-operator-ci
-	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)"" >/dev/null 2>&1; then \
+	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)" >/dev/null 2>&1; then \
 		echo "$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION) already exists. ";                                                         \
 	else                                                                                                                             \
 		docker push "$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)";                                                                   \

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,11 @@
 #   Master/dev branch: "1.0.0-dev"
 VERSION=11.0.0-dev
 
-DOCKER_IMAGE_OPERATOR_CI ?= quay.io/gravitational/teleport-operator-ci
 DOCKER_IMAGE_QUAY ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_ECR ?= public.ecr.aws/gravitational/teleport
 DOCKER_IMAGE_STAGING ?= 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport
+DOCKER_IMAGE_OPERATOR_STAGING ?= 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator
+
 
 GOPATH ?= $(shell go env GOPATH)
 
@@ -1024,11 +1025,11 @@ publish-ci: image-ci
 # Docker image build for Teleport Operator
 .PHONY: image-operator-ci
 image-operator-ci:
-	make -C operator docker-build IMG=$(DOCKER_IMAGE_OPERATOR_CI):$(VERSION)
+	make -C operator docker-build IMG=$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)
 
 .PHONY: publish-operator-ci
 publish-operator-ci: image-operator-ci
-	docker push $(DOCKER_IMAGE_OPERATOR_CI):$(VERSION)
+	docker push $(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)
 
 .PHONY: print-version
 print-version:

--- a/Makefile
+++ b/Makefile
@@ -1018,10 +1018,10 @@ image-ci: clean docker-binaries
 # https://docs.docker.com/engine/reference/commandline/cli/#experimental-features
 .PHONY: publish-ci
 publish-ci: image-ci
-	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$(DOCKER_IMAGE_STAGING):$(VERSION)" 2>&1 >/dev/null; then\
+	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$(DOCKER_IMAGE_STAGING):$(VERSION)" >/dev/null 2>&1; then\
 		echo "$(DOCKER_IMAGE_STAGING):$(VERSION) already exists. ";     \
 	else                                                                \
-		docker push "$(DOCKER_IMAGE_STAGING):$(VERSION)"";                 \
+		docker push "$(DOCKER_IMAGE_STAGING):$(VERSION)";                 \
 	fi
 	if [ -f e/Makefile ]; then $(MAKE) -C e publish-ci; fi
 

--- a/Makefile
+++ b/Makefile
@@ -1016,6 +1016,9 @@ image-ci: clean docker-binaries
 
 # DOCKER_CLI_EXPERIMENTAL=enabled is set to allow inspecting the manifest for present images.
 # https://docs.docker.com/engine/reference/commandline/cli/#experimental-features
+# The internal staging images use amazon ECR's immutable repository settings. This makes overwrites impossible currently. 
+# This can cause issues when drone tagging pipelines must be re-run due to failures. 
+# Currently the work around for this is to not attempt to push to the image when it already exists.
 .PHONY: publish-ci
 publish-ci: image-ci
 	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$(DOCKER_IMAGE_STAGING):$(VERSION)" >/dev/null 2>&1; then\
@@ -1032,6 +1035,9 @@ image-operator-ci:
 
 # DOCKER_CLI_EXPERIMENTAL=enabled is set to allow inspecting the manifest for present images.
 # https://docs.docker.com/engine/reference/commandline/cli/#experimental-features
+# The internal staging images use amazon ECR's immutable repository settings. This makes overwrites impossible currently. 
+# This can cause issues when drone tagging pipelines must be re-run due to failures. 
+# Currently the work around for this is to not attempt to push to the image when it already exists.
 .PHONY: publish-operator-ci
 publish-operator-ci: image-operator-ci
 	@if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$(DOCKER_IMAGE_OPERATOR_STAGING):$(VERSION)" >/dev/null 2>&1; then \

--- a/dronegen/promote.go
+++ b/dronegen/promote.go
@@ -58,11 +58,13 @@ func buildDockerPromotionPipelineECR() pipeline {
 			fmt.Sprintf("docker pull %s/gravitational/teleport:$${VERSION}", StagingRegistry),
 			fmt.Sprintf("docker pull %s/gravitational/teleport-ent:$${VERSION}", StagingRegistry),
 			fmt.Sprintf("docker pull %s/gravitational/teleport-ent:$${VERSION}-fips", StagingRegistry),
+			fmt.Sprintf("docker pull %s/gravitational/teleport-operator:$${VERSION}", StagingRegistry),
 			// retag images to production naming
 			"echo \"---> Tagging images for $${VERSION}\"",
 			fmt.Sprintf("docker tag %s/gravitational/teleport:$${VERSION} %s/gravitational/teleport:$${VERSION}", StagingRegistry, ProductionRegistry),
 			fmt.Sprintf("docker tag %s/gravitational/teleport-ent:$${VERSION} %s/gravitational/teleport-ent:$${VERSION}", StagingRegistry, ProductionRegistry),
 			fmt.Sprintf("docker tag %s/gravitational/teleport-ent:$${VERSION}-fips %s/gravitational/teleport-ent:$${VERSION}-fips", StagingRegistry, ProductionRegistry),
+			fmt.Sprintf("docker tag %s/gravitational/teleport-operator:$${VERSION} %s/gravitational/teleport-operator:$${VERSION}", StagingRegistry, ProductionRegistry),
 			// authenticate with production credentials
 			"docker logout " + StagingRegistry,
 			"aws ecr-public get-login-password --region=us-east-1 | docker login -u=\"AWS\" --password-stdin " + ProductionRegistry,
@@ -72,6 +74,7 @@ func buildDockerPromotionPipelineECR() pipeline {
 			fmt.Sprintf("docker push %s/gravitational/teleport:$${VERSION}", ProductionRegistry),
 			fmt.Sprintf("docker push %s/gravitational/teleport-ent:$${VERSION}", ProductionRegistry),
 			fmt.Sprintf("docker push %s/gravitational/teleport-ent:$${VERSION}-fips", ProductionRegistry),
+			fmt.Sprintf("docker push %s/gravitational/teleport-operator:$${VERSION}", ProductionRegistry),
 		},
 	})
 
@@ -98,8 +101,6 @@ func buildDockerPromotionPipelineQuay() pipeline {
 		Name:  "Pull/retag Docker images",
 		Image: "docker",
 		Environment: map[string]value{
-			"STAGING_QUAY_USERNAME": {fromSecret: "QUAYIO_DOCKER_USERNAME"},
-			"STAGING_QUAY_PASSWORD": {fromSecret: "QUAYIO_DOCKER_PASSWORD"},
 			"QUAY_USERNAME":         {fromSecret: "PRODUCTION_QUAYIO_DOCKER_USERNAME"},
 			"QUAY_PASSWORD":         {fromSecret: "PRODUCTION_QUAYIO_DOCKER_PASSWORD"},
 			"AWS_ACCESS_KEY_ID":     {fromSecret: "STAGING_TELEPORT_DRONE_USER_ECR_KEY"},
@@ -110,22 +111,20 @@ func buildDockerPromotionPipelineQuay() pipeline {
 			"apk add --no-cache aws-cli",
 			"export VERSION=${DRONE_TAG##v}",
 			// authenticate with staging credentials
-			`docker login -u="$STAGING_QUAY_USERNAME" -p="$STAGING_QUAY_PASSWORD" ` + ProductionRegistryQuay,
 			"aws ecr get-login-password --region=us-west-2 | docker login -u=\"AWS\" --password-stdin " + StagingRegistry,
 			// pull staging images
 			"echo \"---> Pulling images for $${VERSION}\"",
 			fmt.Sprintf("docker pull %s/gravitational/teleport:$${VERSION}", StagingRegistry),
 			fmt.Sprintf("docker pull %s/gravitational/teleport-ent:$${VERSION}", StagingRegistry),
 			fmt.Sprintf("docker pull %s/gravitational/teleport-ent:$${VERSION}-fips", StagingRegistry),
-			fmt.Sprintf("docker pull %s/gravitational/teleport-operator-ci:$${VERSION}", ProductionRegistryQuay),
+			fmt.Sprintf("docker pull %s/gravitational/teleport-operator:$${VERSION}", StagingRegistry),
 			// retag images to production naming
 			"echo \"---> Tagging images for $${VERSION}\"",
 			fmt.Sprintf("docker tag %s/gravitational/teleport:$${VERSION} %s/gravitational/teleport:$${VERSION}", StagingRegistry, ProductionRegistryQuay),
 			fmt.Sprintf("docker tag %s/gravitational/teleport-ent:$${VERSION} %s/gravitational/teleport-ent:$${VERSION}", StagingRegistry, ProductionRegistryQuay),
 			fmt.Sprintf("docker tag %s/gravitational/teleport-ent:$${VERSION}-fips %s/gravitational/teleport-ent:$${VERSION}-fips", StagingRegistry, ProductionRegistryQuay),
-			fmt.Sprintf("docker tag %s/gravitational/teleport-operator-ci:$${VERSION} %s/gravitational/teleport-operator:$${VERSION}", ProductionRegistryQuay, ProductionRegistryQuay),
+			fmt.Sprintf("docker tag %s/gravitational/teleport-operator:$${VERSION} %s/gravitational/teleport-operator:$${VERSION}", StagingRegistry, ProductionRegistryQuay),
 			// authenticate with production credentials
-			"docker logout " + ProductionRegistryQuay,
 			"docker logout " + StagingRegistry,
 			"docker login -u=\"$QUAY_USERNAME\" -p=\"$QUAY_PASSWORD\" " + ProductionRegistryQuay,
 			// push production images


### PR DESCRIPTION
This PR updates `.drone.yml` to leverage amazon ECR for the internal staging registry and is a part of [RFD 73](https://github.com/gravitational/teleport/blob/master/rfd/0073-public-image-registry.md). 

## Testing
[Drone build showing successful docker build](https://github.com/gravitational/ops/blob/master/houston/k8s/poddisruptionbudget.yaml)