### PR TITLE
Move prometheus collectors from `utils` to `metrics`

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -72,6 +72,7 @@ import (
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -96,7 +97,7 @@ type ServerOption func(*Server) error
 
 // NewServer creates and configures a new Server instance
 func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
-	err := utils.RegisterPrometheusCollectors(prometheusCollectors...)
+	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/joinserver"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
@@ -4231,7 +4232,7 @@ func (cfg *GRPCServerConfig) CheckAndSetDefaults() error {
 
 // NewGRPCServer returns a new instance of GRPC server
 func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
-	err := utils.RegisterPrometheusCollectors(heartbeatConnectionsReceived, watcherEventsEmitted, watcherEventSizes, connectedResources)
+	err := metrics.RegisterPrometheusCollectors(heartbeatConnectionsReceived, watcherEventsEmitted, watcherEventSizes, connectedResources)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/multiplexer"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -135,8 +136,8 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	}
 
 	// sets up grpc metrics interceptor
-	grpcMetrics := utils.CreateGRPCServerMetrics(cfg.Metrics.GRPCServerLatency, prometheus.Labels{teleport.TagServer: "teleport-auth"})
-	err = utils.RegisterPrometheusCollectors(grpcMetrics)
+	grpcMetrics := metrics.CreateGRPCServerMetrics(cfg.Metrics.GRPCServerLatency, prometheus.Labels{teleport.TagServer: "teleport-auth"})
+	err = metrics.RegisterPrometheusCollectors(grpcMetrics)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	cq "github.com/gravitational/teleport/lib/utils/concurrentqueue"
@@ -187,7 +188,7 @@ var _ backend.Backend = &EtcdBackend{}
 
 // New returns new instance of Etcd-powered backend
 func New(ctx context.Context, params backend.Params) (*EtcdBackend, error) {
-	err := utils.RegisterPrometheusCollectors(prometheusCollectors...)
+	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -21,12 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/types"
-	apiutils "github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/lib/observability/tracing"
-	"github.com/gravitational/teleport/lib/utils"
-
 	"github.com/gravitational/trace"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/jonboulle/clockwork"
@@ -34,6 +28,12 @@ import (
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+	"github.com/gravitational/teleport/lib/observability/tracing"
 )
 
 const reporterDefaultCacheSize = 1000
@@ -86,7 +86,7 @@ type Reporter struct {
 
 // NewReporter returns a new Reporter.
 func NewReporter(cfg ReporterConfig) (*Reporter, error) {
-	err := utils.RegisterPrometheusCollectors(prometheusCollectors...)
+	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/bpf/command.go
+++ b/lib/bpf/command.go
@@ -20,10 +20,10 @@ limitations under the License.
 package bpf
 
 import (
-	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/utils"
-
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 
 	"github.com/aquasecurity/libbpfgo"
 	"github.com/prometheus/client_golang/prometheus"
@@ -79,7 +79,7 @@ type exec struct {
 // startExec will load, start, and pull events off the ring buffer
 // for the BPF program.
 func startExec(bufferSize int) (*exec, error) {
-	err := utils.RegisterPrometheusCollectors(lostCommandEvents)
+	err := metrics.RegisterPrometheusCollectors(lostCommandEvents)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/bpf/disk.go
+++ b/lib/bpf/disk.go
@@ -20,9 +20,10 @@ limitations under the License.
 package bpf
 
 import (
-	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 
 	"github.com/aquasecurity/libbpfgo"
 	"github.com/prometheus/client_golang/prometheus"
@@ -75,7 +76,7 @@ type open struct {
 // startOpen will compile, load, start, and pull events off the perf buffer
 // for the BPF program.
 func startOpen(bufferSize int) (*open, error) {
-	err := utils.RegisterPrometheusCollectors(lostDiskEvents)
+	err := metrics.RegisterPrometheusCollectors(lostDiskEvents)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/bpf/network.go
+++ b/lib/bpf/network.go
@@ -21,9 +21,10 @@ package bpf
 
 import (
 	"github.com/aquasecurity/libbpfgo"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport/lib/observability/metrics"
 
 	"github.com/gravitational/teleport"
 
@@ -104,7 +105,7 @@ type conn struct {
 }
 
 func startConn(bufferSize int) (*conn, error) {
-	err := utils.RegisterPrometheusCollectors(lostNetworkEvents)
+	err := metrics.RegisterPrometheusCollectors(lostNetworkEvents)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -658,7 +659,7 @@ const (
 
 // New creates a new instance of Cache
 func New(config Config) (*Cache, error) {
-	if err := utils.RegisterPrometheusCollectors(cacheCollectors...); err != nil {
+	if err := metrics.RegisterPrometheusCollectors(cacheCollectors...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if err := config.CheckAndSetDefaults(); err != nil {

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -220,7 +221,7 @@ func (a *AuditLogConfig) CheckAndSetDefaults() error {
 // NewAuditLog creates and returns a new Audit Log object which will store its log files in
 // a given directory.
 func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
-	err := utils.RegisterPrometheusCollectors(prometheusCollectors...)
+	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -272,7 +273,7 @@ type event struct {
 // New returns new instance of Firestore backend.
 // It's an implementation of backend API's NewFunc
 func New(cfg EventsConfig) (*Log, error) {
-	err := utils.RegisterPrometheusCollectors(prometheusCollectors...)
+	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -25,11 +25,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/session"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+	"github.com/gravitational/teleport/lib/session"
 
 	"cloud.google.com/go/storage"
 	"github.com/prometheus/client_golang/prometheus"
@@ -188,7 +189,7 @@ func DefaultNewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 
 // NewHandler returns a new handler with specific context, cancelFunc, and client
 func NewHandler(ctx context.Context, cancelFunc context.CancelFunc, cfg Config, client *storage.Client) (*Handler, error) {
-	err := utils.RegisterPrometheusCollectors(prometheusCollectors...)
+	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/observability/metrics/dynamo/api.go
+++ b/lib/observability/metrics/dynamo/api.go
@@ -23,7 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 )
 
 // APIMetrics wraps a dynamodbiface.DynamoDBAPI implementation and
@@ -35,7 +35,7 @@ type APIMetrics struct {
 
 // NewAPIMetrics returns a new APIMetrics for the provided TableType
 func NewAPIMetrics(tableType TableType, api dynamodbiface.DynamoDBAPI) (*APIMetrics, error) {
-	if err := utils.RegisterPrometheusCollectors(dynamoCollectors...); err != nil {
+	if err := metrics.RegisterPrometheusCollectors(dynamoCollectors...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/observability/metrics/dynamo/streams.go
+++ b/lib/observability/metrics/dynamo/streams.go
@@ -23,7 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams/dynamodbstreamsiface"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 )
 
 // StreamsMetricsAPI wraps a dynamodbstreamsiface.DynamoDBStreamsAPI implementation and
@@ -35,7 +35,7 @@ type StreamsMetricsAPI struct {
 
 // NewStreamsMetricsAPI returns a new StreamsMetricsAPI for the provided TableType
 func NewStreamsMetricsAPI(tableType TableType, api dynamodbstreamsiface.DynamoDBStreamsAPI) (*StreamsMetricsAPI, error) {
-	if err := utils.RegisterPrometheusCollectors(dynamoCollectors...); err != nil {
+	if err := metrics.RegisterPrometheusCollectors(dynamoCollectors...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/observability/metrics/prometheus.go
+++ b/lib/observability/metrics/prometheus.go
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package metrics
 
 import (
 	"runtime"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	om "github.com/grpc-ecosystem/go-grpc-middleware/providers/openmetrics/v2"
-
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport"
 )
 
 // RegisterPrometheusCollectors is a wrapper around prometheus.Register that

--- a/lib/observability/metrics/s3/api.go
+++ b/lib/observability/metrics/s3/api.go
@@ -23,7 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 )
 
 type APIMetrics struct {
@@ -31,7 +31,7 @@ type APIMetrics struct {
 }
 
 func NewAPIMetrics(api s3iface.S3API) (*APIMetrics, error) {
-	if err := utils.RegisterPrometheusCollectors(s3Collectors...); err != nil {
+	if err := metrics.RegisterPrometheusCollectors(s3Collectors...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/observability/metrics/s3/manager.go
+++ b/lib/observability/metrics/s3/manager.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 )
 
 type UploadAPIMetrics struct {
@@ -32,7 +32,7 @@ type UploadAPIMetrics struct {
 }
 
 func NewUploadAPIMetrics(api s3manageriface.UploaderAPI) (*UploadAPIMetrics, error) {
-	if err := utils.RegisterPrometheusCollectors(s3Collectors...); err != nil {
+	if err := metrics.RegisterPrometheusCollectors(s3Collectors...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -53,7 +53,7 @@ type DownloadAPIMetrics struct {
 }
 
 func NewDownloadAPIMetrics(api s3manageriface.DownloaderAPI) (*DownloadAPIMetrics, error) {
-	if err := utils.RegisterPrometheusCollectors(s3Collectors...); err != nil {
+	if err := metrics.RegisterPrometheusCollectors(s3Collectors...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/proxy/clientmetrics.go
+++ b/lib/proxy/clientmetrics.go
@@ -15,10 +15,10 @@
 package proxy
 
 import (
-	"github.com/gravitational/teleport/lib/utils"
-
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport/lib/observability/metrics"
 )
 
 const (
@@ -30,7 +30,7 @@ const (
 	errorProxyPeerProxiesUnreachable = "PROXIES_UNREACHABLE"
 )
 
-// clientMetrics represents a collection of metrics for a proxy peer client
+// clientMetrics represents a collection of grpcMetrics for a proxy peer client
 type clientMetrics struct {
 	dialErrors      *prometheus.CounterVec
 	connections     *prometheus.GaugeVec
@@ -41,7 +41,7 @@ type clientMetrics struct {
 	messageReceived *prometheus.HistogramVec
 }
 
-// newClientMetrics inits and registers client metrics prometheus collectors.
+// newClientMetrics inits and registers client grpcMetrics prometheus collectors.
 func newClientMetrics() (*clientMetrics, error) {
 	cm := &clientMetrics{
 		dialErrors: prometheus.NewCounterVec(
@@ -117,7 +117,7 @@ func newClientMetrics() (*clientMetrics, error) {
 		),
 	}
 
-	if err := utils.RegisterPrometheusCollectors(
+	if err := metrics.RegisterPrometheusCollectors(
 		cm.dialErrors,
 		cm.connections,
 		cm.rpcs,

--- a/lib/proxy/reporter.go
+++ b/lib/proxy/reporter.go
@@ -23,7 +23,7 @@ import (
 // messageByteBuckets creates buckets ranging from 32-65536 bytes.
 var messageByteBuckets = prometheus.ExponentialBuckets(32, 2, 12)
 
-type metrics interface {
+type grpcMetrics interface {
 	getConnectionGauge() *prometheus.GaugeVec
 	getRPCGauge() *prometheus.GaugeVec
 	getRPCCounter() *prometheus.CounterVec
@@ -32,16 +32,16 @@ type metrics interface {
 	getMessageReceived() *prometheus.HistogramVec
 }
 
-// reporter is grpc request specific metrics reporter.
+// reporter is grpc request specific grpcMetrics reporter.
 type reporter struct {
-	metrics
+	grpcMetrics
 }
 
 // newReporter returns a new reporter object that is used to
-// report metrics relative to proxy peer client or server.
-func newReporter(m metrics) *reporter {
+// report grpcMetrics relative to proxy peer client or server.
+func newReporter(m grpcMetrics) *reporter {
 	return &reporter{
-		metrics: m,
+		grpcMetrics: m,
 	}
 }
 

--- a/lib/proxy/servermetrics.go
+++ b/lib/proxy/servermetrics.go
@@ -15,13 +15,13 @@
 package proxy
 
 import (
-	"github.com/gravitational/teleport/lib/utils"
-
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport/lib/observability/metrics"
 )
 
-// serverMetrics represents a collection of metrics for a proxy peer server
+// serverMetrics represents a collection of grpcMetrics for a proxy peer server
 type serverMetrics struct {
 	connections     *prometheus.GaugeVec
 	rpcs            *prometheus.GaugeVec
@@ -31,7 +31,7 @@ type serverMetrics struct {
 	messageReceived *prometheus.HistogramVec
 }
 
-// newServerMetrics inits and registers client metrics prometheus collectors.
+// newServerMetrics inits and registers client grpcMetrics prometheus collectors.
 func newServerMetrics() (*serverMetrics, error) {
 	sm := &serverMetrics{
 		connections: prometheus.NewGaugeVec(
@@ -97,7 +97,7 @@ func newServerMetrics() (*serverMetrics, error) {
 		),
 	}
 
-	if err := utils.RegisterPrometheusCollectors(
+	if err := metrics.RegisterPrometheusCollectors(
 		sm.connections,
 		sm.rpcs,
 		sm.rpcTotal,

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/forward"
@@ -44,7 +45,7 @@ import (
 )
 
 func newlocalSite(srv *server, domainName string, authServers []string) (*localSite, error) {
-	err := utils.RegisterPrometheusCollectors(localClusterCollectors...)
+	err := metrics.RegisterPrometheusCollectors(localClusterCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshca"
@@ -269,7 +270,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 // NewServer creates and returns a reverse tunnel server which is fully
 // initialized but hasn't been started yet
 func NewServer(cfg Config) (Server, error) {
-	err := utils.RegisterPrometheusCollectors(prometheusCollectors...)
+	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -1131,8 +1132,8 @@ func (process *TeleportProcess) newClientDirect(authServers []utils.NetAddr, tls
 
 	var dialOpts []grpc.DialOption
 	if role == types.RoleProxy {
-		grpcMetrics := utils.CreateGRPCClientMetrics(process.Config.Metrics.GRPCClientLatency, prometheus.Labels{teleport.TagClient: "teleport-proxy"})
-		if err := utils.RegisterPrometheusCollectors(grpcMetrics); err != nil {
+		grpcMetrics := metrics.CreateGRPCClientMetrics(process.Config.Metrics.GRPCClientLatency, prometheus.Labels{teleport.TagClient: "teleport-proxy"})
+		if err := metrics.RegisterPrometheusCollectors(grpcMetrics); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		dialOpts = append(dialOpts, []grpc.DialOption{

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -21,11 +21,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 )
 
 type componentStateEnum byte
@@ -69,7 +70,7 @@ type componentState struct {
 
 // newProcessState returns a new FSM that tracks the state of the Teleport process.
 func newProcessState(process *TeleportProcess) (*processState, error) {
-	err := utils.RegisterPrometheusCollectors(stateGauge)
+	err := metrics.RegisterPrometheusCollectors(stateGauge)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 var clusterNameNotFound = prometheus.NewCounter(
@@ -45,7 +45,7 @@ type ClusterConfigurationService struct {
 
 // NewClusterConfigurationService returns a new ClusterConfigurationService.
 func NewClusterConfigurationService(backend backend.Backend) (*ClusterConfigurationService, error) {
-	err := utils.RegisterPrometheusCollectors(clusterNameNotFound)
+	err := metrics.RegisterPrometheusCollectors(clusterNameNotFound)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -32,6 +32,7 @@ import (
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
@@ -96,7 +97,7 @@ type AuthHandlers struct {
 
 // NewAuthHandlers initializes authorization and authentication handlers
 func NewAuthHandlers(config *AuthHandlerConfig) (*AuthHandlers, error) {
-	err := utils.RegisterPrometheusCollectors(prometheusCollectors...)
+	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -36,6 +36,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
@@ -189,7 +190,7 @@ func (p *proxySubsysRequest) SetDefaults() {
 // a port forwarding request, used to implement ProxyJump feature in proxy
 // and reuse the code
 func newProxySubsys(ctx *srv.ServerContext, srv *Server, req proxySubsysRequest) (*proxySubsys, error) {
-	err := utils.RegisterPrometheusCollectors(prometheusCollectors...)
+	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/pam"
 	restricted "github.com/gravitational/teleport/lib/restrictedsession"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -692,7 +693,7 @@ func New(addr utils.NetAddr,
 	auth auth.ClientI,
 	options ...ServerOption,
 ) (*Server, error) {
-	err := utils.RegisterPrometheusCollectors(userSessionLimitHitCount)
+	err := metrics.RegisterPrometheusCollectors(userSessionLimitHitCount)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/filesessions"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
@@ -130,7 +131,7 @@ func NewSessionRegistry(cfg SessionRegistryConfig) (*SessionRegistry, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	err := utils.RegisterPrometheusCollectors(serverSessions)
+	err := metrics.RegisterPrometheusCollectors(serverSessions)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -164,7 +165,7 @@ func NewServer(
 	ah AuthMethods,
 	opts ...ServerOption,
 ) (*Server, error) {
-	err := utils.RegisterPrometheusCollectors(proxyConnectionLimitHitCount)
+	err := metrics.RegisterPrometheusCollectors(proxyConnectionLimitHitCount)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -21,12 +21,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/tool/teleport/common"
 )
 
 func init() {
-	utils.RegisterPrometheusCollectors(utils.BuildCollector())
+	metrics.RegisterPrometheusCollectors(metrics.BuildCollector())
 	rand.Seed(time.Now().UnixNano())
 }
 


### PR DESCRIPTION
Corresponding e PR: https://github.com/gravitational/teleport.e/pull/506