### PR TITLE
Improve passwordless docs

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -132,10 +132,10 @@ chart.
 
   You can download one of the following .pkg installers for macOS:
 
-  |Link|Binaries|
-  |-|-|
-  |[`teleport-(=teleport.version=).pkg`](https://get.gravitational.com/teleport-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`|
-  |[`tsh-(=teleport.version=).pkg`](https://get.gravitational.com/tsh-(=teleport.version=).pkg)|`tsh`|
+  |Link|Binaries|Additional Info|
+  |-|-|-|
+  |[`teleport-(=teleport.version=).pkg`](https://get.gravitational.com/teleport-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`||
+  |[`tsh-(=teleport.version=).pkg`](https://get.gravitational.com/tsh-(=teleport.version=).pkg)|`tsh`|Supports passwordless login with TouchID|
 
   You can also fetch an installer via the command line: 
 


### PR DESCRIPTION
It took me quite long time to figure out that I need to install tsh sparely with support for touch ID, even though I click link in troubleshooting (https://goteleport.com/docs/access-controls/guides/passwordless/#touch-id-not-usable) few times.

I am open for suggestion with better phrasing etc.