### PR TITLE
Add better handling for common libfido2 errors

### DIFF
--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -544,6 +544,8 @@ func runOnFIDO2Devices(
 	prompt runPrompt,
 	filter deviceFilterFunc,
 	deviceCallback deviceCallbackFunc) error {
+	cb := withRetries(deviceCallback)
+
 	// Do we have readily available devices?
 	knownPaths := make(map[string]struct{}) // filled by findSuitableDevices*
 	prompted := false
@@ -568,7 +570,7 @@ func runOnFIDO2Devices(
 			return trace.Wrap(err)
 		}
 	}
-	dev, requiresPIN, err := selectDevice(ctx, "" /* pin */, devices, deviceCallback)
+	dev, requiresPIN, err := selectDevice(ctx, "" /* pin */, devices, cb)
 	switch {
 	case err != nil:
 		return trace.Wrap(err)
@@ -593,7 +595,7 @@ func runOnFIDO2Devices(
 
 	// Run the callback again with the informed PIN.
 	// selectDevice is used since it correctly deals with cancellation.
-	_, _, err = selectDevice(ctx, pin, []deviceWithInfo{dev}, deviceCallback)
+	_, _, err = selectDevice(ctx, pin, []deviceWithInfo{dev}, cb)
 	return trace.Wrap(err)
 }
 
@@ -681,6 +683,44 @@ func findSuitableDevices(filter deviceFilterFunc, knownPaths map[string]struct{}
 	log.Debugf("FIDO2: Found %v suitable devices", l)
 
 	return devs, nil
+}
+
+// withRetries wraps callback with retries and error handling for commonly seen
+// errors.
+func withRetries(callback deviceCallbackFunc) deviceCallbackFunc {
+	return func(dev FIDODevice, info *deviceInfo, pin string) error {
+		const maxRetries = 3
+		var err error
+		for i := 0; i < maxRetries; i++ {
+			err = callback(dev, info, pin)
+			if err == nil {
+				return err
+			}
+
+			// Important: errors mapped by go-libfido2 aren't returned as
+			// libfido2.Error, instead they have their own specialized (string-based)
+			// constants.
+			var fidoErr libfido2.Error
+			if !errors.As(err, &fidoErr) {
+				return err
+			}
+
+			// See https://github.com/Yubico/libfido2/blob/main/src/fido/err.h#L32.
+			switch fidoErr.Code {
+			case 60: // FIDO_ERR_UV_BLOCKED, 0x3c
+				const msg = "" +
+					"The user verification function in your security key is blocked. " +
+					"This is likely due to too many failed authentication attempts. " +
+					"Consult your manufacturer documentation for how to unblock your security key."
+				return trace.Wrap(err, msg)
+			case 63: // FIDO_ERR_UV_INVALID, 0x3f
+				log.Debug("FIDO2: Retrying libfido2 error 63")
+				continue
+			}
+		}
+
+		return fmt.Errorf("max retry attempts reached: %w", err)
+	}
 }
 
 func selectDevice(

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -1736,7 +1736,8 @@ type fakeFIDO2Device struct {
 	u2fOnly bool
 
 	// assertionErrors is a chain of errors to return from Assertion.
-	// Errors are returned from start to end and removed from the slice.
+	// Errors are returned from start to end and removed, one-by-one, on each
+	// invocation of the Assertion method.
 	// If the slice is empty, Assertion runs normally.
 	assertionErrors []error
 


### PR DESCRIPTION
Improve the error message for libfido2 error 60 (UV blocked) and automatically retry error 63 (UV invalid).

libfido2 error 63 happens with some frequency with Yubikey Bio. The biometric sensor is a bit finicky, so if the finger is a bit off it tends to happen.

Fixes #13900.