### PR TITLE
Pick correct cert when signing Connect

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6371,6 +6371,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: 3be4cf26b1ce2d8c2b72d45c64ccf8b74a96f2a566c3936929e9acc9f7487260
+hmac: 1ac2bbbd3ecc42e83a2d1ef49e5db1c4e4b35567603f9dc9aa231bba79bf0d51
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -570,6 +570,7 @@ steps:
   - export PKG_CONFIG_PATH="$(build.assets/build-fido2-macos.sh pkg_config_path)"
   - rustup override set $RUST_VERSION
   - export BUILD_NUMBER=$DRONE_BUILD_NUMBER
+  - export CSC_NAME=0FFD3E3413AB4C599C53FBB1D8CA690915E33D83
   - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
   - security find-identity -v
   - make clean release OS=$OS ARCH=$ARCH FIDO2=yes TOUCHID=yes
@@ -3291,6 +3292,7 @@ steps:
   - export PKG_CONFIG_PATH="$(build.assets/build-fido2-macos.sh pkg_config_path)"
   - rustup override set $RUST_VERSION
   - export BUILD_NUMBER=$DRONE_BUILD_NUMBER
+  - export CSC_NAME=0FFD3E3413AB4C599C53FBB1D8CA690915E33D83
   - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
   - security find-identity -v
   - make clean release OS=$OS ARCH=$ARCH FIDO2=yes TOUCHID=yes
@@ -6325,6 +6327,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: 8ece36469050311a0d0aa6f30e51f0b66e6e60614447b519ee037ecb21b13832
+hmac: 58a2ea33c7fabd9a44137e4da10c114a1d342554d9c3f6e31f254eb573e411c9
 
 ...

--- a/dronegen/mac.go
+++ b/dronegen/mac.go
@@ -348,6 +348,10 @@ func darwinTagBuildCommands(b buildType, opts darwinBuildOptions) []string {
 		// This makes the full app version look like this: 9.3.5.12489
 		// https://www.electron.build/configuration/configuration.html#Configuration-buildVersion
 		`export BUILD_NUMBER=$DRONE_BUILD_NUMBER`,
+		// CSC_NAME tells electron-builder which cert to use for signing when there are multiple certs
+		// available.
+		// https://www.electron.build/code-signing
+		`export CSC_NAME=0FFD3E3413AB4C599C53FBB1D8CA690915E33D83`,
 	}
 
 	if opts.unlockKeychain {


### PR DESCRIPTION
There are multiple Apple Developer ID certs available on our darwin build machines. By default, electron-builder tries to automatically pick one that can be used for signing the app.

However, in gravitational/webapps#1033 we're trying to grant access to Connect so that it can use the same Touch ID Secure Enclave keys as tsh.app. To do that we need to distribute a provisioning profile. A provisioning profile is bound to a single specific Apple Developer ID. Alan and I made it so that the provisioning profile for Connect is going to be bound to the same Dev ID as the provisioning profile for tsh.app.

Unfortunately, the Dev ID cert picked by default by electron-builder is not the one bound to the provisioning profile. This PR makes it so that the correct Dev ID is picked.

This change shouldn't have any effect on the whole process until we add the provisioning profile but [I'm making a tag build](https://drone.platform.teleport.sh/gravitational/teleport/14491/12/1) to verify again that this change doesn't break the signing process. I'll post a link to the signed build once Drone uploads the build.