### PR TITLE
[v9] auditlog: fix panic during concurrent streams of the same session

### DIFF
--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -1051,7 +1051,6 @@ func (l *AuditLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, orde
 // channel if one is encountered. Otherwise the event channel is closed when the stream ends.
 // The event channel is not closed on error to prevent race conditions in downstream select statements.
 func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
-	// TODO(zmb3): check that sessionID is non-emtpy
 	l.log.Debugf("StreamSessionEvents(%v)", sessionID)
 	e := make(chan error, 1)
 	c := make(chan apievents.AuditEvent)

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -1051,6 +1051,7 @@ func (l *AuditLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, orde
 // channel if one is encountered. Otherwise the event channel is closed when the stream ends.
 // The event channel is not closed on error to prevent race conditions in downstream select statements.
 func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
+	// TODO(zmb3): check that sessionID is non-emtpy
 	l.log.Debugf("StreamSessionEvents(%v)", sessionID)
 	e := make(chan error, 1)
 	c := make(chan apievents.AuditEvent)
@@ -1067,8 +1068,10 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 			e <- trace.BadParameter("audit log is closing, aborting the download")
 			return c, e
 		}
+	} else {
+		defer cancel()
 	}
-	defer cancel()
+
 	rawSession, err := os.OpenFile(tarballPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0640)
 	if err != nil {
 		e <- trace.Wrap(err)

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -200,6 +200,17 @@ func (u *UploadCompleter) checkUploads(ctx context.Context) error {
 
 		uploadData := u.cfg.Uploader.GetUploadMetadata(upload.SessionID)
 
+		// It's possible that we don't have a session ID here. For example,
+		// an S3 multipart upload may have been completed by another auth
+		// server, in which case the API returns an empty key, leaving us
+		// no way to derive the session ID from the upload.
+		//
+		// If this is the case, there's no work left to do, and we can
+		// proceed to the next upload.
+		if uploadData.SessionID == "" {
+			continue
+		}
+
 		// Schedule a background operation to check for (and emit) a session end event.
 		// This is necessary because we'll need to download the session in order to
 		// enumerate its events, and the S3 API takes a little while after the upload


### PR DESCRIPTION
The code attempts to wait on an existing download if one is already
in progress rather than starting a concurrent download of the same
session. If this code path runs, we incorrectly defer a call to a
nil function, triggering a panic.

This bug was introduced in #7360.

Fixes #15349