### PR TITLE
[backport v10] Make dir before trying to open config file on `teleport configure --output=/some/dir `

### DIFF
--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -576,6 +577,18 @@ func dumpConfigFile(outputURI, contents, comment string) (string, error) {
 		if !filepath.IsAbs(uri.Path) {
 			return "", trace.BadParameter("please use absolute path for file %v", uri.Path)
 		}
+
+		configDir := path.Dir(outputURI)
+		err := os.MkdirAll(configDir, 0755)
+		err = trace.ConvertSystemError(err)
+		if err != nil {
+			if trace.IsAccessDenied(err) {
+				return "", trace.Wrap(err, "permission denied creating directory %s", configDir)
+			}
+
+			return "", trace.Wrap(err, "error creating config file directory %s", configDir)
+		}
+
 		f, err := os.OpenFile(uri.Path, os.O_RDWR|os.O_CREATE|os.O_EXCL, teleport.FileMaskOwnerOnly)
 		err = trace.ConvertSystemError(err)
 		if err != nil {

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -171,6 +172,34 @@ func TestConfigure(t *testing.T) {
 		err := flags.CheckAndSetDefaults()
 		require.NoError(t, err)
 	})
+}
+
+func TestDumpConfigFile(t *testing.T) {
+	tt := []struct {
+		name      string
+		outputURI string
+		contents  string
+		comment   string
+		assert    require.ErrorAssertionFunc
+	}{
+		{
+			name:      "errors on relative path",
+			assert:    require.Error,
+			outputURI: "../",
+		},
+		{
+			name:      "doesn't error on unexisting config path",
+			assert:    require.NoError,
+			outputURI: fmt.Sprintf("%s/unexisting/dir/%s", t.TempDir(), "config.yaml"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := dumpConfigFile(tc.outputURI, tc.contents, tc.comment)
+			tc.assert(t, err)
+		})
+	}
 }
 
 const configData = `


### PR DESCRIPTION
This pr backports https://github.com/gravitational/teleport/pull/14691 to v10.

Basically, make sure the path in `--output` exists before trying to write the output to it.