### PR TITLE
Update helm chart snapshots and tests for amazon ECR Public

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -538,7 +538,7 @@ If you are deploying multiple releases of the Helm chart in the same cluster you
 
 | Type | Default value | Can be used in `custom` mode? |
 | - | - | - |
-| `string` | `quay.io/gravitational/teleport-operator`| ✅ |
+| `string` | `public.ecr.aws/gravitational/teleport-operator`| ✅ |
 
 `operator.image` sets the Teleport Kubernetes Operator container image used for Teleport pods in the cluster.
 You can override this to use your own Teleport Operator image rather than a Teleport-published image.
@@ -1176,7 +1176,7 @@ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.pem
 
 | Type | Default value | Can be used in `custom` mode? |
 | - | - | - |
-| `string` | `quay.io/gravitational/teleport` | ✅ |
+| `string` | `public.ecr.aws/gravitational/teleport` | ✅ |
 
 `image` sets the Teleport container image used for Teleport Community pods in the cluster.
 
@@ -1199,7 +1199,7 @@ You can override this to use your own Teleport Community image rather than a Tel
 
 | Type | Default value | Can be used in `custom` mode? |
 | - | - | - |
-| `string` | `quay.io/gravitational/teleport-ent` | ✅ |
+| `string` | `public.ecr.aws/gravitational/teleport-ent` | ✅ |
 
 `enterpriseImage` sets the container image used for Teleport Enterprise pods in the cluster.
 

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -731,7 +731,7 @@ The size of persistent volume to create.
 
 | Type | Default value |
 | - | - |
-| `string` | `quay.io/gravitational/teleport` |
+| `string` | `public.ecr.aws/gravitational/teleport` |
 
 `image` sets the container image used for Teleport pods run by the `teleport-kube-agent` chart.
 

--- a/examples/chart/teleport-cluster/README.md
+++ b/examples/chart/teleport-cluster/README.md
@@ -35,8 +35,8 @@ secret `license` in the chart namespace.
 | `clusterName`              | Teleport cluster name (must be an FQDN)                                     |                                                  | yes      |
 | `authentication.type`      | Type of authentication to use (`local`, `github`, ...)                      | `local`                                          | no       |
 | `teleportVersionOverride`  | Teleport version                                                            | Current stable version                           | no       |
-| `image`                    | OSS Docker image                                                            | `quay.io/gravitational/teleport`                 | no       |
-| `enterpriseImage`          | Enterprise Docker image                                                     | `quay.io/gravitational/teleport-ent`             | no       |
+| `image`                    | OSS Docker image                                                            | `public.ecr.aws/gravitational/teleport`                 | no       |
+| `enterpriseImage`          | Enterprise Docker image                                                     | `public.ecr.aws/gravitational/teleport-ent`             | no       |
 | `acme`                     | Enable ACME support in Teleport (Letsencrypt.org)                           | `false`                                          | no       |
 | `acmeEmail`                | Email to use for ACME certificates                                          |                                                  | no       |
 | `acmeURI`                  | ACME server to use for certificates                                         | `https://acme-v02.api.letsencrypt.org/directory` | no       |

--- a/examples/chart/teleport-cluster/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/deployment_test.yaml.snap
@@ -3,7 +3,7 @@ sets Deployment annotations when specified:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -48,7 +48,7 @@ sets Pod annotations when specified:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -93,7 +93,7 @@ should add PersistentVolumeClaim as volume when in custom mode and persistence.e
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -138,7 +138,7 @@ should add PersistentVolumeClaim as volume when in standalone mode and persisten
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -180,7 +180,7 @@ should add PersistentVolumeClaim as volume when in standalone mode and persisten
         claimName: RELEASE-NAME
 should add an operator side-car when operator is enabled:
   1: |
-    image: quay.io/gravitational/teleport-operator:11.0.0-dev
+    image: public.ecr.aws/gravitational/teleport-operator:11.0.0-dev
     imagePullPolicy: IfNotPresent
     livenessProbe:
       httpGet:
@@ -218,7 +218,7 @@ should add emptyDir for data in AWS mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -274,7 +274,7 @@ should add emptyDir for data in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -322,7 +322,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --insecure
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -367,7 +367,7 @@ should add named PersistentVolumeClaim as volume when in custom mode and persist
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -413,7 +413,7 @@ should add named PersistentVolumeClaim as volume when in custom mode and persist
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -458,7 +458,7 @@ should do enterprise things when when enterprise is set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport-ent:8.3.4
+      image: public.ecr.aws/gravitational/teleport-ent:8.3.4
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -509,7 +509,7 @@ should expose diag port:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -554,7 +554,7 @@ should have Recreate strategy in standalone mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -611,7 +611,7 @@ should have multiple replicas when replicaCount is set:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -668,7 +668,7 @@ should mount ConfigMap for config in AWS mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -724,7 +724,7 @@ should mount ConfigMap for config in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -771,7 +771,7 @@ should mount ConfigMap for config in custom mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -816,7 +816,7 @@ should mount ConfigMap for config in standalone mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -873,7 +873,7 @@ should mount GCP credentials for initContainer in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -946,7 +946,7 @@ should mount GCP credentials in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1005,7 +1005,7 @@ should mount TLS certs for initContainer when cert-manager is enabled:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1087,7 +1087,7 @@ should mount TLS certs when cert-manager is enabled:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1152,7 +1152,7 @@ should mount cert-manager TLS secret when highAvailability.certManager.enabled i
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1203,7 +1203,7 @@ should mount extraVolumes and extraVolumeMounts:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1256,7 +1256,7 @@ should mount tls.existingCASecretName and set environment when set in values:
       env:
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1318,7 +1318,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: some-value
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1375,7 +1375,7 @@ should mount tls.existingSecretName when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1426,7 +1426,7 @@ should not add PersistentVolumeClaim as volume when in custom mode and persisten
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1470,7 +1470,7 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1515,7 +1515,7 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1560,7 +1560,7 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1604,7 +1604,7 @@ should not do enterprise things when when enterprise is not set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:8.3.4
+      image: public.ecr.aws/gravitational/teleport:8.3.4
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1649,7 +1649,7 @@ should not have more than one replica in standalone mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1706,7 +1706,7 @@ should not have strategy in AWS mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1762,7 +1762,7 @@ should not have strategy in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1809,7 +1809,7 @@ should not have strategy in custom mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1854,7 +1854,7 @@ should not mount TLS secrets when when highAvailability.certManager.enabled is f
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1899,7 +1899,7 @@ should not set securityContext when is empty object (default value):
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1947,7 +1947,7 @@ should provision initContainer correctly when set in values:
       env:
       - name: SOME_ENVIRONMENT_VARIABLE
         value: some-value
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2026,7 +2026,7 @@ should set affinity when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2074,7 +2074,7 @@ should set environment when extraEnv set in values:
       env:
       - name: SOME_ENVIRONMENT_VARIABLE
         value: some-value
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2119,7 +2119,7 @@ should set imagePullPolicy when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2164,7 +2164,7 @@ should set postStart command if set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       lifecycle:
         postStart:
@@ -2215,7 +2215,7 @@ should set priorityClassName when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2261,7 +2261,7 @@ should set probeTimeoutSeconds when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2316,7 +2316,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2360,7 +2360,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2412,7 +2412,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2476,7 +2476,7 @@ should set tolerations when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-cluster/tests/deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/deployment_test.yaml
@@ -160,7 +160,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: quay.io/gravitational/teleport-ent:8.3.4
+          value: public.ecr.aws/gravitational/teleport-ent:8.3.4
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -183,7 +183,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: quay.io/gravitational/teleport:8.3.4
+          value: public.ecr.aws/gravitational/teleport:8.3.4
       - notContains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -232,7 +232,7 @@
                 "image": {
                     "$id": "#/properties/operator/properties/image",
                     "type": "string",
-                    "default": "quay.io/gravitational/teleport-operator"
+                    "default": "public.ecr.aws/gravitational/teleport-operator"
                 },
                 "resources": {
                     "$id": "#/properties/operator/properties/resources",
@@ -560,12 +560,12 @@
         "image": {
             "$id": "#/properties/image",
             "type": "string",
-            "default": "quay.io/gravitational/teleport"
+            "default": "public.ecr.aws/gravitational/teleport"
         },
         "enterpriseImage": {
             "$id": "#/properties/enterpriseImage",
             "type": "string",
-            "default": "quay.io/gravitational/teleport-ent"
+            "default": "public.ecr.aws/gravitational/teleport-ent"
         },
         "logLevel": {
             "$id": "#/properties/logLevel",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -129,7 +129,7 @@ operator:
   # Set enabled to true to add the Kubernetes Teleport Operator
   enabled: false
   # Kubernetes Teleport Operator image
-  image: quay.io/gravitational/teleport-operator
+  image: public.ecr.aws/gravitational/teleport-operator
   # Resources to request for the operator container
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources: {}
@@ -288,9 +288,9 @@ tls:
 ##################################################
 
 # Container image for the cluster.
-image: quay.io/gravitational/teleport
+image: public.ecr.aws/gravitational/teleport
 # Enterprise version of the image
-enterpriseImage: quay.io/gravitational/teleport-ent
+enterpriseImage: public.ecr.aws/gravitational/teleport-ent
 # Teleport logging configuration
 log:
   # Log level for the Teleport process.

--- a/examples/chart/teleport-kube-agent/.lint/imagepullsecrets.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/imagepullsecrets.yaml
@@ -2,6 +2,6 @@ authToken: auth-token
 proxyAddr: proxy.example.com:3080
 roles: kube
 kubeClusterName: test-kube-cluster
-image: quay.io/gravitational/teleport
+image: public.ecr.aws/gravitational/teleport
 imagePullSecrets:
 - name: myRegistryKeySecretName

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets Deployment annotations when specified if action is Upgrade:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: quay.io/gravitational/teleport:11.0.0-dev
+            image: public.ecr.aws/gravitational/teleport:11.0.0-dev
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -95,7 +95,7 @@ sets Deployment labels when specified if action is Upgrade:
         containers:
         - args:
           - --diag-addr=0.0.0.0:3000
-          image: quay.io/gravitational/teleport:11.0.0-dev
+          image: public.ecr.aws/gravitational/teleport:11.0.0-dev
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -150,7 +150,7 @@ sets Pod annotations when specified if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -205,7 +205,7 @@ sets Pod labels when specified if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -260,7 +260,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -316,7 +316,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
     - args:
       - --diag-addr=0.0.0.0:3000
       - --insecure
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -371,7 +371,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -424,7 +424,7 @@ should expose diag port if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -491,7 +491,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -558,7 +558,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -613,7 +613,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -668,7 +668,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -731,7 +731,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
       env:
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -797,7 +797,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -858,7 +858,7 @@ should provision initContainer correctly when set in values if action is Upgrade
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -949,7 +949,7 @@ should set SecurityContext if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1024,7 +1024,7 @@ should set affinity when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1079,7 +1079,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1137,7 +1137,7 @@ should set environment when extraEnv set in values if action is Upgrade:
       env:
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1192,7 +1192,7 @@ should set image and tag correctly if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:8.3.4
+      image: public.ecr.aws/gravitational/teleport:8.3.4
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1247,7 +1247,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1302,7 +1302,7 @@ should set nodeSelector if set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1359,7 +1359,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1426,7 +1426,7 @@ should set preferred affinity when more than one replica is used if action is Up
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1481,7 +1481,7 @@ should set priorityClassName when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1537,7 +1537,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1602,7 +1602,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1657,7 +1657,7 @@ should set resources when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1719,7 +1719,7 @@ should set serviceAccountName when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1774,7 +1774,7 @@ should set tolerations when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -14,7 +14,7 @@ sets Pod annotations when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -80,7 +80,7 @@ sets Pod labels when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -170,7 +170,7 @@ sets StatefulSet labels when specified:
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: quay.io/gravitational/teleport:11.0.0-dev
+            image: public.ecr.aws/gravitational/teleport:11.0.0-dev
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -247,7 +247,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -313,7 +313,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -399,7 +399,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: quay.io/gravitational/teleport:11.0.0-dev
+            image: public.ecr.aws/gravitational/teleport:11.0.0-dev
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -475,7 +475,7 @@ should add volumeMount for data volume when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -541,7 +541,7 @@ should expose diag port:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -607,7 +607,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -687,7 +687,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -765,7 +765,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -831,7 +831,7 @@ should have one replica when replicaCount is not set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -897,7 +897,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -965,7 +965,7 @@ should mount extraVolumes and extraVolumeMounts:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1038,7 +1038,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: RELEASE-NAME
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1116,7 +1116,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1190,7 +1190,7 @@ should not add emptyDir for data when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1256,7 +1256,7 @@ should provision initContainer correctly when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1358,7 +1358,7 @@ should set SecurityContext:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1444,7 +1444,7 @@ should set affinity when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1510,7 +1510,7 @@ should set default serviceAccountName when not set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1578,7 +1578,7 @@ should set environment when extraEnv set in values:
         value: RELEASE-NAME
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1644,7 +1644,7 @@ should set image and tag correctly:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:8.3.4
+      image: public.ecr.aws/gravitational/teleport:8.3.4
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1710,7 +1710,7 @@ should set imagePullPolicy when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1776,7 +1776,7 @@ should set nodeSelector if set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1856,7 +1856,7 @@ should set preferred affinity when more than one replica is used:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1922,7 +1922,7 @@ should set probeTimeoutSeconds when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1998,7 +1998,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2064,7 +2064,7 @@ should set resources when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2137,7 +2137,7 @@ should set serviceAccountName when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2203,7 +2203,7 @@ should set storage.requests when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2269,7 +2269,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2335,7 +2335,7 @@ should set tolerations when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: quay.io/gravitational/teleport:11.0.0-dev
+      image: public.ecr.aws/gravitational/teleport:11.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
@@ -296,7 +296,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: quay.io/gravitational/teleport:8.3.4
+          value: public.ecr.aws/gravitational/teleport:8.3.4
       - matchSnapshot:
           path: spec.template.spec
 

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -199,7 +199,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: quay.io/gravitational/teleport:8.3.4
+          value: public.ecr.aws/gravitational/teleport:8.3.4
       - matchSnapshot:
           path: spec.template.spec
 

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -199,7 +199,7 @@
         "image": {
             "$id": "#/properties/image",
             "type": "string",
-            "default": "quay.io/gravitational/teleport"
+            "default": "public.ecr.aws/gravitational/teleport"
         },
         "imagePullSecrets": {
             "$id": "#/properties/imagePullSecrets",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -150,7 +150,7 @@ storage:
 
 # Container image for the agent. Since this runs without the auth_service, we
 # don't need the enterprise version.
-image: quay.io/gravitational/teleport
+image: public.ecr.aws/gravitational/teleport
 # Optional array of imagePullSecrets, to use when pulling from a private registry
 imagePullSecrets: []
 # - name: myRegistryKeySecretName


### PR DESCRIPTION
This PR updates the helm-charts to use amazon ECR Public images instead of quay.io and is part of a broader documentation update tracked here: https://github.com/gravitational/cloud/issues/1839

## Testing
Confirmed after updating snapshots that the helm tests pass.