### PR TITLE
Update last report date for SOC 2 report

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1010,7 +1010,7 @@
       "control_url": "https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/control?version=5.1&number="
     },
     "soc2": {
-      "last_report": "April 12th, 2021"
+      "last_report": "August 9th, 2022"
     },
     "cloud": {
       "version": "8.3.4",


### PR DESCRIPTION
Our latest SOC 2 report just came out today, so updating `soc2.last_report` variable.