### PR TITLE
Add info to login command about passwordless

### DIFF
--- a/tool/tsh/help.go
+++ b/tool/tsh/help.go
@@ -21,6 +21,9 @@ const (
 	loginUsageFooter = `NOTES:
   The proxy address format is host:https_port,ssh_proxy_port
 
+  Passwordless only works in local auth
+  --auth=passwordless flag can be omitted if your cluster configuration set the connector_name: passwordless option.
+
 EXAMPLES:
   Use ports 8080 and 8023 for https and SSH proxy:
   $ tsh --proxy=host.example.com:8080,8023 login
@@ -32,7 +35,10 @@ EXAMPLES:
   $ tsh --proxy=host.example.com login two
 
   Select cluster "two" using existing credentials and proxy:
-  $ tsh login two`
+  $ tsh login two
+
+  For passwordless authentication use:
+  $ tsh login --auth=passwordless`
 
 	// missingPrincipalsFooter is printed at the bottom of `tsh ls` when no results are returned.
 	missingPrincipalsFooter = `


### PR DESCRIPTION
Fixes (https://github.com/gravitational/teleport/issues/14311)

Adds following line to `tsh login --help` footer:
```
  ...

  For passwordless access use:
  $ tsh --auth=passwordless login
```

I am not sure if this is good enough or maybe you have some other suggestions
