### PR TITLE
Store AuthConnector in profile

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -71,10 +71,7 @@ type Profile struct {
 	// Username is the Teleport username for the client.
 	Username string `yaml:"user,omitempty"`
 
-	// AuthType (like "google")
-	AuthType string `yaml:"auth_type,omitempty"`
-
-	// SiteName is equivalient to --cluster argument
+	// SiteName is equivalent to the --cluster flag
 	SiteName string `yaml:"cluster,omitempty"`
 
 	// ForwardedPorts is the list of ports to forward to the target node.
@@ -90,6 +87,10 @@ type Profile struct {
 	// TLSRoutingEnabled indicates that proxy supports ALPN SNI server where
 	// all proxy services are exposed on a single TLS listener (Proxy Web Listener).
 	TLSRoutingEnabled bool `yaml:"tls_routing_enabled,omitempty"`
+
+	// AuthConnector (like "google", "passwordless").
+	// Equivalent to the --auth tsh flag.
+	AuthConnector string `yaml:"auth_connector,omitempty"`
 }
 
 // Name returns the name of the profile.

--- a/api/profile/profile_test.go
+++ b/api/profile/profile_test.go
@@ -43,6 +43,7 @@ func TestProfileBasics(t *testing.T) {
 		DynamicForwardedPorts: []string{"localhost:8080"},
 		Dir:                   dir,
 		SiteName:              "example.com",
+		AuthConnector:         "passwordless",
 	}
 
 	// verify that profile name is proxy host component

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1110,6 +1110,7 @@ func (c *Config) LoadProfile(profileDir string, proxyName string) error {
 	c.MongoProxyAddr = cp.MongoProxyAddr
 	c.TLSRoutingEnabled = cp.TLSRoutingEnabled
 	c.KeysDir = profileDir
+	c.AuthConnector = cp.AuthConnector
 
 	c.LocalForwardPorts, err = ParsePortForwardSpec(cp.ForwardedPorts)
 	if err != nil {
@@ -1144,6 +1145,7 @@ func (c *Config) SaveProfile(dir string, makeCurrent bool) error {
 	cp.ForwardedPorts = c.LocalForwardPorts.String()
 	cp.SiteName = c.SiteName
 	cp.TLSRoutingEnabled = c.TLSRoutingEnabled
+	cp.AuthConnector = c.AuthConnector
 
 	if err := cp.SaveToDir(dir, makeCurrent); err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/14764

I think it should be fairly safe to store all auth_connectors, not only the one for passwordless, right?

Moreover I have deleted AuthType which seems to be never used.