### PR TITLE
Allow tctl to set tls-server-name for k8s configs

### DIFF
--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -144,6 +144,8 @@ type WriteConfig struct {
 	// KubeProxyAddr is the public address of the proxy with its kubernetes
 	// port. KubeProxyAddr is only used when Format is FormatKubernetes.
 	KubeProxyAddr string
+	// KubeTLSServerName is the SNI host value passed to the server.
+	KubeTLSServerName string
 	// OverwriteDestination forces all existing destination files to be
 	// overwritten. When false, user will be prompted for confirmation of
 	// overwrite first.
@@ -331,6 +333,7 @@ func Write(cfg WriteConfig) (filesWritten []string, err error) {
 			TeleportClusterName: cfg.Key.ClusterName,
 			ClusterAddr:         cfg.KubeProxyAddr,
 			Credentials:         cfg.Key,
+			TLSServerName:       cfg.KubeTLSServerName,
 		}); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -65,6 +65,7 @@ type AuthCommand struct {
 	proxyAddr                  string
 	leafCluster                string
 	kubeCluster                string
+	kubeTLSServerName          string
 	appName                    string
 	dbService                  string
 	dbName                     string
@@ -120,6 +121,7 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, config *service.Confi
 	a.authSign.Flag("kube-cluster", `Leaf cluster to generate identity file for when --format is set to "kubernetes"`).Hidden().StringVar(&a.leafCluster)
 	a.authSign.Flag("leaf-cluster", `Leaf cluster to generate identity file for when --format is set to "kubernetes"`).StringVar(&a.leafCluster)
 	a.authSign.Flag("kube-cluster-name", `Kubernetes cluster to generate identity file for when --format is set to "kubernetes"`).StringVar(&a.kubeCluster)
+	a.authSign.Flag("kube-tls-server-name", `Kubernetes cluster SNI to pass to the server for when --format is set to "kubernetes"`).StringVar(&a.kubeTLSServerName)
 	a.authSign.Flag("app-name", `Application to generate identity file for. Mutually exclusive with "--db-service".`).StringVar(&a.appName)
 	a.authSign.Flag("db-service", `Database to generate identity file for. Mutually exclusive with "--app-name".`).StringVar(&a.dbService)
 	a.authSign.Flag("db-user", `Database user placed on the identity file. Only used when "--db-service" is set.`).StringVar(&a.dbUser)
@@ -686,6 +688,7 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI auth.Clie
 		Key:                  key,
 		Format:               a.outputFormat,
 		KubeProxyAddr:        a.proxyAddr,
+		KubeTLSServerName:    a.kubeTLSServerName,
 		OverwriteDestination: a.signOverwrite,
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/14489

This allows multiplexed Teleport servers to use the generated TLS cert
(because the SNI is different from the hostname).

It'd be ideal if this could be backported to v9.x, but it's unclear to
me what the process for that is.