### PR TITLE
Use Debug flag in aws scripts

### DIFF
--- a/assets/aws/files/bin/teleport-all-pre-start
+++ b/assets/aws/files/bin/teleport-all-pre-start
@@ -1,7 +1,9 @@
 #!/bin/bash
 # This script prepares a Letsencrypt certificate before all-in-one Teleport starts for the first time (if needed)
 set -e
-set -x
+if [[ "${DEBUG}" == "true" ]]; then
+    set -x
+fi
 
 # Source variables from user-data (if present)
 if [ -f /etc/teleport.d/conf ]; then

--- a/assets/aws/files/bin/teleport-check-cert
+++ b/assets/aws/files/bin/teleport-check-cert
@@ -2,8 +2,9 @@
 
 # This script is called hourly to check if the certificate
 # has been renewed on S3 and if it has been renewed, restart teleport proxies
-
-set -x
+if [[ "${DEBUG}" == "true" ]]; then
+    set -x
+fi
 
 # Source variables from user-data
 . /etc/teleport.d/conf

--- a/assets/aws/files/bin/teleport-get-cert
+++ b/assets/aws/files/bin/teleport-get-cert
@@ -4,7 +4,9 @@
 # to prove to letsencrypt that they own the domain.
 
 set -e
-set -x
+if [[ "${DEBUG}" == "true" ]]; then
+    set -x
+fi
 
 # Source variables from user-data
 . /etc/teleport.d/conf

--- a/assets/aws/files/bin/teleport-lock
+++ b/assets/aws/files/bin/teleport-lock
@@ -2,8 +2,11 @@
 # Locking service makes sure that there is only one auth server performing certain action,
 # for example renewing or getting letsencrypt certificates
 
-set -x
 set -e
+if [[ "${DEBUG}" == "true" ]]; then
+    set -x
+fi
+
 
 # Source variables from user-data
 . /etc/teleport.d/conf

--- a/assets/aws/files/bin/teleport-renew-cert
+++ b/assets/aws/files/bin/teleport-renew-cert
@@ -4,7 +4,9 @@
 # needs renewal, and renews the cert after that
 
 set -e
-set -x
+if [[ "${DEBUG}" == "true" ]]; then
+    set -x
+fi
 
 # Source variables from user-data
 . /etc/teleport.d/conf

--- a/assets/aws/files/bin/teleport-upload-cert
+++ b/assets/aws/files/bin/teleport-upload-cert
@@ -2,7 +2,9 @@
 # This script is called to upload renewed cert
 # to the S3 bucket
 set -e
-set -x
+if [[ "${DEBUG}" == "true" ]]; then
+    set -x
+fi
 
 # Source variables from user-data
 . /etc/teleport.d/conf

--- a/assets/aws/files/install.sh
+++ b/assets/aws/files/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -x
+if [[ "${DEBUG}" == "true" ]]; then
+    set -x
+fi
 
 # Update packages
 yum -y update


### PR DESCRIPTION
Wrap set -x with DEBUG check to prevent inadvertently logging secrets, such as join tokens held in the /etc/teleport.d/conf.

This was requested in #dev-teleport-support