### PR TITLE
docs: Improve cloud security/compliance documentation

### DIFF
--- a/docs/pages/cloud/architecture.mdx
+++ b/docs/pages/cloud/architecture.mdx
@@ -1,14 +1,14 @@
 ---
 title: Teleport Cloud Architecture
-description: Cloud security, availability and networking details.
+description: Cloud security, availability, and networking details.
 ---
 
 ## Security
 
-We have designed the Teleport Cloud environment to be secure; however we are still in the process of
-scrutinizing and executing on our security roadmap and working with independent security
-auditors to identify any gaps. Only once this is complete, the team will evaluate
-whether the Teleport Cloud is ready for strict compliance use-cases.
+We have designed the Teleport Cloud environment to be secure. We work with independent
+security auditors on a regular basis to identify and correct any gaps, while also
+continuing to iterate on improvements to fortify the platform for the most strict of
+compliance use-cases.
 
 ## Compliance
 
@@ -18,7 +18,7 @@ whether the Teleport Cloud is ready for strict compliance use-cases.
 
 SSH sessions are recorded [on nodes](../architecture/nodes.mdx).
 Teleport Cloud Proxy does not terminate SSH sessions when using OpenSSH and `tsh` sessions.
-The Cloud Proxy terminates TLS for Application, Database and Kubernetes sessions.
+The Cloud Proxy terminates TLS for Application, Database, and Kubernetes sessions.
 
 ## Data retention
 Data retention cannot currently be configured by customers. All Teleport Cloud
@@ -46,7 +46,6 @@ The Teleport [proxy service](https://goteleport.com/docs/architecture/proxy/) ca
 - sa-east-1
 
 The multi-region option is currently opt-in by default. Once you have an account, please reach out to your account manager, customer success engineer, or support@goteleport.com. A future update will expand the region availability and make all regions available by default.
-
 
 ## Service Level Agreement
 

--- a/docs/pages/cloud/faq.mdx
+++ b/docs/pages/cloud/faq.mdx
@@ -110,7 +110,6 @@ $ tsh login --proxy=myinstance.teleport.sh
 $ tctl status
 ```
 
-
 ## Why am I getting `permission denied` errors when using `tctl`?
 
 If you have a local file `/etc/teleport.yaml` on your machine `tctl` will attempt to use the local cluster. Set the environment variable `TELEPORT_CONFIG_FILE` to `""` so it will not attempt to use that Teleport configuration file.
@@ -131,7 +130,7 @@ $ tctl nodes add --ttl=5m --roles=node,proxy --token=$(uuid)
 
 ## Is an independent security audit available?
 
-A security audit has been completed and is available at our [Audit Report 2021](https://goteleport.com/resources/audits/teleport-cloud-security-audit-2021/) page.
+Security audits by independent third-parties are performed at least annually, with the results made available on our [Audit Reports](https://goteleport.com/resources/audits/) page.
 
 ## Where does Teleport Cloud run?
 
@@ -144,7 +143,7 @@ The Teleport control plane is routinely upgraded within 1-2 weeks of a Teleport 
 New features may not be available to cloud users until compatibility is tested and fixed, and some features may not work in the cloud environment.
 Individual customers may not be upgraded to the latest release if they are running agents that are outside of the supported compatibility of the control plane.
 
-## Does your SOCII report include Teleport Cloud?
+## Does your SOC 2 report include Teleport Cloud?
 
 (!docs/pages/includes/soc2.mdx!)
 
@@ -224,7 +223,3 @@ If you plan on connecting more than 10,000 nodes or agents, please contact your 
 
 Teleport components communicate with themselves using mTLS, with a separate certificate authority for each tenant. Connections to AWS services, such as DynamoDB and
 S3, are established using encryption provided by AWS, both at rest and in transit. Each tenant has its own credentials that isolate it to interacting with only its own data.
-
-
-
-

--- a/docs/pages/includes/soc2.mdx
+++ b/docs/pages/includes/soc2.mdx
@@ -4,6 +4,6 @@ The report covers:
 
 - Teleport Open Source
 - Teleport Enterprise, self-hosted
-- Teleport Enterprise, cloud-hosted
+- Teleport Enterprise, cloud-hosted (SaaS)
 
 Reach out to https://goteleport.com/cloud/sales for report details.


### PR DESCRIPTION
Update outdated language about the security of Teleport Cloud and correct some compliance/audit language.