### PR TITLE
Add redirect from /user-manual

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1442,6 +1442,11 @@
     	"source": "/enterprise/workflow/role-requests/",
     	"destination": "/access-controls/access-requests/role-requests/",
     	"permanent": true
+    },
+    {
+    	"source": "/user-manual/",
+    	"destination": "/",
+    	"permanent": true
     }
   ]
 }


### PR DESCRIPTION
An earlier commit erroneously removed the /user-manual redirect, causing
404s for several pages on the goteleport site that still point to this
outdated URL. This change reinstates the redirect.