### PR TITLE
[v9] Replace `Tile` components with lists of links

### DIFF
--- a/docs/pages/access-controls/guides.mdx
+++ b/docs/pages/access-controls/guides.mdx
@@ -4,30 +4,16 @@ description: Detailed guides for configuring Teleport Access Controls.
 layout: tocless-doc
 ---
 
-<ul>
-  <ScopedBlock scope={["cloud", "enterprise"]}>
-  <li>
-    [Dual Authorization](./guides/dual-authz.mdx). Protect access to critical resources with dual authorization.
-  </li>
-  </ScopedBlock>
-  <li>
-    [Role Templates](./guides/role-templates.mdx). Setup dynamic access policies with Role Templates.
-  </li>
-  <li>
-    [Impersonating Teleport Users](./guides/impersonation.mdx). Create certs for CI/CD using impersonation.
-  </li>
-  <li>
-    [Second Factor - WebAuthn](./guides/webauthn.mdx). Add Two-Factor Authentication through WebAuthn.
-  </li>
-  <li>
-    [Per-session MFA](./guides/per-session-mfa.mdx). Per-session Multi-Factor Authentication.
-  </li>
-  <li>
-    [Locking](./guides/locking.mdx). Lock access to active user sessions or hosts.
-  </li>
-  <ScopedBlock scope={["cloud", "enterprise"]}>
-  <li>
-    [Moderated Sessions](./guides/moderated-sessions.mdx). Require session auditors and allow fine-grained live session access.
-  </li>
-  </ScopedBlock>
-</ul>
+Teleport gives you fine-grained control over who can access resources in your
+infrastructure as well as how they can access those resources. Once you have
+deployed a Teleport cluster, configure access controls to achieve the right
+security policies for your organization.
+
+- [Dual Authorization](./guides/dual-authz.mdx): Protect access to critical resources with dual authorization.
+- [Role Templates](./guides/role-templates.mdx): Set up dynamic access policies with role templates.
+- [Impersonating Teleport Users](./guides/impersonation.mdx): Create certificates for other users with impersonation.
+- [WebAuthn](./guides/webauthn.mdx): Add two-factor authentication through WebAuthn.
+- [Per-Session MFA](./guides/per-session-mfa.mdx): Per-session multi-mactor authentication.
+- [Locking](./guides/locking.mdx): Lock access to active user sessions or hosts.
+- [Moderated Sessions](./guides/moderated-sessions.mdx): Require session auditors and allow fine-grained live session access.
+

--- a/docs/pages/access-controls/introduction.mdx
+++ b/docs/pages/access-controls/introduction.mdx
@@ -24,26 +24,12 @@ guide.
 
 ## Guides
 
-<TileSet>
-  <Tile icon="lock" title="Dual Authorization" href="./guides/dual-authz.mdx">
-      Dual Authorization for SSH and Kubernetes.
-  </Tile>
-  <Tile icon="lock" title="Teleport Role Templates" href="./guides/role-templates.mdx">
-     Dynamic Access Policies with Role Templates.
-  </Tile>
-  <Tile icon="lock" title="Impersonating Teleport Users" href="./guides/impersonation.mdx">
-    Create certs for CI/CD using impersonation.
-  </Tile>
-  <Tile icon="lock" title="Second Factor - WebAuthn" href="./guides/webauthn.mdx">
-    Add Two-Factor Authentication through WebAuthn.
-  </Tile>
-  <Tile icon="lock" title="Per-session MFA" href="./guides/per-session-mfa.mdx">
-    Per-session Multi-Factor Authentication.
-  </Tile>
-  <Tile icon="lock" title="Locking" href="./guides/locking.mdx">
-    Locking sessions and identities.
-  </Tile>
-</TileSet>
+- [Dual Authorization](./guides/dual-authz.mdx): Dual Authorization for SSH and Kubernetes.
+- [Teleport Role Templates](./guides/role-templates.mdx): Dynamic Access Policies with Role Templates.
+- [Impersonating Teleport Users](./guides/impersonation.mdx): Create certs for CI/CD using impersonation.
+- [Second Factor - WebAuthn](./guides/webauthn.mdx): Add Two-Factor Authentication through WebAuthn.
+- [Per-session MFA](./guides/per-session-mfa.mdx): Per-session Multi-Factor Authentication.
+- [Locking](./guides/locking.mdx): Locking sessions and identities.
 
 ## How does it work?
 

--- a/docs/pages/api/introduction.mdx
+++ b/docs/pages/api/introduction.mdx
@@ -20,8 +20,5 @@ Here is what you can do with the Go Client:
  - Performing CRUD actions on resources, such as `roles`, `auth connectors`, and `provisioning tokens`.
  - Dynamically configuring Teleport.
 
-<TileSet>
-  <Tile icon="list" title="Go Client" href="./getting-started.mdx">
-    Create an API client in 3 minutes with the Getting Started Guide.
-  </Tile>
-</TileSet>
+Create an API client in 3 minutes with the [Getting Started
+Guide](./getting-started.mdx).

--- a/docs/pages/application-access/guides.mdx
+++ b/docs/pages/application-access/guides.mdx
@@ -6,17 +6,7 @@ layout: tocless-doc
 
 These guides explain basic Teleport Application Access usage.
 
-<TileSet>
-  <Tile icon="window" title="Connecting Applications" href="./guides/connecting-apps.mdx">
-    How to use Teleport for Application Access.
-  </Tile>
-  <Tile icon="window" title="API Access" href="./guides/api-access.mdx">
-    How to access REST APIs with Teleport Application Access.
-  </Tile>
-  <Tile icon="cloud" title="AWS Console Access" href="./guides/aws-console.mdx">
-    How to access AWS Management Console with Teleport Application Access.
-  </Tile>
-  <Tile icon="wrench" title="Dynamic Registration" href="./guides/dynamic-registration.mdx">
-    Register/unregister apps without restarting Teleport.
-  </Tile>
-</TileSet>
+- [Web App Access](./guides/connecting-apps.mdx): How to access web apps with Teleport Application Access.
+- [API Access](./guides/api-access.mdx): How to access REST APIs with Teleport Application Access.
+- [AWS Console Access](./guides/aws-console.mdx): How to access AWS Management Console with Teleport Application Access.
+- [Dynamic Registration](./guides/dynamic-registration.mdx): Register/unregister apps without restarting Teleport.

--- a/docs/pages/application-access/introduction.mdx
+++ b/docs/pages/application-access/introduction.mdx
@@ -43,38 +43,11 @@ Get started with Application Access in a 10 minute [guide](./getting-started.mdx
 
 These guides explain basic Teleport Application Access usage.
 
-<TileSet>
-  <Tile icon="window" title="Connecting Applications" href="./guides/connecting-apps.mdx">
-    How to use Teleport for Application Access.
-  </Tile>
-  <Tile icon="window" title="API Access" href="./guides/api-access.mdx">
-    How to access REST APIs with Teleport Application Access.
-  </Tile>
-  <Tile icon="cloud" title="AWS Console Access" href="./guides/aws-console.mdx">
-    How to access AWS Management Console with Teleport Application Access.
-  </Tile>
-  <Tile icon="wrench" title="Dynamic Registration" href="./guides/dynamic-registration.mdx">
-    Register/unregister apps without restarting Teleport.
-  </Tile>
-    <Tile icon="window" title="Interactive Lab" href="https://play.instruqt.com/teleport/invite/rgvuva4gzkon">
-    Try Teleport using our guided Teleport Application Access lab.
-  </Tile>
-</TileSet>
-
-## JWT guides
-
-These guides explain how web apps behind Teleport Application Access can
-leverage Teleport-signed JWT tokens to implement authentication and
-authorization.
-
-<TileSet>
-  <Tile icon="window" title="Introduction" href="./jwt/introduction.mdx">
-    Introduction to JWT tokens with Application Access.
-  </Tile>
-  <Tile icon="window" title="Elasticsearch" href="./jwt/elasticsearch.mdx">
-    How to use JWT authentication with Elasticsearch.
-  </Tile>
-</TileSet>
+- [Web App Access](./guides/connecting-apps.mdx): How to access web apps with Teleport Application Access.
+- [API Access](./guides/api-access.mdx): How to access REST APIs with Teleport Application Access.
+- [AWS Console Access](./guides/aws-console.mdx): How to access AWS Management Console with Teleport Application Access.
+- [Dynamic Registration](./guides/dynamic-registration.mdx): Register/unregister apps without restarting Teleport.
+- [Interactive Lab](https://play.instruqt.com/teleport/invite/rgvuva4gzkon): Try Teleport using our guided Teleport Application Access lab.
 
 ## Example legacy apps
 

--- a/docs/pages/application-access/jwt.mdx
+++ b/docs/pages/application-access/jwt.mdx
@@ -8,11 +8,5 @@ These guides explain how web apps behind Teleport Application Access can
 leverage Teleport-signed JWT tokens to implement authentication and
 authorization.
 
-<TileSet>
-  <Tile icon="window" title="Introduction" href="./jwt/introduction.mdx">
-    Introduction to JWT tokens with Application Access.
-  </Tile>
-  <Tile icon="window" title="Elasticsearch" href="./jwt/elasticsearch.mdx">
-    How to use JWT authentication with Elasticsearch.
-  </Tile>
-</TileSet>
+- [Introduction](./jwt/introduction.mdx): Introduction to JWT tokens with Application Access.
+- [Elasticsearch](./jwt/elasticsearch.mdx): How to use JWT authentication with Elasticsearch.

--- a/docs/pages/cloud/introduction.mdx
+++ b/docs/pages/cloud/introduction.mdx
@@ -27,35 +27,11 @@ desktops, and service accounts.
 
 ## Next steps
 
-<TileSet>
-<Tile icon="cloud" title="Sign up" href="https://goteleport.com/signup/">
-
-Sign up for a free trial of Teleport Cloud
-
-</Tile>
-<Tile icon="cloud" title="Get started" href="./getting-started.mdx">
-
-Start using your Teleport Cloud account
-
-</Tile>
-<Tile icon="cloud" title="Download Teleport" href="./downloads.mdx">
-
-Download Teleport binaries for your agents and clients
-
-</Tile>
-</TileSet>
+- [Sign up](https://goteleport.com/signup/): Sign up for a free trial of Teleport Cloud
+- [Get started](./getting-started.mdx): Start using your Teleport Cloud account
+- [Download Teleport](./downloads.mdx): Download Teleport binaries for your agents and clients
 
 ## Learn more
 
-<TileSet>
-<Tile icon="cloud" title="Architecture" href="./architecture.mdx">
-
-Learn more about how Teleport Cloud works
-
-</Tile>
-<Tile icon="cloud" title="FAQ" href="./faq.mdx">
-
-Get answers to frequently asked questions about Teleport Cloud
-
-</Tile>
-</TileSet>
+- [Architecture](./architecture.mdx): Learn more about how Teleport Cloud works
+- [FAQ](./faq.mdx): Get answers to frequently asked questions about Teleport Cloud

--- a/docs/pages/database-access/introduction.mdx
+++ b/docs/pages/database-access/introduction.mdx
@@ -51,11 +51,7 @@ with GitHub, execute a few SQL queries and observe them in the audit log:
 
 ## Getting started
 
-<TileSet>
-  <Tile icon="database" title="Getting started" href="./getting-started.mdx">
-    Connect Aurora PostgreSQL in a 10 minute guide.
-  </Tile>
-</TileSet>
+- [Getting started](./getting-started.mdx): Connect Aurora PostgreSQL in a 10 minute guide.
 
 (!docs/pages/includes/database-access/guides.mdx!)
 

--- a/docs/pages/desktop-access/introduction.mdx
+++ b/docs/pages/desktop-access/introduction.mdx
@@ -27,28 +27,14 @@ Desktop Access, you get:
 
 ## Getting started
 
-<TileSet>
-  <Tile icon="desktop" title="Getting started" href="./getting-started.mdx">
-    Connect an Active Directory domain.
-  </Tile>
-</TileSet>
+- [Getting started](./getting-started.mdx): Connect an Active Directory domain.
 
 ## Resources
 
-<TileSet>
-  <Tile icon="wrench" title="Configuration" href="./reference/configuration.mdx">
-    Configure Windows Desktop Service
-  </Tile>
-  <Tile icon="lock" title="RBAC" href="./rbac.mdx">
-    Role-based Access Control for Teleport Desktop Access
-  </Tile>
-  <Tile icon="window" title="CLI" href="./reference/cli.mdx">
-    CLI Reference
-  </Tile>
-  <Tile icon="list" title="Audit" href="./reference/audit.mdx">
-    Audit Events
-  </Tile>
-</TileSet>
+- [Configuration](./reference/configuration.mdx): Configure Windows Desktop Service
+- [RBAC](./rbac.mdx): Role-based Access Control for Teleport Desktop Access
+- [CLI](./reference/cli.mdx): CLI Reference
+- [Audit](./reference/audit.mdx): Audit Events
 
 ## Troubleshooting
 

--- a/docs/pages/desktop-access/reference.mdx
+++ b/docs/pages/desktop-access/reference.mdx
@@ -3,17 +3,7 @@ title: Desktop Access Reference
 layout: tocless-doc
 ---
 
-<TileSet>
-  <Tile icon="wrench" title="Configuration" href="./reference/configuration.mdx">
-    Configure Teleport Desktop Access.
-  </Tile>
-  <Tile icon="list" title="Audit" href="./reference/audit.mdx">
-    Desktop Access audit events.
-  </Tile>
-  <Tile icon="copy" title="Clipboard" href="./reference/clipboard.mdx">
-    Share your clipboard with a remote desktop.
-  </Tile>
-  <Tile icon="play" title="Session Recording" href="./reference/sessions.mdx">
-    Desktop session recording and playback
-  </Tile>
-</TileSet>
+- [Configuration](./reference/configuration.mdx): Configure Teleport Desktop Access.
+- [Audit](./reference/audit.mdx): Desktop Access audit events.
+- [Clipboard](./reference/clipboard.mdx): Share your clipboard with a remote desktop.
+- [Session Recording](./reference/sessions.mdx): Desktop session recording and playback

--- a/docs/pages/enterprise/sso.mdx
+++ b/docs/pages/enterprise/sso.mdx
@@ -8,29 +8,13 @@ Users of the Enterprise edition of Teleport can log in to servers, Kubernetes
 clusters, databases, web applications, and Windows desktops through their
 organization's Single Sign-On (SSO) provider.
 
-<TileSet>
-  <Tile icon="bolt" title="Azure Active Directory (AD)" href="./sso/azuread.mdx">
-    Configure Azure Active Directory SSO for SSH, Kubernetes, databases, desktops and web apps.
-  </Tile>
-  <Tile icon="bolt" title="Active Directory (ADFS)" href="./sso/adfs.mdx">
-    Configure Windows Active Directory SSO for SSH, Kubernetes, databases, desktops and web apps.
-  </Tile>
-  <Tile icon="bolt" title="Google Workspace" href="./sso/google-workspace.mdx">
-    Configure Google Workspace SSO for SSH, Kubernetes, databases, desktops and web apps.
-  </Tile>
-  <Tile icon="bolt" title="GitLab" href="./sso/gitlab.mdx">
-    Configure GitLab SSO for SSH, Kubernetes, databases, desktops and web apps.
-  </Tile>
-  <Tile icon="bolt" title="OneLogin" href="./sso/one-login.mdx">
-    Configure OneLogin SSO for SSH, Kubernetes, databases, desktops and web apps.
-  </Tile>
-  <Tile icon="bolt" title="OIDC" href="./sso/oidc.mdx">
-    Configure OIDC SSO for SSH, Kubernetes, databases, desktops and web apps.
-  </Tile>
-  <Tile icon="bolt" title="Okta" href="./sso/okta.mdx">
-    Configure Okta SSO for SSH, Kubernetes, databases, desktops and web apps.
-  </Tile>
-</TileSet>
+- [Azure Active Directory (AD)](./sso/azuread.mdx): Configure Azure Active Directory SSO for SSH, Kubernetes, databases, desktops and web apps.
+- [Active Directory (ADFS)](./sso/adfs.mdx): Configure Windows Active Directory SSO for SSH, Kubernetes, databases, desktops and web apps.
+- [Google Workspace](./sso/google-workspace.mdx): Configure Google Workspace SSO for SSH, Kubernetes, databases, desktops and web apps.
+- [GitLab](./sso/gitlab.mdx): Configure GitLab SSO for SSH, Kubernetes, databases, desktops and web apps.
+- [OneLogin](./sso/one-login.mdx): Configure OneLogin SSO for SSH, Kubernetes, databases, desktops and web apps.
+- [OIDC](./sso/oidc.mdx): Configure OIDC SSO for SSH, Kubernetes, databases, desktops and web apps.
+- [Okta](./sso/okta.mdx): Configure Okta SSO for SSH, Kubernetes, databases, desktops and web apps.
 
 ## How does SSO work?
 

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -8,17 +8,9 @@ Follow these guides to get started using Teleport.
 
 ## Try a lab on your local machine
 
-<TileSet>
-  <Tile icon="code" title="Browser Lab" href="https://goteleport.com/labs">
-    Try Teleport using our guided interactive labs.
-  </Tile>
-  <Tile icon="integrations" title="Docker Compose Lab" href="./getting-started/docker-compose.mdx">
-    Try Teleport locally using Docker Compose.
-  </Tile>
-    <Tile icon="kubernetes" title="Kubernetes Lab" href="./getting-started/local-kubernetes.mdx">
-    See how Teleport runs on Kubernetes with this local lab.
-  </Tile>
-</TileSet>
+- [Browser Lab](https://goteleport.com/labs): Try Teleport using our guided interactive labs.
+- [Docker Compose Lab](./getting-started/docker-compose.mdx): Try Teleport locally using Docker Compose.
+- [Kubernetes Lab](./getting-started/local-kubernetes.mdx): See how Teleport runs on Kubernetes with this local lab.
 
 ## Deploy to production
 
@@ -29,72 +21,27 @@ Not sure which edition of Teleport is right for you? View our [comparison chart]
 
 Host your own Teleport deployment.
 
-<TileSet>
-  <Tile 
-  icon="bolt"
-  title="Linux Server"
-  href="./getting-started/linux-server.mdx"
-  >
+- [Linux Server](./getting-started/linux-server.mdx): Learn how to host your own open source Teleport deployment on a standalone Linux server.
+- [Kubernetes](./getting-started/kubernetes-cluster.mdx): Learn how to host your own open source Teleport deployment on Kubernetes.
 
-  Learn how to host your own open source Teleport deployment on a standalone
-  Linux server.
-
-  </Tile>
-  <Tile 
-  icon="kubernetes"
-  title="Kubernetes"
-  href="./getting-started/kubernetes-cluster/?scope=oss"
-  >
-
-  Learn how to host your own open source Teleport deployment on Kubernetes.
-
-  </Tile>
-  </TileSet>
 </TabItem>
 <TabItem scope="cloud" label="Teleport Cloud">
 
 Teleport Cloud is a deployment of the Auth Service and Proxy Service,
 managed by a dedicated team at Teleport.
 
-<TileSet>
-  <Tile icon="cloud" title="Learn More" href="./cloud/getting-started.mdx/?scope=cloud">
+- [Learn More](./cloud/getting-started.mdx): Learn how to start using Teleport Cloud.
+- [Start your Free Trial](https://goteleport.com/signup): Try Teleport hosted by us in the cloud for free.
 
-    Learn how to start using Teleport Cloud.
-
-  </Tile>
-  <Tile icon="cloud" title="Start your Free Trial" href="https://goteleport.com/signup">
-
-    Try Teleport hosted by us in the cloud for free.
-
-  </Tile>
-  </TileSet>
 </TabItem>
 <TabItem scope="enterprise" label="Teleport Enterprise">
 
   Get started with a self-hosted Teleport Enterprise deployment, which gives you
   more advanced features and full customization.
 
-<TileSet>
+- [Getting Started](./enterprise/getting-started.mdx): Learn how to deploy Teleport Enterprise.
+- [Kubernetes](./getting-started/kubernetes-cluster.mdx): Learn how to host your Teleport Enterprise deployment on Kubernetes.
 
-  <Tile
-  icon="bolt"
-  title="Getting Started"
-  href="./enterprise/getting-started.mdx/?scope=enterprise"
-  >
-
-  Learn how to deploy Teleport Enterprise.
-
-  </Tile>
-    <Tile 
-  icon="kubernetes"
-  title="Kubernetes"
-  href="./getting-started/kubernetes-cluster.mdx/?scope=enterprise"
-  >
-
-  Learn how to host your Teleport Enterprise deployment on Kubernetes.
-
-  </Tile>
-  </TileSet>
 </TabItem>
 </Tabs>
 

--- a/docs/pages/includes/database-access/guides.mdx
+++ b/docs/pages/includes/database-access/guides.mdx
@@ -1,57 +1,21 @@
 ## Database guides
 
-<TileSet>
-  <Tile icon="cloud" title="AWS RDS & Aurora" href="./guides/rds.mdx">
-    Connect AWS RDS or Aurora PostgreSQL or MySQL database.
-  </Tile>
-  <Tile icon="cloud" title="AWS Redshift" href="./guides/postgres-redshift.mdx">
-    Connect AWS Redshift database.
-  </Tile>
-  <Tile icon="cloud" title="GCP Cloud SQL PostgreSQL" href="./guides/postgres-cloudsql.mdx">
-    Connect GCP Cloud SQL PostgreSQL database.
-  </Tile>
-  <Tile icon="cloud" title="GCP Cloud SQL MySQL" href="./guides/mysql-cloudsql.mdx">
-    Connect GCP Cloud SQL MySQL database.
-  </Tile>
-  <Tile icon="cloud" title="Azure PostgreSQL & MySQL" href="./guides/azure-postgres-mysql.mdx">
-    Connect Azure PostgreSQL or MySQL.
-  </Tile>
-  <Tile icon="cloud" title="MongoDB Atlas" href="./guides/mongodb-atlas.mdx">
-    Connect MongoDB Atlas cluster.
-  </Tile>
-  <Tile icon="database" title="Self-hosted PostgreSQL" href="./guides/postgres-self-hosted.mdx">
-    Connect self-hosted PostgreSQL database.
-  </Tile>
-  <Tile icon="database" title="Self-hosted MySQL & MariaDB" href="./guides/mysql-self-hosted.mdx">
-    Connect self-hosted MySQL or MariaDB database.
-  </Tile>
-  <Tile icon="database" title="Self-hosted MongoDB" href="./guides/mongodb-self-hosted.mdx">
-    Connect self-hosted MongoDB database.
-  </Tile>
-  <Tile icon="database" title="Self-hosted CockroachDB" href="./guides/cockroachdb-self-hosted.mdx">
-    Connect self-hosted CockroachDB database.
-  </Tile>
-  <Tile icon="database" title="Self-hosted Redis" href="./guides/redis.mdx">
-    Connect self-hosted Redis.
-  </Tile>
-  <Tile icon="database" title="Self-hosted Redis Cluster" href="./guides/redis-cluster.mdx">
-    Connect a self-hosted Redis Cluster.
-  </Tile>
-  <Tile icon="database" title="Active Directory SQL Server (Preview)" href="./guides/sql-server-ad.mdx">
-    Connect Microsoft SQL Server with Active Directory authentication.
-  </Tile>
-</TileSet>
+- [AWS RDS & Aurora](../../database-access/guides/rds.mdx): Connect AWS RDS or Aurora PostgreSQL, MariaDB or MySQL database.
+- [AWS Redshift](../../database-access/guides/postgres-redshift.mdx): Connect AWS Redshift database.
+- [GCP Cloud SQL PostgreSQL](../../database-access/guides/postgres-cloudsql.mdx): Connect GCP Cloud SQL PostgreSQL database.
+- [GCP Cloud SQL MySQL](../../database-access/guides/mysql-cloudsql.mdx): Connect GCP Cloud SQL MySQL database.
+- [Azure PostgreSQL & MySQL](../../database-access/guides/azure-postgres-mysql.mdx): Connect Azure PostgreSQL or MySQL.
+- [MongoDB Atlas](../../database-access/guides/mongodb-atlas.mdx): Connect MongoDB Atlas cluster.
+- [Self-hosted PostgreSQL](../../database-access/guides/postgres-self-hosted.mdx): Connect self-hosted PostgreSQL database.
+- [Self-hosted MySQL & MariaDB](../../database-access/guides/mysql-self-hosted.mdx): Connect self-hosted MySQL or MariaDB database.
+- [Self-hosted MongoDB](../../database-access/guides/mongodb-self-hosted.mdx): Connect self-hosted MongoDB database.
+- [Self-hosted CockroachDB](../../database-access/guides/cockroachdb-self-hosted.mdx): Connect self-hosted CockroachDB database.
+- [Self-hosted Redis](../../database-access/guides/redis.mdx): Connect self-hosted Redis.
+- [Self-hosted Redis Cluster](../../database-access/guides/redis-cluster.mdx): Connect a self-hosted Redis Cluster.
+- [Active Directory SQL Server (Preview)](../../database-access/guides/sql-server-ad.mdx): Connect Microsoft SQL Server with Active Directory authentication.
 
 ## Other guides
 
-<TileSet>
-  <Tile icon="window" title="GUI clients" href="./guides/gui-clients.mdx">
-    Configure database graphical clients.
-  </Tile>
-  <Tile icon="wrench" title="Dynamic Registration" href="./guides/dynamic-registration.mdx">
-    Register/unregister databases without restarting Teleport.
-  </Tile>
-  <Tile icon="integrations" title="High Availability" href="./guides/ha.mdx">
-    Deploy database access in HA configuration.
-  </Tile>
-</TileSet>
+- [GUI clients](../../database-access/guides/gui-clients.mdx): Configure database graphical clients.
+- [Dynamic Registration](../../database-access/guides/dynamic-registration.mdx): Register/unregister databases without restarting Teleport.
+- [High Availability](../../database-access/guides/ha.mdx): Deploy database access in HA configuration.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -19,17 +19,9 @@ With Teleport you can:
 
 Quickly see how Teleport works in one of our demo environments.
 
-<TileSet>
-  <Tile icon="code2" title="Browser Lab" href="https://play.instruqt.com/teleport/invite/rgvuva4gzkon">
-    Try Teleport using our guided interactive labs.
-  </Tile>
-  <Tile icon="integrations" title="Docker Compose Lab" href="./getting-started/docker-compose.mdx">
-    Try Teleport locally using Docker Compose.
-  </Tile>
-    <Tile icon="kubernetes" title="Kubernetes Lab" href="./getting-started/local-kubernetes.mdx">
-    See how Teleport runs on Kubernetes with this local lab.
-  </Tile>
-</TileSet>
+- [Browser Lab](https://goteleport.com/labs/): Try Teleport using our guided interactive labs.
+- [Docker Compose Lab](./getting-started/docker-compose.mdx): Try Teleport locally using Docker Compose.
+- [Kubernetes Lab](./getting-started/local-kubernetes.mdx): See how Teleport runs on Kubernetes with this local lab.
 
 ## Choose an edition
 
@@ -38,96 +30,32 @@ Teleport, Teleport Enterprise, or Teleport Cloud.
 
 You can also [compare Teleport editions](faq.mdx#how-is-open-source-different-from-enterprise).
 
-<TileSet>
-  <Tile 
-  icon="stack"
-  title="Open Source Teleport"
-  href="./getting-started/linux-server.mdx"
-  >
-
-  Learn how to host your own open source Teleport deployment on a standalone
-  Linux server.
-
-  </Tile>
-  <Tile
-  icon="building"
-  title="Teleport Enterprise"
-  href="./enterprise/introduction.mdx"
-  >
-
-  Get started with a self-hosted Teleport Enterprise deployment, which gives you
-  more advanced features and full customization.
-
-  </Tile>
-
-  <Tile icon="cloud" title="Teleport Cloud" href="./cloud/getting-started.mdx">
-
-    Try Teleport hosted by us in the cloud for free.
-
-  </Tile>
-</TileSet>
+- [Open Source Teleport](./getting-started/linux-server.mdx): Learn how to host your own open source Teleport deployment on a standalone Linux server.
+- [Teleport Enterprise](./enterprise/introduction.mdx): Get started with a self-hosted Teleport Enterprise deployment, which gives you more advanced features and full customization.
+- [Teleport Cloud](./cloud/getting-started.mdx): Try Teleport hosted by us in the cloud for free.
 
 ## Configure access
 
 Secure your infrastructure while keeping your engineers productive.
 
-<TileSet>
 <ScopedBlock scope={["cloud", "enterprise"]}>
-<Tile
-  title="Set up SSO"
-  icon="list"
-  href="./enterprise/sso.mdx"
->
-
-Configure Teleport's integration with your SSO provider so you can automatically
-on– and off-board users.
-
-</Tile>
+- [Set up SSO](./enterprise/sso.mdx):Configure Teleport's integration with your SSO provider so you can automaticallyon– and off-board users.
 </ScopedBlock>
 <ScopedBlock scope={["oss"]}>
-<Tile
-  title="Set up SSO"
-  icon="github"
-  href="./setup/admin/github-sso.mdx"
->
-
-Configure Teleport's integration with GitHub so you can automatically on– and
-off-board users.
-
-</Tile>
+- [Set up SSO](./setup/admin/github-sso.mdx):Configure Teleport's integration with GitHub so you can automatically on– andoff-board users.
 </ScopedBlock>
-<Tile
-  title="Define roles"
-  icon="lock"
-  href="./access-controls/guides/role-templates.mdx"
->
-
-Manage who can access which parts of your infrastructure.
-
-</Tile>
-</TileSet>
+- [Define roles](./access-controls/guides/role-templates.mdx):Manage who can access which parts of your infrastructure.
 
 ## Add your infrastructure
 
 Use Teleport to provide secure access to all of your infrastructure.
 
-<TileSet>
-  <Tile icon="bolt" title="Server Access" href="./getting-started.mdx">
-    Single sign-on, short-lived certificates, and auditing for SSH servers.
-  </Tile>
-  <Tile icon="window" title="Application Access" href="./application-access/introduction.mdx">
-    Secure access to internal dashboards and web applications.
-  </Tile>
-  <Tile icon="kubernetes" title="Kubernetes Access" href="./kubernetes-access/introduction.mdx">
-    Single sign-on, auditing, and unified access for Kubernetes clusters.
-  </Tile>
-  <Tile icon="database" title="Database Access" href="./database-access/introduction.mdx">
-    Secure access to SQL and NoSQL databases.
-  </Tile>
-  <Tile icon="desktop" title="Desktop Access" href="./desktop-access/introduction.mdx">
-    Secure browser-based access to desktop environments.
-  </Tile>
-</TileSet>
+- [Server Access](./getting-started.mdx): Single sign-on, short-lived certificates, and auditing for SSH servers.
+- [Application Access](./application-access/introduction.mdx): Secure access to internal dashboards and web applications.
+- [Kubernetes Access](./kubernetes-access/introduction.mdx): Single sign-on, auditing, and unified access for Kubernetes clusters.
+- [Database Access](./database-access/introduction.mdx): Secure access to SQL and NoSQL databases.
+- [Desktop Access](./desktop-access/introduction.mdx): Secure browser-based access to desktop environments.
+
 
 <TileSet>
   <TileList title="Reach out" icon="question">

--- a/docs/pages/kubernetes-access/guides.mdx
+++ b/docs/pages/kubernetes-access/guides.mdx
@@ -4,17 +4,7 @@ description: Detailed guides for configuring Teleport Kubernetes Access.
 layout: tocless-doc
 ---
 
-<TileSet>
-  <Tile icon="kubernetes" title="Teleport Kubernetes Access for CI/CD" href="./guides/cicd.mdx">
-    Teleport Kubernetes Access for CI/CD.
-  </Tile>
-  <Tile icon="kubernetes" title="Teleport Kubernetes Access and Trusted Clusters" href="./guides/federation.mdx">
-    Federated Access using Teleport Trusted Clusters.
-  </Tile>
-  <Tile icon="kubernetes" title="Kubernetes Access Multiple Clusters" href="./guides/multiple-clusters.mdx">
-    Connecting Multiple Clusters with Teleport Kubernetes Access.
-  </Tile>
-  <Tile icon="kubernetes" title="Kubernetes Access from standalone Teleport" href="./guides/standalone-teleport.mdx">
-    Connecting standalone Teleport installations to Kubernetes clusters
-  </Tile>
-</TileSet>
+- [Teleport Kubernetes Access for CI/CD](./guides/cicd.mdx): Teleport Kubernetes Access for CI/CD.
+- [Teleport Kubernetes Access and Trusted Clusters](./guides/federation.mdx): Federated Access using Teleport Trusted Clusters.
+- [Kubernetes Access Multiple Clusters](./guides/multiple-clusters.mdx): Connecting Multiple Clusters with Teleport Kubernetes Access.
+- [Kubernetes Access from standalone Teleport](./guides/standalone-teleport.mdx): Connecting standalone Teleport installations to Kubernetes clusters

--- a/docs/pages/kubernetes-access/introduction.mdx
+++ b/docs/pages/kubernetes-access/introduction.mdx
@@ -33,27 +33,11 @@ Set up SSO, capture audit events, and sessions with Teleport running in a Kubern
 
 ## Get started
 
-<TileSet>
-  <Tile icon="kubernetes" title="Teleport Kubernetes Access" href="./getting-started.mdx">
-
-    Get started with Teleport Kubernetes Access.
-
-  </Tile>
-</TileSet>
+- [Teleport Kubernetes Access](./getting-started.mdx): Get started with Teleport Kubernetes Access.
 
 ## Guides
 
-<TileSet>
-  <Tile icon="kubernetes" title="Teleport Kubernetes Access for CI/CD" href="./guides/cicd.mdx">
-    Teleport Kubernetes Access for CI/CD.
-  </Tile>
-  <Tile icon="kubernetes" title="Teleport Kubernetes Access and Trusted Clusters" href="./guides/federation.mdx">
-    Federated Access using Teleport Trusted Clusters.
-  </Tile>
-  <Tile icon="kubernetes" title="Kubernetes Access Multiple Clusters" href="./guides/multiple-clusters.mdx">
-    Connecting Multiple Clusters with Teleport Kubernetes Access.
-  </Tile>
-  <Tile icon="kubernetes" title="Kubernetes Access from standalone Teleport" href="./guides/standalone-teleport.mdx">
-    Connecting standalone Teleport installations to Kubernetes clusters
-  </Tile>
-</TileSet>
+- [Teleport Kubernetes Access for CI/CD](./guides/cicd.mdx): Teleport Kubernetes Access for CI/CD.
+- [Teleport Kubernetes Access and Trusted Clusters](./guides/federation.mdx): Federated Access using Teleport Trusted Clusters.
+- [Kubernetes Access Multiple Clusters](./guides/multiple-clusters.mdx): Connecting Multiple Clusters with Teleport Kubernetes Access.
+- [Kubernetes Access from standalone Teleport](./guides/standalone-teleport.mdx): Connecting standalone Teleport installations to Kubernetes clusters

--- a/docs/pages/machine-id/guides.mdx
+++ b/docs/pages/machine-id/guides.mdx
@@ -4,14 +4,6 @@ description: Teleport Machine ID guides.
 layout: tocless-doc
 ---
 
-<TileSet>
-  <Tile icon="server" title="Using Teleport Machine ID with Ansible" href="./guides/ansible.mdx">
-    How to integrate Teleport Machine ID with Ansible.
-  </Tile>
-  <Tile icon="server" title="Using Teleport Machine ID with Jenkins" href="./guides/jenkins.mdx">
-    How to integrate Teleport Machine ID with Jenkins.
-  </Tile>
-  <Tile icon="database" title="Using Teleport Machine ID with Databases" href="./guides/databases.mdx">
-How to use Machine ID to connect custom applications to your databases.
-  </Tile>
-</TileSet>
+- [Using Teleport Machine ID with Ansible](./guides/ansible.mdx): How to integrate Teleport Machine ID with Ansible.
+- [Using Teleport Machine ID with Jenkins](./guides/jenkins.mdx): How to integrate Teleport Machine ID with Jenkins.
+- [Using Teleport Machine ID with Databases](./guides/databases.mdx): How to use Machine ID to connect custom applications to your databases.

--- a/docs/pages/machine-id/introduction.mdx
+++ b/docs/pages/machine-id/introduction.mdx
@@ -50,8 +50,4 @@ Let's create a bot and use the machine identity to connect to a server.
 
 ## Getting started
 
-<TileSet>
-  <Tile icon="wand" title="Getting started" href="./getting-started.mdx">
-    Getting started with Teleport Machine ID
-  </Tile>
-</TileSet>
+- [Getting started](./getting-started.mdx): Getting started with Teleport Machine ID

--- a/docs/pages/server-access/guides.mdx
+++ b/docs/pages/server-access/guides.mdx
@@ -4,25 +4,9 @@ description: Teleport Server Access guides.
 layout: tocless-doc
 ---
 
-<TileSet>
-  <Tile icon="server" title="Using Teleport with PAM" href="./guides/ssh-pam.mdx">
-    How to configure Teleport SSH with PAM (Pluggable Authentication Modules).
-  </Tile>
-  <Tile icon="server" title="OpenSSH Guide" href="./guides/openssh.mdx">
-    How to use Teleport on legacy systems with OpenSSH and sshd.
-  </Tile>
-  <ScopedBlock scope={["oss", "enterprise"]}>
-    <Tile icon="server" title="Recording Proxy Mode" href="./guides/recording-proxy-mode.mdx">
-      How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
-    </Tile>
-  </ScopedBlock>
-  <Tile icon="server" title="BPF Session Recording" href="./guides/bpf-session-recording.mdx">
-    How to use BPF to record SSH session commands, modified files and network connections.
-  </Tile>
-  <Tile icon="server" title="Restricted Session" href="./guides/restricted-session.mdx">
-    How to configure and use Restricted Session to apply security policies to SSH sessions.
-  </Tile>
-  <Tile icon="server" title="Visual Studio Code" href="./guides/vscode.mdx">
-    How to remotely develop with Visual Studio Code and Teleport.
-  </Tile>
-</TileSet>
+- [Using Teleport with PAM](./guides/ssh-pam.mdx): How to configure Teleport SSH with PAM (Pluggable Authentication Modules).
+- [OpenSSH Guide](./guides/openssh.mdx): How to use Teleport on legacy systems with OpenSSH and sshd.
+- [Recording Proxy Mode](./guides/recording-proxy-mode.mdx): How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
+- [BPF Session Recording](./guides/bpf-session-recording.mdx): How to use BPF to record SSH session commands, modified files and network connections.
+- [Restricted Session](./guides/restricted-session.mdx): How to configure and use Restricted Session to apply security policies to SSH sessions.
+- [Visual Studio Code](./guides/vscode.mdx): How to remotely develop with Visual Studio Code and Teleport.

--- a/docs/pages/server-access/introduction.mdx
+++ b/docs/pages/server-access/introduction.mdx
@@ -17,39 +17,14 @@ Teleport Server Access is designed for the following kinds of scenarios:
 
 ## Getting started
 
-<TileSet>
-  <Tile icon="server" title="Get started" href="getting-started.mdx">
-    Get started using Teleport Server Access in 10 minutes. Server access for most common SSH use-cases.
-  </Tile>
-  <Tile icon="server" title="Integrate with OpenSSH" href="guides/openssh.mdx">
-    SSO and short-lived certificates for OpenSSH.
-  </Tile>
-</TileSet>
+- [Get started](getting-started.mdx): Get started using Teleport Server Access in 10 minutes. Server access for most common SSH use-cases.
+- [Integrate with OpenSSH](guides/openssh.mdx): SSO and short-lived certificates for OpenSSH.
 
 ## Guides
 
-<TileSet>
-  <Tile icon="server" title="Using Teleport with PAM" href="./guides/ssh-pam.mdx">
-    How to configure Teleport SSH with PAM (Pluggable Authentication Modules).
-  </Tile>
-  <Tile icon="server" title="Using Teleport with Ansible" href="./guides/ansible.mdx">
-    How to configure Teleport SSH with Ansible.
-  </Tile>
-  <Tile icon="server" title="OpenSSH Guide" href="./guides/openssh.mdx">
-    How to use Teleport on legacy systems with OpenSSH and sshd.
-  </Tile>
-  <ScopedBlock scope={["oss", "enterprise"]}>
-    <Tile icon="server" title="Recording Proxy Mode" href="./guides/recording-proxy-mode.mdx">
-      How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
-    </Tile>
-  </ScopedBlock>
-  <Tile icon="server" title="BPF Session Recording" href="./guides/bpf-session-recording.mdx">
-    How to use BPF to record SSH session commands, modified files and network connections.
-  </Tile>
-  <Tile icon="server" title="Restricted Session" href="./guides/restricted-session.mdx">
-    How to configure and use Restricted Session to apply security policies to SSH sessions.
-  </Tile>
-  <Tile icon="server" title="Visual Studio Code" href="./guides/vscode.mdx">
-    How to remotely develop with Visual Studio Code and Teleport.
-  </Tile>
-</TileSet>
+- [Using Teleport with PAM](./guides/ssh-pam.mdx): How to configure Teleport SSH with PAM (Pluggable Authentication Modules).
+- [OpenSSH Guide](./guides/openssh.mdx): How to use Teleport on legacy systems with OpenSSH and sshd.
+- [Recording Proxy Mode](./guides/recording-proxy-mode.mdx): How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
+- [BPF Session Recording](./guides/bpf-session-recording.mdx): How to use BPF to record SSH session commands, modified files and network connections.
+- [Restricted Session](./guides/restricted-session.mdx): How to configure and use Restricted Session to apply security policies to SSH sessions.
+- [Visual Studio Code](./guides/vscode.mdx): How to remotely develop with Visual Studio Code and Teleport.

--- a/docs/pages/setup/admin.mdx
+++ b/docs/pages/setup/admin.mdx
@@ -14,41 +14,19 @@ cluster maintenance tasks.
 
 ## Run Teleport
 
-<TileSet>
-  <Tile href="./admin/daemon.mdx" title="Teleport Daemon" icon="wrench">
-    Set up Teleport as a daemon on Linux with systemd.
-  </Tile>
-  <Tile href="./admin/graceful-restarts.mdx" title="Upgrade the Teleport Binary" icon="wrench">
-    Upgrade the `teleport` binary without losing connections.
-  </Tile>
-</TileSet>
+- [Teleport Daemon](./admin/daemon.mdx): Set up Teleport as a daemon on Linux with systemd.
+- [Upgrade the Teleport Binary](./admin/upgrading-the-teleport-binary.mdx): Upgrade the `teleport` binary without losing connections.
 
 ## Manage users and resources
 
-<TileSet>
-  <Tile href="./admin/github-sso.mdx" title="GitHub SSO" icon="wrench">
-    Set up single sign-on with GitHub.
-  </Tile>
-  <Tile href="./admin/adding-nodes.mdx" title="Adding Nodes" icon="wrench">
-    Add Nodes to your Teleport cluster.
-  </Tile>
-  <Tile href="./admin/trustedclusters.mdx" title="Trusted Clusters" icon="wrench">
-    Connect multiple Teleport clusters using Trusted Clusters.
-  </Tile>
-  <Tile href="./admin/labels.mdx" title="Labels" icon="wrench">
-    Manage resource metadata with labels.
-  </Tile>
-  <Tile href="./admin/users.mdx" title="Local Users" icon="wrench">
-    Manage local user accounts.
-  </Tile>
-</TileSet>
+- [GitHub SSO](./admin/github-sso.mdx): Set up single sign-on with GitHub.
+- [Adding Nodes](./admin/adding-nodes.mdx): Add Nodes to your Teleport cluster.
+- [Trusted Clusters](./admin/trustedclusters.mdx): Connect multiple Teleport clusters using Trusted Clusters.
+- [Labels](./admin/labels.mdx): Manage resource metadata with labels.
+- [Local Users](./admin/users.mdx): Manage local user accounts.
 
 ## Troubleshoot issues
 
-<TileSet>
-  <Tile href="./admin/troubleshooting.mdx" title="Troubleshooting" icon="wrench">
-    Collect metrics and diagnostic information from Teleport.
-  </Tile>
-</TileSet>
+- [Troubleshooting](./admin/troubleshooting.mdx): Collect metrics and diagnostic information from Teleport.
 
 

--- a/docs/pages/setup/deployments.mdx
+++ b/docs/pages/setup/deployments.mdx
@@ -7,28 +7,7 @@ layout: tocless-doc
 These guides show you how to set up a full self-hosted Teleport deployment on
 the platform of your choice.
 
-<TileSet>
-  <Tile
-  title="DigitalOcean"
-  href="./deployments/digitalocean/"
-  >
-
-    Use our DigitalOcean 1-Click App to quickly spin up Teleport on a droplet.
-    
-  </Tile>
-  <Tile href="./deployments/aws-terraform.mdx" title="AWS Terraform">
-
-    Deploy HA Teleport with Terraform Provider on AWS.
-
-  </Tile>
-  <Tile href="./deployments/gcp.mdx" title="GCP">
-
-    Deploy HA Teleport on GCP.
-
-  </Tile>
-  <Tile href="./deployments/ibm.mdx" title="IBM Cloud">
-
-    Deploy HA Teleport on IBM cloud.
-
-  </Tile>
-</TileSet>
+- [DigitalOcean](./deployments/digitalocean.mdx/): Use our DigitalOcean 1-Click App to quickly spin up Teleport on a droplet. 
+- [AWS Terraform](./deployments/aws-terraform.mdx): Deploy HA Teleport with Terraform Provider on AWS.
+- [GCP](./deployments/gcp.mdx): Deploy HA Teleport on GCP.
+- [IBM Cloud](./deployments/ibm.mdx): Deploy HA Teleport on IBM cloud.

--- a/docs/pages/setup/deployments/digitalocean.mdx
+++ b/docs/pages/setup/deployments/digitalocean.mdx
@@ -102,20 +102,8 @@ Finally, you are a step closer to managing secure access to your infrastructure 
 Teleport lets you enable [certificate-based authentication for SSH](../../server-access/getting-started.mdx) access. If you want to protect public access to internal applications such as GitLab or Grafana, check out our getting started guide on [Application Access](../../application-access/getting-started.mdx).  
 
 You can also secure access to databases, DigitalOcean Marketplace apps, and Kubernetes clusters using Teleport. Below are the links to get started further:
-<TileSet>
-  <Tile icon="server" title="Server Access" href="../../server-access/getting-started.mdx">
-    Single Sign-On, short-lived certificates, and audit for SSH servers.
-  </Tile>
-  <Tile icon="window" title="Application Access" href="../../application-access/getting-started.mdx">
-    Secure access to internal dashboards and web applications.
-  </Tile>
-  <Tile icon="kubernetes" title="Kubernetes Access" href="../../kubernetes-access/getting-started.mdx">
-    Single Sign-On, audit and unified access for Kubernetes clusters.
-  </Tile>
-  <Tile icon="database" title="Database Access" href="../../database-access/getting-started.mdx">
-    Secure access to PostgreSQL, MySQL and MongoDB databases.
-  </Tile>
-  <Tile icon="desktop" title="Desktop Access" href="../../desktop-access/getting-started.mdx">
-    Secure access to Windows Server.
-  </Tile>
-</TileSet>
+- [Server Access](../../server-access/getting-started.mdx): Single Sign-On, short-lived certificates, and audit for SSH servers.
+- [Application Access](../../application-access/getting-started.mdx): Secure access to internal dashboards and web applications.
+- [Kubernetes Access](../../kubernetes-access/getting-started.mdx): Single Sign-On, audit and unified access for Kubernetes clusters.
+- [Database Access](../../database-access/getting-started.mdx): Secure access to PostgreSQL, MySQL and MongoDB databases.
+- [Desktop Access](../../desktop-access/getting-started.mdx): Secure access to Windows Server.

--- a/docs/pages/setup/helm-deployments.mdx
+++ b/docs/pages/setup/helm-deployments.mdx
@@ -9,26 +9,11 @@ layout: tocless-doc
 These guides show you how to set up a full self-hosted Teleport deployment using
 our `teleport-cluster` Helm chart.
 
-<TileSet>
-    <Tile icon="kubernetes" title="HA AWS Teleport Cluster" href="./helm-deployments/aws.mdx">
-        Running an HA Teleport cluster in Kubernetes using an AWS EKS Cluster
-    </Tile>
-    <Tile icon="kubernetes" title="HA GCP Teleport Cluster" href="./helm-deployments/gcp.mdx">
-        Running an HA Teleport cluster in Kubernetes using a Google Cloud GKE cluster
-    </Tile>
-    <Tile icon="kubernetes" title="Custom Teleport config" href="./helm-deployments/custom.mdx">
-        Running a Teleport cluster in Kubernetes with a custom Teleport config
-    </Tile>
-</TileSet>
+- [HA AWS Teleport Cluster](./helm-deployments/aws.mdx): Running an HA Teleport cluster in Kubernetes using an AWS EKS Cluster
+- [HA GCP Teleport Cluster](./helm-deployments/gcp.mdx): Running an HA Teleport cluster in Kubernetes using a Google Cloud GKE cluster
+- [Custom Teleport config](./helm-deployments/custom.mdx): Running a Teleport cluster in Kubernetes with a custom Teleport config
 
 ## Migration Guides
 
-<TileSet>
-<Tile
-href="./guides/migration.mdx"
-title="Migrating from the legacy Teleport chart"
-icon="kubernetes"
->
-</Tile>
-</TileSet>
+- [Migrating from the legacy Teleport chart](./helm-deployments/migration.mdx):
 

--- a/docs/pages/setup/helm-deployments/digitalocean.mdx
+++ b/docs/pages/setup/helm-deployments/digitalocean.mdx
@@ -13,14 +13,8 @@ Instead, Teleport Cloud users should consult the following guide, which shows
 you how to connect a Teleport Kubernetes Service instance to an existing Teleport
 cluster:
 
-<TileSet>
-<Tile
-title="Connect a Kubernetes Cluster to Teleport"
-href="./agent.mdx"
-icon="kubernetes"
->
-</Tile>
-</TileSet>
+- [Connect a Kubernetes Cluster to
+  Teleport](../../kubernetes-access/getting-started.mdx):
 
 </ScopedBlock>
 

--- a/docs/pages/setup/helm-reference.mdx
+++ b/docs/pages/setup/helm-reference.mdx
@@ -4,18 +4,9 @@ description: Comprehensive lists of configuration values in Teleport's Helm char
 layout: tocless-doc
 ---
 
-<TileSet>
-<Tile href="./helm-reference/teleport-cluster.mdx" icon="kubernetes" title="teleport-cluster">
-![Teleport ](../../img/k8s/mini-diagrams/teleport-in-k8s-mono.svg)
-
-Deploy the `teleport` daemon on Kubernetes with preset configurations for the
-Auth and Proxy Services and support for any Teleport service configuration.
-
-</Tile>
-<Tile href="./helm-reference/teleport-kube-agent.mdx" icon="kubernetes" title="teleport-kube-agent">
-![Kubernetes agent](../../img/k8s/mini-diagrams/k8s-to-teleport-mono.svg)
-
-Deploy the Teleport Kubernetes Service, Application Service, or Database Service on Kubernetes.
-
-</Tile>
-</TileSet>
+- [teleport-cluster](./helm-reference/teleport-cluster.mdx): Deploy the
+  `teleport` daemon on Kubernetes with preset configurations for the Auth and
+  Proxy Services and support for any Teleport service configuration.
+- [teleport-kube-agent](./helm-reference/teleport-kube-agent.mdx): Deploy the
+  Teleport Kubernetes Service, Application Service, or Database Service on
+  Kubernetes.

--- a/docs/pages/setup/operations.mdx
+++ b/docs/pages/setup/operations.mdx
@@ -10,24 +10,8 @@ on an already running Teleport cluster.
 For guides on the fundamentals of setting up your cluster, you should consult
 the [Cluster Administration Guides](./admin.mdx) section.
 
-<TileSet>
-  <ScopedBlock scope={["oss", "enterprise"]}>
-    <Tile href="./operations/scaling.mdx" title="Scaling" icon="wrench">
-    How to configure Teleport for large-scale deployments.
-    </Tile>
-  </ScopedBlock>
-  <Tile href="./operations/upgrading.mdx" title="Upgrading" icon="wrench">
-  Learn about how to upgrade your Teleport cluster while ensuring that components remain compatible.
-  </Tile>
-  <Tile href="./operations/backup-restore.mdx" title="Backup and Restore" icon="wrench">
-  Backing up and restoring the cluster.
-  </Tile>
-  <Tile href="./operations/ca-rotation.mdx" title="CA Rotation" icon="wrench">
-  Rotating Teleport certificate authorities.
-  </Tile>
-  <ScopedBlock scope={["oss", "enterprise"]}>
-    <Tile href="./operations/tls-routing.mdx" title="TLS Routing Migration" icon="wrench">
-    Migrating your Teleport cluster to single-port TLS routing mode.
-    </Tile>
-  </ScopedBlock>
-</TileSet>
+- [Scaling](./operations/scaling.mdx): How to configure Teleport for large-scale deployments.
+- [Upgrading](./operations/upgrading.mdx): Learn about how to upgrade your Teleport cluster while ensuring that components remain compatible.
+- [Backup and Restore](./operations/backup-restore.mdx): Backing up and restoring the cluster.
+- [CA Rotation](./operations/ca-rotation.mdx): Rotating Teleport certificate authorities.
+- [TLS Routing Migration](./operations/tls-routing.mdx): Migrating your Teleport cluster to single-port TLS routing mode.


### PR DESCRIPTION
Backports #15266

This change replaces all `Tile`s in the docs with lists of links. This
achieves two things:

- Helps us move toward a more text-focused look and feel for the docs.
  See gravitational/docs#93.
- Makes it easier to reorganize the docs. Currently, there's no linting
  for internal links in `Tile` hrefs (See gravitational/docs#100).

I used this script to edit each docs page, invoking the script for all
MDX files in docs/pages:

```
gawk '
    BEGIN{inopentag=0; indesc=0; desc=""; title=""; href="";}
    /<\/?TileSet>/{next;}
    /<Tile/ {
        inopentag=1;
    }
    inopentag==1 && /title=/{
        title=gensub(/.*title="([^"]+)".*/, "\\1", "g", $0);
    }
    inopentag==1 && /href=/{
        href=gensub(/.*href="([^"]+)".*/, "\\1", "g", $0);
    }
    inopentag==1 && />/ {
      inopentag=0;
      indesc=1;
      next;
    }
    indesc==1 && !/<\/Tile/{
        gsub(/(\n|\t|\s{2,})/," ",$0);
	desc=desc ($0);
	next;
    }
    /<\/Tile/{
        print "- [" title "](" href "):" desc;
	indesc=0;
	desc="";
	title="";
	href="";
	next;
    }
    inopentag==0 && indesc==0{ print $0 }

' $1 > "$1.tmp";
cat "$1.tmp" > "$1";
rm "$1.tmp";
```

I then cleaned up each file changed by the script and fixed any
incorrect URLs.