### PR TITLE
preserve explicit local auth disable

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -459,12 +459,10 @@ func (c *AuthPreferenceV2) CheckAndSetDefaults() error {
 	}
 
 	switch c.Spec.Type {
-	case constants.Local:
-		if !c.Spec.AllowLocalAuth.Value {
-			log.Warn("Ignoring local_auth=false when authentication.type=local")
-			c.Spec.AllowLocalAuth.Value = true
-		}
-	case constants.OIDC, constants.SAML, constants.Github:
+	case constants.Local, constants.OIDC, constants.SAML, constants.Github:
+		// Note that "type:local" and "local_auth:false" is considered a valid
+		// setting, as it is a common idiom for clusters that rely on dynamic
+		// configuration.
 	default:
 		return trace.BadParameter("authentication type %q not supported", c.Spec.Type)
 	}

--- a/api/types/authentication_authpreference_test.go
+++ b/api/types/authentication_authpreference_test.go
@@ -350,7 +350,7 @@ func TestAuthPreferenceV2_CheckAndSetDefaults_secondFactor(t *testing.T) {
 		},
 		// AllowLocalAuth
 		{
-			name: "OK AllowLocalAuth forced true for type=local",
+			name: "OK AllowLocalAuth preserve explicit false for type=local",
 			secondFactors: []constants.SecondFactorType{
 				constants.SecondFactorOff, // doesn't matter for this test
 				constants.SecondFactorOTP,
@@ -358,6 +358,20 @@ func TestAuthPreferenceV2_CheckAndSetDefaults_secondFactor(t *testing.T) {
 			spec: types.AuthPreferenceSpecV2{
 				Type:           constants.Local,
 				AllowLocalAuth: types.NewBoolOption(false),
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				assert.False(t, got.GetAllowLocalAuth(), "AllowLocalAuth")
+			},
+		},
+		// AllowLocalAuth
+		{
+			name: "OK AllowLocalAuth default to true for type=local",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOff, // doesn't matter for this test
+				constants.SecondFactorOTP,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				Type: constants.Local,
 			},
 			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
 				assert.True(t, got.GetAllowLocalAuth(), "AllowLocalAuth")


### PR DESCRIPTION
Don't override explicit `local_auth: false` (still defaults to `true` if `local_auth` is unspecified).

Fixes https://github.com/gravitational/teleport/issues/15441