### PR TITLE
improve semaphore flakiness test

### DIFF
--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1180,7 +1180,7 @@ func (s *ServicesTestSuite) SemaphoreFlakiness(t *testing.T) {
 
 	cfg := services.SemaphoreLockConfig{
 		Service:  wrapper,
-		Expiry:   time.Second,
+		Expiry:   time.Hour,
 		TickRate: time.Millisecond * 50,
 		Params: types.AcquireSemaphoreRequest{
 			SemaphoreKind: types.SemaphoreKindConnection,
@@ -1201,7 +1201,7 @@ func (s *ServicesTestSuite) SemaphoreFlakiness(t *testing.T) {
 			continue
 		case <-lock.Done():
 			t.Fatalf("Lost semaphore lock: %v", lock.Wait())
-		case <-time.After(time.Second):
+		case <-time.After(time.Second * 30):
 			t.Fatalf("Timeout waiting for renewals")
 		}
 	}


### PR DESCRIPTION
Reduces the sensitivity of `TestSemaphoreFlakiness` to CI env by moving all short timeouts out of the happy path, and by forcing retries to observe the accelerated tick rate already used by other elements of semaphore test coverage.

Fixes https://github.com/gravitational/teleport/issues/13562