### PR TITLE
Improve error logging on reconnect node

### DIFF
--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -45,14 +45,14 @@ func (a *Server) checkTokenJoinRequestCommon(ctx context.Context, req *types.Reg
 	// make sure the token is valid
 	provisionToken, err := a.ValidateToken(ctx, req.Token)
 	if err != nil {
-		log.Warningf("%q [%v] can not join the cluster with role %s, token error: %v", req.NodeName, req.HostID, req.Role, err)
+		log.Warningf("%q can not join the cluster with role %s, token error: %v", req.NodeName, req.Role, err)
 		msg := "the token is not valid" // default to most generic message
 		if strings.Contains(err.Error(), TokenExpiredOrNotFound) {
 			// propagate ExpiredOrNotFound message so that clients can attempt
 			// assertion-based fallback if appropriate.
 			msg = TokenExpiredOrNotFound
 		}
-		return nil, trace.AccessDenied("%q [%v] can not join the cluster with role %q, %s", req.NodeName, req.HostID, req.Role, msg)
+		return nil, trace.AccessDenied("%q can not join the cluster with role %q, %s", req.NodeName, req.Role, msg)
 	}
 
 	// instance certs can be requested by any agent that has at least one local service role (e.g. proxy, node, etc).

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -103,7 +103,8 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 		// clear assertion ID
 		assertionID = ""
 
-		if role == types.RoleInstance && connectErr != nil && strings.Contains(connectErr.Error(), auth.TokenExpiredOrNotFound) {
+		switch {
+		case role == types.RoleInstance && connectErr != nil && strings.Contains(connectErr.Error(), auth.TokenExpiredOrNotFound):
 			process.log.Infof("Token too old for direct instance cert request, will attempt to use system role assertions.")
 			id, assertionErr := process.assertSystemRoles()
 			if assertionErr == nil {
@@ -111,7 +112,9 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			} else {
 				process.log.Errorf("Failed to perform system role assertions: %v", assertionErr)
 			}
-		} else if connectErr != nil {
+		case role == types.RoleNode && connectErr != nil && strings.Contains(connectErr.Error(), auth.TokenExpiredOrNotFound):
+			process.log.Error("Can not join the cluster as node, the token expired or not found. Regenerate the token and try again.")
+		case connectErr != nil:
 			process.log.Errorf("%v failed to establish connection to cluster: %v.", role, connectErr)
 		}
 


### PR DESCRIPTION
This PR improves message when SSH node tries to reconnect with expired token.  

Fixes: https://github.com/gravitational/teleport/issues/15370

