### PR TITLE
Expose `tctl auth export` as a public endpoint

### DIFF
--- a/lib/auth/export.go
+++ b/lib/auth/export.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"encoding/pem"
+	"strings"
+	"time"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/trace"
+)
+
+// ExportAuthoritiesRequest has the required fields to create an export authorities request.
+// An empty AuthType exports all types.
+type ExportAuthoritiesRequest struct {
+	AuthType                   string
+	Client                     ClientI
+	ExportAuthorityFingerprint string
+	ExportPrivateKeys          bool
+	CompatVersion              string
+}
+
+// ExportAuthorities returns the list of authorities in OpenSSH compatible formats
+// If the ExportAuthoritiesRequest.AuthType is present only prints keys for CAs of this type,
+// otherwise returns all keys concatenated
+func ExportAuthorities(ctx context.Context, req ExportAuthoritiesRequest) (string, error) {
+	ret := strings.Builder{}
+
+	var typesToExport []types.CertAuthType
+
+	// this means to export TLS authority
+	switch req.AuthType {
+	// "tls" is supported for backwards compatibility.
+	// "tls-host" and "tls-user" were added later to allow export of the user
+	// TLS CA.
+	case "tls", "tls-host":
+		return exportTLSAuthority(ctx, req.Client, types.HostCA, false, req.ExportPrivateKeys)
+	case "tls-user":
+		return exportTLSAuthority(ctx, req.Client, types.UserCA, false, req.ExportPrivateKeys)
+	case "db":
+		return exportTLSAuthority(ctx, req.Client, types.DatabaseCA, false, req.ExportPrivateKeys)
+	case "tls-user-der", "windows":
+		return exportTLSAuthority(ctx, req.Client, types.UserCA, true, req.ExportPrivateKeys)
+	}
+
+	// if no --type flag is given, export HostCA and UserCA.
+	if req.AuthType == "" {
+		typesToExport = []types.CertAuthType{types.HostCA, types.UserCA}
+	} else {
+		authType := types.CertAuthType(req.AuthType)
+		if err := authType.Check(); err != nil {
+			return "", trace.Wrap(err)
+		}
+		typesToExport = []types.CertAuthType{authType}
+	}
+	localAuthName, err := req.Client.GetDomainName(ctx)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// fetch authorities via auth API (and only take local CAs, ignoring
+	// trusted ones)
+	var authorities []types.CertAuthority
+	for _, at := range typesToExport {
+		cas, err := req.Client.GetCertAuthorities(ctx, at, req.ExportPrivateKeys)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		for _, ca := range cas {
+			if ca.GetClusterName() == localAuthName {
+				authorities = append(authorities, ca)
+			}
+		}
+	}
+
+	for _, ca := range authorities {
+		if req.ExportPrivateKeys {
+			for _, key := range ca.GetActiveKeys().SSH {
+				fingerprint, err := sshutils.PrivateKeyFingerprint(key.PrivateKey)
+				if err != nil {
+					return "", trace.Wrap(err)
+				}
+				if req.ExportAuthorityFingerprint != "" && fingerprint != req.ExportAuthorityFingerprint {
+					continue
+				}
+				ret.WriteString(string(key.PrivateKey) + "\n")
+			}
+		} else {
+			for _, key := range ca.GetTrustedSSHKeyPairs() {
+				fingerprint, err := sshutils.AuthorizedKeyFingerprint(key.PublicKey)
+				if err != nil {
+					return "", trace.Wrap(err)
+				}
+				if req.ExportAuthorityFingerprint != "" && fingerprint != req.ExportAuthorityFingerprint {
+					continue
+				}
+
+				// export certificates in the old 1.0 format where host and user
+				// certificate authorities were exported in the known_hosts format.
+				if req.CompatVersion == "1.0" {
+					castr, err := hostCAFormat(ca, key.PublicKey, req.Client)
+					if err != nil {
+						return "", trace.Wrap(err)
+					}
+
+					ret.WriteString(castr + "\n")
+					continue
+				}
+
+				// export certificate authority in user or host ca format
+				var castr string
+				switch ca.GetType() {
+				case types.UserCA:
+					castr, err = userCAFormat(ca, key.PublicKey)
+				case types.HostCA:
+					castr, err = hostCAFormat(ca, key.PublicKey, req.Client)
+				default:
+					return "", trace.BadParameter("unknown user type: %q", ca.GetType())
+				}
+				if err != nil {
+					return "", trace.Wrap(err)
+				}
+
+				// write the export friendly string
+				ret.WriteString(castr + "\n")
+			}
+		}
+	}
+
+	return ret.String(), nil
+}
+
+func exportTLSAuthority(ctx context.Context, client ClientI, typ types.CertAuthType, unpackPEM bool, exportPrivateKeys bool) (string, error) {
+	ret := strings.Builder{}
+
+	clusterName, err := client.GetDomainName(ctx)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	certAuthority, err := client.GetCertAuthority(
+		ctx,
+		types.CertAuthID{Type: typ, DomainName: clusterName},
+		exportPrivateKeys,
+	)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	if len(certAuthority.GetActiveKeys().TLS) != 1 {
+		return "", trace.BadParameter("expected one TLS key pair, got %v", len(certAuthority.GetActiveKeys().TLS))
+	}
+	keyPair := certAuthority.GetActiveKeys().TLS[0]
+
+	marhsalKeyPair := func(data []byte) error {
+		if !unpackPEM {
+			ret.WriteString(string(data) + "\n")
+			return nil
+		}
+
+		b, _ := pem.Decode(data)
+		if b == nil {
+			return trace.BadParameter("no PEM data in CA data: %q", data)
+		}
+		ret.WriteString(string(b.Bytes) + "\n")
+
+		return nil
+	}
+
+	if exportPrivateKeys {
+		if err := marhsalKeyPair(keyPair.Key); err != nil {
+			return "", trace.Wrap(err)
+		}
+	}
+
+	if err := marhsalKeyPair(keyPair.Cert); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return ret.String(), nil
+}
+
+// userCAFormat returns the certificate authority public key exported as a single
+// line that can be placed in ~/.ssh/authorized_keys file. The format adheres to the
+// man sshd (8) authorized_keys format, a space-separated list of: options, keytype,
+// base64-encoded key, comment.
+// For example:
+//
+//    cert-authority AAA... type=user&clustername=cluster-a
+//
+// URL encoding is used to pass the CA type and cluster name into the comment field.
+func userCAFormat(ca types.CertAuthority, keyBytes []byte) (string, error) {
+	return sshutils.MarshalAuthorizedKeysFormat(ca.GetClusterName(), keyBytes)
+}
+
+// hostCAFormat returns the certificate authority public key exported as a single line
+// that can be placed in ~/.ssh/authorized_hosts. The format adheres to the man sshd (8)
+// authorized_hosts format, a space-separated list of: marker, hosts, key, and comment.
+// For example:
+//
+//    @cert-authority *.cluster-a ssh-rsa AAA... type=host
+//
+// URL encoding is used to pass the CA type and allowed logins into the comment field.
+func hostCAFormat(ca types.CertAuthority, keyBytes []byte, client ClientI) (string, error) {
+	roles, err := services.FetchRoles(ca.GetRoles(), client, nil)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	allowedLogins, _ := roles.GetLoginsForTTL(apidefaults.MinCertDuration + time.Second)
+	return sshutils.MarshalAuthorizedHostsFormat(ca.GetClusterName(), keyBytes, allowedLogins)
+}

--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package auth
+package client
 
 import (
 	"context"
@@ -24,27 +24,55 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/trace"
 )
 
 // ExportAuthoritiesRequest has the required fields to create an export authorities request.
+//
 // An empty AuthType exports all types.
+//
+// When exporting private keys, you can set ExportAuthorityFingerprint to filter the authority.
+// Fingerprint must be the SHA256 of the Authority's public key.
+//
+// You can export using the old 1.0 format where host and user
+// certificate authorities were exported in the known_hosts format.
+// To do so, set CompatVersion to "1.0".
+// No other CompatVersion value is accepted.
 type ExportAuthoritiesRequest struct {
 	AuthType                   string
-	Client                     ClientI
 	ExportAuthorityFingerprint string
 	ExportPrivateKeys          bool
 	CompatVersion              string
 }
 
-// ExportAuthorities returns the list of authorities in OpenSSH compatible formats
+// ExportAuthorities returns the list of authorities in OpenSSH compatible formats as a string.
 // If the ExportAuthoritiesRequest.AuthType is present only prints keys for CAs of this type,
-// otherwise returns all keys concatenated
-func ExportAuthorities(ctx context.Context, req ExportAuthoritiesRequest) (string, error) {
-	ret := strings.Builder{}
-
+// otherwise returns all keys concatenated.
+//
+// Exporting using "tls*", "database", "windows" AuthType:
+// Returns the certificate authority public key to be used by systems that rely on TLS.
+// The format can be PEM or DER depending on the target.
+//
+// Exporting using "user" AuthType:
+// Returns the certificate authority public key exported as a single
+// line that can be placed in ~/.ssh/authorized_keys file. The format adheres to the
+// man sshd (8) authorized_keys format, a space-separated list of: options, keytype,
+// base64-encoded key, comment.
+// For example:
+// > cert-authority AAA... type=user&clustername=cluster-a
+// URL encoding is used to pass the CA type and cluster name into the comment field.
+//
+// Exporting using "host" AuthType:
+// Returns the certificate authority public key exported as a single line
+// that can be placed in ~/.ssh/authorized_hosts. The format adheres to the man sshd (8)
+// authorized_hosts format, a space-separated list of: marker, hosts, key, and comment.
+// For example:
+// > @cert-authority *.cluster-a ssh-rsa AAA... type=host
+// URL encoding is used to pass the CA type and allowed logins into the comment field.
+func ExportAuthorities(ctx context.Context, client auth.ClientI, req ExportAuthoritiesRequest) (string, error) {
 	var typesToExport []types.CertAuthType
 
 	// this means to export TLS authority
@@ -53,16 +81,36 @@ func ExportAuthorities(ctx context.Context, req ExportAuthoritiesRequest) (strin
 	// "tls-host" and "tls-user" were added later to allow export of the user
 	// TLS CA.
 	case "tls", "tls-host":
-		return exportTLSAuthority(ctx, req.Client, types.HostCA, false, req.ExportPrivateKeys)
+		req := exportTLSAuthorityRequest{
+			AuthType:          types.HostCA,
+			UnpackPEM:         false,
+			ExportPrivateKeys: req.ExportPrivateKeys,
+		}
+		return exportTLSAuthority(ctx, client, req)
 	case "tls-user":
-		return exportTLSAuthority(ctx, req.Client, types.UserCA, false, req.ExportPrivateKeys)
+		req := exportTLSAuthorityRequest{
+			AuthType:          types.UserCA,
+			UnpackPEM:         false,
+			ExportPrivateKeys: req.ExportPrivateKeys,
+		}
+		return exportTLSAuthority(ctx, client, req)
 	case "db":
-		return exportTLSAuthority(ctx, req.Client, types.DatabaseCA, false, req.ExportPrivateKeys)
+		req := exportTLSAuthorityRequest{
+			AuthType:          types.DatabaseCA,
+			UnpackPEM:         false,
+			ExportPrivateKeys: req.ExportPrivateKeys,
+		}
+		return exportTLSAuthority(ctx, client, req)
 	case "tls-user-der", "windows":
-		return exportTLSAuthority(ctx, req.Client, types.UserCA, true, req.ExportPrivateKeys)
+		req := exportTLSAuthorityRequest{
+			AuthType:          types.UserCA,
+			UnpackPEM:         true,
+			ExportPrivateKeys: req.ExportPrivateKeys,
+		}
+		return exportTLSAuthority(ctx, client, req)
 	}
 
-	// if no --type flag is given, export HostCA and UserCA.
+	// If no AuthType is given, export both HostCA and UserCA.
 	if req.AuthType == "" {
 		typesToExport = []types.CertAuthType{types.HostCA, types.UserCA}
 	} else {
@@ -72,7 +120,7 @@ func ExportAuthorities(ctx context.Context, req ExportAuthoritiesRequest) (strin
 		}
 		typesToExport = []types.CertAuthType{authType}
 	}
-	localAuthName, err := req.Client.GetDomainName(ctx)
+	localAuthName, err := client.GetDomainName(ctx)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -81,7 +129,7 @@ func ExportAuthorities(ctx context.Context, req ExportAuthoritiesRequest) (strin
 	// trusted ones)
 	var authorities []types.CertAuthority
 	for _, at := range typesToExport {
-		cas, err := req.Client.GetCertAuthorities(ctx, at, req.ExportPrivateKeys)
+		cas, err := client.GetCertAuthorities(ctx, at, req.ExportPrivateKeys)
 		if err != nil {
 			return "", trace.Wrap(err)
 		}
@@ -92,6 +140,7 @@ func ExportAuthorities(ctx context.Context, req ExportAuthoritiesRequest) (strin
 		}
 	}
 
+	ret := strings.Builder{}
 	for _, ca := range authorities {
 		if req.ExportPrivateKeys {
 			for _, key := range ca.GetActiveKeys().SSH {
@@ -102,76 +151,87 @@ func ExportAuthorities(ctx context.Context, req ExportAuthoritiesRequest) (strin
 				if req.ExportAuthorityFingerprint != "" && fingerprint != req.ExportAuthorityFingerprint {
 					continue
 				}
-				ret.WriteString(string(key.PrivateKey) + "\n")
+				ret.WriteString(string(key.PrivateKey))
+				ret.WriteString("\n")
 			}
-		} else {
-			for _, key := range ca.GetTrustedSSHKeyPairs() {
-				fingerprint, err := sshutils.AuthorizedKeyFingerprint(key.PublicKey)
-				if err != nil {
-					return "", trace.Wrap(err)
-				}
-				if req.ExportAuthorityFingerprint != "" && fingerprint != req.ExportAuthorityFingerprint {
-					continue
-				}
+			continue
+		}
 
-				// export certificates in the old 1.0 format where host and user
-				// certificate authorities were exported in the known_hosts format.
-				if req.CompatVersion == "1.0" {
-					castr, err := hostCAFormat(ca, key.PublicKey, req.Client)
-					if err != nil {
-						return "", trace.Wrap(err)
-					}
+		for _, key := range ca.GetTrustedSSHKeyPairs() {
+			fingerprint, err := sshutils.AuthorizedKeyFingerprint(key.PublicKey)
+			if err != nil {
+				return "", trace.Wrap(err)
+			}
+			if req.ExportAuthorityFingerprint != "" && fingerprint != req.ExportAuthorityFingerprint {
+				continue
+			}
 
-					ret.WriteString(castr + "\n")
-					continue
-				}
-
-				// export certificate authority in user or host ca format
-				var castr string
-				switch ca.GetType() {
-				case types.UserCA:
-					castr, err = userCAFormat(ca, key.PublicKey)
-				case types.HostCA:
-					castr, err = hostCAFormat(ca, key.PublicKey, req.Client)
-				default:
-					return "", trace.BadParameter("unknown user type: %q", ca.GetType())
-				}
+			// export certificates in the old 1.0 format where host and user
+			// certificate authorities were exported in the known_hosts format.
+			if req.CompatVersion == "1.0" {
+				castr, err := hostCAFormat(ca, key.PublicKey, client)
 				if err != nil {
 					return "", trace.Wrap(err)
 				}
 
-				// write the export friendly string
-				ret.WriteString(castr + "\n")
+				ret.WriteString(castr)
+				ret.WriteString("\n")
+				continue
 			}
+
+			// export certificate authority in user or host ca format
+			var castr string
+			switch ca.GetType() {
+			case types.UserCA:
+				castr, err = userCAFormat(ca, key.PublicKey)
+			case types.HostCA:
+				castr, err = hostCAFormat(ca, key.PublicKey, client)
+			default:
+				return "", trace.BadParameter("unknown user type: %q", ca.GetType())
+			}
+			if err != nil {
+				return "", trace.Wrap(err)
+			}
+
+			// write the export friendly string
+			ret.WriteString(castr)
+			ret.WriteString("\n")
 		}
 	}
 
 	return ret.String(), nil
 }
 
-func exportTLSAuthority(ctx context.Context, client ClientI, typ types.CertAuthType, unpackPEM bool, exportPrivateKeys bool) (string, error) {
-	ret := strings.Builder{}
+type exportTLSAuthorityRequest struct {
+	AuthType          types.CertAuthType
+	UnpackPEM         bool
+	ExportPrivateKeys bool
+}
 
+func exportTLSAuthority(ctx context.Context, client auth.ClientI, req exportTLSAuthorityRequest) (string, error) {
 	clusterName, err := client.GetDomainName(ctx)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
 	certAuthority, err := client.GetCertAuthority(
 		ctx,
-		types.CertAuthID{Type: typ, DomainName: clusterName},
-		exportPrivateKeys,
+		types.CertAuthID{Type: req.AuthType, DomainName: clusterName},
+		req.ExportPrivateKeys,
 	)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
+
 	if len(certAuthority.GetActiveKeys().TLS) != 1 {
 		return "", trace.BadParameter("expected one TLS key pair, got %v", len(certAuthority.GetActiveKeys().TLS))
 	}
 	keyPair := certAuthority.GetActiveKeys().TLS[0]
 
+	ret := strings.Builder{}
 	marhsalKeyPair := func(data []byte) error {
-		if !unpackPEM {
-			ret.WriteString(string(data) + "\n")
+		if !req.UnpackPEM {
+			ret.WriteString(string(data))
+			ret.WriteString("\n")
 			return nil
 		}
 
@@ -179,12 +239,13 @@ func exportTLSAuthority(ctx context.Context, client ClientI, typ types.CertAuthT
 		if b == nil {
 			return trace.BadParameter("no PEM data in CA data: %q", data)
 		}
-		ret.WriteString(string(b.Bytes) + "\n")
+		ret.WriteString(string(b.Bytes))
+		ret.WriteString("\n")
 
 		return nil
 	}
 
-	if exportPrivateKeys {
+	if req.ExportPrivateKeys {
 		if err := marhsalKeyPair(keyPair.Key); err != nil {
 			return "", trace.Wrap(err)
 		}
@@ -203,7 +264,7 @@ func exportTLSAuthority(ctx context.Context, client ClientI, typ types.CertAuthT
 // base64-encoded key, comment.
 // For example:
 //
-//    cert-authority AAA... type=user&clustername=cluster-a
+//	cert-authority AAA... type=user&clustername=cluster-a
 //
 // URL encoding is used to pass the CA type and cluster name into the comment field.
 func userCAFormat(ca types.CertAuthority, keyBytes []byte) (string, error) {
@@ -215,10 +276,10 @@ func userCAFormat(ca types.CertAuthority, keyBytes []byte) (string, error) {
 // authorized_hosts format, a space-separated list of: marker, hosts, key, and comment.
 // For example:
 //
-//    @cert-authority *.cluster-a ssh-rsa AAA... type=host
+//	@cert-authority *.cluster-a ssh-rsa AAA... type=host
 //
 // URL encoding is used to pass the CA type and allowed logins into the comment field.
-func hostCAFormat(ca types.CertAuthority, keyBytes []byte, client ClientI) (string, error) {
+func hostCAFormat(ca types.CertAuthority, keyBytes []byte, client auth.ClientI) (string, error) {
 	roles, err := services.FetchRoles(ca.GetRoles(), client, nil)
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -75,7 +75,7 @@ func ExportAuthorities(ctx context.Context, client auth.ClientI, req ExportAutho
 }
 
 // ExportAuthoritiesWithSecrets exports the Authority Certificate and its secrets (private keys).
-// It exposts the secrets first and then the certificate (separated by an empty line).
+// It exports the secrets first and then the certificate (separated by an empty line).
 // See ExportAuthorities for more information.
 func ExportAuthoritiesWithSecrets(ctx context.Context, client auth.ClientI, req ExportAuthoritiesRequest) (string, error) {
 	return exportAuth(ctx, client, req, true /* exportSecrets */)

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/stretchr/testify/require"
+)
+
+type mockAuthClient struct {
+	auth.ClientI
+	server *auth.Server
+}
+
+func (m *mockAuthClient) GetDomainName(ctx context.Context) (string, error) {
+	return m.server.GetDomainName()
+}
+
+func (m *mockAuthClient) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
+	return m.server.GetCertAuthorities(ctx, caType, loadKeys, opts...)
+}
+
+func (m *mockAuthClient) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
+	return m.server.GetCertAuthority(ctx, id, loadKeys, opts...)
+}
+
+func TestExportAuthorities(t *testing.T) {
+	ctx := context.Background()
+	const localClusterName = "localcluster"
+
+	testAuth, err := auth.NewTestAuthServer(auth.TestAuthServerConfig{
+		ClusterName: localClusterName,
+		Dir:         t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	validateTLSCertificateDERFunc := func(t *testing.T, s string) {
+		cert, err := x509.ParseCertificate([]byte(s))
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+		require.Equal(t, cert.Subject.CommonName, localClusterName, "unexpected certificate subject CN")
+	}
+
+	validateTLSCertificatePEMFunc := func(t *testing.T, s string) {
+		pemBlock, _ := pem.Decode([]byte(s))
+		require.NotNil(t, pemBlock)
+
+		validateTLSCertificateDERFunc(t, string(pemBlock.Bytes))
+	}
+
+	validatePrivateKeyPEMFunc := func(t *testing.T, s string) {
+		pemBlock, _ := pem.Decode([]byte(s))
+		require.NotNil(t, pemBlock)
+
+		require.Equal(t, pemBlock.Type, "RSA PRIVATE KEY", "unexpected private key type")
+	}
+
+	validatePrivateKeyDERFunc := func(t *testing.T, s string) {
+		res := strings.Split(s, "\n\n")
+		require.Len(t, res, 2, "expected private key and certificate separated by one empty line")
+
+		privKey, err := x509.ParsePKCS1PrivateKey([]byte(res[0]))
+		require.NoError(t, err)
+		require.NotNil(t, privKey)
+
+		validateTLSCertificateDERFunc(t, res[1])
+	}
+
+	for _, exportSecrets := range []bool{false, true} {
+		for _, tt := range []struct {
+			name          string
+			req           ExportAuthoritiesRequest
+			errorCheck    require.ErrorAssertionFunc
+			assertOutput  func(t *testing.T, output string)
+			assertSecrets func(t *testing.T, output string)
+		}{
+			{
+				name: "ssh host and user ca",
+				req: ExportAuthoritiesRequest{
+					AuthType: "",
+				},
+				errorCheck: require.NoError,
+				assertOutput: func(t *testing.T, output string) {
+					require.Contains(t, output, "@cert-authority localcluster,*.localcluster ssh-rsa")
+					require.Contains(t, output, "cert-authority ssh-rsa")
+				},
+				assertSecrets: func(t *testing.T, output string) {
+
+				},
+			},
+			{
+				name: "user",
+				req: ExportAuthoritiesRequest{
+					AuthType: "user",
+				},
+				errorCheck: require.NoError,
+				assertOutput: func(t *testing.T, output string) {
+					require.Contains(t, output, "cert-authority ssh-rsa")
+				},
+				assertSecrets: validatePrivateKeyPEMFunc,
+			},
+			{
+				name: "host",
+				req: ExportAuthoritiesRequest{
+					AuthType: "host",
+				},
+				errorCheck: require.NoError,
+				assertOutput: func(t *testing.T, output string) {
+					require.Contains(t, output, "@cert-authority localcluster,*.localcluster ssh-rsa")
+				},
+				assertSecrets: validatePrivateKeyPEMFunc,
+			},
+			{
+				name: "tls",
+				req: ExportAuthoritiesRequest{
+					AuthType: "tls",
+				},
+				errorCheck:    require.NoError,
+				assertOutput:  validateTLSCertificatePEMFunc,
+				assertSecrets: validatePrivateKeyPEMFunc,
+			},
+			{
+				name: "windows",
+				req: ExportAuthoritiesRequest{
+					AuthType: "windows",
+				},
+				errorCheck:    require.NoError,
+				assertOutput:  validateTLSCertificateDERFunc,
+				assertSecrets: validatePrivateKeyDERFunc,
+			},
+			{
+				name: "invalid",
+				req: ExportAuthoritiesRequest{
+					AuthType: "invalid",
+				},
+				errorCheck: func(tt require.TestingT, err error, i ...interface{}) {
+					require.ErrorContains(tt, err, `"invalid" authority type is not supported`)
+				},
+			},
+			{
+				name: "fingerprint not found",
+				req: ExportAuthoritiesRequest{
+					AuthType:                   "user",
+					ExportAuthorityFingerprint: "not found fingerprint",
+				},
+				errorCheck: require.NoError,
+				assertOutput: func(t *testing.T, output string) {
+					require.Empty(t, output)
+				},
+				assertSecrets: func(t *testing.T, output string) {
+					require.Empty(t, output)
+				},
+			},
+			{
+				name: "fingerprint not found",
+				req: ExportAuthoritiesRequest{
+					AuthType:                   "user",
+					ExportAuthorityFingerprint: "fake fingerprint",
+				},
+				errorCheck: require.NoError,
+				assertOutput: func(t *testing.T, output string) {
+					require.Empty(t, output)
+				},
+				assertSecrets: func(t *testing.T, output string) {
+					require.Empty(t, output)
+				},
+			},
+			{
+				name: "using compat version",
+				req: ExportAuthoritiesRequest{
+					AuthType:         "user",
+					UseCompatVersion: true,
+				},
+				errorCheck: require.NoError,
+				assertOutput: func(t *testing.T, output string) {
+					// compat version (using 1.0) returns cert-authority to be used in the server
+					// even when asking for ssh authorized hosts / known hosts
+					require.Contains(t, output, "@cert-authority localcluster,*.localcluster ssh-rsa")
+				},
+				assertSecrets: validatePrivateKeyPEMFunc,
+			},
+		} {
+			testName := tt.name
+			if exportSecrets {
+				testName = tt.name + "_exportSecrets"
+			}
+			t.Run(testName, func(t *testing.T) {
+				mockedClient := &mockAuthClient{
+					server: testAuth.AuthServer,
+				}
+				var (
+					err      error
+					exported string
+				)
+
+				if exportSecrets {
+					exported, err = ExportAuthoritiesWithSecrets(ctx, mockedClient, tt.req)
+					tt.errorCheck(t, err)
+				} else {
+					exported, err = ExportAuthorities(ctx, mockedClient, tt.req)
+					tt.errorCheck(t, err)
+				}
+
+				if err != nil {
+					return
+				}
+
+				if exportSecrets {
+					tt.assertSecrets(t, exported)
+				} else {
+					tt.assertOutput(t, exported)
+				}
+			})
+		}
+	}
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3134,11 +3134,14 @@ func SSOSetWebSessionAndRedirectURL(w http.ResponseWriter, r *http.Request, resp
 //
 // GET /webapi/sites/:site/auth/export?type=<auth type>
 func (h *Handler) authExportPublic(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-	authorities, err := auth.ExportAuthorities(r.Context(), auth.ExportAuthoritiesRequest{
-		Client:            h.GetProxyClient(),
-		AuthType:          r.URL.Query().Get("type"),
-		ExportPrivateKeys: false,
-	})
+	authorities, err := client.ExportAuthorities(
+		r.Context(),
+		h.GetProxyClient(),
+		client.ExportAuthoritiesRequest{
+			AuthType:          r.URL.Query().Get("type"),
+			ExportPrivateKeys: false,
+		},
+	)
 	if err != nil {
 		h.log.WithError(err).Debug("Failed to generate CA Certs.")
 		http.Error(w, err.Error(), trace.ErrorToCode(err))

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -19,7 +19,6 @@ limitations under the License.
 package web
 
 import (
-	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/base64"
@@ -3138,8 +3137,7 @@ func (h *Handler) authExportPublic(w http.ResponseWriter, r *http.Request, p htt
 		r.Context(),
 		h.GetProxyClient(),
 		client.ExportAuthoritiesRequest{
-			AuthType:          r.URL.Query().Get("type"),
-			ExportPrivateKeys: false,
+			AuthType: r.URL.Query().Get("type"),
 		},
 	)
 	if err != nil {
@@ -3148,9 +3146,9 @@ func (h *Handler) authExportPublic(w http.ResponseWriter, r *http.Request, p htt
 		return
 	}
 
-	contentsReader := bytes.NewReader([]byte(authorities))
+	reader := strings.NewReader(authorities)
 
 	// ServeContent sets the correct headers: Content-Type, Content-Length and Accept-Ranges.
 	// It also handles the Range negotiation
-	http.ServeContent(w, r, "authorized_hosts.txt", time.Now(), contentsReader)
+	http.ServeContent(w, r, "authorized_hosts.txt", time.Now(), reader)
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2495,13 +2495,13 @@ func TestAuthExport(t *testing.T) {
 	validateTLSCertificateDERFunc := func(t *testing.T, b []byte) {
 		cert, err := x509.ParseCertificate(b)
 		require.NoError(t, err)
-		require.NotNil(t, cert)
-		require.Equal(t, cert.Subject.CommonName, "localhost", "unexpected certificate subject CN")
+		require.NotNil(t, cert, "ParseCertificate failed")
+		require.Equal(t, "localhost", cert.Subject.CommonName, "unexpected certificate subject CN")
 	}
 
 	validateTLSCertificatePEMFunc := func(t *testing.T, b []byte) {
 		pemBlock, _ := pem.Decode(b)
-		require.NotNil(t, pemBlock)
+		require.NotNil(t, pemBlock, "pem.Decode failed")
 
 		validateTLSCertificateDERFunc(t, pemBlock.Bytes)
 	}

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -16,7 +16,6 @@ package common
 
 import (
 	"context"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"net"
@@ -40,7 +39,6 @@ import (
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/kingpin"
@@ -168,147 +166,20 @@ var allowedCertificateTypes = []string{"user", "host", "tls-host", "tls-user", "
 // If --type flag is given, only prints keys for CAs of this type, otherwise
 // prints all keys
 func (a *AuthCommand) ExportAuthorities(ctx context.Context, client auth.ClientI) error {
-	var typesToExport []types.CertAuthType
-
-	// this means to export TLS authority
-	switch a.authType {
-	// "tls" is supported for backwards compatibility.
-	// "tls-host" and "tls-user" were added later to allow export of the user
-	// TLS CA.
-	case "tls", "tls-host":
-		return a.exportTLSAuthority(ctx, client, types.HostCA, false)
-	case "tls-user":
-		return a.exportTLSAuthority(ctx, client, types.UserCA, false)
-	case "db":
-		return a.exportTLSAuthority(ctx, client, types.DatabaseCA, false)
-	case "tls-user-der", "windows":
-		return a.exportTLSAuthority(ctx, client, types.UserCA, true)
-	}
-
-	// if no --type flag is given, export HostCA and UserCA.
-	if a.authType == "" {
-		typesToExport = []types.CertAuthType{types.HostCA, types.UserCA}
-	} else {
-		authType := types.CertAuthType(a.authType)
-		if err := authType.Check(); err != nil {
-			return trace.Wrap(err)
-		}
-		typesToExport = []types.CertAuthType{authType}
-	}
-	localAuthName, err := client.GetDomainName(ctx)
+	authorities, err := auth.ExportAuthorities(ctx, auth.ExportAuthoritiesRequest{
+		AuthType:                   a.authType,
+		Client:                     client,
+		ExportAuthorityFingerprint: a.exportAuthorityFingerprint,
+		ExportPrivateKeys:          a.exportPrivateKeys,
+		CompatVersion:              a.compatVersion,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	// fetch authorities via auth API (and only take local CAs, ignoring
-	// trusted ones)
-	var authorities []types.CertAuthority
-	for _, at := range typesToExport {
-		cas, err := client.GetCertAuthorities(ctx, at, a.exportPrivateKeys)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		for _, ca := range cas {
-			if ca.GetClusterName() == localAuthName {
-				authorities = append(authorities, ca)
-			}
-		}
-	}
+	fmt.Println(authorities)
 
-	// print:
-	for _, ca := range authorities {
-		if a.exportPrivateKeys {
-			for _, key := range ca.GetActiveKeys().SSH {
-				fingerprint, err := sshutils.PrivateKeyFingerprint(key.PrivateKey)
-				if err != nil {
-					return trace.Wrap(err)
-				}
-				if a.exportAuthorityFingerprint != "" && fingerprint != a.exportAuthorityFingerprint {
-					continue
-				}
-				os.Stdout.Write(key.PrivateKey)
-				fmt.Fprintf(os.Stdout, "\n")
-			}
-		} else {
-			for _, key := range ca.GetTrustedSSHKeyPairs() {
-				fingerprint, err := sshutils.AuthorizedKeyFingerprint(key.PublicKey)
-				if err != nil {
-					return trace.Wrap(err)
-				}
-				if a.exportAuthorityFingerprint != "" && fingerprint != a.exportAuthorityFingerprint {
-					continue
-				}
-
-				// export certificates in the old 1.0 format where host and user
-				// certificate authorities were exported in the known_hosts format.
-				if a.compatVersion == "1.0" {
-					castr, err := hostCAFormat(ca, key.PublicKey, client)
-					if err != nil {
-						return trace.Wrap(err)
-					}
-
-					fmt.Println(castr)
-					continue
-				}
-
-				// export certificate authority in user or host ca format
-				var castr string
-				switch ca.GetType() {
-				case types.UserCA:
-					castr, err = userCAFormat(ca, key.PublicKey)
-				case types.HostCA:
-					castr, err = hostCAFormat(ca, key.PublicKey, client)
-				default:
-					return trace.BadParameter("unknown user type: %q", ca.GetType())
-				}
-				if err != nil {
-					return trace.Wrap(err)
-				}
-
-				// print the export friendly string
-				fmt.Println(castr)
-			}
-		}
-	}
 	return nil
-}
-
-func (a *AuthCommand) exportTLSAuthority(ctx context.Context, client auth.ClientI, typ types.CertAuthType, unpackPEM bool) error {
-	clusterName, err := client.GetDomainName(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	certAuthority, err := client.GetCertAuthority(
-		ctx,
-		types.CertAuthID{Type: typ, DomainName: clusterName},
-		a.exportPrivateKeys,
-	)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if len(certAuthority.GetActiveKeys().TLS) != 1 {
-		return trace.BadParameter("expected one TLS key pair, got %v", len(certAuthority.GetActiveKeys().TLS))
-	}
-	keyPair := certAuthority.GetActiveKeys().TLS[0]
-
-	print := func(data []byte) error {
-		if !unpackPEM {
-			fmt.Println(string(data))
-			return nil
-		}
-		b, _ := pem.Decode(data)
-		if b == nil {
-			return trace.BadParameter("no PEM data in CA data: %q", data)
-		}
-		fmt.Println(string(b.Bytes))
-		return nil
-	}
-	if a.exportPrivateKeys {
-		if err := print(keyPair.Key); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-	return trace.Wrap(print(keyPair.Cert))
 }
 
 // GenerateKeys generates a new keypair
@@ -936,36 +807,6 @@ func (a *AuthCommand) checkProxyAddr(clusterAPI auth.ClientI) error {
 	}
 
 	return trace.BadParameter("couldn't find registered public proxies, specify --proxy when using --format=%q", identityfile.FormatKubernetes)
-}
-
-// userCAFormat returns the certificate authority public key exported as a single
-// line that can be placed in ~/.ssh/authorized_keys file. The format adheres to the
-// man sshd (8) authorized_keys format, a space-separated list of: options, keytype,
-// base64-encoded key, comment.
-// For example:
-//
-//	cert-authority AAA... type=user&clustername=cluster-a
-//
-// URL encoding is used to pass the CA type and cluster name into the comment field.
-func userCAFormat(ca types.CertAuthority, keyBytes []byte) (string, error) {
-	return sshutils.MarshalAuthorizedKeysFormat(ca.GetClusterName(), keyBytes)
-}
-
-// hostCAFormat returns the certificate authority public key exported as a single line
-// that can be placed in ~/.ssh/authorized_hosts. The format adheres to the man sshd (8)
-// authorized_hosts format, a space-separated list of: marker, hosts, key, and comment.
-// For example:
-//
-//	@cert-authority *.cluster-a ssh-rsa AAA... type=host
-//
-// URL encoding is used to pass the CA type and allowed logins into the comment field.
-func hostCAFormat(ca types.CertAuthority, keyBytes []byte, client auth.ClientI) (string, error) {
-	roles, err := services.FetchRoles(ca.GetRoles(), client, nil)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-	allowedLogins, _ := roles.GetLoginsForTTL(apidefaults.MinCertDuration + time.Second)
-	return sshutils.MarshalAuthorizedHostsFormat(ca.GetClusterName(), keyBytes, allowedLogins)
 }
 
 func getApplicationServer(ctx context.Context, clusterAPI auth.ClientI, appName string) (types.AppServer, error) {

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -165,14 +165,17 @@ var allowedCertificateTypes = []string{"user", "host", "tls-host", "tls-user", "
 // ExportAuthorities outputs the list of authorities in OpenSSH compatible formats
 // If --type flag is given, only prints keys for CAs of this type, otherwise
 // prints all keys
-func (a *AuthCommand) ExportAuthorities(ctx context.Context, client auth.ClientI) error {
-	authorities, err := auth.ExportAuthorities(ctx, auth.ExportAuthoritiesRequest{
-		AuthType:                   a.authType,
-		Client:                     client,
-		ExportAuthorityFingerprint: a.exportAuthorityFingerprint,
-		ExportPrivateKeys:          a.exportPrivateKeys,
-		CompatVersion:              a.compatVersion,
-	})
+func (a *AuthCommand) ExportAuthorities(ctx context.Context, clt auth.ClientI) error {
+	authorities, err := client.ExportAuthorities(
+		ctx,
+		clt,
+		client.ExportAuthoritiesRequest{
+			AuthType:                   a.authType,
+			ExportAuthorityFingerprint: a.exportAuthorityFingerprint,
+			ExportPrivateKeys:          a.exportPrivateKeys,
+			CompatVersion:              a.compatVersion,
+		},
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -166,14 +166,18 @@ var allowedCertificateTypes = []string{"user", "host", "tls-host", "tls-user", "
 // If --type flag is given, only prints keys for CAs of this type, otherwise
 // prints all keys
 func (a *AuthCommand) ExportAuthorities(ctx context.Context, clt auth.ClientI) error {
-	authorities, err := client.ExportAuthorities(
+	exportFunc := client.ExportAuthorities
+	if a.exportPrivateKeys {
+		exportFunc = client.ExportAuthoritiesWithSecrets
+	}
+
+	authorities, err := exportFunc(
 		ctx,
 		clt,
 		client.ExportAuthoritiesRequest{
 			AuthType:                   a.authType,
 			ExportAuthorityFingerprint: a.exportAuthorityFingerprint,
-			ExportPrivateKeys:          a.exportPrivateKeys,
-			CompatVersion:              a.compatVersion,
+			UseCompatVersion:           a.compatVersion == "1.0",
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Public endpoint that exports CA Certificates

It supports the same types that we currently support when running `tctl auth export --type=t`
Fix https://github.com/gravitational/teleport/issues/7413

Demo
```
marco@lenix ~> curl --insecure "https://127.0.0.1.nip.io:3080/v1/webapi/sites/lenix/auth/export"
@cert-authority lenix,*.lenix ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0TxkYYZ+EKHdgA09h/fK0upJzaPe8Sxr63wxPLzqJNDr8O4mxy24UZ08t5tojyaEXHwRLvqOdUBXhbpQpmrUkuN2LLS/k1ijk+V98j+6vWaviL3fDPbZw4PRRl0QtCjAFE/kxH9uLmqvMwnCpeNOQaugq1slVOibDZDrP7FcKmrTzKldk5ohSJSTl0sH6TQzQG2Sj+awXLk7LWcYvE5PN0YVh/S9kzmTpCugaIGd5LOAL3JSuQJ+pwwKmVEg+EPYcbzv7lcLgnew9weCDK0uk4PuNnMXrt1KcCEFttMrceeGnnqOr5JogFLiWL/TP+9kBgleNZhXEaXSz2r1i7pNt type=host
cert-authority ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDHoDSouxSrXq/X+qZWBM8saHEIb3O3dXOfpRtGrkV6LymPpojhzN1dcYKUqYvWYMw2+WOKIyeAgg9p0zrIQaP7AQPP42sjDhB4keJMbSHh43Hnb7pITRBBpsSCGYMr1U1utQDdz1dbzp96OlvXoNL+ltZKPYNBvG7obqlqhFhHV6ReNvb7FT1OSrtC7UEElPyrYgd3+QMBTTNNYg3Lu+712ySKHqjdM6mLG8XWfSbkmLVbKRTcV3qPj6vEnarXHOnATv+AJElkIlaJjx+RmIxEA9AlE+mjxm2PR+uwsFLV+YD20oPWHaqVyKzT3x7/UNQttBTZD1G0D2fwZg2lDO29 clustername=lenix&type=user
marco@lenix ~> curl --insecure "https://127.0.0.1.nip.io:3080/v1/webapi/sites/lenix/auth/export?type=db"
-----BEGIN CERTIFICATE-----
MIIDcDCCAligAwIBAgIQUppf1u3b6mtJig/5GwAUNjANBgkqhkiG9w0BAQsFADBS
MQ4wDAYDVQQKEwVsZW5peDEOMAwGA1UEAxMFbGVuaXgxMDAuBgNVBAUTJzEwOTc5
ODI1MzIyNzkzMDM5OTA4OTE3NjQ1MzMyMDAzMDU1NzIzODAeFw0yMjA4MzAxMDA5
NThaFw0zMjA4MjcxMDA5NThaMFIxDjAMBgNVBAoTBWxlbml4MQ4wDAYDVQQDEwVs
ZW5peDEwMC4GA1UEBRMnMTA5Nzk4MjUzMjI3OTMwMzk5MDg5MTc2NDUzMzIwMDMw
NTU3MjM4MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4AyI3MnQHLjv
hko3qE1F0SqlPMKfCPaBaCHZj5yI7Gm/U6BKx+mm4zl0R7xqDjUIQo751DUVQoJh
etuHOpgJ9OyzTYG8BqqhuuGFqWy9RkPcMSup2gQInpcma+iVs6HPYeIZa4MlnYJH
nBVjRgXyiURAtdg0wlq12SNh0R0FUBAo4i6bqNLlqQkA9WJkea5RxIk337qgYo/r
pRb0QlOWaeUYsVU4yn21h1dnrZCg21iaxLDjV97dV47BYcK5yPFFSRAVVgyR74r2
SF3p6R45qH1Ll+gEwxZf7M0IFPAUbWxaZ3KPz11BE+ISKH1NN7j/Aj5rPqwAULnp
e79S94asmQIDAQABo0IwQDAOBgNVHQ8BAf8EBAMCAaYwDwYDVR0TAQH/BAUwAwEB
/zAdBgNVHQ4EFgQUOXJtvj3lcOi/epoPRO32lEHgM8wwDQYJKoZIhvcNAQELBQAD
ggEBAMe0zhNLzNNlxYWTgD5uefhP1KPb/44gmh7n1/xF3Wd11QktDraPN9cyy30R
qeMdBmwgn6Ek7Dy+E22nPSVLh49DSRPrXATgRetNW4g4iMvQKnZi8k7agnXedxWq
irLUsFApAagKwFNJyQQsGpdUxUgZiK43JaZ/dAHGvXYEJA4BYepIQRtEdraa/T5h
M9HDWVHEuPCjMH8/10wTWjDiikVHPCwAAab6/r7WJ7Jn+Bv4PBOxYOwHeuboBNgl
khF9lGAqonSP6kx3gLSApLW5S3QX0U+4qukmIE970evwIAzc43hwaNaI8gM9nswE
dpX8vd+vaed76+ZzxQmBlh4hgQU=
-----END CERTIFICATE-----

marco@lenix ~>
```