### PR TITLE
bot: don't treat docs reviewers as external authors

### DIFF
--- a/.github/workflows/robot/go.mod
+++ b/.github/workflows/robot/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/google/go-github/v37 v37.0.0
 	github.com/gravitational/trace v1.1.15
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 )
 

--- a/.github/workflows/robot/go.sum
+++ b/.github/workflows/robot/go.sum
@@ -130,8 +130,8 @@ github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/.github/workflows/robot/internal/review/review.go
+++ b/.github/workflows/robot/internal/review/review.go
@@ -272,7 +272,10 @@ func (r *Assignments) checkCodeReviews(author string, reviews []github.Review) e
 	// return an error.
 	v, ok := r.c.CodeReviewers[author]
 	if !ok {
-		return trace.BadParameter("rejecting checking external review")
+		v, ok = r.c.DocsReviewers[author]
+		if !ok {
+			return trace.BadParameter("rejecting checking external review")
+		}
 	}
 
 	// Cloud and Internal get reviews from the Core team. Other teams do own


### PR DESCRIPTION
This fixes a corner case where a docs reviewer who submits a PR that
touches code or examples is treated as an external author instead
of an internal employee.