### PR TITLE
Fix inverted check for `join_params` and `auth_token` mutual exclusion

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2146,8 +2146,6 @@ func applyTokenConfig(fc *FileConfig, cfg *service.Config) error {
 	if fc.AuthToken != "" {
 		cfg.JoinMethod = types.JoinMethodToken
 		cfg.SetToken(fc.AuthToken)
-
-		return nil
 	}
 
 	if fc.JoinParams != (JoinParams{}) {
@@ -2164,5 +2162,6 @@ func applyTokenConfig(fc *FileConfig, cfg *service.Config) error {
 			return trace.BadParameter(`unknown value for join_params.method: %q, expected one of %v`, fc.JoinParams.Method, []types.JoinMethod{types.JoinMethodEC2, types.JoinMethodIAM, types.JoinMethodToken})
 		}
 	}
+
 	return nil
 }

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2149,7 +2149,7 @@ func applyTokenConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 
 	if fc.JoinParams != (JoinParams{}) {
-		if !cfg.HasToken() {
+		if cfg.HasToken() {
 			return trace.BadParameter("only one of auth_token or join_params should be set")
 		}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2604,3 +2604,100 @@ func TestApplyConfigSessionRecording(t *testing.T) {
 		})
 	}
 }
+
+func TestJoinParams(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc             string
+		input            string
+		expectToken      string
+		expectJoinMethod types.JoinMethod
+		expectError      bool
+	}{
+		{
+			desc: "empty",
+		},
+		{
+			desc: "auth_token",
+			input: `
+teleport:
+  auth_token: xxxyyy
+`,
+			expectToken:      "xxxyyy",
+			expectJoinMethod: types.JoinMethodToken,
+		},
+		{
+			desc: "join_params token",
+			input: `
+teleport:
+  join_params:
+    token_name: xxxyyy
+    method: token
+`,
+			expectToken:      "xxxyyy",
+			expectJoinMethod: types.JoinMethodToken,
+		},
+		{
+			desc: "join_params ec2",
+			input: `
+teleport:
+  join_params:
+    token_name: xxxyyy
+    method: ec2
+`,
+			expectToken:      "xxxyyy",
+			expectJoinMethod: types.JoinMethodEC2,
+		},
+		{
+			desc: "join_params iam",
+			input: `
+teleport:
+  join_params:
+    token_name: xxxyyy
+    method: iam
+`,
+			expectToken:      "xxxyyy",
+			expectJoinMethod: types.JoinMethodIAM,
+		},
+		{
+			desc: "join_params invalid",
+			input: `
+teleport:
+  join_params:
+    token_name: xxxyyy
+    method: invalid
+`,
+			expectError: true,
+		},
+		{
+			desc: "both set",
+			input: `
+teleport:
+  auth_token: xxxyyy
+  join_params:
+    token_name: xxxyyy
+    method: iam
+`,
+			expectError: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			conf, err := ReadConfig(strings.NewReader(tc.input))
+			require.NoError(t, err)
+
+			cfg := service.MakeDefaultConfig()
+			err = ApplyFileConfig(conf, cfg)
+
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			token, err := cfg.Token()
+			require.NoError(t, err)
+			require.Equal(t, tc.expectToken, token)
+			require.Equal(t, tc.expectJoinMethod, cfg.JoinMethod)
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/15512

https://github.com/gravitational/teleport/commit/29175e57d32b76d1466448c193eb75f5fc609981 introduced an inverted check which makes any `join_params` set in the file config cause teleport to fail startup. This PR fixes the check and adds a test so we can't do this again.