### PR TITLE
Fix tsh login when using a custom proxy port

### DIFF
--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -473,6 +473,12 @@ type KeyPairPath struct {
 	Certificate string
 }
 
+// CLIProxyFlag returns the proxy address in a format suitable for use
+// with the --proxy flag for tsh and tctl.
+func (c ProxyConfig) CLIProxyFlag() string {
+	return fmt.Sprintf("%v,%d", c.WebAddr.Addr, c.SSHAddr.Port(defaults.SSHProxyListenPort))
+}
+
 // KubeAddr returns the address for the Kubernetes endpoint on this proxy that
 // can be reached by clients.
 func (c ProxyConfig) KubeAddr() (string, error) {

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -73,7 +73,7 @@ func TestDatabaseLogin(t *testing.T) {
 
 	// Log into Teleport cluster.
 	err = Run(context.Background(), []string{
-		"login", "--insecure", "--debug", "--auth", connector.GetName(), "--proxy", proxyAddr.String(),
+		"login", "--insecure", "--debug", "--auth", connector.GetName(), "--proxy", proxyProcess.Config.Proxy.CLIProxyFlag(),
 	}, setHomePath(tmpHomePath), cliOption(func(cf *CLIConf) error {
 		cf.mockSSOLogin = mockSSOLogin(t, authServer, alice)
 		return nil

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -60,7 +60,7 @@ func onProxyCommandSSH(cf *CLIConf) error {
 	}
 
 	err = libclient.RetryWithRelogin(cf.Context, tc, func() error {
-		proxyParams, err := getSSHProxyParams(cf, tc)
+		proxyParams, err := getSSHProxyParams(cf.Context, tc)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -94,7 +94,7 @@ type sshProxyParams struct {
 }
 
 // getSSHProxyParams prepares parameters for establishing an SSH proxy connection.
-func getSSHProxyParams(cf *CLIConf, tc *libclient.TeleportClient) (*sshProxyParams, error) {
+func getSSHProxyParams(ctx context.Context, tc *libclient.TeleportClient) (*sshProxyParams, error) {
 	targetHost, targetPort, err := net.SplitHostPort(tc.Host)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -121,7 +121,7 @@ func getSSHProxyParams(cf *CLIConf, tc *libclient.TeleportClient) (*sshProxyPara
 	// proxy directly. Call its ping endpoint to figure out the cluster details
 	// such as cluster name, SSH proxy address, etc.
 	ping, err := webclient.Find(&webclient.Config{
-		Context:   cf.Context,
+		Context:   ctx,
 		ProxyAddr: tc.JumpHosts[0].Addr.Addr,
 		Insecure:  tc.InsecureSkipVerify,
 	})

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -91,7 +91,7 @@ func testRootClusterSSHAccess(t *testing.T, s *suite) {
 
 	identityFile := mustLoginIdentity(t, s)
 	err = Run(context.Background(), []string{
-		"--proxy", s.root.Config.Proxy.WebAddr.String(),
+		"--proxy", s.root.Config.Proxy.CLIProxyFlag(),
 		"--insecure",
 		"-i", identityFile,
 		"ssh",
@@ -114,7 +114,7 @@ func testLeafClusterSSHAccess(t *testing.T, s *suite) {
 
 	identityFile := mustLoginIdentity(t, s)
 	err := Run(context.Background(), []string{
-		"--proxy", s.root.Config.Proxy.WebAddr.String(),
+		"--proxy", s.root.Config.Proxy.CLIProxyFlag(),
 		"--insecure",
 		"-i", identityFile,
 		"ssh",
@@ -214,7 +214,7 @@ func TestProxySSH(t *testing.T) {
 			runProxySSH := func(proxyRequest string, opts ...cliOption) error {
 				return Run(context.Background(), []string{
 					"--insecure",
-					"--proxy", s.root.Config.Proxy.WebAddr.Addr,
+					"--proxy", s.root.Config.Proxy.CLIProxyFlag(),
 					"proxy", "ssh", proxyRequest,
 				}, opts...)
 			}
@@ -474,7 +474,7 @@ func mustLogin(t *testing.T, s *suite, args ...string) string {
 		"login",
 		"--insecure",
 		"--debug",
-		"--proxy", s.root.Config.Proxy.WebAddr.String(),
+		"--proxy", s.root.Config.Proxy.CLIProxyFlag(),
 	}, args...)
 	err := Run(context.Background(), args, setMockSSOLogin(t, s), setHomePath(tshHome))
 	require.NoError(t, err)
@@ -491,7 +491,7 @@ func mustLoginSetEnv(t *testing.T, s *suite, args ...string) string {
 		"login",
 		"--insecure",
 		"--debug",
-		"--proxy", s.root.Config.Proxy.WebAddr.String(),
+		"--proxy", s.root.Config.Proxy.CLIProxyFlag(),
 	}, args...)
 	err := Run(context.Background(), args, setMockSSOLogin(t, s), setHomePath(tshHome))
 	require.NoError(t, err)

--- a/tool/tsh/tctl_test.go
+++ b/tool/tsh/tctl_test.go
@@ -41,15 +41,12 @@ func TestLoadConfigFromProfile(t *testing.T) {
 	authServer := authProcess.GetAuthServer()
 	require.NotNil(t, authServer)
 
-	proxyAddr, err := proxyProcess.ProxyWebAddr()
-	require.NoError(t, err)
-
 	err = Run(context.Background(), []string{
 		"login",
 		"--insecure",
 		"--debug",
 		"--auth", connector.GetName(),
-		"--proxy", proxyAddr.String(),
+		"--proxy", proxyProcess.Config.Proxy.CLIProxyFlag(),
 	}, setHomePath(tmpHomePath), cliOption(func(cf *CLIConf) error {
 		cf.mockSSOLogin = mockSSOLogin(t, authServer, alice)
 		return nil

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1194,10 +1194,10 @@ func serializeVersion(format string, proxyVersion string) (string, error) {
 //
 // Each of these modes has two subcases:
 // a) --session-id ends with ".tar" - tsh operates on a local file
-//    containing a previously downloaded session
+// containing a previously downloaded session
 //
 // b) --session-id is the ID of a session - tsh operates on the session
-//    recording by connecting to the Teleport cluster
+// recording by connecting to the Teleport cluster
 func onPlay(cf *CLIConf) error {
 	if format := strings.ToLower(cf.Format); format == teleport.PTY {
 		return playSession(cf)
@@ -2955,8 +2955,7 @@ func makeClientForProxy(cf *CLIConf, proxy string, useProfileLogin bool) (*clien
 		c.Username = cf.Username
 	}
 	c.ExplicitUsername = cf.ExplicitUsername
-	// if proxy is set, and proxy is not equal to profile's
-	// loaded addresses, override the values
+
 	if err := setClientWebProxyAddr(cf, c); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1187,14 +1187,15 @@ func serializeVersion(format string, proxyVersion string) (string, error) {
 // onPlay is used to interact with recorded sessions.
 // It has several modes:
 //
-// 1. If --format is "pty" (the default), then the recorded
-//    session is played back in the user's terminal.
-// 2. Otherwise, `tsh play` is used to export a session from the
-//    binary protobuf format into YAML or JSON.
+//  1. If --format is "pty" (the default), then the recorded
+//     session is played back in the user's terminal.
+//  2. Otherwise, `tsh play` is used to export a session from the
+//     binary protobuf format into YAML or JSON.
 //
 // Each of these modes has two subcases:
 // a) --session-id ends with ".tar" - tsh operates on a local file
 //    containing a previously downloaded session
+//
 // b) --session-id is the ID of a session - tsh operates on the session
 //    recording by connecting to the Teleport cluster
 func onPlay(cf *CLIConf) error {
@@ -3174,10 +3175,8 @@ var defaultWebProxyPorts = []int{
 //
 // If successful, setClientWebProxyAddr will modify the client Config in-place.
 func setClientWebProxyAddr(cf *CLIConf, c *client.Config) error {
-	// If the user has specified a proxy on the command line, and one has not
-	// already been specified from configuration...
-
-	if cf.Proxy != "" && c.WebProxyAddr == "" {
+	// If the user has specified a proxy on the command line.
+	if cf.Proxy != "" {
 		parsedAddrs, err := client.ParseProxyHost(cf.Proxy)
 		if err != nil {
 			return trace.Wrap(err)

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -3101,3 +3101,33 @@ func TestShowSessions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, buf.String())
 }
+
+func TestSetClientWebProxyAddr(t *testing.T) {
+	for _, test := range []struct {
+		proxyFlag        string
+		wantWebProxyAddr string
+		wantSSHProxyAddr string
+	}{
+		{
+			// specify only web proxy port
+			proxyFlag:        "teleport.example.com:3088",
+			wantWebProxyAddr: "teleport.example.com:3088",
+			wantSSHProxyAddr: "teleport.example.com:3023",
+		},
+		{
+			// specify web proxy and SSH proxy ports
+			proxyFlag:        "teleport.example.com:3088,3089",
+			wantWebProxyAddr: "teleport.example.com:3088",
+			wantSSHProxyAddr: "teleport.example.com:3089",
+		},
+	} {
+		t.Run(test.proxyFlag, func(t *testing.T) {
+			cf := &CLIConf{Proxy: test.proxyFlag}
+			var c client.Config
+
+			require.NoError(t, setClientWebProxyAddr(cf, &c))
+			require.Equal(t, test.wantWebProxyAddr, c.WebProxyAddr)
+			require.Equal(t, test.wantSSHProxyAddr, c.SSHProxyAddr)
+		})
+	}
+}


### PR DESCRIPTION
Ensure that we attempt to connect to the correct port when a port
is specified in the --proxy flag.

Before (ignores port specified on command line):

```
➜ tsh login --proxy proxy.127.0.0.1.nip.io:3088 --user zac
ERROR: Get "https://proxy.127.0.0.1.nip.io:3080/webapi/ping": dial tcp 127.0.0.1:3080: connect: connection refused
```

After:

```
➜ tsh login --proxy proxy.127.0.0.1.nip.io:3088 --user zac
> Profile URL:        https://proxy.127.0.0.1.nip.io:3088
  Logged in as:       zac
  Cluster:            zac-local
  Roles:              access, auditor, editor
  Logins:             zmb, -teleport-internal-join
  Kubernetes:         enabled
  Valid until:        2022-08-16 23:28:35 -0600 MDT [valid for 11h28m0s]
  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
```

Fixes #2458