### PR TITLE
ami: update Grafana to 9.0.7 (#4218)

### DIFF
--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -38,7 +38,7 @@ TELEGRAF_VERSION ?= 1.9.3
 INFLUXDB_VERSION ?= 1.8.5
 
 # Grafana version
-GRAFANA_VERSION ?= 5.4.3
+GRAFANA_VERSION ?= 9.0.7
 
 # AWS account ID which hosts the public Teleport AMIs
 AWS_ACCOUNT_ID ?= 126027368216

--- a/assets/aws/files/install.sh
+++ b/assets/aws/files/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [[ "${DEBUG}" == "true" ]]; then
+if [[ "${DEBUG:-false}" == "true" ]]; then
     set -x
 fi
 
@@ -17,17 +17,17 @@ amazon-linux-extras install nginx1
 CURL_OPTS="-L --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300"
 
 # Install telegraf to collect stats from influx
-curl ${CURL_OPTS} -o /tmp/telegraf.rpm https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}-1.x86_64.rpm
+curl ${CURL_OPTS} -o /tmp/telegraf.rpm "https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}-1.x86_64.rpm"
 yum install -y /tmp/telegraf.rpm
 rm -f /tmp/telegraf.rpm
 
 # Install grafana
-curl ${CURL_OPTS} -o /tmp/grafana.rpm https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${GRAFANA_VERSION}-1.x86_64.rpm
+curl ${CURL_OPTS} -o /tmp/grafana.rpm "https://dl.grafana.com/oss/release/grafana-${GRAFANA_VERSION}-1.x86_64.rpm"
 yum install -y /tmp/grafana.rpm
 rm -f /tmp/grafana.rpm
 
 # Install InfluxDB
-curl $CURL_OPTS -o /tmp/influxdb.rpm https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}.x86_64.rpm
+curl $CURL_OPTS -o /tmp/influxdb.rpm "https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}.x86_64.rpm"
 yum install -y /tmp/influxdb.rpm
 rm -f /tmp/influxdb.rpm
 

--- a/examples/aws/terraform/ha-autoscale-cluster/assets/grafana-nginx-acm.conf
+++ b/examples/aws/terraform/ha-autoscale-cluster/assets/grafana-nginx-acm.conf
@@ -3,7 +3,7 @@ user nginx;
 pid /run/nginx.pid;
 
 events {
-    worker_connections 2048;
+	worker_connections 2048;
 }
 
 http {
@@ -33,13 +33,30 @@ http {
 	##
 	gzip on;
 
-    #
-    # Frontend grafana (no TLS as we're using ACM on the LB)
-    #
-    server {
-        listen 8444 default_server;
-        location / {
-            proxy_pass http://127.0.0.1:3000;
-        }
-    }
+	##
+	# Websocket settings
+	##
+	map $http_upgrade $connection_upgrade {
+		default upgrade;
+		'' close;
+	}
+
+	#
+	# Frontend grafana (no TLS as we're using ACM on the LB)
+	#
+	server {
+		listen 8444 default_server;
+		location / {
+			proxy_pass http://127.0.0.1:3000;
+			proxy_set_header Host $http_host;
+		}
+		# Proxy Grafana Live WebSocket connections.
+		location /api/live/ {
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection $connection_upgrade;
+			proxy_set_header Host $http_host;
+			proxy_pass http://127.0.0.1:3000;
+		}
+	}
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/assets/grafana-nginx.conf
+++ b/examples/aws/terraform/ha-autoscale-cluster/assets/grafana-nginx.conf
@@ -3,7 +3,7 @@ user nginx;
 pid /run/nginx.pid;
 
 events {
-    worker_connections 2048;
+	worker_connections 2048;
 }
 
 http {
@@ -22,7 +22,7 @@ http {
 
 	##
 	# TLS settings - we are pretty strict here
-    # but well, it's a dev service, why not?
+	# but well, it's a dev service, why not?
 	##
 	ssl_protocols TLSv1.2;
 	ssl_prefer_server_ciphers on;
@@ -40,16 +40,33 @@ http {
 	##
 	gzip on;
 
-    #
-    # Frontend grafana with TLS
-    #
-    server {
-        listen 8443 default_server ssl;
-        ssl_certificate_key     /etc/tls/certs/privkey.pem;
-        ssl_certificate  /etc/tls/certs/fullchain.pem;
-        ssl_ciphers AES256+EECDH:AES256+EDH:!aNULL;
-        location / {
-            proxy_pass http://127.0.0.1:3000;
-        }
-    }
+	##
+	# Websocket settings
+	##
+	map $http_upgrade $connection_upgrade {
+		default upgrade;
+		'' close;
+	}
+
+	#
+	# Frontend grafana with TLS
+	#
+	server {
+		listen 8443 default_server ssl;
+		ssl_certificate_key	 /etc/tls/certs/privkey.pem;
+		ssl_certificate  /etc/tls/certs/fullchain.pem;
+		ssl_ciphers AES256+EECDH:AES256+EDH:!aNULL;
+		location / {
+			proxy_pass http://127.0.0.1:3000;
+			proxy_set_header Host $http_host;
+		}
+		# Proxy Grafana Live WebSocket connections.
+		location /api/live/ {
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection $connection_upgrade;
+			proxy_set_header Host $http_host;
+			proxy_pass http://127.0.0.1:3000;
+		}
+	}
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/s3.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/s3.tf
@@ -16,7 +16,7 @@ resource "aws_s3_bucket_object" "grafana_teleport_dashboard" {
   bucket = aws_s3_bucket.certs.bucket
   key    = "health-dashboard.json"
   source = "./assets/health-dashboard.json"
-  etag    = filemd5("./assets/health-dashboard.json")
+  etag   = filemd5("./assets/health-dashboard.json")
 }
 
 // Grafana nginx config (letsencrypt)
@@ -25,7 +25,7 @@ resource "aws_s3_bucket_object" "grafana_teleport_nginx" {
   key    = "grafana-nginx.conf"
   source = "./assets/grafana-nginx.conf"
   count  = var.use_acm ? 0 : 1
-  etag    = filemd5("./assets/grafana-nginx.conf")
+  etag   = filemd5("./assets/grafana-nginx.conf")
 }
 
 // Grafana nginx config (ACM)
@@ -34,6 +34,6 @@ resource "aws_s3_bucket_object" "grafana_teleport_nginx_acm" {
   key    = "grafana-nginx.conf"
   source = "./assets/grafana-nginx-acm.conf"
   count  = var.use_acm ? 1 : 0
-  etag    = filemd5("./assets/grafana-nginx-acm.conf")
+  etag   = filemd5("./assets/grafana-nginx-acm.conf")
 }
 

--- a/examples/aws/terraform/ha-autoscale-cluster/s3.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/s3.tf
@@ -16,6 +16,7 @@ resource "aws_s3_bucket_object" "grafana_teleport_dashboard" {
   bucket = aws_s3_bucket.certs.bucket
   key    = "health-dashboard.json"
   source = "./assets/health-dashboard.json"
+  etag    = filemd5("./assets/health-dashboard.json")
 }
 
 // Grafana nginx config (letsencrypt)
@@ -24,6 +25,7 @@ resource "aws_s3_bucket_object" "grafana_teleport_nginx" {
   key    = "grafana-nginx.conf"
   source = "./assets/grafana-nginx.conf"
   count  = var.use_acm ? 0 : 1
+  etag    = filemd5("./assets/grafana-nginx.conf")
 }
 
 // Grafana nginx config (ACM)
@@ -32,5 +34,6 @@ resource "aws_s3_bucket_object" "grafana_teleport_nginx_acm" {
   key    = "grafana-nginx.conf"
   source = "./assets/grafana-nginx-acm.conf"
   count  = var.use_acm ? 1 : 0
+  etag    = filemd5("./assets/grafana-nginx-acm.conf")
 }
 


### PR DESCRIPTION
Fixes #4218

The PR:
- Bumps the Grafana version
- Fixes the packer script failing when `DEBUG` is unset
- Makes Nginx propagate the Host header required since https://grafana.com/blog/2022/02/08/grafana-7.5.15-and-8.3.5-released-with-moderate-severity-security-fixes/
- Makes Nginx proxy websocket calls properly (kinda necessary since grafana 8)
- Retab Nginx conf files that were a mix of tabs and spaces
- Makes Terraform compute s3 files' md5 to detect and apply changes