### PR TITLE
Fix bot's test

### DIFF
--- a/.github/workflows/robot/Makefile
+++ b/.github/workflows/robot/Makefile
@@ -1,0 +1,6 @@
+#
+# test executes the bot's full test suite.
+#
+.PHONY: test
+test:
+	go test -v -count 1 -race ./...

--- a/.github/workflows/robot/internal/bot/label_test.go
+++ b/.github/workflows/robot/internal/bot/label_test.go
@@ -85,7 +85,7 @@ func TestLabel(t *testing.T) {
 						Organization: "foo",
 						Repository:   "bar",
 						Number:       0,
-						UnsafeHead:   test.branch,
+						UnsafeBase:   test.branch,
 					},
 				},
 			}


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/14068 fixed the issue with bot not adding backport labels but the test wasn't updated and was failing.

I also added a Makefile and a `test` target so it's easy to run the bot's tests.