### PR TITLE
Ignore Logins when listing Nodes

### DIFF
--- a/integration/proxy_tunnel_strategy_test.go
+++ b/integration/proxy_tunnel_strategy_test.go
@@ -424,7 +424,7 @@ func (p *proxyTunnelStrategy) makeDatabase(t *testing.T) {
 		},
 	}
 
-	_, role, err := auth.CreateUserAndRole(p.auth.Process.GetAuthServer(), p.username, nil)
+	_, role, err := auth.CreateUserAndRole(p.auth.Process.GetAuthServer(), p.username, []string{p.username})
 	require.NoError(t, err)
 
 	role.SetDatabaseUsers(types.Allow, []string{types.Wildcard})

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1039,26 +1039,6 @@ func (a *ServerWithRoles) NewWatcher(ctx context.Context, watch types.Watch) (ty
 	return a.authServer.NewWatcher(ctx, watch)
 }
 
-// filterNodes filters nodes based off the role of the logged in user.
-func (a *ServerWithRoles) filterNodes(checker *nodeChecker, nodes []types.Server) ([]types.Server, error) {
-	// Loop over all nodes and check if the caller has access.
-	var filteredNodes []types.Server
-	for _, node := range nodes {
-		err := checker.CanAccess(node)
-		if err != nil {
-			if trace.IsAccessDenied(err) {
-				continue
-			}
-
-			return nil, trace.Wrap(err)
-		}
-
-		filteredNodes = append(filteredNodes, node)
-	}
-
-	return filteredNodes, nil
-}
-
 // DeleteAllNodes deletes all nodes in a given namespace
 func (a *ServerWithRoles) DeleteAllNodes(ctx context.Context, namespace string) error {
 	if err := a.action(namespace, types.KindNode, types.VerbDelete); err != nil {
@@ -1085,16 +1065,12 @@ func (a *ServerWithRoles) GetNode(ctx context.Context, namespace, name string) (
 		return nil, trace.Wrap(err)
 	}
 
-	checker, err := newNodeChecker(a.context, a.authServer)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	if err := a.checkAccessToNode(node); err != nil {
+		if trace.IsAccessDenied(err) {
+			return nil, trace.NotFound("not found")
+		}
 
-	// Run node through filter to check if it's for the connected identity.
-	if filteredNodes, err := a.filterNodes(checker, []types.Server{node}); err != nil {
 		return nil, trace.Wrap(err)
-	} else if len(filteredNodes) == 0 {
-		return nil, trace.NotFound("not found")
 	}
 
 	return node, nil
@@ -1113,16 +1089,19 @@ func (a *ServerWithRoles) GetNodes(ctx context.Context, namespace string) ([]typ
 	}
 	elapsedFetch := time.Since(startFetch)
 
-	checker, err := newNodeChecker(a.context, a.authServer)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// Filter nodes to return the ones for the connected identity.
+	filteredNodes := make([]types.Server, 0)
 	startFilter := time.Now()
-	filteredNodes, err := a.filterNodes(checker, nodes)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	for _, node := range nodes {
+		if err := a.checkAccessToNode(node); err != nil {
+			if trace.IsAccessDenied(err) {
+				continue
+			}
+
+			return nil, trace.Wrap(err)
+		}
+
+		filteredNodes = append(filteredNodes, node)
 	}
 	elapsedFilter := time.Since(startFilter)
 
@@ -1286,57 +1265,11 @@ func (r resourceChecker) CanAccess(resource types.Resource) error {
 		return r.CheckAccess(rr, mfaParams)
 	case types.WindowsDesktop:
 		return r.CheckAccess(rr, mfaParams)
+	case types.Server:
+		return r.CheckAccess(rr, mfaParams)
 	default:
 		return trace.BadParameter("could not check access to resource type %T", r)
 	}
-}
-
-// nodeChecker is a resourceAccessChecker that checks for access to nodes
-type nodeChecker struct {
-	accessChecker services.AccessChecker
-	builtinRole   bool
-}
-
-// newNodeChecker returns a new nodeChecker that checks access to nodes with the
-// the provided user if necessary. This prevents the need to load the role set each time
-// a node is checked.
-func newNodeChecker(authContext Context, authServer *Server) (*nodeChecker, error) {
-	// For certain built-in roles, continue to allow full access and return
-	// the full set of nodes to not break existing clusters during migration.
-	//
-	// In addition, allow proxy (and remote proxy) to access all nodes for its
-	// smart resolution address resolution. Once the smart resolution logic is
-	// moved to the auth server, this logic can be removed.
-	builtinRole := HasBuiltinRole(authContext, string(types.RoleAdmin)) ||
-		HasBuiltinRole(authContext, string(types.RoleProxy)) ||
-		HasRemoteBuiltinRole(authContext, string(types.RoleRemoteProxy))
-
-	return &nodeChecker{
-		accessChecker: authContext.Checker,
-		builtinRole:   builtinRole,
-	}, nil
-}
-
-// CanAccess checks if the user has access to the node
-func (n *nodeChecker) CanAccess(resource types.Resource) error {
-	server, ok := resource.(types.Server)
-	if !ok {
-		return trace.BadParameter("unexpected resource type %T", resource)
-	}
-
-	if n.builtinRole {
-		return nil
-	}
-
-	// Check if we can access the node with any of our possible logins.
-	for _, login := range n.accessChecker.GetAllLogins() {
-		err := n.accessChecker.CheckAccess(server, services.AccessMFAParams{Verified: true}, services.NewLoginMatcher(login))
-		if err == nil {
-			return nil
-		}
-	}
-
-	return trace.AccessDenied("access to node %q denied", server.GetHostname())
 }
 
 // kubeChecker is a resourceAccessChecker that checks for access to kubernetes services
@@ -1422,10 +1355,8 @@ func (k *kubeChecker) canAccessKubernetes(server types.KubeServer) error {
 // newResourceAccessChecker creates a resourceAccessChecker for the provided resource type
 func (a *ServerWithRoles) newResourceAccessChecker(resource string) (resourceAccessChecker, error) {
 	switch resource {
-	case types.KindAppServer, types.KindDatabaseServer, types.KindWindowsDesktop:
+	case types.KindAppServer, types.KindDatabaseServer, types.KindWindowsDesktop, types.KindNode:
 		return &resourceChecker{AccessChecker: a.context.Checker}, nil
-	case types.KindNode:
-		return newNodeChecker(a.context, a.authServer)
 	case types.KindKubeService, types.KindKubeServer:
 		return newKubeChecker(a.context), nil
 	default:
@@ -4651,6 +4582,13 @@ func (a *ServerWithRoles) DeleteAllApps(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (a *ServerWithRoles) checkAccessToNode(node types.Server) error {
+	return a.context.Checker.CheckAccess(node,
+		// MFA is not required for operations on node resources but
+		// will be enforced at the connection time.
+		services.AccessMFAParams{Verified: true})
 }
 
 func (a *ServerWithRoles) checkAccessToDatabase(database types.Database) error {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -3479,7 +3479,6 @@ func TestListResources_WithRoles(t *testing.T) {
 	createRole := func(ctx context.Context, t *testing.T, srv *Server, name string, labels map[string]apiutils.Strings) {
 		role, err := types.NewRoleV3(name, types.RoleSpecV5{
 			Allow: types.RoleConditions{
-				Logins: []string{"root"},
 				NodeLabels: types.Labels{
 					"*": []string{types.Wildcard},
 				},

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -1050,7 +1050,7 @@ func TestIsMFARequired(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a fake user.
-	user, role, err := CreateUserAndRole(srv.Auth(), "no-mfa-user", []string{"role"})
+	user, role, err := CreateUserAndRole(srv.Auth(), "no-mfa-user", []string{"no-mfa-user"})
 	require.NoError(t, err)
 
 	for _, required := range []bool{true, false} {

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -1051,7 +1051,7 @@ func CreateUserAndRole(clt clt, username string, allowedLogins []string) (types.
 		return nil, nil, trace.Wrap(err)
 	}
 	role := services.RoleForUser(user)
-	role.SetLogins(types.Allow, []string{user.GetName()})
+	role.SetLogins(types.Allow, allowedLogins)
 	err = clt.UpsertRole(ctx, role)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)


### PR DESCRIPTION
Currently, we require users to have at least one Allowed Login in order
for them to list/read nodes.

This is different from the other resources.
In those, only the `<resource>_labels` needs to match what the roleset
allows/denies to the user.

This could lead to, for example, not being able to list Nodes even
though the user had a role allowing them to access any Node (ie
```
NodeLabels:
  - '*' : '*'
```

### When we don't have any login:
We can list the servers:
![image](https://user-images.githubusercontent.com/689271/185152432-8508df7c-774e-4d41-963f-f94d5edda114.png)

Trying to ssh into a node returns an error (web ui and `tsh`)
```bash
$ tsh --insecure --proxy 127.0.0.1.nip.io:3080 ssh marco@lenix
ERROR: access denied to marco connecting to lenix on cluster lenix
```

![image](https://user-images.githubusercontent.com/689271/185938766-ba6db481-8ccd-4d13-8c21-51e1cc01f544.png)


Adding a single login and then trying to login with a different login
(in this case we added a `andre` login but tried to login as `marco`)
```bash
$ tsh --insecure --proxy 127.0.0.1.nip.io:3080 ssh marco@lenix
ERROR: access denied to marco connecting to lenix on cluster lenix
```
![image](https://user-images.githubusercontent.com/689271/185939601-83210370-97ad-4d25-aba2-d565785de1bf.png)

Setting the `marco` as a denied login, we can't use it anymore even if it's part of the allowed logins:
```bash
$ tsh --insecure --proxy 127.0.0.1.nip.io:3080 ssh marco@lenix
Enter password for Teleport user marco:
WARNING: You are using insecure connection to SSH proxy https://127.0.0.1.nip.io:3080
ERROR: access denied to marco connecting to lenix on cluster lenix
```

![image](https://user-images.githubusercontent.com/689271/185940230-1dfe2afb-7909-4c75-8ebc-bad1dc5b69c1.png)
![image](https://user-images.githubusercontent.com/689271/185940272-ca948272-eefc-4e6b-be8d-d59b17dcffec.png)

Removing the login denial allows for a successful login:
![image](https://user-images.githubusercontent.com/689271/185940527-0acba499-541a-4ef8-ba6b-fb8bc9c867af.png)
