### PR TITLE
[v8] Document `teleport.dev/database_name` tag. (#14923)

### DIFF
--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -245,6 +245,10 @@ $ tsh db login redshift
   You can be logged into multiple databases simultaneously.
 </Admonition>
 
+<Admonition type="note" title="Note">
+  You can override the database name by applying the `teleport.dev/database_name` AWS tag to the resource. The value of the tag will be used as the database name.
+</Admonition>
+
 You can optionally specify the database name and the user to use by default
 when connecting to the database instance:
 

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -365,6 +365,8 @@ $ tsh db ls
   Primary, reader, and custom endpoints of Aurora clusters have names of
   `<cluster-id>`, `<cluster-id>-reader`, and
   `<cluster-id>-custom-<endpoint-name>` respectively.
+
+  You can override the `<cluster-id>` part of the name with `teleport.dev/database_name` AWS tag.
 </Admonition>
 
 Log into particular database using `tsh db login` command:


### PR DESCRIPTION
Backport #14923 to v8.

---

* Document `teleport.dev/database_name` tag.

Co-authored-by: Paul Gottschling <paul.gottschling@goteleport.com>