### PR TITLE
[v8] Manually instrument cache.Cache

### DIFF
--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -34,7 +34,7 @@ type collection interface {
 	// will apply said resources to the cache.  fetch *must*
 	// not mutate cache state outside of the apply function.
 	fetch(ctx context.Context) (apply func(ctx context.Context) error, err error)
-	// process processes event
+	// processEvent processes event
 	processEvent(ctx context.Context, e types.Event) error
 	// watchKind returns a watch
 	// required for this collection

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1646,6 +1646,7 @@ func (process *TeleportProcess) newAccessCache(cfg accessCacheConfig) (*cache.Ca
 		WebToken:        cfg.services.WebTokens(),
 		Component:       teleport.Component(append(cfg.cacheName, process.id, teleport.ComponentCache)...),
 		MetricComponent: teleport.Component(append(cfg.cacheName, teleport.ComponentCache)...),
+		Tracer:          process.TracingProvider.Tracer(teleport.ComponentCache),
 	}))
 }
 
@@ -2520,9 +2521,9 @@ func (process *TeleportProcess) getAdditionalPrincipals(role types.SystemRole) (
 
 // initProxy gets called if teleport runs with 'proxy' role enabled.
 // this means it will do two things:
-//    1. serve a web UI
-//    2. proxy SSH connections to nodes running with 'node' role
-//    3. take care of reverse tunnels
+//  1. serve a web UI
+//  2. proxy SSH connections to nodes running with 'node' role
+//  3. take care of reverse tunnels
 func (process *TeleportProcess) initProxy() error {
 	// If no TLS key was provided for the web listener, generate a self-signed cert
 	if len(process.Config.Proxy.KeyPairs) == 0 &&


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/13318 to branch/v9

**Note:** the second commit also includes the portion of https://github.com/gravitational/teleport/pull/14658 that added tracing to fetch. This wasn't included in the backport of https://github.com/gravitational/teleport/pull/14658 because it depended on the commit in this PR :)