### PR TITLE
bot: Add support for preferred reviewers

### DIFF
--- a/.github/workflows/robot/internal/bot/assign.go
+++ b/.github/workflows/robot/internal/bot/assign.go
@@ -76,7 +76,7 @@ func (b *Bot) getReviewers(ctx context.Context, files []github.PullRequestFile) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return b.c.Review.Get(b.c.Environment.Author, docs, code), nil
+	return b.c.Review.Get(b.c.Environment.Author, docs, code, files), nil
 }
 
 func (b *Bot) backportReviewers(ctx context.Context) ([]string, error) {

--- a/.github/workflows/robot/internal/bot/label.go
+++ b/.github/workflows/robot/internal/bot/label.go
@@ -103,7 +103,7 @@ var prefixes = map[string][]string{
 	"examples/chart":      {"helm"},
 	"lib/bpf/":            {"bpf"},
 	"lib/events":          {"audit-log"},
-	"lib/kube":            {"kubernetes"},
+	"lib/kube":            {"kubernetes-access"},
 	"lib/tbot/":           {"machine-id"},
 	"lib/srv/desktop":     {"desktop-access"},
 	"lib/srv/desktop/rdp": {"desktop-access", "rdp"},

--- a/.github/workflows/robot/internal/review/review.go
+++ b/.github/workflows/robot/internal/review/review.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"log"
 	"math/rand"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/gravitational/teleport/.github/workflows/robot/internal/github"
@@ -33,13 +35,21 @@ type Reviewer struct {
 	Team string `json:"team"`
 	// Owner is true if the reviewer is a code or docs owner (required for all reviews).
 	Owner bool `json:"owner"`
+	// PreferredReviewerFor contains a list of file paths that this reviewer
+	// should be selected to review.
+	PreferredReviewerFor []string `json:"preferredReviewerFor,omitempty"`
+}
+
+// Rand allows to override randon number generator in tests.
+type Rand interface {
+	Intn(int) int
 }
 
 // Config holds code reviewer configuration.
 type Config struct {
 	// Rand is a random number generator. It is not safe for cryptographic
 	// operations.
-	Rand *rand.Rand
+	Rand Rand
 
 	// CodeReviewers and CodeReviewersOmit is a map of code reviews and code
 	// reviewers to omit.
@@ -121,7 +131,7 @@ func (r *Assignments) IsInternal(author string) bool {
 }
 
 // Get will return a list of code reviewers for a given author.
-func (r *Assignments) Get(author string, docs bool, code bool) []string {
+func (r *Assignments) Get(author string, docs bool, code bool, files []github.PullRequestFile) []string {
 	var reviewers []string
 
 	// TODO: consider existing review assignments here
@@ -131,10 +141,10 @@ func (r *Assignments) Get(author string, docs bool, code bool) []string {
 	case docs && code:
 		log.Printf("Assign: Found docs and code changes.")
 		reviewers = append(reviewers, r.getDocsReviewers(author)...)
-		reviewers = append(reviewers, r.getCodeReviewers(author)...)
+		reviewers = append(reviewers, r.getCodeReviewers(author, files)...)
 	case !docs && code:
 		log.Printf("Assign: Found code changes.")
-		reviewers = append(reviewers, r.getCodeReviewers(author)...)
+		reviewers = append(reviewers, r.getCodeReviewers(author, files)...)
 	case docs && !code:
 		log.Printf("Assign: Found docs changes.")
 		reviewers = append(reviewers, r.getDocsReviewers(author)...)
@@ -158,13 +168,62 @@ func (r *Assignments) getDocsReviewers(author string) []string {
 	return reviewers
 }
 
-func (r *Assignments) getCodeReviewers(author string) []string {
+func (r *Assignments) getCodeReviewers(author string, files []github.PullRequestFile) []string {
+	// Obtain full sets of reviewers.
 	setA, setB := r.getCodeReviewerSets(author)
 
-	return []string{
-		setA[r.c.Rand.Intn(len(setA))],
-		setB[r.c.Rand.Intn(len(setB))],
+	// Sort the sets to get predictable order. It doesn't matter in real use
+	// because selection is randomized but helps in tests.
+	sort.Strings(setA)
+	sort.Strings(setB)
+
+	// See if there are preferred reviewers for the changeset.
+	preferredSetA := r.getPreferredReviewers(setA, files)
+	preferredSetB := r.getPreferredReviewers(setB, files)
+
+	// All preferred reviewers should be requested reviews. If there are none,
+	// pick from the overall set at random.
+	resultingSetA := preferredSetA
+	if len(resultingSetA) == 0 {
+		resultingSetA = append(resultingSetA, setA[r.c.Rand.Intn(len(setA))])
 	}
+	resultingSetB := preferredSetB
+	if len(resultingSetB) == 0 {
+		resultingSetB = append(resultingSetB, setB[r.c.Rand.Intn(len(setB))])
+	}
+
+	return append(resultingSetA, resultingSetB...)
+}
+
+// getPreferredReviewers returns a list of reviewers that would be preferrable
+// to review the provided changeset.
+func (r *Assignments) getPreferredReviewers(set []string, files []github.PullRequestFile) (preferredReviewers []string) {
+	// To avoid assigning too many reviewers iterate over paths that we have
+	// preferred reviewers for and see if any of them are among the changeset.
+	for path, reviewers := range r.getPreferredReviewersMap(set) {
+		for _, file := range files {
+			if strings.HasPrefix(file.Name, path) {
+				reviewer := reviewers[r.c.Rand.Intn(len(reviewers))]
+				log.Printf("Picking %v as preferred reviewer for %v which matches %v.", reviewer, file.Name, path)
+				preferredReviewers = append(preferredReviewers, reviewer)
+				break
+			}
+		}
+	}
+	return preferredReviewers
+}
+
+// getPreferredReviewersMap builds a map of preferred reviewers for file paths.
+func (r *Assignments) getPreferredReviewersMap(set []string) map[string][]string {
+	m := make(map[string][]string)
+	for _, name := range set {
+		if reviewer, ok := r.c.CodeReviewers[name]; ok {
+			for _, path := range reviewer.PreferredReviewerFor {
+				m[path] = append(m[path], name)
+			}
+		}
+	}
+	return m
 }
 
 func (r *Assignments) getAdminReviewers(author string) []string {


### PR DESCRIPTION
This PR adds support for "preferred reviewers" to the Github bot. With this, we will be able to declaratively assign code paths that require reviews from a specific set of people (i.e. subject matter experts for a particular part of the codebase) in the reviewers.json file. For example:

```yaml
{
    "codeReviewers": {
        "smallinsky": {
            "team": "Core",
            "owner": true,
            "preferredReviewerFor": [
                "lib/srv/db",
                "lib/srv/alpnproxy"
            ]
        },
        "zmb3": {
            "team": "Core",
            "owner": true,
            "preferredReviewerFor": [
                "lib/srv/dekstop"
            ]
        }
    }
}
```

I have considered just doing this by team (i.e. "database access" reviews "lib/srv/db") but opted for this approach for a couple of reasons:

- This is more flexible than because oftentimes people are SMEs in multiple areas.
- Managing this in the reviewers.json file allows to tweak this without changing the bot.

Note, this only works for code reviewers for now. Can extend to docs as well in future.