### PR TITLE
moved redirect path param to RawQuery and added escaping

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -381,9 +381,10 @@ func HasName(r *http.Request, proxyPublicAddrs []utils.NetAddr) (string, bool) {
 	// At this point, it is assumed the caller is requesting an application and
 	// not the proxy, redirect the caller to the application launcher.
 	u := url.URL{
-		Scheme: "https",
-		Host:   proxyPublicAddrs[0].String(),
-		Path:   fmt.Sprintf("/web/launch/%v?path=%v", raddr.Host(), r.URL.Path),
+		Scheme:   "https",
+		Host:     proxyPublicAddrs[0].String(),
+		Path:     fmt.Sprintf("/web/launch/%s", raddr.Host()),
+		RawQuery: fmt.Sprintf("path=%s", url.QueryEscape(r.URL.Path)),
 	}
 	return u.String(), true
 }

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -127,7 +127,7 @@ func TestHasName(t *testing.T) {
 			hasName:     true,
 		},
 		{
-			desc:        "OK - adds path",
+			desc:        "OK - adds paths with ampersands",
 			addrs:       []string{"proxy.com"},
 			reqURL:      "https://app1.proxy.com/foo/this&/that",
 			expectedURL: "https://proxy.com/web/launch/app1.proxy.com?path=%2Ffoo%2Fthis%26%2Fthat",

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -123,14 +123,21 @@ func TestHasName(t *testing.T) {
 			desc:        "OK - adds path",
 			addrs:       []string{"proxy.com"},
 			reqURL:      "https://app1.proxy.com/foo",
-			expectedURL: "https://proxy.com/web/launch/app1.proxy.com%3Fpath=/foo",
+			expectedURL: "https://proxy.com/web/launch/app1.proxy.com?path=%2Ffoo",
+			hasName:     true,
+		},
+		{
+			desc:        "OK - adds path",
+			addrs:       []string{"proxy.com"},
+			reqURL:      "https://app1.proxy.com/foo/this&/that",
+			expectedURL: "https://proxy.com/web/launch/app1.proxy.com?path=%2Ffoo%2Fthis%26%2Fthat",
 			hasName:     true,
 		},
 		{
 			desc:        "OK - adds root path",
 			addrs:       []string{"proxy.com"},
 			reqURL:      "https://app1.proxy.com/",
-			expectedURL: "https://proxy.com/web/launch/app1.proxy.com%3Fpath=/",
+			expectedURL: "https://proxy.com/web/launch/app1.proxy.com?path=%2F",
 			hasName:     true,
 		},
 	} {

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -51,11 +51,23 @@ const js = `
     <title>Teleport Redirection Service</title>
     <script nonce="%v">
       (function() {
+
         var url = new URL(window.location);
         var params = new URLSearchParams(url.search);
         var searchParts = window.location.search.split('=');
         var stateValue = params.get("state");
         var path = params.get("path");
+
+        // this utility is used to check if a passed in path param is a full URL (which we dont want)
+        function isFullUrl (pathToCheck) {
+          try {
+            const validUrl = new URL(pathToCheck)
+            return true
+          } catch (error) {
+            return false
+          }
+        }
+
         if (!stateValue) {
           return;
         }
@@ -67,6 +79,7 @@ const js = `
           state_value: stateValue,
           cookie_value: hashParts[1],
         };
+
         fetch('/x-teleport-auth', {
           method: 'POST',
           mode: 'same-origin',
@@ -79,7 +92,8 @@ const js = `
           if (response.ok) {
             try {
               // if a path parameter was passed through the redirect, append that path to the target url
-              if (path) {
+              // if the path given is a full url, redirect to url.origin ONLY
+              if (path && !isFullUrl(path)) {
                 var redirectUrl = new URL(path, url.origin)
                 window.location.replace(redirectUrl.toString());
               } else {


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/15546

Problem: During app access authentication, a `path` parameter was being sent to preserver the apps path (`https://example.com/foo/bar`) would have a query param of `path=/foo/bar` added to the redirect URL.
However, the `?` would be escaped in the redirect url and have the redirect become `example.com%3Fpath=/` which would then try to load an app named `exampe.com%3Fpath=/` instead of `example.com`.

Solution: Do not create a string with included query params, and instead, use `url.QueryEscape` to add to the `RawQuery` when creating the redirectUrl

I also added in a small fix to the URL building in the redirect service that will boot out any valid URL as path param, to avoid redirect hijacking (ex: path=https://badwebsite.com). 

