### PR TITLE
Correctly handle U2F public key typecast failure

### DIFF
--- a/lib/auth/webauthn/device.go
+++ b/lib/auth/webauthn/device.go
@@ -80,7 +80,7 @@ func u2fDERKeyToCBOR(der []byte) ([]byte, error) {
 	// https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#h3_registration-response-message-success.
 	pubKey, ok := pubKeyI.(*ecdsa.PublicKey)
 	if !ok {
-		return nil, trace.Wrap(err)
+		return nil, trace.BadParameter("U2F public key has an unexpected type: %T", pubKeyI)
 	}
 	return U2FKeyToCBOR(pubKey)
 }


### PR DESCRIPTION
U2F keys are always [ECDSA/P-256 keys][1], making this an impossible branch in practice, but better safe than sorry.

[1]: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#registration-response-message-success