### PR TITLE
(helm charts) : do not use PodSecurityPolicy in >= 1.25.x as the policy/…

### DIFF
--- a/examples/chart/teleport-cluster/templates/psp.yaml
+++ b/examples/chart/teleport-cluster/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.25.x" .Capabilities.KubeVersion.Version -}}
 {{- if .Values.podSecurityPolicy.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -59,4 +60,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}
+{{- end -}}
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/psp.yaml
+++ b/examples/chart/teleport-kube-agent/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.25.x" .Capabilities.KubeVersion.Version -}}
 {{- if .Values.podSecurityPolicy.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -63,4 +64,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccountName | default .Release.Name }}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
…v1beta1 API version of PodSecurityPolicy will be removed in v1.25
see #11287
Signed-off-by: Yann Toqué <toqueyann@gmail.com>