### PR TITLE
NodeJoin script: fix when no labels are provided

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -45,7 +45,7 @@ JOIN_METHOD_FLAG=""
 
 # inject labels into the configuration
 LABELS='{{.labels}}'
-LABELS_FLAG=""
+LABELS_FLAG=()
 [ -n "$LABELS" ] && LABELS_FLAG=(--labels "${LABELS}")
 
 # When all stanza generators have been updated to use the new


### PR DESCRIPTION
Recently we added a way to add labels on newly added nodes based on the
token.
https://github.com/gravitational/teleport/pull/15114
Each token now has a list of SuggestedLabels, which are used to feed
that list.

However, if that list is empty, the generated script would trigger the
following error when running the `teleport node configure ...` command: 
`teleport: error: unexpected`

This happens because the command is generating an empty argument `""`
when running the `teleport node configure ...` command.
So it looks like this:
```bash
${TELEPORT_BINARY_DIR}/teleport node configure \
      --token token \
      joinmethod \
      --ca-pin pin \
      --auth-server host:port \
      "" \
      --output someport
```
That empty argument breaks things.

So, in order to fix it, we are going to change the default value when no
labels are provided.
Instead of an empty string, we'll use an empty array.

Demo (teleport node configure message removed for brev
No label
```bash
$ LABELS_FLAG=(); f=$(mktemp -d)/node.yaml; teleport node configure --auth-server w:1 "${LABELS_FLAG[@]}" --output $f && yq .s
sh_service.labels $f

enabled: "yes"
commands:
  - name: hostname
    command: [hostname]
    period: 1m0s

```

Single label
```bash
$ LABELS_FLAG=(--labels x=y); f=$(mktemp -d)/node.yaml; teleport node configure --auth-server w:1 "${LABELS_FLAG[@]}" --output $f && yq .ssh_service $f

enabled: "yes"
labels:
  x: "y"
commands:
  - name: hostname
    command: [hostname]
    period: 1m0s

```

Multiple labels
```bash
$ LABELS_FLAG=(--labels x=y,dev=prod); f=$(mktemp -d)/node.yaml; teleport node configure --auth-server w:1 "${LABELS_FLAG[@]}" --output $f && yq .ssh_service $f

enabled: "yes"
labels:
  dev: prod
  x: "y"
commands:
  - name: hostname
    command: [hostname]
    period: 1m0s
```