### PR TITLE
Docs: Update contributing page

### DIFF
--- a/docs/pages/contributing/documentation/how-to-contribute.mdx
+++ b/docs/pages/contributing/documentation/how-to-contribute.mdx
@@ -18,7 +18,7 @@ Different versions of the documentation are organized into the `content` directo
 Navigate to the root of your local clone of the `gravitational/docs` repository and run the following command to populate the `content` directory:
 
 ```code
-$ git submodule update --init --recursive
+$ git submodule update --init --recursive --remote
 ```
 
 Next, navigate to the directory under `content` that corresponds to the latest version of Teleport.


### PR DESCRIPTION
This PR adds the `--remote` flag to the command updating git submodules.

When I was following this page the dev environment wouldn't build because of content that was out of date from the submodule (this repo). When I looked at the docs repo's readme, it suggests running a yarn script to update submodules. That script is basically the same command, but with the `--remote` flag.