### PR TITLE
Implement RFD 82: Session Tracker Resource RBAC

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -261,14 +261,7 @@ func (a *ServerWithRoles) CreateSessionTracker(ctx context.Context, tracker type
 	return tracker, nil
 }
 
-func (a *ServerWithRoles) filterSessionTracker(ctx context.Context, joinerRoles []types.Role, tracker types.SessionTracker) bool {
-	evaluator := NewSessionAccessEvaluator(tracker.GetHostPolicySets(), tracker.GetSessionKind(), tracker.GetHostUser())
-	modes := evaluator.CanJoin(SessionAccessContext{Username: a.context.User.GetName(), Roles: joinerRoles})
-
-	if len(modes) == 0 {
-		return false
-	}
-
+func (a *ServerWithRoles) filterSessionTracker(ctx context.Context, joinerRoles []types.Role, tracker types.SessionTracker, verb string) bool {
 	// Apply RFD 45 RBAC rules to the session if it's SSH.
 	// This is a bit of a hack. It converts to the old legacy format
 	// which we don't have all data for, luckily the fields we don't have aren't made available
@@ -295,12 +288,19 @@ func (a *ServerWithRoles) filterSessionTracker(ctx context.Context, joinerRoles 
 		}
 
 		// Skip past it if there's a deny rule in place blocking access.
-		if err := a.context.Checker.CheckAccessToRule(ruleCtx, apidefaults.Namespace, types.KindSSHSession, types.VerbList, true /* silent */); err != nil {
+		if err := a.context.Checker.CheckAccessToRule(ruleCtx, apidefaults.Namespace, types.KindSSHSession, verb, true /* silent */); err != nil {
 			return false
 		}
 	}
 
-	return true
+	ruleCtx := &services.Context{User: a.context.User, SessionTracker: tracker}
+	if a.context.Checker.CheckAccessToRule(ruleCtx, apidefaults.Namespace, types.KindSessionTracker, types.VerbList, true /* silent */) == nil {
+		return true
+	}
+
+	evaluator := NewSessionAccessEvaluator(tracker.GetHostPolicySets(), tracker.GetSessionKind(), tracker.GetHostUser())
+	modes := evaluator.CanJoin(SessionAccessContext{Username: a.context.User.GetName(), Roles: joinerRoles})
+	return len(modes) != 0
 }
 
 const (
@@ -416,7 +416,7 @@ func (a *ServerWithRoles) GetSessionTracker(ctx context.Context, sessionID strin
 		return nil, trace.Wrap(err)
 	}
 
-	ok := a.filterSessionTracker(ctx, joinerRoles, tracker)
+	ok := a.filterSessionTracker(ctx, joinerRoles, tracker, types.VerbRead)
 	if !ok {
 		return nil, trace.NotFound("session %v not found", sessionID)
 	}
@@ -443,7 +443,7 @@ func (a *ServerWithRoles) GetActiveSessionTrackers(ctx context.Context) ([]types
 	}
 
 	for _, sess := range sessions {
-		ok := a.filterSessionTracker(ctx, joinerRoles, sess)
+		ok := a.filterSessionTracker(ctx, joinerRoles, sess, types.VerbList)
 		if ok {
 			filteredSessions = append(filteredSessions, sess)
 		}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -3868,31 +3868,33 @@ func TestGetActiveSessionTrackers(t *testing.T) {
 	}()}
 
 	for _, testCase := range testCases {
-		ctx := context.Background()
-		srv := newTestTLSServer(t)
-		err := srv.Auth().CreateRole(ctx, testCase.role)
-		require.NoError(t, err)
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			srv := newTestTLSServer(t)
+			err := srv.Auth().CreateRole(ctx, testCase.role)
+			require.NoError(t, err)
 
-		_, err = srv.Auth().CreateSessionTracker(ctx, testCase.tracker)
-		require.NoError(t, err)
+			_, err = srv.Auth().CreateSessionTracker(ctx, testCase.tracker)
+			require.NoError(t, err)
 
-		user, err := types.NewUser(uuid.NewString())
-		require.NoError(t, err)
+			user, err := types.NewUser(uuid.NewString())
+			require.NoError(t, err)
 
-		user.AddRole(testCase.role.GetName())
-		err = srv.Auth().UpsertUser(user)
-		require.NoError(t, err)
+			user.AddRole(testCase.role.GetName())
+			err = srv.Auth().UpsertUser(user)
+			require.NoError(t, err)
 
-		clt, err := srv.NewClient(TestUser(user.GetName()))
-		require.NoError(t, err)
+			clt, err := srv.NewClient(TestUser(user.GetName()))
+			require.NoError(t, err)
 
-		found, err := clt.GetActiveSessionTrackers(ctx)
-		require.NoError(t, err)
+			found, err := clt.GetActiveSessionTrackers(ctx)
+			require.NoError(t, err)
 
-		if len(found) == 0 {
-			require.False(t, testCase.hasAccess)
-		} else {
-			require.True(t, testCase.hasAccess)
-		}
+			if len(found) == 0 {
+				require.False(t, testCase.hasAccess)
+			} else {
+				require.True(t, testCase.hasAccess)
+			}
+		})
 	}
 }

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -3839,7 +3839,7 @@ func TestGetActiveSessionTrackers(t *testing.T) {
 				Rules: []types.Rule{{
 					Resources: []string{types.KindSessionTracker},
 					Verbs:     []string{types.VerbList, types.VerbRead},
-					Where:     "equals(tracker.session_id, \"1\")",
+					Where:     "equals(session_tracker.session_id, \"1\")",
 				}},
 			},
 		})
@@ -3858,7 +3858,7 @@ func TestGetActiveSessionTrackers(t *testing.T) {
 				Rules: []types.Rule{{
 					Resources: []string{types.KindSessionTracker},
 					Verbs:     []string{types.VerbList, types.VerbRead},
-					Where:     "equals(tracker.session_id, \"1\")",
+					Where:     "equals(session_tracker.session_id, \"1\")",
 				}},
 			},
 		})

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -3789,6 +3789,7 @@ func TestGenerateHostCert(t *testing.T) {
 }
 
 type getActiveSessionsTestCase struct {
+	name      string
 	tracker   types.SessionTracker
 	role      types.Role
 	hasAccess bool
@@ -3797,7 +3798,7 @@ type getActiveSessionsTestCase struct {
 func TestGetActiveSessionTrackers(t *testing.T) {
 	t.Parallel()
 
-	case1 := func() getActiveSessionsTestCase {
+	testCases := []getActiveSessionsTestCase{func() getActiveSessionsTestCase {
 		tracker, err := types.NewSessionTracker(types.SessionTrackerSpecV1{
 			SessionID: "1",
 			Kind:      string(types.SSHSessionKind),
@@ -3814,10 +3815,8 @@ func TestGetActiveSessionTrackers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		return getActiveSessionsTestCase{tracker, role, true}
-	}
-
-	case2 := func() getActiveSessionsTestCase {
+		return getActiveSessionsTestCase{"with access simple", tracker, role, true}
+	}(), func() getActiveSessionsTestCase {
 		tracker, err := types.NewSessionTracker(types.SessionTrackerSpecV1{
 			SessionID: "1",
 			Kind:      string(types.SSHSessionKind),
@@ -3827,10 +3826,8 @@ func TestGetActiveSessionTrackers(t *testing.T) {
 		role, err := types.NewRole("foo", types.RoleSpecV5{})
 		require.NoError(t, err)
 
-		return getActiveSessionsTestCase{tracker, role, false}
-	}
-
-	case3 := func() getActiveSessionsTestCase {
+		return getActiveSessionsTestCase{"with no access rule", tracker, role, false}
+	}(), func() getActiveSessionsTestCase {
 		tracker, err := types.NewSessionTracker(types.SessionTrackerSpecV1{
 			SessionID: "1",
 			Kind:      string(types.KubernetesSessionKind),
@@ -3848,10 +3845,8 @@ func TestGetActiveSessionTrackers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		return getActiveSessionsTestCase{tracker, role, true}
-	}
-
-	case4 := func() getActiveSessionsTestCase {
+		return getActiveSessionsTestCase{"access with match expression", tracker, role, true}
+	}(), func() getActiveSessionsTestCase {
 		tracker, err := types.NewSessionTracker(types.SessionTrackerSpecV1{
 			SessionID: "2",
 			Kind:      string(types.KubernetesSessionKind),
@@ -3869,10 +3864,8 @@ func TestGetActiveSessionTrackers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		return getActiveSessionsTestCase{tracker, role, false}
-	}
-
-	testCases := []getActiveSessionsTestCase{case1(), case2(), case3(), case4()}
+		return getActiveSessionsTestCase{"no access with match expression", tracker, role, false}
+	}()}
 
 	for _, testCase := range testCases {
 		ctx := context.Background()

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -3889,12 +3889,7 @@ func TestGetActiveSessionTrackers(t *testing.T) {
 
 			found, err := clt.GetActiveSessionTrackers(ctx)
 			require.NoError(t, err)
-
-			if len(found) == 0 {
-				require.False(t, testCase.hasAccess)
-			} else {
-				require.True(t, testCase.hasAccess)
-			}
+			require.Equal(t, testCase.hasAccess, len(found) != 0)
 		})
 	}
 }

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -541,6 +541,7 @@ func createPresets(ctx context.Context, asrv *Server) error {
 				return trace.WrapWithMessage(err, "failed to create preset role %v", role.GetName())
 			}
 
+<<<<<<< HEAD
 			currentRole, err := asrv.GetRole(ctx, role.GetName())
 			if err != nil {
 				return trace.Wrap(err)
@@ -551,6 +552,14 @@ func createPresets(ctx context.Context, asrv *Server) error {
 			err = asrv.UpsertRole(ctx, role)
 			if err != nil {
 				return trace.WrapWithMessage(err, "failed to update preset role %v", role.GetName())
+=======
+			if role.GetName() == teleport.PresetAuditorRoleName {
+				role = services.UpdateAuditorRoleRFD82(role)
+				err = asrv.UpsertRole(ctx, role)
+				if err != nil {
+					return trace.WrapWithMessage(err, "failed to update preset role %v", role.GetName())
+				}
+>>>>>>> 4aa70edc6b (add role migration)
 			}
 		}
 	}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -541,7 +541,6 @@ func createPresets(ctx context.Context, asrv *Server) error {
 				return trace.WrapWithMessage(err, "failed to create preset role %v", role.GetName())
 			}
 
-<<<<<<< HEAD
 			currentRole, err := asrv.GetRole(ctx, role.GetName())
 			if err != nil {
 				return trace.Wrap(err)
@@ -552,19 +551,6 @@ func createPresets(ctx context.Context, asrv *Server) error {
 			err = asrv.UpsertRole(ctx, role)
 			if err != nil {
 				return trace.WrapWithMessage(err, "failed to update preset role %v", role.GetName())
-=======
-			if role.GetName() == teleport.PresetAuditorRoleName {
-				currentRole, err := asrv.GetRole(ctx, role.GetName())
-				if err != nil {
-					return trace.WrapWithMessage(err, "to fetch auditor preset role %v", role.GetName())
-				}
-
-				role = services.UpdateAuditorRoleRFD82(currentRole)
-				err = asrv.UpsertRole(ctx, role)
-				if err != nil {
-					return trace.WrapWithMessage(err, "failed to update preset role %v", role.GetName())
-				}
->>>>>>> 4aa70edc6b (add role migration)
 			}
 		}
 	}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -554,7 +554,12 @@ func createPresets(ctx context.Context, asrv *Server) error {
 				return trace.WrapWithMessage(err, "failed to update preset role %v", role.GetName())
 =======
 			if role.GetName() == teleport.PresetAuditorRoleName {
-				role = services.UpdateAuditorRoleRFD82(role)
+				currentRole, err := asrv.GetRole(ctx, role.GetName())
+				if err != nil {
+					return trace.WrapWithMessage(err, "to fetch auditor preset role %v", role.GetName())
+				}
+
+				role = services.UpdateAuditorRoleRFD82(currentRole)
 				err = asrv.UpsertRole(ctx, role)
 				if err != nil {
 					return trace.WrapWithMessage(err, "failed to update preset role %v", role.GetName())

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -273,6 +273,8 @@ type Context struct {
 	SSHSession *session.Session
 	// HostCert is an optional host certificate.
 	HostCert *HostCertContext
+	// SessionTracker is an optional session tracker, in case if the rule checks access to the tracker.
+	SessionTracker types.SessionTracker
 }
 
 // String returns user friendly representation of this context
@@ -299,6 +301,8 @@ const (
 	ImpersonateUserIdentifier = "impersonate_user"
 	// HostCertIdentifier refers to a host certificate being created.
 	HostCertIdentifier = "host_cert"
+	// SessionTrackerIdentifier refers to a session tracker in the rules.
+	SessionTrackerIdentifier = "tracker"
 )
 
 // GetResource returns resource specified in the context,
@@ -348,8 +352,67 @@ func (ctx *Context) GetIdentifier(fields []string) (interface{}, error) {
 			hostCert = ctx.HostCert
 		}
 		return predicate.GetFieldByTag(hostCert, teleport.JSON, fields[1:])
+	case SessionTrackerIdentifier:
+		return predicate.GetFieldByTag(toCtxTracker(ctx.SessionTracker), teleport.JSON, fields[1:])
 	default:
 		return nil, trace.NotFound("%v is not defined", strings.Join(fields, "."))
+	}
+}
+
+// ctxSession represents the public contract of a session.Session, as exposed
+// to a Context rule.
+// See RFD 82: https://github.com/gravitational/teleport/blob/master/rfd/0082-session-tracker-resource-rbac.md
+type ctxTracker struct {
+	SessionID    string   `json:"session_id"`
+	Kind         string   `json:"kind"`
+	Participants []string `json:"participants"`
+	State        string   `json:"state"`
+	Hostname     string   `json:"hostname"`
+	Address      string   `json:"address"`
+	Login        string   `json:"login"`
+	Cluster      string   `json:"cluster"`
+	KubeCluster  string   `json:"kube_cluster"`
+	HostUser     string   `json:"host_user"`
+	HostRoles    []string `json:"host_roles"`
+}
+
+func toCtxTracker(t types.SessionTracker) ctxTracker {
+	if t == nil {
+		return ctxTracker{}
+	}
+
+	getParticipants := func(s types.SessionTracker) []string {
+		participants := s.GetParticipants()
+		names := make([]string, len(participants))
+		for i, participant := range participants {
+			names[i] = participant.User
+		}
+
+		return names
+	}
+
+	getHostRoles := func(s types.SessionTracker) []string {
+		policySets := s.GetHostPolicySets()
+		roles := make([]string, len(policySets))
+		for i, policySet := range policySets {
+			roles[i] = policySet.Name
+		}
+
+		return roles
+	}
+
+	return ctxTracker{
+		t.GetSessionID(),
+		t.GetKind(),
+		getParticipants(t),
+		string(t.GetState()),
+		t.GetHostname(),
+		t.GetAddress(),
+		t.GetLogin(),
+		t.GetClusterName(),
+		t.GetKubeCluster(),
+		t.GetHostUser(),
+		getHostRoles(t),
 	}
 }
 

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -302,7 +302,7 @@ const (
 	// HostCertIdentifier refers to a host certificate being created.
 	HostCertIdentifier = "host_cert"
 	// SessionTrackerIdentifier refers to a session tracker in the rules.
-	SessionTrackerIdentifier = "tracker"
+	SessionTrackerIdentifier = "session_tracker"
 )
 
 // GetResource returns resource specified in the context,
@@ -402,17 +402,17 @@ func toCtxTracker(t types.SessionTracker) ctxTracker {
 	}
 
 	return ctxTracker{
-		t.GetSessionID(),
-		t.GetKind(),
-		getParticipants(t),
-		string(t.GetState()),
-		t.GetHostname(),
-		t.GetAddress(),
-		t.GetLogin(),
-		t.GetClusterName(),
-		t.GetKubeCluster(),
-		t.GetHostUser(),
-		getHostRoles(t),
+		SessionID:    t.GetSessionID(),
+		Kind:         t.GetKind(),
+		Participants: getParticipants(t),
+		State:        string(t.GetState()),
+		Hostname:     t.GetHostname(),
+		Address:      t.GetAddress(),
+		Login:        t.GetLogin(),
+		Cluster:      t.GetClusterName(),
+		KubeCluster:  t.GetKubeCluster(),
+		HostUser:     t.GetHostUser(),
+		HostRoles:    getHostRoles(t),
 	}
 }
 

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -155,6 +155,7 @@ func NewPresetAuditorRole() types.Role {
 				Rules: []types.Rule{
 					types.NewRule(types.KindSession, RO()),
 					types.NewRule(types.KindEvent, RO()),
+					types.NewRule(types.KindSessionTracker, RO()),
 					// Please see defaultAllowRules when adding a new rule.
 				},
 			},
@@ -168,9 +169,11 @@ func NewPresetAuditorRole() types.Role {
 // This is used to update the current cluster roles when deploying a new resource.
 func defaultAllowRules() map[string][]types.Rule {
 	return map[string][]types.Rule{
+		teleport.PresetAuditorRoleName: {
+			types.NewRule(types.KindSessionTracker, RO()),
+		},
 		teleport.PresetEditorRoleName: {
 			types.NewRule(types.KindConnectionDiagnostic, RW()),
-			types.NewRule(types.KindSessionTracker, RO()),
 		},
 	}
 }

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -170,6 +170,7 @@ func defaultAllowRules() map[string][]types.Rule {
 	return map[string][]types.Rule{
 		teleport.PresetEditorRoleName: {
 			types.NewRule(types.KindConnectionDiagnostic, RW()),
+			types.NewRule(types.KindSessionTracker, RO()),
 		},
 	}
 }

--- a/rfd/0082-session-tracker-resource-rbac.md
+++ b/rfd/0082-session-tracker-resource-rbac.md
@@ -1,6 +1,6 @@
 ---
 authors: Joel Wejdenstål (jwejdenstal@goteleport.com)
-state: draft
+state: implemented
 ---
 
 # RFD 82 - Session Tracker Resource RBAC


### PR DESCRIPTION
This PR implements session tracker resource RBAC according to [RFD 82](https://github.com/gravitational/teleport/blob/master/rfd/0082-session-tracker-resource-rbac.md). Should be a fairly straightforward review using largely the same logic as SSH Session RBAC.

Fixes #15381