### PR TITLE
Introduce config v3, add auth_server and proxy_server, remove auth_addresses

### DIFF
--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -33,7 +33,7 @@
   # token is read as a parameter from the AWS ssm script run and
   # passed as the first argument to the script
   sudo /usr/local/bin/teleport node configure \
-    --auth-server="{{ .PublicProxyAddr }}" \
+    --proxy="{{ .PublicProxyAddr }}" \
     --join-method=iam \
     --token="$1" \
     --output=file \

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/api/defaults"
+	apiutils "github.com/gravitational/teleport/api/utils"
 
 	"github.com/gravitational/trace"
 )
@@ -38,6 +39,21 @@ const (
 	// JoinMethodIAM indicates that the node will join with the IAM join method.
 	JoinMethodIAM JoinMethod = "iam"
 )
+
+var JoinMethods = []JoinMethod{
+	JoinMethodToken,
+	JoinMethodEC2,
+	JoinMethodIAM,
+}
+
+func ValidateJoinMethod(method JoinMethod) error {
+	hasJoinMethod := apiutils.SliceContainsStr(JoinMethods, method)
+	if !hasJoinMethod {
+		return trace.BadParameter("join_params.method must be one of %s", apiutils.JoinStrings(JoinMethods, ", "))
+	}
+
+	return nil
+}
 
 // ProvisionToken is a provisioning token
 type ProvisionToken interface {

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -49,7 +49,7 @@ var JoinMethods = []JoinMethod{
 func ValidateJoinMethod(method JoinMethod) error {
 	hasJoinMethod := apiutils.SliceContainsStr(JoinMethods, method)
 	if !hasJoinMethod {
-		return trace.BadParameter("join_params.method must be one of %s", apiutils.JoinStrings(JoinMethods, ", "))
+		return trace.BadParameter("join method must be one of %s", apiutils.JoinStrings(JoinMethods, ", "))
 	}
 
 	return nil

--- a/api/utils/slices.go
+++ b/api/utils/slices.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package utils
 
+import (
+	"strings"
+)
+
 // CopyByteSlice returns a copy of the byte slice.
 func CopyByteSlice(in []byte) []byte {
 	if in == nil {
@@ -52,13 +56,36 @@ func StringSlicesEqual(a, b []string) bool {
 }
 
 // SliceContainsStr returns 'true' if the slice contains the given value
-func SliceContainsStr(slice []string, value string) bool {
+func SliceContainsStr[T ~string](slice []T, value T) bool {
 	for i := range slice {
 		if slice[i] == value {
 			return true
 		}
 	}
 	return false
+}
+
+// JoinStrings returns 'true' if the slice contains the given value
+func JoinStrings[T ~string](elems []T, sep string) T {
+	switch len(elems) {
+	case 0:
+		return ""
+	case 1:
+		return elems[0]
+	}
+	n := len(sep) * (len(elems) - 1)
+	for i := 0; i < len(elems); i++ {
+		n += len(elems[i])
+	}
+
+	var b strings.Builder
+	b.Grow(n)
+	b.WriteString(string(elems[0]))
+	for _, s := range elems[1:] {
+		b.WriteString(sep)
+		b.WriteString(string(s))
+	}
+	return T(b.String())
 }
 
 // Deduplicate deduplicates list of strings

--- a/api/utils/slices.go
+++ b/api/utils/slices.go
@@ -65,7 +65,9 @@ func SliceContainsStr[T ~string](slice []T, value T) bool {
 	return false
 }
 
-// JoinStrings returns 'true' if the slice contains the given value
+// JoinStrings returns a string that is all the elements in the slice `T[]` joined by `sep`
+// This being generic allows for the usage of custom string times, without having to convert
+// the elements to a string to be passed into `strings.Join`.
 func JoinStrings[T ~string](elems []T, sep string) T {
 	switch len(elems) {
 	case 0:

--- a/assets/aws/files/bin/teleport-generate-config
+++ b/assets/aws/files/bin/teleport-generate-config
@@ -307,8 +307,11 @@ elif [[ "${TELEPORT_ROLE}" == "proxy" ]]; then
     # Teleport proxy proxies and optionally records
     # SSH sessions
     cat >${USE_CONFIG_PATH} <<EOF
+version: v3
 teleport:
-  auth_token: /var/lib/teleport/token
+  join_params:
+    join_method: token
+    token_name: /var/lib/teleport/token
   ca_pin: CA_PIN_HASH_PLACEHOLDER
   nodename: ${LOCAL_HOSTNAME}
   advertise_ip: ${LOCAL_IP}
@@ -324,8 +327,7 @@ teleport:
   storage:
     type: dir
     path: /var/lib/teleport/backend
-  auth_servers:
-    - ${TELEPORT_AUTH_SERVER_LB}:3025
+  auth_server: ${TELEPORT_AUTH_SERVER_LB}:3025
 
 auth_service:
   enabled: no
@@ -348,7 +350,7 @@ EOF
     if [[ "${USE_ACM}" != "true" ]]; then
         write_https_keypairs_section
     fi
-    
+
     # set up the database listeners
     write_database_section TELEPORT_DOMAIN_NAME
 
@@ -374,8 +376,11 @@ elif [[ "${TELEPORT_ROLE}" == "node" ]]; then
     echo "node" > ${USE_CONFD_DIR}/role.node
     # Teleport node handles incoming connections
     cat >${USE_CONFIG_PATH} <<EOF
+version: v3
 teleport:
-  auth_token: /var/lib/teleport/token
+  join_params:
+      join_method: token
+      token_name: /var/lib/teleport/token
   ca_pin: CA_PIN_HASH_PLACEHOLDER
   nodename: ${LOCAL_HOSTNAME}
   advertise_ip: ${LOCAL_IP}
@@ -386,8 +391,7 @@ teleport:
   storage:
     type: dir
     path: /var/lib/teleport/backend
-  auth_servers:
-    - ${TELEPORT_AUTH_SERVER_LB}:3025
+  auth_server: ${TELEPORT_AUTH_SERVER_LB}:443
 
 auth_service:
   enabled: no
@@ -506,7 +510,7 @@ EOF
 
             # set up the database listeners
             write_database_section TELEPORT_EXTERNAL_HOSTNAME
-    
+
             # set up the kubernetes listener
             write_kubernetes_section TELEPORT_EXTERNAL_HOSTNAME
 
@@ -527,7 +531,7 @@ EOF
 
         # set up the database listeners
         write_database_section TELEPORT_EXTERNAL_HOSTNAME
-            
+
         # set up the kubernetes listener
         write_kubernetes_section TELEPORT_EXTERNAL_HOSTNAME
 
@@ -588,7 +592,7 @@ EOF
 
     # write ssh/tunnel config
     write_ssh_and_tunnel_section 3080
-    
+
     # set up the database listeners
     write_database_section TELEPORT_EXTERNAL_HOSTNAME
 
@@ -767,13 +771,16 @@ EOF
 elif [[ "${TELEPORT_ROLE}" == "agent" ]]; then
     echo "agent" > ${USE_CONFD_DIR}/role.agent
     cat >${USE_CONFIG_PATH} <<EOF
+version: v3
 teleport:
   log:
     output: stderr
     severity: INFO
   data_dir: /var/lib/teleport
-  auth_token: ${TELEPORT_JOIN_TOKEN}
-  auth_servers: ['${TELEPORT_PROXY_SERVER_LB}']
+  join_params:
+    join_method: token
+    token_name: ${TELEPORT_JOIN_TOKEN}
+  proxy_server: ${TELEPORT_PROXY_SERVER_LB}
 
 auth_service:
   enabled: no

--- a/assets/aws/files/bin/teleport-generate-config
+++ b/assets/aws/files/bin/teleport-generate-config
@@ -310,7 +310,7 @@ elif [[ "${TELEPORT_ROLE}" == "proxy" ]]; then
 version: v3
 teleport:
   join_params:
-    join_method: token
+    method: token
     token_name: /var/lib/teleport/token
   ca_pin: CA_PIN_HASH_PLACEHOLDER
   nodename: ${LOCAL_HOSTNAME}
@@ -379,7 +379,7 @@ elif [[ "${TELEPORT_ROLE}" == "node" ]]; then
 version: v3
 teleport:
   join_params:
-      join_method: token
+      method: token
       token_name: /var/lib/teleport/token
   ca_pin: CA_PIN_HASH_PLACEHOLDER
   nodename: ${LOCAL_HOSTNAME}
@@ -778,7 +778,7 @@ teleport:
     severity: INFO
   data_dir: /var/lib/teleport
   join_params:
-    join_method: token
+    method: token
     token_name: ${TELEPORT_JOIN_TOKEN}
   proxy_server: ${TELEPORT_PROXY_SERVER_LB}
 

--- a/assets/aws/files/bin/teleport-generate-config
+++ b/assets/aws/files/bin/teleport-generate-config
@@ -309,9 +309,7 @@ elif [[ "${TELEPORT_ROLE}" == "proxy" ]]; then
     cat >${USE_CONFIG_PATH} <<EOF
 version: v3
 teleport:
-  join_params:
-    method: token
-    token_name: /var/lib/teleport/token
+  auth_token: /var/lib/teleport/token
   ca_pin: CA_PIN_HASH_PLACEHOLDER
   nodename: ${LOCAL_HOSTNAME}
   advertise_ip: ${LOCAL_IP}
@@ -378,9 +376,7 @@ elif [[ "${TELEPORT_ROLE}" == "node" ]]; then
     cat >${USE_CONFIG_PATH} <<EOF
 version: v3
 teleport:
-  join_params:
-      method: token
-      token_name: /var/lib/teleport/token
+  auth_token: /var/lib/teleport/token
   ca_pin: CA_PIN_HASH_PLACEHOLDER
   nodename: ${LOCAL_HOSTNAME}
   advertise_ip: ${LOCAL_IP}
@@ -777,9 +773,7 @@ teleport:
     output: stderr
     severity: INFO
   data_dir: /var/lib/teleport
-  join_params:
-    method: token
-    token_name: ${TELEPORT_JOIN_TOKEN}
+  auth_token: ${TELEPORT_JOIN_TOKEN}
   proxy_server: ${TELEPORT_PROXY_SERVER_LB}
 
 auth_service:

--- a/assets/aws/files/tests/agent-app.bats
+++ b/assets/aws/files/tests/agent-app.bats
@@ -18,16 +18,16 @@ load fixtures/common
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_servers is set correctly" {
+@test "[${TEST_SUITE?}] teleport.proxy_server is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_servers:" -A1 | grep -q "${TELEPORT_PROXY_SERVER_LB?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  proxy_server:" -A1 | grep -q "${TELEPORT_PROXY_SERVER_LB?}"
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_token is set correctly" {
+@test "[${TEST_SUITE?}] teleport.join_params.token_name is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_token:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^    token_name:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
 }
 
 @test "[${TEST_SUITE?}] auth_service is not enabled" {

--- a/assets/aws/files/tests/agent-app.bats
+++ b/assets/aws/files/tests/agent-app.bats
@@ -24,10 +24,10 @@ load fixtures/common
     cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  proxy_server:" -A1 | grep -q "${TELEPORT_PROXY_SERVER_LB?}"
 }
 
-@test "[${TEST_SUITE?}] teleport.join_params.token_name is set correctly" {
+@test "[${TEST_SUITE?}] teleport.auth_token is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^    token_name:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_token:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
 }
 
 @test "[${TEST_SUITE?}] auth_service is not enabled" {

--- a/assets/aws/files/tests/agent-db.bats
+++ b/assets/aws/files/tests/agent-db.bats
@@ -20,16 +20,16 @@ load fixtures/common
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_servers is set correctly" {
+@test "[${TEST_SUITE?}] teleport.proxy_server is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_servers:" -A1 | grep -q "${TELEPORT_PROXY_SERVER_LB?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  proxy_server:" -A1 | grep -q "${TELEPORT_PROXY_SERVER_LB?}"
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_token is set correctly" {
+@test "[${TEST_SUITE?}] teleport.join_params.token_name is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_token:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^    token_name:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
 }
 
 @test "[${TEST_SUITE?}] auth_service is not enabled" {

--- a/assets/aws/files/tests/agent-db.bats
+++ b/assets/aws/files/tests/agent-db.bats
@@ -26,10 +26,10 @@ load fixtures/common
     cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  proxy_server:" -A1 | grep -q "${TELEPORT_PROXY_SERVER_LB?}"
 }
 
-@test "[${TEST_SUITE?}] teleport.join_params.token_name is set correctly" {
+@test "[${TEST_SUITE?}] teleport.auth_token is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^    token_name:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_token:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
 }
 
 @test "[${TEST_SUITE?}] auth_service is not enabled" {

--- a/assets/aws/files/tests/agent-ssh.bats
+++ b/assets/aws/files/tests/agent-ssh.bats
@@ -15,16 +15,16 @@ load fixtures/common
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_servers is set correctly" {
+@test "[${TEST_SUITE?}] teleport.proxy_server is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_servers:" -A1 | grep -q "${TELEPORT_PROXY_SERVER_LB?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  proxy_server:" -A1 | grep -q "${TELEPORT_PROXY_SERVER_LB?}"
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_token is set correctly" {
+@test "[${TEST_SUITE?}] teleport.join_params.token_name is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_token:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^    token_name:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
 }
 
 @test "[${TEST_SUITE?}] auth_service is not enabled" {

--- a/assets/aws/files/tests/agent-ssh.bats
+++ b/assets/aws/files/tests/agent-ssh.bats
@@ -21,10 +21,10 @@ load fixtures/common
     cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  proxy_server:" -A1 | grep -q "${TELEPORT_PROXY_SERVER_LB?}"
 }
 
-@test "[${TEST_SUITE?}] teleport.join_params.token_name is set correctly" {
+@test "[${TEST_SUITE?}] teleport.auth_token is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^    token_name:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_token:" -A1 | grep -q "${TELEPORT_JOIN_TOKEN?}"
 }
 
 @test "[${TEST_SUITE?}] auth_service is not enabled" {

--- a/assets/aws/files/tests/ha-node.bats
+++ b/assets/aws/files/tests/ha-node.bats
@@ -15,9 +15,9 @@ load fixtures/common
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_servers is set correctly" {
+@test "[${TEST_SUITE?}] teleport.auth_server is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_servers:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_server:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
 }
 
 # in each test, we echo the block so that if the test fails, the block is outputted

--- a/assets/aws/files/tests/ha-proxy-acm-alias.bats
+++ b/assets/aws/files/tests/ha-proxy-acm-alias.bats
@@ -22,10 +22,10 @@ load fixtures/common
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_servers is set correctly" {
+@test "[${TEST_SUITE?}] teleport.auth_server is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_servers:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_server:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
 }
 
 # in each test, we echo the block so that if the test fails, the block is outputted

--- a/assets/aws/files/tests/ha-proxy-acm.bats
+++ b/assets/aws/files/tests/ha-proxy-acm.bats
@@ -21,10 +21,10 @@ load fixtures/common
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_servers is set correctly" {
+@test "[${TEST_SUITE?}] teleport.auth_server is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_servers:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_server:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
 }
 
 # in each test, we echo the block so that if the test fails, the block is outputted

--- a/assets/aws/files/tests/ha-proxy-mysql.bats
+++ b/assets/aws/files/tests/ha-proxy-mysql.bats
@@ -22,10 +22,10 @@ load fixtures/common
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_servers is set correctly" {
+@test "[${TEST_SUITE?}] teleport.auth_server is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_servers:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_server:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
 }
 
 # in each test, we echo the block so that if the test fails, the block is outputted

--- a/assets/aws/files/tests/ha-proxy-no-db.bats
+++ b/assets/aws/files/tests/ha-proxy-no-db.bats
@@ -22,10 +22,10 @@ load fixtures/common
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_servers is set correctly" {
+@test "[${TEST_SUITE?}] teleport.auth_server is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_servers:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_server:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
 }
 
 # in each test, we echo the block so that if the test fails, the block is outputted

--- a/assets/aws/files/tests/ha-proxy.bats
+++ b/assets/aws/files/tests/ha-proxy.bats
@@ -22,10 +22,10 @@ load fixtures/common
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]
 }
 
-@test "[${TEST_SUITE?}] teleport.auth_servers is set correctly" {
+@test "[${TEST_SUITE?}] teleport.auth_server is set correctly" {
     load ${TELEPORT_CONFD_DIR?}/conf
     cat "${TELEPORT_CONFIG_PATH?}"
-    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_servers:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
+    cat "${TELEPORT_CONFIG_PATH?}" | grep -E "^  auth_server:" -A1 | grep -q "${TELEPORT_AUTH_SERVER_LB?}"
 }
 
 # in each test, we echo the block so that if the test fails, the block is outputted

--- a/assets/loadtest/teleport/teleport-iot-node.yaml
+++ b/assets/loadtest/teleport/teleport-iot-node.yaml
@@ -9,7 +9,7 @@ teleport:
     type: dir
   proxy_server: ${PROXY_HOST}:3080
   join_params:
-    join_method: token
+    method: token
     token_name: "node-${NODE_TOKEN}"
 auth_service:
   enabled: false

--- a/assets/loadtest/teleport/teleport-iot-node.yaml
+++ b/assets/loadtest/teleport/teleport-iot-node.yaml
@@ -1,3 +1,4 @@
+version: v3
 teleport:
   data_dir: /var/lib/teleport
   log:
@@ -6,8 +7,10 @@ teleport:
       output: json
   storage:
     type: dir
-  auth_servers: ["${PROXY_HOST}:3080"]
-  auth_token: "node-${NODE_TOKEN}"
+  proxy_server: ${PROXY_HOST}:3080
+  join_params:
+    join_method: token
+    token_name: "node-${NODE_TOKEN}"
 auth_service:
   enabled: false
 proxy_service:

--- a/assets/loadtest/teleport/teleport-iot-node.yaml
+++ b/assets/loadtest/teleport/teleport-iot-node.yaml
@@ -7,10 +7,8 @@ teleport:
       output: json
   storage:
     type: dir
+  auth_token: "node-${NODE_TOKEN}"
   proxy_server: ${PROXY_HOST}:3080
-  join_params:
-    method: token
-    token_name: "node-${NODE_TOKEN}"
 auth_service:
   enabled: false
 proxy_service:

--- a/assets/loadtest/teleport/teleport-node.yaml
+++ b/assets/loadtest/teleport/teleport-node.yaml
@@ -9,7 +9,7 @@ teleport:
     type: dir
   auth_server: auth:3025
   join_params:
-    join_method: token
+    method: token
     token_name: "node-${NODE_TOKEN}"
 auth_service:
   enabled: false

--- a/assets/loadtest/teleport/teleport-node.yaml
+++ b/assets/loadtest/teleport/teleport-node.yaml
@@ -1,3 +1,4 @@
+version: v3
 teleport:
   data_dir: /var/lib/teleport
   log:
@@ -6,8 +7,10 @@ teleport:
       output: json
   storage:
     type: dir
-  auth_servers: ["auth:3025"]
-  auth_token: "node-${NODE_TOKEN}"
+  auth_server: auth:3025
+  join_params:
+    join_method: token
+    token_name: "node-${NODE_TOKEN}"
 auth_service:
   enabled: false
 proxy_service:

--- a/assets/loadtest/teleport/teleport-node.yaml
+++ b/assets/loadtest/teleport/teleport-node.yaml
@@ -7,10 +7,8 @@ teleport:
       output: json
   storage:
     type: dir
+  auth_token: "node-${NODE_TOKEN}"
   auth_server: auth:3025
-  join_params:
-    method: token
-    token_name: "node-${NODE_TOKEN}"
 auth_service:
   enabled: false
 proxy_service:

--- a/assets/loadtest/teleport/teleport-proxy.yaml
+++ b/assets/loadtest/teleport/teleport-proxy.yaml
@@ -8,7 +8,7 @@ teleport:
   data_dir: /var/lib/teleport
   auth_server: auth:3025
   join_params:
-    join_method: token
+    method: token
     token_name: "proxy-${PROXY_TOKEN}"
   cache:
     type: in-memory

--- a/assets/loadtest/teleport/teleport-proxy.yaml
+++ b/assets/loadtest/teleport/teleport-proxy.yaml
@@ -1,3 +1,4 @@
+version: v3
 teleport:
   log:
     severity: DEBUG
@@ -5,8 +6,10 @@ teleport:
       output: json
 
   data_dir: /var/lib/teleport
-  auth_servers: ["auth:3025"]
-  auth_token: "proxy-${PROXY_TOKEN}"
+  auth_server: auth:3025
+  join_params:
+    join_method: token
+    token_name: "proxy-${PROXY_TOKEN}"
   cache:
     type: in-memory
   connection_limits:

--- a/assets/loadtest/teleport/teleport-proxy.yaml
+++ b/assets/loadtest/teleport/teleport-proxy.yaml
@@ -7,9 +7,7 @@ teleport:
 
   data_dir: /var/lib/teleport
   auth_server: auth:3025
-  join_params:
-    method: token
-    token_name: "proxy-${PROXY_TOKEN}"
+  auth_token: "proxy-${PROXY_TOKEN}"
   cache:
     type: in-memory
   connection_limits:

--- a/docker/one-node.yaml
+++ b/docker/one-node.yaml
@@ -2,7 +2,7 @@ version: v3
 teleport:
   auth_server: one
   join_params:
-    join_method: token
+    method: token
     token_name: foo
   log:
     output: /var/lib/teleport/teleport.log

--- a/docker/one-node.yaml
+++ b/docker/one-node.yaml
@@ -1,14 +1,17 @@
+version: v3
 teleport:
-  auth_servers: ["one"]
-  auth_token: foo
+  auth_server: one
+  join_params:
+    join_method: token
+    token_name: foo
   log:
     output: /var/lib/teleport/teleport.log
     severity: INFO
 
   data_dir: /var/lib/teleport
   storage:
-      path: /var/lib/teleport/backend
-      type: dir
+    path: /var/lib/teleport/backend
+    type: dir
 
 auth_service:
   enabled: no
@@ -16,11 +19,11 @@ auth_service:
 ssh_service:
   enabled: yes
   labels:
-      cluster: one
+    cluster: one
   commands:
-      - name: kernel
-        command: [/bin/uname, -r]
-        period: 5m
+    - name: kernel
+      command: [ /bin/uname, -r ]
+      period: 5m
 
 proxy_service:
   enabled: no

--- a/docker/one-node.yaml
+++ b/docker/one-node.yaml
@@ -1,9 +1,7 @@
 version: v3
 teleport:
   auth_server: one
-  join_params:
-    method: token
-    token_name: foo
+  auth_token: foo
   log:
     output: /var/lib/teleport/teleport.log
     severity: INFO

--- a/docker/one-proxy.yaml
+++ b/docker/one-proxy.yaml
@@ -2,7 +2,7 @@
 version: v3
 teleport:
   join_params:
-    join_method: token
+    method: token
     token_name: foo
   nodename: one-proxy
   advertise_ip: 172.10.1.10

--- a/docker/one-proxy.yaml
+++ b/docker/one-proxy.yaml
@@ -1,17 +1,19 @@
 # standalone proxy connected to
+version: v3
 teleport:
-  auth_token: foo
+  join_params:
+    join_method: token
+    token_name: foo
   nodename: one-proxy
   advertise_ip: 172.10.1.10
   log:
     output: stdout
     severity: DEBUG
-  auth_servers:
-    - one:3025
+  auth_server: one:3025
   data_dir: /var/lib/teleport
   storage:
-      path: /var/lib/teleport/backend
-      type: dir
+    path: /var/lib/teleport/backend
+    type: dir
 
 auth_service:
   enabled: no

--- a/docker/one-proxy.yaml
+++ b/docker/one-proxy.yaml
@@ -1,9 +1,7 @@
 # standalone proxy connected to
 version: v3
 teleport:
-  join_params:
-    method: token
-    token_name: foo
+  auth_token: foo
   nodename: one-proxy
   advertise_ip: 172.10.1.10
   log:

--- a/docker/two-node.yaml
+++ b/docker/two-node.yaml
@@ -1,25 +1,28 @@
 # Dumb SSH node for cluster "two"
+version: v3
 teleport:
   nodename: node-on-second-cluster
-  auth_servers: ["two-auth"]
-  auth_token: foo
+  auth_server: two-auth
+  join_params:
+    join_method: token
+    token_name: foo
   advertise_ip: 172.10.1.4
   log:
     output: stdout
     severity: DEBUG
   data_dir: /var/lib/teleport
   storage:
-      path: /var/lib/teleport/backend
-      type: dir
+    path: /var/lib/teleport/backend
+    type: dir
 
 ssh_service:
   enabled: yes
   labels:
-      cluster: two
-      role: dumb_node
+    cluster: two
+    role: dumb_node
 
 proxy_service:
-   enabled: no
+  enabled: no
 
 auth_service:
   enabled: no

--- a/docker/two-node.yaml
+++ b/docker/two-node.yaml
@@ -4,7 +4,7 @@ teleport:
   nodename: node-on-second-cluster
   auth_server: two-auth
   join_params:
-    join_method: token
+    method: token
     token_name: foo
   advertise_ip: 172.10.1.4
   log:

--- a/docker/two-node.yaml
+++ b/docker/two-node.yaml
@@ -3,9 +3,7 @@ version: v3
 teleport:
   nodename: node-on-second-cluster
   auth_server: two-auth
-  join_params:
-    method: token
-    token_name: foo
+  auth_token: foo
   advertise_ip: 172.10.1.4
   log:
     output: stdout

--- a/docker/two-proxy.yaml
+++ b/docker/two-proxy.yaml
@@ -1,15 +1,18 @@
 # Proxy server for cluster "two". Also runs "node" role
+version: v3
 teleport:
   nodename: two-proxy
-  auth_servers: ["two-auth"]
-  auth_token: foo
+  auth_server: two-auth
+  join_params:
+    join_method: token
+    token_name: foo
   log:
     output: stdout
     severity: DEBUG
   data_dir: /var/lib/teleport
   storage:
-      path: /var/lib/teleport/backend
-      type: dir
+    path: /var/lib/teleport/backend
+    type: dir
 
 auth_service:
   enabled: no
@@ -17,14 +20,14 @@ auth_service:
 ssh_service:
   enabled: yes
   labels:
-      cluster: two
-      role: proxy+node
+    cluster: two
+    role: proxy+node
   commands:
-      - name: kernel
-        command: [/bin/uname, -r]
-        period: 5m
+    - name: kernel
+      command: [ /bin/uname, -r ]
+      period: 5m
 
 proxy_service:
-   enabled: yes
-   listen_addr: 0.0.0.0:5023
-   web_listen_addr: 0.0.0.0:5080
+  enabled: yes
+  listen_addr: 0.0.0.0:5023
+  web_listen_addr: 0.0.0.0:5080

--- a/docker/two-proxy.yaml
+++ b/docker/two-proxy.yaml
@@ -4,7 +4,7 @@ teleport:
   nodename: two-proxy
   auth_server: two-auth
   join_params:
-    join_method: token
+    method: token
     token_name: foo
   log:
     output: stdout

--- a/docker/two-proxy.yaml
+++ b/docker/two-proxy.yaml
@@ -3,9 +3,7 @@ version: v3
 teleport:
   nodename: two-proxy
   auth_server: two-auth
-  join_params:
-    method: token
-    token_name: foo
+  auth_token: foo
   log:
     output: stdout
     severity: DEBUG

--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -59,7 +59,7 @@ teleport:
   # We recommend to use tools like `pwgen` to generate sufficiently random
   # tokens of 32+ byte length.
   join_params:
-    join_method: token
+    method: token
     token_name: zw6C82kq7VEUSJeSDzuldWsxakql6jrTYmphxRQOlrATTGbLQoaIwEBo48o9
 
 auth_service:
@@ -97,7 +97,7 @@ Service host:
 version: v3
 teleport:
   join_params:
-    join_method: token
+    method: token
     token_name: zw6C82kq7VEUSJeSDzuldWsxakql6jrTYmphxRQOlrATTGbLQoaIwEBo48o9
 
   # Specify either the proxy address

--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -49,8 +49,8 @@ $ sudo ./install
 Now, save the following configuration file as `/etc/teleport.yaml` on the auth server.
 
 ```yaml
+version: v3
 teleport:
-  auth_token: zw6C82kq7VEUSJeSDzuldWsxakql6jrTYmphxRQOlrATTGbLQoaIwEBo48o9
   # Pre-defined tokens for adding new nodes to a cluster. Each token specifies
   # the role a new node will be allowed to assume. The more secure way to
   # add nodes is to use `ttl node add --ttl` command to generate auto-expiring
@@ -58,8 +58,9 @@ teleport:
   #
   # We recommend to use tools like `pwgen` to generate sufficiently random
   # tokens of 32+ byte length.
-  # you can also use auth server's IP, i.e. "10.1.1.10:3025"
-  auth_servers: [ "10.1.1.10:3025" ]
+  join_params:
+    join_method: token
+    token_name: zw6C82kq7VEUSJeSDzuldWsxakql6jrTYmphxRQOlrATTGbLQoaIwEBo48o9
 
 auth_service:
   # enable the auth service:
@@ -93,11 +94,18 @@ Save the following configuration file as `/etc/teleport.yaml` on the Node
 Service host:
 
 ```yaml
+version: v3
 teleport:
-  auth_token: zw6C82kq7VEUSJeSDzuldWsxakql6jrTYmphxRQOlrATTGbLQoaIwEBo48o9
-  auth_servers: [ "10.1.1.10:3025" ]
+  join_params:
+    join_method: token
+    token_name: zw6C82kq7VEUSJeSDzuldWsxakql6jrTYmphxRQOlrATTGbLQoaIwEBo48o9
 
-  # enable ssh service and disable auth and proxy:
+  # Specify either the proxy address
+  proxy_server: teleport.example.com:3080
+  # or the auth server address
+  auth_server: 10.1.1.10:3025
+
+# Enable ssh service and disable auth and proxy:
 ssh_service:
   enabled: true
 auth_service:

--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -51,6 +51,7 @@ Now, save the following configuration file as `/etc/teleport.yaml` on the auth s
 ```yaml
 version: v3
 teleport:
+  auth_token: xxxx-token-xxxx
   # Pre-defined tokens for adding new nodes to a cluster. Each token specifies
   # the role a new node will be allowed to assume. The more secure way to
   # add nodes is to use `ttl node add --ttl` command to generate auto-expiring
@@ -58,9 +59,8 @@ teleport:
   #
   # We recommend to use tools like `pwgen` to generate sufficiently random
   # tokens of 32+ byte length.
-  join_params:
-    method: token
-    token_name: xxxx-token-xxxx
+  # you can also use auth server's IP, i.e. "10.1.1.10:3025"
+  auth_server: 10.1.1.10:3025
 
 auth_service:
   # enable the auth service:
@@ -70,7 +70,7 @@ auth_service:
   # this static token is used for other nodes to join this Teleport cluster
   - proxy,node:xxxx-token-xxxx
   # this token is used to establish trust with other Teleport clusters
-  - trusted_cluster:TaZff3DLbpsMZmIMhvEr7kulOgegjg7yyQNTS0q6UFWfsJ9N6rxVBjg6t7nw
+  - trusted_cluster:xxxx-different-token-xxxx
 
   # To Support FIPS local_auth needs to be turned off and a SSO connector is
   # required to log into Teleport.
@@ -96,9 +96,7 @@ Service host:
 ```yaml
 version: v3
 teleport:
-  join_params:
-    method: token
-    token_name: xxxx-token-xxxx
+  auth_token: xxxx-token-xxxx
 
   # Specify either the proxy address
   proxy_server: teleport.example.com:3080

--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -60,7 +60,7 @@ teleport:
   # tokens of 32+ byte length.
   join_params:
     method: token
-    token_name: zw6C82kq7VEUSJeSDzuldWsxakql6jrTYmphxRQOlrATTGbLQoaIwEBo48o9
+    token_name: xxxx-token-xxxx
 
 auth_service:
   # enable the auth service:
@@ -68,7 +68,7 @@ auth_service:
 
   tokens:
   # this static token is used for other nodes to join this Teleport cluster
-  - proxy,node:zw6C82kq7VEUSJeSDzuldWsxakql6jrTYmphxRQOlrATTGbLQoaIwEBo48o9
+  - proxy,node:xxxx-token-xxxx
   # this token is used to establish trust with other Teleport clusters
   - trusted_cluster:TaZff3DLbpsMZmIMhvEr7kulOgegjg7yyQNTS0q6UFWfsJ9N6rxVBjg6t7nw
 
@@ -98,7 +98,7 @@ version: v3
 teleport:
   join_params:
     method: token
-    token_name: zw6C82kq7VEUSJeSDzuldWsxakql6jrTYmphxRQOlrATTGbLQoaIwEBo48o9
+    token_name: xxxx-token-xxxx
 
   # Specify either the proxy address
   proxy_server: teleport.example.com:3080

--- a/docs/pages/application-access/guides/aws-console.mdx
+++ b/docs/pages/application-access/guides/aws-console.mdx
@@ -171,7 +171,7 @@ teleport:
   # Instructs the service to load the join token from the specified file
   # during initial registration with the cluster.
   join_params:
-    join_method: token
+    method: token
     token_name: /var/lib/teleport-app/token
   # Proxy address to connect to. Note that it has to be the proxy address
   # because the app service always connects to the cluster over a reverse

--- a/docs/pages/application-access/guides/aws-console.mdx
+++ b/docs/pages/application-access/guides/aws-console.mdx
@@ -12,7 +12,7 @@ This guide will explain how to:
 
 - Access AWS Management Console through Teleport.
 - View Teleport users' AWS console activity in CloudTrail.
-- Access the AWS Command Line Interface (CLI) through Teleport. 
+- Access the AWS Command Line Interface (CLI) through Teleport.
 - Access applications using AWS SDKs through Teleport.
 
 ## Prerequisites
@@ -75,7 +75,7 @@ This step is only required if you are allowing access from another account. The 
 </Admonition>
 
 Teleport uses AWS [federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html) to generate sign-in URLs for users, which relies on the `AssumeRole` API
-for getting temporary security credentials. 
+for getting temporary security credentials.
 You will need to update your IAM roles' "Trusted entities" to include your AWS account ID.
 
 Go to the [Roles](https://console.aws.amazon.com/iamv2/home#/roles) list, pick
@@ -163,18 +163,20 @@ for details.
 Add AWS management console to your application service configuration:
 
 ```yaml
+version: v3
 teleport:
   # Data directory for the Application Proxy service. If running on the same
   # node as Auth/Proxy service, make sure to use different data directories.
   data_dir: /var/lib/teleport-app
   # Instructs the service to load the join token from the specified file
   # during initial registration with the cluster.
-  auth_token: /var/lib/teleport-app/token
+  join_params:
+    join_method: token
+    token_name: /var/lib/teleport-app/token
   # Proxy address to connect to. Note that it has to be the proxy address
   # because the app service always connects to the cluster over a reverse
   # tunnel.
-  auth_servers:
-  - teleport.example.com:3080
+  proxy_server: teleport.example.com:3080
 app_service:
   enabled: "yes"
   apps:

--- a/docs/pages/application-access/guides/aws-console.mdx
+++ b/docs/pages/application-access/guides/aws-console.mdx
@@ -168,11 +168,9 @@ teleport:
   # Data directory for the Application Proxy service. If running on the same
   # node as Auth/Proxy service, make sure to use different data directories.
   data_dir: /var/lib/teleport-app
-  # Instructs the service to load the join token from the specified file
+  # Instructs the service to load the auth token from the specified file
   # during initial registration with the cluster.
-  join_params:
-    method: token
-    token_name: /var/lib/teleport-app/token
+  auth_token: /var/lib/teleport-app/token
   # Proxy address to connect to. Note that it has to be the proxy address
   # because the app service always connects to the cluster over a reverse
   # tunnel.

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -141,7 +141,7 @@ teleport:
   # Instructs the service to load the join token from the specified file
   # during initial registration with the cluster.
   join_params:
-    join_method: token
+    method: token
     token_name: /tmp/token
   # Proxy address to connect to. Note that it has to be the proxy address
   # because the app service always connects to the cluster over a reverse

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -133,18 +133,20 @@ Teleport proxy server.
 Example `teleport.yaml` configuration:
 
 ```yaml
+version: v3
 teleport:
   # Data directory for the Application Proxy service. If running on the same
   # node as Auth/Proxy service, make sure to use different data directories.
   data_dir: /var/lib/teleport-app
   # Instructs the service to load the join token from the specified file
   # during initial registration with the cluster.
-  auth_token: /tmp/token
+  join_params:
+    join_method: token
+    token_name: /tmp/token
   # Proxy address to connect to. Note that it has to be the proxy address
   # because the app service always connects to the cluster over a reverse
   # tunnel.
-  auth_servers:
-  - teleport.example.com:3080
+  proxy_server: teleport.example.com:3080
 app_service:
     enabled: yes
     # Teleport provides a small debug app that can be used to make sure application

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -138,11 +138,9 @@ teleport:
   # Data directory for the Application Proxy service. If running on the same
   # node as Auth/Proxy service, make sure to use different data directories.
   data_dir: /var/lib/teleport-app
-  # Instructs the service to load the join token from the specified file
+  # Instructs the service to load the auth token from the specified file
   # during initial registration with the cluster.
-  join_params:
-    method: token
-    token_name: /tmp/token
+  auth_token: /tmp/token
   # Proxy address to connect to. Note that it has to be the proxy address
   # because the app service always connects to the cluster over a reverse
   # tunnel.

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -77,10 +77,12 @@ Create the Application Service configuration file `/etc/teleport.yaml` with
 the following contents:
 
 ```yaml
+version: v3
 teleport:
-  auth_token: "/tmp/token"
-  auth_servers:
-  - teleport.example.com:3080
+  join_params:
+    join_method: token
+    token_name: "/tmp/token"
+  proxy_server: teleport.example.com:3080
 auth_service:
   enabled: "no"
 ssh_service:

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -80,7 +80,7 @@ the following contents:
 version: v3
 teleport:
   join_params:
-    join_method: token
+    method: token
     token_name: "/tmp/token"
   proxy_server: teleport.example.com:3080
 auth_service:

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -79,9 +79,7 @@ the following contents:
 ```yaml
 version: v3
 teleport:
-  join_params:
-    method: token
-    token_name: "/tmp/token"
+  auth_token: "/tmp/token"
   proxy_server: teleport.example.com:3080
 auth_service:
   enabled: "no"

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -78,7 +78,7 @@ On the node where you will run the Teleport Database Service, run
 version: v3
 teleport:
   join_params:
-    join_method: token
+    method: token
     token_name: "/tmp/token"
   proxy_server: teleport.example.com:443
 db_service:
@@ -127,7 +127,7 @@ On the node where you will run the Teleport Database Service, run
 version: v3
 teleport:
   join_params:
-    join_method: token
+    method: token
     token_name: "/tmp/token"
   proxy_server: mytenant.teleport.sh
 db_service:

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -75,10 +75,12 @@ On the node where you will run the Teleport Database Service, run
 `teleport db start` with the following in `/etc/teleport.yaml`:
 
 ```yaml
+version: v3
 teleport:
-  auth_token: "/tmp/token"
-  auth_servers:
-  - "teleport.example.com:443"
+  join_params:
+    join_method: token
+    token_name: "/tmp/token"
+  proxy_server: teleport.example.com:443
 db_service:
   enabled: "yes"
   databases:
@@ -122,10 +124,12 @@ On the node where you will run the Teleport Database Service, run
 `teleport db start` with the following in `/etc/teleport.yaml`:
 
 ```yaml
+version: v3
 teleport:
-  auth_token: "/tmp/token"
-  auth_servers:
-  - "mytenant.teleport.sh"
+  join_params:
+    join_method: token
+    token_name: "/tmp/token"
+  proxy_server: mytenant.teleport.sh
 db_service:
   enabled: "yes"
   databases:

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -77,9 +77,7 @@ On the node where you will run the Teleport Database Service, run
 ```yaml
 version: v3
 teleport:
-  join_params:
-    method: token
-    token_name: "/tmp/token"
+  auth_token: "/tmp/token"
   proxy_server: teleport.example.com:443
 db_service:
   enabled: "yes"
@@ -126,9 +124,7 @@ On the node where you will run the Teleport Database Service, run
 ```yaml
 version: v3
 teleport:
-  join_params:
-    method: token
-    token_name: "/tmp/token"
+  auth_token: "/tmp/token"
   proxy_server: mytenant.teleport.sh
 db_service:
   enabled: "yes"

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -134,14 +134,14 @@ a single Cloud SQL MySQL database:
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```yaml
+version: v3
 teleport:
   data_dir: /var/lib/teleport-db
   nodename: test
   # Proxy address to connect to. Note that it has to be the proxy address
   # because the Database Service always connects to the cluster over a reverse
   # tunnel.
-  auth_servers:
-  - teleport.example.com:3080
+  proxy_server: teleport.example.com:3080
 db_service:
   enabled: "yes"
   # This section contains definitions of all databases proxied by this
@@ -178,12 +178,12 @@ proxy_service:
 <ScopedBlock scope={["cloud"]}>
 
 ```yaml
+version: v3
 teleport:
   data_dir: /var/lib/teleport-db
   nodename: test
   # Proxy address to connect to. Use your Teleport Cloud tenant address.
-  auth_servers:
-  - mytenant.teleport.sh
+  proxy_server: mytenant.teleport.sh
 db_service:
   enabled: "yes"
   # This section contains definitions of all databases proxied by this

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -205,14 +205,14 @@ a single Cloud SQL PostgreSQL database:
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```yaml
+version: v3
 teleport:
   data_dir: /var/lib/teleport-db
   nodename: test
   # Proxy address to connect to. Note that it has to be the proxy address
   # because the Database Service always connects to the cluster over a reverse
   # tunnel.
-  auth_servers:
-  - teleport.example.com:3080
+  proxy_server: teleport.example.com:3080
 db_service:
   enabled: "yes"
   # This section contains definitions of all databases proxied by this
@@ -249,12 +249,12 @@ proxy_service:
 <ScopedBlock scope={["cloud"]}>
 
 ```yaml
+version: v3
 teleport:
   data_dir: /var/lib/teleport-db
   nodename: test
   # Proxy address to connect to. Use your Teleport Cloud tenant address here.
-  auth_servers:
-  - mytenant.teleport.sh
+  proxy_server: mytenant.teleport.sh
 db_service:
   enabled: "yes"
   # This section contains definitions of all databases proxied by this

--- a/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
@@ -746,8 +746,7 @@ $ aws elbv2 describe-load-balancers --names "${TF_VAR_cluster_name}-auth" --quer
 With this method, the Nodes should be configured like so:
 
 ```yaml
-auth_servers:
-  - example-cluster-auth-c5b0fc2764ee015b.elb.us-east-1.amazonaws.com:3025
+auth_server: example-cluster-auth-c5b0fc2764ee015b.elb.us-east-1.amazonaws.com:3025
 ```
 
 ### Joining Nodes via Teleport IoT/Node tunneling
@@ -759,8 +758,7 @@ With this method, you can join the nodes using the public facing proxy address -
 example.
 
 ```yaml
-auth_servers:
-  - teleport.example.com:443
+proxy_server: teleport.example.com:443
 ```
 
 ### Trusted Clusters

--- a/docs/pages/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/gcp.mdx
@@ -191,7 +191,7 @@ Save the following configuration file as `/etc/teleport.yaml` on the Proxy Serve
 version: v3
 teleport:
   join_params:
-    join_method: token
+    method: token
     token_name: EXAMPLE-PROXY-JOIN-TOKEN
   # We recommend using a TCP load balancer pointed to the auth servers when
   # setting up in High Availability mode.
@@ -219,7 +219,7 @@ Save the following configuration file as `/etc/teleport.yaml` on the Node:
 version: v3
 teleport:
   join_params:
-    join_method: token
+    method: token
     token_name: EXAMPLE-NODE-JOIN-TOKEN
   # Nodes and other agents can be joined to the cluster via the proxy's public address.
   # This will establish a reverse tunnel between the proxy and the node which is used for all traffic.

--- a/docs/pages/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/gcp.mdx
@@ -188,12 +188,14 @@ Save the following configuration file as `/etc/teleport.yaml` on the Proxy Serve
 
 ```yaml
 # enable multiplexing all traffic on TCP port 443
-version: v2
+version: v3
 teleport:
-  auth_token: EXAMPLE-PROXY-JOIN-TOKEN
+  join_params:
+    join_method: token
+    token_name: EXAMPLE-PROXY-JOIN-TOKEN
   # We recommend using a TCP load balancer pointed to the auth servers when
   # setting up in High Availability mode.
-  auth_servers: [ "auth.example.com:3025" ]
+  auth_server: auth.example.com:3025
 # enable proxy service, disable auth and ssh
 ssh_service:
   enabled: false
@@ -214,11 +216,14 @@ proxy_service:
 Save the following configuration file as `/etc/teleport.yaml` on the Node:
 
 ```yaml
+version: v3
 teleport:
-  auth_token: EXAMPLE-NODE-JOIN-TOKEN
+  join_params:
+    join_method: token
+    token_name: EXAMPLE-NODE-JOIN-TOKEN
   # Nodes and other agents can be joined to the cluster via the proxy's public address.
   # This will establish a reverse tunnel between the proxy and the node which is used for all traffic.
-  auth_servers: [ "teleport.example.com:443" ]
+  proxy_server: teleport.example.com:443
 # enable ssh service and disable auth and proxy
 ssh_service:
   enabled: true

--- a/docs/pages/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/gcp.mdx
@@ -190,9 +190,7 @@ Save the following configuration file as `/etc/teleport.yaml` on the Proxy Serve
 # enable multiplexing all traffic on TCP port 443
 version: v3
 teleport:
-  join_params:
-    method: token
-    token_name: EXAMPLE-PROXY-JOIN-TOKEN
+  auth_token: EXAMPLE-PROXY-JOIN-TOKEN
   # We recommend using a TCP load balancer pointed to the auth servers when
   # setting up in High Availability mode.
   auth_server: auth.example.com:3025
@@ -218,9 +216,7 @@ Save the following configuration file as `/etc/teleport.yaml` on the Node:
 ```yaml
 version: v3
 teleport:
-  join_params:
-    method: token
-    token_name: EXAMPLE-NODE-JOIN-TOKEN
+  auth_token: EXAMPLE-NODE-JOIN-TOKEN
   # Nodes and other agents can be joined to the cluster via the proxy's public address.
   # This will establish a reverse tunnel between the proxy and the node which is used for all traffic.
   proxy_server: teleport.example.com:443

--- a/docs/pages/deploy-a-cluster/teleport-enterprise/getting-started.mdx
+++ b/docs/pages/deploy-a-cluster/teleport-enterprise/getting-started.mdx
@@ -16,7 +16,7 @@ You will be deploying three Teleport services on a single host:
   resources or manage the cluster.
 
 - The **SSH Service**  is an SSH server implementation that provides seamless
-  access to Linux hosts in your cluster. 
+  access to Linux hosts in your cluster.
 
   SSH Service instances are called **Teleport Nodes**. When a Teleport Node
   receives a connection request, the request is authenticated through the
@@ -197,7 +197,7 @@ permissions and the option to download your license file:
 Save your license file on the host where you will install Teleport at the path,
 `/var/lib/teleport/license.pem`.
 
-### Start Teleport 
+### Start Teleport
 
 On the host where you are running Teleport, generate a systemd unit file for
 Teleport and save it in `/etc/systemd/system/teleport.service`:
@@ -213,7 +213,7 @@ $ sudo systemctl enable teleport
 $ sudo systemctl start teleport
 ```
 
-Confirm that the `teleport` service has started: 
+Confirm that the `teleport` service has started:
 
 ```
 $ sudo systemctl status teleport
@@ -238,9 +238,9 @@ The output should look something like this:
 ```code
 $ sudo netstat -lptne | grep teleport
 tcp6       0      0 :::443                  :::*                    LISTEN
-0          168760     29504/teleport    
+0          168760     29504/teleport
 tcp6       0      0 :::3022                 :::*                    LISTEN
-0          167812     29504/teleport    
+0          167812     29504/teleport
 tcp6       0      0 :::3025                 :::*                    LISTEN
 0          168741     29504/teleport
 ```
@@ -297,7 +297,7 @@ Run the following commands to download and run the Teleport installer:
   ```code
   $ curl -O https://get.gravitational.com/teleport-ent-(=teleport.version=).pkg
   # Installs on Macintosh HD
-  $ sudo installer -pkg teleport-ent-(=teleport.version=).pkg -target / 
+  $ sudo installer -pkg teleport-ent-(=teleport.version=).pkg -target /
   # Password:
   # installer: Package name is teleport-ent-(=teleport.version=)
   # installer: Upgrading at base path /
@@ -359,7 +359,7 @@ $ tsh --proxy=auth.example.com login --user=myuser
 ```
 
 Note that you can omit the `--user` flag if the `$USER` environment variable
-is equal to your Teleport username.  
+is equal to your Teleport username.
 
 If successful, the `tsh login` command will retrieve a user certificate for
 `myuser` and store it in the `~/.tsh/keys/<proxy>` directory.
@@ -405,8 +405,8 @@ List all SSH servers connected to Teleport:
 
 ```code
 $ tsh ls
-Node Name        Address        Labels                                
----------------- -------------- ------------------------------------- 
+Node Name        Address        Labels
+---------------- -------------- -------------------------------------
 mynode 127.0.0.1:3022 env=example,hostname=mynode
 ```
 

--- a/docs/pages/deploy-a-cluster/teleport-enterprise/getting-started.mdx
+++ b/docs/pages/deploy-a-cluster/teleport-enterprise/getting-started.mdx
@@ -16,7 +16,7 @@ You will be deploying three Teleport services on a single host:
   resources or manage the cluster.
 
 - The **SSH Service**  is an SSH server implementation that provides seamless
-  access to Linux hosts in your cluster.
+  access to Linux hosts in your cluster. 
 
   SSH Service instances are called **Teleport Nodes**. When a Teleport Node
   receives a connection request, the request is authenticated through the
@@ -197,7 +197,7 @@ permissions and the option to download your license file:
 Save your license file on the host where you will install Teleport at the path,
 `/var/lib/teleport/license.pem`.
 
-### Start Teleport
+### Start Teleport 
 
 On the host where you are running Teleport, generate a systemd unit file for
 Teleport and save it in `/etc/systemd/system/teleport.service`:
@@ -213,7 +213,7 @@ $ sudo systemctl enable teleport
 $ sudo systemctl start teleport
 ```
 
-Confirm that the `teleport` service has started:
+Confirm that the `teleport` service has started: 
 
 ```
 $ sudo systemctl status teleport
@@ -238,9 +238,9 @@ The output should look something like this:
 ```code
 $ sudo netstat -lptne | grep teleport
 tcp6       0      0 :::443                  :::*                    LISTEN
-0          168760     29504/teleport
+0          168760     29504/teleport    
 tcp6       0      0 :::3022                 :::*                    LISTEN
-0          167812     29504/teleport
+0          167812     29504/teleport    
 tcp6       0      0 :::3025                 :::*                    LISTEN
 0          168741     29504/teleport
 ```
@@ -297,7 +297,7 @@ Run the following commands to download and run the Teleport installer:
   ```code
   $ curl -O https://get.gravitational.com/teleport-ent-(=teleport.version=).pkg
   # Installs on Macintosh HD
-  $ sudo installer -pkg teleport-ent-(=teleport.version=).pkg -target /
+  $ sudo installer -pkg teleport-ent-(=teleport.version=).pkg -target / 
   # Password:
   # installer: Package name is teleport-ent-(=teleport.version=)
   # installer: Upgrading at base path /
@@ -359,7 +359,7 @@ $ tsh --proxy=auth.example.com login --user=myuser
 ```
 
 Note that you can omit the `--user` flag if the `$USER` environment variable
-is equal to your Teleport username.
+is equal to your Teleport username.  
 
 If successful, the `tsh login` command will retrieve a user certificate for
 `myuser` and store it in the `~/.tsh/keys/<proxy>` directory.
@@ -405,8 +405,8 @@ List all SSH servers connected to Teleport:
 
 ```code
 $ tsh ls
-Node Name        Address        Labels
----------------- -------------- -------------------------------------
+Node Name        Address        Labels                                
+---------------- -------------- ------------------------------------- 
 mynode 127.0.0.1:3022 env=example,hostname=mynode
 ```
 

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -335,7 +335,7 @@ gpupdate.exe /force
 
 <Admonition type="note" title="Secure Cipher Suites">
   Teleport's RDP client supports only secure algorithms
-  for making TLS connections, so we have to configure our Domain Controller 
+  for making TLS connections, so we have to configure our Domain Controller
   to support those cipher suites as well.
   This step is only *necessary* for Windows Server 2012 R2 Domain Controller as it does not support
   secure algorithms by default. If it does not apply to you, you can skip this step and go to the [next step](#step-57-export-your-ldap-ca-certificate).
@@ -466,7 +466,7 @@ windows_desktop_service:
 </Details>
 <Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={"cloud"}>
 For Teleport Cloud, Windows Desktop Service should establish a reverse tunnel to
-the hosted proxy. This requires setting `auth_servers` to your cloud tenant and
+the hosted proxy. This requires setting `proxy_server` to your cloud tenant and
 providing a join token.
 
 First, generate a join token with the following command:
@@ -479,10 +479,12 @@ Copy the join token to a file on the instance where you will run Windows Desktop
 Service, and then use the following configuration:
 
 ```yaml
+version: v3
 teleport:
-  auth_token: /path/to/token
-  auth_servers:
-  - mytenant.teleport.sh # replace with your cloud tenant
+  join_params:
+    join_method: token
+    token_name: /path/to/token
+  proxy_server: mytenant.teleport.sh # replace with your cloud tenant
 windows_desktop_service:
   enabled: yes
   ldap:

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -482,7 +482,7 @@ Service, and then use the following configuration:
 version: v3
 teleport:
   join_params:
-    join_method: token
+    method: token
     token_name: /path/to/token
   proxy_server: mytenant.teleport.sh # replace with your cloud tenant
 windows_desktop_service:

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -481,9 +481,7 @@ Service, and then use the following configuration:
 ```yaml
 version: v3
 teleport:
-  join_params:
-    method: token
-    token_name: /path/to/token
+  auth_token: /path/to/token
   proxy_server: mytenant.teleport.sh # replace with your cloud tenant
 windows_desktop_service:
   enabled: yes

--- a/docs/pages/desktop-access/reference/configuration.mdx
+++ b/docs/pages/desktop-access/reference/configuration.mdx
@@ -25,7 +25,7 @@ The Windows Desktop Service can be deployed in two modes.
 In *direct* mode, Windows Desktop Services registers directly with the Teleport
 Auth Server, and listens for desktop connections from the Teleport Proxy. To
 enable direct mode, set `windows_desktop_service.listen_addr` in
-`teleport.yaml`, and ensure that `teleport.auth_servers` points directly at the
+`teleport.yaml`, and ensure that `teleport.auth_server` points directly at the
 Auth Server. Direct mode requires network connectivity from the Teleport Proxy
 to Windows Desktop Service, and from Windows Desktop Service to the Auth Server.
 
@@ -36,5 +36,5 @@ connection to a Teleport Proxy. The Windows Desktop Service establishes a
 reverse tunnel to the proxy, and both registration with the Auth Server and
 desktop sessions are performed over this tunnel. To enable this mode, ensure
 that `windows_desktop_service.listen_addr` is *unset*, and point
-`teleport.auth_servers` at a Teleport Proxy.
+`teleport.proxy_server` at a Teleport Proxy.
 

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -104,13 +104,14 @@ On the host where you will run your Node, paste the following content into
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```yaml
-version: v2
+version: v3
 teleport:
-  auth_servers:
-    # The address of your Auth Service. You can also use a Proxy Service
-    # address, e.g., tele.example.com:443, if your Auth Service is not
-    # exposed to the internet.
-    - tele.example.com:3025
+  # The address of your Auth Service.
+  auth_server: tele.example.com:3025
+  # Or, you can also use a Proxy Service
+  # address, e.g., tele.example.com:443, if your Auth Service is not
+  # exposed to the internet.
+  proxy_server: tele.example.com:443
 
 auth_service:
   enabled: false
@@ -129,11 +130,10 @@ ssh_service:
 <ScopedBlock scope={["cloud"]}>
 
 ```yaml
-version: v2
+version: v3
 teleport:
-  auth_servers:
-    # Your Teleport Cloud tenant address
-    - mytenant.teleport.sh:443
+  # Your Teleport Cloud tenant address
+  proxy_server: mytenant.teleport.sh:443
 
 auth_service:
   enabled: false
@@ -161,8 +161,8 @@ machine. Your Teleport user must be authorized to access the Node.
 
 ```code
 $ tsh ls --query 'labels["environment"]=="dev"'
-Node Name    Address    Labels          
------------- ---------- --------------- 
+Node Name    Address    Labels
+------------ ---------- ---------------
 bdcb47b87ad6 ⟵ Tunnel environment=dev
 ```
 
@@ -231,7 +231,7 @@ host:
      kubernetes_groups: null
      kubernetes_users: null
 -    logins: null
-+    logins: 
++    logins:
 +      - root
      windows_logins: null
  version: v2
@@ -240,7 +240,7 @@ host:
 Apply your changes:
 
 ```code
-$ tctl create -f user.yaml 
+$ tctl create -f user.yaml
 user "myuser" has been updated
 ```
 
@@ -261,10 +261,9 @@ Edit `/etc/teleport.yaml` to define a `commands` array as shown below:
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```yaml
-version: v2
+version: v3
 teleport:
-  auth_servers:
-    - tele.example.com:3025
+  auth_server: tele.example.com:3025
 
 auth_service:
   enabled: false
@@ -290,10 +289,9 @@ ssh_service:
 <ScopedBlock scope={["cloud"]}>
 
 ```yaml
-version: v2
+version: v3
 teleport:
-  auth_servers:
-    - mytenant.teleport.sh:443
+  proxy_server: mytenant.teleport.sh:443
 
 auth_service:
   enabled: false
@@ -360,9 +358,9 @@ machine. Your Teleport user must be authorized to access the Node.
 
 ```code
 $ tsh ls
-Node Name         Address    Labels          
------------------ ---------- --------------- 
-ip-192-0-2-0      ⟵ Tunnel arch=x86_64,hostname=ip-172-30-156-233 
+Node Name         Address    Labels
+----------------- ---------- ---------------
+ip-192-0-2-0      ⟵ Tunnel arch=x86_64,hostname=ip-172-30-156-233
 ```
 
 <Details title="Problems re-joining the Node?">

--- a/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
@@ -23,7 +23,7 @@ IAM credentials with `ec2:DescribeInstances` permissions are required on
 your Teleport Auth Service. No IAM credentials are required on the Nodes or
 Proxy Service instances.
 
-<Details 
+<Details
 opened
 title="Other AWS Node joining methods"
 scope={["oss", "enterprise"]}
@@ -63,8 +63,8 @@ more in the following guide:
   See [Installation](../../installation.mdx) for details.
 
 - An AWS EC2 instance to act as a Teleport Node, with the Teleport binary
-  installed. The Node should not have an existing data dir (`/var/lib/teleport` by default). 
-  Remove the data directory if this instance has previously joined a Teleport cluster.  
+  installed. The Node should not have an existing data dir (`/var/lib/teleport` by default).
+  Remove the data directory if this instance has previously joined a Teleport cluster.
 
 </TabItem>
 <TabItem
@@ -126,7 +126,7 @@ policy and attach it to your EC2 instance running the Teleport Auth Server.
 
 If you are running your Teleport Auth Server outside of AWS you can attach
 the `teleport-DescribeInstances-policy` directly to an IAM user which
-Teleport will use to authenticate. 
+Teleport will use to authenticate.
 
 You can provide the IAM credentials to Teleport through a shared configuration
 file or environment variables. See
@@ -195,12 +195,12 @@ and `method: ec2` as shown in the following example config:
 
 ```
 # /etc/teleport.yaml
+version: v3
 teleport:
   join_params:
     token_name: ec2-token
     method: ec2
-  auth_servers:
-  - https://teleport.example.com:443
+  proxy_server: https://teleport.example.com:443
 ssh_service:
   enabled: yes
 auth_service:

--- a/docs/pages/management/guides/joining-nodes-aws-iam.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-iam.mdx
@@ -13,8 +13,8 @@ an EC2 instance with an attached IAM role. No specific permissions or IAM policy
 is required: an IAM role with no attached policies is sufficient. No IAM
 credentials are required on the Teleport Auth Service.
 
-<Details 
-scope={["oss", "enterprise"]} 
+<Details
+scope={["oss", "enterprise"]}
 scopeOnly
 opened
 title="Other AWS Node joining methods"
@@ -38,8 +38,8 @@ Read more in the following guide:
 [Adding Nodes to the cluster](../admin/adding-nodes.mdx)
 
 </Details>
-<Details 
-scope={["cloud"]} 
+<Details
+scope={["cloud"]}
 scopeOnly
 opened
 title="Another AWS Node joining method"
@@ -149,12 +149,12 @@ and `method: iam` as shown in the following example config:
 
 ```
 # /etc/teleport.yaml
+version: v3
 teleport:
   join_params:
     token_name: iam-token
     method: iam
-  auth_servers:
-  - https://teleport.example.com:443
+  proxy_server: https://teleport.example.com:443
 ssh_service:
   enabled: yes
 auth_service:

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -42,10 +42,9 @@ run in a highly available fashion.
 
 ## Auth Server State
 
-To run multiple instances of Teleport Auth Server, you must switch to a High Availability secrets back-end first. Also, you must tell each node in a cluster that there is more than one auth server available. There are two ways to do this:
+To run multiple instances of Teleport Auth Server, you must switch to a High Availability secrets back-end first.
 
-- Use a load balancer to create a single auth API access point (AP) and specify this AP in `auth_servers` section of Teleport configuration for all nodes in a cluster. This load balancer should do TCP level forwarding.
-- If a load balancer is not an option, you must specify each instance of an auth server in `auth_servers` section of Teleport configuration.
+To do this, use a load balancer to create a single auth API access point (AP) and specify this AP in `auth_server` section of Teleport configuration for all nodes in a cluster. This load balancer should do TCP level forwarding.
 
 **IMPORTANT:** with multiple instances of the auth servers running, special
 attention needs to be paid to keeping their configuration identical. Settings
@@ -119,8 +118,7 @@ To configure Teleport for using etcd as a storage backend:
     don't already have a TLS setup.
 - Configure all Teleport Auth servers to use etcd in the "storage" section of the config file as shown below.
 - Deploy several auth servers connected to etcd backend.
-- Deploy several proxy nodes that have `auth_servers` pointed to the list of auth
-  servers to connect to.
+- Deploy several proxy nodes that have `auth_server` pointed to the auth server to connect to.
 
 ```yaml
 teleport:

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -44,7 +44,7 @@ run in a highly available fashion.
 
 To run multiple instances of Teleport Auth Server, you must switch to a High Availability secrets back-end first.
 
-To do this, use a load balancer to create a single auth API access point (AP) and specify this AP in `auth_server` section of Teleport configuration for all nodes in a cluster. This load balancer should do TCP level forwarding.
+To do this, use a load balancer to create a single auth API access point (AP) and specify this AP in the `auth_server` field of the Teleport configuration file for all Nodes in a cluster. This load balancer should do TCP-level forwarding.
 
 **IMPORTANT:** with multiple instances of the auth servers running, special
 attention needs to be paid to keeping their configuration identical. Settings
@@ -118,7 +118,7 @@ To configure Teleport for using etcd as a storage backend:
     don't already have a TLS setup.
 - Configure all Teleport Auth servers to use etcd in the "storage" section of the config file as shown below.
 - Deploy several auth servers connected to etcd backend.
-- Deploy several proxy nodes that have `auth_server` pointed to the auth server to connect to.
+- Deploy several Proxy Service instances that have `auth_server` pointed to the auth server to connect to.
 
 ```yaml
 teleport:

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -11,7 +11,7 @@ By default, it is stored in `/etc/teleport.yaml`.
 
 <Admonition type="note" title="Config v3">
 
-Config version v3 removes both `auth_token` and `auth_servers` from the `teleport` section.
+Teleport 11 introduces config version v3, which removes both `auth_token` and `auth_servers` from the `teleport` section.
 
 To migrate from v2 to v3, change `auth_token` to `join_params.token_name`. You should change
 `auth_servers` to either `auth_server` or `proxy_server`, depending on which one is being
@@ -37,6 +37,8 @@ teleport:
     method: token
     token_name: xxxx-token-xxxx
 ```
+
+[View the config changelog here.](#changelog)
 
 </Admonition>
 
@@ -811,3 +813,19 @@ kubernetes_service:
 # This section configures the windows desktop service
 (!docs/pages/includes/desktop-access/desktop-config.yaml!)
 ```
+
+## Changelog
+
+### v3
+
+**Introduced in Teleport v11**
+
+Replaced `teleport.auth_servers` with either `teleport.auth_server` or `teleport.proxy_address`.
+
+Removed `teleport.auth_token` in favor of `teleport.join_params.token_name`.
+
+### v2
+
+**Introduced in Teleport v8**
+
+Added support for multiplexing via `auth_service.proxy_listener_mode`.

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -9,6 +9,37 @@ Teleport uses the YAML file format for configuration. A full configuration refer
 file is shown below, this provides comments and all available options for `teleport.yaml`
 By default, it is stored in `/etc/teleport.yaml`.
 
+<Admonition type="note" title="Config v3">
+
+Config version v3 removes both `auth_token` and `auth_servers` from the `teleport` section.
+
+To migrate from v2 to v3, change `auth_token` to `join_params.token_name`. You should change
+`auth_servers` to either `auth_server` or `proxy_server`, depending on which one is being
+specified in your config already.
+
+Before:
+
+```yaml
+version: v2
+teleport:
+  auth_token: xxxx-token-xxxx
+  auth_servers:
+    - teleport-proxy.example.com:443
+```
+
+After:
+
+```yaml
+version: v3
+teleport:
+  proxy_server: teleport-proxy.example.com:443
+  join_params:
+    join_method: token
+    token_name: xxxx-token-xxxx
+```
+
+</Admonition>
+
 <Admonition type="danger" title="Before using this reference">
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
@@ -65,8 +96,8 @@ By default, it is stored in `/etc/teleport.yaml`.
 ```yaml
 # By default, this file should be stored in /etc/teleport.yaml
 
-# Configuration file version. The current version is "v2".
-version: v2
+# Configuration file version. The current version is "v3".
+version: v3
 
 # This section of the configuration file applies to all teleport
 # services.
@@ -83,14 +114,6 @@ teleport:
     # PID file for Teleport process
     #pid_file: /var/run/teleport.pid
 
-    # The invitation token or an absolute path to a file containing the token used
-    # to join a cluster. It is not used on subsequent starts.
-    # If using a file, it only needs to exist when teleport is first ran.
-    #
-    # File path example:
-    # auth_token: /var/lib/teleport/tokenjoin
-    auth_token: xxxx-token-xxxx
-
     # join_params are parameters to set when joining a cluster via
     # EC2, IAM or a token.
     #
@@ -99,16 +122,21 @@ teleport:
     # IAM join method documentation:
     # https://goteleport.com/docs/setup/guides/joining-nodes-aws-iam/
     join_params:
-        # method, when set to "token", is equivalent to using auth_token.
+        # method when set to "token", is equivalent to using auth_token.
         method: "token"|"ec2"|"iam"
-        # When method is "token", token_name is either the
-        # token or the path to a file containing the token.
+
+        # If method is "iam" or "ec2", token_name will be will be the name of
+        # the joining token resource, e.g., "ec2-token" or "iam-token" as created
+        # in the Joining Nodes via EC2 or IAM guides.
+
+        # If method is "token", token_name will be the invitation token
+        # or an absolute path to a file containing the token used to join a cluster.
+        # It is not used on subsequent starts.
+        # If using a file, it only needs to exist when teleport is first ran.
         #
-        # If method is "iam" or "ec2", token_name will be will be
-        # the name of the joining token resource, e.g., "ec2-token" or
-        # "iam-token" as created in the Joining Nodes via EC2 or IAM
-        # guides.
-        token_name:  "token-name"
+        # File path example:
+        # token_name: /var/lib/teleport/tokenjoin
+        token_name: "token-name"
 
     # Optional CA pin of the auth server. This enables a more secure way of
     # adding new nodes to a cluster. See "Adding Nodes to your Cluster"
@@ -128,14 +156,24 @@ teleport:
     # https://goteleport.com/docs/setup/reference/metrics/
     diag_addr: "127.0.0.1:3000"
 
+
+    # Only use one of auth_server or proxy_server.
+    #
+    # When you have either the application service or database service enabled,
+    # only tunneling through the proxy is supported, so you should specify proxy_server.
+    # All other services support both tunneling through the proxy and directly connecting
+    # to the auth server, so you can specify either auth_server or proxy_server.
+
     # Auth Server address and port to connect to. If you enable the Teleport
     # Auth Server to run in High Availability configuration, the address should
     # point to a Load Balancer.
-    # If adding a node located behind NAT, use the Proxy URL. e.g.
-    #  auth_servers:
-    #     - teleport-proxy.example.com:443
-    auth_servers:
-        - 10.1.0.5:3025
+    # If adding a node located behind NAT, specify `proxy_servers` instead
+    auth_server: 10.1.0.5:3025
+
+    # Proxy Server address and port to connect to. If you enable the Teleport
+    # Proxy Server to run in High Availability configuration, the address should
+    # point to a Load Balancer.
+    proxy_server: teleport-proxy.example.com:443
 
     # cache:
     #  # The cache is enabled by default, it can be disabled with this flag

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -820,7 +820,7 @@ kubernetes_service:
 
 **Introduced in Teleport v11**
 
-Replaced `teleport.auth_servers` with either `teleport.auth_server` or `teleport.proxy_address`.
+Replaced `teleport.auth_servers` with either `teleport.auth_server` or `teleport.proxy_server`.
 
 Removed `teleport.auth_token` in favor of `teleport.join_params.token_name`.
 

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -34,7 +34,7 @@ version: v3
 teleport:
   proxy_server: teleport-proxy.example.com:443
   join_params:
-    join_method: token
+    method: token
     token_name: xxxx-token-xxxx
 ```
 

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -116,6 +116,18 @@ teleport:
     # PID file for Teleport process
     #pid_file: /var/run/teleport.pid
 
+    # The invitation token or an absolute path to a file containing the token used
+    # to join a cluster. It is not used on subsequent starts.
+    # If using a file, it only needs to exist when teleport is first ran.
+    #
+    # File path example:
+    # auth_token: /var/lib/teleport/tokenjoin
+    #
+    # This is the same as setting join_params.method to "token", and join_params.token_name
+    # to the value of auth_token.
+    # You should only use either auth_token or join_params.
+    auth_token: xxxx-token-xxxx
+
     # join_params are parameters to set when joining a cluster via
     # EC2, IAM or a token.
     #
@@ -124,7 +136,8 @@ teleport:
     # IAM join method documentation:
     # https://goteleport.com/docs/setup/guides/joining-nodes-aws-iam/
     join_params:
-        # method when set to "token", is equivalent to using auth_token.
+        # When `method` is set to "token", it is the equivalent to using `auth_token` above.
+        # You should only use either auth_token or join_params.
         method: "token"|"ec2"|"iam"
 
         # If method is "iam" or "ec2", token_name will be will be the name of
@@ -821,8 +834,6 @@ kubernetes_service:
 **Introduced in Teleport v11**
 
 Replaced `teleport.auth_servers` with either `teleport.auth_server` or `teleport.proxy_server`.
-
-Removed `teleport.auth_token` in favor of `teleport.join_params.token_name`.
 
 ### v2
 

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -9,39 +9,6 @@ Teleport uses the YAML file format for configuration. A full configuration refer
 file is shown below, this provides comments and all available options for `teleport.yaml`
 By default, it is stored in `/etc/teleport.yaml`.
 
-<Admonition type="note" title="Config v3">
-
-Teleport 11 introduces config version v3, which removes both `auth_token` and `auth_servers` from the `teleport` section.
-
-To migrate from v2 to v3, change `auth_token` to `join_params.token_name`. You should change
-`auth_servers` to either `auth_server` or `proxy_server`, depending on which one is being
-specified in your config already.
-
-Before:
-
-```yaml
-version: v2
-teleport:
-  auth_token: xxxx-token-xxxx
-  auth_servers:
-    - teleport-proxy.example.com:443
-```
-
-After:
-
-```yaml
-version: v3
-teleport:
-  proxy_server: teleport-proxy.example.com:443
-  join_params:
-    method: token
-    token_name: xxxx-token-xxxx
-```
-
-[View the config changelog here.](#changelog)
-
-</Admonition>
-
 <Admonition type="danger" title="Before using this reference">
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">

--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -136,17 +136,23 @@ $ tctl tokens rm (=presets.tokens.first=)
 
 ### Create a configuration file
 
-Set up your Teleport Node with the following content in `/etc/teleport.yaml`. 
+Set up your Teleport Node with the following content in `/etc/teleport.yaml`.
 
 ```yaml
 # Example config to be saved as etc/teleport.yaml
+version: v3
 teleport:
   nodename: graviton-node
   # The token you created earlier
-  auth_token: (=presets.tokens.first=)
-  auth_servers:
-  # Replace with the address of the Teleport Auth Service or Proxy Service.
-  - 127.0.0.1:3025
+  join_params:
+    join_method: token
+    token_name: (=presets.tokens.first=)
+
+  # Replace with the address of the Teleport Auth Service
+  auth_server: 127.0.0.1:3025
+  # Or specify the Proxy Service address.
+  proxy_server: 127.0.0.1:3080
+
   data_dir: /var/lib/teleport
 proxy_service:
   enabled: false

--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -145,7 +145,7 @@ teleport:
   nodename: graviton-node
   # The token you created earlier
   join_params:
-    join_method: token
+    method: token
     token_name: (=presets.tokens.first=)
 
   # Replace with the address of the Teleport Auth Service

--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -144,9 +144,7 @@ version: v3
 teleport:
   nodename: graviton-node
   # The token you created earlier
-  join_params:
-    method: token
-    token_name: (=presets.tokens.first=)
+  auth_token: (=presets.tokens.first=)
 
   # Replace with the address of the Teleport Auth Service
   auth_server: 127.0.0.1:3025

--- a/docs/pages/server-access/guides/restricted-session.mdx
+++ b/docs/pages/server-access/guides/restricted-session.mdx
@@ -63,12 +63,14 @@ Set up your Teleport Node with the following content in `/etc/teleport.yaml`.
 
 ```yaml
 # Example config to be saved as /etc/teleport.yaml
+version: v3
 teleport:
   nodename: graviton-node
-  auth_token: exampletoken
-  auth_servers:
+  join_params:
+    join_method: token
+    token_name: exampletoken
   # Replace with the address of the Teleport Auth Server.
-  - 127.0.0.1:3025
+  auth_server: 127.0.0.1:3025
   data_dir: /var/lib/teleport
 proxy_service:
   enabled: false

--- a/docs/pages/server-access/guides/restricted-session.mdx
+++ b/docs/pages/server-access/guides/restricted-session.mdx
@@ -67,7 +67,7 @@ version: v3
 teleport:
   nodename: graviton-node
   join_params:
-    join_method: token
+    method: token
     token_name: exampletoken
   # Replace with the address of the Teleport Auth Server.
   auth_server: 127.0.0.1:3025

--- a/docs/pages/server-access/guides/restricted-session.mdx
+++ b/docs/pages/server-access/guides/restricted-session.mdx
@@ -66,9 +66,7 @@ Set up your Teleport Node with the following content in `/etc/teleport.yaml`.
 version: v3
 teleport:
   nodename: graviton-node
-  join_params:
-    method: token
-    token_name: exampletoken
+  auth_token: exampletoken
   # Replace with the address of the Teleport Auth Server.
   auth_server: 127.0.0.1:3025
   data_dir: /var/lib/teleport

--- a/examples/aws/eks/teleport.yaml
+++ b/examples/aws/eks/teleport.yaml
@@ -2,6 +2,7 @@ export TELEPORT_PUBLIC_DNS_NAME="[teleport-proxy.example.com]"
 export TELEPORT_CLUSTER_NAME="[teleport-cluster-name]"
   cat > teleport.yaml << EOF
   # By default, this file should be stored in /etc/teleport.yaml
+  version: v3
   teleport:
     nodename: $TELEPORT_PUBLIC_DNS_NAME
     cluster_name: $TELEPORT_CLUSTER_NAME
@@ -11,8 +12,7 @@ export TELEPORT_CLUSTER_NAME="[teleport-cluster-name]"
       severity: ERROR
     storage:
       type: dir
-    auth_servers:
-    - 127.0.0.1:3025
+    auth_server: 127.0.0.1:3025
     log:
       output: stderr
       severity: INFO

--- a/examples/chart/teleport-cluster/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/deployment_test.yaml.snap
@@ -34,9 +34,6 @@ sets Deployment annotations when specified:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -79,9 +76,6 @@ sets Pod annotations when specified:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -124,9 +118,6 @@ should add PersistentVolumeClaim as volume when in custom mode and persistence.e
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -169,9 +160,6 @@ should add PersistentVolumeClaim as volume when in standalone mode and persisten
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -249,9 +237,6 @@ should add emptyDir for data in AWS mode:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -353,9 +338,6 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -398,9 +380,6 @@ should add named PersistentVolumeClaim as volume when in custom mode and persist
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -444,9 +423,6 @@ should add named PersistentVolumeClaim as volume when in custom mode and persist
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -495,9 +471,6 @@ should do enterprise things when when enterprise is set in values:
     - name: license
       secret:
         secretName: license
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -540,9 +513,6 @@ should expose diag port:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -585,9 +555,6 @@ should have Recreate strategy in standalone mode:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -642,9 +609,6 @@ should have multiple replicas when replicaCount is set:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -699,9 +663,6 @@ should mount ConfigMap for config in AWS mode:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -802,9 +763,6 @@ should mount ConfigMap for config in custom mode:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -847,9 +805,6 @@ should mount ConfigMap for config in standalone mode:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1186,9 +1141,6 @@ should mount cert-manager TLS secret when highAvailability.certManager.enabled i
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - name: teleport-tls
       secret:
         secretName: teleport-tls
@@ -1236,9 +1188,6 @@ should mount extraVolumes and extraVolumeMounts:
         name: my-mount
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1293,9 +1242,6 @@ should mount tls.existingCASecretName and set environment when set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - name: teleport-tls
       secret:
         secretName: helm-lint-existing-tls-secret
@@ -1355,9 +1301,6 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - name: teleport-tls
       secret:
         secretName: helm-lint-existing-tls-secret
@@ -1409,9 +1352,6 @@ should mount tls.existingSecretName when set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - name: teleport-tls
       secret:
         secretName: helm-lint-existing-tls-secret
@@ -1457,9 +1397,6 @@ should not add PersistentVolumeClaim as volume when in custom mode and persisten
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1501,9 +1438,6 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1546,9 +1480,6 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1591,9 +1522,6 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1635,9 +1563,6 @@ should not do enterprise things when when enterprise is not set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1680,9 +1605,6 @@ should not have more than one replica in standalone mode:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1737,9 +1659,6 @@ should not have strategy in AWS mode:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1840,9 +1759,6 @@ should not have strategy in custom mode:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1885,9 +1801,6 @@ should not mount TLS secrets when when highAvailability.certManager.enabled is f
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -1930,9 +1843,6 @@ should not set securityContext when is empty object (default value):
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2003,9 +1913,6 @@ should provision initContainer correctly when set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2057,9 +1964,6 @@ should set affinity when set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2105,9 +2009,6 @@ should set environment when extraEnv set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2150,9 +2051,6 @@ should set imagePullPolicy when set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2201,9 +2099,6 @@ should set postStart command if set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2247,9 +2142,6 @@ should set priorityClassName when set in values:
     priorityClassName: system-cluster-critical
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2292,9 +2184,6 @@ should set probeTimeoutSeconds when set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2347,9 +2236,6 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2398,9 +2284,6 @@ should set resources when set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2450,9 +2333,6 @@ should set securityContext when set in values:
         name: data
     serviceAccountName: RELEASE-NAME
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config
@@ -2516,9 +2396,6 @@ should set tolerations when set in values:
       operator: Equal
       value: teleport
     volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: teleport-gcp-credentials
     - configMap:
         name: RELEASE-NAME
       name: config

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -22,7 +22,7 @@ data:
     version: v3
     teleport:
       join_params:
-        join_method: token
+        method: token
         token_name: "/etc/teleport-secrets/auth-token"
       proxy_server: {{ required "proxyAddr is required in chart values" .Values.proxyAddr }}
       {{- if .Values.caPin }}

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -19,9 +19,12 @@ metadata:
   {{- end }}
 data:
   teleport.yaml: |
+    version: v3
     teleport:
-      auth_token: "/etc/teleport-secrets/auth-token"
-      auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
+      join_params:
+        join_method: token
+        token_name: "/etc/teleport-secrets/auth-token"
+      proxy_server: {{ required "proxyAddr is required in chart values" .Values.proxyAddr }}
       {{- if .Values.caPin }}
       ca_pin: {{- toYaml .Values.caPin | nindent 8 }}
       {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -21,9 +21,7 @@ data:
   teleport.yaml: |
     version: v3
     teleport:
-      join_params:
-        method: token
-        token_name: "/etc/teleport-secrets/auth-token"
+      auth_token: "/etc/teleport-secrets/auth-token"
       proxy_server: {{ required "proxyAddr is required in chart values" .Values.proxyAddr }}
       {{- if .Values.caPin }}
       ca_pin: {{- toYaml .Values.caPin | nindent 8 }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -6,7 +6,7 @@ does not generate a config for clusterrole.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -44,7 +44,7 @@ does not generate a config for pdb.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -82,7 +82,7 @@ matches snapshot and tests for annotations.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -123,7 +123,7 @@ matches snapshot and tests for extra-labels.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -164,7 +164,7 @@ matches snapshot for affinity.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -202,7 +202,7 @@ matches snapshot for all-v6.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -256,7 +256,7 @@ matches snapshot for aws-databases.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -306,7 +306,7 @@ matches snapshot for backwards-compatibility.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -344,7 +344,7 @@ matches snapshot for ca-pin.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           ca_pin:
@@ -384,7 +384,7 @@ matches snapshot for db.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -427,7 +427,7 @@ matches snapshot for dynamic-app.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -467,7 +467,7 @@ matches snapshot for dynamic-db.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -507,7 +507,7 @@ matches snapshot for imagepullsecrets.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -545,7 +545,7 @@ matches snapshot for initcontainers.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -583,7 +583,7 @@ matches snapshot for log-basic.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -621,7 +621,7 @@ matches snapshot for log-extra.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -659,7 +659,7 @@ matches snapshot for log-legacy.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -697,7 +697,7 @@ matches snapshot for node-selector.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -735,7 +735,7 @@ matches snapshot for pdb.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -773,7 +773,7 @@ matches snapshot for resources.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -811,7 +811,7 @@ matches snapshot for stateful.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -849,7 +849,7 @@ matches snapshot for tolerations.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
@@ -887,7 +887,7 @@ matches snapshot for volumes.yaml:
         version: v3
         teleport:
           join_params:
-            join_method: token
+            method: token
             token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -3,9 +3,12 @@ does not generate a config for clusterrole.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -38,9 +41,12 @@ does not generate a config for pdb.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -73,9 +79,12 @@ matches snapshot and tests for annotations.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -111,9 +120,12 @@ matches snapshot and tests for extra-labels.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -149,9 +161,12 @@ matches snapshot for affinity.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -184,9 +199,12 @@ matches snapshot for all-v6.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -235,9 +253,12 @@ matches snapshot for aws-databases.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -282,9 +303,12 @@ matches snapshot for backwards-compatibility.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -317,9 +341,12 @@ matches snapshot for ca-pin.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           ca_pin:
             - sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1
           log:
@@ -354,9 +381,12 @@ matches snapshot for db.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -394,9 +424,12 @@ matches snapshot for dynamic-app.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -431,9 +464,12 @@ matches snapshot for dynamic-db.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -468,9 +504,12 @@ matches snapshot for imagepullsecrets.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -503,9 +542,12 @@ matches snapshot for initcontainers.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -538,9 +580,12 @@ matches snapshot for log-basic.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -573,9 +618,12 @@ matches snapshot for log-extra.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: DEBUG
             output: /var/lib/teleport/test.log
@@ -608,9 +656,12 @@ matches snapshot for log-legacy.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: DEBUG
             output: stderr
@@ -643,9 +694,12 @@ matches snapshot for node-selector.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -678,9 +732,12 @@ matches snapshot for pdb.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: DEBUG
             output: /var/lib/teleport/test.log
@@ -713,9 +770,12 @@ matches snapshot for resources.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -748,9 +808,12 @@ matches snapshot for stateful.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -783,9 +846,12 @@ matches snapshot for tolerations.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr
@@ -818,9 +884,12 @@ matches snapshot for volumes.yaml:
     apiVersion: v1
     data:
       teleport.yaml: |
+        version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
-          auth_servers: ["proxy.example.com:3080"]
+          join_params:
+            join_method: token
+            token_name: "/etc/teleport-secrets/auth-token"
+          proxy_server: proxy.example.com:3080
           log:
             severity: INFO
             output: stderr

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -5,9 +5,7 @@ does not generate a config for clusterrole.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -43,9 +41,7 @@ does not generate a config for pdb.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -81,9 +77,7 @@ matches snapshot and tests for annotations.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -122,9 +116,7 @@ matches snapshot and tests for extra-labels.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -163,9 +155,7 @@ matches snapshot for affinity.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -201,9 +191,7 @@ matches snapshot for all-v6.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -255,9 +243,7 @@ matches snapshot for aws-databases.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -305,9 +291,7 @@ matches snapshot for backwards-compatibility.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -343,9 +327,7 @@ matches snapshot for ca-pin.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           ca_pin:
             - sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1
@@ -383,9 +365,7 @@ matches snapshot for db.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -426,9 +406,7 @@ matches snapshot for dynamic-app.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -466,9 +444,7 @@ matches snapshot for dynamic-db.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -506,9 +482,7 @@ matches snapshot for imagepullsecrets.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -544,9 +518,7 @@ matches snapshot for initcontainers.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -582,9 +554,7 @@ matches snapshot for log-basic.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -620,9 +590,7 @@ matches snapshot for log-extra.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: DEBUG
@@ -658,9 +626,7 @@ matches snapshot for log-legacy.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: DEBUG
@@ -696,9 +662,7 @@ matches snapshot for node-selector.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -734,9 +698,7 @@ matches snapshot for pdb.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: DEBUG
@@ -772,9 +734,7 @@ matches snapshot for resources.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -810,9 +770,7 @@ matches snapshot for stateful.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -848,9 +806,7 @@ matches snapshot for tolerations.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO
@@ -886,9 +842,7 @@ matches snapshot for volumes.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          join_params:
-            method: token
-            token_name: "/etc/teleport-secrets/auth-token"
+          auth_token: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -18,7 +18,7 @@ sets Deployment annotations when specified if action is Upgrade:
       template:
         metadata:
           annotations:
-            checksum/config: a123e1127ab5c900da5375a0d6431a4294b34ab8b602186dd4dd14d921ad08c9
+            checksum/config: 86f6dbba4770bdad3f51ef88a27a971e397b4640a555859485071cf7b6f6f235
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -86,7 +86,7 @@ sets Deployment labels when specified if action is Upgrade:
     template:
       metadata:
         annotations:
-          checksum/config: 206894fa05a641e5c342b1c03ab0e2651e9838abcf30888fc05268d8fbc334fe
+          checksum/config: 915b19683b4d241ee638d91a018d5a09edf61068d6a2581987ffc672e77d5993
         labels:
           app: RELEASE-NAME
           app.kubernetes.io/name: teleport-kube-agent

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -18,7 +18,7 @@ sets Deployment annotations when specified if action is Upgrade:
       template:
         metadata:
           annotations:
-            checksum/config: 511656bfc4345260ef1ddc4319c2a30ff1e004c72c518c82020a76e088a10cd8
+            checksum/config: a123e1127ab5c900da5375a0d6431a4294b34ab8b602186dd4dd14d921ad08c9
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -86,7 +86,7 @@ sets Deployment labels when specified if action is Upgrade:
     template:
       metadata:
         annotations:
-          checksum/config: b37ca9b3da292ffe343a4629c7da7dc006ec03156fc19268123a24df51dfeb78
+          checksum/config: 206894fa05a641e5c342b1c03ab0e2651e9838abcf30888fc05268d8fbc334fe
         labels:
           app: RELEASE-NAME
           app.kubernetes.io/name: teleport-kube-agent

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -18,7 +18,7 @@ sets Deployment annotations when specified if action is Upgrade:
       template:
         metadata:
           annotations:
-            checksum/config: 86f6dbba4770bdad3f51ef88a27a971e397b4640a555859485071cf7b6f6f235
+            checksum/config: 40ee068e95f9baae75f3b7f6ef1a62a7ffdf3d9005e74514e597dbd4c4af595e
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -86,7 +86,7 @@ sets Deployment labels when specified if action is Upgrade:
     template:
       metadata:
         annotations:
-          checksum/config: 915b19683b4d241ee638d91a018d5a09edf61068d6a2581987ffc672e77d5993
+          checksum/config: e23c34c3027af13bb06e161dfe1fe316312a1d5621ef217502a5c76596e49668
         labels:
           app: RELEASE-NAME
           app.kubernetes.io/name: teleport-kube-agent

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -150,7 +150,7 @@ sets StatefulSet labels when specified:
       template:
         metadata:
           annotations:
-            checksum/config: 206894fa05a641e5c342b1c03ab0e2651e9838abcf30888fc05268d8fbc334fe
+            checksum/config: 915b19683b4d241ee638d91a018d5a09edf61068d6a2581987ffc672e77d5993
           labels:
             app: RELEASE-NAME
             app.kubernetes.io/name: teleport-kube-agent
@@ -381,7 +381,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
       template:
         metadata:
           annotations:
-            checksum/config: e036edd154f82bcb0f14c9d5327344820c3122cc1e47ba800ad49db352eff91f
+            checksum/config: ded8528054c143cfea065d0cbf2e81c5ce390affa8d0dedaa79aa846216b8c78
           labels:
             app: RELEASE-NAME
         spec:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -150,7 +150,7 @@ sets StatefulSet labels when specified:
       template:
         metadata:
           annotations:
-            checksum/config: b37ca9b3da292ffe343a4629c7da7dc006ec03156fc19268123a24df51dfeb78
+            checksum/config: 206894fa05a641e5c342b1c03ab0e2651e9838abcf30888fc05268d8fbc334fe
           labels:
             app: RELEASE-NAME
             app.kubernetes.io/name: teleport-kube-agent
@@ -381,7 +381,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
       template:
         metadata:
           annotations:
-            checksum/config: b68f736b13876b204549cacfa6683f63942acdfe1e98c43d74f9868eb8f1edff
+            checksum/config: e036edd154f82bcb0f14c9d5327344820c3122cc1e47ba800ad49db352eff91f
           labels:
             app: RELEASE-NAME
         spec:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -150,7 +150,7 @@ sets StatefulSet labels when specified:
       template:
         metadata:
           annotations:
-            checksum/config: 915b19683b4d241ee638d91a018d5a09edf61068d6a2581987ffc672e77d5993
+            checksum/config: e23c34c3027af13bb06e161dfe1fe316312a1d5621ef217502a5c76596e49668
           labels:
             app: RELEASE-NAME
             app.kubernetes.io/name: teleport-kube-agent
@@ -381,7 +381,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
       template:
         metadata:
           annotations:
-            checksum/config: ded8528054c143cfea065d0cbf2e81c5ce390affa8d0dedaa79aa846216b8c78
+            checksum/config: 85faa83e7e3e6789b109a5d52e61141243de9d7c5e408af802fb5ad544f79698
           labels:
             app: RELEASE-NAME
         spec:

--- a/examples/local-cluster/node/teleport.yaml
+++ b/examples/local-cluster/node/teleport.yaml
@@ -1,8 +1,10 @@
+version: v3
 teleport:
   nodename: graviton-node
-  auth_token: hello
-  auth_servers:
-  - 127.0.0.1:5000
+  join_params:
+    join_method: token
+    token_name: hello
+  auth_server: 127.0.0.1:5000
   data_dir: .data
 proxy_service:
   enabled: "no"

--- a/examples/local-cluster/node/teleport.yaml
+++ b/examples/local-cluster/node/teleport.yaml
@@ -2,7 +2,7 @@ version: v3
 teleport:
   nodename: graviton-node
   join_params:
-    join_method: token
+    method: token
     token_name: hello
   auth_server: 127.0.0.1:5000
   data_dir: .data

--- a/examples/local-cluster/node/teleport.yaml
+++ b/examples/local-cluster/node/teleport.yaml
@@ -1,9 +1,7 @@
 version: v3
 teleport:
   nodename: graviton-node
-  join_params:
-    method: token
-    token_name: hello
+  auth_token: hello
   auth_server: 127.0.0.1:5000
   data_dir: .data
 proxy_service:

--- a/examples/local-cluster/proxy/teleport.yaml
+++ b/examples/local-cluster/proxy/teleport.yaml
@@ -1,8 +1,10 @@
+version: v3
 teleport:
   nodename: graviton-proxy
-  auth_token: hello
-  auth_servers:
-  - 127.0.0.1:5000
+  join_params:
+    join_method: token
+    token_name: hello
+  auth_server: 127.0.0.1:5000
   data_dir: .data
 proxy_service:
   enabled: "yes"

--- a/examples/local-cluster/proxy/teleport.yaml
+++ b/examples/local-cluster/proxy/teleport.yaml
@@ -2,7 +2,7 @@ version: v3
 teleport:
   nodename: graviton-proxy
   join_params:
-    join_method: token
+    method: token
     token_name: hello
   auth_server: 127.0.0.1:5000
   data_dir: .data

--- a/examples/local-cluster/proxy/teleport.yaml
+++ b/examples/local-cluster/proxy/teleport.yaml
@@ -1,9 +1,7 @@
 version: v3
 teleport:
   nodename: graviton-proxy
-  join_params:
-    method: token
-    token_name: hello
+  auth_token: hello
   auth_server: 127.0.0.1:5000
   data_dir: .data
 proxy_service:

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -556,12 +556,12 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, extraApps []service.
 		raConf.Log = log
 		raConf.DataDir = t.TempDir()
 		raConf.SetToken("static-token-value")
-		raConf.AuthServers = []utils.NetAddr{
+		raConf.SetAuthServerAddresses([]utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
 				Addr:        p.rootCluster.Web,
 			},
-		}
+		})
 		raConf.Auth.Enabled = false
 		raConf.Proxy.Enabled = false
 		raConf.SSH.Enabled = false
@@ -701,12 +701,12 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, extraApps []service.
 		laConf.Log = log
 		laConf.DataDir = t.TempDir()
 		laConf.SetToken("static-token-value")
-		laConf.AuthServers = []utils.NetAddr{
+		laConf.SetAuthServerAddresses([]utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
 				Addr:        p.leafCluster.Web,
 			},
-		}
+		})
 		laConf.Auth.Enabled = false
 		laConf.Proxy.Enabled = false
 		laConf.SSH.Enabled = false

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -556,11 +556,9 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, extraApps []service.
 		raConf.Log = log
 		raConf.DataDir = t.TempDir()
 		raConf.SetToken("static-token-value")
-		raConf.SetAuthServerAddresses([]utils.NetAddr{
-			{
-				AddrNetwork: "tcp",
-				Addr:        p.rootCluster.Web,
-			},
+		raConf.SetAuthServerAddress(utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        p.rootCluster.Web,
 		})
 		raConf.Auth.Enabled = false
 		raConf.Proxy.Enabled = false
@@ -701,11 +699,9 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, extraApps []service.
 		laConf.Log = log
 		laConf.DataDir = t.TempDir()
 		laConf.SetToken("static-token-value")
-		laConf.SetAuthServerAddresses([]utils.NetAddr{
-			{
-				AddrNetwork: "tcp",
-				Addr:        p.leafCluster.Web,
-			},
+		laConf.SetAuthServerAddress(utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        p.leafCluster.Web,
 		})
 		laConf.Auth.Enabled = false
 		laConf.Proxy.Enabled = false

--- a/integration/db/fixture.go
+++ b/integration/db/fixture.go
@@ -109,11 +109,9 @@ func (pack *databaseClusterPack) StartDatabaseServices(t *testing.T, clock clock
 	conf := service.MakeDefaultConfig()
 	conf.DataDir = filepath.Join(t.TempDir(), pack.name)
 	conf.SetToken("static-token-value")
-	conf.SetAuthServerAddresses([]utils.NetAddr{
-		{
-			AddrNetwork: "tcp",
-			Addr:        pack.Cluster.Web,
-		},
+	conf.SetAuthServerAddress(utils.NetAddr{
+		AddrNetwork: "tcp",
+		Addr:        pack.Cluster.Web,
 	})
 	conf.Databases.Enabled = true
 	conf.Databases.Databases = []service.Database{
@@ -400,11 +398,9 @@ func (p *DatabasePack) startRootDatabaseAgent(t *testing.T, params databaseAgent
 	conf.DataDir = t.TempDir()
 	conf.SetToken("static-token-value")
 	conf.DiagnosticAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerDiagnostic, &conf.FileDescriptors))
-	conf.SetAuthServerAddresses([]utils.NetAddr{
-		{
-			AddrNetwork: "tcp",
-			Addr:        p.Root.Cluster.Web,
-		},
+	conf.SetAuthServerAddress(utils.NetAddr{
+		AddrNetwork: "tcp",
+		Addr:        p.Root.Cluster.Web,
 	})
 	conf.Clock = p.clock
 	conf.Databases.Enabled = true

--- a/integration/db/fixture.go
+++ b/integration/db/fixture.go
@@ -109,12 +109,12 @@ func (pack *databaseClusterPack) StartDatabaseServices(t *testing.T, clock clock
 	conf := service.MakeDefaultConfig()
 	conf.DataDir = filepath.Join(t.TempDir(), pack.name)
 	conf.SetToken("static-token-value")
-	conf.AuthServers = []utils.NetAddr{
+	conf.SetAuthServerAddresses([]utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
 			Addr:        pack.Cluster.Web,
 		},
-	}
+	})
 	conf.Databases.Enabled = true
 	conf.Databases.Databases = []service.Database{
 		pack.PostgresService,
@@ -400,12 +400,12 @@ func (p *DatabasePack) startRootDatabaseAgent(t *testing.T, params databaseAgent
 	conf.DataDir = t.TempDir()
 	conf.SetToken("static-token-value")
 	conf.DiagnosticAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerDiagnostic, &conf.FileDescriptors))
-	conf.AuthServers = []utils.NetAddr{
+	conf.SetAuthServerAddresses([]utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
 			Addr:        p.Root.Cluster.Web,
 		},
-	}
+	})
 	conf.Clock = p.clock
 	conf.Databases.Enabled = true
 	conf.Databases.Databases = params.databases

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -63,7 +63,7 @@ func newNodeConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, joinM
 	config.Auth.Enabled = false
 	config.Proxy.Enabled = false
 	config.DataDir = t.TempDir()
-	config.SetAuthServerAddresses(append(config.AuthServerAddresses(), authAddr))
+	config.SetAuthServerAddress(authAddr)
 	config.Log = newSilentLogger()
 	config.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	return config
@@ -84,7 +84,7 @@ func newProxyConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, join
 	config.Proxy.EnableProxyProtocol = true
 
 	config.DataDir = t.TempDir()
-	config.SetAuthServerAddresses(append(config.AuthServerAddresses(), authAddr))
+	config.SetAuthServerAddress(authAddr)
 	config.Log = newSilentLogger()
 	config.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	return config
@@ -107,7 +107,7 @@ func newAuthConfig(t *testing.T, clock clockwork.Clock) *service.Config {
 		ClusterName: "testcluster",
 	})
 	require.NoError(t, err)
-	config.SetAuthServerAddresses(append(config.AuthServerAddresses(), config.Auth.ListenAddr))
+	config.SetAuthServerAddress(config.Auth.ListenAddr)
 	config.Auth.StorageConfig = storageConfig
 	config.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 	config.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
@@ -342,7 +342,7 @@ func TestEC2Labels(t *testing.T) {
 	tconf.Proxy.DisableWebInterface = true
 	tconf.Auth.StorageConfig = storageConfig
 	tconf.Auth.ListenAddr.Addr = helpers.NewListener(t, service.ListenerAuth, &tconf.FileDescriptors)
-	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), tconf.Auth.ListenAddr))
+	tconf.SetAuthServerAddress(tconf.Auth.ListenAddr)
 
 	tconf.SSH.Enabled = true
 	tconf.SSH.Addr.Addr = helpers.NewListener(t, service.ListenerNodeSSH, &tconf.FileDescriptors)
@@ -447,7 +447,7 @@ func TestEC2Hostname(t *testing.T) {
 	tconf.Proxy.WebAddr.Addr = helpers.NewListener(t, service.ListenerProxyWeb, &tconf.FileDescriptors)
 	tconf.Auth.StorageConfig = storageConfig
 	tconf.Auth.ListenAddr.Addr = helpers.NewListener(t, service.ListenerAuth, &tconf.FileDescriptors)
-	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), tconf.Auth.ListenAddr))
+	tconf.SetAuthServerAddress(tconf.Auth.ListenAddr)
 
 	tconf.SSH.Enabled = true
 	tconf.SSH.Addr.Addr = helpers.NewListener(t, service.ListenerNodeSSH, &tconf.FileDescriptors)

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -63,7 +63,7 @@ func newNodeConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, joinM
 	config.Auth.Enabled = false
 	config.Proxy.Enabled = false
 	config.DataDir = t.TempDir()
-	config.AuthServers = append(config.AuthServers, authAddr)
+	config.SetAuthServerAddresses(append(config.AuthServerAddresses(), authAddr))
 	config.Log = newSilentLogger()
 	config.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	return config
@@ -84,7 +84,7 @@ func newProxyConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, join
 	config.Proxy.EnableProxyProtocol = true
 
 	config.DataDir = t.TempDir()
-	config.AuthServers = append(config.AuthServers, authAddr)
+	config.SetAuthServerAddresses(append(config.AuthServerAddresses(), authAddr))
 	config.Log = newSilentLogger()
 	config.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	return config
@@ -107,7 +107,7 @@ func newAuthConfig(t *testing.T, clock clockwork.Clock) *service.Config {
 		ClusterName: "testcluster",
 	})
 	require.NoError(t, err)
-	config.AuthServers = append(config.AuthServers, config.Auth.ListenAddr)
+	config.SetAuthServerAddresses(append(config.AuthServerAddresses(), config.Auth.ListenAddr))
 	config.Auth.StorageConfig = storageConfig
 	config.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 	config.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
@@ -342,7 +342,7 @@ func TestEC2Labels(t *testing.T) {
 	tconf.Proxy.DisableWebInterface = true
 	tconf.Auth.StorageConfig = storageConfig
 	tconf.Auth.ListenAddr.Addr = helpers.NewListener(t, service.ListenerAuth, &tconf.FileDescriptors)
-	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.ListenAddr)
+	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), tconf.Auth.ListenAddr))
 
 	tconf.SSH.Enabled = true
 	tconf.SSH.Addr.Addr = helpers.NewListener(t, service.ListenerNodeSSH, &tconf.FileDescriptors)
@@ -447,7 +447,7 @@ func TestEC2Hostname(t *testing.T) {
 	tconf.Proxy.WebAddr.Addr = helpers.NewListener(t, service.ListenerProxyWeb, &tconf.FileDescriptors)
 	tconf.Auth.StorageConfig = storageConfig
 	tconf.Auth.ListenAddr.Addr = helpers.NewListener(t, service.ListenerAuth, &tconf.FileDescriptors)
-	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.ListenAddr)
+	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), tconf.Auth.ListenAddr))
 
 	tconf.SSH.Enabled = true
 	tconf.SSH.Addr.Addr = helpers.NewListener(t, service.ListenerNodeSSH, &tconf.FileDescriptors)

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -508,7 +508,7 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 			tconf.Proxy.MongoAddr.Addr = i.Mongo
 		}
 	}
-	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), tconf.Auth.ListenAddr))
+	tconf.SetAuthServerAddress(tconf.Auth.ListenAddr)
 	tconf.Auth.StorageConfig = backend.Config{
 		Type:   lite.GetName(),
 		Params: backend.Params{"path": dataDir + string(os.PathListSeparator) + defaults.BackendDir, "poll_stream_period": 50 * time.Millisecond},
@@ -620,7 +620,7 @@ func (i *TeleInstance) StartNodeWithTargetPort(tconf *service.Config, authPort s
 
 	if tconf.ProxyServer.IsEmpty() {
 		authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
-		tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), *authServer))
+		tconf.SetAuthServerAddress(*authServer)
 	}
 
 	tconf.SetToken("token")
@@ -674,11 +674,9 @@ func (i *TeleInstance) StartApp(conf *service.Config) (*service.TeleportProcess,
 	i.tempDirs = append(i.tempDirs, dataDir)
 
 	conf.DataDir = dataDir
-	conf.SetAuthServerAddresses([]utils.NetAddr{
-		{
-			AddrNetwork: "tcp",
-			Addr:        i.Web,
-		},
+	conf.SetAuthServerAddress(utils.NetAddr{
+		AddrNetwork: "tcp",
+		Addr:        i.Web,
 	})
 	conf.SetToken("token")
 	conf.UploadEventsC = i.UploadEventsC
@@ -726,11 +724,9 @@ func (i *TeleInstance) StartApps(configs []*service.Config) ([]*service.Teleport
 			}
 
 			cfg.DataDir = dataDir
-			cfg.SetAuthServerAddresses([]utils.NetAddr{
-				{
-					AddrNetwork: "tcp",
-					Addr:        i.Web,
-				},
+			cfg.SetAuthServerAddress(utils.NetAddr{
+				AddrNetwork: "tcp",
+				Addr:        i.Web,
 			})
 			cfg.SetToken("token")
 			cfg.UploadEventsC = i.UploadEventsC
@@ -790,11 +786,9 @@ func (i *TeleInstance) StartDatabase(conf *service.Config) (*service.TeleportPro
 	i.tempDirs = append(i.tempDirs, dataDir)
 
 	conf.DataDir = dataDir
-	conf.SetAuthServerAddresses([]utils.NetAddr{
-		{
-			AddrNetwork: "tcp",
-			Addr:        i.Web,
-		},
+	conf.SetAuthServerAddress(utils.NetAddr{
+		AddrNetwork: "tcp",
+		Addr:        i.Web,
 	})
 	conf.SetToken("token")
 	conf.UploadEventsC = i.UploadEventsC
@@ -853,11 +847,9 @@ func (i *TeleInstance) StartKube(t *testing.T, conf *service.Config, clusterName
 	i.tempDirs = append(i.tempDirs, dataDir)
 
 	conf.DataDir = dataDir
-	conf.SetAuthServerAddresses([]utils.NetAddr{
-		{
-			AddrNetwork: "tcp",
-			Addr:        i.Web,
-		},
+	conf.SetAuthServerAddress(utils.NetAddr{
+		AddrNetwork: "tcp",
+		Addr:        i.Web,
 	})
 	conf.SetToken("token")
 	conf.UploadEventsC = i.UploadEventsC
@@ -906,7 +898,7 @@ func (i *TeleInstance) StartNodeAndProxy(t *testing.T, name string) (sshPort, we
 
 	tconf.Log = i.Log
 	authServer := utils.MustParseAddr(i.Auth)
-	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), *authServer))
+	tconf.SetAuthServerAddress(*authServer)
 	tconf.SetToken("token")
 	tconf.HostUUID = name
 	tconf.Hostname = name
@@ -997,7 +989,7 @@ func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnel.Server, *servi
 	tconf.Console = nil
 	tconf.Log = i.Log
 	authServer := utils.MustParseAddr(i.Auth)
-	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), *authServer))
+	tconf.SetAuthServerAddress(*authServer)
 	tconf.CachePolicy = service.CachePolicy{Enabled: true}
 	tconf.DataDir = dataDir
 	tconf.UploadEventsC = i.UploadEventsC

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -618,8 +618,11 @@ func (i *TeleInstance) StartNodeWithTargetPort(tconf *service.Config, authPort s
 
 	tconf.DataDir = dataDir
 
-	authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
-	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), *authServer))
+	if tconf.ProxyServer.IsEmpty() {
+		authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
+		tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), *authServer))
+	}
+
 	tconf.SetToken("token")
 	tconf.UploadEventsC = i.UploadEventsC
 	tconf.CachePolicy = service.CachePolicy{

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -508,7 +508,7 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 			tconf.Proxy.MongoAddr.Addr = i.Mongo
 		}
 	}
-	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.ListenAddr)
+	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), tconf.Auth.ListenAddr))
 	tconf.Auth.StorageConfig = backend.Config{
 		Type:   lite.GetName(),
 		Params: backend.Params{"path": dataDir + string(os.PathListSeparator) + defaults.BackendDir, "poll_stream_period": 50 * time.Millisecond},
@@ -619,7 +619,7 @@ func (i *TeleInstance) StartNodeWithTargetPort(tconf *service.Config, authPort s
 	tconf.DataDir = dataDir
 
 	authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
-	tconf.AuthServers = append(tconf.AuthServers, *authServer)
+	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), *authServer))
 	tconf.SetToken("token")
 	tconf.UploadEventsC = i.UploadEventsC
 	tconf.CachePolicy = service.CachePolicy{
@@ -671,12 +671,12 @@ func (i *TeleInstance) StartApp(conf *service.Config) (*service.TeleportProcess,
 	i.tempDirs = append(i.tempDirs, dataDir)
 
 	conf.DataDir = dataDir
-	conf.AuthServers = []utils.NetAddr{
+	conf.SetAuthServerAddresses([]utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
 			Addr:        i.Web,
 		},
-	}
+	})
 	conf.SetToken("token")
 	conf.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
@@ -723,12 +723,12 @@ func (i *TeleInstance) StartApps(configs []*service.Config) ([]*service.Teleport
 			}
 
 			cfg.DataDir = dataDir
-			cfg.AuthServers = []utils.NetAddr{
+			cfg.SetAuthServerAddresses([]utils.NetAddr{
 				{
 					AddrNetwork: "tcp",
 					Addr:        i.Web,
 				},
-			}
+			})
 			cfg.SetToken("token")
 			cfg.UploadEventsC = i.UploadEventsC
 			cfg.Auth.Enabled = false
@@ -787,12 +787,12 @@ func (i *TeleInstance) StartDatabase(conf *service.Config) (*service.TeleportPro
 	i.tempDirs = append(i.tempDirs, dataDir)
 
 	conf.DataDir = dataDir
-	conf.AuthServers = []utils.NetAddr{
+	conf.SetAuthServerAddresses([]utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
 			Addr:        i.Web,
 		},
-	}
+	})
 	conf.SetToken("token")
 	conf.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
@@ -850,12 +850,12 @@ func (i *TeleInstance) StartKube(t *testing.T, conf *service.Config, clusterName
 	i.tempDirs = append(i.tempDirs, dataDir)
 
 	conf.DataDir = dataDir
-	conf.AuthServers = []utils.NetAddr{
+	conf.SetAuthServerAddresses([]utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
 			Addr:        i.Web,
 		},
-	}
+	})
 	conf.SetToken("token")
 	conf.UploadEventsC = i.UploadEventsC
 	conf.Auth.Enabled = false
@@ -903,7 +903,7 @@ func (i *TeleInstance) StartNodeAndProxy(t *testing.T, name string) (sshPort, we
 
 	tconf.Log = i.Log
 	authServer := utils.MustParseAddr(i.Auth)
-	tconf.AuthServers = append(tconf.AuthServers, *authServer)
+	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), *authServer))
 	tconf.SetToken("token")
 	tconf.HostUUID = name
 	tconf.Hostname = name
@@ -994,7 +994,7 @@ func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnel.Server, *servi
 	tconf.Console = nil
 	tconf.Log = i.Log
 	authServer := utils.MustParseAddr(i.Auth)
-	tconf.AuthServers = append(tconf.AuthServers, *authServer)
+	tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), *authServer))
 	tconf.CachePolicy = service.CachePolicy{Enabled: true}
 	tconf.DataDir = dataDir
 	tconf.UploadEventsC = i.UploadEventsC

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -618,9 +618,16 @@ func (i *TeleInstance) StartNodeWithTargetPort(tconf *service.Config, authPort s
 
 	tconf.DataDir = dataDir
 
-	if tconf.ProxyServer.IsEmpty() {
+	if tconf.Version == defaults.TeleportConfigVersionV3 {
+		if tconf.ProxyServer.IsEmpty() {
+			authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
+			tconf.SetAuthServerAddress(*authServer)
+		}
+	} else {
 		authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
-		tconf.SetAuthServerAddress(*authServer)
+		if err := tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), *authServer)); err != nil {
+			return nil, err
+		}
 	}
 
 	tconf.SetToken("token")

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -253,7 +253,7 @@ func newHSMAuthConfig(ctx context.Context, t *testing.T, storageConfig *backend.
 		ClusterName: "testcluster",
 	})
 	require.NoError(t, err)
-	config.AuthServers = append(config.AuthServers, config.Auth.ListenAddr)
+	config.SetAuthServerAddresses(append(config.AuthServerAddresses(), config.Auth.ListenAddr))
 	config.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
 		StaticTokens: []types.ProvisionTokenV1{
 			{
@@ -291,7 +291,7 @@ func newProxyConfig(ctx context.Context, t *testing.T, authAddr utils.NetAddr, l
 	config.PollingPeriod = 1 * time.Second
 	config.ShutdownTimeout = time.Minute
 	config.DataDir = t.TempDir()
-	config.AuthServers = append(config.AuthServers, authAddr)
+	config.SetAuthServerAddresses(append(config.AuthServerAddresses(), authAddr))
 	config.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	config.Log = log
 	return config

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -253,7 +253,7 @@ func newHSMAuthConfig(ctx context.Context, t *testing.T, storageConfig *backend.
 		ClusterName: "testcluster",
 	})
 	require.NoError(t, err)
-	config.SetAuthServerAddresses(append(config.AuthServerAddresses(), config.Auth.ListenAddr))
+	config.SetAuthServerAddress(config.Auth.ListenAddr)
 	config.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
 		StaticTokens: []types.ProvisionTokenV1{
 			{
@@ -291,7 +291,7 @@ func newProxyConfig(ctx context.Context, t *testing.T, authAddr utils.NetAddr, l
 	config.PollingPeriod = 1 * time.Second
 	config.ShutdownTimeout = time.Minute
 	config.DataDir = t.TempDir()
-	config.SetAuthServerAddresses(append(config.AuthServerAddresses(), authAddr))
+	config.SetAuthServerAddress(authAddr)
 	config.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	config.Log = log
 	return config

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -720,11 +720,9 @@ func (s *integrationTestSuite) newTeleportIoT(t *testing.T, logins []string) *he
 		tconf := s.defaultServiceConfig()
 		tconf.Hostname = Host
 		tconf.SetToken("token")
-		tconf.SetAuthServerAddresses([]utils.NetAddr{
-			{
-				AddrNetwork: "tcp",
-				Addr:        main.Web,
-			},
+		tconf.SetAuthServerAddress(utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        main.Web,
 		})
 
 		tconf.Auth.Enabled = false
@@ -2695,11 +2693,9 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 		tconf := suite.defaultServiceConfig()
 		tconf.Hostname = tunnelNodeHostname
 		tconf.SetToken("token")
-		tconf.SetAuthServerAddresses([]utils.NetAddr{
-			{
-				AddrNetwork: "tcp",
-				Addr:        aux.Web,
-			},
+		tconf.SetAuthServerAddress(utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        aux.Web,
 		})
 		tconf.Auth.Enabled = false
 		tconf.Proxy.Enabled = false
@@ -3107,11 +3103,9 @@ func testReverseTunnelCollapse(t *testing.T, suite *integrationTestSuite) {
 		tconf := suite.defaultServiceConfig()
 		tconf.Hostname = "cluster-main-node"
 		tconf.SetToken("token")
-		tconf.SetAuthServerAddresses([]utils.NetAddr{
-			{
-				AddrNetwork: "tcp",
-				Addr:        proxyConfig.WebAddr,
-			},
+		tconf.SetAuthServerAddress(utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        proxyConfig.WebAddr,
 		})
 		tconf.Auth.Enabled = false
 		tconf.Proxy.Enabled = false
@@ -3248,11 +3242,9 @@ func testDiscoveryNode(t *testing.T, suite *integrationTestSuite) {
 		tconf := suite.defaultServiceConfig()
 		tconf.Hostname = "cluster-main-node"
 		tconf.SetToken("token")
-		tconf.SetAuthServerAddresses([]utils.NetAddr{
-			{
-				AddrNetwork: "tcp",
-				Addr:        main.Web,
-			},
+		tconf.SetAuthServerAddress(utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        main.Web,
 		})
 
 		tconf.Auth.Enabled = false
@@ -6303,9 +6295,7 @@ func testListResourcesAcrossClusters(t *testing.T, suite *integrationTestSuite) 
 			conf.DataDir = t.TempDir()
 			conf.SetToken("token")
 			conf.UploadEventsC = i.UploadEventsC
-			conf.SetAuthServerAddresses([]utils.NetAddr{
-				*utils.MustParseAddr(net.JoinHostPort(i.Hostname, helpers.PortStr(t, i.Web))),
-			})
+			conf.SetAuthServerAddress(*utils.MustParseAddr(net.JoinHostPort(i.Hostname, helpers.PortStr(t, i.Web))))
 			conf.HostUUID = name
 			conf.Hostname = name
 			conf.SSH.Enabled = true

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -65,7 +65,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/client"
-	libdefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/modules"
@@ -135,7 +134,6 @@ func TestIntegrations(t *testing.T) {
 	t.Run("MultiplexingTrustedClusters", suite.bind(testMultiplexingTrustedClusters))
 	t.Run("PAM", suite.bind(testPAM))
 	t.Run("PortForwarding", suite.bind(testPortForwarding))
-	t.Run("ProxyServer", suite.bind(testProxyServer))
 	t.Run("ProxyHostKeyCheck", suite.bind(testProxyHostKeyCheck))
 	t.Run("ReverseTunnelCollapse", suite.bind(testReverseTunnelCollapse))
 	t.Run("RotateRollback", suite.bind(testRotateRollback))
@@ -3556,50 +3554,6 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 			}
 		})
 	}
-}
-
-// testProxyServer uses the forwarding proxy to connect to a server that
-// presents a host key instead of a certificate in different configurations
-// for the host key checking parameter in services.ClusterConfig.
-func testProxyServer(t *testing.T, suite *integrationTestSuite) {
-	// Create a Teleport instance with Auth/Proxy.
-	mainConfig := func() *service.Config {
-		tconf := suite.defaultServiceConfig()
-		tconf.Auth.Enabled = true
-
-		tconf.Proxy.Enabled = true
-		tconf.Proxy.DisableWebService = false
-		tconf.Proxy.DisableWebInterface = true
-
-		tconf.SSH.Enabled = false
-
-		return tconf
-	}
-
-	main := suite.NewTeleportWithConfig(t, nil, nil, mainConfig())
-	defer main.StopAll()
-
-	nodeConfig := func() *service.Config {
-		tconf := suite.defaultServiceConfig()
-		tconf.Version = libdefaults.TeleportConfigVersionV3
-		tconf.Hostname = Host
-		tconf.SetToken("token")
-		tconf.ProxyServer = utils.NetAddr{
-			AddrNetwork: "tcp",
-			Addr:        main.Web,
-		}
-
-		tconf.Auth.Enabled = false
-		tconf.Proxy.Enabled = false
-		tconf.SSH.Enabled = true
-
-		return tconf
-	}
-
-	_, err := main.StartReverseTunnelNode(nodeConfig())
-	require.NoError(t, err)
-
-	verifySessionJoin(t, suite.Me.Username, main)
 }
 
 // testProxyHostKeyCheck uses the forwarding proxy to connect to a server that

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -178,12 +178,12 @@ func (p *Suite) addNodeToLeafCluster(t *testing.T, tunnelNodeHostname string) {
 		tconf.Log = utils.NewLoggerForTests()
 		tconf.Hostname = tunnelNodeHostname
 		tconf.SetToken("token")
-		tconf.AuthServers = []utils.NetAddr{
+		tconf.SetAuthServerAddresses([]utils.NetAddr{
 			{
 				AddrNetwork: "tcp",
 				Addr:        p.leaf.Web,
 			},
-		}
+		})
 		tconf.Auth.Enabled = false
 		tconf.Proxy.Enabled = false
 		tconf.SSH.Enabled = true
@@ -517,12 +517,12 @@ func makeNodeConfig(nodeName, authAddr string) *service.Config {
 	nodeConfig := service.MakeDefaultConfig()
 	nodeConfig.Hostname = nodeName
 	nodeConfig.SetToken("token")
-	nodeConfig.AuthServers = []utils.NetAddr{
+	nodeConfig.SetAuthServerAddresses([]utils.NetAddr{
 		{
 			AddrNetwork: "tcp",
 			Addr:        authAddr,
 		},
-	}
+	})
 	nodeConfig.Auth.Enabled = false
 	nodeConfig.Proxy.Enabled = false
 	nodeConfig.SSH.Enabled = true

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -178,11 +178,9 @@ func (p *Suite) addNodeToLeafCluster(t *testing.T, tunnelNodeHostname string) {
 		tconf.Log = utils.NewLoggerForTests()
 		tconf.Hostname = tunnelNodeHostname
 		tconf.SetToken("token")
-		tconf.SetAuthServerAddresses([]utils.NetAddr{
-			{
-				AddrNetwork: "tcp",
-				Addr:        p.leaf.Web,
-			},
+		tconf.SetAuthServerAddress(utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        p.leaf.Web,
 		})
 		tconf.Auth.Enabled = false
 		tconf.Proxy.Enabled = false

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -518,10 +518,7 @@ func makeNodeConfig(nodeName, authAddr string) *service.Config {
 	nodeConfig.Hostname = nodeName
 	nodeConfig.SetToken("token")
 	nodeConfig.SetAuthServerAddresses([]utils.NetAddr{
-		{
-			AddrNetwork: "tcp",
-			Addr:        authAddr,
-		},
+		*utils.MustParseAddr(authAddr),
 	})
 	nodeConfig.Auth.Enabled = false
 	nodeConfig.Proxy.Enabled = false

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -513,13 +513,12 @@ func mustStartALPNLocalProxyWithConfig(t *testing.T, config alpnproxy.LocalProxy
 	return lp
 }
 
-func makeNodeConfig(nodeName, authAddr string) *service.Config {
+func makeNodeConfig(nodeName, proxyAddr string) *service.Config {
 	nodeConfig := service.MakeDefaultConfig()
+	nodeConfig.Version = defaults.TeleportConfigVersionV3
 	nodeConfig.Hostname = nodeName
 	nodeConfig.SetToken("token")
-	nodeConfig.SetAuthServerAddresses([]utils.NetAddr{
-		*utils.MustParseAddr(authAddr),
-	})
+	nodeConfig.ProxyServer = *utils.MustParseAddr(proxyAddr)
 	nodeConfig.Auth.Enabled = false
 	nodeConfig.Proxy.Enabled = false
 	nodeConfig.SSH.Enabled = true

--- a/integration/proxy/proxy_tunnel_strategy_test.go
+++ b/integration/proxy/proxy_tunnel_strategy_test.go
@@ -329,7 +329,7 @@ func (p *proxyTunnelStrategy) makeProxy(t *testing.T) {
 	authAddr := utils.MustParseAddr(p.auth.Auth)
 
 	conf := service.MakeDefaultConfig()
-	conf.SetAuthServerAddresses(append(conf.AuthServerAddresses(), *authAddr))
+	conf.SetAuthServerAddress(*authAddr)
 	conf.SetToken("token")
 	conf.DataDir = t.TempDir()
 
@@ -372,7 +372,7 @@ func (p *proxyTunnelStrategy) makeNode(t *testing.T) {
 	})
 
 	conf := service.MakeDefaultConfig()
-	conf.SetAuthServerAddresses(append(conf.AuthServerAddresses(), utils.FromAddr(p.lb.Addr())))
+	conf.SetAuthServerAddress(utils.FromAddr(p.lb.Addr()))
 	conf.SetToken("token")
 	conf.DataDir = t.TempDir()
 
@@ -414,7 +414,7 @@ func (p *proxyTunnelStrategy) makeDatabase(t *testing.T) {
 	})
 
 	conf := service.MakeDefaultConfig()
-	conf.SetAuthServerAddresses(append(conf.AuthServerAddresses(), utils.FromAddr(p.lb.Addr())))
+	conf.SetAuthServerAddress(utils.FromAddr(p.lb.Addr()))
 	conf.SetToken("token")
 	conf.DataDir = t.TempDir()
 

--- a/integration/proxy/proxy_tunnel_strategy_test.go
+++ b/integration/proxy/proxy_tunnel_strategy_test.go
@@ -329,7 +329,7 @@ func (p *proxyTunnelStrategy) makeProxy(t *testing.T) {
 	authAddr := utils.MustParseAddr(p.auth.Auth)
 
 	conf := service.MakeDefaultConfig()
-	conf.AuthServers = append(conf.AuthServers, *authAddr)
+	conf.SetAuthServerAddresses(append(conf.AuthServerAddresses(), *authAddr))
 	conf.SetToken("token")
 	conf.DataDir = t.TempDir()
 
@@ -372,7 +372,7 @@ func (p *proxyTunnelStrategy) makeNode(t *testing.T) {
 	})
 
 	conf := service.MakeDefaultConfig()
-	conf.AuthServers = append(conf.AuthServers, utils.FromAddr(p.lb.Addr()))
+	conf.SetAuthServerAddresses(append(conf.AuthServerAddresses(), utils.FromAddr(p.lb.Addr())))
 	conf.SetToken("token")
 	conf.DataDir = t.TempDir()
 
@@ -414,7 +414,7 @@ func (p *proxyTunnelStrategy) makeDatabase(t *testing.T) {
 	})
 
 	conf := service.MakeDefaultConfig()
-	conf.AuthServers = append(conf.AuthServers, utils.FromAddr(p.lb.Addr()))
+	conf.SetAuthServerAddresses(append(conf.AuthServerAddresses(), utils.FromAddr(p.lb.Addr())))
 	conf.SetToken("token")
 	conf.DataDir = t.TempDir()
 

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -226,7 +226,7 @@ func TestRegisterBotOnboardFeatureDisabled(t *testing.T) {
 		ID: IdentityID{
 			Role: types.RoleBot,
 		},
-		Servers:      []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
+		AuthServers:  []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
 		PublicTLSKey: tlsPublicKey,
 		PublicSSHKey: publicKey,
 	})
@@ -291,7 +291,7 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 		ID: IdentityID{
 			Role: types.RoleBot,
 		},
-		Servers:      []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
+		AuthServers:  []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
 		PublicTLSKey: tlsPublicKey,
 		PublicSSHKey: publicKey,
 	})
@@ -348,7 +348,7 @@ func TestRegisterBotCertificateGenerationStolen(t *testing.T) {
 		ID: IdentityID{
 			Role: types.RoleBot,
 		},
-		Servers:      []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
+		AuthServers:  []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
 		PublicTLSKey: tlsPublicKey,
 		PublicSSHKey: publicKey,
 	})

--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -344,7 +344,7 @@ func TestRegister_Bot(t *testing.T) {
 				ID: IdentityID{
 					Role: types.RoleBot,
 				},
-				Servers:      []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
+				AuthServers:  []utils.NetAddr{*utils.MustParseAddr(srv.Addr().String())},
 				PublicTLSKey: tlsPublicKey,
 				PublicSSHKey: publicKey,
 			})

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -178,14 +178,11 @@ func Register(params RegisterParams) (*proto.Certs, error) {
 	if !params.ProxyServer.IsEmpty() {
 		log.WithField("proxy-server", params.ProxyServer).Debugf("Registering node to the cluster.")
 
-		registerMethods = []registerMethod{}
+		registerMethods = []registerMethod{registerThroughProxy}
 
 		if proxyServerIsAuth(params.ProxyServer) {
 			log.Debugf("The specified proxy server appears to be an auth server.")
-			registerMethods = append(registerMethods, registerThroughAuth)
 		}
-
-		registerMethods = append(registerMethods, registerThroughProxy)
 	} else {
 		log.WithField("auth-servers", params.AuthServers).Debugf("Registering node to the cluster.")
 

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -126,10 +126,31 @@ type RegisterParams struct {
 	FIPS bool
 }
 
-func (r *RegisterParams) setDefaults() {
+func (r *RegisterParams) checkAndSetDefaults() error {
 	if r.Clock == nil {
 		r.Clock = clockwork.NewRealClock()
 	}
+
+	if err := r.verifyAuthOrProxyAddress(); err != nil {
+		return trace.BadParameter("no auth or proxy servers set")
+	}
+
+	return nil
+}
+
+func (r *RegisterParams) verifyAuthOrProxyAddress() error {
+	haveAuthServers := len(r.AuthServers) > 0
+	haveProxyServer := !r.ProxyServer.IsEmpty()
+
+	if !haveAuthServers && !haveProxyServer {
+		return trace.BadParameter("no auth or proxy servers set")
+	}
+
+	if haveAuthServers && haveProxyServer {
+		return trace.BadParameter("only one of auth or proxy server should be set")
+	}
+
+	return nil
 }
 
 // CredGetter is an interface for a client that can be used to get host
@@ -142,7 +163,9 @@ type HostCredentials func(context.Context, string, bool, types.RegisterUsingToke
 // tokens to prove a valid auth server was used to issue the joining request
 // as well as a method for the node to validate the auth server.
 func Register(params RegisterParams) (*proto.Certs, error) {
-	params.setDefaults()
+	if err := params.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	// Read in the token. The token can either be passed in or come from a file
 	// on disk.
 	token, err := utils.TryReadValueAsFile(params.Token)
@@ -229,10 +252,6 @@ func proxyServerIsAuth(server utils.NetAddr) bool {
 
 // registerThroughProxy is used to register through the proxy server.
 func registerThroughProxy(token string, params RegisterParams) (*proto.Certs, error) {
-	if err := verifyAuthOrProxyAddress(params); err != nil {
-		return nil, trace.BadParameter("no auth or proxy servers set")
-	}
-
 	var certs *proto.Certs
 	if params.JoinMethod == types.JoinMethodIAM {
 		// IAM join method requires gRPC client
@@ -267,14 +286,6 @@ func registerThroughProxy(token string, params RegisterParams) (*proto.Certs, er
 		}
 	}
 	return certs, nil
-}
-
-func verifyAuthOrProxyAddress(params RegisterParams) error {
-	if len(params.AuthServers) == 0 && params.ProxyServer.IsEmpty() {
-		return trace.BadParameter("no auth or proxy servers set")
-	}
-
-	return nil
 }
 
 func getHostAddresses(params RegisterParams) []string {
@@ -332,10 +343,6 @@ func registerThroughAuth(token string, params RegisterParams) (*proto.Certs, err
 // proxy. The Proxy's TLS cert will be verified using the host's root CA pool
 // (PKI) unless the --insecure flag was passed.
 func proxyJoinServiceClient(params RegisterParams) (*client.JoinServiceClient, error) {
-	if err := verifyAuthOrProxyAddress(params); err != nil {
-		return nil, trace.BadParameter("no auth or proxy servers set")
-	}
-
 	tlsConfig := utils.TLSConfig(params.CipherSuites)
 	tlsConfig.Time = params.Clock.Now
 	// set NextProtos for TLS routing, the actual protocol will be h2

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -2777,8 +2777,8 @@ func TestRegisterCAPin(t *testing.T) {
 
 	// Attempt to register with valid CA pin, should work.
 	_, err = Register(RegisterParams{
-		Servers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
-		Token:   token,
+		AuthServers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
+		Token:       token,
 		ID: IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
@@ -2795,8 +2795,8 @@ func TestRegisterCAPin(t *testing.T) {
 	// Attempt to register with multiple CA pins where the auth server only
 	// matches one, should work.
 	_, err = Register(RegisterParams{
-		Servers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
-		Token:   token,
+		AuthServers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
+		Token:       token,
 		ID: IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
@@ -2812,8 +2812,8 @@ func TestRegisterCAPin(t *testing.T) {
 
 	// Attempt to register with invalid CA pin, should fail.
 	_, err = Register(RegisterParams{
-		Servers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
-		Token:   token,
+		AuthServers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
+		Token:       token,
 		ID: IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
@@ -2829,8 +2829,8 @@ func TestRegisterCAPin(t *testing.T) {
 
 	// Attempt to register with multiple invalid CA pins, should fail.
 	_, err = Register(RegisterParams{
-		Servers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
-		Token:   token,
+		AuthServers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
+		Token:       token,
 		ID: IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
@@ -2865,8 +2865,8 @@ func TestRegisterCAPin(t *testing.T) {
 
 	// Attempt to register with multiple CA pins, should work
 	_, err = Register(RegisterParams{
-		Servers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
-		Token:   token,
+		AuthServers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
+		Token:       token,
 		ID: IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
@@ -2908,8 +2908,8 @@ func TestRegisterCAPath(t *testing.T) {
 
 	// Attempt to register with nothing at the CA path, should work.
 	_, err = Register(RegisterParams{
-		Servers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
-		Token:   token,
+		AuthServers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
+		Token:       token,
 		ID: IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",
@@ -2937,8 +2937,8 @@ func TestRegisterCAPath(t *testing.T) {
 
 	// Attempt to register with valid CA path, should work.
 	_, err = Register(RegisterParams{
-		Servers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
-		Token:   token,
+		AuthServers: []utils.NetAddr{utils.FromAddr(tt.server.Addr())},
+		Token:       token,
 		ID: IdentityID{
 			HostUUID: "once",
 			NodeName: "node-name",

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -370,7 +370,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	cfg.Clock = clock
 	cfg.Console = console
 	cfg.Log = logger
-	cfg.SetAuthServerAddresses([]utils.NetAddr{randomAddr}) // must be present
+	cfg.SetAuthServerAddress(randomAddr) // must be present
 	cfg.Auth.Preference, err = types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
 		SecondFactor: constants.SecondFactorOptional,
@@ -453,7 +453,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	cfg.Clock = clock
 	cfg.Console = console
 	cfg.Log = logger
-	cfg.SetAuthServerAddresses([]utils.NetAddr{*authAddr})
+	cfg.SetAuthServerAddress(*authAddr)
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = true
 	cfg.Proxy.WebAddr = randomAddr

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -370,7 +370,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	cfg.Clock = clock
 	cfg.Console = console
 	cfg.Log = logger
-	cfg.AuthServers = []utils.NetAddr{randomAddr} // must be present
+	cfg.SetAuthServerAddresses([]utils.NetAddr{randomAddr}) // must be present
 	cfg.Auth.Preference, err = types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
 		SecondFactor: constants.SecondFactorOptional,
@@ -453,7 +453,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	cfg.Clock = clock
 	cfg.Console = console
 	cfg.Log = logger
-	cfg.AuthServers = []utils.NetAddr{*authAddr}
+	cfg.SetAuthServerAddresses([]utils.NetAddr{*authAddr})
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = true
 	cfg.Proxy.WebAddr = randomAddr

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -592,8 +592,8 @@ func applyAuthConfig(fc *FileConfig, cfg *service.Config) error {
 			return trace.Wrap(err)
 		}
 		cfg.Auth.ListenAddr = *addr
-		if err := cfg.SetAuthServerAddresses(append(cfg.AuthServerAddresses(), *addr)); err != nil {
-			return trace.Wrap(err)
+		if len(cfg.AuthServerAddresses()) == 0 {
+			cfg.SetAuthServerAddress(*addr)
 		}
 	}
 	for _, t := range fc.Auth.ReverseTunnels {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -476,7 +476,7 @@ func applyAuthOrProxyAddress(fc *FileConfig, cfg *service.Config) error {
 	// From v3 onwards, either auth_server or proxy_server should be set
 	case defaults.TeleportConfigVersionV3:
 		if len(fc.AuthServers) > 0 {
-			return trace.BadParameter("config version v3 requires the use of auth_server or proxy_server")
+			return trace.BadParameter("config v3 has replaced auth_servers with either auth_server or proxy_server")
 		}
 
 		if fc.AuthServer != "" {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -906,7 +906,9 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 		switch fc.Version {
 		case defaults.TeleportConfigVersionV2, defaults.TeleportConfigVersionV3:
 			// Always enable kube service if using config v2 onwards (TLS routing is supported)
-			cfg.Proxy.Kube.Enabled = true
+			if fc.Version != defaults.TeleportConfigVersionV1 {
+				cfg.Proxy.Kube.Enabled = true
+			}
 		}
 	}
 	if len(fc.Proxy.PublicAddr) != 0 {
@@ -1002,9 +1004,8 @@ func getPostgresDefaultPort(cfg *service.Config) int {
 }
 
 func applyDefaultProxyListenerAddresses(cfg *service.Config) {
-	switch cfg.Version {
-	case defaults.TeleportConfigVersionV2, defaults.TeleportConfigVersionV3:
-		// From v2 onwards. if an address is not provided don't fall back to the default values.
+	// From v2 onwards. if an address is not provided don't fall back to the default values.
+	if cfg.Version != defaults.TeleportConfigVersionV1 {
 		return
 	}
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -489,7 +489,7 @@ func applyAuthOrProxyAddress(fc *FileConfig, cfg *service.Config) error {
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			
+
 			cfg.ProxyServer = *addr
 		}
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -455,10 +455,6 @@ func applyAuthOrProxyAddress(fc *FileConfig, cfg *service.Config) error {
 					return trace.Wrap(err)
 				}
 
-				if err != nil {
-					return trace.Errorf("cannot parse auth server address: '%v'", as)
-				}
-
 				parsedAddresses = append(parsedAddresses, *addr)
 			}
 
@@ -485,10 +481,6 @@ func applyAuthOrProxyAddress(fc *FileConfig, cfg *service.Config) error {
 				return trace.Wrap(err)
 			}
 
-			if err != nil {
-				return trace.BadParameter("cannot parse auth server address: '%v'", fc.AuthServer)
-			}
-
 			cfg.SetAuthServerAddresses([]utils.NetAddr{*addr})
 		}
 
@@ -497,11 +489,7 @@ func applyAuthOrProxyAddress(fc *FileConfig, cfg *service.Config) error {
 			if err != nil {
 				return trace.Wrap(err)
 			}
-
-			if err != nil {
-				return trace.BadParameter("cannot parse proxy address: '%v'", fc.ProxyServer)
-			}
-
+			
 			cfg.ProxyServer = *addr
 		}
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2254,13 +2254,11 @@ func applyTokenConfig(fc *FileConfig, cfg *service.Config) error {
 
 			cfg.JoinMethod = types.JoinMethodToken
 			cfg.SetToken(fc.AuthToken)
+
+			return nil
 		}
-
-		return nil
-	}
-
-	// from config v3 onwards, we have removed auth_token
-	if fc.AuthToken != "" {
+	} else if fc.AuthToken != "" {
+		// from config v3 onwards, we have removed auth_token
 		return trace.BadParameter("auth_token is no longer supported in config v3 onwards, use join_params instead")
 	}
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -914,7 +914,7 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 	case legacyKube && newKube:
 		return trace.BadParameter("proxy_service should either set kube_listen_addr/kube_public_addr or kubernetes.enabled, not both; keep kubernetes.enabled if you don't enable kubernetes_service, or keep kube_listen_addr otherwise")
 	case !legacyKube && !newKube:
-		if fc.Version != defaults.TeleportConfigVersionV1 {
+		if fc.Version != "" && fc.Version != defaults.TeleportConfigVersionV1 {
 			cfg.Proxy.Kube.Enabled = true
 		}
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2248,21 +2248,15 @@ func splitRoles(roles string) []string {
 
 // applyTokenConfig applies the auth_token and join_params to the config
 func applyTokenConfig(fc *FileConfig, cfg *service.Config) error {
-	// config v1 and v2 allow for `auth_token` to set `join_params.method` and `join_params.token_name`
-	if fc.Version == defaults.TeleportConfigVersionV1 || fc.Version == defaults.TeleportConfigVersionV2 {
-		if fc.AuthToken != "" {
-			if fc.JoinParams != (JoinParams{}) {
-				return trace.BadParameter("only one of auth_token or join_params should be set")
-			}
-
-			cfg.JoinMethod = types.JoinMethodToken
-			cfg.SetToken(fc.AuthToken)
-
-			return nil
+	if fc.AuthToken != "" {
+		if fc.JoinParams != (JoinParams{}) {
+			return trace.BadParameter("only one of auth_token or join_params should be set")
 		}
-	} else if fc.AuthToken != "" {
-		// from config v3 onwards, we have removed auth_token
-		return trace.BadParameter("auth_token is no longer supported in config v3 onwards, use join_params instead")
+
+		cfg.JoinMethod = types.JoinMethodToken
+		cfg.SetToken(fc.AuthToken)
+
+		return nil
 	}
 
 	if fc.JoinParams != (JoinParams{}) {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1012,7 +1012,7 @@ func getPostgresDefaultPort(cfg *service.Config) int {
 
 func applyDefaultProxyListenerAddresses(cfg *service.Config) {
 	// From v2 onwards if an address is not provided don't fall back to the default values.
-	if cfg.Version != defaults.TeleportConfigVersionV1 {
+	if cfg.Version != "" && cfg.Version != defaults.TeleportConfigVersionV1 {
 		return
 	}
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -477,7 +477,14 @@ func applyAuthOrProxyAddress(fc *FileConfig, cfg *service.Config) error {
 			return trace.BadParameter("config v3 has replaced auth_servers with either auth_server or proxy_server")
 		}
 
-		if fc.AuthServer != "" {
+		haveAuthServer := fc.AuthServer != ""
+		haveProxyServer := fc.ProxyServer != ""
+
+		if haveProxyServer && haveAuthServer {
+			return trace.BadParameter("only one of auth_server or proxy_server should be set")
+		}
+
+		if haveAuthServer {
 			addr, err := utils.ParseHostPortAddr(fc.AuthServer, defaults.AuthListenPort)
 			if err != nil {
 				return trace.Wrap(err)
@@ -486,7 +493,7 @@ func applyAuthOrProxyAddress(fc *FileConfig, cfg *service.Config) error {
 			cfg.SetAuthServerAddress(*addr)
 		}
 
-		if fc.ProxyServer != "" {
+		if haveProxyServer {
 			addr, err := utils.ParseHostPortAddr(fc.ProxyServer, defaults.HTTPListenPort)
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -914,12 +914,8 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 	case legacyKube && newKube:
 		return trace.BadParameter("proxy_service should either set kube_listen_addr/kube_public_addr or kubernetes.enabled, not both; keep kubernetes.enabled if you don't enable kubernetes_service, or keep kube_listen_addr otherwise")
 	case !legacyKube && !newKube:
-		switch fc.Version {
-		case defaults.TeleportConfigVersionV2, defaults.TeleportConfigVersionV3:
-			// Always enable kube service if using config v2 onwards (TLS routing is supported)
-			if fc.Version != defaults.TeleportConfigVersionV1 {
-				cfg.Proxy.Kube.Enabled = true
-			}
+		if fc.Version != defaults.TeleportConfigVersionV1 {
+			cfg.Proxy.Kube.Enabled = true
 		}
 	}
 	if len(fc.Proxy.PublicAddr) != 0 {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1011,7 +1011,7 @@ func getPostgresDefaultPort(cfg *service.Config) int {
 }
 
 func applyDefaultProxyListenerAddresses(cfg *service.Config) {
-	// From v2 onwards. if an address is not provided don't fall back to the default values.
+	// From v2 onwards if an address is not provided don't fall back to the default values.
 	if cfg.Version != defaults.TeleportConfigVersionV1 {
 		return
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2259,7 +2259,7 @@ func applyTokenConfig(fc *FileConfig, cfg *service.Config) error {
 		}
 	case defaults.TeleportConfigVersionV3:
 		if fc.AuthToken != "" {
-			return trace.BadParameter("auth_token is no longer supported, use join_params instead")
+			return trace.BadParameter("auth_token is no longer supported in config v3, use join_params instead")
 		}
 	}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1215,7 +1215,7 @@ func TestParseCachePolicy(t *testing.T) {
 }
 
 func checkStaticConfig(t *testing.T, conf *FileConfig) {
-	require.Equal(t, conf.JoinParams.TokenName, "xxxyyy")
+	require.Equal(t, conf.AuthToken, "xxxyyy")
 	require.Equal(t, conf.AdvertiseIP, "10.10.10.1:3022")
 	require.Equal(t, conf.PIDFile, "/var/run/teleport.pid")
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2769,6 +2769,15 @@ func TestJoinParams(t *testing.T) {
 			desc: "empty",
 		},
 		{
+			desc: "auth_token",
+			input: `
+teleport:
+  auth_token: xxxyyy
+`,
+			expectToken:      "xxxyyy",
+			expectJoinMethod: types.JoinMethodToken,
+		},
+		{
 			desc: "join_params token",
 			input: `
 teleport:
@@ -2808,6 +2817,17 @@ teleport:
   join_params:
     token_name: xxxyyy
     method: invalid
+`,
+			expectError: true,
+		},
+		{
+			desc: "both set",
+			input: `
+teleport:
+  auth_token: xxxyyy
+  join_params:
+    token_name: xxxyyy
+    method: iam
 `,
 			expectError: true,
 		},

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1215,7 +1215,7 @@ func TestParseCachePolicy(t *testing.T) {
 }
 
 func checkStaticConfig(t *testing.T, conf *FileConfig) {
-	require.Equal(t, conf.AuthToken, "xxxyyy")
+	require.Equal(t, conf.JoinParams.TokenName, "xxxyyy")
 	require.Equal(t, conf.AdvertiseIP, "10.10.10.1:3022")
 	require.Equal(t, conf.PIDFile, "/var/run/teleport.pid")
 
@@ -2769,15 +2769,6 @@ func TestJoinParams(t *testing.T) {
 			desc: "empty",
 		},
 		{
-			desc: "auth_token",
-			input: `
-teleport:
-  auth_token: xxxyyy
-`,
-			expectToken:      "xxxyyy",
-			expectJoinMethod: types.JoinMethodToken,
-		},
-		{
 			desc: "join_params token",
 			input: `
 teleport:
@@ -2817,17 +2808,6 @@ teleport:
   join_params:
     token_name: xxxyyy
     method: invalid
-`,
-			expectError: true,
-		},
-		{
-			desc: "both set",
-			input: `
-teleport:
-  auth_token: xxxyyy
-  join_params:
-    token_name: xxxyyy
-    method: iam
 `,
 			expectError: true,
 		},

--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -44,7 +44,7 @@ teleport:
   data_dir: {{ .DataDir }}
   proxy_server: {{ .ProxyServer }}
   join_params: 
-    join_method: token
+    method: token
     token_name: {{ .AuthToken }}
   {{- if .CAPins }}
   ca_pin:

--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -38,14 +38,14 @@ var databaseAgentConfigurationTemplate = template.Must(template.New("").Funcs(da
 # Teleport database agent configuration file.
 # Configuration reference: https://goteleport.com/docs/database-access/reference/configuration/
 #
+version: v3
 teleport:
   nodename: {{ .NodeName }}
   data_dir: {{ .DataDir }}
-  auth_token: {{ .AuthToken }}
-  auth_servers:
-  {{- range .AuthServersAddr }}
-  - {{ . }}
-  {{- end }}
+  proxy_server: {{ .ProxyServer }}
+  join_params: 
+    join_method: token
+    token_name: {{ .AuthToken }}
   {{- if .CAPins }}
   ca_pin:
   {{- range .CAPins }}
@@ -312,7 +312,7 @@ type DatabaseSampleFlags struct {
 	// the user.
 	StaticDatabaseStaticLabels map[string]string
 	// StaticDatabaseDynamicLabels list of database dynamic labels provided by
-	// the user.
+	// the user.`
 	StaticDatabaseDynamicLabels services.CommandLabels
 	// StaticDatabaseRawLabels "raw" list of database labels provided by the
 	// user.
@@ -321,9 +321,8 @@ type DatabaseSampleFlags struct {
 	NodeName string
 	// DataDir `data_dir` configuration.
 	DataDir string
-	// ProxyServerAddr is a list of addresses of the auth servers placed on
-	// the configuration.
-	AuthServersAddr []string
+	// ProxyServer is the address of the proxy servers
+	ProxyServer string
 	// AuthToken auth server token.
 	AuthToken string
 	// CAPins are the SKPI hashes of the CAs used to verify the Auth Server.

--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -43,9 +43,7 @@ teleport:
   nodename: {{ .NodeName }}
   data_dir: {{ .DataDir }}
   proxy_server: {{ .ProxyServer }}
-  join_params: 
-    method: token
-    token_name: {{ .AuthToken }}
+  auth_token: {{ .AuthToken }}
   {{- if .CAPins }}
   ca_pin:
   {{- range .CAPins }}

--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -40,7 +40,7 @@ func TestMakeDatabaseConfig(t *testing.T) {
 
 		require.Equal(t, flags.NodeName, fileConfig.NodeName)
 		require.Equal(t, flags.DataDir, fileConfig.DataDir)
-		require.ElementsMatch(t, flags.ProxyServer, fileConfig.ProxyServer)
+		require.Equal(t, flags.ProxyServer, fileConfig.ProxyServer)
 		require.Equal(t, flags.AuthToken, fileConfig.JoinParams.TokenName)
 		require.ElementsMatch(t, flags.CAPins, fileConfig.CAPin)
 	})

--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -25,11 +25,11 @@ import (
 func TestMakeDatabaseConfig(t *testing.T) {
 	t.Run("Global", func(t *testing.T) {
 		flags := DatabaseSampleFlags{
-			NodeName:        "testlocal",
-			DataDir:         "/var/lib/data",
-			AuthServersAddr: []string{"localhost:3080"},
-			AuthToken:       "/tmp/token.txt",
-			CAPins:          []string{"pin-1", "pin-2"},
+			NodeName:    "testlocal",
+			DataDir:     "/var/lib/data",
+			ProxyServer: "localhost:3080",
+			AuthToken:   "/tmp/token.txt",
+			CAPins:      []string{"pin-1", "pin-2"},
 		}
 
 		configString, err := MakeDatabaseAgentConfigString(flags)
@@ -40,8 +40,8 @@ func TestMakeDatabaseConfig(t *testing.T) {
 
 		require.Equal(t, flags.NodeName, fileConfig.NodeName)
 		require.Equal(t, flags.DataDir, fileConfig.DataDir)
-		require.ElementsMatch(t, flags.AuthServersAddr, fileConfig.AuthServers)
-		require.Equal(t, flags.AuthToken, fileConfig.AuthToken)
+		require.ElementsMatch(t, flags.ProxyServer, fileConfig.ProxyServer)
+		require.Equal(t, flags.AuthToken, fileConfig.JoinParams.TokenName)
 		require.ElementsMatch(t, flags.CAPins, fileConfig.CAPin)
 	})
 

--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -41,7 +41,7 @@ func TestMakeDatabaseConfig(t *testing.T) {
 		require.Equal(t, flags.NodeName, fileConfig.NodeName)
 		require.Equal(t, flags.DataDir, fileConfig.DataDir)
 		require.Equal(t, flags.ProxyServer, fileConfig.ProxyServer)
-		require.Equal(t, flags.AuthToken, fileConfig.JoinParams.TokenName)
+		require.Equal(t, flags.AuthToken, fileConfig.AuthToken)
 		require.ElementsMatch(t, flags.CAPins, fileConfig.CAPin)
 	})
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -160,6 +160,8 @@ type SampleFlags struct {
 	Roles string
 	// AuthServer is the address of the auth server
 	AuthServer string
+	// ProxyAddress is the address of the proxy
+	ProxyAddress string
 	// AppName is the name of the application to start
 	AppName string
 	// AppURI is the internal address of the application to proxy
@@ -220,6 +222,10 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 
 	if flags.AuthServer != "" {
 		g.AuthServers = []string{flags.AuthServer}
+	}
+
+	if flags.ProxyAddress != "" {
+		g.ProxyServer = flags.ProxyAddress
 	}
 
 	g.CAPin = strings.Split(flags.CAPin, ",")
@@ -311,7 +317,8 @@ func makeSampleAuthConfig(conf *service.Config, flags SampleFlags, enabled bool)
 			a.LicenseFile = flags.LicensePath
 		}
 
-		if flags.Version == defaults.TeleportConfigVersionV2 {
+		switch flags.Version {
+		case defaults.TeleportConfigVersionV2, defaults.TeleportConfigVersionV3:
 			a.ProxyListenerMode = types.ProxyListenerMode_Multiplex
 		}
 	} else {
@@ -574,12 +581,14 @@ type Global struct {
 	DataDir  string `yaml:"data_dir,omitempty"`
 	PIDFile  string `yaml:"pid_file,omitempty"`
 
-	// AuthToken is the old way of configuring the token to be used by the
-	// node to join the Teleport cluster. `JoinParams.TokenName` should be
-	// used instead with `JoinParams.JoinMethod = types.JoinMethodToken`.
-	AuthToken   string           `yaml:"auth_token,omitempty"`
-	JoinParams  JoinParams       `yaml:"join_params,omitempty"`
-	AuthServers []string         `yaml:"auth_servers,omitempty"`
+	JoinParams JoinParams `yaml:"join_params,omitempty"`
+
+	// v1, v2
+	AuthServers []string `yaml:"auth_servers,omitempty"`
+	// v3
+	AuthServer  string `yaml:"auth_server,omitempty"`
+	ProxyServer string `yaml:"proxy_server,omitempty"`
+
 	Limits      ConnectionLimits `yaml:"connection_limits,omitempty"`
 	Logger      Log              `yaml:"log,omitempty"`
 	Storage     backend.Config   `yaml:"storage,omitempty"`

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -317,8 +317,8 @@ func makeSampleAuthConfig(conf *service.Config, flags SampleFlags, enabled bool)
 			a.LicenseFile = flags.LicensePath
 		}
 
-		switch flags.Version {
-		case defaults.TeleportConfigVersionV2, defaults.TeleportConfigVersionV3:
+		// from config v2 onwards, we support `proxy_listener_mode`, so we set it to `multiplex`
+		if flags.Version != defaults.TeleportConfigVersionV1 {
 			a.ProxyListenerMode = types.ProxyListenerMode_Multiplex
 		}
 	} else {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -585,6 +585,12 @@ type Global struct {
 
 	// v1, v2
 	AuthServers []string `yaml:"auth_servers,omitempty"`
+	// AuthToken is the old way of configuring the token to be used by the
+	// node to join the Teleport cluster. `JoinParams.TokenName` should be
+	// used instead with `JoinParams.JoinMethod = types.JoinMethodToken`.
+	// This field will error if set with config version v3
+	AuthToken string `yaml:"auth_token,omitempty"`
+
 	// v3
 	AuthServer  string `yaml:"auth_server,omitempty"`
 	ProxyServer string `yaml:"proxy_server,omitempty"`

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -588,7 +588,6 @@ type Global struct {
 	// AuthToken is the old way of configuring the token to be used by the
 	// node to join the Teleport cluster. `JoinParams.TokenName` should be
 	// used instead with `JoinParams.JoinMethod = types.JoinMethodToken`.
-	// This field will error if set with config version v3
 	AuthToken string `yaml:"auth_token,omitempty"`
 
 	// v3

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -27,7 +27,7 @@ teleport:
   pid_file: /var/run/teleport.pid
   auth_server: auth0.server.example.org:3024
   join_params:
-    join_method: token
+    method: token
     token_name: xxxyyy
   log:
     output: stderr
@@ -91,7 +91,7 @@ teleport:
   advertise_ip: 10.10.10.1
   pid_file: /var/run/teleport.pid
   join_params:
-    join_method: token
+    method: token
     token_name: %v
   auth_server: auth0.server.example.org:3024
   log:

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -20,14 +20,15 @@ const StaticConfigString = `
 #
 # Some comments
 #
+version: v3
 teleport:
   nodename: edsger.example.com
   advertise_ip: 10.10.10.1:3022
   pid_file: /var/run/teleport.pid
-  auth_servers:
-    - auth0.server.example.org:3024
-    - auth1.server.example.org:3024
-  auth_token: xxxyyy
+  auth_server: auth0.server.example.org:3024
+  join_params:
+    join_method: token
+    token_name: xxxyyy
   log:
     output: stderr
     severity: INFO
@@ -84,14 +85,15 @@ ssh_service:
 `
 
 const SmallConfigString = `
+version: v3
 teleport:
   nodename: cat.example.com
   advertise_ip: 10.10.10.1
   pid_file: /var/run/teleport.pid
-  auth_token: %v
-  auth_servers:
-    - auth0.server.example.org:3024
-    - auth1.server.example.org:3024
+  join_params:
+    join_method: token
+    token_name: %v
+  auth_server: auth0.server.example.org:3024
   log:
     output: stderr
     severity: INFO

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -26,9 +26,7 @@ teleport:
   advertise_ip: 10.10.10.1:3022
   pid_file: /var/run/teleport.pid
   auth_server: auth0.server.example.org:3024
-  join_params:
-    method: token
-    token_name: xxxyyy
+  auth_token: xxxyyy
   log:
     output: stderr
     severity: INFO
@@ -90,9 +88,7 @@ teleport:
   nodename: cat.example.com
   advertise_ip: 10.10.10.1
   pid_file: /var/run/teleport.pid
-  join_params:
-    method: token
-    token_name: %v
+  auth_token: %v
   auth_server: auth0.server.example.org:3024
   log:
     output: stderr

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/defaults"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -816,7 +817,26 @@ const (
 	TeleportConfigVersionV1 string = "v1"
 	// TeleportConfigVersionV2 is the teleport proxy configuration v2 version.
 	TeleportConfigVersionV2 string = "v2"
+	// TeleportConfigVersionV3 is the teleport proxy configuration v3 version.
+	TeleportConfigVersionV3 string = "v3"
 )
+
+// TeleportVersions is an exported slice of the allowed versions in the config file,
+//for convenience (looping through, etc)
+var TeleportVersions = []string{
+	TeleportConfigVersionV1,
+	TeleportConfigVersionV2,
+	TeleportConfigVersionV3,
+}
+
+func ValidateVersion(version string) error {
+	hasVersion := apiutils.SliceContainsStr(TeleportVersions, version)
+	if !hasVersion {
+		return trace.BadParameter("version must be one of %s", strings.Join(TeleportVersions, ", "))
+	}
+
+	return nil
+}
 
 // Default values for tsh and tctl commands.
 const (

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -822,7 +822,7 @@ const (
 )
 
 // TeleportConfigVersions is an exported slice of the allowed versions in the config file,
-//for convenience (looping through, etc)
+// for convenience (looping through, etc)
 var TeleportConfigVersions = []string{
 	TeleportConfigVersionV1,
 	TeleportConfigVersionV2,

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -821,18 +821,18 @@ const (
 	TeleportConfigVersionV3 string = "v3"
 )
 
-// TeleportVersions is an exported slice of the allowed versions in the config file,
+// TeleportConfigVersions is an exported slice of the allowed versions in the config file,
 //for convenience (looping through, etc)
-var TeleportVersions = []string{
+var TeleportConfigVersions = []string{
 	TeleportConfigVersionV1,
 	TeleportConfigVersionV2,
 	TeleportConfigVersionV3,
 }
 
-func ValidateVersion(version string) error {
-	hasVersion := apiutils.SliceContainsStr(TeleportVersions, version)
+func ValidateConfigVersion(version string) error {
+	hasVersion := apiutils.SliceContainsStr(TeleportConfigVersions, version)
 	if !hasVersion {
-		return trace.BadParameter("version must be one of %s", strings.Join(TeleportVersions, ", "))
+		return trace.BadParameter("version must be one of %s", strings.Join(TeleportConfigVersions, ", "))
 	}
 
 	return nil

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -90,10 +90,8 @@ type Config struct {
 	// JoinMethod is the method the instance will use to join the auth server
 	JoinMethod types.JoinMethod
 
-	// AuthServers is a list of auth servers, proxies and peer auth servers to
-	// connect to. Yes, this is not just auth servers, the field name is
-	// misleading.
-	AuthServers []utils.NetAddr
+	// ProxyServer is the address of the proxy
+	ProxyServer utils.NetAddr
 
 	// Identities is an optional list of pre-generated key pairs
 	// for teleport roles, this is helpful when server is preconfigured
@@ -269,6 +267,58 @@ type Config struct {
 	// This is private to avoid external packages reading the value - the value should be obtained
 	// using Token()
 	token string
+
+	// v1, v2 -
+	// AuthServers is a list of auth servers, proxies and peer auth servers to
+	// connect to. Yes, this is not just auth servers, the field name is
+	// misleading.
+	// v3 -
+	// AuthServers contains a single address that is set by `auth_server` in the config
+	// A proxy address would be specified separately, so this no longer contains both
+	// auth servers and proxies.
+	//
+	// In order to keep backwards compatibility between v3 and v2/v1, this is now private
+	// and the value is retrieved via AuthServerAddresses() and set via SetAuthServerAddresses()
+	// as we still need to keep multiple addresses and return them for older config versions.
+	authServers []utils.NetAddr
+}
+
+// AuthServerAddresses returns the value of authServers for config versions v1 and v2 and
+// will return just the first (as only one should be set) address for config versions v3
+// onwards.
+func (cfg *Config) AuthServerAddresses() []utils.NetAddr {
+	switch cfg.Version {
+	case defaults.TeleportConfigVersionV1, defaults.TeleportConfigVersionV2:
+		return cfg.authServers
+
+	// we only want to return one auth server if the config version is v3 or above
+	case defaults.TeleportConfigVersionV3:
+		if len(cfg.authServers) > 0 {
+			return cfg.authServers[0:1]
+		}
+	}
+
+	return []utils.NetAddr{}
+}
+
+// SetAuthServerAddresses sets the value of authServers, filtering out any empty addresses
+// If the config version is v1 or v2, it will set the value to all the given addresses (as
+// multiple can be specified).
+// If the config version is v3 or onwards, it'll only the first non-empty address.
+func (cfg *Config) SetAuthServerAddresses(addrs []utils.NetAddr) {
+	cfg.authServers = []utils.NetAddr{}
+
+	for _, addr := range addrs {
+		if !addr.IsEmpty() {
+			cfg.authServers = append(cfg.authServers, addr)
+
+			switch cfg.Version {
+			case defaults.TeleportConfigVersionV3:
+				// we only want to allow one auth server to be set when the config version is v3 or above
+				return
+			}
+		}
+	}
 }
 
 // Token returns token needed to join the auth server
@@ -329,7 +379,7 @@ func (cfg *Config) RoleConfig() RoleConfig {
 		DataDir:     cfg.DataDir,
 		HostUUID:    cfg.HostUUID,
 		HostName:    cfg.Hostname,
-		AuthServers: cfg.AuthServers,
+		AuthServers: cfg.AuthServerAddresses(),
 		Auth:        cfg.Auth,
 		Console:     cfg.Console,
 	}

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -287,18 +287,7 @@ type Config struct {
 // will return just the first (as only one should be set) address for config versions v3
 // onwards.
 func (cfg *Config) AuthServerAddresses() []utils.NetAddr {
-	switch cfg.Version {
-	case defaults.TeleportConfigVersionV1, defaults.TeleportConfigVersionV2:
-		return cfg.authServers
-
-	// we only want to return one auth server if the config version is v3 or above
-	case defaults.TeleportConfigVersionV3:
-		if len(cfg.authServers) > 0 {
-			return cfg.authServers[0:1]
-		}
-	}
-
-	return []utils.NetAddr{}
+	return cfg.authServers
 }
 
 // SetAuthServerAddresses sets the value of authServers, filtering out any empty addresses

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -1358,6 +1358,8 @@ func ApplyDefaults(cfg *Config) {
 	var sc ssh.Config
 	sc.SetDefaults()
 
+	cfg.Version = defaults.TeleportConfigVersionV1
+
 	if cfg.Log == nil {
 		cfg.Log = utils.NewLogger()
 	}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1078,7 +1078,7 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 	}
 
 	switch process.Config.Version {
-	// for config v1 and v2, attempt to directly connect to the auth server and fall back to tunnelling
+	// for config v1 and v2, attempt to directly connect to the auth server and fall back to tunneling
 	case defaults.TeleportConfigVersionV1, defaults.TeleportConfigVersionV2:
 		// if we don't have a proxy address, try to connect to the auth server directly
 		logger := process.log.WithField("auth-addrs", utils.NetAddrsToStrings(authServers))
@@ -1126,7 +1126,7 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 
 			tunnelClient, err := process.newClientThroughTunnel([]utils.NetAddr{proxyServer}, tlsConfig, sshClientConfig)
 			if err != nil {
-				return nil, trace.Errorf("Failed to connect to Proxy Server through tunnel.")
+				return nil, trace.Errorf("Failed to connect to Proxy Server through tunnel: %v", err)
 			}
 
 			logger.Debug("Connected to Proxy Server through tunnel.")

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -591,6 +591,11 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 			return nil, trace.Wrap(err)
 		}
 
+		dataDir := defaults.DataDir
+		if process.Config.DataDir != "" {
+			dataDir = process.Config.DataDir
+		}
+
 		certs, err := auth.Register(auth.RegisterParams{
 			Token:                token,
 			ID:                   id,
@@ -602,7 +607,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 			PublicSSHKey:         keyPair.PublicSSHKey,
 			CipherSuites:         process.Config.CipherSuites,
 			CAPins:               process.Config.CAPins,
-			CAPath:               filepath.Join(defaults.DataDir, defaults.CACertFile),
+			CAPath:               filepath.Join(dataDir, defaults.CACertFile),
 			GetHostCredentials:   client.HostCredentials,
 			Clock:                process.Clock,
 			JoinMethod:           process.Config.JoinMethod,

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1067,14 +1067,14 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 	authServers := process.Config.AuthServerAddresses()
 	connectToAuthServer := func(logger *logrus.Entry) (*auth.Client, error) {
 		logger.Debug("Attempting to connect to Auth Server directly.")
-		directClient, directErr := process.newClientDirect(authServers, tlsConfig, identity.ID.Role)
-		if directErr != nil {
+		client, err := process.newClientDirect(authServers, tlsConfig, identity.ID.Role)
+		if err != nil {
 			logger.Debug("Failed to connect to Auth Server directly.")
-			return nil, directErr
+			return nil, err
 		}
 
 		logger.Debug("Connected to Auth Server with direct connection.")
-		return directClient, nil
+		return client, nil
 	}
 
 	switch process.Config.Version {

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1122,14 +1122,14 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 		proxyServer := process.Config.ProxyServer
 		if !proxyServer.IsEmpty() {
 			logger := process.log.WithField("proxy-server", proxyServer.String())
-			logger.Debug("Attempting to connect to Proxy Server through tunnel.")
+			logger.Debug("Attempting to connect to Auth Server through tunnel.")
 
 			tunnelClient, err := process.newClientThroughTunnel([]utils.NetAddr{proxyServer}, tlsConfig, sshClientConfig)
 			if err != nil {
 				return nil, trace.Errorf("Failed to connect to Proxy Server through tunnel: %v", err)
 			}
 
-			logger.Debug("Connected to Proxy Server through tunnel.")
+			logger.Debug("Connected to Auth Server through tunnel.")
 
 			return tunnelClient, nil
 		}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -594,7 +594,8 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 		certs, err := auth.Register(auth.RegisterParams{
 			Token:                token,
 			ID:                   id,
-			Servers:              process.Config.AuthServerAddresses(),
+			AuthServers:          process.Config.AuthServerAddresses(),
+			ProxyServer:          process.Config.ProxyServer,
 			AdditionalPrincipals: additionalPrincipals,
 			DNSNames:             dnsNames,
 			PublicTLSKey:         keyPair.PublicTLSKey,

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -253,7 +253,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 			}, nil
 		}
 		process.log.Infof("Connecting to the cluster %v with TLS client certificate.", identity.ClusterName)
-		clt, err := process.newClient(process.Config.AuthServers, identity)
+		clt, err := process.newClient(process.Config.AuthServerAddresses(), process.Config.ProxyServer, identity)
 		if err != nil {
 			// In the event that a user is attempting to connect a machine to
 			// a different cluster it will give a cryptic warning about an
@@ -282,7 +282,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 					ServerIdentity: identity,
 				}, nil
 			}
-			clt, err := process.newClient(process.Config.AuthServers, identity)
+			clt, err := process.newClient(process.Config.AuthServerAddresses(), process.Config.ProxyServer, identity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -304,7 +304,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 					ServerIdentity: identity,
 				}, nil
 			}
-			clt, err := process.newClient(process.Config.AuthServers, newIdentity)
+			clt, err := process.newClient(process.Config.AuthServerAddresses(), process.Config.ProxyServer, newIdentity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -326,7 +326,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 					ServerIdentity: newIdentity,
 				}, nil
 			}
-			clt, err := process.newClient(process.Config.AuthServers, newIdentity)
+			clt, err := process.newClient(process.Config.AuthServerAddresses(), process.Config.ProxyServer, newIdentity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -346,7 +346,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 					ServerIdentity: identity,
 				}, nil
 			}
-			clt, err := process.newClient(process.Config.AuthServers, identity)
+			clt, err := process.newClient(process.Config.AuthServerAddresses(), process.Config.ProxyServer, identity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -511,7 +511,7 @@ func (process *TeleportProcess) firstTimeConnectWithAssertions(role types.System
 	}
 	process.deleteKeyPair(role, reason)
 
-	clt, err := process.newClient(process.Config.AuthServers, identity)
+	clt, err := process.newClient(process.Config.AuthServerAddresses(), process.Config.ProxyServer, identity)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -594,7 +594,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 		certs, err := auth.Register(auth.RegisterParams{
 			Token:                token,
 			ID:                   id,
-			Servers:              process.Config.AuthServers,
+			Servers:              process.Config.AuthServerAddresses(),
 			AdditionalPrincipals: additionalPrincipals,
 			DNSNames:             dnsNames,
 			PublicTLSKey:         keyPair.PublicTLSKey,
@@ -631,7 +631,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 			ServerIdentity: identity,
 		}
 	} else {
-		clt, err := process.newClient(process.Config.AuthServers, identity)
+		clt, err := process.newClient(process.Config.AuthServerAddresses(), process.Config.ProxyServer, identity)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1042,16 +1042,39 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 	}
 }
 
-// newClient attempts to connect directly to the Auth Server. If it fails, it
-// falls back to trying to connect to the Auth Server through the proxy.
-// The proxy address might be configured in process environment as apidefaults.TunnelPublicAddrEnvar
-// in which case, no attempt at discovering the reverse tunnel address is made.
-func (process *TeleportProcess) newClient(authServers []utils.NetAddr, identity *auth.Identity) (*auth.Client, error) {
+// newClient attempts to tunnel to either the proxy server or auth server
+// When a proxy server is specified (config v3 onwards), it will only attempt to tunnel to the proxy
+// and will error if the connection fails.
+// When only auth servers are specified (config v1 and v2 can have multiple auth servers, v3 only allows one)
+// It will attempt to direct dial the auth server, and fallback to trying to tunnel connect to the
+// Auth Server through the proxy.
+func (process *TeleportProcess) newClient(authServers []utils.NetAddr, proxyAddress utils.NetAddr, identity *auth.Identity) (*auth.Client, error) {
 	tlsConfig, err := identity.TLSConfig(process.Config.CipherSuites)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
+	sshClientConfig, err := identity.SSHClientConfig(process.Config.FIPS)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// try and connect to the proxy server first to avoid the extra direct dial when using the value from auth servers
+	if !proxyAddress.IsEmpty() {
+		logger := process.log.WithField("proxy-address", proxyAddress.String())
+		logger.Debug("Attempting to connect to Proxy Server through tunnel.")
+
+		tunnelClient, err := process.newClientThroughTunnel([]utils.NetAddr{proxyAddress}, tlsConfig, sshClientConfig)
+		if err != nil {
+			return nil, trace.Errorf("Failed to connect to Proxy Server through tunnel.")
+		}
+
+		logger.Debug("Connected to Proxy Server through tunnel.")
+
+		return tunnelClient, nil
+	}
+
+	// if we don't have a proxy address, try to connect to the auth server directly
 	logger := process.log.WithField("auth-addrs", utils.NetAddrsToStrings(authServers))
 	logger.Debug("Attempting to connect to Auth Server directly.")
 	directClient, directErr := process.newClientDirect(authServers, tlsConfig, identity.ID.Role)
@@ -1068,11 +1091,10 @@ func (process *TeleportProcess) newClient(authServers []utils.NetAddr, identity 
 
 	logger.Debug("Attempting to discover reverse tunnel address.")
 
+	// if that fails, attempt to connect to the auth server through a tunnel
+
 	logger.Debug("Attempting to connect to Auth Server through tunnel.")
-	sshClientConfig, err := identity.SSHClientConfig(process.Config.FIPS)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+
 	tunnelClient, err := process.newClientThroughTunnel(authServers, tlsConfig, sshClientConfig)
 	if err != nil {
 		process.log.Errorf("Node failed to establish connection to Teleport Proxy. We have tried the following endpoints:")

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -86,9 +86,9 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 	// Filter out cases where both listen_addr and tunnel are set or both are
 	// not set.
 	case useTunnel && !cfg.WindowsDesktop.ListenAddr.IsEmpty():
-		return trace.BadParameter("either set windows_desktop_service.listen_addr if this process can be reached from a teleport proxy or point teleport.auth_servers to a proxy to dial out, but don't set both")
+		return trace.BadParameter("either set windows_desktop_service.listen_addr if this process can be reached from a teleport proxy or point teleport.proxy_server to a proxy to dial out, but don't set both")
 	case !useTunnel && cfg.WindowsDesktop.ListenAddr.IsEmpty():
-		return trace.BadParameter("set windows_desktop_service.listen_addr if this process can be reached from a teleport proxy or point teleport.auth_servers to a proxy to dial out")
+		return trace.BadParameter("set windows_desktop_service.listen_addr if this process can be reached from a teleport proxy or point teleport.proxy_server to a proxy to dial out")
 
 	// Start a local listener and let proxies dial in.
 	case !useTunnel && !cfg.WindowsDesktop.ListenAddr.IsEmpty():

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -86,7 +86,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 	// Filter out cases where both listen_addr and tunnel are set or both are
 	// not set.
 	case conn.UseTunnel() && !cfg.Kube.ListenAddr.IsEmpty():
-		return trace.BadParameter("either set kubernetes_service.listen_addr if this process can be reached from a teleport proxy or point teleport.proxy_address to a proxy to dial out, but don't set both")
+		return trace.BadParameter("either set kubernetes_service.listen_addr if this process can be reached from a teleport proxy or point teleport.proxy_server to a proxy to dial out, but don't set both")
 	case !conn.UseTunnel() && cfg.Kube.ListenAddr.IsEmpty():
 		// TODO(awly): if this process runs auth, proxy and kubernetes
 		// services, the proxy should be able to route requests to this
@@ -96,7 +96,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 		//
 		// For now, as a lazy shortcut, kuberentes_service.listen_addr is
 		// always required when running in the same process with a proxy.
-		return trace.BadParameter("set kubernetes_service.listen_addr if this process can be reached from a teleport proxy or point teleport.proxy_address to a proxy to dial out")
+		return trace.BadParameter("set kubernetes_service.listen_addr if this process can be reached from a teleport proxy or point teleport.proxy_server to a proxy to dial out")
 
 	// Start a local listener and let proxies dial in.
 	case !conn.UseTunnel() && !cfg.Kube.ListenAddr.IsEmpty():

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -86,7 +86,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 	// Filter out cases where both listen_addr and tunnel are set or both are
 	// not set.
 	case conn.UseTunnel() && !cfg.Kube.ListenAddr.IsEmpty():
-		return trace.BadParameter("either set kubernetes_service.listen_addr if this process can be reached from a teleport proxy or point teleport.auth_servers to a proxy to dial out, but don't set both")
+		return trace.BadParameter("either set kubernetes_service.listen_addr if this process can be reached from a teleport proxy or point teleport.proxy_address to a proxy to dial out, but don't set both")
 	case !conn.UseTunnel() && cfg.Kube.ListenAddr.IsEmpty():
 		// TODO(awly): if this process runs auth, proxy and kubernetes
 		// services, the proxy should be able to route requests to this
@@ -96,7 +96,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 		//
 		// For now, as a lazy shortcut, kuberentes_service.listen_addr is
 		// always required when running in the same process with a proxy.
-		return trace.BadParameter("set kubernetes_service.listen_addr if this process can be reached from a teleport proxy or point teleport.auth_servers to a proxy to dial out")
+		return trace.BadParameter("set kubernetes_service.listen_addr if this process can be reached from a teleport proxy or point teleport.proxy_address to a proxy to dial out")
 
 	// Start a local listener and let proxies dial in.
 	case !conn.UseTunnel() && !cfg.Kube.ListenAddr.IsEmpty():

--- a/lib/service/proxy_settings.go
+++ b/lib/service/proxy_settings.go
@@ -48,7 +48,7 @@ func (p *proxySettings) GetProxySettings(ctx context.Context) (*webclient.ProxyS
 	}
 
 	switch p.cfg.Version {
-	case defaults.TeleportConfigVersionV2:
+	case defaults.TeleportConfigVersionV2, defaults.TeleportConfigVersionV3:
 		return p.buildProxySettingsV2(resp.GetProxyListenerMode()), nil
 	default:
 		return p.buildProxySettings(resp.GetProxyListenerMode()), nil

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -970,14 +970,14 @@ func NewTeleport(cfg *Config, opts ...NewTeleportOption) (*TeleportProcess, erro
 	// if user started auth and another service (without providing the auth address for
 	// that service, the address of the in-process auth will be used
 	if process.Config.Auth.Enabled && len(process.Config.AuthServerAddresses()) == 0 {
-		process.Config.SetAuthServerAddresses([]utils.NetAddr{process.Config.Auth.ListenAddr})
+		process.Config.SetAuthServerAddress(process.Config.Auth.ListenAddr)
 	}
 
 	if len(process.Config.AuthServerAddresses()) != 0 && process.Config.AuthServerAddresses()[0].Port(0) == 0 {
 		// port appears undefined, attempt early listener creation so that we can get the real port
 		listener, err := process.importOrCreateListener(ListenerAuth, process.Config.Auth.ListenAddr.Addr)
 		if err == nil {
-			process.Config.SetAuthServerAddresses([]utils.NetAddr{utils.FromAddr(listener.Addr())})
+			process.Config.SetAuthServerAddress(utils.FromAddr(listener.Addr()))
 		}
 	}
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -969,15 +969,15 @@ func NewTeleport(cfg *Config, opts ...NewTeleportOption) (*TeleportProcess, erro
 
 	// if user started auth and another service (without providing the auth address for
 	// that service, the address of the in-process auth will be used
-	if process.Config.Auth.Enabled && len(process.Config.AuthServers) == 0 {
-		process.Config.AuthServers = []utils.NetAddr{process.Config.Auth.ListenAddr}
+	if process.Config.Auth.Enabled && len(process.Config.AuthServerAddresses()) == 0 {
+		process.Config.SetAuthServerAddresses([]utils.NetAddr{process.Config.Auth.ListenAddr})
 	}
 
-	if len(process.Config.AuthServers) != 0 && process.Config.AuthServers[0].Port(0) == 0 {
+	if len(process.Config.AuthServerAddresses()) != 0 && process.Config.AuthServerAddresses()[0].Port(0) == 0 {
 		// port appears undefined, attempt early listener creation so that we can get the real port
 		listener, err := process.importOrCreateListener(ListenerAuth, process.Config.Auth.ListenAddr.Addr)
 		if err == nil {
-			process.Config.AuthServers = []utils.NetAddr{utils.FromAddr(listener.Addr())}
+			process.Config.SetAuthServerAddresses([]utils.NetAddr{utils.FromAddr(listener.Addr())})
 		}
 	}
 
@@ -3456,7 +3456,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				NodeWatcher:                   nodeWatcher,
 				CertAuthorityWatcher:          caWatcher,
 				CircuitBreakerConfig:          process.Config.CircuitBreakerConfig,
-				LocalAuthAddresses:            utils.NetAddrsToStrings(process.Config.AuthServers),
+				LocalAuthAddresses:            utils.NetAddrsToStrings(process.Config.AuthServerAddresses()),
 			})
 		if err != nil {
 			return trace.Wrap(err)
@@ -3507,7 +3507,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 		webConfig := web.Config{
 			Proxy:            tsrv,
-			AuthServers:      cfg.AuthServers[0],
+			AuthServers:      cfg.AuthServerAddresses()[0],
 			DomainName:       cfg.Hostname,
 			ProxyClient:      conn.Client,
 			ProxySSHAddr:     proxySSHAddr,
@@ -3676,7 +3676,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		ReverseTunnelServer: tsrv,
 		FIPS:                process.Config.FIPS,
 		Log:                 rcWatchLog,
-		LocalAuthAddresses:  utils.NetAddrsToStrings(process.Config.AuthServers),
+		LocalAuthAddresses:  utils.NetAddrsToStrings(process.Config.AuthServerAddresses()),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -3873,7 +3873,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	var alpnServer *alpnproxy.Proxy
 	if !cfg.Proxy.DisableTLS && !cfg.Proxy.DisableALPNSNIListener && listeners.web != nil {
-		authDialerService := alpnproxyauth.NewAuthProxyDialerService(tsrv, clusterName, utils.NetAddrsToStrings(process.Config.AuthServers))
+		authDialerService := alpnproxyauth.NewAuthProxyDialerService(tsrv, clusterName, utils.NetAddrsToStrings(process.Config.AuthServerAddresses()))
 		alpnRouter.Add(alpnproxy.HandlerDecs{
 			MatchFunc:           alpnproxy.MatchByALPNPrefix(string(alpncommon.ProtocolAuth)),
 			HandlerWithConnInfo: authDialerService.HandleConnection,
@@ -4647,47 +4647,6 @@ func (process *TeleportProcess) Close() error {
 	}
 
 	return trace.NewAggregate(errors...)
-}
-
-func validateConfig(cfg *Config) error {
-	if !cfg.Auth.Enabled && !cfg.SSH.Enabled && !cfg.Proxy.Enabled && !cfg.Kube.Enabled && !cfg.Apps.Enabled && !cfg.Databases.Enabled && !cfg.WindowsDesktop.Enabled && !cfg.Discovery.Enabled {
-		return trace.BadParameter(
-			"config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service or discovery_service")
-	}
-
-	if cfg.DataDir == "" {
-		return trace.BadParameter("config: please supply data directory")
-	}
-
-	if cfg.Console == nil {
-		cfg.Console = io.Discard
-	}
-
-	if cfg.Log == nil {
-		cfg.Log = logrus.StandardLogger()
-	}
-
-	if len(cfg.AuthServers) == 0 {
-		return trace.BadParameter("auth_servers is empty")
-	}
-	for i := range cfg.Auth.Authorities {
-		if err := services.ValidateCertAuthority(cfg.Auth.Authorities[i]); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-	for _, tun := range cfg.ReverseTunnels {
-		if err := services.ValidateReverseTunnel(tun); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
-	if cfg.PollingPeriod == 0 {
-		cfg.PollingPeriod = defaults.LowResPollingPeriod
-	}
-
-	cfg.SSH.Namespace = types.ProcessNamespace(cfg.SSH.Namespace)
-
-	return nil
 }
 
 // initSelfSignedHTTPSCert generates and self-signs a TLS key+cert pair for https connection

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -95,7 +95,7 @@ func TestMonitor(t *testing.T) {
 	var err error
 	cfg.DataDir = t.TempDir()
 	cfg.DiagnosticAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
-	cfg.AuthServers = []utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}}
+	cfg.SetAuthServerAddresses([]utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}})
 	cfg.Auth.Enabled = true
 	cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
 	cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
@@ -459,7 +459,7 @@ func TestDesktopAccessFIPS(t *testing.T) {
 
 	// Create and configure a default Teleport configuration.
 	cfg := MakeDefaultConfig()
-	cfg.AuthServers = []utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}}
+	cfg.SetAuthServerAddresses([]utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}})
 	cfg.Clock = clockwork.NewFakeClock()
 	cfg.DataDir = t.TempDir()
 	cfg.Auth.Enabled = false
@@ -580,7 +580,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	// Create and configure a default Teleport configuration.
 	cfg := MakeDefaultConfig()
-	cfg.AuthServers = []utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}}
+	cfg.SetAuthServerAddresses([]utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}})
 	cfg.Clock = clock
 	cfg.DataDir = t.TempDir()
 	cfg.Auth.Enabled = false
@@ -641,7 +641,7 @@ func TestTeleportProcessAuthVersionCheck(t *testing.T) {
 
 	// Create Node process.
 	nodeCfg := MakeDefaultConfig()
-	nodeCfg.AuthServers = []utils.NetAddr{listenAddr}
+	nodeCfg.SetAuthServerAddresses([]utils.NetAddr{listenAddr})
 	nodeCfg.DataDir = t.TempDir()
 	nodeCfg.SetToken(token)
 	nodeCfg.Auth.Enabled = false
@@ -669,7 +669,7 @@ func TestTeleportProcessAuthVersionCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	authCfg := MakeDefaultConfig()
-	authCfg.AuthServers = []utils.NetAddr{listenAddr}
+	authCfg.SetAuthServerAddresses([]utils.NetAddr{listenAddr})
 	authCfg.DataDir = t.TempDir()
 	authCfg.Auth.Enabled = true
 	authCfg.Auth.StaticTokens = staticTokens

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -95,7 +95,7 @@ func TestMonitor(t *testing.T) {
 	var err error
 	cfg.DataDir = t.TempDir()
 	cfg.DiagnosticAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
-	cfg.SetAuthServerAddresses([]utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}})
+	cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
 	cfg.Auth.Enabled = true
 	cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
 	cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
@@ -459,7 +459,7 @@ func TestDesktopAccessFIPS(t *testing.T) {
 
 	// Create and configure a default Teleport configuration.
 	cfg := MakeDefaultConfig()
-	cfg.SetAuthServerAddresses([]utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}})
+	cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
 	cfg.Clock = clockwork.NewFakeClock()
 	cfg.DataDir = t.TempDir()
 	cfg.Auth.Enabled = false
@@ -580,7 +580,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	// Create and configure a default Teleport configuration.
 	cfg := MakeDefaultConfig()
-	cfg.SetAuthServerAddresses([]utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}})
+	cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
 	cfg.Clock = clock
 	cfg.DataDir = t.TempDir()
 	cfg.Auth.Enabled = false
@@ -641,7 +641,7 @@ func TestTeleportProcessAuthVersionCheck(t *testing.T) {
 
 	// Create Node process.
 	nodeCfg := MakeDefaultConfig()
-	nodeCfg.SetAuthServerAddresses([]utils.NetAddr{listenAddr})
+	nodeCfg.SetAuthServerAddress(listenAddr)
 	nodeCfg.DataDir = t.TempDir()
 	nodeCfg.SetToken(token)
 	nodeCfg.Auth.Enabled = false
@@ -669,7 +669,7 @@ func TestTeleportProcessAuthVersionCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	authCfg := MakeDefaultConfig()
-	authCfg.SetAuthServerAddresses([]utils.NetAddr{listenAddr})
+	authCfg.SetAuthServerAddress(listenAddr)
 	authCfg.DataDir = t.TempDir()
 	authCfg.Auth.Enabled = true
 	authCfg.Auth.StaticTokens = staticTokens

--- a/lib/service/validateconfig.go
+++ b/lib/service/validateconfig.go
@@ -19,6 +19,7 @@ package service
 import (
 	"io"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
@@ -105,18 +106,18 @@ func validateAuthOrProxyServices(cfg *Config) error {
 		}
 
 		if haveProxyServer {
-			port := cfg.ProxyServer.Port(defaults.HTTPListenPort)
+			port := cfg.ProxyServer.Port(0)
 			if port == defaults.AuthListenPort {
-				cfg.Log.Warnf("config: your proxy_server is pointing to port %d, have you specified your auth server instead?", defaults.AuthListenPort)
+				cfg.Log.Warnf("config: proxy_server is pointing to port %d, is this the auth server address?", defaults.AuthListenPort)
 			}
 		}
 
 		if haveAuthServers {
-			authServerPort := cfg.authServers[0].Port(defaults.AuthListenPort)
-			checkPorts := []int{defaults.HTTPListenPort, 443}
+			authServerPort := cfg.authServers[0].Port(0)
+			checkPorts := []int{defaults.HTTPListenPort, teleport.StandardHTTPSPort}
 			for _, port := range checkPorts {
 				if authServerPort == port {
-					cfg.Log.Warnf("config: your auth_server is pointing to port %d, have you specified your proxy address instead?", port)
+					cfg.Log.Warnf("config: auth_server is pointing to port %d, is this the proxy server address?", port)
 				}
 			}
 		}

--- a/lib/service/validateconfig.go
+++ b/lib/service/validateconfig.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"io"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/trace"
+
+	"github.com/sirupsen/logrus"
+)
+
+func validateConfig(cfg *Config) error {
+	applyDefaults(cfg)
+
+	if err := defaults.ValidateVersion(cfg.Version); err != nil {
+		return err
+	}
+
+	if err := verifyEnabledService(cfg); err != nil {
+		return err
+	}
+
+	if err := validateAuthOrProxyServices(cfg); err != nil {
+		return err
+	}
+
+	if cfg.DataDir == "" {
+		return trace.BadParameter("config: please supply data directory")
+	}
+
+	for i := range cfg.Auth.Authorities {
+		if err := services.ValidateCertAuthority(cfg.Auth.Authorities[i]); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	for _, tun := range cfg.ReverseTunnels {
+		if err := services.ValidateReverseTunnel(tun); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	cfg.SSH.Namespace = types.ProcessNamespace(cfg.SSH.Namespace)
+
+	return nil
+}
+
+func applyDefaults(cfg *Config) {
+	if cfg.Version == "" {
+		cfg.Version = defaults.TeleportConfigVersionV1
+	}
+
+	if cfg.Console == nil {
+		cfg.Console = io.Discard
+	}
+
+	if cfg.Log == nil {
+		cfg.Log = logrus.StandardLogger()
+	}
+
+	if cfg.PollingPeriod == 0 {
+		cfg.PollingPeriod = defaults.LowResPollingPeriod
+	}
+}
+
+func validateAuthOrProxyServices(cfg *Config) error {
+	haveAuthServers := len(cfg.authServers) > 0
+	haveProxyServer := !cfg.ProxyServer.IsEmpty()
+
+	if cfg.Version == defaults.TeleportConfigVersionV3 {
+		if haveAuthServers && haveProxyServer {
+			return trace.BadParameter("config: cannot use both auth_server and proxy_server")
+		}
+
+		if !haveAuthServers && !haveProxyServer {
+			return trace.BadParameter("config: auth_server or proxy_server is required")
+		}
+
+		if haveAuthServers && cfg.Apps.Enabled {
+			return trace.BadParameter("config: when app_service is enabled, proxy_server must be specified instead of auth_server")
+		}
+
+		if haveAuthServers && cfg.Databases.Enabled {
+			return trace.BadParameter("config: when db_service is enabled, proxy_server must be specified instead of auth_server")
+		}
+
+		if haveProxyServer {
+			port := cfg.ProxyServer.Port(defaults.HTTPListenPort)
+			if port == defaults.AuthListenPort {
+				cfg.Log.Warnf("config: your proxy_server is pointing to port %d, have you specified your auth server instead?", defaults.AuthListenPort)
+			}
+		}
+
+		if haveAuthServers {
+			authServerPort := cfg.authServers[0].Port(defaults.AuthListenPort)
+			checkPorts := []int{defaults.HTTPListenPort, 443}
+			for _, port := range checkPorts {
+				if authServerPort == port {
+					cfg.Log.Warnf("config: your auth_server is pointing to port %d, have you specified your proxy address instead?", port)
+				}
+			}
+		}
+
+		return nil
+	}
+
+	if haveProxyServer {
+		return trace.BadParameter("config: proxy_server is supported from config version v3 onwards")
+	}
+
+	if !haveAuthServers {
+		return trace.BadParameter("config: auth_servers is required")
+	}
+
+	return nil
+}
+
+func verifyEnabledService(cfg *Config) error {
+	enabled := []bool{
+		cfg.Auth.Enabled,
+		cfg.SSH.Enabled,
+		cfg.Proxy.Enabled,
+		cfg.Kube.Enabled,
+		cfg.Apps.Enabled,
+		cfg.Databases.Enabled,
+		cfg.WindowsDesktop.Enabled,
+		cfg.Discovery.Enabled,
+	}
+
+	has := false
+	for _, item := range enabled {
+		if item {
+			has = true
+
+			break
+		}
+	}
+
+	if !has {
+		return trace.BadParameter(
+			"config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service or discover_service")
+	}
+
+	return nil
+}

--- a/lib/service/validateconfig.go
+++ b/lib/service/validateconfig.go
@@ -94,12 +94,14 @@ func validateAuthOrProxyServices(cfg *Config) error {
 			return trace.BadParameter("config: auth_server or proxy_server is required")
 		}
 
-		if haveAuthServers && cfg.Apps.Enabled {
-			return trace.BadParameter("config: when app_service is enabled, proxy_server must be specified instead of auth_server")
-		}
+		if !cfg.Auth.Enabled {
+			if haveAuthServers && cfg.Apps.Enabled {
+				return trace.BadParameter("config: when app_service is enabled, proxy_server must be specified instead of auth_server")
+			}
 
-		if haveAuthServers && cfg.Databases.Enabled {
-			return trace.BadParameter("config: when db_service is enabled, proxy_server must be specified instead of auth_server")
+			if haveAuthServers && cfg.Databases.Enabled {
+				return trace.BadParameter("config: when db_service is enabled, proxy_server must be specified instead of auth_server")
+			}
 		}
 
 		if haveProxyServer {

--- a/lib/service/validateconfig.go
+++ b/lib/service/validateconfig.go
@@ -148,19 +148,12 @@ func verifyEnabledService(cfg *Config) error {
 		cfg.Discovery.Enabled,
 	}
 
-	has := false
 	for _, item := range enabled {
 		if item {
-			has = true
-
-			break
+			return nil
 		}
 	}
 
-	if !has {
-		return trace.BadParameter(
-			"config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service or discover_service")
-	}
-
-	return nil
+	return trace.BadParameter(
+		"config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service or discover_service")
 }

--- a/lib/service/validateconfig.go
+++ b/lib/service/validateconfig.go
@@ -31,7 +31,7 @@ import (
 func validateConfig(cfg *Config) error {
 	applyDefaults(cfg)
 
-	if err := defaults.ValidateVersion(cfg.Version); err != nil {
+	if err := defaults.ValidateConfigVersion(cfg.Version); err != nil {
 		return err
 	}
 

--- a/lib/service/validateconfig_test.go
+++ b/lib/service/validateconfig_test.go
@@ -41,7 +41,7 @@ func TestValidateConfig(t *testing.T) {
 			config: &Config{
 				Version: "v1.1",
 			},
-			err: fmt.Sprintf("version must be one of %s", strings.Join(defaults.TeleportVersions, ", ")),
+			err: fmt.Sprintf("version must be one of %s", strings.Join(defaults.TeleportConfigVersions, ", ")),
 		},
 		{
 			desc: "no service enabled",

--- a/lib/service/validateconfig_test.go
+++ b/lib/service/validateconfig_test.go
@@ -1,0 +1,120 @@
+/*
+ *
+ * Copyright 2015-2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ *
+ */
+
+package service
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		desc   string
+		config *Config
+		err    string
+	}{
+		{
+			desc: "invalid version",
+			config: &Config{
+				Version: "v1.1",
+			},
+			err: fmt.Sprintf("version must be one of %s", strings.Join(defaults.TeleportVersions, ", ")),
+		},
+		{
+			desc: "no service enabled",
+			config: &Config{
+				Version: defaults.TeleportConfigVersionV2,
+			},
+			err: "config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service or windows_desktop_service",
+		},
+		{
+			desc: "no auth_servers or proxy_server specified",
+			config: &Config{
+				Version: defaults.TeleportConfigVersionV3,
+				Auth: AuthConfig{
+					Enabled: true,
+				},
+			},
+			err: "config: auth_server or proxy_server is required",
+		},
+		{
+			desc: "no auth_servers specified",
+			config: &Config{
+				Version: defaults.TeleportConfigVersionV2,
+				Auth: AuthConfig{
+					Enabled: true,
+				},
+			},
+			err: "config: auth_servers is required",
+		},
+		{
+			desc: "specifying proxy_server with the wrong config version",
+			config: &Config{
+				Version: defaults.TeleportConfigVersionV2,
+				Auth: AuthConfig{
+					Enabled: true,
+				},
+				ProxyServer: *utils.MustParseAddr("0.0.0.0"),
+			},
+			err: "config: proxy_server is supported from config version v3 onwards",
+		},
+		{
+			desc: "specifying auth_server when app_service is enabled",
+			config: &Config{
+				Version: defaults.TeleportConfigVersionV3,
+				Apps: AppsConfig{
+					Enabled: true,
+				},
+				DataDir:     "/",
+				authServers: []utils.NetAddr{*utils.MustParseAddr("0.0.0.0")},
+			},
+			err: "config: when app_service is enabled, proxy_server must be specified instead of auth_server",
+		},
+		{
+			desc: "specifying auth_server when db_service is enabled",
+			config: &Config{
+				Version: defaults.TeleportConfigVersionV3,
+				Databases: DatabasesConfig{
+					Enabled: true,
+				},
+				DataDir:     "/",
+				authServers: []utils.NetAddr{*utils.MustParseAddr("0.0.0.0")},
+			},
+			err: "config: when db_service is enabled, proxy_server must be specified instead of auth_server",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			err := validateConfig(test.config)
+			if test.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, test.err)
+			}
+		})
+	}
+}

--- a/lib/service/validateconfig_test.go
+++ b/lib/service/validateconfig_test.go
@@ -48,7 +48,7 @@ func TestValidateConfig(t *testing.T) {
 			config: &Config{
 				Version: defaults.TeleportConfigVersionV2,
 			},
-			err: "config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service or windows_desktop_service",
+			err: "config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service or discover_service",
 		},
 		{
 			desc: "no auth_servers or proxy_server specified",

--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -464,7 +464,7 @@ func (b *Bot) getIdentityFromToken() (*identity.Identity, error) {
 		ID: auth.IdentityID{
 			Role: types.RoleBot,
 		},
-		Servers:            []utils.NetAddr{*addr},
+		AuthServers:        []utils.NetAddr{*addr},
 		PublicTLSKey:       tlsPublicKey,
 		PublicSSHKey:       sshPublicKey,
 		CAPins:             b.cfg.Onboarding.CAPins,

--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -159,7 +159,7 @@ func MakeBotAuthClient(t *testing.T, fc *config.FileConfig, ident *identity.Iden
 	authConfig.TLS, err = ident.TLSConfig(cfg.CipherSuites)
 	require.NoError(t, err)
 
-	authConfig.AuthServers = cfg.AuthServers
+	authConfig.AuthServers = cfg.AuthServerAddresses()
 	authConfig.Log = cfg.Log
 
 	client, err := authclient.Connect(context.Background(), authConfig)
@@ -188,7 +188,7 @@ func MakeDefaultAuthClient(t *testing.T, log utils.Logger, fc *config.FileConfig
 	authConfig.TLS, err = identity.TLSConfig(cfg.CipherSuites)
 	require.NoError(t, err)
 
-	authConfig.AuthServers = cfg.AuthServers
+	authConfig.AuthServers = cfg.AuthServerAddresses()
 	authConfig.Log = log
 
 	client, err := authclient.Connect(context.Background(), authConfig)
@@ -239,7 +239,7 @@ func MakeMemoryBotConfig(t *testing.T, fc *config.FileConfig, botParams *proto.C
 	require.NoError(t, err)
 
 	cfg := &botconfig.BotConfig{
-		AuthServer: authCfg.AuthServers[0].String(),
+		AuthServer: authCfg.AuthServerAddresses()[0].String(),
 		Onboarding: &botconfig.OnboardingConfig{
 			JoinMethod: botParams.JoinMethod,
 		},

--- a/lib/web/scripts/desktop/configure-ad.ps1
+++ b/lib/web/scripts/desktop/configure-ad.ps1
@@ -140,9 +140,12 @@ $COMPUTER_IP = (Resolve-DnsName -Type A $Env:COMPUTERNAME).Address
 $LDAP_ADDR="$COMPUTER_IP" + ":636"
 
 $DESKTOP_ACCESS_CONFIG_YAML=@'
+version v3
 teleport:
-  auth_token: {0}
-  auth_servers: [ {1} ]
+  proxy_server: {1}
+  join_params:
+    method: token
+    token_name: {0}
 
 auth_service:
   enabled: no

--- a/lib/web/scripts/desktop/configure-ad.ps1
+++ b/lib/web/scripts/desktop/configure-ad.ps1
@@ -142,10 +142,8 @@ $LDAP_ADDR="$COMPUTER_IP" + ":636"
 $DESKTOP_ACCESS_CONFIG_YAML=@'
 version v3
 teleport:
+  auth_token: {0}
   proxy_server: {1}
-  join_params:
-    method: token
-    token_name: {0}
 
 auth_service:
   enabled: no

--- a/lib/web/scripts/node-join/README.md
+++ b/lib/web/scripts/node-join/README.md
@@ -54,10 +54,10 @@ Required arguments:
 | Flag | Description | Example value | Required |
 | - | - | - | - |
 | `-v` | Teleport version | `4.3.5` | yes |
-| `-h` | Hostname for the Teleport auth/proxy server | `teleport.example.com` | yes |
+| `-h` | Hostname for the Teleport proxy server | `teleport.example.com` | yes |
 | `-j` | A valid node join token | `ool7ahpo4thohmeuS1gieY7laiwae7oo` | yes |
 | `-c` | The CA pin hash of the cluster being joined | `sha256:6abdd3a143a230fd31c9706d668bba3ee25a6e0eec54fcd69680c1ec0530fe9c` | yes |
-| `-p` | Port connect to on the Teleport auth/proxy server | `3080` | no |
+| `-p` | Port connect to on the Teleport proxy server | `3080` | no |
 
 If any of these arguments is not provided via CLI flags, they will be requested interactively at runtime.
 

--- a/lib/web/scripts/node-join/README.md
+++ b/lib/web/scripts/node-join/README.md
@@ -54,10 +54,10 @@ Required arguments:
 | Flag | Description | Example value | Required |
 | - | - | - | - |
 | `-v` | Teleport version | `4.3.5` | yes |
-| `-h` | Hostname for the Teleport proxy server | `teleport.example.com` | yes |
+| `-h` | Hostname for the Teleport Proxy Service | `teleport.example.com` | yes |
 | `-j` | A valid node join token | `ool7ahpo4thohmeuS1gieY7laiwae7oo` | yes |
 | `-c` | The CA pin hash of the cluster being joined | `sha256:6abdd3a143a230fd31c9706d668bba3ee25a6e0eec54fcd69680c1ec0530fe9c` | yes |
-| `-p` | Port connect to on the Teleport proxy server | `3080` | no |
+| `-p` | Port connect to on the Teleport Proxy Service | `3080` | no |
 
 If any of these arguments is not provided via CLI flags, they will be requested interactively at runtime.
 

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -418,7 +418,7 @@ version: v3
 teleport:
   nodename: ${NODENAME}
   join_params:
-    join_method: token
+    method: token
     token_name: ${JOIN_TOKEN}
 ${CA_PINS_CONFIG}
   proxy_server: ${TARGET_HOSTNAME}:${TARGET_PORT}

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -414,12 +414,14 @@ install_teleport_app_config() {
     log "Writing Teleport app service config to ${TELEPORT_CONFIG_PATH}"
     CA_PINS_CONFIG=$(get_yaml_list "ca_pin" "${CA_PIN_HASHES}" "  ")
     cat << EOF > ${TELEPORT_CONFIG_PATH}
+version: v3
 teleport:
   nodename: ${NODENAME}
-  auth_token: ${JOIN_TOKEN}
+  join_params:
+    join_method: token
+    token_name: ${JOIN_TOKEN}
 ${CA_PINS_CONFIG}
-  auth_servers:
-  - ${TARGET_HOSTNAME}:${TARGET_PORT}
+  proxy_server: ${TARGET_HOSTNAME}:${TARGET_PORT}
   log:
     output: stderr
     severity: INFO
@@ -444,7 +446,7 @@ install_teleport_node_config() {
       --token ${JOIN_TOKEN} \
       ${JOIN_METHOD_FLAG} \
       --ca-pin ${CA_PINS} \
-      --auth-server ${TARGET_HOSTNAME}:${TARGET_PORT} \
+      --proxy ${TARGET_HOSTNAME}:${TARGET_PORT} \
       "${LABELS_FLAG[@]}" \
       --output ${TELEPORT_CONFIG_PATH}
 }

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -417,9 +417,7 @@ install_teleport_app_config() {
 version: v3
 teleport:
   nodename: ${NODENAME}
-  join_params:
-    method: token
-    token_name: ${JOIN_TOKEN}
+  auth_token: ${JOIN_TOKEN}
 ${CA_PINS_CONFIG}
   proxy_server: ${TARGET_HOSTNAME}:${TARGET_PORT}
   log:

--- a/operator/sidecar/sidecar.go
+++ b/operator/sidecar/sidecar.go
@@ -73,10 +73,12 @@ func createAuthClientConfig(opts Options) (*authclient.Config, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	cfg.AuthServers, err = utils.ParseAddrs([]string{opts.Addr})
+	authServers, err := utils.ParseAddrs([]string{opts.Addr})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	cfg.SetAuthServerAddresses(authServers)
 
 	// read the host UUID only in case the identity was not provided,
 	// because it will be used for reading local auth server identity
@@ -99,7 +101,7 @@ func createAuthClientConfig(opts Options) (*authclient.Config, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	authConfig.AuthServers = cfg.AuthServers
+	authConfig.AuthServers = cfg.AuthServerAddresses()
 	authConfig.Log = cfg.Log
 
 	return authConfig, nil

--- a/operator/sidecar/sidecar.go
+++ b/operator/sidecar/sidecar.go
@@ -78,7 +78,9 @@ func createAuthClientConfig(opts Options) (*authclient.Config, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	cfg.SetAuthServerAddresses(authServers)
+	if err := cfg.SetAuthServerAddresses(authServers); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	// read the host UUID only in case the identity was not provided,
 	// because it will be used for reading local auth server identity

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -223,6 +223,10 @@ func ApplyConfig(ccf *GlobalCLIFlags, cfg *service.Config) (*authclient.Config, 
 	}
 	cfg.Log = log.StandardLogger()
 
+	if cfg.Version == "" {
+		cfg.Version = defaults.TeleportConfigVersionV1
+	}
+
 	// If the config file path provided is not a blank string, load the file and apply its values
 	var fileConf *config.FileConfig
 	var err error

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -257,7 +257,9 @@ func ApplyConfig(ccf *GlobalCLIFlags, cfg *service.Config) (*authclient.Config, 
 			return nil, trace.Wrap(err)
 		}
 		// Overwrite any existing configuration with flag values.
-		cfg.SetAuthServerAddresses(authServers)
+		if err := cfg.SetAuthServerAddresses(authServers); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// Config file should take precedence, if available.
@@ -282,7 +284,9 @@ func ApplyConfig(ccf *GlobalCLIFlags, cfg *service.Config) (*authclient.Config, 
 			return nil, trace.Wrap(err)
 		}
 
-		cfg.SetAuthServerAddresses(authServers)
+		if err := cfg.SetAuthServerAddresses(authServers); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	authConfig := new(authclient.Config)
@@ -428,7 +432,7 @@ func LoadConfigFromProfile(ccf *GlobalCLIFlags, cfg *service.Config) (*authclien
 			return nil, trace.Wrap(err)
 		}
 		log.Debugf("Setting auth server to web proxy %v.", webProxyAddr)
-		cfg.SetAuthServerAddresses([]utils.NetAddr{*webProxyAddr})
+		cfg.SetAuthServerAddress(*webProxyAddr)
 	}
 	authConfig.AuthServers = cfg.AuthServerAddresses()
 	authConfig.Log = cfg.Log

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -345,7 +345,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dumpNodeConfigure.Flag("data-dir", "Path to a directory where Teleport keep its data.").Default(defaults.DataDir).StringVar(&dumpFlags.DataDir)
 	dumpNodeConfigure.Flag("token", "Invitation token to register with an auth server.").StringVar(&dumpFlags.AuthToken)
 	dumpNodeConfigure.Flag("auth-server", "Address of the auth server.").StringVar(&dumpFlags.AuthServer)
-	dumpNodeConfigure.Flag("proxy", "Address of the auth server.").StringVar(&dumpFlags.ProxyAddress)
+	dumpNodeConfigure.Flag("proxy", "Address of the proxy server.").StringVar(&dumpFlags.ProxyAddress)
 	dumpNodeConfigure.Flag("labels", "Comma-separated list of labels to add to newly created nodes ex) env=staging,cloud=aws.").StringVar(&dumpFlags.NodeLabels)
 	dumpNodeConfigure.Flag("ca-pin", "Comma-separated list of SKPI hashes for the CA used to verify the auth server.").StringVar(&dumpFlags.CAPin)
 	dumpNodeConfigure.Flag("join-method", "Method to use to join the cluster (token, iam, ec2)").Default("token").EnumVar(&dumpFlags.JoinMethod, "token", "iam", "ec2")

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -496,7 +496,7 @@ func checkConfigurationFileVersion(version string) error {
 		return nil
 	}
 
-	return defaults.ValidateVersion(version)
+	return defaults.ValidateConfigVersion(version)
 }
 
 // onConfigDump is the handler for "configure" CLI command

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -206,12 +206,14 @@ func TestDumpConfigFile(t *testing.T) {
 }
 
 const configData = `
+version: v3
 teleport:
   advertise_ip: 10.5.5.5
   nodename: hvostongo.example.org
-  auth_servers:
-    - auth.server.example.org:3024
-  auth_token: xxxyyy
+  auth_servers: auth.server.example.org:3024
+  join_params:
+    join_method: token
+    token_name: xxxyyy
   log:
     output: stderr
     severity: DEBUG

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -210,7 +210,7 @@ version: v3
 teleport:
   advertise_ip: 10.5.5.5
   nodename: hvostongo.example.org
-  auth_servers: auth.server.example.org:3024
+  auth_server: auth.server.example.org:3024
   join_params:
     method: token
     token_name: xxxyyy

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -212,7 +212,7 @@ teleport:
   nodename: hvostongo.example.org
   auth_servers: auth.server.example.org:3024
   join_params:
-    join_method: token
+    method: token
     token_name: xxxyyy
   log:
     output: stderr

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -211,9 +211,7 @@ teleport:
   advertise_ip: 10.5.5.5
   nodename: hvostongo.example.org
   auth_server: auth.server.example.org:3024
-  join_params:
-    method: token
-    token_name: xxxyyy
+  auth_token: xxxyyy
   log:
     output: stderr
     severity: DEBUG

--- a/tool/tsh/aws_test.go
+++ b/tool/tsh/aws_test.go
@@ -146,7 +146,7 @@ func makeTestApplicationServer(t *testing.T, auth *service.TeleportProcess, prox
 	proxyAddr, err := proxy.ProxyWebAddr()
 	require.NoError(t, err)
 
-	cfg.AuthServers = []utils.NetAddr{*proxyAddr}
+	cfg.SetAuthServerAddresses([]utils.NetAddr{*proxyAddr})
 
 	token, err := proxy.Config.Token()
 	require.NoError(t, err)

--- a/tool/tsh/aws_test.go
+++ b/tool/tsh/aws_test.go
@@ -146,7 +146,7 @@ func makeTestApplicationServer(t *testing.T, auth *service.TeleportProcess, prox
 	proxyAddr, err := proxy.ProxyWebAddr()
 	require.NoError(t, err)
 
-	cfg.SetAuthServerAddresses([]utils.NetAddr{*proxyAddr})
+	cfg.SetAuthServerAddress(*proxyAddr)
 
 	token, err := proxy.Config.Token()
 	require.NoError(t, err)

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -370,7 +370,7 @@ func makeTestDatabaseServer(t *testing.T, auth *service.TeleportProcess, proxy *
 	proxyAddr, err := proxy.ProxyWebAddr()
 	require.NoError(t, err)
 
-	cfg.AuthServers = []utils.NetAddr{*proxyAddr}
+	cfg.SetAuthServerAddresses([]utils.NetAddr{*proxyAddr})
 
 	token, err := proxy.Config.Token()
 	require.NoError(t, err)

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -370,7 +370,7 @@ func makeTestDatabaseServer(t *testing.T, auth *service.TeleportProcess, proxy *
 	proxyAddr, err := proxy.ProxyWebAddr()
 	require.NoError(t, err)
 
-	cfg.SetAuthServerAddresses([]utils.NetAddr{*proxyAddr})
+	cfg.SetAuthServerAddress(*proxyAddr)
 
 	token, err := proxy.Config.Token()
 	require.NoError(t, err)

--- a/tool/tsh/tctl_test.go
+++ b/tool/tsh/tctl_test.go
@@ -233,9 +233,9 @@ func TestSetAuthServerFlagWhileLoggedIn(t *testing.T) {
 
 			_, err = common.ApplyConfig(ccf, cfg)
 			require.NoError(t, err)
-			require.NotEmpty(t, cfg.AuthServers, "auth servers should be set to a non-empty default if not specified")
+			require.NotEmpty(t, cfg.AuthServerAddresses(), "auth servers should be set to a non-empty default if not specified")
 
-			require.ElementsMatch(t, tt.want, cfg.AuthServers)
+			require.ElementsMatch(t, tt.want, cfg.AuthServerAddresses())
 		})
 	}
 }

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -2280,7 +2280,7 @@ func makeTestSSHNode(t *testing.T, authAddr *utils.NetAddr, opts ...testServerOp
 	cfg.Hostname = "node"
 	cfg.DataDir = t.TempDir()
 
-	cfg.SetAuthServerAddresses([]utils.NetAddr{*authAddr})
+	cfg.SetAuthServerAddress(*authAddr)
 	cfg.SetToken(staticToken)
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
@@ -2326,7 +2326,7 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	cfg.Hostname = "localhost"
 	cfg.DataDir = t.TempDir()
 
-	cfg.SetAuthServerAddresses([]utils.NetAddr{{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}})
+	cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())})
 	cfg.Auth.Resources = options.bootstrap
 	cfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(cfg.DataDir, defaults.BackendDir)}
 	cfg.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
@@ -2371,7 +2371,7 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	cfg.Hostname = "localhost"
 	cfg.DataDir = t.TempDir()
 
-	cfg.SetAuthServerAddresses([]utils.NetAddr{*authAddr})
+	cfg.SetAuthServerAddress(*authAddr)
 	cfg.SetToken(staticToken)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = false

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -2280,7 +2280,7 @@ func makeTestSSHNode(t *testing.T, authAddr *utils.NetAddr, opts ...testServerOp
 	cfg.Hostname = "node"
 	cfg.DataDir = t.TempDir()
 
-	cfg.AuthServers = []utils.NetAddr{*authAddr}
+	cfg.SetAuthServerAddresses([]utils.NetAddr{*authAddr})
 	cfg.SetToken(staticToken)
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
@@ -2326,7 +2326,7 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	cfg.Hostname = "localhost"
 	cfg.DataDir = t.TempDir()
 
-	cfg.AuthServers = []utils.NetAddr{{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}}
+	cfg.SetAuthServerAddresses([]utils.NetAddr{{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}})
 	cfg.Auth.Resources = options.bootstrap
 	cfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(cfg.DataDir, defaults.BackendDir)}
 	cfg.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
@@ -2371,7 +2371,7 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	cfg.Hostname = "localhost"
 	cfg.DataDir = t.TempDir()
 
-	cfg.AuthServers = []utils.NetAddr{*authAddr}
+	cfg.SetAuthServerAddresses([]utils.NetAddr{*authAddr})
 	cfg.SetToken(staticToken)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = false

--- a/vagrant/opt/b-node/teleport.yaml
+++ b/vagrant/opt/b-node/teleport.yaml
@@ -1,8 +1,11 @@
 # Node for cluster-B
+version: v3
 teleport:
   nodename: bear
-  auth_token: hello
-  auth_servers: ["b-auth:5025"] 
+  join_params:
+    join_method: token
+    token_name: hello
+  auth_server: b-auth:5025
   log:
     output: stderr
     severity: INFO

--- a/vagrant/opt/b-node/teleport.yaml
+++ b/vagrant/opt/b-node/teleport.yaml
@@ -3,7 +3,7 @@ version: v3
 teleport:
   nodename: bear
   join_params:
-    join_method: token
+    method: token
     token_name: hello
   auth_server: b-auth:5025
   log:

--- a/vagrant/opt/b-node/teleport.yaml
+++ b/vagrant/opt/b-node/teleport.yaml
@@ -2,9 +2,7 @@
 version: v3
 teleport:
   nodename: bear
-  join_params:
-    method: token
-    token_name: hello
+  auth_token: hello
   auth_server: b-auth:5025
   log:
     output: stderr


### PR DESCRIPTION
This introduces a new version of the config, v3, as we're adding a new item to the schema (`proxy_server`) and making `auth_servers` no longer pluralised (`auth_server`).

This allows us to go straight to tunnelling through the proxy server if specified via `proxy_server`, as we know it's not an auth server and we don't need to attempt to direct dial it first.

This updates all docs to reference config v3, and also adds a config changelog to the bottom of the config reference page

![image](https://user-images.githubusercontent.com/7922109/192575684-f0da8f1b-276e-465b-bff0-a3866922e820.png)

It also adds `--proxy` to `teleport node configure` and `teleport configure`, matching that of `teleport db configure create`. These commands have all been updated to produce a v3 valid config.