### PR TITLE
RFD 0084 - Azure backend storage

### DIFF
--- a/rfd/0084-azure-backend.md
+++ b/rfd/0084-azure-backend.md
@@ -12,7 +12,11 @@ state: draft
 
 ## What
 
-Add support for Azure IAM authentication to the Postgres backend, add audit log capabilities to the `sqlbk`/Postgres backend, add a session uploader that uses Azure Blob Storage (with the same IAM authentication).
+Enable users to leverage Azure-native services as a Teleport backend.
+We will accomplish this by:
+- Add support for Azure IAM authentication to the existing Postgres backend
+- Add audit log capabilities to the `sqlbk`/Postgres backend
+- Add a session uploader that uses Azure Blob Storage (with the same IAM authentication)
 
 ## Why
 

--- a/rfd/0084-azure-backend.md
+++ b/rfd/0084-azure-backend.md
@@ -1,0 +1,130 @@
+---
+authors: Edoardo Spadolini (edoardo.spadolini@goteleport.com)
+state: draft
+---
+
+# RFD 0084 - Azure backend storage
+
+## Required Approvers
+* Engineering: TBD
+* Security: TBD
+* Product: TBD
+
+## What
+
+Add support for Azure IAM authentication to the Postgres backend, add audit log capabilities to the `sqlbk`/Postgres backend, add a session uploader that uses Azure Blob Storage (with the same IAM authentication).
+
+## Why
+
+To support deployments of Teleport in Azure with the same convenience and reliability that's currently available when using managed storage in AWS and GCP.
+
+## Details
+
+### Auth backend
+
+Even though our backend is ultimately just a key-value store, the managed NoSQL database offering in Azure, called Cosmos DB, is not sufficient for our purpose, because our cache propagation model relies on all auth servers having access to a stream of events that replicates all the changes applied to the backend. Cosmos DB has a change feed, but it doesn't contain every change to values and it doesn't have deletions - as such, it's not usable as the backing store for our auth backend (a "full fidelity" change feed has been [in private preview since 2020](https://azure.microsoft.com/en-us/updates/change-feed-with-full-database-operations-for-azure-cosmos-db/)).
+
+As using Postgres as the backend storage for Teleport has been possible (in Preview) since v9.0.4, and Azure offers a managed Postgres service, we will be adding support for Azure AD authentication to the Postgres backend - that's the only change needed to support Azure Postgres in Teleport. As of August 2022, only the "Single Server" flavor of Azure Postgres supports AD authentication and it's limited to Postgres 11, which will be [deprecated in November 2023](https://docs.microsoft.com/en-us/azure/postgresql/single-server/concepts-version-policy#major-version-retirement-policy), but it seems likely that AD authentication will also be supported in the "Flexible Server" offering by then.
+
+### Configuration
+
+This are some options on how the configuration side might look like.
+
+The original SQL Backend RFD imagined something like:
+
+```yaml
+teleport:
+  storage:
+    type: postgres
+    addr: pgservername.postgres.database.azure.com
+    database: dbname_defaulting_to_teleport
+    tls:
+      ca_file: path/to/azure_postgres_trust_roots.pem
+    azure:
+      username: pgusername@pgservername
+```
+
+Alternatively, we could provide additional aliases for the Postgres backend:
+
+```yaml
+teleport:
+  storage:
+    type: azurepostgres
+    addr: pgservername.postgres.database.azure.com
+    username: pgusername@pgservername
+    database: dbname_defaulting_to_teleport
+    tls:
+      ca_file: path/to/azure_postgres_trust_roots.pem
+```
+
+Or we could add some "authentication type" field:
+
+```yaml
+teleport:
+  storage:
+    type: postgres
+    addr: pgservername.postgres.database.azure.com
+    username: pgusername@pgservername
+    database: dbname_defaulting_to_teleport
+    authentication: azure
+    tls:
+      ca_file: path/to/azure_postgres_trust_roots.pem
+```
+
+Other options such as checking for the `.postgres.database.azure.com` suffix in the hostname seem a bit too fragile.
+
+Authentication will happen according to the default behavior of [the Azure Go SDK](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity), which will try to use credentials from envvars, from the IDMS accessible from Azure VMs, and from the command-line `az` tool - it would be straightforward to add some tunables to the configuration file if some specific need arose in the future.
+
+## Audit log
+
+The current two cloud storage options (DynamoDB on AWS and Firestore on GCP) can store both the auth backend and the events in the audit log. For user convenience, we'll implement audit log storage for the `sqlbk`/Postgres backend - an alternative would be to store the audit log in Cosmos DB, but that would require that our users set up both a Postgres server and a Cosmos DB account. As a bonus, this storage option will also be usable outside of Azure.
+
+An `audit` table will be added to the current db schema, with indices on a `time` field and an optional `sid` field.
+
+Assuming it's fine to store the log in the same database as the backend, a minimal configuration could be as simple as:
+
+```yaml
+teleport:
+  storage:
+    ...
+
+    audit_events_uri: ['backend://']
+```
+
+With the relevant `ClusterAuditConfigSpecV2` options such as `audit_retention_period` that affect all audit logs being specified in the usual way, and future tunables for the backend-adjacent audit log being added either as extra options for the audit-aware backend or in the URI.
+
+If we decide to go for a setup in which the audit log is completely independent of the backend storage, we could just specify a URI with all the relevant options and open a whole new connection pool for it:
+
+```yaml
+teleport:
+  storage:
+    ...
+
+    audit_events_uri: ['postgres://host:123/database?sslmode=verify-full&sslrootcert=cafile&sslcert=certfile&sslkey=keyfile']
+```
+
+IAM authentication in such case would require some bespoke parameter in the query of the URI:
+
+```yaml
+teleport:
+  storage:
+    ...
+
+    audit_events_uri: ['postgres://host:123/database?sslmode=verify-full&sslrootcert=cafile&user=pgusername%40pgservername&authentication=azure']
+```
+
+Additional security could be provided by only granting `INSERT` (and `SELECT`) privileges to the Postgres user on the table that stores audit events, but not `UPDATE` or `DELETE` privileges; such a setup couldn't be automatically managed by Teleport, and thus would require detailed documentation and some care.
+
+## Session storage (wip)
+
+Azure Blob Storage offers similar functionality to S3, including all we need for `lib/events.MultipartUploader` in the strictest sense. In addition to that, it's possible to configure containers (the equivalent of a S3 bucket) to have a time-based immutability policy that prevents moving, renaming, overwriting or deleting a blob for a fixed amount of time after it's first written, which seems to be exactly what we're currently using versioning for.
+
+Similarly to other cloud-based session storage, it would be configured like this (details pending):
+
+```yaml
+teleport:
+  storage:
+    ...
+
+    audit_sessions_uri: "azblob://accountname.blob.core.windows.net/containername"
+```

--- a/rfd/0084-azure-backend.md
+++ b/rfd/0084-azure-backend.md
@@ -135,7 +135,7 @@ teleport:
     audit_sessions_uri: "azblob://accountname.blob.core.windows.net"
 ```
 
-Other configuration options, if required, will be passed in as query parameters in the URI, like the other session storage backends.
+It's possible to specify a client ID for a managed identity (to allow for different identities to be used for backend, events and sessions, as opposed to setting the `AZURE_CLIENT_ID` envvar and using the default credentials) by specifying a URL fragment of `#azure_client_id=11111111-2222-3333-4444-555555555555`. The `azblob` schema is only used by Teleport to identify the storage backend, and will actually result in a `https` URL. For testing against simulators (or other services with the same API surface) over `http`, the `azblob-http` schema is also supported (but we should probably leave it undocumented for end users).
 
 Teleport will require access to two containers in the storage account, named `session`, which will store the completed session files, and `inprogress`, which will be used as temporary space to hold parts.
 

--- a/rfd/0084-azure-backend.md
+++ b/rfd/0084-azure-backend.md
@@ -14,9 +14,9 @@ state: draft
 
 Enable users to leverage Azure-native services as a Teleport backend.
 We will accomplish this by:
-- Add support for Azure IAM authentication to the existing Postgres backend
-- Add audit log capabilities to the `sqlbk`/Postgres backend
-- Add a session uploader that uses Azure Blob Storage (with the same IAM authentication)
+- adding support for Azure IAM authentication to the existing Postgres backend
+- adding audit log capabilities to the `sqlbk`/Postgres backend
+- adding a session uploader that uses Azure Blob Storage (with the same or similar IAM authentication)
 
 ## Why
 

--- a/rfd/0084-azure-backend.md
+++ b/rfd/0084-azure-backend.md
@@ -96,7 +96,7 @@ Additional security could be provided by only granting `INSERT` (and `SELECT`) p
 
 Azure Blob Storage offers similar functionality to S3, including all we need for `lib/events.MultipartUploader` in the strictest sense. In addition to that, it's possible to configure containers (the equivalent of a S3 bucket) to have a time-based immutability policy that prevents moving, renaming, overwriting or deleting a blob for a fixed amount of time after it's first written, which seems to be exactly what we're currently using versioning for.
 
-Similarly to other cloud-based session storage, it would be configured like this, specifying a storage account URL, replacing the `https` schema with `azblob`; an (undocumented?) alternate `azblob-http` schema will be provided to use an endpoint without encryption, for local development.
+Similarly to other cloud-based session storage, the configuration looks like this, specifying a storage account URL.
 
 ```yaml
 teleport:

--- a/rfd/0084-azure-backend.md
+++ b/rfd/0084-azure-backend.md
@@ -32,9 +32,7 @@ As using Postgres as the backend storage for Teleport has been possible (in Prev
 
 ### Configuration
 
-This are some options on how the configuration side might look like.
-
-The original SQL Backend RFD imagined something like:
+Following the idea in the original SQL Backend RFD, the configuration is as such:
 
 ```yaml
 teleport:
@@ -48,36 +46,7 @@ teleport:
       username: pgusername@pgservername
 ```
 
-Alternatively, we could provide additional aliases for the Postgres backend:
-
-```yaml
-teleport:
-  storage:
-    type: azurepostgres
-    addr: pgservername.postgres.database.azure.com
-    username: pgusername@pgservername
-    database: dbname_defaulting_to_teleport
-    tls:
-      ca_file: path/to/azure_postgres_trust_roots.pem
-```
-
-Or we could add some "authentication type" field:
-
-```yaml
-teleport:
-  storage:
-    type: postgres
-    addr: pgservername.postgres.database.azure.com
-    username: pgusername@pgservername
-    database: dbname_defaulting_to_teleport
-    authentication: azure
-    tls:
-      ca_file: path/to/azure_postgres_trust_roots.pem
-```
-
-Other options such as checking for the `.postgres.database.azure.com` suffix in the hostname seem a bit too fragile.
-
-Authentication will happen according to the default behavior of [the Azure Go SDK](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity), which will try to use credentials from envvars, from the IDMS accessible from Azure VMs, and from the command-line `az` tool - it would be straightforward to add some tunables to the configuration file if some specific need arose in the future.
+Authentication will happen according to the default behavior of [the Azure Go SDK](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity), which will try to use credentials from envvars, from the IDMS accessible from Azure VMs, and from the command-line `az` tool. If the optional parameter `client_id` is specified under `azure:`, only authentication using credentials from the matching managed identity will be attempted (to allow for different client IDs to be specified for different services).
 
 ## Audit log
 

--- a/rfd/0084-azure-backend.md
+++ b/rfd/0084-azure-backend.md
@@ -68,7 +68,7 @@ CREATE INDEX ON audit (time, event, sid, ei);
 
 We'll have to make sure to leave the SQL backend schema and the SQL audit log schema compatible, so that they can use the same database and credentials, for ease of setup.
 
-Configuration will be something like the following:
+Configuration will be something like the following for static credentials:
 
 ```yaml
 teleport:
@@ -78,15 +78,17 @@ teleport:
     audit_events_uri: ['postgres://host:123/database?sslmode=verify-full&sslrootcert=cafile&sslcert=certfile&sslkey=keyfile']
 ```
 
-IAM authentication in such case would require some bespoke parameter in the query or fragment of the URI:
+And for Azure IAM authentication:
 
 ```yaml
 teleport:
   storage:
     ...
 
-    audit_events_uri: ['postgres://host:123/database?sslmode=verify-full&sslrootcert=cafile&user=pgusername%40pgservername#auth=azure']
+    audit_events_uri: ['postgres://host:123/database?sslmode=verify-full&sslrootcert=cafile&user=pgusername@pgservername&auth_mode=azure']
 ```
+
+Optionally, the `azure_client_id` parameter can also be specified, to define which managed identity to use.
 
 Additional security could be provided by only granting `INSERT` (and `SELECT`) privileges to the Postgres user on the table that stores audit events, but not `UPDATE` or `DELETE` privileges; such a setup couldn't be automatically managed by Teleport, and thus would require detailed documentation and some care.
 

--- a/rfd/0084-azure-backend.md
+++ b/rfd/0084-azure-backend.md
@@ -107,7 +107,7 @@ teleport:
     audit_events_uri: ['backend://']
 ```
 
-With the relevant `ClusterAuditConfigSpecV2` options such as `audit_retention_period` that affect all audit logs being specified in the usual way, and future tunables for the backend-adjacent audit log being added either as extra options for the audit-aware backend or in the URI.
+with the relevant `ClusterAuditConfigSpecV2` options such as `audit_retention_period` that affect all audit logs being specified in the usual way, and future tunables for the backend-adjacent audit log being added either as extra options for the audit-aware backend or in the URI. An `audit_events_uri` that contains a `backend://` will result in an error if the configured backend cannot act as storage for the audit log.
 
 If we decide to go for a setup in which the audit log is completely independent of the backend storage, we could just specify a URI with all the relevant options and open a whole new connection pool for it:
 

--- a/rfd/0084-azure-backend.md
+++ b/rfd/0084-azure-backend.md
@@ -83,7 +83,19 @@ Authentication will happen according to the default behavior of [the Azure Go SD
 
 The current two cloud storage options (DynamoDB on AWS and Firestore on GCP) can store both the auth backend and the events in the audit log. For user convenience, we'll implement audit log storage for the `sqlbk`/Postgres backend - an alternative would be to store the audit log in Cosmos DB, but that would require that our users set up both a Postgres server and a Cosmos DB account. As a bonus, this storage option will also be usable outside of Azure.
 
-An `audit` table will be added to the current db schema, with indices on a `time` field and an optional `sid` field.
+An `audit` table will be added to the current database schema:
+```pgsql
+CREATE TABLE audit (
+    count BIGSERIAL PRIMARY KEY,
+    time TIMESTAMP NOT NULL,
+    event TEXT NOT NULL,
+    sid UUID,
+    ei BIGINT NOT NULL,
+    data JSONB,
+    UNIQUE (sid, ei)
+);
+CREATE INDEX ON audit (time, event, sid, ei);
+```
 
 Assuming it's fine to store the log in the same database as the backend, a minimal configuration could be as simple as:
 


### PR DESCRIPTION
Tracking issue: https://github.com/gravitational/teleport/issues/15147

Open questions (postgres):
- How do we reconcile ease of setup (Teleport creating its own table and index) vs. security (Teleport only granted SELECT and INSERT permissions over the audit table)?

Open questions (blob storage):
- Should the container names be configurable?
- Should we specify an immutability policy "by hand" whenever we complete a blob, so it's configurable via Teleport?

Fixes https://github.com/gravitational/teleport/issues/15147