### PR TITLE
Deflake TestEC2Hostname

### DIFF
--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -457,19 +457,5 @@ func TestEC2Hostname(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, proc.Start())
 	t.Cleanup(func() { require.NoError(t, proc.Close()) })
-
-	ctx := context.Background()
-	authServer := proc.GetAuthServer()
-	var node types.Server
-	require.Eventually(t, func() bool {
-		nodes, err := authServer.GetNodes(ctx, tconf.SSH.Namespace)
-		require.NoError(t, err)
-		if len(nodes) == 1 {
-			node = nodes[0]
-			return true
-		}
-		return false
-	}, 10*time.Second, time.Second)
-
-	require.Equal(t, teleportHostname, node.GetHostname())
+	require.Equal(t, teleportHostname, proc.Config.Hostname)
 }


### PR DESCRIPTION
`TestEC2Hostname` was the top failing integration test last week. This PR removes its dependency on having an actual node - the test does not actually need to wait for the node to start up, it should be enough to just make sure that the EC2 label hostname was set in the Teleport config during service initialization. This also speeds up the test a little bit.