### PR TITLE
[v9] Fix an issue `tsh aws s3` fails when using path with special characters

### DIFF
--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -26,8 +26,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
@@ -39,8 +42,8 @@ func TestHandleAWSAccessSigVerification(t *testing.T) {
 		firstAWSCred  = credentials.NewStaticCredentials("userID", "firstSecret", "")
 		secondAWSCred = credentials.NewStaticCredentials("userID", "secondSecret", "")
 
-		awsRegion  = "s3"
-		awsService = "eu-central-1"
+		awsService = "s3"
+		awsRegion  = "eu-central-1"
 	)
 
 	testCases := []struct {
@@ -86,7 +89,7 @@ func TestHandleAWSAccessSigVerification(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.originCred != nil {
-				v4.NewSigner(tc.originCred).Sign(req, pr, awsRegion, awsService, time.Now())
+				v4.NewSigner(tc.originCred).Sign(req, pr, awsService, awsRegion, time.Now())
 			}
 
 			resp, err := http.DefaultClient.Do(req)
@@ -95,6 +98,34 @@ func TestHandleAWSAccessSigVerification(t *testing.T) {
 			require.NoError(t, resp.Body.Close())
 		})
 	}
+
+	// Verifies s3 requests are signed without URL escaping to match AWS SDKs.
+	t.Run("disable URI escape when signing s3", func(t *testing.T) {
+		lp := createAWSAccessProxySuite(t, firstAWSCred)
+
+		// Avoid loading extra things.
+		t.Setenv("AWS_SDK_LOAD_CONFIG", "false")
+
+		// Create a real AWS SDK s3 client.
+		awsConfig := aws.NewConfig().
+			WithDisableSSL(true).
+			WithRegion(awsRegion).
+			WithCredentials(firstAWSCred).
+			WithEndpoint(lp.GetAddr()).
+			WithS3ForcePathStyle(true)
+
+		session, err := session.NewSession(awsConfig)
+		require.NoError(t, err)
+
+		s3client := s3.New(session)
+
+		// Use a bucket name with special charaters. AWS SDK actually signs the
+		// request with the unescaped bucket name.
+		_, err = s3client.ListObjects(&s3.ListObjectsInput{
+			Bucket: aws.String("=bucket=name="),
+		})
+		require.NoError(t, err)
+	})
 }
 
 func createAWSAccessProxySuite(t *testing.T, cred *credentials.Credentials) *LocalProxy {

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -98,34 +98,34 @@ func TestHandleAWSAccessSigVerification(t *testing.T) {
 			require.NoError(t, resp.Body.Close())
 		})
 	}
+}
 
-	// Verifies s3 requests are signed without URL escaping to match AWS SDKs.
-	t.Run("disable URI escape when signing s3", func(t *testing.T) {
-		lp := createAWSAccessProxySuite(t, firstAWSCred)
+// Verifies s3 requests are signed without URL escaping to match AWS SDKs.
+func TestHandleAWSAccessS3Signing(t *testing.T) {
+	cred := credentials.NewStaticCredentials("access-key", "secret-key", "")
+	lp := createAWSAccessProxySuite(t, cred)
 
-		// Avoid loading extra things.
-		t.Setenv("AWS_SDK_LOAD_CONFIG", "false")
+	// Avoid loading extra things.
+	t.Setenv("AWS_SDK_LOAD_CONFIG", "false")
 
-		// Create a real AWS SDK s3 client.
-		awsConfig := aws.NewConfig().
-			WithDisableSSL(true).
-			WithRegion(awsRegion).
-			WithCredentials(firstAWSCred).
-			WithEndpoint(lp.GetAddr()).
-			WithS3ForcePathStyle(true)
+	// Create a real AWS SDK s3 client.
+	awsConfig := aws.NewConfig().
+		WithDisableSSL(true).
+		WithRegion("local").
+		WithCredentials(cred).
+		WithEndpoint(lp.GetAddr()).
+		WithS3ForcePathStyle(true)
 
-		session, err := session.NewSession(awsConfig)
-		require.NoError(t, err)
+	s3client := s3.New(session.Must(session.NewSession(awsConfig)))
 
-		s3client := s3.New(session)
-
-		// Use a bucket name with special charaters. AWS SDK actually signs the
-		// request with the unescaped bucket name.
-		_, err = s3client.ListObjects(&s3.ListObjectsInput{
-			Bucket: aws.String("=bucket=name="),
-		})
-		require.NoError(t, err)
+	// Use a bucket name with special charaters. AWS SDK actually signs the
+	// request with the unescaped bucket name.
+	_, err := s3client.ListObjects(&s3.ListObjectsInput{
+		Bucket: aws.String("=bucket=name="),
 	})
+
+	// Our signature verification should succeed to match what AWS SDK signs.
+	require.NoError(t, err)
 }
 
 func createAWSAccessProxySuite(t *testing.T, cred *credentials.Credentials) *LocalProxy {

--- a/lib/srv/app/aws/handler.go
+++ b/lib/srv/app/aws/handler.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
-	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/gravitational/oxy/forward"
 	"github.com/gravitational/oxy/utils"
 	"github.com/gravitational/trace"
@@ -188,7 +187,7 @@ func (s *SigningService) prepareSignedRequest(r *http.Request, re *endpoints.Res
 	}
 	rewriteHeaders(r, reqCopy)
 	// Sign the copy of the request.
-	signer := v4.NewSigner(s.getSigningCredentials(s.Session, sessionCtx))
+	signer := awsutils.NewSigner(s.getSigningCredentials(s.Session, sessionCtx), re.SigningName)
 	_, err = signer.Sign(reqCopy, bytes.NewReader(payload), re.SigningName, re.SigningRegion, s.Clock.Now())
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/utils/aws/aws.go
+++ b/lib/utils/aws/aws.go
@@ -201,10 +201,10 @@ func VerifyAWSSignature(req *http.Request, credentials *credentials.Credentials)
 // NewSigner creates a new V4 signer.
 func NewSigner(credentials *credentials.Credentials, signingServiceName string) *v4.Signer {
 	options := func(s *v4.Signer) {
-		// Service s3 and s3control sign with URL unescaped. Both services use
-		// "s3" as signing name.
-		//
-		// https://github.com/aws/aws-sdk-go/blob/d4f5f556a9fb0bdca8da5e52f752b7fba6bedce5/aws/signer/v4/v4.go#L182-L189
+		// s3 and s3control requests are signed with URL unescaped (found by
+		// searching "DisableURIPathEscaping" in "aws-sdk-go/service"). Both
+		// services use "s3" as signing name. See description of
+		// "DisableURIPathEscaping" for more details.
 		if signingServiceName == "s3" {
 			s.DisableURIPathEscaping = true
 		}


### PR DESCRIPTION
Backport #15784 to branch/v9