### PR TITLE
Refactor bpf/restrictedsession usage in lib/srv

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -38,6 +38,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	controlgroup "github.com/gravitational/teleport/lib/cgroup"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/srv"
 
 	"github.com/gravitational/trace"
 	"github.com/gravitational/ttlmap"
@@ -53,24 +54,24 @@ const ArgsCacheSize = 1024
 // SessionWatch is a map of cgroup IDs that the BPF service is watching and
 // emitting events for.
 type SessionWatch struct {
-	watch map[uint64]*SessionContext
+	watch map[uint64]*srv.ServerContext
 	mu    sync.Mutex
 }
 
 func NewSessionWatch() SessionWatch {
 	return SessionWatch{
-		watch: make(map[uint64]*SessionContext),
+		watch: make(map[uint64]*srv.ServerContext),
 	}
 }
 
-func (w *SessionWatch) Get(cgoupID uint64) (ctx *SessionContext, ok bool) {
+func (w *SessionWatch) Get(cgoupID uint64) (ctx *srv.ServerContext, ok bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	ctx, ok = w.watch[cgoupID]
 	return
 }
 
-func (w *SessionWatch) Add(cgroupID uint64, ctx *SessionContext) {
+func (w *SessionWatch) Add(cgroupID uint64, ctx *srv.ServerContext) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -210,13 +211,14 @@ func (s *Service) Close() error {
 
 // OpenSession will place a process within a cgroup and being monitoring all
 // events from that cgroup and emitting the results to the audit log.
-func (s *Service) OpenSession(ctx *SessionContext) (uint64, error) {
-	err := s.cgroup.Create(ctx.SessionID)
+func (s *Service) OpenSession(ctx *srv.ServerContext) (uint64, error) {
+	sessionID := ctx.SessionID()
+	err := s.cgroup.Create(sessionID.String())
 	if err != nil {
 		return 0, trace.Wrap(err)
 	}
 
-	cgroupID, err := s.cgroup.ID(ctx.SessionID)
+	cgroupID, err := s.cgroup.ID(sessionID.String())
 	if err != nil {
 		return 0, trace.Wrap(err)
 	}
@@ -225,7 +227,7 @@ func (s *Service) OpenSession(ctx *SessionContext) (uint64, error) {
 	s.watch.Add(cgroupID, ctx)
 
 	// Place requested PID into cgroup.
-	err = s.cgroup.Place(ctx.SessionID, ctx.PID)
+	err = s.cgroup.Place(sessionID.String(), ctx.GetPID())
 	if err != nil {
 		return 0, trace.Wrap(err)
 	}
@@ -235,8 +237,9 @@ func (s *Service) OpenSession(ctx *SessionContext) (uint64, error) {
 
 // CloseSession will stop monitoring events from a particular cgroup and
 // remove the cgroup.
-func (s *Service) CloseSession(ctx *SessionContext) error {
-	cgroupID, err := s.cgroup.ID(ctx.SessionID)
+func (s *Service) CloseSession(ctx *srv.ServerContext) error {
+	sessionID := ctx.SessionID()
+	cgroupID, err := s.cgroup.ID(sessionID.String())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -246,7 +249,7 @@ func (s *Service) CloseSession(ctx *SessionContext) error {
 
 	// Move all PIDs to the root cgroup and remove the cgroup created for this
 	// session.
-	err = s.cgroup.Remove(ctx.SessionID)
+	err = s.cgroup.Remove(sessionID.String())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -294,7 +297,7 @@ func (s *Service) emitCommandEvent(eventBytes []byte) {
 	}
 
 	// If the command event is not being monitored, don't process it.
-	_, ok = ctx.Events[constants.EnhancedRecordingCommand]
+	_, ok = ctx.Identity.AccessChecker.EnhancedRecordingSet()[constants.EnhancedRecordingCommand]
 	if !ok {
 		return
 	}
@@ -326,21 +329,22 @@ func (s *Service) emitCommandEvent(eventBytes []byte) {
 		argv := args.([]string)
 
 		// Emit "command" event.
+		sessionID := ctx.SessionID()
 		sessionCommandEvent := &apievents.SessionCommand{
 			Metadata: apievents.Metadata{
 				Type: events.SessionCommandEvent,
 				Code: events.SessionCommandCode,
 			},
 			ServerMetadata: apievents.ServerMetadata{
-				ServerID:        ctx.ServerID,
-				ServerNamespace: ctx.Namespace,
+				ServerID:        ctx.GetServer().HostUUID(),
+				ServerNamespace: ctx.GetServer().GetNamespace(),
 			},
 			SessionMetadata: apievents.SessionMetadata{
-				SessionID: ctx.SessionID,
+				SessionID: sessionID.String(),
 			},
 			UserMetadata: apievents.UserMetadata{
-				User:  ctx.User,
-				Login: ctx.Login,
+				User:  ctx.Identity.TeleportUser,
+				Login: ctx.Identity.Login,
 			},
 			BPFMetadata: apievents.BPFMetadata{
 				CgroupID: event.CgroupID,
@@ -352,7 +356,7 @@ func (s *Service) emitCommandEvent(eventBytes []byte) {
 			Path:       argv[0],
 			Argv:       argv[1:],
 		}
-		if err := ctx.Emitter.EmitAuditEvent(ctx.Context, sessionCommandEvent); err != nil {
+		if err := ctx.StreamWriter().EmitAuditEvent(ctx.Context, sessionCommandEvent); err != nil {
 			log.WithError(err).Warn("Failed to emit command event.")
 		}
 
@@ -378,26 +382,27 @@ func (s *Service) emitDiskEvent(eventBytes []byte) {
 	}
 
 	// If the network event is not being monitored, don't process it.
-	_, ok = ctx.Events[constants.EnhancedRecordingDisk]
+	_, ok = ctx.Identity.AccessChecker.EnhancedRecordingSet()[constants.EnhancedRecordingDisk]
 	if !ok {
 		return
 	}
 
+	sessionID := ctx.SessionID()
 	sessionDiskEvent := &apievents.SessionDisk{
 		Metadata: apievents.Metadata{
 			Type: events.SessionDiskEvent,
 			Code: events.SessionDiskCode,
 		},
 		ServerMetadata: apievents.ServerMetadata{
-			ServerID:        ctx.ServerID,
-			ServerNamespace: ctx.Namespace,
+			ServerID:        ctx.GetServer().HostUUID(),
+			ServerNamespace: ctx.GetServer().GetNamespace(),
 		},
 		SessionMetadata: apievents.SessionMetadata{
-			SessionID: ctx.SessionID,
+			SessionID: sessionID.String(),
 		},
 		UserMetadata: apievents.UserMetadata{
-			User:  ctx.User,
-			Login: ctx.Login,
+			User:  ctx.Identity.TeleportUser,
+			Login: ctx.Identity.Login,
 		},
 		BPFMetadata: apievents.BPFMetadata{
 			CgroupID: event.CgroupID,
@@ -409,7 +414,7 @@ func (s *Service) emitDiskEvent(eventBytes []byte) {
 		ReturnCode: event.ReturnCode,
 	}
 	// Logs can be DoS by event failures here
-	_ = ctx.Emitter.EmitAuditEvent(ctx.Context, sessionDiskEvent)
+	_ = ctx.StreamWriter().EmitAuditEvent(ctx.Context, sessionDiskEvent)
 }
 
 // emit4NetworkEvent will parse and emit IPv4 events to the Audit Log.
@@ -429,7 +434,7 @@ func (s *Service) emit4NetworkEvent(eventBytes []byte) {
 	}
 
 	// If the network event is not being monitored, don't process it.
-	_, ok = ctx.Events[constants.EnhancedRecordingNetwork]
+	_, ok = ctx.Identity.AccessChecker.EnhancedRecordingSet()[constants.EnhancedRecordingNetwork]
 	if !ok {
 		return
 	}
@@ -444,21 +449,22 @@ func (s *Service) emit4NetworkEvent(eventBytes []byte) {
 	binary.LittleEndian.PutUint32(dst, event.DstAddr)
 	dstAddr := net.IP(dst)
 
+	sessionID := ctx.SessionID()
 	sessionNetworkEvent := &apievents.SessionNetwork{
 		Metadata: apievents.Metadata{
 			Type: events.SessionNetworkEvent,
 			Code: events.SessionNetworkCode,
 		},
 		ServerMetadata: apievents.ServerMetadata{
-			ServerID:        ctx.ServerID,
-			ServerNamespace: ctx.Namespace,
+			ServerID:        ctx.GetServer().HostUUID(),
+			ServerNamespace: ctx.GetServer().GetNamespace(),
 		},
 		SessionMetadata: apievents.SessionMetadata{
-			SessionID: ctx.SessionID,
+			SessionID: sessionID.String(),
 		},
 		UserMetadata: apievents.UserMetadata{
-			User:  ctx.User,
-			Login: ctx.Login,
+			User:  ctx.Identity.TeleportUser,
+			Login: ctx.Identity.Login,
 		},
 		BPFMetadata: apievents.BPFMetadata{
 			CgroupID: event.CgroupID,
@@ -470,7 +476,7 @@ func (s *Service) emit4NetworkEvent(eventBytes []byte) {
 		SrcAddr:    srcAddr.String(),
 		TCPVersion: 4,
 	}
-	if err := ctx.Emitter.EmitAuditEvent(ctx.Context, sessionNetworkEvent); err != nil {
+	if err := ctx.StreamWriter().EmitAuditEvent(ctx.Context, sessionNetworkEvent); err != nil {
 		log.WithError(err).Warn("Failed to emit network event.")
 	}
 }
@@ -492,7 +498,7 @@ func (s *Service) emit6NetworkEvent(eventBytes []byte) {
 	}
 
 	// If the network event is not being monitored, don't process it.
-	_, ok = ctx.Events[constants.EnhancedRecordingNetwork]
+	_, ok = ctx.Identity.AccessChecker.EnhancedRecordingSet()[constants.EnhancedRecordingNetwork]
 	if !ok {
 		return
 	}
@@ -513,21 +519,22 @@ func (s *Service) emit6NetworkEvent(eventBytes []byte) {
 	binary.LittleEndian.PutUint32(dst[12:], event.DstAddr[3])
 	dstAddr := net.IP(dst)
 
+	sessionID := ctx.SessionID()
 	sessionNetworkEvent := &apievents.SessionNetwork{
 		Metadata: apievents.Metadata{
 			Type: events.SessionNetworkEvent,
 			Code: events.SessionNetworkCode,
 		},
 		ServerMetadata: apievents.ServerMetadata{
-			ServerID:        ctx.ServerID,
-			ServerNamespace: ctx.Namespace,
+			ServerID:        ctx.GetServer().HostUUID(),
+			ServerNamespace: ctx.GetServer().GetNamespace(),
 		},
 		SessionMetadata: apievents.SessionMetadata{
-			SessionID: ctx.SessionID,
+			SessionID: sessionID.String(),
 		},
 		UserMetadata: apievents.UserMetadata{
-			User:  ctx.User,
-			Login: ctx.Login,
+			User:  ctx.Identity.TeleportUser,
+			Login: ctx.Identity.Login,
 		},
 		BPFMetadata: apievents.BPFMetadata{
 			CgroupID: event.CgroupID,
@@ -539,7 +546,7 @@ func (s *Service) emit6NetworkEvent(eventBytes []byte) {
 		SrcAddr:    srcAddr.String(),
 		TCPVersion: 6,
 	}
-	if err := ctx.Emitter.EmitAuditEvent(ctx.Context, sessionNetworkEvent); err != nil {
+	if err := ctx.StreamWriter().EmitAuditEvent(ctx.Context, sessionNetworkEvent); err != nil {
 		log.WithError(err).Warn("Failed to emit network event.")
 	}
 }

--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -34,16 +34,26 @@ import (
 	"unsafe"
 
 	"github.com/gravitational/teleport/api/constants"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv"
 
 	"github.com/aquasecurity/libbpfgo"
-	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+type terminal struct {
+	srv.Terminal
+	pid int
+}
+
+func (t terminal) PID() int {
+	return t.pid
+}
 
 func TestRootWatch(t *testing.T) {
 	// TODO(jakule): Find a way to run this test in CI. Disable for now to not block all BPF tests.
@@ -79,22 +89,22 @@ func TestRootWatch(t *testing.T) {
 	err = cmd.Start()
 	require.NoError(t, err)
 
-	// Create a monitoring session for init. The events we execute should not
-	// have PID 1, so nothing should be captured in the Audit Log.
-	cgroupID, err := service.OpenSession(&SessionContext{
-		Namespace: apidefaults.Namespace,
-		SessionID: uuid.New().String(),
-		ServerID:  uuid.New().String(),
-		Login:     "foo",
-		User:      "foo@example.com",
-		PID:       cmd.Process.Pid,
-		Emitter:   emitter,
-		Events: map[string]bool{
-			constants.EnhancedRecordingCommand: true,
-			constants.EnhancedRecordingDisk:    true,
-			constants.EnhancedRecordingNetwork: true,
+	server := srv.NewMockServer(t)
+	server.MockEmitter = emitter
+
+	role, err := types.NewRole("bpf", types.RoleSpecV5{
+		Options: types.RoleOptions{
+			BPF: []string{constants.EnhancedRecordingCommand, constants.EnhancedRecordingDisk, constants.EnhancedRecordingNetwork},
 		},
 	})
+	require.NoError(t, err)
+
+	srvctx := srv.NewTestServerContext(t, server, services.NewRoleSet(role))
+	srvctx.SetTerm(terminal{pid: os.Getpid()})
+
+	// Create a monitoring session for init. The events we execute should not
+	// have PID 1, so nothing should be captured in the Audit Log.
+	cgroupID, err := service.OpenSession(srvctx)
 	require.NoError(t, err)
 	require.Greater(t, cgroupID, 0)
 

--- a/lib/bpf/common.go
+++ b/lib/bpf/common.go
@@ -22,11 +22,9 @@ package bpf
 import "C"
 
 import (
-	"context"
-
 	"github.com/gravitational/teleport/api/constants"
-	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -38,48 +36,13 @@ import (
 type BPF interface {
 	// OpenSession will start monitoring all events within a session and
 	// emitting them to the Audit Log.
-	OpenSession(ctx *SessionContext) (uint64, error)
+	OpenSession(ctx *srv.ServerContext) (uint64, error)
 
 	// CloseSession will stop monitoring events for a particular session.
-	CloseSession(ctx *SessionContext) error
+	CloseSession(ctx *srv.ServerContext) error
 
 	// Close will stop any running BPF programs.
 	Close() error
-}
-
-// SessionContext contains all the information needed to track and emit
-// events for a particular session. Most of this information is already within
-// srv.ServerContext, unfortunately due to circular imports with lib/srv and
-// lib/bpf, part of that structure is reproduced in SessionContext.
-type SessionContext struct {
-	// Context is a cancel context, scoped to a server, and not a session.
-	Context context.Context
-
-	// Namespace is the namespace within which this session occurs.
-	Namespace string
-
-	// SessionID is the UUID of the given session.
-	SessionID string
-
-	// ServerID is the UUID of the server this session is executing on.
-	ServerID string
-
-	// Login is the Unix login for this session.
-	Login string
-
-	// User is the Teleport user.
-	User string
-
-	// PID is the process ID of Teleport when it re-executes itself. This is
-	// used by Teleport to find itself by cgroup.
-	PID int
-
-	// Emitter is used to record events for a particular session
-	Emitter apievents.Emitter
-
-	// Events is the set of events (command, disk, or network) to record for
-	// this session.
-	Events map[string]bool
 }
 
 // Config holds configuration for the BPF service.
@@ -122,8 +85,7 @@ func (c *Config) CheckAndSetDefaults() error {
 }
 
 // NOP is used on either non-Linux systems or when BPF support is not enabled.
-type NOP struct {
-}
+type NOP struct{}
 
 // Close closes the NOP service. Note this function does nothing.
 func (s *NOP) Close() error {
@@ -131,12 +93,12 @@ func (s *NOP) Close() error {
 }
 
 // OpenSession opens a NOP session. Note this function does nothing.
-func (s *NOP) OpenSession(_ *SessionContext) (uint64, error) {
+func (s *NOP) OpenSession(_ *srv.ServerContext) (uint64, error) {
 	return 0, nil
 }
 
 // CloseSession closes a NOP session. Note this function does nothing.
-func (s *NOP) CloseSession(_ *SessionContext) error {
+func (s *NOP) CloseSession(_ *srv.ServerContext) error {
 	return nil
 }
 

--- a/lib/bpf/helper.go
+++ b/lib/bpf/helper.go
@@ -218,7 +218,7 @@ func (c *Counter) Close() {
 }
 
 func (c *Counter) loop() {
-	for _ = range c.doorbellCh {
+	for range c.doorbellCh {
 		var key int32 = 0
 		cntBytes, err := c.arr.GetValue(unsafe.Pointer(&key))
 		if err != nil {

--- a/lib/restrictedsession/manager.go
+++ b/lib/restrictedsession/manager.go
@@ -18,8 +18,8 @@ package restrictedsession
 
 import (
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv"
 )
 
 // RestrictionsWatcherClient is used by changeset to fetch a list
@@ -32,20 +32,20 @@ type RestrictionsWatcherClient interface {
 // Manager starts and stop enforcing restrictions for a given session.
 type Manager interface {
 	// OpenSession starts enforcing restrictions for a cgroup with cgroupID
-	OpenSession(ctx *bpf.SessionContext, cgroupID uint64)
+	OpenSession(ctx *srv.ServerContext, cgroupID uint64)
 	// CloseSession stops enforcing restrictions for a cgroup with cgroupID
-	CloseSession(ctx *bpf.SessionContext, cgroupID uint64)
+	CloseSession(ctx *srv.ServerContext, cgroupID uint64)
 	// Close stops the manager, cleaning up any resources
 	Close()
 }
 
-// Stubbed out Manager interface for cases where the real thing is not used.
+// NOP is a stubbed implementation of Manager for cases where the real thing is not used.
 type NOP struct{}
 
-func (NOP) OpenSession(ctx *bpf.SessionContext, cgroupID uint64) {
+func (NOP) OpenSession(ctx *srv.ServerContext, cgroupID uint64) {
 }
 
-func (NOP) CloseSession(ctx *bpf.SessionContext, cgroupID uint64) {
+func (NOP) CloseSession(ctx *srv.ServerContext, cgroupID uint64) {
 }
 
 func (NOP) UpdateNetworkRestrictions(r *NetworkRestrictions) error {

--- a/lib/restrictedsession/restricted.go
+++ b/lib/restrictedsession/restricted.go
@@ -27,13 +27,14 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/aquasecurity/libbpfgo"
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/aquasecurity/libbpfgo"
 	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/gravitational/teleport/lib/srv"
 )
 
 var log = logrus.WithFields(logrus.Fields{
@@ -163,7 +164,7 @@ func (m *sessionMgr) Close() {
 
 // OpenSession inserts the cgroupID into the BPF hash map to enable
 // enforcement by the kernel
-func (m *sessionMgr) OpenSession(ctx *bpf.SessionContext, cgroupID uint64) {
+func (m *sessionMgr) OpenSession(ctx *srv.ServerContext, cgroupID uint64) {
 	m.watch.Add(cgroupID, ctx)
 
 	key := make([]byte, 8)
@@ -176,7 +177,7 @@ func (m *sessionMgr) OpenSession(ctx *bpf.SessionContext, cgroupID uint64) {
 
 // CloseSession removes the cgroupID from the BPF hash map to enable
 // enforcement by the kernel
-func (m *sessionMgr) CloseSession(ctx *bpf.SessionContext, cgroupID uint64) {
+func (m *sessionMgr) CloseSession(ctx *srv.ServerContext, cgroupID uint64) {
 	key := make([]byte, 8)
 	binary.LittleEndian.PutUint64(key, cgroupID)
 
@@ -291,7 +292,7 @@ func (l *auditEventLoop) loop() {
 			continue
 		}
 
-		if err = ctx.Emitter.EmitAuditEvent(ctx.Context, event); err != nil {
+		if err = ctx.StreamWriter().EmitAuditEvent(ctx.Context, event); err != nil {
 			log.WithError(err).Warn("Failed to emit network event.")
 		}
 	}

--- a/lib/restrictedsession/restricted_test.go
+++ b/lib/restrictedsession/restricted_test.go
@@ -30,17 +30,16 @@ import (
 	"testing"
 	"time"
 
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	api "github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/utils"
 
 	go_cmp "github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,7 +63,7 @@ const (
 
 var (
 	testRanges = []blockedRange{
-		blockedRange{
+		{
 			ver:   4,
 			allow: "39.156.69.70/28",
 			deny:  "39.156.69.71",
@@ -77,7 +76,7 @@ var (
 				"72.156.69.80": denied,
 			},
 		},
-		blockedRange{
+		{
 			ver:   4,
 			allow: "77.88.55.88",
 			probe: map[string]blockAction{
@@ -87,7 +86,7 @@ var (
 				"67.88.55.86": denied,
 			},
 		},
-		blockedRange{
+		{
 			ver:   6,
 			allow: "39.156.68.48/28",
 			deny:  "39.156.68.48/31",
@@ -101,7 +100,7 @@ var (
 				"::ffff:72.156.68.80": denied,
 			},
 		},
-		blockedRange{
+		{
 			ver:   6,
 			allow: "fc80::/64",
 			deny:  "fc80::10/124",
@@ -114,7 +113,7 @@ var (
 				"fc60:0:0:1::": denied,
 			},
 		},
-		blockedRange{
+		{
 			ver:   6,
 			allow: "2607:f8b0:4005:80a::200e",
 			probe: map[string]blockAction{
@@ -130,7 +129,7 @@ var (
 type bpfContext struct {
 	cgroupDir        string
 	cgroupID         uint64
-	ctx              *bpf.SessionContext
+	ctx              *srv.ServerContext
 	enhancedRecorder bpf.BPF
 	restrictedMgr    Manager
 	srcAddrs         map[int]string
@@ -138,6 +137,15 @@ type bpfContext struct {
 	// Audit events emitted by us
 	emitter             eventstest.MockEmitter
 	expectedAuditEvents []apievents.AuditEvent
+}
+
+type terminal struct {
+	srv.Terminal
+	pid int
+}
+
+func (t terminal) PID() int {
+	return t.pid
 }
 
 func setupBPFContext(t *testing.T) *bpfContext {
@@ -168,25 +176,24 @@ func setupBPFContext(t *testing.T) *bpfContext {
 	})
 	require.NoError(t, err)
 
-	// Create the SessionContext used by both enhanced recording and us (restricted session)
-	tt.ctx = &bpf.SessionContext{
-		Namespace: apidefaults.Namespace,
-		SessionID: uuid.New().String(),
-		ServerID:  uuid.New().String(),
-		Login:     "foo",
-		User:      "foo@example.com",
-		PID:       os.Getpid(),
-		Emitter:   &tt.emitter,
-		Events:    map[string]bool{},
-	}
+	server := srv.NewMockServer(t)
+	server.MockEmitter = &tt.emitter
+
+	role, err := api.NewRole("restricted", api.RoleSpecV5{})
+	require.NoError(t, err)
+
+	srvctx := srv.NewTestServerContext(t, server, services.NewRoleSet(role))
+	srvctx.SetTerm(terminal{pid: os.Getpid()})
+
+	tt.ctx = srvctx
 
 	// Create enhanced recording session to piggy-back on.
 	tt.cgroupID, err = tt.enhancedRecorder.OpenSession(tt.ctx)
 	require.NoError(t, err)
 	require.Equal(t, tt.cgroupID > 0, true)
 
-	deny := []api.AddressCondition{}
-	allow := []api.AddressCondition{}
+	var deny []api.AddressCondition
+	var allow []api.AddressCondition
 	for _, r := range testRanges {
 		if len(r.deny) > 0 {
 			deny = append(deny, api.AddressCondition{CIDR: r.deny})
@@ -294,26 +301,27 @@ func (tt *bpfContext) sendExpectDeny(t *testing.T, ver int, ip string) {
 }
 
 func (tt *bpfContext) expectedAuditEvent(ver int, ip string, op apievents.SessionNetwork_NetworkOperation) apievents.AuditEvent {
+	sessionID := tt.ctx.SessionID()
 	return &apievents.SessionNetwork{
 		Metadata: apievents.Metadata{
 			Type: events.SessionNetworkEvent,
 			Code: events.SessionNetworkCode,
 		},
 		ServerMetadata: apievents.ServerMetadata{
-			ServerID:        tt.ctx.ServerID,
-			ServerNamespace: tt.ctx.Namespace,
+			ServerID:        tt.ctx.GetServer().HostUUID(),
+			ServerNamespace: tt.ctx.GetServer().GetNamespace(),
 		},
 		SessionMetadata: apievents.SessionMetadata{
-			SessionID: tt.ctx.SessionID,
+			SessionID: sessionID.String(),
 		},
 		UserMetadata: apievents.UserMetadata{
-			User:  tt.ctx.User,
-			Login: tt.ctx.Login,
+			User:  tt.ctx.Identity.TeleportUser,
+			Login: tt.ctx.Identity.Login,
 		},
 		BPFMetadata: apievents.BPFMetadata{
 			CgroupID: tt.cgroupID,
 			Program:  "restrictedsessi",
-			PID:      uint64(tt.ctx.PID),
+			PID:      uint64(tt.ctx.GetPID()),
 		},
 		DstPort:    testPort,
 		DstAddr:    ip,
@@ -337,7 +345,7 @@ func TestRootNetwork(t *testing.T) {
 		expected blockAction
 	}
 
-	tests := []testCase{}
+	var tests []testCase
 	for _, r := range testRanges {
 		for ip, expected := range r.probe {
 			tests = append(tests, testCase{

--- a/lib/srv/ctx_test.go
+++ b/lib/srv/ctx_test.go
@@ -19,14 +19,15 @@ package srv
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCheckFileCopyingAllowed(t *testing.T) {
-	srv := newMockServer(t)
-	ctx := newTestServerContext(t, srv, nil)
+	srv := NewMockServer(t)
+	ctx := NewTestServerContext(t, srv, nil)
 
 	tests := []struct {
 		name                 string

--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -29,8 +29,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
@@ -51,7 +52,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestOSCommandPrep(t *testing.T) {
-	srv := newMockServer(t)
+	srv := NewMockServer(t)
 	scx := newExecServerContext(t, srv)
 
 	usr, err := user.Current()
@@ -134,7 +135,7 @@ func TestOSCommandPrep(t *testing.T) {
 // TestContinue tests if the process hangs if a continue signal is not sent
 // and makes sure the process continues once it has been sent.
 func TestContinue(t *testing.T) {
-	srv := newMockServer(t)
+	srv := NewMockServer(t)
 	scx := newExecServerContext(t, srv)
 
 	// Configure Session Context to re-exec "ls".

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -23,11 +23,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
 	"github.com/gravitational/teleport"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/sshutils"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ssh"
 )
 
 // TestEmitExecAuditEvent make sure the full command and exit code for a
@@ -35,7 +36,7 @@ import (
 func TestEmitExecAuditEvent(t *testing.T) {
 	t.Parallel()
 
-	srv := newMockServer(t)
+	srv := NewMockServer(t)
 	scx := newExecServerContext(t, srv)
 
 	expectedUsr, err := user.Current()
@@ -110,7 +111,7 @@ func TestLoginDefsParser(t *testing.T) {
 }
 
 func newExecServerContext(t *testing.T, srv Server) *ServerContext {
-	scx := newTestServerContext(t, srv, nil)
+	scx := NewTestServerContext(t, srv, nil)
 
 	term, err := newLocalTerminal(scx)
 	require.NoError(t, err)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -279,14 +279,25 @@ func (s *Server) UseTunnel() bool {
 	return s.useTunnel
 }
 
-// GetBPF returns the BPF service used by enhanced session recording.
-func (s *Server) GetBPF() bpf.BPF {
-	return s.ebpf
+// OpenBPFSession will start monitoring all events within a session and
+// emitting them to the Audit Log.
+func (s *Server) OpenBPFSession(ctx *srv.ServerContext) (uint64, error) {
+	return s.ebpf.OpenSession(ctx)
 }
 
-// GetRestrictedSessionManager returns the manager for restricting user activity.
-func (s *Server) GetRestrictedSessionManager() restricted.Manager {
-	return s.restrictedMgr
+// CloseBPFSession will stop monitoring events for a particular session.
+func (s *Server) CloseBPFSession(ctx *srv.ServerContext) error {
+	return s.ebpf.CloseSession(ctx)
+}
+
+// OpenRestrictedSession  starts enforcing restrictions for a cgroup with cgroupID
+func (s *Server) OpenRestrictedSession(ctx *srv.ServerContext, cgroupID uint64) {
+	s.restrictedMgr.OpenSession(ctx, cgroupID)
+}
+
+// CloseRestrictedSession stops enforcing restrictions for a cgroup with cgroupID
+func (s *Server) CloseRestrictedSession(ctx *srv.ServerContext, cgroupID uint64) {
+	s.restrictedMgr.CloseSession(ctx, cgroupID)
 }
 
 // GetLockWatcher gets the server's lock watcher.

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -125,7 +125,7 @@ func TestSession_newRecorder(t *testing.T) {
 				log: logger,
 				registry: &SessionRegistry{
 					SessionRegistryConfig: SessionRegistryConfig{
-						Srv: &mockServer{
+						Srv: &MockServer{
 							component: teleport.ComponentNode,
 						},
 					},
@@ -148,7 +148,7 @@ func TestSession_newRecorder(t *testing.T) {
 				log: logger,
 				registry: &SessionRegistry{
 					SessionRegistryConfig: SessionRegistryConfig{
-						Srv: &mockServer{
+						Srv: &MockServer{
 							component: teleport.ComponentNode,
 						},
 					},
@@ -171,7 +171,7 @@ func TestSession_newRecorder(t *testing.T) {
 				log: logger,
 				registry: &SessionRegistry{
 					SessionRegistryConfig: SessionRegistryConfig{
-						Srv: &mockServer{
+						Srv: &MockServer{
 							component: teleport.ComponentNode,
 						},
 					},
@@ -179,7 +179,7 @@ func TestSession_newRecorder(t *testing.T) {
 			},
 			sctx: &ServerContext{
 				SessionRecordingConfig: nodeRecording,
-				srv: &mockServer{
+				srv: &MockServer{
 					component: teleport.ComponentNode,
 				},
 			},
@@ -193,7 +193,7 @@ func TestSession_newRecorder(t *testing.T) {
 				log: logger,
 				registry: &SessionRegistry{
 					SessionRegistryConfig: SessionRegistryConfig{
-						Srv: &mockServer{
+						Srv: &MockServer{
 							component: teleport.ComponentNode,
 						},
 					},
@@ -201,7 +201,7 @@ func TestSession_newRecorder(t *testing.T) {
 			},
 			sctx: &ServerContext{
 				SessionRecordingConfig: nodeRecordingSync,
-				srv: &mockServer{
+				srv: &MockServer{
 					component: teleport.ComponentNode,
 				},
 				Identity: IdentityContext{
@@ -231,7 +231,7 @@ func TestSession_newRecorder(t *testing.T) {
 				log: logger,
 				registry: &SessionRegistry{
 					SessionRegistryConfig: SessionRegistryConfig{
-						Srv: &mockServer{
+						Srv: &MockServer{
 							component: teleport.ComponentNode,
 						},
 					},
@@ -240,7 +240,7 @@ func TestSession_newRecorder(t *testing.T) {
 			sctx: &ServerContext{
 				ClusterName:            "test",
 				SessionRecordingConfig: nodeRecordingSync,
-				srv: &mockServer{
+				srv: &MockServer{
 					component: teleport.ComponentNode,
 				},
 				Identity: IdentityContext{
@@ -275,7 +275,7 @@ func TestSession_newRecorder(t *testing.T) {
 				log: logger,
 				registry: &SessionRegistry{
 					SessionRegistryConfig: SessionRegistryConfig{
-						Srv: &mockServer{
+						Srv: &MockServer{
 							component: teleport.ComponentNode,
 						},
 					},
@@ -284,7 +284,7 @@ func TestSession_newRecorder(t *testing.T) {
 			sctx: &ServerContext{
 				ClusterName:            "test",
 				SessionRecordingConfig: nodeRecordingSync,
-				srv: &mockServer{
+				srv: &MockServer{
 					MockEmitter: &eventstest.MockEmitter{},
 				},
 			},
@@ -315,7 +315,7 @@ func TestSession_emitAuditEvent(t *testing.T) {
 	})
 
 	t.Run("FallbackConcurrency", func(t *testing.T) {
-		srv := newMockServer(t)
+		srv := NewMockServer(t)
 		reg, err := NewSessionRegistry(SessionRegistryConfig{
 			Srv:                   srv,
 			SessionTrackerService: srv.auth,
@@ -328,7 +328,7 @@ func TestSession_emitAuditEvent(t *testing.T) {
 			log:      logger,
 			recorder: &mockRecorder{done: true},
 			registry: reg,
-			scx:      newTestServerContext(t, srv, nil),
+			scx:      NewTestServerContext(t, srv, nil),
 		}
 
 		controlCh := make(chan struct{})
@@ -355,7 +355,7 @@ func TestSession_emitAuditEvent(t *testing.T) {
 // Multiple sessions are opened in parallel tests to test for
 // deadlocks between session registry, sessions, and parties.
 func TestInteractiveSession(t *testing.T) {
-	srv := newMockServer(t)
+	srv := NewMockServer(t)
 	srv.component = teleport.ComponentNode
 
 	reg, err := NewSessionRegistry(SessionRegistryConfig{
@@ -384,7 +384,7 @@ func TestInteractiveSession(t *testing.T) {
 // TestStopUnstarted tests that a session may be stopped before it launches.
 func TestStopUnstarted(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise, TestFeatures: modules.Features{ModeratedSessions: true}})
-	srv := newMockServer(t)
+	srv := NewMockServer(t)
 	srv.component = teleport.ComponentNode
 
 	reg, err := NewSessionRegistry(SessionRegistryConfig{
@@ -426,7 +426,7 @@ func TestStopUnstarted(t *testing.T) {
 func TestParties(t *testing.T) {
 	t.Parallel()
 
-	srv := newMockServer(t)
+	srv := NewMockServer(t)
 	srv.component = teleport.ComponentNode
 
 	// Use a separate clock from srv so we can use BlockUntil.
@@ -498,7 +498,7 @@ func TestParties(t *testing.T) {
 }
 
 func testJoinSession(t *testing.T, reg *SessionRegistry, sess *session) {
-	scx := newTestServerContext(t, reg.Srv, nil)
+	scx := NewTestServerContext(t, reg.Srv, nil)
 	scx.setSession(sess)
 
 	// Open a new session
@@ -532,7 +532,7 @@ func TestSessionRecordingModes(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			srv := newMockServer(t)
+			srv := NewMockServer(t)
 			srv.component = teleport.ComponentNode
 
 			reg, err := NewSessionRegistry(SessionRegistryConfig{
@@ -601,7 +601,7 @@ func TestSessionRecordingModes(t *testing.T) {
 }
 
 func testOpenSession(t *testing.T, reg *SessionRegistry, roleSet services.RoleSet) (*session, ssh.Channel) {
-	scx := newTestServerContext(t, reg.Srv, roleSet)
+	scx := NewTestServerContext(t, reg.Srv, roleSet)
 
 	// Open a new session
 	sshChanOpen := newMockSSHChannel()


### PR DESCRIPTION
Invert the relationship of `lib/srv` and `lib/bpf`,
`lib/restrictedsession` such that `lib/bpf` is only imported in
`lib/srv/regular`. Since not everything is built with the `bpf`
tag it's important to reduce the surface area of `lib/bpf` such
that it isn't inadvertantly imported. For instance it was entirely
possible to import a package in `tsh` that transitively
depends on `lib/bpf` - which breaks the build since `tsh` is not
compiled with the `bpf` tag.

By refactoring the `srv.Server` interface not to use the `bpf.BPF`
and `restrictedsession.Manager` interfaces directly anything that
imports `lib/srv` now won't require that `-tags=bpf` is set in
order to compile.