### PR TITLE
Remove TestMux/Timeout reliance on real time

### DIFF
--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -300,16 +300,17 @@ func TestMux(t *testing.T) {
 		require.NotNil(t, err)
 	})
 
-	// Timeout tests client timeout - client dials, but writes nothing
-	// make sure server hangs up
+	// Timeout test makes sure that multiplexer respects read deadlines.
 	t.Run("Timeout", func(t *testing.T) {
 		t.Parallel()
 		listener, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 
 		config := Config{
-			Listener:            listener,
-			ReadDeadline:        time.Millisecond,
+			Listener: listener,
+			// Set read deadline in the past to remove reliance on real time
+			// and simulate scenario when read deadline has elapsed.
+			ReadDeadline:        -time.Millisecond,
 			EnableProxyProtocol: true,
 		}
 		mux, err := New(config)
@@ -334,9 +335,6 @@ func TestMux(t *testing.T) {
 		conn, err := net.Dial("tcp", parsedURL.Host)
 		require.NoError(t, err)
 		defer conn.Close()
-
-		// sleep until well after the deadline
-		time.Sleep(config.ReadDeadline + 50*time.Millisecond)
 
 		// upgrade connection to TLS
 		tlsConn := tls.Client(conn, clientConfig(backend1))


### PR DESCRIPTION
`TestMux/Timeout` is one of the most commonly failing unit tests and it relies on real time.

This change removes its dependency on short timeouts/deadlines which are very prone to flakiness by setting the read deadline in the past ensuring that client request will fail and eliminating the need for sleep.

Another approach would be to try and mock the connection/listener that multiplexer uses to explicitly handle deadlines but it's much more involved solution so I wasn't sure we wanna go that route - in my opinion setting deadline in the past still verifies what the test is testing quite well - it makes sure that read deadlines are respected.
