### PR TITLE
Apply linters to legacy protos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ ssh.config
 # Go workspace files
 go.work
 go.work.sum
+
+# Buf side-effects
+/github.com

--- a/Makefile
+++ b/Makefile
@@ -902,18 +902,16 @@ protos/build: buf/installed
 	$(BUF) build
 	cd lib/teleterm && $(BUF) build
 
-# TODO(codingllama): Uncomment lib/teleterm lines.
 .PHONY: protos/format
 protos/format: buf/installed
 	$(BUF) format -w
-	#cd lib/teleterm && $(BUF) format -w
+	cd lib/teleterm && $(BUF) format -w
 
-# TODO(codingllama): Uncomment lib/teleterm lines.
 .PHONY: protos/lint
 protos/lint: buf/installed
 	$(BUF) lint
 	cd api/proto && $(BUF) lint --config=buf-legacy.yaml
-	#cd lib/teleterm && buf lint
+	cd lib/teleterm && $(BUF) lint
 
 .PHONY: lint-protos
 lint-protos: protos/lint
@@ -956,9 +954,8 @@ grpc-teleterm:
 # grpc-teleterm/host generates GRPC stubs.
 # Unlike grpc-teleterm, this target runs locally.
 .PHONY: grpc-teleterm/host
-# TODO(codingllama): Depend on protos/all here too.
-grpc-teleterm/host:
-	cd lib/teleterm && buf build && buf lint && buf format -w && buf generate
+grpc-teleterm/host: protos/all
+	cd lib/teleterm && $(BUF) generate
 
 .PHONY: goinstall
 goinstall:

--- a/api/proto/buf-legacy.yaml
+++ b/api/proto/buf-legacy.yaml
@@ -1,0 +1,24 @@
+version: v1
+deps:
+  # gogo/protobuf v1.3.2, keep in sync with build.assets/Makefile.
+  - buf.build/gogo/protobuf:b03c65ea87cdc3521ede29f62fe3ce239267c1bc
+lint:
+  use:
+    - DEFAULT
+  except:
+    # MINIMAL
+    - PACKAGE_DIRECTORY_MATCH
+    # BASIC
+    - ENUM_VALUE_UPPER_SNAKE_CASE
+    - FIELD_LOWER_SNAKE_CASE
+    - ONEOF_LOWER_SNAKE_CASE
+    # DEFAULT
+    - ENUM_VALUE_PREFIX
+    - ENUM_ZERO_VALUE_SUFFIX
+    - PACKAGE_VERSION_SUFFIX
+    - RPC_REQUEST_RESPONSE_UNIQUE
+    - RPC_REQUEST_STANDARD_NAME
+    - RPC_RESPONSE_STANDARD_NAME
+breaking:
+  use:
+    - FILE

--- a/build.assets/genproto.sh
+++ b/build.assets/genproto.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 #
-# Builds, formats, lints and generates protos for teleport and teleport/api.
+# Generates protos for Teleport and Teleport API.
 set -eu
 
 main() {
   cd "$(dirname "$0")"  # ./build-assets/
   cd ../                # teleport root
-
-  buf build
-  buf lint
-  buf format -w
 
   # Generated protos are written to
   # <teleport-root>/github.com/gravitational/teleport/..., so we copy them to

--- a/build.assets/genproto.sh
+++ b/build.assets/genproto.sh
@@ -10,11 +10,10 @@ main() {
   # Generated protos are written to
   # <teleport-root>/github.com/gravitational/teleport/..., so we copy them to
   # the correct relative path.
+  trap 'rm -fr github.com' EXIT   # don't leave github.com/ behind
+  rm -fr api/gen/proto gen/proto  # cleanup gen/proto folders
   buf generate
-  find github.com -name '*.pb.go' | while read -r f; do
-    mv "$f" "${f#github.com/gravitational/teleport/}"
-  done
-  rm -fr github.com/  # Remove empty generated root.
+  cp -r github.com/gravitational/teleport/* .
 }
 
 main "$@"


### PR DESCRIPTION
Applies linters to legacy protos and adds a few additional Makefile targets to make it easier to manage protos locally.

Proto linters now run in CI.

#15187