### PR TITLE
Find outdated Go Modules in CI

### DIFF
--- a/.cloudbuild/ci/lint.yaml
+++ b/.cloudbuild/ci/lint.yaml
@@ -1,6 +1,6 @@
 steps:
   - name: public.ecr.aws/gravitational/teleport-buildbox:teleport11
     id: lint
-    args: ['make', 'lint']
+    args: ['make', 'lint-diff', 'lint']
 options:
   machineType: 'E2_HIGHCPU_32'

--- a/Makefile
+++ b/Makefile
@@ -779,6 +779,15 @@ fix-license: $(ADDLICENSE)
 $(ADDLICENSE):
 	cd && go install github.com/google/addlicense@v1.0.0
 
+# lint-diff runs targets that potentially modify the workspace and fails if
+# changes are present.
+.PHONY: lint-diff
+lint-diff: lint-diff/gomod
+
+.PHONY: lint-diff/gomod
+lint-diff/gomod:
+	@build.assets/diff_gomod.sh
+
 # This rule triggers re-generation of version files if Makefile changes.
 .PHONY: version
 version: $(VERSRC)

--- a/build.assets/diff_gomod.sh
+++ b/build.assets/diff_gomod.sh
@@ -8,6 +8,10 @@ main() {
     pushd "$d" >/dev/null
     go mod tidy
     if [[ -n "$(git status --porcelain)" ]]; then
+      # Print status and diff to allow easier debugging.
+      git status --porcelain >&2
+      git diff "$f" >&2
+
       echo -e "Found untidy Go Module at $f." \
         "Please run the following command in your workspace try again:"\
         "\n\tcd $d && go mod tidy" >&2

--- a/build.assets/diff_gomod.sh
+++ b/build.assets/diff_gomod.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu
+
+main() {
+  find . -name go.mod | while read -r f; do
+    local d=''
+    d="$(dirname "$f")"
+    pushd "$d" >/dev/null
+    go mod tidy
+    if [[ -n "$(git status --porcelain)" ]]; then
+      echo -e "Found untidy Go Module at $f." \
+        "Please run the following command in your workspace try again:"\
+        "\n\tcd $d && go mod tidy" >&2
+      exit 1
+    fi
+    popd >/dev/null
+  done
+}
+
+main "$@"


### PR DESCRIPTION
Break the lint pipeline if outdated Go Modules are found. Helps keeping modules up-to-date and triggers early failures for other potentially confusing problems (such as golangci-lint failures).