### PR TITLE
[v9] Remove deprecated upsert password endpoint (#15855)

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -122,7 +122,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	// Passwords and sessions
 	srv.POST("/:version/users", srv.withAuth(srv.upsertUser))
 	srv.PUT("/:version/users/:user/web/password", srv.withAuth(srv.changePassword))
-	srv.POST("/:version/users/:user/web/password", srv.withAuth(srv.upsertPassword))
 	srv.POST("/:version/users/:user/web/password/check", srv.withRate(srv.withAuth(srv.checkPassword)))
 	srv.POST("/:version/users/:user/web/sessions", srv.withAuth(srv.createWebSession))
 	srv.POST("/:version/users/:user/web/authenticate", srv.withAuth(srv.authenticateWebUser))
@@ -852,25 +851,6 @@ func (s *APIServer) changePassword(auth ClientI, w http.ResponseWriter, r *http.
 	}
 
 	return message(fmt.Sprintf("password has been changed for user %q", req.User)), nil
-}
-
-type upsertPasswordReq struct {
-	Password string `json:"password"`
-}
-
-func (s *APIServer) upsertPassword(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	var req *upsertPasswordReq
-	if err := httplib.ReadJSON(r, &req); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	user := p.ByName("user")
-	err := auth.UpsertPassword(user, []byte(req.Password))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return message(fmt.Sprintf("password for for user %q upserted", user)), nil
 }
 
 type upsertUserRawReq struct {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -271,7 +271,6 @@ func (a *ServerWithRoles) CreateSessionTracker(ctx context.Context, tracker type
 		return nil, trace.Wrap(err)
 	}
 	return tracker, nil
-
 }
 
 func (a *ServerWithRoles) filterSessionTracker(ctx context.Context, joinerRoles []types.Role, tracker types.SessionTracker) bool {
@@ -1547,13 +1546,6 @@ func (a *ServerWithRoles) UpsertToken(ctx context.Context, token types.Provision
 		return trace.Wrap(err)
 	}
 	return a.authServer.UpsertToken(ctx, token)
-}
-
-func (a *ServerWithRoles) UpsertPassword(user string, password []byte) error {
-	if err := a.currentUserAction(user); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.UpsertPassword(user, password)
 }
 
 // ChangePassword updates users password based on the old password.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -950,21 +950,6 @@ func (c *Client) GetU2FAppID() (string, error) {
 	return appid, nil
 }
 
-// UpsertPassword updates web access password for the user
-func (c *Client) UpsertPassword(user string, password []byte) error {
-	_, err := c.PostJSON(
-		context.TODO(),
-		c.Endpoint("users", user, "web", "password"),
-		upsertPasswordReq{
-			Password: string(password),
-		})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
-}
-
 // UpsertUser user updates user entry.
 func (c *Client) UpsertUser(user types.User) error {
 	data, err := services.MarshalUser(user)
@@ -1092,8 +1077,8 @@ func (c *Client) GenerateKeyPair(pass string) ([]byte, []byte, error) {
 // plain text format, signs it using Host Certificate Authority private key and returns the
 // resulting certificate.
 func (c *Client) GenerateHostCert(
-	key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error) {
-
+	key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration,
+) ([]byte, error) {
 	out, err := c.PostJSON(context.TODO(), c.Endpoint("ca", "host", "certs"),
 		generateHostCertReq{
 			Key:         key,
@@ -1747,9 +1732,6 @@ type WebService interface {
 
 // IdentityService manages identities and users
 type IdentityService interface {
-	// UpsertPassword updates web access password for the user
-	UpsertPassword(user string, password []byte) error
-
 	// UpsertOIDCConnector updates or creates OIDC connector
 	UpsertOIDCConnector(ctx context.Context, connector types.OIDCConnector) error
 

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1026,18 +1026,20 @@ func (s *TLSSuite) TestReverseTunnelsCRUD(c *check.C) {
 }
 
 func (s *TLSSuite) TestUsersCRUD(c *check.C) {
+	ctx := context.Background()
 	clt, err := s.server.NewClient(TestAdmin())
 	c.Assert(err, check.IsNil)
 
-	err = clt.UpsertPassword("user1", []byte("some pass"))
+	usr, err := types.NewUser("user1")
 	c.Assert(err, check.IsNil)
+	c.Assert(clt.CreateUser(ctx, usr), check.IsNil)
 
 	users, err := clt.GetUsers(false)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(users), check.Equals, 1)
 	c.Assert(users[0].GetName(), check.Equals, "user1")
 
-	c.Assert(clt.DeleteUser(context.TODO(), "user1"), check.IsNil)
+	c.Assert(clt.DeleteUser(ctx, "user1"), check.IsNil)
 
 	users, err = clt.GetUsers(false)
 	c.Assert(err, check.IsNil)
@@ -1069,8 +1071,8 @@ func (s *TLSSuite) TestPasswordCRUD(c *check.C) {
 	err = clt.CheckPassword("user1", pass, "123456")
 	c.Assert(err, check.NotNil)
 
-	err = clt.UpsertPassword("user1", pass)
-	c.Assert(err, check.IsNil)
+	err = s.server.Auth().UpsertPassword("user1", pass)
+	c.Assert(err, check.NotNil)
 
 	dev, err := services.NewTOTPDevice("otp", otpSecret, s.clock.Now())
 	c.Assert(err, check.IsNil)
@@ -1172,7 +1174,7 @@ func makeSessionRecording(sessionID string, serverID string) (io.Reader, error) 
 
 	hdr := &tar.Header{
 		Name: fmt.Sprintf("%v-0.events.gz", sessionID),
-		Mode: 0600,
+		Mode: 0o600,
 		Size: int64(zbuf.Len()),
 	}
 	err = tw.WriteHeader(hdr)
@@ -1288,7 +1290,7 @@ func (s *TLSSuite) TestSharedSessions(c *check.C) {
 
 	// emit two events: "one" and "two" for this session, and event "three"
 	// for some other session
-	err = os.MkdirAll(filepath.Join(uploadDir, "upload", "sessions", apidefaults.Namespace), 0755)
+	err = os.MkdirAll(filepath.Join(uploadDir, "upload", "sessions", apidefaults.Namespace), 0o755)
 	c.Assert(err, check.IsNil)
 	forwarder, err := events.NewForwarder(events.ForwarderConfig{
 		Namespace:      apidefaults.Namespace,
@@ -1412,6 +1414,8 @@ func (s *TLSSuite) TestSharedSessions(c *check.C) {
 }
 
 func (s *TLSSuite) TestOTPCRUD(c *check.C) {
+	ctx := context.Background()
+
 	clt, err := s.server.NewClient(TestAdmin())
 	c.Assert(err, check.IsNil)
 
@@ -1421,11 +1425,10 @@ func (s *TLSSuite) TestOTPCRUD(c *check.C) {
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
 	// upsert a password and totp secret
-	err = clt.UpsertPassword("user1", pass)
+	err = s.server.Auth().UpsertPassword("user1", pass)
 	c.Assert(err, check.IsNil)
 	dev, err := services.NewTOTPDevice("otp", otpSecret, s.clock.Now())
 	c.Assert(err, check.IsNil)
-	ctx := context.Background()
 	err = s.server.Auth().UpsertMFADevice(ctx, user, dev)
 	c.Assert(err, check.IsNil)
 
@@ -1484,7 +1487,7 @@ func (s *TLSSuite) TestWebSessionWithoutAccessRequest(c *check.C) {
 	_, err = proxy.AuthenticateWebUser(ctx, req)
 	fixtures.ExpectAccessDenied(c, err)
 
-	err = clt.UpsertPassword(user, pass)
+	err = s.server.Auth().UpsertPassword(user, pass)
 	c.Assert(err, check.IsNil)
 
 	// success with password set up
@@ -1546,7 +1549,7 @@ func (s *TLSSuite) TestWebSessionWithApprovedAccessRequestAndSwitchback(c *check
 		},
 	}
 
-	err = clt.UpsertPassword(user, pass)
+	err = s.server.Auth().UpsertPassword(user, pass)
 	c.Assert(err, check.IsNil)
 
 	ws, err := proxy.AuthenticateWebUser(ctx, req)
@@ -2619,7 +2622,7 @@ func (s *TLSSuite) TestLoginAttempts(c *check.C) {
 	proxy, err := s.server.NewClient(TestBuiltin(types.RoleProxy))
 	c.Assert(err, check.IsNil)
 
-	err = clt.UpsertPassword(user, pass)
+	err = s.server.Auth().UpsertPassword(user, pass)
 	c.Assert(err, check.IsNil)
 
 	req := AuthenticateUserRequest{
@@ -2712,7 +2715,7 @@ func (s *TLSSuite) TestLoginNoLocalAuth(c *check.C) {
 	c.Assert(err, check.IsNil)
 	_, _, err = CreateUserAndRole(clt, user, []string{user})
 	c.Assert(err, check.IsNil)
-	err = clt.UpsertPassword(user, pass)
+	err = s.server.Auth().UpsertPassword(user, pass)
 	c.Assert(err, check.IsNil)
 
 	// Set auth preference to disallow local auth.


### PR DESCRIPTION
* remove UpsertPassword endpoint from Auth HTTP API server

* fix merge

* Fix TestUsersCRUD