### PR TITLE
Add retries on operation denied in fido2

### DIFF
--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -703,10 +703,14 @@ func withRetries(callback deviceCallbackFunc) deviceCallbackFunc {
 			if err == nil {
 				return err
 			}
-
-			// Important: errors mapped by go-libfido2 aren't returned as
-			// libfido2.Error, instead they have their own specialized (string-based)
-			// constants.
+			// Handle errors mapped by go-libfido2.
+			// ErrOperationDenied happens when fingerprint reading fails (UV=false).
+			if errors.Is(err, libfido2.ErrOperationDenied) {
+				fmt.Println("Gesture validation failed, make sure you use registered fingerprint")
+				log.Debug("FIDO2: Retrying libfido2 error 'operation denied'")
+				continue
+			}
+			// Handle generic libfido2.Error instances.
 			var fidoErr libfido2.Error
 			if !errors.As(err, &fidoErr) {
 				return err

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -706,7 +706,7 @@ func withRetries(callback deviceCallbackFunc) deviceCallbackFunc {
 			// Handle errors mapped by go-libfido2.
 			// ErrOperationDenied happens when fingerprint reading fails (UV=false).
 			if errors.Is(err, libfido2.ErrOperationDenied) {
-				fmt.Println("Gesture validation failed, make sure you use registered fingerprint")
+				fmt.Println("Gesture validation failed, make sure you use a registered fingerprint")
 				log.Debug("FIDO2: Retrying libfido2 error 'operation denied'")
 				continue
 			}

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -722,7 +722,9 @@ func withRetries(callback deviceCallbackFunc) deviceCallbackFunc {
 				const msg = "" +
 					"The user verification function in your security key is blocked. " +
 					"This is likely due to too many failed authentication attempts. " +
-					"Consult your manufacturer documentation for how to unblock your security key."
+					"Consult your manufacturer documentation for how to unblock your security key. " +
+					"Alternatively, you may unblock your device by using it in the Web UI."
+
 				return trace.Wrap(err, msg)
 			case 63: // FIDO_ERR_UV_INVALID, 0x3f
 				log.Debug("FIDO2: Retrying libfido2 error 63")

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -1072,6 +1072,14 @@ func TestFIDO2Login_bioErrorHandling(t *testing.T) {
 			},
 			wantMsg: "libfido2 error 63",
 		},
+		{
+			name: "retry on operation denied",
+			setAssertionErrors: func() {
+				bio.assertionErrors = []error{
+					libfido2.ErrOperationDenied,
+				}
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -1076,6 +1076,8 @@ func TestFIDO2Login_bioErrorHandling(t *testing.T) {
 			name: "retry on operation denied",
 			setAssertionErrors: func() {
 				bio.assertionErrors = []error{
+					// Note: this happens only for UV=false assertions. UV=true failures
+					// return error 63.
 					libfido2.ErrOperationDenied,
 				}
 			},


### PR DESCRIPTION
Fixes issue when gesture validation failes using biometric key (for example using different fingerprint) by adding retry and user msg.
Fido2 library returns `ErrOperationDenied` in that scenario when `UV` is not set. 
