### PR TITLE
docs: Fix link to standalone Kubernetes guide in chart reference

### DIFF
--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -22,7 +22,7 @@ The `teleport-cluster` chart can be deployed in four different modes. Get starte
 
 | `chartMode` | Guide |
 | - | - |
-| `standalone` | [Getting Started - Kubernetes with SSO](../helm-deployments/aws.mdx) |
+| `standalone` | [Getting Started - Kubernetes with SSO](../../getting-started/kubernetes-cluster.mdx) |
 | `aws` | [Running an HA Teleport cluster using an AWS EKS Cluster](../helm-deployments/aws.mdx) |
 | `gcp` | [Running an HA Teleport cluster using a Google Cloud GKE cluster](../helm-deployments/gcp.mdx) |
 | `custom` | [Running a Teleport cluster with a custom config](../helm-deployments/custom.mdx) |


### PR DESCRIPTION
Looks like the link got munged during a refactor.