### PR TITLE
[v10] Apply linters to legacy protos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ ssh.config
 # Go workspace files
 go.work
 go.work.sum
+
+# Buf side-effects
+/github.com

--- a/Makefile
+++ b/Makefile
@@ -641,7 +641,7 @@ integration-root: $(TEST_LOG_DIR) $(RENDER_TESTS)
 # changes (or last commit).
 #
 .PHONY: lint
-lint: lint-sh lint-helm lint-api lint-go lint-license lint-rust lint-tools
+lint: lint-sh lint-helm lint-api lint-go lint-license lint-rust lint-tools lint-protos
 
 .PHONY: lint-tools
 lint-tools: lint-build-tooling lint-bot lint-ci-scripts lint-backport
@@ -884,6 +884,40 @@ enter/centos7:
 enter/teleterm:
 	make -C build.assets enter/teleterm
 
+
+BUF := buf
+
+# protos/all runs build, lint and format on all protos.
+# Use `make grpc` to regenerate protos inside buildbox.
+.PHONY: protos/all
+protos/all: protos/build protos/lint protos/format
+
+.PHONY: protos/build
+protos/build: buf/installed
+	$(BUF) build
+	cd lib/teleterm && $(BUF) build
+
+.PHONY: protos/format
+protos/format: buf/installed
+	$(BUF) format -w
+	cd lib/teleterm && $(BUF) format -w
+
+.PHONY: protos/lint
+protos/lint: buf/installed
+	$(BUF) lint
+	cd api/proto && $(BUF) lint --config=buf-legacy.yaml
+	cd lib/teleterm && $(BUF) lint
+
+.PHONY: lint-protos
+lint-protos: protos/lint
+
+.PHONY: buf/installed
+buf/installed:
+	@if ! type -p $(BUF) >/dev/null; then \
+		echo 'Buf is required to build/format/lint protos. Follow https://docs.buf.build/installation.'; \
+		exit 1; \
+	fi
+
 # grpc generates GRPC stubs from service definitions.
 # This target runs in the buildbox container.
 .PHONY: grpc
@@ -893,7 +927,7 @@ grpc:
 # grpc/host generates GRPC stubs.
 # Unlike grpc, this target runs locally.
 .PHONY: grpc/host
-grpc/host:
+grpc/host: protos/all
 	@build.assets/genproto.sh
 
 print/env:
@@ -915,8 +949,8 @@ grpc-teleterm:
 # grpc-teleterm/host generates GRPC stubs.
 # Unlike grpc-teleterm, this target runs locally.
 .PHONY: grpc-teleterm/host
-grpc-teleterm/host:
-	cd lib/teleterm && buf build && buf lint && buf format -w && buf generate
+grpc-teleterm/host: protos/all
+	cd lib/teleterm && $(BUF) generate
 
 .PHONY: goinstall
 goinstall:

--- a/api/proto/buf-legacy.yaml
+++ b/api/proto/buf-legacy.yaml
@@ -1,0 +1,24 @@
+version: v1
+deps:
+  # gogo/protobuf v1.3.2, keep in sync with build.assets/Makefile.
+  - buf.build/gogo/protobuf:b03c65ea87cdc3521ede29f62fe3ce239267c1bc
+lint:
+  use:
+    - DEFAULT
+  except:
+    # MINIMAL
+    - PACKAGE_DIRECTORY_MATCH
+    # BASIC
+    - ENUM_VALUE_UPPER_SNAKE_CASE
+    - FIELD_LOWER_SNAKE_CASE
+    - ONEOF_LOWER_SNAKE_CASE
+    # DEFAULT
+    - ENUM_VALUE_PREFIX
+    - ENUM_ZERO_VALUE_SUFFIX
+    - PACKAGE_VERSION_SUFFIX
+    - RPC_REQUEST_RESPONSE_UNIQUE
+    - RPC_REQUEST_STANDARD_NAME
+    - RPC_RESPONSE_STANDARD_NAME
+breaking:
+  use:
+    - FILE

--- a/build.assets/genproto.sh
+++ b/build.assets/genproto.sh
@@ -1,24 +1,19 @@
 #!/bin/bash
 #
-# Builds, formats, lints and generates protos for teleport and teleport/api.
+# Generates protos for Teleport and Teleport API.
 set -eu
 
 main() {
   cd "$(dirname "$0")"  # ./build-assets/
   cd ../                # teleport root
 
-  buf build
-  buf lint
-  buf format -w
-
   # Generated protos are written to
   # <teleport-root>/github.com/gravitational/teleport/..., so we copy them to
   # the correct relative path.
+  trap 'rm -fr github.com' EXIT   # don't leave github.com/ behind
+  rm -fr api/gen/proto gen/proto  # cleanup gen/proto folders
   buf generate
-  find github.com -name '*.pb.go' | while read -r f; do
-    mv "$f" "${f#github.com/gravitational/teleport/}"
-  done
-  rm -fr github.com/  # Remove empty generated root.
+  cp -r github.com/gravitational/teleport/* .
 }
 
 main "$@"


### PR DESCRIPTION
Applies linters to legacy protos and adds a few additional Makefile targets to
make it easier to manage protos locally.

Proto linters now run in CI.

#15187

Backport #15879 to branch/v10