### PR TITLE
Prevent ssh.Session SendRequest from wrapping payload twice

### DIFF
--- a/api/observability/tracing/ssh/session.go
+++ b/api/observability/tracing/ssh/session.go
@@ -49,7 +49,9 @@ func (s *Session) SendRequest(ctx context.Context, name string, wantReply bool, 
 	)
 	defer span.End()
 
-	return s.Session.SendRequest(name, wantReply, wrapPayload(ctx, s.wrapper.capability, config.TextMapPropagator, payload))
+	// no need to wrap payload here, the session's channel wrapper will do it for us
+	s.wrapper.addContext(ctx, name)
+	return s.Session.SendRequest(name, wantReply, payload)
 }
 
 // Setenv sets an environment variable that will be applied to any

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -446,15 +446,7 @@ func (ns *NodeSession) updateTerminalSize(ctx context.Context, s *tracessh.Sessi
 			}
 
 			// Send the "window-change" request over the channel.
-			_, err = s.SendRequest(
-				ctx,
-				sshutils.WindowChangeRequest,
-				false,
-				ssh.Marshal(sshutils.WinChangeReqParams{
-					W: uint32(currWidth),
-					H: uint32(currHeight),
-				}))
-			if err != nil {
+			if err = s.WindowChange(ctx, int(currHeight), int(currWidth)); err != nil {
 				log.Warnf("Unable to send %v reqest: %v.", sshutils.WindowChangeRequest, err)
 				continue
 			}

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -201,10 +201,14 @@ func parseWinChange(req *ssh.Request) (*rsession.TerminalParams, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	// DELETE IN 12.0
+	// TODO(tross): needed for backward compatibility with sending the sshutils.WindowChangeRequest
+	// directly instead of leveraging ssh.Session.WindowChange
+	if r.Columns == 0 && r.Rows == 0 && r.H != 0 && r.W != 0 {
+		params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
+		return params, trace.Wrap(err)
 	}
 
-	return params, nil
+	params, err := rsession.NewTerminalParamsFromUint32(r.Columns, r.Rows)
+	return params, trace.Wrap(err)
 }

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -201,14 +201,6 @@ func parseWinChange(req *ssh.Request) (*rsession.TerminalParams, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// DELETE IN 12.0
-	// TODO(tross): needed for backward compatibility with sending the sshutils.WindowChangeRequest
-	// directly instead of leveraging ssh.Session.WindowChange
-	if r.Columns == 0 && r.Rows == 0 && r.H != 0 && r.W != 0 {
-		params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
-		return params, trace.Wrap(err)
-	}
-
-	params, err := rsession.NewTerminalParamsFromUint32(r.Columns, r.Rows)
+	params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
 	return params, trace.Wrap(err)
 }

--- a/lib/sshutils/req.go
+++ b/lib/sshutils/req.go
@@ -34,6 +34,15 @@ type EnvReqParams struct {
 
 // WinChangeReqParams specifies parameters for window changes
 type WinChangeReqParams struct {
+	// From RFC 4254 Section 6.7. - these values are sent when using ssh.Session.WindowChange
+	Columns uint32
+	Rows    uint32
+	Width   uint32
+	Height  uint32
+
+	// DELETE IN 12.0
+	// TODO(tross): needed for backward compatibility with sending the sshutils.WindowChangeRequest
+	// directly instead of leveraging ssh.Session.WindowChange
 	W   uint32
 	H   uint32
 	Wpx uint32
@@ -53,22 +62,21 @@ type PTYReqParams struct {
 // TerminalModes converts encoded terminal modes into a ssh.TerminalModes map.
 // The encoding is described in: https://tools.ietf.org/html/rfc4254#section-8
 //
-//   All 'encoded terminal modes' (as passed in a pty request) are encoded
-//   into a byte stream.  It is intended that the coding be portable
-//   across different environments.  The stream consists of opcode-
-//   argument pairs wherein the opcode is a byte value.  Opcodes 1 to 159
-//   have a single uint32 argument.  Opcodes 160 to 255 are not yet
-//   defined, and cause parsing to stop (they should only be used after
-//   any other data).  The stream is terminated by opcode TTY_OP_END
-//   (0x00).
+//	All 'encoded terminal modes' (as passed in a pty request) are encoded
+//	into a byte stream.  It is intended that the coding be portable
+//	across different environments.  The stream consists of opcode-
+//	argument pairs wherein the opcode is a byte value.  Opcodes 1 to 159
+//	have a single uint32 argument.  Opcodes 160 to 255 are not yet
+//	defined, and cause parsing to stop (they should only be used after
+//	any other data).  The stream is terminated by opcode TTY_OP_END
+//	(0x00).
 //
 // In practice, this means encoded terminal modes get translated like below:
 //
-//  0x80 0x00 0x00 0x38 0x40  0x81 0x00 0x00 0x38 0x40  0x35 0x00 0x00 0x00 0x00  0x00
-//  |___|__________________|  |___|__________________|  |___|__________________|  |__|
-//         0x80: 0x3840              0x81: 0x3840              0x35: 0x00         0x00
-//  ssh.TTY_OP_ISPEED: 14400  ssh.TTY_OP_OSPEED: 14400         ssh.ECHO:0
-//
+//	0x80 0x00 0x00 0x38 0x40  0x81 0x00 0x00 0x38 0x40  0x35 0x00 0x00 0x00 0x00  0x00
+//	|___|__________________|  |___|__________________|  |___|__________________|  |__|
+//	       0x80: 0x3840              0x81: 0x3840              0x35: 0x00         0x00
+//	ssh.TTY_OP_ISPEED: 14400  ssh.TTY_OP_OSPEED: 14400         ssh.ECHO:0
 func (p *PTYReqParams) TerminalModes() (ssh.TerminalModes, error) {
 	terminalModes := ssh.TerminalModes{}
 

--- a/lib/sshutils/req.go
+++ b/lib/sshutils/req.go
@@ -34,15 +34,6 @@ type EnvReqParams struct {
 
 // WinChangeReqParams specifies parameters for window changes
 type WinChangeReqParams struct {
-	// From RFC 4254 Section 6.7. - these values are sent when using ssh.Session.WindowChange
-	Columns uint32
-	Rows    uint32
-	Width   uint32
-	Height  uint32
-
-	// DELETE IN 12.0
-	// TODO(tross): needed for backward compatibility with sending the sshutils.WindowChangeRequest
-	// directly instead of leveraging ssh.Session.WindowChange
 	W   uint32
 	H   uint32
 	Wpx uint32

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -552,15 +552,7 @@ func (t *TerminalHandler) windowChange(ctx context.Context, params *session.Term
 		return
 	}
 
-	_, err := t.sshSession.SendRequest(
-		ctx,
-		sshutils.WindowChangeRequest,
-		false,
-		ssh.Marshal(sshutils.WinChangeReqParams{
-			W: uint32(params.W),
-			H: uint32(params.H),
-		}))
-	if err != nil {
+	if err := t.sshSession.WindowChange(ctx, params.H, params.W); err != nil {
 		t.log.Error(err)
 	}
 }


### PR DESCRIPTION
Payloads were inadvertently being wrapped twice by sessions making
the ssh server unable to parse the request payload. This is largely
only an issue for window-change requests, as they are the only request
being sent directly via a session that contains a payload.

As a means to migrate away from sending window-change requests directly
and to using the builtin ssh.Session WindowChange function this updates
the WinChangeReqParams to contain the values that will be sent in
accordance with RFC 4254 once we leverage the WindowChange function
instead of sending the request ourselves.