### PR TITLE
Add an `is_empty` field to `FileSystemObject`

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -417,6 +417,7 @@ func (c *Client) start() {
 							last_modified: C.uint64_t(m.Fso.LastModified),
 							size:          C.uint64_t(m.Fso.Size),
 							file_type:     m.Fso.FileType,
+							is_empty:      C.uint8_t(m.Fso.IsEmpty),
 							path:          path,
 						},
 					}); errCode != C.ErrCodeSuccess {
@@ -435,6 +436,7 @@ func (c *Client) start() {
 							last_modified: C.uint64_t(m.Fso.LastModified),
 							size:          C.uint64_t(m.Fso.Size),
 							file_type:     m.Fso.FileType,
+							is_empty:      C.uint8_t(m.Fso.IsEmpty),
 							path:          path,
 						},
 					}); errCode != C.ErrCodeSuccess {
@@ -464,6 +466,7 @@ func (c *Client) start() {
 							last_modified: C.uint64_t(fso.LastModified),
 							size:          C.uint64_t(fso.Size),
 							file_type:     fso.FileType,
+							is_empty:      C.uint8_t(fso.IsEmpty),
 							path:          path,
 						})
 					}

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -1469,6 +1469,7 @@ impl From<ServerCreateDriveRequest> for SharedDirectoryInfoRequest {
 pub struct SharedDirectoryInfoResponse {
     completion_id: u32,
     err_code: TdpErrCode,
+
     fso: FileSystemObject,
 }
 
@@ -1501,6 +1502,7 @@ pub struct FileSystemObject {
     last_modified: u64,
     size: u64,
     file_type: FileType,
+    is_empty: u8,
     path: UnixPath,
 }
 
@@ -1523,6 +1525,7 @@ pub struct CGOFileSystemObject {
     pub last_modified: u64,
     pub size: u64,
     pub file_type: FileType,
+    pub is_empty: u8,
     pub path: *const c_char,
 }
 
@@ -1538,6 +1541,7 @@ impl From<CGOFileSystemObject> for FileSystemObject {
                 last_modified: cgo_fso.last_modified,
                 size: cgo_fso.size,
                 file_type: cgo_fso.file_type,
+                is_empty: cgo_fso.is_empty,
                 path: UnixPath::from(from_go_string(cgo_fso.path)),
             }
         }

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/consts.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/consts.rs
@@ -120,6 +120,7 @@ pub enum NTSTATUS {
     STATUS_NOT_A_DIRECTORY = 0xC0000103,
     STATUS_NO_SUCH_FILE = 0xC000000F,
     STATUS_NOT_SUPPORTED = 0xC00000BB,
+    STATUS_DIRECTORY_NOT_EMPTY = 0xC0000101,
 }
 
 /// 2.4 File Information Classes [MS-FSCC]
@@ -206,3 +207,7 @@ pub const I8_SIZE: u32 = size_of::<i8>();
 pub const U8_SIZE: u32 = size_of::<u8>();
 pub const FILE_ATTR_SIZE: u32 = size_of::<flags::FileAttributes>();
 pub const BOOL_SIZE: u32 = size_of::<Boolean>();
+
+pub const TDP_FALSE: u8 = 0;
+#[allow(dead_code)]
+pub const TDP_TRUE: u8 = 1;

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/mod.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/mod.rs
@@ -39,7 +39,7 @@ use consts::{
     FileSystemInformationClassLevel, MajorFunction, MinorFunction, PacketId, BOOL_SIZE,
     DIRECTORY_SHARE_CLIENT_NAME, DRIVE_CAPABILITY_VERSION_02, FILE_ATTR_SIZE,
     GENERAL_CAPABILITY_VERSION_02, I64_SIZE, I8_SIZE, NTSTATUS, SCARD_DEVICE_ID,
-    SMARTCARD_CAPABILITY_VERSION_01, U32_SIZE, U8_SIZE, VERSION_MAJOR, VERSION_MINOR,
+    SMARTCARD_CAPABILITY_VERSION_01, TDP_FALSE, U32_SIZE, U8_SIZE, VERSION_MAJOR, VERSION_MINOR,
 };
 use num_traits::{FromPrimitive, ToPrimitive};
 use rdp::core::mcs;
@@ -768,7 +768,6 @@ impl Client {
         self.tdp_sd_write(rdp_req)
     }
 
-    #[allow(clippy::wildcard_in_or_patterns)]
     fn process_irp_set_information(
         &mut self,
         device_io_request: DeviceIoRequest,
@@ -777,10 +776,27 @@ impl Client {
         let rdp_req = ServerDriveSetInformationRequest::decode(device_io_request, payload)?;
         debug!("received RDP: {:?}", rdp_req);
 
+        // Determine whether to send back a STATUS_DIRECTORY_NOT_EMPTY
+        // or STATUS_SUCCESS in the case of a succesful operation
+        // https://github.com/FreeRDP/FreeRDP/blob/dfa231c0a55b005af775b833f92f6bcd30363d77/channels/drive/client/drive_main.c#L430-L431
+        let io_status = match self.file_cache.get(rdp_req.device_io_request.file_id) {
+            Some(file) => {
+                if file.fso.file_type == FileType::Directory && file.fso.is_empty == TDP_FALSE {
+                    NTSTATUS::STATUS_DIRECTORY_NOT_EMPTY
+                } else {
+                    NTSTATUS::STATUS_SUCCESS
+                }
+            }
+            None => {
+                // File not found in cache
+                return self.prep_set_info_response(&rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL);
+            }
+        };
+
         match rdp_req.file_information_class_level {
             FileInformationClassLevel::FileRenameInformation => match rdp_req.set_buffer {
                 FileInformationClass::FileRenameInformation(ref rename_info) => {
-                    self.rename(rdp_req.clone(), rename_info)
+                    self.rename(rdp_req.clone(), rename_info, io_status)
                 }
                 _ => Err(invalid_data_error(
                     "FileInformationClass does not match FileInformationClassLevel",
@@ -789,8 +805,12 @@ impl Client {
             FileInformationClassLevel::FileDispositionInformation => match rdp_req.set_buffer {
                 FileInformationClass::FileDispositionInformation(ref info) => {
                     if let Some(file) = self.file_cache.get_mut(rdp_req.device_io_request.file_id) {
-                        file.delete_pending = info.delete_pending == 1;
-                        return self.prep_set_info_response(&rdp_req, NTSTATUS::STATUS_SUCCESS);
+                        if !(file.fso.file_type == FileType::Directory && file.fso.is_empty == TDP_FALSE) {
+                            // https://github.com/FreeRDP/FreeRDP/blob/dfa231c0a55b005af775b833f92f6bcd30363d77/channels/drive/client/drive_file.c#L681
+                            file.delete_pending = info.delete_pending == 1;
+                        }
+
+                        return self.prep_set_info_response(&rdp_req, io_status);
                     }
 
                     // File not found in cache
@@ -807,7 +827,7 @@ impl Client {
                 // Each of these ask us to change something we don't have control over at the browser
                 // level, so we just do nothing and send back a success.
                 // https://github.com/FreeRDP/FreeRDP/blob/dfa231c0a55b005af775b833f92f6bcd30363d77/channels/drive/client/drive_file.c#L579
-                self.prep_set_info_response(&rdp_req, NTSTATUS::STATUS_SUCCESS)
+                self.prep_set_info_response(&rdp_req, io_status)
             }
 
             _ => {
@@ -1377,11 +1397,12 @@ impl Client {
         &mut self,
         rdp_req: ServerDriveSetInformationRequest,
         rename_info: &FileRenameInformation,
+        io_status: NTSTATUS,
     ) -> RdpResult<Vec<Vec<u8>>> {
         // https://github.com/FreeRDP/FreeRDP/blob/dfa231c0a55b005af775b833f92f6bcd30363d77/channels/drive/client/drive_file.c#L709
         match rename_info.replace_if_exists {
-            Boolean::True => self.rename_replace_if_exists(rdp_req, rename_info),
-            Boolean::False => self.rename_dont_replace_if_exists(rdp_req, rename_info),
+            Boolean::True => self.rename_replace_if_exists(rdp_req, rename_info, io_status),
+            Boolean::False => self.rename_dont_replace_if_exists(rdp_req, rename_info, io_status),
         }
     }
 
@@ -1389,16 +1410,18 @@ impl Client {
         &mut self,
         rdp_req: ServerDriveSetInformationRequest,
         rename_info: &FileRenameInformation,
+        io_status: NTSTATUS,
     ) -> RdpResult<Vec<Vec<u8>>> {
         // If replace_if_exists is true, we can just send a TDP SharedDirectoryMoveRequest,
         // which works like the unix `mv` utility (meaning it will automatically replace if exists).
-        self.tdp_sd_move(rdp_req, rename_info)
+        self.tdp_sd_move(rdp_req, rename_info, io_status)
     }
 
     fn rename_dont_replace_if_exists(
         &mut self,
         rdp_req: ServerDriveSetInformationRequest,
         rename_info: &FileRenameInformation,
+        io_status: NTSTATUS,
     ) -> RdpResult<Vec<Vec<u8>>> {
         let new_path = UnixPath::from(&rename_info.file_name);
         // If replace_if_exists is false, first check if the new_path exists.
@@ -1417,7 +1440,7 @@ impl Client {
                       -> RdpResult<Vec<Vec<u8>>> {
                     if res.err_code == TdpErrCode::DoesNotExist {
                         // If the file doesn't already exist, send a move request.
-                        return cli.tdp_sd_move(rdp_req, &rename_info);
+                        return cli.tdp_sd_move(rdp_req, &rename_info, io_status);
                     }
                     // If it does, send back a name collision error, as is done in FreeRDP.
                     cli.prep_set_info_response(&rdp_req, NTSTATUS::STATUS_OBJECT_NAME_COLLISION)
@@ -1432,6 +1455,7 @@ impl Client {
         &mut self,
         rdp_req: ServerDriveSetInformationRequest,
         rename_info: &FileRenameInformation,
+        io_status: NTSTATUS,
     ) -> RdpResult<Vec<Vec<u8>>> {
         if let Some(file) = self.file_cache.get(rdp_req.device_io_request.file_id) {
             (self.tdp_sd_move_request)(SharedDirectoryMoveRequest {
@@ -1452,7 +1476,7 @@ impl Client {
                                 .prep_set_info_response(&rdp_req, NTSTATUS::STATUS_UNSUCCESSFUL);
                         }
 
-                        cli.prep_set_info_response(&rdp_req, NTSTATUS::STATUS_SUCCESS)
+                        cli.prep_set_info_response(&rdp_req, io_status)
                     },
                 ),
             );
@@ -1579,6 +1603,7 @@ impl Iterator for FileCacheObject {
                 last_modified: self.fso.last_modified,
                 size: self.fso.size,
                 file_type: self.fso.file_type,
+                is_empty: TDP_FALSE,
                 path: UnixPath::from(".".to_string()),
             })
         } else if !self.dotdot_sent {
@@ -1588,6 +1613,7 @@ impl Iterator for FileCacheObject {
                 last_modified: self.fso.last_modified,
                 size: 0,
                 file_type: FileType::Directory,
+                is_empty: TDP_FALSE,
                 path: UnixPath::from("..".to_string()),
             })
         } else {
@@ -2246,21 +2272,32 @@ pub struct DeviceCreateRequest {
 
 impl DeviceCreateRequest {
     fn decode(device_io_request: DeviceIoRequest, payload: &mut Payload) -> RdpResult<Self> {
-        let invalid_flags = || invalid_data_error("invalid flags in Device Create Request");
+        debug!("In DeviceCreateRequest decode");
+        let invalid_flags = |flag_name: &str, v: u32| {
+            invalid_data_error(&format!(
+                "invalid flags in Device Create Request: {} = {}",
+                flag_name, v
+            ))
+        };
 
-        let desired_access = flags::DesiredAccess::from_bits(payload.read_u32::<LittleEndian>()?)
-            .ok_or_else(invalid_flags)?;
+        let desired_access = payload.read_u32::<LittleEndian>()?;
         let allocation_size = payload.read_u64::<LittleEndian>()?;
-        let file_attributes = flags::FileAttributes::from_bits(payload.read_u32::<LittleEndian>()?)
-            .ok_or_else(invalid_flags)?;
-        let shared_access = flags::SharedAccess::from_bits(payload.read_u32::<LittleEndian>()?)
-            .ok_or_else(invalid_flags)?;
-        let create_disposition =
-            flags::CreateDisposition::from_bits(payload.read_u32::<LittleEndian>()?)
-                .ok_or_else(invalid_flags)?;
-        let create_options = flags::CreateOptions::from_bits(payload.read_u32::<LittleEndian>()?)
-            .ok_or_else(invalid_flags)?;
+        let file_attributes = payload.read_u32::<LittleEndian>()?;
+        let shared_access = payload.read_u32::<LittleEndian>()?;
+        let create_disposition = payload.read_u32::<LittleEndian>()?;
+        let create_options = payload.read_u32::<LittleEndian>()?;
         let path_length = payload.read_u32::<LittleEndian>()?;
+
+        let desired_access = flags::DesiredAccess::from_bits(desired_access)
+            .ok_or_else(|| invalid_flags("desired_access", desired_access))?;
+        let file_attributes = flags::FileAttributes::from_bits(file_attributes)
+            .ok_or_else(|| invalid_flags("file_attributes", file_attributes))?;
+        let shared_access = flags::SharedAccess::from_bits(shared_access)
+            .ok_or_else(|| invalid_flags("shared_access", shared_access))?;
+        let create_disposition = flags::CreateDisposition::from_bits(create_disposition)
+            .ok_or_else(|| invalid_flags("create_disposition", create_disposition))?;
+        let create_options = flags::CreateOptions::from_bits(create_options)
+            .ok_or_else(|| invalid_flags("create_options", create_options))?;
 
         // usize is 32 bits on a 32 bit target and 64 on a 64, so we can safely say try_into().unwrap()
         // for a u32 will never panic on the machines that run teleport.

--- a/lib/srv/desktop/tdp/proto.go
+++ b/lib/srv/desktop/tdp/proto.go
@@ -815,15 +815,17 @@ type FileSystemObject struct {
 	LastModified uint64
 	Size         uint64
 	FileType     uint32
+	IsEmpty      uint8
 	Path         string
 }
 
-func (s FileSystemObject) Encode() ([]byte, error) {
+func (f FileSystemObject) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, s.LastModified)
-	binary.Write(buf, binary.BigEndian, s.Size)
-	binary.Write(buf, binary.BigEndian, s.FileType)
-	if err := encodeString(buf, s.Path); err != nil {
+	binary.Write(buf, binary.BigEndian, f.LastModified)
+	binary.Write(buf, binary.BigEndian, f.Size)
+	binary.Write(buf, binary.BigEndian, f.FileType)
+	buf.WriteByte(f.IsEmpty)
+	if err := encodeString(buf, f.Path); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return buf.Bytes(), nil
@@ -832,6 +834,7 @@ func (s FileSystemObject) Encode() ([]byte, error) {
 func decodeFileSystemObject(in peekReader) (FileSystemObject, error) {
 	var lastModified, size uint64
 	var fileType uint32
+	var isEmpty uint8
 	err := binary.Read(in, binary.BigEndian, &lastModified)
 	if err != nil {
 		return FileSystemObject{}, trace.Wrap(err)
@@ -844,6 +847,10 @@ func decodeFileSystemObject(in peekReader) (FileSystemObject, error) {
 	if err != nil {
 		return FileSystemObject{}, trace.Wrap(err)
 	}
+	err = binary.Read(in, binary.BigEndian, &isEmpty)
+	if err != nil {
+		return FileSystemObject{}, trace.Wrap(err)
+	}
 	path, err := decodeString(in, tdpMaxPathLength)
 	if err != nil {
 		return FileSystemObject{}, trace.Wrap(err)
@@ -853,6 +860,7 @@ func decodeFileSystemObject(in peekReader) (FileSystemObject, error) {
 		LastModified: lastModified,
 		Size:         size,
 		FileType:     fileType,
+		IsEmpty:      isEmpty,
 		Path:         path,
 	}, nil
 }

--- a/lib/srv/desktop/tdp/proto.go
+++ b/lib/srv/desktop/tdp/proto.go
@@ -847,7 +847,7 @@ func decodeFileSystemObject(in peekReader) (FileSystemObject, error) {
 	if err != nil {
 		return FileSystemObject{}, trace.Wrap(err)
 	}
-	err = binary.Read(in, binary.BigEndian, &isEmpty)
+	isEmpty, err = in.ReadByte()
 	if err != nil {
 		return FileSystemObject{}, trace.Wrap(err)
 	}

--- a/rfd/0067-desktop-access-file-system-sharing.md
+++ b/rfd/0067-desktop-access-file-system-sharing.md
@@ -446,8 +446,12 @@ This message is sent by the client to the server in response to a `Shared Direct
 ##### File System Object (fso)
 
 ```
-| last_modified uint64 | size uint64 | file_type uint32 | path_length uint32 | path byte[] |
+| last_modified uint64 | size uint64 | file_type uint32 | is_empty bool | path_length uint32 | path byte[] |
 ```
+
+The design of this message is constrained by [what information is made available to us by the browser](https://developer.mozilla.org/en-US/docs/Web/API/File) and
+which [File Information Classes](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/4718fc40-e539-4014-8e33-b675af74e3e1) are potentially
+requested by RDP.
 
 For files, `last_modified` is the last modified time of the file as specified by the [`mtime`](https://www.makeuseof.com/linux-file-timestamps/), in milliseconds
 since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time). For directories, `last_modified` should also be set to the
@@ -464,9 +468,8 @@ types available in RDP's [File Attributes](https://docs.microsoft.com/en-us/open
 0. file
 1. directory
 
-The design of this message is constrained by [what information is made available to us by the browser](https://developer.mozilla.org/en-US/docs/Web/API/File) and
-which [File Information Classes](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/4718fc40-e539-4014-8e33-b675af74e3e1) are potentially
-requested by RDP.
+`is_empty` says whether or not a directory is empty. For objects where `file_type = 0` (files), this field should be
+ignored.
 
 `path_length` is the length in bytes of the `path`
 
@@ -487,6 +490,13 @@ For now, all errors will be unspecified, and translated into
 [`NTSTATUS::STATUS_UNSUCCESSFUL`](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55) over RDP. Later, we
 can add more specific error messages for more specific RDP error handling,
 [as they do in FreeRDP](https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L67-L132).
+
+##### bool
+
+`bool` is a `uint8` specifying True or False:
+
+0. False
+1. True
 
 ## RDP --> TDP Translation for `IRP_MJ_READ`
 


### PR DESCRIPTION
This change adds an `is_empty` field to the `FileSystemObject`, which is then used when fielding `IRP_MJ_SET_INFORMATION` requests to determine: 

1. whether or not to set the `delete_pending` bit.
2. whether to send back an `NTSTATUS::STATUS_DIRECTORY_NOT_EMPTY` or an `NTSTATUS::STATUS_SUCCESS` on a successful response.

fixes https://github.com/gravitational/teleport/issues/15984

corresponds with https://github.com/gravitational/webapps/pull/1174