### PR TITLE
[v10] Make the Fluentd guide more usable

### DIFF
--- a/docs/pages/management/guides/fluentd.mdx
+++ b/docs/pages/management/guides/fluentd.mdx
@@ -38,11 +38,17 @@ from Teleport's events API, and forwards them to Fluentd.
   ```
   </TabItem>
 
-  <TabItem label="MacOS">
+  <TabItem label="macOS">
+
   ```code
   $ curl -L -O https://get.gravitational.com/teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
-  $ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+  $ tar -zxvf teleport-event-handler-v(=teleport.plugin.version=)-darwin-amd64-bin.tar.gz
   ```
+
+  We currently only build the event handler plugin for amd64 machines. If your
+  macOS machine uses Apple silicon, you will need to [install
+  Rosetta](https://support.apple.com/en-us/HT211861) before you can run the
+  event handler plugin. You can also build from source.
   </TabItem>
 
   <TabItem label="Docker">
@@ -55,6 +61,21 @@ from Teleport's events API, and forwards them to Fluentd.
   ```code
   $ helm repo add teleport https://charts.releases.teleport.dev/
   ```
+  </TabItem>
+  <TabItem label="From Source">
+  Ensure that you have Docker installed and running.
+
+  Run the following commands to build the plugin:
+
+  ```code
+  $ git clone https://github.com/gravitational/teleport-plugins.git --depth 1
+  $ cd teleport-plugins/event-handler/build.assets
+  $ make build
+  ```
+
+  You can find the compiled binary within your clone of the `teleport-plugins`
+  repo, with the file path, `event-handler/build/teleport-event-handler`.
+
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Backports #14450
Fixes #16317

* Make the Fluentd guide more usable

Fix a mismatch between archive names in the two commands within the
"MacOS" tab in Step 1 the accompanying text.

* Respond to PR feedback

* Respond to PR feedback

- Mention Rosetta
- Restore the tab re: building from source
