### PR TITLE
Fix infinite session heartbeat failures

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1446,7 +1446,12 @@ func (s *session) heartbeat(ctx context.Context, scx *ServerContext) {
 				ID:        s.id,
 				Parties:   &partyList,
 			})
-			if err != nil {
+
+			switch {
+			case trace.IsNotFound(err):
+				s.log.Warnf("Aborting heartbeat for non-existent session %v ", s.id)
+				return
+			case err != nil:
 				s.log.Warnf("Unable to update session %v as active: %v", s.id, err)
 			}
 		case <-ctx.Done():

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1449,6 +1449,8 @@ func (s *session) heartbeat(ctx context.Context, scx *ServerContext) {
 			if err != nil {
 				s.log.Warnf("Unable to update session %v as active: %v", s.id, err)
 			}
+		case <-ctx.Done():
+			return
 		case <-s.stopC:
 			return
 		}


### PR DESCRIPTION
The session heartbeat loop wasn't checking if the context was
done, which resulted in an infinite loop of UpdateSession calls
that would never succeed and constantly trip the circuit breaker.

The context will only be cancelled if the session is terminated, so
we can simply return when either the context is done or the stop
channel was closed, whichever comes first.

Fixes #15695

**NOTE**: The heartbeat loop was removed on master as part of cleanup
for v11 to switch to session trackers. 