### PR TITLE
rework tctl cmd registration

### DIFF
--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import (
+	"github.com/gravitational/teleport/tool/tctl/sso/configure"
+	"github.com/gravitational/teleport/tool/tctl/sso/tester"
+)
+
+// Commads returns the set of commands that are to oss and ent
+// variants of tctl.
+func Commands() []CLICommand {
+	return []CLICommand{
+		&UserCommand{},
+		&NodeCommand{},
+		&TokensCommand{},
+		&AuthCommand{},
+		&StatusCommand{},
+		&TopCommand{},
+		&AccessRequestCommand{},
+		&AppsCommand{},
+		&DBCommand{},
+		&KubeCommand{},
+		&DesktopCommand{},
+		&LockCommand{},
+		&BotsCommand{},
+		&InventoryCommand{},
+		&RecordingsCommand{},
+		&AlertCommand{},
+	}
+}
+
+// OSSCommands returns the oss variants of commands that use different variants
+// for oss and ent.
+func OSSCommands() []CLICommand {
+	return []CLICommand{
+		&ResourceCommand{},
+		&configure.SSOConfigureCommand{},
+		&tester.SSOTestCommand{},
+	}
+}

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -18,32 +18,13 @@ package main
 
 import (
 	"github.com/gravitational/teleport/tool/tctl/common"
-	"github.com/gravitational/teleport/tool/tctl/sso/configure"
-	"github.com/gravitational/teleport/tool/tctl/sso/tester"
 )
 
 func main() {
-	// Note: these commands should be kept in sync with e/tool/tctl/main.go.
-	commands := []common.CLICommand{
-		&common.UserCommand{},
-		&common.NodeCommand{},
-		&common.TokensCommand{},
-		&common.AuthCommand{},
-		&common.ResourceCommand{},
-		&common.StatusCommand{},
-		&common.TopCommand{},
-		&common.AccessRequestCommand{},
-		&configure.SSOConfigureCommand{},
-		&tester.SSOTestCommand{},
-		&common.AppsCommand{},
-		&common.DBCommand{},
-		&common.KubeCommand{},
-		&common.DesktopCommand{},
-		&common.LockCommand{},
-		&common.BotsCommand{},
-		&common.InventoryCommand{},
-		&common.RecordingsCommand{},
-		&common.AlertCommand{},
-	}
+
+	// aggregate common and oss-specific command variants
+	commands := common.Commands()
+	commands = append(commands, common.OSSCommands()...)
+
 	common.Run(commands)
 }


### PR DESCRIPTION
Reworks `tctl` cmd registration so that we don't need to register common commands separately in ent.

This PR also fixes registration of the new `alerts` command in ent.