### PR TITLE
[v10] Add comment and import cycle proto linters

### DIFF
--- a/api/proto/buf-legacy.yaml
+++ b/api/proto/buf-legacy.yaml
@@ -5,6 +5,13 @@ deps:
 lint:
   use:
     - DEFAULT
+    - PACKAGE_NO_IMPORT_CYCLE
+    # Top-level types require comments.
+    # TODO(codingllama): Fix messages and enable linters below.
+    # - COMMENT_ENUM
+    # - COMMENT_MESSAGE
+    - COMMENT_RPC
+    - COMMENT_SERVICE
   except:
     # MINIMAL
     - PACKAGE_DIRECTORY_MATCH

--- a/api/proto/buf.yaml
+++ b/api/proto/buf.yaml
@@ -5,6 +5,12 @@ deps:
 lint:
   use:
     - DEFAULT
+    - PACKAGE_NO_IMPORT_CYCLE
+    # Top-level types require comments.
+    - COMMENT_ENUM
+    - COMMENT_MESSAGE
+    - COMMENT_RPC
+    - COMMENT_SERVICE
   except:
     # Allow Google API-style responses (CreateFoo returns Foo).
     # See https://cloud.google.com/apis/design/standard_methods.

--- a/api/proto/teleport/legacy/client/proto/authservice.proto
+++ b/api/proto/teleport/legacy/client/proto/authservice.proto
@@ -2454,6 +2454,7 @@ service AuthService {
 
   // GetWindowsDesktopServices returns all registered Windows desktop services.
   rpc GetWindowsDesktopServices(google.protobuf.Empty) returns (GetWindowsDesktopServicesResponse);
+  // TODO(zmb3): Document me.
   rpc GetWindowsDesktopService(GetWindowsDesktopServiceRequest) returns (GetWindowsDesktopServiceResponse);
   // UpsertWindowsDesktopService registers a new Windows desktop service.
   rpc UpsertWindowsDesktopService(types.WindowsDesktopServiceV3) returns (types.KeepAlive);

--- a/api/proto/teleport/legacy/client/proto/joinservice.proto
+++ b/api/proto/teleport/legacy/client/proto/joinservice.proto
@@ -21,6 +21,7 @@ import "teleport/legacy/types/types.proto";
 
 option go_package = "github.com/gravitational/teleport/api/client/proto";
 
+// TODO(nklaassen): Document me.
 message RegisterUsingIAMMethodRequest {
   // RegisterUsingTokenRequest holds registration parameters common to all
   // join methods.

--- a/lib/teleterm/api/proto/buf.yaml
+++ b/lib/teleterm/api/proto/buf.yaml
@@ -2,6 +2,13 @@ version: v1
 lint:
   use:
     - DEFAULT
+    - PACKAGE_NO_IMPORT_CYCLE
+    # Top-level types require comments.
+    - COMMENT_ENUM
+    # TODO(ravicious): Fix message and enable linter below.
+    # - COMMENT_MESSAGE
+    - COMMENT_RPC
+    - COMMENT_SERVICE
   except:
     - RPC_RESPONSE_STANDARD_NAME
     - RPC_REQUEST_RESPONSE_UNIQUE

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -2,6 +2,12 @@ version: v1
 lint:
   use:
     - DEFAULT
+    - PACKAGE_NO_IMPORT_CYCLE
+    # Top-level types require comments.
+    - COMMENT_ENUM
+    - COMMENT_MESSAGE
+    - COMMENT_RPC
+    - COMMENT_SERVICE
   ignore:
     # "legacy" lib protos.
     - teleport/lib/multiplexer/test/ping.proto


### PR DESCRIPTION
Require top-level proto types to have comments and introduce import cycle linter.

Backport #16082 to branch/v10