### PR TITLE
Drop libudev-dev from buildbox dependencies

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -108,7 +108,6 @@ RUN apt-get update -y --fix-missing && \
         libpam-dev \
         libsqlite3-0 \
         libssl-dev \
-        libudev-dev \
         llvm-10 \
         locales \
         mingw-w64 \


### PR DESCRIPTION
We use a manually-built libudev-zero, so that dependency is not required.