### PR TITLE
Improve `TestPingConnection/ConcurrentReads` timeout handling

### DIFF
--- a/lib/srv/alpnproxy/conn_test.go
+++ b/lib/srv/alpnproxy/conn_test.go
@@ -123,9 +123,6 @@ func TestPingConnection(t *testing.T) {
 	// Messages can be out of order due to concurrent reads. Other tests must
 	// guarantee message ordering.
 	t.Run("ConcurrentReads", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
 		// Number of writes performed.
 		nWrites := 10
 		// Data that is going to be written/read on the connection.
@@ -140,6 +137,9 @@ func TestPingConnection(t *testing.T) {
 		defer w.Close()
 
 		readChan := make(chan []byte)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 
 		// Write routine
 		go func() {
@@ -157,8 +157,21 @@ func TestPingConnection(t *testing.T) {
 				buf := make([]byte, readSize)
 				for {
 					n, err := r.Read(buf)
-					if err != nil && !errors.Is(err, io.EOF) {
-						require.Fail(t, "Failed to read from connection: %v", err)
+					if err != nil {
+						switch {
+						// Since we're partially reading the message, the last
+						// read will return an EOF. In this case, do nothing
+						// and send the remaining bytes.
+						case errors.Is(err, io.EOF):
+						// The connection will be closed only if the test is
+						// completed. The read result will be empty, so return
+						// the function to complete the goroutine.
+						case errors.Is(err, io.ErrClosedPipe):
+							return
+						// Any other error should fail the test.
+						default:
+							require.Fail(t, "Failed to read from connection: %v", err)
+						}
 					}
 
 					chanBytes := make([]byte, n)

--- a/lib/srv/alpnproxy/conn_test.go
+++ b/lib/srv/alpnproxy/conn_test.go
@@ -136,7 +136,14 @@ func TestPingConnection(t *testing.T) {
 		defer r.Close()
 		defer w.Close()
 
-		readChan := make(chan []byte)
+		// readResult struct is used to store the result of a read.
+		type readResult struct {
+			data []byte
+			err  error
+		}
+
+		// Channel is used to store the result of a read.
+		resChan := make(chan readResult)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -170,13 +177,13 @@ func TestPingConnection(t *testing.T) {
 							return
 						// Any other error should fail the test.
 						default:
-							require.Fail(t, "Failed to read from connection: %v", err)
+							resChan <- readResult{err: err}
 						}
 					}
 
 					chanBytes := make([]byte, n)
 					copy(chanBytes, buf[:n])
-					readChan <- chanBytes
+					resChan <- readResult{data: chanBytes}
 				}
 			}()
 		}
@@ -187,8 +194,9 @@ func TestPingConnection(t *testing.T) {
 				select {
 				case <-ctx.Done():
 					require.Fail(t, "Failed to read message (context timeout)")
-				case data := <-readChan:
-					aggregator = append(aggregator, data...)
+				case res := <-resChan:
+					require.NoError(t, res.err, "Failed to read message")
+					aggregator = append(aggregator, res.data...)
 				}
 			}
 		}

--- a/lib/srv/alpnproxy/conn_test.go
+++ b/lib/srv/alpnproxy/conn_test.go
@@ -175,9 +175,11 @@ func TestPingConnection(t *testing.T) {
 						// the function to complete the goroutine.
 						case errors.Is(err, io.ErrClosedPipe):
 							return
-						// Any other error should fail the test.
+						// Any other error should fail the test and complete the
+						// goroutine.
 						default:
 							resChan <- readResult{err: err}
+							return
 						}
 					}
 


### PR DESCRIPTION
This PR consists in two improvements on the `TestPingConnection/ConcurrentReads` test:

1. Better `Read` error handling: When an `io.ErrClosedPipe` is returned, we shouldn't fail the test because it is already completed (doing it would cause a panic). Instead, complete the Go routine;
2. Place the `context.WithTimeout` call after setting up the TLS connection and certificates. It avoids having the setup most of the test time;