### PR TITLE
Fix flaky TestHandlerConnectionUpgrade

### DIFF
--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -87,7 +87,7 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 		go func() {
 			// serverConn will be hijacked.
 			w := newResponseWriterHijacker(nil, serverConn)
-			_, err = h.connectionUpgrade(w, r, nil)
+			_, err := h.connectionUpgrade(w, r, nil)
 			require.NoError(t, err)
 		}()
 


### PR DESCRIPTION
Fixes #16128

Log from capture in the original issue.
```
WARNING: DATA RACE
Write at 0x00c00115b600 by goroutine 519:
  github.com/gravitational/teleport/lib/web.TestHandlerConnectionUpgrade.func3()
      /workspace/lib/web/conn_upgrade_test.go:101 +0x864
  testing.tRunner()
      /opt/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1486 +0x47

Previous write at 0x00c00115b600 by goroutine 309:
  github.com/gravitational/teleport/lib/web.TestHandlerConnectionUpgrade.func3.1()
      /workspace/lib/web/conn_upgrade_test.go:90 +0x244

Goroutine 519 (running) created at:
  testing.(*T).Run()
      /opt/go/src/testing/testing.go:1486 +0x724
  github.com/gravitational/teleport/lib/web.TestHandlerConnectionUpgrade()
      /workspace/lib/web/conn_upgrade_test.go:78 +0x377
  testing.tRunner()
      /opt/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1486 +0x47

Goroutine 309 (finished) created at:
  github.com/gravitational/teleport/lib/web.TestHandlerConnectionUpgrade.func3()
      /workspace/lib/web/conn_upgrade_test.go:87 +0x585
  testing.tRunner()
      /opt/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1486 +0x47
```