### PR TITLE
Azure Blob Storage for sessions

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -337,8 +337,20 @@ const (
 	// storage
 	SchemeGCS = "gs"
 
+	// SchemeAZBlob is the Azure Blob Storage scheme, used as the scheme in the
+	// session storage URI to identify a storage account accessed over https.
+	SchemeAZBlob = "azblob"
+
+	// SchemeAZBlobHTTP is the Azure Blob Storage scheme, used as the scheme in the
+	// session storage URI to identify a storage account accessed over http.
+	SchemeAZBlobHTTP = "azblob-http"
+
 	// GCSTestURI turns on GCS tests
 	GCSTestURI = "TEST_GCS_URI"
+
+	// AZBlobTestURI specifies the storage account URL to use for Azure Blob
+	// Storage tests.
+	AZBlobTestURI = "TEST_AZBLOB_URI"
 
 	// AWSRunTests turns on tests executed against AWS directly
 	AWSRunTests = "TEST_AWS"

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.1
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1
 	github.com/Clever/go-utils v0.0.0-20180917210021-2dac0ec6f2ac
 	github.com/HdrHistogram/hdrhistogram-go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.0.0/go.mod h1:GgxvszemyuFZyiw4vPxGib+Cp6z7Q3rYQb4DsKPOAAw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.0.0 h1:vsovXlTyKHZXnqzQyt7QMVkwpJBDkHchQL53qXaGBRY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.0.0/go.mod h1:UZy1vHcRdEymNP1d6fTrvYHpSdkXoUdowfrvffcQOOU=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.1 h1:QSdcrd/UFJv6Bp/CfoVf2SrENpFn9P6Yh8yb+xNhYMM=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.1/go.mod h1:eZ4g6GUvXiGulfIbbhh1Xr4XwUYaYaWMqzGD/284wCA=
 github.com/Azure/azure-service-bus-go v0.9.1/go.mod h1:yzBx6/BUGfjfeqbRZny9AQIbIe3AcV9WZbAdpkoXOa0=
 github.com/Azure/azure-storage-blob-go v0.8.0/go.mod h1:lPI3aLPpuLTeUwh1sViKXFxwl2B6teiRqI0deQUvsw0=
 github.com/Azure/azure-storage-blob-go v0.14.0 h1:1BCg74AmVdYwO3dlKwtFU1V0wU2PZdREkXvAmZJRUlM=

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -170,15 +170,15 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 		if !trace.IsNotFound(err) && !trace.IsAccessDenied(err) {
 			return nil, err
 		}
-		cfg.Log.WithError(err).Debugf("Failed to confirm that the %v container exists, attempting creation.", sessionContainerName)
+		cfg.Log.WithError(err).Debug("Failed to confirm that the " + sessionContainerName + " container exists, attempting creation.")
 		// someone else might've created the container between GetProperties and
 		// Create, so we ignore AlreadyExists
 		if _, err := cErr2(session.Create(ctx, nil)); err != nil && !trace.IsAlreadyExists(err) {
 			if !trace.IsAccessDenied(err) {
 				return nil, err
 			}
-			cfg.Log.WithError(err).Warnf(
-				"Could not create the %v container, please ensure it exists or session recordings will not be stored correctly.", sessionContainerName)
+			cfg.Log.WithError(err).Warn(
+				"Could not create the " + sessionContainerName + " container, please ensure it exists or session recordings will not be stored correctly.")
 		}
 	}
 
@@ -186,15 +186,15 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 		if !trace.IsNotFound(err) {
 			return nil, err
 		}
-		cfg.Log.WithError(err).Debugf("Failed to confirm that the %v container exists, attempting creation.", inprogressContainerName)
+		cfg.Log.WithError(err).Debug("Failed to confirm that the " + inprogressContainerName + " container exists, attempting creation.")
 		// someone else might've created the container between GetProperties and
 		// Create, so we ignore AlreadyExists
 		if _, err := cErr2(inprogress.Create(ctx, nil)); err != nil && !trace.IsAlreadyExists(err) {
 			if !trace.IsAccessDenied(err) {
 				return nil, err
 			}
-			cfg.Log.WithError(err).Warnf(
-				"Could not create the %v container, please ensure it exists or session recordings will not be stored correctly.", inprogressContainerName)
+			cfg.Log.WithError(err).Warn(
+				"Could not create the " + inprogressContainerName + " container, please ensure it exists or session recordings will not be stored correctly.")
 		}
 	}
 

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -113,7 +113,7 @@ func (c *Config) SetFromURL(u *url.URL) error {
 
 	params, err := url.ParseQuery(c.ServiceURL.EscapedFragment())
 	if err != nil {
-		return err
+		return trace.Wrap(err)
 	}
 	c.ServiceURL.Fragment = ""
 	c.ServiceURL.RawFragment = ""

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -98,6 +98,10 @@ type Config struct {
 }
 
 func (c *Config) SetFromURL(u *url.URL) error {
+	if u == nil {
+		return nil
+	}
+
 	c.ServiceURL = *u
 
 	switch c.ServiceURL.Scheme {

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -1,0 +1,518 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azsessions
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/session"
+)
+
+const (
+	sessionContainerName    = "session"
+	inprogressContainerName = "inprogress"
+
+	// uploadMarkerPrefix is the prefix for upload markers, stored at `upload/<session ID>/<upload ID>`.
+	uploadMarkerPrefix = "upload/"
+	// uploadMarkerFmt is the format string for upload markers, stored at `upload/<session ID>/<upload ID>`.
+	uploadMarkerFmt = "upload/%v/%v"
+
+	// partFmt is the format string for upload parts, stored at `part/<session ID>/<upload ID>/<part number>`.
+	partFmt = "part/%v/%v/%v"
+
+	// clientIDFragParam is the parameter in the fragment that specifies the optional client ID.
+	clientIDFragParam = "azure_client_id"
+)
+
+// field names used for logging
+const (
+	fieldSessionID  = "session_id"
+	fieldUploadID   = "upload_id"
+	fieldPartNumber = "part"
+	fieldPartCount  = "parts"
+)
+
+type Config struct {
+	// ServiceURL is the URL for the storage account to use.
+	ServiceURL url.URL
+
+	// ClientID, when set, defines the managed identity's client ID to use for
+	// authentication.
+	ClientID string
+
+	// Log is the logger to use. If unset, it will default to the global logger
+	// with a component of "azblob".
+	Log logrus.FieldLogger
+}
+
+func (c *Config) SetFromURL(u *url.URL) error {
+	c.ServiceURL = *u
+
+	switch c.ServiceURL.Scheme {
+	case teleport.SchemeAZBlob:
+		c.ServiceURL.Scheme = "https"
+	case teleport.SchemeAZBlobHTTP:
+		c.ServiceURL.Scheme = "http"
+	}
+
+	params, err := url.ParseQuery(c.ServiceURL.EscapedFragment())
+	if err != nil {
+		return err
+	}
+	c.ServiceURL.Fragment = ""
+	c.ServiceURL.RawFragment = ""
+
+	c.ClientID = params.Get(clientIDFragParam)
+
+	return nil
+}
+
+func (c *Config) CheckAndSetDefaults() error {
+	if c.Log == nil {
+		c.Log = logrus.WithField(trace.Component, teleport.SchemeAZBlob)
+	}
+
+	return nil
+}
+
+func NewHandlerFromURL(ctx context.Context, u *url.URL) (*Handler, error) {
+	var cfg Config
+	if err := cfg.SetFromURL(u); err != nil {
+		return nil, err
+	}
+	return NewHandler(ctx, cfg)
+}
+
+func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, err
+	}
+
+	var cred azcore.TokenCredential
+	if cfg.ClientID != "" {
+		c, err := azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{
+			ID: azidentity.ClientID(cfg.ClientID),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		cred = c
+	} else {
+		c, err := azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		cred = c
+	}
+
+	cred = &cachedTokenCredential{TokenCredential: cred}
+
+	service, err := azblob.NewServiceClient(cfg.ServiceURL.String(), cred, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	session, err := service.NewContainerClient(sessionContainerName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	inprogress, err := service.NewContainerClient(inprogressContainerName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if _, err := cErr2(session.GetProperties(ctx, nil)); err != nil {
+		if !trace.IsNotFound(err) && !trace.IsAccessDenied(err) {
+			return nil, err
+		}
+		cfg.Log.WithError(err).Debugf("Failed to confirm that the %v container exists, attempting creation.", sessionContainerName)
+		// someone else might've created the container between GetProperties and
+		// Create, so we ignore AlreadyExists
+		if _, err := cErr2(session.Create(ctx, nil)); err != nil && !trace.IsAlreadyExists(err) {
+			if !trace.IsAccessDenied(err) {
+				return nil, err
+			}
+			cfg.Log.WithError(err).Warnf(
+				"Could not create the %v container, please ensure it exists or session recordings will not be stored correctly.", sessionContainerName)
+		}
+	}
+
+	if _, err := cErr2(inprogress.GetProperties(ctx, nil)); err != nil {
+		if !trace.IsNotFound(err) {
+			return nil, err
+		}
+		cfg.Log.WithError(err).Debugf("Failed to confirm that the %v container exists, attempting creation.", inprogressContainerName)
+		// someone else might've created the container between GetProperties and
+		// Create, so we ignore AlreadyExists
+		if _, err := cErr2(inprogress.Create(ctx, nil)); err != nil && !trace.IsAlreadyExists(err) {
+			if !trace.IsAccessDenied(err) {
+				return nil, err
+			}
+			cfg.Log.WithError(err).Warnf(
+				"Could not create the %v container, please ensure it exists or session recordings will not be stored correctly.", inprogressContainerName)
+		}
+	}
+
+	return &Handler{c: cfg, cred: cred, session: session, inprogress: inprogress}, nil
+}
+
+type Handler struct {
+	c          Config
+	cred       azcore.TokenCredential
+	session    *azblob.ContainerClient
+	inprogress *azblob.ContainerClient
+}
+
+var _ events.MultipartHandler = (*Handler)(nil)
+
+// sessionBlob returns a BlockBlobClient for the blob of the recording of the
+// session. Not expected to ever fail.
+func (h *Handler) sessionBlob(sessionID session.ID) (*azblob.BlockBlobClient, error) {
+	blobName := sessionID.String()
+	client, err := h.session.NewBlockBlobClient(blobName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return client, nil
+}
+
+// uploadMarkerBlob returns a BlockBlobClient for the marker blob of the stream
+// upload. Not expected to ever fail.
+func (h *Handler) uploadMarkerBlob(upload events.StreamUpload) (*azblob.BlockBlobClient, error) {
+	blobName := fmt.Sprintf(uploadMarkerFmt, upload.SessionID, upload.ID)
+	client, err := h.inprogress.NewBlockBlobClient(blobName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return client, nil
+}
+
+// partBlob returns a BlockBlobClient for the blob of the part of the specified
+// upload, with the given part number. Not expected to ever fail.
+func (h *Handler) partBlob(upload events.StreamUpload, partNumber int64) (*azblob.BlockBlobClient, error) {
+	blobName := fmt.Sprintf(partFmt, upload.SessionID, upload.ID, partNumber)
+	client, err := h.inprogress.NewBlockBlobClient(blobName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return client, nil
+}
+
+func (h *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	blob, err := h.sessionBlob(sessionID)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := cErr2(blob.UploadStream(ctx, reader, azblob.UploadStreamOptions{
+		BlobAccessConditions: &blobDoesNotExist,
+	})); err != nil {
+		return "", err
+	}
+	h.c.Log.WithField(fieldSessionID, sessionID).Debug("Uploaded session.")
+
+	return blob.URL(), nil
+}
+
+func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+	blob, err := h.sessionBlob(sessionID)
+	if err != nil {
+		return err
+	}
+
+	const beginOffset = 0
+	if err := cErr(blob.DownloadToWriterAt(ctx, beginOffset, azblob.CountToEnd, writer, azblob.DownloadOptions{})); err != nil {
+		return err
+	}
+	h.c.Log.WithField(fieldSessionID, sessionID).Debug("Downloaded session.")
+
+	return nil
+}
+
+func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+	upload := events.StreamUpload{
+		ID:        uuid.NewString(),
+		SessionID: sessionID,
+	}
+
+	blob, err := h.uploadMarkerBlob(upload)
+	if err != nil {
+		return nil, err
+	}
+
+	emptyBody := streaming.NopCloser(&bytes.Reader{})
+	if _, err := cErr2(blob.Upload(ctx, emptyBody, &azblob.BlockBlobUploadOptions{
+		BlobAccessConditions: &blobDoesNotExist,
+	})); err != nil {
+		return nil, err
+	}
+	h.c.Log.WithField(fieldSessionID, sessionID).Debug("Created upload marker.")
+
+	return &upload, nil
+}
+
+func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload, parts []events.StreamPart) error {
+	blob, err := h.sessionBlob(upload.SessionID)
+	if err != nil {
+		return err
+	}
+
+	// TODO(espadolini): explore the possibility of using leases to get
+	// exclusive access while writing, and to guarantee that leftover parts are
+	// cleaned up before a new attempt
+
+	parts = slices.Clone(parts)
+	slices.SortFunc(parts, func(a, b events.StreamPart) bool { return a.Number < b.Number })
+
+	partURLs := make([]string, 0, len(parts))
+	for _, part := range parts {
+		b, err := h.partBlob(upload, part.Number)
+		if err != nil {
+			return err
+		}
+		partURLs = append(partURLs, b.URL())
+	}
+
+	token, err := h.cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{"https://storage.azure.com/.default"},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	copySourceAuthorization := "Bearer " + token.Token
+	stageOptions := &azblob.BlockBlobStageBlockFromURLOptions{
+		CopySourceAuthorization: &copySourceAuthorization,
+	}
+
+	log := h.c.Log.WithFields(logrus.Fields{
+		fieldSessionID: upload.SessionID,
+		fieldUploadID:  upload.ID,
+	})
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(5) // default parallelism as used by azblob.DoBatchTransfer
+
+	log.WithField(fieldPartCount, len(parts)).Debug("Beginning upload completion.")
+	blockNames := make([]string, len(parts))
+	// TODO(espadolini): use stable names (upload id, part number and then some
+	// hash maybe) to avoid re-staging parts more than once across multiple
+	// completion attempts?
+	for i := range parts {
+		i := i
+		eg.Go(func() error {
+			// we use block names that are local to this function so we don't
+			// interact with other ongoing uploads; trick copied from
+			// (*BlockBlobClient).UploadBuffer and UploadFile
+			u := uuid.New()
+			blockNames[i] = base64.StdEncoding.EncodeToString(u[:])
+
+			const contentLength = 0 // required by the API to be zero
+			if _, err := cErr2(blob.StageBlockFromURL(egCtx, blockNames[i], partURLs[i], contentLength, stageOptions)); err != nil {
+				return err
+			}
+			log.WithField(fieldPartNumber, i).Debug("Staged part.")
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	log.Debug("Committing part list.")
+	if _, err := cErr2(blob.CommitBlockList(ctx, blockNames, &azblob.BlockBlobCommitBlockListOptions{
+		BlobAccessConditions: &blobDoesNotExist,
+	})); err != nil {
+		if !trace.IsAlreadyExists(err) {
+			return err
+		}
+		log.Warn("Session upload already exists, cleaning up marker.")
+		parts = nil // don't delete parts that we didn't persist
+	} else {
+		log.Debug("Completed session upload.")
+	}
+
+	// TODO(espadolini): should the cleanup run in its own goroutine? What
+	// should the cancellation context for the cleanup be in that case?
+	markerBlob, err := h.uploadMarkerBlob(upload)
+	if err != nil {
+		log.Warn("Failed to clean up upload marker.")
+		return nil
+	}
+	if _, err := cErr2(markerBlob.Delete(ctx, nil)); err != nil && !trace.IsNotFound(err) {
+		log.WithError(err).Warn("Failed to clean up upload marker.")
+		return nil
+	}
+
+	// TODO(espadolini): group deletes together with Blob Batch, not supported
+	// by the SDK
+	for _, part := range parts {
+		b, err := h.partBlob(upload, part.Number)
+		if err != nil {
+			log.WithField(fieldPartNumber, part.Number).Warn("Failed to clean up part.")
+		}
+		if _, err := cErr2(b.Delete(ctx, nil)); err != nil {
+			log.WithField(fieldPartNumber, part.Number).WithError(err).Warn("Failed to clean up part.")
+		}
+	}
+
+	return nil
+}
+
+func (*Handler) ReserveUploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64) error {
+	return nil
+}
+
+func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64, partBody io.ReadSeeker) (*events.StreamPart, error) {
+	blob, err := h.partBlob(upload, partNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	// our parts are just over 5 MiB (events.MinUploadPartSizeBytes) so we can
+	// upload them in one shot
+	if _, err := cErr2(blob.Upload(ctx, streaming.NopCloser(partBody), nil)); err != nil {
+		return nil, err
+	}
+	h.c.Log.WithFields(logrus.Fields{
+		fieldSessionID:  upload.SessionID,
+		fieldUploadID:   upload.ID,
+		fieldPartNumber: partNumber,
+	}).Debug("Uploaded part.")
+
+	return &events.StreamPart{Number: partNumber}, nil
+}
+
+func (h *Handler) ListParts(ctx context.Context, upload events.StreamUpload) ([]events.StreamPart, error) {
+	prefix := fmt.Sprintf(partFmt, upload.SessionID, upload.ID, "")
+
+	var parts []events.StreamPart
+	pager := h.inprogress.ListBlobsFlat(&azblob.ContainerListBlobsFlatOptions{
+		Prefix: &prefix,
+	})
+	for pager.NextPage(ctx) {
+		resp := pager.PageResponse()
+		if resp.Segment == nil {
+			continue
+		}
+		parts = slices.Grow(parts, len(resp.Segment.BlobItems))
+		for _, b := range resp.Segment.BlobItems {
+			if b == nil ||
+				b.Name == nil ||
+				!strings.HasPrefix(*b.Name, prefix) {
+				continue
+			}
+
+			pn := strings.TrimPrefix(*b.Name, prefix)
+			partNumber, err := strconv.ParseInt(pn, 10, 0)
+			if err != nil {
+				continue
+			}
+
+			parts = append(parts, events.StreamPart{Number: partNumber})
+		}
+	}
+	if err := cErr(pager.Err()); err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(parts, func(a, b events.StreamPart) bool { return a.Number < b.Number })
+
+	return parts, nil
+}
+
+func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error) {
+	prefix := uploadMarkerPrefix
+	var uploads []events.StreamUpload
+
+	pager := h.inprogress.ListBlobsFlat(&azblob.ContainerListBlobsFlatOptions{
+		Prefix: &prefix,
+	})
+	for pager.NextPage(ctx) {
+		r := pager.PageResponse()
+		if r.Segment == nil {
+			continue
+		}
+		uploads = slices.Grow(uploads, len(r.Segment.BlobItems))
+		for _, b := range r.Segment.BlobItems {
+			if b == nil ||
+				b.Name == nil ||
+				!strings.HasPrefix(*b.Name, prefix) ||
+				b.Properties == nil ||
+				b.Properties.CreationTime == nil {
+				continue
+			}
+
+			name := strings.TrimPrefix(*b.Name, prefix)
+			sid, uid, ok := strings.Cut(name, "/")
+			if !ok {
+				continue
+			}
+			if _, err := session.ParseID(sid); err != nil {
+				continue
+			}
+			if _, err := uuid.Parse(uid); err != nil {
+				continue
+			}
+
+			uploads = append(uploads, events.StreamUpload{
+				ID:        uid,
+				SessionID: session.ID(sid),
+				Initiated: *b.Properties.CreationTime,
+			})
+		}
+	}
+	if err := cErr(pager.Err()); err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(uploads, func(a, b events.StreamUpload) bool { return a.Initiated.Before(b.Initiated) })
+
+	return uploads, nil
+}
+
+func (h *Handler) GetUploadMetadata(sessionID session.ID) events.UploadMetadata {
+	url := h.c.ServiceURL
+	url.Path = path.Join(url.Path, sessionContainerName, sessionID.String())
+
+	return events.UploadMetadata{
+		URL:       url.String(),
+		SessionID: sessionID,
+	}
+}

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -127,14 +127,6 @@ func (c *Config) CheckAndSetDefaults() error {
 	return nil
 }
 
-func NewHandlerFromURL(ctx context.Context, u *url.URL) (*Handler, error) {
-	var cfg Config
-	if err := cfg.SetFromURL(u); err != nil {
-		return nil, err
-	}
-	return NewHandler(ctx, cfg)
-}
-
 func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, err

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -318,7 +318,7 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 
 	markerBlob, err := h.uploadMarkerBlob(upload)
 	if err != nil {
-		return nil
+		return trace.Wrap(err)
 	}
 
 	// TODO(espadolini): explore the possibility of using leases to get

--- a/lib/events/azsessions/azsessions_test.go
+++ b/lib/events/azsessions/azsessions_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azsessions
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/events/test"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestMain(m *testing.M) {
+	utils.InitLoggerForTests()
+	os.Exit(m.Run())
+}
+
+func TestStreams(t *testing.T) {
+	ctx := context.Background()
+
+	envURL := os.Getenv(teleport.AZBlobTestURI)
+	if envURL == "" {
+		t.Skipf("Skipping azsessions tests as %q is not set.", teleport.AZBlobTestURI)
+	}
+
+	u, err := url.Parse(envURL)
+	require.NoError(t, err)
+
+	handler, err := NewHandlerFromURL(ctx, u)
+	require.Nil(t, err)
+
+	t.Run("StreamSinglePart", func(t *testing.T) {
+		test.StreamSinglePart(t, handler)
+	})
+	t.Run("UploadDownload", func(t *testing.T) {
+		test.UploadDownload(t, handler)
+	})
+	t.Run("DownloadNotFound", func(t *testing.T) {
+		test.DownloadNotFound(t, handler)
+	})
+}

--- a/lib/events/azsessions/azsessions_test.go
+++ b/lib/events/azsessions/azsessions_test.go
@@ -32,6 +32,8 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// TestStreams runs the standard events test suite over azsessions, if a
+// configuration URL is specified in the appropriate envvar.
 func TestStreams(t *testing.T) {
 	ctx := context.Background()
 

--- a/lib/events/azsessions/azsessions_test.go
+++ b/lib/events/azsessions/azsessions_test.go
@@ -43,7 +43,11 @@ func TestStreams(t *testing.T) {
 	u, err := url.Parse(envURL)
 	require.NoError(t, err)
 
-	handler, err := NewHandlerFromURL(ctx, u)
+	var config Config
+	err = config.SetFromURL(u)
+	require.NoError(t, err)
+
+	handler, err := NewHandler(ctx, config)
 	require.Nil(t, err)
 
 	t.Run("StreamSinglePart", func(t *testing.T) {

--- a/lib/events/azsessions/utils.go
+++ b/lib/events/azsessions/utils.go
@@ -1,0 +1,90 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azsessions
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/gravitational/trace"
+)
+
+var eTagAny = azblob.ETagAny
+
+var blobDoesNotExist = azblob.BlobAccessConditions{
+	ModifiedAccessConditions: &azblob.ModifiedAccessConditions{
+		IfNoneMatch: &eTagAny,
+	},
+}
+
+// cErr attempts to convert err to a meaningful trace error if it's a
+// *azblob.StorageError; if it can't, it'll return the error, wrapped.
+func cErr(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var stErr *azblob.StorageError
+	if !errors.As(err, &stErr) || stErr == nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.WrapWithMessage(trace.ReadError(stErr.StatusCode(), nil), stErr.ErrorCode)
+}
+
+// cErr2 converts the error as in cErr, leaving the first argument untouched.
+func cErr2[T any](v T, err error) (T, error) {
+	return v, cErr(err)
+}
+
+// cachedTokenCredential is a TokenCredential that will cache the last requested
+// AccessToken, and will reuse it without fetching one again as long as the
+// TokenRequestOptions match and the token has at least 10 more minutes before
+// expiration.
+type cachedTokenCredential struct {
+	azcore.TokenCredential
+
+	mu      sync.Mutex
+	options policy.TokenRequestOptions
+	token   azcore.AccessToken
+}
+
+var _ azcore.TokenCredential = (*cachedTokenCredential)(nil)
+
+func (c *cachedTokenCredential) GetToken(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	c.mu.Lock()
+	if reflect.DeepEqual(options, c.options) && c.token.ExpiresOn.After(time.Now().Add(10*time.Minute)) {
+		defer c.mu.Unlock()
+		return c.token, nil
+	}
+	c.mu.Unlock()
+
+	token, err := c.TokenCredential.GetToken(ctx, options)
+	if err != nil {
+		return azcore.AccessToken{}, err
+	}
+
+	c.mu.Lock()
+	c.options, c.token = options, token
+	c.mu.Unlock()
+
+	return token, nil
+}

--- a/lib/events/azsessions/utils.go
+++ b/lib/events/azsessions/utils.go
@@ -69,6 +69,7 @@ type cachedTokenCredential struct {
 
 var _ azcore.TokenCredential = (*cachedTokenCredential)(nil)
 
+// GetToken implements azcore.TokenCredential
 func (c *cachedTokenCredential) GetToken(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	c.mu.Lock()
 	if reflect.DeepEqual(options, c.options) && c.token.ExpiresOn.After(time.Now().Add(10*time.Minute)) {

--- a/lib/events/azsessions/utils.go
+++ b/lib/events/azsessions/utils.go
@@ -79,7 +79,7 @@ func (c *cachedTokenCredential) GetToken(ctx context.Context, options policy.Tok
 
 	token, err := c.TokenCredential.GetToken(ctx, options)
 	if err != nil {
-		return azcore.AccessToken{}, err
+		return azcore.AccessToken{}, trace.Wrap(err)
 	}
 
 	c.mu.Lock()

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -77,6 +77,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/azsessions"
 	"github.com/gravitational/teleport/lib/events/dynamoevents"
 	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/events/firestoreevents"
@@ -1316,6 +1317,12 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 		}
 
 		handler, err := s3sessions.NewHandler(ctx, config)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return handler, nil
+	case teleport.SchemeAZBlob, teleport.SchemeAZBlobHTTP:
+		handler, err := azsessions.NewHandlerFromURL(ctx, uri)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1322,7 +1322,11 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 		}
 		return handler, nil
 	case teleport.SchemeAZBlob, teleport.SchemeAZBlobHTTP:
-		handler, err := azsessions.NewHandlerFromURL(ctx, uri)
+		var config azsessions.Config
+		if err := config.SetFromURL(uri); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		handler, err := azsessions.NewHandler(ctx, config)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
Part of the implementation of #15771. Tracking issue: #15147.

This PR adds a new handler for session recordings backed by Azure Blob Storage.

Example config:
```yaml
teleport:
  storage:
    audit_sessions_uri: "azblob://storageaccountname.blob.core.windows.net"
```

For a specific managed identity ID, append `#azure_client_id=11111111-2222-3333-4444-555555555555` to the URI (to allow for different IDs for different services in the same auth server), otherwise the behavior of [`azidentity.DefaultAzureCredential`](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#DefaultAzureCredential) applies.

The storage backend will use two containers, `inprogress` and `session`, in the specified storage account (checking for their existence and attempting to create them during startup) to store the upload parts during uploads and to store the finished recordings.

A multipart upload is stored as an empty blob with name `upload/<session id>/<upload id>` plus some amount of parts with name `part/<session id>/<upload id>/<part number>`; to complete an upload, parts are pushed as blocks into the final recording blob at `<session id>` (in the `session` container) and then the block list is committed. This is done without fetching and uploading, by passing blob URLs to `Put Block By URL`.

The preconditions for `MultipartUploader` are not very well defined, but we seem to upload parts that are slightly bigger than 5MiB (except for the last one, which can be smaller but non-empty) and we upload at most 10000 parts; all very well within the limits of Azure Blob Storage and the APIs that we're using here. It's unclear if it's possible to have more than one upload for the same session ID at the same time (or if the same upload ID/session ID can be worked upon by multiple clients at once) but care has been taken to avoid corruption and data loss, all the same. If competing executions of `CompleteUpload` were more of a hard requirement rather than the potential result of a race condition bug, we could add some extra checks to avoid extra work - as it is, it shouldn't be a problem.

As mentioned in the related RFD, the choice of using separate containers was made so that it's possible to set an immutability policy at the container level on the `session` container, to prevent any potential tampering with data. It's important to note, however, that this is not a requirement - we're still going to explicitly avoid overwriting data.

Likewise, clean up of old session recordings can be done via a data retention policy. The `inprogress` container shouldn't need any clean up - leftover blobs in there after all sessions are uploaded should be considered a bug.

Fixes https://github.com/gravitational/teleport/issues/15147