### PR TITLE
Fix version target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ CLANG_FORMAT_STYLE = '{ColumnLimit: 100, IndentWidth: 4, Language: Proto}'
 #            This is the default build target for convenience of working on
 #            a web UI.
 .PHONY: all
-all: version
+all:
 	@echo "---> Building OSS binaries."
 	$(MAKE) $(BINARIES)
 

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ CLANG_FORMAT_STYLE = '{ColumnLimit: 100, IndentWidth: 4, Language: Proto}'
 #            This is the default build target for convenience of working on
 #            a web UI.
 .PHONY: all
-all:
+all: version
 	@echo "---> Building OSS binaries."
 	$(MAKE) $(BINARIES)
 
@@ -779,9 +779,17 @@ fix-license: $(ADDLICENSE)
 $(ADDLICENSE):
 	cd && go install github.com/google/addlicense@v1.0.0
 
+# This rule updates version files and Helm snapshots based on the Makefile
+# VERSION variable.
+#
+# Used prior to a release by bumping VERSION in this Makefile and then
+# running "make update-version".
+.PHONY: update-version
+update-version: version test-helm-update-snapshots
+
 # This rule triggers re-generation of version files if Makefile changes.
 .PHONY: version
-version: $(VERSRC) test-helm-update-snapshots
+version: $(VERSRC)
 
 # This rule triggers re-generation of version files specified if Makefile changes.
 $(VERSRC): Makefile


### PR DESCRIPTION
Fixes a CI build issue caused by https://github.com/gravitational/teleport/pull/16186 which added the `test-helm-update-snapshots` target as a dependency for `version` target:

```
make[3]: *** [Makefile:804: update-api-import-path] Error 1
--
9235 | helm unittest -u examples/chart/teleport-cluster
9236 | /bin/bash: helm: command not found
9237 | make[2]: *** [Makefile:509: test-helm-update-snapshots] Error 127
```

Turns out CI does `make all` and `all` target for some reason depends on `version` target which fails since our buildbox does not have Helm in it.

It looks like `all` target is used in several places in CI and release pipelines so in hindsight adding extra stuff to `version` wasn't a great idea. Instead, move it to a new `update-version` target that combines both "version" and "update helm snapshots".