### PR TITLE
Change caching resolver to return a copy of cached data

### DIFF
--- a/lib/reversetunnel/resolver.go
+++ b/lib/reversetunnel/resolver.go
@@ -47,7 +47,13 @@ func CachingResolver(ctx context.Context, resolver Resolver, clock clockwork.Clo
 		if err != nil {
 			return nil, err
 		}
-		return a.(*utils.NetAddr), nil
+		addr := a.(*utils.NetAddr)
+		if addr != nil {
+			// make a copy to avoid a data race when the caching resolver is shared by goroutines.
+			addrCopy := *addr
+			return &addrCopy, nil
+		}
+		return addr, nil
 	}, nil
 }
 


### PR DESCRIPTION
This PR changes the `reversetunnel.CachingResolver` func to make a copy of its cached `utils.NetAddr` and return a pointer to the copy.

The motivation for doing this is that I found a very subtle data race made possible by returning reference types from a cached resolver.

The code in question where the race detector found a race:
https://github.com/gravitational/teleport/blob/880e15f9844cbbfc667af904f9b1e45a9400143c/lib/reversetunnel/transport.go#L89-L99

Unrelated to the possible data race issue, this code is being changed which will the remove the race here. However, the reason this code can lead to data race relies on several subtle facts:
1. `t.Resolver(ctx)` can be a caching resolver. It can return the same exact thing twice.
2. `err` in this case can be a `trace.TraceError`, and `err.Error()` reads from `TraceError.Messages`
3. `trace.Wrap(err, "some message")` will modify the the passed in `err` instead of creating a new error, if the err is already `TraceError`.

With these facts, all we need for a race to be possible is for two goroutines to call `DialContext` with the same caching resolver. This is exactly what happens. We create a caching resolver and use it to make a gRPC api client and an HTTP client here: 
https://github.com/gravitational/teleport/blob/880e15f9844cbbfc667af904f9b1e45a9400143c/lib/auth/authclient/authclient.go#L84-L106

The gRPC code spawns some goroutine(s) that call `DialContext` with the caching resolver. Now if we get an error back from the caching resolver, we can have one goroutine reading `TraceError.Messages` while another is writing to it via `trace.Wrap`.

In order to prevent this very subtle race from being possible in the future, we should return a copy of the `utils.NetAddr` and return a pointer to the copy instead, so we don't accidentally cause a race by mutating the address returned.

This issue was found due to the return error though. It should not be the case that `trace.Wrap` mutates the error - that's very unintuitive and not obvious based on the function signature. I have a separate issue open in our trace repo to change the way `trace.Wrap` works, which will address the potential footgun using that: https://github.com/gravitational/trace/issues/81