### PR TITLE
Test smartcard initialization sequence

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -169,6 +169,9 @@ impl Client {
                     self.handle_server_announce(&mut payload)?
                 }
                 PacketId::PAKID_CORE_SERVER_CAPABILITY => {
+                    if self.test_debug_logs {
+                        debug!("got PAKID_CORE_SERVER_CAPABILITY");
+                    }
                     self.handle_server_capability(&mut payload)?
                 }
                 PacketId::PAKID_CORE_CLIENTID_CONFIRM => {
@@ -189,6 +192,10 @@ impl Client {
                     vec![]
                 }
             };
+
+            if self.test_debug_logs {
+                debug!("returning RDP raw: {:?}", responses);
+            }
 
             return Ok(responses);
         }

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -169,15 +169,20 @@ impl Client {
                     self.handle_server_announce(&mut payload)?
                 }
                 PacketId::PAKID_CORE_SERVER_CAPABILITY => {
-                    if self.test_debug_logs {
-                        debug!("got PAKID_CORE_SERVER_CAPABILITY");
-                    }
                     self.handle_server_capability(&mut payload)?
                 }
                 PacketId::PAKID_CORE_CLIENTID_CONFIRM => {
+                    if self.test_debug_logs {
+                        debug!("got PAKID_CORE_CLIENTID_CONFIRM");
+                    }
                     self.handle_client_id_confirm(&mut payload)?
                 }
-                PacketId::PAKID_CORE_DEVICE_REPLY => self.handle_device_reply(&mut payload)?,
+                PacketId::PAKID_CORE_DEVICE_REPLY => {
+                    if self.test_debug_logs {
+                        debug!("got PAKID_CORE_DEVICE_REPLY");
+                    }
+                    self.handle_device_reply(&mut payload)?
+                }
                 // Device IO request is where communication with the smartcard and shared drive actually happens.
                 // Everything up to this point was negotiation (and smartcard device registration).
                 PacketId::PAKID_CORE_DEVICE_IOREQUEST => {
@@ -4227,7 +4232,7 @@ mod tests {
         );
 
         // Response payload of:
-        // ClientCoreCapabilityResponse: [3, 0, 0, 0, 1, 0, 44, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 12, 0, 255, 127, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 5, 0, 8, 0, 1, 0, 0, 0, 4, 0, 8, 0, 2, 0, 0, 0]
+        // ClientCoreCapabilityResponse { num_capabilities: 3, padding: 0, capabilities: [CapabilitySet { header: CapabilityHeader { cap_type: CAP_GENERAL_TYPE, length: 44, version: 2 }, data: General(GeneralCapabilitySet { os_type: 0, os_version: 0, protocol_major_version: 1, protocol_minor_version: 12, io_code_1: 32767, io_code_2: 0, extended_pdu: 3, extra_flags_1: 0, extra_flags_2: 0, special_type_device_cap: 1 }) }, CapabilitySet { header: CapabilityHeader { cap_type: CAP_SMARTCARD_TYPE, length: 8, version: 1 }, data: Smartcard }, CapabilitySet { header: CapabilityHeader { cap_type: CAP_DRIVE_TYPE, length: 8, version: 2 }, data: Drive }] }
         let encoded_responses = vec![vec![
             68, 0, 0, 0, 3, 0, 0, 0, 114, 68, 80, 67, 3, 0, 0, 0, 1, 0, 44, 0, 2, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 1, 0, 12, 0, 255, 127, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
Adds tests for `handle_server_capability`, `handle_client_id_confirm`, and `handle_device_io_request`, abstracting the common logic of the tests out into `test_payload`.

Initially I had all of this as their own separate tests, but ran into an issue in `test_handle_device_reply` wherein I had to manually call `c.push_active_device_id(SCARD_DEVICE_ID)`:
https://github.com/gravitational/teleport/blob/ca5f785018056bca4671cb0639fa4c1cf99779c6/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs#L4269-L4284

In an ordinary initialization sequence, `c.push_active_device_id(SCARD_DEVICE_ID)` gets called during the processing of the previous message (in `c.handle_client_id_confirm`). This got me thinking that its probably best to run through all of these tests sequentially in a single test, since that way we are also testing the internal state of our `rdpdr::Client`:

https://github.com/gravitational/teleport/blob/02556c75c9499c4badc6b5e85565559c40684553/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs#L4269-L4277