### PR TITLE
Calculate shasums of TCon Linux OS packages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2098,6 +2098,10 @@ steps:
     -o -iname "teleport-connect*.deb" \) -print -exec cp {} /go/artifacts/ \;
   - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256;
     done && ls -l
+  - |-
+    cd /go/artifacts && for FILE in teleport-connect*.deb teleport-connect*.rpm; do
+      sha256sum $FILE > $FILE.sha256;
+    done && ls -l
 - name: Upload to S3
   image: plugins/s3
   settings:
@@ -7050,6 +7054,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 2d50f73226640e621d790dadf4f07b891eeb3e9e11f9b2cc8e93f6d4bed8841b
+hmac: b68fe9d35dc388588d492226f5a4da5df5590f397dd37292be5c0d3812fd64b3
 
 ...

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -177,6 +177,13 @@ func tagCopyArtifactCommands(b buildType) []string {
 
 	// generate checksums
 	commands = append(commands, fmt.Sprintf(`cd /go/artifacts && for FILE in teleport*%s; do sha256sum $FILE > $FILE.sha256; done && ls -l`, extension))
+
+	if b.os == "linux" && b.hasTeleportConnect() {
+		commands = append(commands,
+			`cd /go/artifacts && for FILE in teleport-connect*.deb teleport-connect*.rpm; do
+  sha256sum $FILE > $FILE.sha256;
+done && ls -l`)
+	}
 	return commands
 }
 


### PR DESCRIPTION
Current code assumes only `tar.gz` artifacts are built in the `build-linux-amd64` step and only calculates shasums for those:

https://github.com/gravitational/teleport/blob/4fc0291365cba303e5aff186855bd4be9b54a9e3/dronegen/tag.go#L179

This is because Linux OS packages are traditionally built in a separate pipeline. That is not true for Teleport Connect, where we build DEBs and RPMs in `build-linux-amd64`.

Currently, shasums are missing for Teleport Connect Linux packages. This has the following effects:
* Release API does not pick them up, as the CI integration code skips assets that do not have a corresponding `.sha256` file
* Houston accepts these assets, but fails to present a SHA256 in the web UI:
![image](https://user-images.githubusercontent.com/662666/189207271-81cfc7e0-6f68-4c68-a4d6-aad67857fe36.png)

This PR special-cases Linux/TCon pipeline to also calculate shasums for DEBs and RPMs.

It would also be great if someone with relevant permissions could manually upload these shasums for existing TCon Linux releases (currently only 10.2.0) to the S3 bucket, as that will solve the Houston issue for these releases.