### PR TITLE
Dial by UUID for label based ssh

### DIFF
--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -1048,12 +1048,10 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 					RequireSessionMFA: true,
 				},
 			},
-			setup:        registerPasswordlessDeviceWithWebauthnSolver,
-			hostLabels:   "env=dev",
-			errAssertion: require.Error,
-			// label is missing however tsh will try to connect over to agent "env=dev:3022"
-			// and fail, however that's why it require sign
-			deviceSignCount: 1,
+			setup:           registerPasswordlessDeviceWithWebauthnSolver,
+			hostLabels:      "env=dev",
+			errAssertion:    require.Error,
+			deviceSignCount: 0,
 			stdoutAssertion: require.Empty,
 		},
 	}


### PR DESCRIPTION
Switches label based ssh to always use the node UUID instead of its address. This prevents issues that occurred when dialing by address if the `public_addr` isn't set correctly.

Closes #3214