### PR TITLE
operator: Fix flaky drift tests (#15815)

### DIFF
--- a/operator/controllers/resources/role_controller_test.go
+++ b/operator/controllers/resources/role_controller_test.go
@@ -41,7 +41,7 @@ import (
 // the corresponding TeleportRole must be created/deleted in Teleport.
 func TestRoleCreation(t *testing.T) {
 	ctx := context.Background()
-	setup := setupKubernetesAndTeleport(t)
+	setup := setupTestEnv(t)
 	roleName := validRandomResourceName("role-")
 
 	// End of setup, we create the role in Kubernetes
@@ -75,7 +75,7 @@ func TestRoleCreation(t *testing.T) {
 
 func TestRoleCreationFromYAML(t *testing.T) {
 	ctx := context.Background()
-	setup := setupKubernetesAndTeleport(t)
+	setup := setupTestEnv(t)
 	tests := []struct {
 		name         string
 		roleSpecYAML string
@@ -233,9 +233,12 @@ func compareRoleSpecs(t *testing.T, expectedRole, actualRole types.Role) {
 	require.Equal(t, expected["spec"], actual["spec"])
 }
 
+// TestRoleDeletionDrift tests how the Kubernetes operator reacts when it is asked to delete a role that was
+// already deleted in Teleport
 func TestRoleDeletionDrift(t *testing.T) {
+	// Setup section: start the operator, and create a role
 	ctx := context.Background()
-	setup := setupKubernetesAndTeleport(t)
+	setup := setupTestEnv(t)
 	roleName := validRandomResourceName("role-")
 
 	// The role is created in K8S
@@ -255,6 +258,9 @@ func TestRoleDeletionDrift(t *testing.T) {
 
 		return true
 	})
+	// We cause a drift by altering the Teleport resource.
+	// To make sure the operator does not reconcile while we're finished we suspend the operator
+	setup.stopKubernetesOperator()
 
 	err := setup.tClient.DeleteRole(ctx, roleName)
 	require.NoError(t, err)
@@ -263,9 +269,13 @@ func TestRoleDeletionDrift(t *testing.T) {
 		return trace.IsNotFound(err)
 	})
 
-	// The role is deleted in K8S
+	// We flag the role for deletion in Kubernetes (it won't be fully remopved until the operator has processed it and removed the finalizer)
 	k8sDeleteRole(ctx, t, setup.k8sClient, roleName, setup.namespace.Name)
 
+	// Test section: We resume the operator, it should reconcile and recover from the drift
+	setup.startKubernetesOperator(t)
+
+	// The operator should handle the failed Teleport deletion gracefully and unlock the Kubernetes resource deletion
 	var k8sRole resourcesv5.TeleportRole
 	fastEventually(t, func() bool {
 		err = setup.k8sClient.Get(ctx, kclient.ObjectKey{
@@ -278,7 +288,7 @@ func TestRoleDeletionDrift(t *testing.T) {
 
 func TestRoleUpdate(t *testing.T) {
 	ctx := context.Background()
-	setup := setupKubernetesAndTeleport(t)
+	setup := setupTestEnv(t)
 	roleName := validRandomResourceName("role-")
 
 	// The role does not exist in K8S

--- a/operator/controllers/resources/suite_test.go
+++ b/operator/controllers/resources/suite_test.go
@@ -27,18 +27,21 @@ import (
 	"github.com/gravitational/teleport/api/identityfile"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/utils"
-	"github.com/sirupsen/logrus"
-
-	"github.com/google/uuid"
 	"github.com/gravitational/teleport/lib/service"
-	"github.com/stretchr/testify/require"
+	"github.com/gravitational/teleport/lib/utils"
+
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
@@ -112,63 +115,51 @@ func defaultTeleportServiceConfig(t *testing.T) (*helpers.TeleInstance, string) 
 	return teleportServer, operatorName
 }
 
-func startKubernetesOperator(t *testing.T, teleportClient auth.ClientI) kclient.Client {
-	testEnv := &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+// startKubernetesOperator creates and start a new operator
+func (s *testSetup) startKubernetesOperator(t *testing.T) {
+	// If there was an operator running previously we make sure it is stopped
+	if s.operatorCancel != nil {
+		s.stopKubernetesOperator()
 	}
 
-	cfg, err := testEnv.Start()
-	require.NoError(t, err)
-	require.NotNil(t, cfg)
-
-	err = resourcesv5.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-
-	err = resourcesv2.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-
-	k8sClient, err := kclient.New(cfg, kclient.Options{Scheme: scheme.Scheme})
-	require.NoError(t, err)
-	require.NotNil(t, k8sClient)
-
+	// We have to create a new Manager on each start because the Manager does not support to be restarted
 	clientAccessor := func(ctx context.Context) (auth.ClientI, error) {
-		return teleportClient, nil
+		return s.tClient, nil
 	}
 
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+	k8sManager, err := ctrl.NewManager(s.k8sRestConfig, ctrl.Options{
 		Scheme:             scheme.Scheme,
 		MetricsBindAddress: "0",
 	})
 	require.NoError(t, err)
 
 	err = (&RoleReconciler{
-		Client:                 k8sClient,
+		Client:                 s.k8sClient,
 		Scheme:                 k8sManager.GetScheme(),
 		TeleportClientAccessor: clientAccessor,
 	}).SetupWithManager(k8sManager)
 	require.NoError(t, err)
 
 	err = (&UserReconciler{
-		Client:                 k8sClient,
+		Client:                 s.k8sClient,
 		Scheme:                 k8sManager.GetScheme(),
 		TeleportClientAccessor: clientAccessor,
 	}).SetupWithManager(k8sManager)
 	require.NoError(t, err)
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	s.operator = k8sManager
+	s.operatorCancel = ctxCancel
+
 	go func() {
-		err = k8sManager.Start(ctx)
+		err := s.operator.Start(ctx)
 		require.NoError(t, err)
 	}()
+}
 
-	t.Cleanup(func() {
-		ctxCancel()
-		err = testEnv.Stop()
-		require.NoError(t, err)
-	})
-
-	return k8sClient
+func (s *testSetup) stopKubernetesOperator() {
+	s.operatorCancel()
 }
 
 func createNamespaceForTest(t *testing.T, kc kclient.Client) *core.Namespace {
@@ -178,10 +169,6 @@ func createNamespaceForTest(t *testing.T, kc kclient.Client) *core.Namespace {
 
 	err := kc.Create(context.Background(), ns)
 	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		deleteNamespaceForTest(t, kc, ns)
-	})
 
 	return ns
 }
@@ -202,20 +189,20 @@ func validRandomResourceName(prefix string) string {
 }
 
 type testSetup struct {
-	tClient   auth.ClientI
-	k8sClient kclient.Client
-	namespace *core.Namespace
+	tClient        auth.ClientI
+	k8sClient      kclient.Client
+	k8sRestConfig  *rest.Config
+	namespace      *core.Namespace
+	operator       manager.Manager
+	operatorCancel context.CancelFunc
 }
 
-func setupKubernetesAndTeleport(t *testing.T) testSetup {
+// setupTestEnv creates a Kubernetes server, a teleport server and starts the operator
+func setupTestEnv(t *testing.T) *testSetup {
+	// Create a Teleport server and its client
 	teleportServer, operatorName := defaultTeleportServiceConfig(t)
-
 	require.NoError(t, teleportServer.Start())
-
 	tClient := clientForTeleport(t, teleportServer, operatorName)
-	k8sClient := startKubernetesOperator(t, tClient)
-
-	ns := createNamespaceForTest(t, k8sClient)
 
 	t.Cleanup(func() {
 		err := tClient.Close()
@@ -223,7 +210,45 @@ func setupKubernetesAndTeleport(t *testing.T) testSetup {
 		err = teleportServer.StopAll()
 		require.NoError(t, err)
 	})
-	return testSetup{tClient: tClient, k8sClient: k8sClient, namespace: ns}
+
+	// Create a Kubernetes server, its client and the namespace we are testing in
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	err = resourcesv5.AddToScheme(scheme.Scheme)
+	require.NoError(t, err)
+
+	err = resourcesv2.AddToScheme(scheme.Scheme)
+	require.NoError(t, err)
+
+	k8sClient, err := kclient.New(cfg, kclient.Options{Scheme: scheme.Scheme})
+	require.NoError(t, err)
+	require.NotNil(t, k8sClient)
+
+	ns := createNamespaceForTest(t, k8sClient)
+
+	t.Cleanup(func() {
+		deleteNamespaceForTest(t, k8sClient, ns)
+		err = testEnv.Stop()
+		require.NoError(t, err)
+	})
+
+	setup := &testSetup{tClient: tClient, k8sClient: k8sClient, namespace: ns, k8sRestConfig: cfg}
+
+	// Create and start the Kubernetes operator
+	setup.startKubernetesOperator(t)
+
+	t.Cleanup(func() {
+		setup.stopKubernetesOperator()
+	})
+
+	return setup
 }
 
 func teleportCreateDummyRole(ctx context.Context, t *testing.T, roleName string, tClient auth.ClientI) {

--- a/operator/controllers/resources/user_controller_test.go
+++ b/operator/controllers/resources/user_controller_test.go
@@ -47,7 +47,7 @@ var teleportUserGVK = schema.GroupVersionKind{
 
 func TestUserCreation(t *testing.T) {
 	ctx := context.Background()
-	setup := setupKubernetesAndTeleport(t)
+	setup := setupTestEnv(t)
 	userName := validRandomResourceName("user-")
 
 	teleportCreateDummyRole(ctx, t, "a", setup.tClient)
@@ -80,7 +80,7 @@ func TestUserCreation(t *testing.T) {
 }
 func TestUserCreationFromYAML(t *testing.T) {
 	ctx := context.Background()
-	setup := setupKubernetesAndTeleport(t)
+	setup := setupTestEnv(t)
 	teleportCreateDummyRole(ctx, t, "a", setup.tClient)
 	tests := []struct {
 		name         string
@@ -227,9 +227,12 @@ func compareUserSpecs(t *testing.T, expectedUser, actualUser types.User) {
 	require.Equal(t, expected["spec"], actual["spec"])
 }
 
+// TestUserDeletionDrift tests how the Kubernetes operator reacts when it is asked to delete a user that was
+// already deleted in Teleport
 func TestUserDeletionDrift(t *testing.T) {
+	// Setup section: start the operator, and create a user
 	ctx := context.Background()
-	setup := setupKubernetesAndTeleport(t)
+	setup := setupTestEnv(t)
 	userName := validRandomResourceName("user-")
 
 	teleportCreateDummyRole(ctx, t, "a", setup.tClient)
@@ -252,6 +255,9 @@ func TestUserDeletionDrift(t *testing.T) {
 
 		return true
 	})
+	// We cause a drift by altering the Teleport resource.
+	// To make sure the operator does not reconcile while we're finished we suspend the operator
+	setup.stopKubernetesOperator()
 
 	err := setup.tClient.DeleteUser(ctx, userName)
 	require.NoError(t, err)
@@ -260,9 +266,13 @@ func TestUserDeletionDrift(t *testing.T) {
 		return trace.IsNotFound(err)
 	})
 
-	// The role is deleted in K8S
+	// We flag the role for deletion in Kubernetes (it won't be fully remopved until the operator has processed it and removed the finalizer)
 	k8sDeleteUser(ctx, t, setup.k8sClient, userName, setup.namespace.Name)
 
+	// Test section: We resume the operator, it should reconcile and recover from the drift
+	setup.startKubernetesOperator(t)
+
+	// The operator should handle the failed Teleport deletion gracefully and unlock the Kubernetes resource deletion
 	var k8sUser resourcesv2.TeleportUser
 	fastEventually(t, func() bool {
 		err = setup.k8sClient.Get(ctx, kclient.ObjectKey{
@@ -275,7 +285,7 @@ func TestUserDeletionDrift(t *testing.T) {
 
 func TestUserUpdate(t *testing.T) {
 	ctx := context.Background()
-	setup := setupKubernetesAndTeleport(t)
+	setup := setupTestEnv(t)
 	teleportCreateDummyRole(ctx, t, "a", setup.tClient)
 	teleportCreateDummyRole(ctx, t, "b", setup.tClient)
 	teleportCreateDummyRole(ctx, t, "x", setup.tClient)


### PR DESCRIPTION
Fixes #15815

The drift tests were not suspending the operator reconciliation loop when causing the drift. If the operator reconciles before during the drift setup, we are not testing what we want (the oeprator creates the resource back in Teleport).

This PR adds the methods `startKubernetesOperator` and `stopKubernetesOperator` on the `testSetup` struct to fix drift tests.