### PR TITLE
Unhide tctl alert create

### DIFF
--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -38,9 +38,10 @@ import (
 type AlertCommand struct {
 	config *service.Config
 
-	message string
-
-	labels string
+	message  string
+	labels   string
+	severity string
+	ttl      time.Duration
 
 	verbose bool
 
@@ -57,8 +58,10 @@ func (c *AlertCommand) Initialize(app *kingpin.Application, config *service.Conf
 	c.alertList.Flag("verbose", "Show detailed alert info").Short('v').BoolVar(&c.verbose)
 	c.alertList.Flag("labels", labelHelp).StringVar(&c.labels)
 
-	c.alertCreate = alert.Command("create", "Create cluster alerts").Hidden()
+	c.alertCreate = alert.Command("create", "Create cluster alerts")
 	c.alertCreate.Arg("message", "Alert body message").Required().StringVar(&c.message)
+	c.alertCreate.Flag("ttl", "Time duration after which the alert expires.").DurationVar(&c.ttl)
+	c.alertCreate.Flag("severity", "Severity of the alert (low, medium, or high)").Default("low").EnumVar(&c.severity, "low", "medium", "high")
 	c.alertCreate.Flag("labels", labelHelp).StringVar(&c.labels)
 }
 
@@ -130,12 +133,30 @@ func (c *AlertCommand) Create(ctx context.Context, client auth.ClientI) error {
 		return trace.Wrap(err)
 	}
 
-	alert, err := types.NewClusterAlert(uuid.New().String(), c.message)
+	var sev types.AlertSeverity
+	switch c.severity {
+	case "low":
+		sev = types.AlertSeverity_LOW
+	case "medium":
+		sev = types.AlertSeverity_MEDIUM
+	case "high":
+		sev = types.AlertSeverity_HIGH
+	}
+
+	alert, err := types.NewClusterAlert(uuid.New().String(), c.message, types.WithAlertSeverity(sev))
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
+	if len(labels) == 0 {
+		labels[types.AlertOnLogin] = "yes"
+		labels[types.AlertPermitAll] = "yes"
+	}
 	alert.Metadata.Labels = labels
+
+	if c.ttl > 0 {
+		alert.SetExpiry(time.Now().UTC().Add(c.ttl))
+	}
 
 	return trace.Wrap(client.UpsertClusterAlert(ctx, alert))
 }


### PR DESCRIPTION
Also add optional --ttl and --severity flags.
This allows cluster administrators to set custom alerts (during maintenance periods, for example).

Fixes #6442