### PR TITLE
ci: Add govulncheck as a new linter

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,26 @@
+name: govulncheck
+
+on:
+  push:
+    branches:
+      - master
+      - branch/*
+    paths-ignore:
+      - 'docs/**'
+      - 'rfd/**'
+      - '**.md'
+  pull_request:
+    branches:
+      - master
+      - branch/*
+    paths-ignore:
+      - 'docs/**'
+      - 'rfd/**'
+      - '**.md'
+  workflow_dispatch:
+
+jobs:
+  govulncheck:
+    uses: gravitational/shared-workflows/.github/workflows/govulncheck.yaml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
Run `govulncheck` in each directory containing `go.mod`.

References:
* https://go.dev/blog/vuln
* https://vuln.go.dev/
* https://go.dev/security/vuln/