### PR TITLE
Fix incorrect use of loop variables

### DIFF
--- a/integration/proxy/proxy_tunnel_strategy_test.go
+++ b/integration/proxy/proxy_tunnel_strategy_test.go
@@ -125,6 +125,7 @@ func testProxyTunnelStrategyAgentMesh(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			p := newProxyTunnelStrategy(t, "proxy-tunnel-agent-mesh",

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -222,6 +222,7 @@ func (u *UploadCompleter) checkUploads(ctx context.Context) error {
 		// This is necessary because we'll need to download the session in order to
 		// enumerate its events, and the S3 API takes a little while after the upload
 		// is completed before version metadata becomes available.
+		upload := upload // capture range variable
 		go func() {
 			select {
 			case <-ctx.Done():

--- a/lib/observability/tracing/client_test.go
+++ b/lib/observability/tracing/client_test.go
@@ -101,6 +101,7 @@ func TestRotatingFileClient(t *testing.T) {
 	}
 
 	for _, tt := range cases {
+		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()

--- a/lib/observability/tracing/tracing_test.go
+++ b/lib/observability/tracing/tracing_test.go
@@ -338,6 +338,7 @@ func TestTraceProvider(t *testing.T) {
 	}
 
 	for _, tt := range cases {
+		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			collector, err := NewCollector(CollectorConfig{

--- a/operator/controllers/resources/role_controller_test.go
+++ b/operator/controllers/resources/role_controller_test.go
@@ -155,6 +155,7 @@ allow:
 	}
 
 	for _, tc := range tests {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			// Creating the Kubernetes resource. We are using an untyped client to be able to create invalid resources.

--- a/operator/controllers/resources/user_controller_test.go
+++ b/operator/controllers/resources/user_controller_test.go
@@ -145,6 +145,7 @@ traits:
 	}
 
 	for _, tc := range tests {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			// Creating the Kubernetes resource. We are using an untyped client to be able to create invalid resources.

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -73,6 +73,7 @@ func TestSSH(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tc.fn(t, s)


### PR DESCRIPTION
This commit fixes a few occurrences of loop variables being incorrectly used in the context of Go-routines or (most frequently) parallel tests. To fix the issues, we create a local copy of the range variables before the parallel tests (or Go-routine), as suggested in the documentation of the `testing` package:

https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks

Issues were found using the `loopvarcapture` linter.