### PR TITLE
[v10] docs: Add missing commands key to dynamic labels in reference

### DIFF
--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -83,7 +83,7 @@ teleport:
     # PID file for Teleport process
     #pid_file: /var/run/teleport.pid
 
-    # The invitation token or an absolute path to a file containing the token used 
+    # The invitation token or an absolute path to a file containing the token used
     # to join a cluster. It is not used on subsequent starts.
     # If using a file, it only needs to exist when teleport is first ran.
     #
@@ -203,7 +203,7 @@ teleport:
         # set `journal` to `WAL` and `sync` to `NORMAL`, but only when using a filesystem
         # that supports locks (see https://www.sqlite.org/pragma.html#pragma_journal_mode).
         #journal: DELETE
-        
+
         # DynamoDB-specific section:
 
         # continuous_backups is used to enable continuous backups.
@@ -759,6 +759,7 @@ kubernetes_service:
     labels:
       env: "prod"
     # Optional Dynamic Labels
+    commands:
     - name: "os"
        command: ["/usr/bin/uname"]
        period: "5s"


### PR DESCRIPTION
Backport #15869 to branch/v10