### PR TITLE
Tweak TestAgentForward

### DIFF
--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -663,7 +663,7 @@ func TestAgentForward(t *testing.T) {
 			return true
 		}
 		return false
-	}, 5*time.Second, 10*time.Millisecond, "failed to read socket path")
+	}, 10*time.Second, 100*time.Millisecond, "failed to read socket path")
 
 	// try dialing the ssh agent socket:
 	file, err := net.Dial("unix", socketPath)
@@ -704,10 +704,10 @@ func TestAgentForward(t *testing.T) {
 	// clt must be nullified to prevent double-close during test cleanup
 	f.ssh.clt = nil
 	require.Eventually(t, func() bool {
-		_, err := net.Dial("unix", socketPath)
+		_, err := clientAgent.List()
 		return err != nil
 	},
-		150*time.Millisecond, 50*time.Millisecond,
+		10*time.Second, 100*time.Millisecond,
 		"expected socket to be closed, still could dial")
 }
 


### PR DESCRIPTION
We haven't been able to reproduce this test flakiness outside CI even by running it in a loop for several days in a row. So these tweaks are purely opportunistic in hope to reduce the flakiness until we're able to rewrite the test:

- Tweak the timeouts to allow the test more time to check for conditions as 150ms seems quite low.
- Replace socket dial with actually trying to use the agent's API which is expected to fail, to account for potential races where the socket file may still exist after being closed.