### PR TITLE
[v9] Fix clippy warnings in roletester

### DIFF
--- a/lib/datalog/roletester/build.rs
+++ b/lib/datalog/roletester/build.rs
@@ -14,7 +14,13 @@
 
 use std::io::Result;
 
+// See https://github.com/tokio-rs/prost/issues/661
+const DERIVE_EQ: &str = "#[derive(Eq)]";
+
 fn main() -> Result<()> {
-    prost_build::compile_protos(&["../types.proto"], &["../"])?;
+    prost_build::Config::new()
+        .type_attribute("Facts", DERIVE_EQ)
+        .type_attribute("Predicate", DERIVE_EQ)
+        .compile_protos(&["../types.proto"], &["../"])?;
     Ok(())
 }

--- a/lib/datalog/roletester/src/role_tester.rs
+++ b/lib/datalog/roletester/src/role_tester.rs
@@ -105,10 +105,11 @@ fn create_error_ptr(e: String) -> Output {
 ///
 /// This function should not be called if input is invalid
 #[no_mangle]
-pub unsafe extern "C" fn process_access(input: *mut c_uchar, input_len: size_t) -> *mut Output {
+pub unsafe extern "C" fn process_access(input: *const c_uchar, input_len: size_t) -> *mut Output {
     let mut runtime = Crepe::new();
-    let b = slice::from_raw_parts_mut(input, input_len);
-    let r = match types::Facts::decode(BytesMut::from(&b[..])) {
+
+    let b = slice::from_raw_parts(input, input_len);
+    let r = match types::Facts::decode(BytesMut::from(b)) {
         Ok(b) => b,
         Err(e) => return Box::into_raw(Box::new(create_error_ptr(e.to_string()))),
     };


### PR DESCRIPTION
The tip of `branch/v9` seems to be failing the clippy lint step. 

```
error: you are deriving `PartialEq` and can implement `Eq`
 --> /workspace/target/debug/build/role_tester-8b0c83067b92a0db/out/datalog.rs:9:21
  |
9 |     #[derive(Clone, PartialEq, ::prost::Message)]
  |                     ^^^^^^^^^ help: consider deriving `Eq` as well: `PartialEq, Eq`
  |
  = note: `-D clippy::derive-partial-eq-without-eq` implied by `-D warnings`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

error: redundant slicing of the whole range
   --> lib/datalog/roletester/src/role_tester.rs:111:55
    |
111 |     let r = match types::Facts::decode(BytesMut::from(&b[..])) {
    |                                                       ^^^^^^ help: use the original value instead: `b`
    |
    = note: `-D clippy::redundant-slicing` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_slicing
```

This attempts a fix.