### PR TITLE
Reduce number of auth dials for tsh commands

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -28,7 +28,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -40,12 +42,9 @@ import (
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/teleagent"
-
-	"github.com/gravitational/trace"
-	"golang.org/x/crypto/ssh/agent"
 )
 
-// commandOptions controls how the SSH command is built.
+// CommandOptions controls how the SSH command is built.
 type CommandOptions struct {
 	ForwardAgent bool
 	ForcePTY     bool

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1728,7 +1728,7 @@ func testInvalidLogins(t *testing.T, suite *integrationTestSuite) {
 	})
 	require.NoError(t, err)
 	err = tc.SSH(context.TODO(), cmd, false)
-	require.Regexp(t, "cluster wrong-site not found", err.Error())
+	require.Contains(t, err.Error(), `unknown cluster \"wrong-site\"`)
 }
 
 // TestTwoClustersTunnel creates two teleport clusters: "a" and "b" and creates a
@@ -3484,73 +3484,75 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 	}
 
 	for _, tt := range tests {
-		controlDir, err := os.MkdirTemp("", "teleport-")
-		require.NoError(t, err)
-		defer os.RemoveAll(controlDir)
-		controlPath := filepath.Join(controlDir, "control-path")
-
-		// Create a Teleport instance with auth, proxy, and node.
-		makeConfig := func() (*testing.T, []string, []*helpers.InstanceSecrets, *service.Config) {
-			recConfig, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
-				Mode: tt.inRecordLocation,
-			})
+		t.Run(fmt.Sprintf("recording_mode=%s", tt.inRecordLocation), func(t *testing.T) {
+			controlDir, err := os.MkdirTemp("", "teleport-")
 			require.NoError(t, err)
+			defer os.RemoveAll(controlDir)
+			controlPath := filepath.Join(controlDir, "control-path")
 
-			tconf := suite.defaultServiceConfig()
-			tconf.Auth.Enabled = true
-			tconf.Auth.SessionRecordingConfig = recConfig
+			// Create a Teleport instance with auth, proxy, and node.
+			makeConfig := func() (*testing.T, []string, []*helpers.InstanceSecrets, *service.Config) {
+				recConfig, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
+					Mode: tt.inRecordLocation,
+				})
+				require.NoError(t, err)
 
-			tconf.Proxy.Enabled = true
-			tconf.Proxy.DisableWebService = true
-			tconf.Proxy.DisableWebInterface = true
+				tconf := suite.defaultServiceConfig()
+				tconf.Auth.Enabled = true
+				tconf.Auth.SessionRecordingConfig = recConfig
 
-			tconf.SSH.Enabled = true
+				tconf.Proxy.Enabled = true
+				tconf.Proxy.DisableWebService = true
+				tconf.Proxy.DisableWebInterface = true
 
-			return t, nil, nil, tconf
-		}
-		teleport := suite.NewTeleportWithConfig(makeConfig())
-		defer teleport.StopAll()
+				tconf.SSH.Enabled = true
 
-		// Generate certificates for the user simulating login.
-		creds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{
-			Process:  teleport.Process,
-			Username: suite.Me.Username,
-		})
-		require.NoError(t, err)
-
-		// Start (and defer close) a agent that runs during this integration test.
-		teleAgent, socketDirPath, socketPath, err := helpers.CreateAgent(suite.Me, &creds.Key)
-		require.NoError(t, err)
-		defer helpers.CloseAgent(teleAgent, socketDirPath)
-
-		// Create and run an exec command twice with the passed in ControlPath. This
-		// will cause re-use of the connection and creation of two sessions within
-		// the connection.
-		for i := 0; i < 2; i++ {
-			execCmd, err := helpers.ExternalSSHCommand(helpers.CommandOptions{
-				ForcePTY:     true,
-				ForwardAgent: true,
-				ControlPath:  controlPath,
-				SocketPath:   socketPath,
-				ProxyPort:    helpers.PortStr(t, teleport.SSHProxy),
-				NodePort:     helpers.PortStr(t, teleport.SSH),
-				Command:      "echo hello",
-			})
-			require.NoError(t, err)
-
-			// Execute SSH command and check the output is what we expect.
-			output, err := execCmd.Output()
-			if err != nil {
-				// If an *exec.ExitError is returned, parse it and return stderr. If this
-				// is not done then c.Assert will just print a byte array for the error.
-				er, ok := err.(*exec.ExitError)
-				if ok {
-					t.Fatalf("Unexpected error: %v", string(er.Stderr))
-				}
+				return t, nil, nil, tconf
 			}
+			teleport := suite.NewTeleportWithConfig(makeConfig())
+			defer teleport.StopAll()
+
+			// Generate certificates for the user simulating login.
+			creds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{
+				Process:  teleport.Process,
+				Username: suite.Me.Username,
+			})
 			require.NoError(t, err)
-			require.True(t, strings.HasSuffix(strings.TrimSpace(string(output)), "hello"))
-		}
+
+			// Start (and defer close) a agent that runs during this integration test.
+			teleAgent, socketDirPath, socketPath, err := helpers.CreateAgent(suite.Me, &creds.Key)
+			require.NoError(t, err)
+			defer helpers.CloseAgent(teleAgent, socketDirPath)
+
+			// Create and run an exec command twice with the passed in ControlPath. This
+			// will cause re-use of the connection and creation of two sessions within
+			// the connection.
+			for i := 0; i < 2; i++ {
+				execCmd, err := helpers.ExternalSSHCommand(helpers.CommandOptions{
+					ForcePTY:     true,
+					ForwardAgent: true,
+					ControlPath:  controlPath,
+					SocketPath:   socketPath,
+					ProxyPort:    helpers.PortStr(t, teleport.SSHProxy),
+					NodePort:     helpers.PortStr(t, teleport.SSH),
+					Command:      "echo hello",
+				})
+				require.NoError(t, err)
+
+				// Execute SSH command and check the output is what we expect.
+				output, err := execCmd.Output()
+				if err != nil {
+					// If an *exec.ExitError is returned, parse it and return stderr. If this
+					// is not done then c.Assert will just print a byte array for the error.
+					er, ok := err.(*exec.ExitError)
+					if ok {
+						t.Fatalf("Unexpected error: %v", string(er.Stderr))
+					}
+				}
+				require.NoError(t, err)
+				require.True(t, strings.HasSuffix(strings.TrimSpace(string(output)), "hello"))
+			}
+		})
 	}
 }
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1851,12 +1851,7 @@ func (tc *TeleportClient) NewTracingClient(ctx context.Context) (*apitracing.Cli
 		return nil, trace.Wrap(err)
 	}
 
-	site, err := proxyClient.currentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	clt, err := proxyClient.NewTracingClient(ctx, site.Name)
+	clt, err := proxyClient.NewTracingClient(ctx, tc.SiteName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1888,10 +1883,7 @@ func (tc *TeleportClient) SSH(ctx context.Context, command []string, runLocally 
 		return trace.Wrap(err)
 	}
 	defer proxyClient.Close()
-	siteInfo, err := proxyClient.currentCluster(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+
 	// which nodes are we executing this commands on?
 	nodeAddrs, err := tc.getTargetNodes(ctx, proxyClient)
 	if err != nil {
@@ -1902,9 +1894,9 @@ func (tc *TeleportClient) SSH(ctx context.Context, command []string, runLocally 
 	}
 
 	if len(nodeAddrs) > 1 {
-		return tc.runShellOrCommandOnMultipleNodes(ctx, siteInfo.Name, nodeAddrs, proxyClient, command)
+		return tc.runShellOrCommandOnMultipleNodes(ctx, tc.SiteName, nodeAddrs, proxyClient, command)
 	}
-	return tc.runShellOrCommandOnSingleNode(ctx, siteInfo.Name, nodeAddrs[0], proxyClient, command, runLocally)
+	return tc.runShellOrCommandOnSingleNode(ctx, tc.SiteName, nodeAddrs[0], proxyClient, command, runLocally)
 }
 
 func (tc *TeleportClient) runShellOrCommandOnSingleNode(ctx context.Context, siteName string, nodeAddr string, proxyClient *ProxyClient, command []string, runLocally bool) error {
@@ -2045,10 +2037,7 @@ func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipan
 		return trace.Wrap(err)
 	}
 	defer proxyClient.Close()
-	site, err := proxyClient.ConnectToCurrentCluster(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	site := proxyClient.CurrentCluster()
 
 	// Session joining is not supported in proxy recording mode
 	if recConfig, err := site.GetSessionRecordingConfig(ctx); err != nil {
@@ -2133,10 +2122,8 @@ func (tc *TeleportClient) Play(ctx context.Context, namespace, sessionID string)
 	}
 	defer proxyClient.Close()
 
-	site, err := proxyClient.ConnectToCurrentCluster(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	site := proxyClient.CurrentCluster()
+
 	// request events for that session (to get timing data)
 	sessionEvents, err = site.GetSessionEvents(namespace, *sid, 0, true)
 	if err != nil {
@@ -2194,10 +2181,8 @@ func (tc *TeleportClient) GetSessionEvents(ctx context.Context, namespace, sessi
 	}
 	defer proxyClient.Close()
 
-	site, err := proxyClient.ConnectToCurrentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	site := proxyClient.CurrentCluster()
+
 	events, err := site.GetSessionEvents(namespace, *sid, 0, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2252,11 +2237,6 @@ func (tc *TeleportClient) ExecuteSCP(ctx context.Context, cmd scp.Command) (err 
 	}
 	defer proxyClient.Close()
 
-	clusterInfo, err := proxyClient.currentCluster(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	// which nodes are we executing this commands on?
 	nodeAddrs, err := tc.getTargetNodes(ctx, proxyClient)
 	if err != nil {
@@ -2268,7 +2248,7 @@ func (tc *TeleportClient) ExecuteSCP(ctx context.Context, cmd scp.Command) (err 
 
 	nodeClient, err := proxyClient.ConnectToNode(
 		ctx,
-		NodeDetails{Addr: nodeAddrs[0], Namespace: tc.Namespace, Cluster: clusterInfo.Name},
+		NodeDetails{Addr: nodeAddrs[0], Namespace: tc.Namespace, Cluster: tc.SiteName},
 		tc.Config.HostLogin,
 	)
 	if err != nil {
@@ -2327,17 +2307,14 @@ func (tc *TeleportClient) SCP(ctx context.Context, args []string, port int, flag
 
 	// helper function connects to the src/target node:
 	connectToNode := func(addr, hostLogin string) (*NodeClient, error) {
-		// determine which cluster we're connecting to:
-		siteInfo, err := proxyClient.currentCluster(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 		if hostLogin == "" {
 			hostLogin = tc.Config.HostLogin
 		}
-		return proxyClient.ConnectToNode(ctx,
-			NodeDetails{Addr: addr, Namespace: tc.Namespace, Cluster: siteInfo.Name},
-			hostLogin)
+		return proxyClient.ConnectToNode(
+			ctx,
+			NodeDetails{Addr: addr, Namespace: tc.Namespace, Cluster: tc.SiteName},
+			hostLogin,
+		)
 	}
 
 	// gets called to convert SSH error code to tc.ExitStatus
@@ -3141,7 +3118,7 @@ func (tc *TeleportClient) connectToProxy(ctx context.Context) (*ProxyClient, err
 		return nil, trace.Wrap(err)
 	}
 
-	return &ProxyClient{
+	pc := &ProxyClient{
 		teleportClient:  tc,
 		Client:          sshClient,
 		proxyAddress:    sshProxyAddr,
@@ -3152,7 +3129,24 @@ func (tc *TeleportClient) connectToProxy(ctx context.Context) (*ProxyClient, err
 		siteName:        clusterName(),
 		clientAddr:      tc.ClientAddr,
 		Tracer:          tc.Tracer,
-	}, nil
+	}
+
+	// Create the auth.ClientI for the local auth server
+	// once per ProxyClient. This is an inexpensive
+	// operation since the actual dialing of the auth
+	// server is lazy - meaning it won't happen until the
+	// first use of the auth.ClientI. By establishing
+	// the auth.ClientI here we can ensure that any connections
+	// to the local cluster will end up reusing this auth.ClientI
+	// for the lifespan of the ProxyClient.
+	clt, err := pc.ConnectToCluster(ctx, pc.siteName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	pc.currentCluster = clt
+
+	return pc, nil
 }
 
 // makeProxySSHClient creates an SSH client by following steps:
@@ -3827,7 +3821,7 @@ func (tc *TeleportClient) GetTrustedCA(ctx context.Context, clusterName string) 
 	defer proxyClient.Close()
 
 	// Get a client to the Auth Server.
-	clt, err := proxyClient.ClusterAccessPoint(ctx, clusterName)
+	clt, err := proxyClient.ConnectToCluster(ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4518,11 +4512,9 @@ func (tc *TeleportClient) SearchSessionEvents(ctx context.Context, fromUTC, toUT
 		return nil, trace.Wrap(err)
 	}
 	defer proxyClient.Close()
-	authClient, err := proxyClient.CurrentClusterAccessPoint(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	authClient := proxyClient.CurrentCluster()
 	defer authClient.Close()
+
 	sessions, err := GetPaginatedSessions(ctx, fromUTC, toUTC,
 		pageSize, order, max, authClient)
 	if err != nil {

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1054,23 +1054,23 @@ func (proxy *ProxyClient) ListResources(ctx context.Context, namespace, resource
 	return resp.Resources, resp.NextKey, nil
 }
 
-// authClient is a wrapper around auth.ClientI which
+// sharedAuthClient is a wrapper around auth.ClientI which
 // prevents the underlying client from being closed.
-type authClient struct {
+type sharedAuthClient struct {
 	auth.ClientI
 }
 
 // Close is a no-op
-func (a authClient) Close() error {
+func (a sharedAuthClient) Close() error {
 	return nil
 }
 
 // CurrentCluster returns an authenticated auth server client for the local cluster.
 func (proxy *ProxyClient) CurrentCluster() auth.ClientI {
-	// The auth.ClientI is wrapped in an authClient to prevent callers from
+	// The auth.ClientI is wrapped in an sharedAuthClient to prevent callers from
 	// being able to close the client. The auth.ClientI is only to be closed
 	// when the ProxyClient is closed.
-	return authClient{ClientI: proxy.currentCluster}
+	return sharedAuthClient{ClientI: proxy.currentCluster}
 }
 
 // ConnectToRootCluster connects to the auth server of the root cluster
@@ -1335,12 +1335,7 @@ func (proxy *ProxyClient) clusterDetails(ctx context.Context) (sshutils.ClusterD
 		return details, trace.Wrap(err)
 	}
 
-	clt, err := proxy.ConnectToCurrentCluster(ctx)
-	if err != nil {
-		return details, trace.Wrap(err)
-	}
-
-	pong, err := clt.Ping(ctx)
+	pong, err := proxy.CurrentCluster().Ping(ctx)
 	if err != nil {
 		return details, trace.Wrap(err)
 	}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -71,6 +71,11 @@ type ProxyClient struct {
 	authMethods     []ssh.AuthMethod
 	siteName        string
 	clientAddr      string
+
+	// currentCluster is a client for the local teleport auth server that
+	// the proxy is connected to. This should be reused for the duration
+	// of the ProxyClient to ensure the auth server is only dialed once.
+	currentCluster auth.ClientI
 }
 
 // NodeClient implements ssh client to a ssh node (teleport or any regular ssh node)
@@ -83,6 +88,11 @@ type NodeClient struct {
 	TC          *TeleportClient
 	OnMFA       func()
 	FIPSEnabled bool
+}
+
+// ClusterName returns the name of the cluster the proxy is a member of.
+func (proxy *ProxyClient) ClusterName() string {
+	return proxy.siteName
 }
 
 // GetSites returns list of the "sites" (AKA teleport clusters) connected to the proxy
@@ -619,10 +629,8 @@ func (proxy *ProxyClient) CreateAccessRequest(ctx context.Context, req types.Acc
 	)
 	defer span.End()
 
-	site, err := proxy.ConnectToCurrentCluster(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	site := proxy.CurrentCluster()
+
 	return site.CreateAccessRequest(ctx, req)
 }
 
@@ -639,10 +647,8 @@ func (proxy *ProxyClient) GetAccessRequests(ctx context.Context, filter types.Ac
 	)
 	defer span.End()
 
-	site, err := proxy.ConnectToCurrentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	site := proxy.CurrentCluster()
+
 	reqs, err := site.GetAccessRequests(ctx, filter)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -662,10 +668,8 @@ func (proxy *ProxyClient) GetRole(ctx context.Context, name string) (types.Role,
 	)
 	defer span.End()
 
-	site, err := proxy.ConnectToCurrentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	site := proxy.CurrentCluster()
+
 	role, err := site.GetRole(ctx, name)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -685,10 +689,8 @@ func (proxy *ProxyClient) NewWatcher(ctx context.Context, watch types.Watch) (ty
 	)
 	defer span.End()
 
-	site, err := proxy.ConnectToCurrentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	site := proxy.CurrentCluster()
+
 	watcher, err := site.NewWatcher(ctx, watch)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -711,11 +713,7 @@ func (proxy *ProxyClient) FindNodesByFilters(ctx context.Context, req proto.List
 	)
 	defer span.End()
 
-	cluster, err := proxy.currentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	servers, err := proxy.FindNodesByFiltersForCluster(ctx, req, cluster.Name)
+	servers, err := proxy.FindNodesByFiltersForCluster(ctx, req, proxy.siteName)
 	return servers, trace.Wrap(err)
 }
 
@@ -727,10 +725,7 @@ func (proxy *ProxyClient) GetClusterAlerts(ctx context.Context, req types.GetClu
 	)
 	defer span.End()
 
-	site, err := proxy.CurrentClusterAccessPoint(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	site := proxy.CurrentCluster()
 	defer site.Close()
 
 	alerts, err := site.GetClusterAlerts(ctx, req)
@@ -755,7 +750,7 @@ func (proxy *ProxyClient) FindNodesByFiltersForCluster(ctx context.Context, req 
 
 	req.ResourceType = types.KindNode
 
-	site, err := proxy.ClusterAccessPoint(ctx, cluster)
+	site, err := proxy.ConnectToCluster(ctx, cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -788,11 +783,7 @@ func (proxy *ProxyClient) FindAppServersByFilters(ctx context.Context, req proto
 	)
 	defer span.End()
 
-	cluster, err := proxy.currentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	servers, err := proxy.FindAppServersByFiltersForCluster(ctx, req, cluster.Name)
+	servers, err := proxy.FindAppServersByFiltersForCluster(ctx, req, proxy.siteName)
 	return servers, trace.Wrap(err)
 }
 
@@ -813,7 +804,7 @@ func (proxy *ProxyClient) FindAppServersByFiltersForCluster(ctx context.Context,
 	defer span.End()
 
 	req.ResourceType = types.KindAppServer
-	authClient, err := proxy.ClusterAccessPoint(ctx, cluster)
+	authClient, err := proxy.ConnectToCluster(ctx, cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -869,7 +860,7 @@ func (proxy *ProxyClient) CreateAppSession(ctx context.Context, req types.Create
 		return nil, trace.Wrap(err)
 	}
 	// Make sure to wait for the created app session to propagate through the cache.
-	accessPoint, err := proxy.ClusterAccessPoint(ctx, clusterName)
+	accessPoint, err := proxy.ConnectToCluster(ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -941,11 +932,7 @@ func (proxy *ProxyClient) FindDatabaseServersByFilters(ctx context.Context, req 
 	)
 	defer span.End()
 
-	cluster, err := proxy.currentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	servers, err := proxy.FindDatabaseServersByFiltersForCluster(ctx, req, cluster.Name)
+	servers, err := proxy.FindDatabaseServersByFiltersForCluster(ctx, req, proxy.siteName)
 	return servers, trace.Wrap(err)
 }
 
@@ -966,7 +953,7 @@ func (proxy *ProxyClient) FindDatabaseServersByFiltersForCluster(ctx context.Con
 	defer span.End()
 
 	req.ResourceType = types.KindDatabaseServer
-	authClient, err := proxy.ClusterAccessPoint(ctx, cluster)
+	authClient, err := proxy.ConnectToCluster(ctx, cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1011,12 +998,7 @@ func (proxy *ProxyClient) FindDatabasesByFilters(ctx context.Context, req proto.
 	)
 	defer span.End()
 
-	cluster, err := proxy.currentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	databases, err := proxy.FindDatabasesByFiltersForCluster(ctx, req, cluster.Name)
+	databases, err := proxy.FindDatabasesByFiltersForCluster(ctx, req, proxy.siteName)
 	return databases, trace.Wrap(err)
 }
 
@@ -1058,10 +1040,8 @@ func (proxy *ProxyClient) ListResources(ctx context.Context, namespace, resource
 	)
 	defer span.End()
 
-	authClient, err := proxy.CurrentClusterAccessPoint(ctx)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
+	authClient := proxy.CurrentCluster()
+
 	resp, err := authClient.ListResources(ctx, proto.ListResourcesRequest{
 		Namespace:    namespace,
 		ResourceType: resource,
@@ -1074,73 +1054,27 @@ func (proxy *ProxyClient) ListResources(ctx context.Context, namespace, resource
 	return resp.Resources, resp.NextKey, nil
 }
 
-// CurrentClusterAccessPoint returns cluster access point to the currently
-// selected cluster and is used for discovery
-// and could be cached based on the access policy
-func (proxy *ProxyClient) CurrentClusterAccessPoint(ctx context.Context) (auth.ClientI, error) {
-	ctx, span := proxy.Tracer.Start(
-		ctx,
-		"proxyClient/CurrentClusterAccessPoint",
-		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-	)
-	defer span.End()
-
-	// get the current cluster:
-	cluster, err := proxy.currentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return proxy.ClusterAccessPoint(ctx, cluster.Name)
+// authClient is a wrapper around auth.ClientI which
+// prevents the underlying client from being closed.
+type authClient struct {
+	auth.ClientI
 }
 
-// ClusterAccessPoint returns cluster access point used for discovery
-// and could be cached based on the access policy
-func (proxy *ProxyClient) ClusterAccessPoint(ctx context.Context, clusterName string) (auth.ClientI, error) {
-	ctx, span := proxy.Tracer.Start(
-		ctx,
-		"proxyClient/ClusterAccessPoint",
-		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-		oteltrace.WithAttributes(
-			attribute.String("cluster", clusterName),
-		),
-	)
-	defer span.End()
-
-	if clusterName == "" {
-		return nil, trace.BadParameter("parameter clusterName is missing")
-	}
-	clt, err := proxy.ConnectToCluster(ctx, clusterName)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return clt, nil
+// Close is a no-op
+func (a authClient) Close() error {
+	return nil
 }
 
-// ConnectToCurrentCluster connects to the auth server of the currently selected
-// cluster via proxy. It returns connected and authenticated auth server client
-//
-// if 'quiet' is set to true, no errors will be printed to stdout, otherwise
-// any connection errors are visible to a user.
-func (proxy *ProxyClient) ConnectToCurrentCluster(ctx context.Context) (auth.ClientI, error) {
-	ctx, span := proxy.Tracer.Start(
-		ctx,
-		"proxyClient/ConnectToCurrentCluster",
-		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-	)
-	defer span.End()
-
-	cluster, err := proxy.currentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return proxy.ConnectToCluster(ctx, cluster.Name)
+// CurrentCluster returns an authenticated auth server client for the local cluster.
+func (proxy *ProxyClient) CurrentCluster() auth.ClientI {
+	// The auth.ClientI is wrapped in an authClient to prevent callers from
+	// being able to close the client. The auth.ClientI is only to be closed
+	// when the ProxyClient is closed.
+	return authClient{ClientI: proxy.currentCluster}
 }
 
 // ConnectToRootCluster connects to the auth server of the root cluster
 // via proxy. It returns connected and authenticated auth server client
-//
-// if 'quiet' is set to true, no errors will be printed to stdout, otherwise
-// any connection errors are visible to a user.
 func (proxy *ProxyClient) ConnectToRootCluster(ctx context.Context) (auth.ClientI, error) {
 	ctx, span := proxy.Tracer.Start(
 		ctx,
@@ -1226,6 +1160,12 @@ func (proxy *ProxyClient) shouldDialWithTLSRouting(ctx context.Context) (string,
 // ConnectToCluster connects to the auth server of the given cluster via proxy.
 // It returns connected and authenticated auth server client
 func (proxy *ProxyClient) ConnectToCluster(ctx context.Context, clusterName string) (auth.ClientI, error) {
+	// If connecting to the local cluster then return the already
+	// established auth client instead of dialing it a second time.
+	if clusterName == proxy.siteName && proxy.currentCluster != nil {
+		return proxy.CurrentCluster(), nil
+	}
+
 	ctx, span := proxy.Tracer.Start(
 		ctx,
 		"proxyClient/ConnectToCluster",
@@ -1897,8 +1837,9 @@ func newClientConn(
 	}
 }
 
+// Close closes the proxy and auth clients
 func (proxy *ProxyClient) Close() error {
-	return proxy.Client.Close()
+	return trace.NewAggregate(proxy.Client.Close(), proxy.currentCluster.Close())
 }
 
 // ExecuteSCP runs remote scp command(shellCmd) on the remote server and
@@ -2196,33 +2137,6 @@ func (c *NodeClient) GetRemoteTerminalSize(ctx context.Context, sessionID string
 // Close closes client and it's operations
 func (c *NodeClient) Close() error {
 	return c.Client.Close()
-}
-
-// currentCluster returns the connection to the API of the current cluster
-func (proxy *ProxyClient) currentCluster(ctx context.Context) (*types.Site, error) {
-	ctx, span := proxy.Tracer.Start(
-		ctx,
-		"proxyClient/currentCluster",
-		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-	)
-	defer span.End()
-
-	sites, err := proxy.GetSites(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if len(sites) == 0 {
-		return nil, trace.NotFound("no clusters registered")
-	}
-	if proxy.siteName == "" {
-		return &sites[0], nil
-	}
-	for _, site := range sites {
-		if site.Name == proxy.siteName {
-			return &site, nil
-		}
-	}
-	return nil, trace.NotFound("cluster %v not found", proxy.siteName)
 }
 
 func (proxy *ProxyClient) sessionSSHCertificate(ctx context.Context, nodeAddr NodeDetails) ([]ssh.AuthMethod, error) {

--- a/lib/client/conntest/ssh.go
+++ b/lib/client/conntest/ssh.go
@@ -176,6 +176,7 @@ func (s *SSHConnectionTester) TestConnection(ctx context.Context, req TestConnec
 	clientConf.UseKeyPrincipals = true
 	clientConf.Username = currentUser.GetName()
 	clientConf.WebProxyAddr = s.webProxyAddr
+	clientConf.SiteName = clusterName.GetClusterName()
 
 	tc, err := client.NewClient(clientConf)
 	if err != nil {

--- a/tool/tsh/access_request.go
+++ b/tool/tsh/access_request.go
@@ -379,16 +379,7 @@ func onRequestSearch(cf *CLIConf) error {
 	}
 	defer proxyClient.Close()
 
-	authClient, err := proxyClient.CurrentClusterAccessPoint(cf.Context)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	clusterNameResource, err := authClient.GetClusterName()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	clusterName := clusterNameResource.GetClusterName()
+	authClient := proxyClient.CurrentCluster()
 
 	req := proto.ListResourcesRequest{
 		ResourceType:        services.MapResourceKindToListResourcesType(cf.ResourceKind),
@@ -412,11 +403,11 @@ func onRequestSearch(cf *CLIConf) error {
 		resources = append(resources, leafResources...)
 	}
 
-	rows := [][]string{}
+	var rows [][]string
 	var resourceIDs []string
 	for _, resource := range resources {
 		resourceID := types.ResourceIDToString(types.ResourceID{
-			ClusterName: clusterName,
+			ClusterName: proxyClient.ClusterName(),
 			Kind:        resource.GetKind(),
 			Name:        resource.GetName(),
 		})

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -100,7 +100,7 @@ func isRoleSetRequiredForShowDatabases(cf *CLIConf) bool {
 }
 
 func fetchRoleSetForCluster(ctx context.Context, profile *client.ProfileStatus, proxy *client.ProxyClient, clusterName string) (services.RoleSet, error) {
-	cluster, err := proxy.ClusterAccessPoint(ctx, clusterName)
+	cluster, err := proxy.ConnectToCluster(ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -109,10 +109,7 @@ func (c *kubeJoinCommand) getSessionMeta(ctx context.Context, tc *client.Telepor
 		return nil, trace.Wrap(err)
 	}
 
-	site, err := proxy.ConnectToCurrentCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	site := proxy.CurrentCluster()
 
 	return site.GetSessionTracker(ctx, c.session)
 }
@@ -500,11 +497,7 @@ func (c *kubeSessionsCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	site, err := proxy.ConnectToCurrentCluster(cf.Context)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
+	site := proxy.CurrentCluster()
 	sessions, err := site.GetActiveSessionTrackers(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
@@ -942,18 +935,11 @@ func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleport
 			return trace.Wrap(err)
 		}
 		defer pc.Close()
-		ac, err := pc.ConnectToCurrentCluster(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+
+		ac := pc.CurrentCluster()
 		defer ac.Close()
 
-		cn, err := ac.GetClusterName()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		teleportCluster = cn.GetClusterName()
-
+		teleportCluster = pc.ClusterName()
 		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, ac, proto.ListResourcesRequest{
 			SearchKeywords:      tc.SearchKeywords,
 			PredicateExpression: tc.PredicateExpression,

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -2913,6 +2913,8 @@ func makeClientForProxy(cf *CLIConf, proxy string, useProfileLogin bool) (*clien
 		clusters := []string{rootCluster}
 		if cf.SiteName != "" {
 			clusters = append(clusters, cf.SiteName)
+		} else {
+			cf.SiteName = rootCluster
 		}
 		hostAuthFunc, err = key.HostKeyCallbackForClusters(cf.InsecureSkipVerify, apiutils.Deduplicate(clusters))
 		if err != nil {


### PR DESCRIPTION
One of the major areas of latency for `tsh ssh` is creating multiple auth clients. Since the auth client is lazy and only actually performs the dial on first use we can create an auth client once and simply reuse it. This is done by adding an `auth.ClientI` to `ProxyClient` which is created via `connectToProxy`. All attempts to connect to the current auth server via the `ProxyClient` will be given the cached `auth.ClientI`.

The new method of retrieving the current auth client also allowed to remove a number of calls to `GetSites` which were used to obtain the current cluster name. The local profile already contains the name of the cluster and calls to `GetSites` were unnecessary. All instances which relied on the site name now retrieve from information that the `ProxyClient` already has.

In an effort to reduce ambiguity and confusion `CurrentClusterAccessPoint` and `ClusterAccessPoint` were also removed. AccessPoint denotes that you are connecting to a cache, but the `ProxyClient` is always going to be hitting the auth server directly. The two have been replaced with `CurrentCluster` and `ConnectToCluster`, which they were merely wrappers for anyhow.