### PR TITLE
Use the version of Go from `go.mod` during CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,5 +53,4 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      env:
-        CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16
+      timeout-minutes: 60

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,6 +47,8 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        debug: true
+        trap-caching: true
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,6 +34,15 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+      if: ${{ matrix.language == 'go' }}
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+      if: ${{ matrix.language == 'go' }}
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:


### PR DESCRIPTION
Currently, the CodeQL check for Go is failing to build teleport

```
  [2022-09-14 12:19:40] [build-stderr] 2022/09/14 12:19:40 Error running go tooling: err: exit status 1: stderr: go build github.com/Azure/azure-sdk-for-go/sdk/azcore: build constraints exclude all Go files in /home/runner/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0
  [2022-09-14 12:19:40] [build-stderr] go build github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared: build constraints exclude all Go files in /home/runner/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/internal/shared
  [2022-09-14 12:19:40] [build-stderr] go build github.com/Azure/azure-sdk-for-go/sdk/azcore/policy: build constraints exclude all Go files in /home/runner/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.0.0/policy
  [2022-09-14 12:19:40] [build-stderr] go build github.com/Azure/azure-sdk-for-go/sdk/internal/temporal: build constraints exclude all Go files in /home/runner/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/internal@v1.0.0/temporal
  [2022-09-14 12:19:40] [build-stderr] go build github.com/Azure/azure-sdk-for-go/sdk/azidentity: build constraints exclude all Go files in /home/runner/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azidentity@v1.0.0
  [2022-09-14 12:19:40] [build-stderr] 2022/09/14 12:19:40 Extraction failed: exit status 1
```

This is because the version of Go on the machine is `1.17.13`

```
  [2022-09-14 12:15:15] [build-stderr] go mod tidy: go.mod file indicates go 1.18, but maximum supported version is 1.17
```

`github.com/Azure/azure-sdk-for-go/sdk/azcore/policy` has a build constraint of `go1.18`

```go
//go:build go1.18
// +build go1.18
```

This updates the workflow to (if the language being checked is go) grab the go version from `go.mod`, export it to an environment variable and then use `actions/setup-go@v2` to install that version of go. The CodeQL tool should pick up Go from the environment.

This should be easily backported as it relies on the `go.mod` file for the go version.