### PR TITLE
[v8] OS compatibility tbot fix

### DIFF
--- a/.cloudbuild/ci/os-compatibility-test.yaml
+++ b/.cloudbuild/ci/os-compatibility-test.yaml
@@ -10,7 +10,7 @@ steps:
     entrypoint: "/bin/bash"
     args: 
       - '-c'
-      - 'make build/tctl build/tsh build/tbot build/teleport'  
+      - 'make build/tctl build/tsh build/teleport'  
     timeout: 10m
     env:
       - GOCACHE=/tmp/gocache

--- a/build.assets/build-test-compat.sh
+++ b/build.assets/build-test-compat.sh
@@ -98,7 +98,6 @@ do
   run_docker "$DISTRO" $PWD/build/teleport version
   run_docker "$DISTRO" $PWD/build/tsh version
   run_docker "$DISTRO" $PWD/build/tctl version
-  run_docker "$DISTRO" $PWD/build/tbot version
 done
 
 exit $EXIT_CODE


### PR DESCRIPTION
#16264 (the v8 backport for #16141) fails when attempting to build `tbot`, which doesn't exist in `branch/v8`. This removes the build and check for `tbot`.