### PR TITLE
docs: move S3 IAM policy into an include

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -106,46 +106,7 @@ You'll need to replace these values in the policy example below:
 
 ### S3 IAM policy
 
-You'll need to replace these values in the policy example below:
-
-| Placeholder value | Replace with |
-| - | - |
-| `teleport-helm-sessions` | Name to use for the Teleport S3 session recording bucket |
-
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "BucketActions",
-            "Effect": "Allow",
-            "Action": [
-                "s3:PutEncryptionConfiguration",
-                "s3:PutBucketVersioning",
-                "s3:ListBucketVersions",
-                "s3:ListBucketMultipartUploads",
-                "s3:ListBucket",
-                "s3:GetEncryptionConfiguration",
-                "s3:GetBucketVersioning",
-                "s3:CreateBucket"
-            ],
-            "Resource": "arn:aws:s3:::teleport-helm-sessions"
-        },
-        {
-            "Sid": "ObjectActions",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObjectVersion",
-                "s3:GetObjectRetention",
-                "s3:*Object",
-                "s3:ListMultipartUploadParts",
-                "s3:AbortMultipartUpload"
-            ],
-            "Resource": "arn:aws:s3:::teleport-helm-sessions/*"
-        }
-    ]
-}
-```
+(!docs/pages/includes/s3-iam-policy.mdx!)
 
 Note that Teleport will only use S3 buckets with versioning enabled. This
 ensures that a session log cannot be permanently altered or deleted, as

--- a/docs/pages/includes/s3-iam-policy.mdx
+++ b/docs/pages/includes/s3-iam-policy.mdx
@@ -1,0 +1,40 @@
+You'll need to replace these values in the policy example below:
+
+| Placeholder value | Replace with |
+| - | - |
+| `your-sessions-bucket` | Name to use for the Teleport S3 session recording bucket |
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "BucketActions",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutEncryptionConfiguration",
+                "s3:PutBucketVersioning",
+                "s3:ListBucketVersions",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListBucket",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetBucketVersioning",
+                "s3:CreateBucket"
+            ],
+            "Resource": "arn:aws:s3:::your-sessions-bucket"
+        },
+        {
+            "Sid": "ObjectActions",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObjectVersion",
+                "s3:GetObjectRetention",
+                "s3:*Object",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload"
+            ],
+            "Resource": "arn:aws:s3:::your-sessions-bucket/*"
+        }
+    ]
+}
+```

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -234,6 +234,10 @@ Service reads these parameters to configure its interactions with S3:
 - `acl=private` - set the [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) to use. Must be one of the predefined ACL values.
 - `use_fips_endpoint=true` -  [Configure S3 FIPS endpoints](#configuring-aws-fips-endpoints)
 
+### S3 IAM policy
+
+(!docs/pages/includes/s3-iam-policy.mdx!)
+
 ### S3 Server Side Encryption
 
 Teleport supports using a custom AWS KMS Customer Managed Key for encrypting objects uploaded to S3.


### PR DESCRIPTION
Prior to this change, the only place you could find a complete IAM policy for using S3 to store session recordings was in the helm deployment section.

Move the IAM policy into an include so that we can also include it in the S3 section of the backends reference page.