### PR TITLE
Release 9.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 9.3.19
+## 9.3.20
 
 This release of Teleport contains multiple improvements and bug fixes.
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=9.3.19
+VERSION=9.3.20
 
 DOCKER_IMAGE_QUAY ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_ECR ?= public.ecr.aws/gravitational/teleport

--- a/api/version.go
+++ b/api/version.go
@@ -3,7 +3,7 @@
 package api
 
 const (
-	Version = "9.3.19"
+	Version = "9.3.20"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -44,7 +44,7 @@ RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
 
 RUN chmod a-w /
 
-# Install cargo as ci user
+# Cargo should be installed as a ci user, otherwise it will cause build failures
 USER ci
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
     rustup --version && \

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -44,11 +44,16 @@ RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
 
 RUN chmod a-w /
 
+# Install cargo as ci user
+USER ci
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
     rustup --version && \
     cargo --version && \
     rustc --version && \
     rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy
+
+# Restore user back to root
+USER root
 
 ENV GOPATH="/go" \
     GOROOT="/opt/go" \

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-cluster
 apiVersion: v2
-version: "9.3.19"
-appVersion: "9.3.19"
+version: "9.3.20"
+appVersion: "9.3.20"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: "9.3.19"
-appVersion: "9.3.19"
+version: "9.3.20"
+appVersion: "9.3.20"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "9.3.19"
+	Version = "9.3.20"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Looks like https://github.com/gravitational/teleport/pull/16262/files#diff-1172aa5c43d888e112a13bcb4fd283e93571f754c994bd3983c95a682512d13bL47 change the default Docker user to `root` for Rust installation that causes some issue when building Teleport.
This PR restores the previous behavior.