### PR TITLE
Update toolchain to Go 1.19

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ name: push-build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
   UID: "1000"
 trigger:
   event:
@@ -150,7 +150,7 @@ name: push-build-linux-386
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
   UID: "1000"
 trigger:
   event:
@@ -253,7 +253,7 @@ name: push-build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
   UID: "1000"
 trigger:
   event:
@@ -360,7 +360,7 @@ name: push-build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
   UID: "1000"
 trigger:
   event:
@@ -525,7 +525,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.18.6
+    RUNTIME: go1.19.1
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -960,7 +960,7 @@ name: push-build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
   UID: "1000"
 trigger:
   event:
@@ -1063,7 +1063,7 @@ name: push-build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
   UID: "1000"
 trigger:
   event:
@@ -1694,7 +1694,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
 trigger:
   event:
     include:
@@ -1854,7 +1854,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
 trigger:
   event:
     include:
@@ -2013,7 +2013,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
 trigger:
   event:
     include:
@@ -2185,7 +2185,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
 trigger:
   event:
     include:
@@ -3078,7 +3078,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
 trigger:
   event:
     include:
@@ -3661,7 +3661,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.18.6
+    RUNTIME: go1.19.1
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -4178,7 +4178,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
 trigger:
   event:
     include:
@@ -4335,7 +4335,7 @@ type: kubernetes
 name: build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
 trigger:
   event:
     include:
@@ -5228,7 +5228,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.18.6
+  RUNTIME: go1.19.1
 trigger:
   event:
     include:
@@ -7054,6 +7054,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 122d13c57fd07c1ea1baf781df66fe8f867338f089eb2a4636a7aef23a3dee30
+hmac: 6820f97d5d9c565d4a77e1f2c6a0b8091df655a1540a4133a5860f31f8414ff3
 
 ...

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -69,22 +69,13 @@ RUN yum groupinstall -y 'Development Tools' && \
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
-# BoringCrypto (unlike regular Go) requires glibc 2.14, so we have to build from source.
-# 1) Install older binary Go runtime for bootstrapping
-# 2) Get source for the correct Go boringcrypto runtime and compile it with Go bootstrap runtime
-# 3) Erase Go bootstrap runtime and create build directories
-# 4) Print compiled Go version
-ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
+# Install Go.
 ARG GOLANG_VERSION
-RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
-    mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLANG_VERSION.src.tar.gz | tar xz && \
-    cd /opt/go/src && GOROOT_BOOTSTRAP=/go-bootstrap/go ./make.bash && \
-    rm -rf /go-bootstrap && \
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-amd64.tar.gz | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
-    chmod a-w / && \
-    /opt/go/bin/go version
+    chmod a-w /
 ENV GOEXPERIMENT=boringcrypto \
     GOPATH="/go" \
     GOROOT="/opt/go" \

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -34,9 +34,6 @@ ENV LANGUAGE=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LC_CTYPE=en_US.UTF-8
 
-ARG BORINGCRYPTO_RUNTIME
-ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
-
 ARG UID
 ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
@@ -63,7 +60,7 @@ RUN yum groupinstall -y 'Development Tools' && \
     which \
     zip \
     # required by PIV integration
-    pcsc-lite-devel \  
+    pcsc-lite-devel \
     # required by libbpf
     zlib-static && \
     yum clean all
@@ -77,8 +74,10 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
 # 2) Get source for the correct Go boringcrypto runtime and compile it with Go bootstrap runtime
 # 3) Erase Go bootstrap runtime and create build directories
 # 4) Print compiled Go version
+ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
+ARG GOLANG_VERSION
 RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
-    mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${BORINGCRYPTO_RUNTIME}.src.tar.gz | tar xz && \
+    mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLANG_VERSION.src.tar.gz | tar xz && \
     cd /opt/go/src && GOROOT_BOOTSTRAP=/go-bootstrap/go ./make.bash && \
     rm -rf /go-bootstrap && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
@@ -86,8 +85,8 @@ RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/
     chmod a+w /var/lib && \
     chmod a-w / && \
     /opt/go/bin/go version
-
-ENV GOPATH="/go" \
+ENV GOEXPERIMENT=boringcrypto \
+    GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="/opt/llvm/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -57,13 +57,14 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # Install Go.
-ARG BORINGCRYPTO_RUNTIME
-RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${BORINGCRYPTO_RUNTIME}.linux-amd64.tar.gz | tar xz && \
+ARG GOLANG_VERSION
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-amd64.tar.gz | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
     chmod a-w /
-ENV GOPATH="/go" \
+ENV GOEXPERIMENT=boringcrypto \
+    GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -28,7 +28,6 @@ GOLANG_VERSION ?= go1.19.1
 NODE_VERSION ?= 16.13.2
 
 RUST_VERSION ?= 1.63.0 # don't bump this without checking GLIBC compatibility
-BORINGCRYPTO_RUNTIME=$(GOLANG_VERSION)b7
 LIBBPF_VERSION ?= 0.7.0-teleport
 
 UID := $$(id -u)
@@ -154,7 +153,7 @@ buildbox-fips:
 		docker build \
 			--build-arg UID=$(UID) \
 			--build-arg GID=$(GID) \
-			--build-arg BORINGCRYPTO_RUNTIME=$(BORINGCRYPTO_RUNTIME) \
+			--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 			--cache-from $(BUILDBOX_FIPS) \
 			--tag $(BUILDBOX_FIPS) -f Dockerfile-fips . ; \
@@ -186,7 +185,7 @@ buildbox-centos7-fips:
 	docker build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
-		--build-arg BORINGCRYPTO_RUNTIME=$(BORINGCRYPTO_RUNTIME) \
+		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--cache-from $(BUILDBOX_CENTOS7_FIPS) \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -23,14 +23,8 @@ OS ?= linux
 ARCH ?= amd64
 BUILDBOX_VERSION ?= teleport11
 
-# NOTE: Windows Drone scripts hardcode $GOLANG_VERSION rather than drawing it
-#       from here at build time, so any changes here must be reflected in
-#       `dronegen/windows.go`
-GOLANG_VERSION ?= go1.18.6
+GOLANG_VERSION ?= go1.19.1
 
-# NOTE: Windows Drone scripts hardcode $NODE_VERSION rather than drawing it
-#       from here at build time, so any changes here must be reflected in
-#       `dronegen/windows.go`
 NODE_VERSION ?= 16.13.2
 
 RUST_VERSION ?= 1.63.0 # don't bump this without checking GLIBC compatibility

--- a/build.assets/webapps/webapps-version.sh
+++ b/build.assets/webapps/webapps-version.sh
@@ -2,7 +2,7 @@
 
 # If this build was triggered from a tag on the teleport repo,
 # then assume we can use the same tag for the webapps repo.
-if [ ! -z "$DRONE_TAG" ]
+if [ -n "$DRONE_TAG" ]
 then
     echo "$DRONE_TAG"
     exit 0


### PR DESCRIPTION
Update Go toolchain, allowing for a possible go.mod bump to 1.19.

Since Go 1.19 BoringCrypto is no longer a separate branch, but instead it's enabled by a [GOEXPERIMENT][1].

Release notes: https://tip.golang.org/doc/go1.19.

[1]: https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/internal/goexperiment/exp_boringcrypto_on.go;l=3.