### PR TITLE
Update golangci-lint to 1.49.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - goimports
     - gosimple
@@ -23,10 +22,8 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
-    - unused
     - unconvert
-    - varcheck
+    - unused
 
 linters-settings:
   depguard:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,12 @@ issues:
     - linters:
       - revive
       text: "exported: exported const"
+    # TODO(codingllama): Remove ignore after the new golangci-lint image lands.
+    # For some reason this particular files causes problems between different
+    # goimports versions.
+    - path: lib/services/role_test.go
+      linters:
+      - goimports
   exclude-use-default: true
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -298,10 +298,10 @@ func New(cfg Config) (*CircuitBreaker, error) {
 }
 
 // Execute calls the provided function depending on the CircuitBreaker state.
-// - StateStandby: all functions are executed.
-// - StateTripped: no functions are executed and ErrStateTripped is returned.
-// - StateRecovering: some functions are executed, some functions are not,
-//                    when not executed ErrLimitExceeded is returned.
+//   - StateStandby: all functions are executed.
+//   - StateTripped: no functions are executed and ErrStateTripped is returned.
+//   - StateRecovering: some functions are executed, some functions are not,
+//     when not executed ErrLimitExceeded is returned.
 //
 // The CircuitBreaker state is updated according to the outcome of executing the
 // provided function and the current state. See package docs for a more detailed

--- a/api/breaker/doc.go
+++ b/api/breaker/doc.go
@@ -30,5 +30,4 @@
 //
 // * Config.OnTripped is called on transition (StateStandby -> StateTripped)
 // * Config.OnStandBy is called on transition (StateRecovering -> StateStandby)
-//
 package breaker

--- a/api/client/credentials.go
+++ b/api/client/credentials.go
@@ -83,7 +83,8 @@ func (c *tlsConfigCreds) SSHClientConfig() (*ssh.ClientConfig, error) {
 // KeyPair Credentials can only be used to connect directly to a Teleport Auth server.
 //
 // New KeyPair files can be generated with tsh or tctl.
-//  $ tctl auth sign --format=tls --user=api-user --out=path/to/certs
+//
+//	$ tctl auth sign --format=tls --user=api-user --out=path/to/certs
 //
 // The certificates' time to live can be specified with --ttl.
 //
@@ -142,8 +143,9 @@ func (c *keypairCreds) SSHClientConfig() (*ssh.ClientConfig, error) {
 // or through a reverse tunnel.
 //
 // A new identity file can be generated with tsh or tctl.
-//  $ tsh login --user=api-user --out=identity-file-path
-//  $ tctl auth sign --user=api-user --out=identity-file-path
+//
+//	$ tsh login --user=api-user --out=identity-file-path
+//	$ tctl auth sign --user=api-user --out=identity-file-path
 //
 // The identity file's time to live can be specified with --ttl.
 //
@@ -212,8 +214,9 @@ func (c *identityCredsFile) load() error {
 // or through a reverse tunnel.
 //
 // A new identity file can be generated with tsh or tctl.
-//  $ tsh login --user=api-user --out=identity-file-path
-//  $ tctl auth sign --user=api-user --out=identity-file-path
+//
+//	$ tsh login --user=api-user --out=identity-file-path
+//	$ tctl auth sign --user=api-user --out=identity-file-path
 //
 // The identity file's time to live can be specified with --ttl.
 //
@@ -288,7 +291,8 @@ func (c *identityCredsString) load() error {
 // tunnel address and make a connection through it.
 //
 // A new profile can be generated with tsh.
-//  $ tsh login --user=api-user
+//
+//	$ tsh login --user=api-user
 func LoadProfile(dir, name string) Credentials {
 	return &profileCreds{
 		dir:  dir,

--- a/api/client/doc_test.go
+++ b/api/client/doc_test.go
@@ -129,7 +129,9 @@ func ExampleNew() {
 }
 
 // Generate tsh profile with tsh.
-//  $ tsh login --user=api-user
+//
+//	$ tsh login --user=api-user
+//
 // Load credentials from the default directory and current profile, or specify the directory and profile.
 func ExampleCredentials_loadProfile() {
 	client.LoadProfile("", "")
@@ -143,8 +145,10 @@ func ExampleLoadProfile() {
 }
 
 // Generate identity file with tsh or tctl.
-//  $ tsh login --user=api-user --out=identity-file-path
-//  $ tctl auth sign --user=api-user --out=identity-file-path
+//
+//	$ tsh login --user=api-user --out=identity-file-path
+//	$ tctl auth sign --user=api-user --out=identity-file-path
+//
 // Load credentials from the specified identity file.
 func ExampleCredentials_loadIdentity() {
 	client.LoadIdentityFile("identity-file-path")
@@ -156,9 +160,11 @@ func ExampleLoadIdentityFile() {
 }
 
 // Generate identity file with tsh or tctl.
-//  $ tsh login --user=api-user --out=identity-file-path
-//  $ tctl auth sign --user=api-user --out=identity-file-path
-//  $ export TELEPORT_IDENTITY=$(cat identity-file-path)
+//
+//	$ tsh login --user=api-user --out=identity-file-path
+//	$ tctl auth sign --user=api-user --out=identity-file-path
+//	$ export TELEPORT_IDENTITY=$(cat identity-file-path)
+//
 // Load credentials from the envrironment variable.
 func ExampleCredentials_loadIdentityString() {
 	client.LoadIdentityFileFromString(os.Getenv("TELEPORT_IDENTITY"))
@@ -170,7 +176,9 @@ func ExampleLoadIdentityFileFromString() {
 }
 
 // Generate certificate key pair with tctl.
-//  $ tctl auth sign --format=tls --user=api-user --out=path/to/certs
+//
+//	$ tctl auth sign --format=tls --user=api-user --out=path/to/certs
+//
 // Load credentials from the specified certificate files.
 func ExampleCredentials_loadKeyPair() {
 	client.LoadKeyPair(

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -105,8 +105,9 @@ func newWebClient(cfg *Config) (*http.Client, error) {
 
 // doWithFallback attempts to execute an HTTP request using https, and then
 // fall back to plain HTTP under certain, very specific circumstances.
-//  * The caller must specifically allow it via the allowPlainHTTP parameter, and
-//  * The target host must resolve to the loopback address.
+//   - The caller must specifically allow it via the allowPlainHTTP parameter, and
+//   - The target host must resolve to the loopback address.
+//
 // If these conditions are not met, then the plain-HTTP fallback is not allowed,
 // and a the HTTPS failure will be considered final.
 func doWithFallback(clt *http.Client, allowPlainHTTP bool, extraHeaders map[string]string, req *http.Request) (*http.Response, error) {

--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -49,7 +49,6 @@ const (
 //
 // Profiles can be stored in a profile file, allowing TSH users to
 // type fewer CLI args.
-//
 type Profile struct {
 	// WebProxyAddr is the host:port the web proxy can be accessed at.
 	WebProxyAddr string `yaml:"web_proxy_addr,omitempty"`

--- a/api/types/system_role_test.go
+++ b/api/types/system_role_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/api/utils/conv.go
+++ b/api/utils/conv.go
@@ -32,24 +32,23 @@ import (
 //
 // Example: assume you have two structs:
 //
-// type A struct {
-//     Name string `json:"name"`
-//	   Age  int    `json:"age"`
-// }
+//	type A struct {
+//	    Name string `json:"name"`
+//		   Age  int    `json:"age"`
+//	}
 //
-// type B struct {
-//	   FullName string `json:"name"`
-// }
+//	type B struct {
+//		   FullName string `json:"name"`
+//	}
 //
 // Now you can convert B to A:
 //
-//		b := &B{ FullName: "Bob Dilan"}
-//		var a *A
-//		utils.ObjectToStruct(b, &a)
-//		fmt.Println(a.Name)
+//			b := &B{ FullName: "Bob Dilan"}
+//			var a *A
+//			utils.ObjectToStruct(b, &a)
+//			fmt.Println(a.Name)
 //
-//  > "Bob Dilan"
-//
+//	 > "Bob Dilan"
 func ObjectToStruct(in interface{}, out interface{}) error {
 	bytes, err := json.Marshal(in)
 	if err != nil {

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -165,9 +165,7 @@ ENV GOPATH="/go" \
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install golangci-lint.
-RUN (curl -L https://github.com/golangci/golangci-lint/releases/download/v1.46.0/golangci-lint-1.46.0-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz && \
-     cp golangci-lint-1.46.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ && \
-     rm -r golangci-lint*)
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
 
 # Install helm.
 RUN (mkdir -p helm-tarball && curl -L https://get.helm.sh/helm-v3.5.2-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C helm-tarball -xz && \

--- a/doc.go
+++ b/doc.go
@@ -18,23 +18,25 @@ of Linux servers via SSH or HTTPS. It is intended to be used instead of sshd.
 
 Teleport enables teams to easily adopt the best SSH practices like:
 
-	- No need to distribute keys: Teleport uses certificate-based access with
-	  automatic expiration time.
-	- Enforcement of 2nd factor authentication.
-	- Cluster introspection: every Teleport node becomes a part of a cluster
-	  and is visible on the Web UI.
-	- Record and replay SSH sessions for knowledge sharing and auditing purposes.
-	- Collaboratively troubleshoot issues through session sharing.
-	- Connect to clusters located behind firewalls without direct Internet
-	  access via SSH bastions.
-	- Ability to integrate SSH credentials with your organization identities
-	  via OAuth (Google Apps, Github).
-	- Keep the full audit log of all SSH sessions within a cluster.
+  - No need to distribute keys: Teleport uses certificate-based access with
+    automatic expiration time.
+  - Enforcement of 2nd factor authentication.
+  - Cluster introspection: every Teleport node becomes a part of a cluster
+    and is visible on the Web UI.
+  - Record and replay SSH sessions for knowledge sharing and auditing purposes.
+  - Collaboratively troubleshoot issues through session sharing.
+  - Connect to clusters located behind firewalls without direct Internet
+    access via SSH bastions.
+  - Ability to integrate SSH credentials with your organization identities
+    via OAuth (Google Apps, Github).
+  - Keep the full audit log of all SSH sessions within a cluster.
 
 Teleport web site:
+
 	https://gravitational.com/teleport/
 
 Teleport on Github:
+
 	https://github.com/gravitational/teleport
 */
 package teleport

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -31,11 +31,11 @@ func promoteBuildOsRepoPipelines() []pipeline {
 
 // Used for one-off migrations of older versions.
 // Use cases include:
-//  * We want to support another OS while providing backwards compatibility
-//  * We want to support another OS version while providing backwards compatibility
-//  * A customer wants to be able to install an older version via APT/YUM even if we
-//      no longer support it
-//  * RPM migrations after new YUM pipeline is done
+//   - We want to support another OS while providing backwards compatibility
+//   - We want to support another OS version while providing backwards compatibility
+//   - A customer wants to be able to install an older version via APT/YUM even if we
+//     no longer support it
+//   - RPM migrations after new YUM pipeline is done
 func artifactMigrationPipeline() []pipeline {
 	migrationVersions := []string{
 		// These versions were migrated as a part of the new `promoteAptPipeline`

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -1213,13 +1213,11 @@ func tlsClientConfig(cfg *rest.Config) (*tls.Config, error) {
 		return nil, trace.BadParameter("failed to append certs from PEM")
 	}
 
-	tlsConfig := &tls.Config{
+	return &tls.Config{
 		RootCAs:      pool,
 		Certificates: []tls.Certificate{cert},
 		ClientAuth:   tls.RequireAndVerifyClientCert,
-	}
-	tlsConfig.BuildNameToCertificate()
-	return tlsConfig, nil
+	}, nil
 }
 
 func kubeProxyTLSConfig(cfg kube.ProxyConfig) (*tls.Config, error) {

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -42,10 +42,10 @@ import (
 )
 
 // TestGenerateAndUpsertRecoveryCodes tests the following:
-//  - generation of recovery codes are of correct format
-//  - recovery codes are upserted
-//  - recovery codes can be verified and marked used
-//  - reusing a used or non-existing token returns error
+//   - generation of recovery codes are of correct format
+//   - recovery codes are upserted
+//   - recovery codes can be verified and marked used
+//   - reusing a used or non-existing token returns error
 func TestGenerateAndUpsertRecoveryCodes(t *testing.T) {
 	t.Parallel()
 	srv := newTestTLSServer(t)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -1040,11 +1040,12 @@ type githubAuthRawResponse struct {
 	HostSigners []json.RawMessage `json:"host_signers"`
 }
 
-/* validateGithubAuthRequest validates Github auth callback redirect
+/*
+validateGithubAuthRequest validates Github auth callback redirect
 
-   POST /:version/github/requests/validate
+	POST /:version/github/requests/validate
 
-   Success response: githubAuthRawResponse
+	Success response: githubAuthRawResponse
 */
 func (s *APIServer) validateGithubAuthCallback(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req validateGithubAuthCallbackReq
@@ -1085,9 +1086,10 @@ func (s *APIServer) validateGithubAuthCallback(auth ClientI, w http.ResponseWrit
 // HTTP GET /:version/events?query
 //
 // Query fields:
-//	'from'  : time filter in RFC3339 format
-//	'to'    : time filter in RFC3339 format
-//  ...     : other fields are passed directly to the audit backend
+//
+//		'from'  : time filter in RFC3339 format
+//		'to'    : time filter in RFC3339 format
+//	 ...     : other fields are passed directly to the audit backend
 func (s *APIServer) searchEvents(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var err error
 	to := time.Now().In(time.UTC)
@@ -1168,8 +1170,9 @@ func (s *APIServer) searchSessionEvents(auth ClientI, w http.ResponseWriter, r *
 
 // HTTP GET /:version/sessions/:id/stream?offset=x&bytes=y
 // Query parameters:
-//   "offset"   : bytes from the beginning
-//   "bytes"    : number of bytes to read (it won't return more than 512Kb)
+//
+//	"offset"   : bytes from the beginning
+//	"bytes"    : number of bytes to read (it won't return more than 512Kb)
 func (s *APIServer) getSessionChunk(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	sid, err := session.ParseID(p.ByName("id"))
 	if err != nil {
@@ -1206,7 +1209,8 @@ func (s *APIServer) getSessionChunk(auth ClientI, w http.ResponseWriter, r *http
 
 // HTTP GET /:version/sessions/:id/events?maxage=n
 // Query:
-//    'after' : cursor value to return events newer than N. Defaults to 0, (return all)
+//
+//	'after' : cursor value to return events newer than N. Defaults to 0, (return all)
 func (s *APIServer) getSessionEvents(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	sid, err := session.ParseID(p.ByName("id"))
 	if err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3790,15 +3790,15 @@ func (a *ServerWithRoles) SignDatabaseCSR(ctx context.Context, req *proto.Databa
 //
 // This certificate can be requested by:
 //
-//  - Cluster administrator using "tctl auth sign --format=db" command locally
-//    on the auth server to produce a certificate for configuring a self-hosted
-//    database.
-//  - Remote user using "tctl auth sign --format=db" command with a remote
-//    proxy (e.g. Teleport Cloud), as long as they can impersonate system
-//    role Db.
-//  - Database service when initiating connection to a database instance to
-//    produce a client certificate.
-//  - Proxy service when generating mTLS files to a database
+//   - Cluster administrator using "tctl auth sign --format=db" command locally
+//     on the auth server to produce a certificate for configuring a self-hosted
+//     database.
+//   - Remote user using "tctl auth sign --format=db" command with a remote
+//     proxy (e.g. Teleport Cloud), as long as they can impersonate system
+//     role Db.
+//   - Database service when initiating connection to a database instance to
+//     produce a client certificate.
+//   - Proxy service when generating mTLS files to a database
 func (a *ServerWithRoles) GenerateDatabaseCert(ctx context.Context, req *proto.DatabaseCertRequest) (*proto.DatabaseCertResponse, error) {
 	// Check if the User can `create` DatabaseCertificates
 	err := a.action(apidefaults.Namespace, types.KindDatabaseCertificate, types.VerbCreate)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -860,7 +860,7 @@ func (c *Client) DeleteWebSession(ctx context.Context, user string, sid string) 
 	return trace.Wrap(err)
 }
 
-// GenerateHostCert takes the public key in the Open SSH ``authorized_keys``
+// GenerateHostCert takes the public key in the Open SSH “authorized_keys“
 // plain text format, signs it using Host Certificate Authority private key and returns the
 // resulting certificate.
 func (c *Client) GenerateHostCert(

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -178,6 +179,15 @@ func orgUsesExternalSSO(ctx context.Context, org string, client httpRequester) (
 		var urlErr *url.Error
 
 		resp, err = makeHTTPGetReq(ctx, ssoURL, client)
+		// Drain and close the body regardless of outcome.
+		// Errors handled below.
+		if resp != nil {
+			io.Copy(io.Discard, resp.Body)
+			if bodyErr := resp.Body.Close(); bodyErr != nil {
+				logrus.WithError(bodyErr).Error("Error closing response body.")
+			}
+		}
+		// Handle makeHTTPGetReq errors.
 		if err == nil {
 			break
 		} else if errors.As(err, &urlErr) && urlErr.Timeout() {
@@ -191,10 +201,6 @@ func orgUsesExternalSSO(ctx context.Context, org string, client httpRequester) (
 		}
 		// Unknown error, don't try making any more requests
 		return false, trace.Wrap(err, "Unknown error trying to reach GitHub to check for organization external SSO")
-	}
-	err := resp.Body.Close()
-	if err != nil {
-		logrus.WithError(err).Error("Error closing response body.")
 	}
 
 	// "sso" page exists, org uses external SSO

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package auth
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net"
@@ -309,7 +310,7 @@ func (m mockHTTPRequester) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	resp := new(http.Response)
-	resp.Body = io.NopCloser(nil)
+	resp.Body = io.NopCloser(bytes.NewReader([]byte{}))
 	resp.StatusCode = m.statusCode
 
 	return resp, nil

--- a/lib/auth/keystore/doc.go
+++ b/lib/auth/keystore/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package keystore provides a generic client and associated helpers for handling
 // private keys that may be backed by an HSM.
 //
-// Notes on testing
+// # Notes on testing
 //
 // Testing the Keystore package predictably requires an HSM. Testcases are
 // currently written for the "raw" KeyStore (no HSM), SoftHSMv2, YubiHSM2, and
@@ -25,7 +25,7 @@ limitations under the License.
 // SoftHSM is enabled by default in the Teleport docker buildbox and will be
 // run in CI.
 //
-// Testing this package with SoftHSMv2
+// # Testing this package with SoftHSMv2
 //
 // To test with SoftHSMv2, you must install it (see
 // https://github.com/opendnssec/SoftHSMv2 or
@@ -36,7 +36,7 @@ limitations under the License.
 //
 // The test will create its own config file and token, and clean up after itself.
 //
-// Testing this package with YubiHSM2
+// # Testing this package with YubiHSM2
 //
 // To test with YubiHSM2, you must:
 //
@@ -46,7 +46,7 @@ limitations under the License.
 //
 // 3. start the connector "yubihsm-connector -d"
 //
-// 4. create a config file
+//  4. create a config file
 //     connector = http://127.0.0.1:12345
 //     debug
 //
@@ -56,7 +56,7 @@ limitations under the License.
 //
 // The test will use the factory default pin of "0001password" in slot 0.
 //
-// Testing this package with AWS CloudHSM
+// # Testing this package with AWS CloudHSM
 //
 // 1. Create a CloudHSM Cluster and HSM, and activate them https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html
 //
@@ -70,7 +70,7 @@ limitations under the License.
 //
 // 6. Run the test on the connected EC2 instance
 //
-// Testing Teleport with an HSM-backed CA
+// # Testing Teleport with an HSM-backed CA
 //
 // TBD as full support is added.
 package keystore

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -368,8 +368,8 @@ func (k *Keygen) GenerateUserCertWithoutValidation(c services.UserCertParams) ([
 // BuildPrincipals takes a hostID, nodeName, clusterName, and role and builds a list of
 // principals to insert into a certificate. This function is backward compatible with
 // older clients which means:
-//    * If RoleAdmin is in the list of roles, only a single principal is returned: hostID
-//    * If nodename is empty, it is not included in the list of principals.
+//   - If RoleAdmin is in the list of roles, only a single principal is returned: hostID
+//   - If nodename is empty, it is not included in the list of principals.
 func BuildPrincipals(hostID string, nodeName string, clusterName string, roles types.SystemRoles) []string {
 	// TODO(russjones): This should probably be clusterName, but we need to
 	// verify changing this won't break older clients.

--- a/lib/auth/native/native_test.go
+++ b/lib/auth/native/native_test.go
@@ -97,13 +97,13 @@ func TestGenerateUserCert(t *testing.T) {
 
 // TestBuildPrincipals makes sure that the list of principals for a host
 // certificate is correctly built.
-//   * If the node has role admin, then only the host ID should be listed
+//   - If the node has role admin, then only the host ID should be listed
 //     in the principals field.
-//   * If only a host ID is provided, don't include a empty node name
+//   - If only a host ID is provided, don't include a empty node name
 //     this is for backward compatibility.
-//   * If both host ID and node name are given, then both should be included
+//   - If both host ID and node name are given, then both should be included
 //     on the certificate.
-//   * If the host ID and node name are the same, only list one.
+//   - If the host ID and node name are the same, only list one.
 func TestBuildPrincipals(t *testing.T) {
 	t.Parallel()
 

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -135,8 +135,8 @@ type rotationReq struct {
 //
 // Here are the supported rotation states:
 //
-//  * Standby - the cluster is in standby mode and ready to take action.
-//  * In-progress - cluster CA rotation is in progress.
+//   - Standby - the cluster is in standby mode and ready to take action.
+//   - In-progress - cluster CA rotation is in progress.
 //
 // In-progress state is split into multiple phases and the cluster
 // can traverse between phases using supported transitions.
@@ -183,7 +183,7 @@ type rotationReq struct {
 // reload again, but the "new" CA is discarded and is no longer trusted,
 // cluster goes back to the original state.
 //
-// Rotation modes
+// # Rotation modes
 //
 // There are two rotation modes supported - manual or automatic.
 //
@@ -200,7 +200,6 @@ type rotationReq struct {
 //
 // It is possible to switch from automatic to manual by setting the phase
 // to the rollback phase.
-//
 func (a *Server) RotateCertAuthority(ctx context.Context, req RotateRequest) error {
 	if err := req.CheckAndSetDefaults(a.clock); err != nil {
 		return trace.Wrap(err)
@@ -699,10 +698,10 @@ func (a *Server) startNewRotation(req rotationReq, ca types.CertAuthority) error
 
 // updateClients swaps old and new CA key sets.
 //
-// * Old CAs continue to be trusted, but are no longer used for signing.
-// * New CAs are used for signing.
-// * Remote components will reload with new certificates used for client
-//   connections.
+//   - Old CAs continue to be trusted, but are no longer used for signing.
+//   - New CAs are used for signing.
+//   - Remote components will reload with new certificates used for client
+//     connections.
 func updateClients(ca types.CertAuthority, mode string) error {
 	oldActive, oldTrusted := ca.GetActiveKeys(), ca.GetAdditionalTrustedKeys()
 	if err := ca.SetActiveKeys(oldTrusted); err != nil {

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -20,7 +20,6 @@ limitations under the License.
 // * Authority server itself that implements signing and acl logic
 // * HTTP server wrapper for authority server
 // * HTTP client wrapper
-//
 package auth
 
 import (

--- a/lib/auth/webauthn/login_mfa.go
+++ b/lib/auth/webauthn/login_mfa.go
@@ -59,15 +59,15 @@ func (l *loginWithDevices) GetMFADevices(_ context.Context, _ string, _ bool) ([
 //
 // The login flow consists of:
 //
-// 1. Client requests a CredentialAssertion (containing, among other info, a
-//    challenge to be signed)
-// 2. Server runs Begin(), generates a credential assertion.
-// 3. Client validates the assertion, performs a user presence test (usually by
-//    asking the user to touch a secure token), and replies with
-//    CredentialAssertionResponse (containing the signed challenge)
-// 4. Server runs Finish()
-// 5. If all server-side checks are successful, then login/authentication is
-//    complete.
+//  1. Client requests a CredentialAssertion (containing, among other info, a
+//     challenge to be signed)
+//  2. Server runs Begin(), generates a credential assertion.
+//  3. Client validates the assertion, performs a user presence test (usually by
+//     asking the user to touch a secure token), and replies with
+//     CredentialAssertionResponse (containing the signed challenge)
+//  4. Server runs Finish()
+//  5. If all server-side checks are successful, then login/authentication is
+//     complete.
 type LoginFlow struct {
 	U2F      *types.U2F
 	Webauthn *types.Webauthn

--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -103,16 +103,16 @@ func sessionDataKey(user, sessionID string) string {
 //
 // Registration consists of:
 //
-// 1. Client requests a CredentialCreation (containing a challenge and various
-//    settings that may constrain allowed authenticators).
-// 2. Server runs Begin(), generates a credential creation.
-// 3. Client validates the credential creation, performs a user presence test
-//    (usually by asking the user to touch a secure token), and replies with a
-//    CredentialCreationResponse (containing the signed challenge and
-//    information about the credential and authenticator)
-// 4. Server runs Finish()
-// 5. If all server-side checks are successful, then registration is complete
-//    and the authenticator may now be used to login.
+//  1. Client requests a CredentialCreation (containing a challenge and various
+//     settings that may constrain allowed authenticators).
+//  2. Server runs Begin(), generates a credential creation.
+//  3. Client validates the credential creation, performs a user presence test
+//     (usually by asking the user to touch a secure token), and replies with a
+//     CredentialCreationResponse (containing the signed challenge and
+//     information about the credential and authenticator)
+//  4. Server runs Finish()
+//  5. If all server-side checks are successful, then registration is complete
+//     and the authenticator may now be used to login.
 type RegistrationFlow struct {
 	Webauthn *types.Webauthn
 	Identity RegistrationIdentity

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -122,7 +122,6 @@ type Batch interface {
 // lease, err := backend.Create(ctx, item)
 // expires := time.Now().Add(20 * time.Second)
 // err = backend.KeepAlive(ctx, lease, expires)
-//
 type Lease struct {
 	// Key is an object representing lease
 	Key []byte

--- a/lib/backend/doc.go
+++ b/lib/backend/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // backend package allows for pluggable back-ends for secrets storage.
 // To implement a new storage back-end you have to supply an object
 // which:
-//	 - implements backend.Backend interface
+//   - implements backend.Backend interface
 //   - implements backend.NewFunc function
 package backend

--- a/lib/backend/dynamo/doc.go
+++ b/lib/backend/dynamo/doc.go
@@ -21,7 +21,7 @@ auth server. Originally contributed by https://github.com/apestel
 
 limitations:
 
-* Paging is not implemented, hence all range operations are limited
-  to 1MB result set
+  - Paging is not implemented, hence all range operations are limited
+    to 1MB result set
 */
 package dynamo

--- a/lib/backend/firestore/doc.go
+++ b/lib/backend/firestore/doc.go
@@ -18,6 +18,5 @@ for Teleport auth service, similar to DynamoDB backend.
 
 firestore package implements the FirestoreBackend storage back-end for the
 auth server. Originally contributed by https://github.com/joshdurbin
-
 */
 package firestore

--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -53,7 +53,6 @@ func TestMain(m *testing.M) {
 // to verify backwards compatibility. Gogoproto is incompatible with ApiV2 protoc-gen-go code.
 //
 // Track the issue here: https://github.com/gogo/protobuf/issues/678
-//
 func TestMarshal(t *testing.T) {
 	meta := adminpb.IndexOperationMetadata{}
 	data, err := proto.Marshal(&meta)

--- a/lib/backend/postgres/doc.go
+++ b/lib/backend/postgres/doc.go
@@ -17,18 +17,19 @@ limitations under the License.
 /*
 Package postgres implements a SQL backend for PostgreSQL and CockroachDB.
 
-Schema
+# Schema
 
 The database schema consists of three tables: item, lease, and event.
-    ┌──────────┐ ┌──────────┐ ┌──────────┐
-    │  item    │ │  lease   │ │  event   │
-    ├──────────┤ ├──────────┤ ├──────────┤
-    │* key     │ │* key     │ │* eventid │
-    │* id      │ │  id      │ │  created │
-    │  value   │ │  expires │ │  key     │
-    │          │ │          │ │  id      │
-    │          │ │          │ │  type    │
-    └──────────┘ └──────────┘ └──────────┘
+
+	┌──────────┐ ┌──────────┐ ┌──────────┐
+	│  item    │ │  lease   │ │  event   │
+	├──────────┤ ├──────────┤ ├──────────┤
+	│* key     │ │* key     │ │* eventid │
+	│* id      │ │  id      │ │  created │
+	│  value   │ │  expires │ │  key     │
+	│          │ │          │ │  id      │
+	│          │ │          │ │  type    │
+	└──────────┘ └──────────┘ └──────────┘
 
 The item table contains the backend item's value and is insert-only. The table
 supports multiple items per key. Updates to an item's value creates a new
@@ -44,6 +45,5 @@ type represents the value of types.OpType.
 
 The design allows for items to be updated before an event for previous item has
 been emitted without duplicating storage for value.
-
 */
 package postgres

--- a/lib/backend/postgres/schema.go
+++ b/lib/backend/postgres/schema.go
@@ -37,7 +37,8 @@ func getMigration(version int) string {
 //
 // Keys are stored as BYTEA to avoid collation ordering.
 // When debugging, convert the key to a readable value using:
-//   SELECT encode(key, 'escape') FROM lease;
+//
+//	SELECT encode(key, 'escape') FROM lease;
 const migrateV1 = `
 	CREATE TABLE item (
 		key BYTEA NOT NULL,

--- a/lib/backend/sqlbk/doc.go
+++ b/lib/backend/sqlbk/doc.go
@@ -24,12 +24,10 @@ an interface to create transactions with cancellation through a Tx interface.
 
 	Driver -> DB -> Tx
 
-Testing
+# Testing
 
 Test a Driver implementation using the TestDriver package function. The test
 will configure the driver for use with a test backend and execute the backend
 test suite. See driver implementations for details about configuring tests.
-
-
 */
 package sqlbk

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -862,23 +862,23 @@ func (c *Cache) notify(ctx context.Context, event Event) {
 // and consistently ordered thanks to Raft. Unfortunately, DynamoDB
 // does not provide such a mechanism for its event system, so
 // some tradeoffs have to be made:
-//   a. We assume that events are ordered in regards to the
-//   individual key operations which is the guarantees both Etcd and DynamoDB
-//   provide.
-//   b. Thanks to the init event sent by the server on a successful connect,
-//   and guarantees 1 and 2a, client assumes that once it connects and receives an event,
-//   it will not miss any events, however it can receive stale events.
-//   Event could be stale, if it relates to a change that happened before
-//   the version read by client from the database, for example,
-//   given the event stream: 1. Update a=1 2. Delete a 3. Put a = 2
-//   Client could have subscribed before event 1 happened,
-//   read the value a=2 and then received events 1 and 2 and 3.
-//   The cache will replay all events 1, 2 and 3 and end up in the correct
-//   state 3. If we had a consistent revision number, we could
-//   have skipped 1 and 2, but in the absence of such mechanism in Dynamo
-//   we assume that this cache will eventually end up in a correct state
-//   potentially lagging behind the state of the database.
 //
+//	a. We assume that events are ordered in regards to the
+//	individual key operations which is the guarantees both Etcd and DynamoDB
+//	provide.
+//	b. Thanks to the init event sent by the server on a successful connect,
+//	and guarantees 1 and 2a, client assumes that once it connects and receives an event,
+//	it will not miss any events, however it can receive stale events.
+//	Event could be stale, if it relates to a change that happened before
+//	the version read by client from the database, for example,
+//	given the event stream: 1. Update a=1 2. Delete a 3. Put a = 2
+//	Client could have subscribed before event 1 happened,
+//	read the value a=2 and then received events 1 and 2 and 3.
+//	The cache will replay all events 1, 2 and 3 and end up in the correct
+//	state 3. If we had a consistent revision number, we could
+//	have skipped 1 and 2, but in the absence of such mechanism in Dynamo
+//	we assume that this cache will eventually end up in a correct state
+//	potentially lagging behind the state of the database.
 func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry, timer *time.Timer) error {
 	watcher, err := c.Events.NewWatcher(c.ctx, types.Watch{
 		QueueSize:       c.QueueSize,

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -341,7 +341,8 @@ type standaloneBundle struct {
 }
 
 // TODO(codingllama): Consider refactoring newStandaloneTeleport into a public
-//  function and reusing in other places.
+//
+//	function and reusing in other places.
 func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundle {
 	randomAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -86,7 +86,6 @@ type NodeClient struct {
 
 // GetSites returns list of the "sites" (AKA teleport clusters) connected to the proxy
 // Each site is returned as an instance of its auth server
-//
 func (proxy *ProxyClient) GetSites(ctx context.Context) ([]types.Site, error) {
 	ctx, span := proxy.Tracer.Start(
 		ctx,

--- a/lib/client/conntest/ssh.go
+++ b/lib/client/conntest/ssh.go
@@ -72,9 +72,10 @@ func NewSSHConnectionTester(cfg SSHConnectionTesterConfig) (*SSHConnectionTester
 }
 
 // TestConnection tests an SSH Connection to the target Node using
-//  - the provided client
-//  - resource name
-//  - principal / linux user
+//   - the provided client
+//   - resource name
+//   - principal / linux user
+//
 // A new ConnectionDiagnostic is created and used to store the traces as it goes through the checkpoints
 // To set up the SSH client, it will generate a new cert and inject the ConnectionDiagnosticID
 //   - add a trace of whether the SSH Node was reachable

--- a/lib/client/db/postgres/servicefile.go
+++ b/lib/client/db/postgres/servicefile.go
@@ -67,18 +67,18 @@ func LoadFromPath(path string) (*ServiceFile, error) {
 // The profile goes into a separate section with the name equal to the
 // name of the database that user is logged into and looks like this:
 //
-//   [postgres]
-//   host=proxy.example.com
-//   port=3080
-//   sslmode=verify-full
-//   sslrootcert=/home/user/.tsh/keys/proxy.example.com/certs.pem
-//   sslcert=/home/user/.tsh/keys/proxy.example.com/alice-db/root/aurora-x509.pem
-//   sslkey=/home/user/.tsh/keys/proxy.example.com/user
+//	[postgres]
+//	host=proxy.example.com
+//	port=3080
+//	sslmode=verify-full
+//	sslrootcert=/home/user/.tsh/keys/proxy.example.com/certs.pem
+//	sslcert=/home/user/.tsh/keys/proxy.example.com/alice-db/root/aurora-x509.pem
+//	sslkey=/home/user/.tsh/keys/proxy.example.com/user
 //
 // With the profile like this, a user can refer to it using "service" psql
 // parameter:
 //
-//   $ psql "service=postgres <other parameters>"
+//	$ psql "service=postgres <other parameters>"
 func (s *ServiceFile) Upsert(profile profile.ConnectProfile) error {
 	section := s.iniFile.Section(profile.Name)
 	if section != nil {

--- a/lib/client/db/profile.go
+++ b/lib/client/db/profile.go
@@ -18,10 +18,12 @@ limitations under the License.
 // that combine connection parameters for a particular database.
 //
 // For Postgres it's the connection service file:
-//   https://www.postgresql.org/docs/current/libpq-pgservice.html
+//
+//	https://www.postgresql.org/docs/current/libpq-pgservice.html
 //
 // For MySQL it's the option file:
-//   https://dev.mysql.com/doc/refman/8.0/en/option-files.html
+//
+//	https://dev.mysql.com/doc/refman/8.0/en/option-files.html
 package db
 
 import (

--- a/lib/client/escape/reader.go
+++ b/lib/client/escape/reader.go
@@ -62,11 +62,11 @@ type Reader struct {
 // NewReader creates a new Reader to catch escape sequences from 'in'.
 //
 // Two sequences are supported:
-// - "~?": prints help text to 'out' listing supported sequences
-// - "~.": disconnect stops any future reads from in; after this sequence,
-//   callers can still read any unread data up to this sequence from Reader but
-//   all future Read calls will return ErrDisconnect; onDisconnect will also be
-//   called with ErrDisconnect immediately
+//   - "~?": prints help text to 'out' listing supported sequences
+//   - "~.": disconnect stops any future reads from in; after this sequence,
+//     callers can still read any unread data up to this sequence from Reader but
+//     all future Read calls will return ErrDisconnect; onDisconnect will also be
+//     called with ErrDisconnect immediately
 //
 // NewReader starts consuming 'in' immediately in the background. This allows
 // Reader to detect sequences without the caller actively calling Read (such as

--- a/lib/client/https_client.go
+++ b/lib/client/https_client.go
@@ -90,11 +90,11 @@ type WebClient struct {
 
 // PostJSONWithFallback serializes an object to JSON and attempts to execute a POST
 // using HTTPS, and then fall back to plain HTTP under certain, very specific circumstances.
-//  * The caller must specifically allow it via the allowHTTPFallback parameter, and
-//  * The target host must resolve to the loopback address.
+//   - The caller must specifically allow it via the allowHTTPFallback parameter, and
+//   - The target host must resolve to the loopback address.
+//
 // If these conditions are not met, then the plain-HTTP fallback is not allowed,
 // and a the HTTPS failure will be considered final.
-//
 func (w *WebClient) PostJSONWithFallback(ctx context.Context, endpoint string, val interface{}, allowHTTPFallback bool) (*roundtrip.Response, error) {
 	// First try HTTPS and see how that goes
 	log.Debugf("Attempting %s", endpoint)

--- a/lib/client/identityfile/inmemory_config_writer.go
+++ b/lib/client/identityfile/inmemory_config_writer.go
@@ -36,7 +36,8 @@ func NewInMemoryConfigWriter() *InMemoryConfigWriter {
 }
 
 // InMemoryConfigWriter is a basic virtual file system abstraction that writes into memory
-//  instead of writing to a more persistent storage.
+//
+//	instead of writing to a more persistent storage.
 type InMemoryConfigWriter struct {
 	mux   *sync.RWMutex
 	files map[string]*utils.InMemoryFile

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -333,7 +333,6 @@ func (k *Key) clientCertPool(clusters ...string) (*x509.CertPool, error) {
 //
 // The config is set up to authenticate to proxy with the first available principal
 // and ( if keyStore != nil ) trust local SSH CAs without asking for public keys.
-//
 func (k *Key) ProxyClientSSHConfig(keyStore sshKnowHostGetter, host string) (*ssh.ClientConfig, error) {
 	sshCert, err := k.SSHCert()
 	if err != nil {

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -83,12 +83,12 @@ func makeSuite(t *testing.T) *KeyAgentTestSuite {
 }
 
 // TestAddKey ensures correct adding of ssh keys. This test checks the following:
-//   * When adding a key it's written to disk.
-//   * When we add a key, it's added to both the teleport ssh agent as well
+//   - When adding a key it's written to disk.
+//   - When we add a key, it's added to both the teleport ssh agent as well
 //     as the system ssh agent.
-//   * When we add a key, both the certificate and private key are added into
+//   - When we add a key, both the certificate and private key are added into
 //     the both the teleport ssh agent and the system ssh agent.
-//   * When we add a key, it's tagged with a comment that indicates that it's
+//   - When we add a key, it's tagged with a comment that indicates that it's
 //     a teleport key with the teleport username.
 func TestAddKey(t *testing.T) {
 	s := makeSuite(t)
@@ -157,8 +157,8 @@ func TestAddKey(t *testing.T) {
 
 // TestLoadKey ensures correct loading of a key into an agent. This test
 // checks the following:
-//   * Loading a key multiple times overwrites the same key.
-//   * The key is correctly loaded into the agent. This is tested by having
+//   - Loading a key multiple times overwrites the same key.
+//   - The key is correctly loaded into the agent. This is tested by having
 //     the agent sign data that is then verified using the public key
 //     directly.
 func TestLoadKey(t *testing.T) {

--- a/lib/client/terminal/terminal_common.go
+++ b/lib/client/terminal/terminal_common.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/client/terminal/terminal_unix.go
+++ b/lib/client/terminal/terminal_unix.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/client/terminal/terminal_windows.go
+++ b/lib/client/terminal/terminal_windows.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/cloud/gcp.go
+++ b/lib/cloud/gcp.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Package config provides facilities for configuring Teleport daemons
 // including
-//	- parsing YAML configuration
-//	- parsing CLI flags
+//   - parsing YAML configuration
+//   - parsing CLI flags
 package config
 
 import (

--- a/lib/defaults/defaults_test.go
+++ b/lib/defaults/defaults_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -29,12 +29,12 @@ type Event struct {
 // There is no strict algorithm for picking an event code, however existing
 // event codes are currently loosely categorized as follows:
 //
-//  * Teleport event codes start with "T" and belong in this const block.
+//   - Teleport event codes start with "T" and belong in this const block.
 //
-//  * Related events are grouped starting with the same number.
-//		eg: All user related events are grouped under 1xxx.
+//   - Related events are grouped starting with the same number.
+//     eg: All user related events are grouped under 1xxx.
 //
-//  * Suffix code with one of these letters: I (info), W (warn), E (error).
+//   - Suffix code with one of these letters: I (info), W (warn), E (error).
 const (
 	// UserLocalLoginCode is the successful local user login event code.
 	UserLocalLoginCode = "T1000I"

--- a/lib/events/doc.go
+++ b/lib/events/doc.go
@@ -27,11 +27,12 @@ and session log events like session.start.
 Example audit log event:
 
 {"addr.local":"172.10.1.20:3022",
- "addr.remote":"172.10.1.254:58866",
- "event":"session.start",
- "login":"root",
- "user":"klizhentas@gmail.com"
-}
+
+	 "addr.remote":"172.10.1.254:58866",
+	 "event":"session.start",
+	 "login":"root",
+	 "user":"klizhentas@gmail.com"
+	}
 
 Session Logs
 ------------
@@ -40,15 +41,15 @@ Session logs are a series of events and recorded SSH interactive session playbac
 
 Example session log event:
 
-{
-  "time":"2018-01-04T02:12:40.245Z",
-  "event":"print",
-  "bytes":936,
-  "ms":40962,
-  "offset":16842,
-  "ei":31,
-  "ci":29
-}
+	{
+	  "time":"2018-01-04T02:12:40.245Z",
+	  "event":"print",
+	  "bytes":936,
+	  "ms":40962,
+	  "offset":16842,
+	  "ei":31,
+	  "ci":29
+	}
 
 Print event fields
 ------------------
@@ -124,8 +125,8 @@ Files:
 	/var/lib/teleport/log/<auth-server-id>/<session-id>-<first-chunk-in-file-offset>.chunks
 
 Where:
-	- .events   (same events as in the main log, but related to the session)
-	- .chunks (recorded session bytes: PTY IO)
+  - .events   (same events as in the main log, but related to the session)
+  - .chunks (recorded session bytes: PTY IO)
 
 Examples
 ~~~~~~~~
@@ -159,7 +160,8 @@ emitted by print event with chunk index 0
 **Multiple Auth Servers**
 
 In High Availability mode scenario, multiple auth servers will be
- deployed behind a load balancer.
+
+	deployed behind a load balancer.
 
 Any auth server can go down during session and clients will retry the delivery
 to the other auth server.
@@ -217,6 +219,5 @@ Log Search and Playback
 
 Log search and playback is aware of multiple auth servers, merges
 indexes, event streams stored on multiple auth servers.
-
 */
 package events

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -46,7 +46,6 @@ import (
 // Data race detector slows down the test significantly (10x+),
 // that is why the test is skipped when tests are running with
 // `go test -race` flag or `go test -short` flag
-//
 func TestChaosUpload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping chaos test in short mode.")

--- a/lib/events/firestoreevents/doc.go
+++ b/lib/events/firestoreevents/doc.go
@@ -18,6 +18,5 @@ for Teleport event storage.
 
 firestoreevents package implements the Log storage back-end for the
 auth server. Originally contributed by https://github.com/joshdurbin
-
 */
 package firestoreevents

--- a/lib/events/gcssessions/doc.go
+++ b/lib/events/gcssessions/doc.go
@@ -18,6 +18,5 @@ for Teleport session recording persistence.
 
 gcssessions package implements the Handler session recording storage for
 auth server. Originally contributed by https://github.com/joshdurbin
-
 */
 package gcssessions

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -225,7 +225,6 @@ func (cfg *ProtoStreamConfig) CheckAndSetDefaults() error {
 // The individual session stream is represented by continuous globally
 // ordered sequence of events serialized to binary protobuf format.
 //
-//
 // The stream is split into ordered slices of gzipped audit events.
 //
 // Each slice is composed of three parts:
@@ -247,7 +246,6 @@ func (cfg *ProtoStreamConfig) CheckAndSetDefaults() error {
 //
 // This design allows the streamer to upload slices using S3-compatible APIs
 // in parallel without buffering to disk.
-//
 func NewProtoStream(cfg ProtoStreamConfig) (*ProtoStream, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/inventory/store_test.go
+++ b/lib/inventory/store_test.go
@@ -95,7 +95,6 @@ func BenchmarkStore(b *testing.B) {
 // TestStoreAccess verifies the two most important properties of the store:
 // 1. Handles are loadable by ID.
 // 2. When multiple handles have the same ID, loads are distributed across them.
-//
 func TestStoreAccess(t *testing.T) {
 	store := NewStore()
 

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -66,10 +66,10 @@ type ImpersonationPermissionsChecker func(ctx context.Context, clusterName strin
 // getKubeCreds fetches the kubernetes API credentials.
 //
 // There are 2 possible sources of credentials:
-// - pod service account credentials: files in hardcoded paths when running
-//   inside of a k8s pod; this is used when kubeClusterName is set
-// - kubeconfig: a file with a set of k8s endpoints and credentials mapped to
-//   them this is used when kubeconfigPath is set
+//   - pod service account credentials: files in hardcoded paths when running
+//     inside of a k8s pod; this is used when kubeClusterName is set
+//   - kubeconfig: a file with a set of k8s endpoints and credentials mapped to
+//     them this is used when kubeconfigPath is set
 //
 // serviceType changes the loading behavior:
 // - LegacyProxyService:
@@ -77,8 +77,10 @@ type ImpersonationPermissionsChecker func(ctx context.Context, clusterName strin
 //     returned map key matches tpClusterName
 //   - if no credentials are loaded, no error is returned
 //   - permission self-test failures are only logged
+//
 // - ProxyService:
 //   - no credentials are loaded and no error is returned
+//
 // - KubeService:
 //   - if loading from kubeconfig, all contexts are returned
 //   - if no credentials are loaded, returns an error

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -2009,6 +2009,7 @@ func (f *Forwarder) requestCertificate(ctx authContext) (*tls.Config, error) {
 		RootCAs:      pool,
 		Certificates: []tls.Certificate{cert},
 	}
+	//nolint:staticcheck // Keep BuildNameToCertificate to avoid changes in legacy behavior.
 	tlsConfig.BuildNameToCertificate()
 
 	return tlsConfig, nil

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -768,7 +768,7 @@ func TestNewClusterSessionRemote(t *testing.T) {
 	// getClientCreds returns the cached version of the client tlsConfig.
 	require.NotNil(t, f.getClientCreds(authCtx))
 	require.NotSame(t, f.getClientCreds(authCtx), sess.tlsConfig)
-	//lint:ignore SA1019 there's no non-deprecated public API for testing the contents of the RootCAs pool
+	//nolint:staticcheck // SA1019 there's no non-deprecated public API for testing the contents of the RootCAs pool
 	require.Equal(t, [][]byte{f.cfg.AuthClient.(*mockCSRClient).ca.Cert.RawSubject}, sess.tlsConfig.RootCAs.Subjects())
 	require.Equal(t, 1, f.clientCredentials.Len())
 }
@@ -821,7 +821,7 @@ func TestNewClusterSessionDirect(t *testing.T) {
 
 	// Make sure newClusterSession obtained a new client cert instead of using f.creds.
 	require.Equal(t, f.cfg.AuthClient.(*mockCSRClient).lastCert.Raw, sess.tlsConfig.Certificates[0].Certificate[0])
-	//lint:ignore SA1019 there's no non-deprecated public API for testing the contents of the RootCAs pool
+	//nolint:staticcheck // SA1019 there's no non-deprecated public API for testing the contents of the RootCAs pool
 	require.Equal(t, [][]byte{f.cfg.AuthClient.(*mockCSRClient).ca.Cert.RawSubject}, sess.tlsConfig.RootCAs.Subjects())
 	// Make sure that sess.tlsConfig was cloned from the value we store in the cache.
 	// This is important because each connection must refer to a different memory address so it can be manipulated to enable/disable http2

--- a/lib/kube/proxy/streamproto/proto_test.go
+++ b/lib/kube/proxy/streamproto/proto_test.go
@@ -100,8 +100,12 @@ func TestPingPong(t *testing.T) {
 	defer server.Close()
 
 	url := "ws" + strings.TrimPrefix(server.URL, "http")
-	ws, _, err := websocket.DefaultDialer.Dial(url, nil)
+	ws, resp, err := websocket.DefaultDialer.Dial(url, nil)
 	require.NoError(t, err)
+
+	// Always drain/close the body.
+	io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
 
 	go func() {
 		defer ws.Close()

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -137,7 +137,6 @@ func GetKubeConfig(configPath string, allConfigEntries bool, clusterName string)
 //
 // It is hex encoded to allow wildcard matching to work. In DNS wildcard match
 // include only one '.'
-//
 func EncodeClusterName(clusterName string) string {
 	// k is to avoid first letter to be a number
 	return "k" + hex.EncodeToString([]byte(clusterName))

--- a/lib/labels/ec2/ec2_test.go
+++ b/lib/labels/ec2/ec2_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/modules/test.go
+++ b/lib/modules/test.go
@@ -38,19 +38,18 @@ type TestModules struct {
 // and reverts the change in the test cleanup function.
 // It must not be used in parallel tests.
 //
-//    func TestWithFakeModules(t *testing.T) {
-//       modules.SetTestModules(t, &modules.TestModules{
-//         TestBuildType: modules.BuildEnterprise,
-//         TestFeatures: modules.Features{
-//            Cloud: true,
-//         },
-//       })
+//	func TestWithFakeModules(t *testing.T) {
+//	   modules.SetTestModules(t, &modules.TestModules{
+//	     TestBuildType: modules.BuildEnterprise,
+//	     TestFeatures: modules.Features{
+//	        Cloud: true,
+//	     },
+//	   })
 //
-//       // test implementation
+//	   // test implementation
 //
-//       // cleanup will revert module changes after test completes
-//    }
-//
+//	   // cleanup will revert module changes after test completes
+//	}
 func SetTestModules(t *testing.T, testModules *TestModules) {
 	defaultModules := GetModules()
 	t.Cleanup(func() { SetModules(defaultModules) })

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -20,7 +20,6 @@ limitations under the License.
 // mux, _ := multiplexer.New(Config{Listener: listener})
 // mux.SSH() // returns listener getting SSH connections
 // mux.TLS() // returns listener getting TLS connections
-//
 package multiplexer
 
 import (

--- a/lib/observability/metrics/prometheus.go
+++ b/lib/observability/metrics/prometheus.go
@@ -27,9 +27,9 @@ import (
 )
 
 // RegisterPrometheusCollectors is a wrapper around prometheus.Register that
-// - ignores equal or re-registered collectors
-// - returns an error if a collector does not fulfill the consistency and
-//   uniqueness criteria
+//   - ignores equal or re-registered collectors
+//   - returns an error if a collector does not fulfill the consistency and
+//     uniqueness criteria
 func RegisterPrometheusCollectors(collectors ...prometheus.Collector) error {
 	var errs []error
 	for _, c := range collectors {

--- a/lib/pam/pam.go
+++ b/lib/pam/pam.go
@@ -402,9 +402,9 @@ func (p *PAM) Close() error {
 // variables and it is the responsibility of the caller to free that memory.
 // From http://man7.org/linux/man-pages/man3/pam_getenvlist.3.html:
 //
-//   It should be noted that this memory will never be free()'d by libpam.
-//   Once obtained by a call to pam_getenvlist, it is the responsibility
-//   of the calling application to free() this memory.
+//	It should be noted that this memory will never be free()'d by libpam.
+//	Once obtained by a call to pam_getenvlist, it is the responsibility
+//	of the calling application to free() this memory.
 func (p *PAM) Environment() []string {
 	// Get list of additional environment variables requested from PAM.
 	pam_envlist := C._pam_getenvlist(pamHandle, p.pamh)

--- a/lib/reversetunnel/conn_metric.go
+++ b/lib/reversetunnel/conn_metric.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/reversetunnel/doc.go
+++ b/lib/reversetunnel/doc.go
@@ -16,28 +16,30 @@ limitations under the License.
 
 /*
 Package reversetunnel provides interfaces for accessing remote clusters
-   via reverse tunnels and directly.
+
+	via reverse tunnels and directly.
 
 Reverse Tunnels
 
-      Proxy server                      Proxy agent
-                     Reverse tunnel
-      +----------+                      +---------+
-      |          <----------------------+         |
-      |          |                      |         |
+	Proxy server                      Proxy agent
+	               Reverse tunnel
+	+----------+                      +---------+
+	|          <----------------------+         |
+	|          |                      |         |
+
 +-----+----------+                      +---------+-----+
 |                |                      |               |
 |                |                      |               |
 +----------------+                      +---------------+
- Proxy Cluster "A"                      Proxy Cluster "B"
 
+	Proxy Cluster "A"                      Proxy Cluster "B"
 
 Reverse tunnel is established from a cluster "B" Proxy
 to the a cluster "A" proxy, and clients of the cluster "A"
 can access servers of the cluster "B" via reverse tunnel connection,
 even if the cluster "B" is behind the firewall.
 
-Multiple Proxies and Revese Tunnels
+# Multiple Proxies and Revese Tunnels
 
 With multiple proxies behind the load balancer,
 proxy agents will eventually discover and establish connections to all
@@ -47,24 +49,28 @@ proxies in cluster.
 * Proxy 1 starts sending information about all available proxies
 to the the Proxy Agent . This process is called "sending discovery request".
 
-
 +----------+
 |          <--------+
 |          |        |
 +----------+        |     +-----------+             +----------+
-  Proxy 1           +-------------------------------+          |
-                          |           |             |          |
-                          +-----------+             +----------+
-                           Load Balancer             Proxy Agent
+
+	Proxy 1           +-------------------------------+          |
+	                        |           |             |          |
+	                        +-----------+             +----------+
+	                         Load Balancer             Proxy Agent
+
 +----------+
 |          |
 |          |
 +----------+
-  Proxy 2
+
+	Proxy 2
 
 * Agent will use the discovery request to establish new connections
 and check if it has connected and "discovered" all the proxies specified
- in the discovery request.
+
+	in the discovery request.
+
 * Assuming that load balancer uses fair load balancing algorithm,
 agent will eventually discover and connect back to all the proxies.
 
@@ -72,17 +78,17 @@ agent will eventually discover and connect back to all the proxies.
 |          <--------+
 |          |        |
 +----------+        |     +-----------+             +----------+
-  Proxy 1           +-------------------------------+          |
-                    |     |           |             |          |
-                    |     +-----------+             +----------+
-                    |      Load Balancer             Proxy Agent
+
+	Proxy 1           +-------------------------------+          |
+	                  |     |           |             |          |
+	                  |     +-----------+             +----------+
+	                  |      Load Balancer             Proxy Agent
+
 +----------+        |
 |          <--------+
 |          |
 +----------+
-  Proxy 2
 
-
-
+	Proxy 2
 */
 package reversetunnel

--- a/lib/service/db_test.go
+++ b/lib/service/db_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2560,6 +2560,7 @@ func (process *TeleportProcess) initMetricsService() error {
 
 		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 		tlsConfig.ClientCAs = pool
+		//nolint:staticcheck // Keep BuildNameToCertificate to avoid changes in legacy behavior.
 		tlsConfig.BuildNameToCertificate()
 
 		listener = tls.NewListener(listener, tlsConfig)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -210,13 +210,13 @@ type accessChecker struct {
 // NewAccessChecker returns a new AccessChecker which can be used to check
 // access to resources.
 // Args:
-// - `info *AccessInfo` should hold the roles, traits, and allowed resource IDs
-//   for the identity.
-// - `localCluster string` should be the name of the local cluster in which
-//   access will be checked. You cannot check for access to resources in remote
-//   clusters.
-// - `access RoleGetter` should be a RoleGetter which will be used to fetch the
-//   full RoleSet
+//   - `info *AccessInfo` should hold the roles, traits, and allowed resource IDs
+//     for the identity.
+//   - `localCluster string` should be the name of the local cluster in which
+//     access will be checked. You cannot check for access to resources in remote
+//     clusters.
+//   - `access RoleGetter` should be a RoleGetter which will be used to fetch the
+//     full RoleSet
 func NewAccessChecker(info *AccessInfo, localCluster string, access RoleGetter) (AccessChecker, error) {
 	roleSet, err := FetchRoles(info.Roles, access, info.Traits)
 	if err != nil {

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1314,16 +1314,16 @@ func MarshalAccessRequest(accessRequest types.AccessRequest, opts ...MarshalOpti
 }
 
 // pruneResourceRequestRoles takes an access request and does one of two things:
-// 1. If it is a role request, returns it unchanged.
-// 2. If it is a resource request, all available `search_as_roles` for the user
-//    should have been populated on the request by `ValidateAccessReqeustForUser`.
-//    This function will attempt to prune these roles to a minimal necessary set
-//    based on the following rules:
-//    - If a role does not grant access to any resources in the set, it is pruned.
-//    - If the request includes a LoginHint, access to a node with that login
-//      should be satisfied by exactly 1 role. The first such role will be
-//      requested, all others will be pruned unless they are necessary to access
-//      a different resource in the set.
+//  1. If it is a role request, returns it unchanged.
+//  2. If it is a resource request, all available `search_as_roles` for the user
+//     should have been populated on the request by `ValidateAccessReqeustForUser`.
+//     This function will attempt to prune these roles to a minimal necessary set
+//     based on the following rules:
+//     - If a role does not grant access to any resources in the set, it is pruned.
+//     - If the request includes a LoginHint, access to a node with that login
+//     should be satisfied by exactly 1 role. The first such role will be
+//     requested, all others will be pruned unless they are necessary to access
+//     a different resource in the set.
 func (m *RequestValidator) pruneResourceRequestRoles(
 	ctx context.Context,
 	resourceIDs []types.ResourceID,

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -202,11 +202,11 @@ func matchResourceByFilters(resource types.ResourceWithLabels, filter MatchResou
 }
 
 // matchAndFilterKubeClusters is similar to MatchResourceByFilters, but does two things in addition:
-//  1) handles kube service having a 1-N relationship (service-clusters)
+//  1. handles kube service having a 1-N relationship (service-clusters)
 //     so each kube cluster goes through the filters
-//  2) filters out the non-matched clusters on the kube service and the kube service is
+//  2. filters out the non-matched clusters on the kube service and the kube service is
 //     modified in place with only the matched clusters
-//  3) only returns true if the service contained any matched cluster
+//  3. only returns true if the service contained any matched cluster
 func matchAndFilterKubeClusters(resource types.ResourceWithLabels, filter MatchResourceFilter) (bool, error) {
 	if len(filter.Labels) == 0 && len(filter.SearchKeywords) == 0 && filter.PredicateExpression == "" {
 		return true, nil

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -653,9 +653,10 @@ func newParserForIdentifierSubcondition(ctx RuleContext, identifier string) (pre
 // NewResourceParser returns a parser made for boolean expressions based on a
 // json-serialiable resource. Customized to allow short identifiers common in all
 // resources:
-//  - `metadata.name` can be referenced with `name` ie: `name == "jenkins"``
-//  - `metadata.labels + spec.dynamic_labels` can be referenced with `labels`
+//   - `metadata.name` can be referenced with `name` ie: `name == "jenkins"“
+//   - `metadata.labels + spec.dynamic_labels` can be referenced with `labels`
 //     ie: `labels.env == "prod"`
+//
 // All other fields can be referenced by starting expression with identifier `resource`
 // followed by the names of the json fields ie: `resource.spec.public_addr`.
 func NewResourceParser(resource types.ResourceWithLabels) (BoolPredicateParser, error) {

--- a/lib/services/plugin_data.go
+++ b/lib/services/plugin_data.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-//MarshalPluginData marshals the PluginData resource to JSON.
+// MarshalPluginData marshals the PluginData resource to JSON.
 func MarshalPluginData(pluginData types.PluginData, opts ...MarshalOption) ([]byte, error) {
 	if err := pluginData.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -416,6 +416,7 @@ func applyValueTraitsSlice(inputs []string, traits map[string][]string, fieldNam
 // and traits from identity provider. For example:
 //
 // cluster_labels:
+//
 //	env: ['{{external.groups}}']
 //
 // and groups: ['admins', 'devs']
@@ -423,6 +424,7 @@ func applyValueTraitsSlice(inputs []string, traits map[string][]string, fieldNam
 // will be interpolated to:
 //
 // cluster_labels:
+//
 //	env: ['admins', 'devs']
 func applyLabelsTraits(inLabels types.Labels, traits map[string][]string) types.Labels {
 	outLabels := make(types.Labels, len(inLabels))

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -3964,22 +3964,21 @@ func TestCheckAccessToWindowsDesktop(t *testing.T) {
 //
 // To run benchmark:
 //
-//    go test -bench=.
+//	go test -bench=.
 //
 // To run benchmark and obtain CPU and memory profiling:
 //
-//    go test -bench=. -cpuprofile=cpu.prof -memprofile=mem.prof
+//	go test -bench=. -cpuprofile=cpu.prof -memprofile=mem.prof
 //
 // To use the command line tool to read the profile:
 //
-//   go tool pprof cpu.prof
-//   go tool pprof cpu.prof
+//	go tool pprof cpu.prof
+//	go tool pprof cpu.prof
 //
 // To generate a graph:
 //
-//   go tool pprof --pdf cpu.prof > cpu.pdf
-//   go tool pprof --pdf mem.prof > mem.pdf
-//
+//	go tool pprof --pdf cpu.prof > cpu.pdf
+//	go tool pprof --pdf mem.prof > mem.pdf
 func BenchmarkCheckAccessToServer(b *testing.B) {
 	servers := make([]*types.ServerV2, 0, 4000)
 
@@ -4717,7 +4716,7 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 		server  types.Server
 	}{
 		{
-			test: "test exact match, one sudoer entry, one role",
+			test:    "test exact match, one sudoer entry, one role",
 			sudoers: []string{"%sudo	ALL=(ALL) ALL"},
 			roles: NewRoleSet(&types.RoleV5{
 
@@ -4726,7 +4725,7 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 						CreateHostUser: types.NewBoolOption(true),
 					},
 					Allow: types.RoleConditions{
-						NodeLabels: types.Labels{"success": []string{"abc"}},
+						NodeLabels:  types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{"%sudo	ALL=(ALL) ALL"},
 					},
 				},
@@ -4790,7 +4789,7 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 						CreateHostUser: types.NewBoolOption(true),
 					},
 					Allow: types.RoleConditions{
-						NodeLabels: types.Labels{"success": []string{"abc"}},
+						NodeLabels:  types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{"%sudo	ALL=(ALL) ALL"},
 					},
 				},
@@ -4814,7 +4813,7 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 			},
 		},
 		{
-			test: "line deny",
+			test:    "line deny",
 			sudoers: []string{"%sudo	ALL=(ALL) ALL"},
 			roles: NewRoleSet(&types.RoleV5{
 				Spec: types.RoleSpecV5{

--- a/lib/srv/alpnproxy/conn.go
+++ b/lib/srv/alpnproxy/conn.go
@@ -42,36 +42,41 @@ func newBufferedConn(conn net.Conn, header io.Reader) *bufferedConn {
 //
 // Example: Prepend Read buff to the connection.
 // conn, err := conn.Read(buff)
-// if err != nil {
-//    return err
-// }
+//
+//	if err != nil {
+//	   return err
+//	}
+//
 // Now the client can peek at buff read by conn.Read call.
 //
 // But to not alter the connection the buff can be prepended to the connection and
 // the buffered connection should be sued for further operations.
 // conn = newBufferedConn(conn, bytes.NewReader(buff))
-// if err := handleConnection(conn); err != nil {
-//    return err
-// }
+//
+//	if err := handleConnection(conn); err != nil {
+//	   return err
+//	}
 //
 // The bufferedConn is useful in more complex cases when connection Read call is done in an external library
 // Example: Reading the client TLS Hello message TLS termination.
 // var hello *tls.ClientHelloInfo
 // buff := new(bytes.Buffer)
-// tlsConn := tls.Server(readOnlyConn{reader: io.TeeReader(conn, buff)}, &tls.Config{
-// 	 GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
-// 	    hello = info
-// 	    return nil, nil
-// 	 },
-// })
+//
+//	tlsConn := tls.Server(readOnlyConn{reader: io.TeeReader(conn, buff)}, &tls.Config{
+//		 GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+//		    hello = info
+//		    return nil, nil
+//		 },
+//	})
+//
 // err := tlsConn.Handshake()
-// if hello == nil {
-//    return trace.Wrap(err)
-// }
+//
+//	if hello == nil {
+//	   return trace.Wrap(err)
+//	}
 //
 // Create the bufferedConn with prepended buff obtained from TLS Handshake.
 // conn := newBufferedConn(conn, buff)
-//
 type bufferedConn struct {
 	net.Conn
 	r io.Reader

--- a/lib/srv/alpnproxy/proxy.go
+++ b/lib/srv/alpnproxy/proxy.go
@@ -353,14 +353,14 @@ type ConnectionInfo struct {
 type HandlerFuncWithInfo func(ctx context.Context, conn net.Conn, info ConnectionInfo) error
 
 // handleConn routes incoming connection based on SNI TLS information to the proper Handler by following steps:
-// 1) Read TLS hello message without TLS termination and returns conn that will be used for further operations.
-// 2) Get routing rules for p.Router.Router based on SNI and ALPN fields read in step 1.
-// 3) If the selected handler was configured with the ForwardTLS
-//    forwards the connection to the handler without TLS termination.
-// 4) Trigger TLS handshake and terminates the TLS connection.
-// 5) For backward compatibility check RouteToDatabase identity field
-//    was set if yes forward to the generic TLS DB handler.
-// 6) Forward connection to the handler obtained in step 2.
+//  1. Read TLS hello message without TLS termination and returns conn that will be used for further operations.
+//  2. Get routing rules for p.Router.Router based on SNI and ALPN fields read in step 1.
+//  3. If the selected handler was configured with the ForwardTLS
+//     forwards the connection to the handler without TLS termination.
+//  4. Trigger TLS handshake and terminates the TLS connection.
+//  5. For backward compatibility check RouteToDatabase identity field
+//     was set if yes forward to the generic TLS DB handler.
+//  6. Forward connection to the handler obtained in step 2.
 func (p *Proxy) handleConn(ctx context.Context, clientConn net.Conn, defaultOverride *tls.Config) error {
 	hello, conn, err := p.readHelloMessageWithoutTLSTermination(clientConn)
 	if err != nil {

--- a/lib/srv/app/aws/handler.go
+++ b/lib/srv/app/aws/handler.go
@@ -124,18 +124,18 @@ func (s *SigningServiceConfig) CheckAndSetDefaults() error {
 // Handling steps:
 // 1) Decoded Authorization Header. Authorization Header example:
 //
-//    Authorization: AWS4-HMAC-SHA256
-//    Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,
-//    SignedHeaders=host;range;x-amz-date,
-//    Signature=fe5f80f77d5fa3beca038a248ff027d0445342fe2855ddc963176630326f1024
+//		Authorization: AWS4-HMAC-SHA256
+//		Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,
+//		SignedHeaders=host;range;x-amz-date,
+//		Signature=fe5f80f77d5fa3beca038a248ff027d0445342fe2855ddc963176630326f1024
 //
-// 2) Extract credential section from credential Authorization Header.
-// 3) Extract aws-region and aws-service from the credential section.
-// 4) Build AWS API endpoint based on extracted aws-region and aws-service fields.
-//    Not that for endpoint resolving the https://github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
-//    package is used and when Amazon releases a new API the dependency update is needed.
-// 5) Sign HTTP request.
-// 6) Forward the signed HTTP request to the AWS API.
+//	 2. Extract credential section from credential Authorization Header.
+//	 3. Extract aws-region and aws-service from the credential section.
+//	 4. Build AWS API endpoint based on extracted aws-region and aws-service fields.
+//	    Not that for endpoint resolving the https://github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
+//	    package is used and when Amazon releases a new API the dependency update is needed.
+//	 5. Sign HTTP request.
+//	 6. Forward the signed HTTP request to the AWS API.
 func (s *SigningService) RoundTrip(req *http.Request) (*http.Response, error) {
 	sessionCtx, err := common.GetSessionContext(req)
 	if err != nil {

--- a/lib/srv/app/cloud_test.go
+++ b/lib/srv/app/cloud_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/srv/db/cloud/users/users.go
+++ b/lib/srv/db/cloud/users/users.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/srv/db/cloud/watchers/elasticache.go
+++ b/lib/srv/db/cloud/watchers/elasticache.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/srv/db/cloud/watchers/memorydb.go
+++ b/lib/srv/db/cloud/watchers/memorydb.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/srv/db/mongodb/doc.go
+++ b/lib/srv/db/mongodb/doc.go
@@ -30,9 +30,9 @@ limitations under the License.
 //
 // For example, this configuration will make Teleport to connect to a secondary:
 //
-//  - name: "mongo-rs"
-//    protocol: "mongodb"
-//    uri: "mongodb://mongo1:27017,mongo2:27017/?replicaSet=rs0&readPreference=secondary"
+//   - name: "mongo-rs"
+//     protocol: "mongodb"
+//     uri: "mongodb://mongo1:27017,mongo2:27017/?replicaSet=rs0&readPreference=secondary"
 //
 // Command authorization
 // =====================

--- a/lib/srv/db/mongodb/engine.go
+++ b/lib/srv/db/mongodb/engine.go
@@ -102,14 +102,14 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 
 // handleClientMessage implements the client message's roundtrip which can go
 // down a few different ways:
-// 1. If the client's command is not allowed by user's role, we do not pass it
-//    to the server and return an error to the client.
-// 2. In the most common case, we send client message to the server, read its
-//    reply and send it back to the client.
-// 3. Some client commands do not receive a reply in which case we just return
-//    after sending message to the server and wait for next client message.
-// 4. Server can also send multiple messages in a row in which case we exhaust
-//    them before returning to listen for next client message.
+//  1. If the client's command is not allowed by user's role, we do not pass it
+//     to the server and return an error to the client.
+//  2. In the most common case, we send client message to the server, read its
+//     reply and send it back to the client.
+//  3. Some client commands do not receive a reply in which case we just return
+//     after sending message to the server and wait for next client message.
+//  4. Server can also send multiple messages in a row in which case we exhaust
+//     them before returning to listen for next client message.
 func (e *Engine) handleClientMessage(ctx context.Context, sessionCtx *common.Session, clientMessage protocol.Message, clientConn net.Conn, serverConn driver.Connection) error {
 	e.Log.Debugf("===> %v", clientMessage)
 	// First check the client command against user's role and log in the audit.

--- a/lib/srv/db/mongodb/protocol/doc.go
+++ b/lib/srv/db/mongodb/protocol/doc.go
@@ -30,18 +30,18 @@ limitations under the License.
 //
 // Package layout:
 //
-// * message.go: Defines wire message common interface and provides methods for
-//   reading wire messages from client/server connections.
+//   - message.go: Defines wire message common interface and provides methods for
+//     reading wire messages from client/server connections.
 //
-// * opmsg.go: Contains marshal/unmarshal for OP_MSG - extensible message that
-//   MongoDB 3.6 and higher use for all commands.
+//   - opmsg.go: Contains marshal/unmarshal for OP_MSG - extensible message that
+//     MongoDB 3.6 and higher use for all commands.
 //
-// * opquery.go: Contains marshal/unmarshal for OP_QUERY - a legacy command,
-//   still used for some operations (e.g. first "isMaster" handshake message).
+//   - opquery.go: Contains marshal/unmarshal for OP_QUERY - a legacy command,
+//     still used for some operations (e.g. first "isMaster" handshake message).
 //
-// * opreply.go: Contains marshal/unmarshal for OP_REPLY - a reply message sent
-//   by a database to an OP_QUERY command.
+//   - opreply.go: Contains marshal/unmarshal for OP_REPLY - a reply message sent
+//     by a database to an OP_QUERY command.
 //
-// * errors.go: Provides methods for sending errors in wire message to client
-//   connections.
+//   - errors.go: Provides methods for sending errors in wire message to client
+//     connections.
 package protocol

--- a/lib/srv/db/mongodb/protocol/opcompressed.go
+++ b/lib/srv/db/mongodb/protocol/opcompressed.go
@@ -30,13 +30,13 @@ import (
 //
 // https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op_compressed
 //
-// struct {
-//     MsgHeader header;           // standard message header
-//     int32  originalOpcode;      // value of wrapped opcode
-//     int32  uncompressedSize;    // size of deflated compressedMessage, excluding MsgHeader
-//     uint8  compressorId;        // ID of compressor that compressed message
-//     char    *compressedMessage; // opcode itself, excluding MsgHeader
-// }
+//	struct {
+//	    MsgHeader header;           // standard message header
+//	    int32  originalOpcode;      // value of wrapped opcode
+//	    int32  uncompressedSize;    // size of deflated compressedMessage, excluding MsgHeader
+//	    uint8  compressorId;        // ID of compressor that compressed message
+//	    char    *compressedMessage; // opcode itself, excluding MsgHeader
+//	}
 type MessageOpCompressed struct {
 	Header            MessageHeader
 	OriginalOpcode    wiremessage.OpCode

--- a/lib/srv/db/mongodb/protocol/opdelete.go
+++ b/lib/srv/db/mongodb/protocol/opdelete.go
@@ -30,13 +30,13 @@ import (
 //
 // https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op_delete
 //
-// struct {
-//     MsgHeader header;             // standard message header
-//     int32     ZERO;               // 0 - reserved for future use
-//     cstring   fullCollectionName; // "dbname.collectionname"
-//     int32     flags;              // bit vector - see below for details.
-//     document  selector;           // query object.  See below for details.
-// }
+//	struct {
+//	    MsgHeader header;             // standard message header
+//	    int32     ZERO;               // 0 - reserved for future use
+//	    cstring   fullCollectionName; // "dbname.collectionname"
+//	    int32     flags;              // bit vector - see below for details.
+//	    document  selector;           // query object.  See below for details.
+//	}
 //
 // OP_DELETE is deprecated starting MongoDB 5.0 in favor of OP_MSG.
 type MessageOpDelete struct {

--- a/lib/srv/db/mongodb/protocol/opgetmore.go
+++ b/lib/srv/db/mongodb/protocol/opgetmore.go
@@ -30,13 +30,13 @@ import (
 //
 // https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op_get_more
 //
-// struct {
-//     MsgHeader header;             // standard message header
-//     int32     ZERO;               // 0 - reserved for future use
-//     cstring   fullCollectionName; // "dbname.collectionname"
-//     int32     numberToReturn;     // number of documents to return
-//     int64     cursorID;           // cursorID from the OP_REPLY
-// }
+//	struct {
+//	    MsgHeader header;             // standard message header
+//	    int32     ZERO;               // 0 - reserved for future use
+//	    cstring   fullCollectionName; // "dbname.collectionname"
+//	    int32     numberToReturn;     // number of documents to return
+//	    int64     cursorID;           // cursorID from the OP_REPLY
+//	}
 //
 // OP_GET_MORE is deprecated starting MongoDB 5.0 in favor of OP_MSG.
 type MessageOpGetMore struct {

--- a/lib/srv/db/mongodb/protocol/opinsert.go
+++ b/lib/srv/db/mongodb/protocol/opinsert.go
@@ -30,12 +30,12 @@ import (
 //
 // https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op_insert
 //
-// struct {
-//     MsgHeader header;             // standard message header
-//     int32     flags;              // bit vector - see below
-//     cstring   fullCollectionName; // "dbname.collectionname"
-//     document* documents;          // one or more documents to insert into the collection
-// }
+//	struct {
+//	    MsgHeader header;             // standard message header
+//	    int32     flags;              // bit vector - see below
+//	    cstring   fullCollectionName; // "dbname.collectionname"
+//	    document* documents;          // one or more documents to insert into the collection
+//	}
 //
 // OP_INSERT is deprecated starting MongoDB 5.0 in favor of OP_MSG.
 type MessageOpInsert struct {

--- a/lib/srv/db/mongodb/protocol/opkillcursors.go
+++ b/lib/srv/db/mongodb/protocol/opkillcursors.go
@@ -29,12 +29,12 @@ import (
 //
 // https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op_kill_cursors
 //
-// struct {
-//     MsgHeader header;            // standard message header
-//     int32     ZERO;              // 0 - reserved for future use
-//     int32     numberOfCursorIDs; // number of cursorIDs in message
-//     int64*    cursorIDs;         // sequence of cursorIDs to close
-// }
+//	struct {
+//	    MsgHeader header;            // standard message header
+//	    int32     ZERO;              // 0 - reserved for future use
+//	    int32     numberOfCursorIDs; // number of cursorIDs in message
+//	    int64*    cursorIDs;         // sequence of cursorIDs to close
+//	}
 //
 // OP_KILL_CURSORS is deprecated starting MongoDB 5.0 in favor of OP_MSG.
 type MessageOpKillCursors struct {

--- a/lib/srv/db/mongodb/protocol/opmsg.go
+++ b/lib/srv/db/mongodb/protocol/opmsg.go
@@ -30,12 +30,12 @@ import (
 //
 // https://docs.mongodb.com/master/reference/mongodb-wire-protocol/#op-msg
 //
-// OP_MSG {
-//     MsgHeader header;          // standard message header
-//     uint32 flagBits;           // message flags
-//     Sections[] sections;       // data sections
-//     optional<uint32> checksum; // optional CRC-32C checksum
-// }
+//	OP_MSG {
+//	    MsgHeader header;          // standard message header
+//	    uint32 flagBits;           // message flags
+//	    Sections[] sections;       // data sections
+//	    optional<uint32> checksum; // optional CRC-32C checksum
+//	}
 type MessageOpMsg struct {
 	Header                   MessageHeader
 	Flags                    wiremessage.MsgFlag

--- a/lib/srv/db/mongodb/protocol/opupdate.go
+++ b/lib/srv/db/mongodb/protocol/opupdate.go
@@ -30,14 +30,14 @@ import (
 //
 // https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op_update
 //
-// struct OP_UPDATE {
-//     MsgHeader header;             // standard message header
-//     int32     ZERO;               // 0 - reserved for future use
-//     cstring   fullCollectionName; // "dbname.collectionname"
-//     int32     flags;              // bit vector. see below
-//     document  selector;           // the query to select the document
-//     document  update;             // specification of the update to perform
-// }
+//	struct OP_UPDATE {
+//	    MsgHeader header;             // standard message header
+//	    int32     ZERO;               // 0 - reserved for future use
+//	    cstring   fullCollectionName; // "dbname.collectionname"
+//	    int32     flags;              // bit vector. see below
+//	    document  selector;           // the query to select the document
+//	    document  update;             // specification of the update to perform
+//	}
 //
 // OP_UPDATE is deprecated starting MongoDB 5.0 in favor of OP_MSG.
 type MessageOpUpdate struct {

--- a/lib/srv/db/mysql/doc.go
+++ b/lib/srv/db/mysql/doc.go
@@ -18,11 +18,11 @@ limitations under the License.
 //
 // It has the following components:
 //
-// * Proxy. Runs inside Teleport proxy and proxies connections from MySQL
-//   clients to appropriate Teleport database services over reverse tunnel.
+//   - Proxy. Runs inside Teleport proxy and proxies connections from MySQL
+//     clients to appropriate Teleport database services over reverse tunnel.
 //
-// * Engine. Runs inside Teleport database service, accepts connections coming
-//   from proxy over reverse tunnel and proxies them to MySQL databases.
+//   - Engine. Runs inside Teleport database service, accepts connections coming
+//     from proxy over reverse tunnel and proxies them to MySQL databases.
 //
 // Protocol
 // --------
@@ -33,14 +33,14 @@ limitations under the License.
 // get client's x509 certificate which contains all the auth and routing
 // information in it:
 //
-//   https://dev.mysql.com/doc/internals/en/connection-phase.html
-//   https://dev.mysql.com/doc/internals/en/ssl-handshake.html
-//   https://dev.mysql.com/doc/internals/en/connection-phase-packets.html
+//	https://dev.mysql.com/doc/internals/en/connection-phase.html
+//	https://dev.mysql.com/doc/internals/en/ssl-handshake.html
+//	https://dev.mysql.com/doc/internals/en/connection-phase-packets.html
 //
 // The engine component plugs into the command phase and interperts all protocol
 // messages flying through it:
 //
-//   https://dev.mysql.com/doc/internals/en/command-phase.html
+//	https://dev.mysql.com/doc/internals/en/command-phase.html
 //
 // MySQL protocol is server-initiated meaning the first "handshake" packet
 // is sent by MySQL server, as such the proxy (which acts as a server) has
@@ -49,28 +49,33 @@ limitations under the License.
 // Connection sequence diagram:
 //
 // mysql                   proxy
-//  |                        |
-//  | <--- HandshakeV10 ---  |
-//  |                        |
-//  | - HandshakeResponse -> |
-//  |                        |
+//
+//	|                        |
+//	| <--- HandshakeV10 ---  |
+//	|                        |
+//	| - HandshakeResponse -> |
+//	|                        |
+//
 // ------- TLS upgrade --------                  engine
-//  |                        |                      |
-//  |                        | ----- connect -----> |
-//  |                        |                      |
-//  |                        |               ---- authz ----            MySQL
-//  |                        |                      |                     |
-//  |                        |                      | ----- connect ----> |
-//  |                        |                      |                     |
-//  |                        | <------- OK -------- |                     |
-//  |                        |                      |                     |
-//  | <-------- OK --------- |                      |                     |
-//  |                        |                      |                     |
+//
+//	|                        |                      |
+//	|                        | ----- connect -----> |
+//	|                        |                      |
+//	|                        |               ---- authz ----            MySQL
+//	|                        |                      |                     |
+//	|                        |                      | ----- connect ----> |
+//	|                        |                      |                     |
+//	|                        | <------- OK -------- |                     |
+//	|                        |                      |                     |
+//	| <-------- OK --------- |                      |                     |
+//	|                        |                      |                     |
+//
 // ------------------------------ Command phase ----------------------------
-//  |                        |                      |                     |
-//  | ----------------------------- COM_QUERY --------------------------> |
-//  | <---------------------------- Response ---------------------------- |
-//  |                        |                      |                     |
-//  | ----------------------------- COM_QUIT ---------------------------> |
-//  |                        |                      |                     |
+//
+//	|                        |                      |                     |
+//	| ----------------------------- COM_QUERY --------------------------> |
+//	| <---------------------------- Response ---------------------------- |
+//	|                        |                      |                     |
+//	| ----------------------------- COM_QUIT ---------------------------> |
+//	|                        |                      |                     |
 package mysql

--- a/lib/srv/db/mysql/protocol/doc.go
+++ b/lib/srv/db/mysql/protocol/doc.go
@@ -24,11 +24,14 @@ limitations under the License.
 // The following resources are helpful to understand protocol details.
 //
 // Packet structure:
-//   https://dev.mysql.com/doc/internals/en/mysql-packet.html
+//
+//	https://dev.mysql.com/doc/internals/en/mysql-packet.html
 //
 // Generic response packets:
-//   https://dev.mysql.com/doc/internals/en/generic-response-packets.html
+//
+//	https://dev.mysql.com/doc/internals/en/generic-response-packets.html
 //
 // Packets sent in the command phase:
-//   https://dev.mysql.com/doc/internals/en/command-phase.html
+//
+//	https://dev.mysql.com/doc/internals/en/command-phase.html
 package protocol

--- a/lib/srv/db/mysql/protocol/packet.go
+++ b/lib/srv/db/mysql/protocol/packet.go
@@ -71,17 +71,19 @@ func ParsePacket(conn io.Reader) (Packet, error) {
 //
 // MySQL wire protocol packet has the following structure:
 //
-//   4-byte
-//   header      payload
-//   ________    _________ ...
-//  |        |  |
+//	 4-byte
+//	 header      payload
+//	 ________    _________ ...
+//	|        |  |
+//
 // xx xx xx xx xx xx xx xx ...
-//  |_____|  |  |
-//  payload  |  message
-//  length   |  type
-//           |
-//           sequence
-//           number
+//
+//	|_____|  |  |
+//	payload  |  message
+//	length   |  type
+//	         |
+//	         sequence
+//	         number
 //
 // https://dev.mysql.com/doc/internals/en/mysql-packet.html
 func ReadPacket(conn io.Reader) (pkt []byte, pktType byte, err error) {

--- a/lib/srv/db/postgres/doc.go
+++ b/lib/srv/db/postgres/doc.go
@@ -26,14 +26,14 @@ limitations under the License.
 //
 // The package provides the following main types:
 //
-// * Proxy. Runs inside Teleport proxy and proxies connections from Postgres
-//   clients to appropriate database servers over reverse tunnel.
+//   - Proxy. Runs inside Teleport proxy and proxies connections from Postgres
+//     clients to appropriate database servers over reverse tunnel.
 //
-// * Engine. Runs inside Teleport database service, accepts connections
-//   coming from proxy over reversetunnel and proxies them to databases.
+//   - Engine. Runs inside Teleport database service, accepts connections
+//     coming from proxy over reversetunnel and proxies them to databases.
 //
-// * TestServer. Fake Postgres server that implements a small part of its
-//   wire protocol, used in functional tests.
+//   - TestServer. Fake Postgres server that implements a small part of its
+//     wire protocol, used in functional tests.
 //
 // Protocol
 // --------
@@ -55,23 +55,24 @@ limitations under the License.
 // The sequence diagram roughly looks like this:
 //
 // psql                   proxy
-//  |                       |
-//  | ---- SSLRequest ----> |
-//  |                       |
-//  | <------  'S' -------- |
-//  |                       |
-//  | -- StartupMessage --> |                     engine
-//  |                       |                       |
-//  |                       | -- StartupMessage --> |                  Postgres
-//  |                       |                       |                     |
-//  |                       |                       | ----- connect ----> |
-//  |                       |                       |                     |
-//  | <-------------- ReadyForQuery --------------- |                     |
-//  |                       |                       |                     |
-//  | ------------------------------ Query -----------------------------> |
-//  | <---------------------------- DataRow ----------------------------- |
-//  | <------------------------- ReadyForQuery -------------------------- |
-//  |                       |                       |                     |
-//  | ----------------------------- Terminate --------------------------> |
-//  |                       |                       |                     |
+//
+//	|                       |
+//	| ---- SSLRequest ----> |
+//	|                       |
+//	| <------  'S' -------- |
+//	|                       |
+//	| -- StartupMessage --> |                     engine
+//	|                       |                       |
+//	|                       | -- StartupMessage --> |                  Postgres
+//	|                       |                       |                     |
+//	|                       |                       | ----- connect ----> |
+//	|                       |                       |                     |
+//	| <-------------- ReadyForQuery --------------- |                     |
+//	|                       |                       |                     |
+//	| ------------------------------ Query -----------------------------> |
+//	| <---------------------------- DataRow ----------------------------- |
+//	| <------------------------- ReadyForQuery -------------------------- |
+//	|                       |                       |                     |
+//	| ----------------------------- Terminate --------------------------> |
+//	|                       |                       |                     |
 package postgres

--- a/lib/srv/db/redis/client.go
+++ b/lib/srv/db/redis/client.go
@@ -189,11 +189,11 @@ func authConnection(ctx context.Context, conn *redis.Conn, username, password st
 // go-redis `Process()` function which doesn't handel all Cluster commands like for ex. DBSIZE, FLUSHDB, etc.
 // This function provides additional processing for those commands enabling more Redis commands in Cluster mode.
 // Commands are override by a simple rule:
-// * If command work only on a single slot (one shard) without any modifications and returns a CROSSSLOT error if executed on
-//   multiple keys it's send the Redis client as it is, and it's the client responsibility to make sure keys are in a single slot.
-// * If a command returns incorrect result in the Cluster mode (for ex. DBSIZE as it would return only size of one shard not whole cluster)
-//   then it's handled by Teleport or blocked if reasonable processing is not possible.
-// * Otherwise a commands is sent to Redis without any modifications.
+//   - If command work only on a single slot (one shard) without any modifications and returns a CROSSSLOT error if executed on
+//     multiple keys it's send the Redis client as it is, and it's the client responsibility to make sure keys are in a single slot.
+//   - If a command returns incorrect result in the Cluster mode (for ex. DBSIZE as it would return only size of one shard not whole cluster)
+//     then it's handled by Teleport or blocked if reasonable processing is not possible.
+//   - Otherwise a commands is sent to Redis without any modifications.
 func (c *clusterClient) Process(ctx context.Context, inCmd redis.Cmder) error {
 	cmd, ok := inCmd.(*redis.Cmd)
 	if !ok {

--- a/lib/srv/db/redis/cmds.go
+++ b/lib/srv/db/redis/cmds.go
@@ -49,9 +49,9 @@ const (
 
 // processCmd processes commands received from connected client. Most commands are just passed to Redis instance,
 // but some require special actions:
-//  * Redis 7.0+ commands are rejected as at the moment of writing Redis 7.0 hasn't been released and go-redis doesn't support it.
-//  * RESP3 commands are rejected as Teleport/go-redis currently doesn't support this version of protocol.
-//  * Subscribe related commands created a new DB connection as they change Redis request-response model to Pub/Sub.
+//   - Redis 7.0+ commands are rejected as at the moment of writing Redis 7.0 hasn't been released and go-redis doesn't support it.
+//   - RESP3 commands are rejected as Teleport/go-redis currently doesn't support this version of protocol.
+//   - Subscribe related commands created a new DB connection as they change Redis request-response model to Pub/Sub.
 func (e *Engine) processCmd(ctx context.Context, cmd *redis.Cmd) error {
 	switch strings.ToLower(cmd.Name()) {
 	case helloCmd, punsubscribeCmd, ssubscribeCmd, sunsubscribeCmd:

--- a/lib/srv/db/redis/connection.go
+++ b/lib/srv/db/redis/connection.go
@@ -62,11 +62,13 @@ type ConnectionOptions struct {
 // connection options like address and connection mode. If port is skipped
 // default Redis 6379 is used.
 // Correct inputs:
-// 	rediss://redis.example.com:6379?mode=cluster
-// 	redis://redis.example.com:6379
-// 	redis.example.com:6379
+//
+//	rediss://redis.example.com:6379?mode=cluster
+//	redis://redis.example.com:6379
+//	redis.example.com:6379
 //
 // Incorrect input:
+//
 //	redis.example.com:6379?mode=cluster
 func ParseRedisAddress(addr string) (*ConnectionOptions, error) {
 	// Default to the single mode.

--- a/lib/srv/db/redis/doc.go
+++ b/lib/srv/db/redis/doc.go
@@ -38,7 +38,7 @@ limitations under the License.
 // using connection URI instead of host + port combination.
 // Example:
 //
-//  - name: "redis-cluster"
-//    protocol: "redis"
-//    uri: "rediss://redis.example.com:6379?mode=cluster"
+//   - name: "redis-cluster"
+//     protocol: "redis"
+//     uri: "rediss://redis.example.com:6379?mode=cluster"
 package redis

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -1094,18 +1094,21 @@ func (s *WindowsService) updateCA(ctx context.Context) error {
 // private key archival.
 //
 // This function is equivalent to running:
-//     certutil –dspublish –f <PathToCertFile.cer> NTAuthCA
+//
+//	certutil –dspublish –f <PathToCertFile.cer> NTAuthCA
 //
 // You can confirm the cert is present by running:
-//     certutil -viewstore "ldap:///CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,DC=example,DC=com>?caCertificate"
+//
+//	certutil -viewstore "ldap:///CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,DC=example,DC=com>?caCertificate"
 //
 // Once the CA is published to LDAP, it should eventually sync and be present in the
 // machine's enterprise NTAuth store. You can check that with:
-//     certutil -viewstore -enterprise NTAuth
+//
+//	certutil -viewstore -enterprise NTAuth
 //
 // You can expedite the synchronization by running:
-//     certutil -pulse
 //
+//	certutil -pulse
 func (s *WindowsService) updateCAInNTAuthStore(ctx context.Context, caDER []byte) error {
 	// Check if our CA is already in the store. The LDAP entry for NTAuth store
 	// is constant and it should always exist.

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -91,10 +91,11 @@ type proxySubsys struct {
 // proxy subsystem
 //
 // proxy subsystem name can take the following forms:
-//  "proxy:host:22"          - standard SSH request to connect to  host:22 on the 1st cluster
-//  "proxy:@clustername"        - Teleport request to connect to an auth server for cluster with name 'clustername'
-//  "proxy:host:22@clustername" - Teleport request to connect to host:22 on cluster 'clustername'
-//  "proxy:host:22@namespace@clustername"
+//
+//	"proxy:host:22"          - standard SSH request to connect to  host:22 on the 1st cluster
+//	"proxy:@clustername"        - Teleport request to connect to an auth server for cluster with name 'clustername'
+//	"proxy:host:22@clustername" - Teleport request to connect to host:22 on cluster 'clustername'
+//	"proxy:host:22@namespace@clustername"
 func parseProxySubsysRequest(request string) (proxySubsysRequest, error) {
 	log.Debugf("parse_proxy_subsys(%q)", request)
 	var (

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2190,7 +2190,7 @@ func newCertAuthorityWatcher(ctx context.Context, t *testing.T, client types.Eve
 //
 // See the following links for more details.
 //
-//   https://man7.org/linux/man-pages/man7/pipe.7.html
-//   https://github.com/afborchert/pipebuf
-//   https://unix.stackexchange.com/questions/11946/how-big-is-the-pipe-buffer
+//	https://man7.org/linux/man-pages/man7/pipe.7.html
+//	https://github.com/afborchert/pipebuf
+//	https://unix.stackexchange.com/questions/11946/how-big-is-the-pipe-buffer
 const maxPipeSize = 65536 + 1

--- a/lib/srv/uacc/uacc_linux.go
+++ b/lib/srv/uacc/uacc_linux.go
@@ -71,8 +71,8 @@ func Open(utmpPath, wtmpPath string, username, hostname string, remote [4]int32,
 	}
 
 	// Convert Go strings into C strings that we can pass over ffi.
-	var cUtmpPath *C.char = nil
-	var cWtmpPath *C.char = nil
+	var cUtmpPath *C.char
+	var cWtmpPath *C.char
 	if len(utmpPath) > 0 {
 		cUtmpPath = C.CString(utmpPath)
 		defer C.free(unsafe.Pointer(cUtmpPath))
@@ -136,8 +136,8 @@ func Close(utmpPath, wtmpPath string, tty *os.File) error {
 	}
 
 	// Convert Go strings into C strings that we can pass over ffi.
-	var cUtmpPath *C.char = nil
-	var cWtmpPath *C.char = nil
+	var cUtmpPath *C.char
+	var cWtmpPath *C.char
 	if len(utmpPath) > 0 {
 		cUtmpPath = C.CString(utmpPath)
 		defer C.free(unsafe.Pointer(cUtmpPath))
@@ -182,7 +182,7 @@ func UserWithPtyInDatabase(utmpPath string, username string) error {
 	}
 
 	// Convert Go strings into C strings that we can pass over ffi.
-	var cUtmpPath *C.char = nil
+	var cUtmpPath *C.char
 	if len(utmpPath) > 0 {
 		cUtmpPath = C.CString(utmpPath)
 		defer C.free(unsafe.Pointer(cUtmpPath))

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -134,7 +134,9 @@ type HostUserManagement struct {
 var _ HostUsers = &HostUserManagement{}
 
 // Under the section "Including other files from within sudoers":
-//           https://man7.org/linux/man-pages/man5/sudoers.5.html
+//
+//	https://man7.org/linux/man-pages/man5/sudoers.5.html
+//
 // '.', '~' and '/' will cause a file not to be read and these can be
 // included in a username, removing slash to avoid escaping a
 // directory

--- a/lib/sshutils/marshal.go
+++ b/lib/sshutils/marshal.go
@@ -28,7 +28,7 @@ import (
 // base64-encoded key, comment.
 // For example:
 //
-//    cert-authority AAA... type=user&clustername=cluster-a
+//	cert-authority AAA... type=user&clustername=cluster-a
 //
 // URL encoding is used to pass the CA type and cluster name into the comment field.
 func MarshalAuthorizedKeysFormat(clusterName string, keyBytes []byte) (string, error) {
@@ -45,7 +45,7 @@ func MarshalAuthorizedKeysFormat(clusterName string, keyBytes []byte) (string, e
 // authorized_hosts format, a space-separated list of: marker, hosts, key, and comment.
 // For example:
 //
-//    @cert-authority *.cluster-a,cluster-a ssh-rsa AAA... type=host
+//	@cert-authority *.cluster-a,cluster-a ssh-rsa AAA... type=host
 //
 // URL encoding is used to pass the CA type and allowed logins into the comment field.
 func MarshalAuthorizedHostsFormat(clusterName string, keyBytes []byte, logins []string) (string, error) {

--- a/lib/sshutils/scp/scp_test.go
+++ b/lib/sshutils/scp/scp_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/sshutils/tcpip.go
+++ b/lib/sshutils/tcpip.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/sshutils/x11/conn.go
+++ b/lib/sshutils/x11/conn.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/sshutils/x11/display.go
+++ b/lib/sshutils/x11/display.go
@@ -177,7 +177,7 @@ func GetXDisplay() (Display, error) {
 
 // ParseDisplay parses the given display value and returns the host,
 // display number, and screen number, or a parsing error. display must be
-//in one of the following formats - hostname:d[.s], unix:d[.s], :d[.s], ::d[.s].
+// in one of the following formats - hostname:d[.s], unix:d[.s], :d[.s], ::d[.s].
 func ParseDisplay(displayString string) (Display, error) {
 
 	if displayString == "" {

--- a/lib/tbot/botfs/fs_other.go
+++ b/lib/tbot/botfs/fs_other.go
@@ -85,16 +85,18 @@ func Write(path string, data []byte, symlinksMode SymlinksMode) error {
 	return nil
 }
 
-//nolint:staticcheck // staticcheck does not like our nop implementations.
 // VerifyACL verifies whether the ACL of the given file allows writes from the
 // bot user.
+//
+//nolint:staticcheck // staticcheck does not like our nop implementations.
 func VerifyACL(path string, opts *ACLOptions) error {
 	return trace.NotImplemented("ACLs not supported on this platform")
 }
 
-//nolint:staticcheck // staticcheck does not like our nop implementations.
 // ConfigureACL configures ACLs of the given file to allow writes from the bot
 // user.
+//
+//nolint:staticcheck // staticcheck does not like our nop implementations.
 func ConfigureACL(path string, owner *user.User, opts *ACLOptions) error {
 	return trace.NotImplemented("ACLs not supported on this platform")
 }

--- a/lib/teleterm/clusters/cluster_leaves.go
+++ b/lib/teleterm/clusters/cluster_leaves.go
@@ -38,7 +38,7 @@ type LeafCluster struct {
 	Connected bool
 }
 
-//GetLeafClusters returns leaf clusters
+// GetLeafClusters returns leaf clusters
 func (c *Cluster) GetLeafClusters(ctx context.Context) ([]LeafCluster, error) {
 	var remoteClusters []types.RemoteCluster
 	err := addMetadataToRetryableError(ctx, func() error {

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -297,7 +297,6 @@ func (id *Identity) CheckAndSetDefaults() error {
 // https://serverfault.com/questions/551477/is-there-reserved-oid-space-for-internal-enterprise-cas
 //
 // http://oid-info.com/get/1.3.9999
-//
 var (
 	// KubeUsersASN1ExtensionOID is an extension ID used when encoding/decoding
 	// license payload into certificates

--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -202,13 +202,12 @@ func VerifyCertificateChain(certificateChain []*x509.Certificate) error {
 //
 // From RFC5280: https://tools.ietf.org/html/rfc5280#section-4.2.1.1
 //
-//   The signature on a self-signed certificate is generated with the private
-//   key associated with the certificate's subject public key. (This
-//   proves that the issuer possesses both the public and private keys.)
-//   In this case, the subject and authority key identifiers would be
-//   identical, but only the subject key identifier is needed for
-//   certification path building.
-//
+//	The signature on a self-signed certificate is generated with the private
+//	key associated with the certificate's subject public key. (This
+//	proves that the issuer possesses both the public and private keys.)
+//	In this case, the subject and authority key identifiers would be
+//	identical, but only the subject key identifier is needed for
+//	certification path building.
 func IsSelfSigned(certificateChain []*x509.Certificate) bool {
 	if len(certificateChain) != 1 {
 		return false

--- a/lib/utils/certs_test.go
+++ b/lib/utils/certs_test.go
@@ -54,5 +54,6 @@ func TestNewCertPoolFromPath(t *testing.T) {
 
 	pool, err := NewCertPoolFromPath("../../fixtures/certs/ca.pem")
 	require.NoError(t, err)
+	//nolint:staticcheck // Pool not returned by SystemCertPool
 	require.Len(t, pool.Subjects(), 1)
 }

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -366,7 +366,7 @@ func SplitIdentifiers(s string) []string {
 // EscapeControl escapes all ANSI escape sequences from string and returns a
 // string that is safe to print on the CLI. This is to ensure that malicious
 // servers can not hide output. For more details, see:
-//   * https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt
+//   - https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt
 func EscapeControl(s string) string {
 	if needsQuoting(s) {
 		return fmt.Sprintf("%q", s)
@@ -377,7 +377,7 @@ func EscapeControl(s string) string {
 // AllowNewlines escapes all ANSI escape sequences except newlines from string and returns a
 // string that is safe to print on the CLI. This is to ensure that malicious
 // servers can not hide output. For more details, see:
-//   * https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt
+//   - https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt
 func AllowNewlines(s string) string {
 	if !strings.Contains(s, "\n") {
 		return EscapeControl(s)

--- a/lib/utils/concurrentqueue/queue.go
+++ b/lib/utils/concurrentqueue/queue.go
@@ -77,9 +77,11 @@ type item struct {
 // Queue is a data processing helper which uses a worker pool to apply a closure to a series of
 // values concurrently, preserving the correct ordering of results.  It is essentially the concurrent
 // equivalent of this:
-//    for msg := range inputChannel {
-//        outputChannel <- workFunction(msg)
-//    }
+//
+//	for msg := range inputChannel {
+//	    outputChannel <- workFunction(msg)
+//	}
+//
 // In order to prevent indefinite memory growth within the queue due to slow consumption and/or
 // workers, the queue will exert backpressure over its input channel once a configurable capacity
 // is reached.

--- a/lib/utils/ec2.go
+++ b/lib/utils/ec2.go
@@ -75,11 +75,16 @@ func GetEC2NodeID() (string, error) {
 }
 
 // EC2 Node IDs are {AWS account ID}-{EC2 resource ID} eg:
-//   123456789012-i-1234567890abcdef0
+//
+//	123456789012-i-1234567890abcdef0
+//
 // AWS account ID is always a 12 digit number, see
-//   https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html
+//
+//	https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html
+//
 // EC2 resource ID is i-{8 or 17 hex digits}, see
-//   https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/resource-ids.html
+//
+//	https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/resource-ids.html
 var ec2NodeIDRE = regexp.MustCompile("^[0-9]{12}-i-[0-9a-f]{8,}$")
 
 // IsEC2NodeID returns true if the given ID looks like an EC2 node ID. Uses a
@@ -134,7 +139,8 @@ func NewInstanceMetadataClient(ctx context.Context, opts ...InstanceMetadataClie
 }
 
 // EC2 resource ID is i-{8 or 17 hex digits}, see
-//   https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/resource-ids.html
+//
+//	https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/resource-ids.html
 var ec2ResourceIDRE = regexp.MustCompile("^i-[0-9a-f]{8,}$")
 
 // IsAvailable checks if instance metadata is available.

--- a/lib/utils/environment_test.go
+++ b/lib/utils/environment_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/utils/jsontools_test.go
+++ b/lib/utils/jsontools_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/utils/linking.go
+++ b/lib/utils/linking.go
@@ -74,8 +74,8 @@ type WebLinks struct {
 //
 // Link headers typically look like:
 //
-//   Link: <https://api.github.com/user/teams?page=2>; rel="next",
-//     <https://api.github.com/user/teams?page=34>; rel="last"
+//	Link: <https://api.github.com/user/teams?page=2>; rel="next",
+//	  <https://api.github.com/user/teams?page=34>; rel="last"
 func ParseWebLinks(response *http.Response) WebLinks {
 	wls := WebLinks{}
 

--- a/lib/utils/round.go
+++ b/lib/utils/round.go
@@ -20,9 +20,10 @@ const (
 // Round returns the nearest integer, rounding half away from zero.
 //
 // Special cases are:
-//  Round(±0) = ±0
-//  Round(±Inf) = ±Inf
-//  Round(NaN) = NaN
+//
+//	Round(±0) = ±0
+//	Round(±Inf) = ±Inf
+//	Round(NaN) = NaN
 //
 // Note: Copied from Go standard library to support Go 1.9.7 releases. This
 // function was added in the standard library in Go 1.10.

--- a/lib/utils/timeout.go
+++ b/lib/utils/timeout.go
@@ -28,7 +28,6 @@ import (
 // Usage example:
 // tc := utils.ObeyIdleTimeout(conn, time.Second * 30, "ssh connection")
 // io.Copy(tc, xxx)
-//
 type TimeoutConn struct {
 	net.Conn
 	TimeoutDuration time.Duration

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -684,7 +684,6 @@ func (h *Handler) handleGetUserOrResetToken(w http.ResponseWriter, r *http.Reque
 // getUserContext returns user context
 //
 // GET /webapi/sites/:site/context
-//
 func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httprouter.Params, c *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	cn, err := h.cfg.AccessPoint.GetClusterName()
 	if err != nil {
@@ -1641,10 +1640,9 @@ func newSessionResponse(ctx *SessionContext) (*CreateSessionResponse, error) {
 //
 // {"user": "alex", "pass": "abc123", "second_factor_token": "token", "second_factor_type": "totp"}
 //
-// Response
+// # Response
 //
 // {"type": "bearer", "token": "bearer token", "user": {"name": "alex", "allowed_logins": ["admin", "bob"]}, "expires_in": 20}
-//
 func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
 	var req *CreateSessionReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
@@ -1722,7 +1720,6 @@ func clientMetaFromReq(r *http.Request) *auth.ForwardedClientMetadata {
 // Response:
 //
 // {"message": "ok"}
-//
 func (h *Handler) deleteSession(w http.ResponseWriter, r *http.Request, _ httprouter.Params, ctx *SessionContext) (interface{}, error) {
 	err := h.logout(r.Context(), w, ctx)
 	if err != nil {
@@ -1970,7 +1967,7 @@ func (h *Handler) mfaLoginBegin(w http.ResponseWriter, r *http.Request, p httpro
 // { "user": "bob", "password": "pass", "pub_key": "key to sign", "ttl": 1000000000 }                   # password-only
 // { "user": "bob", "webauthn_challenge_response": {...}, "pub_key": "key to sign", "ttl": 1000000000 } # mfa
 //
-// Success response
+// # Success response
 //
 // { "cert": "base64 encoded signed cert", "host_signers": [{"domain_name": "example.com", "checking_keys": ["base64 encoded public signing key"]}] }
 func (h *Handler) mfaLoginFinish(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
@@ -2029,7 +2026,6 @@ func (h *Handler) mfaLoginFinishSession(w http.ResponseWriter, r *http.Request, 
 // Successful response:
 //
 // {"sites": {"name": "localhost", "last_connected": "RFC3339 time", "status": "active"}}
-//
 func (h *Handler) getClusters(w http.ResponseWriter, r *http.Request, p httprouter.Params, c *SessionContext) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in users identity. The
 	// identity of the logged in user is used to fetch the list of nodes.
@@ -2065,7 +2061,8 @@ type getSiteNamespacesResponse struct {
 	Namespaces []types.Namespace `json:"namespaces"`
 }
 
-/* getSiteNamespaces returns a list of namespaces for a given site
+/*
+	getSiteNamespaces returns a list of namespaces for a given site
 
 GET /v1/webapi/sites/:site/namespaces
 
@@ -2156,7 +2153,6 @@ func (h *Handler) clusterLoginAlertsGet(w http.ResponseWriter, r *http.Request, 
 // {"server_id": "uuid", "login": "admin", "term": {"h": 120, "w": 100}, "sid": "123"}
 //
 // Successful response is a websocket stream that allows read write to the server
-//
 func (h *Handler) siteNodeConnect(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -2332,7 +2328,6 @@ func (h *Handler) siteSessionsGet(w http.ResponseWriter, r *http.Request, p http
 // Response body:
 //
 // {"session": {"id": "sid", "terminal_params": {"w": 100, "h": 100}, "parties": [], "login": "bob"}}
-//
 func (h *Handler) siteSessionGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	sessionID, err := session.ParseID(p.ByName("sid"))
 	if err != nil {
@@ -2377,16 +2372,17 @@ func toFieldsSlice(rawEvents []apievents.AuditEvent) ([]events.EventFields, erro
 // GET /v1/webapi/sites/:site/events/search
 //
 // Query parameters:
-//   "from"    : date range from, encoded as RFC3339
-//   "to"      : date range to, encoded as RFC3339
-//   "limit"   : optional maximum number of events to return on each fetch
-//   "startKey": resume events search from the last event received,
-//               empty string means start search from beginning
-//   "include" : optional comma-separated list of event names to return e.g.
-//               include=session.start,session.end, all are returned if empty
-//   "order":    optional ordering of events. Can be either "asc" or "desc"
-//               for ascending and descending respectively.
-//               If no order is provided it defaults to descending.
+//
+//	"from"    : date range from, encoded as RFC3339
+//	"to"      : date range to, encoded as RFC3339
+//	"limit"   : optional maximum number of events to return on each fetch
+//	"startKey": resume events search from the last event received,
+//	            empty string means start search from beginning
+//	"include" : optional comma-separated list of event names to return e.g.
+//	            include=session.start,session.end, all are returned if empty
+//	"order":    optional ordering of events. Can be either "asc" or "desc"
+//	            for ascending and descending respectively.
+//	            If no order is provided it defaults to descending.
 func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	values := r.URL.Query()
 
@@ -2406,14 +2402,15 @@ func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p 
 // GET /v1/webapi/sites/:site/sessions/search
 //
 // Query parameters:
-//   "from"    : date range from, encoded as RFC3339
-//   "to"      : date range to, encoded as RFC3339
-//   "limit"   : optional maximum number of events to return on each fetch
-//   "startKey": resume events search from the last event received,
-//               empty string means start search from beginning
-//   "order":    optional ordering of events. Can be either "asc" or "desc"
-//               for ascending and descending respectively.
-//               If no order is provided it defaults to descending.
+//
+//	"from"    : date range from, encoded as RFC3339
+//	"to"      : date range to, encoded as RFC3339
+//	"limit"   : optional maximum number of events to return on each fetch
+//	"startKey": resume events search from the last event received,
+//	            empty string means start search from beginning
+//	"order":    optional ordering of events. Can be either "asc" or "desc"
+//	            for ascending and descending respectively.
+//	            If no order is provided it defaults to descending.
 func (h *Handler) clusterSearchSessionEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	searchSessionEvents := func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error) {
 		return clt.SearchSessionEvents(from, to, limit, order, startKey, nil, "")
@@ -2533,8 +2530,9 @@ func queryOrder(query url.Values, name string, def types.EventOrder) (types.Even
 // GET /v1/webapi/sites/:site/namespaces/:namespace/sessions/:sid/stream?query
 //
 // Query parameters:
-//   "offset"   : bytes from the beginning
-//   "bytes"    : number of bytes to read (it won't return more than 512Kb)
+//
+//	"offset"   : bytes from the beginning
+//	"bytes"    : number of bytes to read (it won't return more than 512Kb)
 //
 // Unlike other request handlers, this one does not return JSON.
 // It returns the binary stream unencoded, directly in the respose body,
@@ -2643,13 +2641,13 @@ type eventsListGetResponse struct {
 // GET /v1/webapi/sites/:site/namespaces/:namespace/sessions/:sid/events?after=N
 //
 // Query:
-//    "after" : cursor value of an event to return "newer than" events
-//              good for repeated polling
+//
+//	"after" : cursor value of an event to return "newer than" events
+//	          good for repeated polling
 //
 // Response body (each event is an arbitrary JSON structure)
 //
 // {"events": [{...}, {...}, ...}
-//
 func (h *Handler) siteSessionEventsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	sessionID, err := session.ParseID(p.ByName("sid"))
 	if err != nil {
@@ -2701,10 +2699,9 @@ func (h *Handler) hostCredentials(w http.ResponseWriter, r *http.Request, p http
 //
 // { "user": "bob", "password": "pass", "otp_token": "tok", "pub_key": "key to sign", "ttl": 1000000000 }
 //
-// Success response
+// # Success response
 //
 // { "cert": "base64 encoded signed cert", "host_signers": [{"domain_name": "example.com", "checking_keys": ["base64 encoded public signing key"]}] }
-//
 func (h *Handler) createSSHCert(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
 	var req *client.CreateSSHCertReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
@@ -2746,16 +2743,16 @@ func (h *Handler) createSSHCert(w http.ResponseWriter, r *http.Request, p httpro
 //
 // * Request body:
 //
-// {
-//     "token": "foo",
-//     "certificate_authorities": ["AQ==", "Ag=="]
-// }
+//	{
+//	    "token": "foo",
+//	    "certificate_authorities": ["AQ==", "Ag=="]
+//	}
 //
 // * Response:
 //
-// {
-//     "certificate_authorities": ["AQ==", "Ag=="]
-// }
+//	{
+//	    "certificate_authorities": ["AQ==", "Ag=="]
+//	}
 func (h *Handler) validateTrustedCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
 	var validateRequestRaw auth.ValidateTrustedClusterRequestRaw
 	if err := httplib.ReadJSON(r, &validateRequestRaw); err != nil {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3602,8 +3602,8 @@ func TestWebSessionsRenewAllowsOldBearerTokenToLinger(t *testing.T) {
 }
 
 // TestChangeUserAuthentication_recoveryCodesReturnedForCloud tests for following:
-//  - Recovery codes are not returned for usernames that are not emails
-//  - Recovery codes are returned for usernames that are valid emails
+//   - Recovery codes are not returned for usernames that are not emails
+//   - Recovery codes are returned for usernames that are valid emails
 func TestChangeUserAuthentication_recoveryCodesReturnedForCloud(t *testing.T) {
 	env := newWebPack(t, 1)
 	ctx := context.Background()

--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -36,6 +37,11 @@ func TestWriteUpgradeResponse(t *testing.T) {
 
 	resp, err := http.ReadResponse(bufio.NewReader(&buf), nil)
 	require.NoError(t, err)
+
+	// Always drain/close the body.
+	io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
 	require.Equal(t, resp.StatusCode, http.StatusSwitchingProtocols)
 	require.Equal(t, "custom", resp.Header.Get("Upgrade"))
 }
@@ -93,9 +99,14 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 
 		// Verify clientConn receives http.StatusSwitchingProtocols.
 		clientConnReader := bufio.NewReader(clientConn)
-		response, err := http.ReadResponse(clientConnReader, r)
+		resp, err := http.ReadResponse(clientConnReader, r)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusSwitchingProtocols, response.StatusCode)
+
+		// Always drain/close the body.
+		io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
 
 		// Verify clientConn receives data sent by Config.ALPNHandler.
 		receive, err := clientConnReader.ReadString(byte('@'))

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -41,6 +41,7 @@ exit 1
 
 // InstallNodeBashScript is the script that will run on user's machine
 // to install teleport and join a teleport cluster.
+//
 //go:embed node-join/install.sh
 var installNodeBashScript string
 

--- a/lib/web/sign.go
+++ b/lib/web/sign.go
@@ -39,13 +39,15 @@ signDatabaseCertificate returns the necessary files to set up mTLS using the `db
 This is the equivalent of running the tctl command
 As an example, requesting:
 POST /webapi/sites/mycluster/sign/db
-{
-	"hostname": "pg.example.com",
-	"ttl": "2190h"
-}
+
+	{
+		"hostname": "pg.example.com",
+		"ttl": "2190h"
+	}
 
 Should be equivalent to running:
-   tctl auth sign --host=pg.example.com --ttl=2190h --format=db
+
+	tctl auth sign --host=pg.example.com --ttl=2190h --format=db
 
 This endpoint returns a tar.gz compressed archive containing the required files to setup mTLS for the database.
 */

--- a/operator/apis/resources/v2/groupversion_info.go
+++ b/operator/apis/resources/v2/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v2 contains API Schema definitions for the resources v2 API group
-//+kubebuilder:object:generate=true
-//+groupName=resources.teleport.dev
+// +kubebuilder:object:generate=true
+// +groupName=resources.teleport.dev
 package v2
 
 import (

--- a/operator/apis/resources/v5/groupversion_info.go
+++ b/operator/apis/resources/v5/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v5 contains API Schema definitions for the resources v5 API group
-//+kubebuilder:object:generate=true
-//+groupName=resources.teleport.dev
+// +kubebuilder:object:generate=true
+// +groupName=resources.teleport.dev
 package v5
 
 import (

--- a/tool/tbot/main_test.go
+++ b/tool/tbot/main_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -842,7 +842,7 @@ func (a *AuthCommand) checkProxyAddr(clusterAPI auth.ClientI) error {
 // base64-encoded key, comment.
 // For example:
 //
-//    cert-authority AAA... type=user&clustername=cluster-a
+//	cert-authority AAA... type=user&clustername=cluster-a
 //
 // URL encoding is used to pass the CA type and cluster name into the comment field.
 func userCAFormat(ca types.CertAuthority, keyBytes []byte) (string, error) {
@@ -854,7 +854,7 @@ func userCAFormat(ca types.CertAuthority, keyBytes []byte) (string, error) {
 // authorized_hosts format, a space-separated list of: marker, hosts, key, and comment.
 // For example:
 //
-//    @cert-authority *.cluster-a ssh-rsa AAA... type=host
+//	@cert-authority *.cluster-a ssh-rsa AAA... type=host
 //
 // URL encoding is used to pass the CA type and allowed logins into the comment field.
 func hostCAFormat(ca types.CertAuthority, keyBytes []byte, client auth.ClientI) (string, error) {

--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -74,7 +74,6 @@ type GlobalCLIFlags struct {
 // This allows OSS and Enterprise Teleport editions to plug their own
 // implementations of different CLI commands into the common execution
 // framework
-//
 type CLICommand interface {
 	// Initialize allows a caller-defined command to plug itself into CLI
 	// argument parsing


### PR DESCRIPTION
Update metalinter, fix a few lint warnings and replace deprecated linters.

`deadcode`, `structcheck` and `varcheck` are abandoned and now replaced by [`unused`][1].

Since 1.19, `go fmt` reformats godocs according to https://go.dev/doc/comment. I've done a bulk-reformatting of the codebase to keep the linter happy. Backporting is mostly harmless (the exception being `lib/services/role_test.go`, that for some reason breaks the _old_ linter using the new format).

[1]: https://golangci-lint.run/usage/linters/