### PR TITLE
Update the docs issues contributing guide

### DIFF
--- a/docs/pages/contributing/documentation/issues.mdx
+++ b/docs/pages/contributing/documentation/issues.mdx
@@ -9,14 +9,6 @@ GitHub issue.
 
 [Issue: Documentation](https://github.com/gravitational/teleport/issues/new?assignees=&labels=documentation&template=documentation.md)
 
-To help us organize our time responding to issues and pull requests, please add the `documentation` label if you are proposing or making a change to the documentation. 
-
-You can help us estimate the time it will take to plan or review a change by adding one of the following labels:
-
-|Label|Meaning|
-|:---|:---|
-|docs-new|Requires creating a new docs page|
-|docs-edit|Requires editing an existing docs page (perhaps substantially)|
-|docs-plumbing|Changes to how we build, display, and deploy the docs—may involve [gravitational/docs](https://github.com/gravitational/docs)|
-|docs-minor-tweak|Straightforward change to a single paragraph or code snippet|
-|docs-assess-scope|Need to assess the scope of the project before starting work|
+To help us organize our time responding to issues and pull requests, please add
+the `documentation` label if you are proposing or making a change to the
+documentation.


### PR DESCRIPTION
Remove the table of labels. We no longer use these, so this change removes the table to ensure that instructions are up to date.