### PR TITLE
terraform: Fix all `tfsec` and `ansible-lint` warnings within `examples/aws/terraform`

### DIFF
--- a/examples/aws/terraform/README.md
+++ b/examples/aws/terraform/README.md
@@ -11,13 +11,13 @@ If you are planning on using our Terraform example in production, please referen
 
 We recommend familiarizing yourself with the following resources prior to reviewing our Terraform examples:
 
-- [Teleport Architecture](https://goteleport.com/teleport/docs/architecture/overview/)
-- [Admin Guide](https://gravitational.com/teleport/docs/admin-guide/)
+- [Teleport Architecture](https://goteleport.com/docs/architecture/overview/)
+- [Admin Guide](https://goteleport.com/docs/management/admin/)
 
 In order to spin up AWS resources using these Terraform examples, you need the following software:
 
-- terraform v0.12+ [install docs](https://learn.hashicorp.com/terraform/getting-started/install.html)
-- awscli v1.14+ [install docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+- terraform v1.0+ [install docs](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+- awscli v1.14+ [install docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 
 ## Projects
 
@@ -29,7 +29,7 @@ In order to spin up AWS resources using these Terraform examples, you need the f
 
 ## How to get help
 
-If you're having trouble, check out our [Discourse community](https://community.gravitational.com).
+If you're having trouble, check out our [GitHub Discussions](https://github.com/gravitational/teleport/discussions).
 
 For bugs related to this code, please [open an issue](https://github.com/gravitational/teleport/issues/new/choose).
 

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -4,8 +4,8 @@ Terraform specifies example provisioning script for Teleport auth, proxy and nod
 
 Use these examples as possible deployment patterns suggested by Teleport developers.
 
-The scripts set up LetsEncrypt certificates using DNS-01 challenge. This means that users have to control the DNS zone
-via Route 53. ACM can optionally be used too, but Route 53 integration is still required.
+The scripts set up Let's Encrypt certificates using DNS-01 challenge. This means that users have to control the DNS
+zone via Route 53. ACM can optionally be used too, but Route 53 integration is still required.
 
 Teleport join tokens are distributed using SSM parameter store, and certificates are distributed using encrypted S3
 bucket.
@@ -21,12 +21,12 @@ the ports to the other parts.
 We recommend familiarizing yourself with the following resources prior to reviewing our Terraform examples:
 
 - [Teleport Architecture](https://goteleport.com/docs/architecture/overview/)
-- [Admin Guide](https://gravitational.com/teleport/docs/admin-guide/)
+- [Admin Guide](https://goteleport.com/docs/management/admin/)
 
 In order to spin up AWS resources using these Terraform examples, you need the following software:
 
-- terraform v0.12+ [install docs](https://learn.hashicorp.com/terraform/getting-started/install.html)
-- awscli v1.14+ [install docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+- terraform v1.0+ [install docs](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+- awscli v1.14+ [install docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 
 ```bash
 # Set variables for Terraform
@@ -50,13 +50,13 @@ export TF_VAR_ami_name="gravitational-teleport-ami-ent-10.2.6"
 # AWS SSH key name to provision in installed instances, should be available in the region
 export TF_VAR_key_name="example"
 
-# (optional) Set to true to use ACM (Amazon Certificate Manager) to provision certificates rather than LetsEncrypt
+# (optional) Set to true to use ACM (Amazon Certificate Manager) to provision certificates rather than Let's Encrypt
 # If you wish to use a pre-existing ACM certificate rather than having Terraform generate one for you, you can import it:
 # Terraform import aws_acm_certificate.cert <certificate_arn>
 # export TF_VAR_use_acm="false"
 
-# Full absolute path to the license file for Teleport Enterprise or Pro.
-# This license will be copied into SSM and then pulled down on the auth nodes to enable Enterprise/Pro functionality
+# Full absolute path to the license file for Teleport Enterprise.
+# This license will be copied into SSM and then pulled down on the auth nodes to enable Enterprise functionality
 export TF_VAR_license_path="/path/to/license"
 
 # Route 53 zone to use, should be the zone registered in AWS, e.g. example.com
@@ -70,13 +70,13 @@ export TF_VAR_route53_domain="cluster.example.com"
 # This is used to enable Teleport Application Access
 export TF_VAR_add_wildcard_route53_record="true"
 
-# Enable adding MongoDB listeners in Teleport proxy, load balancer ports and security groups
+# Enable adding MongoDB listeners in Teleport proxy, load balancer ports, and security groups
 export TF_VAR_enable_mongodb_listener="true"
 
-# Enable adding MySQL listeners in Teleport proxy, load balancer ports and security groups
+# Enable adding MySQL listeners in Teleport proxy, load balancer ports, and security groups
 export TF_VAR_enable_mysql_listener="true"
 
-# Enable adding Postgres listeners in Teleport proxy, load balancer ports and security groups
+# Enable adding Postgres listeners in Teleport proxy, load balancer ports, and security groups
 export TF_VAR_enable_postgres_listener="true"
 
 # (optional) If using ACM, set an additional DNS alias which will be added pointing to the NLB. This can
@@ -86,10 +86,10 @@ export TF_VAR_enable_postgres_listener="true"
 # This setting only takes effect when using ACM, it will be ignored otherwise.
 #export TF_VAR_route53_domain_acm_nlb_alias="cluster-nlb.example.com"
 
-# Bucket name to store encrypted letsencrypt certificates.
+# Bucket name to store encrypted Let's Encrypt certificates.
 export TF_VAR_s3_bucket_name="teleport.example.com"
 
-# Email of your support org, used for Letsencrypt cert registration process.
+# Email of your support org, used for Let's Encrypt cert registration process.
 export TF_VAR_email="support@example.com"
 
 # Setup grafana password for "admin" user. Grafana will be served on https://cluster.example.com:8443 after install

--- a/examples/aws/terraform/ha-autoscale-cluster/acm.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/acm.tf
@@ -14,7 +14,7 @@ resource "aws_acm_certificate" "cert" {
     create_before_destroy = true
   }
   subject_alternative_names = [
-      "*.${var.route53_domain}"
+    "*.${var.route53_domain}"
   ]
 }
 

--- a/examples/aws/terraform/ha-autoscale-cluster/ansible/access.yaml
+++ b/examples/aws/terraform/ha-autoscale-cluster/ansible/access.yaml
@@ -4,7 +4,7 @@
 # ansible-playbook -v -i ec2.py --private-key=/key.pem access.yaml
 - hosts: "auth[0]"
   name: Install resources
-  become: yes
+  become: true
   remote_user: admin
   become_method: sudo
   tasks:
@@ -21,4 +21,3 @@
         dest: /tmp/resources.yaml
     - name: Setup resources
       shell: "sudo -u teleport tctl create -f /tmp/resources.yaml"
-

--- a/examples/aws/terraform/ha-autoscale-cluster/ansible/upgrade.yaml
+++ b/examples/aws/terraform/ha-autoscale-cluster/ansible/upgrade.yaml
@@ -13,7 +13,7 @@
 #
 - hosts: "auth, proxy, node"
   name: Download new version of teleport to auth and proxies
-  become: yes
+  become: true
   remote_user: admin
   become_method: sudo
   tasks:
@@ -23,35 +23,35 @@
     - name: Copy binaries from local directory
       when: teleport_path is defined
       block:
-      - copy:
-          src: "{{teleport_path}}/teleport"
-          dest: /usr/local/bin
+        - copy:
+            src: "{{teleport_path}}/teleport"
+            dest: /usr/local/bin
 
-      - copy:
-          src: "{{teleport_path}}/tctl"
-          dest: /usr/local/bin
+        - copy:
+            src: "{{teleport_path}}/tctl"
+            dest: /usr/local/bin
 
     - name: Copy binaries from official repository
       when: teleport_version is defined
       block:
-      - name: Download and unpack new version of teleport
-        get_url:
-          url: https://get.gravitational.com/teleport/{{teleport_version}}/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
-          dest: /tmp/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
-      - name: Unpack teleport binaries
-        unarchive:
-          extra_opts: ['--strip-components=1', '--show-stored-names']
-          exclude:
-            - "examples/*"
-            - "README.md"
-            - "VERSION"
-            - "INSTALL"
-            - "CHANGELOG"
-          src: /tmp/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
-          dest: /usr/local/bin
-          remote_src: yes
-          owner: "{{ 'root' if 'node' in group_names else 'teleport' }}"
-          group: "{{ 'root' if 'node' in group_names else 'teleport' }}"
+        - name: Download and unpack new version of teleport
+          get_url:
+            url: https://get.gravitational.com/teleport/{{teleport_version}}/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
+            dest: /tmp/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
+        - name: Unpack teleport binaries
+          unarchive:
+            extra_opts: ['--strip-components=1', '--show-stored-names']
+            exclude:
+              - "examples/*"
+              - "README.md"
+              - "VERSION"
+              - "INSTALL"
+              - "CHANGELOG"
+            src: /tmp/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
+            dest: /usr/local/bin
+            remote_src: true
+            owner: "{{ 'root' if 'node' in group_names else 'teleport' }}"
+            group: "{{ 'root' if 'node' in group_names else 'teleport' }}"
 
 
 # Scale down all auth servers but the first one
@@ -59,7 +59,7 @@
 # there should be only one auth server available
 - hosts: "auth[1:]"
   name: Scale down all auth servers but one
-  become: yes
+  become: true
   remote_user: admin
   become_method: sudo
   tasks:
@@ -73,7 +73,7 @@
 
 - hosts: "auth[0]"
   name: Restart the first auth server
-  become: yes
+  become: true
   remote_user: admin
   become_method: sudo
   tasks:
@@ -87,7 +87,7 @@
 
 - hosts: "auth[1:]"
   name: Restart the rest of auth servers
-  become: yes
+  become: true
   remote_user: admin
   become_method: sudo
   tasks:
@@ -102,7 +102,7 @@
 
 - hosts: "proxy"
   name: Restart the proxies
-  become: yes
+  become: true
   remote_user: admin
   become_method: sudo
   tasks:
@@ -116,7 +116,7 @@
 
 - hosts: "node"
   name: Restart the nodes
-  become: yes
+  become: true
   remote_user: admin
   become_method: sudo
   tasks:

--- a/examples/aws/terraform/ha-autoscale-cluster/ansible/vars.yaml
+++ b/examples/aws/terraform/ha-autoscale-cluster/ansible/vars.yaml
@@ -4,4 +4,3 @@
   fail:
     msg: "No teleport_version or teleport_path is specified"
   when: teleport_version is not defined and teleport_path is not defined
-

--- a/examples/aws/terraform/ha-autoscale-cluster/assets/grafana-nginx-acm.conf
+++ b/examples/aws/terraform/ha-autoscale-cluster/assets/grafana-nginx-acm.conf
@@ -42,7 +42,7 @@ http {
 	}
 
 	#
-	# Frontend grafana (no TLS as we're using ACM on the LB)
+	# Frontend grafana (no TLS, as we're using ACM on the LB)
 	#
 	server {
 		listen 8444 default_server;

--- a/examples/aws/terraform/ha-autoscale-cluster/assets/grafana-nginx.conf
+++ b/examples/aws/terraform/ha-autoscale-cluster/assets/grafana-nginx.conf
@@ -24,8 +24,9 @@ http {
 	# TLS settings - we are pretty strict here
 	# but well, it's a dev service, why not?
 	##
-	ssl_protocols TLSv1.2;
-	ssl_prefer_server_ciphers on;
+	ssl_protocols TLSv1.2 TLSv1.3;
+	ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+	ssl_prefer_server_ciphers off;
 
 	##
 	# Logging Settings
@@ -52,10 +53,12 @@ http {
 	# Frontend grafana with TLS
 	#
 	server {
-		listen 8443 default_server ssl;
-		ssl_certificate_key	 /etc/tls/certs/privkey.pem;
-		ssl_certificate  /etc/tls/certs/fullchain.pem;
-		ssl_ciphers AES256+EECDH:AES256+EDH:!aNULL;
+		listen 8443 default_server ssl http2;
+		ssl_certificate_key /etc/tls/certs/privkey.pem;
+		ssl_certificate /etc/tls/certs/fullchain.pem;
+		ssl_session_timeout 1d;
+		ssl_session_cache shared:SSL:10m;  # about 40000 sessions
+		ssl_session_tickets off;
 		location / {
 			proxy_pass http://127.0.0.1:3000;
 			proxy_set_header Host $http_host;

--- a/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
@@ -44,10 +44,10 @@ resource "aws_launch_configuration" "auth" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix                 = "${var.cluster_name}-auth-"
-  image_id                    = data.aws_ami.base.id
-  instance_type               = var.auth_instance_type
-  user_data                   = templatefile(
+  name_prefix   = "${var.cluster_name}-auth-"
+  image_id      = data.aws_ami.base.id
+  instance_type = var.auth_instance_type
+  user_data = templatefile(
     "${path.module}/auth-user-data.tpl",
     {
       region                   = var.region
@@ -66,10 +66,15 @@ resource "aws_launch_configuration" "auth" {
       use_acm                  = var.use_acm
     }
   )
+  metadata_options {
+    http_tokens = "required"
+  }
+  root_block_device {
+    encrypted = true
+  }
   key_name                    = var.key_name
   ebs_optimized               = true
   associate_public_ip_address = false
   security_groups             = [aws_security_group.auth.id]
   iam_instance_profile        = aws_iam_instance_profile.auth.id
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/auth_network.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/auth_network.tf
@@ -39,8 +39,9 @@ resource "aws_route_table_association" "auth" {
 // Security groups for auth servers only allow access to 3025 port from
 // public subnets, and not the internet
 resource "aws_security_group" "auth" {
-  name   = "${var.cluster_name}-auth"
-  vpc_id = local.vpc_id
+  name        = "${var.cluster_name}-auth"
+  description = "Security group for ${var.cluster_name}-auth"
+  vpc_id      = local.vpc_id
   tags = {
     TeleportCluster = var.cluster_name
   }
@@ -48,6 +49,7 @@ resource "aws_security_group" "auth" {
 
 // SSH emergency access via bastion security groups
 resource "aws_security_group_rule" "auth_ingress_allow_ssh" {
+  description              = "SSH emergency access via bastion security groups"
   type                     = "ingress"
   from_port                = 22
   to_port                  = 22
@@ -58,6 +60,7 @@ resource "aws_security_group_rule" "auth_ingress_allow_ssh" {
 
 // Internal traffic within the security group is allowed.
 resource "aws_security_group_rule" "auth_ingress_allow_internal_traffic" {
+  description       = "Internal traffic within the security group is allowed"
   type              = "ingress"
   from_port         = 0
   to_port           = 0
@@ -68,11 +71,12 @@ resource "aws_security_group_rule" "auth_ingress_allow_internal_traffic" {
 
 // Allow traffic from public subnet to auth servers - this is to
 // let proxies to talk to auth server API.
-// This rule uses CIDR as opposed to security group ip becasue traffic coming from NLB
+// This rule uses CIDR as opposed to security group ip because traffic coming from NLB
 // (network load balancer from Amazon)
 // is not marked with security group ID and rules using the security group ids do not work,
 // so CIDR ranges are necessary.
 resource "aws_security_group_rule" "auth_ingress_allow_cidr_traffic" {
+  description       = "Allow traffic from public subnet to auth servers in order to allow proxies to talk to auth server API"
   type              = "ingress"
   from_port         = 3025
   to_port           = 3025
@@ -88,6 +92,7 @@ resource "aws_security_group_rule" "auth_ingress_allow_cidr_traffic" {
 // is not marked with security group ID and rules using the security group ids do not work,
 // so CIDR ranges are necessary.
 resource "aws_security_group_rule" "auth_ingress_allow_node_cidr_traffic" {
+  description       = "Allow traffic from nodes to auth servers in order to allow Teleport nodes heartbeat presence to auth server"
   type              = "ingress"
   from_port         = 3025
   to_port           = 3025
@@ -98,6 +103,7 @@ resource "aws_security_group_rule" "auth_ingress_allow_node_cidr_traffic" {
 
 // This rule allows non NLB traffic originating directly from proxies
 resource "aws_security_group_rule" "auth_ingress_allow_public_traffic" {
+  description              = "Allow non-NLB traffic originating directly from proxies"
   type                     = "ingress"
   from_port                = 3025
   to_port                  = 3025
@@ -107,7 +113,9 @@ resource "aws_security_group_rule" "auth_ingress_allow_public_traffic" {
 }
 
 // All egress traffic is allowed
+// tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "auth_egress_allow_all_traffic" {
+  description       = "Permit all egress traffic"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -148,4 +156,3 @@ resource "aws_lb_listener" "auth" {
     type             = "forward"
   }
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/bastion.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/bastion.tf
@@ -10,6 +10,15 @@ resource "aws_instance" "bastion" {
   source_dest_check           = false
   vpc_security_group_ids      = [aws_security_group.bastion.id]
   subnet_id                   = element(aws_subnet.public.*.id, 0)
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  root_block_device {
+    encrypted = true
+  }
+
   tags = {
     TeleportCluster = var.cluster_name
     TeleportRole    = "bastion"
@@ -18,15 +27,18 @@ resource "aws_instance" "bastion" {
 
 // Bastions are open to internet access
 resource "aws_security_group" "bastion" {
-  name   = "${var.cluster_name}-bastion"
-  vpc_id = local.vpc_id
+  name        = "${var.cluster_name}-bastion"
+  description = "Bastions are open to internet access"
+  vpc_id      = local.vpc_id
   tags = {
     TeleportCluster = var.cluster_name
   }
 }
 
 // Ingress traffic is allowed to SSH 22 port only
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "bastion_ingress_allow_ssh" {
+  description       = "Ingress traffic is allowed to SSH only"
   type              = "ingress"
   from_port         = 22
   to_port           = 22
@@ -36,7 +48,9 @@ resource "aws_security_group_rule" "bastion_ingress_allow_ssh" {
 }
 
 // Egress traffic is allowed everywhere
+// tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "proxy_egress_bastion_all_traffic" {
+  description       = "Egress traffic is allowed everywhere"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -44,4 +58,3 @@ resource "aws_security_group_rule" "proxy_egress_bastion_all_traffic" {
   cidr_blocks       = var.allowed_bastion_ssh_egress_cidr_blocks
   security_group_id = aws_security_group.bastion.id
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/data.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/data.tf
@@ -33,4 +33,3 @@ locals {
 data "aws_kms_alias" "ssm" {
   name = var.kms_alias_name
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/dynamo.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/dynamo.tf
@@ -7,7 +7,14 @@ resource "aws_dynamodb_table" "teleport" {
   write_capacity = 20
   hash_key       = "HashKey"
   range_key      = "FullPath"
+
+  // For demo purposes, CMK isn't necessary
+  // tfsec:ignore:aws-dynamodb-table-customer-key
   server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
     enabled = true
   }
 
@@ -49,7 +56,13 @@ resource "aws_dynamodb_table" "teleport_events" {
   hash_key       = "SessionID"
   range_key      = "EventIndex"
 
+  // For demo purposes, CMK isn't necessary
+  // tfsec:ignore:aws-dynamodb-table-customer-key
   server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
     enabled = true
   }
 
@@ -138,6 +151,8 @@ EOF
 
 }
 
+// Not able to use a specific resource constraint
+// tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "autoscaler_cloudwatch" {
   name = "${var.cluster_name}-autoscaler-cloudwatch"
   role = aws_iam_role.autoscaler.id
@@ -210,4 +225,3 @@ resource "aws_appautoscaling_policy" "write_policy" {
     target_value = var.autoscale_write_target
   }
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/locks.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/locks.tf
@@ -7,6 +7,16 @@ resource "aws_dynamodb_table" "locks" {
   write_capacity = 10
   hash_key       = "Lock"
 
+  // For demo purposes, CMK isn't necessary
+  // tfsec:ignore:aws-dynamodb-table-customer-key
+  server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
   attribute {
     name = "Lock"
     type = "S"
@@ -21,4 +31,3 @@ resource "aws_dynamodb_table" "locks" {
     TeleportCluster = var.cluster_name
   }
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/monitor_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/monitor_asg.tf
@@ -2,7 +2,7 @@
 // Grafana is available on port 8443
 // Internal influxdb HTTP collector service listens on port 8086
 
-// letsencrypt
+// Let's Encrypt
 resource "aws_autoscaling_group" "monitor" {
   name                      = "${var.cluster_name}-monitor"
   max_size                  = 1
@@ -76,14 +76,16 @@ resource "aws_autoscaling_group" "monitor_acm" {
   }
 }
 
+// Needs to have a public IP
+// tfsec:ignore:aws-ec2-no-public-ip
 resource "aws_launch_configuration" "monitor" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix                 = "${var.cluster_name}-monitor-"
-  image_id                    = data.aws_ami.base.id
-  instance_type               = var.monitor_instance_type
-  user_data                   = templatefile(
+  name_prefix   = "${var.cluster_name}-monitor-"
+  image_id      = data.aws_ami.base.id
+  instance_type = var.monitor_instance_type
+  user_data = templatefile(
     "${path.module}/monitor-user-data.tpl",
     {
       region           = var.region
@@ -96,6 +98,12 @@ resource "aws_launch_configuration" "monitor" {
       use_acm          = var.use_acm
     }
   )
+  metadata_options {
+    http_tokens = "required"
+  }
+  root_block_device {
+    encrypted = true
+  }
   key_name                    = var.key_name
   ebs_optimized               = true
   associate_public_ip_address = true
@@ -103,10 +111,11 @@ resource "aws_launch_configuration" "monitor" {
   iam_instance_profile        = aws_iam_instance_profile.monitor.id
 }
 
-// Monitors support traffic comming from internal cluster subnets and expose 8443 for grafana
+// Monitors support traffic coming from internal cluster subnets and expose 8443 for grafana
 resource "aws_security_group" "monitor" {
-  name   = "${var.cluster_name}-monitor"
-  vpc_id = local.vpc_id
+  name        = "${var.cluster_name}-monitor"
+  description = "SG for ${var.cluster_name}-monitor"
+  vpc_id      = local.vpc_id
   tags = {
     TeleportCluster = var.cluster_name
   }
@@ -114,6 +123,7 @@ resource "aws_security_group" "monitor" {
 
 // SSH access via bastion only
 resource "aws_security_group_rule" "monitor_ingress_allow_ssh" {
+  description              = "SSH access via bastion only"
   type                     = "ingress"
   from_port                = 22
   to_port                  = 22
@@ -122,8 +132,10 @@ resource "aws_security_group_rule" "monitor_ingress_allow_ssh" {
   source_security_group_id = aws_security_group.bastion.id
 }
 
-// Ingress traffic to SSL port 8443 is allowed from everywhere (letsencrypt)
+// Ingress traffic to SSL port 8443 is allowed from everywhere (Let's Encrypt)
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "monitor_ingress_allow_web" {
+  description       = "Ingress traffic to SSL port 8443 is allowed from everywhere (Lets Encrypt)"
   type              = "ingress"
   from_port         = 8443
   to_port           = 8443
@@ -134,7 +146,9 @@ resource "aws_security_group_rule" "monitor_ingress_allow_web" {
 }
 
 // Ingress traffic to non-SSL port 8444 is allowed from everywhere (ACM)
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "monitor_ingress_allow_web_acm" {
+  description       = "Ingress traffic to non-SSL port 8444 is allowed from everywhere (ACM)"
   type              = "ingress"
   from_port         = 8444
   to_port           = 8444
@@ -147,6 +161,7 @@ resource "aws_security_group_rule" "monitor_ingress_allow_web_acm" {
 // Influxdb metrics collector traffic is limited to internal VPC CIDR
 // We use CIDR here because traffic arriving from NLB is not marked with security group
 resource "aws_security_group_rule" "monitor_collector_ingress_allow_vpc_cidr_traffic" {
+  description       = "Influxdb metrics collector traffic is limited to internal VPC CIDR"
   type              = "ingress"
   from_port         = 8086
   to_port           = 8086
@@ -156,7 +171,9 @@ resource "aws_security_group_rule" "monitor_collector_ingress_allow_vpc_cidr_tra
 }
 
 // All egress traffic is allowed
+// tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "monitor_egress_allow_all_traffic" {
+  description       = "All egress traffic is allowed"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -200,4 +217,3 @@ resource "aws_lb_listener" "monitor" {
     type             = "forward"
   }
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/node_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/node_asg.tf
@@ -38,10 +38,10 @@ resource "aws_launch_configuration" "node" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix                 = "${var.cluster_name}-node-"
-  image_id                    = data.aws_ami.base.id
-  instance_type               = var.node_instance_type
-  user_data                   = templatefile(
+  name_prefix   = "${var.cluster_name}-node-"
+  image_id      = data.aws_ami.base.id
+  instance_type = var.node_instance_type
+  user_data = templatefile(
     "${path.module}/node-user-data.tpl",
     {
       region           = var.region
@@ -52,9 +52,14 @@ resource "aws_launch_configuration" "node" {
       use_acm          = var.use_acm
     }
   )
+  metadata_options {
+    http_tokens = "required"
+  }
+  root_block_device {
+    encrypted = true
+  }
   key_name                    = var.key_name
   associate_public_ip_address = false
   security_groups             = [aws_security_group.node.id]
   iam_instance_profile        = aws_iam_instance_profile.node.id
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/node_network.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/node_network.tf
@@ -39,8 +39,9 @@ resource "aws_route_table_association" "node" {
 // and only allow traffic comming in from proxies or
 // emergency access bastions
 resource "aws_security_group" "node" {
-  name   = "${var.cluster_name}-node"
-  vpc_id = local.vpc_id
+  name        = "${var.cluster_name}-node"
+  description = "SG for ${var.cluster_name}-node"
+  vpc_id      = local.vpc_id
   tags = {
     TeleportCluster = var.cluster_name
   }
@@ -48,6 +49,7 @@ resource "aws_security_group" "node" {
 
 // SSH access is allowed via bastions and proxies
 resource "aws_security_group_rule" "node_ingress_allow_ssh_bastion" {
+  description              = "Allow SSH access via bastion"
   type                     = "ingress"
   from_port                = 22
   to_port                  = 22
@@ -57,6 +59,7 @@ resource "aws_security_group_rule" "node_ingress_allow_ssh_bastion" {
 }
 
 resource "aws_security_group_rule" "node_ingress_allow_ssh_proxy" {
+  description              = "Allow SSH access via proxy"
   type                     = "ingress"
   from_port                = 3022
   to_port                  = 3022
@@ -65,7 +68,9 @@ resource "aws_security_group_rule" "node_ingress_allow_ssh_proxy" {
   source_security_group_id = aws_security_group.proxy.id
 }
 
+// tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "node_egress_allow_all_traffic" {
+  description       = "Allow all egress traffic"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -73,4 +78,3 @@ resource "aws_security_group_rule" "node_egress_allow_all_traffic" {
   cidr_blocks       = var.allowed_node_egress_cidr_blocks
   security_group_id = aws_security_group.node.id
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/provider.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/provider.tf
@@ -1,25 +1,17 @@
 terraform {
-  required_version = ">= 0.13, < 2.0.0"
+  required_version = ">= 1.0, < 2.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.2.0"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2.1"
+      version = "~> 3.0"
     }
   }
 }
 
 provider "aws" {
   region = var.region
-}
-
-variable "aws_max_retries" {
-  default = 5
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/proxy_network.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/proxy_network.tf
@@ -3,8 +3,9 @@
 
 // Proxy SG for instances behind network LB
 resource "aws_security_group" "proxy" {
-  name   = "${var.cluster_name}-proxy"
-  vpc_id = local.vpc_id
+  name        = "${var.cluster_name}-proxy"
+  description = "Proxy SG for instances behind network LB"
+  vpc_id      = local.vpc_id
   tags = {
     TeleportCluster = var.cluster_name
   }
@@ -12,9 +13,10 @@ resource "aws_security_group" "proxy" {
 
 // Proxy SG for application LB (ACM)
 resource "aws_security_group" "proxy_acm" {
-  name   = "${var.cluster_name}-proxy-acm"
-  vpc_id = local.vpc_id
-  count  = var.use_acm ? 1 : 0
+  name        = "${var.cluster_name}-proxy-acm"
+  description = "Proxy SG for application LB (ACM)"
+  vpc_id      = local.vpc_id
+  count       = var.use_acm ? 1 : 0
   tags = {
     TeleportCluster = var.cluster_name
   }
@@ -22,6 +24,7 @@ resource "aws_security_group" "proxy_acm" {
 
 // SSH emergency access via bastion only
 resource "aws_security_group_rule" "proxy_ingress_allow_ssh" {
+  description              = "SSH emergency access via bastion only"
   type                     = "ingress"
   from_port                = 22
   to_port                  = 22
@@ -31,7 +34,9 @@ resource "aws_security_group_rule" "proxy_ingress_allow_ssh" {
 }
 
 // Ingress traffic to web port 443 is allowed from all directions (ACM)
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "proxy_ingress_allow_web_acm" {
+  description       = "Ingress traffic to web port 443 is allowed from all directions (ACM)"
   type              = "ingress"
   from_port         = 443
   to_port           = 443
@@ -42,7 +47,9 @@ resource "aws_security_group_rule" "proxy_ingress_allow_web_acm" {
 }
 
 // Ingress proxy traffic is allowed from all ports
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "proxy_ingress_allow_proxy" {
+  description       = "Ingress proxy traffic is allowed from all ports"
   type              = "ingress"
   from_port         = 3023
   to_port           = 3023
@@ -52,7 +59,9 @@ resource "aws_security_group_rule" "proxy_ingress_allow_proxy" {
 }
 
 // Ingress traffic to tunnel port 3024 is allowed from all directions (ACM)
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "proxy_ingress_allow_tunnel" {
+  description       = "Ingress traffic to tunnel port 3024 is allowed from all directions (ACM)"
   type              = "ingress"
   from_port         = 3024
   to_port           = 3024
@@ -63,7 +72,9 @@ resource "aws_security_group_rule" "proxy_ingress_allow_tunnel" {
 }
 
 // Ingress traffic to web port 3026 is allowed from all directions
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "proxy_ingress_allow_kube" {
+  description       = "Ingress traffic to web port 3026 is allowed from all directions"
   type              = "ingress"
   from_port         = 3026
   to_port           = 3026
@@ -73,36 +84,48 @@ resource "aws_security_group_rule" "proxy_ingress_allow_kube" {
 }
 
 // Permit inbound to Teleport mysql services
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "proxy_ingress_allow_mysql" {
+  description       = "Permit inbound to Teleport mysql services"
   type              = "ingress"
   from_port         = 3036
   to_port           = 3036
   protocol          = "tcp"
   cidr_blocks       = var.allowed_proxy_ingress_cidr_blocks
   security_group_id = aws_security_group.proxy.id
+  count             = var.enable_mysql_listener ? 1 : 0
 }
+
 // Permit inbound to Teleport postgres services
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "proxy_ingress_allow_postgres" {
+  description       = "Permit inbound to Teleport postgres services"
   type              = "ingress"
   from_port         = 5432
   to_port           = 5432
   protocol          = "tcp"
   cidr_blocks       = var.allowed_proxy_ingress_cidr_blocks
   security_group_id = aws_security_group.proxy.id
+  count             = var.enable_postgres_listener ? 1 : 0
 }
 
 // Permit inbound to Teleport mongodb services
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "cluster_ingress_mongodb" {
+  description       = "Permit inbound to Teleport mongodb services"
   type              = "ingress"
   from_port         = 27017
   to_port           = 27017
   protocol          = "tcp"
   cidr_blocks       = var.allowed_proxy_ingress_cidr_blocks
   security_group_id = aws_security_group.proxy.id
+  count             = var.enable_mongodb_listener ? 1 : 0
 }
 
 // Ingress traffic to web port 3080 is allowed from all directions
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "proxy_ingress_allow_web" {
+  description       = "Ingress traffic to web port 3080 is allowed from all directions"
   type              = "ingress"
   from_port         = 3080
   to_port           = 3080
@@ -112,7 +135,9 @@ resource "aws_security_group_rule" "proxy_ingress_allow_web" {
 }
 
 // Ingress traffic to grafana port 8443 is allowed from all directions (ACM)
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "proxy_ingress_allow_grafana_acm" {
+  description       = "Ingress traffic to grafana port 8443 is allowed from all directions (ACM)"
   type              = "ingress"
   from_port         = 8443
   to_port           = 8443
@@ -123,7 +148,9 @@ resource "aws_security_group_rule" "proxy_ingress_allow_grafana_acm" {
 }
 
 // Egress traffic is allowed everywhere
+// tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "proxy_egress_allow_all_traffic" {
+  description       = "Egress traffic is allowed everywhere"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -133,7 +160,9 @@ resource "aws_security_group_rule" "proxy_egress_allow_all_traffic" {
 }
 
 // Egress traffic is allowed everywhere (ACM)
+// tfsec:ignore:aws-ec2-no-public-iegress-sgr
 resource "aws_security_group_rule" "proxy_egress_allow_all_traffic_acm" {
+  description       = "Egress traffic is allowed everywhere (ACM)"
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -144,13 +173,15 @@ resource "aws_security_group_rule" "proxy_egress_allow_all_traffic_acm" {
 }
 
 // Network load balancer for proxy server
+// Expected to be public-facing
+// tfsec:ignore:aws-elb-alb-not-public
 resource "aws_lb" "proxy" {
-  name                              = "${var.cluster_name}-proxy"
-  internal                          = false
-  subnets                           = aws_subnet.public.*.id
-  load_balancer_type                = "network"
-  idle_timeout                      = 3600
-  enable_cross_zone_load_balancing  = true
+  name                             = "${var.cluster_name}-proxy"
+  internal                         = false
+  subnets                          = aws_subnet.public.*.id
+  load_balancer_type               = "network"
+  idle_timeout                     = 3600
+  enable_cross_zone_load_balancing = true
 
   tags = {
     TeleportCluster = var.cluster_name
@@ -343,7 +374,7 @@ resource "aws_lb_listener" "proxy_web_acm" {
 
 // This is a small hack to expose grafana over web port 8443
 // feel free to remove it or replace with something else
-// letsencrypt
+// Let's Encrypt
 resource "aws_lb_target_group" "proxy_grafana" {
   name     = "${var.cluster_name}-proxy-grafana"
   port     = 8443
@@ -385,4 +416,3 @@ resource "aws_lb_listener" "proxy_grafana_acm" {
     type             = "forward"
   }
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/s3.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/s3.tf
@@ -1,26 +1,54 @@
-// S3 bucket is used to distribute letsencrypt certificates
+// S3 bucket is used to distribute Let's Encrypt certificates
+// For demo purposes, don't need bucket logging
+// tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "certs" {
   bucket        = var.s3_bucket_name
-  acl           = "private"
   force_destroy = true
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+}
+
+resource "aws_s3_bucket_acl" "certs" {
+  bucket = aws_s3_bucket.certs.bucket
+  acl    = "private"
+}
+
+// For demo purposes, CMK is not needed
+// tfsec:ignore:aws-s3-encryption-customer-key
+resource "aws_s3_bucket_server_side_encryption_configuration" "certs" {
+  bucket = aws_s3_bucket.certs.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }
 
-resource "aws_s3_bucket_object" "grafana_teleport_dashboard" {
+resource "aws_s3_bucket_versioning" "certs" {
+  bucket = aws_s3_bucket.certs.bucket
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "certs" {
+  bucket = aws_s3_bucket.certs.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_object" "grafana_teleport_dashboard" {
   bucket = aws_s3_bucket.certs.bucket
   key    = "health-dashboard.json"
   source = "./assets/health-dashboard.json"
   etag   = filemd5("./assets/health-dashboard.json")
 }
 
-// Grafana nginx config (letsencrypt)
-resource "aws_s3_bucket_object" "grafana_teleport_nginx" {
+// Grafana nginx config (Let's Encrypt)
+resource "aws_s3_object" "grafana_teleport_nginx" {
   bucket = aws_s3_bucket.certs.bucket
   key    = "grafana-nginx.conf"
   source = "./assets/grafana-nginx.conf"
@@ -29,11 +57,10 @@ resource "aws_s3_bucket_object" "grafana_teleport_nginx" {
 }
 
 // Grafana nginx config (ACM)
-resource "aws_s3_bucket_object" "grafana_teleport_nginx_acm" {
+resource "aws_s3_object" "grafana_teleport_nginx_acm" {
   bucket = aws_s3_bucket.certs.bucket
   key    = "grafana-nginx.conf"
   source = "./assets/grafana-nginx-acm.conf"
   count  = var.use_acm ? 1 : 0
   etag   = filemd5("./assets/grafana-nginx-acm.conf")
 }
-

--- a/examples/aws/terraform/ha-autoscale-cluster/vars.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/vars.tf
@@ -69,21 +69,21 @@ variable "add_wildcard_route53_record" {
 }
 
 // whether to enable the mongodb listener
-// adds security group setting, maps load balancer to port and adds to teleport config
+// adds security group setting, maps load balancer to port, and adds to teleport config
 variable "enable_mongodb_listener" {
   type    = bool
   default = false
 }
 
 // whether to enable the mysql listener
-// adds security group setting, maps load balancer to port and adds to teleport config
+// adds security group setting, maps load balancer to port, and adds to teleport config
 variable "enable_mysql_listener" {
   type    = bool
   default = false
 }
 
 // whether to enable the postgres listener
-// adds security group setting, maps load balancer to port and adds to teleport config
+// adds security group setting, maps load balancer to port, and adds to teleport config
 variable "enable_postgres_listener" {
   type    = bool
   default = false
@@ -102,6 +102,7 @@ variable "s3_bucket_name" {
 // AWS KMS alias used for encryption/decryption
 // default is alias used in SSM
 variable "kms_alias_name" {
+  type    = string
   default = "alias/aws/ssm"
 }
 
@@ -171,74 +172,74 @@ variable "grafana_pass" {
 // Whether to use Amazon-issued certificates via ACM or not
 // This must be set to true for any use of ACM whatsoever, regardless of whether Terraform generates/approves the cert
 variable "use_acm" {
-  type = string
-  default = "false"
+  type    = bool
+  default = false
 }
 
 // CIDR blocks allowed to connect to the bastion SSH port
 variable "allowed_bastion_ssh_ingress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
 
 // CIDR blocks allowed for egress from bastion
 variable "allowed_bastion_ssh_egress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
 // CIDR blocks allowed for ingress for Teleport Proxy ports
 variable "allowed_proxy_ingress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
 // CIDR blocks allowed for egress from Teleport Proxies
 variable "allowed_proxy_egress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
 // CIDR blocks allowed for egress from Teleport Auth servers
 variable "allowed_auth_egress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
 // CIDR blocks allowed for ingress for Teleport Monitor ports
 variable "allowed_monitor_ingress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
 // CIDR blocks allowed for egress from Teleport Monitor
 variable "allowed_monitor_egress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
 // CIDR blocks allowed for egress from Teleport Node
 variable "allowed_node_egress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
 // Internet gateway destination CIDR Block
 variable "internet_gateway_dest_cidr_block" {
-  type = string
+  type    = string
   default = "0.0.0.0/0"
 }
 
 // Route allowed for Auth Servers Destination CIDR Block
 variable "auth_aws_route_dest_cidr_block" {
-  type = string
+  type    = string
   default = "0.0.0.0/0"
 }
 
 // Route allowed for Node Servers Destination CIDR Block
 variable "node_aws_route_dest_cidr_block" {
-  type = string
+  type    = string
   default = "0.0.0.0/0"
 }
 
@@ -250,6 +251,6 @@ variable "node_aws_route_dest_cidr_block" {
 // it can be used by applications which connect to it directly (like kubectl) rather
 // than discovering the NLB's address through the Teleport API (like tsh does)
 variable "route53_domain_acm_nlb_alias" {
-  type = string
+  type    = string
   default = ""
 }

--- a/examples/aws/terraform/starter-cluster/Makefile
+++ b/examples/aws/terraform/starter-cluster/Makefile
@@ -9,8 +9,8 @@ TF_VAR_cluster_name ?=
 # AWS SSH key name to provision in installed instances, should be available in the region
 TF_VAR_key_name ?=
 
-# Full absolute path to the license file for Teleport Enterprise or Pro.
-# This license will be copied into SSM and then pulled down on the auth nodes to enable Enterprise/Pro functionality
+# Full absolute path to the license file for Teleport Enterprise.
+# This license will be copied into SSM and then pulled down on the auth nodes to enable Enterprise functionality
 TF_VAR_license_path ?=
 
 # AMI name contains the version of Teleport to install, and whether to use OSS or Enterprise version
@@ -40,19 +40,19 @@ TF_VAR_enable_mysql_listener ?= true
 # Enable adding Postgres listeners in Teleport proxy, load balancer ports and security groups
 TF_VAR_enable_postgres_listener ?= true
 
-# Bucket name to store encrypted letsencrypt certificates.
+# Bucket name to store encrypted Let's Encrypt certificates.
 TF_VAR_s3_bucket_name ?=
 
-# Email of your support org, used for Letsencrypt cert registration process.
+# Email of your support org, used for Let's Encrypt cert registration process.
 TF_VAR_email ?=
 
-# Set to true to use LetsEncrypt to provision certificates
-TF_VAR_use_letsencrypt ?=true
+# Set to true to use Let's Encrypt to provision certificates
+TF_VAR_use_letsencrypt ?= true
 
 # Set to true to use ACM (Amazon Certificate Manager) to provision certificates
 # If you wish to use a pre-existing ACM certificate rather than having Terraform generate one for you, you can import it:
 # terraform import aws_acm_certificate.cert <certificate_arn>
-TF_VAR_use_acm ?=false
+TF_VAR_use_acm ?= false
 
 export
 

--- a/examples/aws/terraform/starter-cluster/README.md
+++ b/examples/aws/terraform/starter-cluster/README.md
@@ -24,8 +24,8 @@ This Terraform example will configure the following AWS resources:
 
 ### Build Requirements
 
-- terraform v0.14+ [install docs](https://learn.hashicorp.com/terraform/getting-started/install.html)
-- awscli v1.14+ [install docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+- terraform v1.0+ [install docs](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+- awscli v1.14+ [install docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 
 ### Usage
 
@@ -68,17 +68,17 @@ Update the included Makefile to define your configuration.
 # Region to run in - we currently have AMIs in the following regions:
 # ap-south-1, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2
 # sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2
-TF_VAR_region ?="us-east-1"
+TF_VAR_region ?= "us-east-1"
 
 # Cluster name is a unique cluster name to use, should be unique and not contain spaces or other special characters
-TF_VAR_cluster_name ?="TeleportCluster1"
+TF_VAR_cluster_name ?= "TeleportCluster1"
 
 # AWS SSH key pair name to provision in installed instances, must be a key pair available in the above defined region (AWS Console > EC2 > Key Pairs)
-TF_VAR_key_name ?="example"
+TF_VAR_key_name ?= "example"
 
 # Full absolute path to the license file, on the machine executing Terraform, for Teleport Enterprise.
 # This license will be copied into AWS SSM and then pulled down on the auth nodes to enable Enterprise functionality
-TF_VAR_license_path ?="/path/to/license"
+TF_VAR_license_path ?= "/path/to/license"
 
 # AMI name contains the version of Teleport to install, and whether to use OSS or Enterprise version
 # These AMIs are published by Teleport and shared as public whenever a new version of Teleport is released
@@ -86,41 +86,41 @@ TF_VAR_license_path ?="/path/to/license"
 # OSS: aws ec2 describe-images --owners 126027368216 --filters 'Name=name,Values=gravitational-teleport-ami-oss*'
 # Enterprise: aws ec2 describe-images --owners 126027368216 --filters 'Name=name,Values=gravitational-teleport-ami-ent*'
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
-TF_VAR_ami_name ?="gravitational-teleport-ami-ent-10.2.6"
+TF_VAR_ami_name ?= "gravitational-teleport-ami-ent-10.2.6"
 
 # Route 53 hosted zone to use, must be a root zone registered in AWS, e.g. example.com
-TF_VAR_route53_zone ?="example.com"
+TF_VAR_route53_zone ?= "example.com"
 
 # Subdomain to set up in the zone above, e.g. cluster.example.com
 # This will be used for users connecting to Teleport proxy
-TF_VAR_route53_domain ?="cluster.example.com"
+TF_VAR_route53_domain ?= "cluster.example.com"
 
 # Set to true to add a wildcard subdomain entry to point to the proxy, e.g. *.cluster.example.com
 # This is used to enable Teleport Application Access
 export TF_VAR_add_wildcard_route53_record="true"
 
-# Enable adding MongoDB listeners in Teleport proxy, load balancer ports and security groups
+# Enable adding MongoDB listeners in Teleport proxy, load balancer ports, and security groups
 export TF_VAR_enable_mongodb_listener="true"
 
-# Enable adding MySQL listeners in Teleport proxy, load balancer ports and security groups
+# Enable adding MySQL listeners in Teleport proxy, load balancer ports, and security groups
 export TF_VAR_enable_mysql_listener="true"
 
-# Enable adding Postgres listeners in Teleport proxy, load balancer ports and security groups
+# Enable adding Postgres listeners in Teleport proxy, load balancer ports, and security groups
 export TF_VAR_enable_postgres_listener="true"
 
-# Bucket name to store encrypted LetsEncrypt certificates.
-TF_VAR_s3_bucket_name ?="teleport.example.com"
+# Bucket name to store encrypted Let's Encrypt certificates.
+TF_VAR_s3_bucket_name ?= "teleport.example.com"
 
-# Email to be used for LetsEncrypt certificate registration process.
-TF_VAR_email ?="support@example.com"
+# Email to be used for Let's Encrypt certificate registration process.
+TF_VAR_email ?= "support@example.com"
 
-# Set to true to use LetsEncrypt to provision certificates
-TF_VAR_use_letsencrypt ?=true
+# Set to true to use Let's Encrypt to provision certificates
+TF_VAR_use_letsencrypt ?= true
 
 # Set to true to use ACM (Amazon Certificate Manager) to provision certificates
 # If you wish to use a pre-existing ACM certificate rather than having Terraform generate one for you, you can import it:
 # terraform import aws_acm_certificate.cert <certificate_arn>
-TF_VAR_use_acm ?=false
+TF_VAR_use_acm ?= false
 
 # plan
 make plan

--- a/examples/aws/terraform/starter-cluster/cluster.tf
+++ b/examples/aws/terraform/starter-cluster/cluster.tf
@@ -1,34 +1,38 @@
-// Configuration data for teleport.yaml generation
-data "template_file" "node_user_data" {
-  template = file("data.tpl")
-
-  vars = {
-    region                   = var.region
-    cluster_name             = var.cluster_name
-    email                    = var.email
-    domain_name              = var.route53_domain
-    dynamo_table_name        = aws_dynamodb_table.teleport.name
-    dynamo_events_table_name = aws_dynamodb_table.teleport_events.name
-    locks_table_name         = aws_dynamodb_table.teleport_locks.name
-    license_path             = var.license_path
-    s3_bucket                = var.s3_bucket_name
-    enable_mongodb_listener  = var.enable_mongodb_listener
-    enable_mysql_listener    = var.enable_mysql_listener
-    enable_postgres_listener = var.enable_postgres_listener
-    use_acm                  = var.use_acm
-    use_letsencrypt          = var.use_letsencrypt
-  }
-}
-
 // Auth, node, proxy (aka Teleport Cluster) on single AWS instance
 resource "aws_instance" "cluster" {
   key_name                    = var.key_name
   ami                         = data.aws_ami.base.id
   instance_type               = var.cluster_instance_type
-  subnet_id                   = tolist(data.aws_subnet_ids.all.ids)[0]
+  subnet_id                   = tolist(data.aws_subnets.all.ids)[0]
   vpc_security_group_ids      = [aws_security_group.cluster.id]
   associate_public_ip_address = true
-  user_data                   = data.template_file.node_user_data.rendered
   iam_instance_profile        = aws_iam_role.cluster.id
-}
 
+  user_data = templatefile(
+    "data.tpl",
+    {
+      region                   = var.region
+      cluster_name             = var.cluster_name
+      email                    = var.email
+      domain_name              = var.route53_domain
+      dynamo_table_name        = aws_dynamodb_table.teleport.name
+      dynamo_events_table_name = aws_dynamodb_table.teleport_events.name
+      locks_table_name         = aws_dynamodb_table.teleport_locks.name
+      license_path             = var.license_path
+      s3_bucket                = var.s3_bucket_name
+      enable_mongodb_listener  = var.enable_mongodb_listener
+      enable_mysql_listener    = var.enable_mysql_listener
+      enable_postgres_listener = var.enable_postgres_listener
+      use_acm                  = var.use_acm
+      use_letsencrypt          = var.use_letsencrypt
+    }
+  )
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  root_block_device {
+    encrypted = true
+  }
+}

--- a/examples/aws/terraform/starter-cluster/cluster_sg.tf
+++ b/examples/aws/terraform/starter-cluster/cluster_sg.tf
@@ -1,14 +1,15 @@
 /* 
 Security Groups and Rules for Cluster.
 
-Note: Please see the list of networking ports documentation for their usage. 
+Note: Please see the list of networking ports documentation for their usage.
 https://goteleport.com/docs/setup/reference/networking/#ports
 */
 
 // Create a Security Group
 resource "aws_security_group" "cluster" {
-  name   = "${var.cluster_name}-cluster"
-  vpc_id = data.aws_vpc.default.id
+  name        = "${var.cluster_name}-cluster"
+  description = "${var.cluster_name} cluster"
+  vpc_id      = data.aws_vpc.default.id
 
   tags = {
     TeleportCluster = var.cluster_name
@@ -16,7 +17,9 @@ resource "aws_security_group" "cluster" {
 }
 
 // Permit inbound to SSH
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "cluster_ingress_ssh" {
+  description       = "Permit inbound to SSH"
   type              = "ingress"
   from_port         = 22
   to_port           = 22
@@ -24,8 +27,11 @@ resource "aws_security_group_rule" "cluster_ingress_ssh" {
   cidr_blocks       = var.allowed_ssh_ingress_cidr_blocks
   security_group_id = aws_security_group.cluster.id
 }
+
 // Permit inbound to Teleport Web interface
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "cluster_ingress_web" {
+  description       = "Permit inbound to Teleport Web interface"
   type              = "ingress"
   from_port         = 3080
   to_port           = 3080
@@ -33,8 +39,11 @@ resource "aws_security_group_rule" "cluster_ingress_web" {
   cidr_blocks       = var.allowed_ingress_cidr_blocks
   security_group_id = aws_security_group.cluster.id
 }
+
 // Permit inbound to Teleport services
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "cluster_ingress_services" {
+  description       = "Permit inbound to Teleport services"
   type              = "ingress"
   from_port         = 3022
   to_port           = 3025
@@ -42,41 +51,50 @@ resource "aws_security_group_rule" "cluster_ingress_services" {
   cidr_blocks       = var.allowed_ingress_cidr_blocks
   security_group_id = aws_security_group.cluster.id
 }
+
 // Permit inbound to Teleport mysql services
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "cluster_ingress_mysql" {
+  description       = "Permit inbound to Teleport mysql services"
   type              = "ingress"
   from_port         = 3036
   to_port           = 3036
   protocol          = "tcp"
   cidr_blocks       = var.allowed_ingress_cidr_blocks
   security_group_id = aws_security_group.cluster.id
-  count  = var.enable_mysql_listener ? 1 : 0
+  count             = var.enable_mysql_listener ? 1 : 0
 }
 
 // Permit inbound to Teleport postgres services
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "cluster_ingress_postgres" {
+  description       = "Permit inbound to Teleport postgres services"
   type              = "ingress"
   from_port         = 5432
   to_port           = 5432
   protocol          = "tcp"
   cidr_blocks       = var.allowed_ingress_cidr_blocks
   security_group_id = aws_security_group.cluster.id
-  count  = var.enable_postgres_listener ? 1 : 0
+  count             = var.enable_postgres_listener ? 1 : 0
 }
 
 // Permit inbound to Teleport mongodb services
+// tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "cluster_ingress_mongodb" {
+  description       = "Permit inbound to Teleport mongodb services"
   type              = "ingress"
   from_port         = 27017
   to_port           = 27017
   protocol          = "tcp"
   cidr_blocks       = var.allowed_ingress_cidr_blocks
   security_group_id = aws_security_group.cluster.id
-  count  = var.enable_mongodb_listener ? 1 : 0
+  count             = var.enable_mongodb_listener ? 1 : 0
 }
 
 // Permit all outbound traffic
+// tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "cluster_egress" {
+  description       = "Permit all outbound traffic"
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/examples/aws/terraform/starter-cluster/data.tf
+++ b/examples/aws/terraform/starter-cluster/data.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 1.0, < 2.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }
@@ -15,8 +16,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 data "aws_ami" "base" {
@@ -38,9 +42,6 @@ data "aws_caller_identity" "current" {
 
 data "aws_region" "current" {
   name = var.region
-}
-
-data "aws_availability_zones" "available" {
 }
 
 // SSM is picking alias for key to use for encryption in SSM

--- a/examples/aws/terraform/starter-cluster/dynamo.tf
+++ b/examples/aws/terraform/starter-cluster/dynamo.tf
@@ -11,7 +11,14 @@ resource "aws_dynamodb_table" "teleport" {
   write_capacity = 10
   hash_key       = "HashKey"
   range_key      = "FullPath"
+
+  // For demo purposes, CMK isn't necessary
+  // tfsec:ignore:aws-dynamodb-table-customer-key
   server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
     enabled = true
   }
 
@@ -53,7 +60,13 @@ resource "aws_dynamodb_table" "teleport_events" {
   hash_key       = "SessionID"
   range_key      = "EventIndex"
 
+  // For demo purposes, CMK isn't necessary
+  // tfsec:ignore:aws-dynamodb-table-customer-key
   server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
     enabled = true
   }
 
@@ -106,6 +119,16 @@ resource "aws_dynamodb_table" "teleport_locks" {
   read_capacity  = 5
   write_capacity = 5
   hash_key       = "Lock"
+
+  // For demo purposes, CMK isn't necessary
+  // tfsec:ignore:aws-dynamodb-table-customer-key
+  server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
 
   billing_mode = "PROVISIONED"
 

--- a/examples/aws/terraform/starter-cluster/route53.tf
+++ b/examples/aws/terraform/starter-cluster/route53.tf
@@ -9,7 +9,7 @@ resource "aws_route53_record" "cluster" {
   zone_id = data.aws_route53_zone.cluster.zone_id
   name    = var.route53_domain
   type    = "A"
-  ttl     = "300"
+  ttl     = 300
   records = [aws_instance.cluster.public_ip]
 }
 
@@ -18,7 +18,7 @@ resource "aws_route53_record" "wildcard-cluster" {
   zone_id = data.aws_route53_zone.cluster.zone_id
   name    = "*.${var.route53_domain}"
   type    = "A"
-  ttl     = "300"
+  ttl     = 300
   records = [aws_instance.cluster.public_ip]
-  count  = var.add_wildcard_route53_record ? 1 : 0
+  count   = var.add_wildcard_route53_record ? 1 : 0
 }

--- a/examples/aws/terraform/starter-cluster/s3.tf
+++ b/examples/aws/terraform/starter-cluster/s3.tf
@@ -1,20 +1,47 @@
-/* 
+/*
 Configuration of S3 bucket for certs and replay
 storage. Uses server side encryption to secure
 session replays and SSL certificates.
 */
 
 // S3 bucket for cluster storage
+// For demo purposes, don't need bucket logging
+// tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "storage" {
   bucket        = var.s3_bucket_name
-  acl           = "private"
   force_destroy = true
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_acl" "storage" {
+  bucket = aws_s3_bucket.storage.bucket
+  acl    = "private"
+}
+
+// For demo purposes, CMK is not needed
+// tfsec:ignore:aws-s3-encryption-customer-key
+resource "aws_s3_bucket_server_side_encryption_configuration" "storage" {
+  bucket = aws_s3_bucket.storage.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
+}
+
+resource "aws_s3_bucket_versioning" "storage" {
+  bucket = aws_s3_bucket.storage.bucket
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "storage" {
+  bucket = aws_s3_bucket.storage.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }

--- a/examples/aws/terraform/starter-cluster/vars.tf
+++ b/examples/aws/terraform/starter-cluster/vars.tf
@@ -19,7 +19,7 @@ variable "ami_name" {
   type = string
 }
 
-// DNS and letsencrypt integration variables
+// DNS and Let's Encrypt integration variables
 // Zone name to host DNS record, e.g. example.com
 variable "route53_zone" {
   type = string
@@ -31,79 +31,78 @@ variable "route53_domain" {
   type = string
 }
 
-// Whether to add a while a wildcard entry *.proxy.example.com for application access
+// Whether to add a wildcard entry *.proxy.example.com for application access
 variable "add_wildcard_route53_record" {
-  type = string
+  type = bool
 }
 
 // whether to enable the mongodb listener
-// adds security group setting, maps load balancer to port and adds to teleport config
+// adds security group setting, maps load balancer to port, and adds to teleport config
 variable "enable_mongodb_listener" {
   type    = bool
   default = false
 }
 
 // whether to enable the mysql listener
-// adds security group setting, maps load balancer to port and adds to teleport config
+// adds security group setting, maps load balancer to port, and adds to teleport config
 variable "enable_mysql_listener" {
   type    = bool
   default = false
 }
 
 // whether to enable the postgres listener
-// adds security group setting, maps load balancer to port and adds to teleport config
+// adds security group setting, maps load balancer to port, and adds to teleport config
 variable "enable_postgres_listener" {
   type    = bool
   default = false
 }
 
-// S3 Bucket to create for encrypted letsencrypt certificates
+// S3 Bucket to create for encrypted Let's Encrypt certificates
 variable "s3_bucket_name" {
   type = string
 }
 
-// Email for LetsEncrypt domain registration
+// Email for Let's Encrypt domain registration
 variable "email" {
   type = string
 }
-
 
 // SSH key name to provision instances with
 variable "key_name" {
   type = string
 }
 
-// Whether to use Amazon-issued certificates via ACM or not
-// This must be set to true for any use of ACM whatsoever, regardless of whether Terraform generates/approves the cert
+// Whether to use Let's Encrypt-issued certificates
 variable "use_letsencrypt" {
-  type = string
+  type = bool
 }
 
 // Whether to use Amazon-issued certificates via ACM or not
 // This must be set to true for any use of ACM whatsoever, regardless of whether Terraform generates/approves the cert
 variable "use_acm" {
-  type = string
+  type = bool
 }
 
 // CIDR blocks allowed to connect to the SSH port
 variable "allowed_ssh_ingress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
-// CIDR blocks allowed for ingress for all Teleport ports 
+// CIDR blocks allowed for ingress for all Teleport ports
 variable "allowed_ingress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
 // CIDR blocks allowed for egress from Teleport
 variable "allowed_egress_cidr_blocks" {
-  type = list
+  type    = list(any)
   default = ["0.0.0.0/0"]
 }
 
 variable "kms_alias_name" {
+  type    = string
   default = "alias/aws/ssm"
 }
 

--- a/examples/resources/terraform/terraform-user-role-cloud.tf
+++ b/examples/resources/terraform/terraform-user-role-cloud.tf
@@ -18,10 +18,10 @@ resource "teleport_role" "terraform-test" {
     name        = "terraform-test"
     description = "Terraform test role"
     labels = {
-      example  = "yes"
+      example = "yes"
     }
   }
-  
+
   spec = {
     options = {
       forward_agent           = false
@@ -39,7 +39,7 @@ resource "teleport_role" "terraform-test" {
       rules = [
         {
           resources = ["user", "role"]
-          verbs = ["list"]
+          verbs     = ["list"]
         }
       ]
 
@@ -55,8 +55,8 @@ resource "teleport_role" "terraform-test" {
       }
 
       node_labels = {
-         key = ["example"]
-         alabel = ["with", "multiple", "values"]
+        key    = ["example"]
+        alabel = ["with", "multiple", "values"]
       }
     }
 
@@ -73,7 +73,7 @@ resource "teleport_user" "terraform-test" {
     expires     = "2022-10-12T07:20:50Z"
 
     labels = {
-      test      = "true"
+      test = "true"
     }
   }
 

--- a/examples/resources/terraform/terraform-user-role-self-hosted.tf
+++ b/examples/resources/terraform/terraform-user-role-self-hosted.tf
@@ -10,10 +10,10 @@ terraform {
 provider "teleport" {
   # Update addr to point to Teleport Auth/Proxy
   # addr               = "auth.example.com:3025"
-  addr               = "proxy.example.com:443"
-  cert_path          = "auth.crt"
-  key_path           = "auth.key"
-  root_ca_path       = "auth.cas"
+  addr         = "proxy.example.com:443"
+  cert_path    = "auth.crt"
+  key_path     = "auth.key"
+  root_ca_path = "auth.cas"
 }
 
 resource "teleport_role" "terraform-test" {
@@ -21,10 +21,10 @@ resource "teleport_role" "terraform-test" {
     name        = "terraform-test"
     description = "Terraform test role"
     labels = {
-      example  = "yes"
+      example = "yes"
     }
   }
-  
+
   spec = {
     options = {
       forward_agent           = false
@@ -42,7 +42,7 @@ resource "teleport_role" "terraform-test" {
       rules = [
         {
           resources = ["user", "role"]
-          verbs = ["list"]
+          verbs     = ["list"]
         }
       ]
 
@@ -58,8 +58,8 @@ resource "teleport_role" "terraform-test" {
       }
 
       node_labels = {
-         key = ["example"]
-         alabel = ["with", "multiple", "values"]
+        key    = ["example"]
+        alabel = ["with", "multiple", "values"]
       }
     }
 
@@ -76,7 +76,7 @@ resource "teleport_user" "terraform-test" {
     expires     = "2022-10-12T07:20:50Z"
 
     labels = {
-      test      = "true"
+      test = "true"
     }
   }
 


### PR DESCRIPTION
There were numerous `tfsec` and `ansible-lint` warnings within the `examples/aws/terraform` directory. Address all issues, adding ignores where needed to bring warning count down to zero.