### PR TITLE
Fix lint warnings

### DIFF
--- a/.cloudbuild/scripts/internal/artifacts/artifacts.go
+++ b/.cloudbuild/scripts/internal/artifacts/artifacts.go
@@ -66,22 +66,23 @@ func ValidatePatterns(workspace string, patterns []string) ([]string, error) {
 // so be wary of including multiple artifacts with the same name.
 //
 // For example, given a directory tree that looks like
-//   /
-//   ├── mystery-machine.yaml
-//   ├── dogs
-//   │   └── scooby.yaml
-//   └── people
-//       └── shaggy.yaml
+//
+//	/
+//	├── mystery-machine.yaml
+//	├── dogs
+//	│   └── scooby.yaml
+//	└── people
+//	    └── shaggy.yaml
 //
 // calling
-//   Upload(ctx, "bucket-name", "build-unique-id", []string{"/**/*.yaml"}))
+//
+//	Upload(ctx, "bucket-name", "build-unique-id", []string{"/**/*.yaml"}))
 //
 // will result in a bucket with the added objects
 //
 // - "build-unique-id/mystery-machine.yaml"
 // - "build-unique-id/scooby.yaml"
 // - "build-unique-id/shaggy.yaml"
-//
 func FindAndUpload(ctx context.Context, bucketName, objectPrefix string, artifactPatterns []string) error {
 	artifacts := find(artifactPatterns)
 
@@ -148,7 +149,6 @@ func find(artifactPatterns []string) []string {
 // the bucket under the supplied prefix, using the file's base name to
 // disambiguate. Be wary of including multiple artifacts with the same name, as
 // later object may clobber earlier ones.
-//
 func upload(ctx context.Context, bucket bucketHandle, prefix string, files []string) error {
 	var uploadErrors *multierror.Error
 

--- a/build.assets/tooling/cmd/build-os-package-repos/aptly.go
+++ b/build.assets/tooling/cmd/build-os-package-repos/aptly.go
@@ -601,9 +601,10 @@ func (a *Aptly) CreateReposFromPublishedPath(localPublishedPath string) ([]*Repo
 
 // Creates or gets Aptly repos for all permutations of the provided requirements.
 // Returns a list of repo objects describing the Aptly repos, regardless of if they
-//   already existed.
+// already existed.
+//
 // supportedOSInfo should be a dictionary keyed by OS name, with values being a list of
-//   supported OS version codenames.
+// supported OS version codenames.
 func (a *Aptly) CreateReposFromArtifactRequirements(supportedOSInfo map[string][]string,
 	releaseChannel string, majorVersion string) ([]*Repo, error) {
 	logrus.Infoln("Creating new repos from artifact requirements:")

--- a/build.assets/tooling/cmd/build-os-package-repos/s3manager.go
+++ b/build.assets/tooling/cmd/build-os-package-repos/s3manager.go
@@ -183,7 +183,7 @@ func createLinks(linkMap map[string]string) error {
 }
 
 // This could potentially be made more efficient by running `os.RemoveAll` in a goroutine
-//  as random access on storage devices performs better at a higher queue depth
+// as random access on storage devices performs better at a higher queue depth
 func deleteAllFilesInDirectory(dir string) error {
 	// Note that os.ReadDir does not follow/eval links which is important here
 	dirEntries, err := os.ReadDir(dir)

--- a/build.assets/tooling/cmd/query-latest/main.go
+++ b/build.assets/tooling/cmd/query-latest/main.go
@@ -18,11 +18,12 @@ limitations under the License.
 // query-latest ignores drafts and pre-releases.
 //
 // For example:
-//  query-latest v8.1.5     -> v8.1.5
-//  query-latest v8.1.3     -> error, no matching release (this is a tag, but not a release)
-//  query-latest v8.0.0-rc3 -> error, no matching release (this is a pre-release, in github and in semver)
-//  query-latest v7.0       -> v7.0.2
-//  query-latest v5         -> v5.2.4
+//
+//	query-latest v8.1.5     -> v8.1.5
+//	query-latest v8.1.3     -> error, no matching release (this is a tag, but not a release)
+//	query-latest v8.0.0-rc3 -> error, no matching release (this is a pre-release, in github and in semver)
+//	query-latest v7.0       -> v7.0.2
+//	query-latest v5         -> v5.2.4
 package main
 
 import (


### PR DESCRIPTION
To fix failing Teleport-Lint check after golangci-lint was upgraded in https://github.com/gravitational/teleport/pull/16507.

Example failing build:

https://console.cloud.google.com/cloud-build/builds/86aec83a-7561-44e0-b2b2-ed1aa0a03c6b?project=ci-account&authuser=1