### PR TITLE
Events backend for Postgres/CRDB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -245,6 +245,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgtype v1.10.0 // indirect
+	github.com/jackc/puddle v1.2.1 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
 	github.com/jcmturner/gofork v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -853,6 +853,7 @@ github.com/jackc/pgx/v4 v4.15.0/go.mod h1:D/zyOyXiaM1TmVWnOM18p0xdDtdakRBa0RsVGI
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.2.1 h1:gI8os0wpRXFd4FiAY2dWiqRK037tjj3t7rKFeO4X5iw=
 github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=

--- a/lib/backend/postgres/azure.go
+++ b/lib/backend/postgres/azure.go
@@ -27,13 +27,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// azureBeforeConnect will return a pgx BeforeConnect function suitable for
+// AzureBeforeConnect will return a pgx BeforeConnect function suitable for
 // Azure AD authentication. The returned function will set the password of the
 // pgx.ConnConfig to a token for the relevant scope, fetching it and reusing it
 // until expired (a burst of connections right at backend start is expected). If
 // a client ID is provided, authentication will only be attempted as the managed
 // identity with said ID rather than with all the default credentials.
-func azureBeforeConnect(clientID string, log logrus.FieldLogger) (func(ctx context.Context, config *pgx.ConnConfig) error, error) {
+func AzureBeforeConnect(clientID string, log logrus.FieldLogger) (func(ctx context.Context, config *pgx.ConnConfig) error, error) {
 	var cred azcore.TokenCredential
 	if clientID != "" {
 		log.WithField("azure_client_id", clientID).Debug("Using Azure AD authentication with managed identity.")

--- a/lib/backend/postgres/backend.go
+++ b/lib/backend/postgres/backend.go
@@ -113,7 +113,7 @@ func (c *Config) CheckAndSetDefaults() error {
 		return trace.Wrap(err)
 	}
 
-	err = validateDatabaseName(c.Database)
+	err = ValidateDatabaseName(c.Database)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -121,10 +121,10 @@ func (c *Config) CheckAndSetDefaults() error {
 	return nil
 }
 
-// validateDatabaseName returns true when name contains only alphanumeric and/or
+// ValidateDatabaseName returns true when name contains only alphanumeric and/or
 // underscore/dollar characters, the first character is not a digit, and the
 // name's length is less than MaxDatabaseNameLength (63 bytes).
-func validateDatabaseName(name string) error {
+func ValidateDatabaseName(name string) error {
 	if MaxDatabaseNameLength <= len(name) {
 		return trace.BadParameter("invalid PostgreSQL database name, length exceeds %d bytes. See https://www.postgresql.org/docs/14/sql-syntax-lexical.html.", MaxDatabaseNameLength)
 	}

--- a/lib/backend/postgres/backend_test.go
+++ b/lib/backend/postgres/backend_test.go
@@ -205,7 +205,7 @@ func TestValidateDatabaseName(t *testing.T) {
 		{valid: true, name: "This_table_name_is_exactly_the_63_byte_maximum_limit__________"},
 	}
 	for i, test := range testCases {
-		err := validateDatabaseName(test.name)
+		err := ValidateDatabaseName(test.name)
 		require.True(t, test.valid == (err == nil), "Test case %d: %q", i, test.name)
 	}
 }

--- a/lib/backend/postgres/driver.go
+++ b/lib/backend/postgres/driver.go
@@ -66,7 +66,7 @@ func (d *pgDriver) open(ctx context.Context, u *url.URL) (sqlbk.DB, error) {
 
 	beforeConnect := func(ctx context.Context, config *pgx.ConnConfig) error { return nil }
 	if d.cfg.Azure.Username != "" {
-		beforeConnect, err = azureBeforeConnect(d.cfg.Azure.ClientID, d.cfg.Log)
+		beforeConnect, err = AzureBeforeConnect(d.cfg.Azure.ClientID, d.cfg.Log)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -125,7 +125,7 @@ func (d *pgDriver) maybeCreateDatabase(ctx context.Context, connConfig *pgx.Conn
 	// Verify the database name is valid to prevent SQL injection. This
 	// should've already been done in CheckAndSetDefaults of the Config,
 	// but check again to be sure.
-	err := validateDatabaseName(connConfig.Database)
+	err := ValidateDatabaseName(connConfig.Database)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -317,7 +317,7 @@ CREATE TABLE audit (
 	event_data json NOT NULL,
 	creation_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
-CREATE INDEX audit_search_events_idx ON audit (event_time, session_id, event_index, audit_id, event_type);
+CREATE INDEX audit_search_events_idx ON audit (event_time, session_id, event_index, audit_id);
 CREATE INDEX audit_creation_time_idx ON audit (creation_time);
 `}
 

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -527,10 +527,9 @@ func (l *Log) searchEvents(
 		}
 		q.Append(" ORDER BY event_time DESC, session_id DESC, event_index DESC, audit_id DESC")
 	}
-	q.Append(" LIMIT %v", limit)
 
 	var evs []apievents.AuditEvent
-	var shortRead bool
+	var sizeLimit bool
 	var endKeyset keyset
 
 	const fetchSize = defaults.EventsIterationLimit
@@ -538,14 +537,14 @@ func (l *Log) searchEvents(
 
 	if err := l.beginTxFunc(ctx, txReadOnly, func(tx pgx.Tx) error {
 		evs = evs[:0]
-		totalSize := 0
-		shortRead = false
+		sizeLimit = false
 
 		if _, err := tx.Exec(ctx, q.String(), q.Args()...); err != nil {
 			return trace.Wrap(err)
 		}
 
-		for len(evs) < limit && !shortRead {
+		totalSize := 0
+		for len(evs) < limit && !sizeLimit {
 			rows, err := tx.Query(ctx, fetchQuery)
 			if err != nil {
 				return trace.Wrap(err)
@@ -571,7 +570,7 @@ func (l *Log) searchEvents(
 				}
 
 				if len(data)+totalSize > events.MaxEventBytesInResponse {
-					shortRead = true
+					sizeLimit = true
 					rows.Close()
 					break
 				}
@@ -585,6 +584,11 @@ func (l *Log) searchEvents(
 
 				evs = append(evs, ev)
 				endKeyset = ks
+
+				if len(evs) >= limit {
+					rows.Close()
+					break
+				}
 			}
 			if err := rows.Err(); err != nil {
 				return trace.Wrap(err)
@@ -600,7 +604,7 @@ func (l *Log) searchEvents(
 	}
 
 	nextKey := ""
-	if len(evs) > 0 && (len(evs) >= limit || shortRead) {
+	if len(evs) > 0 && (len(evs) >= limit || sizeLimit) {
 		nextKey = endKeyset.ToKey()
 	}
 

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -1,0 +1,641 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgevents
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	postgresbk "github.com/gravitational/teleport/lib/backend/postgres"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	Schema    = "postgres"
+	AltSchema = "postgresql"
+
+	// componentName is the component name used for logging.
+	componentName = "pgevents"
+)
+
+const (
+	defaultRetentionPeriod = 8766 * time.Hour // 365.25 days
+	defaultCleanupInterval = time.Hour
+)
+
+// URL parameters for configuration.
+const (
+	authModeParam        = "auth_mode"
+	azureClientIDParam   = "azure_client_id"
+	disableCleanupParam  = "disable_cleanup"
+	cleanupIntervalParam = "cleanup_interval"
+)
+
+var (
+	txReadWrite = pgx.TxOptions{
+		IsoLevel:   pgx.Serializable,
+		AccessMode: pgx.ReadWrite,
+	}
+	txReadOnly = pgx.TxOptions{
+		IsoLevel:   pgx.Serializable,
+		AccessMode: pgx.ReadOnly,
+	}
+)
+
+// AuthMode determines if we should use some environment-specific authentication
+// mechanism or credentials.
+type AuthMode string
+
+const (
+	// FixedAuth uses the static credentials as defined in the connection
+	// string.
+	FixedAuth AuthMode = ""
+	// AzureADAuth gets a connection token from Azure and uses it as the
+	// password when connecting.
+	AzureADAuth AuthMode = "azure"
+)
+
+// Check returns an error if the AuthMode is invalid.
+func (a AuthMode) Check() error {
+	switch a {
+	case FixedAuth, AzureADAuth:
+		return nil
+	default:
+		return trace.BadParameter("invalid authentication mode %q", a)
+	}
+}
+
+// Config is the configuration struct to pass to New.
+type Config struct {
+	Log        logrus.FieldLogger
+	PoolConfig *pgxpool.Config
+
+	AuthMode      AuthMode
+	AzureClientID string
+
+	DisableCleanup  bool
+	RetentionPeriod time.Duration
+	CleanupInterval time.Duration
+}
+
+// SetFromURL sets config params from the URL, as per pgxpool.ParseConfig (with
+// some additional query params for our own options).
+func (c *Config) SetFromURL(u *url.URL) error {
+	if u == nil {
+		return nil
+	}
+
+	poolConfig, err := pgxpool.ParseConfig(u.String())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	c.PoolConfig = poolConfig
+
+	popParam := func(k string) (string, bool) {
+		if v, ok := poolConfig.ConnConfig.RuntimeParams[k]; ok {
+			delete(poolConfig.ConnConfig.RuntimeParams, k)
+			return v, true
+		}
+		return "", false
+	}
+
+	if s, ok := popParam(authModeParam); ok {
+		c.AuthMode = AuthMode(s)
+	}
+
+	if s, ok := popParam(azureClientIDParam); ok {
+		c.AzureClientID = s
+	}
+
+	if s, ok := popParam(disableCleanupParam); ok {
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.DisableCleanup = b
+	}
+
+	if s, ok := popParam(cleanupIntervalParam); ok {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.CleanupInterval = d
+	}
+
+	return nil
+}
+
+// SetFromAuditConfig sets parameters of the Config based on a
+// ClusterAuditConfig. For now, it only sets RetentionPeriod.
+func (c *Config) SetFromAuditConfig(auditConfig types.ClusterAuditConfig) {
+	if auditConfig == nil {
+		return
+	}
+
+	if d := auditConfig.RetentionPeriod(); d != nil {
+		c.RetentionPeriod = d.Duration()
+	}
+}
+
+// SetLogFromParent sets the Log, from a parent log, giving it a component name.
+func (c *Config) SetLogFromParent(parent logrus.FieldLogger) {
+	c.Log = parent.WithField(trace.Component, teleport.Component(componentName))
+}
+
+// CheckAndSetDefaults checks if the Config is valid, setting default parameters
+// where they're unset. PoolConfig is only checked for presence.
+func (c *Config) CheckAndSetDefaults() error {
+	if c.PoolConfig == nil || c.PoolConfig.ConnConfig == nil {
+		return trace.BadParameter("missing pool config")
+	}
+
+	if err := postgresbk.ValidateDatabaseName(c.PoolConfig.ConnConfig.Database); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := c.AuthMode.Check(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if c.AzureClientID != "" && c.AuthMode != AzureADAuth {
+		return trace.BadParameter("azure client ID requires azure auth mode")
+	}
+
+	if c.RetentionPeriod < 0 {
+		return trace.BadParameter("retention period must be non-negative")
+	}
+	if c.RetentionPeriod == 0 {
+		c.RetentionPeriod = defaultRetentionPeriod
+	}
+
+	if c.CleanupInterval < 0 {
+		return trace.BadParameter("cleanup interval must be non-negative")
+	}
+	if c.CleanupInterval == 0 {
+		c.CleanupInterval = defaultCleanupInterval
+	}
+
+	if c.Log == nil {
+		c.SetLogFromParent(logrus.StandardLogger())
+	}
+
+	return nil
+}
+
+// Returns a new Log given a Config. Starts a background cleanup task unless
+// disabled in the Config.
+func New(ctx context.Context, cfg Config) (*Log, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if cfg.AuthMode == AzureADAuth {
+		bc, err := postgresbk.AzureBeforeConnect(cfg.AzureClientID, cfg.Log)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		cfg.PoolConfig.BeforeConnect = bc
+	}
+
+	cfg.Log.Info("Setting up events backend.")
+
+	if pgConn, err := connectPostgres(ctx, cfg.PoolConfig); err != nil {
+		cfg.Log.WithError(err).Warn("Failed to connect to the \"postgres\" database.")
+	} else {
+		createDB := fmt.Sprintf("CREATE DATABASE \"%v\" TEMPLATE 'template0' ENCODING 'UTF-8' LC_COLLATE 'C' LC_CTYPE 'C'",
+			cfg.PoolConfig.ConnConfig.Database)
+		if _, err := pgConn.Exec(ctx, createDB); err != nil && !isCode(err, duplicateDatabaseCode) {
+			// CREATE will check permissions first and we may not have CREATEDB
+			// privileges in more hardened setups; the subsequent connection
+			// will fail immediately if we can't connect, anyway, so we can log
+			// permission errors at debug level here.
+			if isCode(err, insufficientPrivilegeCode) {
+				cfg.Log.WithError(err).Debug("Error creating database.")
+			} else {
+				cfg.Log.WithError(err).Warn("Error creating database.")
+			}
+		}
+		if err := pgConn.Close(ctx); err != nil {
+			cfg.Log.WithError(err).Warn("Error closing connection to the \"postgres\" database.")
+		}
+	}
+
+	pool, err := pgxpool.ConnectConfig(ctx, cfg.PoolConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	l := &Log{
+		cfg:  cfg,
+		pool: pool,
+	}
+
+	if err := l.setupAndMigrate(ctx); err != nil {
+		l.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	if !cfg.DisableCleanup {
+		periodicCtx, periodicCancel := context.WithCancel(context.Background())
+		go l.periodicCleanup(periodicCtx)
+		l.periodicCancel = periodicCancel
+	}
+
+	cfg.Log.Info("Started events backend.")
+
+	return l, nil
+}
+
+// Log is an external events.IAuditLog backed by a PostgreSQL or CockroachDB
+// database.
+type Log struct {
+	cfg  Config
+	pool *pgxpool.Pool
+
+	// periodicCancel cancels the context in which the periodic cleanup runs.
+	// Can be nil.
+	periodicCancel context.CancelFunc
+}
+
+var _ events.IAuditLog = (*Log)(nil)
+
+// Close stops the potential background cleanup task and closes the connection
+// pool.
+func (l *Log) Close() error {
+	l.cfg.Log.Info("Closing events backend.")
+	if l.periodicCancel != nil {
+		l.periodicCancel()
+	}
+	l.pool.Close()
+	l.cfg.Log.Info("Closed events backend.")
+	return nil
+}
+
+// beginTxFunc wraps the pool's BeginTxFunc with automatic retries. It's
+// important that f resets any shared state at the beginning, and that any
+// exfiltrated data is only used after the transaction commits cleanly.
+func (l *Log) beginTxFunc(ctx context.Context, txOptions pgx.TxOptions, f func(pgx.Tx) error) error {
+	// TODO(espadolini): retry logic (just for serialization errors?)
+	return trace.Wrap(l.pool.BeginTxFunc(ctx, txOptions, f))
+}
+
+var schemas = []string{`
+CREATE TABLE audit (
+	event_time timestamp NOT NULL,
+	event_type text NOT NULL,
+	session_id uuid NOT NULL,
+	event_index bigint NOT NULL,
+	audit_id uuid PRIMARY KEY,
+	event_data json NOT NULL,
+	creation_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX audit_search_events_idx ON audit (event_time, session_id, event_index, audit_id, event_type);
+CREATE INDEX audit_creation_time_idx ON audit (creation_time);
+`}
+
+// setupAndMigrate will create the required tables and indices in the database,
+// by applying the SQL in the schemas slice consecutively. Stores the versions
+// of the applied schemas in the audit_version table.
+func (l *Log) setupAndMigrate(ctx context.Context) error {
+	var currentVersion int
+	if err := l.beginTxFunc(ctx, txReadWrite, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `
+			CREATE TABLE IF NOT EXISTS audit_version (
+				version int PRIMARY KEY CHECK (version > 0),
+				creation_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)`,
+		); err != nil && !isCode(err, insufficientPrivilegeCode) {
+			return trace.Wrap(err)
+		}
+
+		if err := tx.QueryRow(ctx,
+			"SELECT coalesce(max(version), 0) FROM audit_version",
+		).Scan(&currentVersion); err != nil {
+			return trace.Wrap(err)
+		}
+
+		for i := currentVersion; i < len(schemas); i++ {
+			if _, err := tx.Exec(ctx, schemas[i]); err != nil {
+				return trace.Wrap(err)
+			}
+			if _, err := tx.Exec(ctx,
+				"INSERT INTO audit_version ( version ) VALUES ( $1 )",
+				i+1,
+			); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if currentVersion != len(schemas) {
+		l.cfg.Log.WithFields(logrus.Fields{
+			"prev_version": currentVersion,
+			"cur_version":  len(schemas),
+		}).Info("Migrated database schema.")
+	}
+
+	return nil
+}
+
+// periodicCleanup removes events past their retention period from the table,
+// periodically. Returns after the context is done.
+func (l *Log) periodicCleanup(ctx context.Context) {
+	tk := time.NewTicker(l.cfg.CleanupInterval)
+	defer tk.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tk.C:
+			l.cfg.Log.Debug("Executing periodic cleanup.")
+			var deletedRows int64
+			if err := l.beginTxFunc(ctx, txReadWrite, func(tx pgx.Tx) error {
+				// the cast to interval is required, even though RetentionPeriod is
+				// a time.Duration
+				tag, err := tx.Exec(ctx,
+					"DELETE FROM audit WHERE creation_time < (current_timestamp - $1::interval)",
+					l.cfg.RetentionPeriod)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+
+				deletedRows = tag.RowsAffected()
+				return nil
+			}); err != nil {
+				l.cfg.Log.WithError(err).Warn("Failed to execute periodic cleanup.")
+				continue
+			}
+			l.cfg.Log.WithField("deleted_rows", deletedRows).Debug("Executed periodic cleanup.")
+		}
+	}
+}
+
+// EmitAuditEvent implements events.IAuditLog
+func (l *Log) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+	var sid uuid.UUID
+	if s := events.GetSessionID(event); s != "" {
+		u, err := uuid.Parse(s)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		sid = u
+	}
+
+	err := l.beginTxFunc(ctx, txReadWrite, func(tx pgx.Tx) error {
+		// there's no "generate a random UUID" polyglot that works across
+		// versions of postgres and in crdb, so we generate the id ourselves
+		_, err := tx.Exec(ctx, `
+			INSERT INTO audit ( event_time, event_type, session_id, event_index, audit_id, event_data )
+			VALUES ( $1, $2, $3, $4, $5, $6 )`,
+			event.GetTime(), event.GetType(), sid, event.GetIndex(), uuid.New(), event,
+		)
+		return trace.Wrap(err)
+	})
+
+	return trace.Wrap(err)
+}
+
+// GetSessionEvents implements events.IAuditLog
+func (l *Log) GetSessionEvents(_ string, sid session.ID, after int, _ bool) ([]events.EventFields, error) {
+	ctx := context.TODO()
+
+	usid, err := uuid.Parse(string(sid))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if usid == uuid.Nil {
+		return nil, trace.BadParameter("invalid all-zero session id")
+	}
+
+	var evs []events.EventFields
+	if err := l.beginTxFunc(ctx, txReadOnly, func(tx pgx.Tx) error {
+		evs = evs[:0]
+
+		var ev events.EventFields
+		_, err := tx.QueryFunc(ctx, `
+			SELECT event_data
+			FROM audit
+			WHERE session_id = $1 AND event_index >= $2
+			ORDER BY event_time, event_index, audit_id
+			LIMIT $3`,
+			[]any{usid, after, defaults.EventsMaxIterationLimit}, []any{&ev},
+			func(pgx.QueryFuncRow) error { evs = append(evs, ev); ev = nil; return nil },
+		)
+		return trace.Wrap(err)
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return evs, nil
+}
+
+// searchEvents returns events within the time range, filtering (optionally) by
+// event types, session id, and a generic condition, limiting results by a count
+// and by a maximum size of the underlying json data of
+// events.MaxEventBytesInResponse, sorting by time, session id and event index
+// either ascending or descending, and returning an opaque, URL-safe string that
+// can be passed to the same function to continue fetching data.
+func (l *Log) searchEvents(
+	ctx context.Context, fromUTC, toUTC time.Time,
+	eventTypes []string, cond *types.WhereExpr, sessionID string,
+	limit int, order types.EventOrder, startKey string,
+) ([]apievents.AuditEvent, string, error) {
+	if limit <= 0 {
+		limit = defaults.EventsIterationLimit
+	}
+	if limit > defaults.EventsMaxIterationLimit {
+		return nil, "", trace.BadParameter("limit %v exceeds %v", limit, defaults.MaxIterationLimit)
+	}
+
+	var startKeyset keyset
+	if startKey != "" {
+		if err := startKeyset.FromKey(startKey); err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+	}
+
+	var condFn utils.FieldsCondition
+	if cond != nil {
+		f, err := utils.ToFieldsCondition(cond)
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		condFn = f
+	}
+
+	var q queryBuilder
+	q.Append(`
+		DECLARE cur CURSOR FOR SELECT
+			event_data,
+			event_time,
+			session_id,
+			event_index,
+			audit_id
+		FROM audit
+		WHERE event_time BETWEEN %v AND %v`,
+		fromUTC.UTC(), toUTC.UTC())
+	if len(eventTypes) > 0 {
+		q.Append(" AND event_type = ANY (%v)", eventTypes)
+	}
+	if len(sessionID) > 0 {
+		q.Append(" AND session_id = %v", sessionID)
+	}
+	if order != types.EventOrderDescending {
+		if len(startKey) > 0 {
+			q.Append(" AND (event_time, session_id, event_index, audit_id) > (%v, %v, %v, %v)",
+				startKeyset.t, startKeyset.sid, startKeyset.ei, startKeyset.id)
+		}
+		q.Append(" ORDER BY event_time, session_id, event_index, audit_id")
+	} else {
+		if len(startKey) > 0 {
+			q.Append(" AND (event_time, session_id, event_index, audit_id) < (%v, %v, %v, %v)",
+				startKeyset.t, startKeyset.sid, startKeyset.ei, startKeyset.id)
+		}
+		q.Append(" ORDER BY event_time DESC, session_id DESC, event_index DESC, audit_id DESC")
+	}
+	q.Append(" LIMIT %v", limit)
+
+	var evs []apievents.AuditEvent
+	var shortRead bool
+	var endKeyset keyset
+
+	const fetchSize = defaults.EventsIterationLimit
+	fetchQuery := fmt.Sprintf("FETCH %d FROM cur", fetchSize)
+
+	if err := l.beginTxFunc(ctx, txReadOnly, func(tx pgx.Tx) error {
+		evs = evs[:0]
+		totalSize := 0
+		shortRead = false
+
+		if _, err := tx.Exec(ctx, q.String(), q.Args()...); err != nil {
+			return trace.Wrap(err)
+		}
+
+		for len(evs) < limit && !shortRead {
+			rows, err := tx.Query(ctx, fetchQuery)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			var data []byte
+			var ks keyset
+			for rows.Next() {
+				if err := rows.Scan(&data, &ks.t, &ks.sid, &ks.ei, &ks.id); err != nil {
+					rows.Close()
+					return trace.Wrap(err)
+				}
+
+				var evf events.EventFields
+				if err := utils.FastUnmarshal(data, &evf); err != nil {
+					rows.Close()
+					return trace.Wrap(err)
+				}
+
+				// TODO(espadolini): encode cond as a condition in the query
+				if condFn != nil && !condFn(utils.Fields(evf)) {
+					continue
+				}
+
+				if len(data)+totalSize > events.MaxEventBytesInResponse {
+					shortRead = true
+					rows.Close()
+					break
+				}
+				totalSize += len(data)
+
+				ev, err := events.FromEventFields(evf)
+				if err != nil {
+					rows.Close()
+					return trace.Wrap(err)
+				}
+
+				evs = append(evs, ev)
+				endKeyset = ks
+			}
+			if err := rows.Err(); err != nil {
+				return trace.Wrap(err)
+			}
+
+			if rows.CommandTag().RowsAffected() < fetchSize {
+				break
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	nextKey := ""
+	if len(evs) > 0 && (len(evs) >= limit || shortRead) {
+		nextKey = endKeyset.ToKey()
+	}
+
+	return evs, nextKey, nil
+}
+
+// SearchEvents implements events.IAuditLog
+func (l *Log) SearchEvents(
+	fromUTC, toUTC time.Time,
+	_ string, eventTypes []string,
+	limit int, order types.EventOrder, startKey string,
+) ([]apievents.AuditEvent, string, error) {
+	var emptyCond *types.WhereExpr
+	const emptySessionID = ""
+	return l.searchEvents(context.TODO(), fromUTC, toUTC, eventTypes, emptyCond, emptySessionID, limit, order, startKey)
+}
+
+// SearchSessionEvents implements events.IAuditLog
+func (l *Log) SearchSessionEvents(
+	fromUTC, toUTC time.Time,
+	limit int, order types.EventOrder, startKey string,
+	cond *types.WhereExpr, sessionID string,
+) ([]apievents.AuditEvent, string, error) {
+	sessionEndTypes := []string{events.SessionEndEvent, events.WindowsDesktopSessionEndEvent}
+	return l.searchEvents(context.TODO(), fromUTC, toUTC, sessionEndTypes, cond, sessionID, limit, order, startKey)
+}
+
+// GetSessionChunk does not implement events.IAuditLog
+func (*Log) GetSessionChunk(string, session.ID, int, int) ([]byte, error) {
+	return nil, trace.NotImplemented("not implemented by external log pgevents")
+}
+
+// StreamSessionEvents does not implement events.IAuditLog
+func (*Log) StreamSessionEvents(context.Context, session.ID, int64) (chan apievents.AuditEvent, chan error) {
+	errC := make(chan error, 1)
+	errC <- trace.NotImplemented("not implemented by external log pgevents")
+	return nil, errC
+}

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sirupsen/logrus"
@@ -30,6 +31,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	postgresbk "github.com/gravitational/teleport/lib/backend/postgres"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -233,12 +235,12 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 		// this will error out if the encoding of template1 is not UTF8; in such
 		// cases, the database creation should probably be done manually anyway
 		createDB := fmt.Sprintf("CREATE DATABASE \"%v\" ENCODING UTF8", cfg.PoolConfig.ConnConfig.Database)
-		if _, err := pgConn.Exec(ctx, createDB); err != nil && !isCode(err, duplicateDatabaseCode) {
+		if _, err := pgConn.Exec(ctx, createDB); err != nil && !isCode(err, pgerrcode.DuplicateDatabase) {
 			// CREATE will check permissions first and we may not have CREATEDB
 			// privileges in more hardened setups; the subsequent connection
 			// will fail immediately if we can't connect, anyway, so we can log
 			// permission errors at debug level here.
-			if isCode(err, insufficientPrivilegeCode) {
+			if isCode(err, pgerrcode.InsufficientPrivilege) {
 				cfg.Log.WithError(err).Debug("Error creating database.")
 			} else {
 				cfg.Log.WithError(err).Warn("Error creating database.")
@@ -304,8 +306,44 @@ func (l *Log) Close() error {
 // important that f resets any shared state at the beginning, and that any
 // exfiltrated data is only used after the transaction commits cleanly.
 func (l *Log) beginTxFunc(ctx context.Context, txOptions pgx.TxOptions, f func(pgx.Tx) error) error {
-	// TODO(espadolini): retry logic (just for serialization errors?)
-	return trace.Wrap(l.pool.BeginTxFunc(ctx, txOptions, f))
+	retrySerialization := func() error {
+		for i := 0; i < 20; i++ {
+			err := l.pool.BeginTxFunc(ctx, txOptions, f)
+			if err == nil || !isCode(err, pgerrcode.SerializationFailure) || !isCode(err, pgerrcode.DeadlockDetected) {
+				return trace.Wrap(err)
+			}
+			l.cfg.Log.WithError(err).WithField("attempt", i).Debug("Serialization failure.")
+		}
+		return trace.LimitExceeded("too many serialization failures")
+	}
+
+	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
+		First:  0,
+		Step:   100 * time.Millisecond,
+		Max:    750 * time.Millisecond,
+		Jitter: retryutils.NewHalfJitter(),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for i := 1; i < 20; i++ {
+		err = retrySerialization()
+		if err == nil {
+			return nil
+		}
+
+		select {
+		case <-retry.After():
+			l.cfg.Log.WithError(err).WithField("attempt", i).Debug("Retrying transaction.")
+			retry.Inc()
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+	}
+
+	return trace.LimitExceeded("too many retries, last error: %v", err)
 }
 
 var schemas = []string{`
@@ -333,7 +371,7 @@ func (l *Log) setupAndMigrate(ctx context.Context) error {
 				version int PRIMARY KEY CHECK (version > 0),
 				creation_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 			)`,
-		); err != nil && !isCode(err, insufficientPrivilegeCode) {
+		); err != nil && !isCode(err, pgerrcode.InsufficientPrivilege) {
 			return trace.Wrap(err)
 		}
 

--- a/lib/events/pgevents/pgevents_test.go
+++ b/lib/events/pgevents/pgevents_test.go
@@ -1,0 +1,88 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgevents
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/log/logrusadapter"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/events/test"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestMain(m *testing.M) {
+	utils.InitLoggerForTests()
+	os.Exit(m.Run())
+}
+
+const urlEnvVar = "TELEPORT_TEST_PGEVENTS_URL"
+
+func TestPostgresEvents(t *testing.T) {
+	s, ok := os.LookupEnv(urlEnvVar)
+	if !ok {
+		t.Skipf("Missing %v environment variable.", urlEnvVar)
+	}
+
+	u, err := url.Parse(s)
+	require.NoError(t, err)
+
+	var cfg Config
+	require.NoError(t, cfg.SetFromURL(u))
+
+	cfg.PoolConfig.ConnConfig.Logger = logrusadapter.NewLogger(
+		logrus.WithField(trace.Component, "pgx"))
+	cfg.PoolConfig.ConnConfig.LogLevel = pgx.LogLevelDebug
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	log, err := New(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, log.Close()) })
+
+	suite := test.EventsSuite{
+		Log:   log,
+		Clock: clockwork.NewRealClock(),
+	}
+
+	// the tests in the suite expect a blank slate each time
+	setup := func(t *testing.T) {
+		_, err := log.pool.Exec(ctx, "TRUNCATE audit")
+		require.NoError(t, err)
+	}
+
+	t.Run("SessionEventsCRUD", func(t *testing.T) {
+		setup(t)
+		suite.SessionEventsCRUD(t)
+	})
+	t.Run("EventPagination", func(t *testing.T) {
+		setup(t)
+		suite.EventPagination(t)
+	})
+	t.Run("SearchSessionEvensBySessionID", func(t *testing.T) {
+		setup(t)
+		suite.SearchSessionEvensBySessionID(t)
+	})
+}

--- a/lib/events/pgevents/utils.go
+++ b/lib/events/pgevents/utils.go
@@ -1,0 +1,142 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgevents
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+// queryBuilder is a dynamic SQL query builder.
+type queryBuilder struct {
+	builder strings.Builder
+	args    []any
+}
+
+// Append adds a chunk of text to the query, replacing %v with consecutive
+// placeholder strings. It's also possible to use positional format specifiers
+// such as %[2]v to specify the same placeholder multiple times.
+func (q *queryBuilder) Append(s string, args ...any) {
+	fmtArgs := make([]any, 0, len(args))
+	for _, a := range args {
+		q.args = append(q.args, a)
+		fmtArgs = append(fmtArgs, fmt.Sprintf("$%v", len(q.args)))
+	}
+
+	fmt.Fprintf(&q.builder, s, fmtArgs...)
+}
+
+// String returns the text of the query.
+func (q *queryBuilder) String() string {
+	return q.builder.String()
+}
+
+// Args returns the arguments representing the
+func (q *queryBuilder) Args() []any {
+	return q.args
+}
+
+// connectPostgres will open a single connection to the "postgres" database in
+// the database cluster specified in poolConfig.
+func connectPostgres(ctx context.Context, poolConfig *pgxpool.Config) (*pgx.Conn, error) {
+	connConfig := poolConfig.ConnConfig.Copy()
+	connConfig.Database = "postgres"
+
+	if poolConfig.BeforeConnect != nil {
+		if err := poolConfig.BeforeConnect(ctx, connConfig); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	conn, err := pgx.ConnectConfig(ctx, connConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if poolConfig.AfterConnect != nil {
+		if err := poolConfig.AfterConnect(ctx, conn); err != nil {
+			conn.Close(ctx)
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return conn, nil
+}
+
+// keyset is a point at which the searchEvents pagination ended, and can be
+// resumed from.
+type keyset struct {
+	t   time.Time
+	sid uuid.UUID
+	ei  int64
+	id  uuid.UUID
+}
+
+// FromKey attempts to parse a keyset from a string. The string is a URL-safe
+// base64 encoding of the time in microseconds as an int64, the session id, the
+// event index as an int64, and the event UUID; numbers are encoded in
+// little-endian.
+func (ks *keyset) FromKey(key string) error {
+	if key == "" {
+		return nil
+	}
+
+	b, err := base64.URLEncoding.DecodeString(key)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if len(b) != 48 {
+		return trace.BadParameter("malformed pagination key")
+	}
+
+	ks.t = time.UnixMicro(int64(binary.LittleEndian.Uint64(b[0:8]))).UTC()
+	ks.sid, _ = uuid.FromBytes(b[8:24])
+	ks.ei = int64(binary.LittleEndian.Uint64(b[24:32]))
+	ks.id, _ = uuid.FromBytes(b[32:48])
+
+	return nil
+}
+
+// ToKey converts the keyset into a URL-safe string.
+func (ks *keyset) ToKey() string {
+	var b [48]byte
+	binary.LittleEndian.PutUint64(b[0:8], uint64(ks.t.UnixMicro()))
+	copy(b[8:24], ks.sid[:])
+	binary.LittleEndian.PutUint64(b[24:32], uint64(ks.ei))
+	copy(b[32:48], ks.id[:])
+	return base64.URLEncoding.EncodeToString(b[:])
+}
+
+const (
+	insufficientPrivilegeCode = "42501"
+	duplicateDatabaseCode     = "42P04"
+)
+
+// isCode checks if the passed error is a Postgres error with the given code.
+func isCode(err error, code string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == code
+}

--- a/lib/events/pgevents/utils.go
+++ b/lib/events/pgevents/utils.go
@@ -130,11 +130,6 @@ func (ks *keyset) ToKey() string {
 	return base64.URLEncoding.EncodeToString(b[:])
 }
 
-const (
-	insufficientPrivilegeCode = "42501"
-	duplicateDatabaseCode     = "42P04"
-)
-
 // isCode checks if the passed error is a Postgres error with the given code.
 func isCode(err error, code string) bool {
 	var pgErr *pgconn.PgError

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1351,7 +1351,7 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 }
 
 // initAuthAuditLog initializes the auth server's audit log.
-func initAuthAuditLog(ctx context.Context, auditConfig types.ClusterAuditConfig, backend backend.Backend) (events.IAuditLog, error) {
+func initAuthAuditLog(ctx context.Context, auditConfig types.ClusterAuditConfig, log logrus.FieldLogger) (events.IAuditLog, error) {
 	var hasNonFileLog bool
 	var loggers []events.IAuditLog
 	for _, eventsURI := range auditConfig.AuditEventsURIs() {
@@ -1512,7 +1512,7 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 		// initialize external loggers.  may return (nil, nil) if no
 		// external loggers have been defined.
-		externalLog, err := initAuthAuditLog(process.ExitContext(), cfg.Auth.AuditConfig, process.backend)
+		externalLog, err := initAuthAuditLog(process.ExitContext(), cfg.Auth.AuditConfig, process.log)
 		if err != nil {
 			if !trace.IsNotFound(err) {
 				return trace.Wrap(err)


### PR DESCRIPTION
Part of the implementation of #15771. Tracking issue: #15147.

This PR adds a new audit events backend backed by PostgreSQL or CockroachDB. Does not conflict with the workings of the Postgres cluster backend, even in the same database.

Unless disabled, it will periodically (every hour) clean up events older than the retention period, which defaults to a year. If the automatic cleanup is disabled, it's possible to only grant INSERT and SELECT permissions for the audit events table to Teleport, so that it's not possible to retroactively mutate it. In such case, the schema must be manually kept up to date, and the events cleanup should be scheduled with something like `pg_cron`.

Config example (on-prem):

```yaml
teleport:
  storage:
    audit_events_uri: ["postgresql://username@address.of.server:port/auditdbname?sslmode=verify-full&sslrootcert=path/to/certs.pem"]
```

Config example (Azure):
```yaml
teleport:
  storage:
    audit_events_uri: ["postgresql://username@dbname.postgres.database.azure.com/auditdbname?ssl-mode=verify-full&sslrootcert=path/to/certs.pem&auth_mode=azure"]
```

Fixes https://github.com/gravitational/teleport/issues/15147