### PR TITLE
[v7] Update helm publishing for new repo

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1111,7 +1111,7 @@ steps:
     image: amazon/aws-cli
     commands:
       - cd /go/chart
-      - aws s3 sync --acl public-read . s3://$AWS_S3_BUCKET/
+      - aws s3 sync . s3://$AWS_S3_BUCKET/
     environment:
       AWS_REGION: us-west-2
       AWS_S3_BUCKET:
@@ -5899,7 +5899,7 @@ steps:
         path: /root/.aws
     commands:
       - cd /go/chart/
-      - aws s3 sync --acl public-read . s3://$AWS_S3_BUCKET/
+      - aws s3 sync . s3://$AWS_S3_BUCKET/
 
   # NOTE: all mandatory steps for a release promotion need to go BEFORE this
   # step, as there is a chance that everything afterwards will be skipped.
@@ -6164,6 +6164,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: b3700e5f80785478a9624c47cb8983e9378716daf68a0c156d4d0e3c5484bee1
+hmac: 632e7785eabc662c792458af5068aa51517db561afd89ad6c703d0738d528ec3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4969,19 +4969,16 @@ steps:
       - ls /go/chart
 
   - name: "Helm: Publish chart repository to S3"
-    image: plugins/s3
-    settings:
-      bucket:
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
         from_secret: PRODUCTION_CHARTS_AWS_S3_BUCKET
-      access_key:
+      AWS_ACCESS_KEY_ID:
         from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
-      secret_key:
+      AWS_SECRET_ACCESS_KEY:
         from_secret: PRODUCTION_CHARTS_AWS_SECRET_ACCESS_KEY
-      region: us-east-2
-      acl: public-read
-      source: /go/chart/*
-      target: /
-      strip_prefix: /go/chart
+    commands:
+      - aws s3 sync /go/chart s3://$AWS_S3_BUCKET/ 
 
   # NOTE: all mandatory steps for a release promotion need to go BEFORE this
   # step, as there is a chance that everything afterwards will be skipped.
@@ -5192,6 +5189,6 @@ volumes:
       medium: memory
 ---
 kind: signature
-hmac: f2fa0639f22d555aa1bbde0c68bdebfc0ae2e83b0a12db986b50cbabb8fcfbf0
+hmac: 8b209f4419749bfa64e0a59f1dd5e1ea4eecd4c315f6723651ae317c05f06574
 
 ...


### PR DESCRIPTION
Backport of #17827

As part of migrating the AWS account used to host the helm chart repository,
the bucket for the helm chart repo is moving from `us-east-2` to `us-west-2`.

This change updates the drone script to use the new region.

See-Also: #15184
See-Also: #16582
See-Also: #17827