### PR TITLE
[v7] Move GitHub review bot to shared-workflows repository (#16226)

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -1,5 +1,5 @@
 # This workflow is run whenever a pull request is opened, re-opened, or taken
-# out of draft (ready for review). 
+# out of draft (ready for review).
 #
 # NOTE: pull_request_target behaves the same as pull_request except it grants a
 # read/write token to workflows running on a pull request from a fork. While
@@ -33,15 +33,18 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
-      # Checkout master branch of Teleport repository. This is to prevent an
-      # attacker from submitting their own review assignment logic.
-      - name: Checkout master branch
-        uses: actions/checkout@v2
+      # Checkout main branch of shared-workflow repository.
+      - name: Checkout shared-workflow
+        uses: actions/checkout@v3
         with:
-          ref: master
-      - name: Installing the latest version of Go.
-        uses: actions/setup-go@v2
-      # Run "assign" subcommand on bot.
+          token: ${{ secrets.SHARED_WORKFLOWS_GITHUB_TOKEN }}
+          repository: gravitational/shared-workflows
+          path: .github/shared-workflows
+          ref: main
+      - name: Installing Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: .github/shared-workflows/bot/go.mod
+        # Run "check" subcommand on bot.
       - name: Assigning reviewers
-        run: cd .github/workflows/robot && go run main.go -workflow=assign -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
-  
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=assign -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,6 @@
 # Workflow will trigger on all pull request (except draft), pull request
 # review, and commit push to a pull request (synchronize) event types
-# 
+#
 # NOTE: pull_request_target behaves the same as pull_request except it grants a
 # read/write token to workflows running on a pull request from a fork. While
 # this may seem unsafe, the permissions for the token are limited below and
@@ -35,14 +35,18 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
-      # Checkout master branch of Teleport repository. This is to prevent an
-      # attacker from submitting their own review assignment logic. 
-      - name: Checkout master branch
-        uses: actions/checkout@v2
+      # Checkout main branch of shared-workflow repository.
+      - name: Checkout shared-workflow
+        uses: actions/checkout@v3
         with:
-          ref: master
-      - name: Installing the latest version of Go.
-        uses: actions/setup-go@v2
+          token: ${{ secrets.SHARED_WORKFLOWS_GITHUB_TOKEN }}
+          repository: gravitational/shared-workflows
+          path: .github/shared-workflows
+          ref: main
+      - name: Installing Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: .github/shared-workflows/bot/go.mod
         # Run "check" subcommand on bot.
       - name: Checking reviewers
-        run: cd .github/workflows/robot && go run main.go -workflow=check -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=check -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"


### PR DESCRIPTION
* RFD 0029 : Move GitHub review bot to shared-workflows repository

Apart from relocating the code to a different location and renaming the package, this is a no-op change

Depends-on: gravitational/shared-workflows#12

* remove mentions of the GitHub review bot from Makefile targets