### PR TITLE
Update OpenSSL/libcrypto to 1.1.1q

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -25,9 +25,9 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 # Instal openssl.
 # Pulled from source because repository versions are too old.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1o && \
+RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1q && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = "ca2e0784d2c38edcefd5d68028f4d954bd8faddb" ] && \    
+    [ "$(git rev-parse HEAD)" = "29708a562a1887a91de0fa6ca668c71871accde9" ] && \
     ./config --release && \
     make && \
     make install_sw

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -15,7 +15,7 @@ readonly MACOS_VERSION_MIN=10.13
 
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.9.0
-readonly CRYPTO_VERSION=OpenSSL_1_1_1o
+readonly CRYPTO_VERSION=OpenSSL_1_1_1q
 readonly FIDO2_VERSION=1.11.0
 
 readonly LIB_CACHE="/tmp/teleport-fido2-cache"


### PR DESCRIPTION
libcrypto is required by libfido2.

All other libfido2 dependencies, including the lib itself, are up-to-date.

Release notes for OpenSSL: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1q/CHANGES.