### PR TITLE
[v8] ci: Swap CodeQL to larger runner and improve workflow (#16535)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - branch/*
-    paths-ignore:
-      - 'docs/**'
-      - 'rfd/**'
-      - '**.md'
   pull_request:
     branches:
       - master
@@ -21,7 +17,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-32core
     permissions:
       actions: read
       contents: read
@@ -36,15 +32,27 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Initialize CodeQL
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: 'go.mod'
+      if: ${{ matrix.language == 'go' }}
+
+    - name: Initialize the CodeQL tools for scanning
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
+      if: ${{ matrix.language != 'go' }}
+
+    - name: Build Teleport OSS
+      run: |
+        make full
+      if: ${{ matrix.language == 'go' }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      env:
-        CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
We now have access to larger runners, so move CodeQL workflow to use a runner with Ubuntu 22.04 LTS with 32 cores and 128GB RAM.

https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners

Additionally, change CodeQL workflow to include recommendations from GitHub CodeQL team.