### PR TITLE
fix sql server proxy tunnel through trusted cluster

### DIFF
--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -671,7 +671,7 @@ func prepareLocalProxyOptions(arg *localProxyConfig) (localProxyOpts, error) {
 	// For SQL Server connections, local proxy must be configured with the
 	// client certificate that will be used to route connections.
 	if arg.routeToDatabase.Protocol == defaults.ProtocolSQLServer {
-		opts.certFile = arg.profile.DatabaseCertPathForCluster("", arg.routeToDatabase.ServiceName)
+		opts.certFile = arg.profile.DatabaseCertPathForCluster(arg.teleportClient.SiteName, arg.routeToDatabase.ServiceName)
 		opts.keyFile = arg.profile.KeyPath()
 	}
 


### PR DESCRIPTION
This PR fixes db cert lookup for sql server in a proxy tunnel (and we always need a proxy tunnel for sql server), when the sql server is in a remote cluster.

Prior behavior was to lookup the db cert by using the active profile's cluster as the cluster name under `.tsh/keys/<proxy>/<user>-db/<cluster>/<db>-x509.pem`. This fails when the sql db is in a remote cluster, because the db cert is saved under the remote cluster's name, not the active profile's cluster name.

Example I tested manually:
root cluster: `gavin-dev.cloud.gravitational.io`
remote cluster: `sql.teleportdemo.net`
```sh
$ tsh login --user=gavin.frazar@goteleport.com --proxy=gavin-dev.cloud.gravitational.io:443
...omitted status output...
$ tsh db ls --cluster sql.teleportdemo.net
Name Description         Allowed Users Labels Connect 
---- ------------------- ------------- ------ ------- 
sql  SQL Server / AWS AD [*]   
$ tsh db login --cluster sql.teleportdemo.net sql
$ tree ~/.tsh
/Users/gavin/.tsh
├── current-profile
├── gavin-dev.cloud.gravitational.io.yaml
├── keys
│   └── gavin-dev.cloud.gravitational.io
│       ├── cas
│       │   ├── gavin-dev.cloud.gravitational.io.pem
│       │   └── sql.teleportdemo.net.pem
│       ├── certs.pem
│       ├── gavin.frazar@goteleport.com
│       ├── gavin.frazar@goteleport.com-db
│       │   └── sql.teleportdemo.net
│       │       └── sql-x509.pem
│       ├── gavin.frazar@goteleport.com-ssh
│       │   └── gavin-dev.cloud.gravitational.io-cert.pub
│       ├── gavin.frazar@goteleport.com-x509.pem
│       └── gavin.frazar@goteleport.com.pub
└── known_hosts
$ tsh proxy db --tunnel --port 8080 --cluster sql.teleportdemo.net sql
ERROR: open /Users/gavin/.tsh/keys/gavin-dev.cloud.gravitational.io/gavin.frazar@goteleport.com-db/gavin-dev.cloud.gravitational.io/sql-x509.pem: no such file or directory
```
It tried to find my db cert at `/Users/gavin/.tsh/keys/gavin-dev.cloud.gravitational.io/gavin.frazar@goteleport.com-db/gavin-dev.cloud.gravitational.io/sql-x509.pem`

but the db cert is actually located at `/Users/gavin/.tsh/keys/gavin-dev.cloud.gravitational.io/gavin.frazar@goteleport.com-db/sql.teleportdemo.net/sql-x509.pem`

The solution is to use the TeleportClient.SiteName as the cluster name.

I tested that this solution worked manually and I was able to access sql server via the DataGrip GUI client through my local proxy tunnel.