### PR TITLE
Connect windows webauthn with tsh

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -95,6 +95,10 @@ type Profile struct {
 	// LoadAllCAs indicates that tsh should load the CAs of all clusters
 	// instead of just the current cluster.
 	LoadAllCAs bool `yaml:"load_all_cas,omitempty"`
+
+	// MFAMode ("auto", "platform", "cross-platform").
+	// Equivalent to the --mfa-mode tsh flag.
+	MFAMode string `yaml:"mfa_mode,omitempty"`
 }
 
 // Name returns the name of the profile.

--- a/api/profile/profile_test.go
+++ b/api/profile/profile_test.go
@@ -44,6 +44,7 @@ func TestProfileBasics(t *testing.T) {
 		Dir:                   dir,
 		SiteName:              "example.com",
 		AuthConnector:         "passwordless",
+		MFAMode:               "auto",
 	}
 
 	// verify that profile name is proxy host component

--- a/lib/auth/webauthncli/api.go
+++ b/lib/auth/webauthncli/api.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/lib/auth/touchid"
+	"github.com/gravitational/teleport/lib/auth/webauthnwin"
 	"github.com/gravitational/trace"
 
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
@@ -35,6 +36,18 @@ const (
 	AttachmentCrossPlatform
 	AttachmentPlatform
 )
+
+func (a AuthenticatorAttachment) String() string {
+	switch a {
+	case AttachmentAuto:
+		return "auto"
+	case AttachmentCrossPlatform:
+		return "cross-platform"
+	case AttachmentPlatform:
+		return "platform"
+	}
+	return ""
+}
 
 // CredentialInfo holds information about a WebAuthn credential, typically a
 // resident public key credential.
@@ -110,6 +123,13 @@ func Login(
 		user = opts.User
 	}
 
+	if webauthnwin.IsAvailable() {
+		log.Debug("WebAuthnWin: Using windows webauthn for credential assertion")
+		return webauthnwin.Login(ctx, origin, assertion, &webauthnwin.LoginOpts{
+			AuthenticatorAttachment: webauthnwin.AuthenticatorAttachment(attachment),
+		})
+	}
+
 	switch attachment {
 	case AttachmentCrossPlatform:
 		log.Debug("Cross-platform login")
@@ -133,7 +153,7 @@ func crossPlatformLogin(
 	ctx context.Context,
 	origin string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt, opts *LoginOpts,
 ) (*proto.MFAAuthenticateResponse, string, error) {
-	if IsFIDO2Available() {
+	if isLibfido2Enabled() {
 		log.Debug("FIDO2: Using libfido2 for assertion")
 		return FIDO2Login(ctx, origin, assertion, prompt, opts)
 	}
@@ -179,7 +199,12 @@ type RegisterPrompt interface {
 func Register(
 	ctx context.Context,
 	origin string, cc *wanlib.CredentialCreation, prompt RegisterPrompt) (*proto.MFARegisterResponse, error) {
-	if IsFIDO2Available() {
+	if webauthnwin.IsAvailable() {
+		log.Debug("WebAuthnWin: Using windows webauthn for credential creation")
+		return webauthnwin.Register(ctx, origin, cc)
+	}
+
+	if isLibfido2Enabled() {
 		log.Debug("FIDO2: Using libfido2 for credential creation")
 		return FIDO2Register(ctx, origin, cc, prompt)
 	}
@@ -188,4 +213,16 @@ func Register(
 		return nil, trace.Wrap(err)
 	}
 	return U2FRegister(ctx, origin, cc)
+}
+
+// HasPlatformSupport returns true if the platform supports client-side
+// WebAuthn-compatible logins.
+func HasPlatformSupport() bool {
+	return IsFIDO2Available() || touchid.IsAvailable() || isU2FAvailable()
+}
+
+// IsFIDO2Available returns true if FIDO2 is implemented either via native
+// libfido2 library or Windows WebAuthn API.
+func IsFIDO2Available() bool {
+	return isLibfido2Enabled() || webauthnwin.IsAvailable()
 }

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -72,8 +72,8 @@ var fidoNewDevice = func(path string) (FIDODevice, error) {
 	return libfido2.NewDevice(path)
 }
 
-// IsFIDO2Available returns true if libfido2 is available in the current build.
-func IsFIDO2Available() bool {
+// isLibfido2Enabled returns true if libfido2 is available in the current build.
+func isLibfido2Enabled() bool {
 	val, ok := os.LookupEnv("TELEPORT_FIDO2")
 	// Default to enabled, otherwise obey the env variable.
 	return !ok || val == "1"

--- a/lib/auth/webauthncli/fido2_common.go
+++ b/lib/auth/webauthncli/fido2_common.go
@@ -67,7 +67,7 @@ type FIDO2DiagResult struct {
 // User interaction is required.
 func FIDO2Diag(ctx context.Context, promptOut io.Writer) (*FIDO2DiagResult, error) {
 	res := &FIDO2DiagResult{}
-	if !IsFIDO2Available() {
+	if !isLibfido2Enabled() {
 		return res, nil
 	}
 	res.Available = true

--- a/lib/auth/webauthncli/fido2_other.go
+++ b/lib/auth/webauthncli/fido2_other.go
@@ -28,8 +28,8 @@ import (
 
 var errFIDO2Unavailable = errors.New("FIDO2 unavailable in current build")
 
-// IsFIDO2Available returns true if libfido2 is available in the current build.
-func IsFIDO2Available() bool {
+// isLibfido2Enabled returns true if libfido2 is available in the current build.
+func isLibfido2Enabled() bool {
 	return false
 }
 

--- a/lib/auth/webauthncli/u2f_other.go
+++ b/lib/auth/webauthncli/u2f_other.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Gravitational, Inc
+// Copyright 2022 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
+// +build !windows
+
 package webauthncli
 
-// HasPlatformSupport returns true if the platform supports client-side
-// WebAuthn-compatible logins.
-func HasPlatformSupport() bool {
-	return false
+func isU2FAvailable() bool {
+	return true
 }

--- a/lib/auth/webauthncli/u2f_windows.go
+++ b/lib/auth/webauthncli/u2f_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Gravitational, Inc
+// Copyright 2022 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
-// +build !windows
-
 package webauthncli
 
-// HasPlatformSupport returns true if the platform supports client-side
-// WebAuthn-compatible logins.
-func HasPlatformSupport() bool {
-	return true
+func isU2FAvailable() bool {
+	return false
 }

--- a/lib/auth/webauthnwin/api.go
+++ b/lib/auth/webauthnwin/api.go
@@ -12,12 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package winwebauthn is wrapper around Windows webauthn API.
+// Package webauthnwin is wrapper around Windows webauthn API.
 // It loads system webauthn.dll and uses its methods.
 // It supports API versions 1+.
 // API definition: https://github.com/microsoft/webauthn/blob/master/webauthn.h
 // As Windows Webauthn device can be used both Windows Hello and FIDO devices.
 package webauthnwin
+
+import (
+	"context"
+	"io"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/duo-labs/webauthn/protocol/webauthncose"
+	"github.com/gravitational/teleport/api/client/proto"
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	"github.com/gravitational/trace"
+)
 
 // LoginOpts groups non-mandatory options for Login.
 type LoginOpts struct {
@@ -33,10 +44,211 @@ const (
 	AttachmentPlatform
 )
 
+// nativeWebauthn represents the native windows webauthn interface.
+// Implementors must provide a global variable called `native`.
+type nativeWebauthn interface {
+	CheckSupport() CheckSupportResult
+	GetAssertion(origin string, in *getAssertionRequest) (*wanlib.CredentialAssertionResponse, error)
+	MakeCredential(origin string, in *makeCredentialRequest) (*wanlib.CredentialCreationResponse, error)
+}
+
+type getAssertionRequest struct {
+	rpID                  *uint16
+	clientData            *webauthnClientData
+	jsonEncodedClientData []byte
+	opts                  *webauthnAuthenticatorGetAssertionOptions
+}
+
+type makeCredentialRequest struct {
+	rp                    *webauthnRPEntityInformation
+	user                  *webauthnUserEntityInformation
+	credParameters        *webauthnCoseCredentialParameters
+	clientData            *webauthnClientData
+	jsonEncodedClientData []byte
+	opts                  *webauthnAuthenticatorMakeCredentialOptions
+}
+
+// Login implements Login for Windows Webauthn API.
+func Login(ctx context.Context, origin string, assertion *wanlib.CredentialAssertion, loginOpts *LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
+	if origin == "" {
+		return nil, "", trace.BadParameter("origin required")
+	}
+	if err := assertion.Validate(); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	rpid, err := utf16PtrFromString(assertion.Response.RelyingPartyID)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	cd, jsonEncodedCD, err := clientDataToCType(assertion.Response.Challenge.String(), origin, string(protocol.AssertCeremony))
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	assertOpts, err := assertOptionsToCType(assertion.Response, loginOpts)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	resp, err := native.GetAssertion(origin, &getAssertionRequest{
+		rpID:                  rpid,
+		clientData:            cd,
+		jsonEncodedClientData: jsonEncodedCD,
+		opts:                  assertOpts,
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	return &proto.MFAAuthenticateResponse{
+		Response: &proto.MFAAuthenticateResponse_Webauthn{
+			Webauthn: wanlib.CredentialAssertionResponseToProto(resp),
+		},
+	}, "", nil
+}
+
+// Register implements Register for Windows Webauthn API.
+func Register(
+	ctx context.Context,
+	origin string, cc *wanlib.CredentialCreation,
+) (*proto.MFARegisterResponse, error) {
+	if origin == "" {
+		return nil, trace.BadParameter("origin required")
+	}
+	if err := cc.Validate(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rp, err := rpToCType(cc.Response.RelyingParty)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	u, err := userToCType(cc.Response.User)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	credParam, err := credParamToCType(cc.Response.Parameters)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cd, jsonEncodedCD, err := clientDataToCType(cc.Response.Challenge.String(), origin, string(protocol.CreateCeremony))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	opts, err := makeCredOptionsToCType(cc.Response)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	resp, err := native.MakeCredential(origin, &makeCredentialRequest{
+		rp:                    rp,
+		user:                  u,
+		credParameters:        credParam,
+		clientData:            cd,
+		jsonEncodedClientData: jsonEncodedCD,
+		opts:                  opts,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &proto.MFARegisterResponse{
+		Response: &proto.MFARegisterResponse_Webauthn{
+			Webauthn: wanlib.CredentialCreationResponseToProto(resp),
+		},
+	}, nil
+}
+
 // CheckSupport is the result from a Windows webauthn support check.
 type CheckSupportResult struct {
 	HasCompileSupport  bool
 	IsAvailable        bool
 	HasPlatformUV      bool
 	WebAuthnAPIVersion int
+}
+
+// IsAvailable returns true if Windows webauthn library is available in the
+// system. Typically, a series of checks is performed in an attempt to avoid
+// false positives.
+// See CheckSupport.
+func IsAvailable() bool {
+	return CheckSupport().IsAvailable
+}
+
+// CheckSupport return information whether Windows Webauthn is supported and
+// information about API version.
+func CheckSupport() CheckSupportResult {
+	return native.CheckSupport()
+}
+
+type DiagResult struct {
+	Available                           bool
+	RegisterSuccessful, LoginSuccessful bool
+}
+
+// Diag runs a few diagnostic commands and returns the result.
+// User interaction is required.
+func Diag(ctx context.Context, promptOut io.Writer) (*DiagResult, error) {
+	res := &DiagResult{}
+	if !IsAvailable() {
+		return res, nil
+	}
+	res.Available = true
+
+	// Attempt registration.
+	const origin = "localhost"
+	cc := &wanlib.CredentialCreation{
+		Response: protocol.PublicKeyCredentialCreationOptions{
+			Challenge: make([]byte, 32),
+			RelyingParty: protocol.RelyingPartyEntity{
+				ID: "localhost",
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "test RP",
+				},
+			},
+			User: protocol.UserEntity{
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "test",
+				},
+				ID:          []byte("test"),
+				DisplayName: "test",
+			},
+			Parameters: []protocol.CredentialParameter{
+				{
+					Type:      protocol.PublicKeyCredentialType,
+					Algorithm: webauthncose.AlgES256,
+				},
+				{
+					Type:      protocol.PublicKeyCredentialType,
+					Algorithm: webauthncose.AlgRS256,
+				},
+			},
+			Attestation: protocol.PreferNoAttestation,
+		},
+	}
+	ccr, err := Register(ctx, origin, cc)
+	if err != nil {
+		return res, trace.Wrap(err)
+	}
+	res.RegisterSuccessful = true
+
+	// Attempt login.
+	assertion := &wanlib.CredentialAssertion{
+		Response: protocol.PublicKeyCredentialRequestOptions{
+			Challenge:      make([]byte, 32),
+			RelyingPartyID: cc.Response.RelyingParty.ID,
+			AllowedCredentials: []protocol.CredentialDescriptor{
+				{
+					Type:         protocol.PublicKeyCredentialType,
+					CredentialID: ccr.GetWebauthn().GetRawId(),
+				},
+			},
+			UserVerification: protocol.VerificationDiscouraged,
+		},
+	}
+	if _, _, err := Login(ctx, origin, assertion, &LoginOpts{}); err != nil {
+		return res, trace.Wrap(err)
+	}
+	res.LoginSuccessful = true
+
+	return res, nil
 }

--- a/lib/auth/webauthnwin/api_test.go
+++ b/lib/auth/webauthnwin/api_test.go
@@ -1,0 +1,297 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthnwin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/duo-labs/webauthn/protocol/webauthncose"
+	"github.com/gravitational/teleport/api/types/webauthn"
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegister(t *testing.T) {
+	resetNativeAfterTests(t)
+
+	const origin = "https://example.com"
+	okCC := &wanlib.CredentialCreation{
+		Response: protocol.PublicKeyCredentialCreationOptions{
+			Challenge: make([]byte, 32),
+			RelyingParty: protocol.RelyingPartyEntity{
+				ID: "example.com",
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "Teleport",
+				},
+			},
+			User: protocol.UserEntity{
+				ID:          []byte{1, 2, 3, 4},
+				DisplayName: "display name",
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "user name",
+				},
+			},
+			Parameters: []protocol.CredentialParameter{
+				{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256},
+				{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgRS256},
+			},
+			AuthenticatorSelection: protocol.AuthenticatorSelection{
+				UserVerification: protocol.VerificationDiscouraged,
+			},
+			Attestation: protocol.PreferNoAttestation,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		origin   string
+		createCC func() *wanlib.CredentialCreation
+		assertFn func(t *testing.T, ccr *webauthn.CredentialCreationResponse, req *makeCredentialRequest)
+	}{
+		{
+			name:     "flow with auto attachment and discouraged UV",
+			origin:   origin,
+			createCC: func() *wanlib.CredentialCreation { return okCC },
+			assertFn: func(t *testing.T, ccr *webauthn.CredentialCreationResponse, req *makeCredentialRequest) {
+
+				assert.Equal(t, webauthnAttachmentAny, req.opts.dwAuthenticatorAttachment)
+
+				assert.Equal(t, webauthnUserVerificationDiscouraged, req.opts.dwUserVerificationRequirement)
+
+				assert.Equal(t, uint32(0), req.opts.bRequireResidentKey)
+			},
+		},
+		{
+			name:   "with UV required and cross-platform and RRK",
+			origin: origin,
+			createCC: func() *wanlib.CredentialCreation {
+				cc := *okCC
+				cc.Response.User.DisplayName = "display name"
+				cc.Response.AuthenticatorSelection.UserVerification = protocol.VerificationRequired
+				cc.Response.AuthenticatorSelection.AuthenticatorAttachment = protocol.CrossPlatform
+				cc.Response.AuthenticatorSelection.ResidentKey = protocol.ResidentKeyRequirementRequired
+				return &cc
+			},
+			assertFn: func(t *testing.T, ccr *webauthn.CredentialCreationResponse, req *makeCredentialRequest) {
+
+				assert.Equal(t, webauthnUserVerificationRequired, req.opts.dwUserVerificationRequirement)
+
+				assert.Equal(t, webauthnAttachmentCrossPlatform, req.opts.dwAuthenticatorAttachment)
+
+				assert.Equal(t, uint32(1), req.opts.bRequireResidentKey)
+			},
+		},
+		{
+			name:   "with UV preferred and platform",
+			origin: origin,
+			createCC: func() *wanlib.CredentialCreation {
+				cc := *okCC
+				cc.Response.AuthenticatorSelection.UserVerification = protocol.VerificationPreferred
+				cc.Response.AuthenticatorSelection.AuthenticatorAttachment = protocol.Platform
+				return &cc
+			},
+			assertFn: func(t *testing.T, ccr *webauthn.CredentialCreationResponse, req *makeCredentialRequest) {
+
+				assert.Equal(t, webauthnUserVerificationPreferred, req.opts.dwUserVerificationRequirement)
+
+				assert.Equal(t, webauthnAttachmentPlatform, req.opts.dwAuthenticatorAttachment)
+			},
+		},
+		{
+			name:   "with UV discouraged and platform",
+			origin: origin,
+			createCC: func() *wanlib.CredentialCreation {
+				cc := *okCC
+				cc.Response.AuthenticatorSelection.UserVerification = protocol.VerificationDiscouraged
+				return &cc
+			},
+			assertFn: func(t *testing.T, ccr *webauthn.CredentialCreationResponse, req *makeCredentialRequest) {
+
+				assert.Equal(t, webauthnUserVerificationDiscouraged, req.opts.dwUserVerificationRequirement)
+
+			},
+		},
+		{
+			name:   "RRK from RequireResidentKey if is empty ResidentKey",
+			origin: origin,
+			createCC: func() *wanlib.CredentialCreation {
+				cc := *okCC
+				cc.Response.AuthenticatorSelection.RequireResidentKey = protocol.ResidentKeyRequired()
+				return &cc
+			},
+			assertFn: func(t *testing.T, ccr *webauthn.CredentialCreationResponse, req *makeCredentialRequest) {
+				assert.Equal(t, uint32(1), req.opts.bRequireResidentKey)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := &mockNative{}
+			*Native = mock
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+			defer cancel()
+
+			resp, err := Register(ctx, test.origin, test.createCC())
+			require.NoError(t, err, "Register failed")
+			if test.assertFn != nil {
+				test.assertFn(t, resp.GetWebauthn(), mock.makeCredentialReq)
+			}
+
+		})
+	}
+}
+
+func TestLogin(t *testing.T) {
+	resetNativeAfterTests(t)
+
+	const origin = "https://example.com"
+	okAssertion := &wanlib.CredentialAssertion{
+		Response: protocol.PublicKeyCredentialRequestOptions{
+			Challenge:      make([]byte, 32),
+			RelyingPartyID: "example.com",
+			AllowedCredentials: []protocol.CredentialDescriptor{
+				{Type: protocol.PublicKeyCredentialType, CredentialID: []byte{1, 2, 3, 4, 5}},
+			},
+			UserVerification: protocol.VerificationDiscouraged,
+		},
+	}
+
+	tests := []struct {
+		name        string
+		origin      string
+		assertionIn func() *wanlib.CredentialAssertion
+		opts        LoginOpts
+		wantErr     string
+		assertFn    func(t *testing.T, car *webauthn.CredentialAssertionResponse, req *getAssertionRequest)
+	}{
+		{
+			name:        "uv discouraged, attachment auto",
+			origin:      origin,
+			assertionIn: func() *wanlib.CredentialAssertion { return okAssertion },
+			assertFn: func(t *testing.T, car *webauthn.CredentialAssertionResponse, req *getAssertionRequest) {
+
+				assert.Equal(t, uint32(6), req.opts.dwVersion)
+
+				assert.Equal(t, webauthnUserVerificationDiscouraged, req.opts.dwUserVerificationRequirement)
+
+				assert.Equal(t, webauthnAttachmentAny, req.opts.dwAuthenticatorAttachment)
+			},
+		},
+		{
+			name:   "uv required, attachment platform",
+			origin: origin,
+			assertionIn: func() *wanlib.CredentialAssertion {
+				out := *okAssertion
+				out.Response.UserVerification = protocol.VerificationRequired
+				return &out
+			},
+			opts: LoginOpts{AuthenticatorAttachment: AttachmentPlatform},
+			assertFn: func(t *testing.T, car *webauthn.CredentialAssertionResponse, req *getAssertionRequest) {
+
+				assert.Equal(t, uint32(6), req.opts.dwVersion)
+
+				assert.Equal(t, webauthnUserVerificationRequired, req.opts.dwUserVerificationRequirement)
+
+				assert.Equal(t, webauthnAttachmentPlatform, req.opts.dwAuthenticatorAttachment)
+
+			},
+		},
+		{
+			name:   "uv preferred, attachment cross-platform",
+			origin: origin,
+			assertionIn: func() *wanlib.CredentialAssertion {
+				out := *okAssertion
+				out.Response.UserVerification = protocol.VerificationPreferred
+				return &out
+			},
+			opts: LoginOpts{AuthenticatorAttachment: AttachmentCrossPlatform},
+			assertFn: func(t *testing.T, car *webauthn.CredentialAssertionResponse, req *getAssertionRequest) {
+
+				assert.Equal(t, uint32(6), req.opts.dwVersion)
+
+				assert.Equal(t, webauthnUserVerificationPreferred, req.opts.dwUserVerificationRequirement)
+
+				assert.Equal(t, webauthnAttachmentCrossPlatform, req.opts.dwAuthenticatorAttachment)
+
+			},
+		},
+		{
+			name:   "uv discouraged",
+			origin: origin,
+			assertionIn: func() *wanlib.CredentialAssertion {
+				out := *okAssertion
+				out.Response.UserVerification = protocol.VerificationDiscouraged
+				return &out
+			},
+			opts: LoginOpts{AuthenticatorAttachment: AttachmentCrossPlatform},
+			assertFn: func(t *testing.T, car *webauthn.CredentialAssertionResponse, req *getAssertionRequest) {
+
+				assert.Equal(t, uint32(6), req.opts.dwVersion)
+
+				assert.Equal(t, webauthnUserVerificationDiscouraged, req.opts.dwUserVerificationRequirement)
+
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := &mockNative{}
+			*Native = mock
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+			defer cancel()
+
+			resp, _, err := Login(ctx, test.origin, test.assertionIn(), &test.opts)
+			require.NoError(t, err, "Login failed")
+			if test.assertFn != nil {
+				test.assertFn(t, resp.GetWebauthn(), mock.getAssersionReq)
+			}
+		})
+	}
+}
+
+func resetNativeAfterTests(t *testing.T) {
+	n := *Native
+	t.Cleanup(func() {
+		*Native = n
+	})
+}
+
+type mockNative struct {
+	getAssersionReq   *getAssertionRequest
+	makeCredentialReq *makeCredentialRequest
+}
+
+func (m *mockNative) CheckSupport() CheckSupportResult {
+	return CheckSupportResult{
+		HasCompileSupport: true,
+		IsAvailable:       true,
+	}
+}
+
+func (m *mockNative) GetAssertion(origin string, in *getAssertionRequest) (*wanlib.CredentialAssertionResponse, error) {
+	m.getAssersionReq = in
+	return &wanlib.CredentialAssertionResponse{}, nil
+}
+
+func (m *mockNative) MakeCredential(origin string, in *makeCredentialRequest) (*wanlib.CredentialCreationResponse, error) {
+	m.makeCredentialReq = in
+	return &wanlib.CredentialCreationResponse{}, nil
+}

--- a/lib/auth/webauthnwin/conv.go
+++ b/lib/auth/webauthnwin/conv.go
@@ -1,0 +1,333 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthnwin
+
+import (
+	"encoding/json"
+	"strings"
+	"syscall"
+	"unicode/utf16"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/gravitational/trace"
+)
+
+func assertOptionsToCType(in protocol.PublicKeyCredentialRequestOptions, loginOpts *LoginOpts) (*webauthnAuthenticatorGetAssertionOptions, error) {
+	allowCredList, err := credentialsExToCType(in.AllowedCredentials)
+	if err != nil {
+		return nil, err
+	}
+
+	var dwAuthenticatorAttachment uint32
+	if loginOpts != nil {
+		switch loginOpts.AuthenticatorAttachment {
+		case AttachmentPlatform:
+			dwAuthenticatorAttachment = 1
+		case AttachmentCrossPlatform:
+			dwAuthenticatorAttachment = 2
+		}
+	}
+
+	return &webauthnAuthenticatorGetAssertionOptions{
+		// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L36-L97
+		// contains information about different versions.
+		// We can set newest version and it still works on older APIs.
+		dwVersion:                     6,
+		dwTimeoutMilliseconds:         uint32(in.Timeout),
+		dwAuthenticatorAttachment:     dwAuthenticatorAttachment,
+		dwUserVerificationRequirement: userVerificationToCType(in.UserVerification),
+		// TODO(tobiaszheller): support U2fAppId.
+		pAllowCredentialList: allowCredList,
+	}, nil
+}
+
+func rpToCType(in protocol.RelyingPartyEntity) (*webauthnRPEntityInformation, error) {
+	if in.ID == "" {
+		return nil, trace.BadParameter("missing RelyingPartyEntity.Id")
+	}
+	if in.Name == "" {
+		return nil, trace.BadParameter("missing RelyingPartyEntity.Name")
+	}
+	id, err := utf16PtrFromString(in.ID)
+	if err != nil {
+		return nil, err
+	}
+	name, err := utf16PtrFromString(in.Name)
+	if err != nil {
+		return nil, err
+	}
+	var icon *uint16
+	if in.Icon != "" {
+		icon, err = utf16PtrFromString(in.Icon)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &webauthnRPEntityInformation{
+		dwVersion: 1,
+		pwszID:    id,
+		pwszName:  name,
+		pwszIcon:  icon,
+	}, nil
+}
+
+func userToCType(in protocol.UserEntity) (*webauthnUserEntityInformation, error) {
+	if len(in.ID) == 0 {
+		return nil, trace.BadParameter("missing UserEntity.Id")
+	}
+	if in.Name == "" {
+		return nil, trace.BadParameter("missing UserEntity.Name")
+	}
+
+	name, err := utf16PtrFromString(in.Name)
+	if err != nil {
+		return nil, err
+	}
+	var displayName *uint16
+	if in.DisplayName != "" {
+		displayName, err = utf16PtrFromString(in.DisplayName)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var icon *uint16
+	if in.Icon != "" {
+		icon, err = utf16PtrFromString(in.Icon)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &webauthnUserEntityInformation{
+		dwVersion:       1,
+		cbID:            uint32(len(in.ID)),
+		pbID:            &in.ID[0],
+		pwszName:        name,
+		pwszDisplayName: displayName,
+		pwszIcon:        icon,
+	}, nil
+}
+
+func credParamToCType(in []protocol.CredentialParameter) (*webauthnCoseCredentialParameters, error) {
+	if len(in) == 0 {
+		return nil, trace.BadParameter("missing CredentialParameter")
+	}
+	out := make([]webauthnCoseCredentialParameter, 0, len(in))
+	for _, c := range in {
+		pwszCredentialType, err := utf16PtrFromString(string(c.Type))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, webauthnCoseCredentialParameter{
+			dwVersion:          1,
+			pwszCredentialType: pwszCredentialType,
+			lAlg:               int32(c.Algorithm),
+		})
+	}
+	return &webauthnCoseCredentialParameters{
+		cCredentialParameters: uint32(len(out)),
+		pCredentialParameters: &out[0],
+	}, nil
+}
+
+func clientDataToCType(challenge, origin, cdType string) (*webauthnClientData, []byte, error) {
+	if challenge == "" {
+		return nil, nil, trace.BadParameter("missing ClientData.Challenge")
+	}
+	if origin == "" {
+		return nil, nil, trace.BadParameter("missing ClientData.Origin")
+	}
+	algID, err := utf16PtrFromString("SHA-256")
+	if err != nil {
+		return nil, nil, err
+	}
+	type clientDataJSON struct {
+		Type      string `json:"type"`
+		Challenge string `json:"challenge"`
+		Origin    string `json:"origin"`
+	}
+	cd := clientDataJSON{
+		Type:      cdType,
+		Challenge: challenge,
+		Origin:    origin,
+	}
+	jsonCD, err := json.Marshal(cd)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &webauthnClientData{
+		dwVersion:        1,
+		cbClientDataJSON: uint32(len(jsonCD)),
+		pbClientDataJSON: &jsonCD[0],
+		pwszHashAlgID:    algID,
+	}, jsonCD, nil
+
+}
+
+func credentialsExToCType(in []protocol.CredentialDescriptor) (*webauthnCredentialList, error) {
+	exCredList := make([]*webauthnCredentialEX, 0, len(in))
+	for _, e := range in {
+		if e.Type == "" {
+			return nil, trace.BadParameter("missing CredentialDescriptor.Type")
+		}
+		if len(e.CredentialID) == 0 {
+			return nil, trace.BadParameter("missing CredentialDescriptor.CredentialID")
+		}
+		pwszCredentialType, err := utf16PtrFromString(string(e.Type))
+		if err != nil {
+			return nil, err
+		}
+		exCredList = append(exCredList, &webauthnCredentialEX{
+			dwVersion:          1,
+			cbID:               uint32(len(e.CredentialID)),
+			pbID:               &e.CredentialID[0],
+			pwszCredentialType: pwszCredentialType,
+			dwTransports:       transportsToCType(e.Transport),
+		})
+	}
+
+	if len(exCredList) == 0 {
+		return nil, nil
+	}
+	return &webauthnCredentialList{
+		cCredentials:  uint32(len(exCredList)),
+		ppCredentials: &exCredList[0],
+	}, nil
+}
+
+func transportsToCType(in []protocol.AuthenticatorTransport) uint32 {
+	if len(in) == 0 {
+		return 0
+	}
+	var out uint32
+	for _, at := range in {
+		// Mappped based on:
+		// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L249-L254
+		switch at {
+		case protocol.USB:
+			out |= 0x1
+		case protocol.NFC:
+			out |= 0x2
+		case protocol.BLE:
+			out |= 0x4
+		case protocol.Internal:
+			out |= 0x10
+		}
+	}
+	return out
+}
+
+func attachmentToCType(in protocol.AuthenticatorAttachment) uint32 {
+	// Mapped based on:
+	// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L493-L496
+	switch in {
+	case protocol.Platform:
+		return webauthnAttachmentPlatform
+	case protocol.CrossPlatform:
+		return webauthnAttachmentCrossPlatform
+	default:
+		return webauthnAttachmentAny
+	}
+}
+
+func conveyancePreferenceToCType(in protocol.ConveyancePreference) uint32 {
+	// Mapped based on:
+	// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L503-L506
+	switch in {
+	case protocol.PreferNoAttestation:
+		return 1
+	case protocol.PreferIndirectAttestation:
+		return 2
+	case protocol.PreferDirectAttestation:
+		return 3
+	default:
+		return 0
+	}
+}
+
+func userVerificationToCType(in protocol.UserVerificationRequirement) uint32 {
+	// Mapped based on:
+	// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L498-L501
+	switch in {
+	case protocol.VerificationRequired:
+		return webauthnUserVerificationRequired
+	case protocol.VerificationPreferred:
+		return webauthnUserVerificationPreferred
+	case protocol.VerificationDiscouraged:
+		return webauthnUserVerificationDiscouraged
+	default:
+		return webauthnUserVerificationAny
+	}
+}
+
+func requirePreferResidentKey(in protocol.AuthenticatorSelection) (requireRK bool, preferRK bool) {
+	switch in.ResidentKey {
+	case protocol.ResidentKeyRequirementRequired:
+		return true, false
+	case protocol.ResidentKeyRequirementPreferred:
+		return false, true
+	case protocol.ResidentKeyRequirementDiscouraged:
+		return false, false
+	default:
+		if in.RequireResidentKey != nil && *in.RequireResidentKey {
+			return true, false
+		}
+		return false, false
+	}
+}
+
+func makeCredOptionsToCType(in protocol.PublicKeyCredentialCreationOptions) (*webauthnAuthenticatorMakeCredentialOptions, error) {
+	exCredList, err := credentialsExToCType(in.CredentialExcludeList)
+	if err != nil {
+		return nil, err
+	}
+
+	requiredRK, preferRK := requirePreferResidentKey(in.AuthenticatorSelection)
+	return &webauthnAuthenticatorMakeCredentialOptions{
+		// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L36-L97
+		// contains information about different versions.
+		// We can set newest version and it still works on older APIs.
+		dwVersion:                         5,
+		dwTimeoutMilliseconds:             uint32(in.Timeout),
+		dwAuthenticatorAttachment:         attachmentToCType(in.AuthenticatorSelection.AuthenticatorAttachment),
+		dwAttestationConveyancePreference: conveyancePreferenceToCType(in.Attestation),
+		bRequireResidentKey:               boolToUint32(requiredRK),
+		dwUserVerificationRequirement:     userVerificationToCType(in.AuthenticatorSelection.UserVerification),
+		pExcludeCredentialList:            exCredList,
+		bPreferResidentKey:                boolToUint32(preferRK),
+	}, nil
+}
+
+func boolToUint32(in bool) uint32 {
+	if in {
+		return 1
+	}
+	return 0
+}
+
+// utf16PtrFromString is copied from golang.org/x/sys/windows because we want
+// to test conversions on linux machines also.
+func utf16PtrFromString(s string) (*uint16, error) {
+	utf16FromString := func(s string) ([]uint16, error) {
+		if strings.IndexByte(s, 0) != -1 {
+			return nil, syscall.EINVAL
+		}
+		return utf16.Encode([]rune(s + "\x00")), nil
+	}
+	a, err := utf16FromString(s)
+	if err != nil {
+		return nil, err
+	}
+	return &a[0], nil
+}

--- a/lib/auth/webauthnwin/ctypes.go
+++ b/lib/auth/webauthnwin/ctypes.go
@@ -14,12 +14,23 @@
 
 package webauthnwin
 
-import "golang.org/x/sys/windows"
+const (
+	// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L493-L496
+	webauthnAttachmentAny           = uint32(0)
+	webauthnAttachmentPlatform      = uint32(1)
+	webauthnAttachmentCrossPlatform = uint32(2)
+
+	// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L498-L501
+	webauthnUserVerificationAny         = uint32(0)
+	webauthnUserVerificationRequired    = uint32(1)
+	webauthnUserVerificationPreferred   = uint32(2)
+	webauthnUserVerificationDiscouraged = uint32(3)
+)
 
 type webauthnRPEntityInformation struct {
 	dwVersion uint32
 	// Identifier for the RP. This field is required.
-	pwszId *uint16
+	pwszID *uint16
 	// Contains the friendly name of the Relying Party, such as
 	// "Acme Corporation", "Widgets Inc" or "Awesome Site".
 	// This field is required.
@@ -31,8 +42,8 @@ type webauthnRPEntityInformation struct {
 type webauthnUserEntityInformation struct {
 	dwVersion uint32
 	// Identifier for the User. This field is required.
-	cbId uint32
-	pbId *byte
+	cbID uint32
+	pbID *byte
 	// Contains a detailed name for this account, such as
 	// "john.p.smith@example.com".
 	// It holds the Teleport user name.
@@ -60,10 +71,12 @@ type webauthnCoseCredentialParameter struct {
 type webauthnAuthenticatorMakeCredentialOptions struct {
 	dwVersion             uint32
 	dwTimeoutMilliseconds uint32
-	// Credentials used for exclusion.
-	CredentialList webauthnCredentials
+	// For excluding credentials use pExcludeCredentialList.
+	// This field is kept just to keep size of struct valid.
+	_ webauthnCredentials
 	// Optional extensions to parse when performing the operation.
-	Extensions webauthnExtenstions
+	// Right now not supported by Teleport.
+	_ webauthnExtensions
 	// Optional. Platform vs Cross-Platform Authenticators.
 	dwAuthenticatorAttachment uint32
 	// Optional. Require key to be resident or not. Defaulting to FALSE.
@@ -73,14 +86,15 @@ type webauthnAuthenticatorMakeCredentialOptions struct {
 	// Attestation Conveyance Preference.
 	dwAttestationConveyancePreference uint32
 	// Reserved for future Use
-	dwFlags uint32
+	_ uint32
 
 	//
 	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_2
 	//
 
 	// Cancellation Id - Optional - See WebAuthNGetCancellationId
-	pCancellationId *windows.GUID
+	// This field is kept just to keep size of struct valid.
+	_ *GUID
 
 	//
 	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_3
@@ -94,11 +108,13 @@ type webauthnAuthenticatorMakeCredentialOptions struct {
 	//
 
 	// Enterprise Attestation
-	dwEnterpriseAttestation uint32
+	// This field is kept just to keep size of struct valid.
+	_ uint32
 	// Large Blob Support: none, required or preferred
 	// NTE_INVALID_PARAMETER when large blob required or preferred and
 	//   bRequireResidentKey isn't set to TRUE
-	dwLargeBlobSupport uint32
+	// This field is kept just to keep size of struct valid.
+	_ uint32
 	// Optional. Prefer key to be resident. Defaulting to FALSE. When TRUE,
 	// overrides the above bRequireResidentKey.
 	bPreferResidentKey uint32
@@ -108,29 +124,35 @@ type webauthnAuthenticatorMakeCredentialOptions struct {
 	//
 
 	// Optional. BrowserInPrivate Mode. Defaulting to FALSE.
-	bBrowserInPrivateMode uint32
+	// This field is kept just to keep size of struct valid.
+	_ uint32
 }
 
+//nolint:unused // This struct is kept just to keep size of struct valid.
 type webauthnCredentials struct {
-	cCredentials uint32
-	pCredentials *webauthnCredential
+	_ uint32
+	_ *webauthnCredential
 }
 
+//nolint:unused // TODO: remove when linter runs on windows build tag
 type webauthnCredential struct {
 	dwVersion uint32
 	// Size of pbID.
-	cbId uint32
-	pbId *byte
+	cbID uint32
+	pbID *byte
 	// Well-known credential type specifying what this particular credential is.
 	pwszCredentialType *uint16
 }
 
+//nolint:unused // This struct is kept just to keep size of struct valid.
 type webauthnExtension struct {
 	pwszExtensionIdentifier *uint16
 	cbExtension             uint32
 	pvExtension             *byte
 }
-type webauthnExtenstions struct {
+
+//nolint:unused // This struct is kept just to keep size of struct valid.
+type webauthnExtensions struct {
 	cExtensions uint32
 	pExtensions *webauthnExtension
 }
@@ -138,9 +160,9 @@ type webauthnExtenstions struct {
 type webauthnCredentialEX struct {
 	dwVersion uint32
 	// Size of pbID.
-	cbId uint32
+	cbID uint32
 	// Unique ID for this particular credential.
-	pbId *byte
+	pbID *byte
 	// Well-known credential type specifying what this particular credential is.
 	pwszCredentialType *uint16
 	// Transports. 0 means no transport restrictions.
@@ -151,6 +173,7 @@ type webauthnCredentialList struct {
 	ppCredentials **webauthnCredentialEX
 }
 
+//nolint:unused // TODO: remove when linter runs on windows build tag
 type webauthnCredentialAttestation struct {
 	dwVersion uint32
 	// Attestation format type
@@ -176,14 +199,14 @@ type webauthnCredentialAttestation struct {
 	pbAttestationObject *byte
 	// The CredentialId bytes extracted from the Authenticator Data.
 	// Used by Edge to return to the RP.
-	cbCredentialId uint32
-	pbCredentialId *byte
+	cbCredentialID uint32
+	pbCredentialID *byte
 
 	//
 	// Following fields have been added in WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_2
 	//
 
-	Extensions webauthnExtenstions
+	Extensions webauthnExtensions
 
 	//
 	// Following fields have been added in WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_3
@@ -209,7 +232,7 @@ type webauthnClientData struct {
 	// UTF-8 encoded JSON serialization of the client data.
 	pbClientDataJSON *byte
 	// Hash algorithm ID used to hash the pbClientDataJSON field.
-	pwszHashAlgId *uint16
+	pwszHashAlgID *uint16
 }
 
 type webauthnAuthenticatorGetAssertionOptions struct {
@@ -218,32 +241,38 @@ type webauthnAuthenticatorGetAssertionOptions struct {
 	// This is used as guidance, and can be overridden by the platform.
 	dwTimeoutMilliseconds uint32
 	// Allowed Credentials List.
-	CredentialList webauthnCredentials
+	// This field is kept just to keep size of struct valid.
+	_ webauthnCredentials
 	// Optional extensions to parse when performing the operation.
-	Extensions webauthnExtenstions
+	// Right now not supported by Teleport.
+	_ webauthnExtensions
 	// Optional. Platform vs Cross-Platform Authenticators.
 	dwAuthenticatorAttachment uint32
 	// User Verification Requirement.
 	dwUserVerificationRequirement uint32
 	// Flags
-	dwFlags uint32
+	// This field is kept just to keep size of struct valid.
+	_ uint32
 
 	//
 	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_2
 	//
 
 	// Optional identifier for the U2F AppId. Converted to UTF8 before being hashed. Not lower cased.
-	pwszU2fAppId *uint16
+	//nolint:unused // TODO(tobiaszheller): rm nolint when support for U2FappID is added
+	pwszU2fAppID *uint16
 	// If the following is non-NULL, then, set to TRUE if the above pwszU2fAppid was used instead of
 	// PCWSTR pwszRpId;
-	pbU2fAppId uint32
+	//nolint:unused // TODO(tobiaszheller): rm nolint when support for U2FappID is added
+	pbU2fAppID uint32
 
 	//
 	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_3
 	//
 
 	// Cancellation Id - Optional - See WebAuthNGetCancellationId
-	pCancellationId *windows.GUID
+	// This field is kept just to keep size of struct valid.
+	_ *GUID
 
 	//
 	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_4
@@ -255,13 +284,16 @@ type webauthnAuthenticatorGetAssertionOptions struct {
 	//
 	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_5
 	//
-
-	dwCredLargeBlobOperation uint32
+	// This field is kept just to keep size of struct valid.
+	_ uint32
 	// Size of pbCredLargeBlob
-	cbCredLargeBlob uint32
-	pbCredLargeBlob *byte
+	// This field is kept just to keep size of struct valid.
+	_ uint32
+	// This field is kept just to keep size of struct valid.
+	_ *byte
 }
 
+//nolint:unused // TODO: remove when linter runs on windows build tag
 type webauthnAssertion struct {
 	dwVersion uint32
 
@@ -278,16 +310,16 @@ type webauthnAssertion struct {
 	// Credential that was used for this assertion.
 	Credential webauthnCredential
 
-	// Size of User Id
-	cbUserId uint32
-	// UserId
-	pbUserId *byte
+	// Size of User ID
+	cbUserID uint32
+	// UserID
+	pbUserID *byte
 
 	//
 	// Following fields have been added in WEBAUTHN_ASSERTION_VERSION_2
 	//
 
-	Extensions webauthnExtenstions
+	Extensions webauthnExtensions
 
 	// Size of pbCredLargeBlob
 	cbCredLargeBlob       uint32
@@ -295,6 +327,7 @@ type webauthnAssertion struct {
 	dwCredLargeBlobStatus uint32
 }
 
+//nolint:unused // TODO: remove when linter runs on windows build tag
 type webauthnX5C struct {
 	// Length of X.509 encoded certificate
 	cbData uint32
@@ -302,28 +335,9 @@ type webauthnX5C struct {
 	pbData *byte
 }
 
-type webauthnCommonAttestation struct {
-	dwVersion uint32
-
-	// Hash and Padding Algorithm
-	//
-	// The following won't be set for "fido-u2f" which assumes "ES256".
-	pwszAlg *uint16
-	lAlg    int32 // COSE algorithm
-
-	// Signature that was generated for this attestation.
-	cbSignature uint32
-	pbSignature *byte
-
-	// Following is set for Full Basic Attestation. If not, set then, this is Self Attestation.
-	// Array of X.509 DER encoded certificates. The first certificate is the signer, leaf certificate.
-	cX5c uint32
-	pX5c *webauthnX5C
-
-	// Following are also set for TPM
-	pwszVer    *uint16 // "2.0"
-	cbCertInfo uint32
-	pbCertInfo *byte
-	cbPubArea  uint32
-	pbPubArea  *byte
+type GUID struct {
+	Data1 uint32
+	Data2 uint16
+	Data3 uint16
+	Data4 [8]byte
 }

--- a/lib/auth/webauthnwin/export_test.go
+++ b/lib/auth/webauthnwin/export_test.go
@@ -1,0 +1,19 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthnwin
+
+// Native exposes the native webauthnwin implementation so that it may be
+// replaced by tests.
+var Native = &native

--- a/lib/auth/webauthnwin/webauthn_other.go
+++ b/lib/auth/webauthnwin/webauthn_other.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package webauthnwin
+
+import (
+	"errors"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+)
+
+var native nativeWebauthn = noopNative{}
+
+var errUnavailable = errors.New("windows webauthn unavailable in current build")
+
+type noopNative struct{}
+
+func (n noopNative) CheckSupport() CheckSupportResult {
+	return CheckSupportResult{
+		HasCompileSupport: false,
+	}
+}
+
+func (n noopNative) GetAssertion(origin string, in *getAssertionRequest) (*wanlib.CredentialAssertionResponse, error) {
+	return nil, errUnavailable
+}
+
+func (n noopNative) MakeCredential(origin string, in *makeCredentialRequest) (*wanlib.CredentialCreationResponse, error) {
+	return nil, errUnavailable
+}

--- a/lib/auth/webauthnwin/webauthn_windows.go
+++ b/lib/auth/webauthnwin/webauthn_windows.go
@@ -16,7 +16,6 @@ package webauthnwin
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"syscall"
@@ -45,6 +44,8 @@ var (
 	modUser32               = windows.NewLazySystemDLL("user32.dll")
 	procGetForegroundWindow = modUser32.NewProc("GetForegroundWindow")
 )
+
+var native nativeWebauthn = newNativeImpl()
 
 // nativeImpl keeps diagnostic informations about windows webauthn support.
 type nativeImpl struct {
@@ -94,33 +95,22 @@ func (n *nativeImpl) CheckSupport() CheckSupportResult {
 // GetAssertion calls WebAuthNAuthenticatorGetAssertion endpoint from
 // webauthn.dll and returns CredentialAssertionResponse.
 // It interacts with both FIDO2 and Windows Hello depending on
-// loginOpts.AuthenticatorAttachment (using auto results in possibilty to select
+// opts.AuthenticatorAttachment (using auto results in possibilty to select
 // either security key or Windows Hello).
 // It does not accept username - during passwordless login webauthn.dll provides
 // its own dialog with credentials selection.
-func (n *nativeImpl) GetAssertion(origin string, in *wanlib.CredentialAssertion, loginOpts *LoginOpts) (*wanlib.CredentialAssertionResponse, error) {
+func (n *nativeImpl) GetAssertion(origin string, in *getAssertionRequest) (*wanlib.CredentialAssertionResponse, error) {
 	hwnd, err := getForegroundWindow()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	rpid, err := windows.UTF16PtrFromString(in.Response.RelyingPartyID)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	cd, jsonEncodedCD, err := clientDataToCType(in.Response.Challenge.String(), origin, string(protocol.AssertCeremony))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	opts, err := n.assertOptionsToCType(in.Response, loginOpts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+
 	var out *webauthnAssertion
 	ret, _, err := procWebAuthNAuthenticatorGetAssertion.Call(
 		uintptr(hwnd),
-		uintptr(unsafe.Pointer(rpid)),
-		uintptr(unsafe.Pointer(cd)),
-		uintptr(unsafe.Pointer(opts)),
+		uintptr(unsafe.Pointer(in.rpID)),
+		uintptr(unsafe.Pointer(in.clientData)),
+		uintptr(unsafe.Pointer(in.opts)),
 		uintptr(unsafe.Pointer(&out)),
 	)
 	if ret != 0 {
@@ -137,8 +127,8 @@ func (n *nativeImpl) GetAssertion(origin string, in *wanlib.CredentialAssertion,
 
 	authData := bytesFromCBytes(out.cbAuthenticatorData, out.pbAuthenticatorData)
 	signature := bytesFromCBytes(out.cbSignature, out.pbSignature)
-	userID := bytesFromCBytes(out.cbUserId, out.pbUserId)
-	credential := bytesFromCBytes(out.Credential.cbId, out.Credential.pbId)
+	userID := bytesFromCBytes(out.cbUserID, out.pbUserID)
+	credential := bytesFromCBytes(out.Credential.cbID, out.Credential.pbID)
 	credType := windows.UTF16PtrToString(out.Credential.pwszCredentialType)
 
 	return &wanlib.CredentialAssertionResponse{
@@ -154,7 +144,7 @@ func (n *nativeImpl) GetAssertion(origin string, in *wanlib.CredentialAssertion,
 			Signature:         signature,
 			UserHandle:        userID,
 			AuthenticatorResponse: wanlib.AuthenticatorResponse{
-				ClientDataJSON: jsonEncodedCD,
+				ClientDataJSON: in.jsonEncodedClientData,
 			},
 		},
 	}, nil
@@ -162,43 +152,24 @@ func (n *nativeImpl) GetAssertion(origin string, in *wanlib.CredentialAssertion,
 
 // MakeCredential calls WebAuthNAuthenticatorMakeCredential endpoint from
 // webauthn.dll and returns CredentialCreationResponse.
-// It interacts with both FIDO2 and Windows Hello depending on
-// wanlib.CredentialCreation (using auto starts with Windows Hello but there is
+// It interacts with both FIDO2 and Windows Hello depending on opts
+// (using auto starts with Windows Hello but there is
 // option to select other devices).
 // Windows Hello keys are always resident.
-func (n *nativeImpl) MakeCredential(origin string, in *wanlib.CredentialCreation) (*wanlib.CredentialCreationResponse, error) {
+func (n *nativeImpl) MakeCredential(origin string, in *makeCredentialRequest) (*wanlib.CredentialCreationResponse, error) {
 	hwnd, err := getForegroundWindow()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	rp, err := rpToCType(in.Response.RelyingParty)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	u, err := userToCType(in.Response.User)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	credParam, err := credParamToCType(in.Response.Parameters)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	cd, jsonEncodedCD, err := clientDataToCType(in.Response.Challenge.String(), origin, string(protocol.CreateCeremony))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	opts, err := n.makeCredOptionsToCType(in.Response)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+
 	var out *webauthnCredentialAttestation
 	ret, _, err := procWebAuthNAuthenticatorMakeCredential.Call(
 		uintptr(hwnd),
-		uintptr(unsafe.Pointer(rp)),
-		uintptr(unsafe.Pointer(u)),
-		uintptr(unsafe.Pointer(credParam)),
-		uintptr(unsafe.Pointer(cd)),
-		uintptr(unsafe.Pointer(opts)),
+		uintptr(unsafe.Pointer(in.rp)),
+		uintptr(unsafe.Pointer(in.user)),
+		uintptr(unsafe.Pointer(in.credParameters)),
+		uintptr(unsafe.Pointer(in.clientData)),
+		uintptr(unsafe.Pointer(in.opts)),
 		uintptr(unsafe.Pointer(&out)),
 	)
 	if ret != 0 {
@@ -213,7 +184,7 @@ func (n *nativeImpl) MakeCredential(origin string, in *wanlib.CredentialCreation
 	// We don't care about free error so ignore it explicitly.
 	defer func() { _ = freeCredentialAttestation(out) }()
 
-	credential := bytesFromCBytes(out.cbCredentialId, out.pbCredentialId)
+	credential := bytesFromCBytes(out.cbCredentialID, out.pbCredentialID)
 
 	return &wanlib.CredentialCreationResponse{
 		PublicKeyCredential: wanlib.PublicKeyCredential{
@@ -225,7 +196,7 @@ func (n *nativeImpl) MakeCredential(origin string, in *wanlib.CredentialCreation
 		},
 		AttestationResponse: wanlib.AuthenticatorAttestationResponse{
 			AuthenticatorResponse: wanlib.AuthenticatorResponse{
-				ClientDataJSON: jsonEncodedCD,
+				ClientDataJSON: in.jsonEncodedClientData,
 			},
 			AttestationObject: bytesFromCBytes(out.cbAttestationObject, out.pbAttestationObject),
 		},
@@ -295,291 +266,6 @@ func isUVPlatformAuthenticatorAvailable() (bool, error) {
 		return false, getErrorNameOrLastErr(ret, err)
 	}
 	return out == 1, nil
-}
-
-func (n *nativeImpl) assertOptionsToCType(in protocol.PublicKeyCredentialRequestOptions, loginOpts *LoginOpts) (*webauthnAuthenticatorGetAssertionOptions, error) {
-	allowCredList, err := credentialsExToCType(in.AllowedCredentials)
-	if err != nil {
-		return nil, err
-	}
-
-	var dwAuthenticatorAttachment uint32
-	if loginOpts != nil {
-		switch loginOpts.AuthenticatorAttachment {
-		case AttachmentPlatform:
-			dwAuthenticatorAttachment = 1
-		case AttachmentCrossPlatform:
-			dwAuthenticatorAttachment = 2
-		}
-	}
-
-	return &webauthnAuthenticatorGetAssertionOptions{
-		// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L36-L97
-		// contains information about different versions.
-		// We can set newest version and it still works on older APIs.
-		dwVersion:                     6,
-		dwTimeoutMilliseconds:         uint32(in.Timeout),
-		dwAuthenticatorAttachment:     dwAuthenticatorAttachment,
-		dwUserVerificationRequirement: userVerificationToCType(in.UserVerification),
-		// TODO(tobiaszheller): support U2fAppId.
-		pAllowCredentialList: allowCredList,
-	}, nil
-}
-
-func rpToCType(in protocol.RelyingPartyEntity) (*webauthnRPEntityInformation, error) {
-	if in.ID == "" {
-		return nil, errors.New("missing RelyingPartyEntity.Id")
-	}
-	if in.Name == "" {
-		return nil, errors.New("missing RelyingPartyEntity.Name")
-	}
-	id, err := windows.UTF16PtrFromString(in.ID)
-	if err != nil {
-		return nil, err
-	}
-	name, err := windows.UTF16PtrFromString(in.Name)
-	if err != nil {
-		return nil, err
-	}
-	var icon *uint16
-	if in.Icon != "" {
-		icon, err = windows.UTF16PtrFromString(in.Icon)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &webauthnRPEntityInformation{
-		dwVersion: 1,
-		pwszId:    id,
-		pwszName:  name,
-		pwszIcon:  icon,
-	}, nil
-}
-
-func userToCType(in protocol.UserEntity) (*webauthnUserEntityInformation, error) {
-	if len(in.ID) == 0 {
-		return nil, errors.New("missing UserEntity.Id")
-	}
-	if in.Name == "" {
-		return nil, errors.New("missing UserEntity.Name")
-	}
-
-	name, err := windows.UTF16PtrFromString(in.Name)
-	if err != nil {
-		return nil, err
-	}
-	var displayName *uint16
-	if in.DisplayName != "" {
-		displayName, err = windows.UTF16PtrFromString(in.DisplayName)
-		if err != nil {
-			return nil, err
-		}
-	}
-	var icon *uint16
-	if in.Icon != "" {
-		icon, err = windows.UTF16PtrFromString(in.Icon)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &webauthnUserEntityInformation{
-		dwVersion:       1,
-		cbId:            uint32(len(in.ID)),
-		pbId:            &in.ID[0],
-		pwszName:        name,
-		pwszDisplayName: displayName,
-		pwszIcon:        icon,
-	}, nil
-}
-
-func credParamToCType(in []protocol.CredentialParameter) (*webauthnCoseCredentialParameters, error) {
-	if len(in) == 0 {
-		return nil, errors.New("missing CredentialParameter")
-	}
-	out := make([]webauthnCoseCredentialParameter, 0, len(in))
-	for _, c := range in {
-		pwszCredentialType, err := windows.UTF16PtrFromString(string(c.Type))
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, webauthnCoseCredentialParameter{
-			dwVersion:          1,
-			pwszCredentialType: pwszCredentialType,
-			lAlg:               int32(c.Algorithm),
-		})
-	}
-	return &webauthnCoseCredentialParameters{
-		cCredentialParameters: uint32(len(out)),
-		pCredentialParameters: &out[0],
-	}, nil
-}
-
-func clientDataToCType(challenge, origin, cdType string) (*webauthnClientData, []byte, error) {
-	if challenge == "" {
-		return nil, nil, errors.New("missing ClientData.Challenge")
-	}
-	if origin == "" {
-		return nil, nil, errors.New("missing ClientData.Origin")
-	}
-	algId, err := windows.UTF16PtrFromString("SHA-256")
-	if err != nil {
-		return nil, nil, err
-	}
-	type clientDataJson struct {
-		Type      string `json:"type"`
-		Challenge string `json:"challenge"`
-		Origin    string `json:"origin"`
-	}
-	cd := clientDataJson{
-		Type:      cdType,
-		Challenge: challenge,
-		Origin:    origin,
-	}
-	jsonCD, err := json.Marshal(cd)
-	if err != nil {
-		return nil, nil, err
-	}
-	return &webauthnClientData{
-		dwVersion:        1,
-		cbClientDataJSON: uint32(len(jsonCD)),
-		pbClientDataJSON: &jsonCD[0],
-		pwszHashAlgId:    algId,
-	}, jsonCD, nil
-
-}
-
-func credentialsExToCType(in []protocol.CredentialDescriptor) (*webauthnCredentialList, error) {
-	exCredList := make([]*webauthnCredentialEX, 0, len(in))
-	for _, e := range in {
-		if e.Type == "" {
-			return nil, errors.New("missing CredentialDescriptor.Type")
-		}
-		if len(e.CredentialID) == 0 {
-			return nil, errors.New("missing CredentialDescriptor.CredentialID")
-		}
-		pwszCredentialType, err := windows.UTF16PtrFromString(string(e.Type))
-		if err != nil {
-			return nil, err
-		}
-		exCredList = append(exCredList, &webauthnCredentialEX{
-			dwVersion:          1,
-			cbId:               uint32(len(e.CredentialID)),
-			pbId:               &e.CredentialID[0],
-			pwszCredentialType: pwszCredentialType,
-			dwTransports:       transportsToCType(e.Transport),
-		})
-	}
-
-	if len(exCredList) == 0 {
-		return nil, nil
-	}
-	return &webauthnCredentialList{
-		cCredentials:  uint32(len(exCredList)),
-		ppCredentials: &exCredList[0],
-	}, nil
-}
-
-func transportsToCType(in []protocol.AuthenticatorTransport) uint32 {
-	if len(in) == 0 {
-		return 0
-	}
-	var out uint32
-	for _, at := range in {
-		// Mappped based on:
-		// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L249-L254
-		switch at {
-		case protocol.USB:
-			out += 0x1
-		case protocol.NFC:
-			out += 0x2
-		case protocol.BLE:
-			out += 0x4
-		case protocol.Internal:
-			out += 0x10
-		}
-	}
-	return out
-}
-
-func attachmentToCType(in protocol.AuthenticatorAttachment) uint32 {
-	// Mapped based on:
-	// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L493-L496
-	switch in {
-	case protocol.Platform:
-		return 1
-	case protocol.CrossPlatform:
-		return 2
-	default:
-		return 0
-	}
-}
-
-func conveyancePreferenceToCType(in protocol.ConveyancePreference) uint32 {
-	// Mapped based on:
-	// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L503-L506
-	switch in {
-	case protocol.PreferNoAttestation:
-		return 1
-	case protocol.PreferIndirectAttestation:
-		return 2
-	case protocol.PreferDirectAttestation:
-		return 3
-	default:
-		return 0
-	}
-}
-
-func userVerificationToCType(in protocol.UserVerificationRequirement) uint32 {
-	// Mapped based on:
-	// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L498-L501
-	switch in {
-	case protocol.VerificationRequired:
-		return 1
-	case protocol.VerificationPreferred:
-		return 2
-	case protocol.VerificationDiscouraged:
-		return 3
-	default:
-		return 0
-	}
-}
-
-func requireResidentKeyToCType(in *bool) uint32 {
-	if in == nil {
-		return 0
-	}
-	return boolToUint32(*in)
-}
-
-func (n *nativeImpl) makeCredOptionsToCType(in protocol.PublicKeyCredentialCreationOptions) (*webauthnAuthenticatorMakeCredentialOptions, error) {
-	exCredList, err := credentialsExToCType(in.CredentialExcludeList)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO (tobiaszheller): teleport server right now does not support
-	// preferResidentKey.
-	var bPreferResidentKey uint32
-	return &webauthnAuthenticatorMakeCredentialOptions{
-		// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L36-L97
-		// contains information about different versions.
-		// We can set newest version and it still works on older APIs.
-		dwVersion:                         5,
-		dwTimeoutMilliseconds:             uint32(in.Timeout),
-		dwAuthenticatorAttachment:         attachmentToCType(in.AuthenticatorSelection.AuthenticatorAttachment),
-		dwAttestationConveyancePreference: conveyancePreferenceToCType(in.Attestation),
-		bRequireResidentKey:               requireResidentKeyToCType(in.AuthenticatorSelection.RequireResidentKey),
-		dwUserVerificationRequirement:     userVerificationToCType(in.AuthenticatorSelection.UserVerification),
-		pExcludeCredentialList:            exCredList,
-		bPreferResidentKey:                bPreferResidentKey,
-	}, nil
-}
-
-func boolToUint32(in bool) uint32 {
-	if in {
-		return 1
-	}
-	return 0
 }
 
 // bytesFromCBytes gets slice of bytes from C type and copies it to new slice

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/webauthncli"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	"github.com/gravitational/teleport/lib/client/terminal"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -1135,6 +1136,10 @@ func (c *Config) LoadProfile(profileDir string, proxyName string) error {
 	c.KeysDir = profileDir
 	c.AuthConnector = cp.AuthConnector
 	c.LoadAllCAs = cp.LoadAllCAs
+	c.AuthenticatorAttachment, err = parseMFAMode(cp.MFAMode)
+	if err != nil {
+		return trace.BadParameter("unable to parse mfa mode in user profile: %v.", err)
+	}
 
 	c.LocalForwardPorts, err = ParsePortForwardSpec(cp.ForwardedPorts)
 	if err != nil {
@@ -1170,6 +1175,7 @@ func (c *Config) SaveProfile(dir string, makeCurrent bool) error {
 	cp.SiteName = c.SiteName
 	cp.TLSRoutingEnabled = c.TLSRoutingEnabled
 	cp.AuthConnector = c.AuthConnector
+	cp.MFAMode = c.AuthenticatorAttachment.String()
 	cp.LoadAllCAs = c.LoadAllCAs
 
 	if err := cp.SaveToDir(dir, makeCurrent); err != nil {
@@ -4614,4 +4620,17 @@ func (tc *TeleportClient) SearchSessionEvents(ctx context.Context, fromUTC, toUT
 		return nil, trace.Wrap(err)
 	}
 	return sessions, nil
+}
+
+func parseMFAMode(in string) (webauthncli.AuthenticatorAttachment, error) {
+	switch in {
+	case "auto", "":
+		return webauthncli.AttachmentAuto, nil
+	case "platform":
+		return webauthncli.AttachmentPlatform, nil
+	case "cross-platform":
+		return webauthncli.AttachmentCrossPlatform, nil
+	default:
+		return 0, trace.BadParameter("unsupported mfa mode %q", in)
+	}
 }

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -77,9 +77,15 @@ func TestTeleportClient_Login_local(t *testing.T) {
 
 	// Reset functions after tests.
 	oldStdin, oldWebauthn := prompt.Stdin(), *client.PromptWebauthn
+	oldHasPlatformSupport := *client.HasPlatformSupport
+	*client.HasPlatformSupport = func() bool {
+		return true
+	}
+
 	t.Cleanup(func() {
 		prompt.SetStdin(oldStdin)
 		*client.PromptWebauthn = oldWebauthn
+		*client.HasPlatformSupport = oldHasPlatformSupport
 	})
 
 	waitForCancelFn := func(ctx context.Context) (string, error) {

--- a/lib/client/export.go
+++ b/lib/client/export.go
@@ -16,3 +16,4 @@ package client
 
 var PromptMFAStandalone = &promptMFAStandalone
 var PromptWebauthn = &promptWebauthn
+var HasPlatformSupport = &hasPlatformSupport

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -76,6 +76,9 @@ type PromptMFAChallengeOpts struct {
 // promptMFAStandalone is used to mock PromptMFAChallenge for tests.
 var promptMFAStandalone = PromptMFAChallenge
 
+// hasPlatformSupport is used to mock wancli.HasPlatformSupport for tests.
+var hasPlatformSupport = wancli.HasPlatformSupport
+
 // PromptMFAChallenge prompts the user to complete MFA authentication
 // challenges.
 // If proxyAddr is empty, the TeleportClient.WebProxyAddr is used.
@@ -121,9 +124,9 @@ func PromptMFAChallenge(ctx context.Context, c *proto.MFAAuthenticateChallenge, 
 
 	// Does the current platform support hardware MFA? Adjust accordingly.
 	switch {
-	case !hasTOTP && !wancli.HasPlatformSupport():
+	case !hasTOTP && !hasPlatformSupport():
 		return nil, trace.BadParameter("hardware device MFA not supported by your platform, please register an OTP device")
-	case !wancli.HasPlatformSupport():
+	case !hasPlatformSupport():
 		// Do not prompt for hardware devices, it won't work.
 		hasWebauthn = false
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -831,6 +831,8 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	// touchid subcommands.
 	tid := newTouchIDCommand(app)
 
+	webauthnwin := newWebauthnwinCommand(app)
+
 	if runtime.GOOS == constants.WindowsOS {
 		bench.Hidden()
 	}
@@ -1071,6 +1073,8 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 		err = onFIDO2Diag(&cf)
 	case tid.diag.FullCommand():
 		err = tid.diag.run(&cf)
+	case webauthnwin.diag.FullCommand():
+		err = webauthnwin.diag.run(&cf)
 	default:
 		// Handle commands that might not be available.
 		switch {

--- a/tool/tsh/winwebauthn.go
+++ b/tool/tsh/winwebauthn.go
@@ -1,0 +1,69 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gravitational/kingpin"
+	"github.com/gravitational/teleport/lib/auth/webauthnwin"
+	"github.com/gravitational/trace"
+)
+
+type webauthnwinCommand struct {
+	diag *webauthnwinDiagCommand
+}
+
+// newWebauthnwinCommand returns webauthnwin subcommands.
+// `diag` is always available.
+func newWebauthnwinCommand(app *kingpin.Application) *webauthnwinCommand {
+	wid := app.Command("webauthnwin", "Manage Windows WebAuthn").Hidden()
+	cmd := &webauthnwinCommand{
+		diag: newWebauthnwinDiagCommand(wid),
+	}
+	return cmd
+}
+
+type webauthnwinDiagCommand struct {
+	*kingpin.CmdClause
+}
+
+func newWebauthnwinDiagCommand(app *kingpin.CmdClause) *webauthnwinDiagCommand {
+	return &webauthnwinDiagCommand{
+		CmdClause: app.Command("diag", "Run windows webauthn diagnostics").Hidden(),
+	}
+}
+
+func (w *webauthnwinDiagCommand) run(cf *CLIConf) error {
+	diag := webauthnwin.CheckSupport()
+	fmt.Printf("\nWebauthnWin available: %v\n", diag.IsAvailable)
+	fmt.Printf("Compile support: %v\n", diag.HasCompileSupport)
+	fmt.Printf("DLL API version: %v\n", diag.WebAuthnAPIVersion)
+	fmt.Printf("Has platform UV: %v\n", diag.HasPlatformUV)
+
+	if !diag.IsAvailable {
+		return nil
+	}
+	resp, err := webauthnwin.Diag(cf.Context, os.Stdout)
+	// Abort if we got a nil diagnostic, otherwise print as much as we can.
+	if resp == nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf("Register successful: %v\n", resp.RegisterSuccessful)
+	fmt.Printf("Login successful: %v\n", resp.LoginSuccessful)
+	return nil
+}


### PR DESCRIPTION
implementes https://github.com/gravitational/teleport/pull/16360
Uses wrapper implemented in https://github.com/gravitational/teleport/pull/16634 to connec via tsh.

What has changed?

- support for fido devices and windows hello on windows platform
- storing mfa-mode in tsh profile file

Support for extension: app_id will be provided in other PR.
Integration/manual tests will be provided in other PR.
Deleting credentials will be added in separate PR (only supported in v4)

Solves: https://github.com/gravitational/teleport/issues/15148