### PR TITLE
[v9] Speed up TestTerminalPing

### DIFF
--- a/lib/srv/keepalive.go
+++ b/lib/srv/keepalive.go
@@ -62,7 +62,7 @@ func StartKeepAliveLoop(p KeepAliveParams) {
 	log := logrus.WithFields(logrus.Fields{
 		trace.Component: teleport.ComponentKeepAlive,
 	})
-	log.Debugf("Starting keep-alive loop with with interval %v and max count %v.", p.Interval, p.MaxCount)
+	log.Debugf("Starting keep-alive loop with interval %v and max count %v.", p.Interval, p.MaxCount)
 
 	tickerCh := time.NewTicker(p.Interval)
 	defer tickerCh.Stop()

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -141,7 +141,7 @@ type TerminalHandler struct {
 	// log holds the structured logger.
 	log *logrus.Entry
 
-	// params is the initial PTY size.
+	// params describes the request for a PTY
 	params TerminalRequest
 
 	// ctx is a web session context for the currently logged in user.


### PR DESCRIPTION
This test takes between 10-20 seconds to run, because it waits for a websocket ping message and pings run on a 10s timer by default.

It turns out, we allow specifying the keepalive interval in the terminal request, but due to a bug we would always overwrite that value with what's in the cluster networking config.

Fix the bug and speed up the test by overriding the keepalive interval to something shorter for this test.

Before:

    ➜ go test -run TestTerminalPing -race ./lib/web -count=1
    ok      github.com/gravitational/teleport/lib/web       13.122s

After:

    ➜ go test -run TestTerminalPing -race ./lib/web -count=1
    ok      github.com/gravitational/teleport/lib/web       3.394s