### PR TITLE
Make host case-insensitive when using ssh config

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -91,7 +91,7 @@ func ExternalSSHCommand(o CommandOptions) (*exec.Cmd, error) {
 		proxyCommand = append(proxyCommand, "-oForwardAgent=yes")
 	}
 	proxyCommand = append(proxyCommand, fmt.Sprintf("-p %v", o.ProxyPort))
-	proxyCommand = append(proxyCommand, `%r@localhost -s proxy:%h:%p`)
+	proxyCommand = append(proxyCommand, `%r@localhost -s proxy:%n:%p`)
 
 	// Add in ProxyCommand option, needed for all Teleport connections.
 	execArgs = append(execArgs, fmt.Sprintf("-oProxyCommand=%v", strings.Join(proxyCommand, " ")))

--- a/lib/tbot/config/configtemplate_ssh_client.go
+++ b/lib/tbot/config/configtemplate_ssh_client.go
@@ -289,7 +289,7 @@ Host *.{{ .ClusterName }} {{ .ProxyHost }}
 # Flags for all {{ .ClusterName }} hosts except the proxy
 Host *.{{ .ClusterName }} !{{ .ProxyHost }}
     Port 3022
-    ProxyCommand "{{ .TBotPath }}" proxy --destination-dir={{ .DestinationDir }} --proxy={{ .ProxyHost }} ssh --cluster={{ .ClusterName }}  %r@%h:%p
+    ProxyCommand "{{ .TBotPath }}" proxy --destination-dir={{ .DestinationDir }} --proxy={{ .ProxyHost }} ssh --cluster={{ .ClusterName }}  %r@%n:%p
 
 # End generated Teleport configuration
 `))

--- a/tool/tsh/config.go
+++ b/tool/tsh/config.go
@@ -41,7 +41,7 @@ Host *.{{ .ClusterName }} {{ .ProxyHost }}
 # Flags for all {{ .ClusterName }} hosts except the proxy
 Host *.{{ .ClusterName }} !{{ .ProxyHost }}
     Port 3022
-    ProxyCommand "{{ .TSHPath }}" proxy ssh --cluster={{ .ClusterName }} --proxy={{ .ProxyHost }} %r@%h:%p
+    ProxyCommand "{{ .TSHPath }}" proxy ssh --cluster={{ .ClusterName }} --proxy={{ .ProxyHost }} %r@%n:%p
 `
 
 type hostConfigParameters struct {

--- a/tool/tsh/config_test.go
+++ b/tool/tsh/config_test.go
@@ -37,7 +37,7 @@ Host *.test-cluster localhost
 # Flags for all test-cluster hosts except the proxy
 Host *.test-cluster !localhost
     Port 3022
-    ProxyCommand "/bin/tsh" proxy ssh --cluster=test-cluster --proxy=localhost %r@%h:%p
+    ProxyCommand "/bin/tsh" proxy ssh --cluster=test-cluster --proxy=localhost %r@%n:%p
 `
 
 	var sb strings.Builder

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -179,7 +179,7 @@ func setupJumpHost(cf *CLIConf, tc *libclient.TeleportClient, sp sshProxyParams)
 }
 
 // sshProxy opens up a new SSH session connected to the Teleport Proxy's SSH proxy subsystem,
-// This is the equivalent of `ssh -o 'ForwardAgent yes' -p port %r@host -s proxy:%h:%p`.
+// This is the equivalent of `ssh -o 'ForwardAgent yes' -p port %r@host -s proxy:%n:%p`.
 // If tls routing is enabled, the connection to RemoteProxyAddr is wrapped with TLS protocol.
 func sshProxy(ctx context.Context, tc *libclient.TeleportClient, sp sshProxyParams) error {
 	upstreamConn, err := dialSSHProxy(ctx, tc, sp)

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -291,9 +291,9 @@ proxy_templates:
 	sshConfigFile := filepath.Join(tshHome, "sshconfig")
 	os.WriteFile(sshConfigFile, []byte(fmt.Sprintf(`
 Host *
-  HostName %%h
+  HostName %%n
   StrictHostKeyChecking no
-  ProxyCommand %v -d --insecure proxy ssh -J {{proxy}} %%r@%%h:%%p
+  ProxyCommand %v -d --insecure proxy ssh -J {{proxy}} %%r@%%n:%%p
 `, tshPath)), 0644)
 
 	// Connect to "localnode" with OpenSSH.


### PR DESCRIPTION
Our current `ProxyCommand` in ssh config file uses `%h` to represent the hostname. One side-effect of `%h` is always converting the hostname to lowercase, which prevents people from connecting to hosts with uppercase characters. According to OpenSSH documentation https://www.man7.org/linux/man-pages/man5/ssh_config.5.html#TOKENS `%n` uses exactly the same name as provided on the command-line.

Closes https://github.com/gravitational/teleport/issues/16457