### PR TITLE
fix(asciitable): Default maxCellLength to 0 if negative

### DIFF
--- a/lib/asciitable/table.go
+++ b/lib/asciitable/table.go
@@ -107,7 +107,7 @@ func MakeTableWithTruncatedColumn(columnOrder []string, rows [][]string, truncat
 
 	for _, column := range columns {
 		if column.Title == truncatedColumn {
-			column.MaxCellLength = width - totalLen - len("... ")
+			column.MaxCellLength = max(width - totalLen - len("... "), 0)
 		}
 		t.AddColumn(column)
 	}


### PR DESCRIPTION
Trying to run `tsh db ls` will panic in a small terminal session (in my case, 73 cols wide, in a split tmux-session):
```
❯ tsh db ls
panic: runtime error: slice bounds out of range [:-3]

goroutine 1 [running]:
github.com/gravitational/teleport/lib/asciitable.(*Table).truncateCell(0x14000e70748?, 0x1?, {0x14000c63600?, 0x107396220?})
        /private/tmp/teleport-20220916-10028-11awu4w/teleport-10.2.2/lib/asciitable/table.go:149 +0x168
github.com/gravitational/teleport/lib/asciitable.(*Table).AddRow(0x14000e70748, {0x14000623d60, 0x5, 0x5})
        /private/tmp/teleport-20220916-10028-11awu4w/teleport-10.2.2/lib/asciitable/table.go:131 +0x98
github.com/gravitational/teleport/lib/asciitable.MakeTableWithTruncatedColumn({0x14000e70938, 0x5, 0x0?}, {0x1400102c000, 0x13, 0x0?}, {0x1069a499b, 0x6})
        /private/tmp/teleport-20220916-10028-11awu4w/teleport-10.2.2/lib/asciitable/table.go:116 +0x204
main.showDatabasesAsText({0x1075a21a0, 0x140001aa008}, {0x0?, 0x0?}, {0x140000d4600?, 0x13?, 0x5?}, {0x140001c5c80?, 0x1?, 0x1?}, ...)
        /private/tmp/teleport-20220916-10028-11awu4w/teleport-10.2.2/tool/tsh/tsh.go:2344 +0x24c
main.showDatabases({0x1075a21a0, 0x140001aa008}, {0x0, 0x0}, {0x140000d4600, 0x13, 0x20}, {0x140001c5c80, 0x1, 0x1}, ...)
        /private/tmp/teleport-20220916-10028-11awu4w/teleport-10.2.2/tool/tsh/tsh.go:2224 +0xd0
main.onListDatabases(0x14000c10000)
        /private/tmp/teleport-20220916-10028-11awu4w/teleport-10.2.2/tool/tsh/db.go:93 +0x390
main.Run({0x1075c6850, 0x14000ab5b40}, {0x1400019c190, 0x2, 0x2}, {0x0, 0x0, 0x300000002?})
        /private/tmp/teleport-20220916-10028-11awu4w/teleport-10.2.2/tool/tsh/tsh.go:1037 +0x995c
main.main()
        /private/tmp/teleport-20220916-10028-11awu4w/teleport-10.2.2/tool/tsh/tsh.go:444 +0x2d0
```

Teleport version ran on macOS:
```
❯ tsh version
Teleport v10.2.2 git: go1.19.1
```

This is probably not a perfect fix, but it resolves the panic. I'm sure people won't get much useful information from this if working in such a small terminal, but at least it won't completely crash `tsh`.

This should fix #13130 (depending on the "perfectness" required) (sorry, I saw it was already assigned, but nothing has happened for a while, and I had already had a stab at it myself).

I wasn't completely sure if this was the best solution for this problem, so feel free to give pointers on other solutions/problems.