### PR TITLE
[v10] helm: add minReadySeconds to teleport-cluster chart

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1104,6 +1104,31 @@ Sets the `Group` of `Issuer` to be used when issuing certificates with `cert-man
   </TabItem>
 </Tabs>
 
+## `highAvailability.minReadySeconds`
+
+| Type | Default value | Can be used in `custom` mode? |
+| - | - | - | - |
+| `integer` | `15` | ✅ |
+
+Amount of time to wait during a pod rollout before moving to the next pod.
+[See Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds).
+
+This is used to give time for the agents to connect back to newly created pods before continuing the rollout.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  highAvailability:
+    minReadySeconds: 15
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```shell
+  --set highAvailability.minReadySeconds=15
+  ```
+  </TabItem>
+</Tabs>
+
 ## `tls.existingSecretName`
 
 | Type | Default value | Can be used in `custom` mode? | `teleport.yaml` equivalent |

--- a/examples/chart/teleport-cluster/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/deployment.yaml
@@ -28,6 +28,7 @@ metadata:
 spec:
   {{- if not (eq .Values.chartMode "standalone") }}
   replicas: {{ .Values.highAvailability.replicaCount }}
+  minReadySeconds: {{ .Values.highAvailability.minReadySeconds }}
   {{- else }}
   replicas: 1
   {{- end }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/serviceaccount_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/serviceaccount_test.yaml.snap
@@ -1,3 +1,12 @@
+changes ServiceAccount name when specified:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        kubernetes.io/serviceaccount: test-annotation
+      name: helm-lint
+      namespace: NAMESPACE
 sets ServiceAccount annotations when specified:
   1: |
     apiVersion: v1

--- a/examples/chart/teleport-cluster/tests/deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/deployment_test.yaml
@@ -838,3 +838,13 @@ tests:
             value: some-value
       - matchSnapshot:
           path: spec.template.spec
+
+  - it: should set minReadySeconds in non-standalone mode
+    set:
+      chartMode: custom
+      highAvailability:
+        minReadySeconds: 60
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 60

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -465,6 +465,7 @@
                 "replicaCount",
                 "requireAntiAffinity",
                 "certManager",
+                "minReadySeconds",
                 "podDisruptionBudget"
             ],
             "properties": {
@@ -514,6 +515,11 @@
                             "default": "cert-manager.io"
                         }
                     }
+                },
+                "minReadySeconds": {
+                    "$id": "#/properties/highAvailability/properties/minReadySeconds",
+                    "type": "integer",
+                    "default": 15
                 },
                 "podDisruptionBudget": {
                     "$id": "#/properties/highAvailability/properties/podDisruptionBudget",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -269,6 +269,9 @@ highAvailability:
     # Group of Issuer that cert-manager should look for.
     # This defaults to 'cert-manager.io' which is the default Issuer group.
     issuerGroup: cert-manager.io
+  # Injects delay when performing pod rollouts to mitigate the loss of all agent tunnels at the same time
+  # See https://github.com/gravitational/teleport/issues/13129
+  minReadySeconds: 15
 
 # Settings for mounting your own TLS keypair to secure Teleport's web UI.
 # These settings are mutually exclusive with the "highAvailability.certManager" and "acme" values above.


### PR DESCRIPTION
Backport #16465 to branch/v10