### PR TITLE
Fix ControlMaster integration test

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1621,6 +1621,15 @@ func (s *session) trackSession(teleportUser string, policySet []*types.SessionTr
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		go func() {
+			err := s.tracker.WaitOnState(s.serverCtx, types.SessionState_SessionStateTerminated)
+			if err != nil {
+				s.log.WithError(err).Error("Failed to wait on session state.")
+			}
+
+			bk.Close()
+		}()
 	} else {
 		var err error
 		s.tracker, err = NewSessionTracker(s.serverCtx, trackerSpec, s.registry.SessionTrackerService)

--- a/lib/srv/sessiontracker.go
+++ b/lib/srv/sessiontracker.go
@@ -45,15 +45,17 @@ type SessionTracker struct {
 
 // NewSessionTracker returns a new SessionTracker for the given types.SessionTracker
 func NewSessionTracker(ctx context.Context, trackerSpec types.SessionTrackerSpecV1, service services.SessionTrackerService) (*SessionTracker, error) {
+	if service == nil {
+		return nil, trace.BadParameter("missing parameter service")
+	}
+
 	t, err := types.NewSessionTracker(trackerSpec)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if service != nil {
-		if t, err = service.CreateSessionTracker(ctx, t); err != nil {
-			return nil, trace.Wrap(err)
-		}
+	if t, err = service.CreateSessionTracker(ctx, t); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return &SessionTracker{
@@ -104,20 +106,16 @@ func (s *SessionTracker) UpdateExpiration(ctx context.Context, expiry time.Time)
 	s.tracker.SetExpiry(expiry)
 	s.trackerCond.Broadcast()
 
-	if s.service != nil {
-		err := s.service.UpdateSessionTracker(ctx, &proto.UpdateSessionTrackerRequest{
-			SessionID: s.tracker.GetSessionID(),
-			Update: &proto.UpdateSessionTrackerRequest_UpdateExpiry{
-				UpdateExpiry: &proto.SessionTrackerUpdateExpiry{
-					Expires: &expiry,
-				},
+	err := s.service.UpdateSessionTracker(ctx, &proto.UpdateSessionTrackerRequest{
+		SessionID: s.tracker.GetSessionID(),
+		Update: &proto.UpdateSessionTrackerRequest_UpdateExpiry{
+			UpdateExpiry: &proto.SessionTrackerUpdateExpiry{
+				Expires: &expiry,
 			},
-		})
+		},
+	})
 
-		return trace.Wrap(err)
-	}
-
-	return nil
+	return trace.Wrap(err)
 }
 
 func (s *SessionTracker) AddParticipant(ctx context.Context, p *types.Participant) error {
@@ -126,20 +124,16 @@ func (s *SessionTracker) AddParticipant(ctx context.Context, p *types.Participan
 	s.tracker.AddParticipant(*p)
 	s.trackerCond.Broadcast()
 
-	if s.service != nil {
-		err := s.service.UpdateSessionTracker(ctx, &proto.UpdateSessionTrackerRequest{
-			SessionID: s.tracker.GetSessionID(),
-			Update: &proto.UpdateSessionTrackerRequest_AddParticipant{
-				AddParticipant: &proto.SessionTrackerAddParticipant{
-					Participant: p,
-				},
+	err := s.service.UpdateSessionTracker(ctx, &proto.UpdateSessionTrackerRequest{
+		SessionID: s.tracker.GetSessionID(),
+		Update: &proto.UpdateSessionTrackerRequest_AddParticipant{
+			AddParticipant: &proto.SessionTrackerAddParticipant{
+				Participant: p,
 			},
-		})
+		},
+	})
 
-		return trace.Wrap(err)
-	}
-
-	return nil
+	return trace.Wrap(err)
 }
 
 func (s *SessionTracker) RemoveParticipant(ctx context.Context, participantID string) error {
@@ -148,20 +142,16 @@ func (s *SessionTracker) RemoveParticipant(ctx context.Context, participantID st
 	s.tracker.RemoveParticipant(participantID)
 	s.trackerCond.Broadcast()
 
-	if s.service != nil {
-		err := s.service.UpdateSessionTracker(ctx, &proto.UpdateSessionTrackerRequest{
-			SessionID: s.tracker.GetSessionID(),
-			Update: &proto.UpdateSessionTrackerRequest_RemoveParticipant{
-				RemoveParticipant: &proto.SessionTrackerRemoveParticipant{
-					ParticipantID: participantID,
-				},
+	err := s.service.UpdateSessionTracker(ctx, &proto.UpdateSessionTrackerRequest{
+		SessionID: s.tracker.GetSessionID(),
+		Update: &proto.UpdateSessionTrackerRequest_RemoveParticipant{
+			RemoveParticipant: &proto.SessionTrackerRemoveParticipant{
+				ParticipantID: participantID,
 			},
-		})
+		},
+	})
 
-		return trace.Wrap(err)
-	}
-
-	return nil
+	return trace.Wrap(err)
 }
 
 func (s *SessionTracker) UpdateState(ctx context.Context, state types.SessionState) error {
@@ -170,20 +160,16 @@ func (s *SessionTracker) UpdateState(ctx context.Context, state types.SessionSta
 	s.tracker.SetState(state)
 	s.trackerCond.Broadcast()
 
-	if s.service != nil {
-		err := s.service.UpdateSessionTracker(ctx, &proto.UpdateSessionTrackerRequest{
-			SessionID: s.tracker.GetSessionID(),
-			Update: &proto.UpdateSessionTrackerRequest_UpdateState{
-				UpdateState: &proto.SessionTrackerUpdateState{
-					State: state,
-				},
+	err := s.service.UpdateSessionTracker(ctx, &proto.UpdateSessionTrackerRequest{
+		SessionID: s.tracker.GetSessionID(),
+		Update: &proto.UpdateSessionTrackerRequest_UpdateState{
+			UpdateState: &proto.SessionTrackerUpdateState{
+				State: state,
 			},
-		})
+		},
+	})
 
-		return trace.Wrap(err)
-	}
-
-	return nil
+	return trace.Wrap(err)
 }
 
 // WaitForStateUpdate waits for the tracker's state to be updated and returns the new state.


### PR DESCRIPTION
From my testing, this fixes the flakiness of the `ControlMaster` integration test which has started to fail often in the proxy recording mode case as a result of #15155. I tracked it down to this change - and to be honest, I still don't have a completely sound argument for why this happens, I'd appreciate any ideas. To avoid duplicate trackers I ended up creating a local service to preserve behaviour as opposed to hitting the cluster local tracker service.