### PR TITLE
Improve unit tests in CI

### DIFF
--- a/.cloudbuild/ci/unit-tests.yaml
+++ b/.cloudbuild/ci/unit-tests.yaml
@@ -1,4 +1,4 @@
-timeout: 25m
+timeout: 30m
 
 options:
   machineType: E2_HIGHCPU_32

--- a/.cloudbuild/scripts/cmd/unit-tests/main.go
+++ b/.cloudbuild/scripts/cmd/unit-tests/main.go
@@ -178,7 +178,7 @@ func run() error {
 	}
 
 	log.Printf("Running unit tests...")
-	err = runUnitTests(args.workspace)
+	err = runUnitTests(args.workspace, ch)
 	if err != nil {
 		return trace.Wrap(err, "unit tests failed")
 	}
@@ -188,14 +188,29 @@ func run() error {
 	return nil
 }
 
-func runUnitTests(workspace string) error {
+func runUnitTests(workspace string, ch changes.Changes) error {
 	enableTests := []string{
 		"TELEPORT_ETCD_TEST=yes",
 		"TELEPORT_XAUTH_TEST=yes",
 		"TELEPORT_BPF_TEST=yes",
 	}
 
-	cmd := exec.Command("make", "test")
+	targets := []string{"test-go", "test-sh", "test-api"}
+	if ch.Helm {
+		targets = append(targets, "test-helm")
+	}
+	if ch.CI {
+		targets = append(targets, "test-ci")
+	}
+	if ch.Rust {
+		targets = append(targets, "test-rust")
+	}
+	if ch.Operator {
+		targets = append(targets, "test-operator")
+	}
+
+	log.Printf("Running test targets: %v", strings.Join(targets, " "))
+	cmd := exec.Command("make", targets...)
 	cmd.Dir = workspace
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, enableTests...)

--- a/.cloudbuild/scripts/internal/changes/changes.go
+++ b/.cloudbuild/scripts/internal/changes/changes.go
@@ -31,9 +31,13 @@ import (
 
 // Changes describes the kind of changes found in the analyzed workspace.
 type Changes struct {
+	CI         bool
 	Docs       bool
 	Code       bool
 	Enterprise bool
+	Helm       bool
+	Operator   bool
+	Rust       bool
 }
 
 // Analyze examines the workspace for specific changes using its git history,
@@ -64,6 +68,18 @@ func Analyze(workspaceDir string, targetBranch string, commitSHA string) (Change
 		case isDocChange(path):
 			report.Docs = true
 
+		case isHelmChange(path):
+			report.Helm = true
+
+		case isRustChange(path):
+			report.Rust = true
+
+		case isCIChange(path):
+			report.CI = true
+
+		case isOperatorChange(path):
+			report.Operator = true
+
 		default:
 			report.Code = true
 		}
@@ -78,12 +94,34 @@ func Analyze(workspaceDir string, targetBranch string, commitSHA string) (Change
 	return report, nil
 }
 
+func isCIChange(path string) bool {
+	path = strings.ToLower(path)
+	return strings.HasPrefix(path, ".cloudbuild/scripts")
+}
+
+func isOperatorChange(path string) bool {
+	path = strings.ToLower(path)
+	return strings.HasPrefix(path, "operator/")
+}
+
 func isDocChange(path string) bool {
 	path = strings.ToLower(path)
 	return strings.HasPrefix(path, "docs/") ||
 		strings.HasSuffix(path, ".mdx") ||
 		strings.HasSuffix(path, ".md") ||
 		strings.HasPrefix(path, "rfd/")
+}
+
+func isRustChange(path string) bool {
+	path = strings.ToLower(path)
+	return strings.HasSuffix(path, ".rs") ||
+		strings.HasSuffix(path, "Cargo.toml") ||
+		strings.HasSuffix(path, "Cargo.lock")
+}
+
+func isHelmChange(path string) bool {
+	path = strings.ToLower(path)
+	return strings.HasPrefix(path, "examples/chart/")
 }
 
 // getChanges resolves the head of target branch and compares the trees at the


### PR DESCRIPTION
We're seeing lots of timeouts in unit tests today. Attempt to resolve this by:

1. increasing the timeout
2. doing less work if there are no changes