### PR TITLE
ci: Don't run the Dependency Review workflow on `push` actions

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,10 +1,6 @@
 name: Dependency Review
 
 on:
-  push:
-    branches:
-      - master
-      - branch/*
   pull_request:
 
 jobs:


### PR DESCRIPTION
The Dependency Review action only supports the `pull_request` operation currently. Running it on `push` operations throws an error, so remove for now until the action supports that operation.