### PR TITLE
[v9] ci: Don't run the Dependency Review workflow on `push` actions

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,10 +1,6 @@
 name: Dependency Review
 
 on:
-  push:
-    branches:
-      - master
-      - branch/*
   pull_request:
 
 jobs:


### PR DESCRIPTION
Backport #16700 to branch/v9