### PR TITLE
Try to fix ControlMaster integration test flakiness

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -60,6 +60,8 @@ type CommandOptions struct {
 func ExternalSSHCommand(o CommandOptions) (*exec.Cmd, error) {
 	var execArgs []string
 
+	execArgs = append(execArgs, "-v")
+
 	// Don't check the host certificate as part of the testing an external SSH
 	// client, this is done elsewhere.
 	execArgs = append(execArgs, "-oStrictHostKeyChecking=no")

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3483,9 +3483,11 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 	}
 
 	for _, tt := range tests {
-		controlPath := filepath.Join(t.TempDir(), "control-path")
-
-		func() {
+		t.Run(tt.inRecordLocation, func(t *testing.T) {
+			controlDir, err := os.MkdirTemp("", "teleport-")
+			require.NoError(t, err)
+			defer os.RemoveAll(controlDir)
+			controlPath := filepath.Join(controlDir, "control-path")
 			// Create a Teleport instance with auth, proxy, and node.
 			makeConfig := func() (*testing.T, []string, []*helpers.InstanceSecrets, *service.Config) {
 				recConfig, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
@@ -3560,7 +3562,7 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 			})
 			require.NoError(t, err)
 			mustRunControlCmd(t, cmd, "hello")
-		}()
+		})
 	}
 }
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3531,10 +3531,13 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 				SocketPath:   socketPath,
 				ProxyPort:    helpers.PortStr(t, teleport.SSHProxy),
 				NodePort:     helpers.PortStr(t, teleport.SSH),
-				Command:      "sleep 2",
+				Command:      "sleep 5",
 			})
 			require.NoError(t, err)
-			err = controlCmd.Run()
+			output, err := controlCmd.CombinedOutput()
+			if err != nil {
+				t.Logf("ControlMaster unexpected error: %v", string(output))
+			}
 			require.NoError(t, err)
 		}()
 
@@ -3559,10 +3562,6 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 		})
 		require.NoError(t, err)
 		mustRunControlCmd(t, cmd, "hello")
-
-		// Cancel gracefully control command allowing exit background process without error.
-		// ssh -O cancel -oControlPath=controlPath ...
-		helpers.MustCancelForControlMaster(t, controlPath, nodePort)
 	}
 }
 


### PR DESCRIPTION
Related:  https://github.com/gravitational/teleport/issues/16224

## What: 
Try to fix ControlMaster Integration test where the SSH multiplexing feature is used. 
Currently the ControlMaster integration test tries to run ControlMaster command where the ControlProcess fork from ssh command and terminates when the `ControlPersist` timer expires:

After testing the forked ControlProcess exists with status code != 0: 
```
ssh -v                                     \
-oStrictHostKeyChecking=no                 \
-oUserKnownHostsFile=/dev/null             \
-oControlMaster=auto                       \
-oControlPersist=1s                        \
-oConnectTimeout=2                         \
-oControlPath=~/.ssh/controlmasters/test1 \
localhost echo hello
...
debug1: Sending command: echo hello
debug1: Sending env LC_CTYPE = UTF-8
debug1: Sending env LC_TERMINAL = iTerm2
hello
debug1: client_input_channel_req: channel 2 rtype exit-status reply 0
debug1: client_input_channel_req: channel 2 rtype eow@openssh.com reply 0
debug1: channel 2: free: client-session, nchannels 3
debug1: channel 1: free: mux-control, nchannels 2
➜  ~ 
debug1: ControlPersist timeout expired
debug1: channel 0: free: /Users/marek/.ssh/controlmasters/test1, nchannels 1
Transferred: sent 5952, received 2792 bytes, in 2.6 seconds
Bytes per second: sent 2285.0, received 1071.9
debug1: Exit status -1
``` 

## How:
To prevent this the `ControlPersist=1s`  is replaced by `sleep 2` allowing to  terminate ControlMaster process gracefully. 
The test flow looks like bellow: 

1) Run ControlMaster process with `ControlPersist=no` and keep the connection for 2s allowing to reuse multiplexed connection from other process: 

```
ssh -v                                     \
-oStrictHostKeyChecking=no                 \
-oUserKnownHostsFile=/dev/null             \
-oControlMaster=auto                       \
-oControlPersist=no                        \
-oConnectTimeout=2                         \
-oControlPath=~/.ssh/controlmasters/test1 \
localhost sleep 2
```
2) ensure that controlMaster process is running:
```
 ssh -O check -oControlPath=~/.ssh/controlmasters/test1 localhost
 debug2: mux_client_hello_exchange: master version 4
Master running (pid=42511)
```
3) Run `echo hello` command over ControlPath:
```
ssh -v                                     \
-oStrictHostKeyChecking=no                 \
-oUserKnownHostsFile=/dev/null             \
-oControlPath=~/.ssh/controlmasters/test1 \
localhost echo hello
```
4) The ControlMaster process stared in 1) should exit without error: 
```
debug1: Exit status 0
```