### PR TITLE
[v8] Add a version support table to the FAQ (#15924)

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -134,10 +134,33 @@ Here is a detailed breakdown of the differences between Teleport's editions.
 
 ## Which version of Teleport is supported?
 
-Teleport provides security-critical support for the current and two previous releases. With our typical release cadence, this means a release is usually supported for 9 months.
+Teleport provides security-critical support for the current and two previous
+releases. With our typical release cadence, this means a release is usually
+supported for 9 months.
+
+### Supported versions
+
+Here are the major and minor versions of Teleport that we currently support:
+
+|Release|Release Date|Minimum `tsh` version|
+|---|---|---|
+|v10.1|July 29, 2022|v9.x.x|
+|v10.0|July 8, 2022|v9.x.x|
+|v9.3|May 27, 2022|v8.x.x|
+|v9.2|May 4, 2022|v8.x.x|
+|v9.1|April 20, 2022|v8.x.x|
+|v9.0|March 11, 2022|v8.x.x|
+|v8.3|February 15, 2022|v7.x.x|
+|v8.2|February 8, 2022|v7.x.x|
+|v8.1|January 10, 2022|v7.x.x|
+|v8.0|November 15, 2021|v7.x.x|
 
 See our [Upgrading](./setup/operations/upgrading.mdx) guide for more
 information.
+
+### Version compatibility
+
+(!docs/pages/includes/compatibility.mdx!)
 
 ## Does the Web UI support copy and paste?
 

--- a/docs/pages/includes/compatibility.mdx
+++ b/docs/pages/includes/compatibility.mdx
@@ -1,0 +1,16 @@
+When running multiple `teleport` binaries within a cluster, the following rules
+apply:
+
+- **Patch and minor** versions are always compatible, for example, any 8.0.1
+  component will work with any 8.0.3 component and any 8.1.0 component will work
+  with any 8.3.0 component.
+- Servers support clients that are 1 major version behind, but do not support
+  clients that are on a newer major version. For example, an 8.x.x Proxy Service
+  is compatible with 7.x.x resource services and 7.x.x `tsh`, but we don't
+  guarantee that a 9.x.x resource service will work with an 8.x.x Proxy Service.
+  This also means you must not attempt to upgrade from 6.x.x straight to 8.x.x.
+  You must upgrade to 7.x.x first.
+- Proxy Services and resource services do not support Auth Services that are on
+  an older major version, and will fail to connect to older Auth Services by
+  default. This behavior can be overridden by passing `--skip-version-check`
+  when starting Proxy Services and resource services.

--- a/docs/pages/setup/operations/upgrading.mdx
+++ b/docs/pages/setup/operations/upgrading.mdx
@@ -41,17 +41,7 @@ regularly to make sure that your Teleport resource services are compatible.
 
 </Details>
 
-When running multiple binaries of Teleport within a cluster, the following rules apply:
-
-- **Patch and minor** versions are always compatible, for example, any 8.0.1
-  component will work with any 8.0.3 component and any 8.1.0 component will work
-  with any 8.3.0 component.
-- Servers support clients that are 1 major version behind, but do not support
-  clients that are on a newer major version. For example, an 8.x.x Proxy Service
-  is compatible with 7.x.x Nodes and 7.x.x `tsh`, but we don't guarantee that a
-  9.x.x Node will work with an 8.x.x Proxy Service. This also means you must not
-  attempt to upgrade from 6.x.x straight to 8.x.x. You must upgrade to 7.x.x
-  first.
+(!docs/pages/includes/compatibility.mdx!)
 
 ## Backup
 


### PR DESCRIPTION
Backports #16630

* Add a version support table to the FAQ

Fixes #15582

List the minor Teleport versions we currently support, plus their release dates and minimum `tsh` versions. This restores the table that we removed in PR #12641. Unlike that table, this change does not list versions that are EOL, as this is now quite a lengthy list. Instead, this change makes it explicit that the table lists currently supported versions.

* Respond to PR feedback

Add a note about cross-component version compatibility to the FAQ by creating a partial from a similar compatibility note in our Upgrading guide.

Co-authored-by: Paul Gottschling <paul.gottschling@goteleport.com>