### PR TITLE
Disable ControlMaster test for proxy recording mode

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3476,10 +3476,11 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 		{
 			inRecordLocation: types.RecordAtNode,
 		},
-		// Run tests when Teleport is recording sessions at the proxy.
-		{
-			inRecordLocation: types.RecordAtProxy,
-		},
+		// Run tests when Teleport is recording sessions at the proxy
+		// (temporarily disabled, see https://github.com/gravitational/teleport/issues/16224)
+		// {
+		// 	inRecordLocation: types.RecordAtProxy,
+		// },
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Control master functionality is currently broken in proxy recording mode. We're aware of the issue and will disable the test until we are able to fix the underlying issue.

Updates #16224