### PR TITLE
chore!: Update libfido2 to 1.12.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -41,9 +41,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 
 # Install libfido2.
 # Depends on libcbor, libssl-dev, zlib1g-dev and libudev.
-RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.11.0 && \
+RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
-    [ "$(git rev-parse HEAD)" = "e61379ff0a27277fbe0aca29ccc34ff93c57b359" ] && \
+    [ "$(git rev-parse HEAD)" = "659a02679f99fd34a44e06e35dce90794f6ecc86" ] && \
     CFLAGS=-pthread cmake \
         -DBUILD_EXAMPLES=OFF \
         -DBUILD_MANPAGES=OFF \
@@ -251,11 +251,11 @@ COPY --from=libfido2 /usr/local/lib/pkgconfig/ /usr/local/lib/pkgconfig/
 COPY --from=libfido2 \
     /usr/local/lib/libcbor.a \
     /usr/local/lib/libfido2.a \
-    /usr/local/lib/libfido2.so.1.11.0 \
+    /usr/local/lib/libfido2.so.1.12.0 \
     /usr/local/lib/libudev.a \
     /usr/local/lib/
 RUN cd /usr/local/lib && \
-    ln -s libfido2.so.1.11.0 libfido2.so.1 && \
+    ln -s libfido2.so.1.12.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
     ldconfig
 COPY pkgconfig/buildbox/ /

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -7,9 +7,11 @@ FROM centos:7 AS libfido2
 
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
+    yum install -y centos-release-scl-rh && \
     yum update -y && \
     yum install -y \
         cmake3 \
+        devtoolset-11-gcc* \
         git \
         libudev-devel \
         zlib-devel && \
@@ -47,19 +49,18 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 # Install libfido2.
 # Depends on libcbor, openssl, zlib-devel and libudev.
 # Linked so `make build/tsh` finds the library where it expects it.
-RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.11.0 && \
+RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
-    [ "$(git rev-parse HEAD)" = "e61379ff0a27277fbe0aca29ccc34ff93c57b359" ] && \
-    cmake3 \
-        -DBUILD_EXAMPLES=OFF \
-        -DBUILD_MANPAGES=OFF \
-        -DBUILD_TOOLS=OFF \
-        -DCMAKE_BUILD_TYPE=Release . && \
-    make && \
+    [ "$(git rev-parse HEAD)" = "659a02679f99fd34a44e06e35dce90794f6ecc86" ] && \
+    scl enable devtoolset-11 "\
+      cmake3 \
+          -DBUILD_EXAMPLES=OFF \
+          -DBUILD_MANPAGES=OFF \
+          -DBUILD_TOOLS=OFF \
+          -DCMAKE_BUILD_TYPE=Release . && \
+      make" && \
     make install && \
-# Update ld.
-    echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
-    ldconfig
+    make clean
 
 ## LIBBPF #####################################################################
 
@@ -207,30 +208,29 @@ COPY --from=libfido2 \
     /usr/local/lib64/libcrypto.a \
     /usr/local/lib64/libcrypto.so.1.1 \
     /usr/local/lib64/libfido2.a \
-    /usr/local/lib64/libfido2.so.1.11.0 \
+    /usr/local/lib64/libfido2.so.1.12.0 \
     /usr/local/lib64/libssl.a \
     /usr/local/lib64/libssl.so.1.1 \
     /usr/local/lib64/libudev.a \
     /usr/local/lib64/
+# Re-create usual lib64 links.
+RUN cd /usr/local/lib64 && \
+    ln -s libcrypto.so.1.1 libcrypto.so && \
+    ln -s libfido2.so.1.12.0 libfido2.so.1 && \
+    ln -s libfido2.so.1 libfido2.so && \
+    ln -s libssl.so.1.1 libssl.so && \
+# Update ld.
+    echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
+    ldconfig
+# Configure pkg-config.
+COPY pkgconfig/centos7/ /
+ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
 
 COPY --from=libpcsclite /usr/local/include/ /usr/local/include/
 COPY --from=libpcsclite /usr/local/lib/pkgconfig/ /usr/local/lib64/pkgconfig/
 COPY --from=libpcsclite \
     /usr/local/lib/libpcsclite.a \
     /usr/local/lib/
-
-# Re-create usual lib64 links.
-RUN cd /usr/local/lib64 && \
-    ln -s libcrypto.so.1.1 libcrypto.so && \
-    ln -s libfido2.so.1.11.0 libfido2.so.1 && \
-    ln -s libfido2.so.1 libfido2.so && \
-    ln -s libssl.so.1.1 libssl.so && \
-# Update ld.
-    echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
-    ldconfig
-    
-COPY pkgconfig/centos7/ /
-ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
 
 # Download pre-built CentOS 7 assets with clang needed to build BPF tools.
 RUN cd / && curl -L https://s3.amazonaws.com/clientbuilds.gravitational.io/go/centos7-assets.tar.gz | tar -xz

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -16,7 +16,7 @@ readonly MACOS_VERSION_MIN=10.13
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.9.0
 readonly CRYPTO_VERSION=OpenSSL_1_1_1q
-readonly FIDO2_VERSION=1.11.0
+readonly FIDO2_VERSION=1.12.0
 
 readonly LIB_CACHE="/tmp/teleport-fido2-cache"
 readonly PKGFILE_DIR="$LIB_CACHE/fido2-${FIDO2_VERSION}_cbor-${CBOR_VERSION}_crypto-${CRYPTO_VERSION}"

--- a/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libfido2-static.pc
+++ b/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libfido2-static.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: libfido2
 Description: A FIDO2 library
 URL: https://github.com/yubico/libfido2
-Version: 1.11.0
+Version: 1.12.0
 Requires: libcrypto-static
 # libfido2, libcbor and libudev combined here for simplicity.
 Libs: ${libdir}/libfido2.a ${libdir}/libcbor.a ${libdir}/libudev.a -pthread

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -6,6 +6,6 @@ enginesdir=${libdir}/engines-1.1
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 1.1.1o
+Version: 1.1.1q
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libfido2-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libfido2-static.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: libfido2
 Description: A FIDO2 library
 URL: https://github.com/yubico/libfido2
-Version: 1.11.0
+Version: 1.12.0
 Requires: libcrypto-static
 # libfido2, libcbor and libudev combined here for simplicity.
 Libs: ${libdir}/libfido2.a ${libdir}/libcbor.a ${libdir}/libudev.a -pthread


### PR DESCRIPTION
Update libfido2 to the latest release.

Centos7 builds require a newer toolchain: [-Wimplicit-fallthrough][1] is the first hurdle for the old toolchain, but there are more after it.

Release notes: https://developers.yubico.com/libfido2/Release_Notes.html.

[1]: https://github.com/Yubico/libfido2/blob/659a02679f99fd34a44e06e35dce90794f6ecc86/CMakeLists.txt#L281