### PR TITLE
Remove cacert flag from curl output during tsh app login.

### DIFF
--- a/tool/tsh/app.go
+++ b/tool/tsh/app.go
@@ -252,7 +252,7 @@ func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, a
 
 	var curlCmd string
 	if insecure {
-		curlCmd = fmt.Sprintf(`curl -k \
+		curlCmd = fmt.Sprintf(`curl --insecure \
   --cert %v \
   --key %v \
   %v`,

--- a/tool/tsh/app.go
+++ b/tool/tsh/app.go
@@ -108,7 +108,7 @@ func onAppLogin(cf *CLIConf) error {
 			"appName": app.GetName(),
 		})
 	}
-	curlCmd, err := formatAppConfig(tc, profile, app.GetName(), app.GetPublicAddr(), appFormatCURL, rootCluster, cf.InsecureSkipVerify)
+	curlCmd, err := formatAppConfig(tc, profile, app.GetName(), app.GetPublicAddr(), appFormatCURL, rootCluster)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -234,7 +234,7 @@ func onAppConfig(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	conf, err := formatAppConfig(tc, profile, app.Name, app.PublicAddr, cf.Format, "", cf.InsecureSkipVerify)
+	conf, err := formatAppConfig(tc, profile, app.Name, app.PublicAddr, cf.Format, "")
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -242,7 +242,7 @@ func onAppConfig(cf *CLIConf) error {
 	return nil
 }
 
-func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, appName, appPublicAddr, format, cluster string, insecure bool) (string, error) {
+func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, appName, appPublicAddr, format, cluster string) (string, error) {
 	var uri string
 	if port := tc.WebProxyPort(); port == teleport.StandardHTTPSPort {
 		uri = fmt.Sprintf("https://%v", appPublicAddr)
@@ -251,7 +251,7 @@ func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, a
 	}
 
 	var curlCmd string
-	if insecure {
+	if tc.InsecureSkipVerify {
 		curlCmd = fmt.Sprintf(`curl --insecure \
   --cert %v \
   --key %v \

--- a/tool/tsh/app.go
+++ b/tool/tsh/app.go
@@ -126,7 +126,7 @@ var appLoginTpl = template.Must(template.New("").Parse(
 
 {{.curlCmd}}{{ if .insecure }}
 
-WARNING: tsh was called with --insecure, so this curl command will be unable to validate the cert presented by teleport.
+WARNING: tsh was called with --insecure, so this curl command will be unable to validate the certificate presented by Teleport.
 {{- end }}
 `))
 

--- a/tool/tsh/app.go
+++ b/tool/tsh/app.go
@@ -108,13 +108,14 @@ func onAppLogin(cf *CLIConf) error {
 			"appName": app.GetName(),
 		})
 	}
-	curlCmd, err := formatAppConfig(tc, profile, app.GetName(), app.GetPublicAddr(), appFormatCURL, rootCluster)
+	curlCmd, err := formatAppConfig(tc, profile, app.GetName(), app.GetPublicAddr(), appFormatCURL, rootCluster, cf.InsecureSkipVerify)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return appLoginTpl.Execute(os.Stdout, map[string]string{
-		"appName": app.GetName(),
-		"curlCmd": curlCmd,
+	return appLoginTpl.Execute(os.Stdout, map[string]interface{}{
+		"appName":  app.GetName(),
+		"curlCmd":  curlCmd,
+		"insecure": cf.InsecureSkipVerify,
 	})
 }
 
@@ -123,7 +124,10 @@ func onAppLogin(cf *CLIConf) error {
 var appLoginTpl = template.Must(template.New("").Parse(
 	`Logged into app {{.appName}}. Example curl command:
 
-{{.curlCmd}}
+{{.curlCmd}}{{ if .insecure }}
+
+WARNING: tsh was called with --insecure, so this curl command will be unable to validate the cert presented by teleport.
+{{- end }}
 `))
 
 // appLoginTCPTpl is the message that gets printed to a user upon successful
@@ -230,7 +234,7 @@ func onAppConfig(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	conf, err := formatAppConfig(tc, profile, app.Name, app.PublicAddr, cf.Format, "")
+	conf, err := formatAppConfig(tc, profile, app.Name, app.PublicAddr, cf.Format, "", cf.InsecureSkipVerify)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -238,22 +242,32 @@ func onAppConfig(cf *CLIConf) error {
 	return nil
 }
 
-func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, appName, appPublicAddr, format, cluster string) (string, error) {
+func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, appName, appPublicAddr, format, cluster string, insecure bool) (string, error) {
 	var uri string
 	if port := tc.WebProxyPort(); port == teleport.StandardHTTPSPort {
 		uri = fmt.Sprintf("https://%v", appPublicAddr)
 	} else {
 		uri = fmt.Sprintf("https://%v:%v", appPublicAddr, port)
 	}
-	curlCmd := fmt.Sprintf(`curl \
-  --cacert %v \
+
+	var curlCmd string
+	if insecure {
+		curlCmd = fmt.Sprintf(`curl -k \
   --cert %v \
   --key %v \
   %v`,
-		profile.CACertPathForCluster(cluster),
-		profile.AppCertPath(appName),
-		profile.KeyPath(),
-		uri)
+			profile.AppCertPath(appName),
+			profile.KeyPath(),
+			uri)
+	} else {
+		curlCmd = fmt.Sprintf(`curl \
+  --cert %v \
+  --key %v \
+  %v`,
+			profile.AppCertPath(appName),
+			profile.KeyPath(),
+			uri)
+	}
 	format = strings.ToLower(format)
 	switch format {
 	case appFormatURI:
@@ -275,7 +289,7 @@ func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, a
 		if err != nil {
 			return "", trace.Wrap(err)
 		}
-		return fmt.Sprintf("%s\n", out), nil
+		return out, nil
 	}
 	return fmt.Sprintf(`Name:      %v
 URI:       %v
@@ -300,7 +314,12 @@ func serializeAppConfig(configInfo *appConfigInfo, format string) (string, error
 	var err error
 	if format == appFormatJSON {
 		out, err = utils.FastMarshalIndent(configInfo, "", "  ")
+		// This JSON marshaling returns a string without a newline at the end, which
+		// makes display of the string look wonky. Let's append it here.
+		out = append(out, '\n')
 	} else {
+		// The YAML marshaling does return a string with a newline, so no need to append
+		// another.
 		out, err = yaml.Marshal(configInfo)
 	}
 	return string(out), trace.Wrap(err)

--- a/tool/tsh/app_test.go
+++ b/tool/tsh/app_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatAppConfig(t *testing.T) {
+	defaultTc := &client.TeleportClient{
+		Config: client.Config{
+			WebProxyAddr: "test-tp.teleport:8443",
+		},
+	}
+	testProfile := &client.ProfileStatus{
+		Username: "test-user",
+		Dir:      "/test/dir",
+	}
+	testAppName := "test-tp"
+	testAppPublicAddr := "test-tp.teleport"
+	testCluster := "test-tp"
+
+	// func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, appName,
+	// appPublicAddr, format, cluster string) (string, error) {
+	tests := []struct {
+		name     string
+		tc       *client.TeleportClient
+		format   string
+		insecure bool
+		expected string
+	}{
+		{
+			name: "format URI standard HTTPS port",
+			tc: &client.TeleportClient{
+				Config: client.Config{
+					WebProxyAddr: "test-tp.teleport:443",
+				},
+			},
+			format:   appFormatURI,
+			expected: "https://test-tp.teleport",
+		},
+		{
+			name:     "format URI standard non-standard HTTPS port",
+			tc:       defaultTc,
+			format:   appFormatURI,
+			expected: "https://test-tp.teleport:8443",
+		},
+		{
+			name:     "format CA",
+			tc:       defaultTc,
+			format:   appFormatCA,
+			expected: "/test/dir/keys/cas/test-tp.pem",
+		},
+		{
+			name:     "format cert",
+			tc:       defaultTc,
+			format:   appFormatCert,
+			expected: "/test/dir/keys/test-user-app/test-tp-x509.pem",
+		},
+		{
+			name:     "format key",
+			tc:       defaultTc,
+			format:   appFormatKey,
+			expected: "/test/dir/keys/test-user",
+		},
+		{
+			name:   "format curl standard non-standard HTTPS port",
+			tc:     defaultTc,
+			format: appFormatCURL,
+			expected: `curl \
+  --cert /test/dir/keys/test-user-app/test-tp-x509.pem \
+  --key /test/dir/keys/test-user \
+  https://test-tp.teleport:8443`,
+		},
+		{
+			name:     "format insecure curl standard non-standard HTTPS port",
+			tc:       defaultTc,
+			format:   appFormatCURL,
+			insecure: true,
+			expected: `curl -k \
+  --cert /test/dir/keys/test-user-app/test-tp-x509.pem \
+  --key /test/dir/keys/test-user \
+  https://test-tp.teleport:8443`,
+		},
+		{
+			name:   "format JSON",
+			tc:     defaultTc,
+			format: appFormatJSON,
+			expected: `{
+  "name": "test-tp",
+  "uri": "https://test-tp.teleport:8443",
+  "ca": "/test/dir/keys/cas/test-tp.pem",
+  "cert": "/test/dir/keys/test-user-app/test-tp-x509.pem",
+  "key": "/test/dir/keys/test-user",
+  "curl": "curl \\\n  --cert /test/dir/keys/test-user-app/test-tp-x509.pem \\\n  --key /test/dir/keys/test-user \\\n  https://test-tp.teleport:8443"
+}
+`,
+		},
+		{
+			name:   "format YAML",
+			tc:     defaultTc,
+			format: appFormatYAML,
+			expected: `ca: /test/dir/keys/cas/test-tp.pem
+cert: /test/dir/keys/test-user-app/test-tp-x509.pem
+curl: |-
+  curl \
+    --cert /test/dir/keys/test-user-app/test-tp-x509.pem \
+    --key /test/dir/keys/test-user \
+    https://test-tp.teleport:8443
+key: /test/dir/keys/test-user
+name: test-tp
+uri: https://test-tp.teleport:8443
+`,
+		},
+		{
+			name:   "format default",
+			tc:     defaultTc,
+			format: "detaul",
+			expected: `Name:      test-tp
+URI:       https://test-tp.teleport:8443
+CA:        /test/dir/keys/cas/test-tp.pem
+Cert:      /test/dir/keys/test-user-app/test-tp-x509.pem
+Key:       /test/dir/keys/test-user
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := formatAppConfig(test.tc, testProfile, testAppName, testAppPublicAddr, test.format, testCluster, test.insecure)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/tool/tsh/app_test.go
+++ b/tool/tsh/app_test.go
@@ -94,7 +94,7 @@ func TestFormatAppConfig(t *testing.T) {
 			tc:       defaultTc,
 			format:   appFormatCURL,
 			insecure: true,
-			expected: `curl -k \
+			expected: `curl --insecure \
   --cert /test/dir/keys/test-user-app/test-tp-x509.pem \
   --key /test/dir/keys/test-user \
   https://test-tp.teleport:8443`,
@@ -144,7 +144,8 @@ Key:       /test/dir/keys/test-user
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := formatAppConfig(test.tc, testProfile, testAppName, testAppPublicAddr, test.format, testCluster, test.insecure)
+			test.tc.InsecureSkipVerify = test.insecure
+			result, err := formatAppConfig(test.tc, testProfile, testAppName, testAppPublicAddr, test.format, testCluster)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expected, result)
 		})


### PR DESCRIPTION
The cacert flag was removed from the curl output during the tsh app login as most production Teleport clusters are likely to be using publicly trusted CAs, and therefore wouldn't need the flag.

Additionally, some tests have been added for the formatAppConfig function. It was discovered that the YAML output format was outputting two newlines, so a small modification was made to remove this.

Addresses issue #7518.