### PR TITLE
[v8] Fix Rust permissions in Docker CentOS image

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -44,12 +44,17 @@ RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
 
 RUN chmod a-w /
 
+# Cargo should be installed as a ci user, otherwise it will cause build failures.
+USER ci
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
     rustup --version && \
     cargo --version && \
     rustc --version && \
     rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy && \
     cargo install --locked --version 0.24.3 cbindgen
+
+# Restore user back to root.
+USER root
 
 ENV GOPATH="/go" \
     GOROOT="/opt/go" \


### PR DESCRIPTION
https://github.com/gravitational/teleport/commit/952259f4a4fb1adca2736ec2561154c255c8c834 changed the user to install Rust packages. As an effect Drone has problem building packages as it uses `ci` user who is not allowed to install any Rust packages during build.
This patch restores the `ci` user for Rust in the CentOS docker container.