### PR TITLE
Ensure audit logging of tsh app login.

### DIFF
--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -22,14 +22,10 @@ import (
 	"context"
 	"net/http"
 
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/reversetunnel"
-	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web/app"
 	"github.com/gravitational/teleport/lib/web/ui"
@@ -188,51 +184,6 @@ func (h *Handler) createAppSession(w http.ResponseWriter, r *http.Request, p htt
 	// racy session creation loop.
 	err = h.waitForAppSession(r.Context(), ws.GetName(), ctx.GetUser())
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Extract the identity of the user.
-	certificate, err := tlsca.ParseCertificatePEM(ws.GetTLSCert())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	identity, err := tlsca.FromSubject(certificate.Subject, certificate.NotAfter)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	userMetadata := identity.GetUserMetadata()
-	userMetadata.User = ws.GetUser()
-	userMetadata.AWSRoleARN = req.AWSRole
-
-	// Now that the certificate has been issued, emit a "new session created"
-	// for all events associated with this certificate.
-	appSessionStartEvent := &apievents.AppSessionStart{
-		Metadata: apievents.Metadata{
-			Type:        events.AppSessionStartEvent,
-			Code:        events.AppSessionStartCode,
-			ClusterName: identity.RouteToApp.ClusterName,
-		},
-		ServerMetadata: apievents.ServerMetadata{
-			ServerID:        h.cfg.HostUUID,
-			ServerNamespace: apidefaults.Namespace,
-		},
-		SessionMetadata: apievents.SessionMetadata{
-			SessionID: identity.RouteToApp.SessionID,
-			WithMFA:   identity.MFAVerified,
-		},
-		UserMetadata: userMetadata,
-		ConnectionMetadata: apievents.ConnectionMetadata{
-			RemoteAddr: r.RemoteAddr,
-		},
-		PublicAddr: identity.RouteToApp.PublicAddr,
-		AppMetadata: apievents.AppMetadata{
-			AppURI:        result.App.GetURI(),
-			AppPublicAddr: result.App.GetPublicAddr(),
-			AppName:       result.App.GetName(),
-		},
-	}
-	if err := h.cfg.Emitter.EmitAuditEvent(h.cfg.Context, appSessionStartEvent); err != nil {
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Application sessions were previously only logged when launching an application session via the UI, and not from the `tsh app login` command. This has been corrected.

Addresses https://github.com/gravitational/teleport/issues/9536.