### PR TITLE
Add remote site connections to reverse tunnel metric

### DIFF
--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -182,6 +182,7 @@ func (s *remoteSite) Close() error {
 	s.cancel()
 	for i := range s.connections {
 		s.connections[i].Close()
+		reverseSSHTunnels.WithLabelValues(s.connections[i].tunnelType).Dec()
 	}
 	s.connections = []*remoteConn{}
 	if s.remoteAccessPoint != nil {
@@ -243,6 +244,7 @@ func (s *remoteSite) removeInvalidConns() {
 			conns = append(conns, s.connections[i])
 		} else {
 			go s.connections[i].Close()
+			reverseSSHTunnels.WithLabelValues(s.connections[i].tunnelType).Dec()
 		}
 	}
 	s.connections = conns
@@ -265,6 +267,7 @@ func (s *remoteSite) addConn(conn net.Conn, sconn ssh.Conn) (*remoteConn, error)
 
 	s.connections = append(s.connections, rconn)
 	s.lastUsed = 0
+	reverseSSHTunnels.WithLabelValues(rconn.tunnelType).Inc()
 	return rconn, nil
 }
 


### PR DESCRIPTION
Increment and decrement the reverse tunnel metric as remote site connections are added and removed.

The tunnel type of these should show up as `proxy`.

I was debating whether this should be incremented once per remote site or once per connection, since a single remote site could have many connections. Ultimately decided on once per connection since that is the true reverse tunnel count.

Going to take a look at `teleport_connected_resources` to see why that is also not reporting remote clusters.