### PR TITLE
Remove GPL/BSD license from BPF modules

### DIFF
--- a/bpf/enhancedrecording/command.bpf.c
+++ b/bpf/enhancedrecording/command.bpf.c
@@ -29,8 +29,6 @@ limitations under the License.
 // the userspace can adjust this value based on config.
 #define EVENTS_BUF_SIZE (4096*8)
 
-char LICENSE[] SEC("license") = "Dual BSD/GPL";
-
 enum event_type {
     EVENT_ARG,
     EVENT_RET,

--- a/bpf/enhancedrecording/counter_test.bpf.c
+++ b/bpf/enhancedrecording/counter_test.bpf.c
@@ -21,8 +21,6 @@ limitations under the License.
 
 #include "../helpers.h"
 
-char LICENSE[] SEC("license") = "Dual BSD/GPL";
-
 BPF_COUNTER(test_counter);
 
 SEC("tp/syscalls/sys_close")

--- a/bpf/enhancedrecording/disk.bpf.c
+++ b/bpf/enhancedrecording/disk.bpf.c
@@ -30,8 +30,6 @@ limitations under the License.
 // the userspace can adjust this value based on config.
 #define EVENTS_BUF_SIZE (4096*128)
 
-char LICENSE[] SEC("license") = "Dual BSD/GPL";
-
 struct val_t {
     u64 pid;
     const char *fname;

--- a/bpf/enhancedrecording/network.bpf.c
+++ b/bpf/enhancedrecording/network.bpf.c
@@ -21,8 +21,6 @@ limitations under the License.
 
 #include "../helpers.h"
 
-char LICENSE[] SEC("license") = "Dual BSD/GPL";
-
 // Maximum number of in-flight connect syscalls supported
 #define INFLIGHT_MAX 8192
 

--- a/bpf/restrictedsession/restricted.bpf.c
+++ b/bpf/restrictedsession/restricted.bpf.c
@@ -39,8 +39,6 @@ limitations under the License.
 // This default is overriden by the userspace portion.
 #define AUDIT_EVENTS_RING_SIZE  (4*4096)
 
-char LICENSE[] SEC("license") = "Dual BSD/GPL";
-
 // Keeps the set of cgroups which are enforced
 BPF_HASH(restricted_cgroups, u64, u8, MAX_RESTRICTED_CGROUPS);
 


### PR DESCRIPTION
Our BPF modules had confusing license declarations as despite including the Apache header, we also included:

```c
char LICENSE[] SEC("license") = "Dual BSD/GPL";
```

which enables the usage of GPL only BPF helpers.

We should ensure that the resulting modules from this PR pass verification (as the verifier appears to enforce these license restrictions) and if so drop the license BSD/GPL declaration.

The alternative would be for us to license our modules under BSD/GPL, which would enable us to use these helpers if we needed to - if this is the case Sasha has suggested we raise this with legal.

Closes https://github.com/gravitational/teleport/issues/16877