### PR TITLE
Enable automatic updates via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
       - dependency-name: github.com/julienschmidt/httprouter v1.3.0
       - dependency-name: github.com/keys-pub/go-libfido2 v1.5.3-0.20220306005615-8ab03fb1ec27
       - dependency-name: github.com/pkg/sftp v1.13.5
-      - dependency-name: github.com/russellhaering/gosaml2 v0.8.1
       - dependency-name: github.com/sirupsen/logrus v1.9.0
       - dependency-name: github.com/vulcand/predicate v1.2.0
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    ignore:
+      # Must be kept in-sync with libbpf
+      - dependency-name: github.com/aquasecurity/libbpfgo
+      # Forked/replaced dependencies
+      - dependency-name: github.com/coreos/go-oidc v2.1.0+incompatible
+      - dependency-name: github.com/denisenkom/go-mssqldb v0.11.0
+      - dependency-name: github.com/go-mysql-org/go-mysql v1.5.0
+      - dependency-name: github.com/go-redis/redis/v8 v8.11.4
+      - dependency-name: github.com/gogo/protobuf v1.3.2
+      - dependency-name: github.com/julienschmidt/httprouter v1.3.0
+      - dependency-name: github.com/keys-pub/go-libfido2 v1.5.3-0.20220306005615-8ab03fb1ec27
+      - dependency-name: github.com/pkg/sftp v1.13.5
+      - dependency-name: github.com/russellhaering/gosaml2 v0.8.1
+      - dependency-name: github.com/sirupsen/logrus v1.9.0
+      - dependency-name: github.com/vulcand/predicate v1.2.0
+    open-pull-requests-limit: 10
+    reviewers:
+      - codingllama
+      - rosstimothy
+      - zmb3
+
+  - package-ecosystem: gomod
+    directory: "/api"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    reviewers:
+      - codingllama
+      - rosstimothy
+      - zmb3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
     ignore:
+      # Breaks backwards compatibility
+      - dependency-name: github.com/gravitational/ttlmap
       # Must be kept in-sync with libbpf
       - dependency-name: github.com/aquasecurity/libbpfgo
       # Forked/replaced dependencies

--- a/go.mod
+++ b/go.mod
@@ -347,6 +347,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
+// Update also `ignore` in .github/dependabot.yml.
 replace (
 	github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.6
 	github.com/denisenkom/go-mssqldb => github.com/gravitational/go-mssqldb v0.11.1-0.20220509084309-3d41480ef74f


### PR DESCRIPTION
Let the robots do regular updates for us.

References:
* [Configure dependabot.yml][1]
* [Configure security updates][2]

[1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
[2]: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file