### PR TITLE
Correct CreateAppSession arguments in proxy integration test.

### DIFF
--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -774,7 +774,7 @@ func TestALPNSNIProxyAppAccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, status)
 
-	sess = pack.CreateAppSession(t, pack.LeafAppPublicAddr(), pack.RootAppName(), pack.RootAppURI(), pack.LeafAppClusterName(), false)
+	sess = pack.CreateAppSession(t, pack.LeafAppPublicAddr(), pack.LeafAppName(), pack.LeafAppURI(), pack.LeafAppClusterName(), false)
 	status, _, err = pack.MakeRequest(sess, http.MethodGet, "/")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, status)


### PR DESCRIPTION
The arguments passed to CreateAppSession in the second call of the TestALPNSNIProxyAppAccess test were incorrect. They have been corrected.