### PR TITLE
V11 prep: compare and swap hb & begin explicit namespace deprecation

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2250,7 +2250,11 @@ func (process *TeleportProcess) initSSH() error {
 		}
 		// TODO: are we missing rm.Close()
 
-		// make sure the namespace exists
+		// make sure the default namespace is used
+		if ns := cfg.SSH.Namespace; ns != "" && ns != apidefaults.Namespace {
+			return trace.BadParameter("cannot start with custom namespace %q, custom namespaces are deprecated. "+
+				"use builtin namespace %q, or omit the 'namespace' config option.", ns, apidefaults.Namespace)
+		}
 		namespace := types.ProcessNamespace(cfg.SSH.Namespace)
 		_, err = authClient.GetNamespace(namespace)
 		if err != nil {

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -244,19 +244,37 @@ func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (
 	if server.GetNamespace() == "" {
 		return nil, trace.BadParameter("missing node namespace")
 	}
+
 	value, err := services.MarshalServer(server)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	lease, err := s.Put(ctx, backend.Item{
-		Key:     backend.Key(nodesPrefix, server.GetNamespace(), server.GetName()),
+
+	key := backend.Key(nodesPrefix, server.GetNamespace(), server.GetName())
+
+	item := backend.Item{
+		Key:     key,
 		Value:   value,
 		Expires: server.Expiry(),
 		ID:      server.GetResourceID(),
-	})
+	}
+
+	prevItem, err := s.Get(ctx, key)
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+
+	var lease *backend.Lease
+	if err == nil {
+		lease, err = s.CompareAndSwap(ctx, *prevItem, item)
+	} else {
+		lease, err = s.Create(ctx, item)
+	}
+
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	if server.Expiry().IsZero() {
 		return &types.KeepAlive{}, nil
 	}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -242,7 +242,11 @@ func (s *PresenceService) GetNodes(ctx context.Context, namespace string) ([]typ
 // specified duration with second resolution if it's >= 1 second.
 func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (*types.KeepAlive, error) {
 	if server.GetNamespace() == "" {
-		return nil, trace.BadParameter("missing node namespace")
+		server.SetNamespace(apidefaults.Namespace)
+	}
+
+	if n := server.GetNamespace(); n != apidefaults.Namespace {
+		return nil, trace.BadParameter("cannot place node in namespace %q, custom namespaces are deprecated", n)
 	}
 
 	value, err := services.MarshalServer(server)


### PR DESCRIPTION
The PR introduces 2 small changes for V11 which aren't really meaningful in and of themselves (prep for future work), but are significant enough that its best to introduce them in a major version change:

1. SSH server heartbeats now use a compare-and-swap instead of an upsert.  We want to start to be able to track info related to version-control system in heartbeats, and this will require compare-and-swap.  For now, the only purpose of the change is to ensure that compare-and-swap's feasibility is validated by our V11 load tests, and to ensure that if there is any impact on backend perf (other than the increased reads, which should still be well below peak), the change occurs across a major version update. 
2. Begin explicitly rejecting custom node namespaces.  Namespaces have already been effectively deprecated for a long time (e.g. nodes in namespaces other than `default` aren't dialable).  That being said, assigning a node to a custom namespace was still technically allowable.  This PR makes it an explicit error.  This change is in preparation for upcoming upgrades work that will be incompatible with namespaces.