### PR TITLE
[v8] limit number of resources loaded into memory for version metrics calculation

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -20,7 +20,6 @@ limitations under the License.
 // * Authority server itself that implements signing and acl logic
 // * HTTP server wrapper for authority server
 // * HTTP client wrapper
-//
 package auth
 
 import (
@@ -303,8 +302,8 @@ var (
 // Server keeps the cluster together. It acts as a certificate authority (CA) for
 // a cluster and:
 //   - generates the keypair for the node it's running on
-//	 - invites other SSH nodes to a cluster, by issuing invite tokens
-//	 - adds other SSH nodes to a cluster, by checking their token and signing their keys
+//   - invites other SSH nodes to a cluster, by issuing invite tokens
+//   - adds other SSH nodes to a cluster, by checking their token and signing their keys
 //   - same for users and their sessions
 //   - checks public keys to see if they're signed by it (can be trusted or not)
 type Server struct {
@@ -416,7 +415,10 @@ func (a *Server) runPeriodicOperations() {
 		Duration: apidefaults.ServerKeepAliveTTL() * 2,
 		Jitter:   utils.NewSeventhJitter(),
 	})
-	promTicker := time.NewTicker(defaults.PrometheusScrapeInterval)
+	promTicker := interval.New(interval.Config{
+		Duration: defaults.PrometheusScrapeInterval,
+		Jitter:   utils.NewSeventhJitter(),
+	})
 	missedKeepAliveCount := 0
 	defer ticker.Stop()
 	defer heartbeatCheckTicker.Stop()
@@ -446,7 +448,7 @@ func (a *Server) runPeriodicOperations() {
 			}
 			// Update prometheus gauge
 			heartbeatsMissedByAuth.Set(float64(missedKeepAliveCount))
-		case <-promTicker.C:
+		case <-promTicker.Next():
 			a.updateVersionMetrics()
 		}
 	}
@@ -455,42 +457,33 @@ func (a *Server) runPeriodicOperations() {
 // updateVersionMetrics leverages the cache to report all versions of teleport servers connected to the
 // cluster via prometheus metrics
 func (a *Server) updateVersionMetrics() {
-	hostID := make(map[string]struct{})
+	const resourceLimit = 1000
+	hostID := make(map[string]bool)
 	versionCount := make(map[string]int)
 
 	// Nodes, Proxies, Auths, KubeServices, and WindowsDesktopServices use the UUID as the name field where
 	// DB and App store it in the spec. Check expiry due to DynamoDB taking up to 48hr to expire from backend
 	// and then store hostID and version count information.
-	serverCheck := func(server interface{}) {
-		type serverKubeWindows interface {
-			Expiry() time.Time
-			GetName() string
-			GetTeleportVersion() string
-		}
-		type appDB interface {
-			serverKubeWindows
-			GetHostID() string
+	resourceCheck := func(resource types.Resource) {
+		if resource.Expiry().Before(a.clock.Now()) {
+			return
 		}
 
-		// appDB needs to be first as it also matches the serverKubeWindows interface
-		if a, ok := server.(appDB); ok {
-			if a.Expiry().Before(time.Now()) {
-				return
-			}
-			if _, present := hostID[a.GetHostID()]; !present {
-				hostID[a.GetHostID()] = struct{}{}
-				versionCount[a.GetTeleportVersion()]++
-			}
-		} else if s, ok := server.(serverKubeWindows); ok {
-			if s.Expiry().Before(time.Now()) {
-				return
-			}
-			if _, present := hostID[s.GetName()]; !present {
-				hostID[s.GetName()] = struct{}{}
-				versionCount[s.GetTeleportVersion()]++
-			}
+		id := resource.GetName()
+		if r, ok := resource.(interface{ GetHostID() string }); ok {
+			id = r.GetHostID()
+		}
+
+		if hostID[id] {
+			return
+		}
+
+		if r, ok := resource.(interface{ GetTeleportVersion() string }); ok {
+			hostID[id] = true
+			versionCount[r.GetTeleportVersion()]++
 		}
 	}
+
 	client := a.GetCache()
 
 	proxyServers, err := client.GetProxies()
@@ -498,7 +491,7 @@ func (a *Server) updateVersionMetrics() {
 		log.Debugf("Failed to get Proxies for teleport_registered_servers metric: %v", err)
 	}
 	for _, proxyServer := range proxyServers {
-		serverCheck(proxyServer)
+		resourceCheck(proxyServer)
 	}
 
 	authServers, err := client.GetAuthServers()
@@ -506,31 +499,52 @@ func (a *Server) updateVersionMetrics() {
 		log.Debugf("Failed to get Auth servers for teleport_registered_servers metric: %v", err)
 	}
 	for _, authServer := range authServers {
-		serverCheck(authServer)
+		resourceCheck(authServer)
 	}
 
-	servers, err := client.GetNodes(a.closeCtx, apidefaults.Namespace)
-	if err != nil {
-		log.Debugf("Failed to get Nodes for teleport_registered_servers metric: %v", err)
-	}
-	for _, server := range servers {
-		serverCheck(server)
+	// retrieve nodes in batches to prevent excessive memory consumption
+	for ok, startKey := true, ""; ok; ok = startKey != "" {
+		req := proto.ListNodesRequest{
+			Namespace: apidefaults.Namespace,
+			Limit:     resourceLimit,
+			StartKey:  startKey,
+		}
+
+		servers, nextKey, err := client.ListNodes(a.closeCtx, req)
+		if err != nil {
+			log.Debugf("Failed to get Nodes for teleport_registered_servers metric :%v", err)
+			startKey = ""
+			continue
+		}
+
+		for _, server := range servers {
+			resourceCheck(server)
+		}
+
+		startKey = nextKey
 	}
 
-	dbs, err := client.GetDatabaseServers(a.closeCtx, apidefaults.Namespace)
-	if err != nil {
-		log.Debugf("Failed to get Database servers for teleport_registered_servers metric: %v", err)
-	}
-	for _, db := range dbs {
-		serverCheck(db)
-	}
+	// retrieve db servers and app servers in batches to prevent excessive memory consumption
+	for _, kind := range []string{types.KindDatabaseServer, types.KindAppServer} {
+		for ok, startKey := true, ""; ok; ok = startKey != "" {
+			resources, nextKey, err := client.ListResources(a.closeCtx, proto.ListResourcesRequest{
+				ResourceType: kind,
+				Namespace:    apidefaults.Namespace,
+				Limit:        resourceLimit,
+				StartKey:     startKey,
+			})
+			if err != nil {
+				log.Debugf("Failed to get %q for teleport_registered_servers  metric: %v", kind, err)
+				startKey = ""
+				continue
+			}
 
-	apps, err := client.GetApplicationServers(a.closeCtx, apidefaults.Namespace)
-	if err != nil {
-		log.Debugf("Failed to get Application servers for teleport_registered_servers metric: %v", err)
-	}
-	for _, app := range apps {
-		serverCheck(app)
+			for _, resource := range resources {
+				resourceCheck(resource)
+			}
+
+			startKey = nextKey
+		}
 	}
 
 	kubeServices, err := client.GetKubeServices(a.closeCtx)
@@ -538,7 +552,7 @@ func (a *Server) updateVersionMetrics() {
 		log.Debugf("Failed to get Kube services for teleport_registered_servers metric: %v", err)
 	}
 	for _, kubeService := range kubeServices {
-		serverCheck(kubeService)
+		resourceCheck(kubeService)
 	}
 
 	windowsServices, err := client.GetWindowsDesktopServices(a.closeCtx)
@@ -546,7 +560,7 @@ func (a *Server) updateVersionMetrics() {
 		log.Debugf("Failed to get Window Desktop Services for teleport_registered_servers metric: %v", err)
 	}
 	for _, windowsService := range windowsServices {
-		serverCheck(windowsService)
+		resourceCheck(windowsService)
 	}
 
 	// reset the gauges so that any versions that fall off are removed from exported metrics


### PR DESCRIPTION
The periodic version metric calculation loaded all nodes, database
servers and app servers into memory in order to tally the versions
of each. For larger clusters unmarshalling all resources and loading
them into memory is quite expensive. To prevent Teleport from potential
being OOM killed we can use `ListNodes` and `ListResources` to limit
the number of resources being loaded into memory.



### Note:
This is not a backport and is a new change to v8 that will need to be forward ported. https://github.com/gravitational/teleport/pull/16518 will replace this on newer versions of Teleport that can leverage the inventory control stream to calculate the metric instead of loading resources from the cache.
