### PR TITLE
[v8] security: log non-interactive SSH commands at beginning of session

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import "github.com/gogo/protobuf/proto"
+
+func trimN(s string, n int) string {
+	if n <= 0 {
+		return s
+	}
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+
+func maxSizePerField(maxLength, customFields int) int {
+	if customFields == 0 {
+		return maxLength
+	}
+	return maxLength / customFields
+}
+
+// TrimToMaxSize trims the DatabaseSessionQuery message content. The maxSize is used to calculate
+// per-filed max size where only user input message fields DatabaseQuery and DatabaseQueryParameters are taken into
+// account.
+func (m *DatabaseSessionQuery) TrimToMaxSize(maxSize int) AuditEvent {
+	size := m.Size()
+	if size <= maxSize {
+		return m
+	}
+
+	out := proto.Clone(m).(*DatabaseSessionQuery)
+	out.DatabaseQuery = ""
+	out.DatabaseQueryParameters = nil
+
+	// Use 10% max size ballast + message size without custom fields.
+	sizeBallast := maxSize/10 + out.Size()
+	maxSize -= sizeBallast
+
+	// Check how many custom fields are set.
+	customFieldsCount := 0
+	if m.DatabaseQuery != "" {
+		customFieldsCount++
+	}
+	for range m.DatabaseQueryParameters {
+		customFieldsCount++
+	}
+
+	maxFieldsSize := maxSizePerField(maxSize, customFieldsCount)
+
+	out.DatabaseQuery = trimN(m.DatabaseQuery, maxFieldsSize)
+	if m.DatabaseQueryParameters != nil {
+		out.DatabaseQueryParameters = make([]string, len(m.DatabaseQueryParameters))
+	}
+	for i, v := range m.DatabaseQueryParameters {
+		out.DatabaseQueryParameters[i] = trimN(v, maxFieldsSize)
+	}
+	return out
+}

--- a/api/types/events/events_test.go
+++ b/api/types/events/events_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrimToMaxSize(t *testing.T) {
+	type messageSizeTrimmer interface {
+		TrimToMaxSize(int) AuditEvent
+	}
+
+	testCases := []struct {
+		name    string
+		maxSize int
+		in      AuditEvent
+		want    AuditEvent
+	}{
+		{
+			name:    "Query exceeds max limit size",
+			maxSize: 6000,
+			in: &DatabaseSessionQuery{
+				DatabaseQuery: strings.Repeat("A", 7000),
+			},
+			want: &DatabaseSessionQuery{
+				DatabaseQuery: strings.Repeat("A", 5377),
+			},
+		},
+		{
+			name:    "Query with query params exceeds max size",
+			maxSize: 2000,
+			in: &DatabaseSessionQuery{
+				DatabaseQuery: strings.Repeat("A", 2000),
+				DatabaseQueryParameters: []string{
+					strings.Repeat("A", 89),
+					strings.Repeat("A", 89),
+				},
+			},
+			want: &DatabaseSessionQuery{
+				DatabaseQuery: strings.Repeat("A", 592),
+				DatabaseQueryParameters: []string{
+					strings.Repeat("A", 89),
+					strings.Repeat("A", 89),
+				},
+			},
+		},
+		{
+			name:    "with metadata",
+			maxSize: 3000,
+			in: &DatabaseSessionQuery{
+				Metadata: Metadata{
+					ClusterName: strings.Repeat("A", 2000),
+					Index:       1,
+				},
+				DatabaseQuery: strings.Repeat("A", 2000),
+				DatabaseQueryParameters: []string{
+					strings.Repeat("A", 89),
+					strings.Repeat("A", 89),
+				},
+			},
+			want: &DatabaseSessionQuery{
+				Metadata: Metadata{
+					ClusterName: strings.Repeat("A", 2000),
+					Index:       1,
+				},
+				DatabaseQuery: strings.Repeat("A", 223),
+				DatabaseQueryParameters: []string{
+					strings.Repeat("A", 89),
+					strings.Repeat("A", 89),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sr, ok := tc.in.(messageSizeTrimmer)
+			require.True(t, ok)
+
+			got := sr.TrimToMaxSize(tc.maxSize)
+
+			require.Empty(t, cmp.Diff(got, tc.want))
+			require.Less(t, got.Size(), tc.maxSize)
+		})
+	}
+}

--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -1117,4 +1118,54 @@ func containsDB(servers []types.DatabaseServer, name string) bool {
 		}
 	}
 	return false
+}
+
+// TestDatabaseAccessLargeQuery tests a scenario where a user connects
+// to a MySQL database running in a root cluster.
+func TestDatabaseAccessLargeQuery(t *testing.T) {
+	pack := setupDatabaseTest(t)
+
+	// Connect to the database service in root cluster.
+	client, err := mysql.MakeTestClient(common.TestClientConfig{
+		AuthClient: pack.root.cluster.GetSiteAPI(pack.root.cluster.Secrets.SiteName),
+		AuthServer: pack.root.cluster.Process.GetAuthServer(),
+		Address:    net.JoinHostPort(Loopback, pack.root.cluster.GetPortMySQL()),
+		Cluster:    pack.root.cluster.Secrets.SiteName,
+		Username:   pack.root.user.GetName(),
+		RouteToDatabase: tlsca.RouteToDatabase{
+			ServiceName: pack.root.mysqlService.Name,
+			Protocol:    pack.root.mysqlService.Protocol,
+			Username:    "root",
+		},
+	})
+	require.NoError(t, err)
+
+	now := time.Now()
+	query := fmt.Sprintf("select %s", strings.Repeat("A", 100*1024))
+	result, err := client.Execute(query)
+	require.NoError(t, err)
+	require.Equal(t, mysql.TestQueryResponse, result)
+	result.Close()
+
+	require.NoError(t, err)
+	require.Equal(t, mysql.TestQueryResponse, result)
+	result.Close()
+
+	ee := waitForAuditEventTypeWithBackoff(t, pack.root.cluster.Process.GetAuthServer(), now, events.DatabaseSessionQueryEvent)
+	require.Len(t, ee, 1)
+
+	query = "select 1"
+	result, err = client.Execute(query)
+	require.NoError(t, err)
+	require.Equal(t, mysql.TestQueryResponse, result)
+	result.Close()
+
+	require.Eventually(t, func() bool {
+		ee := waitForAuditEventTypeWithBackoff(t, pack.root.cluster.Process.GetAuthServer(), now, events.DatabaseSessionQueryEvent)
+		return len(ee) == 2
+	}, time.Second*3, time.Millisecond*500)
+
+	// Disconnect.
+	err = client.Close()
+	require.NoError(t, err)
 }

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -24,12 +24,10 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
@@ -38,13 +36,15 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/stretchr/testify/require"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/check.v1"
-
-	"github.com/gravitational/trace"
 )
 
 const dynamoDBLargeQueryRetries int = 10
@@ -363,4 +363,40 @@ func TestFromWhereExpr(t *testing.T) {
 		attrNames:  map[string]string{"#condName0": "login", "#condName1": "participants"},
 		attrValues: map[string]interface{}{":condValue0": "root", ":condValue1": "admin", ":condValue2": "test-user"},
 	}, params)
+}
+
+// TestEmitAuditEventForLargeEvents tries to emit large audit events to DynamoDB backend.
+func (s *DynamoeventsLargeTableSuite) TestEmitAuditEventForLargeEvents(c *check.C) {
+	ctx := context.Background()
+	now := s.Clock.Now()
+	dbQueryEvent := &apievents.DatabaseSessionQuery{
+		Metadata: apievents.Metadata{
+			Time: s.Clock.Now(),
+			Type: events.DatabaseSessionQueryEvent,
+		},
+		DatabaseQuery: strings.Repeat("A", maxItemSize),
+	}
+	err := s.Log.EmitAuditEvent(ctx, dbQueryEvent)
+	c.Assert(err, check.IsNil)
+
+	result, _, err := s.Log.SearchEvents(
+		now.Add(-1*time.Hour),
+		now.Add(time.Hour),
+		apidefaults.Namespace,
+		[]string{events.DatabaseSessionQueryEvent},
+		0, types.EventOrderAscending,
+		"",
+	)
+	c.Assert(err, check.IsNil)
+	c.Assert(result, check.HasLen, 1)
+
+	appReqEvent := &apievents.AppSessionRequest{
+		Metadata: apievents.Metadata{
+			Time: s.Clock.Now(),
+			Type: events.AppSessionRequestEvent,
+		},
+		Path: strings.Repeat("A", maxItemSize),
+	}
+	err = s.Log.EmitAuditEvent(ctx, appReqEvent)
+	c.Check(trace.Unwrap(err), check.FitsTypeOf, errAWSValidation)
 }

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -58,6 +59,8 @@ type FileLogConfig struct {
 	// SearchDirs is a function that returns
 	// search directories, if not set, only Dir is used
 	SearchDirs func() ([]string, error)
+	// MaxScanTokenSize define maximum line entry size.
+	MaxScanTokenSize int
 }
 
 // CheckAndSetDefaults checks and sets config defaults
@@ -85,6 +88,9 @@ func (cfg *FileLogConfig) CheckAndSetDefaults() error {
 	}
 	if cfg.UIDGenerator == nil {
 		cfg.UIDGenerator = utils.NewRealUID()
+	}
+	if cfg.MaxScanTokenSize == 0 {
+		cfg.MaxScanTokenSize = bufio.MaxScanTokenSize
 	}
 	return nil
 }
@@ -153,6 +159,21 @@ func (l *FileLog) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent
 		return trace.NotFound(
 			"file log is not found due to permission or disk issue")
 	}
+
+	if len(line) > l.MaxScanTokenSize {
+		switch {
+		case canReduceMessageSize(event):
+			line, err = l.trimSizeAndMarshal(event)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+		default:
+			fields := log.Fields{"event_type": event.GetType(), "event_size": len(line)}
+			l.WithFields(fields).Warnf("Got a event that exeeded max allowed size.")
+			return trace.BadParameter("event size %q exceeds max entry size %q", len(line), l.MaxScanTokenSize)
+		}
+	}
+
 	// log it to the main log file:
 	_, err = fmt.Fprintln(l.file, string(line))
 	return trace.ConvertSystemError(err)
@@ -197,6 +218,31 @@ func (l *FileLog) EmitAuditEventLegacy(event Event, fields EventFields) error {
 		fmt.Fprintln(l.file, string(line))
 	}
 	return nil
+}
+
+func canReduceMessageSize(event apievents.AuditEvent) bool {
+	_, ok := event.(messageSizeTrimmer)
+	return ok
+}
+
+func (l *FileLog) trimSizeAndMarshal(event apievents.AuditEvent) ([]byte, error) {
+	s, ok := event.(messageSizeTrimmer)
+	if !ok {
+		return nil, trace.BadParameter("invalid event type %T", event)
+	}
+	sEvent := s.TrimToMaxSize(l.MaxScanTokenSize)
+	line, err := utils.FastMarshal(sEvent)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if len(line) > l.MaxScanTokenSize {
+		return nil, trace.BadParameter("event %T reached max FileLog entry size limit", event.Size())
+	}
+	return line, nil
+}
+
+type messageSizeTrimmer interface {
+	TrimToMaxSize(int) apievents.AuditEvent
 }
 
 // SearchEvents is a flexible way to find events.
@@ -585,10 +631,17 @@ func (l *FileLog) findInFile(path string, filter searchEventsFilter) ([]EventFie
 	}
 	defer lf.Close()
 
+	lineNo := 0
 	// for each line...
-	retval := []EventFields{}
+	var retval []EventFields
 	scanner := bufio.NewScanner(lf)
-	for lineNo := 0; scanner.Scan(); lineNo++ {
+
+	// If custom MaxScanTokenSize was used allocate a custom buffer with a new size.
+	if l.MaxScanTokenSize != bufio.MaxScanTokenSize {
+		buf := make([]byte, 0, l.MaxScanTokenSize)
+		scanner.Buffer(buf, l.MaxScanTokenSize)
+	}
+	for ; scanner.Scan(); lineNo++ {
 		// Optimization: to avoid parsing JSON unnecessarily, we filter out lines
 		// that don't contain the event type.
 		match := len(filter.eventTypes) == 0
@@ -605,7 +658,7 @@ func (l *FileLog) findInFile(path string, filter searchEventsFilter) ([]EventFie
 		// parse JSON on the line and compare event type field to what's
 		// in the query:
 		var ef EventFields
-		if err = json.Unmarshal(scanner.Bytes(), &ef); err != nil {
+		if err := utils.FastUnmarshal(scanner.Bytes(), &ef); err != nil {
 			l.Warnf("invalid JSON in %s line %d", path, lineNo)
 			continue
 		}
@@ -626,6 +679,18 @@ func (l *FileLog) findInFile(path string, filter searchEventsFilter) ([]EventFie
 
 		if accepted {
 			retval = append(retval, ef)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		switch {
+		case errors.Is(err, bufio.ErrTooLong):
+			fields := log.Fields{"path": path, "line": lineNo}
+			l.WithFields(fields).
+				Warnf("FileLog contains very large entries. Scan operation will return partial result.")
+		default:
+			l.WithError(err).Errorf("Failed to scan AuditLog.")
+
 		}
 	}
 

--- a/lib/events/filelog_test.go
+++ b/lib/events/filelog_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package events
 
 import (
+	"bufio"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -86,4 +88,116 @@ func TestFileLogPagination(t *testing.T) {
 	require.Nil(t, err)
 	require.Len(t, eventArr, 1)
 	require.Equal(t, checkpoint, "")
+}
+
+// TestLargeEvent test fileLog behavior in case of large events.
+// If an event is serializable the FileLog handler should trie to trim the event size.
+func TestLargeEvent(t *testing.T) {
+	type check func(t *testing.T, event []events.AuditEvent)
+
+	hasEventsLength := func(n int) check {
+		return func(t *testing.T, ee []events.AuditEvent) {
+			require.Equal(t, n, len(ee), "events length mismatch")
+		}
+	}
+	hasEventsIDs := func(ids ...string) check {
+		return func(t *testing.T, ee []events.AuditEvent) {
+			want := make([]string, 0, len(ee))
+			for _, v := range ee {
+				want = append(want, v.GetID())
+			}
+			require.Equal(t, want, ids)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		in     []events.AuditEvent
+		checks []check
+	}{
+		{
+			name: "event should be trimmed",
+			in: []events.AuditEvent{
+				makeQueryEvent("1", "select 1"),
+				makeQueryEvent("2", strings.Repeat("A", bufio.MaxScanTokenSize)),
+				makeQueryEvent("3", "select 3"),
+			},
+			checks: []check{
+				hasEventsLength(3),
+				hasEventsIDs("1", "2", "3"),
+			},
+		},
+		{
+			name: "large event should not be emitted",
+			in: []events.AuditEvent{
+				makeQueryEvent("1", "select 1"),
+				makeAccessRequestEvent("2", strings.Repeat("A", bufio.MaxScanTokenSize)),
+				makeQueryEvent("3", "select 3"),
+				makeQueryEvent("4", "select 4"),
+			},
+			checks: []check{
+				hasEventsLength(3),
+				hasEventsIDs("1", "3", "4"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			clock := clockwork.NewFakeClockAt(time.Now())
+
+			log, err := NewFileLog(FileLogConfig{
+				Dir:              t.TempDir(),
+				RotationPeriod:   time.Hour * 24,
+				Clock:            clock,
+				MaxScanTokenSize: bufio.MaxScanTokenSize,
+			})
+			require.NoError(t, err)
+			start := time.Now()
+			clock.Advance(1 * time.Minute)
+
+			for _, v := range tc.in {
+				v.SetTime(clock.Now().UTC())
+				log.EmitAuditEvent(ctx, v)
+			}
+			events := mustSearchEvent(t, log, start)
+			for _, ch := range tc.checks {
+				ch(t, events)
+			}
+		})
+	}
+}
+
+func makeQueryEvent(id string, query string) *events.DatabaseSessionQuery {
+	return &events.DatabaseSessionQuery{
+		Metadata: events.Metadata{
+			ID:   id,
+			Type: DatabaseSessionQueryEvent,
+		},
+		DatabaseQuery: query,
+	}
+}
+func makeAccessRequestEvent(id string, in string) *events.AccessRequestDelete {
+	return &events.AccessRequestDelete{
+		Metadata: events.Metadata{
+			ID:   id,
+			Type: DatabaseSessionQueryEvent,
+		},
+		RequestID: in,
+	}
+}
+
+func mustSearchEvent(t *testing.T, log *FileLog, start time.Time) []events.AuditEvent {
+	result, _, err := log.SearchEvents(
+		start,
+		start.Add(time.Hour),
+		"",
+		[]string{},
+		100,
+		types.EventOrderAscending,
+		"",
+	)
+	require.NoError(t, err)
+	return result
 }


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/16872 to branch/v8

Also had to backport part of https://github.com/gravitational/teleport/commit/f22d8e97231329433c9f3b8f11e5e94f9fea143a for the event truncation logic