### PR TITLE
Fix incorrect `proxy_servers` mention in the config reference docs

### DIFF
--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -149,7 +149,7 @@ teleport:
     # Auth Server address and port to connect to. If you enable the Teleport
     # Auth Server to run in High Availability configuration, the address should
     # point to a Load Balancer.
-    # If adding a node located behind NAT, specify `proxy_servers` instead
+    # If adding a node located behind NAT, specify `proxy_server` instead
     auth_server: 10.1.0.5:3025
 
     # Proxy Server address and port to connect to. If you enable the Teleport

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -149,7 +149,8 @@ teleport:
     # Auth Server address and port to connect to. If you enable the Teleport
     # Auth Server to run in High Availability configuration, the address should
     # point to a Load Balancer.
-    # If adding a node located behind NAT, specify `proxy_server` instead
+    # If adding a node located behind NAT, use the Proxy URL (e.g. teleport-proxy.example.com:443)
+    # and set `proxy_server` instead.
     auth_server: 10.1.0.5:3025
 
     # Proxy Server address and port to connect to. If you enable the Teleport


### PR DESCRIPTION
`proxy_servers` isn't a thing, it's `proxy_server`. This will fix the typo I made in #15761.

I've also reworded the line to be a bit clearer and true to the original it replaced. This makes the actual diff

```diff
     # Auth Server address and port to connect to. If you enable the Teleport
     # Auth Server to run in High Availability configuration, the address should
     # point to a Load Balancer.
-    # If adding a node located behind NAT, use the Proxy URL. e.g.
-    #  auth_servers:
-    #     - teleport-proxy.example.com:443
+    # If adding a node located behind NAT, use the Proxy URL (e.g. teleport-proxy.example.com:443)
+    # and set `proxy_server` instead.
+    auth_server: 10.1.0.5:3025
```
