### PR TITLE
Default to passwordless login if platform credentials exists

### DIFF
--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -331,6 +331,24 @@ func Register(origin string, cc *wanlib.CredentialCreation) (*Registration, erro
 	}, nil
 }
 
+// HasCredentials checks if there are any credentials registered for given user.
+// If user is empty it checks if there are credentials registered for any user.
+// It does not require user interactions.
+func HasCredentials(rpid, user string) bool {
+	if !IsAvailable() {
+		return false
+	}
+	if rpid == "" {
+		return false
+	}
+	creds, err := native.FindCredentials(rpid, user)
+	if err != nil {
+		log.WithError(err).Debug("Touch ID: Could not find credentials")
+		return false
+	}
+	return len(creds) > 0
+}
+
 func pubKeyFromRawAppleKey(pubKeyRaw []byte) (*ecdsa.PublicKey, error) {
 	// Verify key length to avoid a potential panic below.
 	// 3 is the smallest number that clears it, but in practice 65 is the more

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -81,11 +81,13 @@ func TestTeleportClient_Login_local(t *testing.T) {
 	*client.HasPlatformSupport = func() bool {
 		return true
 	}
+	oldHasCredentials := *client.HasTouchIDCredentials
 
 	t.Cleanup(func() {
 		prompt.SetStdin(oldStdin)
 		*client.PromptWebauthn = oldWebauthn
 		*client.HasPlatformSupport = oldHasPlatformSupport
+		*client.HasTouchIDCredentials = oldHasCredentials
 	})
 
 	waitForCancelFn := func(ctx context.Context) (string, error) {
@@ -144,13 +146,15 @@ func TestTeleportClient_Login_local(t *testing.T) {
 
 	ctx := context.Background()
 	tests := []struct {
-		name             string
-		secondFactor     constants.SecondFactorType
-		inputReader      *prompt.FakeReader
-		solveWebauthn    func(ctx context.Context, origin string, assertion *wanlib.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error)
-		authConnector    string
-		allowStdinHijack bool
-		preferOTP        bool
+		name                    string
+		secondFactor            constants.SecondFactorType
+		inputReader             *prompt.FakeReader
+		solveWebauthn           func(ctx context.Context, origin string, assertion *wanlib.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error)
+		authConnector           string
+		allowStdinHijack        bool
+		preferOTP               bool
+		hasTouchIDCredentials   bool
+		authenticatorAttachment wancli.AuthenticatorAttachment
 	}{
 		{
 			name:             "OTP device login with hijack",
@@ -199,6 +203,27 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			solveWebauthn: solvePwdless,
 			authConnector: constants.PasswordlessConnector,
 		},
+		{
+			name:                  "default to passwordless if registered",
+			secondFactor:          constants.SecondFactorOptional,
+			inputReader:           prompt.NewFakeReader(), // no inputs
+			solveWebauthn:         solvePwdless,
+			authConnector:         constants.LocalConnector,
+			hasTouchIDCredentials: true,
+		},
+		{
+			name:         "cross-platform attachment doesn't default to passwordless",
+			secondFactor: constants.SecondFactorOptional,
+			inputReader: prompt.NewFakeReader().
+				AddString(password).
+				AddReply(func(ctx context.Context) (string, error) {
+					panic("this should not be called")
+				}),
+			solveWebauthn:           solveWebauthn,
+			authConnector:           constants.LocalConnector,
+			hasTouchIDCredentials:   true,
+			authenticatorAttachment: wancli.AttachmentCrossPlatform,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -214,6 +239,9 @@ func TestTeleportClient_Login_local(t *testing.T) {
 				return resp, "", err
 			}
 
+			*client.HasTouchIDCredentials = func(rpid, user string) bool {
+				return test.hasTouchIDCredentials
+			}
 			authServer := sa.Auth.GetAuthServer()
 			pref, err := authServer.GetAuthPreference(ctx)
 			require.NoError(t, err)
@@ -227,6 +255,7 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			tc.AllowStdinHijack = test.allowStdinHijack
 			tc.AuthConnector = test.authConnector
 			tc.PreferOTP = test.preferOTP
+			tc.AuthenticatorAttachment = test.authenticatorAttachment
 
 			clock.Advance(30 * time.Second)
 			_, err = tc.Login(ctx)

--- a/lib/client/export_test.go
+++ b/lib/client/export_test.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+var HasTouchIDCredentials = &hasTouchIDCredentials


### PR DESCRIPTION
This PR solves: https://github.com/gravitational/teleport/issues/13979.

### What has changed?

Now when TouchId credentials are available, tsh will default to passwordless login, even though local connector was set.

 