### PR TITLE
[v8] Remove cacert flag from curl output during tsh app login.

### DIFF
--- a/tool/tsh/app.go
+++ b/tool/tsh/app.go
@@ -87,9 +87,10 @@ func onAppLogin(cf *CLIConf) error {
 			"awsCmd":     "s3 ls",
 		})
 	}
-	return appLoginTpl.Execute(os.Stdout, map[string]string{
-		"appName": app.GetName(),
-		"curlCmd": formatAppConfig(tc, profile, app.GetName(), app.GetPublicAddr(), appFormatCURL),
+	return appLoginTpl.Execute(os.Stdout, map[string]interface{}{
+		"appName":  app.GetName(),
+		"curlCmd":  formatAppConfig(tc, profile, app.GetName(), app.GetPublicAddr(), appFormatCURL),
+		"insecure": cf.InsecureSkipVerify,
 	})
 }
 
@@ -97,7 +98,10 @@ func onAppLogin(cf *CLIConf) error {
 var appLoginTpl = template.Must(template.New("").Parse(
 	`Logged into app {{.appName}}. Example curl command:
 
-{{.curlCmd}}
+{{.curlCmd}}{{ if .insecure }}
+
+WARNING: tsh was called with --insecure, so this curl command will be unable to validate the certificate presented by Teleport.
+{{- end }}
 `))
 
 // awsCliTpl is the message that gets printed to a user upon successful aws app login.
@@ -190,6 +194,20 @@ func onAppConfig(cf *CLIConf) error {
 }
 
 func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, appName, appPublicAddr, format string) string {
+	var curlInsecureFlag string
+	if tc.InsecureSkipVerify {
+		curlInsecureFlag = "--insecure "
+	}
+
+	curlCmd := fmt.Sprintf(`curl %s\
+  --cert %v \
+  --key %v \
+  https://%v:%v`,
+		curlInsecureFlag,
+		profile.AppCertPath(appName),
+		profile.KeyPath(),
+		appPublicAddr,
+		tc.WebProxyPort())
 	switch format {
 	case appFormatURI:
 		return fmt.Sprintf("https://%v:%v", appPublicAddr, tc.WebProxyPort())
@@ -200,16 +218,7 @@ func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, a
 	case appFormatKey:
 		return profile.KeyPath()
 	case appFormatCURL:
-		return fmt.Sprintf(`curl \
-  --cacert %v \
-  --cert %v \
-  --key %v \
-  https://%v:%v`,
-			profile.CACertPath(),
-			profile.AppCertPath(appName),
-			profile.KeyPath(),
-			appPublicAddr,
-			tc.WebProxyPort())
+		return curlCmd
 	}
 	return fmt.Sprintf(`Name:      %v
 URI:       https://%v:%v

--- a/tool/tsh/app_test.go
+++ b/tool/tsh/app_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 Gravitational, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatAppConfig(t *testing.T) {
+	defaultTc := &client.TeleportClient{
+		Config: client.Config{
+			WebProxyAddr: "test-tp.teleport:8443",
+		},
+	}
+	testProfile := &client.ProfileStatus{
+		Username: "test-user",
+		Dir:      "/test/dir",
+	}
+	testAppName := "test-tp"
+	testAppPublicAddr := "test-tp.teleport"
+
+	// func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, appName,
+	// appPublicAddr, format, cluster string) (string, error) {
+	tests := []struct {
+		name     string
+		tc       *client.TeleportClient
+		format   string
+		insecure bool
+		expected string
+	}{
+		{
+			name: "format URI standard HTTPS port",
+			tc: &client.TeleportClient{
+				Config: client.Config{
+					WebProxyAddr: "test-tp.teleport:443",
+				},
+			},
+			format:   appFormatURI,
+			expected: "https://test-tp.teleport:443",
+		},
+		{
+			name:     "format URI standard non-standard HTTPS port",
+			tc:       defaultTc,
+			format:   appFormatURI,
+			expected: "https://test-tp.teleport:8443",
+		},
+		{
+			name:     "format CA",
+			tc:       defaultTc,
+			format:   appFormatCA,
+			expected: "/test/dir/keys/certs.pem",
+		},
+		{
+			name:     "format cert",
+			tc:       defaultTc,
+			format:   appFormatCert,
+			expected: "/test/dir/keys/test-user-app/test-tp-x509.pem",
+		},
+		{
+			name:     "format key",
+			tc:       defaultTc,
+			format:   appFormatKey,
+			expected: "/test/dir/keys/test-user",
+		},
+		{
+			name:   "format curl standard non-standard HTTPS port",
+			tc:     defaultTc,
+			format: appFormatCURL,
+			expected: `curl \
+  --cert /test/dir/keys/test-user-app/test-tp-x509.pem \
+  --key /test/dir/keys/test-user \
+  https://test-tp.teleport:8443`,
+		},
+		{
+			name:     "format insecure curl standard non-standard HTTPS port",
+			tc:       defaultTc,
+			format:   appFormatCURL,
+			insecure: true,
+			expected: `curl --insecure \
+  --cert /test/dir/keys/test-user-app/test-tp-x509.pem \
+  --key /test/dir/keys/test-user \
+  https://test-tp.teleport:8443`,
+		},
+		{
+			name:   "format default",
+			tc:     defaultTc,
+			format: "detaul",
+			expected: `Name:      test-tp
+URI:       https://test-tp.teleport:8443
+CA:        /test/dir/keys/certs.pem
+Cert:      /test/dir/keys/test-user-app/test-tp-x509.pem
+Key:       /test/dir/keys/test-user
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.tc.InsecureSkipVerify = test.insecure
+			result := formatAppConfig(test.tc, testProfile, testAppName, testAppPublicAddr, test.format)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Backport #16769 to branch/v8