### PR TITLE
[v9] [Docs] Correct protocol name

### DIFF
--- a/docs/pages/architecture/tls-routing.mdx
+++ b/docs/pages/architecture/tls-routing.mdx
@@ -72,7 +72,7 @@ Let's take a look at how each protocol Teleport supports implements TLS routing.
 ## SSH
 
 Teleport client `tsh`, when connecting to an SSH node, first dials Teleport
-proxy over TLS and requests `teleport-ssh-proxy` ALPN protocol.
+proxy over TLS and requests `teleport-proxy-ssh` ALPN protocol.
 
 No local proxy is started in this case as `tsh` uses this TLS connection as a
 transport to establish the SSH connection.
@@ -83,7 +83,7 @@ To support standard OpenSSH client, Teleport provides a `tsh proxy ssh` command
 which can be used as a `ProxyCommand`.
 
 Similarly to `tsh ssh`, `tsh proxy ssh` establishes a TLS tunnel to Teleport
-proxy with `teleport-ssh-proxy` ALPN protocol, which `ssh` then connects over.
+proxy with `teleport-proxy-ssh` ALPN protocol, which `ssh` then connects over.
 
 See the [OpenSSH client](../server-access/guides/openssh.mdx) guide for details on
 how it's configured.

--- a/rfd/0039-sni-alpn-teleport-proxy-routing.md
+++ b/rfd/0039-sni-alpn-teleport-proxy-routing.md
@@ -87,7 +87,7 @@ ALPN SNI proxy service will be responsible for routing incoming traffic to appro
 ALPN (Application-Layer Protocol Negotiation) is a TLS extension that allows the application layer to negotiate which protocol should be performed over a TLS connection. Teleport proxy will leverage ALPN routing in order to reduce the number of exposed ports.
 
 Outgoing traffic send to the ssh-proxy, reverse tunnel, MySQL, Postgres and MongoDB proxy services will be wrapped in TLS protocol where the teleport proxy clients (tsh, teleport internal libs, local db proxy) will be responsible for setting one of the following teleport protocols:
-- teleport-ssh-proxy
+- teleport-proxy-ssh
 - teleport-reverse-tunnel
 - teleport-mysql
 - teleport-postgres
@@ -119,7 +119,7 @@ clusters:
 ### Local teleport proxy
 To handle connections established to teleport proxy by external clients like mysql, psql CLIs where setting custom ALPN value is not possible we will run local teleport proxy. Traffic sent from external teleport clients will be forwarded through the local proxy where the proxy will be responsible for wrapping incoming connections in TLS protocol, setting appropriate ALPN protocol and establishing a connection to the remote teleport proxy.
 
-For the tsh ssh and tsh scp commands scope forwarding traffic through local proxy seems to be superfluous. SSH traffic can be easily wrapped in TLS with custom teleport-ssh-proxy ALPN protocol inside tsh ssh handler after detecting that the teleport proxy_listener_addr listener was enabled but we should consider adding support for ssh proxy in order to enable external SSH and SCP clients like FileZilla, WinSCP and Putty.
+For the tsh ssh and tsh scp commands scope forwarding traffic through local proxy seems to be superfluous. SSH traffic can be easily wrapped in TLS with custom teleport-proxy-ssh ALPN protocol inside tsh ssh handler after detecting that the teleport proxy_listener_addr listener was enabled but we should consider adding support for ssh proxy in order to enable external SSH and SCP clients like FileZilla, WinSCP and Putty.
 
 Question:
 - Do we want to support Unix sockets in local proxy ?


### PR DESCRIPTION
Backport #16848 to branch/v9