### PR TITLE
Fix crdgen tests and add `update-snapshot` make target

### DIFF
--- a/operator/crdgen/Makefile
+++ b/operator/crdgen/Makefile
@@ -21,3 +21,21 @@ test: build
 	EXIT_CODE=$$?;\
 	rm -rf $(CRD_OUT_PATH) $(CUSTOM_IMPORTS_TMP_DIR);\
 	exit $$EXIT_CODE
+
+# Updates CRD snapshots used for `protoc-gen-crd` tests, they are stored in `testdata/golden`
+update-snapshot: build
+	$(eval PROTOBUF_MOD_PATH := $(shell go mod download --json github.com/gogo/protobuf | awk -F: '/"Dir"/ { print $$2 }' | tr -d ' ",'))
+	$(eval CUSTOM_IMPORTS_TMP_DIR := $(shell mktemp -d))
+	mkdir -p $(CUSTOM_IMPORTS_TMP_DIR)/github.com/gravitational/teleport/api/types/wrappers
+	cp testdata/protofiles/wrappers.proto $(CUSTOM_IMPORTS_TMP_DIR)/github.com/gravitational/teleport/api/types/wrappers
+	$(eval CRD_OUT_PATH := $(shell mktemp -d))
+	protoc \
+		-I=testdata/protofiles \
+		-I=$(PROTOBUF_MOD_PATH) \
+		-I=$(CUSTOM_IMPORTS_TMP_DIR) \
+		--plugin=./protoc-gen-crd \
+		--crd_out=$(CRD_OUT_PATH) \
+		types.proto
+	rm -rf testdata/golden
+	cp -r $(CRD_OUT_PATH) testdata/golden
+	rm -rf $(CRD_OUT_PATH)

--- a/operator/crdgen/Makefile
+++ b/operator/crdgen/Makefile
@@ -23,6 +23,7 @@ test: build
 	exit $$EXIT_CODE
 
 # Updates CRD snapshots used for `protoc-gen-crd` tests, they are stored in `testdata/golden`
+.PHONY: update-snapshot
 update-snapshot: build
 	$(eval PROTOBUF_MOD_PATH := $(shell go mod download --json github.com/gogo/protobuf | awk -F: '/"Dir"/ { print $$2 }' | tr -d ' ",'))
 	$(eval CUSTOM_IMPORTS_TMP_DIR := $(shell mktemp -d))

--- a/operator/crdgen/testdata/golden/resources.teleport.dev_roles.yaml
+++ b/operator/crdgen/testdata/golden/resources.teleport.dev_roles.yaml
@@ -874,8 +874,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"

--- a/operator/crdgen/testdata/golden/resources.teleport.dev_users.yaml
+++ b/operator/crdgen/testdata/golden/resources.teleport.dev_users.yaml
@@ -107,8 +107,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"


### PR DESCRIPTION
Fixes `operator/crdgen` tests failing since a dependency update.

Context:
- `protoc-gen-crd` creates the CRD `Status` field by parsing Kubernetes types.
- Kube changed some of its godoc, which appeared in our CRDs
- The tests matching the `protoc-gen-crd` output with snapshots failed

This PR also introduces a `make update-snapshot` target to fix this situation when it will happen again.