### PR TITLE
Revert change from PKCS1 to PKCS8

### DIFF
--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -57,24 +57,11 @@ var startPrecomputeOnce sync.Once
 
 // GenerateKeyPair generates a new RSA key pair.
 func GenerateKeyPair() ([]byte, []byte, error) {
-	priv, err := getOrGenerateRSAPrivateKey()
+	priv, err := GeneratePrivateKey()
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-
-	privPEM := pem.EncodeToMemory(&pem.Block{
-		Type:    "RSA PRIVATE KEY",
-		Headers: nil,
-		Bytes:   x509.MarshalPKCS1PrivateKey(priv),
-	})
-
-	pub, err := ssh.NewPublicKey(&priv.PublicKey)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	pubPEM := ssh.MarshalAuthorizedKey(pub)
-
-	return privPEM, pubPEM, nil
+	return priv.PrivateKeyPEM(), priv.MarshalSSHPublicKey(), nil
 }
 
 // GeneratePrivateKey generates a new RSA private key.
@@ -83,16 +70,16 @@ func GeneratePrivateKey() (*keys.PrivateKey, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	keyDER, err := x509.MarshalPKCS8PrivateKey(rsaKey)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
+	// We encode the private key in PKCS #1, ASN.1 DER form
+	// instead of PKCS #8 to maintain compatibility with some
+	// third party clients.
 	keyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:    keys.PKCS8PrivateKeyType,
+		Type:    keys.PKCS1PrivateKeyType,
 		Headers: nil,
-		Bytes:   keyDER,
+		Bytes:   x509.MarshalPKCS1PrivateKey(rsaKey),
 	})
+
 	return keys.NewPrivateKey(rsaKey, keyPEM)
 }
 

--- a/lib/auth/native/native_test.go
+++ b/lib/auth/native/native_test.go
@@ -18,12 +18,16 @@ package native
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
@@ -31,7 +35,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/test"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/stretchr/testify/require"
 
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/crypto/ssh"
@@ -266,4 +269,20 @@ func TestUserCertCompatibility(t *testing.T) {
 		extVal := userCertificate.Extensions["login@github.com"]
 		require.Equal(t, extVal, "hello")
 	}
+}
+
+// TestGenerateRSAPKSC1Keypair tests that GeneratePrivateKey generates
+// a valid PKCS1 rsa key.
+func TestGeneratePKSC1RSAKey(t *testing.T) {
+	t.Parallel()
+
+	priv, err := GeneratePrivateKey()
+	require.NoError(t, err)
+
+	block, rest := pem.Decode(priv.PrivateKeyPEM())
+	require.NoError(t, err)
+	require.Empty(t, rest)
+
+	_, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Note: third party clients can reasonably be expected to support PKCS8. We may want to reintroduce this change in the future if/when we support ed25519/ecdsa keys. In this case, [like OpenSSL v3.0](https://www.openssl.org/docs/man3.0/man1/openssl-rsa.html#traditional) which now defaults to PKCS8 for generated keys, we should introduce a `--tradictional-rsa` flag to support unsupported clients.

Closes https://github.com/gravitational/teleport/issues/17001