### PR TITLE
Remove minor versions from the support table

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -142,19 +142,12 @@ supported for 9 months.
 
 ### Supported versions
 
-Here are the major and minor versions of Teleport that we currently support:
+Here are the major versions of Teleport that we currently support:
 
 |Release|Release Date|Minimum `tsh` version|
 |---|---|---|
-|v10.1|July 29, 2022|v9.x.x|
 |v10.0|July 8, 2022|v9.x.x|
-|v9.3|May 27, 2022|v8.x.x|
-|v9.2|May 4, 2022|v8.x.x|
-|v9.1|April 20, 2022|v8.x.x|
 |v9.0|March 11, 2022|v8.x.x|
-|v8.3|February 15, 2022|v7.x.x|
-|v8.2|February 8, 2022|v7.x.x|
-|v8.1|January 10, 2022|v7.x.x|
 |v8.0|November 15, 2021|v7.x.x|
 
 See our [Upgrading](./management/operations/upgrading.mdx) guide for more


### PR DESCRIPTION
This makes the table easier to keep up to date. Our version compatibility guarantees ensure that there's no compatibility difference between minor versions anyway, so it's not as important that users know when a minor version is likely to go out of support.

Fixes #16799