### PR TITLE
[v10] Fetch tags when promoting rpm/deb

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6024,7 +6024,7 @@ steps:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
   - git init && git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin
+  - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
   depends_on:
   - Verify build is tagged
@@ -6166,7 +6166,7 @@ steps:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
   - git init && git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin
+  - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
   depends_on:
   - Verify build is tagged
@@ -7085,6 +7085,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 988f4696f1925ee441a15113f5660e8906bec7c3618126a47e69228fde7b8666
+hmac: bec18a0a480759e7187aee70e923cc41243841e22b690466946a66b480749494
 
 ...

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -102,7 +102,7 @@ func cloneRepoCommands(cloneDirectory, commit string) []string {
 		fmt.Sprintf("mkdir -pv %q", cloneDirectory),
 		fmt.Sprintf("cd %q", cloneDirectory),
 		`git init && git remote add origin ${DRONE_REMOTE_URL}`,
-		`git fetch origin`,
+		`git fetch origin --tags`,
 		fmt.Sprintf("git checkout -qf %q", commit),
 	}
 }


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/16991 to branch/v10 (at least the parts of it that weren't already in v10)

Without this any tag that isn't part of the history on the release branch will fail to successfully promote.  This breaks most dev builds, which don't end up as part of master or a release branch. See https://drone.platform.teleport.sh/gravitational/teleport/16103 for an example failure.

(cherry picked from commit 531bc515ae92ee8bbfa30271db0baa4ec0085f39)