### PR TITLE
[v9] Fetch tags when promoting rpm/deb

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5620,7 +5620,7 @@ steps:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
   - git init && git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin
+  - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
   depends_on:
   - Verify build is tagged
@@ -5762,7 +5762,7 @@ steps:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
   - git init && git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin
+  - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
   depends_on:
   - Verify build is tagged
@@ -6450,6 +6450,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 742d732cde9c3416168b6eef88bfad51f4a7ecad9782167156efa90648338cfb
+hmac: 175934506759c8ee67b1ffcc1aec65662a73dbffecdd972d9261eb024434b5d9
 
 ...

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -96,7 +96,7 @@ func cloneRepoCommands(cloneDirectory, commit string) []string {
 		fmt.Sprintf("mkdir -pv %q", cloneDirectory),
 		fmt.Sprintf("cd %q", cloneDirectory),
 		`git init && git remote add origin ${DRONE_REMOTE_URL}`,
-		`git fetch origin`,
+		`git fetch origin --tags`,
 		fmt.Sprintf("git checkout -qf %q", commit),
 	}
 }


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/16991 to branch/v9 (at least the parts of it that weren't already in v9)

Without this any tag that isn't part of the history on the release branch will fail to successfully promote.  This breaks most dev builds, which don't end up as part of master or a release branch. See https://drone.platform.teleport.sh/gravitational/teleport/16103 for an example failure.

(cherry picked from commit 531bc515ae92ee8bbfa30271db0baa4ec0085f39)