### PR TITLE
[v8] Fetch tags when promoting rpm/deb

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5790,7 +5790,7 @@ steps:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
   - git init && git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin
+  - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
   depends_on:
   - Verify build is tagged
@@ -5932,7 +5932,7 @@ steps:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
   - git init && git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin
+  - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
   depends_on:
   - Verify build is tagged
@@ -6528,9 +6528,8 @@ volumes:
     medium: memory
 - name: dockersock
   temp: {}
-
 ---
 kind: signature
-hmac: 826bfb32ac20277b47cf7e7b09b06e7ae87d6f3ee9bd9710ddccebf90a1c2b71
+hmac: da4f80e4901a9cdf5a68b46497cafcbb811d155b3a35e8dc837d88b9447cba74
 
 ...


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/16991 to branch/v8 (at least the parts of it that weren't already in v8)

This is as far back as the changes need to go, as the new apt/deb publishing pipelines do not appear to be in v7.

Without this any tag that isn't part of the history on the release branch will fail to successfully promote.  This breaks most dev builds, which don't end up as part of master or a release branch. See https://drone.platform.teleport.sh/gravitational/teleport/16103 for an example failure.

(cherry picked from commit 531bc515ae92ee8bbfa30271db0baa4ec0085f39)