### PR TITLE
[v9] Desktop Access optimizations

### DIFF
--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -77,8 +77,12 @@ func (c *Conn) Close() error {
 	return err
 }
 
-// InputMessage reads the next incoming message from the connection.
-func (c *Conn) InputMessage() (Message, error) {
+func (c *Conn) ReadRaw() ([]byte, error) {
+	return readRaw(c.bufr)
+}
+
+// ReadMessage reads the next incoming message from the connection.
+func (c *Conn) ReadMessage() (Message, error) {
 	m, err := decode(c.bufr)
 	if c.OnRecv != nil {
 		c.OnRecv(m)
@@ -86,8 +90,8 @@ func (c *Conn) InputMessage() (Message, error) {
 	return m, trace.Wrap(err)
 }
 
-// OutputMessage sends a message to the connection.
-func (c *Conn) OutputMessage(m Message) error {
+// WriteMessage sends a message to the connection.
+func (c *Conn) WriteMessage(m Message) error {
 	buf, err := m.Encode()
 	if err != nil {
 		return trace.Wrap(err)
@@ -102,7 +106,7 @@ func (c *Conn) OutputMessage(m Message) error {
 
 // SendError is a convenience function for sending an error message.
 func (c *Conn) SendError(message string) error {
-	return c.OutputMessage(Error{Message: message})
+	return c.WriteMessage(Error{Message: message})
 }
 
 // LocalAddr returns local address

--- a/lib/srv/desktop/tdp/proto.go
+++ b/lib/srv/desktop/tdp/proto.go
@@ -72,6 +72,7 @@ const (
 	TypeSharedDirectoryMoveResponse   = MessageType(24)
 	TypeSharedDirectoryListRequest    = MessageType(25)
 	TypeSharedDirectoryListResponse   = MessageType(26)
+	TypePNG2Frame                     = MessageType(27)
 )
 
 // Message is a Go representation of a desktop protocol message.
@@ -87,27 +88,48 @@ func Decode(buf []byte) (Message, error) {
 	return decode(bytes.NewReader(buf))
 }
 
-// peekReader is an io.Reader which lets us peek at the first byte
-// (MessageType) for decoding.
-type peekReader interface {
+type byteReader interface {
 	io.Reader
-	io.ByteScanner
+	io.ByteReader
 }
 
-func decode(in peekReader) (Message, error) {
+func readRaw(in byteReader) ([]byte, error) {
 	// Peek at the first byte to figure out message type.
 	t, err := in.ReadByte()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := in.UnreadByte(); err != nil {
+
+	switch mt := MessageType(t); mt {
+	case TypePNG2Frame:
+		return readRawPNG2Frame(t, in)
+	default:
+		message, err := decodeMessage(t, in)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return message.Encode()
+	}
+}
+
+func decode(in byteReader) (Message, error) {
+	// Peek at the first byte to figure out message type.
+	t, err := in.ReadByte()
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	switch MessageType(t) {
+
+	return decodeMessage(t, in)
+}
+
+func decodeMessage(firstByte byte, in byteReader) (Message, error) {
+	switch mt := MessageType(firstByte); mt {
 	case TypeClientScreenSpec:
 		return decodeClientScreenSpec(in)
 	case TypePNGFrame:
 		return decodePNGFrame(in)
+	case TypePNG2Frame:
+		return decodePNG2Frame(in)
 	case TypeMouseMove:
 		return decodeMouseMove(in)
 	case TypeMouseButton:
@@ -157,7 +179,7 @@ func decode(in peekReader) (Message, error) {
 	case TypeSharedDirectoryMoveResponse:
 		return decodeSharedDirectoryMoveResponse(in)
 	default:
-		return nil, trace.BadParameter("unsupported desktop protocol message type %d", t)
+		return nil, trace.BadParameter("unsupported desktop protocol message type %d", firstByte)
 	}
 }
 
@@ -169,30 +191,21 @@ type PNGFrame struct {
 	enc *png.Encoder // optionally override the PNG encoder
 }
 
-func NewPNG(img image.Image, enc *png.Encoder) PNGFrame {
-	return PNGFrame{
+func NewPNG(img image.Image, enc *png.Encoder) PNG2Frame {
+	return PNG2Frame{
 		Img: img,
 		enc: enc,
 	}
 }
 
 func (f PNGFrame) Encode() ([]byte, error) {
-	type header struct {
-		Type          byte
-		Left, Top     uint32
-		Right, Bottom uint32
-	}
-
 	buf := new(bytes.Buffer)
-	if err := binary.Write(buf, binary.BigEndian, header{
-		Type:   byte(TypePNGFrame),
-		Left:   uint32(f.Img.Bounds().Min.X),
-		Top:    uint32(f.Img.Bounds().Min.Y),
-		Right:  uint32(f.Img.Bounds().Max.X),
-		Bottom: uint32(f.Img.Bounds().Max.Y),
-	}); err != nil {
-		return nil, trace.Wrap(err)
-	}
+	buf.WriteByte(byte(TypePNGFrame))
+	writeUint32(buf, uint32(f.Img.Bounds().Min.X))
+	writeUint32(buf, uint32(f.Img.Bounds().Min.Y))
+	writeUint32(buf, uint32(f.Img.Bounds().Max.X))
+	writeUint32(buf, uint32(f.Img.Bounds().Max.Y))
+
 	encoder := f.enc
 	if encoder == nil {
 		encoder = &png.Encoder{}
@@ -203,14 +216,7 @@ func (f PNGFrame) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodePNGFrame(in peekReader) (PNGFrame, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return PNGFrame{}, trace.Wrap(err)
-	}
-	if t != byte(TypePNGFrame) {
-		return PNGFrame{}, trace.BadParameter("got message type %v, expected TypePNGFrame(%v)", t, TypePNGFrame)
-	}
+func decodePNGFrame(in byteReader) (PNGFrame, error) {
 	var header struct {
 		Left, Top     uint32
 		Right, Bottom uint32
@@ -233,6 +239,90 @@ func decodePNGFrame(in peekReader) (PNGFrame, error) {
 	return PNGFrame{Img: img}, nil
 }
 
+// PNG2Frame is a newer versin of PNGFrame that includes the
+// length of the PNG data.
+type PNG2Frame PNGFrame
+
+func decodePNG2Frame(in byteReader) (PNG2Frame, error) {
+	var length uint32
+	var header struct {
+		Left, Top     uint32
+		Right, Bottom uint32
+	}
+	if err := binary.Read(in, binary.BigEndian, &length); err != nil {
+		return PNG2Frame{}, trace.Wrap(err)
+	}
+	if err := binary.Read(in, binary.BigEndian, &header); err != nil {
+		return PNG2Frame{}, trace.Wrap(err)
+	}
+	img, err := png.Decode(io.LimitReader(in, int64(length)))
+	if err != nil {
+		return PNG2Frame{}, trace.Wrap(err)
+	}
+	// PNG encoding does not preserve offset image bounds.
+	// Opportunistically restore them based on the header.
+	switch img := img.(type) {
+	case *image.RGBA:
+		img.Rect = image.Rect(int(header.Left), int(header.Top), int(header.Right), int(header.Bottom))
+	case *image.NRGBA:
+		img.Rect = image.Rect(int(header.Left), int(header.Top), int(header.Right), int(header.Bottom))
+	}
+	return PNG2Frame{Img: img}, nil
+}
+
+func readRawPNG2Frame(firstByte byte, in byteReader) ([]byte, error) {
+	if MessageType(firstByte) != TypePNG2Frame {
+		return nil, trace.Wrap(trace.BadParameter("incorrect first byte passed to readRawPNG2Frame, expected %v but got %v", TypePNG2Frame, firstByte))
+	}
+
+	var pngLength uint32
+	if err := binary.Read(in, binary.BigEndian, &pngLength); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	b := make([]byte, 1+4+pngLength+16)
+	b[0] = firstByte
+
+	binary.BigEndian.PutUint32(b[1:5], pngLength)
+
+	if _, err := io.ReadFull(in, b[5:]); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return b, nil
+}
+
+func (f PNG2Frame) Encode() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	buf.WriteByte(byte(TypePNG2Frame))
+
+	// write 0 as a placeholder length for now
+	writeUint32(buf, uint32(0))
+
+	writeUint32(buf, uint32(f.Img.Bounds().Min.X))
+	writeUint32(buf, uint32(f.Img.Bounds().Min.Y))
+	writeUint32(buf, uint32(f.Img.Bounds().Max.X))
+	writeUint32(buf, uint32(f.Img.Bounds().Max.Y))
+
+	encoder := f.enc
+	if encoder == nil {
+		encoder = &png.Encoder{}
+	}
+	before := buf.Len()
+	if err := encoder.Encode(buf, f.Img); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	after := buf.Len()
+
+	result := buf.Bytes()
+
+	// fill in the length
+	pngLen := after - before
+	binary.BigEndian.PutUint32(result[1:5], uint32(pngLen))
+
+	return result, nil
+}
+
 // MouseMove is the mouse movement message.
 // https://github.com/gravitational/teleport/blob/master/rfd/0037-desktop-access-protocol.md#3---mouse-move
 type MouseMove struct {
@@ -242,22 +332,14 @@ type MouseMove struct {
 func (m MouseMove) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeMouseMove))
-	if err := binary.Write(buf, binary.BigEndian, m); err != nil {
-		return nil, trace.Wrap(err)
-	}
+	writeUint32(buf, m.X)
+	writeUint32(buf, m.Y)
 	return buf.Bytes(), nil
 }
 
-func decodeMouseMove(in peekReader) (MouseMove, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return MouseMove{}, trace.Wrap(err)
-	}
-	if t != byte(TypeMouseMove) {
-		return MouseMove{}, trace.BadParameter("got message type %v, expected TypeMouseMove(%v)", t, TypeMouseMove)
-	}
+func decodeMouseMove(in byteReader) (MouseMove, error) {
 	var m MouseMove
-	err = binary.Read(in, binary.BigEndian, &m)
+	err := binary.Read(in, binary.BigEndian, &m)
 	return m, trace.Wrap(err)
 }
 
@@ -289,16 +371,9 @@ func (m MouseButton) Encode() ([]byte, error) {
 	return []byte{byte(TypeMouseButton), byte(m.Button), byte(m.State)}, nil
 }
 
-func decodeMouseButton(in peekReader) (MouseButton, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return MouseButton{}, trace.Wrap(err)
-	}
-	if t != byte(TypeMouseButton) {
-		return MouseButton{}, trace.BadParameter("got message type %v, expected TypeMouseButton(%v)", t, TypeMouseButton)
-	}
+func decodeMouseButton(in byteReader) (MouseButton, error) {
 	var m MouseButton
-	err = binary.Read(in, binary.BigEndian, &m)
+	err := binary.Read(in, binary.BigEndian, &m)
 	return m, trace.Wrap(err)
 }
 
@@ -312,22 +387,14 @@ type KeyboardButton struct {
 func (k KeyboardButton) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeKeyboardButton))
-	if err := binary.Write(buf, binary.BigEndian, k); err != nil {
-		return nil, trace.Wrap(err)
-	}
+	writeUint32(buf, k.KeyCode)
+	buf.WriteByte(byte(k.State))
 	return buf.Bytes(), nil
 }
 
-func decodeKeyboardButton(in peekReader) (KeyboardButton, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return KeyboardButton{}, trace.Wrap(err)
-	}
-	if t != byte(TypeKeyboardButton) {
-		return KeyboardButton{}, trace.BadParameter("got message type %v, expected TypeKeyboardButton(%v)", t, TypeKeyboardButton)
-	}
+func decodeKeyboardButton(in byteReader) (KeyboardButton, error) {
 	var k KeyboardButton
-	err = binary.Read(in, binary.BigEndian, &k)
+	err := binary.Read(in, binary.BigEndian, &k)
 	return k, trace.Wrap(err)
 }
 
@@ -341,22 +408,14 @@ type ClientScreenSpec struct {
 func (s ClientScreenSpec) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeClientScreenSpec))
-	if err := binary.Write(buf, binary.BigEndian, s); err != nil {
-		return nil, trace.Wrap(err)
-	}
+	writeUint32(buf, s.Width)
+	writeUint32(buf, s.Height)
 	return buf.Bytes(), nil
 }
 
-func decodeClientScreenSpec(in peekReader) (ClientScreenSpec, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return ClientScreenSpec{}, trace.Wrap(err)
-	}
-	if t != byte(TypeClientScreenSpec) {
-		return ClientScreenSpec{}, trace.BadParameter("got message type %v, expected TypeClientScreenSpec(%v)", t, TypeClientScreenSpec)
-	}
+func decodeClientScreenSpec(in io.Reader) (ClientScreenSpec, error) {
 	var s ClientScreenSpec
-	err = binary.Read(in, binary.BigEndian, &s)
+	err := binary.Read(in, binary.BigEndian, &s)
 	return s, trace.Wrap(err)
 }
 
@@ -379,14 +438,7 @@ func (r ClientUsername) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeClientUsername(in peekReader) (ClientUsername, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return ClientUsername{}, trace.Wrap(err)
-	}
-	if t != byte(TypeClientUsername) {
-		return ClientUsername{}, trace.BadParameter("got message type %v, expected TypeClientUsername(%v)", t, TypeClientUsername)
-	}
+func decodeClientUsername(in io.Reader) (ClientUsername, error) {
 	username, err := decodeString(in, windowsMaxUsernameLength)
 	if err != nil {
 		return ClientUsername{}, trace.Wrap(err)
@@ -411,14 +463,7 @@ func (m Error) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeError(in peekReader) (Error, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return Error{}, trace.Wrap(err)
-	}
-	if t != byte(TypeError) {
-		return Error{}, trace.BadParameter("got message type %v, expected TypeError(%v)", t, TypeError)
-	}
+func decodeError(in io.Reader) (Error, error) {
 	message, err := decodeString(in, tdpMaxErrorMessageLength)
 	if err != nil {
 		return Error{}, trace.Wrap(err)
@@ -450,16 +495,9 @@ func (w MouseWheel) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeMouseWheel(in peekReader) (MouseWheel, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return MouseWheel{}, trace.Wrap(err)
-	}
-	if t != byte(TypeMouseWheel) {
-		return MouseWheel{}, trace.BadParameter("got message type %v, expected TypeMouseWheel(%v)", t, TypeMouseWheel)
-	}
+func decodeMouseWheel(in io.Reader) (MouseWheel, error) {
 	var w MouseWheel
-	err = binary.Read(in, binary.BigEndian, &w)
+	err := binary.Read(in, binary.BigEndian, &w)
 	return w, trace.Wrap(err)
 }
 
@@ -471,20 +509,12 @@ type ClipboardData []byte
 func (c ClipboardData) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeClipboardData))
-	binary.Write(buf, binary.BigEndian, uint32(len(c)))
+	writeUint32(buf, uint32(len(c)))
 	buf.Write(c)
 	return buf.Bytes(), nil
 }
 
-func decodeClipboardData(in peekReader, maxLen uint32) (ClipboardData, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if t != byte(TypeClipboardData) {
-		return nil, trace.BadParameter("got message type %v, expected TypeClipboardData(%v)", t, TypeClipboardData)
-	}
-
+func decodeClipboardData(in io.Reader, maxLen uint32) (ClipboardData, error) {
 	var length uint32
 	if err := binary.Read(in, binary.BigEndian, &length); err != nil {
 		return nil, trace.Wrap(err)
@@ -555,20 +585,12 @@ func (m MFA) Encode() ([]byte, error) {
 	if len(buff) > maxMFADataLength {
 		return nil, trace.BadParameter("mfa challenge data exceeds maximum length")
 	}
-	binary.Write(buf, binary.BigEndian, uint32(len(buff)))
+	writeUint32(buf, uint32(len(buff)))
 	buf.Write(buff)
 	return buf.Bytes(), nil
 }
 
-func DecodeMFA(in peekReader) (*MFA, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if t != byte(TypeMFA) {
-		return nil, trace.BadParameter("got message type %v, expected TypeMFA(%v)", t, TypeMFA)
-	}
-
+func DecodeMFA(in byteReader) (*MFA, error) {
 	mt, err := in.ReadByte()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -608,15 +630,7 @@ func DecodeMFA(in peekReader) (*MFA, error) {
 
 // DecodeMFAChallenge is a helper function used in test purpose to decode MFA challenge payload because in
 // real flow this logic is invoked by a fronted client.
-func DecodeMFAChallenge(in peekReader) (*MFA, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if t != byte(TypeMFA) {
-		return nil, trace.BadParameter("got message type %v, expected TypeMFAJson(%v)", t, TypeMFA)
-	}
-
+func DecodeMFAChallenge(in byteReader) (*MFA, error) {
 	mt, err := in.ReadByte()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -665,23 +679,16 @@ type SharedDirectoryAnnounce struct {
 func (s SharedDirectoryAnnounce) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryAnnounce))
-	binary.Write(buf, binary.BigEndian, s.DirectoryID)
+	writeUint32(buf, s.DirectoryID)
 	if err := encodeString(buf, s.Name); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryAnnounce(in peekReader) (SharedDirectoryAnnounce, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryAnnounce{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryAnnounce) {
-		return SharedDirectoryAnnounce{}, trace.BadParameter("got message type %v, expected SharedDirectoryAnnounce(%v)", t, TypeSharedDirectoryAnnounce)
-	}
+func decodeSharedDirectoryAnnounce(in io.Reader) (SharedDirectoryAnnounce, error) {
 	var completionID, directoryID uint32
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryAnnounce{}, trace.Wrap(err)
 	}
@@ -705,25 +712,17 @@ type SharedDirectoryAcknowledge struct {
 	DirectoryID uint32
 }
 
-func decodeSharedDirectoryAcknowledge(in peekReader) (SharedDirectoryAcknowledge, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryAcknowledge{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryAcknowledge) {
-		return SharedDirectoryAcknowledge{}, trace.BadParameter("got message type %v, expected SharedDirectoryAcknowledge(%v)", t, TypeSharedDirectoryAcknowledge)
-	}
-
+func decodeSharedDirectoryAcknowledge(in io.Reader) (SharedDirectoryAcknowledge, error) {
 	var s SharedDirectoryAcknowledge
-	err = binary.Read(in, binary.BigEndian, &s)
+	err := binary.Read(in, binary.BigEndian, &s)
 	return s, trace.Wrap(err)
 }
 
 func (s SharedDirectoryAcknowledge) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryAcknowledge))
-	binary.Write(buf, binary.BigEndian, s.ErrCode)
-	binary.Write(buf, binary.BigEndian, s.DirectoryID)
+	writeUint32(buf, s.ErrCode)
+	writeUint32(buf, s.DirectoryID)
 	return buf.Bytes(), nil
 }
 
@@ -736,24 +735,17 @@ type SharedDirectoryInfoRequest struct {
 func (s SharedDirectoryInfoRequest) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryInfoRequest))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.DirectoryID)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.DirectoryID)
 	if err := encodeString(buf, s.Path); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryInfoRequest(in peekReader) (SharedDirectoryInfoRequest, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryInfoRequest{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryInfoRequest) {
-		return SharedDirectoryInfoRequest{}, trace.BadParameter("got message type %v, expected SharedDirectoryInfoRequest(%v)", t, TypeSharedDirectoryInfoRequest)
-	}
+func decodeSharedDirectoryInfoRequest(in io.Reader) (SharedDirectoryInfoRequest, error) {
 	var completionID, directoryID uint32
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryInfoRequest{}, trace.Wrap(err)
 	}
@@ -782,26 +774,19 @@ type SharedDirectoryInfoResponse struct {
 func (s SharedDirectoryInfoResponse) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryInfoResponse))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.ErrCode)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.ErrCode)
 	fso, err := s.Fso.Encode()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	binary.Write(buf, binary.BigEndian, fso)
+	buf.Write(fso)
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryInfoResponse(in peekReader) (SharedDirectoryInfoResponse, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryInfoResponse{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryInfoResponse) {
-		return SharedDirectoryInfoResponse{}, trace.BadParameter("got message type %v, expected SharedDirectoryInfoResponse(%v)", t, TypeSharedDirectoryInfoResponse)
-	}
+func decodeSharedDirectoryInfoResponse(in byteReader) (SharedDirectoryInfoResponse, error) {
 	var completionID, errCode uint32
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryInfoResponse{}, trace.Wrap(err)
 	}
@@ -833,9 +818,9 @@ type FileSystemObject struct {
 
 func (f FileSystemObject) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, f.LastModified)
-	binary.Write(buf, binary.BigEndian, f.Size)
-	binary.Write(buf, binary.BigEndian, f.FileType)
+	writeUint64(buf, f.LastModified)
+	writeUint64(buf, f.Size)
+	writeUint32(buf, f.FileType)
 	buf.WriteByte(f.IsEmpty)
 	if err := encodeString(buf, f.Path); err != nil {
 		return nil, trace.Wrap(err)
@@ -843,7 +828,7 @@ func (f FileSystemObject) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeFileSystemObject(in peekReader) (FileSystemObject, error) {
+func decodeFileSystemObject(in byteReader) (FileSystemObject, error) {
 	var lastModified, size uint64
 	var fileType uint32
 	var isEmpty uint8
@@ -887,9 +872,9 @@ type SharedDirectoryCreateRequest struct {
 func (s SharedDirectoryCreateRequest) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryCreateRequest))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.DirectoryID)
-	binary.Write(buf, binary.BigEndian, s.FileType)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.DirectoryID)
+	writeUint32(buf, s.FileType)
 	if err := encodeString(buf, s.Path); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -897,16 +882,9 @@ func (s SharedDirectoryCreateRequest) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryCreateRequest(in peekReader) (SharedDirectoryCreateRequest, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryCreateRequest{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryCreateRequest) {
-		return SharedDirectoryCreateRequest{}, trace.BadParameter("got message type %v, expected SharedDirectoryCreateRequest(%v)", t, TypeSharedDirectoryCreateRequest)
-	}
+func decodeSharedDirectoryCreateRequest(in io.Reader) (SharedDirectoryCreateRequest, error) {
 	var completionID, directoryID, fileType uint32
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryCreateRequest{}, trace.Wrap(err)
 	}
@@ -941,8 +919,8 @@ type SharedDirectoryCreateResponse struct {
 func (s SharedDirectoryCreateResponse) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryCreateResponse))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.ErrCode)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.ErrCode)
 	fsoEnc, err := s.Fso.Encode()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -952,16 +930,9 @@ func (s SharedDirectoryCreateResponse) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryCreateResponse(in peekReader) (SharedDirectoryCreateResponse, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryCreateResponse{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryCreateResponse) {
-		return SharedDirectoryCreateResponse{}, trace.BadParameter("got message type %v, expected SharedDirectoryCreateResponse(%v)", t, TypeSharedDirectoryCreateResponse)
-	}
+func decodeSharedDirectoryCreateResponse(in byteReader) (SharedDirectoryCreateResponse, error) {
 	var completionID, errCode uint32
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryCreateResponse{}, trace.Wrap(err)
 	}
@@ -990,8 +961,8 @@ type SharedDirectoryDeleteRequest struct {
 func (s SharedDirectoryDeleteRequest) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryDeleteRequest))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.DirectoryID)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.DirectoryID)
 	if err := encodeString(buf, s.Path); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -999,16 +970,9 @@ func (s SharedDirectoryDeleteRequest) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryDeleteRequest(in peekReader) (SharedDirectoryDeleteRequest, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryDeleteRequest{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryDeleteRequest) {
-		return SharedDirectoryDeleteRequest{}, trace.BadParameter("got message type %v, expected SharedDirectoryDeleteRequest(%v)", t, TypeSharedDirectoryDeleteRequest)
-	}
+func decodeSharedDirectoryDeleteRequest(in io.Reader) (SharedDirectoryDeleteRequest, error) {
 	var completionID, directoryID uint32
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryDeleteRequest{}, trace.Wrap(err)
 	}
@@ -1036,21 +1000,14 @@ type SharedDirectoryDeleteResponse struct {
 func (s SharedDirectoryDeleteResponse) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryDeleteResponse))
-	binary.Write(buf, binary.BigEndian, s)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.ErrCode)
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryDeleteResponse(in peekReader) (SharedDirectoryDeleteResponse, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryDeleteResponse{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryDeleteResponse) {
-		return SharedDirectoryDeleteResponse{}, trace.BadParameter("got message type %v, expected SharedDirectoryDeleteResponse(%v)", t, TypeSharedDirectoryDeleteResponse)
-	}
-
+func decodeSharedDirectoryDeleteResponse(in io.Reader) (SharedDirectoryDeleteResponse, error) {
 	var res SharedDirectoryDeleteResponse
-	err = binary.Read(in, binary.BigEndian, &res)
+	err := binary.Read(in, binary.BigEndian, &res)
 	return res, err
 }
 
@@ -1063,8 +1020,8 @@ type SharedDirectoryListRequest struct {
 func (s SharedDirectoryListRequest) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryListRequest))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.DirectoryID)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.DirectoryID)
 	if err := encodeString(buf, s.Path); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1072,16 +1029,9 @@ func (s SharedDirectoryListRequest) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryListRequest(in peekReader) (SharedDirectoryListRequest, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryListRequest{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryListRequest) {
-		return SharedDirectoryListRequest{}, trace.BadParameter("got message type %v, expected SharedDirectoryListRequest(%v)", t, TypeSharedDirectoryListRequest)
-	}
+func decodeSharedDirectoryListRequest(in io.Reader) (SharedDirectoryListRequest, error) {
 	var completionID, directoryID uint32
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryListRequest{}, trace.Wrap(err)
 	}
@@ -1111,9 +1061,10 @@ type SharedDirectoryListResponse struct {
 func (s SharedDirectoryListResponse) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryListResponse))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.ErrCode)
-	binary.Write(buf, binary.BigEndian, uint32(len(s.FsoList)))
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.ErrCode)
+	writeUint32(buf, uint32(len(s.FsoList)))
+
 	for _, fso := range s.FsoList {
 		fsoEnc, err := fso.Encode()
 		if err != nil {
@@ -1125,16 +1076,9 @@ func (s SharedDirectoryListResponse) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryListResponse(in peekReader) (SharedDirectoryListResponse, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryListResponse{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryListResponse) {
-		return SharedDirectoryListResponse{}, trace.BadParameter("got message type %v, expected SharedDirectoryListResponse(%v)", t, TypeSharedDirectoryListResponse)
-	}
+func decodeSharedDirectoryListResponse(in byteReader) (SharedDirectoryListResponse, error) {
 	var completionID, errCode, fsoListLength uint32
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryListResponse{}, trace.Wrap(err)
 	}
@@ -1175,32 +1119,22 @@ type SharedDirectoryReadRequest struct {
 
 func (s SharedDirectoryReadRequest) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
-
 	buf.WriteByte(byte(TypeSharedDirectoryReadRequest))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.DirectoryID)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.DirectoryID)
 	if err := encodeString(buf, s.Path); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	binary.Write(buf, binary.BigEndian, s.Offset)
-	binary.Write(buf, binary.BigEndian, s.Length)
-
+	writeUint64(buf, s.Offset)
+	writeUint32(buf, s.Length)
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryReadRequest(in peekReader) (SharedDirectoryReadRequest, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryReadRequest{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryReadRequest) {
-		return SharedDirectoryReadRequest{}, trace.BadParameter("got message type %v, expected TypeSharedDirectoryReadRequest(%v)", t, TypeSharedDirectoryReadRequest)
-	}
-
+func decodeSharedDirectoryReadRequest(in io.Reader) (SharedDirectoryReadRequest, error) {
 	var completionID, directoryID, length uint32
 	var offset uint64
 
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryReadRequest{}, trace.Wrap(err)
 	}
@@ -1246,27 +1180,17 @@ type SharedDirectoryReadResponse struct {
 func (s SharedDirectoryReadResponse) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryReadResponse))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.ErrCode)
-	binary.Write(buf, binary.BigEndian, s.ReadDataLength)
-	if _, err := buf.Write(s.ReadData); err != nil {
-		return nil, trace.Wrap(err)
-	}
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.ErrCode)
+	writeUint32(buf, s.ReadDataLength)
+	buf.Write(s.ReadData)
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryReadResponse(in peekReader) (SharedDirectoryReadResponse, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryReadResponse{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryReadResponse) {
-		return SharedDirectoryReadResponse{}, trace.BadParameter("got message type %v, expected TypeSharedDirectoryReadResponse(%v)", t, TypeSharedDirectoryReadResponse)
-	}
-
+func decodeSharedDirectoryReadResponse(in io.Reader) (SharedDirectoryReadResponse, error) {
 	var completionID, errorCode, readDataLength uint32
 
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryReadResponse{}, trace.Wrap(err)
 	}
@@ -1309,33 +1233,22 @@ func (s SharedDirectoryWriteRequest) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	buf.WriteByte(byte(TypeSharedDirectoryWriteRequest))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.DirectoryID)
-	binary.Write(buf, binary.BigEndian, s.Offset)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.DirectoryID)
+	writeUint64(buf, s.Offset)
 	if err := encodeString(buf, s.Path); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	binary.Write(buf, binary.BigEndian, s.WriteDataLength)
-	if _, err := buf.Write(s.WriteData); err != nil {
-		return nil, trace.Wrap(err)
-	}
+	writeUint32(buf, s.WriteDataLength)
+	buf.Write(s.WriteData)
 	return buf.Bytes(), nil
-
 }
 
-func decodeSharedDirectoryWriteRequest(in peekReader) (SharedDirectoryWriteRequest, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryWriteRequest) {
-		return SharedDirectoryWriteRequest{}, trace.BadParameter("got message type %v, expected TypeSharedDirectoryWriteRequest(%v)", t, TypeSharedDirectoryWriteRequest)
-	}
-
+func decodeSharedDirectoryWriteRequest(in byteReader) (SharedDirectoryWriteRequest, error) {
 	var completionID, directoryID, writeDataLength uint32
 	var offset uint64
 
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
 	}
@@ -1387,21 +1300,15 @@ type SharedDirectoryWriteResponse struct {
 func (s SharedDirectoryWriteResponse) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryWriteResponse))
-	binary.Write(buf, binary.BigEndian, s)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.ErrCode)
+	writeUint32(buf, s.BytesWritten)
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryWriteResponse(in peekReader) (SharedDirectoryWriteResponse, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryWriteResponse{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryWriteResponse) {
-		return SharedDirectoryWriteResponse{}, trace.BadParameter("got message type %v, expected SharedDirectoryWriteResponse(%v)", t, TypeSharedDirectoryWriteResponse)
-	}
-
+func decodeSharedDirectoryWriteResponse(in io.Reader) (SharedDirectoryWriteResponse, error) {
 	var res SharedDirectoryWriteResponse
-	err = binary.Read(in, binary.BigEndian, &res)
+	err := binary.Read(in, binary.BigEndian, &res)
 	return res, err
 }
 
@@ -1417,8 +1324,8 @@ type SharedDirectoryMoveRequest struct {
 func (s SharedDirectoryMoveRequest) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryMoveRequest))
-	binary.Write(buf, binary.BigEndian, s.CompletionID)
-	binary.Write(buf, binary.BigEndian, s.DirectoryID)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.DirectoryID)
 	if err := encodeString(buf, s.OriginalPath); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1428,16 +1335,9 @@ func (s SharedDirectoryMoveRequest) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryMoveRequest(in peekReader) (SharedDirectoryMoveRequest, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryMoveRequest{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryMoveRequest) {
-		return SharedDirectoryMoveRequest{}, trace.BadParameter("got message type %v, expected TypeClientUsername(%v)", t, TypeClientUsername)
-	}
+func decodeSharedDirectoryMoveRequest(in io.Reader) (SharedDirectoryMoveRequest, error) {
 	var completionID, directoryID uint32
-	err = binary.Read(in, binary.BigEndian, &completionID)
+	err := binary.Read(in, binary.BigEndian, &completionID)
 	if err != nil {
 		return SharedDirectoryMoveRequest{}, trace.Wrap(err)
 	}
@@ -1469,21 +1369,14 @@ type SharedDirectoryMoveResponse struct {
 func (s SharedDirectoryMoveResponse) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteByte(byte(TypeSharedDirectoryMoveResponse))
-	binary.Write(buf, binary.BigEndian, s)
+	writeUint32(buf, s.CompletionID)
+	writeUint32(buf, s.ErrCode)
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryMoveResponse(in peekReader) (SharedDirectoryMoveResponse, error) {
-	t, err := in.ReadByte()
-	if err != nil {
-		return SharedDirectoryMoveResponse{}, trace.Wrap(err)
-	}
-	if t != byte(TypeSharedDirectoryMoveResponse) {
-		return SharedDirectoryMoveResponse{}, trace.BadParameter("got message type %v, expected SharedDirectoryMoveResponse(%v)", t, TypeSharedDirectoryMoveResponse)
-	}
-
+func decodeSharedDirectoryMoveResponse(in io.Reader) (SharedDirectoryMoveResponse, error) {
 	var res SharedDirectoryMoveResponse
-	err = binary.Read(in, binary.BigEndian, &res)
+	err := binary.Read(in, binary.BigEndian, &res)
 	return res, err
 }
 
@@ -1515,4 +1408,24 @@ func decodeString(r io.Reader, maxLen uint32) (string, error) {
 		return "", trace.Wrap(err)
 	}
 	return string(s), nil
+}
+
+// writeUint32 writes v to b in big endian order
+func writeUint32(b *bytes.Buffer, v uint32) {
+	b.WriteByte(byte(v >> 24))
+	b.WriteByte(byte(v >> 16))
+	b.WriteByte(byte(v >> 8))
+	b.WriteByte(byte(v))
+}
+
+// writeUint64 writes v to b in big endian order
+func writeUint64(b *bytes.Buffer, v uint64) {
+	b.WriteByte(byte(v >> 56))
+	b.WriteByte(byte(v >> 48))
+	b.WriteByte(byte(v >> 40))
+	b.WriteByte(byte(v >> 32))
+	b.WriteByte(byte(v >> 24))
+	b.WriteByte(byte(v >> 16))
+	b.WriteByte(byte(v >> 8))
+	b.WriteByte(byte(v))
 }

--- a/lib/srv/desktop/tdp/proto_test.go
+++ b/lib/srv/desktop/tdp/proto_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"image"
 	"image/color"
 	"os"
@@ -57,14 +58,15 @@ func TestEncodeDecode(t *testing.T) {
 		MouseWheel{Axis: HorizontalWheelAxis, Delta: -123},
 		Error{Message: "An error occurred"},
 	} {
+		t.Run(fmt.Sprintf("%T", m), func(t *testing.T) {
+			buf, err := m.Encode()
+			require.NoError(t, err)
 
-		buf, err := m.Encode()
-		require.NoError(t, err)
+			out, err := Decode(buf)
+			require.NoError(t, err)
 
-		out, err := Decode(buf)
-		require.NoError(t, err)
-
-		require.Empty(t, cmp.Diff(m, out, cmpopts.IgnoreUnexported(PNGFrame{})))
+			require.Empty(t, cmp.Diff(m, out, cmpopts.IgnoreUnexported(PNGFrame{})))
+		})
 	}
 }
 
@@ -102,7 +104,7 @@ func BenchmarkEncodePNG(b *testing.B) {
 	}
 }
 
-func loadBitmaps(b *testing.B) []PNGFrame {
+func loadBitmaps(b *testing.B) []PNG2Frame {
 	b.Helper()
 
 	f, err := os.Open(filepath.Join("testdata", "png_frames.json"))
@@ -111,7 +113,7 @@ func loadBitmaps(b *testing.B) []PNGFrame {
 
 	enc := PNGEncoder()
 
-	var result []PNGFrame
+	var result []PNG2Frame
 	type record struct {
 		Top, Left, Right, Bottom int
 		Pix                      []byte
@@ -148,9 +150,14 @@ func TestMFA(t *testing.T) {
 			},
 		},
 	}
-	err := c.OutputMessage(mfaWant)
+	err := c.WriteMessage(mfaWant)
 	require.NoError(t, err)
-	mfaGot, err := DecodeMFAChallenge(bufio.NewReader(&buff))
+
+	mt, err := buff.ReadByte()
+	require.NoError(t, err)
+	require.Equal(t, TypeMFA, MessageType(mt))
+
+	mfaGot, err := DecodeMFAChallenge(&buff)
 	require.NoError(t, err)
 	require.Equal(t, mfaWant, mfaGot)
 
@@ -166,9 +173,9 @@ func TestMFA(t *testing.T) {
 			},
 		},
 	}
-	err = c.OutputMessage(respWant)
+	err = c.WriteMessage(respWant)
 	require.NoError(t, err)
-	respGot, err := c.InputMessage()
+	respGot, err := c.ReadMessage()
 	require.NoError(t, err)
 	require.Equal(t, respWant, respGot)
 }

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -889,7 +889,7 @@ func (s *WindowsService) makeTDPSendHandler(ctx context.Context, emitter events.
 	id *tlsca.Identity, sessionID, desktopAddr string) func(m tdp.Message, b []byte) {
 	return func(m tdp.Message, b []byte) {
 		switch b[0] {
-		case byte(tdp.TypePNGFrame), byte(tdp.TypeError):
+		case byte(tdp.TypePNG2Frame), byte(tdp.TypePNGFrame), byte(tdp.TypeError):
 			e := &events.DesktopRecording{
 				Metadata: events.Metadata{
 					Type: libevents.DesktopRecordingEvent,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1365,16 +1365,16 @@ func (w *windowsDesktopServiceMock) handleConn(t *testing.T, conn *tls.Conn) {
 	require.NoError(t, err)
 	require.NotEmpty(t, identity.MFAVerified)
 
-	msg, err := tdpConn.InputMessage()
+	msg, err := tdpConn.ReadMessage()
 	require.NoError(t, err)
 	require.IsType(t, tdp.ClientUsername{}, msg)
 
-	msg, err = tdpConn.InputMessage()
+	msg, err = tdpConn.ReadMessage()
 	require.NoError(t, err)
 	require.IsType(t, tdp.ClientScreenSpec{}, msg)
 
 	img := image.NewRGBA(image.Rect(0, 0, 100, 100))
-	err = tdpConn.OutputMessage(tdp.NewPNG(img, tdp.PNGEncoder()))
+	err = tdpConn.WriteMessage(tdp.NewPNG(img, tdp.PNGEncoder()))
 	require.NoError(t, err)
 }
 
@@ -1464,20 +1464,25 @@ func TestDesktopAccessMFARequiresMfa(t *testing.T) {
 
 			tdpClient := tdp.NewConn(&WebsocketIO{Conn: ws})
 
-			msg, err := tdpClient.InputMessage()
+			msg, err := tdpClient.ReadMessage()
 			require.NoError(t, err)
-			require.IsType(t, tdp.PNGFrame{}, msg)
+			require.IsType(t, tdp.PNG2Frame{}, msg)
 		})
 	}
 }
 func handleMFAWebauthnChallenge(t *testing.T, ws *websocket.Conn, dev *auth.TestDevice) {
-	mfaChallange, err := tdp.DecodeMFAChallenge(bufio.NewReader(&WebsocketIO{Conn: ws}))
+	br := bufio.NewReader(&WebsocketIO{Conn: ws})
+	mt, err := br.ReadByte()
+	require.NoError(t, err)
+	require.Equal(t, tdp.TypeMFA, tdp.MessageType(mt))
+
+	mfaChallange, err := tdp.DecodeMFAChallenge(br)
 	require.NoError(t, err)
 	res, err := dev.SolveAuthn(&apiProto.MFAAuthenticateChallenge{
 		WebauthnChallenge: wanlib.CredentialAssertionToProto(mfaChallange.WebauthnChallenge),
 	})
 	require.NoError(t, err)
-	err = tdp.NewConn(&WebsocketIO{Conn: ws}).OutputMessage(tdp.MFA{
+	err = tdp.NewConn(&WebsocketIO{Conn: ws}).WriteMessage(tdp.MFA{
 		Type: defaults.WebsocketWebauthnChallenge[0],
 		MFAAuthenticateResponse: &authproto.MFAAuthenticateResponse{
 			Response: &authproto.MFAAuthenticateResponse_Webauthn{
@@ -1500,7 +1505,7 @@ func handleMFAU2FCChallenge(t *testing.T, ws *websocket.Conn, dev *auth.TestDevi
 		}},
 	})
 	require.NoError(t, err)
-	err = tdp.NewConn(&WebsocketIO{Conn: ws}).OutputMessage(tdp.MFA{
+	err = tdp.NewConn(&WebsocketIO{Conn: ws}).WriteMessage(tdp.MFA{
 		Type: defaults.WebsocketU2FChallenge[0],
 		MFAAuthenticateResponse: &authproto.MFAAuthenticateResponse{
 			Response: &authproto.MFAAuthenticateResponse_U2F{

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1494,7 +1494,12 @@ func handleMFAWebauthnChallenge(t *testing.T, ws *websocket.Conn, dev *auth.Test
 }
 
 func handleMFAU2FCChallenge(t *testing.T, ws *websocket.Conn, dev *auth.TestDevice) {
-	mfaChallange, err := tdp.DecodeMFAChallenge(bufio.NewReader(&WebsocketIO{Conn: ws}))
+	br := bufio.NewReader(&WebsocketIO{Conn: ws})
+	mt, err := br.ReadByte()
+	require.NoError(t, err)
+	require.Equal(t, tdp.TypeMFA, tdp.MessageType(mt))
+
+	mfaChallange, err := tdp.DecodeMFAChallenge(br)
 	require.NoError(t, err)
 	res, err := dev.SolveAuthn(&apiProto.MFAAuthenticateChallenge{
 		U2F: []*apiProto.U2FChallenge{{

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -66,6 +66,12 @@ func (h *Handler) desktopConnectHandle(
 	return nil, nil
 }
 
+const (
+	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/cbe1ed0a-d320-4ea5-be5a-f2eb6e032853#Appendix_A_45
+	maxRDPScreenWidth  = 8192
+	maxRDPScreenHeight = 8192
+)
+
 func (h *Handler) createDesktopConnection(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -74,7 +80,6 @@ func (h *Handler) createDesktopConnection(
 	ctx *SessionContext,
 	site reversetunnel.RemoteSite,
 ) error {
-
 	q := r.URL.Query()
 	username := q.Get("username")
 	if username == "" {
@@ -87,6 +92,12 @@ func (h *Handler) createDesktopConnection(
 	height, err := strconv.Atoi(q.Get("height"))
 	if err != nil {
 		return trace.BadParameter("height missing or invalid")
+	}
+
+	if width > maxRDPScreenWidth || height > maxRDPScreenHeight {
+		return trace.BadParameter("screen size of %d x %d is greater than the maximum allowed by RDP (%d x %d)",
+			width, height, maxRDPScreenWidth, maxRDPScreenHeight,
+		)
 	}
 
 	log.Debugf("Attempting to connect to desktop using username=%v, width=%v, height=%v\n", username, width, height)
@@ -171,11 +182,11 @@ func (h *Handler) createDesktopConnection(
 	log.Debug("Connected to windows_desktop_service")
 
 	tdpConn := tdp.NewConn(serviceConnTLS)
-	err = tdpConn.OutputMessage(tdp.ClientUsername{Username: username})
+	err = tdpConn.WriteMessage(tdp.ClientUsername{Username: username})
 	if err != nil {
 		return trace.NewAggregate(err, sendTDPError(ws, err))
 	}
-	err = tdpConn.OutputMessage(tdp.ClientScreenSpec{Width: uint32(width), Height: uint32(height)})
+	err = tdpConn.WriteMessage(tdp.ClientScreenSpec{Width: uint32(width), Height: uint32(height)})
 	if err != nil {
 		return trace.NewAggregate(err, sendTDPError(ws, err))
 	}
@@ -318,11 +329,12 @@ func proxyWebsocketConn(ws *websocket.Conn, wds net.Conn) error {
 		// (io.Copy's internal buffer could split one message
 		// into multiple ws.WriteMessage calls)
 		tc := tdp.NewConn(wds)
+
+		// we don't care about the content of the message, we just
+		// need to split the stream into individual messages and
+		// write them to the websocket
 		for {
-			// TODO(zmb3): avoid the decode/encode loop here,
-			// and instead just build a tokenizer that reads
-			// the correct amount of bytes
-			msg, err := tc.InputMessage()
+			raw, err := tc.ReadRaw()
 			if utils.IsOKNetworkError(err) {
 				errs <- nil
 				return
@@ -332,13 +344,7 @@ func proxyWebsocketConn(ws *websocket.Conn, wds net.Conn) error {
 				return
 			}
 
-			encoded, err := msg.Encode()
-			if err != nil {
-				errs <- err
-				return
-			}
-
-			err = ws.WriteMessage(websocket.BinaryMessage, encoded)
+			err = ws.WriteMessage(websocket.BinaryMessage, raw)
 			if utils.IsOKNetworkError(err) {
 				errs <- nil
 				return

--- a/lib/web/mfa_codec.go
+++ b/lib/web/mfa_codec.go
@@ -89,7 +89,10 @@ func (tdpMFACodec) encode(chal *auth.MFAAuthenticateChallenge, envelopeType stri
 }
 
 func (tdpMFACodec) decode(buf []byte, envelopeType string) (*authproto.MFAAuthenticateResponse, error) {
-	msg, err := tdp.DecodeMFA(bytes.NewReader(buf))
+	if len(buf) == 0 || tdp.MessageType(buf[0]) != tdp.TypeMFA {
+		return nil, trace.BadParameter("expected MFA message type %v, got %v", tdp.TypeMFA, buf[0])
+	}
+	msg, err := tdp.DecodeMFA(bytes.NewReader(buf[1:]))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/rfd/0037-desktop-access-protocol.md
+++ b/rfd/0037-desktop-access-protocol.md
@@ -223,3 +223,13 @@ Per-session MFA for desktop access works the same way as it does for SSH
 sessions. A JSON-encoded challenge is sent over websocket to the user's browser.
 The only difference is that SSH sessions wrap the MFA JSON in a protobuf
 encoding, where desktop sessions wrap the MFA JSON in a TDP message.
+
+#### 27 - PNG frame 2
+
+```
+| message type (27) | png_length uint32 | left uint32 | top uint32 | right uint32 | bottom uint32 | data []byte |
+```
+
+This is a newer version of the PNG frame message, which includes the length of the PNG data after
+the message type. This allows for efficiently skipping over the PNG data without performing
+a PNG decode.


### PR DESCRIPTION
This includes 3 optimizations to improve performance of desktop sessions:

1. Reuse the same image object when encoding PNGs. This prevents us from making a 16KB allocation for every single bitmap that comes through.
2. Introduce a new PNG frame message that has a length as part of the header. The original message had no length, which required a costly decode operation just to find the message boundary. This fixes a performance regression in the proxy for v10.2.x.
3. Eliminate the use of binary.Write when encoding the most common message types. While convenient, binary.Write uses reflection to detect the type of the input, which slows encoding down.

Co-authored-by: Isaiah Becker-Mayer <isaiah@goteleport.com>

Backports #16864 