### PR TITLE
[v10] fix: data race in NodeSession.runCommand

### DIFF
--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -576,27 +576,22 @@ func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionPartici
 	// support sending SSH_MSG_DISCONNECT. Instead we close the SSH channel and
 	// SSH client, and try and exit as gracefully as possible.
 	return ns.regularSession(ctx, func(s *tracessh.Session) error {
-		var err error
-
-		runContext, cancel := context.WithCancel(ctx)
+		errCh := make(chan error, 1)
 		go func() {
-			defer cancel()
-			err = s.Run(ctx, strings.Join(cmd, " "))
+			errCh <- s.Run(ctx, strings.Join(cmd, " "))
 		}()
 
 		select {
 		// Run returned a result, return that back to the caller.
-		case <-runContext.Done():
+		case err := <-errCh:
 			return trace.Wrap(err)
 		// The passed in context timed out. This is often due to the user hitting
 		// Ctrl-C.
 		case <-ctx.Done():
-			err = s.Close()
-			if err != nil {
+			if err := s.Close(); err != nil {
 				log.Debugf("Unable to close SSH channel: %v", err)
 			}
-			err = ns.NodeClient().Client.Close()
-			if err != nil {
+			if err := ns.NodeClient().Client.Close(); err != nil {
 				log.Debugf("Unable to close SSH client: %v", err)
 			}
 			return trace.ConnectionProblem(ctx.Err(), "connection canceled")


### PR DESCRIPTION
Backport #17048 to branch/v10