### PR TITLE
Rough demonstration of GitHub `tctl`/`tsh` auto configuration

### DIFF
--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -142,10 +142,12 @@ func TryRun(commands []CLICommand, args []string) error {
 		"Base64 encoded configuration string").Hidden().Envar(defaults.ConfigEnvar).StringVar(&ccf.ConfigString)
 	app.Flag("auth-server",
 		fmt.Sprintf("Attempts to connect to specific auth/proxy address(es) instead of local auth [%v]", defaults.AuthConnectAddr().Addr)).
+		Envar("TELEPORT_PROXY").
 		StringsVar(&ccf.AuthServerAddr)
 	app.Flag("identity",
 		"Path to an identity file. Must be provided to make remote connections to auth. An identity file can be exported with 'tctl auth sign'").
 		Short('i').
+		Envar("TELEPORT_IDENTITY_FILE").
 		StringVar(&ccf.IdentityFilePath)
 	app.Flag("insecure", "When specifying a proxy address in --auth-server, do not verify its TLS certificate. Danger: any data you send can be intercepted or modified by an attacker.").
 		BoolVar(&ccf.Insecure)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -461,6 +461,7 @@ const (
 	useLocalSSHAgentEnvVar = "TELEPORT_USE_LOCAL_SSH_AGENT"
 	globalTshConfigEnvVar  = "TELEPORT_GLOBAL_TSH_CONFIG"
 	mfaModeEnvVar          = "TELEPORT_MFA_MODE"
+	identityFileEnvVar     = "TELEPORT_IDENTITY_FILE"
 	debugEnvVar            = teleport.VerboseLogsEnvVar // "TELEPORT_DEBUG"
 
 	clusterHelp = "Specify the Teleport cluster to connect"
@@ -527,7 +528,7 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	}).String()
 
 	app.Flag("ttl", "Minutes to live for a SSH session").Int32Var(&cf.MinsToLive)
-	app.Flag("identity", "Identity file").Short('i').StringVar(&cf.IdentityFileIn)
+	app.Flag("identity", "Identity file").Short('i').Envar(identityFileEnvVar).StringVar(&cf.IdentityFileIn)
 	app.Flag("compat", "OpenSSH compatibility flag").Hidden().StringVar(&cf.Compatibility)
 	app.Flag("cert-format", "SSH certificate format").StringVar(&cf.CertificateFormat)
 	app.Flag("trace", "Capture and export distributed traces").Hidden().BoolVar(&cf.SampleTraces)
@@ -3987,11 +3988,10 @@ type envGetter func(string) string
 
 // setEnvFlags sets flags that can be set via environment variables.
 func setEnvFlags(cf *CLIConf, fn envGetter) {
-	// prioritize CLI input
+	// prioritize CLI inputs
 	if cf.SiteName == "" {
 		setSiteNameFromEnv(cf, fn)
 	}
-	// prioritize CLI input
 	if cf.KubernetesCluster == "" {
 		setKubernetesClusterFromEnv(cf, fn)
 	}
@@ -4030,6 +4030,12 @@ func setKubernetesClusterFromEnv(cf *CLIConf, fn envGetter) {
 func setGlobalTshConfigPathFromEnv(cf *CLIConf, fn envGetter) {
 	if configPath := fn(globalTshConfigEnvVar); configPath != "" {
 		cf.GlobalTshConfigPath = path.Clean(configPath)
+	}
+}
+
+func setIdentityFileFromEnv(cf *CLIConf, fn envGetter) {
+	if identityFile := fn("TELEPORT_IDENTITY_FILE"); identityFile != "" {
+		cf.Proxy = identityFile
 	}
 }
 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -4033,12 +4033,6 @@ func setGlobalTshConfigPathFromEnv(cf *CLIConf, fn envGetter) {
 	}
 }
 
-func setIdentityFileFromEnv(cf *CLIConf, fn envGetter) {
-	if identityFile := fn("TELEPORT_IDENTITY_FILE"); identityFile != "" {
-		cf.Proxy = identityFile
-	}
-}
-
 func handleUnimplementedError(ctx context.Context, perr error, cf CLIConf) error {
 	const (
 		errMsgFormat         = "This server does not implement this feature yet. Likely the client version you are using is newer than the server. The server version: %v, the client version: %v. Please upgrade the server."


### PR DESCRIPTION
```yaml
name: "Test Teleport GH Action"
on:
  push:
    branches:
      - main

jobs:
  demo:
    permissions:
      # This is required or tbot will not be able to authenticate
      id-token: write
      contents: read
    name: demo
    runs-on: ubuntu-latest
    steps:
      - name: Checkout repository
        uses: actions/checkout@v3
      - name: Setup teleport
        uses: gravitational/teleport-actions/setup@7d8f6a63a74e1df8f09f4bc8d3105f317b529b88
        with:
          version: 10.3.1
      - name: Fetch credentials
        run: >
          ./tbot start
            --auth-server=proxy.addr.com:443
            --join-method=github
            --token=github-bot
            --oneshot
            --destination-dir=./certs 
            --data-dir=./data
      - name: Write file to remote
        run: >
          ./tsh ssh noahstride@mac-os "echo $GITHUB_SHA >> ~/github_run_log"
      - name: Use tctl to list proxies
        run: >
          ./tctl proxy ls
```