### PR TITLE
[v7] bot: Don't use a GH token to clone a public repository (gravitational/shared-workflows)

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -37,7 +37,6 @@ jobs:
       - name: Checkout shared-workflow
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.SHARED_WORKFLOWS_GITHUB_TOKEN }}
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
           ref: main

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -39,7 +39,6 @@ jobs:
       - name: Checkout shared-workflow
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.SHARED_WORKFLOWS_GITHUB_TOKEN }}
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
           ref: main


### PR DESCRIPTION
Backport-From: gravitational/teleport#16959