### PR TITLE
Fix signature SSH certificate when using agent.Agent type

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -131,7 +131,7 @@ func CreateAgent(me *user.User, key *client.Key) (*teleagent.AgentServer, string
 	// create a (unstarted) agent and add the agent key(s) to it
 	keyring, ok := agent.NewKeyring().(agent.ExtendedAgent)
 	if !ok {
-		return nil, "", "", trace.Errorf("unexpected keyring type: %T, expected agent.ExtendedKeyring")
+		return nil, "", "", trace.Errorf("unexpected keyring type: %T, expected agent.ExtendedKeyring", keyring)
 	}
 
 	if err := keyring.Add(agentKey); err != nil {

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -129,7 +129,11 @@ func CreateAgent(me *user.User, key *client.Key) (*teleagent.AgentServer, string
 	}
 
 	// create a (unstarted) agent and add the agent key(s) to it
-	keyring := agent.NewKeyring()
+	keyring, ok := agent.NewKeyring().(agent.ExtendedAgent)
+	if !ok {
+		return nil, "", "", trace.Errorf("unexpected keyring type: %T, expected agent.ExtendedKeyring")
+	}
+
 	if err := keyring.Add(agentKey); err != nil {
 		return nil, "", "", trace.Wrap(err)
 	}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -239,7 +239,7 @@ type Config struct {
 	UseKeyPrincipals bool
 
 	// Agent is used when SkipLocalAuth is true
-	Agent agent.Agent
+	Agent agent.ExtendedAgent
 
 	// PreloadKey is a key with which to initialize a local in-memory keystore.
 	PreloadKey *Key
@@ -4209,7 +4209,7 @@ func loopbackPool(proxyAddr string) *x509.CertPool {
 }
 
 // connectToSSHAgent connects to the system SSH agent and returns an agent.Agent.
-func connectToSSHAgent() agent.Agent {
+func connectToSSHAgent() agent.ExtendedAgent {
 	socketPath := os.Getenv(teleport.SSHAuthSock)
 	conn, err := agentconn.Dial(socketPath)
 	if err != nil {

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -546,7 +546,7 @@ func TestApplyProxySettings(t *testing.T) {
 type mockAgent struct {
 	// Agent is embedded to avoid redeclaring all interface methods.
 	// Only the Signers method is implemented by testAgent.
-	agent.Agent
+	agent.ExtendedAgent
 	ValidPrincipals []string
 }
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1570,7 +1570,7 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress NodeDet
 		if proxy.teleportClient.localAgent == nil {
 			return nil, trace.BadParameter("cluster is in proxy recording mode and requires agent forwarding for connections, but no agent was initialized")
 		}
-		err = agent.ForwardToAgent(proxy.Client.Client, proxy.teleportClient.localAgent.Agent)
+		err = agent.ForwardToAgent(proxy.Client.Client, proxy.teleportClient.localAgent.ExtendedAgent)
 		if err != nil && !strings.Contains(err.Error(), "agent: already have handler for") {
 			return nil, trace.Wrap(err)
 		}
@@ -1676,7 +1676,7 @@ func (proxy *ProxyClient) PortForwardToNode(ctx context.Context, nodeAddress Nod
 		if proxy.teleportClient.localAgent == nil {
 			return nil, trace.BadParameter("cluster is in proxy recording mode and requires agent forwarding for connections, but no agent was initialized")
 		}
-		err = agent.ForwardToAgent(proxy.Client.Client, proxy.teleportClient.localAgent.Agent)
+		err = agent.ForwardToAgent(proxy.Client.Client, proxy.teleportClient.localAgent.ExtendedAgent)
 		if err != nil && !strings.Contains(err.Error(), "agent: already have handler for") {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -46,14 +46,14 @@ type LocalKeyAgent struct {
 	// log holds the structured logger.
 	log *logrus.Entry
 
-	// Agent is the teleport agent
-	agent.Agent
+	// ExtendedAgent is the teleport agent
+	agent.ExtendedAgent
 
 	// keyStore is the storage backend for certificates and keys
 	keyStore LocalKeyStore
 
 	// sshAgent is the system ssh agent
-	sshAgent agent.Agent
+	sshAgent agent.ExtendedAgent
 
 	// noHosts is a in-memory map used in tests to track which hosts a user has
 	// manually (via keyboard input) refused connecting to.
@@ -139,7 +139,7 @@ func shouldAddKeysToAgent(addKeysToAgent string) bool {
 // LocalAgentConfig contains parameters for creating the local keys agent.
 type LocalAgentConfig struct {
 	Keystore   LocalKeyStore
-	Agent      agent.Agent
+	Agent      agent.ExtendedAgent
 	ProxyHost  string
 	Username   string
 	KeysOption string
@@ -152,20 +152,24 @@ type LocalAgentConfig struct {
 // and loads them into the local and system agent
 func NewLocalAgent(conf LocalAgentConfig) (a *LocalKeyAgent, err error) {
 	if conf.Agent == nil {
-		conf.Agent = agent.NewKeyring()
+		keyring, ok := agent.NewKeyring().(agent.ExtendedAgent)
+		if !ok {
+			return nil, trace.Errorf("unexpected keyring type: %T, expected agent.ExtendedKeyring")
+		}
+		conf.Agent = keyring
 	}
 	a = &LocalKeyAgent{
 		log: logrus.WithFields(logrus.Fields{
 			trace.Component: teleport.ComponentKeyAgent,
 		}),
-		Agent:      conf.Agent,
-		keyStore:   conf.Keystore,
-		noHosts:    make(map[string]bool),
-		username:   conf.Username,
-		proxyHost:  conf.ProxyHost,
-		insecure:   conf.Insecure,
-		siteName:   conf.Site,
-		loadAllCAs: conf.LoadAllCAs,
+		ExtendedAgent: conf.Agent,
+		keyStore:      conf.Keystore,
+		noHosts:       make(map[string]bool),
+		username:      conf.Username,
+		proxyHost:     conf.ProxyHost,
+		insecure:      conf.Insecure,
+		siteName:      conf.Site,
+		loadAllCAs:    conf.LoadAllCAs,
 	}
 
 	if shouldAddKeysToAgent(conf.KeysOption) {
@@ -242,7 +246,7 @@ func (a *LocalKeyAgent) LoadKey(key Key) error {
 	}
 
 	a.log.Infof("Loading SSH key for user %q and cluster %q.", a.username, key.ClusterName)
-	agents := []agent.Agent{a.Agent}
+	agents := []agent.ExtendedAgent{a.ExtendedAgent}
 	if a.sshAgent != nil {
 		agents = append(agents, a.sshAgent)
 	}
@@ -271,7 +275,7 @@ func (a *LocalKeyAgent) LoadKey(key Key) error {
 // UnloadKey will unload key for user from the teleport ssh agent as well as
 // the system agent.
 func (a *LocalKeyAgent) UnloadKey() error {
-	agents := []agent.Agent{a.Agent}
+	agents := []agent.ExtendedAgent{a.ExtendedAgent}
 	if a.sshAgent != nil {
 		agents = append(agents, a.sshAgent)
 	}
@@ -301,7 +305,7 @@ func (a *LocalKeyAgent) UnloadKey() error {
 // UnloadKeys will unload all Teleport keys from the teleport agent as well as
 // the system agent.
 func (a *LocalKeyAgent) UnloadKeys() error {
-	agents := []agent.Agent{a.Agent}
+	agents := []agent.ExtendedAgent{a.ExtendedAgent}
 	if a.sshAgent != nil {
 		agents = append(agents, a.sshAgent)
 	}

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -154,7 +154,7 @@ func NewLocalAgent(conf LocalAgentConfig) (a *LocalKeyAgent, err error) {
 	if conf.Agent == nil {
 		keyring, ok := agent.NewKeyring().(agent.ExtendedAgent)
 		if !ok {
-			return nil, trace.Errorf("unexpected keyring type: %T, expected agent.ExtendedKeyring")
+			return nil, trace.Errorf("unexpected keyring type: %T, expected agent.ExtendedKeyring", keyring)
 		}
 		conf.Agent = keyring
 	}

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -121,7 +121,7 @@ func TestAddKey(t *testing.T) {
 	}
 
 	// get all agent keys from teleport agent and system agent
-	teleportAgentKeys, err := lka.Agent.List()
+	teleportAgentKeys, err := lka.ExtendedAgent.List()
 	require.NoError(t, err)
 	systemAgentKeys, err := lka.sshAgent.List()
 	require.NoError(t, err)
@@ -182,7 +182,7 @@ func TestLoadKey(t *testing.T) {
 	require.NoError(t, err)
 
 	// get all the keys in the teleport and system agent
-	teleportAgentKeys, err := lka.Agent.List()
+	teleportAgentKeys, err := lka.ExtendedAgent.List()
 	require.NoError(t, err)
 	teleportAgentInitialKeyCount := len(teleportAgentKeys)
 	systemAgentKeys, err := lka.sshAgent.List()
@@ -197,7 +197,7 @@ func TestLoadKey(t *testing.T) {
 	require.NoError(t, err)
 
 	// get all the keys in the teleport and system agent
-	teleportAgentKeys, err = lka.Agent.List()
+	teleportAgentKeys, err = lka.ExtendedAgent.List()
 	require.NoError(t, err)
 	systemAgentKeys, err = lka.sshAgent.List()
 	require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestLoadKey(t *testing.T) {
 	require.Len(t, systemAgentKeys, systemAgentInitialKeyCount+2)
 
 	// now sign data using the teleport agent and system agent
-	teleportAgentSignature, err := lka.Agent.Sign(teleportAgentKeys[0], userdata)
+	teleportAgentSignature, err := lka.ExtendedAgent.Sign(teleportAgentKeys[0], userdata)
 	require.NoError(t, err)
 	systemAgentSignature, err := lka.sshAgent.Sign(systemAgentKeys[0], userdata)
 	require.NoError(t, err)

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -267,14 +267,14 @@ func (ns *NodeSession) createServerSession(ctx context.Context) (*tracessh.Sessi
 
 // selectKeyAgent picks the appropriate key agent for forwarding to the
 // server, if any.
-func selectKeyAgent(tc *TeleportClient) agent.Agent {
+func selectKeyAgent(tc *TeleportClient) agent.ExtendedAgent {
 	switch tc.ForwardAgent {
 	case ForwardAgentYes:
 		log.Debugf("Selecting system key agent.")
 		return tc.localAgent.sshAgent
 	case ForwardAgentLocal:
 		log.Debugf("Selecting local Teleport key agent.")
-		return tc.localAgent.Agent
+		return tc.localAgent.ExtendedAgent
 	default:
 		log.Debugf("No Key Agent selected.")
 		return nil

--- a/lib/teleagent/agent.go
+++ b/lib/teleagent/agent.go
@@ -31,26 +31,26 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
-// Agent extends the agent.Agent interface.
+// Agent extends the agent.ExtendedAgent interface.
 // APIs which accept this interface promise to
 // call `Close()` when they are done using the
 // supplied agent.
 type Agent interface {
-	agent.Agent
+	agent.ExtendedAgent
 	io.Closer
 }
 
 // nopCloser wraps an agent.Agent in the extended
 // Agent interface by adding a NOP closer.
 type nopCloser struct {
-	agent.Agent
+	agent.ExtendedAgent
 }
 
 func (n nopCloser) Close() error { return nil }
 
 // NopCloser wraps an agent.Agent with a NOP closer, allowing it
 // to be passed to APIs which expect the extended agent interface.
-func NopCloser(std agent.Agent) Agent {
+func NopCloser(std agent.ExtendedAgent) Agent {
 	return nopCloser{std}
 }
 

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -300,7 +300,7 @@ func (c *SessionContext) GetAgent() (agent.ExtendedAgent, *ssh.Certificate, erro
 
 	keyring, ok := agent.NewKeyring().(agent.ExtendedAgent)
 	if !ok {
-		return nil, nil, trace.Errorf("unexpected keyring type: %T, expected agent.ExtendedKeyring")
+		return nil, nil, trace.Errorf("unexpected keyring type: %T, expected agent.ExtendedKeyring", keyring)
 	}
 	err = keyring.Add(agent.AddedKey{
 		PrivateKey:  privateKey,

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -446,7 +446,9 @@ func createAgent(t *testing.T) string {
 	sockDir := "test"
 	sockName := "agent.sock"
 
-	keyring := agent.NewKeyring()
+	keyring, ok := agent.NewKeyring().(agent.ExtendedAgent)
+	require.True(t, ok)
+
 	teleAgent := teleagent.NewServer(func() (teleagent.Agent, error) {
 		return teleagent.NopCloser(keyring), nil
 	})

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -758,11 +758,11 @@ func TestMakeClient(t *testing.T) {
 	require.NotNil(t, tc)
 	require.Equal(t, proxyWebAddr.String(), tc.Config.WebProxyAddr)
 	require.Equal(t, proxySSHAddr.Addr, tc.Config.SSHProxyAddr)
-	require.NotNil(t, tc.LocalAgent().Agent)
+	require.NotNil(t, tc.LocalAgent().ExtendedAgent)
 
 	// Client should have an in-memory agent with keys loaded, in case agent
 	// forwarding is required for proxy recording mode.
-	agentKeys, err := tc.LocalAgent().Agent.List()
+	agentKeys, err := tc.LocalAgent().ExtendedAgent.List()
 	require.NoError(t, err)
 	require.Greater(t, len(agentKeys), 0)
 }


### PR DESCRIPTION
Looks like a few tests in my main PR https://github.com/gravitational/teleport/pull/16912 were failing as the keyring used in our tests had the wrong type. Go's ssh library signs all certificates with `SHA-1` has type `agent.Agent`, and SHA-2 is used only when a passed agent has type `agent.ExtendedAgent`. 

Ref:
https://github.com/gravitational/crypto/blob/master/ssh/agent/server.go#L133-L137
https://github.com/gravitational/crypto/blob/master/ssh/agent/keyring.go#L184-L219

This PR changes the` agent.Agent` type in all places to make sure that we use the correct interface in all places.