### PR TITLE
[v10] Add documentation for Slack Helm chart

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1008,13 +1008,21 @@
               "title": "teleport-plugin-event-handler",
               "slug": "/reference/helm-reference/teleport-plugin-event-handler/"
             },
-	    {
-              "title": "teleport-plugin-mattermost",
-              "slug": "/reference/helm-reference/teleport-plugin-mattermost/"
-	    },
+            {
+              "title": "teleport-plugin-jira",
+              "slug": "/reference/helm-reference/teleport-plugin-jira/"
+            },
             {
               "title": "teleport-plugin-pagerduty",
               "slug": "/reference/helm-reference/teleport-plugin-pagerduty/"
+            },
+            {
+              "title": "teleport-plugin-mattermost",
+              "slug": "/reference/helm-reference/teleport-plugin-mattermost/"
+            },
+            {
+              "title": "teleport-plugin-slack",
+              "slug": "/reference/helm-reference/teleport-plugin-slack/"
             }
           ]
         }

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
@@ -32,13 +32,14 @@ Here is an example of sending an Access Request via Teleport's Slack plugin:
 - Slack admin privileges to create an app and install it to your workspace. Your
   Slack profile must have the "Workspace Owner" or "Workspace Admin" banner
   below your profile picture.
+- Either a Linux host or Kubernetes cluster where you will run the Slack plugin.
 
 (!/docs/pages/includes/tctl.mdx!)
 
 ## Step 1/8. Define RBAC resources
 
 Before you set up the Slack plugin, you will need to enable Role Access Requests
-in your Teleport cluster. 
+in your Teleport cluster.
 
 (!/docs/pages/includes/plugins/editor-request-rbac.mdx!)
 
@@ -61,6 +62,13 @@ and will require access to both the public internet and the Teleport Auth Servic
   $ tar -xzf teleport-access-slack-v(=teleport.version=)-linux-amd64-bin.tar.gz
   $ ./teleport-access-slack/install
   ```
+
+  Make sure the binary is installed:
+
+  ```code
+  $ teleport-slack version
+  teleport-slack v(=teleport.plugin.version=) git:teleport-slack-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
+  ```
 </TabItem>
 <TabItem label="From Source">
   To install from source you need `git` and `go` >= (=teleport.golang=)
@@ -72,16 +80,13 @@ and will require access to both the public internet and the Teleport Auth Servic
   $ cd teleport-plugins/access/slack
   $ make
   ```
-  
+
   Place the `teleport-slack` binary into an appropriate location
   within the system's `PATH`, e.g., `/usr/local/bin`:
 
-  ```code 
-  $ mv ./build/teleport-slack /usr/local/bin 
+  ```code
+  $ mv ./build/teleport-slack /usr/local/bin
   ```
-
-</TabItem> 
-</Tabs>
 
   Make sure the binary is installed:
 
@@ -89,6 +94,15 @@ and will require access to both the public internet and the Teleport Auth Servic
   $ teleport-slack version
   teleport-slack v(=teleport.plugin.version=) git:teleport-slack-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
   ```
+
+</TabItem>
+<TabItem label="Helm Chart">
+  ```code
+  $ helm repo add teleport https://charts.releases.teleport.dev/
+  $ helm repo update
+  ```
+</TabItem>
+</Tabs>
 
 ## Step 3/8. Create a user and role for the plugin
 
@@ -164,7 +178,7 @@ Later in this guide, we will configure the plugin to post in other channels as
 well.
 
 After submitting this form, you will see an OAuth token in the "OAuth &
-Permissions" tab under "Tokens for Your Workspace": 
+Permissions" tab under "Tokens for Your Workspace":
 
 ![OAuth Tokens](../../../img/enterprise/plugins/slack/OAuth.png)
 
@@ -178,8 +192,10 @@ configure the Slack plugin to use these credentials. You will also configure the
 plugin to notify the right Slack channels when it receives an Access Request
 update.
 
-### Generate a config file
+### Create a config file
 
+<Tabs>
+<TabItem label="Executable">
 The Teleport Slack plugin uses a config file in TOML format. Generate a
 boilerplate config by running the following command (the plugin will not run
 unless the config file is in `/etc/teleport-slack.toml`):
@@ -193,24 +209,35 @@ This should result in a config file like the one below:
 ```toml
 (!examples/resources/plugins/teleport-slack.toml!)
 ```
+</TabItem>
+<TabItem label="Helm Chart">
+The Slack Helm Chart uses a YAML values file to configure the plugin.
+On your local workstation, create a file called `teleport-slack-helm.yaml`
+based on the following example:
+
+```toml
+(!examples/resources/plugins/teleport-slack-helm.yaml!)
+```
+
+</TabItem>
+</Tabs>
 
 ### Edit the config file
 
-Edit the `teleport-slack.toml` file you created earlier to update the following
-fields:
+Open the configuration file created for the Teleport Slack plugin and update the following fields:
 
 **`[teleport]`**
 
-The Slack plugin uses this section to connect to the Teleport Auth Service. 
+The Slack plugin uses this section to connect to the Teleport Auth Service.
 
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 The address and credentials you configure depend on whether your plugin can
 access the Auth Service directly:
 
-<Tabs>
-  <TabItem label="Connect to the Auth Service"> 
-    
+<Tabs dropdownCaption="Environment type" dropdownSelected="Executable">
+<TabItem label="Connect to the Auth Service" scope={["oss", "enterprise"]} options="Executable">
+
 Set `addr` to the address and port of your Auth Service. This address must be
 reachable from the Teleport Slack Plugin.
 
@@ -225,7 +252,7 @@ client_crt = "/var/lib/teleport/plugins/slack/auth.crt" # Teleport GRPC client c
 root_cas = "/var/lib/teleport/plugins/slack/auth.cas"   # Teleport cluster CA certs
 ```
 </TabItem>
-  <TabItem label="Connect to the Proxy Service">
+<TabItem label="Connect to the Proxy Service" options="Executable">
 
 Set `addr` to  your Proxy Service address with port `443`.
 
@@ -233,27 +260,36 @@ Set `identity` to the identity file generated earlier:
 
 ```toml
 [teleport]
-addr = "mytenant.teleport.sh:443"
+addr = "teleport.example.com:443"
 identity = "/var/lib/teleport/plugins/slack/auth.pem"
 ```
-  </TabItem>
+</TabItem>
+<TabItem label="Connect to the Proxy or Auth Service" scope="cloud" options="Helm Chart">
+
+**`address`**: Include the hostname and port of your Teleport Proxy or Auth Service
+(e.g., `teleport.example.com:443`).
+
+**`identitySecretName`**: Fill in the `identitySecretName` field with the name
+of the Kubernetes secret you created earlier.
+
+</TabItem>
 </Tabs>
 
 </ScopedBlock>
 <ScopedBlock scope="cloud">
 
-Set `addr` to  your Teleport Cloud tenant address with port `443`.
+Set `addr` to  your Teleport Proxy address with port `443`.
 
 Set `identity` to the identity file generated earlier:
 
 ```toml
 [teleport]
-addr = "mytenant.teleport.sh:443"
+addr = "teleport.example.com:443"
 identity = "/var/lib/teleport/plugins/slack/auth.pem"
 ```
 
 </ScopedBlock>
- 
+
 **`[slack]`**
 
 `token`: Open [`https://api.slack.com/apps`](https://api.slack.com/apps), find
@@ -267,6 +303,8 @@ notify when a user requests access to a specific role. When the Slack plugin
 receives an Access Request from the Auth Service, it will look up the role being
 requested and identify the Slack channels to notify.
 
+<Tabs>
+<TabItem label="Executable">
 Here is an example of a `role_to_recipients` map:
 
 ```toml
@@ -275,6 +313,21 @@ Here is an example of a `role_to_recipients` map:
 "dev" = ["dev-slack-channel", "admin-slack-channel"]
 "dba" = "alex@gmail.com"
 ```
+</TabItem>
+<TabItem label="Helm Chart">
+In our Helm chart, the `role_to_recipients` field is called `roleToRecipients`
+and uses the following format:
+
+```yaml
+roleToRecipients:
+  "*": "admin-slack-channel"
+  "dev":
+    - "dev-slack-channel"
+    - "admin-slack-channel"
+  "dba": "alex@gmail.com"
+```
+</TabItem>
+</Tabs>
 
 In the `role_to_recipients` map, each key is the name of a Teleport role. Each
 value configures the Slack channel (or channels) to notify. The value can be a
@@ -308,11 +361,22 @@ by adding the following to your `role_to_recipients` config (replace
 `TELEPORT_USERNAME` with the user you assigned the `editor-reviewer` role
 earlier):
 
+<Tabs>
+<TabItem label="Executable">
 ```toml
 [role_to_recipients]
 "*" = "access-requests"
 "editor" = "TELEPORT_USERNAME"
 ```
+</TabItem>
+<TabItem label="Helm Chart">
+```yaml
+roleToRecipients:
+  "*": "access-requests"
+  "editor": "TELEPORT_USERNAME"
+```
+</TabItem>
+</Tabs>
 
 Either create an `access-requests` channel in your Slack workspace or rename the
 value of the `"*"` key to an existing channel.
@@ -326,13 +390,15 @@ those channels.
 You have already configured the plugin to send direct messages as Slackbot. For
 any other channel you mention in your `role_to_recipients` map, you will need
 to invite the plugin to that channel. Navigate to each channel and enter `/invite
-@teleport` in the message box. 
+@teleport` in the message box.
 
 ## Step 7/8. Test your Slack app
 
 Once Teleport is running, you've created the Slack app, and the plugin is
 configured, you can now run the plugin and test the workflow.
 
+<Tabs>
+<TabItem label="Executable" scope={["oss", "enterprise"]}>
 Start the plugin:
 
 ```code
@@ -346,6 +412,29 @@ $ teleport-slack start
 INFO   Starting Teleport Access Slack Plugin 7.2.1: slack/app.go:80
 INFO   Plugin is ready slack/app.go:101
 ```
+</TabItem>
+<TabItem label="Helm Chart" scope={["oss", "enterprise"]}>
+Install the plugin:
+
+```code
+$ helm upgrade --install teleport-plugin-slack teleport/teleport-plugin-slack --values teleport-slack-helm.yaml
+```
+
+To inspect the plugin's logs, use the following command:
+
+```code
+$ kubectl logs deploy/teleport-plugin-slack
+```
+
+Debug logs can be enabled by setting `log.severity` to `DEBUG` in
+`teleport-slack-helm.yaml` and executing the `helm upgrade ...` command
+above again. Then you can restart the plugin with the following command:
+
+```code
+$ kubectl rollout restart deployment teleport-plugin-slack
+```
+</TabItem>
+</Tabs>
 
 Create an Access Request and check if the plugin works as expected with the
 following steps.
@@ -382,6 +471,9 @@ Auth Service host</ScopedBlock>.
 </Admonition>
 
 ## Step 8/8. Set up systemd
+
+This section is only relevant if you are running the Teleport Slack plugin on a
+Linux host.
 
 In production, we recommend starting the Teleport plugin daemon via an init
 system like systemd.  Here's the recommended Teleport plugin service unit file

--- a/docs/pages/includes/plugins/identity-export.mdx
+++ b/docs/pages/includes/plugins/identity-export.mdx
@@ -52,7 +52,8 @@ This command should result in three PEM-encoded files: `auth.crt`,
 respectively). Later, you will configure the plugin to use these credentials to
 connect to the Auth Service directly.
 </TabItem>
-<TabItem label="Connect to the Proxy or Auth Service" options="Helm Chart">
+<TabItem label="Connect to your Teleport Cluster" options="Helm Chart">
+
 The following `tctl auth sign` command impersonates the `access-plugin` user,
 generates signed credentials, and writes an identity file to the local
 directory:
@@ -75,8 +76,6 @@ Access Request plugin uses the SSH credentials to connect to the Proxy Service,
 which establishes a reverse tunnel connection to the Auth Service. The plugin
 uses this reverse tunnel, along with your TLS credentials, to connect to the
 Auth Service's gRPC endpoint.
-
-The Helm chart only supports the `file` format.
 
 You will refer to this file later when configuring the plugin.
 </TabItem>

--- a/docs/pages/reference/helm-reference.mdx
+++ b/docs/pages/reference/helm-reference.mdx
@@ -21,4 +21,6 @@ layout: tocless-doc
   or denying Access Requests via Mattermost.
 - [teleport-plugin-pagerduty](./helm-reference/teleport-plugin-pagerduty.mdx):
   Deploy the Teleport PagerDuty Plugin, which allows sending PagerDuty alerts
+- [teleport-plugin-slack](./helm-reference/teleport-plugin-slack.mdx): Deploy
+  the Teleport Slack Plugin, which allows notifying Slack users and channels
   when Access Requests are made.

--- a/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
@@ -1,0 +1,236 @@
+---
+title: teleport-plugin-slack Chart Reference
+description: Values that can be set using the teleport-plugin-slack Helm chart
+---
+
+The `teleport-plugin-slack` Helm chart is used to configure the Slack Teleport plugin, which allows users to receive Access Requests via channels or direct messages in Slack.
+
+You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/master/charts/access/slack).
+
+This reference details available values for the `teleport-plugin-slack` chart.
+
+(!docs/pages/includes/backup-warning.mdx!)
+
+## `teleport.address`
+
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `""` | Yes |
+
+This parameter contains the host/port combination of the Teleport Proxy
+Service (or the Auth Service if you are configuring your plugin to
+connect to it directly).
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  teleport:
+    address: "teleport.example.com:3025"
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set teleport.address="teleport.example.com:3025"
+  ```
+  </TabItem>
+</Tabs>
+
+## `teleport.identitySecretName`
+
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `""` | Yes |
+
+Name of the Kubernetes secret that contains the credentials for the connection
+to your Teleport cluster.
+
+The secret should be in the following format:
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: teleport-plugin-slack-identity
+data:
+  auth_id: ...
+```
+
+Check out the [Access Requests with
+Slack](../../access-controls/access-request-plugins/ssh-approval-slack.mdx) guide
+for more information about how to acquire these credentials.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  teleport:
+    identitySecretName: "teleport-plugin-slack-identity"
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set teleport.identitySecretName="teleport-plugin-slack-identity"
+  ```
+  </TabItem>
+</Tabs>
+
+## `teleport.identitySecretPath`
+
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `"auth_id"` | No |
+
+The key in the Kubernetes secret specified by `teleport.identitySecretName` that holds the
+credentials for the connection to your Teleport cluster. If the secret has the path,
+`"auth_id"`, you can omit this field.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  teleport:
+    identitySecretPath: "auth_id"
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set teleport.identitySecretPath="auth_id"
+  ```
+  </TabItem>
+</Tabs>
+
+## `slack.token`
+
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `""` | No |
+
+Slack token of the bot user to impersonate when sending Access Request
+messages. Ignored when `slack.tokenFromSecret` is set.
+It's only recommended for testing purposes. Please use
+[`slack.tokenFromSecret`](#slacktokenfromsecret) instead.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  slack:
+    token: "xoxb-1234"
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set slack.token="xoxb-1234"
+  ```
+  </TabItem>
+</Tabs>
+
+## `slack.tokenFromSecret`
+
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `""` | No |
+
+Secret containing the Slack token of the bot user.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  slack:
+    tokenFromSecret: "teleport-slack-plugin-token"
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set slack.tokenFromSecret="teleport-slack-plugin-token"
+  ```
+  </TabItem>
+</Tabs>
+
+## `slack.tokenSecretPath`
+
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `""` | No |
+
+Key where the token is located inside the secret specified by `slack.tokenFromSecret`.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  slack:
+    tokenSecretPath: "token"
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set slack.tokenSecretPath="token"
+  ```
+  </TabItem>
+</Tabs>
+
+## `roleToRecipients`
+
+| Type | Default value | Required? |
+| - | - | - |
+| `map` | `{}` | Yes |
+
+Mapping of roles to a list of channels and Slack emails. It must contain
+a mapping for `*` in case no matching roles are found.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  roleToRecipients:
+    dev: ["dev-access-requests", "user@example.com"]
+    "*": ["access-requests"]
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set "roleToRecipients.dev[0]=dev-access-requests,roleToRecipients.dev[1]=user@example.com,roleToRecipients.\*[0]=access-requests"
+  ```
+  </TabItem>
+</Tabs>
+
+## `log.output`
+
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `stdout` | No |
+
+Logger output. Could be `stdout`, `stderr` or a file name, eg. `/var/log/teleport/slack.log`
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  log:
+    output: /var/log/teleport/slack.log
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set log.output="/var/log/teleport/slack.log"
+  ```
+  </TabItem>
+</Tabs>
+
+## `log.severity`
+
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `INFO` | No |
+
+Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  log:
+    severity: DEBUG
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set log.severity="DEBUG"
+  ```
+  </TabItem>
+</Tabs>

--- a/examples/resources/plugins/teleport-slack-helm.yaml
+++ b/examples/resources/plugins/teleport-slack-helm.yaml
@@ -1,0 +1,11 @@
+teleport: {}
+  # address: "teleportauth:3025"                        # Teleport Auth Server GRPC API address
+  # identitySecretName: teleport-plugin-slack-identity  # Secret containing identity
+
+slack:
+  token: "xoxb-11xx"  # Slack Bot OAuth token
+
+# Mapping from role to recipients
+roleToRecipients: []
+  # "dev" = "devs-slack-channel"
+  # "*" = ["admin@email.com", "admin-slack-channel"]


### PR DESCRIPTION
Backports #13726

It includes an updated guide and the reference of the new Helm chart.