### PR TITLE
Release 11.0.0-alpha.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=11.0.0-alpha.1
+VERSION=11.0.0-alpha.2
 
 DOCKER_IMAGE_QUAY ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_ECR ?= public.ecr.aws/gravitational/teleport

--- a/api/version.go
+++ b/api/version.go
@@ -3,7 +3,7 @@
 package api
 
 const (
-	Version = "11.0.0-alpha.1"
+	Version = "11.0.0-alpha.2"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "11.0.0-alpha.1"
+.version: &version "11.0.0-alpha.2"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "11.0.0-alpha.1"
+.version: &version "11.0.0-alpha.2"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/deployment_test.yaml.snap
@@ -3,7 +3,7 @@ sets Deployment annotations when specified:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -45,7 +45,7 @@ sets Pod annotations when specified:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -87,7 +87,7 @@ should add PersistentVolumeClaim as volume when in custom mode and persistence.e
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -129,7 +129,7 @@ should add PersistentVolumeClaim as volume when in standalone mode and persisten
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -168,7 +168,7 @@ should add PersistentVolumeClaim as volume when in standalone mode and persisten
         claimName: RELEASE-NAME
 should add an operator side-car when operator is enabled:
   1: |
-    image: public.ecr.aws/gravitational/teleport-operator:11.0.0-alpha.1
+    image: public.ecr.aws/gravitational/teleport-operator:11.0.0-alpha.2
     imagePullPolicy: IfNotPresent
     livenessProbe:
       httpGet:
@@ -206,7 +206,7 @@ should add emptyDir for data in AWS mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -259,7 +259,7 @@ should add emptyDir for data in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -307,7 +307,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --insecure
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -349,7 +349,7 @@ should add named PersistentVolumeClaim as volume when in custom mode and persist
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -392,7 +392,7 @@ should add named PersistentVolumeClaim as volume when in custom mode and persist
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -482,7 +482,7 @@ should expose diag port:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -524,7 +524,7 @@ should have Recreate strategy in standalone mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -578,7 +578,7 @@ should have multiple replicas when replicaCount is set:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -632,7 +632,7 @@ should mount ConfigMap for config in AWS mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -685,7 +685,7 @@ should mount ConfigMap for config in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -732,7 +732,7 @@ should mount ConfigMap for config in custom mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -774,7 +774,7 @@ should mount ConfigMap for config in standalone mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -828,7 +828,7 @@ should mount GCP credentials for initContainer in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -901,7 +901,7 @@ should mount GCP credentials in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -960,7 +960,7 @@ should mount TLS certs for initContainer when cert-manager is enabled:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1042,7 +1042,7 @@ should mount TLS certs when cert-manager is enabled:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1107,7 +1107,7 @@ should mount cert-manager TLS secret when highAvailability.certManager.enabled i
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1155,7 +1155,7 @@ should mount extraVolumes and extraVolumeMounts:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1205,7 +1205,7 @@ should mount tls.existingCASecretName and set environment when set in values:
       env:
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1264,7 +1264,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: some-value
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1318,7 +1318,7 @@ should mount tls.existingSecretName when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1366,7 +1366,7 @@ should not add PersistentVolumeClaim as volume when in custom mode and persisten
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1407,7 +1407,7 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1449,7 +1449,7 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1491,7 +1491,7 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1574,7 +1574,7 @@ should not have more than one replica in standalone mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1628,7 +1628,7 @@ should not have strategy in AWS mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1681,7 +1681,7 @@ should not have strategy in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1728,7 +1728,7 @@ should not have strategy in custom mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1770,7 +1770,7 @@ should not mount TLS secrets when when highAvailability.certManager.enabled is f
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1812,7 +1812,7 @@ should not set securityContext when is empty object (default value):
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1857,7 +1857,7 @@ should provision initContainer correctly when set in values:
       env:
       - name: SOME_ENVIRONMENT_VARIABLE
         value: some-value
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1933,7 +1933,7 @@ should set affinity when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1978,7 +1978,7 @@ should set environment when extraEnv set in values:
       env:
       - name: SOME_ENVIRONMENT_VARIABLE
         value: some-value
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2020,7 +2020,7 @@ should set imagePullPolicy when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2062,7 +2062,7 @@ should set postStart command if set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       lifecycle:
         postStart:
@@ -2110,7 +2110,7 @@ should set priorityClassName when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2153,7 +2153,7 @@ should set probeTimeoutSeconds when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2205,7 +2205,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2246,7 +2246,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2295,7 +2295,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2356,7 +2356,7 @@ should set tolerations when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "11.0.0-alpha.1"
+.version: &version "11.0.0-alpha.2"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets Deployment annotations when specified if action is Upgrade:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+            image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -95,7 +95,7 @@ sets Deployment labels when specified if action is Upgrade:
         containers:
         - args:
           - --diag-addr=0.0.0.0:3000
-          image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+          image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -150,7 +150,7 @@ sets Pod annotations when specified if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -205,7 +205,7 @@ sets Pod labels when specified if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -260,7 +260,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -316,7 +316,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
     - args:
       - --diag-addr=0.0.0.0:3000
       - --insecure
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -371,7 +371,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -424,7 +424,7 @@ should expose diag port if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -491,7 +491,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -558,7 +558,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -613,7 +613,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -668,7 +668,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -731,7 +731,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
       env:
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -797,7 +797,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -858,7 +858,7 @@ should provision initContainer correctly when set in values if action is Upgrade
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -949,7 +949,7 @@ should set SecurityContext if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1024,7 +1024,7 @@ should set affinity when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1079,7 +1079,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1137,7 +1137,7 @@ should set environment when extraEnv set in values if action is Upgrade:
       env:
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1247,7 +1247,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1302,7 +1302,7 @@ should set nodeSelector if set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1359,7 +1359,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1426,7 +1426,7 @@ should set preferred affinity when more than one replica is used if action is Up
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1481,7 +1481,7 @@ should set priorityClassName when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1537,7 +1537,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1602,7 +1602,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1657,7 +1657,7 @@ should set resources when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1719,7 +1719,7 @@ should set serviceAccountName when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1774,7 +1774,7 @@ should set tolerations when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -14,7 +14,7 @@ sets Pod annotations when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -80,7 +80,7 @@ sets Pod labels when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -170,7 +170,7 @@ sets StatefulSet labels when specified:
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+            image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -247,7 +247,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -313,7 +313,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -399,7 +399,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+            image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -475,7 +475,7 @@ should add volumeMount for data volume when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -541,7 +541,7 @@ should expose diag port:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -607,7 +607,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -687,7 +687,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -765,7 +765,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -831,7 +831,7 @@ should have one replica when replicaCount is not set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -897,7 +897,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -965,7 +965,7 @@ should mount extraVolumes and extraVolumeMounts:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1038,7 +1038,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: RELEASE-NAME
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1116,7 +1116,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1190,7 +1190,7 @@ should not add emptyDir for data when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1256,7 +1256,7 @@ should provision initContainer correctly when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1358,7 +1358,7 @@ should set SecurityContext:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1444,7 +1444,7 @@ should set affinity when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1510,7 +1510,7 @@ should set default serviceAccountName when not set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1578,7 +1578,7 @@ should set environment when extraEnv set in values:
         value: RELEASE-NAME
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1710,7 +1710,7 @@ should set imagePullPolicy when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1776,7 +1776,7 @@ should set nodeSelector if set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1856,7 +1856,7 @@ should set preferred affinity when more than one replica is used:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1922,7 +1922,7 @@ should set probeTimeoutSeconds when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1998,7 +1998,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2064,7 +2064,7 @@ should set resources when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2137,7 +2137,7 @@ should set serviceAccountName when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2203,7 +2203,7 @@ should set storage.requests when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2269,7 +2269,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2335,7 +2335,7 @@ should set tolerations when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.1
+      image: public.ecr.aws/gravitational/teleport:11.0.0-alpha.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "11.0.0-alpha.1"
+	Version = "11.0.0-alpha.2"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
alpha.1 publishing failed due to operator Docker image build still being on Go 1.18:

https://drone.platform.teleport.sh/gravitational/teleport/16186/24/3