### PR TITLE
Correct `tctl proxy ls` command help

### DIFF
--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -38,8 +38,8 @@ type ProxyCommand struct {
 func (p *ProxyCommand) Initialize(app *kingpin.Application, config *service.Config) {
 	p.config = config
 
-	authCommand := app.Command("proxy", "Operations with information for cluster proxies").Hidden()
-	p.lsCmd = authCommand.Command("ls", "List connected auth servers")
+	authCommand := app.Command("proxy", "Operations with information for cluster proxies.").Hidden()
+	p.lsCmd = authCommand.Command("ls", "Lists proxies connected to the cluster.")
 	p.lsCmd.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(teleport.YAML).StringVar(&p.format)
 
 }

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -38,8 +38,8 @@ type ProxyCommand struct {
 func (p *ProxyCommand) Initialize(app *kingpin.Application, config *service.Config) {
 	p.config = config
 
-	authCommand := app.Command("proxy", "Operations with information for cluster proxies.").Hidden()
-	p.lsCmd = authCommand.Command("ls", "Lists proxies connected to the cluster.")
+	proxyCommand := app.Command("proxy", "Operations with information for cluster proxies.").Hidden()
+	p.lsCmd = proxyCommand.Command("ls", "Lists proxies connected to the cluster.")
 	p.lsCmd.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(teleport.YAML).StringVar(&p.format)
 
 }


### PR DESCRIPTION
The help currently mentions "auth servers" rather than proxies.