### PR TITLE
Manually print installer scripts instead of using asciitable 

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -931,12 +931,10 @@ func (c *installerCollection) resources() []types.Resource {
 }
 
 func (c *installerCollection) writeText(w io.Writer) error {
-	t := asciitable.MakeTable([]string{"Script"})
 	for _, inst := range c.installers {
-		t.AddRow([]string{
-			inst.GetScript(),
-		})
+		fmt.Printf("Script: %s\n----------\n", inst.GetName())
+		fmt.Println(inst.GetScript())
+		fmt.Println("----------")
 	}
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
+	return nil
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -932,9 +932,9 @@ func (c *installerCollection) resources() []types.Resource {
 
 func (c *installerCollection) writeText(w io.Writer) error {
 	for _, inst := range c.installers {
-		fmt.Printf("Script: %s\n----------\n", inst.GetName())
-		fmt.Println(inst.GetScript())
-		fmt.Println("----------")
+		fmt.Fprintf(w, "Script: %s\n----------\n", inst.GetName())
+		fmt.Fprintln(w, inst.GetScript())
+		fmt.Fprintln(w, "----------")
 	}
 	return nil
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -932,9 +932,15 @@ func (c *installerCollection) resources() []types.Resource {
 
 func (c *installerCollection) writeText(w io.Writer) error {
 	for _, inst := range c.installers {
-		fmt.Fprintf(w, "Script: %s\n----------\n", inst.GetName())
-		fmt.Fprintln(w, inst.GetScript())
-		fmt.Fprintln(w, "----------")
+		if _, err := fmt.Fprintf(w, "Script: %s\n----------\n", inst.GetName()); err != nil {
+			return trace.Wrap(err)
+		}
+		if _, err := fmt.Fprintln(w, inst.GetScript()); err != nil {
+			return trace.Wrap(err)
+		}
+		if _, err := fmt.Fprintln(w, "----------"); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This was leading to some pretty weird outputs it now looks like this

```
Script: [script-name]
----------
#!/bin/sh
echo hello
----------
Script: script-2
...
```