### PR TITLE
Fix setting an incorrect port when generating a Teleport config

### DIFF
--- a/assets/aws/files/bin/teleport-generate-config
+++ b/assets/aws/files/bin/teleport-generate-config
@@ -387,7 +387,7 @@ teleport:
   storage:
     type: dir
     path: /var/lib/teleport/backend
-  auth_server: ${TELEPORT_AUTH_SERVER_LB}:443
+  auth_server: ${TELEPORT_AUTH_SERVER_LB}:3025
 
 auth_service:
   enabled: no


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/15761/files#diff-a4dfba26ed255254bbe8f945e5963629ea822bed91ae310583acb057f201988dL389-R390 I incorrectly changed 

```yaml
  auth_servers:
    - ${TELEPORT_AUTH_SERVER_LB}:3025
```

to 

```yaml
  auth_server: ${TELEPORT_AUTH_SERVER_LB}:443
```

This changed the port to 443 (I'm really not sure why), so this changes it back to the correct 3025.