### PR TITLE
Neaten up the config comments for config v2 and above, remove config changelog

### DIFF
--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -867,3 +867,10 @@ Replaced `teleport.auth_servers` with either `teleport.auth_server` or `teleport
 **Introduced in Teleport v8**
 
 Added support for multiplexing via `auth_service.proxy_listener_mode`.
+
+Removed the default values being set for:
+
+- `proxy_service.kube_listen_addr`
+- `proxy_service.ssh_public_addr`
+- `proxy_service.tunnel_listen_addr`
+- `proxy_service.web_listen_addr`

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -640,7 +640,7 @@ proxy_service:
     #
     # If not set, behavior depends on the config file version:
     #
-    # "v2": listener is not created, SSH is multiplexed on web_listen_addr
+    # "v2" & onwards: listener is not created, SSH is multiplexed on web_listen_addr
     # "v1": defaults to 0.0.0.0:3023
     listen_addr: 0.0.0.0:3023
 
@@ -651,7 +651,7 @@ proxy_service:
     #
     # If not set, behavior depends on the config file version:
     #
-    # "v2": listener is not created, reverse tunnel traffic is multiplexed on web_listen_addr
+    # "v2" & onwards: listener is not created, reverse tunnel traffic is multiplexed on web_listen_addr
     # "v1": defaults to 0.0.0.0:3024
     tunnel_listen_addr: 0.0.0.0:3024
 
@@ -700,7 +700,7 @@ proxy_service:
     #
     # If not set, behavior depends on the config file version:
     #
-    # "v2": listener is not created, Kubernetes traffic is multiplexed on web_listen_addr
+    # "v2" & onwards: listener is not created, Kubernetes traffic is multiplexed on web_listen_addr
     # "v1": defaults to 0.0.0.0:3026
     kube_listen_addr: 0.0.0.0:3026
     # optional: set a different public address for kubernetes access
@@ -710,8 +710,8 @@ proxy_service:
     #
     # If not set, behavior depends on the config file version:
     #
-    # "v2": listener is not created, MySQL traffic is multiplexed on
-    #       web_listen_addr
+    # "v2" & onwards: listener is not created, MySQL traffic is multiplexed on
+    #                 web_listen_addr
     # "v1": defaults to 0.0.0.0:3036
     mysql_listen_addr: "0.0.0.0:3036"
 

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -640,8 +640,8 @@ proxy_service:
     #
     # If not set, behavior depends on the config file version:
     #
-    # "v2" & onwards: listener is not created, SSH is multiplexed on web_listen_addr
-    # "v1": defaults to 0.0.0.0:3023
+    # v2 and above: listener is not created, SSH is multiplexed on web_listen_addr
+    # v1: defaults to 0.0.0.0:3023
     listen_addr: 0.0.0.0:3023
 
     # Reverse tunnel listening address. An auth server (CA) can establish an
@@ -651,8 +651,8 @@ proxy_service:
     #
     # If not set, behavior depends on the config file version:
     #
-    # "v2" & onwards: listener is not created, reverse tunnel traffic is multiplexed on web_listen_addr
-    # "v1": defaults to 0.0.0.0:3024
+    # v2 and above: listener is not created, reverse tunnel traffic is multiplexed on web_listen_addr
+    # v1: defaults to 0.0.0.0:3024
     tunnel_listen_addr: 0.0.0.0:3024
 
     # Proxy Peering listening address. Teleport Proxy Services will advertise this address

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -700,8 +700,8 @@ proxy_service:
     #
     # If not set, behavior depends on the config file version:
     #
-    # "v2" & onwards: listener is not created, Kubernetes traffic is multiplexed on web_listen_addr
-    # "v1": defaults to 0.0.0.0:3026
+    # v2 and above: listener is not created, Kubernetes traffic is multiplexed on web_listen_addr
+    # v1: defaults to 0.0.0.0:3026
     kube_listen_addr: 0.0.0.0:3026
     # optional: set a different public address for kubernetes access
     kube_public_addr: kube.example.com:3026
@@ -710,9 +710,8 @@ proxy_service:
     #
     # If not set, behavior depends on the config file version:
     #
-    # "v2" & onwards: listener is not created, MySQL traffic is multiplexed on
-    #                 web_listen_addr
-    # "v1": defaults to 0.0.0.0:3036
+    # v2 and above: listener is not created, MySQL traffic is multiplexed on web_listen_addr
+    # v1: defaults to 0.0.0.0:3036
     mysql_listen_addr: "0.0.0.0:3036"
 
     # Postgres Proxy listener address. If provided, proxy will use a separate

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -852,24 +852,3 @@ discovery_service:
 # This section configures the windows desktop service
 (!docs/pages/includes/desktop-access/desktop-config.yaml!)
 ```
-
-## Changelog
-
-### v3
-
-**Introduced in Teleport v11**
-
-Replaced `teleport.auth_servers` with either `teleport.auth_server` or `teleport.proxy_server`.
-
-### v2
-
-**Introduced in Teleport v8**
-
-Added support for multiplexing via `auth_service.proxy_listener_mode`.
-
-Removed the default values being set for:
-
-- `proxy_service.kube_listen_addr`
-- `proxy_service.ssh_public_addr`
-- `proxy_service.tunnel_listen_addr`
-- `proxy_service.web_listen_addr`


### PR DESCRIPTION
This just adds "v2 and above" for any comment that mentions v2 behaviours and removes the changelog in favour of the actual change log