### PR TITLE
Remove OS compatibility checks from the test plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -7,7 +7,7 @@ labels: testplan
 ## Manual Testing Plan
 
 Below are the items that should be manually tested with each release of Teleport.
-These tests should be run on both a fresh install of the version to be released
+These tests should be run on both a fresh installation of the version to be released
 as well as an upgrade of the previous version of Teleport.
 
 - [ ] Adding nodes to a cluster
@@ -76,8 +76,8 @@ as well as an upgrade of the previous version of Teleport.
 
     Using Teleport v9, set `auth_service.authentication.second_factor = u2f`,
     restart the server and then register an U2F device (`tsh mfa add`). Upgrade
-    the install to the current Teleport version (one major at a time) and try to
-    login using the U2F device as your second factor - it should work.
+    the installation to the current Teleport version (one major at a time) and try to
+    log in using the U2F device as your second factor - it should work.
 
   - [ ] Login OIDC
   - [ ] Login SAML
@@ -203,32 +203,32 @@ interactive sessions the 12 combinations are below.
 
 * [ ] Deploy Teleport on a single EKS cluster
 * [ ] Deploy Teleport on two EKS clusters and connect them via trusted cluster feature
-* [ ] Deploy Teleport Proxy outside of GKE cluster fronting connections to it (use [this script](https://github.com/gravitational/teleport/blob/master/examples/k8s-auth/get-kubeconfig.sh) to generate a kubeconfig)
-* [ ] Deploy Teleport Proxy outside of EKS cluster fronting connections to it (use [this script](https://github.com/gravitational/teleport/blob/master/examples/k8s-auth/get-kubeconfig.sh) to generate a kubeconfig)
+* [ ] Deploy Teleport Proxy outside GKE cluster fronting connections to it (use [this script](https://github.com/gravitational/teleport/blob/master/examples/k8s-auth/get-kubeconfig.sh) to generate a kubeconfig)
+* [ ] Deploy Teleport Proxy outside EKS cluster fronting connections to it (use [this script](https://github.com/gravitational/teleport/blob/master/examples/k8s-auth/get-kubeconfig.sh) to generate a kubeconfig)
 
 ### Teleport with multiple Kubernetes clusters
 
 Note: you can use GKE or EKS or minikube to run Kubernetes clusters.
 Minikube is the only caveat - it's not reachable publicly so don't run a proxy there.
 
-* [ ] Deploy combo auth/proxy/kubernetes_service outside of a Kubernetes cluster, using a kubeconfig
+* [ ] Deploy combo auth/proxy/kubernetes_service outside a Kubernetes cluster, using a kubeconfig
   * [ ] Login with `tsh login`, check that `tsh kube ls` has your cluster
   * [ ] Run `kubectl get nodes`, `kubectl exec -it $SOME_POD -- sh`
   * [ ] Verify that the audit log recorded the above request and session
-* [ ] Deploy combo auth/proxy/kubernetes_service inside of a Kubernetes cluster
+* [ ] Deploy combo auth/proxy/kubernetes_service inside a Kubernetes cluster
   * [ ] Login with `tsh login`, check that `tsh kube ls` has your cluster
   * [ ] Run `kubectl get nodes`, `kubectl exec -it $SOME_POD -- sh`
   * [ ] Verify that the audit log recorded the above request and session
-* [ ] Deploy combo auth/proxy_service outside of the Kubernetes cluster and kubernetes_service inside of a Kubernetes cluster, connected over a reverse tunnel
+* [ ] Deploy combo auth/proxy_service outside the Kubernetes cluster and kubernetes_service inside of a Kubernetes cluster, connected over a reverse tunnel
   * [ ] Login with `tsh login`, check that `tsh kube ls` has your cluster
   * [ ] Run `kubectl get nodes`, `kubectl exec -it $SOME_POD -- sh`
   * [ ] Verify that the audit log recorded the above request and session
-* [ ] Deploy a second kubernetes_service inside of another Kubernetes cluster, connected over a reverse tunnel
+* [ ] Deploy a second kubernetes_service inside another Kubernetes cluster, connected over a reverse tunnel
   * [ ] Login with `tsh login`, check that `tsh kube ls` has both clusters
   * [ ] Switch to a second cluster using `tsh kube login`
   * [ ] Run `kubectl get nodes`, `kubectl exec -it $SOME_POD -- sh` on the new cluster
   * [ ] Verify that the audit log recorded the above request and session
-* [ ] Deploy combo auth/proxy/kubernetes_service outside of a Kubernetes cluster, using a kubeconfig with multiple clusters in it
+* [ ] Deploy combo auth/proxy/kubernetes_service outside a Kubernetes cluster, using a kubeconfig with multiple clusters in it
   * [ ] Login with `tsh login`, check that `tsh kube ls` has all clusters
 * [ ] Test Kubernetes screen in the web UI (tab is located on left side nav on dashboard):
   * [ ] Verify that all kubes registered are shown with correct `name` and `labels`
@@ -292,19 +292,19 @@ tsh --proxy=proxy.example.com --user=<username> --insecure ssh --cluster=foo.com
 ### Teleport with SSO Providers
 
 - [ ] G Suite install instructions work
-    - [ ] G Suite Screenshots are up to date
+    - [ ] G Suite Screenshots are up-to-date
 - [ ] Azure Active Directory (AD) install instructions work
-    - [ ] Azure Active Directory (AD) Screenshots are up to date
+    - [ ] Azure Active Directory (AD) Screenshots are up-to-date
 - [ ] ActiveDirectory (ADFS) install instructions work
-    - [ ] Active Directory (ADFS) Screenshots are up to date
+    - [ ] Active Directory (ADFS) Screenshots are up-to-date
 - [ ] Okta install instructions work
-    - [ ] Okta Screenshots are up to date
+    - [ ] Okta Screenshots are up-to-date
 - [ ] OneLogin install instructions work
-    - [ ] OneLogin Screenshots are up to date
+    - [ ] OneLogin Screenshots are up-to-date
 - [ ] GitLab install instructions work
-    - [ ] GitLab Screenshots are up to date
+    - [ ] GitLab Screenshots are up-to-date
 - [ ] OIDC install instructions work
-    - [ ] OIDC Screenshots are up to date
+    - [ ] OIDC Screenshots are up-to-date
 - [ ] All providers with guides in docs are covered in this test plan
 
 ### `tctl sso` family of commands
@@ -448,7 +448,7 @@ For help with setting up auth connectors, check out the [Quick GitHub/SAML/OIDC 
 - [ ] Verify that error is shown when saving an invalid YAML
 - [ ] Verify that correct hint text is shown on the right side
 - [ ] Verify that encrypted SAML assertions work with an identity provider that supports it (Azure).
-- [ ] Verify that created github, saml, oidc card has their icons
+- [ ] Verify that created GitHub, saml, oidc card has their icons
 #### Roles
 - [ ] Verify that roles are shown
 - [ ] Verify that "Create New Role" dialog works
@@ -1157,13 +1157,13 @@ tsh bench sessions --max=5000 --web user ls
     - Begin sharing works
       - [ ] The shared directory icon in the top right of the screen is highlighted when directory sharing is initiated
       - [ ] The shared directory appears as a network drive named "<directory_name> on teleport"
-      - [ ] The share directory menu option dissapears from the menu
+      - [ ] The share directory menu option disappears from the menu
     - Navigation
       - [ ] The folders of the shared directory are navigable (move up and down the directory tree)
     - CRUD
       - [ ] A new text file can be created
       - [ ] The text file can be written to (saved)
-      - [ ] The text file can be read (close it, check that its saved on the local machine, then open it again on the remote)
+      - [ ] The text file can be read (close it, check that it's saved on the local machine, then open it again on the remote)
       - [ ] The text file can be deleted
     - File/Folder movement
       - In to out (make at least one of these from a non-top-level-directory)
@@ -1222,13 +1222,7 @@ tsh bench sessions --max=5000 --web user ls
 
 ## Binaries compatibility
 
-- Verify that teleport/tsh/tctl/tbot run on:
-  - [ ] CentOS 7
-  - [ ] CentOS 8
-  - [ ] Ubuntu 18.04
-  - [ ] Ubuntu 20.04
-  - [ ] Debian 9
-- Verify tsh runs on:
+- Verify `tsh` runs on:
   - [ ] Windows 10
   - [ ] MacOS
 
@@ -1401,7 +1395,7 @@ TODO(lxea): replace links with actual docs once merged
 - Verify host users creation functionality
   - [ ] non-existing users are created automatically
   - [ ] users are added to groups
-    - [ ] non existing configured groups are created
+    - [ ] non-existing configured groups are created
 	- [ ] created users are added to the `teleport-system` group
   - [ ] users are cleaned up after their session ends
 	- [ ] cleanup occurs if a program was left running after session ends


### PR DESCRIPTION
We don't need to test our binaries on different Linux systems as, currently, our CI test that for us.
I also included some typo fixes suggested by my IDE.