### PR TITLE
[v11] Fix setting an incorrect port when generating a Teleport config

### DIFF
--- a/assets/aws/files/bin/teleport-generate-config
+++ b/assets/aws/files/bin/teleport-generate-config
@@ -387,7 +387,7 @@ teleport:
   storage:
     type: dir
     path: /var/lib/teleport/backend
-  auth_server: ${TELEPORT_AUTH_SERVER_LB}:443
+  auth_server: ${TELEPORT_AUTH_SERVER_LB}:3025
 
 auth_service:
   enabled: no


### PR DESCRIPTION
Backport #17121 to branch/v11