### PR TITLE
v10: Backport resource watcher initialization channel from #16633

### DIFF
--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -45,9 +45,9 @@ type resourceCollector interface {
 	// notifyStale is called when the maximum acceptable staleness (if specified)
 	// is exceeded.
 	notifyStale()
-	// isInitialized is used to check if the initial state sync has
+	// initializationChan is used to check if the initial state sync has
 	// been completed.
-	isInitialized() bool
+	initializationChan() <-chan struct{}
 }
 
 // ResourceWatcherConfig configures resource watcher.
@@ -158,8 +158,33 @@ func (p *resourceWatcher) Close() {
 	p.cancel()
 }
 
+// IsInitialized is a non-blocking way to check if resource watcher is already
+// initialized.
 func (p *resourceWatcher) IsInitialized() bool {
-	return p.collector.isInitialized()
+	select {
+	case <-p.collector.initializationChan():
+		return true
+	default:
+		return false
+	}
+}
+
+// WaitInitialization blocks until resource watcher is fully initialized with
+// the resources presented in auth server.
+func (p *resourceWatcher) WaitInitialization() error {
+	// wait for resourceWatcher to complete initialization.
+	t := time.NewTicker(500 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-p.collector.initializationChan():
+			return nil
+		case <-t.C:
+			p.Log.Debugf("ResourceWatcher %s is not yet initialized.", p.collector.resourceKind())
+		case <-p.ctx.Done():
+			trace.BadParameter("ResourceWatcher %s failed to initialize.")
+		}
+	}
 }
 
 // hasStaleView returns true when the local view has failed to be updated
@@ -319,6 +344,7 @@ func NewProxyWatcher(ctx context.Context, cfg ProxyWatcherConfig) (*ProxyWatcher
 	}
 	collector := &proxyCollector{
 		ProxyWatcherConfig: cfg,
+		initializationC:    make(chan struct{}),
 	}
 	watcher, err := newResourceWatcher(ctx, collector, cfg.ResourceWatcherConfig)
 	if err != nil {
@@ -339,9 +365,10 @@ type proxyCollector struct {
 	ProxyWatcherConfig
 	// current holds a map of the currently known proxies (keyed by server name,
 	// RWMutex protected).
-	current     map[string]types.Server
-	rw          sync.RWMutex
-	initialized bool
+	current         map[string]types.Server
+	rw              sync.RWMutex
+	initializationC chan struct{}
+	once            sync.Once
 }
 
 // GetCurrent returns the currently stored proxies.
@@ -374,9 +401,16 @@ func (p *proxyCollector) getResourcesAndUpdateCurrent(ctx context.Context) error
 	p.rw.Lock()
 	defer p.rw.Unlock()
 	p.current = newCurrent
-	p.initialized = true
+	p.defineCollectorAsInitialized()
 	p.broadcastUpdate(ctx)
 	return nil
+}
+
+func (p *proxyCollector) defineCollectorAsInitialized() {
+	p.once.Do(func() {
+		// mark whatcher as initialized.
+		close(p.initializationC)
+	})
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -426,10 +460,10 @@ func (p *proxyCollector) broadcastUpdate(ctx context.Context) {
 
 // isInitialized is used to check that the cache has done its initial
 // sync
-func (p *proxyCollector) isInitialized() bool {
+func (p *proxyCollector) initializationChan() <-chan struct{} {
 	p.rw.RUnlock()
 	defer p.rw.RUnlock()
-	return p.initialized
+	return p.initializationC
 }
 
 func (p *proxyCollector) notifyStale() {}
@@ -474,6 +508,7 @@ func NewLockWatcher(ctx context.Context, cfg LockWatcherConfig) (*LockWatcher, e
 	collector := &lockCollector{
 		LockWatcherConfig: cfg,
 		fanout:            NewFanout(),
+		initializationC:   make(chan struct{}),
 	}
 	watcher, err := newResourceWatcher(ctx, collector, cfg.ResourceWatcherConfig)
 	if err != nil {
@@ -500,8 +535,9 @@ type lockCollector struct {
 	currentRW sync.RWMutex
 	// fanout provides support for multiple subscribers to the lock updates.
 	fanout *Fanout
-	// initialized is used to check whether the initial sync has completed
-	initialized bool
+	// initializationC is used to check whether the initial sync has completed
+	initializationC chan struct{}
+	once            sync.Once
 }
 
 // Subscribe is used to subscribe to the lock updates.
@@ -568,12 +604,12 @@ func (p *lockCollector) resourceKind() string {
 	return types.KindLock
 }
 
-// isInitialized is used to check that the cache has done its initial
+// initializationChan is used to check that the cache has done its initial
 // sync
-func (p *lockCollector) isInitialized() bool {
+func (p *lockCollector) initializationChan() <-chan struct{} {
 	p.currentRW.RUnlock()
 	defer p.currentRW.RUnlock()
-	return p.initialized
+	return p.initializationC
 }
 
 // getResourcesAndUpdateCurrent is called when the resources should be
@@ -592,11 +628,18 @@ func (p *lockCollector) getResourcesAndUpdateCurrent(ctx context.Context) error 
 	defer p.currentRW.Unlock()
 	p.current = newCurrent
 	p.isStale = false
-	p.initialized = true
+	p.defineCollectorAsInitialized()
 	for _, lock := range p.current {
 		p.fanout.Emit(types.Event{Type: types.OpPut, Resource: lock})
 	}
 	return nil
+}
+
+func (p *lockCollector) defineCollectorAsInitialized() {
+	p.once.Do(func() {
+		// mark whatcher as initialized.
+		close(p.initializationC)
+	})
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -706,6 +749,7 @@ func NewDatabaseWatcher(ctx context.Context, cfg DatabaseWatcherConfig) (*Databa
 	}
 	collector := &databaseCollector{
 		DatabaseWatcherConfig: cfg,
+		initializationC:       make(chan struct{}),
 	}
 	watcher, err := newResourceWatcher(ctx, collector, cfg.ResourceWatcherConfig)
 	if err != nil {
@@ -728,8 +772,9 @@ type databaseCollector struct {
 	current map[string]types.Database
 	// lock protects the "current" map.
 	lock sync.RWMutex
-	// initialized is used to check that the
-	initialized bool
+	// initializationC is used to check that the
+	initializationC chan struct{}
+	once            sync.Once
 }
 
 // resourceKind specifies the resource kind to watch.
@@ -739,10 +784,10 @@ func (p *databaseCollector) resourceKind() string {
 
 // isInitialized is used to check that the cache has done its initial
 // sync
-func (p *databaseCollector) isInitialized() bool {
+func (p *databaseCollector) initializationChan() <-chan struct{} {
 	p.lock.RUnlock()
 	defer p.lock.RUnlock()
-	return p.initialized
+	return p.initializationC
 }
 
 // getResourcesAndUpdateCurrent refreshes the list of current resources.
@@ -758,7 +803,7 @@ func (p *databaseCollector) getResourcesAndUpdateCurrent(ctx context.Context) er
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	p.current = newCurrent
-	p.initialized = true
+	p.defineCollectorAsInitialized()
 
 	select {
 	case <-ctx.Done():
@@ -767,6 +812,13 @@ func (p *databaseCollector) getResourcesAndUpdateCurrent(ctx context.Context) er
 	}
 
 	return nil
+}
+
+func (p *databaseCollector) defineCollectorAsInitialized() {
+	p.once.Do(func() {
+		// mark whatcher as initialized.
+		close(p.initializationC)
+	})
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -846,6 +898,7 @@ func NewAppWatcher(ctx context.Context, cfg AppWatcherConfig) (*AppWatcher, erro
 	}
 	collector := &appCollector{
 		AppWatcherConfig: cfg,
+		initializationC:  make(chan struct{}),
 	}
 	watcher, err := newResourceWatcher(ctx, collector, cfg.ResourceWatcherConfig)
 	if err != nil {
@@ -868,8 +921,9 @@ type appCollector struct {
 	current map[string]types.Application
 	// lock protects the "current" map.
 	lock sync.RWMutex
-	// initialized is used to check whether the initial sync has completed
-	initialized bool
+	// initializationC is used to check whether the initial sync has completed
+	initializationC chan struct{}
+	once            sync.Once
 }
 
 // resourceKind specifies the resource kind to watch.
@@ -879,10 +933,10 @@ func (p *appCollector) resourceKind() string {
 
 // isInitialized is used to check that the cache has done its initial
 // sync
-func (p *appCollector) isInitialized() bool {
+func (p *appCollector) initializationChan() <-chan struct{} {
 	p.lock.RUnlock()
 	defer p.lock.RUnlock()
-	return p.initialized
+	return p.initializationC
 }
 
 // getResourcesAndUpdateCurrent refreshes the list of current resources.
@@ -898,13 +952,20 @@ func (p *appCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	p.current = newCurrent
-	p.initialized = true
+	p.defineCollectorAsInitialized()
 	select {
 	case <-ctx.Done():
 		return trace.Wrap(ctx.Err())
 	case p.AppsC <- apps:
 	}
 	return nil
+}
+
+func (p *appCollector) defineCollectorAsInitialized() {
+	p.once.Do(func() {
+		// mark whatcher as initialized.
+		close(p.initializationC)
+	})
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -987,6 +1048,7 @@ func NewCertAuthorityWatcher(ctx context.Context, cfg CertAuthorityWatcherConfig
 		CertAuthorityWatcherConfig: cfg,
 		fanout:                     NewFanout(),
 		cas:                        make(map[types.CertAuthType]map[string]types.CertAuthority, len(cfg.Types)),
+		initializationC:            make(chan struct{}),
 	}
 
 	for _, t := range cfg.Types {
@@ -1017,8 +1079,9 @@ type caCollector struct {
 	lock sync.RWMutex
 	// cas maps ca type -> cluster -> ca
 	cas map[types.CertAuthType]map[string]types.CertAuthority
-	// initialized is used to check whether the initial sync has completed
-	initialized bool
+	// initializationC is used to check whether the initial sync has completed
+	initializationC chan struct{}
+	once            sync.Once
 }
 
 // Subscribe is used to subscribe to the lock updates.
@@ -1053,10 +1116,10 @@ func (c *caCollector) resourceKind() string {
 
 // isInitialized is used to check that the cache has done its initial
 // sync
-func (c *caCollector) isInitialized() bool {
+func (c *caCollector) initializationChan() <-chan struct{} {
 	c.lock.RUnlock()
 	defer c.lock.RUnlock()
-	return c.initialized
+	return c.initializationC
 }
 
 // getResourcesAndUpdateCurrent refreshes the list of current resources.
@@ -1083,8 +1146,17 @@ func (c *caCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 		c.cas[ca.GetType()][ca.GetName()] = ca
 		c.fanout.Emit(types.Event{Type: types.OpPut, Resource: ca.Clone()})
 	}
-	c.initialized = true
+
+	c.defineCollectorAsInitialized()
+
 	return nil
+}
+
+func (c *caCollector) defineCollectorAsInitialized() {
+	c.once.Do(func() {
+		// mark whatcher as initialized.
+		close(c.initializationC)
+	})
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -1170,6 +1242,7 @@ func NewNodeWatcher(ctx context.Context, cfg NodeWatcherConfig) (*NodeWatcher, e
 	collector := &nodeCollector{
 		NodeWatcherConfig: cfg,
 		current:           map[string]types.Server{},
+		initializationC:   make(chan struct{}),
 	}
 	watcher, err := newResourceWatcher(ctx, collector, cfg.ResourceWatcherConfig)
 	if err != nil {
@@ -1192,8 +1265,9 @@ type nodeCollector struct {
 	// RWMutex protected).
 	current map[string]types.Server
 	rw      sync.RWMutex
-	// initialized is used to check whether the initial sync has completed
-	initialized bool
+	// initializationC is used to check whether the initial sync has completed
+	initializationC chan struct{}
+	once            sync.Once
 }
 
 // Node is a readonly subset of the types.Server interface which
@@ -1257,10 +1331,9 @@ func (n *nodeCollector) getResourcesAndUpdateCurrent(ctx context.Context) error 
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer n.defineCollectorAsInitialized()
+
 	if len(nodes) == 0 {
-		n.rw.Lock()
-		n.initialized = true
-		n.rw.Unlock()
 		return nil
 	}
 	newCurrent := make(map[string]types.Server, len(nodes))
@@ -1270,8 +1343,14 @@ func (n *nodeCollector) getResourcesAndUpdateCurrent(ctx context.Context) error 
 	n.rw.Lock()
 	defer n.rw.Unlock()
 	n.current = newCurrent
-	n.initialized = true
 	return nil
+}
+
+func (n *nodeCollector) defineCollectorAsInitialized() {
+	n.once.Do(func() {
+		// mark whatcher as initialized.
+		close(n.initializationC)
+	})
 }
 
 // processEventAndUpdateCurrent is called when a watcher event is received.
@@ -1299,10 +1378,10 @@ func (n *nodeCollector) processEventAndUpdateCurrent(ctx context.Context, event 
 	}
 }
 
-func (n *nodeCollector) isInitialized() bool {
+func (n *nodeCollector) initializationChan() <-chan struct{} {
 	n.rw.RLock()
 	defer n.rw.RUnlock()
-	return n.initialized
+	return n.initializationC
 }
 
 func (n *nodeCollector) notifyStale() {}

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -173,7 +173,7 @@ func (p *resourceWatcher) IsInitialized() bool {
 // the resources presented in auth server.
 func (p *resourceWatcher) WaitInitialization() error {
 	// wait for resourceWatcher to complete initialization.
-	t := time.NewTicker(500 * time.Millisecond)
+	t := time.NewTicker(5 * time.Second)
 	defer t.Stop()
 	for {
 		select {
@@ -182,7 +182,7 @@ func (p *resourceWatcher) WaitInitialization() error {
 		case <-t.C:
 			p.Log.Debugf("ResourceWatcher %s is not yet initialized.", p.collector.resourceKind())
 		case <-p.ctx.Done():
-			trace.BadParameter("ResourceWatcher %s failed to initialize.")
+			return trace.BadParameter("ResourceWatcher %s failed to initialize.", p.collector.resourceKind())
 		}
 	}
 }
@@ -408,7 +408,7 @@ func (p *proxyCollector) getResourcesAndUpdateCurrent(ctx context.Context) error
 
 func (p *proxyCollector) defineCollectorAsInitialized() {
 	p.once.Do(func() {
-		// mark whatcher as initialized.
+		// mark watcher as initialized.
 		close(p.initializationC)
 	})
 }
@@ -461,8 +461,6 @@ func (p *proxyCollector) broadcastUpdate(ctx context.Context) {
 // isInitialized is used to check that the cache has done its initial
 // sync
 func (p *proxyCollector) initializationChan() <-chan struct{} {
-	p.rw.RUnlock()
-	defer p.rw.RUnlock()
 	return p.initializationC
 }
 
@@ -607,8 +605,6 @@ func (p *lockCollector) resourceKind() string {
 // initializationChan is used to check that the cache has done its initial
 // sync
 func (p *lockCollector) initializationChan() <-chan struct{} {
-	p.currentRW.RUnlock()
-	defer p.currentRW.RUnlock()
 	return p.initializationC
 }
 
@@ -637,7 +633,7 @@ func (p *lockCollector) getResourcesAndUpdateCurrent(ctx context.Context) error 
 
 func (p *lockCollector) defineCollectorAsInitialized() {
 	p.once.Do(func() {
-		// mark whatcher as initialized.
+		// mark watcher as initialized.
 		close(p.initializationC)
 	})
 }
@@ -785,8 +781,6 @@ func (p *databaseCollector) resourceKind() string {
 // isInitialized is used to check that the cache has done its initial
 // sync
 func (p *databaseCollector) initializationChan() <-chan struct{} {
-	p.lock.RUnlock()
-	defer p.lock.RUnlock()
 	return p.initializationC
 }
 
@@ -816,7 +810,7 @@ func (p *databaseCollector) getResourcesAndUpdateCurrent(ctx context.Context) er
 
 func (p *databaseCollector) defineCollectorAsInitialized() {
 	p.once.Do(func() {
-		// mark whatcher as initialized.
+		// mark watcher as initialized.
 		close(p.initializationC)
 	})
 }
@@ -934,8 +928,6 @@ func (p *appCollector) resourceKind() string {
 // isInitialized is used to check that the cache has done its initial
 // sync
 func (p *appCollector) initializationChan() <-chan struct{} {
-	p.lock.RUnlock()
-	defer p.lock.RUnlock()
 	return p.initializationC
 }
 
@@ -963,7 +955,7 @@ func (p *appCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 
 func (p *appCollector) defineCollectorAsInitialized() {
 	p.once.Do(func() {
-		// mark whatcher as initialized.
+		// mark watcher as initialized.
 		close(p.initializationC)
 	})
 }
@@ -1117,8 +1109,6 @@ func (c *caCollector) resourceKind() string {
 // isInitialized is used to check that the cache has done its initial
 // sync
 func (c *caCollector) initializationChan() <-chan struct{} {
-	c.lock.RUnlock()
-	defer c.lock.RUnlock()
 	return c.initializationC
 }
 
@@ -1154,7 +1144,7 @@ func (c *caCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 
 func (c *caCollector) defineCollectorAsInitialized() {
 	c.once.Do(func() {
-		// mark whatcher as initialized.
+		// mark watcher as initialized.
 		close(c.initializationC)
 	})
 }
@@ -1348,7 +1338,7 @@ func (n *nodeCollector) getResourcesAndUpdateCurrent(ctx context.Context) error 
 
 func (n *nodeCollector) defineCollectorAsInitialized() {
 	n.once.Do(func() {
-		// mark whatcher as initialized.
+		// mark watcher as initialized.
 		close(n.initializationC)
 	})
 }
@@ -1379,8 +1369,6 @@ func (n *nodeCollector) processEventAndUpdateCurrent(ctx context.Context, event 
 }
 
 func (n *nodeCollector) initializationChan() <-chan struct{} {
-	n.rw.RLock()
-	defer n.rw.RUnlock()
 	return n.initializationC
 }
 

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -159,6 +159,11 @@ func (s *Server) handleInstances(instances *server.EC2Instances) error {
 }
 
 func (s *Server) handleEC2Discovery() {
+	if err := s.NodeWatcher.WaitInitialization(); err != nil {
+		s.log.WithError(err).Error("Failed to initialize nodeWatcher.")
+		return
+	}
+
 	go s.cloudWatcher.Run()
 	for {
 		select {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -351,10 +351,6 @@ func TestDiscoveryServer(t *testing.T) {
 			require.NoError(t, err)
 			defer nodeWatcher.Close()
 
-			for !nodeWatcher.IsInitialized() {
-				time.Sleep(100 * time.Millisecond)
-			}
-
 			server, err := New(context.Background(), &Config{
 				Clients: &testClients,
 				Matchers: []services.AWSMatcher{{


### PR DESCRIPTION
Backports changes to watcher.go from #16633 to v10: https://github.com/gravitational/teleport/pull/16633/files#diff-7a030693b277c072225ebea353dbdf312158a3c04c4ee09da1befbef2180e7b3R304-R315

