### PR TITLE
Support `--proxy` and `proxy_server` in `tbot`.

### DIFF
--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -79,9 +79,10 @@ type CLIConf struct {
 
 	Debug bool
 
-	// AuthServer is a Teleport auth server address. It may either point
-	// directly to an auth server, or to a Teleport proxy server in which case
-	// a tunneled auth connection will be established.
+	// AuthServer is a Teleport auth server address. It should point directly
+	// to a Teleport auth server. For now, we will continue to support
+	// specifying the proxy address here, but this support will eventually be
+	// dropped in preference of using Proxy.
 	AuthServer string
 
 	// DataDir stores the bot's internal data.
@@ -209,6 +210,7 @@ type BotConfig struct {
 
 	Debug           bool          `yaml:"debug"`
 	AuthServer      string        `yaml:"auth_server"`
+	ProxyServer     string        `yaml:"proxy_server"`
 	CertificateTTL  time.Duration `yaml:"certificate_ttl"`
 	RenewalInterval time.Duration `yaml:"renewal_interval"`
 	Oneshot         bool          `yaml:"oneshot"`
@@ -316,6 +318,12 @@ func FromCLIConf(cf *CLIConf) (*BotConfig, error) {
 			log.Warnf("CLI parameters are overriding auth server configured in %s", cf.ConfigPath)
 		}
 		config.AuthServer = cf.AuthServer
+	}
+	if cf.Proxy != "" {
+		if config.ProxyServer != "" {
+			log.Warnf("CLI parameters are overriding proxy server configured in %s", cf.ConfigPath)
+		}
+		config.ProxyServer = cf.Proxy
 	}
 
 	if cf.CertificateTTL != 0 {

--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -85,6 +85,7 @@ func (b *Bot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *ident
 		return nil, trace.Wrap(err)
 	}
 
+	// TODO: Use proxy address
 	authAddr, err := utils.ParseAddr(b.cfg.AuthServer)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -66,7 +66,8 @@ func Run(args []string, stdout io.Writer) error {
 	versionCmd := app.Command("version", "Print the version of your tbot binary")
 
 	startCmd := app.Command("start", "Starts the renewal bot, writing certificates to the data dir at a set interval.")
-	startCmd.Flag("auth-server", "Address of the Teleport Auth Server or Proxy Server.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
+	startCmd.Flag("auth-server", "Address of the Teleport Auth Server.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
+	startCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").StringVar(&cf.Proxy)
 	startCmd.Flag("token", "A bot join token, if attempting to onboard a new bot; used on first connect.").Envar(tokenEnvVar).StringVar(&cf.Token)
 	startCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
 	startCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)
@@ -85,7 +86,8 @@ func Run(args []string, stdout io.Writer) error {
 	initCmd.Flag("clean", "If set, remove unexpected files and directories from the destination.").BoolVar(&cf.Clean)
 
 	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).")
-	configureCmd.Flag("auth-server", "Address of the Teleport Auth Server (On-Prem installs) or Proxy Server (Cloud installs).").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
+	configureCmd.Flag("auth-server", "Address of the Teleport Auth Server.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
+	configureCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").StringVar(&cf.Proxy)
 	configureCmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&cf.CAPins)
 	configureCmd.Flag("certificate-ttl", "TTL of short-lived machine certificates.").Default("60m").DurationVar(&cf.CertificateTTL)
 	configureCmd.Flag("data-dir", "Directory to store internal bot data. Access to this directory should be limited.").StringVar(&cf.DataDir)


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/16768