### PR TITLE
Fix `tsh fido2 diag` command

### DIFF
--- a/lib/auth/webauthn/messages.go
+++ b/lib/auth/webauthn/messages.go
@@ -92,13 +92,13 @@ func (cc *CredentialCreation) Validate() error {
 	case cc.Response.RelyingParty.ID == "":
 		return trace.BadParameter("credential creation relying party ID required")
 	case len(cc.Response.RelyingParty.Name) == 0:
-		return trace.BadParameter("relying party name required for resident credential")
+		return trace.BadParameter("relying party name required")
 	case len(cc.Response.User.Name) == 0:
-		return trace.BadParameter("user name required for resident credential")
+		return trace.BadParameter("user name required")
 	case len(cc.Response.User.DisplayName) == 0:
-		return trace.BadParameter("user display name required for resident credential")
+		return trace.BadParameter("user display name required")
 	case len(cc.Response.User.ID) == 0:
-		return trace.BadParameter("user ID required for resident credential")
+		return trace.BadParameter("user ID required")
 	default:
 		return nil
 	}

--- a/lib/auth/webauthncli/fido2_common.go
+++ b/lib/auth/webauthncli/fido2_common.go
@@ -78,14 +78,17 @@ func FIDO2Diag(ctx context.Context, promptOut io.Writer) (*FIDO2DiagResult, erro
 		Response: protocol.PublicKeyCredentialCreationOptions{
 			Challenge: make([]byte, 32),
 			RelyingParty: protocol.RelyingPartyEntity{
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "localhost",
+				},
 				ID: "localhost",
 			},
 			User: protocol.UserEntity{
 				CredentialEntity: protocol.CredentialEntity{
 					Name: "test",
 				},
-				ID:          []byte("test"),
 				DisplayName: "test",
+				ID:          []byte("test"),
 			},
 			Parameters: []protocol.CredentialParameter{
 				{


### PR DESCRIPTION
Add the missing RelyingParty.Name field and tweak error messages.