### PR TITLE
Set the default proxy listen addrs even if a file config isn't present

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -979,8 +979,6 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 	cfg.Proxy.ACME = *acme
 
-	applyDefaultProxyListenerAddresses(cfg)
-
 	return nil
 }
 
@@ -2116,6 +2114,9 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 	if clf.PermitUserEnvironment {
 		cfg.SSH.PermitUserEnvironment = true
 	}
+
+	// set the default proxy listener addresses for config v1, if not already set
+	applyDefaultProxyListenerAddresses(cfg)
 
 	return nil
 }


### PR DESCRIPTION
Previously, the default listen addresses that are set when the config version is v1 were not being set if a `FileConfig` wasn't present.

This caused #17205 as the reverse listen address is never set, so you get something like 

```
INFO [PROXY:SER] Reverse tunnel service 10.3.1:v11.0.0-dev.walt.1-846-g2c6a89898 is starting on . pid:40375.1 utils/cli.go:285
```

I've replicated this on v8 and the latest master.

This fix will set the default proxy listen addresses in `Configure()` instead of in a sub-call of `ApplyFileConfig()`, which wouldn't do anything if a `FileConfig` wasn't present.

This now results in the reverse tunnel listening address being set correctly when the config is v1, or the config file isn't present at all.

```
[PROXY:SER] INFO Reverse tunnel service 12.0.0-dev:v11.0.0-dev.walt.1-846-g2c6a89898 is starting on 0.0.0.0:3024. pid:60385.1 utils/cli.go:284
```