### PR TITLE
[v10] Remove `installer`, `app` and `database` watchers for remote proxies

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -165,12 +165,9 @@ func ForRemoteProxy(cfg Config) Config {
 		{Kind: types.KindTunnelConnection},
 		{Kind: types.KindAppServer},
 		{Kind: types.KindAppServer, Version: types.V2},
-		{Kind: types.KindApp},
 		{Kind: types.KindRemoteCluster},
 		{Kind: types.KindKubeService},
 		{Kind: types.KindDatabaseServer},
-		{Kind: types.KindDatabase},
-		{Kind: types.KindInstaller},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize
 	return cfg


### PR DESCRIPTION
Remote proxies do not require `types.KindInstaller`, `types.KindDatabase`, and `types.KindApp` watchers since they do not affect remote reverse tunnels tracked from leaf clusters. 
Fix incompatibility with pre/post `v10.2.1` versions as the `types.KindInstaller` feature did not exist in older versions.

Fixes #17219