### PR TITLE
[v11] Remove expected `kube_server`, `app`, `database` and `installer` watchers for remote proxies

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -185,6 +185,7 @@ func ForRemoteProxy(cfg Config) Config {
 }
 
 // ForOldRemoteProxy sets up watch configuration for older remote proxies.
+// The Watches defined here are a copy of those defined in ForRemoteProxy in the v10 branch.
 func ForOldRemoteProxy(cfg Config) Config {
 	cfg.target = "remote-proxy-old"
 	cfg.Watches = []types.WatchKind{

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -171,14 +171,10 @@ func ForRemoteProxy(cfg Config) Config {
 		{Kind: types.KindTunnelConnection},
 		{Kind: types.KindAppServer},
 		{Kind: types.KindAppServer, Version: types.V2},
-		{Kind: types.KindApp},
 		{Kind: types.KindRemoteCluster},
 		{Kind: types.KindKubeService},
 		{Kind: types.KindDatabaseServer},
-		{Kind: types.KindDatabase},
 		{Kind: types.KindKubeServer},
-		{Kind: types.KindInstaller},
-		{Kind: types.KindKubernetesCluster},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize
 	return cfg
@@ -205,12 +201,9 @@ func ForOldRemoteProxy(cfg Config) Config {
 		{Kind: types.KindTunnelConnection},
 		{Kind: types.KindAppServer},
 		{Kind: types.KindAppServer, Version: types.V2},
-		{Kind: types.KindApp},
 		{Kind: types.KindRemoteCluster},
 		{Kind: types.KindKubeService},
 		{Kind: types.KindDatabaseServer},
-		{Kind: types.KindDatabase},
-		{Kind: types.KindInstaller},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize
 	return cfg

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -206,7 +206,6 @@ func ForOldRemoteProxy(cfg Config) Config {
 		{Kind: types.KindRemoteCluster},
 		{Kind: types.KindKubeService},
 		{Kind: types.KindDatabaseServer},
-		{Kind: types.KindKubeServer},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize
 	return cfg

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -202,10 +202,14 @@ func ForOldRemoteProxy(cfg Config) Config {
 		{Kind: types.KindAuthServer},
 		{Kind: types.KindReverseTunnel},
 		{Kind: types.KindTunnelConnection},
+		{Kind: types.KindAppServer},
 		{Kind: types.KindAppServer, Version: types.V2},
+		{Kind: types.KindApp},
 		{Kind: types.KindRemoteCluster},
 		{Kind: types.KindKubeService},
 		{Kind: types.KindDatabaseServer},
+		{Kind: types.KindDatabase},
+		{Kind: types.KindInstaller},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize
 	return cfg

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1172,7 +1172,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 // (RFD 28) because older proxy servers will reject that causing the cache
 // to go into a re-sync loop.
 func createRemoteAccessPoint(srv *server, clt auth.ClientI, version, domainName string) (auth.RemoteProxyAccessPoint, error) {
-	ok, err := utils.MinVerWithoutPreRelease(version, utils.VersionBeforeAlpha("8.0.0"))
+	ok, err := utils.MinVerWithoutPreRelease(version, utils.VersionBeforeAlpha("11.0.0"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1167,10 +1167,9 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 }
 
 // createRemoteAccessPoint creates a new access point for the remote cluster.
-// Checks if the cluster that is connecting is a pre-v8 cluster. If it is,
-// don't assume the newer organization of cluster configuration resources
-// (RFD 28) because older proxy servers will reject that causing the cache
-// to go into a re-sync loop.
+// Checks if the cluster that is connecting is a pre-v11 cluster. If it is,
+// we disable the watcher for types.KindKubeServer and types.KindKubeCluster resources
+// since both resources are not supported in a v10 leaf cluster.
 func createRemoteAccessPoint(srv *server, clt auth.ClientI, version, domainName string) (auth.RemoteProxyAccessPoint, error) {
 	ok, err := utils.MinVerWithoutPreRelease(version, utils.VersionBeforeAlpha("11.0.0"))
 	if err != nil {

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -168,19 +168,20 @@ func TestCreateRemoteAccessPoint(t *testing.T) {
 			assertion: require.Error,
 		},
 		{
-			name:      "remote running 9.0.0",
+			name:      "remote running 11.0.0",
 			assertion: require.NoError,
-			version:   "9.0.0",
+			version:   "11.0.0",
 		},
 		{
-			name:      "remote running 8.0.0",
-			assertion: require.NoError,
-			version:   "8.0.0",
-		},
-		{
-			name:           "remote running 7.0.0",
+			name:           "remote running 10.0.0",
 			assertion:      require.NoError,
-			version:        "7.0.0",
+			version:        "10.0.0",
+			oldRemoteProxy: true,
+		},
+		{
+			name:           "remote running 9.0.0",
+			assertion:      require.NoError,
+			version:        "9.0.0",
 			oldRemoteProxy: true,
 		},
 		{


### PR DESCRIPTION
Backport #17212 to branch/v11