### PR TITLE
Set `AuthServer` instead of `AuthServers` during `teleport configure`

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -221,7 +221,7 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 	}
 
 	if flags.AuthServer != "" {
-		g.AuthServers = []string{flags.AuthServer}
+		g.AuthServer = flags.AuthServer
 	}
 
 	if flags.ProxyAddress != "" {

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -1130,7 +1130,7 @@ func TestMakeSampleFileConfig(t *testing.T) {
 			AuthServer: "auth-server",
 		})
 		require.NoError(t, err)
-		require.Equal(t, "auth-server", fc.AuthServers[0])
+		require.Equal(t, "auth-server", fc.AuthServer)
 	})
 
 	t.Run("Data dir", func(t *testing.T) {


### PR DESCRIPTION
I missed trimming an `s`, so when using `teleport configure` it would output a v3 config with `auth_servers` set instead of `auth_server`, and cause an error.

Will fix #17268 