### PR TITLE
Fix FIPS docker publishing AWS credentials

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6630,13 +6630,11 @@ steps:
       GOPATH: /go
       OS: linux
       ARCH: amd64
-      AWS_ACCESS_KEY_ID:
-        from_secret: STAGING_TELEPORT_DRONE_USER_ECR_KEY
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: STAGING_TELEPORT_DRONE_USER_ECR_SECRET
     volumes:
       - name: dockersock
         path: /var/run
+      - name: awsconfig
+        path: /root/.aws
     commands:
       - apk add --no-cache make aws-cli
       - chown -R $UID:$GID /go
@@ -8958,6 +8956,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 0da0c58e70b198937a8389796c397742e5249256ddf8383030711616631b2551
+hmac: 5541685d7fc687b7ffa7e3619a6e2558b079d9097b953cb3c8d1f4340abfecd9
 
 ...


### PR DESCRIPTION
This is follow up to https://github.com/gravitational/teleport/pull/17201, that fixes the build-docker-images pipeline error seen here:

https://drone.platform.teleport.sh/gravitational/teleport/16344/24/1

This was overlooked in https://github.com/gravitational/teleport/pull/17274 as it wasn't a dronegen'd pipeline -- and I made the call to merge based on the success of the dronegen'd pipelines before this completed. :/

This should be the last of the updates, as I'm seeing all other steps complete.

## Backports:
* v11 https://github.com/gravitational/teleport/pull/17298
* v10 https://github.com/gravitational/teleport/pull/17304
* v9 https://github.com/gravitational/teleport/pull/17255
* v8 https://github.com/gravitational/teleport/pull/17260

## Testing Done
Underway at https://drone.platform.teleport.sh/gravitational/teleport/16348