### PR TITLE
[v10] Move webauthncli validation to common place

### DIFF
--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -213,6 +213,13 @@ func Register(origin string, cc *wanlib.CredentialCreation) (*Registration, erro
 		return nil, ErrNotAvailable
 	}
 
+	if origin == "" {
+		return nil, trace.BadParameter("origin required")
+	}
+	if err := cc.Validate(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Ignored cc fields:
 	// - Timeout - we don't control touch ID timeouts (also the server is free to
 	//   enforce it)
@@ -221,23 +228,9 @@ func Register(origin string, cc *wanlib.CredentialCreation) (*Registration, erro
 	// - Extensions - none supported
 	// - Attestation - we always to our best (packed/self-attestation).
 	//   The server is free to ignore/reject.
-	switch {
-	case origin == "":
-		return nil, errors.New("origin required")
-	case cc == nil:
-		return nil, errors.New("credential creation required")
-	case len(cc.Response.Challenge) == 0:
-		return nil, errors.New("challenge required")
-	// Note: we don't need other RelyingParty fields, but technically they would
-	// be required as well.
-	case cc.Response.RelyingParty.ID == "":
-		return nil, errors.New("relying party ID required")
-	case len(cc.Response.User.ID) == 0:
-		return nil, errors.New("user ID required")
-	case cc.Response.User.Name == "":
-		return nil, errors.New("user name required")
-	case cc.Response.AuthenticatorSelection.AuthenticatorAttachment == protocol.CrossPlatform:
-		return nil, fmt.Errorf("cannot fulfil authenticator attachment %q", cc.Response.AuthenticatorSelection.AuthenticatorAttachment)
+
+	if cc.Response.AuthenticatorSelection.AuthenticatorAttachment == protocol.CrossPlatform {
+		return nil, fmt.Errorf("cannot fulfill authenticator attachment %q", cc.Response.AuthenticatorSelection.AuthenticatorAttachment)
 	}
 	ok := false
 	for _, param := range cc.Response.Parameters {
@@ -443,24 +436,21 @@ func Login(origin, user string, assertion *wanlib.CredentialAssertion, picker Cr
 	if !IsAvailable() {
 		return nil, "", ErrNotAvailable
 	}
+	switch {
+	case origin == "":
+		return nil, "", trace.BadParameter("origin required")
+	case picker == nil:
+		return nil, "", trace.BadParameter("picker required")
+	}
+	if err := assertion.Validate(); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
 
 	// Ignored assertion fields:
 	// - Timeout - we don't control touch ID timeouts (also the server is free to
 	//   enforce it)
 	// - UserVerification - always performed
 	// - Extensions - none supported
-	switch {
-	case origin == "":
-		return nil, "", errors.New("origin required")
-	case assertion == nil:
-		return nil, "", errors.New("assertion required")
-	case len(assertion.Response.Challenge) == 0:
-		return nil, "", errors.New("challenge required")
-	case assertion.Response.RelyingPartyID == "":
-		return nil, "", errors.New("relying party ID required")
-	case picker == nil:
-		return nil, "", errors.New("picker required")
-	}
 
 	rpID := assertion.Response.RelyingPartyID
 	infos, err := native.FindCredentials(rpID, user)

--- a/lib/auth/webauthn/messages.go
+++ b/lib/auth/webauthn/messages.go
@@ -76,13 +76,13 @@ func (cc *CredentialCreation) Validate() error {
 	case cc.Response.RelyingParty.ID == "":
 		return trace.BadParameter("credential creation relying party ID required")
 	case len(cc.Response.RelyingParty.Name) == 0:
-		return trace.BadParameter("relying party name required for resident credential")
+		return trace.BadParameter("relying party name required")
 	case len(cc.Response.User.Name) == 0:
-		return trace.BadParameter("user name required for resident credential")
+		return trace.BadParameter("user name required")
 	case len(cc.Response.User.DisplayName) == 0:
-		return trace.BadParameter("user display name required for resident credential")
+		return trace.BadParameter("user display name required")
 	case len(cc.Response.User.ID) == 0:
-		return trace.BadParameter("user ID required for resident credential")
+		return trace.BadParameter("user ID required")
 	default:
 		return nil
 	}

--- a/lib/auth/webauthn/messages.go
+++ b/lib/auth/webauthn/messages.go
@@ -14,10 +14,29 @@
 
 package webauthn
 
-import "github.com/duo-labs/webauthn/protocol"
+import (
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/gravitational/trace"
+)
 
 // CredentialAssertion is the payload sent to authenticators to initiate login.
 type CredentialAssertion protocol.CredentialAssertion
+
+// Validate performs client-side validation of CredentialAssertion.
+// It makes sure that data are valid and can be sent to authenticator.
+// This is general purpose validation and authenticator should add its own
+// on top of it, if necessary.
+func (ca *CredentialAssertion) Validate() error {
+	switch {
+	case ca == nil:
+		return trace.BadParameter("credential assertion required")
+	case len(ca.Response.Challenge) == 0:
+		return trace.BadParameter("credential assertion challenge required")
+	case ca.Response.RelyingPartyID == "":
+		return trace.BadParameter("credential assertion relying party ID required")
+	}
+	return nil
+}
 
 // CredentialAssertionResponse is the reply from authenticators to complete
 // login.
@@ -36,6 +55,38 @@ type CredentialAssertionResponse struct {
 // CredentialCreation is the payload sent to authenticators to initiate
 // registration.
 type CredentialCreation protocol.CredentialCreation
+
+// RequireResidentKey returns information whether resident key is required or
+// not.
+func (cc *CredentialCreation) RequireResidentKey() (bool, error) {
+	as := cc.Response.AuthenticatorSelection
+	return as.RequireResidentKey != nil && *as.RequireResidentKey, nil
+}
+
+// Validate performs client-side validation of CredentialCreation.
+// It makes sure that data are valid and can be sent to authenticator.
+// This is general purpose validation and authenticator should add its own
+// on top of it, if necessary.
+func (cc *CredentialCreation) Validate() error {
+	switch {
+	case cc == nil:
+		return trace.BadParameter("credential creation required")
+	case len(cc.Response.Challenge) == 0:
+		return trace.BadParameter("credential creation challenge required")
+	case cc.Response.RelyingParty.ID == "":
+		return trace.BadParameter("credential creation relying party ID required")
+	case len(cc.Response.RelyingParty.Name) == 0:
+		return trace.BadParameter("relying party name required for resident credential")
+	case len(cc.Response.User.Name) == 0:
+		return trace.BadParameter("user name required for resident credential")
+	case len(cc.Response.User.DisplayName) == 0:
+		return trace.BadParameter("user display name required for resident credential")
+	case len(cc.Response.User.ID) == 0:
+		return trace.BadParameter("user ID required for resident credential")
+	default:
+		return nil
+	}
+}
 
 // CredentialCreationResponse is the reply from authenticators to complete
 // registration.

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -87,14 +87,11 @@ func fido2Login(
 	switch {
 	case origin == "":
 		return nil, "", trace.BadParameter("origin required")
-	case assertion == nil:
-		return nil, "", trace.BadParameter("assertion required")
 	case prompt == nil:
 		return nil, "", trace.BadParameter("prompt required")
-	case len(assertion.Response.Challenge) == 0:
-		return nil, "", trace.BadParameter("assertion challenge required")
-	case assertion.Response.RelyingPartyID == "":
-		return nil, "", trace.BadParameter("assertion relying party ID required")
+	}
+	if err := assertion.Validate(); err != nil {
+		return nil, "", trace.Wrap(err)
 	}
 	if opts == nil {
 		opts = &LoginOpts{}
@@ -320,32 +317,17 @@ func fido2Register(
 	switch {
 	case origin == "":
 		return nil, trace.BadParameter("origin required")
-	case cc == nil:
-		return nil, trace.BadParameter("credential creation required")
 	case prompt == nil:
 		return nil, trace.BadParameter("prompt required")
-	case len(cc.Response.Challenge) == 0:
-		return nil, trace.BadParameter("credential creation challenge required")
-	case cc.Response.RelyingParty.ID == "":
-		return nil, trace.BadParameter("credential creation relying party ID required")
 	}
-
-	rrk := cc.Response.AuthenticatorSelection.RequireResidentKey != nil && *cc.Response.AuthenticatorSelection.RequireResidentKey
+	if err := cc.Validate(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	rrk, err := cc.RequireResidentKey()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	log.Debugf("FIDO2: registration: resident key=%v", rrk)
-	if rrk {
-		// Be more pedantic with resident keys, some of this info gets recorded with
-		// the credential.
-		switch {
-		case len(cc.Response.RelyingParty.Name) == 0:
-			return nil, trace.BadParameter("relying party name required for resident credential")
-		case len(cc.Response.User.Name) == 0:
-			return nil, trace.BadParameter("user name required for resident credential")
-		case len(cc.Response.User.DisplayName) == 0:
-			return nil, trace.BadParameter("user display name required for resident credential")
-		case len(cc.Response.User.ID) == 0:
-			return nil, trace.BadParameter("user ID required for resident credential")
-		}
-	}
 
 	// Can we create ES256 keys?
 	// TODO(codingllama): Consider supporting other algorithms and respecting

--- a/lib/auth/webauthncli/fido2_common.go
+++ b/lib/auth/webauthncli/fido2_common.go
@@ -78,14 +78,17 @@ func FIDO2Diag(ctx context.Context, promptOut io.Writer) (*FIDO2DiagResult, erro
 		Response: protocol.PublicKeyCredentialCreationOptions{
 			Challenge: make([]byte, 32),
 			RelyingParty: protocol.RelyingPartyEntity{
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "localhost",
+				},
 				ID: "localhost",
 			},
 			User: protocol.UserEntity{
 				CredentialEntity: protocol.CredentialEntity{
 					Name: "test",
 				},
-				ID:          []byte("test"),
 				DisplayName: "test",
+				ID:          []byte("test"),
 			},
 			Parameters: []protocol.CredentialParameter{
 				{

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -967,12 +967,22 @@ func TestFIDO2Login_u2fDevice(t *testing.T) {
 			Challenge: []byte{1, 2, 3, 4, 5}, // arbitrary
 			RelyingParty: protocol.RelyingPartyEntity{
 				ID: rpID,
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "rp name",
+				},
 			},
 			Parameters: []protocol.CredentialParameter{
 				{
 					Type:      protocol.PublicKeyCredentialType,
 					Algorithm: webauthncose.AlgES256,
 				},
+			},
+			User: protocol.UserEntity{
+				ID: []byte{1, 2, 3, 4, 1}, // arbitrary,
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "user name",
+				},
+				DisplayName: "user display name",
 			},
 			AuthenticatorSelection: protocol.AuthenticatorSelection{
 				UserVerification: protocol.VerificationDiscouraged,
@@ -1147,10 +1157,10 @@ func TestFIDO2Login_errors(t *testing.T) {
 			wantErr:   "origin",
 		},
 		{
-			name:    "nil assertion",
-			origin:  origin,
-			prompt:  prompt,
-			wantErr: "assertion required",
+			name:      "nil prompt",
+			origin:    origin,
+			assertion: okAssertion,
+			wantErr:   "prompt",
 		},
 		{
 			name:      "assertion without challenge",
@@ -1158,19 +1168,6 @@ func TestFIDO2Login_errors(t *testing.T) {
 			assertion: &nilChallengeAssertion,
 			prompt:    prompt,
 			wantErr:   "challenge",
-		},
-		{
-			name:      "assertion without RPID",
-			origin:    origin,
-			assertion: &emptyRPIDAssertion,
-			prompt:    prompt,
-			wantErr:   "relying party ID",
-		},
-		{
-			name:      "nil prompt",
-			origin:    origin,
-			assertion: okAssertion,
-			wantErr:   "prompt",
 		},
 	}
 	for _, test := range tests {
@@ -1230,12 +1227,22 @@ func TestFIDO2Register(t *testing.T) {
 			Challenge: challenge,
 			RelyingParty: protocol.RelyingPartyEntity{
 				ID: rpID,
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "rp name",
+				},
 			},
 			Parameters: []protocol.CredentialParameter{
 				{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256},
 			},
 			AuthenticatorSelection: protocol.AuthenticatorSelection{
 				UserVerification: protocol.VerificationDiscouraged,
+			},
+			User: protocol.UserEntity{
+				ID: []byte{1, 2, 3, 4, 1}, // arbitrary,
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "user name",
+				},
+				DisplayName: "user display name",
 			},
 			Attestation: protocol.PreferDirectAttestation,
 		},
@@ -1508,12 +1515,22 @@ func TestFIDO2Register_errors(t *testing.T) {
 			Challenge: make([]byte, 32),
 			RelyingParty: protocol.RelyingPartyEntity{
 				ID: "example.com",
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "rp name",
+				},
 			},
 			Parameters: []protocol.CredentialParameter{
 				{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256},
 			},
 			AuthenticatorSelection: protocol.AuthenticatorSelection{
 				UserVerification: protocol.VerificationDiscouraged,
+			},
+			User: protocol.UserEntity{
+				ID: []byte{1, 2, 3, 4, 1}, // arbitrary,
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "user name",
+				},
+				DisplayName: "user display name",
 			},
 			Attestation: protocol.PreferNoAttestation,
 		},
@@ -1555,13 +1572,6 @@ func TestFIDO2Register_errors(t *testing.T) {
 			wantErr:  "origin",
 		},
 		{
-			name:     "nil cc",
-			origin:   origin,
-			createCC: func() *wanlib.CredentialCreation { return nil },
-			prompt:   prompt,
-			wantErr:  "credential creation required",
-		},
-		{
 			name:   "cc without challenge",
 			origin: origin,
 			createCC: func() *wanlib.CredentialCreation {
@@ -1571,17 +1581,6 @@ func TestFIDO2Register_errors(t *testing.T) {
 			},
 			prompt:  prompt,
 			wantErr: "challenge",
-		},
-		{
-			name:   "cc without RPID",
-			origin: origin,
-			createCC: func() *wanlib.CredentialCreation {
-				cp := *okCC
-				cp.Response.RelyingParty.ID = ""
-				return &cp
-			},
-			prompt:  prompt,
-			wantErr: "relying party ID",
 		},
 		{
 			name:   "cc unsupported parameters",
@@ -1601,50 +1600,6 @@ func TestFIDO2Register_errors(t *testing.T) {
 			origin:   origin,
 			createCC: func() *wanlib.CredentialCreation { return okCC },
 			wantErr:  "prompt",
-		},
-		{
-			name:   "rrk empty RP name",
-			origin: origin,
-			createCC: func() *wanlib.CredentialCreation {
-				cp := pwdlessOK
-				cp.Response.RelyingParty.Name = ""
-				return &cp
-			},
-			prompt:  prompt,
-			wantErr: "relying party name",
-		},
-		{
-			name:   "rrk empty user name",
-			origin: origin,
-			createCC: func() *wanlib.CredentialCreation {
-				cp := pwdlessOK
-				cp.Response.User.Name = ""
-				return &cp
-			},
-			prompt:  prompt,
-			wantErr: "user name",
-		},
-		{
-			name:   "rrk empty user display name",
-			origin: origin,
-			createCC: func() *wanlib.CredentialCreation {
-				cp := pwdlessOK
-				cp.Response.User.DisplayName = ""
-				return &cp
-			},
-			prompt:  prompt,
-			wantErr: "user display name",
-		},
-		{
-			name:   "rrk nil user ID",
-			origin: origin,
-			createCC: func() *wanlib.CredentialCreation {
-				cp := pwdlessOK
-				cp.Response.User.ID = nil
-				return &cp
-			},
-			prompt:  prompt,
-			wantErr: "user ID",
 		},
 	}
 	for _, test := range tests {
@@ -1679,12 +1634,22 @@ func TestFIDO2Register_u2fExcludedCredentials(t *testing.T) {
 			Challenge: make([]byte, 32),
 			RelyingParty: protocol.RelyingPartyEntity{
 				ID: "example.com",
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "rp name",
+				},
 			},
 			Parameters: []protocol.CredentialParameter{
 				{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256},
 			},
 			AuthenticatorSelection: protocol.AuthenticatorSelection{
 				UserVerification: protocol.VerificationDiscouraged,
+			},
+			User: protocol.UserEntity{
+				ID: []byte{1, 2, 3, 4, 1}, // arbitrary,
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "user name",
+				},
+				DisplayName: "user display name",
 			},
 			Attestation: protocol.PreferNoAttestation,
 		},


### PR DESCRIPTION
Backport #16879 and #17196 to branch/v10

Note that on v10 we don't have newest `github.com/duo-labs/webauthn` so part of logic with `RequireResidentKey` was dropped. 