### PR TITLE
[v11] Set `AuthServer` instead of `AuthServers` during `teleport configure`

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -221,7 +221,7 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 	}
 
 	if flags.AuthServer != "" {
-		g.AuthServers = []string{flags.AuthServer}
+		g.AuthServer = flags.AuthServer
 	}
 
 	if flags.ProxyAddress != "" {

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -1073,7 +1073,7 @@ func TestMakeSampleFileConfig(t *testing.T) {
 			AuthServer: "auth-server",
 		})
 		require.NoError(t, err)
-		require.Equal(t, "auth-server", fc.AuthServers[0])
+		require.Equal(t, "auth-server", fc.AuthServer)
 	})
 
 	t.Run("Data dir", func(t *testing.T) {


### PR DESCRIPTION
Backport #17270 to branch/v11