### PR TITLE
[v10] Fix yum repo cleanup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7513,7 +7513,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "${ARTIFACT_PATH}/*"
+  - rm -rf "$ARTIFACT_PATH/*"
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.deb*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -7710,7 +7710,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "${ARTIFACT_PATH}/*"
+  - rm -rf "$ARTIFACT_PATH/*"
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.rpm*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -8912,6 +8912,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 6dd9914e20f11895a2e9c859bc4281dd1a19ffc69766f241f3eb36d55b9ab0b5
+hmac: fca221c82f7e8c0eff7016b9b7d6dd2b4b9b164d3f762e96dfe2155b97366721
 
 ...

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -391,7 +391,7 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 			Commands: []string{
 				"mkdir -pv \"$ARTIFACT_PATH\"",
 				// Clear out old versions from previous steps
-				"rm -rf \"${ARTIFACT_PATH}/*\"",
+				"rm -rf \"$ARTIFACT_PATH/*\"",
 				strings.Join(
 					[]string{
 						"aws s3 sync",


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/17334

Previously, "${ARTIFACT_PATH}" was interpreted as Drone variable substitution, resulting in `"rm -rf ${ARTIFACT_PATH}/*"` becoming `"rm -rf /*"`, which deleted credentials on the filesystem.  This causes the error seen here:

```
+ rm -rf "/*"
+ aws s3 sync --no-progress --delete --exclude "*" --include "*.rpm*" s3://$AWS_S3_BUCKET/teleport/tag/10.3.2/ "$ARTIFACT_PATH"
fatal error: An error occurred (AuthorizationHeaderMalformed) when calling the ListObjectsV2 operation: The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.
```

https://drone.platform.teleport.sh/gravitational/teleport/16371/2/5

This has been latent in the publishing logic for since https://github.com/gravitational/teleport/pull/15127/files#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R5469, but it happened to not matter because we weren't storing anything important in the container's filesystem.