### PR TITLE
[v11] Fix yum repo cleanup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7565,7 +7565,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "${ARTIFACT_PATH}/*"
+  - rm -rf "$ARTIFACT_PATH/*"
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.deb*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -7762,7 +7762,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "${ARTIFACT_PATH}/*"
+  - rm -rf "$ARTIFACT_PATH/*"
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.rpm*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -8966,6 +8966,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 77b06908f82db11aa8658a71650f0b5f2c4ea5f80788c841c38582a09e894321
+hmac: c920a0310bbda97402bd2c855ea9d8b21a5b36725ed30df7c4351f2dff0d8e55
 
 ...

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -391,7 +391,7 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 			Commands: []string{
 				"mkdir -pv \"$ARTIFACT_PATH\"",
 				// Clear out old versions from previous steps
-				"rm -rf \"${ARTIFACT_PATH}/*\"",
+				"rm -rf \"$ARTIFACT_PATH/*\"",
 				strings.Join(
 					[]string{
 						"aws s3 sync",


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/17334

Previously, "${ARTIFACT_PATH}" was interpreted as Drone variable substitution, resulting in `rm -rf "${ARTIFACT_PATH}/*"` becoming `rm -rf "/*"`, which deleted credentials on the filesystem.  This causes the error seen here:

```
+ rm -rf "/*"
+ aws s3 sync --no-progress --delete --exclude "*" --include "*.rpm*" s3://$AWS_S3_BUCKET/teleport/tag/10.3.2/ "$ARTIFACT_PATH"
fatal error: An error occurred (AuthorizationHeaderMalformed) when calling the ListObjectsV2 operation: The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.
```

https://drone.platform.teleport.sh/gravitational/teleport/16371/2/5

## Testing
See the testing in https://github.com/gravitational/teleport/pull/17334