### PR TITLE
Allow dev build promotes to proceed in deb/rpm pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7533,16 +7533,6 @@ steps:
   - git init && git remote add origin ${DRONE_REMOTE_URL}
   - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
-  depends_on:
-  - Verify build is tagged
-- name: Check if tag is prerelease
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
-    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
-  depends_on:
-  - Check out code
 - name: Assume Download AWS Role
   image: amazon/aws-cli
   commands:
@@ -7570,7 +7560,6 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Download artifacts for "${DRONE_TAG}"
   image: amazon/aws-cli
   commands:
@@ -7588,7 +7577,6 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
   commands:
@@ -7616,7 +7604,15 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
+- name: Check if tag is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
+    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
+  depends_on:
+  - Verify build is tagged
+  - Check out code
 - name: Publish debs to APT repos for "${DRONE_TAG}"
   image: golang:1.18.4-bullseye
   commands:
@@ -7651,9 +7647,9 @@ steps:
     path: /root/.aws
   depends_on:
   - Download artifacts for "${DRONE_TAG}"
+  - Check if tag is prerelease
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 volumes:
 - name: apt-persistence
   claim:
@@ -7730,16 +7726,6 @@ steps:
   - git init && git remote add origin ${DRONE_REMOTE_URL}
   - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
-  depends_on:
-  - Verify build is tagged
-- name: Check if tag is prerelease
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
-    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
-  depends_on:
-  - Check out code
 - name: Assume Download AWS Role
   image: amazon/aws-cli
   commands:
@@ -7767,7 +7753,6 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Download artifacts for "${DRONE_TAG}"
   image: amazon/aws-cli
   commands:
@@ -7785,7 +7770,6 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
   commands:
@@ -7813,7 +7797,15 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
+- name: Check if tag is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
+    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
+  depends_on:
+  - Verify build is tagged
+  - Check out code
 - name: Publish rpms to YUM repos for "${DRONE_TAG}"
   image: golang:1.18.4-bullseye
   commands:
@@ -7849,9 +7841,9 @@ steps:
     path: /root/.aws
   depends_on:
   - Download artifacts for "${DRONE_TAG}"
+  - Check if tag is prerelease
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 volumes:
 - name: yum-persistence
   claim:
@@ -8977,6 +8969,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 0b2fed5fd5450f6701ef0bfc2ccd90e40590bd73d8ed9ba3c8bbeea6b978c8d7
+hmac: 10f148b38807e7afd04575f7390728e83d06ca11590257674c928067f9f2f72b
 
 ...

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -251,19 +251,6 @@ func waitForDockerStep() step {
 	}
 }
 
-func verifyValidPromoteRunSteps(checkoutPath, commit string, isParallelismEnabled bool) []step {
-	tagStep := verifyTaggedStep()
-	cloneStep := cloneRepoStep(checkoutPath, commit)
-	verifyStep := verifyNotPrereleaseStep(checkoutPath)
-
-	if isParallelismEnabled {
-		cloneStep.DependsOn = []string{tagStep.Name}
-		verifyStep.DependsOn = []string{cloneStep.Name}
-	}
-
-	return []step{tagStep, cloneStep, verifyStep}
-}
-
 func verifyTaggedStep() step {
 	return step{
 		Name:  "Verify build is tagged",


### PR DESCRIPTION
This helps test a couple more changes from this pipeline when cutting a dev build.  Particularly, we saw the download and role assumption steps fail in https://github.com/gravitational/teleport/pull/17334, and this change would have allowed me to catch that error during testing.

@fheinecke: Do you see any way we could move the local yum repo package and sign before the cutoff, and only have the s3 upload be skipped?  I took a look, but I wasn't familiar enough with the codepaths to feel confident making this more aggressive change.

## Testing
I included the fixes from https://github.com/gravitational/teleport/pull/17334 and I am running a complete dev build

tag: https://drone.platform.teleport.sh/gravitational/teleport/16393
promote: https://drone.platform.teleport.sh/gravitational/teleport/16444

Looks like there is still a credentials issue -- so please do not merge yet.