### PR TITLE
Instructions updates for EC2 Auto Discovery

### DIFF
--- a/docs/pages/server-access/guides/ec2-discovery.mdx
+++ b/docs/pages/server-access/guides/ec2-discovery.mdx
@@ -301,8 +301,8 @@ The default installer will take the following actions:
 - Enable and start the Teleport service.
 
 ## Troubleshooting
-  If Installs are showing failed or instances are failing to appear check the Command history in AWS System Manager -> Node Management -> Run Command.  Select the instance-id of the Target to review Errors. 
-  
+
+If Installs are showing failed or instances are failing to appear check the Command history in AWS System Manager -> Node Management -> Run Command.  Select the instance-id of the Target to review Errors.  
 
 ## Next Steps
 

--- a/docs/pages/server-access/guides/ec2-discovery.mdx
+++ b/docs/pages/server-access/guides/ec2-discovery.mdx
@@ -300,6 +300,10 @@ The default installer will take the following actions:
 - Generate the Teleport config file and write it to `/etc/teleport.yaml`.
 - Enable and start the Teleport service.
 
+## Troubleshooting
+  If Installs are showing failed or instances are failing to appear check the Command history in AWS System Manager -> Node Management -> Run Command.  Select the instance-id of the Target to review Errors. 
+  
+
 ## Next Steps
 
 Documentation on IAM invite tokens can be found  in our [Joining Nodes via AWS IAM Role](../../management/guides/joining-nodes-aws-iam.mdx) guide.

--- a/docs/pages/server-access/guides/ec2-discovery.mdx
+++ b/docs/pages/server-access/guides/ec2-discovery.mdx
@@ -26,7 +26,6 @@ authenticating joining Nodes.
 Create a file called `token.yaml`:
 ```yaml
 # token.yaml
----
 kind: token
 version: v2
 metadata:
@@ -78,7 +77,7 @@ mainSteps:
     sourceType: "HTTP"
     destinationPath: "/tmp/installTeleport.sh"
     sourceInfo:
-      url: "https://teleport.example.com/webapi/scripts/{{ scriptName }}"
+      url: "https://teleport.example.com/webapi/scripts/installer/{{ scriptName }}"
 - action: aws:runShellScript
   name: runShellScript
   inputs:
@@ -129,6 +128,7 @@ execute Systems Manager commands and retrieve EC2 instances:
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Effect": "Allow",
             "Action": [
                 "ssm:SendCommand",
                 "ec2:DescribeInstances",


### PR DESCRIPTION
- Missing Effect Allow for teleport discover service policy
- Incorrect URL for installer script