### PR TITLE
Ensure that TrackingReadConn and TrackingReader conform to io.Reader

### DIFF
--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -387,7 +387,11 @@ type TrackingReadConn struct {
 func (t *TrackingReadConn) Read(b []byte) (int, error) {
 	n, err := t.Conn.Read(b)
 	t.UpdateClientActivity()
-	return n, trace.Wrap(err)
+
+	// This has to use the original error type or else utilities using the connection
+	// (like io.Copy, which is used by the oxy forwarder) may incorrectly categorize
+	// the error produced by this and terminate the connection unnecessarily.
+	return n, err
 }
 
 func (t *TrackingReadConn) Close() error {

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -213,5 +213,5 @@ func TestTrackingReadConnEOF(t *testing.T) {
 	// Make sure it returns an EOF and not a wrapped exception.
 	buf := make([]byte, 64)
 	_, err = tc.Read(buf)
-	require.True(t, err == io.EOF)
+	require.Equal(t, io.EOF, err)
 }

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -18,6 +18,7 @@ package srv
 
 import (
 	"context"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -190,4 +191,27 @@ func TestMonitorDisconnectExpiredCertBeforeTimeNow(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Client is still connected.")
 	}
+}
+
+func TestTrackingReadConnEOF(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+
+	// Close the server to force client reads to instantly return EOF.
+	require.NoError(t, server.Close())
+
+	// Wrap the client in a TrackingReadConn.
+	ctx, cancel := context.WithCancel(context.Background())
+	tc, err := NewTrackingReadConn(TrackingReadConnConfig{
+		Conn:    client,
+		Clock:   clockwork.NewFakeClock(),
+		Context: ctx,
+		Cancel:  cancel,
+	})
+	require.NoError(t, err)
+
+	// Make sure it returns an EOF and not a wrapped exception.
+	buf := make([]byte, 64)
+	_, err = tc.Read(buf)
+	require.True(t, err == io.EOF)
 }

--- a/lib/utils/conn.go
+++ b/lib/utils/conn.go
@@ -167,7 +167,11 @@ func (r *TrackingReader) Count() uint64 {
 func (r *TrackingReader) Read(b []byte) (int, error) {
 	n, err := r.r.Read(b)
 	atomic.AddUint64(&r.count, uint64(n))
-	return n, trace.Wrap(err)
+
+	// This has to use the original error type or else utilities using the connection
+	// (like io.Copy, which is used by the oxy forwarder) may incorrectly categorize
+	// the error produced by this and terminate the connection unnecessarily.
+	return n, err
 }
 
 // TrackingWriter is an io.Writer that counts the total number of bytes

--- a/lib/utils/conn_test.go
+++ b/lib/utils/conn_test.go
@@ -33,5 +33,5 @@ func TestTrackingReaderEOF(t *testing.T) {
 	// Make sure it returns an EOF and not a wrapped exception.
 	buf := make([]byte, 64)
 	_, err := tr.Read(buf)
-	require.True(t, err == io.EOF)
+	require.Equal(t, io.EOF, err)
 }

--- a/lib/utils/conn_test.go
+++ b/lib/utils/conn_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackingReaderEOF(t *testing.T) {
+	reader := bytes.NewReader([]byte{})
+
+	// Wrap the reader in a TrackingReader.
+	tr := NewTrackingReader(reader)
+
+	// Make sure it returns an EOF and not a wrapped exception.
+	buf := make([]byte, 64)
+	_, err := tr.Read(buf)
+	require.True(t, err == io.EOF)
+}


### PR DESCRIPTION
Implementations of io.Reader should return io.EOF directly when the end of
the stream is reached, because callers will compare the error using ==.