### PR TITLE
[v10] Speed up TestEC2IsInstanceMetadataAvailable

### DIFF
--- a/lib/utils/ec2_test.go
+++ b/lib/utils/ec2_test.go
@@ -81,13 +81,13 @@ func TestEC2IsInstanceMetadataAvailable(t *testing.T) {
 		{
 			name: "not available",
 			client: func(t *testing.T, ctx context.Context, server *httptest.Server) *InstanceMetadataClient {
-				server.Close()
 				clt, err := NewInstanceMetadataClient(ctx, WithIMDSClient(imds.New(imds.Options{Endpoint: server.URL})))
 				require.NoError(t, err)
-
 				return clt
 			},
-			handler:   func(w http.ResponseWriter, r *http.Request) {},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+			},
 			assertion: require.False,
 		},
 		{
@@ -149,10 +149,11 @@ func TestEC2IsInstanceMetadataAvailable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
 			server := httptest.NewServer(tt.handler)
-			clt := tt.client(t, ctx, server)
+			t.Cleanup(server.Close)
 
+			ctx := context.Background()
+			clt := tt.client(t, ctx, server)
 			tt.assertion(t, clt.IsAvailable(ctx))
 		})
 	}


### PR DESCRIPTION
When testing the "not available" case, this test closed the server and waited for the AWS SDK to make several attempts before finally giving up.

Instead of shutting down the server, return an error. This triggers the same error handling branches, but doesn't require multiple attempts by the SDK.

Backports #17353 (manual backport due to code being in a different package in v10)