### PR TITLE
[v10] Fix build-buildboxes timeouts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -818,7 +818,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -826,7 +826,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -1494,7 +1494,7 @@ steps:
     commands:
     - aws sts get-caller-identity
     - |-
-      printf "[staging]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+      printf "[staging]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
         $(aws sts assume-role \
           --role-arn "$AWS_ROLE" \
           --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -1519,7 +1519,7 @@ steps:
     commands:
     - aws sts get-caller-identity
     - |-
-      printf "[production]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+      printf "[production]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
         $(aws sts assume-role \
           --role-arn "$AWS_ROLE" \
           --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -1756,7 +1756,7 @@ steps:
     commands:
       - aws sts get-caller-identity
       - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
           $(aws sts assume-role \
             --role-arn "$AWS_ROLE" \
             --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -1764,7 +1764,7 @@ steps:
             --output text) \
           > /root/.aws/credentials
       - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity
+      - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
@@ -1928,7 +1928,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -1936,7 +1936,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -2113,7 +2113,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -2121,7 +2121,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -2311,7 +2311,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -2319,7 +2319,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -2494,7 +2494,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -2502,7 +2502,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -2648,7 +2648,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -2656,7 +2656,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -2689,7 +2689,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -2697,7 +2697,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -2750,7 +2750,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -2758,7 +2758,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -2909,7 +2909,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -2917,7 +2917,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -2948,7 +2948,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -2956,7 +2956,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -3008,7 +3008,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3016,7 +3016,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -3173,7 +3173,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3181,7 +3181,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -3214,7 +3214,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3222,7 +3222,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -3266,7 +3266,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3274,7 +3274,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -3420,7 +3420,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3428,7 +3428,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -3459,7 +3459,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3467,7 +3467,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -3510,7 +3510,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3518,7 +3518,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -3693,7 +3693,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3701,7 +3701,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -3847,7 +3847,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3855,7 +3855,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -3888,7 +3888,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3896,7 +3896,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -3949,7 +3949,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -3957,7 +3957,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -4108,7 +4108,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -4116,7 +4116,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -4149,7 +4149,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -4157,7 +4157,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -4201,7 +4201,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -4209,7 +4209,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -4416,7 +4416,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -4424,7 +4424,7 @@ steps:
         --output text) \
       > /tmp/build-darwin-amd64/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -4585,7 +4585,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -4593,7 +4593,7 @@ steps:
         --output text) \
       > /tmp/build-darwin-amd64-pkg/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -4783,7 +4783,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -4791,7 +4791,7 @@ steps:
         --output text) \
       > /tmp/build-darwin-amd64-pkg-tsh/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -5006,7 +5006,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5014,7 +5014,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -5189,7 +5189,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5197,7 +5197,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -5343,7 +5343,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5351,7 +5351,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -5384,7 +5384,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5392,7 +5392,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -5436,7 +5436,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5444,7 +5444,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -5590,7 +5590,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5598,7 +5598,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -5631,7 +5631,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5639,7 +5639,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -5683,7 +5683,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5691,7 +5691,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -5837,7 +5837,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5845,7 +5845,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -5878,7 +5878,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5886,7 +5886,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -5939,7 +5939,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -5947,7 +5947,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -6098,7 +6098,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6106,7 +6106,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -6139,7 +6139,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6147,7 +6147,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -6200,7 +6200,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6208,7 +6208,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -6391,7 +6391,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6399,7 +6399,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -6535,7 +6535,7 @@ steps:
     commands:
     - aws sts get-caller-identity
     - |-
-      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
         $(aws sts assume-role \
           --role-arn "$AWS_ROLE" \
           --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6543,7 +6543,7 @@ steps:
           --output text) \
         > /root/.aws/credentials
     - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-    - aws sts get-caller-identity
+    - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: STAGING_TELEPORT_DRONE_USER_ECR_KEY
@@ -6656,7 +6656,7 @@ steps:
     commands:
     - aws sts get-caller-identity
     - |-
-      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
         $(aws sts assume-role \
           --role-arn "$AWS_ROLE" \
           --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6664,7 +6664,7 @@ steps:
           --output text) \
         > /root/.aws/credentials
     - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-    - aws sts get-caller-identity
+    - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_ACCESS_KEY_ID
@@ -6695,7 +6695,7 @@ steps:
     commands:
     - aws sts get-caller-identity
     - |-
-      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
         $(aws sts assume-role \
           --role-arn "$AWS_ROLE" \
           --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6703,7 +6703,7 @@ steps:
           --output text) \
         > /root/.aws/credentials
     - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-    - aws sts get-caller-identity
+    - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_PACKER_ACCESS_KEY_ID
@@ -6742,7 +6742,7 @@ steps:
     commands:
     - aws sts get-caller-identity
     - |-
-      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
         $(aws sts assume-role \
           --role-arn "$AWS_ROLE" \
           --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6750,7 +6750,7 @@ steps:
           --output text) \
         > /root/.aws/credentials
     - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-    - aws sts get-caller-identity
+    - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_ACCESS_KEY_ID
@@ -6830,7 +6830,7 @@ steps:
     commands:
     - aws sts get-caller-identity
     - |-
-      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
         $(aws sts assume-role \
           --role-arn "$AWS_ROLE" \
           --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6838,7 +6838,7 @@ steps:
           --output text) \
         > /root/.aws/credentials
     - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-    - aws sts get-caller-identity
+    - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_ACCESS_KEY_ID
@@ -6870,7 +6870,7 @@ steps:
     commands:
     - aws sts get-caller-identity
     - |-
-      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
         $(aws sts assume-role \
           --role-arn "$AWS_ROLE" \
           --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6878,7 +6878,7 @@ steps:
           --output text) \
         > /root/.aws/credentials
     - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-    - aws sts get-caller-identity
+    - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_PACKER_ACCESS_KEY_ID
@@ -6918,7 +6918,7 @@ steps:
     commands:
     - aws sts get-caller-identity
     - |-
-      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+      printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
         $(aws sts assume-role \
           --role-arn "$AWS_ROLE" \
           --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -6926,7 +6926,7 @@ steps:
           --output text) \
         > /root/.aws/credentials
     - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-    - aws sts get-caller-identity
+    - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_ACCESS_KEY_ID
@@ -7008,12 +7008,12 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Assume Staging buildbox AWS Role
+- name: Configure Staging AWS Profile
   image: amazon/aws-cli
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[staging]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -7021,7 +7021,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile staging
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: STAGING_BUILDBOX_DRONE_USER_ECR_KEY
@@ -7032,35 +7032,20 @@ steps:
   volumes:
   - name: awsconfig
     path: /root/.aws
-- name: Build buildbox and push to Staging
-  image: docker
-  commands:
-  - apk add --no-cache make aws-cli
-  - chown -R $UID:$GID /go
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - make -C build.assets buildbox
-  - docker tag public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
-  - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Production buildbox AWS Role
+- name: Configure Production AWS Profile
   image: amazon/aws-cli
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[production]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
         --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
         --output text) \
-      > /root/.aws/credentials
+      >> /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile production
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: PRODUCTION_BUILDBOX_DRONE_USER_ECR_KEY
@@ -7071,321 +7056,99 @@ steps:
   volumes:
   - name: awsconfig
     path: /root/.aws
-- name: Push buildbox to Production
+- name: Build and push buildbox
   image: docker
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
+  - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
+    -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - make -C build.assets buildbox
+  - docker tag public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
+  - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
+  - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
+    login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION
   volumes:
   - name: dockersock
     path: /var/run
   - name: awsconfig
     path: /root/.aws
-- name: Assume Staging buildbox-fips AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: STAGING_BUILDBOX_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: STAGING_BUILDBOX_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: STAGING_BUILDBOX_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Build buildbox-fips and push to Staging
+- name: Build and push buildbox-fips
   image: docker
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
+    -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - make -C build.assets buildbox-fips
   - docker tag public.ecr.aws/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION
     146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Production buildbox-fips AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Push buildbox-fips to Production
-  image: docker
-  commands:
-  - apk add --no-cache make aws-cli
-  - chown -R $UID:$GID /go
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
+  - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
+    login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION
   volumes:
   - name: dockersock
     path: /var/run
   - name: awsconfig
     path: /root/.aws
-- name: Assume Staging buildbox-arm AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: STAGING_BUILDBOX_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: STAGING_BUILDBOX_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: STAGING_BUILDBOX_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Build buildbox-arm and push to Staging
+- name: Build and push buildbox-arm
   image: docker
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
+    -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - make -C build.assets buildbox-arm
   - docker tag public.ecr.aws/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION
     146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Production buildbox-arm AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Push buildbox-arm to Production
-  image: docker
-  commands:
-  - apk add --no-cache make aws-cli
-  - chown -R $UID:$GID /go
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
+  - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
+    login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION
   volumes:
   - name: dockersock
     path: /var/run
   - name: awsconfig
     path: /root/.aws
-- name: Assume Staging buildbox-centos7 AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: STAGING_BUILDBOX_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: STAGING_BUILDBOX_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: STAGING_BUILDBOX_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Build buildbox-centos7 and push to Staging
+- name: Build and push buildbox-centos7
   image: docker
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
+    -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - make -C build.assets buildbox-centos7
   - docker tag public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
     146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Production buildbox-centos7 AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Push buildbox-centos7 to Production
-  image: docker
-  commands:
-  - apk add --no-cache make aws-cli
-  - chown -R $UID:$GID /go
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
+  - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
+    login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
   volumes:
   - name: dockersock
     path: /var/run
   - name: awsconfig
     path: /root/.aws
-- name: Assume Staging buildbox-centos7-fips AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: STAGING_BUILDBOX_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: STAGING_BUILDBOX_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: STAGING_BUILDBOX_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Build buildbox-centos7-fips and push to Staging
+- name: Build and push buildbox-centos7-fips
   image: docker
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
+    -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
   - make -C build.assets buildbox-centos7-fips
   - docker tag public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
     146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
   - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Production buildbox-centos7-fips AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: PRODUCTION_BUILDBOX_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Push buildbox-centos7-fips to Production
-  image: docker
-  commands:
-  - apk add --no-cache make aws-cli
-  - chown -R $UID:$GID /go
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
+  - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
+    login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
   volumes:
   - name: dockersock
@@ -7486,7 +7249,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -7494,7 +7257,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -7532,7 +7295,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -7540,7 +7303,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: APT_REPO_NEW_AWS_ACCESS_KEY_ID
@@ -7683,7 +7446,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -7691,7 +7454,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -7729,7 +7492,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -7737,7 +7500,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: YUM_REPO_NEW_AWS_ACCESS_KEY_ID
@@ -7844,7 +7607,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -7852,7 +7615,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
@@ -7954,7 +7717,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -7962,7 +7725,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
@@ -8055,7 +7818,7 @@ steps:
     commands:
       - aws sts get-caller-identity
       - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
           $(aws sts assume-role \
             --role-arn "$AWS_ROLE" \
             --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -8063,7 +7826,7 @@ steps:
             --output text) \
           > /root/.aws/credentials
       - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity
+      - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_ACCESS_KEY_ID
@@ -8093,7 +7856,7 @@ steps:
     commands:
       - aws sts get-caller-identity
       - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
           $(aws sts assume-role \
             --role-arn "$AWS_ROLE" \
             --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -8101,7 +7864,7 @@ steps:
             --output text) \
           > /root/.aws/credentials
       - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity
+      - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: PRODUCTION_AWS_ACCESS_KEY_ID
@@ -8141,7 +7904,7 @@ steps:
     commands:
       - aws sts get-caller-identity
       - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
           $(aws sts assume-role \
             --role-arn "$AWS_ROLE" \
             --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -8149,7 +7912,7 @@ steps:
             --output text) \
           > /root/.aws/credentials
       - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity
+      - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_ACCESS_KEY_ID
@@ -8178,7 +7941,7 @@ steps:
     commands:
       - aws sts get-caller-identity
       - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
           $(aws sts assume-role \
             --role-arn "$AWS_ROLE" \
             --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -8186,7 +7949,7 @@ steps:
             --output text) \
           > /root/.aws/credentials
       - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity
+      - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: PRODUCTION_AWS_ACCESS_KEY_ID
@@ -8216,7 +7979,7 @@ steps:
     commands:
       - aws sts get-caller-identity
       - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
           $(aws sts assume-role \
             --role-arn "$AWS_ROLE" \
             --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -8224,7 +7987,7 @@ steps:
             --output text) \
           > /root/.aws/credentials
       - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity
+      - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
@@ -8268,7 +8031,7 @@ steps:
     commands:
       - aws sts get-caller-identity
       - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
           $(aws sts assume-role \
             --role-arn "$AWS_ROLE" \
             --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -8276,7 +8039,7 @@ steps:
             --output text) \
           > /root/.aws/credentials
       - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity
+      - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
@@ -8323,7 +8086,7 @@ steps:
     commands:
       - aws sts get-caller-identity
       - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
           $(aws sts assume-role \
             --role-arn "$AWS_ROLE" \
             --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -8331,7 +8094,7 @@ steps:
             --output text) \
           > /root/.aws/credentials
       - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity
+      - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: RPMREPO_AWS_ACCESS_KEY_ID
@@ -8425,7 +8188,7 @@ steps:
     commands:
       - aws sts get-caller-identity
       - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
           $(aws sts assume-role \
             --role-arn "$AWS_ROLE" \
             --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -8433,7 +8196,7 @@ steps:
             --output text) \
           > /root/.aws/credentials
       - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity
+      - aws sts get-caller-identity --profile default
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: DEBREPO_AWS_ACCESS_KEY_ID
@@ -8597,7 +8360,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -8605,7 +8368,7 @@ steps:
         --output text) \
       > /root/.aws/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
@@ -8763,7 +8526,7 @@ steps:
   commands:
   - aws sts get-caller-identity
   - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
+    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
       $(aws sts assume-role \
         --role-arn "$AWS_ROLE" \
         --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
@@ -8771,7 +8534,7 @@ steps:
         --output text) \
       > /tmp/build-darwin-amd64-connect/credentials
   - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity
+  - aws sts get-caller-identity --profile default
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -8912,6 +8675,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: fca221c82f7e8c0eff7016b9b7d6dd2b4b9b164d3f762e96dfe2155b97366721
+hmac: 8188efa3bff7b0fbeeb294bb84af3f78d88eea44a9792a961fc4afeeebd40e6e
 
 ...

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -16,7 +16,7 @@ package main
 
 import "fmt"
 
-func allBuildboxPipelineSteps() []step {
+func buildboxPipelineSteps() []step {
 	steps := []step{
 		{
 			Name:  "Check out code",
@@ -27,6 +27,27 @@ func allBuildboxPipelineSteps() []step {
 			},
 		},
 		waitForDockerStep(),
+		kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
+			awsRoleSettings: awsRoleSettings{
+				awsAccessKeyID:     value{fromSecret: "STAGING_BUILDBOX_DRONE_USER_ECR_KEY"},
+				awsSecretAccessKey: value{fromSecret: "STAGING_BUILDBOX_DRONE_USER_ECR_SECRET"},
+				role:               value{fromSecret: "STAGING_BUILDBOX_DRONE_ECR_AWS_ROLE"},
+			},
+			configVolume: volumeRefAwsConfig,
+			name:         "Configure Staging AWS Profile",
+			profile:      "staging",
+		}),
+		kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
+			awsRoleSettings: awsRoleSettings{
+				awsAccessKeyID:     value{fromSecret: "PRODUCTION_BUILDBOX_DRONE_USER_ECR_KEY"},
+				awsSecretAccessKey: value{fromSecret: "PRODUCTION_BUILDBOX_DRONE_USER_ECR_SECRET"},
+				role:               value{fromSecret: "PRODUCTION_BUILDBOX_DRONE_ECR_AWS_ROLE"},
+			},
+			configVolume: volumeRefAwsConfig,
+			name:         "Configure Production AWS Profile",
+			append:       true,
+			profile:      "production",
+		}),
 	}
 
 	for _, name := range []string{"buildbox", "buildbox-arm", "buildbox-centos7"} {
@@ -35,66 +56,36 @@ func allBuildboxPipelineSteps() []step {
 			if name == "buildbox-arm" && fips {
 				continue
 			}
-			steps = append(steps, buildboxPipelineSteps(name, fips)...)
+			steps = append(steps, buildboxPipelineStep(name, fips))
 		}
 	}
 	return steps
 }
 
-func buildboxPipelineSteps(buildboxName string, fips bool) []step {
+func buildboxPipelineStep(buildboxName string, fips bool) step {
 	if fips {
 		buildboxName += "-fips"
 	}
-	assumeStagingRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
-		awsRoleSettings: awsRoleSettings{
-			awsAccessKeyID:     value{fromSecret: "STAGING_BUILDBOX_DRONE_USER_ECR_KEY"},
-			awsSecretAccessKey: value{fromSecret: "STAGING_BUILDBOX_DRONE_USER_ECR_SECRET"},
-			role:               value{fromSecret: "STAGING_BUILDBOX_DRONE_ECR_AWS_ROLE"},
-		},
-		configVolume: volumeRefAwsConfig,
-	})
-	assumeStagingRoleStep.Name = fmt.Sprintf("Assume Staging %s AWS Role", buildboxName)
-	assumeProductionRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
-		awsRoleSettings: awsRoleSettings{
-			awsAccessKeyID:     value{fromSecret: "PRODUCTION_BUILDBOX_DRONE_USER_ECR_KEY"},
-			awsSecretAccessKey: value{fromSecret: "PRODUCTION_BUILDBOX_DRONE_USER_ECR_SECRET"},
-			role:               value{fromSecret: "PRODUCTION_BUILDBOX_DRONE_ECR_AWS_ROLE"},
-		},
-		configVolume: volumeRefAwsConfig,
-	})
-	assumeProductionRoleStep.Name = fmt.Sprintf("Assume Production %s AWS Role", buildboxName)
-	return []step{
-		assumeStagingRoleStep,
-		step{
-			Name:    fmt.Sprintf("Build %s and push to Staging", buildboxName),
-			Image:   "docker",
-			Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
-			Commands: []string{
-				`apk add --no-cache make aws-cli`,
-				`chown -R $UID:$GID /go`,
-				// Authenticate to staging registry
-				`aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin ` + StagingRegistry,
-				// Build buildbox image
-				fmt.Sprintf(`make -C build.assets %s`, buildboxName),
-				// Retag for staging registry
-				fmt.Sprintf(`docker tag %s/gravitational/teleport-%s:$BUILDBOX_VERSION %s/gravitational/teleport-%s:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA`, ProductionRegistry, buildboxName, StagingRegistry, buildboxName),
-				// Push to staging registry
-				fmt.Sprintf(`docker push %s/gravitational/teleport-%s:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA`, StagingRegistry, buildboxName),
-			},
-		},
-		assumeProductionRoleStep,
-		step{
-			Name:    fmt.Sprintf("Push %s to Production", buildboxName),
-			Image:   "docker",
-			Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
-			Commands: []string{
-				`apk add --no-cache make aws-cli`,
-				`chown -R $UID:$GID /go`,
-				// Authenticate to production registry
-				`aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin ` + ProductionRegistry,
-				// Push to production registry
-				fmt.Sprintf(`docker push %s/gravitational/teleport-%s:$BUILDBOX_VERSION`, ProductionRegistry, buildboxName),
-			},
+	return step{
+		Name:    "Build and push " + buildboxName,
+		Image:   "docker",
+		Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
+		Commands: []string{
+			`apk add --no-cache make aws-cli`,
+			`chown -R $UID:$GID /go`,
+			// Authenticate to staging registry
+			`aws ecr get-login-password --profile staging --region=us-west-2 | docker login -u="AWS" --password-stdin ` + StagingRegistry,
+			// Build buildbox image
+			fmt.Sprintf(`make -C build.assets %s`, buildboxName),
+			// Retag for staging registry
+			fmt.Sprintf(`docker tag %s/gravitational/teleport-%s:$BUILDBOX_VERSION %s/gravitational/teleport-%s:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA`, ProductionRegistry, buildboxName, StagingRegistry, buildboxName),
+			// Push to staging registry
+			fmt.Sprintf(`docker push %s/gravitational/teleport-%s:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA`, StagingRegistry, buildboxName),
+			// Authenticate to production registry
+			`docker logout ` + StagingRegistry,
+			`aws ecr-public get-login-password --profile production --region=us-east-1 | docker login -u="AWS" --password-stdin ` + ProductionRegistry,
+			// Push to production registry
+			fmt.Sprintf(`docker push %s/gravitational/teleport-%s:$BUILDBOX_VERSION`, ProductionRegistry, buildboxName),
 		},
 	}
 }
@@ -114,6 +105,6 @@ func buildboxPipeline() pipeline {
 	p.Services = []service{
 		dockerService(),
 	}
-	p.Steps = allBuildboxPipelineSteps()
+	p.Steps = buildboxPipelineSteps()
 	return p
 }

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -365,14 +365,14 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 			role:               value{fromSecret: "AWS_ROLE"},
 		},
 		configVolume: volumeRefAwsConfig,
+		name:         "Assume Download AWS Role",
 	})
-	assumeDownloadRoleStep.Name = "Assume Download AWS Role" // multiple steps cannot have the same name
 
 	assumeUploadRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
 		awsRoleSettings: optpb.bucketSecrets.awsRoleSettings,
 		configVolume:    volumeRefAwsConfig,
+		name:            "Assume Upload AWS Role",
 	})
-	assumeUploadRoleStep.Name = "Assume Upload AWS Role" // multiple steps cannot have the same name
 
 	return []step{
 		assumeDownloadRoleStep,

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -500,8 +500,8 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 			role:               value{fromSecret: "AWS_ROLE"},
 		},
 		configVolume: volumeRefAwsConfig,
+		name:         "Assume Download AWS Role",
 	})
-	assumeDownloadRoleStep.Name = "Assume Download AWS Role"
 	assumeBuildRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
 		awsRoleSettings: awsRoleSettings{
 			awsAccessKeyID:     value{fromSecret: "TELEPORT_BUILD_USER_READ_ONLY_KEY"},
@@ -509,8 +509,8 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 			role:               value{fromSecret: "TELEPORT_BUILD_READ_ONLY_AWS_ROLE"},
 		},
 		configVolume: volumeRefAwsConfig,
+		name:         "Assume Build AWS Role",
 	})
-	assumeBuildRoleStep.Name = "Assume Build AWS Role"
 	assumeUploadRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
 		awsRoleSettings: awsRoleSettings{
 			awsAccessKeyID:     value{fromSecret: "AWS_ACCESS_KEY_ID"},
@@ -518,8 +518,8 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 			role:               value{fromSecret: "AWS_ROLE"},
 		},
 		configVolume: volumeRefAwsConfig,
+		name:         "Assume Upload AWS Role",
 	})
-	assumeUploadRoleStep.Name = "Assume Upload AWS Role"
 
 	pipelineName := fmt.Sprintf("%s-%s", dependentPipeline, packageType)
 


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/17314

I refactored build-buildboxes to uses multiple profiles. This greatly reduces the number of steps in the pipeline, allowing drone-runner-kube to successfully schedule the pipeline.

Furthermore, I also updated un-dronegen'ed pipelines to have same syntax as dronegen'd ones, which is nice for consistency.

Contributes to https://github.com/gravitational/teleport/issues/17310

## Testing
tag: https://drone.platform.teleport.sh/gravitational/teleport/16461
promote: https://drone.platform.teleport.sh/gravitational/teleport/16473
buildboxes: https://drone.platform.teleport.sh/gravitational/teleport/16462

The final buildboxes build was performed with the following diff to enable testing:

```
diff --git a/.drone.yml b/.drone.yml
index a99532449..feb73d98e 100644
--- a/.drone.yml
+++ b/.drone.yml
@@ -6990,6 +6990,7 @@ trigger:
     include:
     - master
     - branch/*
+    - walt/*
 workspace:
   path: /go/src/github.com/gravitational/teleport
 clone:
@@ -8675,6 +8676,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 8188efa3bff7b0fbeeb294bb84af3f78d88eea44a9792a961fc4afeeebd40e6e
+hmac: 82d3e78c39cf13f05f66ef36fd6335daa6621bfc713fabbdbbfe547328af90a2
 
 ...
```