### PR TITLE
[v11] Swap YUM_REPO_NEW_ROLE to YUM_REPO_NEW_AWS_ROLE

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7794,7 +7794,7 @@ steps:
     AWS_ACCESS_KEY_ID:
       from_secret: YUM_REPO_NEW_AWS_ACCESS_KEY_ID
     AWS_ROLE:
-      from_secret: YUM_REPO_NEW_ROLE
+      from_secret: YUM_REPO_NEW_AWS_ROLE
     AWS_SECRET_ACCESS_KEY:
       from_secret: YUM_REPO_NEW_AWS_SECRET_ACCESS_KEY
   volumes:
@@ -8966,6 +8966,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: c920a0310bbda97402bd2c855ea9d8b21a5b36725ed30df7c4351f2dff0d8e55
+hmac: 771715e8f42b097d44826f5352673ff4e4db29d83a35ae8f2aeac8d48ef4e01e
 
 ...

--- a/dronegen/yum.go
+++ b/dronegen/yum.go
@@ -36,7 +36,7 @@ func getYumPipelineBuilder() *OsPackageToolPipelineBuilder {
 			"YUM_REPO_NEW_AWS_S3_BUCKET",
 			"YUM_REPO_NEW_AWS_ACCESS_KEY_ID",
 			"YUM_REPO_NEW_AWS_SECRET_ACCESS_KEY",
-			"YUM_REPO_NEW_ROLE",
+			"YUM_REPO_NEW_AWS_ROLE",
 		),
 	)
 


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/17406

This doesn't fix anything broken -- it updates our drone variables to be more consistent.

All roles environment variables end in `AWS_ROLE`. I typoed `YUM_REPO_NEW_ROLE` name during https://github.com/gravitational/teleport/pull/17201, and fixed it by duplicating the variable in https://github.com/gravitational/ops/pull/436.  I'll undo https://github.com/gravitational/ops/pull/436 once this is available in all branches.

## Testing
None -- this is simple enough I feel ok skipping a dev build.