### PR TITLE
[v10] Swap YUM_REPO_NEW_ROLE to YUM_REPO_NEW_AWS_ROLE

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7742,7 +7742,7 @@ steps:
     AWS_ACCESS_KEY_ID:
       from_secret: YUM_REPO_NEW_AWS_ACCESS_KEY_ID
     AWS_ROLE:
-      from_secret: YUM_REPO_NEW_ROLE
+      from_secret: YUM_REPO_NEW_AWS_ROLE
     AWS_SECRET_ACCESS_KEY:
       from_secret: YUM_REPO_NEW_AWS_SECRET_ACCESS_KEY
   volumes:
@@ -8912,6 +8912,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: fca221c82f7e8c0eff7016b9b7d6dd2b4b9b164d3f762e96dfe2155b97366721
+hmac: 2632e901421fb66343b0dcc0ea608c45b7fbf1d0148c638cd079b1d4aa9d55e5
 
 ...

--- a/dronegen/yum.go
+++ b/dronegen/yum.go
@@ -36,7 +36,7 @@ func getYumPipelineBuilder() *OsPackageToolPipelineBuilder {
 			"YUM_REPO_NEW_AWS_S3_BUCKET",
 			"YUM_REPO_NEW_AWS_ACCESS_KEY_ID",
 			"YUM_REPO_NEW_AWS_SECRET_ACCESS_KEY",
-			"YUM_REPO_NEW_ROLE",
+			"YUM_REPO_NEW_AWS_ROLE",
 		),
 	)
 


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/17406

This doesn't fix anything broken -- it updates our drone variables to be more consistent.

All roles environment variables end in `AWS_ROLE`. I typoed `YUM_REPO_NEW_ROLE` name during https://github.com/gravitational/teleport/pull/17201, and fixed it by duplicating the variable in https://github.com/gravitational/ops/pull/436.  I'll undo https://github.com/gravitational/ops/pull/436 once this is available in all branches.

## Testing
None -- this is simple enough I feel ok skipping a dev build.