### PR TITLE
desktop getting started update

### DIFF
--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -519,7 +519,7 @@ windows_desktop_service:
 Start Teleport after updating `/etc/teleport.yaml`
 
 ```code
-sudo teleport start
+sudo teleport start -c /etc/teleport.yaml
 ```
 
 ## Step 7/7. Log in using Teleport

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -464,7 +464,7 @@ First, generate a join token with the following command:
 $ tctl tokens add --type=windowsdesktop
 ```
 
-Copy the join token and `ca_pin` to a file on the instance where you will run Windows Desktop
+Copy the join token and `ca_pin` to a file on the instance where you will run the Windows Desktop
 Service, and then use the following configuration:
 
 ```yaml

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -453,30 +453,27 @@ In order to enable Desktop Access in Teleport, add the following section in
 configuration fields, see the
 [configuration reference](./reference/configuration.mdx) page.
 
-<Tabs>
-<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
-
-For Teleport Self-Hosted, Windows Desktop Service can connect to the auth service with a
-join token. The Proxy will connect to the desktop listen address port.
+<Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={["oss", "enterprise"]}>
+The Teleport Windows Desktop Service will establish a reverse tunnel to
+the proxy service. This requires setting `proxy_server` to your proxy address and
+providing a join token.
 
 First, generate a join token with the following command:
 
 ```code
 $ tctl tokens add --type=windowsdesktop
-$ tctl status
 ```
 
 Copy the join token and `ca_pin` to a file on the instance where you will run Windows Desktop
 Service, and then use the following configuration:
 
 ```yaml
+version: v3
 teleport:
-  auth_servers:
-  - auth.example.com:3025
-  ca_pin: "sha:..."
+  auth_token: /path/to/token
+  proxy_server: teleport.example.com # replace with your proxy address
 windows_desktop_service:
   enabled: yes
-  listen_addr: "0.0.0.0:3028"
   ldap:
     addr: "$LDAP_SERVER_ADDRESS"
     domain: "$LDAP_DOMAIN_NAME"
@@ -486,8 +483,8 @@ windows_desktop_service:
   discovery:
     base_dn: "*"
 ```
-</TabItem>
-<TabItem scope={["cloud"]} label="Cloud">
+</Details>
+<Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={"cloud"}>
 For Teleport Cloud, Windows Desktop Service should establish a reverse tunnel to
 the hosted proxy. This requires setting `proxy_server` to your cloud tenant and
 providing a join token.
@@ -517,8 +514,7 @@ windows_desktop_service:
   discovery:
     base_dn: "*"
 ```
-</TabItem>
-</Tabs>
+</Details>
 
 Start Teleport after updating `/etc/teleport.yaml`
 

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -482,6 +482,12 @@ windows_desktop_service:
     der_ca_file: /path/to/cert
   discovery:
     base_dn: "*"
+auth_service:
+  enabled: no
+proxy_service:
+  enabled: no
+ssh_service:
+  enabled: no    
 ```
 </Details>
 <Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={"cloud"}>
@@ -513,6 +519,12 @@ windows_desktop_service:
     der_ca_file: /path/to/cert
   discovery:
     base_dn: "*"
+auth_service:
+  enabled: no
+proxy_service:
+  enabled: no
+ssh_service:
+  enabled: no    
 ```
 </Details>
 

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -444,7 +444,7 @@ the filepath to the `der_ca_file` configuration variable.
   order to resolve this.
 </Admonition>
 
-Install Teleport on the host where you will run the Teleport Deskop Service:
+Install Teleport on the host where you will run the Teleport Desktop Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -455,7 +455,7 @@ configuration fields, see the
 
 <Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={["oss", "enterprise"]}>
 The Teleport Windows Desktop Service will establish a reverse tunnel to
-the proxy service. This requires setting `proxy_server` to your proxy address and
+the Proxy Service. This requires setting `proxy_server` to your Proxy Service address and
 providing a join token.
 
 First, generate a join token with the following command:

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -528,7 +528,7 @@ ssh_service:
 ```
 </Details>
 
-Start Teleport after updating `/etc/teleport.yaml`
+Start Teleport after updating `/etc/teleport.yaml`:
 
 ```code
 sudo teleport start -c /etc/teleport.yaml

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -444,13 +444,36 @@ the filepath to the `der_ca_file` configuration variable.
   order to resolve this.
 </Admonition>
 
+Install Teleport on the host where you will run the Teleport Deskop Service:
+
+(!docs/pages/includes/install-linux.mdx!)
+
 In order to enable Desktop Access in Teleport, add the following section in
-`teleport.yaml` on your Linux server. For a detailed description of these
+`/etc/teleport.yaml` on your Linux server. For a detailed description of these
 configuration fields, see the
 [configuration reference](./reference/configuration.mdx) page.
 
-<Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
+
+For Teleport Self-Hosted, Windows Desktop Service can connect to the auth service with a
+join token. The Proxy will connect to the desktop listen address port.
+
+First, generate a join token with the following command:
+
+```code
+$ tctl tokens add --type=windowsdesktop
+$ tctl status
+```
+
+Copy the join token and `ca_pin` to a file on the instance where you will run Windows Desktop
+Service, and then use the following configuration:
+
 ```yaml
+teleport:
+  auth_servers:
+  - auth.example.com:3025
+  ca_pin: "sha:..."
 windows_desktop_service:
   enabled: yes
   listen_addr: "0.0.0.0:3028"
@@ -463,8 +486,8 @@ windows_desktop_service:
   discovery:
     base_dn: "*"
 ```
-</Details>
-<Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={"cloud"}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Cloud">
 For Teleport Cloud, Windows Desktop Service should establish a reverse tunnel to
 the hosted proxy. This requires setting `proxy_server` to your cloud tenant and
 providing a join token.
@@ -494,9 +517,14 @@ windows_desktop_service:
   discovery:
     base_dn: "*"
 ```
-</Details>
+</TabItem>
+</Tabs>
 
-After updating `teleport.yaml`, start Teleport as usual using `teleport start`.
+Start Teleport after updating `/etc/teleport.yaml`
+
+```code
+sudo teleport start
+```
 
 ## Step 7/7. Log in using Teleport
 

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -453,7 +453,8 @@ In order to enable Desktop Access in Teleport, add the following section in
 configuration fields, see the
 [configuration reference](./reference/configuration.mdx) page.
 
-<Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 The Teleport Windows Desktop Service will establish a reverse tunnel to
 the Proxy Service. This requires setting `proxy_server` to your Proxy Service address and
 providing a join token.
@@ -464,7 +465,7 @@ First, generate a join token with the following command:
 $ tctl tokens add --type=windowsdesktop
 ```
 
-Copy the join token and `ca_pin` to a file on the instance where you will run the Windows Desktop
+Copy the join token to a file on the instance where you will run the Windows Desktop
 Service, and then use the following configuration:
 
 ```yaml
@@ -489,8 +490,8 @@ proxy_service:
 ssh_service:
   enabled: no    
 ```
-</Details>
-<Details title="Desktop Service Configuration" min="8.0" scopeOnly={true} scope={"cloud"}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Cloud">
 For Teleport Cloud, Windows Desktop Service should establish a reverse tunnel to
 the hosted proxy. This requires setting `proxy_server` to your cloud tenant and
 providing a join token.
@@ -526,7 +527,8 @@ proxy_service:
 ssh_service:
   enabled: no    
 ```
-</Details>
+</TabItem>
+</Tabs>
 
 Start Teleport after updating `/etc/teleport.yaml`:
 


### PR DESCRIPTION
This updates the desktop getting started more consistent with other guides. 

- Includes Teleport installation section
- Makes Self-hosted a full example.
- Shows starting teleport 
- fixes teleport yaml to prevent proxy, auth and ssh from starting 