### PR TITLE
Add in app access connection monitoring.

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -557,6 +557,56 @@ func TestTCP(t *testing.T) {
 	}
 }
 
+// TestTCPLock tests locking TCP applications.
+func TestTCPLock(t *testing.T) {
+	pack := Setup(t)
+
+	msg := []byte(uuid.New().String())
+
+	// Start the proxy to the two way communication app.
+	address := pack.startLocalProxy(t, pack.rootTCPTwoWayPublicAddr, pack.rootAppClusterName)
+	conn, err := net.Dial("tcp", address)
+	require.NoError(t, err)
+
+	// Read, write, and read again to make sure its working as expected.
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	require.NoError(t, err, buf)
+
+	resp := strings.TrimSpace(string(buf[:n]))
+	require.Equal(t, pack.rootTCPTwoWayMessage, resp)
+
+	_, err = conn.Write(msg)
+	require.NoError(t, err)
+
+	n, err = conn.Read(buf)
+	require.NoError(t, err, buf)
+
+	resp = strings.TrimSpace(string(buf[:n]))
+	require.Equal(t, pack.rootTCPTwoWayMessage, resp)
+
+	// Lock the user and try to write
+	pack.Lock(t)
+	time.Sleep(1 * time.Second)
+
+	_, err = conn.Write(msg)
+	require.NoError(t, err)
+
+	// This read should fail.
+	_, err = conn.Read(buf)
+	require.Error(t, err, buf)
+
+	// Close and re-open the connection
+	require.NoError(t, conn.Close())
+
+	conn, err = net.Dial("tcp", address)
+	require.NoError(t, err)
+
+	// Try to read again, expect a failure.
+	_, err = conn.Read(buf)
+	require.Error(t, err, buf)
+}
+
 func testServersHA(p *Pack, t *testing.T) {
 	type packInfo struct {
 		clusterName    string

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -595,7 +595,7 @@ func TestTCPLock(t *testing.T) {
 
 		_, err = conn.Read(buf)
 		return err != nil
-	}, time.Duration(5*time.Second), time.Duration(100*time.Millisecond))
+	}, 5*time.Second, 100*time.Millisecond)
 	// Close and re-open the connection
 	require.NoError(t, conn.Close())
 

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -607,6 +607,57 @@ func TestTCPLock(t *testing.T) {
 	require.Error(t, err, buf)
 }
 
+// TestTCPCertExpiration tests TCP application with certs expiring.
+func TestTCPCertExpiration(t *testing.T) {
+	pack := SetupWithOptions(t, AppTestOptions{
+		CertificateTTL: 5 * time.Second,
+	})
+
+	msg := []byte(uuid.New().String())
+
+	// Start the proxy to the two way communication app.
+	address := pack.startLocalProxy(t, pack.rootTCPTwoWayPublicAddr, pack.rootAppClusterName)
+	conn, err := net.Dial("tcp", address)
+	require.NoError(t, err)
+
+	// Read, write, and read again to make sure its working as expected.
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	require.NoError(t, err, buf)
+
+	resp := strings.TrimSpace(string(buf[:n]))
+	require.Equal(t, pack.rootTCPTwoWayMessage, resp)
+
+	_, err = conn.Write(msg)
+	require.NoError(t, err)
+
+	n, err = conn.Read(buf)
+	require.NoError(t, err, buf)
+
+	resp = strings.TrimSpace(string(buf[:n]))
+	require.Equal(t, pack.rootTCPTwoWayMessage, resp)
+
+	// Lock the user and try to write
+	require.Eventually(t, func() bool {
+		_, err := conn.Write(msg)
+		if err != nil {
+			return false
+		}
+
+		_, err = conn.Read(buf)
+		return err != nil
+	}, 5*time.Second, 100*time.Millisecond)
+	// Close and re-open the connection
+	require.NoError(t, conn.Close())
+
+	conn, err = net.Dial("tcp", address)
+	require.NoError(t, err)
+
+	// Try to read again, expect a failure.
+	_, err = conn.Read(buf)
+	require.Error(t, err, buf)
+}
+
 func testServersHA(p *Pack, t *testing.T) {
 	type packInfo struct {
 		clusterName    string

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -586,16 +586,16 @@ func TestTCPLock(t *testing.T) {
 	require.Equal(t, pack.rootTCPTwoWayMessage, resp)
 
 	// Lock the user and try to write
-	pack.Lock(t)
-	time.Sleep(1 * time.Second)
+	pack.LockUser(t)
+	require.Eventually(t, func() bool {
+		_, err := conn.Write(msg)
+		if err != nil {
+			return false
+		}
 
-	_, err = conn.Write(msg)
-	require.NoError(t, err)
-
-	// This read should fail.
-	_, err = conn.Read(buf)
-	require.Error(t, err, buf)
-
+		_, err = conn.Read(buf)
+		return err != nil
+	}, time.Duration(5*time.Second), time.Duration(100*time.Millisecond))
 	// Close and re-open the connection
 	require.NoError(t, conn.Close())
 

--- a/integration/appaccess/fixtures.go
+++ b/integration/appaccess/fixtures.go
@@ -41,6 +41,7 @@ type AppTestOptions struct {
 	ExtraLeafApps        []service.App
 	RootClusterListeners helpers.InstanceListenerSetupFunc
 	LeafClusterListeners helpers.InstanceListenerSetupFunc
+	CertificateTTL       time.Duration
 
 	RootConfig func(config *service.Config)
 	LeafConfig func(config *service.Config)
@@ -288,6 +289,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 	rcConf.DataDir = t.TempDir()
 	rcConf.Auth.Enabled = true
 	rcConf.Auth.Preference.SetSecondFactor("off")
+	rcConf.Auth.Preference.SetDisconnectExpiredCert(true)
 	rcConf.Proxy.Enabled = true
 	rcConf.Proxy.DisableWebService = false
 	rcConf.Proxy.DisableWebInterface = true
@@ -304,6 +306,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 	lcConf.DataDir = t.TempDir()
 	lcConf.Auth.Enabled = true
 	lcConf.Auth.Preference.SetSecondFactor("off")
+	lcConf.Auth.Preference.SetDisconnectExpiredCert(true)
 	lcConf.Proxy.Enabled = true
 	lcConf.Proxy.DisableWebService = false
 	lcConf.Proxy.DisableWebInterface = true
@@ -335,7 +338,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 	p.leafAppServers = p.startLeafAppServers(t, leafAppServersCount, opts.ExtraLeafApps)
 
 	// Create user for tests.
-	p.initUser(t, opts)
+	p.initUser(t)
 
 	// Create Web UI session.
 	p.initWebSession(t)
@@ -344,7 +347,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 	p.initCertPool(t)
 
 	// Initialize Teleport client with the user's credentials.
-	p.initTeleportClient(t)
+	p.initTeleportClient(t, opts)
 
 	return p
 }

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -161,7 +161,7 @@ func (p *Pack) LeafAppPublicAddr() string {
 }
 
 // initUser will create a user within the root cluster.
-func (p *Pack) initUser(t *testing.T, opts AppTestOptions) {
+func (p *Pack) initUser(t *testing.T) {
 	p.username = uuid.New().String()
 	p.password = uuid.New().String()
 
@@ -240,10 +240,11 @@ func (p *Pack) initWebSession(t *testing.T) {
 
 // initTeleportClient initializes a Teleport client with this pack's user
 // credentials.
-func (p *Pack) initTeleportClient(t *testing.T) {
+func (p *Pack) initTeleportClient(t *testing.T, opts AppTestOptions) {
 	creds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{
-		Process:  p.rootCluster.Process,
-		Username: p.user.GetName(),
+		Process:        p.rootCluster.Process,
+		Username:       p.user.GetName(),
+		CertificateTTL: opts.CertificateTTL,
 	})
 	require.NoError(t, err)
 

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -281,7 +281,8 @@ func (p *Pack) CreateAppSession(t *testing.T, publicAddr, clusterName string) st
 	return casResp.CookieValue
 }
 
-func (p *Pack) Lock(t *testing.T) {
+// LockUser will lock the configured user for this pack.
+func (p *Pack) LockUser(t *testing.T) {
 	err := p.rootCluster.Process.GetAuthServer().UpsertLock(context.Background(), &types.LockV2{
 		Spec: types.LockSpecV2{
 			Target: types.LockTarget{

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -92,6 +92,11 @@ type Pack struct {
 	rootTCPMessage    string
 	rootTCPAppURI     string
 
+	rootTCPTwoWayAppName    string
+	rootTCPTwoWayPublicAddr string
+	rootTCPTwoWayMessage    string
+	rootTCPTwoWayAppURI     string
+
 	jwtAppName        string
 	jwtAppPublicAddr  string
 	jwtAppClusterName string
@@ -274,6 +279,20 @@ func (p *Pack) CreateAppSession(t *testing.T, publicAddr, clusterName string) st
 	require.NoError(t, err)
 
 	return casResp.CookieValue
+}
+
+func (p *Pack) Lock(t *testing.T) {
+	err := p.rootCluster.Process.GetAuthServer().UpsertLock(context.Background(), &types.LockV2{
+		Spec: types.LockSpecV2{
+			Target: types.LockTarget{
+				User: p.username,
+			},
+		},
+		Metadata: types.Metadata{
+			Name: "test-lock",
+		},
+	})
+	require.NoError(t, err)
 }
 
 // makeWebapiRequest makes a request to the root cluster Web API.
@@ -586,6 +605,11 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, extraApps []service.
 				Name:       p.rootTCPAppName,
 				URI:        p.rootTCPAppURI,
 				PublicAddr: p.rootTCPPublicAddr,
+			},
+			{
+				Name:       p.rootTCPTwoWayAppName,
+				URI:        p.rootTCPTwoWayAppURI,
+				PublicAddr: p.rootTCPTwoWayPublicAddr,
 			},
 			{
 				Name:       p.jwtAppName,

--- a/integration/helpers/usercreds.go
+++ b/integration/helpers/usercreds.go
@@ -98,6 +98,8 @@ type UserCredsRequest struct {
 	RouteToCluster string
 	// SourceIP is an optional source IP to use in SSH certs
 	SourceIP string
+	// CertificateTTL is an optional TTL for the generated user certificate.
+	CertificateTTL time.Duration
 }
 
 // GenerateUserCreds generates key to be used by client
@@ -108,8 +110,12 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 	}
 	a := req.Process.GetAuthServer()
 	sshPub := ssh.MarshalAuthorizedKey(priv.SSHPublicKey())
+	ttl := time.Hour
+	if req.CertificateTTL != 0 {
+		ttl = req.CertificateTTL
+	}
 	sshCert, x509Cert, err := a.GenerateUserTestCerts(
-		sshPub, req.Username, time.Hour, constants.CertificateFormatStandard, req.RouteToCluster, req.SourceIP)
+		sshPub, req.Username, ttl, constants.CertificateFormatStandard, req.RouteToCluster, req.SourceIP)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4424,6 +4424,11 @@ func (process *TeleportProcess) initApps() {
 			return trace.Wrap(err)
 		}
 
+		asyncEmitter, err := process.newAsyncEmitter(conn.Client)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
 		proxyGetter := reversetunnel.NewConnectedProxyGetter()
 
 		appServer, err := app.New(process.ExitContext(), &app.Config{
@@ -4441,6 +4446,8 @@ func (process *TeleportProcess) initApps() {
 			ResourceMatchers:     process.Config.Apps.ResourceMatchers,
 			OnHeartbeat:          process.onHeartbeat(teleport.ComponentApp),
 			ConnectedProxyGetter: proxyGetter,
+			LockWatcher:          lockWatcher,
+			Emitter:              asyncEmitter,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4500,6 +4500,7 @@ func (process *TeleportProcess) initApps() {
 			log.Infof("Shutting down.")
 			warnOnErr(appServer.Close(), log)
 			agentPool.Stop()
+			warnOnErr(asyncEmitter.Close(), log)
 			warnOnErr(conn.Close(), log)
 			log.Infof("Exited.")
 		})

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -188,10 +188,10 @@ type Server struct {
 	heartbeats    map[string]*srv.Heartbeat
 	dynamicLabels map[string]*labels.Dynamic
 
+	connAuthMu sync.Mutex
 	// connAuth is used to map an initial failure of authorization to a connection.
 	// This will force the HTTP server to serve an error and close the connection.
-	connAuthMu sync.Mutex
-	connAuth   map[net.Conn]error
+	connAuth map[net.Conn]error
 
 	// apps are all apps this server currently proxies. Proxied apps are
 	// reconciled against monitoredApps below.
@@ -677,8 +677,7 @@ func (s *Server) handleConnection(conn net.Conn) (net.Conn, error) {
 }
 
 // monitorConn takes a TrackingReadConn and starts a connection monitor. The tracking connection will be
-// auto-terminated if disconnect_expired_cert or idle timeout is configured, and unmodified client connection
-// otherwise.
+// auto-terminated if disconnect_expired_cert or idle timeout is configured.
 func (s *Server) monitorConn(ctx context.Context, tc *srv.TrackingReadConn, authCtx *auth.Context) error {
 	authPref, err := s.c.AuthClient.GetAuthPreference(ctx)
 	if err != nil {

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -617,9 +617,11 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	// httpServer will initiate the close call.
 	closerConn := utils.NewCloserConn(conn)
 
-	tlsConn, err := s.handleConnection(closerConn)
-	// Make sure that the conn auth error is cleaned up.
-	defer s.deleteConnAuth(tlsConn)
+	cleanup, err := s.handleConnection(closerConn)
+	// Make sure that the cleanup function is run
+	if cleanup != nil {
+		defer cleanup()
+	}
 
 	if err != nil {
 		s.log.WithError(err).Warnf("Failed to handle client connection.")
@@ -633,7 +635,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	closerConn.Wait()
 }
 
-func (s *Server) handleConnection(conn net.Conn) (net.Conn, error) {
+func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 	// Make sure everything here is wrapped in the tracking read connection for monitoring.
 	ctx, cancel := context.WithCancel(s.closeContext)
 	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
@@ -650,19 +652,26 @@ func (s *Server) handleConnection(conn net.Conn) (net.Conn, error) {
 	// extract it and run authorization checks on it.
 	tlsConn, user, app, err := s.getConnectionInfo(ctx, tc)
 	if err != nil {
-		return tlsConn, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	authCtx, _, err := s.authorizeContext(context.WithValue(ctx, auth.ContextUser, user))
+
+	// The behavior here is a little hard to track. To be clear here, if authorization fails
+	// the following will occur:
+	// 1. If the application is a TCP application, error out immediately as expected.
+	// 2. If the application is an HTTP application, store the error and let the HTTP handler
+	//    serve the error directly so that it's properly converted to an HTTP status code.
+	//    This will ensure users will get a 403 when authorization fails.
 	if err != nil {
 		if !app.IsTCP() {
 			s.setConnAuth(tlsConn, err)
 		} else {
-			return tlsConn, trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	} else {
 		err = s.monitorConn(ctx, tc, authCtx)
 		if err != nil {
-			return tlsConn, trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 
@@ -670,10 +679,12 @@ func (s *Server) handleConnection(conn net.Conn) (net.Conn, error) {
 	// differently than HTTP requests from web apps.
 	if app.IsTCP() {
 		identity := authCtx.Identity.GetIdentity()
-		return tlsConn, s.handleTCPApp(ctx, tlsConn, &identity, app)
+		return nil, s.handleTCPApp(ctx, tlsConn, &identity, app)
 	}
 
-	return tlsConn, s.handleHTTPApp(ctx, tlsConn)
+	return func() {
+		s.deleteConnAuth(tlsConn)
+	}, s.handleHTTPApp(ctx, tlsConn)
 }
 
 // monitorConn takes a TrackingReadConn and starts a connection monitor. The tracking connection will be
@@ -749,7 +760,11 @@ func (s *Server) handleHTTPApp(ctx context.Context, conn net.Conn) error {
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// See if the initial auth failed. If it didn't, serve the HTTP regularly, which
 	// will include subsequent auth attempts to prevent race-type conditions.
-	err := s.getAndDeleteConnAuth(r.Context().Value(connContextKey).(net.Conn))
+	conn, ok := r.Context().Value(connContextKey).(net.Conn)
+	if !ok {
+		s.log.Errorf("unable to extract connection from context")
+	}
+	err := s.getAndDeleteConnAuth(conn)
 	if err == nil {
 		err = s.serveHTTP(w, r)
 	}

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -20,11 +20,9 @@ limitations under the License.
 package app
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
-	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -52,6 +50,12 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/aws"
+)
+
+type appServerContextKey string
+
+const (
+	connContextKey appServerContextKey = "teleport-connContextKey"
 )
 
 // Config is the configuration for an application server.
@@ -184,6 +188,11 @@ type Server struct {
 	heartbeats    map[string]*srv.Heartbeat
 	dynamicLabels map[string]*labels.Dynamic
 
+	// connAuth is used to map an initial failure of authorization to a connection.
+	// This will force the HTTP server to serve an error and close the connection.
+	connAuthMu sync.Mutex
+	connAuth   map[net.Conn]error
+
 	// apps are all apps this server currently proxies. Proxied apps are
 	// reconciled against monitoredApps below.
 	apps map[string]types.Application
@@ -252,6 +261,7 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		heartbeats:    make(map[string]*srv.Heartbeat),
 		dynamicLabels: make(map[string]*labels.Dynamic),
 		apps:          make(map[string]types.Application),
+		connAuth:      make(map[net.Conn]error),
 		awsSigner:     awsSigner,
 		monitoredApps: monitoredApps{
 			static: c.Apps,
@@ -579,6 +589,26 @@ func (s *Server) ForceHeartbeat() error {
 	return nil
 }
 
+func (s *Server) getAndDeleteConnAuth(conn net.Conn) error {
+	s.connAuthMu.Lock()
+	defer s.connAuthMu.Unlock()
+	err := s.connAuth[conn]
+	delete(s.connAuth, conn)
+	return err
+}
+
+func (s *Server) setConnAuth(conn net.Conn, err error) {
+	s.connAuthMu.Lock()
+	defer s.connAuthMu.Unlock()
+	s.connAuth[conn] = err
+}
+
+func (s *Server) deleteConnAuth(conn net.Conn) {
+	s.connAuthMu.Lock()
+	defer s.connAuthMu.Unlock()
+	delete(s.connAuth, conn)
+}
+
 // HandleConnection takes a connection and wraps it in a listener so it can
 // be passed to http.Serve to process as a HTTP request.
 func (s *Server) HandleConnection(conn net.Conn) {
@@ -587,7 +617,11 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	// httpServer will initiate the close call.
 	closerConn := utils.NewCloserConn(conn)
 
-	if err := s.handleConnection(closerConn); err != nil {
+	tlsConn, err := s.handleConnection(closerConn)
+	// Make sure that the conn auth error is cleaned up.
+	defer s.deleteConnAuth(tlsConn)
+
+	if err != nil {
 		s.log.WithError(err).Warnf("Failed to handle client connection.")
 		if err := conn.Close(); err != nil {
 			s.log.WithError(err).Warnf("Failed to close client connection.")
@@ -599,7 +633,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	closerConn.Wait()
 }
 
-func (s *Server) handleConnection(conn net.Conn) error {
+func (s *Server) handleConnection(conn net.Conn) (net.Conn, error) {
 	// Make sure everything here is wrapped in the tracking read connection for monitoring.
 	ctx, cancel := context.WithCancel(s.closeContext)
 	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
@@ -609,54 +643,37 @@ func (s *Server) handleConnection(conn net.Conn) error {
 		Cancel:  cancel,
 	})
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	// Proxy sends a X.509 client certificate to pass identity information,
 	// extract it and run authorization checks on it.
 	tlsConn, user, app, err := s.getConnectionInfo(ctx, tc)
 	if err != nil {
-		return trace.Wrap(err)
+		return tlsConn, trace.Wrap(err)
 	}
 	authCtx, _, err := s.authorizeContext(context.WithValue(ctx, auth.ContextUser, user))
 	if err != nil {
-		// If the app is not TCP, write an HTTP error response and return nil instead of the error.
-		// This will ensure that HTTP clients will see a "403 Forbidden" code and message and not a 500.
 		if !app.IsTCP() {
-			code := trace.ErrorToCode(err)
-			resp := http.Response{
-				StatusCode: code,
-				Body:       io.NopCloser(bytes.NewReader([]byte(http.StatusText(code)))),
-			}
-			if writeErr := resp.Write(tlsConn); writeErr != nil {
-				s.log.Warnf("error writing HTTP response: %v", writeErr)
-			}
-
-			// Since we're not passing this connection to the http server, we should close
-			// the connection explicitly here.
-			if closeErr := conn.Close(); closeErr != nil {
-				s.log.Warnf("error closing connection: %v", closeErr)
-			}
-
-			return nil
+			s.setConnAuth(tlsConn, err)
+		} else {
+			return tlsConn, trace.Wrap(err)
 		}
-
-		return trace.Wrap(err)
-	}
-
-	err = s.monitorConn(ctx, tc, authCtx)
-	if err != nil {
-		return trace.Wrap(err)
+	} else {
+		err = s.monitorConn(ctx, tc, authCtx)
+		if err != nil {
+			return tlsConn, trace.Wrap(err)
+		}
 	}
 
 	// Application access supports plain TCP connections which are handled
 	// differently than HTTP requests from web apps.
 	if app.IsTCP() {
 		identity := authCtx.Identity.GetIdentity()
-		return s.handleTCPApp(ctx, tlsConn, &identity, app)
+		return tlsConn, s.handleTCPApp(ctx, tlsConn, &identity, app)
 	}
 
-	return s.handleHTTPApp(ctx, tlsConn)
+	return tlsConn, s.handleHTTPApp(ctx, tlsConn)
 }
 
 // monitorConn takes a TrackingReadConn and starts a connection monitor. The tracking connection will be
@@ -731,11 +748,19 @@ func (s *Server) handleHTTPApp(ctx context.Context, conn net.Conn) error {
 
 // ServeHTTP will forward the *http.Request to the target application.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if err := s.serveHTTP(w, r); err != nil {
+	// See if the initial auth failed. If it didn't, serve the HTTP regularly, which
+	// will include subsequent auth attempts to prevent race-type conditions.
+	err := s.getAndDeleteConnAuth(r.Context().Value(connContextKey).(net.Conn))
+	if err == nil {
+		err = s.serveHTTP(w, r)
+	}
+	if err != nil {
 		s.log.Warnf("Failed to serve request: %v.", err)
 
-		// Covert trace error type to HTTP and write response.
+		// Covert trace error type to HTTP and write response, make sure we close the
+		// connection afterwards so that the monitor is recreated if needed.
 		code := trace.ErrorToCode(err)
+		w.Header().Set("Connection", "close")
 		http.Error(w, http.StatusText(code), code)
 	}
 }
@@ -936,6 +961,9 @@ func (s *Server) newHTTPServer() *http.Server {
 		Handler:           httplib.MakeTracingHandler(s.authMiddleware, teleport.ComponentApp),
 		ReadHeaderTimeout: apidefaults.DefaultDialTimeout,
 		ErrorLog:          utils.NewStdlogger(s.log.Error, teleport.ComponentApp),
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			return context.WithValue(ctx, connContextKey, c)
+		},
 	}
 }
 

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -297,6 +297,8 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		apps = config.Apps
 	}
 
+	discard := events.NewDiscardEmitter()
+
 	s.appServer, err = New(s.closeContext, &Config{
 		Clock:            s.clock,
 		DataDir:          s.dataDir,
@@ -313,6 +315,8 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		Cloud:            &testCloud{},
 		ResourceMatchers: config.ResourceMatchers,
 		OnReconcile:      config.OnReconcile,
+		LockWatcher:      lockWatcher,
+		Emitter:          discard,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Application access connection monitoring has been introduced so that, when a lock is created, application access connections will be interrupted until the lock has been cleared. This includes web sockets and TCP applications.