### PR TITLE
Ensure that PingConn conform to io.Reader

### DIFF
--- a/lib/srv/alpnproxy/conn.go
+++ b/lib/srv/alpnproxy/conn.go
@@ -131,7 +131,7 @@ func (c *PingConn) Read(p []byte) (int, error) {
 
 	err := c.discardPingReads()
 	if err != nil {
-		return 0, trace.Wrap(err)
+		return 0, err
 	}
 
 	// Check if the current size is larger than the provided buffer.
@@ -160,7 +160,7 @@ func (c *PingConn) discardPingReads() error {
 	for c.currentSize == 0 {
 		err := binary.Read(c.Conn, binary.BigEndian, &c.currentSize)
 		if err != nil {
-			return trace.Wrap(err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
Implementations of io.Reader should return io.EOF directly when the end of the stream is reached, because callers will compare the error using ==.