### PR TITLE
Added the ability to supply Access Request TTLs

### DIFF
--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -46,11 +46,11 @@ type AccessRequest interface {
 	GetCreationTime() time.Time
 	// SetCreationTime sets the creation time of the request.
 	SetCreationTime(time.Time)
-	// GetAccessExpiry gets the upper limit for which this request
-	// may be considered active.
+	// GetAccessExpiry gets the expiration time for the elevated certificate
+	// that will be issued if the Access Request is approved.
 	GetAccessExpiry() time.Time
-	// SetAccessExpiry sets the upper limit for which this request
-	// may be considered active.
+	// SetAccessExpiry sets the expiration time for the elevated certificate
+	// that will be issued if the Access Request is approved.
 	SetAccessExpiry(time.Time)
 	// GetRequestReason gets the reason for the request's creation.
 	GetRequestReason() string

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -76,6 +76,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -5631,7 +5632,7 @@ func testSessionStartContainsAccessRequest(t *testing.T, suite *integrationTestS
 
 	accessRequestID := req.GetName()
 
-	err = authServer.CreateAccessRequest(context.TODO(), req)
+	err = authServer.CreateAccessRequest(context.TODO(), req, tlsca.Identity{})
 	require.NoError(t, err)
 
 	err = authServer.SetAccessRequestState(context.TODO(), types.AccessRequestUpdate{

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2188,7 +2188,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 		traits = user.GetTraits()
 
 	} else if req.AccessRequestID != "" {
-		accessRequest, err := a.getValidatedAccessRequest(ctx, req.User, req.AccessRequestID)
+		accessRequest, err := a.getValidatedAccessRequest(ctx, identity, req.User, req.AccessRequestID)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2264,7 +2264,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 	return sess, nil
 }
 
-func (a *Server) getValidatedAccessRequest(ctx context.Context, user, accessRequestID string) (types.AccessRequest, error) {
+func (a *Server) getValidatedAccessRequest(ctx context.Context, identity tlsca.Identity, user string, accessRequestID string) (types.AccessRequest, error) {
 	reqFilter := types.AccessRequestFilter{
 		User: user,
 		ID:   accessRequestID,
@@ -2288,7 +2288,7 @@ func (a *Server) getValidatedAccessRequest(ctx context.Context, user, accessRequ
 		return nil, trace.AccessDenied("access request %q is awaiting approval", accessRequestID)
 	}
 
-	if err := services.ValidateAccessRequestForUser(ctx, a, req); err != nil {
+	if err := services.ValidateAccessRequestForUser(ctx, a.clock, a, req, identity); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -2850,34 +2850,16 @@ func (a *Server) DeleteNamespace(namespace string) error {
 	return a.Services.DeleteNamespace(namespace)
 }
 
-func (a *Server) CreateAccessRequest(ctx context.Context, req types.AccessRequest) error {
-	if err := services.ValidateAccessRequestForUser(ctx, a, req,
-		// if request is in state pending, variable expansion must be applied
-		services.ExpandVars(req.GetState().IsPending()),
-	); err != nil {
-		return trace.Wrap(err)
-	}
-
-	ttl, err := a.calculateMaxAccessTTL(ctx, req)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+func (a *Server) CreateAccessRequest(ctx context.Context, req types.AccessRequest, identity tlsca.Identity) error {
 	now := a.clock.Now().UTC()
+
 	req.SetCreationTime(now)
-	exp := now.Add(ttl)
-	// Set acccess expiry if an allowable default was not provided.
-	if req.GetAccessExpiry().Before(now) || req.GetAccessExpiry().After(exp) {
-		req.SetAccessExpiry(exp)
-	}
-	// By default, resource expiry should match access expiry.
-	req.SetExpiry(req.GetAccessExpiry())
-	// If the access-request is in a pending state, then the expiry of the underlying resource
-	// is capped to to PendingAccessDuration in order to limit orphaned access requests.
-	if req.GetState().IsPending() {
-		pexp := now.Add(defaults.PendingAccessDuration)
-		if pexp.Before(req.Expiry()) {
-			req.SetExpiry(pexp)
-		}
+
+	// Always perform variable expansion on creation only, this ensures the
+	// access request that is reviewed is the same that is approved.
+	expandOpts := services.ExpandVars(true)
+	if err := services.ValidateAccessRequestForUser(ctx, a.clock, a, req, identity, expandOpts); err != nil {
+		return trace.Wrap(err)
 	}
 
 	if req.GetDryRun() {
@@ -2886,10 +2868,12 @@ func (a *Server) CreateAccessRequest(ctx context.Context, req types.AccessReques
 		return nil
 	}
 
+	log.Debugf("Creating Access Request %v with expiry %v.", req.GetName(), req.Expiry())
+
 	if err := a.Services.CreateAccessRequest(ctx, req); err != nil {
 		return trace.Wrap(err)
 	}
-	err = a.emitter.EmitAuditEvent(a.closeCtx, &apievents.AccessRequestCreate{
+	err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.AccessRequestCreate{
 		Metadata: apievents.Metadata{
 			Type: events.AccessRequestCreateEvent,
 			Code: events.AccessRequestCreateCode,
@@ -3022,29 +3006,11 @@ func (a *Server) SubmitAccessReview(ctx context.Context, params types.AccessRevi
 }
 
 func (a *Server) GetAccessCapabilities(ctx context.Context, req types.AccessCapabilitiesRequest) (*types.AccessCapabilities, error) {
-	caps, err := services.CalculateAccessCapabilities(ctx, a, req)
+	caps, err := services.CalculateAccessCapabilities(ctx, a.clock, a, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return caps, nil
-}
-
-// calculateMaxAccessTTL determines the maximum allowable TTL for a given access request
-// based on the MaxSessionTTLs of the roles being requested (a access request's life cannot
-// exceed the smallest allowable MaxSessionTTL value of the roles that it requests).
-func (a *Server) calculateMaxAccessTTL(ctx context.Context, req types.AccessRequest) (time.Duration, error) {
-	minTTL := defaults.MaxAccessDuration
-	for _, roleName := range req.GetRoles() {
-		role, err := a.GetRole(ctx, roleName)
-		if err != nil {
-			return 0, trace.Wrap(err)
-		}
-		roleTTL := time.Duration(role.GetOptions().MaxSessionTTL)
-		if roleTTL > 0 && roleTTL < minTTL {
-			minTTL = roleTTL
-		}
-	}
-	return minTTL, nil
 }
 
 // NewKeepAliver returns a new instance of keep aliver

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1923,11 +1923,7 @@ func (a *ServerWithRoles) CreateAccessRequest(ctx context.Context, req types.Acc
 			return trace.Wrap(err)
 		}
 	}
-	// Ensure that an access request cannot outlive the identity that creates it.
-	if req.GetAccessExpiry().Before(a.authServer.GetClock().Now()) || req.GetAccessExpiry().After(a.context.Identity.GetIdentity().Expires) {
-		req.SetAccessExpiry(a.context.Identity.GetIdentity().Expires)
-	}
-	return a.authServer.CreateAccessRequest(ctx, req)
+	return a.authServer.CreateAccessRequest(ctx, req, a.context.Identity.GetIdentity())
 }
 
 func (a *ServerWithRoles) SetAccessRequestState(ctx context.Context, params types.AccessRequestUpdate) error {
@@ -2335,7 +2331,7 @@ func (a *ServerWithRoles) desiredAccessInfoForUser(ctx context.Context, req *pro
 
 	for _, reqID := range finalRequestIDs {
 		// Fetch and validate the access request for this user.
-		accessRequest, err := a.authServer.getValidatedAccessRequest(ctx, req.Username, reqID)
+		accessRequest, err := a.authServer.getValidatedAccessRequest(ctx, currentIdentity, req.Username, reqID)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1371,6 +1371,7 @@ func TestWebSessionMultiAccessRequests(t *testing.T) {
 	roleReq, err := services.NewAccessRequest(username, requestableRoleName)
 	require.NoError(t, err)
 	roleReq.SetState(types.RequestState_APPROVED)
+	roleReq.SetAccessExpiry(tt.clock.Now().Add(8 * time.Hour))
 	err = clt.CreateAccessRequest(ctx, roleReq)
 	require.NoError(t, err)
 
@@ -1710,7 +1711,6 @@ func TestGetCertAuthority(t *testing.T) {
 	}, false)
 	require.NoError(t, err)
 	for _, keyPair := range ca.GetActiveKeys().TLS {
-		fmt.Printf("--> keyPair.Key: %v.\n", keyPair)
 		require.Nil(t, keyPair.Key)
 	}
 	for _, keyPair := range ca.GetActiveKeys().SSH {

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/vulcand/predicate"
 	"golang.org/x/exp/slices"
 
@@ -33,6 +34,8 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/parse"
 )
@@ -143,11 +146,11 @@ type DynamicAccessOracle interface {
 
 // CalculateAccessCapabilities aggregates the requested capabilities using the supplied getter
 // to load relevant resources.
-func CalculateAccessCapabilities(ctx context.Context, clt RequestValidatorGetter, req types.AccessCapabilitiesRequest) (*types.AccessCapabilities, error) {
+func CalculateAccessCapabilities(ctx context.Context, clock clockwork.Clock, clt RequestValidatorGetter, req types.AccessCapabilitiesRequest) (*types.AccessCapabilities, error) {
 	var caps types.AccessCapabilities
 	// all capabilities require use of a request validator.  calculating suggested reviewers
 	// requires that the validator be configured for variable expansion.
-	v, err := NewRequestValidator(ctx, clt, req.User, ExpandVars(req.SuggestedReviewers))
+	v, err := NewRequestValidator(ctx, clock, clt, req.User, ExpandVars(req.SuggestedReviewers))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -873,6 +876,7 @@ func (c *ReviewPermissionChecker) push(role types.Role) error {
 // a set of simple Allow/Deny datastructures.  These, in turn,
 // are used to validate and expand the access request.
 type RequestValidator struct {
+	clock         clockwork.Clock
 	getter        RequestValidatorGetter
 	user          types.User
 	requireReason bool
@@ -894,13 +898,14 @@ type RequestValidator struct {
 }
 
 // NewRequestValidator configures a new RequestValidor for the specified user.
-func NewRequestValidator(ctx context.Context, getter RequestValidatorGetter, username string, opts ...ValidateRequestOption) (RequestValidator, error) {
+func NewRequestValidator(ctx context.Context, clock clockwork.Clock, getter RequestValidatorGetter, username string, opts ...ValidateRequestOption) (RequestValidator, error) {
 	user, err := getter.GetUser(username, false)
 	if err != nil {
 		return RequestValidator{}, trace.Wrap(err)
 	}
 
 	m := RequestValidator{
+		clock:  clock,
 		getter: getter,
 		user:   user,
 	}
@@ -931,7 +936,7 @@ func NewRequestValidator(ctx context.Context, getter RequestValidatorGetter, use
 
 // Validate validates an access request and potentially modifies it depending on how
 // the validator was configured.
-func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest) error {
+func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest, identity tlsca.Identity) error {
 	if m.user.GetName() != req.GetUser() {
 		return trace.BadParameter("request validator configured for different user (this is a bug)")
 	}
@@ -1021,8 +1026,110 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 		if len(req.GetSuggestedReviewers()) == 0 {
 			req.SetSuggestedReviewers(apiutils.Deduplicate(m.SuggestedReviewers))
 		}
+
+		now := m.clock.Now().UTC()
+
+		// Calculate expiration time of the Access Request (how long it
+		// will await approval).
+		ttl, err := m.requestTTL(ctx, identity, req)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.SetExpiry(now.Add(ttl))
+
+		// Calculate expiration time of the elevated certificate that will
+		// be issued if the Access Request is approved.
+		ttl, err = m.sessionTTL(ctx, identity, req)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.SetAccessExpiry(now.Add(ttl))
 	}
+
 	return nil
+}
+
+// requestTTL calculates the TTL of the Access Request (how long it will await
+// approval).
+func (m *RequestValidator) requestTTL(ctx context.Context, identity tlsca.Identity, r types.AccessRequest) (time.Duration, error) {
+	// If no expiration provided, use default.
+	expiry := r.Expiry()
+	if expiry.IsZero() {
+		expiry = m.clock.Now().UTC().Add(defaults.PendingAccessDuration)
+	}
+
+	if expiry.Before(m.clock.Now().UTC()) {
+		return 0, trace.BadParameter("invalid request TTL: Access Request can not be created in the past")
+	}
+
+	ttl, err := m.truncateTTL(ctx, identity, expiry, r.GetRoles())
+	if err != nil {
+		return 0, trace.BadParameter("invalid request TTL: %v", err)
+	}
+
+	// Before returning the TTL, validate that the value requested was smaller
+	// than the maximum value allowed. Used to return a sensible error to the
+	// user.
+	requestedTTL := expiry.Sub(m.clock.Now().UTC())
+	if !r.Expiry().IsZero() && requestedTTL > ttl {
+		return 0, trace.BadParameter("invalid request TTL: %v greater than maximum allowed (%v)", requestedTTL.Round(time.Minute), ttl.Round(time.Minute))
+	}
+
+	return ttl, nil
+}
+
+// sessionTTL calculates the TTL of the elevated certificate that will be issued
+// if the Access Request is approved.
+func (m *RequestValidator) sessionTTL(ctx context.Context, identity tlsca.Identity, r types.AccessRequest) (time.Duration, error) {
+	ttl, err := m.truncateTTL(ctx, identity, r.GetAccessExpiry(), r.GetRoles())
+	if err != nil {
+		return 0, trace.BadParameter("invalid session TTL: %v", err)
+	}
+
+	// Before returning the TTL, validate that the value requested was smaller
+	// than the maximum value allowed. Used to return a sensible error to the
+	// user.
+	requestedTTL := r.GetAccessExpiry().Sub(m.clock.Now().UTC())
+	if !r.GetAccessExpiry().IsZero() && requestedTTL > ttl {
+		return 0, trace.BadParameter("invalid session TTL: %v greater than maximum allowed (%v)", requestedTTL.Round(time.Minute), ttl.Round(time.Minute))
+	}
+
+	return ttl, nil
+}
+
+// truncateTTL will truncate given expiration by identity expiration and
+// shortest session TTL of any role.
+func (m *RequestValidator) truncateTTL(ctx context.Context, identity tlsca.Identity, expiry time.Time, roles []string) (time.Duration, error) {
+	ttl := apidefaults.MaxCertDuration
+
+	// Reduce by remaining TTL on requesting certificate (identity).
+	identityTTL := identity.Expires.Sub(m.clock.Now())
+	if identityTTL > 0 && identityTTL < ttl {
+		ttl = identityTTL
+	}
+
+	// Reduce TTL further if expiration time requested is shorter than that
+	// identity.
+	expiryTTL := expiry.Sub(m.clock.Now())
+	if expiryTTL > 0 && expiryTTL < ttl {
+		ttl = expiryTTL
+	}
+
+	// Loop over the roles requested by the user and reduce certificate TTL
+	// further. Follow the typical Teleport RBAC pattern of strictest setting
+	// wins.
+	for _, roleName := range roles {
+		role, err := m.getter.GetRole(ctx, roleName)
+		if err != nil {
+			return 0, trace.Wrap(err)
+		}
+		roleTTL := time.Duration(role.GetOptions().MaxSessionTTL)
+		if roleTTL > 0 && roleTTL < ttl {
+			ttl = roleTTL
+		}
+	}
+
+	return ttl, nil
 }
 
 // GetRequestableRoles gets the list of all existent roles which the user is
@@ -1283,12 +1390,12 @@ func ExpandVars(expand bool) ValidateRequestOption {
 // *statically assigned* roles. If expandRoles is true, it will also expand wildcard
 // requests, setting their role list to include all roles the user is allowed to request.
 // Expansion should be performed before an access request is initially placed in the backend.
-func ValidateAccessRequestForUser(ctx context.Context, getter RequestValidatorGetter, req types.AccessRequest, opts ...ValidateRequestOption) error {
-	v, err := NewRequestValidator(ctx, getter, req.GetUser(), opts...)
+func ValidateAccessRequestForUser(ctx context.Context, clock clockwork.Clock, getter RequestValidatorGetter, req types.AccessRequest, identity tlsca.Identity, opts ...ValidateRequestOption) error {
+	v, err := NewRequestValidator(ctx, clock, getter, req.GetUser(), opts...)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(v.Validate(ctx, req))
+	return trace.Wrap(v.Validate(ctx, req, identity))
 }
 
 // UnmarshalAccessRequest unmarshals the AccessRequest resource from JSON.

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -20,15 +20,19 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 // mockGetter mocks the UserAndRoleGetter interface.
@@ -218,6 +222,10 @@ func TestReviewThresholds(t *testing.T) {
 				Roles: []string{"dictator"},
 				Where: `contains(request.system_annotations["mechanisms"],"coup") || contains(request.system_annotations["mechanism"],"treachery")`,
 			},
+		},
+		// never is the role that will never be requested
+		"never": {
+			// ...
 		},
 	}
 
@@ -528,12 +536,17 @@ func TestReviewThresholds(t *testing.T) {
 		req, err := types.NewAccessRequest("some-id", tt.requestor, tt.roles...)
 		require.NoError(t, err, "scenario=%q", tt.desc)
 
+		clock := clockwork.NewFakeClock()
+		identity := tlsca.Identity{
+			Expires: clock.Now().UTC().Add(8 * time.Hour),
+		}
+
 		// perform request validation (necessary in order to initialize internal
 		// request variables like annotations and thresholds).
-		validator, err := NewRequestValidator(context.Background(), g, tt.requestor, ExpandVars(true))
+		validator, err := NewRequestValidator(context.Background(), clock, g, tt.requestor, ExpandVars(true))
 		require.NoError(t, err, "scenario=%q", tt.desc)
 
-		require.NoError(t, validator.Validate(context.Background(), req), "scenario=%q", tt.desc)
+		require.NoError(t, validator.Validate(context.Background(), req, identity), "scenario=%q", tt.desc)
 
 	Inner:
 		for ri, rt := range tt.reviews {
@@ -935,6 +948,10 @@ func TestRolesForResourceRequest(t *testing.T) {
 				},
 			},
 		},
+		// splunk-super-admins is a role that will never be requested
+		"splunk-super-admins": {
+			// ...
+		},
 	}
 	roles := make(map[string]types.Role)
 	for name, spec := range roleDesc {
@@ -1034,10 +1051,15 @@ func TestRolesForResourceRequest(t *testing.T) {
 				"some-id", user.GetName(), tc.requestRoles, tc.requestResourceIDs)
 			require.NoError(t, err)
 
-			validator, err := NewRequestValidator(context.Background(), g, user.GetName(), ExpandVars(true))
+			clock := clockwork.NewFakeClock()
+			identity := tlsca.Identity{
+				Expires: clock.Now().UTC().Add(8 * time.Hour),
+			}
+
+			validator, err := NewRequestValidator(context.Background(), clock, g, user.GetName(), ExpandVars(true))
 			require.NoError(t, err)
 
-			err = validator.Validate(context.Background(), req)
+			err = validator.Validate(context.Background(), req, identity)
 			require.ErrorIs(t, err, tc.expectError)
 			if err != nil {
 				return
@@ -1393,10 +1415,15 @@ func TestPruneRequestRoles(t *testing.T) {
 
 			req.SetLoginHint(tc.loginHint)
 
-			accessCaps, err := CalculateAccessCapabilities(ctx, g, types.AccessCapabilitiesRequest{User: user, ResourceIDs: tc.requestResourceIDs})
+			clock := clockwork.NewFakeClock()
+			identity := tlsca.Identity{
+				Expires: clock.Now().UTC().Add(8 * time.Hour),
+			}
+
+			accessCaps, err := CalculateAccessCapabilities(ctx, clock, g, types.AccessCapabilitiesRequest{User: user, ResourceIDs: tc.requestResourceIDs})
 			require.NoError(t, err)
 
-			err = ValidateAccessRequestForUser(ctx, g, req, ExpandVars(true))
+			err = ValidateAccessRequestForUser(ctx, clock, g, req, identity, ExpandVars(true))
 			if tc.expectError {
 				require.Error(t, err)
 				return
@@ -1412,6 +1439,172 @@ func TestPruneRequestRoles(t *testing.T) {
 			require.Len(t, req.GetRoleThresholdMapping(), len(req.GetRoles()),
 				"Length of rtm does not match number of roles. rtm: %v roles %v",
 				req.GetRoleThresholdMapping(), req.GetRoles())
+		})
+	}
+}
+
+// TestRequestTTL verifies that the TTL for the Access Request gets reduced by
+// requested access time and lifetime of the requesting certificate.
+func TestRequestTTL(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	now := clock.Now().UTC()
+
+	tests := []struct {
+		desc          string
+		expiry        time.Time
+		identity      tlsca.Identity
+		maxSessionTTL time.Duration
+		expectedTTL   time.Duration
+		assertion     require.ErrorAssertionFunc
+	}{
+		{
+			desc:          "access request with ttl, below limit",
+			expiry:        now.Add(8 * time.Hour),
+			identity:      tlsca.Identity{Expires: now.Add(10 * time.Hour)},
+			maxSessionTTL: 10 * time.Hour,
+			expectedTTL:   8 * time.Hour,
+			assertion:     require.NoError,
+		},
+		{
+			desc:          "access request with ttl, above limit",
+			expiry:        now.Add(11 * time.Hour),
+			identity:      tlsca.Identity{Expires: now.Add(10 * time.Hour)},
+			maxSessionTTL: 10 * time.Hour,
+			assertion:     require.Error,
+		},
+		{
+			desc:          "access request without ttl (default ttl)",
+			expiry:        time.Time{},
+			identity:      tlsca.Identity{Expires: now.Add(10 * time.Hour)},
+			maxSessionTTL: 10 * time.Hour,
+			expectedTTL:   defaults.PendingAccessDuration,
+			assertion:     require.NoError,
+		},
+		{
+			desc:          "access request without ttl (default ttl), truncation by identity expiration",
+			expiry:        time.Time{},
+			identity:      tlsca.Identity{Expires: now.Add(12 * time.Minute)},
+			maxSessionTTL: 13 * time.Minute,
+			expectedTTL:   12 * time.Minute,
+			assertion:     require.NoError,
+		},
+		{
+			desc:          "access request without ttl (default ttl), truncation by role max session ttl",
+			expiry:        time.Time{},
+			identity:      tlsca.Identity{Expires: now.Add(14 * time.Hour)},
+			maxSessionTTL: 13 * time.Minute,
+			expectedTTL:   13 * time.Minute,
+			assertion:     require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			// Setup test user "foo" and "bar" and the mock auth server that
+			// will return users and roles.
+			user, err := types.NewUser("foo")
+			require.NoError(t, err)
+			user.SetRoles([]string{"bar"})
+
+			role, err := types.NewRole("bar", types.RoleSpecV5{
+				Options: types.RoleOptions{
+					MaxSessionTTL: types.NewDuration(tt.maxSessionTTL),
+				},
+			})
+			require.NoError(t, err)
+
+			getter := &mockGetter{
+				users: map[string]types.User{"foo": user},
+				roles: map[string]types.Role{"bar": role},
+			}
+
+			validator, err := NewRequestValidator(context.Background(), clock, getter, "foo", ExpandVars(true))
+			require.NoError(t, err)
+
+			request, err := types.NewAccessRequest("some-id", "foo", "bar")
+			request.SetExpiry(tt.expiry)
+			require.NoError(t, err)
+
+			ttl, err := validator.requestTTL(context.Background(), tt.identity, request)
+			tt.assertion(t, err)
+			if err == nil {
+				require.Equal(t, tt.expectedTTL, ttl)
+			}
+		})
+	}
+}
+
+// TestSessionTTL verifies that the TTL for elevated access gets reduced by
+// requested access time, lifetime of certificate, and strictest session TTL on
+// any role.
+func TestSessionTTL(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	now := clock.Now().UTC()
+
+	tests := []struct {
+		desc          string
+		accessExpiry  time.Time
+		identity      tlsca.Identity
+		maxSessionTTL time.Duration
+		expectedTTL   time.Duration
+		assertion     require.ErrorAssertionFunc
+	}{
+		{
+			desc:          "less than identity expiration and role session ttl allowed",
+			accessExpiry:  now.Add(13 * time.Minute),
+			identity:      tlsca.Identity{Expires: now.Add(defaults.MaxAccessDuration)},
+			maxSessionTTL: defaults.MaxAccessDuration,
+			expectedTTL:   13 * time.Minute,
+			assertion:     require.NoError,
+		},
+		{
+			desc:          "greater than identity expiration and role session ttl not allowed",
+			accessExpiry:  now.Add(14 * time.Minute),
+			identity:      tlsca.Identity{Expires: now.Add(13 * time.Minute)},
+			maxSessionTTL: 13 * time.Minute,
+			assertion:     require.Error,
+		},
+		{
+			desc:          "greater than certificate duration not allowed",
+			accessExpiry:  now.Add(defaults.MaxAccessDuration).Add(1 * time.Minute),
+			identity:      tlsca.Identity{Expires: now.Add(defaults.MaxAccessDuration)},
+			maxSessionTTL: defaults.MaxAccessDuration,
+			assertion:     require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			// Setup test user "foo" and "bar" and the mock auth server that
+			// will return users and roles.
+			user, err := types.NewUser("foo")
+			require.NoError(t, err)
+			user.SetRoles([]string{"bar"})
+
+			role, err := types.NewRole("bar", types.RoleSpecV5{
+				Options: types.RoleOptions{
+					MaxSessionTTL: types.NewDuration(tt.maxSessionTTL),
+				},
+			})
+			require.NoError(t, err)
+
+			getter := &mockGetter{
+				users: map[string]types.User{"foo": user},
+				roles: map[string]types.Role{"bar": role},
+			}
+
+			validator, err := NewRequestValidator(context.Background(), clock, getter, "foo", ExpandVars(true))
+			require.NoError(t, err)
+
+			request, err := types.NewAccessRequest("some-id", "foo", "bar")
+			request.SetAccessExpiry(tt.accessExpiry)
+			require.NoError(t, err)
+
+			ttl, err := validator.sessionTTL(context.Background(), tt.identity, request)
+			tt.assertion(t, err)
+			if err == nil {
+				require.Equal(t, tt.expectedTTL, ttl)
+			}
 		})
 	}
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -6643,11 +6643,15 @@ func TestUserContextWithAccessRequest(t *testing.T) {
 	err = env.server.Auth().UpsertRole(ctx, requestableRole)
 	require.NoError(t, err)
 
+	identity := tlsca.Identity{
+		Expires: env.clock.Now().Add(1 * time.Hour),
+	}
+
 	// Create and approve an access request for the requestable role.
 	accessReq, err := services.NewAccessRequest(username, requestableRolename)
 	require.NoError(t, err)
 	accessReq.SetState(types.RequestState_APPROVED)
-	err = env.server.Auth().CreateAccessRequest(ctx, accessReq)
+	err = env.server.Auth().CreateAccessRequest(ctx, accessReq, identity)
 	require.NoError(t, err)
 
 	// Get the ID of the created and approved access request.

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
@@ -34,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 // AccessRequestCommand implements `tctl users` set of commands
@@ -264,7 +266,7 @@ func (c *AccessRequestCommand) Create(ctx context.Context, client auth.ClientI) 
 	req.SetRequestReason(c.reason)
 
 	if c.dryRun {
-		err = services.ValidateAccessRequestForUser(ctx, client, req, services.ExpandVars(true))
+		err = services.ValidateAccessRequestForUser(ctx, clockwork.NewRealClock(), client, req, tlsca.Identity{}, services.ExpandVars(true))
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -400,6 +402,8 @@ func printRequestsOverview(reqs []types.AccessRequest, format string) error {
 			"[+]",
 			"Requested resources truncated, use the `tctl requests get` subcommand to view the full list")
 		table.AddColumn(asciitable.Column{Title: "Created At (UTC)"})
+		table.AddColumn(asciitable.Column{Title: "Request TTL"})
+		table.AddColumn(asciitable.Column{Title: "Session TTL"})
 		table.AddColumn(asciitable.Column{Title: "Status"})
 		table.AddColumn(asciitable.Column{
 			Title:         "Request Reason",
@@ -426,6 +430,8 @@ func printRequestsOverview(reqs []types.AccessRequest, format string) error {
 				fmt.Sprintf("roles=%s", strings.Join(req.GetRoles(), ",")),
 				resourceIDsString,
 				req.GetCreationTime().Format(time.RFC822),
+				time.Until(req.Expiry()).Round(time.Minute).String(),
+				time.Until(req.GetAccessExpiry()).Round(time.Minute).String(),
 				req.GetState().String(),
 				quoteOrDefault(req.GetRequestReason(), ""),
 				quoteOrDefault(req.GetResolveReason(), ""),

--- a/tool/tsh/access_request.go
+++ b/tool/tsh/access_request.go
@@ -341,6 +341,8 @@ func showRequestTable(reqs []types.AccessRequest) error {
 	table.AddFootnote("[+]",
 		"Requested resources truncated, use `tsh request show <request-id>` to view the full list")
 	table.AddColumn(asciitable.Column{Title: "Created At (UTC)"})
+	table.AddColumn(asciitable.Column{Title: "Request TTL"})
+	table.AddColumn(asciitable.Column{Title: "Session TTL"})
 	table.AddColumn(asciitable.Column{Title: "Status"})
 	now := time.Now()
 	for _, req := range reqs {
@@ -357,6 +359,8 @@ func showRequestTable(reqs []types.AccessRequest) error {
 			strings.Join(req.GetRoles(), ","),
 			resourceIDsString,
 			req.GetCreationTime().UTC().Format(time.RFC822),
+			time.Until(req.Expiry()).Round(time.Minute).String(),
+			time.Until(req.GetAccessExpiry()).Round(time.Minute).String(),
 			req.GetState().String(),
 		})
 	}


### PR DESCRIPTION
Added the ability to specify two CLI flags for Access Requests: `--request-ttl` and `--session-ttl`.

Updated `CreateAccessRequest` to adhere to the following rules.

If an Access Request does not have a TTL set (expiration time `types.AccessRequest` resource itself), a default of 1 hour is used. Next, the request value is truncated by the lifetime of the certificate, requested expiration, and then strictest session TTL on all roles requested.

Similar logic is followed for the expiration time of the elevated certificate that will be issued if the Access Request is approved. First the requested value is truncated by the lifetime of the certificate, requested expiration, and then strictest session TTL on all roles requested.

The output of `tsh requests ls` and `tctl requests ls` has been updated to display the TTL value.