### PR TITLE
Reorganise web test code for use outside repo

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -63,7 +63,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
@@ -114,26 +113,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-const hostID = "00000000-0000-0000-0000-000000000000"
-
-type WebSuite struct {
-	ctx    context.Context
-	cancel context.CancelFunc
-
-	node        *regular.Server
-	proxy       *regular.Server
-	proxyTunnel reversetunnel.Server
-	srvID       string
-
-	user      string
-	webServer *httptest.Server
-
-	mockU2F     *mocku2f.Key
-	server      *auth.TestServer
-	proxyClient *auth.Client
-	clock       clockwork.FakeClock
-}
-
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise it will run tests as normal.
 func TestMain(m *testing.M) {
@@ -148,381 +127,6 @@ func TestMain(m *testing.M) {
 	// Otherwise run tests as normal.
 	code := m.Run()
 	os.Exit(code)
-}
-
-func newWebSuite(t *testing.T) *WebSuite {
-	mockU2F, err := mocku2f.Create()
-	require.NoError(t, err)
-	require.NotNil(t, mockU2F)
-
-	u, err := user.Current()
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	s := &WebSuite{
-		mockU2F: mockU2F,
-		clock:   clockwork.NewFakeClock(),
-		user:    u.Username,
-		ctx:     ctx,
-		cancel:  cancel,
-	}
-
-	networkingConfig, err := types.NewClusterNetworkingConfigFromConfigFile(types.ClusterNetworkingConfigSpecV2{
-		KeepAliveInterval: types.Duration(10 * time.Second),
-	})
-	require.NoError(t, err)
-
-	s.server, err = auth.NewTestServer(auth.TestServerConfig{
-		Auth: auth.TestAuthServerConfig{
-			ClusterName:             "localhost",
-			Dir:                     t.TempDir(),
-			Clock:                   s.clock,
-			ClusterNetworkingConfig: networkingConfig,
-		},
-	})
-	require.NoError(t, err)
-
-	// Register the auth server, since test auth server doesn't start its own
-	// heartbeat.
-	err = s.server.Auth().UpsertAuthServer(&types.ServerV2{
-		Kind:    types.KindAuthServer,
-		Version: types.V2,
-		Metadata: types.Metadata{
-			Namespace: apidefaults.Namespace,
-			Name:      "auth",
-		},
-		Spec: types.ServerSpecV2{
-			Addr:     s.server.TLS.Listener.Addr().String(),
-			Hostname: "localhost",
-			Version:  teleport.Version,
-		},
-	})
-	require.NoError(t, err)
-
-	priv, pub, err := testauthority.New().GenerateKeyPair()
-	require.NoError(t, err)
-
-	tlsPub, err := auth.PrivateKeyToPublicKeyTLS(priv)
-	require.NoError(t, err)
-
-	// start node
-	certs, err := s.server.Auth().GenerateHostCerts(s.ctx,
-		&authproto.HostCertsRequest{
-			HostID:       hostID,
-			NodeName:     s.server.ClusterName(),
-			Role:         types.RoleNode,
-			PublicSSHKey: pub,
-			PublicTLSKey: tlsPub,
-		})
-	require.NoError(t, err)
-
-	signer, err := sshutils.NewSigner(priv, certs.SSH)
-	require.NoError(t, err)
-
-	nodeID := "node"
-	nodeClient, err := s.server.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
-			Role:     types.RoleNode,
-			Username: nodeID,
-		},
-	})
-	require.NoError(t, err)
-
-	nodeLockWatcher, err := services.NewLockWatcher(s.ctx, services.LockWatcherConfig{
-		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: teleport.ComponentNode,
-			Client:    nodeClient,
-		},
-	})
-	require.NoError(t, err)
-
-	// create SSH service:
-	nodeDataDir := t.TempDir()
-	node, err := regular.New(
-		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
-		s.server.ClusterName(),
-		[]ssh.Signer{signer},
-		nodeClient,
-		nodeDataDir,
-		"",
-		utils.NetAddr{},
-		nodeClient,
-		regular.SetUUID(nodeID),
-		regular.SetNamespace(apidefaults.Namespace),
-		regular.SetShell("/bin/sh"),
-		regular.SetEmitter(nodeClient),
-		regular.SetPAMConfig(&pam.Config{Enabled: false}),
-		regular.SetBPF(&bpf.NOP{}),
-		regular.SetRestrictedSessionManager(&restricted.NOP{}),
-		regular.SetClock(s.clock),
-		regular.SetLockWatcher(nodeLockWatcher),
-	)
-	require.NoError(t, err)
-	s.node = node
-	s.srvID = node.ID()
-	require.NoError(t, s.node.Start())
-	require.NoError(t, auth.CreateUploaderDir(nodeDataDir))
-
-	// create reverse tunnel service:
-	proxyID := "proxy"
-	s.proxyClient, err = s.server.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
-			Role:     types.RoleProxy,
-			Username: proxyID,
-		},
-	})
-	require.NoError(t, err)
-
-	revTunListener, err := net.Listen("tcp", fmt.Sprintf("%v:0", s.server.ClusterName()))
-	require.NoError(t, err)
-
-	proxyLockWatcher, err := services.NewLockWatcher(s.ctx, services.LockWatcherConfig{
-		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: teleport.ComponentProxy,
-			Client:    s.proxyClient,
-		},
-	})
-	require.NoError(t, err)
-
-	proxyNodeWatcher, err := services.NewNodeWatcher(s.ctx, services.NodeWatcherConfig{
-		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: teleport.ComponentProxy,
-			Client:    s.proxyClient,
-		},
-	})
-	require.NoError(t, err)
-
-	caWatcher, err := services.NewCertAuthorityWatcher(s.ctx, services.CertAuthorityWatcherConfig{
-		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: teleport.ComponentProxy,
-			Client:    s.proxyClient,
-		},
-		Types: []types.CertAuthType{types.HostCA, types.UserCA},
-	})
-	require.NoError(t, err)
-	defer caWatcher.Close()
-
-	revTunServer, err := reversetunnel.NewServer(reversetunnel.Config{
-		ID:                    node.ID(),
-		Listener:              revTunListener,
-		ClientTLS:             s.proxyClient.TLSConfig(),
-		ClusterName:           s.server.ClusterName(),
-		HostSigners:           []ssh.Signer{signer},
-		LocalAuthClient:       s.proxyClient,
-		LocalAccessPoint:      s.proxyClient,
-		Emitter:               s.proxyClient,
-		NewCachingAccessPoint: noCache,
-		DataDir:               t.TempDir(),
-		LockWatcher:           proxyLockWatcher,
-		NodeWatcher:           proxyNodeWatcher,
-		CertAuthorityWatcher:  caWatcher,
-		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
-		LocalAuthAddresses:    []string{s.server.TLS.Listener.Addr().String()},
-	})
-	require.NoError(t, err)
-	s.proxyTunnel = revTunServer
-
-	// proxy server:
-	s.proxy, err = regular.New(
-		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
-		s.server.ClusterName(),
-		[]ssh.Signer{signer},
-		s.proxyClient,
-		t.TempDir(),
-		"",
-		utils.NetAddr{},
-		s.proxyClient,
-		regular.SetUUID(proxyID),
-		regular.SetProxyMode("", revTunServer, s.proxyClient),
-		regular.SetEmitter(s.proxyClient),
-		regular.SetNamespace(apidefaults.Namespace),
-		regular.SetBPF(&bpf.NOP{}),
-		regular.SetRestrictedSessionManager(&restricted.NOP{}),
-		regular.SetClock(s.clock),
-		regular.SetLockWatcher(proxyLockWatcher),
-		regular.SetNodeWatcher(proxyNodeWatcher),
-	)
-	require.NoError(t, err)
-
-	// Expired sessions are purged immediately
-	var sessionLingeringThreshold time.Duration
-	fs, err := NewDebugFileSystem("../../webassets/teleport")
-	require.NoError(t, err)
-	handler, err := NewHandler(Config{
-		Proxy:                           revTunServer,
-		AuthServers:                     utils.FromAddr(s.server.TLS.Addr()),
-		DomainName:                      s.server.ClusterName(),
-		ProxyClient:                     s.proxyClient,
-		CipherSuites:                    utils.DefaultCipherSuites(),
-		AccessPoint:                     s.proxyClient,
-		Context:                         s.ctx,
-		HostUUID:                        proxyID,
-		Emitter:                         s.proxyClient,
-		StaticFS:                        fs,
-		cachedSessionLingeringThreshold: &sessionLingeringThreshold,
-		ProxySettings:                   &mockProxySettings{},
-	}, SetSessionStreamPollPeriod(200*time.Millisecond), SetClock(s.clock))
-	require.NoError(t, err)
-
-	s.webServer = httptest.NewUnstartedServer(handler)
-	s.webServer.StartTLS()
-	err = s.proxy.Start()
-	require.NoError(t, err)
-
-	// Wait for proxy to fully register before starting the test.
-	for start := time.Now(); ; {
-		proxies, err := s.proxyClient.GetProxies()
-		require.NoError(t, err)
-		if len(proxies) != 0 {
-			break
-		}
-		if time.Since(start) > 5*time.Second {
-			t.Fatal("proxy didn't register within 5s after startup")
-		}
-	}
-
-	proxyAddr := utils.MustParseAddr(s.proxy.Addr())
-
-	addr := utils.MustParseAddr(s.webServer.Listener.Addr().String())
-	handler.handler.cfg.ProxyWebAddr = *addr
-	handler.handler.cfg.ProxySSHAddr = *proxyAddr
-	_, sshPort, err := net.SplitHostPort(proxyAddr.String())
-	require.NoError(t, err)
-	handler.handler.sshPort = sshPort
-
-	t.Cleanup(func() {
-		// In particular close the lock watchers by canceling the context.
-		s.cancel()
-
-		s.webServer.Close()
-
-		var errors []error
-		if err := s.proxyTunnel.Close(); err != nil {
-			errors = append(errors, err)
-		}
-		if err := s.node.Close(); err != nil {
-			errors = append(errors, err)
-		}
-		s.webServer.Close()
-		if err := s.proxy.Close(); err != nil {
-			errors = append(errors, err)
-		}
-		if err := s.server.Shutdown(context.Background()); err != nil {
-			errors = append(errors, err)
-		}
-		require.Empty(t, errors)
-	})
-
-	return s
-}
-
-func noCache(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
-	return clt, nil
-}
-
-func (r *authPack) renewSession(ctx context.Context, t *testing.T) *roundtrip.Response {
-	resp, err := r.clt.PostJSON(ctx, r.clt.Endpoint("webapi", "sessions", "renew"), nil)
-	require.NoError(t, err)
-	return resp
-}
-
-func (r *authPack) validateAPI(ctx context.Context, t *testing.T) {
-	_, err := r.clt.Get(ctx, r.clt.Endpoint("webapi", "sites"), url.Values{})
-	require.NoError(t, err)
-}
-
-type authPack struct {
-	otpSecret string
-	user      string
-	login     string
-	password  string
-	session   *CreateSessionResponse
-	clt       *client.WebClient
-	cookies   []*http.Cookie
-}
-
-// authPack returns new authenticated package consisting of created valid
-// user, otp token, created web session and authenticated client.
-func (s *WebSuite) authPack(t *testing.T, user string) *authPack {
-	login := s.user
-	pass := "abc123"
-	rawSecret := "def456"
-	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
-
-	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
-		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorOTP,
-	})
-	require.NoError(t, err)
-	err = s.server.Auth().SetAuthPreference(s.ctx, ap)
-	require.NoError(t, err)
-
-	s.createUser(t, user, login, pass, otpSecret)
-
-	// create a valid otp token
-	validToken, err := totp.GenerateCode(otpSecret, s.clock.Now())
-	require.NoError(t, err)
-
-	clt := s.client()
-	req := CreateSessionReq{
-		User:              user,
-		Pass:              pass,
-		SecondFactorToken: validToken,
-	}
-
-	csrfToken := "2ebcb768d0090ea4368e42880c970b61865c326172a4a2343b645cf5d7f20992"
-	re, err := s.login(clt, csrfToken, csrfToken, req)
-	require.NoError(t, err)
-
-	var rawSess *CreateSessionResponse
-	require.NoError(t, json.Unmarshal(re.Bytes(), &rawSess))
-
-	sess, err := rawSess.response()
-	require.NoError(t, err)
-
-	jar, err := cookiejar.New(nil)
-	require.NoError(t, err)
-
-	clt = s.client(roundtrip.BearerAuth(sess.Token), roundtrip.CookieJar(jar))
-	jar.SetCookies(s.url(), re.Cookies())
-
-	return &authPack{
-		otpSecret: otpSecret,
-		user:      user,
-		login:     login,
-		session:   sess,
-		clt:       clt,
-		cookies:   re.Cookies(),
-	}
-}
-
-func (s *WebSuite) createUser(t *testing.T, user string, login string, pass string, otpSecret string) {
-	teleUser, err := types.NewUser(user)
-	require.NoError(t, err)
-	role := services.RoleForUser(teleUser)
-	role.SetLogins(types.Allow, []string{login})
-	options := role.GetOptions()
-	options.ForwardAgent = types.NewBool(true)
-	role.SetOptions(options)
-	err = s.server.Auth().UpsertRole(s.ctx, role)
-	require.NoError(t, err)
-	teleUser.AddRole(role.GetName())
-
-	teleUser.SetCreatedBy(types.CreatedBy{
-		User: types.UserRef{Name: "some-auth-user"},
-	})
-	err = s.server.Auth().CreateUser(s.ctx, teleUser)
-	require.NoError(t, err)
-
-	err = s.server.Auth().UpsertPassword(user, []byte(pass))
-	require.NoError(t, err)
-
-	if otpSecret != "" {
-		dev, err := services.NewTOTPDevice("otp", otpSecret, s.clock.Now())
-		require.NoError(t, err)
-		err = s.server.Auth().UpsertMFADevice(context.Background(), user, dev)
-		require.NoError(t, err)
-	}
 }
 
 func TestValidRedirectURL(t *testing.T) {
@@ -599,7 +203,7 @@ func TestSAML(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			s := newWebSuite(t)
+			s := NewTestWebSuite(t)
 			input := tc.rawConnector
 
 			decoder := kyaml.NewYAMLOrJSONDecoder(strings.NewReader(input), defaults.LookaheadBufSize)
@@ -706,7 +310,7 @@ func TestSAML(t *testing.T) {
 
 func TestWebSessionsCRUD(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	pack := s.authPack(t, "foo")
 
 	// make sure we can use client to make authenticated requests
@@ -730,7 +334,7 @@ func TestWebSessionsCRUD(t *testing.T) {
 
 func TestCSRF(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	type input struct {
 		reqToken    string
 		cookieToken string
@@ -776,7 +380,7 @@ func TestCSRF(t *testing.T) {
 
 func TestPasswordChange(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	pack := s.authPack(t, "foo")
 
 	// invalidate the token
@@ -818,7 +422,7 @@ func TestValidateBearerToken(t *testing.T) {
 
 func TestWebSessionsBadInput(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	user := "bob"
 	pass := "abc123"
 	rawSecret := "def456"
@@ -950,7 +554,7 @@ func TestClusterAlertsGet(t *testing.T) {
 
 func TestSiteNodeConnectInvalidSessionID(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	_, err := s.makeTerminal(t, s.authPack(t, "foo"), withSessionID(session.ID("/../../../foo")))
 	require.Error(t, err)
 }
@@ -1135,7 +739,7 @@ func TestNewTerminalHandler(t *testing.T) {
 
 func TestResizeTerminal(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	sid := session.NewID()
 
 	// Create a new user "foo", open a terminal to a new session, and wait for
@@ -1210,7 +814,7 @@ func TestResizeTerminal(t *testing.T) {
 // TestTerminalPing tests that the server sends continuous ping control messages.
 func TestTerminalPing(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	ws, err := s.makeTerminal(t, s.authPack(t, "foo"), withKeepaliveInterval(500*time.Millisecond))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, ws.Close()) })
@@ -1252,7 +856,7 @@ func TestTerminalPing(t *testing.T) {
 
 func TestTerminal(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	ws, err := s.makeTerminal(t, s.authPack(t, "foo"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, ws.Close()) })
@@ -1526,7 +1130,7 @@ func handleMFAWebauthnChallenge(t *testing.T, ws *websocket.Conn, dev *auth.Test
 
 func TestWebAgentForward(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	ws, err := s.makeTerminal(t, s.authPack(t, "foo"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, ws.Close()) })
@@ -1543,7 +1147,7 @@ func TestWebAgentForward(t *testing.T) {
 
 func TestActiveSessions(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	sid := session.NewID()
 	pack := s.authPack(t, "foo")
 
@@ -1588,7 +1192,7 @@ func TestActiveSessions(t *testing.T) {
 
 func TestCloseConnectionsOnLogout(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	sid := session.NewID()
 	pack := s.authPack(t, "foo")
 
@@ -1677,7 +1281,7 @@ func TestCreateSession(t *testing.T) {
 
 func TestPlayback(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	pack := s.authPack(t, "foo")
 	sid := session.NewID()
 	ws, err := s.makeTerminal(t, pack, withSessionID(sid))
@@ -1687,7 +1291,7 @@ func TestPlayback(t *testing.T) {
 
 func TestLogin(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
 		SecondFactor: constants.SecondFactorOff,
@@ -1775,7 +1379,7 @@ func TestLogin(t *testing.T) {
 // /webapi/motd work when no MotD is set
 func TestEmptyMotD(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	wc := s.client()
 
 	// Given an auth server configured *not* to expose a Message Of The
@@ -1806,7 +1410,7 @@ func TestMotD(t *testing.T) {
 	t.Parallel()
 	const motd = "Hello. I'm a Teleport cluster!"
 
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	wc := s.client()
 
 	// Given an auth server configured to expose a Message Of The Day...
@@ -1836,7 +1440,7 @@ func TestMotD(t *testing.T) {
 
 func TestMultipleConnectors(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	wc := s.client()
 
 	// create two oidc connectors, one named "foo" and another named "bar"
@@ -2004,7 +1608,7 @@ func (f byTimeAndIndex) Swap(i, j int) {
 func TestSearchClusterEvents(t *testing.T) {
 	t.Parallel()
 
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	clock := s.clock
 	sessionEvents := events.GenerateTestSession(events.SessionParams{
 		PrintEvents: 3,
@@ -2136,7 +1740,7 @@ func TestSearchClusterEvents(t *testing.T) {
 
 func TestGetClusterDetails(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	site, err := s.proxyTunnel.GetSite(s.server.ClusterName())
 	require.NoError(t, err)
 	require.NotNil(t, site)
@@ -3350,7 +2954,7 @@ func TestCreateRegisterChallenge(t *testing.T) {
 // be exchanged for an application specific session.
 func TestCreateAppSession(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := NewTestWebSuite(t)
 	pack := s.authPack(t, "foo@example.com")
 
 	// Register an application called "panel".
@@ -4478,65 +4082,6 @@ func (mock authProviderMock) GetSessionTracker(ctx context.Context, sessionID st
 	return nil, trace.NotFound("foo")
 }
 
-type terminalOpt func(t *TerminalRequest)
-
-func withSessionID(sid session.ID) terminalOpt {
-	return func(t *TerminalRequest) { t.SessionID = sid }
-}
-
-func withKeepaliveInterval(d time.Duration) terminalOpt {
-	return func(t *TerminalRequest) { t.KeepAliveInterval = d }
-}
-
-func (s *WebSuite) makeTerminal(t *testing.T, pack *authPack, opts ...terminalOpt) (*websocket.Conn, error) {
-	req := TerminalRequest{
-		Server: s.srvID,
-		Login:  pack.login,
-		Term: session.TerminalParams{
-			W: 100,
-			H: 100,
-		},
-		SessionID: session.NewID(),
-	}
-	for _, opt := range opts {
-		opt(&req)
-	}
-
-	u := url.URL{
-		Host:   s.url().Host,
-		Scheme: client.WSS,
-		Path:   fmt.Sprintf("/v1/webapi/sites/%v/connect", currentSiteShortcut),
-	}
-	data, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-
-	q := u.Query()
-	q.Set("params", string(data))
-	q.Set(roundtrip.AccessTokenQueryParam, pack.session.Token)
-	u.RawQuery = q.Encode()
-
-	dialer := websocket.Dialer{}
-	dialer.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: true,
-	}
-
-	header := http.Header{}
-	header.Add("Origin", "http://localhost")
-	for _, cookie := range pack.cookies {
-		header.Add("Cookie", cookie.String())
-	}
-
-	ws, resp, err := dialer.Dial(u.String(), header)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	require.NoError(t, resp.Body.Close())
-	return ws, nil
-}
-
 func waitForOutput(stream *terminalStream, substr string) error {
 	timeoutCh := time.After(10 * time.Second)
 
@@ -4556,203 +4101,6 @@ func waitForOutput(stream *terminalStream, substr string) error {
 			return nil
 		}
 	}
-}
-
-func (s *WebSuite) waitForRawEvent(ws *websocket.Conn, timeout time.Duration) error {
-	timeoutContext, timeoutCancel := context.WithTimeout(s.ctx, timeout)
-	defer timeoutCancel()
-
-	done := make(chan error, 1)
-
-	go func() {
-		for {
-			ty, raw, err := ws.ReadMessage()
-			if err != nil {
-				done <- trace.Wrap(err)
-				return
-			}
-
-			if ty != websocket.BinaryMessage {
-				done <- trace.BadParameter("expected binary message, got %v", ty)
-				return
-			}
-
-			var envelope Envelope
-			err = proto.Unmarshal(raw, &envelope)
-			if err != nil {
-				done <- trace.Wrap(err)
-				return
-			}
-
-			if envelope.GetType() == defaults.WebsocketRaw {
-				done <- nil
-				return
-			}
-		}
-	}()
-
-	for {
-		select {
-		case <-timeoutContext.Done():
-			return trace.BadParameter("timeout waiting for raw event")
-		case err := <-done:
-			return trace.Wrap(err)
-		}
-	}
-}
-
-func (s *WebSuite) waitForResizeEvent(ws *websocket.Conn, timeout time.Duration) error {
-	timeoutContext, timeoutCancel := context.WithTimeout(s.ctx, timeout)
-	defer timeoutCancel()
-
-	done := make(chan error, 1)
-
-	go func() {
-		for {
-			ty, raw, err := ws.ReadMessage()
-			if err != nil {
-				done <- trace.Wrap(err)
-				return
-			}
-
-			if ty != websocket.BinaryMessage {
-				done <- trace.BadParameter("expected binary message, got %v", ty)
-				return
-			}
-
-			var envelope Envelope
-			err = proto.Unmarshal(raw, &envelope)
-			if err != nil {
-				done <- trace.Wrap(err)
-				return
-			}
-
-			if envelope.GetType() != defaults.WebsocketAudit {
-				continue
-			}
-
-			var e events.EventFields
-			err = json.Unmarshal([]byte(envelope.GetPayload()), &e)
-			if err != nil {
-				done <- trace.Wrap(err)
-				return
-			}
-
-			if e.GetType() == events.ResizeEvent {
-				done <- nil
-				return
-			}
-		}
-	}()
-
-	for {
-		select {
-		case <-timeoutContext.Done():
-			return trace.BadParameter("timeout waiting for resize event")
-		case err := <-done:
-			return trace.Wrap(err)
-		}
-	}
-}
-
-func (s *WebSuite) listenForResizeEvent(ws *websocket.Conn) chan struct{} {
-	ch := make(chan struct{})
-
-	go func() {
-		for {
-			ty, raw, err := ws.ReadMessage()
-			if err != nil {
-				close(ch)
-				return
-			}
-
-			if ty != websocket.BinaryMessage {
-				close(ch)
-				return
-			}
-
-			var envelope Envelope
-			err = proto.Unmarshal(raw, &envelope)
-			if err != nil {
-				close(ch)
-				return
-			}
-
-			if envelope.GetType() != defaults.WebsocketAudit {
-				continue
-			}
-
-			var e events.EventFields
-			err = json.Unmarshal([]byte(envelope.GetPayload()), &e)
-			if err != nil {
-				close(ch)
-				return
-			}
-
-			if e.GetType() == events.ResizeEvent {
-				ch <- struct{}{}
-				return
-			}
-		}
-	}()
-
-	return ch
-}
-
-func (s *WebSuite) clientNoRedirects(opts ...roundtrip.ClientParam) *client.WebClient {
-	hclient := client.NewInsecureWebClient()
-	hclient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
-	opts = append(opts, roundtrip.HTTPClient(hclient))
-	wc, err := client.NewWebClient(s.url().String(), opts...)
-	if err != nil {
-		panic(err)
-	}
-	return wc
-}
-
-func (s *WebSuite) client(opts ...roundtrip.ClientParam) *client.WebClient {
-	opts = append(opts, roundtrip.HTTPClient(client.NewInsecureWebClient()))
-	wc, err := client.NewWebClient(s.url().String(), opts...)
-	if err != nil {
-		panic(err)
-	}
-	return wc
-}
-
-func (s *WebSuite) login(clt *client.WebClient, cookieToken string, reqToken string, reqData interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(clt.RoundTrip(func() (*http.Response, error) {
-		data, err := json.Marshal(reqData)
-		if err != nil {
-			return nil, err
-		}
-		req, err := http.NewRequest("POST", clt.Endpoint("webapi", "sessions"), bytes.NewBuffer(data))
-		if err != nil {
-			return nil, err
-		}
-		addCSRFCookieToReq(req, cookieToken)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set(csrf.HeaderName, reqToken)
-		return clt.HTTPClient().Do(req)
-	}))
-}
-
-func (s *WebSuite) url() *url.URL {
-	u, err := url.Parse("https://" + s.webServer.Listener.Addr().String())
-	if err != nil {
-		panic(err)
-	}
-	return u
-}
-
-func addCSRFCookieToReq(req *http.Request, token string) {
-	cookie := &http.Cookie{
-		Name:  csrf.CookieName,
-		Value: token,
-	}
-
-	req.AddCookie(cookie)
 }
 
 func removeSpace(in string) string {
@@ -4780,10 +4128,6 @@ func decodeSessionCookie(t *testing.T, value string) (sessionID string) {
 	}
 	require.NoError(t, json.Unmarshal(sessionBytes, &cookie))
 	return cookie.SessionID
-}
-
-func (r CreateSessionResponse) response() (*CreateSessionResponse, error) {
-	return &CreateSessionResponse{TokenType: r.TokenType, Token: r.Token, TokenExpiresIn: r.TokenExpiresIn, SessionInactiveTimeoutMS: r.SessionInactiveTimeoutMS}, nil
 }
 
 func newWebPack(t *testing.T, numProxies int) *webPack {
@@ -5322,12 +4666,6 @@ func validateTerminalStream(t *testing.T, conn *websocket.Conn) {
 
 	err = waitForOutput(stream, "foo")
 	require.NoError(t, err)
-}
-
-type mockProxySettings struct{}
-
-func (mock *mockProxySettings) GetProxySettings(ctx context.Context) (*webclient.ProxySettings, error) {
-	return &webclient.ProxySettings{}, nil
 }
 
 // TestUserContextWithAccessRequest checks that the userContext includes the ID of the

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -35,17 +35,17 @@ func (h *Handler) samlSSO(w http.ResponseWriter, r *http.Request, p httprouter.P
 	logger := h.log.WithField("auth", "saml")
 	logger.Debug("Web login start.")
 
-	req, err := parseSSORequestParams(r)
+	req, err := ParseSSORequestParams(r)
 	if err != nil {
 		logger.WithError(err).Error("Failed to extract SSO parameters from request.")
 		return client.LoginFailedRedirectURL
 	}
 
 	response, err := h.cfg.ProxyClient.CreateSAMLAuthRequest(r.Context(), types.SAMLAuthRequest{
-		ConnectorID:       req.connectorID,
-		CSRFToken:         req.csrfToken,
+		ConnectorID:       req.ConnectorID,
+		CSRFToken:         req.CSRFToken,
 		CreateWebSession:  true,
-		ClientRedirectURL: req.clientRedirectURL,
+		ClientRedirectURL: req.ClientRedirectURL,
 	})
 	if err != nil {
 		logger.WithError(err).Error("Error creating auth request.")
@@ -62,12 +62,12 @@ func (h *Handler) samlSSOConsole(w http.ResponseWriter, r *http.Request, p httpr
 	req := new(client.SSOLoginConsoleReq)
 	if err := httplib.ReadJSON(r, req); err != nil {
 		logger.WithError(err).Error("Error reading json.")
-		return nil, trace.AccessDenied(ssoLoginConsoleErr)
+		return nil, trace.AccessDenied(SSOLoginConsoleErr)
 	}
 
 	if err := req.CheckAndSetDefaults(); err != nil {
 		logger.WithError(err).Error("Missing request parameters.")
-		return nil, trace.AccessDenied(ssoLoginConsoleErr)
+		return nil, trace.AccessDenied(SSOLoginConsoleErr)
 	}
 
 	response, err := h.cfg.ProxyClient.CreateSAMLAuthRequest(r.Context(), types.SAMLAuthRequest{
@@ -82,7 +82,7 @@ func (h *Handler) samlSSOConsole(w http.ResponseWriter, r *http.Request, p httpr
 	})
 	if err != nil {
 		logger.WithError(err).Error("Failed to create SAML auth request.")
-		return nil, trace.AccessDenied(ssoLoginConsoleErr)
+		return nil, trace.AccessDenied(SSOLoginConsoleErr)
 	}
 
 	return &client.SSOLoginConsoleResponse{RedirectURL: response.RedirectURL}, nil
@@ -109,7 +109,7 @@ func (h *Handler) samlACS(w http.ResponseWriter, r *http.Request, p httprouter.P
 		// this improves the UX by terminating the failed SSO flow immediately, rather than hoping for a timeout.
 		if requestID, errParse := auth.ParseSAMLInResponseTo(samlResponse); errParse == nil {
 			if request, errGet := h.cfg.ProxyClient.GetSAMLAuthRequest(r.Context(), requestID); errGet == nil && !request.CreateWebSession {
-				if url, errEnc := redirectURLWithError(request.ClientRedirectURL, err); errEnc == nil {
+				if url, errEnc := RedirectURLWithError(request.ClientRedirectURL, err); errEnc == nil {
 					return url.String()
 				}
 			}
@@ -131,19 +131,19 @@ func (h *Handler) samlACS(w http.ResponseWriter, r *http.Request, p httprouter.P
 			redirect = "/web/"
 		}
 
-		res := &ssoCallbackResponse{
-			csrfToken:         response.Req.CSRFToken,
-			username:          response.Username,
-			sessionName:       response.Session.GetName(),
-			clientRedirectURL: redirect,
+		res := &SSOCallbackResponse{
+			CSRFToken:         response.Req.CSRFToken,
+			Username:          response.Username,
+			SessionName:       response.Session.GetName(),
+			ClientRedirectURL: redirect,
 		}
 
-		if err := ssoSetWebSessionAndRedirectURL(w, r, res, response.Req.CSRFToken != ""); err != nil {
+		if err := SSOSetWebSessionAndRedirectURL(w, r, res, response.Req.CSRFToken != ""); err != nil {
 			logger.WithError(err).Error("Error setting web session.")
 			return client.LoginFailedRedirectURL
 		}
 
-		return res.clientRedirectURL
+		return res.ClientRedirectURL
 	}
 
 	logger.Debug("Callback redirecting to console login.")

--- a/lib/web/websuite.go
+++ b/lib/web/websuite.go
@@ -1,0 +1,716 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base32"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"os/user"
+	"testing"
+	"time"
+
+	proto "github.com/gogo/protobuf/proto"
+	"github.com/gorilla/websocket"
+	"github.com/gravitational/roundtrip"
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/breaker"
+	authproto "github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
+	"github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/mocku2f"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/httplib/csrf"
+	"github.com/gravitational/teleport/lib/pam"
+	restricted "github.com/gravitational/teleport/lib/restrictedsession"
+	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/srv/regular"
+	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+const hostID = "00000000-0000-0000-0000-000000000000"
+
+// TestWebSuite is a suite of components for testing the web package. It exists
+// as an exported struct not in a _test.go file so that it can be used from
+// outside this package by external packages that extend the web API (such as
+// SAML and OIDC auth connectors in the enterprise edition).
+type TestWebSuite struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	node        *regular.Server
+	proxy       *regular.Server
+	proxyTunnel reversetunnel.Server
+	srvID       string
+
+	user      string
+	webServer *httptest.Server
+
+	mockU2F     *mocku2f.Key
+	server      *auth.TestServer
+	proxyClient *auth.Client
+	clock       clockwork.FakeClock
+}
+
+func NewTestWebSuite(t *testing.T) *TestWebSuite {
+	mockU2F, err := mocku2f.Create()
+	require.NoError(t, err)
+	require.NotNil(t, mockU2F)
+
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &TestWebSuite{
+		mockU2F: mockU2F,
+		clock:   clockwork.NewFakeClock(),
+		user:    u.Username,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+
+	networkingConfig, err := types.NewClusterNetworkingConfigFromConfigFile(types.ClusterNetworkingConfigSpecV2{
+		KeepAliveInterval: types.Duration(10 * time.Second),
+	})
+	require.NoError(t, err)
+
+	s.server, err = auth.NewTestServer(auth.TestServerConfig{
+		Auth: auth.TestAuthServerConfig{
+			ClusterName:             "localhost",
+			Dir:                     t.TempDir(),
+			Clock:                   s.clock,
+			ClusterNetworkingConfig: networkingConfig,
+		},
+	})
+	require.NoError(t, err)
+
+	// Register the auth server, since test auth server doesn't start its own
+	// heartbeat.
+	err = s.server.Auth().UpsertAuthServer(&types.ServerV2{
+		Kind:    types.KindAuthServer,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Namespace: apidefaults.Namespace,
+			Name:      "auth",
+		},
+		Spec: types.ServerSpecV2{
+			Addr:     s.server.TLS.Listener.Addr().String(),
+			Hostname: "localhost",
+			Version:  teleport.Version,
+		},
+	})
+	require.NoError(t, err)
+
+	priv, pub, err := testauthority.New().GenerateKeyPair()
+	require.NoError(t, err)
+
+	tlsPub, err := auth.PrivateKeyToPublicKeyTLS(priv)
+	require.NoError(t, err)
+
+	// start node
+	certs, err := s.server.Auth().GenerateHostCerts(s.ctx,
+		&authproto.HostCertsRequest{
+			HostID:       hostID,
+			NodeName:     s.server.ClusterName(),
+			Role:         types.RoleNode,
+			PublicSSHKey: pub,
+			PublicTLSKey: tlsPub,
+		})
+	require.NoError(t, err)
+
+	signer, err := sshutils.NewSigner(priv, certs.SSH)
+	require.NoError(t, err)
+
+	nodeID := "node"
+	nodeClient, err := s.server.NewClient(auth.TestIdentity{
+		I: auth.BuiltinRole{
+			Role:     types.RoleNode,
+			Username: nodeID,
+		},
+	})
+	require.NoError(t, err)
+
+	nodeLockWatcher, err := services.NewLockWatcher(s.ctx, services.LockWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentNode,
+			Client:    nodeClient,
+		},
+	})
+	require.NoError(t, err)
+
+	// create SSH service:
+	nodeDataDir := t.TempDir()
+	node, err := regular.New(
+		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
+		s.server.ClusterName(),
+		[]ssh.Signer{signer},
+		nodeClient,
+		nodeDataDir,
+		"",
+		utils.NetAddr{},
+		nodeClient,
+		regular.SetUUID(nodeID),
+		regular.SetNamespace(apidefaults.Namespace),
+		regular.SetShell("/bin/sh"),
+		regular.SetEmitter(nodeClient),
+		regular.SetPAMConfig(&pam.Config{Enabled: false}),
+		regular.SetBPF(&bpf.NOP{}),
+		regular.SetRestrictedSessionManager(&restricted.NOP{}),
+		regular.SetClock(s.clock),
+		regular.SetLockWatcher(nodeLockWatcher),
+	)
+	require.NoError(t, err)
+	s.node = node
+	s.srvID = node.ID()
+	require.NoError(t, s.node.Start())
+	require.NoError(t, auth.CreateUploaderDir(nodeDataDir))
+
+	// create reverse tunnel service:
+	proxyID := "proxy"
+	s.proxyClient, err = s.server.NewClient(auth.TestIdentity{
+		I: auth.BuiltinRole{
+			Role:     types.RoleProxy,
+			Username: proxyID,
+		},
+	})
+	require.NoError(t, err)
+
+	revTunListener, err := net.Listen("tcp", fmt.Sprintf("%v:0", s.server.ClusterName()))
+	require.NoError(t, err)
+
+	proxyLockWatcher, err := services.NewLockWatcher(s.ctx, services.LockWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentProxy,
+			Client:    s.proxyClient,
+		},
+	})
+	require.NoError(t, err)
+
+	proxyNodeWatcher, err := services.NewNodeWatcher(s.ctx, services.NodeWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentProxy,
+			Client:    s.proxyClient,
+		},
+	})
+	require.NoError(t, err)
+
+	caWatcher, err := services.NewCertAuthorityWatcher(s.ctx, services.CertAuthorityWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentProxy,
+			Client:    s.proxyClient,
+		},
+		Types: []types.CertAuthType{types.HostCA, types.UserCA},
+	})
+	require.NoError(t, err)
+	defer caWatcher.Close()
+
+	revTunServer, err := reversetunnel.NewServer(reversetunnel.Config{
+		ID:                    node.ID(),
+		Listener:              revTunListener,
+		ClientTLS:             s.proxyClient.TLSConfig(),
+		ClusterName:           s.server.ClusterName(),
+		HostSigners:           []ssh.Signer{signer},
+		LocalAuthClient:       s.proxyClient,
+		LocalAccessPoint:      s.proxyClient,
+		Emitter:               s.proxyClient,
+		NewCachingAccessPoint: noCache,
+		DataDir:               t.TempDir(),
+		LockWatcher:           proxyLockWatcher,
+		NodeWatcher:           proxyNodeWatcher,
+		CertAuthorityWatcher:  caWatcher,
+		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
+		LocalAuthAddresses:    []string{s.server.TLS.Listener.Addr().String()},
+	})
+	require.NoError(t, err)
+	s.proxyTunnel = revTunServer
+
+	// proxy server:
+	s.proxy, err = regular.New(
+		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
+		s.server.ClusterName(),
+		[]ssh.Signer{signer},
+		s.proxyClient,
+		t.TempDir(),
+		"",
+		utils.NetAddr{},
+		s.proxyClient,
+		regular.SetUUID(proxyID),
+		regular.SetProxyMode("", revTunServer, s.proxyClient),
+		regular.SetEmitter(s.proxyClient),
+		regular.SetNamespace(apidefaults.Namespace),
+		regular.SetBPF(&bpf.NOP{}),
+		regular.SetRestrictedSessionManager(&restricted.NOP{}),
+		regular.SetClock(s.clock),
+		regular.SetLockWatcher(proxyLockWatcher),
+		regular.SetNodeWatcher(proxyNodeWatcher),
+	)
+	require.NoError(t, err)
+
+	// Expired sessions are purged immediately
+	var sessionLingeringThreshold time.Duration
+	fs, err := NewDebugFileSystem("../../webassets/teleport")
+	require.NoError(t, err)
+	handler, err := NewHandler(Config{
+		Proxy:                           revTunServer,
+		AuthServers:                     utils.FromAddr(s.server.TLS.Addr()),
+		DomainName:                      s.server.ClusterName(),
+		ProxyClient:                     s.proxyClient,
+		CipherSuites:                    utils.DefaultCipherSuites(),
+		AccessPoint:                     s.proxyClient,
+		Context:                         s.ctx,
+		HostUUID:                        proxyID,
+		Emitter:                         s.proxyClient,
+		StaticFS:                        fs,
+		cachedSessionLingeringThreshold: &sessionLingeringThreshold,
+		ProxySettings:                   &mockProxySettings{},
+	}, SetSessionStreamPollPeriod(200*time.Millisecond), SetClock(s.clock))
+	require.NoError(t, err)
+
+	s.webServer = httptest.NewUnstartedServer(handler)
+	s.webServer.StartTLS()
+	err = s.proxy.Start()
+	require.NoError(t, err)
+
+	// Wait for proxy to fully register before starting the test.
+	for start := time.Now(); ; {
+		proxies, err := s.proxyClient.GetProxies()
+		require.NoError(t, err)
+		if len(proxies) != 0 {
+			break
+		}
+		if time.Since(start) > 5*time.Second {
+			t.Fatal("proxy didn't register within 5s after startup")
+		}
+	}
+
+	proxyAddr := utils.MustParseAddr(s.proxy.Addr())
+
+	addr := utils.MustParseAddr(s.webServer.Listener.Addr().String())
+	handler.handler.cfg.ProxyWebAddr = *addr
+	handler.handler.cfg.ProxySSHAddr = *proxyAddr
+	_, sshPort, err := net.SplitHostPort(proxyAddr.String())
+	require.NoError(t, err)
+	handler.handler.sshPort = sshPort
+
+	t.Cleanup(func() {
+		// In particular close the lock watchers by canceling the context.
+		s.cancel()
+
+		s.webServer.Close()
+
+		var errors []error
+		if err := s.proxyTunnel.Close(); err != nil {
+			errors = append(errors, err)
+		}
+		if err := s.node.Close(); err != nil {
+			errors = append(errors, err)
+		}
+		s.webServer.Close()
+		if err := s.proxy.Close(); err != nil {
+			errors = append(errors, err)
+		}
+		if err := s.server.Shutdown(context.Background()); err != nil {
+			errors = append(errors, err)
+		}
+		require.Empty(t, errors)
+	})
+
+	return s
+}
+
+func noCache(clt auth.ClientI, cacheName []string) (auth.RemoteProxyAccessPoint, error) {
+	return clt, nil
+}
+
+func (r *authPack) renewSession(ctx context.Context, t *testing.T) *roundtrip.Response {
+	resp, err := r.clt.PostJSON(ctx, r.clt.Endpoint("webapi", "sessions", "renew"), nil)
+	require.NoError(t, err)
+	return resp
+}
+
+func (r *authPack) validateAPI(ctx context.Context, t *testing.T) {
+	_, err := r.clt.Get(ctx, r.clt.Endpoint("webapi", "sites"), url.Values{})
+	require.NoError(t, err)
+}
+
+type authPack struct {
+	otpSecret string
+	user      string
+	login     string
+	password  string
+	session   *CreateSessionResponse
+	clt       *client.WebClient
+	cookies   []*http.Cookie
+}
+
+// authPack returns new authenticated package consisting of created valid
+// user, otp token, created web session and authenticated client.
+func (s *TestWebSuite) authPack(t *testing.T, user string) *authPack {
+	login := s.user
+	pass := "abc123"
+	rawSecret := "def456"
+	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
+
+	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
+		Type:         constants.Local,
+		SecondFactor: constants.SecondFactorOTP,
+	})
+	require.NoError(t, err)
+	err = s.server.Auth().SetAuthPreference(s.ctx, ap)
+	require.NoError(t, err)
+
+	s.createUser(t, user, login, pass, otpSecret)
+
+	// create a valid otp token
+	validToken, err := totp.GenerateCode(otpSecret, s.clock.Now())
+	require.NoError(t, err)
+
+	clt := s.client()
+	req := CreateSessionReq{
+		User:              user,
+		Pass:              pass,
+		SecondFactorToken: validToken,
+	}
+
+	csrfToken := "2ebcb768d0090ea4368e42880c970b61865c326172a4a2343b645cf5d7f20992"
+	re, err := s.login(clt, csrfToken, csrfToken, req)
+	require.NoError(t, err)
+
+	var rawSess *CreateSessionResponse
+	require.NoError(t, json.Unmarshal(re.Bytes(), &rawSess))
+
+	sess, err := rawSess.response()
+	require.NoError(t, err)
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	clt = s.client(roundtrip.BearerAuth(sess.Token), roundtrip.CookieJar(jar))
+	jar.SetCookies(s.url(), re.Cookies())
+
+	return &authPack{
+		otpSecret: otpSecret,
+		user:      user,
+		login:     login,
+		session:   sess,
+		clt:       clt,
+		cookies:   re.Cookies(),
+	}
+}
+
+func (s *TestWebSuite) createUser(t *testing.T, user string, login string, pass string, otpSecret string) {
+	teleUser, err := types.NewUser(user)
+	require.NoError(t, err)
+	role := services.RoleForUser(teleUser)
+	role.SetLogins(types.Allow, []string{login})
+	options := role.GetOptions()
+	options.ForwardAgent = types.NewBool(true)
+	role.SetOptions(options)
+	err = s.server.Auth().UpsertRole(s.ctx, role)
+	require.NoError(t, err)
+	teleUser.AddRole(role.GetName())
+
+	teleUser.SetCreatedBy(types.CreatedBy{
+		User: types.UserRef{Name: "some-auth-user"},
+	})
+	err = s.server.Auth().CreateUser(s.ctx, teleUser)
+	require.NoError(t, err)
+
+	err = s.server.Auth().UpsertPassword(user, []byte(pass))
+	require.NoError(t, err)
+
+	if otpSecret != "" {
+		dev, err := services.NewTOTPDevice("otp", otpSecret, s.clock.Now())
+		require.NoError(t, err)
+		err = s.server.Auth().UpsertMFADevice(context.Background(), user, dev)
+		require.NoError(t, err)
+	}
+}
+
+func (s *TestWebSuite) makeTerminal(t *testing.T, pack *authPack, opts ...terminalOpt) (*websocket.Conn, error) {
+	req := TerminalRequest{
+		Server: s.srvID,
+		Login:  pack.login,
+		Term: session.TerminalParams{
+			W: 100,
+			H: 100,
+		},
+		SessionID: session.NewID(),
+	}
+	for _, opt := range opts {
+		opt(&req)
+	}
+
+	u := url.URL{
+		Host:   s.url().Host,
+		Scheme: client.WSS,
+		Path:   fmt.Sprintf("/v1/webapi/sites/%v/connect", currentSiteShortcut),
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	q.Set("params", string(data))
+	q.Set(roundtrip.AccessTokenQueryParam, pack.session.Token)
+	u.RawQuery = q.Encode()
+
+	dialer := websocket.Dialer{}
+	dialer.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	header := http.Header{}
+	header.Add("Origin", "http://localhost")
+	for _, cookie := range pack.cookies {
+		header.Add("Cookie", cookie.String())
+	}
+
+	ws, resp, err := dialer.Dial(u.String(), header)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	require.NoError(t, resp.Body.Close())
+	return ws, nil
+}
+
+func (s *TestWebSuite) waitForRawEvent(ws *websocket.Conn, timeout time.Duration) error {
+	timeoutContext, timeoutCancel := context.WithTimeout(s.ctx, timeout)
+	defer timeoutCancel()
+
+	done := make(chan error, 1)
+
+	go func() {
+		for {
+			ty, raw, err := ws.ReadMessage()
+			if err != nil {
+				done <- trace.Wrap(err)
+				return
+			}
+
+			if ty != websocket.BinaryMessage {
+				done <- trace.BadParameter("expected binary message, got %v", ty)
+				return
+			}
+
+			var envelope Envelope
+			err = proto.Unmarshal(raw, &envelope)
+			if err != nil {
+				done <- trace.Wrap(err)
+				return
+			}
+
+			if envelope.GetType() == defaults.WebsocketRaw {
+				done <- nil
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-timeoutContext.Done():
+			return trace.BadParameter("timeout waiting for raw event")
+		case err := <-done:
+			return trace.Wrap(err)
+		}
+	}
+}
+
+func (s *TestWebSuite) waitForResizeEvent(ws *websocket.Conn, timeout time.Duration) error {
+	timeoutContext, timeoutCancel := context.WithTimeout(s.ctx, timeout)
+	defer timeoutCancel()
+
+	done := make(chan error, 1)
+
+	go func() {
+		for {
+			ty, raw, err := ws.ReadMessage()
+			if err != nil {
+				done <- trace.Wrap(err)
+				return
+			}
+
+			if ty != websocket.BinaryMessage {
+				done <- trace.BadParameter("expected binary message, got %v", ty)
+				return
+			}
+
+			var envelope Envelope
+			err = proto.Unmarshal(raw, &envelope)
+			if err != nil {
+				done <- trace.Wrap(err)
+				return
+			}
+
+			if envelope.GetType() != defaults.WebsocketAudit {
+				continue
+			}
+
+			var e events.EventFields
+			err = json.Unmarshal([]byte(envelope.GetPayload()), &e)
+			if err != nil {
+				done <- trace.Wrap(err)
+				return
+			}
+
+			if e.GetType() == events.ResizeEvent {
+				done <- nil
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-timeoutContext.Done():
+			return trace.BadParameter("timeout waiting for resize event")
+		case err := <-done:
+			return trace.Wrap(err)
+		}
+	}
+}
+
+func (s *TestWebSuite) listenForResizeEvent(ws *websocket.Conn) chan struct{} {
+	ch := make(chan struct{})
+
+	go func() {
+		for {
+			ty, raw, err := ws.ReadMessage()
+			if err != nil {
+				close(ch)
+				return
+			}
+
+			if ty != websocket.BinaryMessage {
+				close(ch)
+				return
+			}
+
+			var envelope Envelope
+			err = proto.Unmarshal(raw, &envelope)
+			if err != nil {
+				close(ch)
+				return
+			}
+
+			if envelope.GetType() != defaults.WebsocketAudit {
+				continue
+			}
+
+			var e events.EventFields
+			err = json.Unmarshal([]byte(envelope.GetPayload()), &e)
+			if err != nil {
+				close(ch)
+				return
+			}
+
+			if e.GetType() == events.ResizeEvent {
+				ch <- struct{}{}
+				return
+			}
+		}
+	}()
+
+	return ch
+}
+
+func (s *TestWebSuite) clientNoRedirects(opts ...roundtrip.ClientParam) *client.WebClient {
+	hclient := client.NewInsecureWebClient()
+	hclient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	opts = append(opts, roundtrip.HTTPClient(hclient))
+	wc, err := client.NewWebClient(s.url().String(), opts...)
+	if err != nil {
+		panic(err)
+	}
+	return wc
+}
+
+func (s *TestWebSuite) client(opts ...roundtrip.ClientParam) *client.WebClient {
+	opts = append(opts, roundtrip.HTTPClient(client.NewInsecureWebClient()))
+	wc, err := client.NewWebClient(s.url().String(), opts...)
+	if err != nil {
+		panic(err)
+	}
+	return wc
+}
+
+func (s *TestWebSuite) login(clt *client.WebClient, cookieToken string, reqToken string, reqData interface{}) (*roundtrip.Response, error) {
+	return httplib.ConvertResponse(clt.RoundTrip(func() (*http.Response, error) {
+		data, err := json.Marshal(reqData)
+		if err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequest("POST", clt.Endpoint("webapi", "sessions"), bytes.NewBuffer(data))
+		if err != nil {
+			return nil, err
+		}
+		addCSRFCookieToReq(req, cookieToken)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(csrf.HeaderName, reqToken)
+		return clt.HTTPClient().Do(req)
+	}))
+}
+
+func (s *TestWebSuite) url() *url.URL {
+	u, err := url.Parse("https://" + s.webServer.Listener.Addr().String())
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func (r CreateSessionResponse) response() (*CreateSessionResponse, error) {
+	return &CreateSessionResponse{TokenType: r.TokenType, Token: r.Token, TokenExpiresIn: r.TokenExpiresIn, SessionInactiveTimeoutMS: r.SessionInactiveTimeoutMS}, nil
+}
+
+type mockProxySettings struct{}
+
+func (mock *mockProxySettings) GetProxySettings(ctx context.Context) (*webclient.ProxySettings, error) {
+	return &webclient.ProxySettings{}, nil
+}
+
+type terminalOpt func(t *TerminalRequest)
+
+func withSessionID(sid session.ID) terminalOpt {
+	return func(t *TerminalRequest) { t.SessionID = sid }
+}
+
+func withKeepaliveInterval(d time.Duration) terminalOpt {
+	return func(t *TerminalRequest) { t.KeepAliveInterval = d }
+}
+
+func addCSRFCookieToReq(req *http.Request, token string) {
+	cookie := &http.Cookie{
+		Name:  csrf.CookieName,
+		Value: token,
+	}
+
+	req.AddCookie(cookie)
+}


### PR DESCRIPTION
Reorganise the test code in lib/web to make parts available to tests running elsewhere, in particular the enterprise repository for components that are only available in the enterprise edition.

Three changes are:
* Export `webSuite` as `TestWebSuite` and move into the `lib/web` package proper, rather than only being in the `_test.go` files. This allows other packages to use this test setup code.
* Export a bunch of names in the `lib/web` package so code and tests can be moved outside of this package. This is just enough to get the OIDC/SAML connectors moved, not a comprehensive look at what would need to be exported in general.
* Add functional options to `NewTestWebSuite` so parts of the test suite can be configured appropriately for external use.

This is the first of a series of PRs to move the enterprise connectors to the enterprise repository.

Issues: https://github.com/gravitational/teleport.e/issues/525

---

Note: The commits are broken up into reviewable pieces (as much as this renaming and code movement are reviewable). Reviewing the individual commits may be easier than reviewing the whole lot at once.