### PR TITLE
Pass the process log config to Kube Service/Proxy

### DIFF
--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -238,6 +238,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 		StaticLabels:         cfg.Kube.StaticLabels,
 		DynamicLabels:        dynLabels,
 		CloudLabels:          process.cloudLabels,
+		Log:                  log,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3733,6 +3733,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			AccessPoint:   accessPoint,
 			GetRotation:   process.getRotation,
 			OnHeartbeat:   process.onHeartbeat(component),
+			Log:           log,
 		})
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
This PR allows Kube proxy/service to use the global logger settings defined for the process.

Fixes #17461 