### PR TITLE
[Docs] Fix rewrite key example.

### DIFF
--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -772,9 +772,10 @@ app_service:
       # Optional simple rewriting of Location header
       # Rewrite the "Location" header on redirect responses replacing the
       # host with the public address of this application.
-      # redirect:
-      #   - "localhost"
-      #   - "jenkins.internal.dev"
+      # rewrite:
+      #   redirect:
+      #     - "localhost"
+      #     - "jenkins.internal.dev"
 
 ## This section configures the 'kubernetes service'
 (!docs/pages/includes/kubernetes-access/kubernetes-config.yaml!)

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -769,13 +769,18 @@ app_service:
       - name: "os"
         command: ["/usr/bin/uname"]
         period: "5s"
-      # Optional simple rewriting of Location header
-      # Rewrite the "Location" header on redirect responses replacing the
-      # host with the public address of this application.
+      # Optional list of rewrite rules to apply to requests and responses
       # rewrite:
-      #   redirect:
-      #     - "localhost"
-      #     - "jenkins.internal.dev"
+        # Optional simple rewriting of Location header
+        # Rewrite the "Location" header on redirect responses replacing the
+        # host with the public address of this application.
+        # redirect:
+        #   - "localhost"
+        #   - "jenkins.internal.dev"
+        # Optional list of extra headers to inject in to requests.
+        # headers:
+        #   For example:
+        #   - "Host: jenkins.example.com"
 
 ## This section configures the 'kubernetes service'
 (!docs/pages/includes/kubernetes-access/kubernetes-config.yaml!)

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -769,15 +769,15 @@ app_service:
       - name: "os"
         command: ["/usr/bin/uname"]
         period: "5s"
-      # Optional list of rewrite rules to apply to requests and responses
+      ## Optional list of rewrite rules to apply to requests and responses
       # rewrite:
-        # Optional simple rewriting of Location header
-        # Rewrite the "Location" header on redirect responses replacing the
-        # host with the public address of this application.
+        ## Optional simple rewriting of Location header
+        ## Rewrite the "Location" header on redirect responses replacing the
+        ## host with the public address of this application.
         # redirect:
         #   - "localhost"
         #   - "jenkins.internal.dev"
-        # Optional list of extra headers to inject in to requests.
+        ## Optional list of extra headers to inject in to requests.
         # headers:
         #   For example:
         #   - "Host: jenkins.example.com"


### PR DESCRIPTION
## What's done

The `redirect` key is a child of `rewrite`. I've added `rewrite` to the example.

## What's needed

- [x] The descriptive comments were sparse at best before, and outdated now. I don't know what other child keys live under `rewrite`. They should be documented, and the comments updated to match.