### PR TITLE
[Docs] Refactor Install From Linux Instructions

### DIFF
--- a/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
@@ -197,8 +197,9 @@ $ tsh db logout
 ```
 
 ## Further reading
-* [How Amazon Keyspaces works with IAM](https://docs.aws.amazon.com/keyspaces/latest/devguide/security_iam_service-with-iam.html)
-* [What is Amazon Keyspaces (for Apache Cassandra)?](https://docs.aws.amazon.com/keyspaces/latest/devguide/what-is-keyspaces.html)
+
+- [How Amazon Keyspaces works with IAM](https://docs.aws.amazon.com/keyspaces/latest/devguide/security_iam_service-with-iam.html)
+- [What is Amazon Keyspaces (for Apache Cassandra)?](https://docs.aws.amazon.com/keyspaces/latest/devguide/what-is-keyspaces.html)
 
 ## Next steps
 

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,220 +1,186 @@
-<ScopedBlock scope={["oss"]}>
-<Tabs>
-    <TabItem label="Debian/Ubuntu (DEB)">
-        ```code
-        # Download Teleport's PGP public key
-        $ sudo curl https://apt.releases.teleport.dev/gpg \
-          -o /usr/share/keyrings/teleport-archive-keyring.asc
-        # Source variables about OS version
-        $ source /etc/os-release
-        # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
-        # file for each major release of Teleport.
-        # Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
-        # and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
-        # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L42-L67
-        $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
-          https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
-         | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
+<Admonition type="tip">
 
-        $ sudo apt-get update
-        $ sudo apt-get install teleport
-        ```
-    </TabItem>
-    <TabItem label="Amazon Linux 2/RHEL (RPM)">
-        ```code
-        # Source variables about OS version
-        $ source /etc/os-release
-        # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
-        # file for each major release of Teleport.
-        # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
-        # and the codename your distro was forked from instead of '$ID'
-        # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
-        $ sudo yum-config-manager --add-repo $(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")
-        $ sudo yum install teleport
-        #
-        # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
-        # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
-        #
-        # Optional:  Using DNF on newer distributions
-        # $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-        # $ sudo dnf install teleport
-        ```
-    </TabItem>
+In the example commands below, update `$SYSTEM-ARCH` with the appropriate
+value (`amd64`, `arm64`, or `arm`). All example commands using this variable
+will update after one is filled out. This variable may not be present, depending
+on your installation type.
 
-    <TabItem label="Tarball">
-        ```code
-        $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
-        # <checksum> <filename>
-        $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-        $ shasum -a 256 teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-        # Verify that the checksums match
-        $ tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-        $ cd teleport
-        $ sudo ./install
-        ```
-    </TabItem>
+Be sure to select the apporpriate scope at the top of this page (OSS,
+Enterprise, Cloud) to see the correct example commands for your installation
+type.
 
-    <TabItem label="ARMv7 (32-bit)">
-        ```code
-        $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz.sha256
-        # <checksum> <filename>
-        $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-        $ shasum -a 256 teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-        # Verify that the checksums match
-        $ tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-        $ cd teleport
-        $ sudo ./install
-        ```
-  </TabItem>
+</Admonition>
 
-  <TabItem label="ARM64/ARMv8 (64-bit)">
-        ```code
-        $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz.sha256
-        # <checksum> <filename>
-        $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-        $ shasum -a 256 teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-        # Verify that the checksums match
-        $ tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-        $ cd teleport
-        $ sudo ./install
-        ```
-  </TabItem>
-
-  <TabItem label="Debian/Ubuntu Legacy (DEB)">
-        ```code
-        # Using this APT repo may result in breaking upgrades upon "apt upgrade" as all major versions will be
-        # published under the same component. We recommend following the instructions in the
-        # "Debian/Ubuntu (DEB)" tab instead.
-        # Download Teleport's PGP public key
-        $ sudo curl https://deb.releases.teleport.dev/teleport-pubkey.asc \
-          -o /usr/share/keyrings/teleport-archive-keyring.asc
-        # Add the Teleport APT repository
-        $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] https://deb.releases.teleport.dev/ stable main" \
-         | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
-
-        $ sudo apt-get update
-        $ sudo apt-get install teleport
-        ```
-  </TabItem>
-
-  <TabItem label="Amazon Linux 2/RHEL Legacy (RPM)">
-        ```code
-        $ sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-        $ sudo yum install teleport
-
-        # Optional:  Using DNF on newer distributions
-        # $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-        # $ sudo dnf install teleport
-        ```
-  </TabItem>
-
-</Tabs>
-</ScopedBlock>
-<ScopedBlock scope={["enterprise"]}>
+<ScopedBlock scope={["enterprise", "cloud"]}>
 
 Visit the [Downloads Page](https://dashboard.gravitational.com/web/downloads) in
 the customer portal and select the URL for your package of choice.
 
 Next, use the appropriate commands for your environment to install your package.
 
-For example, use the following commands to install Teleport on a machine with an
-x86-64 chip via tarball:
+</ScopedBlock>
 
-```code
-$ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
-# <checksum> <filename>
-$ curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
-$ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
-# Verify that the checksums match
-$ tar -xvf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
-$ cd teleport-ent
-$ sudo ./install
-```
+<ScopedBlock scope={["oss"]}>
+<Tabs>
+  <TabItem label="Debian/Ubuntu (DEB)">
 
-For FedRAMP/FIPS-compliant installations of Teleport Enterprise, package URLs
-will be slightly different:
+  Add the Teleport repository to your repository list:
 
-```code
-$ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz.sha256
-# <checksum> <filename>
-$ curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
-$ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
-# Verify that the checksums match
-$ tar -xvf teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
-$ cd teleport-ent
-$ sudo ./install
-```
+  ```code
+  # Download Teleport's PGP public key
+  $ sudo curl https://apt.releases.teleport.dev/gpg \
+   -o /usr/share/keyrings/teleport-archive-keyring.asc
+  # Source variables about OS version
+  $ source /etc/os-release
+  # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
+  # file for each major release of Teleport.
+  # Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
+  # and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
+  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L42-L67
+  $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+   https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
+   | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 
+  $ sudo apt-get update
+  $ sudo apt-get install teleport
+  ```
+
+  </TabItem>
+  <TabItem label="Amazon Linux 2/RHEL (RPM)">
+
+  ```code
+  # Source variables about OS version
+  $ source /etc/os-release
+  # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
+  # file for each major release of Teleport.
+  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
+  # and the codename your distro was forked from instead of '$ID'
+  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
+  $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+  $ sudo dnf install teleport
+  #
+  # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+  # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
+  #
+  # Optional:  Using YUM on older distributions
+  #$ sudo yum-config-manager --add-repo $(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")
+  #$ sudo yum install teleport
+  ```
+
+  </TabItem>
+  <TabItem label="Tarball">
+
+  ```code
+  $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH" description="The CPU architecture of the system Teleport will be installed on"/>-bin.tar.gz.sha256
+  # <checksum> <filename>
+  $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  $ shasum -a 256 teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  # Verify that the checksums match
+  $ tar -xvf teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  $ cd teleport
+  $ sudo ./install
+  ```
+
+  </TabItem>
+</Tabs>
+</ScopedBlock>
+<ScopedBlock scope={["enterprise"]}>
+<Tabs>
+  <TabItem label="Debian/Ubuntu (DEB)">
+
+  Aftter Downloading the `.deb` file for your system architecture, install it with
+  `dpkg`. The example below assumes the `root` user:
+
+  ```code
+  $ dpkg -i ~/Downloads/teleport-ent_(=teleport.version=)_<Var name="$SYSTEM-ARCH" description="The CPU architecture of the system Teleport will be installed on"/>.deb
+  Selecting previously unselected package teleport-ent.
+  (Reading database ... 30810 files and directories currently installed.)
+  Preparing to unpack teleport-ent_(=teleport.version=)_$SYSTEM_ARCH.deb ...
+  Unpacking teleport-ent (=teleport.version=) ...
+  Setting up teleport-ent (=teleport.version=) ...
+  ```
+
+  </TabItem>
+  <TabItem label="Amazon Linux 2/RHEL (RPM)">
+
+  After Downloading the `.rpm` file for your system architecture, install it with `rpm`:
+
+  ```code
+  $ rpm -i ~/Downloads/teleport-ent-(=teleport.version=).<Var name="$SYSTEM-ARCH"/>.rpm
+  warning: teleport-ent-(=teleport.version=).$SYSTEM-ARCH.rpm: Header V4 RSA/SHA512 Signature, key ID 6282c411: NOKEY
+  ```
+
+  </TabItem>
+  <TabItem label="Tarball">
+
+  ```code
+  $ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz.sha256
+  # <checksum> <filename>
+  $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  $ shasum -a 256 teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  # Verify that the checksums match
+  $ tar -xvf teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  $ cd teleport
+  $ sudo ./install
+  ```
+
+  For FedRAMP/FIPS-compliant installations of Teleport Enterprise, package URLs
+  will be slightly different:
+
+  ```code
+  $ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz.sha256
+  # <checksum> <filename>
+  $ curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz
+  $ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz
+  # Verify that the checksums match
+  $ tar -xvf teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz
+  $ cd teleport-ent
+  $ sudo ./install
+  ```
+
+  </TabItem>
+</Tabs>
 </ScopedBlock>
 <ScopedBlock scope={["cloud"]}>
 <Tabs>
-    <TabItem label="Debian/Ubuntu (DEB)">
-        ```code
-        # Download Teleport's PGP public key
-        $ sudo curl https://deb.releases.teleport.dev/teleport-pubkey.asc \
-          -o /usr/share/keyrings/teleport-archive-keyring.asc
-        # Source variables about OS version
-        $ source /etc/os-release
-        # Add the Teleport APT repository for v(=cloud.major_version=). You'll need to update this
-        # file for each major release of Teleport.
-        # Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
-        # and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
-        # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-apt-repos/main.go#L26
-        $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
-          https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=cloud.major_version=)" \
-         | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
-        $ sudo apt-get update
-        $ sudo apt-get install teleport
-        ```
-    </TabItem>
-    <TabItem label="Amazon Linux 2/RHEL (RPM)">
-        ```code
-        # Source variables about OS version
-        $ source /etc/os-release
-        # Add the Teleport YUM repository for v(=cloud.major_version=). You'll need to update this
-        # file for each major release of Teleport.
-        # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
-        # and the codename your distro was forked from instead of '$ID'
-        $ sudo yum-config-manager \
-            --add-repo $(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=cloud.major_version=)/teleport.repo")
-        $ sudo yum install teleport
-        ```
-    </TabItem>
-    <TabItem label="Tarball">
-        ```code
-        $ curl https://get.gravitational.com/teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz.sha256
-        # <checksum> <filename>
-        $ curl -O https://get.gravitational.com/teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
-        $ shasum -a 256 teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
-        # Verify that the checksums match
-        $ tar -xzf teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
-        $ cd teleport
-        $ sudo ./install
-        ```
-    </TabItem>
-    <TabItem label="ARMv7 (32-bit)">
-        ```code
-        $ curl https://get.gravitational.com/teleport-v(=cloud.version=)-linux-arm-bin.tar.gz.sha256
-        # <checksum> <filename>
-        $ curl -O https://get.gravitational.com/teleport-v(=cloud.version=)-linux-arm-bin.tar.gz
-        $ shasum -a 256 teleport-v(=cloud.version=)-linux-arm-bin.tar.gz
-        # Verify that the checksums match
-        $ tar -xzf teleport-v(=cloud.version=)-linux-arm-bin.tar.gz
-        $ cd teleport
-        $ sudo ./install
-        ```
+  <TabItem label="Debian/Ubuntu (DEB)">
+
+  Aftter Downloading the `.deb` file for your system architecture, install it with
+  `dpkg`. The example below assumes the `root` user:
+
+  ```code
+  $ dpkg -i ~/Downloads/teleport-ent_(=cloud.version=)_<Var name="$SYSTEM-ARCH"/>.deb
+  Selecting previously unselected package teleport-ent.
+  (Reading database ... 30810 files and directories currently installed.)
+  Preparing to unpack teleport-ent_(=cloud.version=)_$SYSTEM_ARCH.deb ...
+  Unpacking teleport-ent (=cloud.version=) ...
+  Setting up teleport-ent (=cloud.version=) ...
+  ```
+
   </TabItem>
-  <TabItem label="ARM64/ARMv8 (64-bit)">
-        ```code
-        $ curl https://get.gravitational.com/teleport-v(=cloud.version=)-linux-arm64-bin.tar.gz.sha256
-        # <checksum> <filename>
-        $ curl -O https://get.gravitational.com/teleport-v(=cloud.version=)-linux-arm64-bin.tar.gz
-        $ shasum -a 256 teleport-v(=cloud.version=)-linux-arm64-bin.tar.gz
-        # Verify that the checksums match
-        $ tar -xzf teleport-v(=cloud.version=)-linux-arm64-bin.tar.gz
-        $ cd teleport
-        $ sudo ./install
-        ```
+  <TabItem label="Amazon Linux 2/RHEL (RPM)">
+
+  After Downloading the `.rpm` file for your system architecture, install it with `rpm`:
+
+  ```code
+  $ rpm -i ~/Downloads/teleport-ent-(=cloud.version=).<Var name="$SYSTEM-ARCH"/>.rpm
+  warning: teleport-ent-(=cloud.version=).$SYSTEM-ARCH.rpm: Header V4 RSA/SHA512 Signature, key ID 6282c411: NOKEY
+  ```
+
+  </TabItem>
+  <TabItem label="Tarball">
+
+  ```code
+  $ curl https://get.gravitational.com/teleport-ent-v(=cloud.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz.sha256
+  # <checksum> <filename>
+  $ curl -O https://get.gravitational.com/teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
+  $ shasum -a 256 teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
+  # Verify that the checksums match
+  $ tar -xvf teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
+  $ cd teleport
+  $ sudo ./install
+  ```
+
   </TabItem>
 </Tabs>
 </ScopedBlock>

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -71,9 +71,9 @@ Next, use the appropriate commands for your environment to install your package.
   <TabItem label="Tarball">
 
   ```code
-  $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH" description="The CPU architecture of the system Teleport will be installed on"/>-bin.tar.gz.sha256
+  $ curl https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH" description="The CPU architecture of the system Teleport will be installed on"/>-bin.tar.gz.sha256
   # <checksum> <filename>
-  $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  $ curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
   $ shasum -a 256 teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
   # Verify that the checksums match
   $ tar -xvf teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
@@ -114,9 +114,9 @@ Next, use the appropriate commands for your environment to install your package.
   <TabItem label="Tarball">
 
   ```code
-  $ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz.sha256
+  $ curl https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz.sha256
   # <checksum> <filename>
-  $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  $ curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
   $ shasum -a 256 teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
   # Verify that the checksums match
   $ tar -xvf teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
@@ -128,9 +128,9 @@ Next, use the appropriate commands for your environment to install your package.
   will be slightly different:
 
   ```code
-  $ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz.sha256
+  $ curl https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz.sha256
   # <checksum> <filename>
-  $ curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz
+  $ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz
   $ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz
   # Verify that the checksums match
   $ tar -xvf teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz
@@ -171,9 +171,9 @@ Next, use the appropriate commands for your environment to install your package.
   <TabItem label="Tarball">
 
   ```code
-  $ curl https://get.gravitational.com/teleport-ent-v(=cloud.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz.sha256
+  $ curl https://cdn.teleport.dev/teleport-ent-v(=cloud.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz.sha256
   # <checksum> <filename>
-  $ curl -O https://get.gravitational.com/teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
+  $ curl -O https://cdn.teleport.dev/teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
   $ shasum -a 256 teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz
   # Verify that the checksums match
   $ tar -xvf teleport-v(=cloud.version=)-linux-amd64-bin.tar.gz

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,16 +1,3 @@
-<Admonition type="tip">
-
-In the example commands below, update `$SYSTEM-ARCH` with the appropriate
-value (`amd64`, `arm64`, or `arm`). All example commands using this variable
-will update after one is filled out. This variable may not be present, depending
-on your installation type.
-
-Be sure to select the apporpriate scope at the top of this page (OSS,
-Enterprise, Cloud) to see the correct example commands for your installation
-type.
-
-</Admonition>
-
 <ScopedBlock scope={["enterprise", "cloud"]}>
 
 Visit the [Downloads Page](https://dashboard.gravitational.com/web/downloads) in
@@ -20,16 +7,17 @@ Next, use the appropriate commands for your environment to install your package.
 
 </ScopedBlock>
 
-<ScopedBlock scope={["oss"]}>
-<Tabs>
-  <TabItem label="Debian/Ubuntu (DEB)">
+<Tabs dropdownView dropdownCaption="Teleport Edition">
+  <TabItem label="Open Source" scope="oss">
+  <Tabs>
+  <TabItem label="Debian/Ubuntu (DEB)" scope="oss">
 
   Add the Teleport repository to your repository list:
 
   ```code
   # Download Teleport's PGP public key
   $ sudo curl https://apt.releases.teleport.dev/gpg \
-   -o /usr/share/keyrings/teleport-archive-keyring.asc
+  -o /usr/share/keyrings/teleport-archive-keyring.asc
   # Source variables about OS version
   $ source /etc/os-release
   # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
@@ -38,15 +26,15 @@ Next, use the appropriate commands for your environment to install your package.
   # and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
   # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L42-L67
   $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
-   https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
-   | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
+  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
+  | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 
   $ sudo apt-get update
   $ sudo apt-get install teleport
   ```
 
   </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL (RPM)">
+  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="oss">
 
   ```code
   # Source variables about OS version
@@ -68,7 +56,7 @@ Next, use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="Tarball">
+  <TabItem label="Tarball" scope="oss">
 
   ```code
   $ curl https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH" description="The CPU architecture of the system Teleport will be installed on"/>-bin.tar.gz.sha256
@@ -82,11 +70,16 @@ Next, use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-</Tabs>
-</ScopedBlock>
-<ScopedBlock scope={["enterprise"]}>
-<Tabs>
-  <TabItem label="Debian/Ubuntu (DEB)">
+  </Tabs>
+  </TabItem>
+  <TabItem label="Enterprise" scope="enterprise">
+
+  In the example commands below, update `$SYSTEM-ARCH` with the appropriate
+  value (`amd64`, `arm64`, or `arm`). All example commands using this variable
+  will update after one is filled out.
+
+  <Tabs>
+  <TabItem label="Debian/Ubuntu (DEB)" scope="enterprise">
 
   Aftter Downloading the `.deb` file for your system architecture, install it with
   `dpkg`. The example below assumes the `root` user:
@@ -101,7 +94,7 @@ Next, use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL (RPM)">
+  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="enterprise">
 
   After Downloading the `.rpm` file for your system architecture, install it with `rpm`:
 
@@ -111,7 +104,7 @@ Next, use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="Tarball">
+  <TabItem label="Tarball" scope="enterprise">
 
   ```code
   $ curl https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz.sha256
@@ -139,11 +132,16 @@ Next, use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-</Tabs>
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
-<Tabs>
-  <TabItem label="Debian/Ubuntu (DEB)">
+  </Tabs>
+  </TabItem>
+  <TabItem label="Cloud" scope="cloud">
+
+  In the example commands below, update `$SYSTEM-ARCH` with the appropriate
+  value (`amd64`, `arm64`, or `arm`). All example commands using this variable
+  will update after one is filled out.
+
+  <Tabs>
+  <TabItem label="Debian/Ubuntu (DEB)" scope="cloud">
 
   Aftter Downloading the `.deb` file for your system architecture, install it with
   `dpkg`. The example below assumes the `root` user:
@@ -158,7 +156,7 @@ Next, use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL (RPM)">
+  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="cloud">
 
   After Downloading the `.rpm` file for your system architecture, install it with `rpm`:
 
@@ -168,7 +166,7 @@ Next, use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="Tarball">
+  <TabItem label="Tarball" scope="cloud">
 
   ```code
   $ curl https://cdn.teleport.dev/teleport-ent-v(=cloud.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz.sha256
@@ -182,5 +180,6 @@ Next, use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
+  </Tabs>
+  </TabItem>
 </Tabs>
-</ScopedBlock>


### PR DESCRIPTION
Refactors the partial file with instructions for installing Teleport on Linux. Main points:
- Uses the Var component to reduce tabs for different CPU archs
- Adds instructions to install Enterprise using package manager tools
- Has cloud users install Enterprise binaries, but using the version matching the current Cloud prod.
- Removes legacy deb/rpm instrucitons
- Adds a tip admonition describing the use of Vars and making sure the reader selects the right scope.


This branch has been recreated and refactored, so this is a new description.
<Details>
<summary>Old copy</summary>
- Most of this diff is formatting this page for [markdownlint](https://github.com/DavidAnson/markdownlint/)
- Lines 124-180 Replace the single Enterprise instruction via tarball with tabs to install via tarball, deb, and rpm. This matches the install instructions we provide for OSS and Cloud scopes.
</Details>