### PR TITLE
[v10] pr-buddy: helm: support join_params in teleport-kube-agent chart

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -63,12 +63,15 @@ If you specify a role here, you may also need to specify some other settings whi
 
 | Type | Default value | Required? |
 | - | - | - |
-| `string` | `nil` | Yes |
+| `string` | `nil` | No |
 
 `authToken` provides a Teleport join token which will be used to join the Teleport instance to a Teleport cluster.
 
-This value **must** be provided for the chart to work. The token that you use must also be valid for every Teleport service that you
-are trying to add with the `teleport-kube-agent` chart. Here are a few examples:
+The value `joinParams` supports more methods to join the Teleport cluster and takes precedence if both `authToken`
+and `joinParams` are set.
+
+A token must be specified for the agent to join the Teleport cluster, either though `authToken`,
+[`joinParams`](#joinparams), or [an existing Kubernetes Secret](#secretname).
 
 | Services | Service Name | `tctl tokens add` example | `teleport.yaml` static token example |
 | - | - | - | - |
@@ -98,6 +101,77 @@ fail to join the Teleport cluster.
   <TabItem label="--set">
   ```code
   $ --set authToken=<replace-with-actual-token>
+  ```
+  </TabItem>
+</Tabs>
+
+## `joinParams`
+
+`joinParams` controls how the Teleport agent joins the Teleport cluster.
+These sub-values must be configured for the agent to connect to a cluster.
+
+### `joinParams.method`
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `token` | Yes |
+
+`joinParams.method` defines which join method will be used to join the Teleport cluster.
+Possible values are `token`, `iam` and `ec2`.
+
+- For `iam`, see [Joining Nodes Via AWS IAM Role](../../management/guides/joining-nodes-aws-iam.mdx).
+- For `ec2`, see [Joining Nodes Via AWS IAM Role](../../management/guides/joining-nodes-aws-ec2.mdx).
+- For `token` (default value), the token must be provided through `joinParams.tokenName` or
+  [through an existing Kubernetes Secret](#secretName).
+
+<Admonition type="note" title="IAM joining requirements">
+Using the IAM joining method requires either the pods to have access to [instance
+metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html),
+or [IAM roles for service
+accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to be
+set up on the pods's service account. For access to instance metadata (the quickest solution), see
+[AWS's examples on how to restrict instance metadata access to a few
+pods](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node).
+</Admonition>
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  joinParams:
+    method: "token"|"ec2"|"iam"
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set joinParams.method="token"|"ec2"|"iam"
+  ```
+  </TabItem>
+</Tabs>
+
+### `joinParams.tokenName`
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `nil` | Yes |
+
+When `joinParams.method` is `iam` or `ec2`, `joinParams.tokenName` contains the name of the token that will be used to
+join the cluster. In this case, the value is not sensitive as authorization is checked through AWS IAM or EC2.
+
+When `joinParams.method` is `token` (by default), `joinParams.tokenName` contains the join token itself. In this case,
+the value is sensitive and is automatically stored in a Kubernetes Secret instead of being directly included in the
+agent's configuration.
+
+If method is `token`, `joinParams.tokenName` can be empty if the token is provided through an existing Kubernetes
+Secret, see [`secretName`](#secretName) for more details and instructions.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  joinParams:
+    tokenName: "my-token"
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set joinParams.token="my-token"
   ```
   </TabItem>
 </Tabs>
@@ -998,10 +1072,11 @@ Ensures that this number of replicas is available during voluntary disruptions, 
 | - | - |
 | `string` | `teleport-kube-agent-join-token` |
 
-`secretName` is the name of the Kubernetes `Secret` used to store the Teleport join token which is used by the `teleport-kube-agent` chart.
+`secretName` is the name of the Kubernetes Secret containing the Teleport join token used by the chart.
 
-If you set this to a blank value, the chart will not attempt to create the secret itself and will instead read the value of the
-existing `teleport-kube-agent-join-token` secret. This allows you to configure this secret externally and avoid having a plaintext
+If `joinParams.method` is `token` and you set both `authToken` and `joinParams.tokenName` to a blank value, the chart
+will not attempt to create the secret itself. Instead, it will read the value from an existing secret. `secretName`
+configures the name of this secret. This allows you to configure this secret externally and avoid having a plaintext
 join token stored in your Teleport chart values.
 
 To create your own join token secret, you can use a command like this:
@@ -1017,12 +1092,17 @@ $ kubectl --namespace teleport create secret generic teleport-kube-agent-join-to
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  serviceAccountName:
+  secretName: "secret-i-created-before"
+  joinParams:
+    method: "token"
+    tokenName: ""
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set serviceAccountName=""
+  $ --set secretName="secret-i-created-before" \
+    --set joinParams.method="token" \
+    --set joinParams.tokenName=""
   ```
   </TabItem>
 </Tabs>

--- a/examples/chart/teleport-kube-agent/.lint/join-params-iam.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/join-params-iam.yaml
@@ -1,0 +1,5 @@
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster-name
+joinParams:
+  tokenName: iam-token
+  method: iam

--- a/examples/chart/teleport-kube-agent/.lint/join-params-token.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/join-params-token.yaml
@@ -1,0 +1,5 @@
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster-name
+joinParams:
+  tokenName: xxxxxxx-secret-token-xxxxxxx
+  method: token

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -20,7 +20,9 @@ metadata:
 data:
   teleport.yaml: |
     teleport:
-      auth_token: "/etc/teleport-secrets/auth-token"
+      join_params:
+        method: "{{ .Values.joinParams.method }}"
+        token_name: "/etc/teleport-secrets/auth-token"
       auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
       {{- if .Values.caPin }}
       ca_pin: {{- toYaml .Values.caPin | nindent 8 }}

--- a/examples/chart/teleport-kube-agent/templates/secret.yaml
+++ b/examples/chart/teleport-kube-agent/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.authToken }}
+{{- if or .Values.authToken .Values.joinParams.tokenName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,5 +11,5 @@ metadata:
 type: Opaque
 stringData:
   auth-token: |
-    {{ .Values.authToken }}
+    {{ coalesce .Values.joinParams.tokenName .Values.authToken }}
 {{- end }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -4,7 +4,9 @@ does not generate a config for clusterrole.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -39,7 +41,9 @@ does not generate a config for pdb.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -74,7 +78,9 @@ matches snapshot and tests for annotations.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -112,7 +118,9 @@ matches snapshot and tests for extra-labels.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -150,7 +158,9 @@ matches snapshot for affinity.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -185,7 +195,9 @@ matches snapshot for all-v6.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -236,7 +248,9 @@ matches snapshot for aws-databases.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -283,7 +297,9 @@ matches snapshot for backwards-compatibility.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -318,7 +334,9 @@ matches snapshot for ca-pin.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           ca_pin:
             - sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1
@@ -355,7 +373,9 @@ matches snapshot for db.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -395,7 +415,9 @@ matches snapshot for dynamic-app.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -432,7 +454,9 @@ matches snapshot for dynamic-db.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -469,7 +493,9 @@ matches snapshot for imagepullsecrets.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -504,7 +530,9 @@ matches snapshot for initcontainers.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -533,13 +561,89 @@ matches snapshot for initcontainers.yaml:
     metadata:
       name: RELEASE-NAME
       namespace: NAMESPACE
+matches snapshot for join-params-iam.yaml:
+  1: |
+    apiVersion: v1
+    data:
+      teleport.yaml: |
+        teleport:
+          join_params:
+            method: "iam"
+            token_name: "/etc/teleport-secrets/auth-token"
+          auth_servers: ["proxy.example.com:3080"]
+          log:
+            severity: INFO
+            output: stderr
+            format:
+              output: text
+              extra_fields: ["timestamp","level","component","caller"]
+
+        kubernetes_service:
+          enabled: true
+          kube_cluster_name: test-kube-cluster-name
+
+        app_service:
+          enabled: false
+
+        db_service:
+          enabled: false
+
+        auth_service:
+          enabled: false
+        ssh_service:
+          enabled: false
+        proxy_service:
+          enabled: false
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME
+      namespace: NAMESPACE
+matches snapshot for join-params-token.yaml:
+  1: |
+    apiVersion: v1
+    data:
+      teleport.yaml: |
+        teleport:
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
+          auth_servers: ["proxy.example.com:3080"]
+          log:
+            severity: INFO
+            output: stderr
+            format:
+              output: text
+              extra_fields: ["timestamp","level","component","caller"]
+
+        kubernetes_service:
+          enabled: true
+          kube_cluster_name: test-kube-cluster-name
+
+        app_service:
+          enabled: false
+
+        db_service:
+          enabled: false
+
+        auth_service:
+          enabled: false
+        ssh_service:
+          enabled: false
+        proxy_service:
+          enabled: false
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for log-basic.yaml:
   1: |
     apiVersion: v1
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -574,7 +678,9 @@ matches snapshot for log-extra.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: DEBUG
@@ -609,7 +715,9 @@ matches snapshot for log-legacy.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: DEBUG
@@ -644,7 +752,9 @@ matches snapshot for node-selector.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -679,7 +789,9 @@ matches snapshot for pdb.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: DEBUG
@@ -714,7 +826,9 @@ matches snapshot for resources.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -749,7 +863,9 @@ matches snapshot for stateful.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -784,7 +900,9 @@ matches snapshot for tolerations.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO
@@ -819,7 +937,9 @@ matches snapshot for volumes.yaml:
     data:
       teleport.yaml: |
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           auth_servers: ["proxy.example.com:3080"]
           log:
             severity: INFO

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -18,7 +18,7 @@ sets Deployment annotations when specified:
       template:
         metadata:
           annotations:
-            checksum/config: 511656bfc4345260ef1ddc4319c2a30ff1e004c72c518c82020a76e088a10cd8
+            checksum/config: d6a8c6262121d39959d11174681133b8a8b7eded1d420957ff2ee7f20e1a25cf
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -86,7 +86,7 @@ sets Deployment labels when specified:
     template:
       metadata:
         annotations:
-          checksum/config: b37ca9b3da292ffe343a4629c7da7dc006ec03156fc19268123a24df51dfeb78
+          checksum/config: e40e91c502b3883cd280381b59705cb433efc9a0920ea3de309d39358673eaad
         labels:
           app: RELEASE-NAME
           app.kubernetes.io/name: teleport-kube-agent

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/secret_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/secret_test.yaml.snap
@@ -9,6 +9,17 @@ generates a secret when authToken is provided:
       auth-token: |
         sample-auth-token-dont-use-this
     type: Opaque
+generates a secret when joinParams.tokenName is provided:
+  1: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: teleport-kube-agent-join-token
+      namespace: NAMESPACE
+    stringData:
+      auth-token: |
+        sample-auth-token-dont-use-this
+    type: Opaque
 generates a secret with a custom name when authToken and secretName are provided:
   1: |
     apiVersion: v1

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -128,7 +128,7 @@ sets StatefulSet labels when specified:
       template:
         metadata:
           annotations:
-            checksum/config: b37ca9b3da292ffe343a4629c7da7dc006ec03156fc19268123a24df51dfeb78
+            checksum/config: e40e91c502b3883cd280381b59705cb433efc9a0920ea3de309d39358673eaad
           labels:
             app: RELEASE-NAME
             app.kubernetes.io/name: teleport-kube-agent

--- a/examples/chart/teleport-kube-agent/tests/config_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/config_test.yaml
@@ -140,6 +140,26 @@ tests:
           of: ConfigMap
       - matchSnapshot: {}
 
+  - it: matches snapshot for join-params-iam.yaml
+    values:
+      - ../.lint/join-params-iam.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot: {}
+
+  - it: matches snapshot for join-params-token.yaml
+    values:
+      - ../.lint/join-params-token.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot: {}
+
   - it: matches snapshot for log-basic.yaml
     values:
       - ../.lint/log-basic.yaml

--- a/examples/chart/teleport-kube-agent/tests/secret_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/secret_test.yaml
@@ -2,9 +2,28 @@ suite: Secret
 templates:
   - secret.yaml
 tests:
+  - it: does not generate a secret when join method is token and neither authToken nor joinParams.tokenName are provided
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: generates a secret when authToken is provided
     set:
       authToken: sample-auth-token-dont-use-this
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: teleport-kube-agent-join-token
+      - matchSnapshot: {}
+
+  - it: generates a secret when joinParams.tokenName is provided
+    set:
+      joinParams:
+        tokenName: sample-auth-token-dont-use-this
     asserts:
       - hasDocuments:
           count: 1

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -220,6 +220,24 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should mount auth token if token is provided
+    values:
+      - ../.lint/stateful.yaml
+      - ../.lint/join-params-token.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/teleport-secrets
+            name: auth-token
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: auth-token
+            secret:
+              secretName: teleport-kube-agent-join-token
+
   - it: should set imagePullPolicy when set in values
     values:
       - ../.lint/stateful.yaml

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -2,9 +2,9 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
     "required": [
-        "authToken",
         "proxyAddr",
         "roles",
+        "joinParams",
         "kubeClusterName",
         "apps",
         "appResources",
@@ -47,6 +47,24 @@
             "$id": "#/properties/roles",
             "type": "string",
             "default": "kube"
+        },
+        "joinParams": {
+            "$id": "#/properties/joinParams",
+            "type": "object",
+            "required": ["method"],
+            "properties": {
+                "tokenName": {
+                    "$id": "#/properties/joinParams/tokenName",
+                    "type": "string",
+                    "default": ""
+                },
+                "method": {
+                    "$id": "#/properties/joinParams/method",
+                    "type": "string",
+                    "default": "token"
+                },
+                "additionalProperties": false
+            }
         },
         "kubeClusterName": {
             "$id": "#/properties/kubeClusterName",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -2,14 +2,29 @@
 # Values that must always be provided by the user.
 ################################################################
 
-# Join token for the cluster.
-# Leave empty if the secret "teleport-kube-agent-join-token"
-# has been created before and contains a valid join token
+# Join token for the cluster. `joinParams` can also pass the join token,
+# but supports more join methods and takes precedence if set.
 authToken: ""
+
 # Address of the teleport proxy with port (usually :3080).
 proxyAddr: ""
 # Comma-separated list of roles to enable (any of: kube,db,app)
 roles: "kube"
+
+################################################################
+# Values that must be provided if IAM or EC2 joining is enabled.
+################################################################
+
+# Specify how to join the Teleport cluster
+joinParams:
+  # Supported join methods are "token", "ec2", "iam".
+  # method "token", is equivalent to using authToken to join a cluster
+  method: "token"
+
+  # Leave empty only when method is "token" and the secret
+  # "teleport-kube-agent-join-token" has been created before and
+  # contains a valid join token.
+  tokenName: ""
 
 ################################################################
 # Values that must be provided if Kubernetes access is enabled.


### PR DESCRIPTION
This is a manual backport of #16351 to `branch/v10`.