### PR TITLE
[v9] pr-buddy: helm: support join_params in teleport-kube-agent chart

### DIFF
--- a/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
@@ -63,12 +63,15 @@ If you specify a role here, you may also need to specify some other settings whi
 
 | Type | Default value | Required? |
 | - | - | - |
-| `string` | `nil` | Yes |
+| `string` | `nil` | No |
 
 `authToken` provides a Teleport join token which will be used to join the Teleport instance to a Teleport cluster.
 
-This value **must** be provided for the chart to work. The token that you use must also be valid for every Teleport service that you
-are trying to add with the `teleport-kube-agent` chart. Here are a few examples:
+The value `joinParams` supports more methods to join the Teleport cluster and takes precedence if both `authToken`
+and `joinParams` are set.
+
+A token must be specified for the agent to join the Teleport cluster, either though `authToken`,
+[`joinParams`](#joinparams), or [an existing Kubernetes Secret](#secretname).
 
 | Services | Service Name | `tctl tokens add` example | `teleport.yaml` static token example |
 | - | - | - | - |
@@ -98,6 +101,77 @@ fail to join the Teleport cluster.
   <TabItem label="--set">
   ```code
   $ --set authToken=<replace-with-actual-token>
+  ```
+  </TabItem>
+</Tabs>
+
+## `joinParams`
+
+`joinParams` controls how the Teleport agent joins the Teleport cluster.
+These sub-values must be configured for the agent to connect to a cluster.
+
+### `joinParams.method`
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `token` | Yes |
+
+`joinParams.method` defines which join method will be used to join the Teleport cluster.
+Possible values are `token`, `iam` and `ec2`.
+
+- For `iam`, see [Joining Nodes Via AWS IAM Role](../../management/guides/joining-nodes-aws-iam.mdx).
+- For `ec2`, see [Joining Nodes Via AWS IAM Role](../../management/guides/joining-nodes-aws-ec2.mdx).
+- For `token` (default value), the token must be provided through `joinParams.tokenName` or
+  [through an existing Kubernetes Secret](#secretName).
+
+<Admonition type="note" title="IAM joining requirements">
+Using the IAM joining method requires either the pods to have access to [instance
+metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html),
+or [IAM roles for service
+accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to be
+set up on the pods's service account. For access to instance metadata (the quickest solution), see
+[AWS's examples on how to restrict instance metadata access to a few
+pods](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node).
+</Admonition>
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  joinParams:
+    method: "token"|"ec2"|"iam"
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set joinParams.method="token"|"ec2"|"iam"
+  ```
+  </TabItem>
+</Tabs>
+
+### `joinParams.tokenName`
+| Type | Default value | Required? |
+| - | - | - |
+| `string` | `nil` | Yes |
+
+When `joinParams.method` is `iam` or `ec2`, `joinParams.tokenName` contains the name of the token that will be used to
+join the cluster. In this case, the value is not sensitive as authorization is checked through AWS IAM or EC2.
+
+When `joinParams.method` is `token` (by default), `joinParams.tokenName` contains the join token itself. In this case,
+the value is sensitive and is automatically stored in a Kubernetes Secret instead of being directly included in the
+agent's configuration.
+
+If method is `token`, `joinParams.tokenName` can be empty if the token is provided through an existing Kubernetes
+Secret, see [`secretName`](#secretName) for more details and instructions.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  joinParams:
+    tokenName: "my-token"
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set joinParams.token="my-token"
   ```
   </TabItem>
 </Tabs>
@@ -820,10 +894,11 @@ Ensures that this number of replicas is available during voluntary disruptions, 
 | - | - |
 | `string` | `teleport-kube-agent-join-token` |
 
-`secretName` is the name of the Kubernetes `Secret` used to store the Teleport join token which is used by the `teleport-kube-agent` chart.
+`secretName` is the name of the Kubernetes Secret containing the Teleport join token used by the chart.
 
-If you set this to a blank value, the chart will not attempt to create the secret itself and will instead read the value of the
-existing `teleport-kube-agent-join-token` secret. This allows you to configure this secret externally and avoid having a plaintext
+If `joinParams.method` is `token` and you set both `authToken` and `joinParams.tokenName` to a blank value, the chart
+will not attempt to create the secret itself. Instead, it will read the value from an existing secret. `secretName`
+configures the name of this secret. This allows you to configure this secret externally and avoid having a plaintext
 join token stored in your Teleport chart values.
 
 To create your own join token secret, you can use a command like this:
@@ -839,12 +914,17 @@ $ kubectl --namespace teleport create secret generic teleport-kube-agent-join-to
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  serviceAccountName:
+  secretName: "secret-i-created-before"
+  joinParams:
+    method: "token"
+    tokenName: ""
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set serviceAccountName=""
+  $ --set secretName="secret-i-created-before" \
+    --set joinParams.method="token" \
+    --set joinParams.tokenName=""
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
@@ -118,8 +118,8 @@ These sub-values must be configured for the agent to connect to a cluster.
 `joinParams.method` defines which join method will be used to join the Teleport cluster.
 Possible values are `token`, `iam` and `ec2`.
 
-- For `iam`, see [Joining Nodes Via AWS IAM Role](../../management/guides/joining-nodes-aws-iam.mdx).
-- For `ec2`, see [Joining Nodes Via AWS IAM Role](../../management/guides/joining-nodes-aws-ec2.mdx).
+- For `iam`, see [Joining Nodes Via AWS IAM Role](../guides/joining-nodes-aws-iam.mdx).
+- For `ec2`, see [Joining Nodes Via AWS IAM Role](../guides/joining-nodes-aws-ec2.mdx).
 - For `token` (default value), the token must be provided through `joinParams.tokenName` or
   [through an existing Kubernetes Secret](#secretName).
 

--- a/examples/chart/teleport-kube-agent/.lint/join-params-iam.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/join-params-iam.yaml
@@ -1,0 +1,5 @@
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster-name
+joinParams:
+  tokenName: iam-token
+  method: iam

--- a/examples/chart/teleport-kube-agent/.lint/join-params-token.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/join-params-token.yaml
@@ -1,0 +1,5 @@
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster-name
+joinParams:
+  tokenName: xxxxxxx-secret-token-xxxxxxx
+  method: token

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -15,7 +15,9 @@ metadata:
 data:
   teleport.yaml: |
     teleport:
-      auth_token: "/etc/teleport-secrets/auth-token"
+      join_params:
+        method: "{{ .Values.joinParams.method }}"
+        token_name: "/etc/teleport-secrets/auth-token"
       auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
       log:
         severity: {{ $logLevel }}

--- a/examples/chart/teleport-kube-agent/templates/secret.yaml
+++ b/examples/chart/teleport-kube-agent/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.authToken }}
+{{- if or .Values.authToken .Values.joinParams.tokenName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,5 +11,5 @@ metadata:
 type: Opaque
 stringData:
   auth-token: |
-    {{ .Values.authToken }}
+    {{ coalesce .Values.joinParams.tokenName .Values.authToken }}
 {{- end }}

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -2,9 +2,9 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
     "required": [
-        "authToken",
         "proxyAddr",
         "roles",
+        "joinParams",
         "kubeClusterName",
         "apps",
         "awsDatabases",
@@ -45,6 +45,24 @@
             "$id": "#/properties/roles",
             "type": "string",
             "default": "kube"
+        },
+        "joinParams": {
+            "$id": "#/properties/joinParams",
+            "type": "object",
+            "required": ["method"],
+            "properties": {
+                "tokenName": {
+                    "$id": "#/properties/joinParams/tokenName",
+                    "type": "string",
+                    "default": ""
+                },
+                "method": {
+                    "$id": "#/properties/joinParams/method",
+                    "type": "string",
+                    "default": "token"
+                },
+                "additionalProperties": false
+            }
         },
         "kubeClusterName": {
             "$id": "#/properties/kubeClusterName",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -2,14 +2,29 @@
 # Values that must always be provided by the user.
 ################################################################
 
-# Join token for the cluster.
-# Leave empty if the secret "teleport-kube-agent-join-token"
-# has been created before and contains a valid join token
+# Join token for the cluster. `joinParams` can also pass the join token,
+# but supports more join methods and takes precedence if set.
 authToken: ""
+
 # Address of the teleport proxy with port (usually :3080).
 proxyAddr: ""
 # Comma-separated list of roles to enable (any of: kube,db,app)
 roles: "kube"
+
+################################################################
+# Values that must be provided if IAM or EC2 joining is enabled.
+################################################################
+
+# Specify how to join the Teleport cluster
+joinParams:
+  # Supported join methods are "token", "ec2", "iam".
+  # method "token", is equivalent to using authToken to join a cluster
+  method: "token"
+
+  # Leave empty only when method is "token" and the secret
+  # "teleport-kube-agent-join-token" has been created before and
+  # contains a valid join token.
+  tokenName: ""
 
 ################################################################
 # Values that must be provided if Kubernetes access is enabled.


### PR DESCRIPTION
This is a manual backport of #16351 to `branch/v9`.