### PR TITLE
Verify attestation statement on the client side first

### DIFF
--- a/api/utils/keys/yubikey.go
+++ b/api/utils/keys/yubikey.go
@@ -207,6 +207,10 @@ func (y *YubiKeyPrivateKey) GetAttestationStatement() (*AttestationStatement, er
 		return nil, trace.Wrap(err)
 	}
 
+	if _, err = piv.Verify(attCert, slotCert); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &AttestationStatement{
 		AttestationStatement: &attestation.AttestationStatement_YubikeyAttestationStatement{
 			YubikeyAttestationStatement: &attestation.YubiKeyAttestationStatement{


### PR DESCRIPTION
Adds a client side check to ensure that a user's PIV key can be properly attested. This may  catch unexpected issues, such as an overwritten attestation certificate.