### PR TITLE
[v10] Improve FIDO2 UX with user-friendly errors

### DIFF
--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -44,7 +44,7 @@ import (
 var (
 	errHasExcludedCredential   = errors.New("device already holds a registered credential")
 	errNoPasswordless          = errors.New("device not registered for passwordless")
-	errNoPlatform              = errors.New("device cannot fulfil platform attachment requirement")
+	errNoPlatform              = errors.New("device cannot fulfill platform attachment requirement")
 	errNoRK                    = errors.New("device lacks resident key capabilities")
 	errNoRegisteredCredentials = errors.New("device lacks registered credentials")
 	errNoUV                    = errors.New("device lacks PIN or user verification capabilities")
@@ -695,7 +695,7 @@ func withInteractiveError(filter deviceFilterFunc, cb pinAwareCallbackFunc) pinA
 		}
 
 		// U2F devices tend to cause problems with the waitForTouch strategy below,
-		// so we filter then silently, as we used to do with all devices in previous
+		// so we filter them silently, as we used to do with all devices in previous
 		// versions.
 		if info.u2f {
 			log.Warnf("FIDO2: Device %v: U2F device filtered due to lack of capabilities", info.path)

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -40,6 +40,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// User-friendly device filter errors.
+var (
+	errHasExcludedCredential   = errors.New("device already holds a registered credential")
+	errNoPasswordless          = errors.New("device not registered for passwordless")
+	errNoPlatform              = errors.New("device cannot fulfil platform attachment requirement")
+	errNoRK                    = errors.New("device lacks resident key capabilities")
+	errNoRegisteredCredentials = errors.New("device lacks registered credentials")
+	errNoUV                    = errors.New("device lacks PIN or user verification capabilities")
+	errPasswordlessU2F         = errors.New("U2F devices cannot do passwordless")
+)
+
 // FIDODevice abstracts *libfido2.Device for testing.
 type FIDODevice interface {
 	// Info mirrors libfido2.Device.Info.
@@ -128,28 +139,32 @@ func fido2Login(
 	var usedAppID bool
 
 	pathToRPID := &sync.Map{} // map[string]string
-	filter := func(dev FIDODevice, info *deviceInfo) (bool, error) {
+	filter := func(dev FIDODevice, info *deviceInfo) error {
 		switch {
+		case info.u2f && (uv || passwordless):
+			return errPasswordlessU2F
+		case passwordless && (!info.uvCapable() || !info.rk):
+			return errNoPasswordless
 		case uv && !info.uvCapable():
-			log.Debugf("FIDO2: Device %v: filtered due to lack of UV", info.path)
-			return false, nil
-		case passwordless && !info.rk:
-			log.Debugf("FIDO2: Device %v: filtered due to lack of RK", info.path)
-			return false, nil
-		case len(allowedCreds) == 0: // Nothing else to check
-			return true, nil
+			// Unlikely that we would ask for UV without passwordless, but let's check
+			// just in case.
+			// If left unchecked this causes libfido2.ErrUnsupportedOption.
+			return errNoUV
+		case passwordless: // Nothing else to check
+			return nil
 		}
 
+		// TODO(codingllama): Kill discoverRPID? It makes behavioral assumptions
+		//  that caused problems before.
 		// Does the device have a suitable credential?
 		const pin = ""
 		actualRPID, err := discoverRPID(dev, info, pin, rpID, appID, allowedCreds)
 		if err != nil {
-			log.Debugf("FIDO2: Device %v: filtered due to lack of allowed credential", info.path)
-			return false, nil
+			return errNoRegisteredCredentials
 		}
 		pathToRPID.Store(info.path, actualRPID)
 
-		return true, nil
+		return nil
 	}
 
 	user := opts.User
@@ -376,19 +391,18 @@ func fido2Register(
 	var mu sync.Mutex
 	var attestation *libfido2.Attestation
 
-	filter := func(dev FIDODevice, info *deviceInfo) (bool, error) {
+	filter := func(dev FIDODevice, info *deviceInfo) error {
 		switch {
+		case info.u2f && (rrk || uv):
+			return errPasswordlessU2F
 		case plat && !info.plat:
-			log.Debugf("FIDO2: Device %v: filtered due to plat mismatch (requested %v, device %v)", info.path, plat, info.plat)
-			return false, nil
+			return errNoPlatform
 		case rrk && !info.rk:
-			log.Debugf("FIDO2: Device %v: filtered due to lack of resident keys", info.path)
-			return false, nil
+			return errNoRK
 		case uv && !info.uvCapable():
-			log.Debugf("FIDO2: Device %v: filtered due to lack of UV", info.path)
-			return false, nil
+			return errNoUV
 		case len(excludeList) == 0:
-			return true, nil
+			return nil
 		}
 
 		// Does the device hold an excluded credential?
@@ -397,20 +411,20 @@ func fido2Register(
 			UP: libfido2.False,
 		}); {
 		case errors.Is(err, libfido2.ErrNoCredentials):
-			return true, nil
+			return nil
 		case errors.Is(err, libfido2.ErrUserPresenceRequired):
 			// Yubikey4 does this when the credential exists.
-			return false, nil
+			return errHasExcludedCredential
 		case err != nil:
 			// Swallow unexpected errors: a double registration is better than
 			// aborting the ceremony.
 			log.Debugf(
 				"FIDO2: Device %v: excluded credential assertion failed, letting device through: err=%q",
 				info.path, err)
-			return true, nil
+			return nil
 		default:
 			log.Debugf("FIDO2: Device %v: filtered due to presence of excluded credential", info.path)
-			return false, nil
+			return errHasExcludedCredential
 		}
 	}
 
@@ -526,48 +540,27 @@ type deviceWithInfo struct {
 	info *deviceInfo
 }
 
-type deviceFilterFunc func(dev FIDODevice, info *deviceInfo) (ok bool, err error)
+type deviceFilterFunc func(dev FIDODevice, info *deviceInfo) error
 type deviceCallbackFunc func(dev FIDODevice, info *deviceInfo, pin string) error
+type pinAwareCallbackFunc func(dev FIDODevice, info *deviceInfo, pin string) (requiresPIN bool, err error)
 
 // runPrompt defines the prompt operations necessary for runOnFIDO2Devices.
 // (RegisterPrompt happens to match the minimal interface required.)
 type runPrompt RegisterPrompt
-
-// errNoSuitableDevices is used internally to loop over findSuitableDevices.
-var errNoSuitableDevices = errors.New("no suitable devices found")
 
 func runOnFIDO2Devices(
 	ctx context.Context,
 	prompt runPrompt,
 	filter deviceFilterFunc,
 	deviceCallback deviceCallbackFunc) error {
-	cb := withRetries(deviceCallback)
-
-	// Do we have readily available devices?
-	knownPaths := make(map[string]struct{}) // filled by findSuitableDevices*
-	prompted := false
-	devices, err := findSuitableDevices(filter, knownPaths)
-	if errors.Is(err, errNoSuitableDevices) {
-		// No readily available devices means we need to prompt, otherwise the
-		// user gets no feedback whatsoever.
-		if err := prompt.PromptTouch(); err != nil {
-			return trace.Wrap(err)
-		}
-		prompted = true
-
-		devices, err = findSuitableDevicesOrTimeout(ctx, filter, knownPaths)
-	}
-	if err != nil {
+	// About to select, prompt user.
+	if err := prompt.PromptTouch(); err != nil {
 		return trace.Wrap(err)
 	}
 
-	if !prompted {
-		// about to select
-		if err := prompt.PromptTouch(); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-	dev, requiresPIN, err := selectDevice(ctx, "" /* pin */, devices, cb)
+	// List/select devices.
+	cb := withPINHandler(withRetries(deviceCallback))
+	dev, requiresPIN, err := findAndSelectDevice(ctx, filter, cb)
 	switch {
 	case err != nil:
 		return trace.Wrap(err)
@@ -592,41 +585,252 @@ func runOnFIDO2Devices(
 
 	// Run the callback again with the informed PIN.
 	// selectDevice is used since it correctly deals with cancellation.
-	_, _, err = selectDevice(ctx, pin, []deviceWithInfo{dev}, cb)
+	cb = withoutPINHandler(withRetries(deviceCallback))
+	_, err = selectDevice(ctx, pin, dev, cb)
 	return trace.Wrap(err)
 }
 
-func findSuitableDevicesOrTimeout(
-	ctx context.Context, filter deviceFilterFunc, knownPaths map[string]struct{}) ([]deviceWithInfo, error) {
-	ticker := time.NewTicker(FIDO2PollInterval)
-	defer ticker.Stop()
+// withRetries wraps callback with retries and error handling for commonly seen
+// errors.
+func withRetries(callback deviceCallbackFunc) deviceCallbackFunc {
+	return func(dev FIDODevice, info *deviceInfo, pin string) error {
+		const maxRetries = 3
+		var err error
+		for i := 0; i < maxRetries; i++ {
+			err = callback(dev, info, pin)
+			if err == nil {
+				return nil
+			}
 
-	for {
-		switch devices, err := findSuitableDevices(filter, knownPaths); {
-		case err == nil:
-			return devices, nil
-		case errors.Is(err, errNoSuitableDevices):
-			// OK, carry on until we find a device or timeout.
-		default:
-			// Unexpected, abort.
-			return nil, trace.Wrap(err)
+			// Handle errors mapped by go-libfido2.
+			// ErrOperationDenied happens when fingerprint reading fails (UV=false).
+			if errors.Is(err, libfido2.ErrOperationDenied) {
+				fmt.Println("Gesture validation failed, make sure you use a registered fingerprint")
+				log.Debug("FIDO2: Retrying libfido2 error 'operation denied'")
+				continue
+			}
+
+			// Handle generic libfido2.Error instances.
+			var fidoErr libfido2.Error
+			if !errors.As(err, &fidoErr) {
+				return err
+			}
+
+			// See https://github.com/Yubico/libfido2/blob/main/src/fido/err.h#L32.
+			switch fidoErr.Code {
+			case 60: // FIDO_ERR_UV_BLOCKED, 0x3c
+				const msg = "" +
+					"The user verification function in your security key is blocked. " +
+					"This is likely due to too many failed authentication attempts. " +
+					"Consult your manufacturer documentation for how to unblock your security key. " +
+					"Alternatively, you may unblock your device by using it in the Web UI."
+				return trace.Wrap(err, msg)
+			case 63: // FIDO_ERR_UV_INVALID, 0x3f
+				log.Debug("FIDO2: Retrying libfido2 error 63")
+				continue
+			default: // Unexpected code.
+				return err
+			}
 		}
 
+		return fmt.Errorf("max retry attempts reached: %w", err)
+	}
+}
+
+func withPINHandler(cb deviceCallbackFunc) pinAwareCallbackFunc {
+	return func(dev FIDODevice, info *deviceInfo, pin string) (requiresPIN bool, err error) {
+		// Attempt to select a device by running "deviceCallback" on it.
+		// For most scenarios this works, saving a touch.
+		err = cb(dev, info, pin)
+		switch {
+		case errors.Is(err, libfido2.ErrPinRequired):
+			// Continued below.
+		case errors.Is(err, libfido2.ErrUnsupportedOption) && pin == "" && !info.uv && info.clientPinSet:
+			// The failing option is likely to be "UV", so we handle this the same as
+			// ErrPinRequired: see if the user selects this device, ask for the PIN and
+			// try again.
+			// Continued below.
+		default:
+			return
+		}
+
+		// ErrPinRequired means we can't use "deviceCallback" as the selection
+		// mechanism. Let's run a different operation to ask for a touch.
+		requiresPIN = true
+
+		err = waitForTouch(dev)
+		if errors.Is(err, libfido2.ErrNoCredentials) {
+			err = nil // OK, selected successfully
+		}
+		return
+	}
+}
+
+func withoutPINHandler(cb deviceCallbackFunc) pinAwareCallbackFunc {
+	return func(dev FIDODevice, info *deviceInfo, pin string) (bool, error) {
+		return false, cb(dev, info, pin)
+	}
+}
+
+// nonInteractiveError tags device errors that happen before user interaction.
+// These are are usually ignored in the context of selecting devices.
+type nonInteractiveError struct {
+	err error
+}
+
+func (e *nonInteractiveError) Error() string {
+	return e.err.Error()
+}
+
+func (e *nonInteractiveError) Is(err error) bool {
+	_, ok := err.(*nonInteractiveError)
+	return ok
+}
+
+func withInteractiveError(filter deviceFilterFunc, cb pinAwareCallbackFunc) pinAwareCallbackFunc {
+	return func(dev FIDODevice, info *deviceInfo, pin string) (bool, error) {
+		filterErr := filter(dev, info)
+		if filterErr == nil {
+			return cb(dev, info, pin)
+		}
+
+		// U2F devices tend to cause problems with the waitForTouch strategy below,
+		// so we filter then silently, as we used to do with all devices in previous
+		// versions.
+		if info.u2f {
+			log.Warnf("FIDO2: Device %v: U2F device filtered due to lack of capabilities", info.path)
+			return false, &nonInteractiveError{filterErr}
+		}
+
+		// Device got filtered out, let's see if the user chooses it and provide a
+		// nice error message.
+		switch waitErr := waitForTouch(dev); {
+		case errors.Is(waitErr, libfido2.ErrKeepaliveCancel):
+			// Device not chosen.
+			return false, &nonInteractiveError{filterErr}
+		case errors.Is(waitErr, libfido2.ErrNoCredentials):
+			// Device chosen, error is useful in this case.
+		default:
+			log.Warnf("FIDO2: Device %v: unexpected wait error: %q", info.path, waitErr)
+		}
+
+		return false, trace.Wrap(filterErr)
+	}
+}
+
+func waitForTouch(dev FIDODevice) error {
+	// TODO(codingllama): What we really want here is fido_dev_get_touch_begin.
+	//  Another option is to put the authenticator into U2F mode.
+	const rpID = "7f364cc0-958c-4177-b3ea-b2d8d7f15d4a" // arbitrary, unlikely to collide with a real RP
+	const cdh = "00000000000000000000000000000000"      // "random", size 32
+	_, err := dev.Assertion(rpID, []byte(cdh), nil /* credentials */, "", &libfido2.AssertionOpts{
+		UP: libfido2.True,
+	})
+	return err
+}
+
+func findAndSelectDevice(ctx context.Context, filter deviceFilterFunc, deviceCallback pinAwareCallbackFunc) (dev *deviceWithInfo, requiresPIN bool, err error) {
+	innerCtx, innerCancel := context.WithCancel(ctx)
+	// innerCancel handled below.
+
+	type devicesResp struct {
+		devs []*deviceWithInfo
+		err  error
+	}
+	devicesC := make(chan devicesResp, 1)
+
+	// Device search goroutine, runs until innerCtx is closed.
+	go func() {
+		knownPaths := make(map[string]struct{})
+
+		ticker := time.NewTicker(FIDO2PollInterval)
+		defer ticker.Stop()
+
+		for {
+			devs, err := findDevices(knownPaths)
+			devicesC <- devicesResp{
+				devs: devs,
+				err:  err,
+			}
+
+			select {
+			case <-innerCtx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+
+	type selectResp struct {
+		dev         *deviceWithInfo
+		requiresPIN bool
+		err         error
+	}
+	selectC := make(chan selectResp)
+	selectGoroutines := 0
+
+	defer func() {
+		innerCancel() // Cancel all goroutines
+
+		// Collect select goroutines.
+		for selectGoroutines > 0 {
+			<-selectC
+			selectGoroutines--
+		}
+
+		// Collect device search goroutine, if blocked.
+		for stop := false; !stop; {
+			select {
+			case <-devicesC:
+			default:
+				stop = true
+			}
+		}
+	}()
+
+	cb := withInteractiveError(filter, deviceCallback)
+	for {
 		select {
+		// New devices found.
+		case resp := <-devicesC:
+			if resp.err != nil {
+				return nil, false, trace.Wrap(resp.err)
+			}
+			for _, dev := range resp.devs {
+				dev := dev
+				selectGoroutines++
+				go func() {
+					requiresPIN, err := selectDevice(innerCtx, "" /* pin */, dev, cb)
+					selectC <- selectResp{
+						dev:         dev,
+						requiresPIN: requiresPIN,
+						err:         err,
+					}
+				}()
+			}
+
+		// User selected device.
+		case resp := <-selectC:
+			selectGoroutines--
+			if errors.Is(resp.err, &nonInteractiveError{}) {
+				continue
+			}
+			return resp.dev, resp.requiresPIN, trace.Wrap(resp.err)
+
+		// Timed out.
 		case <-ctx.Done():
-			return nil, trace.Wrap(ctx.Err())
-		case <-ticker.C:
+			return nil, false, trace.Wrap(ctx.Err())
 		}
 	}
 }
 
-func findSuitableDevices(filter deviceFilterFunc, knownPaths map[string]struct{}) ([]deviceWithInfo, error) {
+func findDevices(knownPaths map[string]struct{}) ([]*deviceWithInfo, error) {
 	locs, err := fidoDeviceLocations()
 	if err != nil {
 		return nil, trace.Wrap(err, "device locations")
 	}
 
-	var devs []deviceWithInfo
+	var devs []*deviceWithInfo
 	for _, loc := range locs {
 		path := loc.Path
 		if _, ok := knownPaths[path]; ok {
@@ -646,183 +850,74 @@ func findSuitableDevices(filter deviceFilterFunc, knownPaths map[string]struct{}
 			info, err = dev.Info()
 			switch {
 			case errors.Is(err, libfido2.ErrNotFIDO2):
-				// Use an empty info and carry on.
-				// A FIDO/U2F device has no capabilities beyond MFA
-				// registrations/assertions.
-				info = &libfido2.DeviceInfo{}
 				u2f = true
 			case errors.Is(err, libfido2.ErrTX):
-				// Happens occasionally, give the device a short grace period and retry.
-				time.Sleep(1 * time.Millisecond)
+				// Happens occasionally, let's retry.
+				fallthrough
+			case err != nil:
+				// Unexpected error, retry anyway.
+				// Note that U2F devices fail in a variety of different ways.
+				time.Sleep(100 * time.Millisecond)
 				continue
-			case err != nil: // unexpected error
-				return nil, trace.Wrap(err, "device %v: info", path)
 			}
 			break // err == nil
 		}
-		if info == nil {
-			return nil, trace.Wrap(libfido2.ErrTX, "device %v: max info attempts reached", path)
+		if !u2f && info == nil {
+			log.Warnf("FIDO2: Device %v: max info attempts reached, treating as U2F", path)
+			u2f = true
 		}
 		log.Debugf("FIDO2: Info for device %v: %#v", path, info)
 
-		di := makeDevInfo(path, info, u2f)
-		switch ok, err := filter(dev, di); {
-		case err != nil:
-			return nil, trace.Wrap(err, "device %v: filter", path)
-		case !ok:
-			continue // Skip device.
-		}
-		devs = append(devs, deviceWithInfo{FIDODevice: dev, info: di})
+		devs = append(devs, &deviceWithInfo{
+			FIDODevice: dev,
+			info:       makeDevInfo(path, info, u2f),
+		})
 	}
 
-	l := len(devs)
-	if l == 0 {
-		return nil, errNoSuitableDevices
+	if l := len(devs); l > 0 {
+		log.Debugf("FIDO2: Found %v new devices", l)
 	}
-	log.Debugf("FIDO2: Found %v suitable devices", l)
 
 	return devs, nil
 }
 
-// withRetries wraps callback with retries and error handling for commonly seen
-// errors.
-func withRetries(callback deviceCallbackFunc) deviceCallbackFunc {
-	return func(dev FIDODevice, info *deviceInfo, pin string) error {
-		const maxRetries = 3
-		var err error
-		for i := 0; i < maxRetries; i++ {
-			err = callback(dev, info, pin)
-			if err == nil {
-				return err
-			}
-			// Handle errors mapped by go-libfido2.
-			// ErrOperationDenied happens when fingerprint reading fails (UV=false).
-			if errors.Is(err, libfido2.ErrOperationDenied) {
-				fmt.Println("Gesture validation failed, make sure you use a registered fingerprint")
-				log.Debug("FIDO2: Retrying libfido2 error 'operation denied'")
-				continue
-			}
-			// Handle generic libfido2.Error instances.
-			var fidoErr libfido2.Error
-			if !errors.As(err, &fidoErr) {
-				return err
-			}
-
-			// See https://github.com/Yubico/libfido2/blob/main/src/fido/err.h#L32.
-			switch fidoErr.Code {
-			case 60: // FIDO_ERR_UV_BLOCKED, 0x3c
-				const msg = "" +
-					"The user verification function in your security key is blocked. " +
-					"This is likely due to too many failed authentication attempts. " +
-					"Consult your manufacturer documentation for how to unblock your security key. " +
-					"Alternatively, you may unblock your device by using it in the Web UI."
-
-				return trace.Wrap(err, msg)
-			case 63: // FIDO_ERR_UV_INVALID, 0x3f
-				log.Debug("FIDO2: Retrying libfido2 error 63")
-				continue
-			}
-		}
-
-		return fmt.Errorf("max retry attempts reached: %w", err)
-	}
-}
-
 func selectDevice(
 	ctx context.Context,
-	pin string, devices []deviceWithInfo, deviceCallback deviceCallbackFunc) (deviceWithInfo, bool, error) {
-	callbackWrapper := func(dev FIDODevice, info *deviceInfo, pin string) (requiresPIN bool, err error) {
-		// Attempt to select a device by running "deviceCallback" on it.
-		// For most scenarios this works, saving a touch.
-		err = deviceCallback(dev, info, pin)
-		switch {
-		case errors.Is(err, libfido2.ErrPinRequired):
-			// Continued below.
-		case errors.Is(err, libfido2.ErrUnsupportedOption) && pin == "" && !info.uv && info.clientPinSet:
-			// The failing option is likely to be "UV", so we handle this the same as
-			// ErrPinRequired: see if the user selects this device, ask for the PIN and
-			// try again.
-			// Continued below.
-		default:
-			return
-		}
+	pin string, dev *deviceWithInfo, cb pinAwareCallbackFunc) (requiresPIN bool, err error) {
+	// Spin a goroutine to run the callback so we can deal with context
+	// cancellation.
+	done := make(chan struct{})
+	go func() {
+		requiresPIN, err = cb(dev, dev.info, pin)
+		close(done)
+	}()
 
-		// ErrPinRequired means we can't use "deviceCallback" as the selection
-		// mechanism. Let's run a different operation to ask for a touch.
-		requiresPIN = true
-
-		// TODO(codingllama): What we really want here is fido_dev_get_touch_begin.
-		//  Another option is to put the authenticator into U2F mode.
-		const rpID = "7f364cc0-958c-4177-b3ea-b2d8d7f15d4a" // arbitrary, unlikely to collide with a real RP
-		const cdh = "00000000000000000000000000000000"      // "random", size 32
-		_, err = dev.Assertion(rpID, []byte(cdh), nil /* credentials */, "", &libfido2.AssertionOpts{
-			UP: libfido2.True,
-		})
-		if errors.Is(err, libfido2.ErrNoCredentials) {
-			err = nil // OK, selected successfully
-		}
-		return
-	}
-
-	type selectResp struct {
-		dev         deviceWithInfo
-		requiresPIN bool
-		err         error
-	}
-
-	respC := make(chan selectResp)
-	numGoroutines := len(devices)
-	for _, dev := range devices {
-		dev := dev
-		go func() {
-			requiresPIN, err := callbackWrapper(dev, dev.info, pin)
-			respC <- selectResp{
-				dev:         dev,
-				requiresPIN: requiresPIN,
-				err:         err,
-			}
-		}()
-	}
-
-	// Stop on timeout or first interaction, whatever comes first wins and gets
-	// returned.
-	var resp selectResp
 	select {
+	case <-done:
+		log.Debugf("FIDO2: device %v: selected with err=%v", dev.info.path, err)
 	case <-ctx.Done():
-		resp.err = ctx.Err()
-	case resp = <-respC:
-		numGoroutines--
-	}
-
-	// Cancel ongoing operations and wait for goroutines to complete.
-	for _, dev := range devices {
-		if dev == resp.dev {
-			continue
-		}
+		log.Debugf("FIDO2: device %v: requesting cancel", dev.info.path)
 		if err := dev.Cancel(); err != nil {
-			log.WithError(err).Tracef("FIDO2: Device cancel")
+			log.Debugf("FIDO2: device %v: cancel errored: %v", dev.info.path, err)
 		}
-	}
 
-	// Do not wait for cancels forever.
-	// A device that ignores/fails Cancel will lock the program.
-	timer := time.NewTimer(1 * time.Second)
-	defer timer.Stop()
-
-	for i := 0; i < numGoroutines; i++ {
+		// Give the device a grace period to cancel/cleanup, but do not wait
+		// forever.
+		timer := time.NewTimer(500 * time.Millisecond)
+		defer timer.Stop()
 		select {
-		case cancelResp := <-respC:
-			if err := cancelResp.err; err != nil && !errors.Is(err, libfido2.ErrKeepaliveCancel) {
-				log.WithError(err).Debugf("FIDO2: Device errored on cancel")
-			}
+		case <-done:
 		case <-timer.C:
 			log.Warnf("FIDO2: " +
 				"Timed out waiting for device cancels. " +
 				"It's possible some devices are left blinking.")
 		}
+
+		return false, trace.Wrap(ctx.Err())
 	}
 
-	return resp.dev, resp.requiresPIN, trace.Wrap(resp.err)
+	// Returns variables captured by goroutine.
+	return
 }
 
 // deviceInfo contains an aggregate of a device's information and capabilities.

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -1945,8 +1945,6 @@ func (f *fakeFIDO2Device) Assertion(
 	switch {
 	case rpID == "":
 		return nil, errors.New("rp.ID required")
-	case f.wantRPID != "" && f.wantRPID != rpID:
-		return nil, libfido2.ErrNoCredentials
 	case len(clientDataHash) == 0:
 		return nil, errors.New("clientDataHash required")
 	}
@@ -1978,6 +1976,12 @@ func (f *fakeFIDO2Device) Assertion(
 	// Block for user presence before accessing any credential data.
 	if err := f.maybeLockUntilInteraction(opts.UP == libfido2.True); err != nil {
 		return nil, err
+	}
+
+	// Does our explicitly set RPID match?
+	// Used to simulate U2F App ID.
+	if f.wantRPID != "" && f.wantRPID != rpID {
+		return nil, libfido2.ErrNoCredentials
 	}
 
 	// Index credentialIDs for easier use.

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -1237,7 +1237,6 @@ func TestFIDO2_LoginRegister_interactionErrors(t *testing.T) {
 			},
 			AuthenticatorSelection: protocol.AuthenticatorSelection{
 				RequireResidentKey: protocol.ResidentKeyUnrequired(),
-				ResidentKey:        protocol.ResidentKeyRequirementDiscouraged,
 				UserVerification:   protocol.VerificationDiscouraged,
 			},
 			Attestation: protocol.PreferNoAttestation,
@@ -1337,7 +1336,6 @@ func TestFIDO2_LoginRegister_interactionErrors(t *testing.T) {
 
 	pwdlessCC := *mfaCC
 	pwdlessCC.Response.AuthenticatorSelection.RequireResidentKey = protocol.ResidentKeyRequired()
-	pwdlessCC.Response.AuthenticatorSelection.ResidentKey = protocol.ResidentKeyRequirementRequired
 	pwdlessCC.Response.AuthenticatorSelection.UserVerification = protocol.VerificationRequired
 
 	// FIDO2Register interaction tests.

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -1182,6 +1182,213 @@ func TestFIDO2Login_errors(t *testing.T) {
 	}
 }
 
+// TestFIDO2_LoginRegister_interactionErrors tests scenarios where the user
+// picks a security key that cannot be used for that particular flow (and the
+// subsequent error message).
+func TestFIDO2_LoginRegister_interactionErrors(t *testing.T) {
+	resetFIDO2AfterTests(t)
+
+	notRegistered := mustNewFIDO2Device("/notregistered", "mysupersecretpinLLAMA", &libfido2.DeviceInfo{
+		Options: pinOpts,
+	})
+	// PIN capable but unset.
+	noPIN := mustNewFIDO2Device("/nouv", "" /* pin */, &libfido2.DeviceInfo{
+		Options: authOpts,
+	})
+	// fictional PIN capable, RK incapable device.
+	noRK := mustNewFIDO2Device("/nork", "" /* pin */, &libfido2.DeviceInfo{
+		Options: []libfido2.Option{
+			{Name: "rk", Value: "false"},       // not capable
+			{Name: "up", Value: "true"},        // expected setting
+			{Name: "plat", Value: "false"},     // expected setting
+			{Name: "clientPin", Value: "true"}, // supported and configured
+		},
+	})
+	// U2F only device (no FIDO2 capabilities).
+	u2f := mustNewFIDO2Device("/u2f", "" /* pin */, nil /* info */)
+	u2f.u2fOnly = true
+
+	f2 := newFakeFIDO2(notRegistered, noPIN, noRK, u2f).withNonMeteredLocations()
+	f2.setCallbacks()
+
+	const rpID = "goteleport.com"
+	const origin = "https://goteleport.com"
+	mfaCC := &wanlib.CredentialCreation{
+		Response: protocol.PublicKeyCredentialCreationOptions{
+			Challenge: []byte{1, 2, 3, 4, 5}, // arbitrary
+			RelyingParty: protocol.RelyingPartyEntity{
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "Teleport",
+				},
+				ID: rpID,
+			},
+			User: protocol.UserEntity{
+				CredentialEntity: protocol.CredentialEntity{
+					Name: "llama",
+				},
+				DisplayName: "Llama",
+				ID:          []byte{1, 1, 1, 1, 1}, // arbitrary
+			},
+			Parameters: []protocol.CredentialParameter{
+				{
+					Type:      protocol.PublicKeyCredentialType,
+					Algorithm: webauthncose.AlgES256,
+				},
+			},
+			AuthenticatorSelection: protocol.AuthenticatorSelection{
+				RequireResidentKey: protocol.ResidentKeyUnrequired(),
+				ResidentKey:        protocol.ResidentKeyRequirementDiscouraged,
+				UserVerification:   protocol.VerificationDiscouraged,
+			},
+			Attestation: protocol.PreferNoAttestation,
+		},
+	}
+
+	// Setup: register all devices (except "notRegistered") for MFA.
+	// A typical MFA registration allows all kinds of devices.
+	ctx := context.Background()
+	var registeredCreds [][]byte
+	for _, dev := range []*fakeFIDO2Device{noPIN, noRK, u2f} {
+		resp, err := wancli.FIDO2Register(ctx, origin, mfaCC, dev)
+		if err != nil {
+			t.Fatalf("FIDO2Register failed, device %v: %v", dev.path, err)
+		}
+		registeredCreds = append(registeredCreds, resp.GetWebauthn().RawId)
+	}
+
+	mfaAssertion := &wanlib.CredentialAssertion{
+		Response: protocol.PublicKeyCredentialRequestOptions{
+			Challenge:        []byte{1, 2, 3, 4, 5}, // arbitrary
+			RelyingPartyID:   rpID,
+			UserVerification: protocol.VerificationDiscouraged,
+		},
+	}
+	for _, cred := range registeredCreds {
+		mfaAssertion.Response.AllowedCredentials = append(mfaAssertion.Response.AllowedCredentials, protocol.CredentialDescriptor{
+			Type:         protocol.PublicKeyCredentialType,
+			CredentialID: cred,
+		})
+	}
+
+	pwdlessAssertion := *mfaAssertion
+	pwdlessAssertion.Response.AllowedCredentials = nil
+	pwdlessAssertion.Response.UserVerification = protocol.VerificationRequired
+
+	// FIDO2Login interaction tests.
+	for _, test := range []struct {
+		name            string
+		createAssertion func() *wanlib.CredentialAssertion
+		prompt          wancli.LoginPrompt
+		wantErr         string
+	}{
+		{
+			name:            "no registered credential",
+			createAssertion: func() *wanlib.CredentialAssertion { return mfaAssertion },
+			prompt:          notRegistered,
+			wantErr:         "lacks registered credential",
+		},
+		{
+			// Theoretically could happen, but not something we do today.
+			name: "mfa lacks UV",
+			createAssertion: func() *wanlib.CredentialAssertion {
+				mfaUV := *mfaAssertion
+				mfaUV.Response.UserVerification = protocol.VerificationRequired
+				return &mfaUV
+			},
+			prompt:  noPIN, // PIN unset means it cannot do UV
+			wantErr: "user verification",
+		},
+		{
+			name:            "passwordless lacks UV",
+			createAssertion: func() *wanlib.CredentialAssertion { return &pwdlessAssertion },
+			prompt:          noPIN, // PIN unset means it cannot do UV
+			wantErr:         "passwordless",
+		},
+		{
+			// Fictional scenario, no real-world authenticators match.
+			name:            "passwordless lacks RK",
+			createAssertion: func() *wanlib.CredentialAssertion { return &pwdlessAssertion },
+			prompt:          noRK,
+			wantErr:         "passwordless",
+		},
+		{
+			name:            "passwordless U2F",
+			createAssertion: func() *wanlib.CredentialAssertion { return &pwdlessAssertion },
+			prompt:          u2f,
+			wantErr:         context.DeadlineExceeded.Error(), // silently filtered, times out
+		},
+	} {
+		t.Run("login/"+test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			defer cancel()
+
+			_, _, err := wancli.FIDO2Login(ctx, origin, test.createAssertion(), test.prompt, nil /* opts */)
+			assert.ErrorContains(t, err, test.wantErr, "FIDO2Login error mismatch")
+		})
+	}
+
+	excludeCC := *mfaCC
+	for _, cred := range registeredCreds {
+		excludeCC.Response.CredentialExcludeList = append(excludeCC.Response.CredentialExcludeList, protocol.CredentialDescriptor{
+			Type:         protocol.PublicKeyCredentialType,
+			CredentialID: cred,
+		})
+	}
+
+	pwdlessCC := *mfaCC
+	pwdlessCC.Response.AuthenticatorSelection.RequireResidentKey = protocol.ResidentKeyRequired()
+	pwdlessCC.Response.AuthenticatorSelection.ResidentKey = protocol.ResidentKeyRequirementRequired
+	pwdlessCC.Response.AuthenticatorSelection.UserVerification = protocol.VerificationRequired
+
+	// FIDO2Register interaction tests.
+	for _, test := range []struct {
+		name     string
+		createCC func() *wanlib.CredentialCreation
+		prompt   wancli.RegisterPrompt
+		wantErr  string
+	}{
+		{
+			name:     "excluded credential",
+			createCC: func() *wanlib.CredentialCreation { return &excludeCC },
+			prompt:   noPIN,
+			wantErr:  "registered credential",
+		},
+		{
+			name:     "excluded credential (U2F)",
+			createCC: func() *wanlib.CredentialCreation { return &excludeCC },
+			prompt:   u2f,
+			wantErr:  context.DeadlineExceeded.Error(), // silently filtered, times out
+		},
+		{
+			name:     "passwordless lacks UV",
+			createCC: func() *wanlib.CredentialCreation { return &pwdlessCC },
+			prompt:   noPIN, // PIN unset means it cannot do UV
+			wantErr:  "user verification",
+		},
+		{
+			// Fictional scenario, no real-world authenticators match.
+			name:     "passwordless lacks RK",
+			createCC: func() *wanlib.CredentialCreation { return &pwdlessCC },
+			prompt:   noRK,
+			wantErr:  "resident key",
+		},
+		{
+			name:     "passwordless U2F",
+			createCC: func() *wanlib.CredentialCreation { return &pwdlessCC },
+			prompt:   u2f,
+			wantErr:  context.DeadlineExceeded.Error(), // silently filtered, times out
+		},
+	} {
+		t.Run("register/"+test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			defer cancel()
+
+			_, err := wancli.FIDO2Register(ctx, origin, test.createCC(), test.prompt)
+			assert.ErrorContains(t, err, test.wantErr, "FIDO2Register error mismatch")
+		})
+	}
+}
+
 func TestFIDO2Register(t *testing.T) {
 	resetFIDO2AfterTests(t)
 


### PR DESCRIPTION
Improves FIDO2 login/registration UX by letting users choose (almost) any
available key and then presenting a user-friendly error if the operation cannot
be done.

New devices are now polled for continuously, as we can't eagerly filter devices
anymore. All FIDO2 devices, regardless of their capabilities, are made to wait
for user interaction: once the user interacts with the device we either complete
the operation successfully or return a reason for failure.

U2F-only devices are still silently ignored, as before. They don't respond well
to FIDO2 APIs and proved to be unwieldy in practical tests. (Maybe we can tackle
those in a follow up.)

Examples of new UX:

```shell
# Attempting passwordless login on a non-capable device (lack of PIN)
$ tsh login --proxy=zarquon --user=ihaveitall --auth=passwordless
> Tap your security key
> ERROR: device not registered for passwordless

# Attempting passwordless registration on a non-capable device (lack of PIN)
$ tsh mfa add --type=WEBAUTHN --name=test --allow-passwordless
> Tap any *registered* security key
> Tap your *new* security key
> ERROR: device lacks PIN or user verification capabilities
```

Backport #17441 to branch/v10