### PR TITLE
[v11] fix rotation handling in GenerateHostCerts

### DIFF
--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -418,6 +418,16 @@ func (r *Rotation) Matches(rotation Rotation) bool {
 	return r.CurrentID == rotation.CurrentID && r.State == rotation.State && r.Phase == rotation.Phase
 }
 
+// IsZero checks if this is the zero value of Rotation. Works on nil and non-nil rotation
+// values.
+func (r *Rotation) IsZero() bool {
+	if r == nil {
+		return true
+	}
+
+	return r.Matches(Rotation{})
+}
+
 // LastRotatedDescription returns human friendly description.
 func (r *Rotation) LastRotatedDescription() string {
 	if r.LastRotated.IsZero() {

--- a/api/types/authority_test.go
+++ b/api/types/authority_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRotationZero verifies expected behavior of Rotataion.IsZero.
+func TestRotationZero(t *testing.T) {
+	tts := []struct {
+		r *Rotation
+		z bool
+		d string
+	}{
+		{
+			r: &Rotation{
+				Phase: RotationPhaseStandby,
+			},
+			z: false,
+			d: "non-empty rotation",
+		},
+		{
+			r: &Rotation{},
+			z: true,
+			d: "empty but non-nil rotation",
+		},
+		{
+			r: nil,
+			z: true,
+			d: "nil rotation",
+		},
+	}
+
+	for _, tt := range tts {
+		require.Equal(t, tt.z, tt.r.IsZero(), tt.d)
+	}
+}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2366,7 +2366,7 @@ func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 	// or auth server is out of sync, either way, for now check that
 	// cache is out of sync, this will result in higher read rate
 	// to the backend, which is a fine tradeoff
-	if !req.NoCache && req.Rotation != nil && !req.Rotation.Matches(ca.GetRotation()) {
+	if !req.NoCache && !req.Rotation.IsZero() && !req.Rotation.Matches(ca.GetRotation()) {
 		log.Debugf("Client sent rotation state %v, cache state is %v, using state from the DB.", req.Rotation, ca.GetRotation())
 		ca, err = a.Services.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -621,6 +621,13 @@ type ReRegisterParams struct {
 
 // ReRegister renews the certificates and private keys based on the client's existing identity.
 func ReRegister(params ReRegisterParams) (*Identity, error) {
+	var rotation *types.Rotation
+	if !params.Rotation.IsZero() {
+		// older auths didn't distinguish between empty and nil rotation
+		// structs, so we go out of our way to only send non-nil rotation
+		// if it is truly non-empty.
+		rotation = &params.Rotation
+	}
 	certs, err := params.Client.GenerateHostCerts(context.Background(),
 		&proto.HostCertsRequest{
 			HostID:                        params.ID.HostID(),
@@ -630,7 +637,7 @@ func ReRegister(params ReRegisterParams) (*Identity, error) {
 			DNSNames:                      params.DNSNames,
 			PublicTLSKey:                  params.PublicTLSKey,
 			PublicSSHKey:                  params.PublicSSHKey,
-			Rotation:                      &params.Rotation,
+			Rotation:                      rotation,
 			SystemRoles:                   params.SystemRoles,
 			UnstableSystemRoleAssertionID: params.UnstableSystemRoleAssertionID,
 		})


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/17598