### PR TITLE
APT/YUM publishing fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7289,19 +7289,6 @@ steps:
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
-- name: Check if tag is prerelease
-  image: golang:1.18-alpine
-  commands:
-  - apk add git
-  - mkdir -pv "/tmp/repo"
-  - cd "/tmp/repo"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "${DRONE_TAG}"
-  - cd "/tmp/repo/build.assets/tooling"
-  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
-    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
 - name: Check out code
   image: alpine/git:latest
   commands:
@@ -7337,7 +7324,6 @@ steps:
     path: /root/.aws
   depends_on:
   - Verify build is tagged
-  - Check if tag is prerelease
   - Check out code
 - name: Download artifacts for "${DRONE_TAG}"
   image: amazon/aws-cli
@@ -7356,7 +7342,6 @@ steps:
   depends_on:
   - Assume Download AWS Role
   - Verify build is tagged
-  - Check if tag is prerelease
   - Check out code
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
@@ -7385,7 +7370,23 @@ steps:
   depends_on:
   - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
-  - Check if tag is prerelease
+  - Check out code
+- name: Check if tag is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - apk add git
+  - mkdir -pv "/tmp/repo"
+  - cd "/tmp/repo"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_TAG}"
+  - cd "/tmp/repo/build.assets/tooling"
+  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
+    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
+  depends_on:
+  - Assume Upload AWS Role
+  - Verify build is tagged
   - Check out code
 - name: Publish debs to APT repos for "${DRONE_TAG}"
   image: golang:1.18-bullseye
@@ -7420,9 +7421,8 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Assume Upload AWS Role
-  - Verify build is tagged
   - Check if tag is prerelease
+  - Verify build is tagged
   - Check out code
 volumes:
 - name: apt-persistence
@@ -7492,19 +7492,6 @@ steps:
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
-- name: Check if tag is prerelease
-  image: golang:1.18-alpine
-  commands:
-  - apk add git
-  - mkdir -pv "/tmp/repo"
-  - cd "/tmp/repo"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "${DRONE_TAG}"
-  - cd "/tmp/repo/build.assets/tooling"
-  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
-    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
 - name: Check out code
   image: alpine/git:latest
   commands:
@@ -7540,7 +7527,6 @@ steps:
     path: /root/.aws
   depends_on:
   - Verify build is tagged
-  - Check if tag is prerelease
   - Check out code
 - name: Download artifacts for "${DRONE_TAG}"
   image: amazon/aws-cli
@@ -7559,7 +7545,6 @@ steps:
   depends_on:
   - Assume Download AWS Role
   - Verify build is tagged
-  - Check if tag is prerelease
   - Check out code
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
@@ -7588,7 +7573,23 @@ steps:
   depends_on:
   - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
-  - Check if tag is prerelease
+  - Check out code
+- name: Check if tag is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - apk add git
+  - mkdir -pv "/tmp/repo"
+  - cd "/tmp/repo"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_TAG}"
+  - cd "/tmp/repo/build.assets/tooling"
+  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
+    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
+  depends_on:
+  - Assume Upload AWS Role
+  - Verify build is tagged
   - Check out code
 - name: Publish rpms to YUM repos for "${DRONE_TAG}"
   image: golang:1.18-bullseye
@@ -7624,9 +7625,8 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Assume Upload AWS Role
-  - Verify build is tagged
   - Check if tag is prerelease
+  - Verify build is tagged
   - Check out code
 volumes:
 - name: yum-persistence
@@ -11579,6 +11579,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 14604baa2d8e374b8c2ae4323aadf1e0ff93c54098dbfd3c1196ef5aa6426d84
+hmac: 45ba388eb8c6898edca566511da05dea51daeca458fed5bcb5baa83177795a5b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7329,7 +7329,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "$ARTIFACT_PATH/*"
+  - rm -rf "$ARTIFACT_PATH"/*
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.deb*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -7532,7 +7532,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "$ARTIFACT_PATH/*"
+  - rm -rf "$ARTIFACT_PATH"/*
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.rpm*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -11579,6 +11579,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 45ba388eb8c6898edca566511da05dea51daeca458fed5bcb5baa83177795a5b
+hmac: bee65ecafb73bb1999f8ceca2c75b205dd5e8d0c8701e69d0a28db87615039cf
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7354,6 +7354,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Assume Download AWS Role
   - Verify build is tagged
   - Check if tag is prerelease
   - Check out code
@@ -7382,6 +7383,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check if tag is prerelease
   - Check out code
@@ -7418,7 +7420,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Download artifacts for "${DRONE_TAG}"
+  - Assume Upload AWS Role
   - Verify build is tagged
   - Check if tag is prerelease
   - Check out code
@@ -7555,6 +7557,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Assume Download AWS Role
   - Verify build is tagged
   - Check if tag is prerelease
   - Check out code
@@ -7583,6 +7586,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check if tag is prerelease
   - Check out code
@@ -7620,7 +7624,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Download artifacts for "${DRONE_TAG}"
+  - Assume Upload AWS Role
   - Verify build is tagged
   - Check if tag is prerelease
   - Check out code
@@ -11575,6 +11579,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 47934b14a6ca045c0beb0357b731373852ce4d490bd3d248db2d45f30025e1e8
+hmac: 14604baa2d8e374b8c2ae4323aadf1e0ff93c54098dbfd3c1196ef5aa6426d84
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7564,7 +7564,7 @@ steps:
     AWS_ACCESS_KEY_ID:
       from_secret: YUM_REPO_NEW_AWS_ACCESS_KEY_ID
     AWS_ROLE:
-      from_secret: YUM_REPO_NEW_ROLE
+      from_secret: YUM_REPO_NEW_AWS_ROLE
     AWS_SECRET_ACCESS_KEY:
       from_secret: YUM_REPO_NEW_AWS_SECRET_ACCESS_KEY
   volumes:
@@ -11579,6 +11579,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: bee65ecafb73bb1999f8ceca2c75b205dd5e8d0c8701e69d0a28db87615039cf
+hmac: e70373fddb9ac5bff144dfcacff1c8d60ece46429a4f70c724bad0307bf03740
 
 ...

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -368,7 +368,7 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 		Commands: []string{
 			"mkdir -pv \"$ARTIFACT_PATH\"",
 			// Clear out old versions from previous steps
-			"rm -rf \"$ARTIFACT_PATH/*\"",
+			"rm -rf \"$ARTIFACT_PATH\"/*",
 			strings.Join(
 				[]string{
 					"aws s3 sync",

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -343,12 +343,6 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 	}
 	toolSetupCommands = append(toolSetupCommands, optpb.setupCommands...)
 
-	downloadStepName := fmt.Sprintf("Download artifacts for %q", version)
-	buildStepDependencies := []string{}
-	if enableParallelism {
-		buildStepDependencies = append(buildStepDependencies, downloadStepName)
-	}
-
 	assumeDownloadRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
 		awsRoleSettings: awsRoleSettings{
 			awsAccessKeyID:     value{fromSecret: "AWS_ACCESS_KEY_ID"},
@@ -359,86 +353,95 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 		name:         "Assume Download AWS Role",
 	})
 
+	downloadStep := step{
+		Name:  fmt.Sprintf("Download artifacts for %q", version),
+		Image: "amazon/aws-cli",
+		Environment: map[string]value{
+			"AWS_S3_BUCKET": {
+				fromSecret: "AWS_S3_BUCKET",
+			},
+			"ARTIFACT_PATH": {
+				raw: optpb.artifactPath,
+			},
+		},
+		Volumes: []volumeRef{volumeRefAwsConfig},
+		Commands: []string{
+			"mkdir -pv \"$ARTIFACT_PATH\"",
+			// Clear out old versions from previous steps
+			"rm -rf \"$ARTIFACT_PATH/*\"",
+			strings.Join(
+				[]string{
+					"aws s3 sync",
+					"--no-progress",
+					"--delete",
+					"--exclude \"*\"",
+					fmt.Sprintf("--include \"*.%s*\"", optpb.packageType),
+					fmt.Sprintf("s3://$AWS_S3_BUCKET/teleport/tag/%s/", bucketFolder),
+					"\"$ARTIFACT_PATH\"",
+				},
+				" ",
+			),
+		},
+	}
+
 	assumeUploadRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
 		awsRoleSettings: optpb.bucketSecrets.awsRoleSettings,
 		configVolume:    volumeRefAwsConfig,
 		name:            "Assume Upload AWS Role",
 	})
 
-	return []step{
-		assumeDownloadRoleStep,
-		{
-			Name:  downloadStepName,
-			Image: "amazon/aws-cli",
-			Environment: map[string]value{
-				"AWS_S3_BUCKET": {
-					fromSecret: "AWS_S3_BUCKET",
-				},
-				"ARTIFACT_PATH": {
-					raw: optpb.artifactPath,
-				},
-			},
-			Volumes: []volumeRef{volumeRefAwsConfig},
-			Commands: []string{
-				"mkdir -pv \"$ARTIFACT_PATH\"",
-				// Clear out old versions from previous steps
-				"rm -rf \"$ARTIFACT_PATH/*\"",
+	buildAndUploadStep := step{
+		Name:        fmt.Sprintf("Publish %ss to %s repos for %q", optpb.packageType, strings.ToUpper(optpb.packageManagerName), version),
+		Image:       fmt.Sprintf("golang:%s-bullseye", GoVersion),
+		Environment: optpb.environmentVars,
+		Commands: append(
+			toolSetupCommands,
+			[]string{
+				"mkdir -pv -m0700 \"$GNUPGHOME\"",
+				"echo \"$GPG_RPM_SIGNING_ARCHIVE\" | base64 -d | tar -xzf - -C $GNUPGHOME",
+				"chown -R root:root \"$GNUPGHOME\"",
+				fmt.Sprintf("cd %q", path.Join(codePath, "build.assets", "tooling")),
+				fmt.Sprintf("export VERSION=%q", version),
+				"export RELEASE_CHANNEL=\"stable\"", // The tool supports several release channels but I'm not sure where this should be configured
 				strings.Join(
-					[]string{
-						"aws s3 sync",
-						"--no-progress",
-						"--delete",
-						"--exclude \"*\"",
-						fmt.Sprintf("--include \"*.%s*\"", optpb.packageType),
-						fmt.Sprintf("s3://$AWS_S3_BUCKET/teleport/tag/%s/", bucketFolder),
-						"\"$ARTIFACT_PATH\"",
-					},
+					append(
+						[]string{
+							// This just makes the (long) command a little more readable
+							"go run ./cmd/build-os-package-repos",
+							optpb.packageManagerName,
+							"-bucket \"$REPO_S3_BUCKET\"",
+							"-local-bucket-path \"$BUCKET_CACHE_PATH\"",
+							"-artifact-version \"$VERSION\"",
+							"-release-channel \"$RELEASE_CHANNEL\"",
+							"-artifact-path \"$ARTIFACT_PATH\"",
+							"-log-level 4", // Set this to 5 for debug logging
+						},
+						optpb.extraArgs...,
+					),
 					" ",
 				),
+			}...,
+		),
+		Volumes: []volumeRef{
+			{
+				Name: optpb.volumeName,
+				Path: optpb.pvcMountPoint,
 			},
+			volumeRefTmpfs,
+			volumeRefAwsConfig,
 		},
+	}
+
+	if enableParallelism {
+		downloadStep.DependsOn = []string{assumeDownloadRoleStep.Name}
+		assumeUploadRoleStep.DependsOn = []string{downloadStep.Name}
+		buildAndUploadStep.DependsOn = []string{assumeUploadRoleStep.Name}
+	}
+
+	return []step{
+		assumeDownloadRoleStep,
+		downloadStep,
 		assumeUploadRoleStep,
-		{
-			Name:        fmt.Sprintf("Publish %ss to %s repos for %q", optpb.packageType, strings.ToUpper(optpb.packageManagerName), version),
-			Image:       fmt.Sprintf("golang:%s-bullseye", GoVersion),
-			Environment: optpb.environmentVars,
-			Commands: append(
-				toolSetupCommands,
-				[]string{
-					"mkdir -pv -m0700 \"$GNUPGHOME\"",
-					"echo \"$GPG_RPM_SIGNING_ARCHIVE\" | base64 -d | tar -xzf - -C $GNUPGHOME",
-					"chown -R root:root \"$GNUPGHOME\"",
-					fmt.Sprintf("cd %q", path.Join(codePath, "build.assets", "tooling")),
-					fmt.Sprintf("export VERSION=%q", version),
-					"export RELEASE_CHANNEL=\"stable\"", // The tool supports several release channels but I'm not sure where this should be configured
-					strings.Join(
-						append(
-							[]string{
-								// This just makes the (long) command a little more readable
-								"go run ./cmd/build-os-package-repos",
-								optpb.packageManagerName,
-								"-bucket \"$REPO_S3_BUCKET\"",
-								"-local-bucket-path \"$BUCKET_CACHE_PATH\"",
-								"-artifact-version \"$VERSION\"",
-								"-release-channel \"$RELEASE_CHANNEL\"",
-								"-artifact-path \"$ARTIFACT_PATH\"",
-								"-log-level 4", // Set this to 5 for debug logging
-							},
-							optpb.extraArgs...,
-						),
-						" ",
-					),
-				}...,
-			),
-			Volumes: []volumeRef{
-				{
-					Name: optpb.volumeName,
-					Path: optpb.pvcMountPoint,
-				},
-				volumeRefTmpfs,
-				volumeRefAwsConfig,
-			},
-			DependsOn: buildStepDependencies,
-		},
+		buildAndUploadStep,
 	}
 }

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -195,10 +195,10 @@ func (optpb *OsPackageToolPipelineBuilder) buildPromoteOsPackagePipeline() pipel
 	p.Trigger = triggerPromote
 	p.Trigger.Repo.Include = []string{"gravitational/teleport"}
 
-	setupSteps := append(
-		verifyValidPromoteRunSteps(),
+	setupSteps := []step{
+		verifyTaggedStep(),
 		cloneRepoStep(checkoutPath, commitName),
-	)
+	}
 
 	setupStepNames := make([]string, 0, len(setupSteps))
 	for _, setupStep := range setupSteps {
@@ -390,6 +390,8 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 		name:            "Assume Upload AWS Role",
 	})
 
+	verifyNotPrereleaseStep := verifyNotPrereleaseStep()
+
 	buildAndUploadStep := step{
 		Name:        fmt.Sprintf("Publish %ss to %s repos for %q", optpb.packageType, strings.ToUpper(optpb.packageManagerName), version),
 		Image:       fmt.Sprintf("golang:%s-bullseye", GoVersion),
@@ -435,13 +437,15 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 	if enableParallelism {
 		downloadStep.DependsOn = []string{assumeDownloadRoleStep.Name}
 		assumeUploadRoleStep.DependsOn = []string{downloadStep.Name}
-		buildAndUploadStep.DependsOn = []string{assumeUploadRoleStep.Name}
+		verifyNotPrereleaseStep.DependsOn = []string{assumeUploadRoleStep.Name}
+		buildAndUploadStep.DependsOn = []string{verifyNotPrereleaseStep.Name}
 	}
 
 	return []step{
 		assumeDownloadRoleStep,
 		downloadStep,
 		assumeUploadRoleStep,
+		verifyNotPrereleaseStep,
 		buildAndUploadStep,
 	}
 }

--- a/dronegen/yum.go
+++ b/dronegen/yum.go
@@ -36,7 +36,7 @@ func getYumPipelineBuilder() *OsPackageToolPipelineBuilder {
 			"YUM_REPO_NEW_AWS_S3_BUCKET",
 			"YUM_REPO_NEW_AWS_ACCESS_KEY_ID",
 			"YUM_REPO_NEW_AWS_SECRET_ACCESS_KEY",
-			"YUM_REPO_NEW_ROLE",
+			"YUM_REPO_NEW_AWS_ROLE",
 		),
 	)
 


### PR DESCRIPTION
This PR includes a variety of fixes and improvements to our apt & yum promotion pipelines. These are broken out by commit:

* `Serialize apt/yum promote pipelines` fixes the errors seen in https://drone.platform.teleport.sh/gravitational/teleport/16694/1/5 by serializing pipeline steps via dependencies.
* `Allow dev build promotes to proceed in deb/rpm pipelines` allows us to test the fix above, which was formerly skipped on promotes of dev builds.  This is the future of the changes proposed in https://github.com/gravitational/teleport/pull/17340
* `Fix globbing bug` fixes a seemingly harmless globbing bug. This was opportunistic cleanup.
* `Swap YUM_REPO_NEW_ROLE to YUM_REPO_NEW_AWS_ROLE` introduces the changes from https://github.com/gravitational/teleport/pull/17406, in case this lands first.

## Backports 
* v11 https://github.com/gravitational/teleport/pull/17645
* v10 https://github.com/gravitational/teleport/pull/17646
* v9 https://github.com/gravitational/teleport/pull/17647
* v8 https://github.com/gravitational/teleport/pull/17648
* dronegen/os_repos.go is not in v7 and below, so there is no need to backport to that branch

## Testing
* Tag https://drone.platform.teleport.sh/gravitational/teleport/16757
* Promote: https://drone.platform.teleport.sh/gravitational/teleport/16763

I won't merge until these are both green.