### PR TITLE
Allow connections to node when auth is offline

### DIFF
--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -282,6 +283,7 @@ func TestTeleportClient_PromptMFAChallenge(t *testing.T) {
 			// MFA opts.
 			AuthenticatorAttachment: wancli.AttachmentAuto,
 			PreferOTP:               false,
+			Tracer:                  tracing.NoopProvider().Tracer("test"),
 		},
 	}
 
@@ -292,6 +294,7 @@ func TestTeleportClient_PromptMFAChallenge(t *testing.T) {
 			// MFA opts.
 			AuthenticatorAttachment: wancli.AttachmentCrossPlatform,
 			PreferOTP:               true,
+			Tracer:                  tracing.NoopProvider().Tracer("test"),
 		},
 	}
 
@@ -348,12 +351,8 @@ func TestTeleportClient_PromptMFAChallenge(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			promptCalled := false
-			*client.PromptMFAStandalone = func(
-				gotCtx context.Context, gotChallenge *proto.MFAAuthenticateChallenge, gotProxy string,
-				gotOpts *client.PromptMFAChallengeOpts,
-			) (*proto.MFAAuthenticateResponse, error) {
+			*client.PromptMFAStandalone = func(gotCtx context.Context, gotChallenge *proto.MFAAuthenticateChallenge, gotProxy string, gotOpts *client.PromptMFAChallengeOpts) (*proto.MFAAuthenticateResponse, error) {
 				promptCalled = true
-				assert.Equal(t, ctx, gotCtx, "ctx mismatch")
 				assert.Equal(t, challenge, gotChallenge, "challenge mismatch")
 				assert.Equal(t, test.wantProxy, gotProxy, "proxy mismatch")
 				assert.Equal(t, test.wantOpts, gotOpts, "opts mismatch")

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -318,8 +318,7 @@ func (t *proxySubsys) proxyToSite(
 
 // proxyToHost establishes a proxy connection from the connected SSH client to the
 // requested remote node (t.host:t.port) via the given site
-func (t *proxySubsys) proxyToHost(
-	ctx context.Context, site reversetunnel.RemoteSite, remoteAddr net.Addr, ch ssh.Channel) error {
+func (t *proxySubsys) proxyToHost(ctx context.Context, site reversetunnel.RemoteSite, remoteAddr net.Addr, ch ssh.Channel) error {
 	//
 	// first, lets fetch a list of servers at the given site. this allows us to
 	// match the given "host name" against node configuration (their 'nodename' setting)
@@ -329,7 +328,7 @@ func (t *proxySubsys) proxyToHost(
 	//
 	var (
 		strategy    types.RoutingStrategy
-		nodeWatcher *services.NodeWatcher
+		nodeWatcher NodesGetter
 		err         error
 	)
 	localCluster, _ := t.srv.proxyAccessPoint.GetClusterName()


### PR DESCRIPTION
The connection flow for `tsh ssh user@foo` was to first check if per-session mfa was required, issue certificates if necesarry, and then attempt to connect to the target. In the event that the first step failed due to intermittent or no connectivity to auth the connection attempt would end there. However, the check to auth is not strictly required though. If the node is still reachable it will determine whether the users existing certificate permits access or whether the user is required to perform per-session MFA.

By making `tsh ssh user@foo` always attempt to connect to the target node even if it can't be certain whether or not per-session MFA is required users will still be able to establish a session in the event auth is unreachable. For users without per-session MFA this means they will always have access to a node if it is reachable. For users with per-session MFA this means in the worst case they attempt to connect to the node and are returned an AccessDenied error and will have to try again when the auth server is reachable to perform the MFA ceremony.

To achieve this, `tsh` now utilizes `TeleportClient.ConnectToNode`, which manages the first part of the initial flow and then calls either `ProxyClient.ConnectToNode` or ProxyClient.PortForwardToNode`. Neither of these perform any of the MFA ceremony anymore and must now explicitly be passed the `ssh.AuthMethods` to be used for the connection. If `TeleportClient.ConnectToNode` is able to talk to auth the `ssh.AuthMethods` will be the certificates received from the MFA ceremony, otherwise they will contain the already established credentials.

Included is also a minor refactoring to how things are passed into `runCommandOnNodes` as the siteName provided was always the site from the `TeleportClient` which we already have access to since its a receiver method.