### PR TITLE
[v11] APT/YUM publishing fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7286,16 +7286,6 @@ steps:
   - git init && git remote add origin ${DRONE_REMOTE_URL}
   - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
-  depends_on:
-  - Verify build is tagged
-- name: Check if tag is prerelease
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
-    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
-  depends_on:
-  - Check out code
 - name: Assume Download AWS Role
   image: amazon/aws-cli
   commands:
@@ -7323,7 +7313,6 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Download artifacts for "${DRONE_TAG}"
   image: amazon/aws-cli
   commands:
@@ -7342,7 +7331,6 @@ steps:
   - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
   commands:
@@ -7371,7 +7359,16 @@ steps:
   - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
+- name: Check if tag is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
+    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
+  depends_on:
+  - Assume Upload AWS Role
+  - Verify build is tagged
+  - Check out code
 - name: Publish debs to APT repos for "${DRONE_TAG}"
   image: golang:1.18.4-bullseye
   commands:
@@ -7405,10 +7402,9 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Assume Upload AWS Role
+  - Check if tag is prerelease
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 volumes:
 - name: apt-persistence
   claim:
@@ -7485,16 +7481,6 @@ steps:
   - git init && git remote add origin ${DRONE_REMOTE_URL}
   - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
-  depends_on:
-  - Verify build is tagged
-- name: Check if tag is prerelease
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
-    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
-  depends_on:
-  - Check out code
 - name: Assume Download AWS Role
   image: amazon/aws-cli
   commands:
@@ -7522,7 +7508,6 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Download artifacts for "${DRONE_TAG}"
   image: amazon/aws-cli
   commands:
@@ -7541,7 +7526,6 @@ steps:
   - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
   commands:
@@ -7570,7 +7554,16 @@ steps:
   - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
+- name: Check if tag is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
+    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
+  depends_on:
+  - Assume Upload AWS Role
+  - Verify build is tagged
+  - Check out code
 - name: Publish rpms to YUM repos for "${DRONE_TAG}"
   image: golang:1.18.4-bullseye
   commands:
@@ -7605,10 +7598,9 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Assume Upload AWS Role
+  - Check if tag is prerelease
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 volumes:
 - name: yum-persistence
   claim:
@@ -8733,6 +8725,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: e9992895713d9c2f4ae7e748ae1dd1a990699936b4a4c4bc99c28de13be0cd10
+hmac: 467f277797ee98b558697809478f100a8e1e6e70c50610b0ee769c8cfe7ba621
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7339,6 +7339,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7367,6 +7368,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7403,7 +7405,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Download artifacts for "${DRONE_TAG}"
+  - Assume Upload AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7536,6 +7538,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7564,6 +7567,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7601,7 +7605,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Download artifacts for "${DRONE_TAG}"
+  - Assume Upload AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -8729,6 +8733,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: b1c9a7bbb841e00e8cf6a36bb2b6f91a72cce77f9b23c47c6d72cad432087711
+hmac: e9992895713d9c2f4ae7e748ae1dd1a990699936b4a4c4bc99c28de13be0cd10
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7544,7 +7544,7 @@ steps:
     AWS_ACCESS_KEY_ID:
       from_secret: YUM_REPO_NEW_AWS_ACCESS_KEY_ID
     AWS_ROLE:
-      from_secret: YUM_REPO_NEW_ROLE
+      from_secret: YUM_REPO_NEW_AWS_ROLE
     AWS_SECRET_ACCESS_KEY:
       from_secret: YUM_REPO_NEW_AWS_SECRET_ACCESS_KEY
   volumes:
@@ -8725,6 +8725,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 4e5574c5b7db8eb12cf8f56816ce66ce1ee883dbbebd4b3fae158933279d5d8a
+hmac: 9cea74329da2b26a902270d647876f08302522d666567528d821b2f28a2877a4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7317,7 +7317,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "$ARTIFACT_PATH/*"
+  - rm -rf "$ARTIFACT_PATH"/*
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.deb*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -7512,7 +7512,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "$ARTIFACT_PATH/*"
+  - rm -rf "$ARTIFACT_PATH"/*
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.rpm*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -8725,6 +8725,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 467f277797ee98b558697809478f100a8e1e6e70c50610b0ee769c8cfe7ba621
+hmac: 4e5574c5b7db8eb12cf8f56816ce66ce1ee883dbbebd4b3fae158933279d5d8a
 
 ...

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -251,19 +251,6 @@ func waitForDockerStep() step {
 	}
 }
 
-func verifyValidPromoteRunSteps(checkoutPath, commit string, isParallelismEnabled bool) []step {
-	tagStep := verifyTaggedStep()
-	cloneStep := cloneRepoStep(checkoutPath, commit)
-	verifyStep := verifyNotPrereleaseStep(checkoutPath)
-
-	if isParallelismEnabled {
-		cloneStep.DependsOn = []string{tagStep.Name}
-		verifyStep.DependsOn = []string{cloneStep.Name}
-	}
-
-	return []step{tagStep, cloneStep, verifyStep}
-}
-
 func verifyTaggedStep() step {
 	return step{
 		Name:  "Verify build is tagged",

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -352,12 +352,6 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 	}
 	toolSetupCommands = append(toolSetupCommands, optpb.setupCommands...)
 
-	downloadStepName := fmt.Sprintf("Download artifacts for %q", version)
-	buildStepDependencies := []string{}
-	if enableParallelism {
-		buildStepDependencies = append(buildStepDependencies, downloadStepName)
-	}
-
 	assumeDownloadRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
 		awsRoleSettings: awsRoleSettings{
 			awsAccessKeyID:     value{fromSecret: "AWS_ACCESS_KEY_ID"},
@@ -368,86 +362,95 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 		name:         "Assume Download AWS Role",
 	})
 
+	downloadStep := step{
+		Name:  fmt.Sprintf("Download artifacts for %q", version),
+		Image: "amazon/aws-cli",
+		Environment: map[string]value{
+			"AWS_S3_BUCKET": {
+				fromSecret: "AWS_S3_BUCKET",
+			},
+			"ARTIFACT_PATH": {
+				raw: optpb.artifactPath,
+			},
+		},
+		Volumes: []volumeRef{volumeRefAwsConfig},
+		Commands: []string{
+			"mkdir -pv \"$ARTIFACT_PATH\"",
+			// Clear out old versions from previous steps
+			"rm -rf \"$ARTIFACT_PATH/*\"",
+			strings.Join(
+				[]string{
+					"aws s3 sync",
+					"--no-progress",
+					"--delete",
+					"--exclude \"*\"",
+					fmt.Sprintf("--include \"*.%s*\"", optpb.packageType),
+					fmt.Sprintf("s3://$AWS_S3_BUCKET/teleport/tag/%s/", bucketFolder),
+					"\"$ARTIFACT_PATH\"",
+				},
+				" ",
+			),
+		},
+	}
+
 	assumeUploadRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
 		awsRoleSettings: optpb.bucketSecrets.awsRoleSettings,
 		configVolume:    volumeRefAwsConfig,
 		name:            "Assume Upload AWS Role",
 	})
 
-	return []step{
-		assumeDownloadRoleStep,
-		{
-			Name:  downloadStepName,
-			Image: "amazon/aws-cli",
-			Environment: map[string]value{
-				"AWS_S3_BUCKET": {
-					fromSecret: "AWS_S3_BUCKET",
-				},
-				"ARTIFACT_PATH": {
-					raw: optpb.artifactPath,
-				},
-			},
-			Volumes: []volumeRef{volumeRefAwsConfig},
-			Commands: []string{
-				"mkdir -pv \"$ARTIFACT_PATH\"",
-				// Clear out old versions from previous steps
-				"rm -rf \"$ARTIFACT_PATH/*\"",
+	buildAndUploadStep := step{
+		Name:        fmt.Sprintf("Publish %ss to %s repos for %q", optpb.packageType, strings.ToUpper(optpb.packageManagerName), version),
+		Image:       "golang:1.18.4-bullseye",
+		Environment: optpb.environmentVars,
+		Commands: append(
+			toolSetupCommands,
+			[]string{
+				"mkdir -pv -m0700 \"$GNUPGHOME\"",
+				"echo \"$GPG_RPM_SIGNING_ARCHIVE\" | base64 -d | tar -xzf - -C $GNUPGHOME",
+				"chown -R root:root \"$GNUPGHOME\"",
+				fmt.Sprintf("cd %q", path.Join(codePath, "build.assets", "tooling")),
+				fmt.Sprintf("export VERSION=%q", version),
+				"export RELEASE_CHANNEL=\"stable\"", // The tool supports several release channels but I'm not sure where this should be configured
 				strings.Join(
-					[]string{
-						"aws s3 sync",
-						"--no-progress",
-						"--delete",
-						"--exclude \"*\"",
-						fmt.Sprintf("--include \"*.%s*\"", optpb.packageType),
-						fmt.Sprintf("s3://$AWS_S3_BUCKET/teleport/tag/%s/", bucketFolder),
-						"\"$ARTIFACT_PATH\"",
-					},
+					append(
+						[]string{
+							// This just makes the (long) command a little more readable
+							"go run ./cmd/build-os-package-repos",
+							optpb.packageManagerName,
+							"-bucket \"$REPO_S3_BUCKET\"",
+							"-local-bucket-path \"$BUCKET_CACHE_PATH\"",
+							"-artifact-version \"$VERSION\"",
+							"-release-channel \"$RELEASE_CHANNEL\"",
+							"-artifact-path \"$ARTIFACT_PATH\"",
+							"-log-level 4", // Set this to 5 for debug logging
+						},
+						optpb.extraArgs...,
+					),
 					" ",
 				),
+			}...,
+		),
+		Volumes: []volumeRef{
+			{
+				Name: optpb.volumeName,
+				Path: optpb.pvcMountPoint,
 			},
+			volumeRefTmpfs,
+			volumeRefAwsConfig,
 		},
+	}
+
+	if enableParallelism {
+		downloadStep.DependsOn = []string{assumeDownloadRoleStep.Name}
+		assumeUploadRoleStep.DependsOn = []string{downloadStep.Name}
+		buildAndUploadStep.DependsOn = []string{assumeUploadRoleStep.Name}
+	}
+
+	return []step{
+		assumeDownloadRoleStep,
+		downloadStep,
 		assumeUploadRoleStep,
-		{
-			Name:        fmt.Sprintf("Publish %ss to %s repos for %q", optpb.packageType, strings.ToUpper(optpb.packageManagerName), version),
-			Image:       "golang:1.18.4-bullseye",
-			Environment: optpb.environmentVars,
-			Commands: append(
-				toolSetupCommands,
-				[]string{
-					"mkdir -pv -m0700 \"$GNUPGHOME\"",
-					"echo \"$GPG_RPM_SIGNING_ARCHIVE\" | base64 -d | tar -xzf - -C $GNUPGHOME",
-					"chown -R root:root \"$GNUPGHOME\"",
-					fmt.Sprintf("cd %q", path.Join(codePath, "build.assets", "tooling")),
-					fmt.Sprintf("export VERSION=%q", version),
-					"export RELEASE_CHANNEL=\"stable\"", // The tool supports several release channels but I'm not sure where this should be configured
-					strings.Join(
-						append(
-							[]string{
-								// This just makes the (long) command a little more readable
-								"go run ./cmd/build-os-package-repos",
-								optpb.packageManagerName,
-								"-bucket \"$REPO_S3_BUCKET\"",
-								"-local-bucket-path \"$BUCKET_CACHE_PATH\"",
-								"-artifact-version \"$VERSION\"",
-								"-release-channel \"$RELEASE_CHANNEL\"",
-								"-artifact-path \"$ARTIFACT_PATH\"",
-								"-log-level 4", // Set this to 5 for debug logging
-							},
-							optpb.extraArgs...,
-						),
-						" ",
-					),
-				}...,
-			),
-			Volumes: []volumeRef{
-				{
-					Name: optpb.volumeName,
-					Path: optpb.pvcMountPoint,
-				},
-				volumeRefTmpfs,
-				volumeRefAwsConfig,
-			},
-			DependsOn: buildStepDependencies,
-		},
+		buildAndUploadStep,
 	}
 }

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -189,7 +189,10 @@ func (optpb *OsPackageToolPipelineBuilder) buildPromoteOsPackagePipeline() pipel
 	p.Trigger = triggerPromote
 	p.Trigger.Repo.Include = []string{"gravitational/teleport"}
 
-	setupSteps := verifyValidPromoteRunSteps(checkoutPath, commitName, true)
+	setupSteps := []step{
+		verifyTaggedStep(),
+		cloneRepoStep(checkoutPath, commitName),
+	}
 
 	setupStepNames := make([]string, 0, len(setupSteps))
 	for _, setupStep := range setupSteps {
@@ -399,6 +402,8 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 		name:            "Assume Upload AWS Role",
 	})
 
+	verifyNotPrereleaseStep := verifyNotPrereleaseStep(codePath)
+
 	buildAndUploadStep := step{
 		Name:        fmt.Sprintf("Publish %ss to %s repos for %q", optpb.packageType, strings.ToUpper(optpb.packageManagerName), version),
 		Image:       "golang:1.18.4-bullseye",
@@ -444,13 +449,15 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 	if enableParallelism {
 		downloadStep.DependsOn = []string{assumeDownloadRoleStep.Name}
 		assumeUploadRoleStep.DependsOn = []string{downloadStep.Name}
-		buildAndUploadStep.DependsOn = []string{assumeUploadRoleStep.Name}
+		verifyNotPrereleaseStep.DependsOn = []string{assumeUploadRoleStep.Name}
+		buildAndUploadStep.DependsOn = []string{verifyNotPrereleaseStep.Name}
 	}
 
 	return []step{
 		assumeDownloadRoleStep,
 		downloadStep,
 		assumeUploadRoleStep,
+		verifyNotPrereleaseStep,
 		buildAndUploadStep,
 	}
 }

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -380,7 +380,7 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 		Commands: []string{
 			"mkdir -pv \"$ARTIFACT_PATH\"",
 			// Clear out old versions from previous steps
-			"rm -rf \"$ARTIFACT_PATH/*\"",
+			"rm -rf \"$ARTIFACT_PATH\"/*",
 			strings.Join(
 				[]string{
 					"aws s3 sync",

--- a/dronegen/yum.go
+++ b/dronegen/yum.go
@@ -36,7 +36,7 @@ func getYumPipelineBuilder() *OsPackageToolPipelineBuilder {
 			"YUM_REPO_NEW_AWS_S3_BUCKET",
 			"YUM_REPO_NEW_AWS_ACCESS_KEY_ID",
 			"YUM_REPO_NEW_AWS_SECRET_ACCESS_KEY",
-			"YUM_REPO_NEW_ROLE",
+			"YUM_REPO_NEW_AWS_ROLE",
 		),
 	)
 


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/17638

This PR includes a variety of fixes and improvements to our apt & yum promotion pipelines. These are broken out by commit:

* `Serialize apt/yum promote pipelines` fixes the errors seen in https://drone.platform.teleport.sh/gravitational/teleport/16694/1/5 by serializing pipeline steps via dependencies.
* `Allow dev build promotes to proceed in deb/rpm pipelines` allows us to test the fix above, which was formerly skipped on promotes of dev builds.  This is the future of the changes proposed in https://github.com/gravitational/teleport/pull/17340
* `Fix globbing bug` fixes a seemingly harmless globbing bug. This was opportunistic cleanup.
* `Swap YUM_REPO_NEW_ROLE to YUM_REPO_NEW_AWS_ROLE` introduces the changes from https://github.com/gravitational/teleport/pull/17407, in case this lands first.

There were a range of merge conflicts, primarily stemming from master's version of this being developed on top of https://github.com/gravitational/teleport/pull/16688, which touched some shared functions.

## Testing
Tag: https://drone.platform.teleport.sh/gravitational/teleport/16750
Promote: https://drone.platform.teleport.sh/gravitational/teleport/16755

I won't merge until these are both green.