### PR TITLE
[v10] APT/YUM publishing fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7287,6 +7287,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7315,6 +7316,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7351,7 +7353,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Download artifacts for "${DRONE_TAG}"
+  - Assume Upload AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7484,6 +7486,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7512,6 +7515,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7549,7 +7553,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Download artifacts for "${DRONE_TAG}"
+  - Assume Upload AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -8675,6 +8679,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 8188efa3bff7b0fbeeb294bb84af3f78d88eea44a9792a961fc4afeeebd40e6e
+hmac: f2ce93fc29511ccb1508db0d32c5ec36623f80a46de8376b81fa230fbef84503
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7492,7 +7492,7 @@ steps:
     AWS_ACCESS_KEY_ID:
       from_secret: YUM_REPO_NEW_AWS_ACCESS_KEY_ID
     AWS_ROLE:
-      from_secret: YUM_REPO_NEW_ROLE
+      from_secret: YUM_REPO_NEW_AWS_ROLE
     AWS_SECRET_ACCESS_KEY:
       from_secret: YUM_REPO_NEW_AWS_SECRET_ACCESS_KEY
   volumes:
@@ -8671,6 +8671,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: bd2edeeac70d807981156fb1c05b1b2477ceb0228b4834f9186350800be07a63
+hmac: 51a0581cf2b17700bb1f40201b9e97893d502ded270d7cf97aa9690011d03c36
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7265,7 +7265,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "$ARTIFACT_PATH/*"
+  - rm -rf "$ARTIFACT_PATH"/*
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.deb*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -7460,7 +7460,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "$ARTIFACT_PATH/*"
+  - rm -rf "$ARTIFACT_PATH"/*
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.rpm*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -8671,6 +8671,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: b0c85456639e36457007a1b727a79270cdcf7dc15d822d0d16bb15721b4a2b52
+hmac: bd2edeeac70d807981156fb1c05b1b2477ceb0228b4834f9186350800be07a63
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7234,16 +7234,6 @@ steps:
   - git init && git remote add origin ${DRONE_REMOTE_URL}
   - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
-  depends_on:
-  - Verify build is tagged
-- name: Check if tag is prerelease
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
-    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
-  depends_on:
-  - Check out code
 - name: Assume Download AWS Role
   image: amazon/aws-cli
   commands:
@@ -7271,7 +7261,6 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Download artifacts for "${DRONE_TAG}"
   image: amazon/aws-cli
   commands:
@@ -7290,7 +7279,6 @@ steps:
   - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
   commands:
@@ -7319,7 +7307,16 @@ steps:
   - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
+- name: Check if tag is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
+    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
+  depends_on:
+  - Assume Upload AWS Role
+  - Verify build is tagged
+  - Check out code
 - name: Publish debs to APT repos for "${DRONE_TAG}"
   image: golang:1.18.4-bullseye
   commands:
@@ -7353,10 +7350,9 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Assume Upload AWS Role
+  - Check if tag is prerelease
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 volumes:
 - name: apt-persistence
   claim:
@@ -7433,16 +7429,6 @@ steps:
   - git init && git remote add origin ${DRONE_REMOTE_URL}
   - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
-  depends_on:
-  - Verify build is tagged
-- name: Check if tag is prerelease
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
-    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
-  depends_on:
-  - Check out code
 - name: Assume Download AWS Role
   image: amazon/aws-cli
   commands:
@@ -7470,7 +7456,6 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Download artifacts for "${DRONE_TAG}"
   image: amazon/aws-cli
   commands:
@@ -7489,7 +7474,6 @@ steps:
   - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
   commands:
@@ -7518,7 +7502,16 @@ steps:
   - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
+- name: Check if tag is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
+    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
+  depends_on:
+  - Assume Upload AWS Role
+  - Verify build is tagged
+  - Check out code
 - name: Publish rpms to YUM repos for "${DRONE_TAG}"
   image: golang:1.18.4-bullseye
   commands:
@@ -7553,10 +7546,9 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Assume Upload AWS Role
+  - Check if tag is prerelease
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 volumes:
 - name: yum-persistence
   claim:
@@ -8679,6 +8671,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: f2ce93fc29511ccb1508db0d32c5ec36623f80a46de8376b81fa230fbef84503
+hmac: b0c85456639e36457007a1b727a79270cdcf7dc15d822d0d16bb15721b4a2b52
 
 ...

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -251,19 +251,6 @@ func waitForDockerStep() step {
 	}
 }
 
-func verifyValidPromoteRunSteps(checkoutPath, commit string, isParallelismEnabled bool) []step {
-	tagStep := verifyTaggedStep()
-	cloneStep := cloneRepoStep(checkoutPath, commit)
-	verifyStep := verifyNotPrereleaseStep(checkoutPath)
-
-	if isParallelismEnabled {
-		cloneStep.DependsOn = []string{tagStep.Name}
-		verifyStep.DependsOn = []string{cloneStep.Name}
-	}
-
-	return []step{tagStep, cloneStep, verifyStep}
-}
-
 func verifyTaggedStep() step {
 	return step{
 		Name:  "Verify build is tagged",

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -352,12 +352,6 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 	}
 	toolSetupCommands = append(toolSetupCommands, optpb.setupCommands...)
 
-	downloadStepName := fmt.Sprintf("Download artifacts for %q", version)
-	buildStepDependencies := []string{}
-	if enableParallelism {
-		buildStepDependencies = append(buildStepDependencies, downloadStepName)
-	}
-
 	assumeDownloadRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
 		awsRoleSettings: awsRoleSettings{
 			awsAccessKeyID:     value{fromSecret: "AWS_ACCESS_KEY_ID"},
@@ -368,86 +362,95 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 		name:         "Assume Download AWS Role",
 	})
 
+	downloadStep := step{
+		Name:  fmt.Sprintf("Download artifacts for %q", version),
+		Image: "amazon/aws-cli",
+		Environment: map[string]value{
+			"AWS_S3_BUCKET": {
+				fromSecret: "AWS_S3_BUCKET",
+			},
+			"ARTIFACT_PATH": {
+				raw: optpb.artifactPath,
+			},
+		},
+		Volumes: []volumeRef{volumeRefAwsConfig},
+		Commands: []string{
+			"mkdir -pv \"$ARTIFACT_PATH\"",
+			// Clear out old versions from previous steps
+			"rm -rf \"$ARTIFACT_PATH/*\"",
+			strings.Join(
+				[]string{
+					"aws s3 sync",
+					"--no-progress",
+					"--delete",
+					"--exclude \"*\"",
+					fmt.Sprintf("--include \"*.%s*\"", optpb.packageType),
+					fmt.Sprintf("s3://$AWS_S3_BUCKET/teleport/tag/%s/", bucketFolder),
+					"\"$ARTIFACT_PATH\"",
+				},
+				" ",
+			),
+		},
+	}
+
 	assumeUploadRoleStep := kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
 		awsRoleSettings: optpb.bucketSecrets.awsRoleSettings,
 		configVolume:    volumeRefAwsConfig,
 		name:            "Assume Upload AWS Role",
 	})
 
-	return []step{
-		assumeDownloadRoleStep,
-		{
-			Name:  downloadStepName,
-			Image: "amazon/aws-cli",
-			Environment: map[string]value{
-				"AWS_S3_BUCKET": {
-					fromSecret: "AWS_S3_BUCKET",
-				},
-				"ARTIFACT_PATH": {
-					raw: optpb.artifactPath,
-				},
-			},
-			Volumes: []volumeRef{volumeRefAwsConfig},
-			Commands: []string{
-				"mkdir -pv \"$ARTIFACT_PATH\"",
-				// Clear out old versions from previous steps
-				"rm -rf \"$ARTIFACT_PATH/*\"",
+	buildAndUploadStep := step{
+		Name:        fmt.Sprintf("Publish %ss to %s repos for %q", optpb.packageType, strings.ToUpper(optpb.packageManagerName), version),
+		Image:       "golang:1.18.4-bullseye",
+		Environment: optpb.environmentVars,
+		Commands: append(
+			toolSetupCommands,
+			[]string{
+				"mkdir -pv -m0700 \"$GNUPGHOME\"",
+				"echo \"$GPG_RPM_SIGNING_ARCHIVE\" | base64 -d | tar -xzf - -C $GNUPGHOME",
+				"chown -R root:root \"$GNUPGHOME\"",
+				fmt.Sprintf("cd %q", path.Join(codePath, "build.assets", "tooling")),
+				fmt.Sprintf("export VERSION=%q", version),
+				"export RELEASE_CHANNEL=\"stable\"", // The tool supports several release channels but I'm not sure where this should be configured
 				strings.Join(
-					[]string{
-						"aws s3 sync",
-						"--no-progress",
-						"--delete",
-						"--exclude \"*\"",
-						fmt.Sprintf("--include \"*.%s*\"", optpb.packageType),
-						fmt.Sprintf("s3://$AWS_S3_BUCKET/teleport/tag/%s/", bucketFolder),
-						"\"$ARTIFACT_PATH\"",
-					},
+					append(
+						[]string{
+							// This just makes the (long) command a little more readable
+							"go run ./cmd/build-os-package-repos",
+							optpb.packageManagerName,
+							"-bucket \"$REPO_S3_BUCKET\"",
+							"-local-bucket-path \"$BUCKET_CACHE_PATH\"",
+							"-artifact-version \"$VERSION\"",
+							"-release-channel \"$RELEASE_CHANNEL\"",
+							"-artifact-path \"$ARTIFACT_PATH\"",
+							"-log-level 4", // Set this to 5 for debug logging
+						},
+						optpb.extraArgs...,
+					),
 					" ",
 				),
+			}...,
+		),
+		Volumes: []volumeRef{
+			{
+				Name: optpb.volumeName,
+				Path: optpb.pvcMountPoint,
 			},
+			volumeRefTmpfs,
+			volumeRefAwsConfig,
 		},
+	}
+
+	if enableParallelism {
+		downloadStep.DependsOn = []string{assumeDownloadRoleStep.Name}
+		assumeUploadRoleStep.DependsOn = []string{downloadStep.Name}
+		buildAndUploadStep.DependsOn = []string{assumeUploadRoleStep.Name}
+	}
+
+	return []step{
+		assumeDownloadRoleStep,
+		downloadStep,
 		assumeUploadRoleStep,
-		{
-			Name:        fmt.Sprintf("Publish %ss to %s repos for %q", optpb.packageType, strings.ToUpper(optpb.packageManagerName), version),
-			Image:       "golang:1.18.4-bullseye",
-			Environment: optpb.environmentVars,
-			Commands: append(
-				toolSetupCommands,
-				[]string{
-					"mkdir -pv -m0700 \"$GNUPGHOME\"",
-					"echo \"$GPG_RPM_SIGNING_ARCHIVE\" | base64 -d | tar -xzf - -C $GNUPGHOME",
-					"chown -R root:root \"$GNUPGHOME\"",
-					fmt.Sprintf("cd %q", path.Join(codePath, "build.assets", "tooling")),
-					fmt.Sprintf("export VERSION=%q", version),
-					"export RELEASE_CHANNEL=\"stable\"", // The tool supports several release channels but I'm not sure where this should be configured
-					strings.Join(
-						append(
-							[]string{
-								// This just makes the (long) command a little more readable
-								"go run ./cmd/build-os-package-repos",
-								optpb.packageManagerName,
-								"-bucket \"$REPO_S3_BUCKET\"",
-								"-local-bucket-path \"$BUCKET_CACHE_PATH\"",
-								"-artifact-version \"$VERSION\"",
-								"-release-channel \"$RELEASE_CHANNEL\"",
-								"-artifact-path \"$ARTIFACT_PATH\"",
-								"-log-level 4", // Set this to 5 for debug logging
-							},
-							optpb.extraArgs...,
-						),
-						" ",
-					),
-				}...,
-			),
-			Volumes: []volumeRef{
-				{
-					Name: optpb.volumeName,
-					Path: optpb.pvcMountPoint,
-				},
-				volumeRefTmpfs,
-				volumeRefAwsConfig,
-			},
-			DependsOn: buildStepDependencies,
-		},
+		buildAndUploadStep,
 	}
 }

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -189,7 +189,10 @@ func (optpb *OsPackageToolPipelineBuilder) buildPromoteOsPackagePipeline() pipel
 	p.Trigger = triggerPromote
 	p.Trigger.Repo.Include = []string{"gravitational/teleport"}
 
-	setupSteps := verifyValidPromoteRunSteps(checkoutPath, commitName, true)
+	setupSteps := []step{
+		verifyTaggedStep(),
+		cloneRepoStep(checkoutPath, commitName),
+	}
 
 	setupStepNames := make([]string, 0, len(setupSteps))
 	for _, setupStep := range setupSteps {
@@ -399,6 +402,8 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 		name:            "Assume Upload AWS Role",
 	})
 
+	verifyNotPrereleaseStep := verifyNotPrereleaseStep(codePath)
+
 	buildAndUploadStep := step{
 		Name:        fmt.Sprintf("Publish %ss to %s repos for %q", optpb.packageType, strings.ToUpper(optpb.packageManagerName), version),
 		Image:       "golang:1.18.4-bullseye",
@@ -444,13 +449,15 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 	if enableParallelism {
 		downloadStep.DependsOn = []string{assumeDownloadRoleStep.Name}
 		assumeUploadRoleStep.DependsOn = []string{downloadStep.Name}
-		buildAndUploadStep.DependsOn = []string{assumeUploadRoleStep.Name}
+		verifyNotPrereleaseStep.DependsOn = []string{assumeUploadRoleStep.Name}
+		buildAndUploadStep.DependsOn = []string{verifyNotPrereleaseStep.Name}
 	}
 
 	return []step{
 		assumeDownloadRoleStep,
 		downloadStep,
 		assumeUploadRoleStep,
+		verifyNotPrereleaseStep,
 		buildAndUploadStep,
 	}
 }

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -380,7 +380,7 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 		Commands: []string{
 			"mkdir -pv \"$ARTIFACT_PATH\"",
 			// Clear out old versions from previous steps
-			"rm -rf \"$ARTIFACT_PATH/*\"",
+			"rm -rf \"$ARTIFACT_PATH\"/*",
 			strings.Join(
 				[]string{
 					"aws s3 sync",

--- a/dronegen/yum.go
+++ b/dronegen/yum.go
@@ -36,7 +36,7 @@ func getYumPipelineBuilder() *OsPackageToolPipelineBuilder {
 			"YUM_REPO_NEW_AWS_S3_BUCKET",
 			"YUM_REPO_NEW_AWS_ACCESS_KEY_ID",
 			"YUM_REPO_NEW_AWS_SECRET_ACCESS_KEY",
-			"YUM_REPO_NEW_ROLE",
+			"YUM_REPO_NEW_AWS_ROLE",
 		),
 	)
 


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/17638

This PR includes a variety of fixes and improvements to our apt & yum promotion pipelines. These are broken out by commit:

* `Serialize apt/yum promote pipelines` fixes the errors seen in https://drone.platform.teleport.sh/gravitational/teleport/16694/1/5 by serializing pipeline steps via dependencies.
* `Allow dev build promotes to proceed in deb/rpm pipelines` allows us to test the fix above, which was formerly skipped on promotes of dev builds.  This is the future of the changes proposed in https://github.com/gravitational/teleport/pull/17340
* `Fix globbing bug` fixes a seemingly harmless globbing bug. This was opportunistic cleanup.
* `Swap YUM_REPO_NEW_ROLE to YUM_REPO_NEW_AWS_ROLE` introduces the changes from https://github.com/gravitational/teleport/pull/17408, in case this lands first.

No further changes changes/merged conflic resolution was needed for v10 beyond  what I did for v11 in https://github.com/gravitational/teleport/pull/17645

## Testing
Tag: https://drone.platform.teleport.sh/gravitational/teleport/16752
Promote: https://drone.platform.teleport.sh/gravitational/teleport/16758

I won't merge until I see both of these are green.