### PR TITLE
[v8] APT/YUM publishing fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7040,7 +7040,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "$ARTIFACT_PATH/*"
+  - rm -rf "$ARTIFACT_PATH"/*
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.deb*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -7235,7 +7235,7 @@ steps:
   image: amazon/aws-cli
   commands:
   - mkdir -pv "$ARTIFACT_PATH"
-  - rm -rf "$ARTIFACT_PATH/*"
+  - rm -rf "$ARTIFACT_PATH"/*
   - aws s3 sync --no-progress --delete --exclude "*" --include "*.rpm*" s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/
     "$ARTIFACT_PATH"
   environment:
@@ -8092,6 +8092,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: f162c7d06af74b0d16a9aa80e0b4dff707915abae8167556c5a28ec2b551c165
+hmac: 10ff6006f98cb6e5e6ac20d7b3fd9fab95b057ebe9926afb9bf03d4891662b21
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6947,7 +6947,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/os_repos.go:250
+# Generated at dronegen/os_repos.go:253
 ################################################
 
 kind: pipeline
@@ -6975,7 +6975,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/os_repos.go:274
+# Generated at dronegen/os_repos.go:277
 ################################################
 
 kind: pipeline
@@ -7009,16 +7009,6 @@ steps:
   - git init && git remote add origin ${DRONE_REMOTE_URL}
   - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
-  depends_on:
-  - Verify build is tagged
-- name: Check if tag is prerelease
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
-    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
-  depends_on:
-  - Check out code
 - name: Assume Download AWS Role
   image: amazon/aws-cli
   commands:
@@ -7046,7 +7036,6 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Download artifacts for "${DRONE_TAG}"
   image: amazon/aws-cli
   commands:
@@ -7065,7 +7054,6 @@ steps:
   - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
   commands:
@@ -7094,7 +7082,16 @@ steps:
   - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
+- name: Check if tag is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
+    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
+  depends_on:
+  - Assume Upload AWS Role
+  - Verify build is tagged
+  - Check out code
 - name: Publish debs to APT repos for "${DRONE_TAG}"
   image: golang:1.18.4-bullseye
   commands:
@@ -7128,10 +7125,9 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Assume Upload AWS Role
+  - Check if tag is prerelease
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 volumes:
 - name: apt-persistence
   claim:
@@ -7146,7 +7142,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/os_repos.go:250
+# Generated at dronegen/os_repos.go:253
 ################################################
 
 kind: pipeline
@@ -7174,7 +7170,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/os_repos.go:274
+# Generated at dronegen/os_repos.go:277
 ################################################
 
 kind: pipeline
@@ -7208,16 +7204,6 @@ steps:
   - git init && git remote add origin ${DRONE_REMOTE_URL}
   - git fetch origin --tags
   - git checkout -qf "${DRONE_TAG}"
-  depends_on:
-  - Verify build is tagged
-- name: Check if tag is prerelease
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
-    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
-  depends_on:
-  - Check out code
 - name: Assume Download AWS Role
   image: amazon/aws-cli
   commands:
@@ -7245,7 +7231,6 @@ steps:
   depends_on:
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Download artifacts for "${DRONE_TAG}"
   image: amazon/aws-cli
   commands:
@@ -7264,7 +7249,6 @@ steps:
   - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
   commands:
@@ -7293,7 +7277,16 @@ steps:
   - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
+- name: Check if tag is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> This is
+    a prerelease, not continuing promotion for ${DRONE_TAG}' && exit 78)
+  depends_on:
+  - Assume Upload AWS Role
+  - Verify build is tagged
+  - Check out code
 - name: Publish rpms to YUM repos for "${DRONE_TAG}"
   image: golang:1.18.4-bullseye
   commands:
@@ -7328,10 +7321,9 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Assume Upload AWS Role
+  - Check if tag is prerelease
   - Verify build is tagged
   - Check out code
-  - Check if tag is prerelease
 volumes:
 - name: yum-persistence
   claim:
@@ -8100,6 +8092,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 40c063a36d5403efe1277d3564ae1fea45a3de4544f39959bd7a2941c89cc459
+hmac: f162c7d06af74b0d16a9aa80e0b4dff707915abae8167556c5a28ec2b551c165
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7062,6 +7062,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7090,6 +7091,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7126,7 +7128,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Download artifacts for "${DRONE_TAG}"
+  - Assume Upload AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7259,6 +7261,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Assume Download AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7287,6 +7290,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
+  - Download artifacts for "${DRONE_TAG}"
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -7324,7 +7328,7 @@ steps:
   - name: awsconfig
     path: /root/.aws
   depends_on:
-  - Download artifacts for "${DRONE_TAG}"
+  - Assume Upload AWS Role
   - Verify build is tagged
   - Check out code
   - Check if tag is prerelease
@@ -8096,6 +8100,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: ef20a2ae8f3c1a1a0c872c7d567875d6377fc67d1f00839f6a34559d07e2ec3d
+hmac: 40c063a36d5403efe1277d3564ae1fea45a3de4544f39959bd7a2941c89cc459
 
 ...


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/17638

This PR includes a variety of fixes and improvements to our apt & yum promotion pipelines. These are broken out by commit:

* `Serialize apt/yum promote pipelines` fixes the errors seen in https://drone.platform.teleport.sh/gravitational/teleport/16694/1/5 by serializing pipeline steps via dependencies.
* `Allow dev build promotes to proceed in deb/rpm pipelines` allows us to test the fix above, which was formerly skipped on promotes of dev builds.  This is the future of the changes proposed in https://github.com/gravitational/teleport/pull/17340
* `Fix globbing bug` fixes a seemingly harmless globbing bug. This was opportunistic cleanup.


Changes for v8:
* Dropped `Swap YUM_REPO_NEW_ROLE to YUM_REPO_NEW_AWS_ROLE` as that fix was already added to this branch in https://github.com/gravitational/teleport/pull/17260
* Removed all dronegen changes

Aside from the drongen and signature conflicts, there were no other merge conflicts.

This change doesn't need to be ported any further, as `dronegen/os_repos.go` and related pipelines aren't in v7.

## Testing
Tag: https://drone.platform.teleport.sh/gravitational/teleport/16761
Promote: https://drone.platform.teleport.sh/gravitational/teleport/16773