### PR TITLE
helm: fix broken snapshot

### DIFF
--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -305,7 +305,9 @@ matches snapshot for azure-databases.yaml:
       teleport.yaml: |
         version: v3
         teleport:
-          auth_token: "/etc/teleport-secrets/auth-token"
+          join_params:
+            method: "token"
+            token_name: "/etc/teleport-secrets/auth-token"
           proxy_server: proxy.example.com:3080
           log:
             severity: INFO


### PR DESCRIPTION
Fix tests on master, a broken test was introduced in https://github.com/gravitational/teleport/pull/16867 but was not detected because of a bot issue (tests did not ran properly because no code change was detected).