### PR TITLE
Fix bot not recognizing certain code changes

### DIFF
--- a/.cloudbuild/scripts/internal/changes/changes.go
+++ b/.cloudbuild/scripts/internal/changes/changes.go
@@ -40,6 +40,11 @@ type Changes struct {
 	Rust       bool
 }
 
+// HasCodeChanges returns true if the changeset includes code changes.
+func (c Changes) HasCodeChanges() bool {
+	return c.Code || c.Helm || c.CI || c.Rust || c.Operator
+}
+
 // Analyze examines the workspace for specific changes using its git history,
 // and then collates and returns a report.
 func Analyze(workspaceDir string, targetBranch string, commitSHA string) (Changes, error) {

--- a/.cloudbuild/scripts/internal/changes/changes_test.go
+++ b/.cloudbuild/scripts/internal/changes/changes_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package changes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasCodeChanges(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Changes
+		out  bool
+	}{
+		{
+			name: "Only docs changes",
+			in:   Changes{Docs: true},
+			out:  false,
+		},
+		{
+			name: "Only Go changes",
+			in:   Changes{Code: true},
+			out:  true,
+		},
+		{
+			name: "Helm and docs changes",
+			in:   Changes{Docs: true, Helm: true},
+			out:  true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.out, test.in.HasCodeChanges())
+		})
+	}
+}


### PR DESCRIPTION
If the changeset does not include any Go changes, our bot thinks there are no code changes at all and skips all unit tests. This results for example in scenarios when a PR contains only, say, Helm and documentation changes, and we don't run any of Helm unit tests.

This PR updates this logic to recognize Helm, CI, Operator and Rust changes as code changes as well. So if the changeset contains only those, respective tests will still run.