### PR TITLE
Bump Go tooling

### DIFF
--- a/api/proto/buf.yaml
+++ b/api/proto/buf.yaml
@@ -2,7 +2,7 @@ version: v1
 deps:
   # gogo/protobuf v1.3.2, keep in sync with build.assets/Makefile.
   - buf.build/gogo/protobuf:b03c65ea87cdc3521ede29f62fe3ce239267c1bc
-  - buf.build/googleapis/googleapis
+  - buf.build/googleapis/googleapis:beb34b4050abfcfff72ff5cc6a28f0afa4043ce0
 lint:
   use:
     - DEFAULT

--- a/api/proto/teleport/legacy/client/proto/authservice.proto
+++ b/api/proto/teleport/legacy/client/proto/authservice.proto
@@ -1821,9 +1821,9 @@ message UpstreamInventoryHello {
   // active.
   repeated string Services = 3 [(gogoproto.casttype) = "github.com/gravitational/teleport/api/types.SystemRole"];
 
-// TODO(fspmarshall): look into what other info can safely be stated here once, instead of
-// being repeatedly announced (e.g. addrs, static labels, etc). may be able to achieve a
-// non-trivial reduction in network usage by doing this.
+  // TODO(fspmarshall): look into what other info can safely be stated here once, instead of
+  // being repeatedly announced (e.g. addrs, static labels, etc). may be able to achieve a
+  // non-trivial reduction in network usage by doing this.
 }
 
 // DownstreamInventoryHello is the hello message sent down the inventory control stream.

--- a/api/proto/teleport/legacy/types/webauthn/webauthn.proto
+++ b/api/proto/teleport/legacy/types/webauthn/webauthn.proto
@@ -234,8 +234,8 @@ message CredentialDescriptor {
   // Raw Credential ID.
   bytes id = 2;
 
-// Notes:
-// * Transport hints omitted (assume no restrictions).
+  // Notes:
+  // * Transport hints omitted (assume no restrictions).
 }
 
 // Parameters for credential creation.

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -165,7 +165,7 @@ ENV GOPATH="/go" \
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install golangci-lint.
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
 # Install helm.
 RUN (mkdir -p helm-tarball && curl -L https://get.helm.sh/helm-v3.5.2-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C helm-tarball -xz && \

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -202,7 +202,7 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1 && \
 
 # Install buf
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.8.0" && \
+    VERSION="1.9.0" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Updates:

* Buf: 1.8.0 -> 1.9.0
* golangci-lint: 1.50.0 -> 1.50.1

Release notes:
* https://github.com/bufbuild/buf/releases/tag/v1.9.0
* https://github.com/golangci/golangci-lint/releases/tag/v1.50.1

Additionally, add a fixed version for googleapi protos (noop change) and reformat protos using the new Buf version.