### PR TITLE
Fix for traits missing error.

### DIFF
--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -124,9 +124,6 @@ func (p *SignParams) Check() error {
 	if len(p.Roles) == 0 {
 		return trace.BadParameter("roles missing")
 	}
-	if len(p.Traits) == 0 {
-		return trace.BadParameter("traits missing")
-	}
 	if p.Expires.IsZero() {
 		return trace.BadParameter("expires missing")
 	}

--- a/lib/jwt/jwt_test.go
+++ b/lib/jwt/jwt_test.go
@@ -50,11 +50,8 @@ func TestSignAndVerify(t *testing.T) {
 	token, err := key.Sign(SignParams{
 		Username: "foo@example.com",
 		Roles:    []string{"foo", "bar"},
-		Traits: wrappers.Traits{
-			"trait1": []string{"value-1", "value-2"},
-		},
-		Expires: clock.Now().Add(1 * time.Minute),
-		URI:     "http://127.0.0.1:8080",
+		Expires:  clock.Now().Add(1 * time.Minute),
+		URI:      "http://127.0.0.1:8080",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Traits is now optional in the JWT SignParams struct.

Note: I updated one of the JWT tests to omit the traits just to make sure it works as expected.

Note: This needs to be verified by @Joerger, as he discovered the regression in https://github.com/gravitational/teleport/issues/17734.