### PR TITLE
[v10] fix: make sure gRPC conns for IAM join method are closed

### DIFF
--- a/api/client/joinservice.go
+++ b/api/client/joinservice.go
@@ -49,6 +49,10 @@ type RegisterChallengeResponseFunc func(challenge string) (*proto.RegisterUsingI
 // *types.RegisterUsingTokenRequest with a signed sts:GetCallerIdentity request
 // including the challenge as a signed header.
 func (c *JoinServiceClient) RegisterUsingIAMMethod(ctx context.Context, challengeResponse RegisterChallengeResponseFunc) (*proto.Certs, error) {
+	// Make sure the gRPC stream is closed when this returns
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// initiate the streaming rpc
 	iamJoinClient, err := c.grpcClient.RegisterUsingIAMMethod(ctx)
 	if err != nil {

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -224,11 +224,14 @@ func registerThroughProxy(token string, params RegisterParams) (*proto.Certs, er
 	var certs *proto.Certs
 	if params.JoinMethod == types.JoinMethodIAM {
 		// IAM join method requires gRPC client
-		client, err := proxyJoinServiceClient(params)
+		conn, err := proxyJoinServiceConn(params)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		certs, err = registerUsingIAMMethod(client, token, params)
+		defer conn.Close()
+
+		joinServiceClient := client.NewJoinServiceClient(proto.NewJoinServiceClient(conn))
+		certs, err = registerUsingIAMMethod(joinServiceClient, token, params)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -304,14 +307,13 @@ func registerThroughAuth(token string, params RegisterParams) (*proto.Certs, err
 	return certs, trace.Wrap(err)
 }
 
-// proxyJoinServiceClient attempts to connect to the join service running on the
+// proxyJoinServiceConn attempts to connect to the join service running on the
 // proxy. The Proxy's TLS cert will be verified using the host's root CA pool
 // (PKI) unless the --insecure flag was passed.
-func proxyJoinServiceClient(params RegisterParams) (*client.JoinServiceClient, error) {
+func proxyJoinServiceConn(params RegisterParams) (*grpc.ClientConn, error) {
 	if len(params.Servers) == 0 {
 		return nil, trace.BadParameter("no auth servers set")
 	}
-
 	tlsConfig := utils.TLSConfig(params.CipherSuites)
 	tlsConfig.Time = params.Clock.Now
 	// set NextProtos for TLS routing, the actual protocol will be h2
@@ -328,11 +330,7 @@ func proxyJoinServiceClient(params RegisterParams) (*client.JoinServiceClient, e
 		grpc.WithStreamInterceptor(metadata.StreamClientInterceptor),
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return client.NewJoinServiceClient(proto.NewJoinServiceClient(conn)), nil
+	return conn, trace.Wrap(err)
 }
 
 // insecureRegisterClient attempts to connects to the Auth Server using the

--- a/lib/joinserver/joinserver_test.go
+++ b/lib/joinserver/joinserver_test.go
@@ -20,11 +20,14 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -49,12 +52,21 @@ func (c *mockJoinServiceClient) RegisterUsingIAMMethod(ctx context.Context, chal
 	return c.returnCerts, c.returnError
 }
 
-func newGRPCServer(t *testing.T) (*grpc.Server, *bufconn.Listener) {
+func ConnectionCountingStreamInterceptor(count *atomic.Int32) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		count.Add(1)
+		defer count.Add(-1)
+		return handler(srv, ss)
+	}
+}
+
+func newGRPCServer(t *testing.T, opts ...grpc.ServerOption) (*grpc.Server, *bufconn.Listener) {
 	lis := bufconn.Listen(1024)
-	s := grpc.NewServer(
-		grpc.UnaryInterceptor(utils.GRPCServerUnaryErrorInterceptor),
-		grpc.StreamInterceptor(utils.GRPCServerStreamErrorInterceptor),
+	opts = append(opts,
+		grpc.ChainUnaryInterceptor(utils.GRPCServerUnaryErrorInterceptor),
+		grpc.ChainStreamInterceptor(utils.GRPCServerStreamErrorInterceptor),
 	)
+	s := grpc.NewServer(opts...)
 	return s, lis
 }
 
@@ -71,29 +83,41 @@ func newGRPCConn(t *testing.T, l *bufconn.Listener) *grpc.ClientConn {
 	return conn
 }
 
-func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
+type testPack struct {
+	authClient, proxyClient         *client.JoinServiceClient
+	authGRPCClient, proxyGRPCClient proto.JoinServiceClient
+	authServer, proxyServer         *JoinServiceGRPCServer
+	streamConnectionCount           *atomic.Int32
+	mockAuthServer                  *mockJoinServiceClient
+}
+
+func newTestPack(t *testing.T) *testPack {
 	// create a mock auth server which implements RegisterUsingIAMMethod
 	mockAuthServer := &mockJoinServiceClient{}
 
+	streamConnectionCount := &atomic.Int32{}
+
 	// create the first instance of JoinServiceGRPCServer wrapping the mock auth
 	// server, to imitate the JoinServiceGRPCServer which runs on Auth
-	authGRPCServer, authGRPCListener := newGRPCServer(t)
-	authJoinService := NewJoinServiceGRPCServer(mockAuthServer)
-	proto.RegisterJoinServiceServer(authGRPCServer, authJoinService)
+	authGRPCServer, authGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(streamConnectionCount)))
+	authServer := NewJoinServiceGRPCServer(mockAuthServer)
+	proto.RegisterJoinServiceServer(authGRPCServer, authServer)
 
 	// create a client to the "auth" gRPC service
 	authConn := newGRPCConn(t, authGRPCListener)
-	authJoinServiceClient := client.NewJoinServiceClient(proto.NewJoinServiceClient(authConn))
+	authGRPCClient := proto.NewJoinServiceClient(authConn)
+	authJoinServiceClient := client.NewJoinServiceClient(authGRPCClient)
 
 	// create a second instance of JoinServiceGRPCServer wrapping the "auth"
 	// gRPC client, to imitate the JoinServiceGRPCServer which runs on Proxy
-	proxyGRPCServer, proxyGRPCListener := newGRPCServer(t)
-	proxyJoinService := NewJoinServiceGRPCServer(authJoinServiceClient)
-	proto.RegisterJoinServiceServer(proxyGRPCServer, proxyJoinService)
+	proxyGRPCServer, proxyGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(streamConnectionCount)))
+	proxyServer := NewJoinServiceGRPCServer(authJoinServiceClient)
+	proto.RegisterJoinServiceServer(proxyGRPCServer, proxyServer)
 
 	// create a client to the "proxy" gRPC service
 	proxyConn := newGRPCConn(t, proxyGRPCListener)
-	proxyJoinServiceClient := client.NewJoinServiceClient(proto.NewJoinServiceClient(proxyConn))
+	proxyGRPCClient := proto.NewJoinServiceClient(proxyConn)
+	proxyJoinServiceClient := client.NewJoinServiceClient(proxyGRPCClient)
 
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
@@ -111,6 +135,22 @@ func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
 		proxyGRPCServer.Stop()
 		wg.Wait()
 	})
+
+	return &testPack{
+		authServer:            authServer,
+		proxyServer:           proxyServer,
+		authGRPCClient:        authGRPCClient,
+		authClient:            authJoinServiceClient,
+		proxyGRPCClient:       proxyGRPCClient,
+		proxyClient:           proxyJoinServiceClient,
+		streamConnectionCount: streamConnectionCount,
+		mockAuthServer:        mockAuthServer,
+	}
+}
+
+func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
+	t.Parallel()
+	testPack := newTestPack(t)
 
 	testCases := []struct {
 		desc                 string
@@ -140,9 +180,9 @@ func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			mockAuthServer.sendChallenge = tc.challenge
-			mockAuthServer.returnCerts = tc.certs
-			mockAuthServer.returnError = tc.authErr
+			testPack.mockAuthServer.sendChallenge = tc.challenge
+			testPack.mockAuthServer.returnCerts = tc.certs
+			testPack.mockAuthServer.returnError = tc.authErr
 			challengeResponder := func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {
 				// client should get the challenge from auth
 				require.Equal(t, tc.challenge, challenge)
@@ -150,8 +190,8 @@ func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
 			}
 
 			for suffix, clt := range map[string]*client.JoinServiceClient{
-				"_auth":  authJoinServiceClient,
-				"_proxy": proxyJoinServiceClient,
+				"_auth":  testPack.authClient,
+				"_proxy": testPack.proxyClient,
 			} {
 				t.Run(tc.desc+suffix, func(t *testing.T) {
 					certs, err := clt.RegisterUsingIAMMethod(context.Background(), challengeResponder)
@@ -172,9 +212,90 @@ func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
 					// client should get the certs from auth
 					require.Equal(t, tc.certs, certs)
 					// auth should get the challenge response from client
-					require.Equal(t, tc.challengeResponse, mockAuthServer.gotChallengeResponse)
+					require.Equal(t, tc.challengeResponse, testPack.mockAuthServer.gotChallengeResponse)
 				})
 			}
+		})
+	}
+}
+
+func TestTimeout(t *testing.T) {
+	t.Parallel()
+
+	testPack := newTestPack(t)
+
+	fakeClock := clockwork.NewFakeClock()
+	testPack.authServer.clock = fakeClock
+	testPack.proxyServer.clock = fakeClock
+
+	for _, tc := range []struct {
+		desc string
+		clt  *client.JoinServiceClient
+	}{
+		{
+			desc: "good auth client",
+			clt:  testPack.authClient,
+		},
+		{
+			desc: "good proxy client",
+			clt:  testPack.proxyClient,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			// When a well-behaved client returns an error responding to the
+			// challenge, the client should cancel the context immediately and all
+			// open stream connections should quickly be closed, much before the
+			// request timeout has to come into effect.
+			tc.clt.RegisterUsingIAMMethod(context.Background(), func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {
+				return nil, trace.BadParameter("")
+			})
+			require.Eventually(t, func() bool {
+				return testPack.streamConnectionCount.Load() == 0
+			}, 10*time.Second, 1*time.Millisecond)
+			// ^ This timeout is absurdly large but I really don't want this to
+			// be flaky in CI. This test is still pretty fast most of the time and
+			// still tests what it is meant to - if the connections never close
+			// this would still fail.
+		})
+	}
+
+	for _, tc := range []struct {
+		desc string
+		clt  proto.JoinServiceClient
+	}{
+		{
+			desc: "bad auth client",
+			clt:  testPack.authGRPCClient,
+		},
+		{
+			desc: "bad proxy client",
+			clt:  testPack.proxyGRPCClient,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			srv, err := tc.clt.RegisterUsingIAMMethod(context.Background())
+			require.NoError(t, err)
+
+			_, err = srv.Recv()
+			require.NoError(t, err)
+
+			// Sanity check there are some open connections after the first gRPC
+			// Recv
+			require.Greater(t, testPack.streamConnectionCount.Load(), int32(0))
+
+			// Instead of sending a challenge response, a poorly behaved client
+			// might just hang and never close the connection.
+			//
+			// Make sure the request is automatically timed out on the server and all
+			// connections are closed shortly after the timeout.
+			fakeClock.Advance(iamJoinRequestTimeout)
+			require.Eventually(t, func() bool {
+				return testPack.streamConnectionCount.Load() == 0
+			}, 10*time.Second, 1*time.Millisecond)
+			// ^ This timeout is absurdly large but I really don't want this to
+			// be flaky in CI. This test is still pretty fast most of the time and
+			// still tests what it is meant to - if the connections never close
+			// this would still fail.
 		})
 	}
 }

--- a/lib/joinserver/joinserver_test.go
+++ b/lib/joinserver/joinserver_test.go
@@ -52,10 +52,10 @@ func (c *mockJoinServiceClient) RegisterUsingIAMMethod(ctx context.Context, chal
 	return c.returnCerts, c.returnError
 }
 
-func ConnectionCountingStreamInterceptor(count *atomic.Int32) grpc.StreamServerInterceptor {
+func ConnectionCountingStreamInterceptor(count *int32) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		count.Add(1)
-		defer count.Add(-1)
+		atomic.AddInt32(count, 1)
+		defer atomic.AddInt32(count, -1)
 		return handler(srv, ss)
 	}
 }
@@ -87,7 +87,7 @@ type testPack struct {
 	authClient, proxyClient         *client.JoinServiceClient
 	authGRPCClient, proxyGRPCClient proto.JoinServiceClient
 	authServer, proxyServer         *JoinServiceGRPCServer
-	streamConnectionCount           *atomic.Int32
+	streamConnectionCount           *int32
 	mockAuthServer                  *mockJoinServiceClient
 }
 
@@ -95,11 +95,11 @@ func newTestPack(t *testing.T) *testPack {
 	// create a mock auth server which implements RegisterUsingIAMMethod
 	mockAuthServer := &mockJoinServiceClient{}
 
-	streamConnectionCount := &atomic.Int32{}
+	var streamConnectionCount int32
 
 	// create the first instance of JoinServiceGRPCServer wrapping the mock auth
 	// server, to imitate the JoinServiceGRPCServer which runs on Auth
-	authGRPCServer, authGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(streamConnectionCount)))
+	authGRPCServer, authGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(&streamConnectionCount)))
 	authServer := NewJoinServiceGRPCServer(mockAuthServer)
 	proto.RegisterJoinServiceServer(authGRPCServer, authServer)
 
@@ -110,7 +110,7 @@ func newTestPack(t *testing.T) *testPack {
 
 	// create a second instance of JoinServiceGRPCServer wrapping the "auth"
 	// gRPC client, to imitate the JoinServiceGRPCServer which runs on Proxy
-	proxyGRPCServer, proxyGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(streamConnectionCount)))
+	proxyGRPCServer, proxyGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(&streamConnectionCount)))
 	proxyServer := NewJoinServiceGRPCServer(authJoinServiceClient)
 	proto.RegisterJoinServiceServer(proxyGRPCServer, proxyServer)
 
@@ -143,7 +143,7 @@ func newTestPack(t *testing.T) *testPack {
 		authClient:            authJoinServiceClient,
 		proxyGRPCClient:       proxyGRPCClient,
 		proxyClient:           proxyJoinServiceClient,
-		streamConnectionCount: streamConnectionCount,
+		streamConnectionCount: &streamConnectionCount,
 		mockAuthServer:        mockAuthServer,
 	}
 }
@@ -250,7 +250,7 @@ func TestTimeout(t *testing.T) {
 				return nil, trace.BadParameter("")
 			})
 			require.Eventually(t, func() bool {
-				return testPack.streamConnectionCount.Load() == 0
+				return atomic.LoadInt32(testPack.streamConnectionCount) == 0
 			}, 10*time.Second, 1*time.Millisecond)
 			// ^ This timeout is absurdly large but I really don't want this to
 			// be flaky in CI. This test is still pretty fast most of the time and
@@ -281,7 +281,7 @@ func TestTimeout(t *testing.T) {
 
 			// Sanity check there are some open connections after the first gRPC
 			// Recv
-			require.Greater(t, testPack.streamConnectionCount.Load(), int32(0))
+			require.Greater(t, atomic.LoadInt32(testPack.streamConnectionCount), int32(0))
 
 			// Instead of sending a challenge response, a poorly behaved client
 			// might just hang and never close the connection.
@@ -290,7 +290,7 @@ func TestTimeout(t *testing.T) {
 			// connections are closed shortly after the timeout.
 			fakeClock.Advance(iamJoinRequestTimeout)
 			require.Eventually(t, func() bool {
-				return testPack.streamConnectionCount.Load() == 0
+				return atomic.LoadInt32(testPack.streamConnectionCount) == 0
 			}, 10*time.Second, 1*time.Millisecond)
 			// ^ This timeout is absurdly large but I really don't want this to
 			// be flaky in CI. This test is still pretty fast most of the time and

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -53,6 +53,7 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
@@ -3825,6 +3826,23 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				utils.GRPCServerStreamErrorInterceptor,
 				proxyLimiter.StreamServerInterceptor,
 			),
+			grpc.KeepaliveParams(keepalive.ServerParameters{
+				// Using an aggressive idle timeout here since this gRPC server
+				// currently only hosts the join service, which has no need for
+				// long-lived idle connections.
+				//
+				// The reason for introducing this is that teleport clients
+				// before #17685 is fixed will hold connections open
+				// indefinitely if they encounter an error during the joining
+				// process, and this seems like the best way for the server to
+				// forcibly close those connections.
+				//
+				// If another gRPC service is added here in the future, it
+				// should be alright to increase or remove this idle timeout as
+				// necessary once the client fix has been released and widely
+				// available for some time.
+				MaxConnectionIdle: 10 * time.Second,
+			}),
 		)
 		joinServiceServer := joinserver.NewJoinServiceGRPCServer(conn.Client)
 		proto.RegisterJoinServiceServer(grpcServer, joinServiceServer)


### PR DESCRIPTION
backport #17565 to branch/v10

- clients close the stream and any connection when they are done with it
- servers close the stream after a 1 minute timeout