### PR TITLE
[v9] fix: make sure gRPC conns for IAM join method are closed

### DIFF
--- a/api/client/joinservice.go
+++ b/api/client/joinservice.go
@@ -49,6 +49,10 @@ type RegisterChallengeResponseFunc func(challenge string) (*proto.RegisterUsingI
 // *types.RegisterUsingTokenRequest with a signed sts:GetCallerIdentity request
 // including the challenge as a signed header.
 func (c *JoinServiceClient) RegisterUsingIAMMethod(ctx context.Context, challengeResponse RegisterChallengeResponseFunc) (*proto.Certs, error) {
+	// Make sure the gRPC stream is closed when this returns
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// initiate the streaming rpc
 	iamJoinClient, err := c.grpcClient.RegisterUsingIAMMethod(ctx)
 	if err != nil {

--- a/lib/joinserver/joinserver_test.go
+++ b/lib/joinserver/joinserver_test.go
@@ -20,11 +20,14 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -49,12 +52,21 @@ func (c *mockJoinServiceClient) RegisterUsingIAMMethod(ctx context.Context, chal
 	return c.returnCerts, c.returnError
 }
 
-func newGRPCServer(t *testing.T) (*grpc.Server, *bufconn.Listener) {
+func ConnectionCountingStreamInterceptor(count *atomic.Int32) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		count.Add(1)
+		defer count.Add(-1)
+		return handler(srv, ss)
+	}
+}
+
+func newGRPCServer(t *testing.T, opts ...grpc.ServerOption) (*grpc.Server, *bufconn.Listener) {
 	lis := bufconn.Listen(1024)
-	s := grpc.NewServer(
-		grpc.UnaryInterceptor(utils.ErrorConvertUnaryInterceptor),
-		grpc.StreamInterceptor(utils.ErrorConvertStreamInterceptor),
+	opts = append(opts,
+		grpc.ChainUnaryInterceptor(utils.ErrorConvertUnaryInterceptor),
+		grpc.ChainStreamInterceptor(utils.ErrorConvertStreamInterceptor),
 	)
+	s := grpc.NewServer(opts...)
 	return s, lis
 }
 
@@ -71,29 +83,41 @@ func newGRPCConn(t *testing.T, l *bufconn.Listener) *grpc.ClientConn {
 	return conn
 }
 
-func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
+type testPack struct {
+	authClient, proxyClient         *client.JoinServiceClient
+	authGRPCClient, proxyGRPCClient proto.JoinServiceClient
+	authServer, proxyServer         *JoinServiceGRPCServer
+	streamConnectionCount           *atomic.Int32
+	mockAuthServer                  *mockJoinServiceClient
+}
+
+func newTestPack(t *testing.T) *testPack {
 	// create a mock auth server which implements RegisterUsingIAMMethod
 	mockAuthServer := &mockJoinServiceClient{}
 
+	streamConnectionCount := &atomic.Int32{}
+
 	// create the first instance of JoinServiceGRPCServer wrapping the mock auth
 	// server, to imitate the JoinServiceGRPCServer which runs on Auth
-	authGRPCServer, authGRPCListener := newGRPCServer(t)
-	authJoinService := NewJoinServiceGRPCServer(mockAuthServer)
-	proto.RegisterJoinServiceServer(authGRPCServer, authJoinService)
+	authGRPCServer, authGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(streamConnectionCount)))
+	authServer := NewJoinServiceGRPCServer(mockAuthServer)
+	proto.RegisterJoinServiceServer(authGRPCServer, authServer)
 
 	// create a client to the "auth" gRPC service
 	authConn := newGRPCConn(t, authGRPCListener)
-	authJoinServiceClient := client.NewJoinServiceClient(proto.NewJoinServiceClient(authConn))
+	authGRPCClient := proto.NewJoinServiceClient(authConn)
+	authJoinServiceClient := client.NewJoinServiceClient(authGRPCClient)
 
 	// create a second instance of JoinServiceGRPCServer wrapping the "auth"
 	// gRPC client, to imitate the JoinServiceGRPCServer which runs on Proxy
-	proxyGRPCServer, proxyGRPCListener := newGRPCServer(t)
-	proxyJoinService := NewJoinServiceGRPCServer(authJoinServiceClient)
-	proto.RegisterJoinServiceServer(proxyGRPCServer, proxyJoinService)
+	proxyGRPCServer, proxyGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(streamConnectionCount)))
+	proxyServer := NewJoinServiceGRPCServer(authJoinServiceClient)
+	proto.RegisterJoinServiceServer(proxyGRPCServer, proxyServer)
 
 	// create a client to the "proxy" gRPC service
 	proxyConn := newGRPCConn(t, proxyGRPCListener)
-	proxyJoinServiceClient := client.NewJoinServiceClient(proto.NewJoinServiceClient(proxyConn))
+	proxyGRPCClient := proto.NewJoinServiceClient(proxyConn)
+	proxyJoinServiceClient := client.NewJoinServiceClient(proxyGRPCClient)
 
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
@@ -111,6 +135,22 @@ func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
 		proxyGRPCServer.Stop()
 		wg.Wait()
 	})
+
+	return &testPack{
+		authServer:            authServer,
+		proxyServer:           proxyServer,
+		authGRPCClient:        authGRPCClient,
+		authClient:            authJoinServiceClient,
+		proxyGRPCClient:       proxyGRPCClient,
+		proxyClient:           proxyJoinServiceClient,
+		streamConnectionCount: streamConnectionCount,
+		mockAuthServer:        mockAuthServer,
+	}
+}
+
+func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
+	t.Parallel()
+	testPack := newTestPack(t)
 
 	testCases := []struct {
 		desc                 string
@@ -140,9 +180,9 @@ func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			mockAuthServer.sendChallenge = tc.challenge
-			mockAuthServer.returnCerts = tc.certs
-			mockAuthServer.returnError = tc.authErr
+			testPack.mockAuthServer.sendChallenge = tc.challenge
+			testPack.mockAuthServer.returnCerts = tc.certs
+			testPack.mockAuthServer.returnError = tc.authErr
 			challengeResponder := func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {
 				// client should get the challenge from auth
 				require.Equal(t, tc.challenge, challenge)
@@ -150,8 +190,8 @@ func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
 			}
 
 			for suffix, clt := range map[string]*client.JoinServiceClient{
-				"_auth":  authJoinServiceClient,
-				"_proxy": proxyJoinServiceClient,
+				"_auth":  testPack.authClient,
+				"_proxy": testPack.proxyClient,
 			} {
 				t.Run(tc.desc+suffix, func(t *testing.T) {
 					certs, err := clt.RegisterUsingIAMMethod(context.Background(), challengeResponder)
@@ -172,9 +212,90 @@ func TestJoinServiceGRPCServer_RegisterUsingIAMMethod(t *testing.T) {
 					// client should get the certs from auth
 					require.Equal(t, tc.certs, certs)
 					// auth should get the challenge response from client
-					require.Equal(t, tc.challengeResponse, mockAuthServer.gotChallengeResponse)
+					require.Equal(t, tc.challengeResponse, testPack.mockAuthServer.gotChallengeResponse)
 				})
 			}
+		})
+	}
+}
+
+func TestTimeout(t *testing.T) {
+	t.Parallel()
+
+	testPack := newTestPack(t)
+
+	fakeClock := clockwork.NewFakeClock()
+	testPack.authServer.clock = fakeClock
+	testPack.proxyServer.clock = fakeClock
+
+	for _, tc := range []struct {
+		desc string
+		clt  *client.JoinServiceClient
+	}{
+		{
+			desc: "good auth client",
+			clt:  testPack.authClient,
+		},
+		{
+			desc: "good proxy client",
+			clt:  testPack.proxyClient,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			// When a well-behaved client returns an error responding to the
+			// challenge, the client should cancel the context immediately and all
+			// open stream connections should quickly be closed, much before the
+			// request timeout has to come into effect.
+			tc.clt.RegisterUsingIAMMethod(context.Background(), func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {
+				return nil, trace.BadParameter("")
+			})
+			require.Eventually(t, func() bool {
+				return testPack.streamConnectionCount.Load() == 0
+			}, 10*time.Second, 1*time.Millisecond)
+			// ^ This timeout is absurdly large but I really don't want this to
+			// be flaky in CI. This test is still pretty fast most of the time and
+			// still tests what it is meant to - if the connections never close
+			// this would still fail.
+		})
+	}
+
+	for _, tc := range []struct {
+		desc string
+		clt  proto.JoinServiceClient
+	}{
+		{
+			desc: "bad auth client",
+			clt:  testPack.authGRPCClient,
+		},
+		{
+			desc: "bad proxy client",
+			clt:  testPack.proxyGRPCClient,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			srv, err := tc.clt.RegisterUsingIAMMethod(context.Background())
+			require.NoError(t, err)
+
+			_, err = srv.Recv()
+			require.NoError(t, err)
+
+			// Sanity check there are some open connections after the first gRPC
+			// Recv
+			require.Greater(t, testPack.streamConnectionCount.Load(), int32(0))
+
+			// Instead of sending a challenge response, a poorly behaved client
+			// might just hang and never close the connection.
+			//
+			// Make sure the request is automatically timed out on the server and all
+			// connections are closed shortly after the timeout.
+			fakeClock.Advance(iamJoinRequestTimeout)
+			require.Eventually(t, func() bool {
+				return testPack.streamConnectionCount.Load() == 0
+			}, 10*time.Second, 1*time.Millisecond)
+			// ^ This timeout is absurdly large but I really don't want this to
+			// be flaky in CI. This test is still pretty fast most of the time and
+			// still tests what it is meant to - if the connections never close
+			// this would still fail.
 		})
 	}
 }

--- a/lib/joinserver/joinserver_test.go
+++ b/lib/joinserver/joinserver_test.go
@@ -52,10 +52,10 @@ func (c *mockJoinServiceClient) RegisterUsingIAMMethod(ctx context.Context, chal
 	return c.returnCerts, c.returnError
 }
 
-func ConnectionCountingStreamInterceptor(count *atomic.Int32) grpc.StreamServerInterceptor {
+func ConnectionCountingStreamInterceptor(count *int32) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		count.Add(1)
-		defer count.Add(-1)
+		atomic.AddInt32(count, 1)
+		defer atomic.AddInt32(count, -1)
 		return handler(srv, ss)
 	}
 }
@@ -87,7 +87,7 @@ type testPack struct {
 	authClient, proxyClient         *client.JoinServiceClient
 	authGRPCClient, proxyGRPCClient proto.JoinServiceClient
 	authServer, proxyServer         *JoinServiceGRPCServer
-	streamConnectionCount           *atomic.Int32
+	streamConnectionCount           *int32
 	mockAuthServer                  *mockJoinServiceClient
 }
 
@@ -95,11 +95,11 @@ func newTestPack(t *testing.T) *testPack {
 	// create a mock auth server which implements RegisterUsingIAMMethod
 	mockAuthServer := &mockJoinServiceClient{}
 
-	streamConnectionCount := &atomic.Int32{}
+	var streamConnectionCount int32
 
 	// create the first instance of JoinServiceGRPCServer wrapping the mock auth
 	// server, to imitate the JoinServiceGRPCServer which runs on Auth
-	authGRPCServer, authGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(streamConnectionCount)))
+	authGRPCServer, authGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(&streamConnectionCount)))
 	authServer := NewJoinServiceGRPCServer(mockAuthServer)
 	proto.RegisterJoinServiceServer(authGRPCServer, authServer)
 
@@ -110,7 +110,7 @@ func newTestPack(t *testing.T) *testPack {
 
 	// create a second instance of JoinServiceGRPCServer wrapping the "auth"
 	// gRPC client, to imitate the JoinServiceGRPCServer which runs on Proxy
-	proxyGRPCServer, proxyGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(streamConnectionCount)))
+	proxyGRPCServer, proxyGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(&streamConnectionCount)))
 	proxyServer := NewJoinServiceGRPCServer(authJoinServiceClient)
 	proto.RegisterJoinServiceServer(proxyGRPCServer, proxyServer)
 
@@ -143,7 +143,7 @@ func newTestPack(t *testing.T) *testPack {
 		authClient:            authJoinServiceClient,
 		proxyGRPCClient:       proxyGRPCClient,
 		proxyClient:           proxyJoinServiceClient,
-		streamConnectionCount: streamConnectionCount,
+		streamConnectionCount: &streamConnectionCount,
 		mockAuthServer:        mockAuthServer,
 	}
 }
@@ -250,7 +250,7 @@ func TestTimeout(t *testing.T) {
 				return nil, trace.BadParameter("")
 			})
 			require.Eventually(t, func() bool {
-				return testPack.streamConnectionCount.Load() == 0
+				return atomic.LoadInt32(testPack.streamConnectionCount) == 0
 			}, 10*time.Second, 1*time.Millisecond)
 			// ^ This timeout is absurdly large but I really don't want this to
 			// be flaky in CI. This test is still pretty fast most of the time and
@@ -281,7 +281,7 @@ func TestTimeout(t *testing.T) {
 
 			// Sanity check there are some open connections after the first gRPC
 			// Recv
-			require.Greater(t, testPack.streamConnectionCount.Load(), int32(0))
+			require.Greater(t, atomic.LoadInt32(testPack.streamConnectionCount), int32(0))
 
 			// Instead of sending a challenge response, a poorly behaved client
 			// might just hang and never close the connection.
@@ -290,7 +290,7 @@ func TestTimeout(t *testing.T) {
 			// connections are closed shortly after the timeout.
 			fakeClock.Advance(iamJoinRequestTimeout)
 			require.Eventually(t, func() bool {
-				return testPack.streamConnectionCount.Load() == 0
+				return atomic.LoadInt32(testPack.streamConnectionCount) == 0
 			}, 10*time.Second, 1*time.Millisecond)
 			// ^ This timeout is absurdly large but I really don't want this to
 			// be flaky in CI. This test is still pretty fast most of the time and


### PR DESCRIPTION
backport #17565 to branch/v9

- clients close the stream and any connection when they are done with it
- servers close the stream after a 1 minute timeout