### PR TITLE
[v11] Add v8 to older-versions docs page

### DIFF
--- a/docs/pages/older-versions.mdx
+++ b/docs/pages/older-versions.mdx
@@ -7,6 +7,7 @@ layout: tocless-doc
 
 Deprecated versions of the Teleport docs can be found at the GitHub links below:
 
+[Teleport 8.0](https://github.com/gravitational/teleport/tree/branch/v8) <br/>
 [Teleport 7.0](https://github.com/gravitational/teleport/tree/branch/v7) <br/>
 [Teleport 6.2](https://github.com/gravitational/teleport/tree/branch/v6.2) <br/>
 [Teleport 6.1](https://github.com/gravitational/teleport/tree/branch/v6.1) <br/>


### PR DESCRIPTION
Backport #17690 to branch/v11