### PR TITLE
Create and Update database http endpoints

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -60,6 +60,8 @@ type Database interface {
 	SetURI(string)
 	// GetCA returns the database CA certificate.
 	GetCA() string
+	// SetCA sets the database CA certificate in the Spec.TLS field.
+	SetCA(string)
 	// GetTLS returns the database TLS configuration.
 	GetTLS() DatabaseTLS
 	// SetStatusCA sets the database CA certificate in the status field.
@@ -265,6 +267,11 @@ func (d *DatabaseV3) GetCA() string {
 		return d.Spec.CACert
 	}
 	return d.Status.CACert
+}
+
+// SetCA sets the database CA certificate in the Spec.TLS.CACert field.
+func (d *DatabaseV3) SetCA(caCert string) {
+	d.Spec.TLS.CACert = caCert
 }
 
 // GetTLS returns Database TLS configuration.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -559,6 +559,8 @@ func (h *Handler) bindDefaultEndpoints(challengeLimiter *limiter.RateLimiter) {
 
 	// Database access handlers.
 	h.GET("/webapi/sites/:site/databases", h.WithClusterAuth(h.clusterDatabasesGet))
+	h.POST("/webapi/sites/:site/databases", h.WithClusterAuth(h.handleDatabaseCreate))
+	h.PUT("/webapi/sites/:site/databases/:database", h.WithClusterAuth(h.handleDatabaseUpdate))
 
 	// Kube access handlers.
 	h.GET("/webapi/sites/:site/kubernetes", h.WithClusterAuth(h.clusterKubesGet))

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5052,7 +5052,7 @@ func TestUpdateDatabase(t *testing.T) {
 			},
 			expectedStatus: http.StatusBadRequest,
 			errAssert: func(tt require.TestingT, err error, i ...interface{}) {
-				require.ErrorContains(t, err, "missing ca_cert field")
+				require.ErrorContains(t, err, "missing CA certificate data")
 			},
 		},
 		{
@@ -5062,7 +5062,7 @@ func TestUpdateDatabase(t *testing.T) {
 			},
 			expectedStatus: http.StatusBadRequest,
 			errAssert: func(tt require.TestingT, err error, i ...interface{}) {
-				require.ErrorContains(t, err, "invalid x509 PEM certificate in ca_cert")
+				require.ErrorContains(t, err, "could not parse provided CA as X.509 PEM certificate")
 			},
 		},
 	} {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -4374,9 +4374,6 @@ func TestDiagnoseSSHConnection(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			// if tt.name != "success" {
-			// 	return
-			// }
 			localEnv := env
 
 			if tt.stopNode {
@@ -4879,6 +4876,212 @@ func TestDiagnoseKubeConnection(t *testing.T) {
 
 			require.Equal(t, expectedFailedTraces, gotFailedTraces)
 		})
+	}
+}
+
+func TestCreateDatabase(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	username := "someuser"
+	roleCreateDatabase, err := types.NewRole(services.RoleNameForUser(username), types.RoleSpecV5{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{
+				types.NewRule(types.KindDatabase,
+					[]string{types.VerbCreate}),
+			},
+			DatabaseLabels: types.Labels{
+				types.Wildcard: {types.Wildcard},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	env := newWebPack(t, 1)
+	clusterName := env.server.ClusterName()
+	pack := env.proxies[0].authPack(t, username, []types.Role{roleCreateDatabase})
+
+	createDatabaseEndpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "databases")
+
+	for _, tt := range []struct {
+		name           string
+		req            createDatabaseRequest
+		expectedStatus int
+		errAssert      require.ErrorAssertionFunc
+	}{
+		{
+			name: "valid",
+			req: createDatabaseRequest{
+				Name:     "mydatabase",
+				Protocol: "mysql",
+				URI:      "someuri",
+			},
+			expectedStatus: http.StatusOK,
+			errAssert:      require.NoError,
+		},
+		{
+			name: "valid with labels",
+			req: createDatabaseRequest{
+				Name:     "dbwithlabels",
+				Protocol: "mysql",
+				URI:      "someuri",
+				Labels: []ui.Label{
+					{
+						Name:  "env",
+						Value: "prod",
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			errAssert:      require.NoError,
+		},
+		{
+			name: "empty name",
+			req: createDatabaseRequest{
+				Name:     "",
+				Protocol: "mysql",
+				URI:      "someuri",
+			},
+			expectedStatus: http.StatusBadRequest,
+			errAssert: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "missing database name")
+			},
+		},
+		{
+			name: "empty protocol",
+			req: createDatabaseRequest{
+				Name:     "emptyprotocol",
+				Protocol: "",
+				URI:      "someuri",
+			},
+			expectedStatus: http.StatusBadRequest,
+			errAssert: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "missing protocol")
+			},
+		},
+		{
+			name: "empty uri",
+			req: createDatabaseRequest{
+				Name:     "emptyuri",
+				Protocol: "mysql",
+				URI:      "",
+			},
+			expectedStatus: http.StatusBadRequest,
+			errAssert: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "missing uri")
+			},
+		},
+	} {
+		// Create database
+		resp, err := pack.clt.PostJSON(ctx, createDatabaseEndpoint, tt.req)
+		tt.errAssert(t, err)
+
+		require.Equal(t, resp.Code(), tt.expectedStatus, "invalid status code received")
+
+		if err != nil {
+			continue
+		}
+
+		// Ensure database exists
+		database, err := env.proxies[0].client.GetDatabase(ctx, tt.req.Name)
+		require.NoError(t, err)
+
+		require.Equal(t, database.GetName(), tt.req.Name)
+		require.Equal(t, database.GetProtocol(), tt.req.Protocol)
+		require.Equal(t, database.GetURI(), tt.req.URI)
+
+		// At least the provided labels exist in the database resource
+		databaseLabels := database.GetAllLabels()
+		for _, label := range tt.req.Labels {
+			require.Contains(t, databaseLabels, label.Name, "label not found")
+			require.Equal(t, label.Value, databaseLabels[label.Name], "label exists but has unexpected value")
+		}
+	}
+}
+
+func TestUpdateDatabase(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	databaseName := "somedb"
+	username := "someuser"
+	roleCreateUpdateDatabase, err := types.NewRole(services.RoleNameForUser(username), types.RoleSpecV5{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{
+				types.NewRule(types.KindDatabase,
+					[]string{types.VerbCreate, types.VerbUpdate, types.VerbRead}),
+			},
+			DatabaseLabels: types.Labels{
+				types.Wildcard: {types.Wildcard},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	env := newWebPack(t, 1)
+	clusterName := env.server.ClusterName()
+	pack := env.proxies[0].authPack(t, username, []types.Role{roleCreateUpdateDatabase})
+
+	// Create database
+	createDatabaseEndpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "databases")
+	_, err = pack.clt.PostJSON(ctx, createDatabaseEndpoint, createDatabaseRequest{
+		Name:     databaseName,
+		Protocol: "mysql",
+		URI:      "somuri",
+	})
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name           string
+		req            updateDatabaseRequest
+		expectedStatus int
+		errAssert      require.ErrorAssertionFunc
+	}{
+		{
+			name: "valid",
+			req: updateDatabaseRequest{
+				CACert: fakeValidTLSCert,
+			},
+			expectedStatus: http.StatusOK,
+			errAssert:      require.NoError,
+		},
+		{
+			name: "empty ca_cert",
+			req: updateDatabaseRequest{
+				CACert: "",
+			},
+			expectedStatus: http.StatusBadRequest,
+			errAssert: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "missing ca_cert field")
+			},
+		},
+		{
+			name: "invalid certificate",
+			req: updateDatabaseRequest{
+				CACert: "Not a certificate",
+			},
+			expectedStatus: http.StatusBadRequest,
+			errAssert: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid x509 PEM certificate in ca_cert")
+			},
+		},
+	} {
+		// Update database's CA Cert
+		updateDatabaseEndpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "databases", databaseName)
+		resp, err := pack.clt.PutJSON(ctx, updateDatabaseEndpoint, tt.req)
+		tt.errAssert(t, err)
+
+		require.Equal(t, resp.Code(), tt.expectedStatus, "invalid status code received")
+
+		if err != nil {
+			continue
+		}
+
+		// Ensure database was updated
+		database, err := env.proxies[0].client.GetDatabase(ctx, databaseName)
+		require.NoError(t, err)
+
+		require.Equal(t, database.GetCA(), fakeValidTLSCert)
 	}
 }
 

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package web
+
+import (
+	"net/http"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/tlsutils"
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/web/ui"
+)
+
+// createDatabaseRequest contains the necessary basic information to create a database.
+// Database here is the database resource, containing information to a real database (protocol, uri)
+type createDatabaseRequest struct {
+	Name     string     `json:"name,omitempty"`
+	Labels   []ui.Label `json:"labels,omitempty"`
+	Protocol string     `json:"protocol,omitempty"`
+	URI      string     `json:"uri,omitempty"`
+}
+
+func (r *createDatabaseRequest) checkAndSetDefaults() error {
+	if r.Name == "" {
+		return trace.BadParameter("missing database name")
+	}
+
+	if r.Protocol == "" {
+		return trace.BadParameter("missing protocol")
+	}
+
+	if r.URI == "" {
+		return trace.BadParameter("missing uri")
+	}
+
+	return nil
+}
+
+// handleDatabaseCreate creates a database's metadata.
+func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	var req *createDatabaseRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := req.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	labels := make(map[string]string)
+	for _, label := range req.Labels {
+		labels[label.Name] = label.Value
+	}
+
+	database, err := types.NewDatabaseV3(
+		types.Metadata{
+			Name:   req.Name,
+			Labels: labels,
+		},
+		types.DatabaseSpecV3{
+			Protocol: req.Protocol,
+			URI:      req.URI,
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clt, err := ctx.GetUserClient(site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := clt.CreateDatabase(r.Context(), database); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.MakeDatabase(database), nil
+}
+
+// updateDatabaseRequest contains some updatable fields of a database resource.
+type updateDatabaseRequest struct {
+	CACert string `json:"ca_cert,omitempty"`
+}
+
+func (r *updateDatabaseRequest) checkAndSetDefaults() error {
+	if r.CACert == "" {
+		return trace.BadParameter("missing ca_cert field")
+	}
+
+	if _, err := tlsutils.ParseCertificatePEM([]byte(r.CACert)); err != nil {
+		return trace.BadParameter("invalid x509 PEM certificate in ca_cert")
+	}
+
+	return nil
+}
+
+// handleDatabaseUpdate updates the database
+func (h *Handler) handleDatabaseUpdate(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	databaseName := p.ByName("database")
+	if databaseName == "" {
+		return nil, trace.BadParameter("a database name is required")
+	}
+
+	var req *updateDatabaseRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := req.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clt, err := ctx.GetUserClient(site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	database, err := clt.GetDatabase(r.Context(), databaseName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	database.SetCA(req.CACert)
+
+	if err := clt.UpdateDatabase(r.Context(), database); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.MakeDatabase(database), nil
+}

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -102,11 +102,11 @@ type updateDatabaseRequest struct {
 
 func (r *updateDatabaseRequest) checkAndSetDefaults() error {
 	if r.CACert == "" {
-		return trace.BadParameter("missing ca_cert field")
+		return trace.BadParameter("missing CA certificate data")
 	}
 
 	if _, err := tlsutils.ParseCertificatePEM([]byte(r.CACert)); err != nil {
-		return trace.BadParameter("invalid x509 PEM certificate in ca_cert")
+		return trace.BadParameter("could not parse provided CA as X.509 PEM certificate")
 	}
 
 	return nil

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestCreateDatabaseRequestParameters(t *testing.T) {
+	t.Parallel()
 
 	for _, test := range []struct {
 		desc      string

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package web
+
+import (
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateDatabaseRequestParameters(t *testing.T) {
+
+	for _, test := range []struct {
+		desc      string
+		req       createDatabaseRequest
+		errAssert require.ErrorAssertionFunc
+	}{
+		{
+			desc: "valid",
+			req: createDatabaseRequest{
+				Name:     "name",
+				Protocol: "protocol",
+				URI:      "uri",
+			},
+			errAssert: require.NoError,
+		},
+		{
+			desc: "invalid missing name",
+			req: createDatabaseRequest{
+				Name:     "",
+				Protocol: "protocol",
+				URI:      "uri",
+			},
+			errAssert: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err), "expected a bad parameter error, got", err)
+			},
+		},
+		{
+			desc: "invalid missing protocol",
+			req: createDatabaseRequest{
+				Name:     "name",
+				Protocol: "",
+				URI:      "uri",
+			},
+			errAssert: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err), "expected a bad parameter error, got", err)
+			},
+		},
+		{
+			desc: "invalid missing uri",
+			req: createDatabaseRequest{
+				Name:     "name",
+				Protocol: "protocol",
+				URI:      "",
+			},
+			errAssert: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err), "expected a bad parameter error, got", err)
+			},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			test.errAssert(t, test.req.checkAndSetDefaults())
+		})
+	}
+}
+
+var fakeValidTLSCert = `-----BEGIN CERTIFICATE-----
+MIIDyzCCArOgAwIBAgIQD3MiJ2Au8PicJpCNFbvcETANBgkqhkiG9w0BAQsFADBe
+MRQwEgYDVQQKEwtleGFtcGxlLmNvbTEUMBIGA1UEAxMLZXhhbXBsZS5jb20xMDAu
+BgNVBAUTJzIwNTIxNzE3NzMzMTIxNzQ2ODMyNjA5NjAxODEwODc0NTAzMjg1ODAe
+Fw0yMTAyMTcyMDI3MjFaFw0yMTAyMTgwODI4MjFaMIGCMRUwEwYDVQQHEwxhY2Nl
+c3MtYWRtaW4xCTAHBgNVBAkTADEYMBYGA1UEEQwPeyJsb2dpbnMiOm51bGx9MRUw
+EwYDVQQKEwxhY2Nlc3MtYWRtaW4xFTATBgNVBAMTDGFjY2Vzcy1hZG1pbjEWMBQG
+BSvODwEHEwtleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAM5FFaCeK59lwIthyXgSCMZbHTDxsy66Cbm/XhwFbKQLngyS0oKkHbh06INN
+UfTAAEaFlMG0CzdAyGyRSu9FK8BE127kRHBs6hb1pTgy2f6TFkFo/h4WTWW4GQSi
+O8Al7A2tuRjc3mAnk71q+kvpQYS7tnkhmFCYE8jKxMtlYG39x4kQ6btll7P9zI6X
+Zv5RRrlzqADuwZpEcLYVi0TjITqPbx3rDZT4l+EmslhaoG+xE5Vu+GYXLlvwB9E/
+amfN1Z9Kps4Ob6Jxxse9kjeMir9mwiNkBWVyhH/LETDA9Xa6sTQ2e75MYM7yXJLY
+OmBKV4g176Qf1T1ye7a/Ggn4t2UCAwEAAaNgMF4wDgYDVR0PAQH/BAQDAgWgMB0G
+A1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB8GA1Ud
+IwQYMBaAFJWqMooE05nf263F341pOO+mPMSqMA0GCSqGSIb3DQEBCwUAA4IBAQCK
+s0yPzkSuCY/LFeHJoJeNJ1SR+EKbk4zoAnD0nbbIsd2quyYIiojshlfehhuZE+8P
+bzpUNG2aYKq+8lb0NO+OdZW7kBEDWq7ZwC8OG8oMDrX385fLcicm7GfbGCmZ6286
+m1gfG9yqEte7pxv3yWM+7X2bzEjCBds4feahuKPNxOAOSfLUZiTpmOVlRzrpRIhu
+2XxiuH+E8n4AP8jf/9bGvKd8PyHohtHVf8HWuKLZxWznQhoKkcfmUmlz5q8ci4Bq
+WQdM2NXAMABGAofGrVklPIiraUoHzr0Xxpia4vQwRewYXv8bCPHW+8g8vGBGvoG2
+gtLit9DL5DR5ac/CRGJt
+-----END CERTIFICATE-----`
+
+func TestUpdateDatabaseRequestParameters(t *testing.T) {
+
+	for _, test := range []struct {
+		desc      string
+		req       updateDatabaseRequest
+		errAssert require.ErrorAssertionFunc
+	}{
+		{
+			desc: "valid",
+			req: updateDatabaseRequest{
+				CACert: fakeValidTLSCert,
+			},
+			errAssert: require.NoError,
+		},
+		{
+			desc: "invalid missing ca_cert",
+			req: updateDatabaseRequest{
+				CACert: "",
+			},
+			errAssert: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err), "expected a bad parameter error, got", err)
+			},
+		},
+		{
+			desc: "invalid ca_cert format",
+			req: updateDatabaseRequest{
+				CACert: "ca_cert",
+			},
+			errAssert: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err), "expected a bad parameter error, got", err)
+			},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			test.errAssert(t, test.req.checkAndSetDefaults())
+		})
+	}
+}

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -234,17 +234,10 @@ type Database struct {
 func MakeDatabase(database types.Database) Database {
 	uiLabels := []Label{}
 
-	for name, value := range database.GetStaticLabels() {
+	for name, value := range database.GetAllLabels() {
 		uiLabels = append(uiLabels, Label{
 			Name:  name,
 			Value: value,
-		})
-	}
-
-	for name, cmd := range database.GetDynamicLabels() {
-		uiLabels = append(uiLabels, Label{
-			Name:  name,
-			Value: cmd.GetResult(),
 		})
 	}
 

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -230,35 +230,40 @@ type Database struct {
 	Labels []Label `json:"labels"`
 }
 
+// MakeDatabase creates a database object.
+func MakeDatabase(database types.Database) Database {
+	uiLabels := []Label{}
+
+	for name, value := range database.GetStaticLabels() {
+		uiLabels = append(uiLabels, Label{
+			Name:  name,
+			Value: value,
+		})
+	}
+
+	for name, cmd := range database.GetDynamicLabels() {
+		uiLabels = append(uiLabels, Label{
+			Name:  name,
+			Value: cmd.GetResult(),
+		})
+	}
+
+	sort.Sort(sortedLabels(uiLabels))
+
+	return Database{
+		Name:     database.GetName(),
+		Desc:     database.GetDescription(),
+		Protocol: database.GetProtocol(),
+		Type:     database.GetType(),
+		Labels:   uiLabels,
+	}
+}
+
 // MakeDatabases creates database objects.
 func MakeDatabases(clusterName string, databases []types.Database) []Database {
 	uiServers := make([]Database, 0, len(databases))
 	for _, database := range databases {
-		uiLabels := []Label{}
-
-		for name, value := range database.GetStaticLabels() {
-			uiLabels = append(uiLabels, Label{
-				Name:  name,
-				Value: value,
-			})
-		}
-
-		for name, cmd := range database.GetDynamicLabels() {
-			uiLabels = append(uiLabels, Label{
-				Name:  name,
-				Value: cmd.GetResult(),
-			})
-		}
-
-		sort.Sort(sortedLabels(uiLabels))
-
-		uiServers = append(uiServers, Database{
-			Name:     database.GetName(),
-			Desc:     database.GetDescription(),
-			Protocol: database.GetProtocol(),
-			Type:     database.GetType(),
-			Labels:   uiLabels,
-		})
+		uiServers = append(uiServers, MakeDatabase(database))
 	}
 
 	return uiServers


### PR DESCRIPTION
This commit adds two new endpoints:
Create a database with

```
POST .../databases
{
  "name": "<databasename>",
  "protocol": "<protocol>",
  "uri": "<uri>",
  "labels": [{"name":"<name>", "value": "<value>"}...]
}
```

Update a database's `ca_cert` (the only updatable field for now)
```
PUT .../databases/:database
{
  "ca_cert": "------BEGIN CERTIFICATE-----\n <certificate> --END..."
}
```

Closes #17454