### PR TITLE
[v11] Make linguist correctly classify JS protobuf files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 webassets/* linguist-vendored
 docs/theme/js/* linguist-vendored
 docs/theme/js/theme.js linguist-vendored=false
+
+# JS protobuf files, not caught by built-in linguist rules.
+# https://github.com/github/linguist/blob/v7.23.0/lib/linguist/generated.rb#L349-L358
+*_pb.js linguist-generated
+*_pb.d.ts linguist-generated


### PR DESCRIPTION
Backport #17782 to branch/v11

Backporting only to v11 since it's unlikely we're going to introduce protobuf changes in Connect on the v10 branch.