### PR TITLE
Fix validation for pre-existing U2F devices

### DIFF
--- a/lib/services/authentication.go
+++ b/lib/services/authentication.go
@@ -39,7 +39,7 @@ func ValidateLocalAuthSecrets(l *types.LocalAuthSecrets) error {
 	}
 	mfaNames := make(map[string]struct{}, len(l.MFA))
 	for _, d := range l.MFA {
-		if err := ValidateMFADevice(d); err != nil {
+		if err := validateMFADevice(d); err != nil {
 			return trace.BadParameter("MFA device named %q is invalid: %v", d.Metadata.Name, err)
 		}
 		if _, ok := mfaNames[d.Metadata.Name]; ok {
@@ -61,17 +61,16 @@ func NewTOTPDevice(name, key string, addedAt time.Time) (*types.MFADevice, error
 	d.Device = &types.MFADevice_Totp{Totp: &types.TOTPDevice{
 		Key: key,
 	}}
-	if err := ValidateMFADevice(d); err != nil {
+	if err := validateMFADevice(d); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return d, nil
 }
 
-// ValidateMFADevice validates the MFA device. It's a more in-depth version of
-// MFADevice.CheckAndSetDefaults.
-//
-// TODO(awly): refactor to keep basic and deep validation on one place.
-func ValidateMFADevice(d *types.MFADevice) error {
+// validateMFADevice runs additional validations for OTP devices.
+// Prefer adding new validation logic to types.MFADevice.CheckAndSetDefaults
+// instead.
+func validateMFADevice(d *types.MFADevice) error {
 	if err := d.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -80,9 +79,8 @@ func ValidateMFADevice(d *types.MFADevice) error {
 		if err := validateTOTPDevice(dd.Totp); err != nil {
 			return trace.Wrap(err)
 		}
+	case *types.MFADevice_U2F:
 	case *types.MFADevice_Webauthn:
-		// TODO(codingllama): Refactor Webauthn device validation so it runs here as
-		//  well?
 	default:
 		return trace.BadParameter("MFADevice has Device field of unknown type %T", d.Device)
 	}

--- a/lib/services/authentication_test.go
+++ b/lib/services/authentication_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package services_test
 
 import (

--- a/lib/services/authentication_test.go
+++ b/lib/services/authentication_test.go
@@ -1,0 +1,46 @@
+package services_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateLocalAuthSecrets_deviceTypes(t *testing.T) {
+	addedAt := time.Now()
+
+	otp, err := services.NewTOTPDevice("otp", "supersecretkeyLLAMA", addedAt)
+	require.NoError(t, err, "NewTOTPDevice failed")
+
+	u2f := types.NewMFADevice("u2f", "u2fID", addedAt)
+	u2f.Device = &types.MFADevice_U2F{
+		U2F: &types.U2FDevice{
+			KeyHandle: []byte{1, 2, 3, 4, 5}, // Contents don't matter.
+			PubKey:    []byte{1, 2, 3, 4, 5},
+			Counter:   1,
+		},
+	}
+
+	wan := types.NewMFADevice("webauthn", "webauthbID", addedAt)
+	wan.Device = &types.MFADevice_Webauthn{
+		Webauthn: &types.WebauthnDevice{
+			CredentialId:     []byte{1, 2, 3, 4, 5}, // Arbitrary
+			PublicKeyCbor:    []byte{1, 2, 3, 4, 5}, // Arbitrary
+			Aaguid:           []byte{1, 2, 3, 4, 5}, // Arbitrary
+			SignatureCounter: 1,
+		},
+	}
+
+	err = services.ValidateLocalAuthSecrets(&types.LocalAuthSecrets{
+		MFA: []*types.MFADevice{
+			otp,
+			u2f,
+			wan,
+		},
+	})
+	assert.NoError(t, err, "ValidateLocalAuthSecrets failed")
+}


### PR DESCRIPTION
Add a test for `services.ValidateLocalAuthSecrets` that includes all device types and reintroduce a case mistakenly dropped by #10476.

I've elected to make `services.ValidateMFADevice` private and keep it around, as this is the least intrusive change. All outdated TODOs are dropped.

#17853