### PR TITLE
cleanup: refactor keystore config

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -185,13 +185,6 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 	if cfg.AssertionReplayService == nil {
 		cfg.AssertionReplayService = local.NewAssertionReplayService(cfg.Backend)
 	}
-	if cfg.KeyStoreConfig.RSAKeyPairSource == nil {
-		native.PrecomputeKeys()
-		cfg.KeyStoreConfig.RSAKeyPairSource = native.GenerateKeyPair
-	}
-	if cfg.KeyStoreConfig.HostUUID == "" {
-		cfg.KeyStoreConfig.HostUUID = cfg.HostUUID
-	}
 	if cfg.TraceClient == nil {
 		cfg.TraceClient = tracing.NewNoopClient()
 	}
@@ -203,6 +196,12 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	if cfg.KeyStoreConfig.PKCS11 != (keystore.PKCS11Config{}) {
+		cfg.KeyStoreConfig.PKCS11.HostUUID = cfg.HostUUID
+	} else {
+		native.PrecomputeKeys()
+		cfg.KeyStoreConfig.Software.RSAKeyPairSource = native.GenerateKeyPair
+	}
 	keyStore, err := keystore.NewKeyStore(cfg.KeyStoreConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -98,7 +98,9 @@ func newTestPack(
 		Authority:              testauthority.New(),
 		SkipPeriodicOperations: true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: testauthority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
+			},
 		},
 	}
 	p.a, err = NewServer(authConfig, opts...)
@@ -879,7 +881,9 @@ func TestUpdateConfig(t *testing.T) {
 		Authority:              testauthority.New(),
 		SkipPeriodicOperations: true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: testauthority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
+			},
 		},
 	}
 	authServer, err := NewServer(authConfig)
@@ -2060,10 +2064,11 @@ func TestCAGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	ksConfig := keystore.Config{
-		RSAKeyPairSource: func() (priv []byte, pub []byte, err error) {
-			return privKey, pubKey, nil
+		Software: keystore.SoftwareConfig{
+			RSAKeyPairSource: func() (priv []byte, pub []byte, err error) {
+				return privKey, pubKey, nil
+			},
 		},
-		HostUUID: HostUUID,
 	}
 	keyStore, err := keystore.NewKeyStore(ksConfig)
 	require.NoError(t, err)

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -77,7 +77,9 @@ func setupGithubContext(ctx context.Context, t *testing.T) *githubContext {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: authority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: authority.New().GenerateKeyPair,
+			},
 		},
 	}
 	tt.a, err = NewServer(authConfig)

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -249,7 +249,9 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		Emitter:                emitter,
 		TraceClient:            cfg.TraceClient,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: authority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: authority.New().GenerateKeyPair,
+			},
 		},
 	}, WithClock(cfg.Clock))
 	if err != nil {

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -607,7 +607,9 @@ func setupConfig(t *testing.T) InitConfig {
 		AuthPreference:          types.DefaultAuthPreference(),
 		SkipPeriodicOperations:  true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: testauthority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
+			},
 		},
 	}
 }

--- a/lib/auth/keystore/keystore.go
+++ b/lib/auth/keystore/keystore.go
@@ -89,36 +89,18 @@ type KeyStore interface {
 
 // Config is used to pass KeyStore configuration to NewKeyStore.
 type Config struct {
-	// RSAKeyPairSource is a function which returns raw keypairs to be used if
-	// an hsm is not configured
-	RSAKeyPairSource RSAKeyPairSource
+	// Software holds configuration parameters specific to software KeyStores
+	Software SoftwareConfig
 
-	// Path is the path to the PKCS11 module.
-	Path string
-	// SlotNumber points to the PKCS11 slot to use, or nil if slot is unused.
-	SlotNumber *int
-	// TokenLabel is the label of the PKCS11 token to use.
-	TokenLabel string
-	// Pin is the PKCS11 pin for the given token.
-	Pin string
-	// HostUUID is the UUID of the local auth server this HSM is connected to.
-	HostUUID string
+	// PKCS11 hold configuration parameters specific to PKCS11 KeyStores.
+	PKCS11 PKCS11Config
 }
 
 func (cfg *Config) CheckAndSetDefaults() error {
-	if cfg.Path == "" && cfg.RSAKeyPairSource == nil {
-		return trace.BadParameter("must provide one of Path or RSAKeyPairSource in keystore.Config")
+	if (cfg.PKCS11 != PKCS11Config{}) {
+		return trace.Wrap(cfg.PKCS11.CheckAndSetDefaults())
 	}
-	if cfg.Path != "" {
-		// HSM is configured, check the rest of the required params
-		if cfg.SlotNumber == nil && cfg.TokenLabel == "" {
-			return trace.BadParameter("must provide one of SlotNumber or TokenLabel in keystore.Config")
-		}
-		if cfg.HostUUID == "" {
-			return trace.BadParameter("must provide HostUUID in keystore.Config")
-		}
-	}
-	return nil
+	return trace.Wrap(cfg.Software.CheckAndSetDefaults())
 }
 
 // NewKeyStore returns a new KeyStore
@@ -126,19 +108,14 @@ func NewKeyStore(cfg Config) (KeyStore, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if cfg.Path == "" {
-		return NewSoftwareKeyStore(&SoftwareConfig{cfg.RSAKeyPairSource}), nil
+	if (cfg.PKCS11 != PKCS11Config{}) {
+		if !modules.GetModules().Features().HSM {
+			return nil, trace.AccessDenied("HSM support is only available with an enterprise license")
+		}
+		keyStore, err := NewPKCS11KeyStore(&cfg.PKCS11)
+		return keyStore, trace.Wrap(err)
 	}
-	if !modules.GetModules().Features().HSM {
-		return nil, trace.AccessDenied("HSM support is only available with an enterprise license")
-	}
-	return NewPKCS11KeyStore(&PKCS11Config{
-		Path:       cfg.Path,
-		SlotNumber: cfg.SlotNumber,
-		TokenLabel: cfg.TokenLabel,
-		Pin:        cfg.Pin,
-		HostUUID:   cfg.HostUUID,
-	})
+	return NewSoftwareKeyStore(&cfg.Software), nil
 }
 
 // KeyType returns the type of the given private key.

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -136,7 +136,7 @@ func TestKeyStore(t *testing.T) {
 	var softHSMConfig Config
 	if !skipSoftHSM {
 		softHSMConfig = SetupSoftHSMTest(t)
-		softHSMConfig.HostUUID = "server1"
+		softHSMConfig.PKCS11.HostUUID = "server1"
 	}
 
 	yubiSlotNumber := 0
@@ -149,7 +149,9 @@ func TestKeyStore(t *testing.T) {
 		{
 			desc: "software keystore",
 			config: Config{
-				RSAKeyPairSource: native.GenerateKeyPair,
+				Software: SoftwareConfig{
+					RSAKeyPairSource: native.GenerateKeyPair,
+				},
 			},
 			isSoftware: true,
 			shouldSkip: func() bool { return false },
@@ -168,10 +170,12 @@ func TestKeyStore(t *testing.T) {
 		{
 			desc: "yubihsm",
 			config: Config{
-				Path:       os.Getenv("YUBIHSM_PKCS11_PATH"),
-				SlotNumber: &yubiSlotNumber,
-				Pin:        "0001password",
-				HostUUID:   "server1",
+				PKCS11: PKCS11Config{
+					Path:       os.Getenv("YUBIHSM_PKCS11_PATH"),
+					SlotNumber: &yubiSlotNumber,
+					Pin:        "0001password",
+					HostUUID:   "server1",
+				},
 			},
 			shouldSkip: func() bool {
 				if os.Getenv("YUBIHSM_PKCS11_CONF") == "" || os.Getenv("YUBIHSM_PKCS11_PATH") == "" {
@@ -184,10 +188,12 @@ func TestKeyStore(t *testing.T) {
 		{
 			desc: "cloudhsm",
 			config: Config{
-				Path:       "/opt/cloudhsm/lib/libcloudhsm_pkcs11.so",
-				TokenLabel: "cavium",
-				Pin:        os.Getenv("CLOUDHSM_PIN"),
-				HostUUID:   "server1",
+				PKCS11: PKCS11Config{
+					Path:       "/opt/cloudhsm/lib/libcloudhsm_pkcs11.so",
+					TokenLabel: "cavium",
+					Pin:        os.Getenv("CLOUDHSM_PIN"),
+					HostUUID:   "server1",
+				},
 			},
 			shouldSkip: func() bool {
 				if os.Getenv("CLOUDHSM_PIN") == "" {
@@ -353,7 +359,7 @@ func TestLicenseRequirement(t *testing.T) {
 	}
 
 	config := SetupSoftHSMTest(t)
-	config.HostUUID = "server1"
+	config.PKCS11.HostUUID = "server1"
 
 	// should fail to create the keystore with default modules
 	_, err := NewKeyStore(config)

--- a/lib/auth/keystore/pkcs11.go
+++ b/lib/auth/keystore/pkcs11.go
@@ -47,6 +47,16 @@ type PKCS11Config struct {
 	HostUUID string
 }
 
+func (cfg *PKCS11Config) CheckAndSetDefaults() error {
+	if cfg.SlotNumber == nil && cfg.TokenLabel == "" {
+		return trace.BadParameter("must provide one of SlotNumber or TokenLabel")
+	}
+	if cfg.HostUUID == "" {
+		return trace.BadParameter("must provide HostUUID")
+	}
+	return nil
+}
+
 type pkcs11KeyStore struct {
 	ctx      *crypto11.Context
 	hostUUID string

--- a/lib/auth/keystore/software.go
+++ b/lib/auth/keystore/software.go
@@ -36,6 +36,13 @@ type SoftwareConfig struct {
 	RSAKeyPairSource RSAKeyPairSource
 }
 
+func (cfg *SoftwareConfig) CheckAndSetDefaults() error {
+	if cfg.RSAKeyPairSource == nil {
+		return trace.BadParameter("must provide RSAKeyPairSource")
+	}
+	return nil
+}
+
 func NewSoftwareKeyStore(config *SoftwareConfig) KeyStore {
 	return &softwareKeyStore{
 		rsaKeyPairSource: config.RSAKeyPairSource,

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -90,9 +90,11 @@ func SetupSoftHSMTest(t *testing.T) Config {
 	}
 
 	cachedConfig = &Config{
-		Path:       path,
-		TokenLabel: tokenLabel,
-		Pin:        "password",
+		PKCS11: PKCS11Config{
+			Path:       path,
+			TokenLabel: tokenLabel,
+			Pin:        "password",
+		},
 	}
 	return *cachedConfig
 }

--- a/lib/auth/oidc_test.go
+++ b/lib/auth/oidc_test.go
@@ -80,7 +80,9 @@ func setUpSuite(t *testing.T) *OIDCSuite {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: authority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: authority.New().GenerateKeyPair,
+			},
 		},
 	}
 	s.a, err = NewServer(authConfig)

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -80,7 +80,9 @@ func setupPasswordSuite(t *testing.T) *passwordSuite {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: authority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: authority.New().GenerateKeyPair,
+			},
 		},
 	}
 	s.a, err = NewServer(authConfig)

--- a/lib/auth/saml_test.go
+++ b/lib/auth/saml_test.go
@@ -67,7 +67,9 @@ func TestCreateSAMLUser(t *testing.T) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: authority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: authority.New().GenerateKeyPair,
+			},
 		},
 	}
 
@@ -193,7 +195,9 @@ func TestPingSAMLWorkaround(t *testing.T) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: authority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: authority.New().GenerateKeyPair,
+			},
 		},
 	}
 
@@ -285,7 +289,9 @@ func TestServer_getConnectorAndProvider(t *testing.T) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: authority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: authority.New().GenerateKeyPair,
+			},
 		},
 	}
 
@@ -405,7 +411,9 @@ func TestServer_ValidateSAMLResponse(t *testing.T) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: authority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: authority.New().GenerateKeyPair,
+			},
 		},
 	}
 

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -284,7 +284,9 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *Serve
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: authority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: authority.New().GenerateKeyPair,
+			},
 		},
 	}
 	a, err := NewServer(authConfig)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -723,13 +723,13 @@ func applyKeyStoreConfig(fc *FileConfig, cfg *service.Config) error {
 			)
 		}
 
-		cfg.Auth.KeyStore.Path = fc.Auth.CAKeyParams.PKCS11.ModulePath
+		cfg.Auth.KeyStore.PKCS11.Path = fc.Auth.CAKeyParams.PKCS11.ModulePath
 	}
 
-	cfg.Auth.KeyStore.TokenLabel = fc.Auth.CAKeyParams.PKCS11.TokenLabel
-	cfg.Auth.KeyStore.SlotNumber = fc.Auth.CAKeyParams.PKCS11.SlotNumber
+	cfg.Auth.KeyStore.PKCS11.TokenLabel = fc.Auth.CAKeyParams.PKCS11.TokenLabel
+	cfg.Auth.KeyStore.PKCS11.SlotNumber = fc.Auth.CAKeyParams.PKCS11.SlotNumber
 
-	cfg.Auth.KeyStore.Pin = fc.Auth.CAKeyParams.PKCS11.Pin
+	cfg.Auth.KeyStore.PKCS11.Pin = fc.Auth.CAKeyParams.PKCS11.Pin
 	if fc.Auth.CAKeyParams.PKCS11.PinPath != "" {
 		if fc.Auth.CAKeyParams.PKCS11.Pin != "" {
 			return trace.BadParameter("can not set both pin and pin_path")
@@ -753,7 +753,7 @@ func applyKeyStoreConfig(fc *FileConfig, cfg *service.Config) error {
 			return trace.Wrap(err)
 		}
 		pin := strings.TrimRight(string(pinBytes), "\r\n")
-		cfg.Auth.KeyStore.Pin = pin
+		cfg.Auth.KeyStore.PKCS11.Pin = pin
 	}
 	return nil
 }

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -832,10 +832,10 @@ SREzU8onbBsjMg9QDiSf5oJLKvd/Ren+zGY7
 		},
 	}, protocmp.Transform()))
 
-	require.Equal(t, pkcs11LibPath, cfg.Auth.KeyStore.Path)
-	require.Equal(t, "example_token", cfg.Auth.KeyStore.TokenLabel)
-	require.Equal(t, 1, *cfg.Auth.KeyStore.SlotNumber)
-	require.Equal(t, "example_pin", cfg.Auth.KeyStore.Pin)
+	require.Equal(t, pkcs11LibPath, cfg.Auth.KeyStore.PKCS11.Path)
+	require.Equal(t, "example_token", cfg.Auth.KeyStore.PKCS11.TokenLabel)
+	require.Equal(t, 1, *cfg.Auth.KeyStore.PKCS11.SlotNumber)
+	require.Equal(t, "example_pin", cfg.Auth.KeyStore.PKCS11.Pin)
 	require.ElementsMatch(t, []string{"ca-pin-from-string", "ca-pin-from-file1", "ca-pin-from-file2"}, cfg.CAPins)
 
 	require.True(t, cfg.Databases.Enabled)
@@ -2700,10 +2700,12 @@ func TestApplyKeyStoreConfig(t *testing.T) {
 				},
 			},
 			want: keystore.Config{
-				TokenLabel: "foo",
-				SlotNumber: &slotNumber,
-				Pin:        "pin",
-				Path:       securePKCS11LibPath,
+				PKCS11: keystore.PKCS11Config{
+					TokenLabel: "foo",
+					SlotNumber: &slotNumber,
+					Pin:        "pin",
+					Path:       securePKCS11LibPath,
+				},
 			},
 		},
 		{
@@ -2719,10 +2721,12 @@ func TestApplyKeyStoreConfig(t *testing.T) {
 				},
 			},
 			want: keystore.Config{
-				TokenLabel: "foo",
-				SlotNumber: &slotNumber,
-				Pin:        "secure-pin-file",
-				Path:       securePKCS11LibPath,
+				PKCS11: keystore.PKCS11Config{
+					TokenLabel: "foo",
+					SlotNumber: &slotNumber,
+					Pin:        "secure-pin-file",
+					Path:       securePKCS11LibPath,
+				},
 			},
 		},
 		{

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -124,7 +124,9 @@ func newMockServer(t *testing.T) *mockServer {
 		ClusterName:  clusterName,
 		StaticTokens: staticTokens,
 		KeyStoreConfig: keystore.Config{
-			RSAKeyPairSource: testauthority.New().GenerateKeyPair,
+			Software: keystore.SoftwareConfig{
+				RSAKeyPairSource: testauthority.New().GenerateKeyPair,
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR refactors the `keystore.Config` type to make it a bit more modular in prep for incoming GCP KMS support.

depends on https://github.com/gravitational/teleport/pull/17906