### PR TITLE
[v11] Modify `teleport configure` to gracefully handle `--auth-server`

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -221,7 +221,7 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 		Method:    types.JoinMethod(joinMethod),
 	}
 
-	if flags.Version == defaults.TeleportConfigVersionV3 {
+	if version == defaults.TeleportConfigVersionV3 {
 		if flags.AuthServer != "" && flags.ProxyAddress != "" {
 			return nil, trace.BadParameter("--proxy and --auth-server cannot both be set")
 		} else if flags.AuthServer != "" {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -234,7 +234,7 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 				return nil, trace.Wrap(err)
 			}
 
-			// Check port to determine if this is obviously a auth server
+			// Check port to determine if this is obviously an auth server
 			// and if not, downgrade to config v2.
 			if addr.Port(0) == defaults.AuthListenPort {
 				g.AuthServer = flags.AuthServer

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -1127,21 +1127,31 @@ func TestMakeSampleFileConfig(t *testing.T) {
 
 	t.Run("Auth server", func(t *testing.T) {
 		fc, err := MakeSampleFileConfig(SampleFlags{
-			Version:    defaults.TeleportConfigVersionV3,
 			AuthServer: "auth-server:3025",
 		})
 		require.NoError(t, err)
 		require.Equal(t, "auth-server:3025", fc.AuthServer)
+		// If it is clearly an auth server, we should expect a v3 config.
+		require.Equal(t, defaults.TeleportConfigVersionV3, fc.Version)
 	})
 
 	t.Run("Downgrade to V2 if unsure of auth server", func(t *testing.T) {
 		fc, err := MakeSampleFileConfig(SampleFlags{
-			Version:    defaults.TeleportConfigVersionV3,
 			AuthServer: "could.be.a.proxy:443",
 		})
 		require.NoError(t, err)
 		require.Equal(t, []string{"could.be.a.proxy:443"}, fc.AuthServers)
 		require.Equal(t, defaults.TeleportConfigVersionV2, fc.Version)
+	})
+
+	t.Run("If explicitly V3, ignore suspicious auth-server parameter", func(t *testing.T) {
+		fc, err := MakeSampleFileConfig(SampleFlags{
+			Version:    defaults.TeleportConfigVersionV3,
+			AuthServer: "could.be.a.proxy:443",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "could.be.a.proxy:443", fc.AuthServer)
+		require.Equal(t, defaults.TeleportConfigVersionV3, fc.Version)
 	})
 
 	t.Run("Data dir", func(t *testing.T) {

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -1127,10 +1127,21 @@ func TestMakeSampleFileConfig(t *testing.T) {
 
 	t.Run("Auth server", func(t *testing.T) {
 		fc, err := MakeSampleFileConfig(SampleFlags{
-			AuthServer: "auth-server",
+			Version:    defaults.TeleportConfigVersionV3,
+			AuthServer: "auth-server:3025",
 		})
 		require.NoError(t, err)
-		require.Equal(t, "auth-server", fc.AuthServer)
+		require.Equal(t, "auth-server:3025", fc.AuthServer)
+	})
+
+	t.Run("Downgrade to V2 if unsure of auth server", func(t *testing.T) {
+		fc, err := MakeSampleFileConfig(SampleFlags{
+			Version:    defaults.TeleportConfigVersionV3,
+			AuthServer: "could.be.a.proxy:443",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"could.be.a.proxy:443"}, fc.AuthServers)
+		require.Equal(t, defaults.TeleportConfigVersionV2, fc.Version)
 	})
 
 	t.Run("Data dir", func(t *testing.T) {

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -550,8 +550,9 @@ func onConfigDump(flags dumpFlags) error {
 		return trace.Wrap(err)
 	}
 
-	if flags.Version == defaults.TeleportConfigVersionV3 && flags.AuthServer != "" {
-		fmt.Fprintf(os.Stderr, "---BREAKING CHANGE IMPENDING---\nFrom Teleport 12, you will no longer be able to specify a Proxy address with --auth-server when using teleport configure. If you are connecting your node to a Proxy, switch to using --proxy before Teleport 12.\n\n")
+	// Detect automatic downgrade behaviour and output warning
+	if flags.Version == defaults.TeleportConfigVersionV3 && sfc.Version == defaults.TeleportConfigVersionV2 {
+		fmt.Fprintf(os.Stderr, "---BREAKING CHANGE IMPENDING---\nConfiguration version 'v3' (introduced in Teleport 11) requires that '--proxy' is used instead of '--auth-server' when connecting a Node to a Proxy rather than directly to the Auth Server.\nWe have detected that you may have provided a proxy address with '--auth-server' and have downgraded the generated config to 'v2' to ensure continuity of service.\nThis behaviour will cease in Teleport 12! Begin using '--proxy' when providing the proxy address as soon as possible.\n\n")
 	}
 
 	entries, err := os.ReadDir(flags.DataDir)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -550,9 +550,9 @@ func onConfigDump(flags dumpFlags) error {
 		return trace.Wrap(err)
 	}
 
-	// Detect automatic downgrade behaviour and output warning
+	// Detect automatic downgrade behavior and output warning
 	if flags.Version == defaults.TeleportConfigVersionV3 && sfc.Version == defaults.TeleportConfigVersionV2 {
-		fmt.Fprintf(os.Stderr, "---BREAKING CHANGE IMPENDING---\nConfiguration version 'v3' (introduced in Teleport 11) requires that '--proxy' is used instead of '--auth-server' when connecting a Node to a Proxy rather than directly to the Auth Server.\nWe have detected that you may have provided a proxy address with '--auth-server' and have downgraded the generated config to 'v2' to ensure continuity of service.\nThis behaviour will cease in Teleport 12! Begin using '--proxy' when providing the proxy address as soon as possible.\n\n")
+		fmt.Fprintf(os.Stderr, "---BREAKING CHANGE IMPENDING---\nConfiguration version 'v3' (introduced in Teleport 11) requires that '--proxy' is used instead of '--auth-server' when connecting a Node to a Proxy rather than directly to the Auth Server.\nWe have detected that you may have provided a proxy address with '--auth-server' and have downgraded the generated config to 'v2' to ensure continuity of service.\nThis behavior will cease in Teleport 12! Begin using '--proxy' when providing the proxy address as soon as possible.\n\n")
 	}
 
 	entries, err := os.ReadDir(flags.DataDir)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -550,6 +550,10 @@ func onConfigDump(flags dumpFlags) error {
 		return trace.Wrap(err)
 	}
 
+	if flags.Version == defaults.TeleportConfigVersionV3 && flags.AuthServer != "" {
+		fmt.Fprintf(os.Stderr, "---BREAKING CHANGE IMPENDING---\nFrom Teleport 12, you will no longer be able to specify a Proxy address with --auth-server when using teleport configure. If you are connecting your node to a Proxy, switch to using --proxy before Teleport 12.\n\n")
+	}
+
 	entries, err := os.ReadDir(flags.DataDir)
 	if err != nil && !os.IsNotExist(err) {
 		fmt.Fprintf(

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -325,7 +325,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dump.Flag("acme-email",
 		"Email to receive updates from Letsencrypt.org.").StringVar(&dumpFlags.ACMEEmail)
 	dump.Flag("test", "Path to a configuration file to test.").ExistingFileVar(&dumpFlags.testConfigFile)
-	dump.Flag("version", "Teleport configuration version.").Default(defaults.TeleportConfigVersionV3).StringVar(&dumpFlags.Version)
+	dump.Flag("version", "Teleport configuration version.").StringVar(&dumpFlags.Version)
 	dump.Flag("public-addr", "The hostport that the proxy advertises for the HTTP endpoint.").StringVar(&dumpFlags.PublicAddr)
 	dump.Flag("cert-file", "Path to a TLS certificate file for the proxy.").ExistingFileVar(&dumpFlags.CertFile)
 	dump.Flag("key-file", "Path to a TLS key file for the proxy.").ExistingFileVar(&dumpFlags.KeyFile)
@@ -345,7 +345,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dumpNodeConfigure.Flag("output",
 		"Write to stdout with -o=stdout, default config file with -o=file or custom path with -o=file:///path").Short('o').Default(
 		teleport.SchemeStdout).StringVar(&dumpFlags.output)
-	dumpNodeConfigure.Flag("version", "Teleport configuration version.").Default(defaults.TeleportConfigVersionV3).StringVar(&dumpFlags.Version)
+	dumpNodeConfigure.Flag("version", "Teleport configuration version.").StringVar(&dumpFlags.Version)
 	dumpNodeConfigure.Flag("public-addr", "The hostport that the node advertises for the SSH endpoint.").StringVar(&dumpFlags.PublicAddr)
 	dumpNodeConfigure.Flag("data-dir", "Path to a directory where Teleport keep its data.").Default(defaults.DataDir).StringVar(&dumpFlags.DataDir)
 	dumpNodeConfigure.Flag("token", "Invitation token to register with an auth server.").StringVar(&dumpFlags.AuthToken)
@@ -551,7 +551,7 @@ func onConfigDump(flags dumpFlags) error {
 	}
 
 	// Detect automatic downgrade behavior and output warning
-	if flags.Version == defaults.TeleportConfigVersionV3 && sfc.Version == defaults.TeleportConfigVersionV2 {
+	if flags.Version == "" && sfc.Version == defaults.TeleportConfigVersionV2 {
 		fmt.Fprintf(os.Stderr, "---BREAKING CHANGE IMPENDING---\nConfiguration version 'v3' (introduced in Teleport 11) requires that '--proxy' is used instead of '--auth-server' when connecting a Node to a Proxy rather than directly to the Auth Server.\nWe have detected that you may have provided a proxy address with '--auth-server' and have downgraded the generated config to 'v2' to ensure continuity of service.\nThis behavior will cease in Teleport 12! Begin using '--proxy' when providing the proxy address as soon as possible.\n\n")
 	}
 


### PR DESCRIPTION
Emits a warning and downgrades the outputted configuration to v2.

Closes https://github.com/gravitational/teleport/issues/17890 

```
➜  teleport git:(strideynet/partially-revert-config-v3) ✗ build/teleport configure --auth-server my.proxy:443
#
# A Sample Teleport configuration file.
#
# Things to update:
#  1. license.pem: You only need a license from https://dashboard.goteleport.com
#     if you are an Enterprise customer.
#
version: v2
teleport:
  nodename: Noahs-MBP-2.cust.communityfibre.co.uk
  data_dir: /var/lib/teleport
  auth_servers:
  - my.proxy:443
  log:
    output: stderr
    severity: INFO
    format:
      output: text
  ca_pin: ""
  diag_addr: ""
auth_service:
  enabled: "yes"
  listen_addr: 0.0.0.0:3025
  proxy_listener_mode: multiplex
ssh_service:
  enabled: "yes"
  commands:
  - name: hostname
    command: [hostname]
    period: 1m0s
proxy_service:
  enabled: "yes"
  https_keypairs: []
  acme: {}

---BREAKING CHANGE IMPENDING---
Configuration version 'v3' (introduced in Teleport 11) requires that '--proxy' is used instead of '--auth-server' when connecting a Node to a Proxy rather than directly to the Auth Server.
We have detected that you may have provided a proxy address with '--auth-server' and have downgraded the generated config to 'v2' to ensure continuity of service.
This behaviour will cease in Teleport 12! Begin using '--proxy' when providing the proxy address as soon as possible.

```

This is being merged directly to `branch/v11`, as we will be discontinuing this fallback behaviour in Teleport 12.