### PR TITLE
Bump OpenSSL to 1.1.1r

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -27,9 +27,9 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 # Instal openssl.
 # Pulled from source because repository versions are too old.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1q && \
+RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1r && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = "29708a562a1887a91de0fa6ca668c71871accde9" ] && \
+    [ "$(git rev-parse HEAD)" = "fbda8a9e3b6266da377a6f57d597d657257d9cff" ] && \
     ./config --release && \
     make && \
     make install_sw

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -15,7 +15,7 @@ readonly MACOS_VERSION_MIN=10.13
 
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.9.0
-readonly CRYPTO_VERSION=OpenSSL_1_1_1q
+readonly CRYPTO_VERSION=OpenSSL_1_1_1r
 readonly FIDO2_VERSION=1.12.0
 
 readonly LIB_CACHE="/tmp/teleport-fido2-cache"


### PR DESCRIPTION
Bump the OpenSSL version used by libfido2, add a HEAD check to build-fido2-macos.sh and fix trap usage.

Release notes: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1r/CHANGES.