### PR TITLE
Update CentOS 7 build to pull OpenSSL from GitHub instead of openssl.org

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -27,7 +27,7 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 # Instal openssl.
 # Pulled from source because repository versions are too old.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1r && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1r && \
     cd openssl && \
     [ "$(git rev-parse HEAD)" = "fbda8a9e3b6266da377a6f57d597d657257d9cff" ] && \
     ./config --release && \


### PR DESCRIPTION
Instead of using `git://git.openssl.org/openssl.git`, swap to the official GitHub mirror at `https://github.com/openssl/openssl.git`. git:// is inheritly insecure, and while we have additional protections in place as far as commit hash checking, best to always pull dependencies from https:// wherever possible.