### PR TITLE
Bump shellcheck from v0.4.6 to v0.8.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -119,7 +119,6 @@ RUN apt-get update -y --fix-missing && \
         python3-setuptools \
         python3-wheel \
         pkg-config \
-        shellcheck \
         softhsm2 \
         sudo \
         tree \
@@ -181,6 +180,13 @@ RUN helm plugin install https://github.com/vbehar/helm3-unittest && \
 RUN (curl -L https://github.com/bats-core/bats-core/archive/v1.2.1.tar.gz | tar -xz && \
      cd bats-core-1.2.1 && ./install.sh /usr/local && cd .. && \
      rm -r bats-core-1.2.1)
+
+# Install shellcheck.
+RUN scversion='v0.8.0' && \
+    curl -sSL "https://github.com/koalaman/shellcheck/releases/download/$scversion/shellcheck-$scversion.linux.x86_64.tar.xz" | \
+        tar -xJv && \
+    cp "shellcheck-$scversion/shellcheck" /usr/local/bin/ && \
+    shellcheck --version
 
 # Install protobuf and grpc build tools.
 ARG PROTOC_VER


### PR DESCRIPTION
Bump shellcheck to the more recent version, pulling from GitHub instead of apt.

See https://github.com/koalaman/shellcheck/tree/v0.8.0#installing (pre-compiled binaries).