### PR TITLE
[v9] Backporting GCB test fixes into v9.

### DIFF
--- a/.cloudbuild/ci/integration-tests.yaml
+++ b/.cloudbuild/ci/integration-tests.yaml
@@ -1,16 +1,16 @@
-timeout: 25m
+timeout: 40m
 
 options:
   machineType: E2_HIGHCPU_32
-  
+
   # This build needs to run in environments where the _GITHUB_DEPLOY_KEY_SRC
   # substitution is defined, but also environments where it isn't. The
-  # ALLOW_LOOSE option disables GCBs strict checking of substitution usage,
+  # ALLOW_LOOSE option disables GCB's strict checking of substitution usage,
   # so that the build will still run if _GITHUB_DEPLOY_KEY_SRC is not defined.
   substitution_option: ALLOW_LOOSE
 
 steps:
-  # Run the integration tests. Actual content of this job depends on the changes 
+  # Run the integration tests. Actual content of this job depends on the changes
   # detected in the PR
   - name: public.ecr.aws/gravitational/teleport-buildbox:teleport9
     id: run-tests
@@ -24,5 +24,8 @@ steps:
           -bucket test-logs                     \
           -build "$BUILD_ID"                    \
           -key-secret "$_GITHUB_DEPLOY_KEY_SRC" \
-          -a "test-logs/*.json"          
-    timeout: 25m
+          -a "test-logs/*.json"
+    # The actual makefile timeout is 30m. We add the 10 minute buffer here to
+    # allow for setup and teardown time, reports to be saved, etc, if the
+    # underlying tests time out.
+    timeout: 40m

--- a/.cloudbuild/ci/unit-tests.yaml
+++ b/.cloudbuild/ci/unit-tests.yaml
@@ -1,16 +1,16 @@
-timeout: 25m
+timeout: 30m
 
 options:
-  machineType: 'E2_HIGHCPU_32'
-  
-  # This build needs to run in environments where the _GITHUB_DEPLOY_KEY_SRC  
+  machineType: E2_HIGHCPU_32
+
+  # This build needs to run in environments where the _GITHUB_DEPLOY_KEY_SRC
   # substitution is defined, but also environments where it isn't. The
-  # ALLOW_LOOSE option disables GCBs strict checking of substitution usage,
+  # ALLOW_LOOSE option disables GCB's strict checking of substitution usage,
   # so that the build will still run if _GITHUB_DEPLOY_KEY_SRC is not defined.
   substitution_option: ALLOW_LOOSE
-  
+
 steps:
-  # Run the unit tests. Actual content of this job depends on the changes 
+  # Run the unit tests. Actual content of this job depends on the changes
   # detected in the PR
   - name: public.ecr.aws/gravitational/teleport-buildbox:teleport9
     id: run-tests


### PR DESCRIPTION
The GCB test fixes from the master branch have been backported to v9.