### PR TITLE
Fix unable to connect to Azure SQL server instances

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -365,7 +365,7 @@ func (d *DatabaseV3) IsCloudSQL() bool {
 
 // IsAzure returns true if this is Azure hosted database.
 func (d *DatabaseV3) IsAzure() bool {
-	return d.GetType() == DatabaseTypeAzure
+	return d.GetType() == DatabaseTypeAzure || d.GetType() == DatabaseTypeAzureSQLServer
 }
 
 // IsElastiCache returns true if this is an AWS ElastiCache database.
@@ -428,7 +428,12 @@ func (d *DatabaseV3) GetType() string {
 	if d.GetGCP().ProjectID != "" {
 		return DatabaseTypeCloudSQL
 	}
+
 	if d.GetAzure().Name != "" {
+		if d.Spec.Protocol == "sqlserver" {
+			return DatabaseTypeAzureSQLServer
+		}
+
 		return DatabaseTypeAzure
 	}
 	return DatabaseTypeSelfHosted
@@ -763,6 +768,8 @@ const (
 	DatabaseTypeAWSKeyspaces = "keyspace"
 	// DatabaseTypeCassandra is AWS-hosted Keyspace database.
 	DatabaseTypeCassandra = "cassandra"
+	// DatabaseTypeAzureSQLServer is Azure-hosted SQL Server database.
+	DatabaseTypeAzureSQLServer = "azure-sql-server"
 )
 
 // GetServerName returns the GCP database project and instance as "<project-id>:<instance-id>".

--- a/lib/srv/db/ca_test.go
+++ b/lib/srv/db/ca_test.go
@@ -100,8 +100,18 @@ func TestInitCACert(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	azureSQLServer, err := types.NewDatabaseV3(types.Metadata{
+		Name: "azure-sql-server",
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolSQLServer,
+		URI:      "localhost:1433",
+		Azure:    types.Azure{Name: "azure-sql-server"},
+	})
+	require.NoError(t, err)
+
 	allDatabases := []types.Database{
 		selfHosted, rds, rdsWithCert, redshift, cloudSQL, azureMySQL, memoryDB,
+		azureSQLServer,
 	}
 
 	tests := []struct {
@@ -142,6 +152,11 @@ func TestInitCACert(t *testing.T) {
 		{
 			desc:     "should download Azure CA when it's not set",
 			database: azureMySQL.GetName(),
+			cert:     fixtures.TLSCACertPEM,
+		},
+		{
+			desc:     "should download Azure CA bundle when it's not set",
+			database: azureSQLServer.GetName(),
 			cert:     fixtures.TLSCACertPEM,
 		},
 	}


### PR DESCRIPTION
## What

When connecting to an Azure SQL Server instance (managed or not), it returns the error `x509: certificate signed by unknown authority.

Database service error:
```
Original Error: *errors.errorString TLS Handshake failed: x509: certificate signed by unknown authority
Stack Trace:
        github.com/gravitational/teleport/lib/srv/db/sqlserver/connect.go:106 github.com/gravitational/teleport/lib/srv/db/sqlserver.(*connector).Connect
        github.com/gravitational/teleport/lib/srv/db/sqlserver/engine.go:92 github.com/gravitational/teleport/lib/srv/db/sqlserver.(*Engine).HandleConnection
        github.com/gravitational/teleport/lib/srv/db/server.go:812 github.com/gravitational/teleport/lib/srv/db.(*Server).handleConnection
        github.com/gravitational/teleport/lib/srv/db/server.go:722 github.com/gravitational/teleport/lib/srv/db.(*Server).HandleConnection
        github.com/gravitational/teleport/lib/reversetunnel/transport.go:275 github.com/gravitational/teleport/lib/reversetunnel.(*transport).start
        github.com/gravitational/teleport/lib/reversetunnel/agent.go:580 github.com/gravitational/teleport/lib/reversetunnel.(*agent).handleDrainChannels.func2
        runtime/asm_amd64.s:1594 runtime.goexit
User Message: TLS Handshake failed: x509: certificate signed by unknown authority] db/server.go:724
``` 

After checking the Azure docs, it seems that the CA we're using [expired on Oct 2020](https://learn.microsoft.com/en-us/azure/azure-sql/updates/ssl-root-certificate-expiring?view=azuresql#what-update-is-going-to-happen). [It suggests bundling the two CAs](https://learn.microsoft.com/en-us/azure/azure-sql/updates/ssl-root-certificate-expiring?view=azuresql#what-do-i-need-to-do-to-maintain-connectivity) (Baltimore CyberTrust Root and DigiCert GlobalRoot G2 Root CA) into one to keep the SQL server connectivity.

Note: This error doesn't happen to all databases. When testing, some new and old databases could connect to it, and some did not. I didn't investigate to see why this was happening.

## Solution
Start downloading both certificates and bundle them into a single file for Azure SQL Server connections. Following how it is done for other databases, this PR introduces the database type `DatabaseTypeAzureSQLServer` and sets a different CA file database that presents this type.

