### PR TITLE
[v11] Fix links in the teleport-cluster reference

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -599,10 +599,8 @@ Normally the version of Teleport being used will match the version of the chart 
 
 You can optionally override this to use a different published Teleport Docker image tag like `6.0.2` or `7`.
 
-See these links for information on Docker image versions:
-
-- [Community Docker image information](../../installation.mdx?scope=oss#docker)
-- [Enterprise Docker image information](../../installation.mdx?scope=enterprise#docker)
+See our [installation guide](../../installation.mdx#docker) for information on
+Docker image versions.
 
 <Tabs>
   <TabItem label="values.yaml">


### PR DESCRIPTION
The links weren't rendering properly because they contained a URL fragment and query string without a URL path.