### PR TITLE
Fix unable to connect to Azure SQL server instances

### DIFF
--- a/lib/srv/db/ca.go
+++ b/lib/srv/db/ca.go
@@ -52,8 +52,9 @@ func (s *Server) initCACert(ctx context.Context, database types.Database) error 
 		types.DatabaseTypeCloudSQL:
 
 	case types.DatabaseTypeAzure:
-		// Azure Cache for Redis uses system cert pool.
-		if database.GetProtocol() == defaults.ProtocolRedis {
+		// Azure Cache for Redis and Azure SQL Server uses system cert pool.
+		if database.GetProtocol() == defaults.ProtocolRedis ||
+			database.GetProtocol() == defaults.ProtocolSQLServer {
 			return nil
 		}
 

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -537,8 +537,10 @@ func setupTLSConfigRootCAs(tlsConfig *tls.Config, sessionCtx *Session) error {
 func shouldUseSystemCertPool(sessionCtx *Session) bool {
 	switch sessionCtx.Database.GetType() {
 	case types.DatabaseTypeAzure:
-		// Azure Cache for Redis certificates are signed by DigiCert Global Root G2.
-		if sessionCtx.Database.GetProtocol() == defaults.ProtocolRedis {
+		// Azure Cache for Redis and Azure SQL server certificates are signed by
+		// DigiCert Global Root G2.
+		if sessionCtx.Database.GetProtocol() == defaults.ProtocolRedis ||
+			sessionCtx.Database.GetProtocol() == defaults.ProtocolSQLServer {
 			return true
 		}
 

--- a/lib/srv/db/common/auth_test.go
+++ b/lib/srv/db/common/auth_test.go
@@ -166,6 +166,12 @@ func TestAuthGetTLSConfig(t *testing.T) {
 			expectInsecureSkipVerify: true,
 			expectVerifyConnection:   true,
 		},
+		{
+			name:             "Azure SQL Server",
+			sessionDatabase:  newAzureSQLDatabase(t, "resource-id"),
+			expectServerName: "test-database.database.windows.net",
+			expectRootCAs:    systemCertPool,
+		},
 	}
 
 	for _, test := range tests {
@@ -426,6 +432,21 @@ func newRDSProxyDatabase(t *testing.T, uri string) types.Database {
 			RDSProxy: types.RDSProxy{
 				Name: "test-database",
 			},
+		},
+	})
+	require.NoError(t, err)
+	return database
+}
+
+func newAzureSQLDatabase(t *testing.T, resourceID string) types.Database {
+	t.Helper()
+	database, err := types.NewDatabaseV3(types.Metadata{
+		Name: "test-database",
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolSQLServer,
+		URI:      "test-database.database.windows.net:1433",
+		Azure: types.Azure{
+			ResourceID: resourceID,
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
## What

When connecting to an Azure SQL Server instance (managed or not), it returns the error `x509: certificate signed by unknown authority.

Database service error:
```
Original Error: *errors.errorString TLS Handshake failed: x509: certificate signed by unknown authority
Stack Trace:
        github.com/gravitational/teleport/lib/srv/db/sqlserver/connect.go:106 github.com/gravitational/teleport/lib/srv/db/sqlserver.(*connector).Connect
        github.com/gravitational/teleport/lib/srv/db/sqlserver/engine.go:92 github.com/gravitational/teleport/lib/srv/db/sqlserver.(*Engine).HandleConnection
        github.com/gravitational/teleport/lib/srv/db/server.go:812 github.com/gravitational/teleport/lib/srv/db.(*Server).handleConnection
        github.com/gravitational/teleport/lib/srv/db/server.go:722 github.com/gravitational/teleport/lib/srv/db.(*Server).HandleConnection
        github.com/gravitational/teleport/lib/reversetunnel/transport.go:275 github.com/gravitational/teleport/lib/reversetunnel.(*transport).start
        github.com/gravitational/teleport/lib/reversetunnel/agent.go:580 github.com/gravitational/teleport/lib/reversetunnel.(*agent).handleDrainChannels.func2
        runtime/asm_amd64.s:1594 runtime.goexit
User Message: TLS Handshake failed: x509: certificate signed by unknown authority] db/server.go:724
``` 

After checking the Azure docs, it seems that the CA we're using [expired on Oct 2020](https://learn.microsoft.com/en-us/azure/azure-sql/updates/ssl-root-certificate-expiring?view=azuresql#what-update-is-going-to-happen). [It suggests bundling the two CAs](https://learn.microsoft.com/en-us/azure/azure-sql/updates/ssl-root-certificate-expiring?view=azuresql#what-do-i-need-to-do-to-maintain-connectivity) (Baltimore CyberTrust Root and DigiCert GlobalRoot G2 Root CA) into one to keep the SQL server connectivity.

Note: This error doesn't happen to all databases. When testing, some new and old databases could connect to it, and some did not. I didn't investigate to see why this was happening.

## Solution
Uses the exact solution of Azure Cache for Redis: when connecting to an Azure SQL Server instance, use the system cert pool instead of downloading the CA. Both required certs should be present on the system cert pool.
