### PR TITLE
plumb context to keystore methods

### DIFF
--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -180,7 +180,7 @@ func (t *teleportService) waitForLocalAdditionalKeys(ctx context.Context) error 
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		hasUsableKeys, err := t.process.GetAuthServer().GetKeyStore().HasUsableAdditionalKeys(ca)
+		hasUsableKeys, err := t.process.GetAuthServer().GetKeyStore().HasUsableAdditionalKeys(ctx, ca)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/integration/kube/fixtures.go
+++ b/integration/kube/fixtures.go
@@ -48,6 +48,7 @@ type ProxyConfig struct {
 
 // ProxyClient returns kubernetes client using local teleport proxy
 func ProxyClient(cfg ProxyConfig) (*kubernetes.Clientset, *rest.Config, error) {
+	ctx := context.Background()
 	authServer := cfg.T.Process.GetAuthServer()
 	clusterName, err := authServer.GetClusterName()
 	if err != nil {
@@ -65,14 +66,14 @@ func ProxyClient(cfg ProxyConfig) (*kubernetes.Clientset, *rest.Config, error) {
 	}
 	ttl := roles.AdjustSessionTTL(10 * time.Minute)
 
-	ca, err := authServer.GetCertAuthority(context.Background(), types.CertAuthID{
+	ca, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	caCert, signer, err := authServer.GetKeyStore().GetTLSCertAndSigner(ca)
+	caCert, signer, err := authServer.GetKeyStore().GetTLSCertAndSigner(ctx, ca)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -656,7 +656,7 @@ func (s *APIServer) generateHostCert(auth ClientI, w http.ResponseWriter, r *htt
 		return nil, trace.BadParameter("exactly one system role is required")
 	}
 
-	cert, err := auth.GenerateHostCert(req.Key, req.HostID, req.NodeName, req.Principals, req.ClusterName, req.Roles[0], req.TTL)
+	cert, err := auth.GenerateHostCert(r.Context(), req.Key, req.HostID, req.NodeName, req.Principals, req.ClusterName, req.Roles[0], req.TTL)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -110,8 +110,6 @@ type ServerOption func(*Server) error
 
 // NewServer creates and configures a new Server instance
 func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
-	closeCtx, cancelFunc := context.WithCancel(context.TODO())
-
 	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -213,7 +211,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		cfg.KeyStoreConfig.Software.RSAKeyPairSource = native.GenerateKeyPair
 	}
 	cfg.KeyStoreConfig.Logger = log
-	keyStore, err := keystore.NewManager(closeCtx, cfg.KeyStoreConfig)
+	keyStore, err := keystore.NewManager(context.Background(), cfg.KeyStoreConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -239,6 +237,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		StatusInternal:        cfg.Status,
 	}
 
+	closeCtx, cancelFunc := context.WithCancel(context.TODO())
 	as := Server{
 		bk:              cfg.Backend,
 		limiter:         limiter,

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -110,6 +110,8 @@ type ServerOption func(*Server) error
 
 // NewServer creates and configures a new Server instance
 func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
+	closeCtx, cancelFunc := context.WithCancel(context.TODO())
+
 	err := metrics.RegisterPrometheusCollectors(prometheusCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -211,7 +213,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		cfg.KeyStoreConfig.Software.RSAKeyPairSource = native.GenerateKeyPair
 	}
 	cfg.KeyStoreConfig.Logger = log
-	keyStore, err := keystore.NewManager(cfg.KeyStoreConfig)
+	keyStore, err := keystore.NewManager(closeCtx, cfg.KeyStoreConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -237,7 +239,6 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		StatusInternal:        cfg.Status,
 	}
 
-	closeCtx, cancelFunc := context.WithCancel(context.TODO())
 	as := Server{
 		bk:              cfg.Backend,
 		limiter:         limiter,
@@ -887,7 +888,7 @@ func (a *Server) GetClusterCACert(ctx context.Context) (*proto.GetClusterCACertR
 
 // GenerateHostCert uses the private key of the CA to sign the public key of the host
 // (along with meta data like host ID, node name, roles, and ttl) to generate a host certificate.
-func (a *Server) GenerateHostCert(hostPublicKey []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error) {
+func (a *Server) GenerateHostCert(ctx context.Context, hostPublicKey []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error) {
 	domainName, err := a.GetDomainName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -902,7 +903,7 @@ func (a *Server) GenerateHostCert(hostPublicKey []byte, hostID, nodeName string,
 		return nil, trace.BadParameter("failed to load host CA for %q: %v", domainName, err)
 	}
 
-	caSigner, err := a.keyStore.GetSSHSigner(ca)
+	caSigner, err := a.keyStore.GetSSHSigner(ctx, ca)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1314,7 +1315,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	caSigner, err := a.keyStore.GetSSHSigner(userCA)
+	caSigner, err := a.keyStore.GetSSHSigner(ctx, userCA)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1391,7 +1392,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 	}
 
 	// generate TLS certificate
-	cert, signer, err := a.keyStore.GetTLSCertAndSigner(userCA)
+	cert, signer, err := a.keyStore.GetTLSCertAndSigner(ctx, userCA)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2411,14 +2412,14 @@ func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 
 	isAdminRole := req.Role == types.RoleAdmin
 
-	cert, signer, err := a.keyStore.GetTLSCertAndSigner(ca)
+	cert, signer, err := a.keyStore.GetTLSCertAndSigner(ctx, ca)
 	if trace.IsNotFound(err) && isAdminRole {
 		// If there is no local TLS signer found in the host CA ActiveKeys, this
 		// auth server may have a newly configured HSM and has only populated
 		// local keys in the AdditionalTrustedKeys until the next CA rotation.
 		// This is the only case where we should be able to get a signer from
 		// AdditionalTrustedKeys but not ActiveKeys.
-		cert, signer, err = a.keyStore.GetAdditionalTrustedTLSCertAndSigner(ca)
+		cert, signer, err = a.keyStore.GetAdditionalTrustedTLSCertAndSigner(ctx, ca)
 	}
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2428,14 +2429,14 @@ func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 		return nil, trace.Wrap(err)
 	}
 
-	caSigner, err := a.keyStore.GetSSHSigner(ca)
+	caSigner, err := a.keyStore.GetSSHSigner(ctx, ca)
 	if trace.IsNotFound(err) && isAdminRole {
 		// If there is no local SSH signer found in the host CA ActiveKeys, this
 		// auth server may have a newly configured HSM and has only populated
 		// local keys in the AdditionalTrustedKeys until the next CA rotation.
 		// This is the only case where we should be able to get a signer from
 		// AdditionalTrustedKeys but not ActiveKeys.
-		caSigner, err = a.keyStore.GetAdditionalTrustedSSHSigner(ca)
+		caSigner, err = a.keyStore.GetAdditionalTrustedSSHSigner(ctx, ca)
 	}
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -3023,14 +3024,14 @@ func (a *Server) GenerateCertAuthorityCRL(ctx context.Context, caType types.Cert
 	// If there are multiple signers (multiple HSMs), we won't have the full CRL coverage.
 	// Generate a CRL per signer and return all of them separately.
 
-	cert, signer, err := a.keyStore.GetTLSCertAndSigner(ca)
+	cert, signer, err := a.keyStore.GetTLSCertAndSigner(ctx, ca)
 	if trace.IsNotFound(err) {
 		// If there is no local TLS signer found in the host CA ActiveKeys, this
 		// auth server may have a newly configured HSM and has only populated
 		// local keys in the AdditionalTrustedKeys until the next CA rotation.
 		// This is the only case where we should be able to get a signer from
 		// AdditionalTrustedKeys but not ActiveKeys.
-		cert, signer, err = a.keyStore.GetAdditionalTrustedTLSCertAndSigner(ca)
+		cert, signer, err = a.keyStore.GetAdditionalTrustedTLSCertAndSigner(ctx, ca)
 	}
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -3797,15 +3798,15 @@ func (a *Server) addAdditionalTrustedKeysAtomic(
 
 // newKeySet generates a new sets of keys for a given CA type.
 // Keep this function in sync with lib/service/suite/suite.go:NewTestCAWithConfig().
-func newKeySet(keyStore *keystore.Manager, caID types.CertAuthID) (types.CAKeySet, error) {
+func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertAuthID) (types.CAKeySet, error) {
 	var keySet types.CAKeySet
 	switch caID.Type {
 	case types.UserCA, types.HostCA:
-		sshKeyPair, err := keyStore.NewSSHKeyPair()
+		sshKeyPair, err := keyStore.NewSSHKeyPair(ctx)
 		if err != nil {
 			return keySet, trace.Wrap(err)
 		}
-		tlsKeyPair, err := keyStore.NewTLSKeyPair(caID.DomainName)
+		tlsKeyPair, err := keyStore.NewTLSKeyPair(ctx, caID.DomainName)
 		if err != nil {
 			return keySet, trace.Wrap(err)
 		}
@@ -3813,13 +3814,13 @@ func newKeySet(keyStore *keystore.Manager, caID types.CertAuthID) (types.CAKeySe
 		keySet.TLS = append(keySet.TLS, tlsKeyPair)
 	case types.DatabaseCA:
 		// Database CA only contains TLS cert.
-		tlsKeyPair, err := keyStore.NewTLSKeyPair(caID.DomainName)
+		tlsKeyPair, err := keyStore.NewTLSKeyPair(ctx, caID.DomainName)
 		if err != nil {
 			return keySet, trace.Wrap(err)
 		}
 		keySet.TLS = append(keySet.TLS, tlsKeyPair)
 	case types.JWTSigner:
-		jwtKeyPair, err := keyStore.NewJWTKeyPair()
+		jwtKeyPair, err := keyStore.NewJWTKeyPair(ctx)
 		if err != nil {
 			return keySet, trace.Wrap(err)
 		}
@@ -3833,7 +3834,7 @@ func newKeySet(keyStore *keystore.Manager, caID types.CertAuthID) (types.CAKeySe
 // ensureLocalAdditionalKeys adds additional trusted keys to the CA if they are not
 // already present.
 func (a *Server) ensureLocalAdditionalKeys(ctx context.Context, ca types.CertAuthority) error {
-	hasUsableKeys, err := a.keyStore.HasUsableAdditionalKeys(ca)
+	hasUsableKeys, err := a.keyStore.HasUsableAdditionalKeys(ctx, ca)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -3842,7 +3843,7 @@ func (a *Server) ensureLocalAdditionalKeys(ctx context.Context, ca types.CertAut
 		return nil
 	}
 
-	newKeySet, err := newKeySet(a.keyStore, ca.GetID())
+	newKeySet, err := newKeySet(ctx, a.keyStore, ca.GetID())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -3850,7 +3851,7 @@ func (a *Server) ensureLocalAdditionalKeys(ctx context.Context, ca types.CertAut
 	// The CA still needs an update while the keystore does not have any usable
 	// keys in the CA.
 	needsUpdate := func(ca types.CertAuthority) (bool, error) {
-		hasUsableKeys, err := a.keyStore.HasUsableAdditionalKeys(ca)
+		hasUsableKeys, err := a.keyStore.HasUsableAdditionalKeys(ctx, ca)
 		return !hasUsableKeys, trace.Wrap(err)
 	}
 	err = a.addAdditionalTrustedKeysAtomic(ctx, ca, newKeySet, needsUpdate)
@@ -3863,8 +3864,8 @@ func (a *Server) ensureLocalAdditionalKeys(ctx context.Context, ca types.CertAut
 
 // createSelfSignedCA creates a new self-signed CA and writes it to the
 // backend, with the type and clusterName given by the argument caID.
-func (a *Server) createSelfSignedCA(caID types.CertAuthID) error {
-	keySet, err := newKeySet(a.keyStore, caID)
+func (a *Server) createSelfSignedCA(ctx context.Context, caID types.CertAuthID) error {
+	keySet, err := newKeySet(ctx, a.keyStore, caID)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1287,7 +1287,7 @@ func TestGenerateHostCertWithLocks(t *testing.T) {
 	keygen := testauthority.New()
 	_, pub, err := keygen.GetNewKeyPairFromPool()
 	require.NoError(t, err)
-	_, err = p.a.GenerateHostCert(pub, hostID, "test-node", []string{},
+	_, err = p.a.GenerateHostCert(ctx, pub, hostID, "test-node", []string{},
 		p.clusterName.GetClusterName(), types.RoleNode, time.Minute)
 	require.NoError(t, err)
 
@@ -1308,12 +1308,12 @@ func TestGenerateHostCertWithLocks(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Timeout waiting for lock update.")
 	}
-	_, err = p.a.GenerateHostCert(pub, hostID, "test-node", []string{}, p.clusterName.GetClusterName(), types.RoleNode, time.Minute)
+	_, err = p.a.GenerateHostCert(ctx, pub, hostID, "test-node", []string{}, p.clusterName.GetClusterName(), types.RoleNode, time.Minute)
 	require.Error(t, err)
 	require.EqualError(t, err, services.LockInForceAccessDenied(lock).Error())
 
 	// Locks targeting nodes should not apply to other system roles.
-	_, err = p.a.GenerateHostCert(pub, hostID, "test-proxy", []string{}, p.clusterName.GetClusterName(), types.RoleProxy, time.Minute)
+	_, err = p.a.GenerateHostCert(ctx, pub, hostID, "test-proxy", []string{}, p.clusterName.GetClusterName(), types.RoleProxy, time.Minute)
 	require.NoError(t, err)
 }
 
@@ -2057,6 +2057,7 @@ func TestFilterResources(t *testing.T) {
 }
 
 func TestCAGeneration(t *testing.T) {
+	ctx := context.Background()
 	const (
 		clusterName = "cluster1"
 		HostUUID    = "0000-000-000-0000"
@@ -2073,13 +2074,13 @@ func TestCAGeneration(t *testing.T) {
 			},
 		},
 	}
-	keyStore, err := keystore.NewManager(ksConfig)
+	keyStore, err := keystore.NewManager(ctx, ksConfig)
 	require.NoError(t, err)
 
 	for _, caType := range types.CertAuthTypes {
 		t.Run(string(caType), func(t *testing.T) {
 			testKeySet := suite.NewTestCA(caType, clusterName, privKey).Spec.ActiveKeys
-			keySet, err := newKeySet(keyStore, types.CertAuthID{Type: caType, DomainName: clusterName})
+			keySet, err := newKeySet(ctx, keyStore, types.CertAuthID{Type: caType, DomainName: clusterName})
 			require.NoError(t, err)
 
 			// Don't compare values as those are different. Only check if the key is set/not set in both cases.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2184,9 +2184,9 @@ func (a *ServerWithRoles) DeleteUser(ctx context.Context, user string) error {
 }
 
 func (a *ServerWithRoles) GenerateHostCert(
-	key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration,
+	ctx context.Context, key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration,
 ) ([]byte, error) {
-	ctx := services.Context{
+	serviceContext := services.Context{
 		User: a.context.User,
 		HostCert: &services.HostCertContext{
 			HostID:      hostID,
@@ -2203,12 +2203,12 @@ func (a *ServerWithRoles) GenerateHostCert(
 	// to expose cert request fields.
 	// We've only got a single verb to check so luckily it's pretty concise.
 	if err := a.withOptions().context.Checker.CheckAccessToRule(
-		&ctx, apidefaults.Namespace, types.KindHostCert, types.VerbCreate, false,
+		&serviceContext, apidefaults.Namespace, types.KindHostCert, types.VerbCreate, false,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return a.authServer.GenerateHostCert(key, hostID, nodeName, principals, clusterName, role, ttl)
+	return a.authServer.GenerateHostCert(ctx, key, hostID, nodeName, principals, clusterName, role, ttl)
 }
 
 // NewKeepAliver not implemented: can only be called locally.

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -3743,7 +3743,7 @@ func TestGenerateHostCert(t *testing.T) {
 			client, err := srv.NewClient(TestUser(user.GetName()))
 			require.NoError(t, err)
 
-			_, err = client.GenerateHostCert(pub, "", "", test.principals, clusterName, types.RoleNode, 0)
+			_, err = client.GenerateHostCert(ctx, pub, "", "", test.principals, clusterName, types.RoleNode, 0)
 			require.True(t, test.expect(err))
 		})
 	}

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -864,9 +864,9 @@ func (c *Client) DeleteWebSession(ctx context.Context, user string, sid string) 
 // plain text format, signs it using Host Certificate Authority private key and returns the
 // resulting certificate.
 func (c *Client) GenerateHostCert(
-	key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration,
+	ctx context.Context, key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration,
 ) ([]byte, error) {
-	out, err := c.PostJSON(context.TODO(), c.Endpoint("ca", "host", "certs"),
+	out, err := c.PostJSON(ctx, c.Endpoint("ca", "host", "certs"),
 		generateHostCertReq{
 			Key:         key,
 			HostID:      hostID,
@@ -1477,7 +1477,7 @@ type IdentityService interface {
 	// GenerateHostCert takes the public key in the Open SSH ``authorized_keys``
 	// plain text format, signs it using Host Certificate Authority private key and returns the
 	// resulting certificate.
-	GenerateHostCert(key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error)
+	GenerateHostCert(ctx context.Context, key []byte, hostID, nodeName string, principals []string, clusterName string, role types.SystemRole, ttl time.Duration) ([]byte, error)
 
 	// GenerateUserCerts takes the public key in the OpenSSH `authorized_keys` plain
 	// text format, signs it using User Certificate Authority signing key and

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -69,7 +69,7 @@ func (s *Server) GenerateDatabaseCert(ctx context.Context, req *proto.DatabaseCe
 			return nil, trace.Wrap(err)
 		}
 	}
-	caCert, signer, err := getCAandSigner(s.GetKeyStore(), databaseCA, req)
+	caCert, signer, err := getCAandSigner(ctx, s.GetKeyStore(), databaseCA, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -101,14 +101,14 @@ func (s *Server) GenerateDatabaseCert(ctx context.Context, req *proto.DatabaseCe
 // This function covers the database CA rotation scenario when on rotation init phase additional/new TLS
 // key should be used to sign the database CA. Otherwise, the trust chain will break after the old CA is
 // removed - standby phase.
-func getCAandSigner(keyStore *keystore.Manager, databaseCA types.CertAuthority, req *proto.DatabaseCertRequest,
+func getCAandSigner(ctx context.Context, keyStore *keystore.Manager, databaseCA types.CertAuthority, req *proto.DatabaseCertRequest,
 ) ([]byte, crypto.Signer, error) {
 	if req.RequesterName == proto.DatabaseCertRequest_TCTL &&
 		databaseCA.GetRotation().Phase == types.RotationPhaseInit {
-		return keyStore.GetAdditionalTrustedTLSCertAndSigner(databaseCA)
+		return keyStore.GetAdditionalTrustedTLSCertAndSigner(ctx, databaseCA)
 	}
 
-	return keyStore.GetTLSCertAndSigner(databaseCA)
+	return keyStore.GetTLSCertAndSigner(ctx, databaseCA)
 }
 
 // getServerNames returns deduplicated list of server names from signing request.
@@ -193,7 +193,7 @@ func (s *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 		return nil, trace.Wrap(err)
 	}
 
-	cert, signer, err := s.GetKeyStore().GetTLSCertAndSigner(ca)
+	cert, signer, err := s.GetKeyStore().GetTLSCertAndSigner(ctx, ca)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -260,7 +260,7 @@ func (s *Server) GenerateSnowflakeJWT(ctx context.Context, req *proto.SnowflakeJ
 
 	subject, issuer := getSnowflakeJWTParams(req.AccountName, req.UserName, pubKey)
 
-	_, signer, err := s.GetKeyStore().GetTLSCertAndSigner(ca)
+	_, signer, err := s.GetKeyStore().GetTLSCertAndSigner(ctx, ca)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/desktop.go
+++ b/lib/auth/desktop.go
@@ -52,7 +52,7 @@ func (s *Server) GenerateWindowsDesktopCert(ctx context.Context, req *proto.Wind
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	caCert, signer, err := s.GetKeyStore().GetTLSCertAndSigner(userCA)
+	caCert, signer, err := s.GetKeyStore().GetTLSCertAndSigner(ctx, userCA)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -232,7 +232,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 		}
 		if firstStart {
 			log.Infof("Applying %v bootstrap resources (first initialization)", len(cfg.Resources))
-			if err := checkResourceConsistency(asrv.keyStore, domainName, cfg.Resources...); err != nil {
+			if err := checkResourceConsistency(ctx, asrv.keyStore, domainName, cfg.Resources...); err != nil {
 				return nil, trace.Wrap(err, "refusing to bootstrap backend")
 			}
 			if err := local.CreateResources(ctx, cfg.Backend, cfg.Resources...); err != nil {
@@ -359,12 +359,12 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 				return nil, trace.Wrap(err)
 			}
 			log.Infof("First start: generating %s certificate authority.", caID.Type)
-			if err := asrv.createSelfSignedCA(caID); err != nil {
+			if err := asrv.createSelfSignedCA(ctx, caID); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		} else {
 			// Already have a CA. Make sure the keyStore has usable keys.
-			hasUsableActiveKeys, err := asrv.keyStore.HasUsableActiveKeys(ca)
+			hasUsableActiveKeys, err := asrv.keyStore.HasUsableActiveKeys(ctx, ca)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -391,11 +391,11 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 					}
 				}
 			}
-			hasUsableActiveKeys, err = asrv.keyStore.HasUsableActiveKeys(ca)
+			hasUsableActiveKeys, err = asrv.keyStore.HasUsableActiveKeys(ctx, ca)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			hasUsableAdditionalKeys, err := asrv.keyStore.HasUsableAdditionalKeys(ca)
+			hasUsableAdditionalKeys, err := asrv.keyStore.HasUsableAdditionalKeys(ctx, ca)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -593,7 +593,7 @@ func isFirstStart(ctx context.Context, authServer *Server, cfg InitConfig) (bool
 }
 
 // checkResourceConsistency checks far basic conflicting state issues.
-func checkResourceConsistency(keyStore *keystore.Manager, clusterName string, resources ...types.Resource) error {
+func checkResourceConsistency(ctx context.Context, keyStore *keystore.Manager, clusterName string, resources ...types.Resource) error {
 	for _, rsc := range resources {
 		switch r := rsc.(type) {
 		case types.CertAuthority:
@@ -605,11 +605,11 @@ func checkResourceConsistency(keyStore *keystore.Manager, clusterName string, re
 			var signerErr error
 			switch r.GetType() {
 			case types.HostCA, types.UserCA:
-				_, signerErr = keyStore.GetSSHSigner(r)
+				_, signerErr = keyStore.GetSSHSigner(ctx, r)
 			case types.DatabaseCA:
-				_, _, signerErr = keyStore.GetTLSCertAndSigner(r)
+				_, _, signerErr = keyStore.GetTLSCertAndSigner(ctx, r)
 			case types.JWTSigner:
-				_, signerErr = keyStore.GetJWTSigner(r)
+				_, signerErr = keyStore.GetJWTSigner(ctx, r)
 			default:
 				return trace.BadParameter("unexpected cert_authority type %s for cluster %v", r.GetType(), clusterName)
 			}

--- a/lib/auth/keystore/gcp_kms.go
+++ b/lib/auth/keystore/gcp_kms.go
@@ -93,9 +93,7 @@ type gcpKMSKeyStore struct {
 
 // newGCPKMSKeyStore returns a new keystore configured to use a GCP KMS keyring
 // to manage all key material.
-func newGCPKMSKeyStore(cfg *GCPKMSConfig, logger logrus.FieldLogger) (*gcpKMSKeyStore, error) {
-	ctx := context.TODO()
-
+func newGCPKMSKeyStore(ctx context.Context, cfg *GCPKMSConfig, logger logrus.FieldLogger) (*gcpKMSKeyStore, error) {
 	kmsClient, err := kms.NewKeyManagementClient(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -117,9 +115,7 @@ func newGCPKMSKeyStore(cfg *GCPKMSConfig, logger logrus.FieldLogger) (*gcpKMSKey
 // crypto.Signer. The returned identifier for gcpKMSKeyStore encoded the full
 // GCP KMS key version name, and can be passed to getSigner later to get the same
 // crypto.Signer.
-func (g *gcpKMSKeyStore) generateRSA(opts ...RSAKeyOption) ([]byte, crypto.Signer, error) {
-	ctx := context.TODO()
-
+func (g *gcpKMSKeyStore) generateRSA(ctx context.Context, opts ...RSAKeyOption) ([]byte, crypto.Signer, error) {
 	options := &RSAKeyOptions{}
 	for _, opt := range opts {
 		opt(options)
@@ -168,8 +164,7 @@ func (g *gcpKMSKeyStore) generateRSA(opts ...RSAKeyOption) ([]byte, crypto.Signe
 }
 
 // getSigner returns a crypto.Signer for the given pem-encoded private key.
-func (g *gcpKMSKeyStore) getSigner(rawKey []byte) (crypto.Signer, error) {
-	ctx := context.TODO()
+func (g *gcpKMSKeyStore) getSigner(ctx context.Context, rawKey []byte) (crypto.Signer, error) {
 	keyID, err := parseGCPKMSKeyID(rawKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -198,7 +193,7 @@ func (g *gcpKMSKeyStore) deleteKey(ctx context.Context, rawKey []byte) error {
 // configured with the same keyring. This is a divergence from the PKCS#11
 // keystore where different auth servers will always create their own keys even
 // if configured to use the same HSM
-func (g *gcpKMSKeyStore) canSignWithKey(raw []byte, keyType types.PrivateKeyType) (bool, error) {
+func (g *gcpKMSKeyStore) canSignWithKey(ctx context.Context, raw []byte, keyType types.PrivateKeyType) (bool, error) {
 	if keyType != types.PrivateKeyType_GCP_KMS {
 		return false, nil
 	}

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -127,6 +127,9 @@ JhuTMEqUaAOZBoQLn+txjl3nu9WwTThJzlY0L4w=
 )
 
 func TestKeyStore(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
@@ -235,20 +238,20 @@ func TestKeyStore(t *testing.T) {
 			}
 
 			// create the keystore manager
-			keyStore, err := NewManager(tc.config)
+			keyStore, err := NewManager(ctx, tc.config)
 			require.NoError(t, err)
 
 			// create a key
-			key, signer, err := keyStore.generateRSA()
+			key, signer, err := keyStore.generateRSA(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, key)
 			require.NotNil(t, signer)
 
 			// delete the key when we're done with it
-			t.Cleanup(func() { require.NoError(t, keyStore.deleteKey(context.Background(), key)) })
+			t.Cleanup(func() { require.NoError(t, keyStore.deleteKey(ctx, key)) })
 
 			// get a signer from the key
-			signer, err = keyStore.getSigner(key)
+			signer, err = keyStore.getSigner(ctx, key)
 			require.NoError(t, err)
 			require.NotNil(t, signer)
 
@@ -311,17 +314,17 @@ func TestKeyStore(t *testing.T) {
 			require.NoError(t, err)
 
 			// test that keyStore is able to select the correct key and get a signer
-			sshSigner, err = keyStore.GetSSHSigner(ca)
+			sshSigner, err = keyStore.GetSSHSigner(ctx, ca)
 			require.NoError(t, err)
 			require.NotNil(t, sshSigner)
 
-			tlsCert, tlsSigner, err := keyStore.GetTLSCertAndSigner(ca)
+			tlsCert, tlsSigner, err := keyStore.GetTLSCertAndSigner(ctx, ca)
 			require.NoError(t, err)
 			require.NotNil(t, tlsCert)
 			require.NotEqual(t, testPKCS11TLSKeyPair.Cert, tlsCert)
 			require.NotNil(t, tlsSigner)
 
-			jwtSigner, err := keyStore.GetJWTSigner(ca)
+			jwtSigner, err := keyStore.GetJWTSigner(ctx, ca)
 			require.NoError(t, err)
 			require.NotNil(t, jwtSigner)
 
@@ -345,26 +348,26 @@ func TestKeyStore(t *testing.T) {
 
 			if !tc.isSoftware {
 				// hsm keyStore should not get any signer from raw keys
-				_, err = keyStore.GetSSHSigner(ca)
+				_, err = keyStore.GetSSHSigner(ctx, ca)
 				require.True(t, trace.IsNotFound(err))
 
-				_, _, err = keyStore.GetTLSCertAndSigner(ca)
+				_, _, err = keyStore.GetTLSCertAndSigner(ctx, ca)
 				require.True(t, trace.IsNotFound(err))
 
-				_, err = keyStore.GetJWTSigner(ca)
+				_, err = keyStore.GetJWTSigner(ctx, ca)
 				require.True(t, trace.IsNotFound(err))
 			} else {
 				// software keyStore should be able to get a signer
-				sshSigner, err = keyStore.GetSSHSigner(ca)
+				sshSigner, err = keyStore.GetSSHSigner(ctx, ca)
 				require.NoError(t, err)
 				require.NotNil(t, sshSigner)
 
-				tlsCert, tlsSigner, err = keyStore.GetTLSCertAndSigner(ca)
+				tlsCert, tlsSigner, err = keyStore.GetTLSCertAndSigner(ctx, ca)
 				require.NoError(t, err)
 				require.NotNil(t, tlsCert)
 				require.NotNil(t, tlsSigner)
 
-				jwtSigner, err = keyStore.GetJWTSigner(ca)
+				jwtSigner, err = keyStore.GetJWTSigner(ctx, ca)
 				require.NoError(t, err)
 				require.NotNil(t, jwtSigner)
 			}
@@ -383,36 +386,36 @@ func TestKeyStore(t *testing.T) {
 			}
 
 			// create the keystore manager
-			keyStore, err := NewManager(tc.config)
+			keyStore, err := NewManager(ctx, tc.config)
 			require.NoError(t, err)
 
 			// create some keys to test DeleteUnusedKeys
 			const numKeys = 3
 			var rawKeys [][]byte
 			for i := 0; i < numKeys; i++ {
-				key, _, err := keyStore.generateRSA()
+				key, _, err := keyStore.generateRSA(ctx)
 				require.NoError(t, err)
 				rawKeys = append(rawKeys, key)
 			}
 
 			// say that only the first key is in use, delete the rest
 			usedKeys := [][]byte{rawKeys[0]}
-			err = keyStore.DeleteUnusedKeys(context.Background(), usedKeys)
+			err = keyStore.DeleteUnusedKeys(ctx, usedKeys)
 			require.NoError(t, err)
 
 			// make sure the first key is still good
-			signer, err := keyStore.getSigner(rawKeys[0])
+			signer, err := keyStore.getSigner(ctx, rawKeys[0])
 			require.NoError(t, err)
 			require.NotNil(t, signer)
 
 			// make sure all other keys are deleted
 			for i := 1; i < numKeys; i++ {
-				_, err := keyStore.getSigner(rawKeys[i])
+				_, err := keyStore.getSigner(ctx, rawKeys[i])
 				require.Error(t, err)
 			}
 
 			// delete the final key so we don't leak it
-			err = keyStore.deleteKey(context.Background(), rawKeys[0])
+			err = keyStore.deleteKey(ctx, rawKeys[0])
 			require.NoError(t, err)
 		})
 	}

--- a/lib/auth/keystore/manager.go
+++ b/lib/auth/keystore/manager.go
@@ -63,17 +63,17 @@ type backend interface {
 	// generateRSA creates a new RSA private key and returns its identifier and
 	// a crypto.Signer. The returned identifier can be passed to getSigner
 	// later to get the same crypto.Signer.
-	generateRSA(...RSAKeyOption) (keyID []byte, signer crypto.Signer, err error)
+	generateRSA(context.Context, ...RSAKeyOption) (keyID []byte, signer crypto.Signer, err error)
 
 	// getSigner returns a crypto.Signer for the given key identifier, if it is found.
-	getSigner(keyID []byte) (crypto.Signer, error)
+	getSigner(ctx context.Context, keyID []byte) (crypto.Signer, error)
 
 	// deleteKey deletes the given key from the KeyStore.
 	deleteKey(ctx context.Context, keyID []byte) error
 
 	// canSignWithKey returns true if this KeyStore is able to sign with the
 	// given key.
-	canSignWithKey(raw []byte, keyType types.PrivateKeyType) (bool, error)
+	canSignWithKey(ctx context.Context, raw []byte, keyType types.PrivateKeyType) (bool, error)
 }
 
 // Config holds configuration parameters for the keystore. A software keystore
@@ -104,7 +104,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 }
 
 // NewManager returns a new keystore Manager
-func NewManager(cfg Config) (*Manager, error) {
+func NewManager(ctx context.Context, cfg Config) (*Manager, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -119,7 +119,7 @@ func NewManager(cfg Config) (*Manager, error) {
 		return &Manager{backend: backend}, trace.Wrap(err)
 	}
 	if (cfg.GCPKMS != GCPKMSConfig{}) {
-		backend, err := newGCPKMSKeyStore(&cfg.GCPKMS, logger)
+		backend, err := newGCPKMSKeyStore(ctx, &cfg.GCPKMS, logger)
 		return &Manager{backend: backend}, trace.Wrap(err)
 	}
 	return &Manager{backend: newSoftwareKeyStore(&cfg.Software, logger)}, nil
@@ -127,28 +127,28 @@ func NewManager(cfg Config) (*Manager, error) {
 
 // GetSSHSigner selects a usable SSH keypair from the given CA ActiveKeys and
 // returns an [ssh.Signer].
-func (m *Manager) GetSSHSigner(ca types.CertAuthority) (ssh.Signer, error) {
-	signer, err := m.getSSHSigner(ca.GetActiveKeys())
+func (m *Manager) GetSSHSigner(ctx context.Context, ca types.CertAuthority) (ssh.Signer, error) {
+	signer, err := m.getSSHSigner(ctx, ca.GetActiveKeys())
 	return signer, trace.Wrap(err)
 }
 
 // GetSSHSigner selects a usable SSH keypair from the given CA
 // AdditionalTrustedKeys and returns an [ssh.Signer].
-func (m *Manager) GetAdditionalTrustedSSHSigner(ca types.CertAuthority) (ssh.Signer, error) {
-	signer, err := m.getSSHSigner(ca.GetAdditionalTrustedKeys())
+func (m *Manager) GetAdditionalTrustedSSHSigner(ctx context.Context, ca types.CertAuthority) (ssh.Signer, error) {
+	signer, err := m.getSSHSigner(ctx, ca.GetAdditionalTrustedKeys())
 	return signer, trace.Wrap(err)
 }
 
-func (m *Manager) getSSHSigner(keySet types.CAKeySet) (ssh.Signer, error) {
+func (m *Manager) getSSHSigner(ctx context.Context, keySet types.CAKeySet) (ssh.Signer, error) {
 	for _, keyPair := range keySet.SSH {
-		canSign, err := m.backend.canSignWithKey(keyPair.PrivateKey, keyPair.PrivateKeyType)
+		canSign, err := m.backend.canSignWithKey(ctx, keyPair.PrivateKey, keyPair.PrivateKeyType)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		if !canSign {
 			continue
 		}
-		signer, err := m.backend.getSigner(keyPair.PrivateKey)
+		signer, err := m.backend.getSigner(ctx, keyPair.PrivateKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -160,28 +160,28 @@ func (m *Manager) getSSHSigner(keySet types.CAKeySet) (ssh.Signer, error) {
 
 // GetTLSCertAndSigner selects a usable TLS keypair from the given CA
 // and returns the PEM-encoded TLS certificate and a [crypto.Signer].
-func (m *Manager) GetTLSCertAndSigner(ca types.CertAuthority) ([]byte, crypto.Signer, error) {
-	cert, signer, err := m.getTLSCertAndSigner(ca.GetActiveKeys())
+func (m *Manager) GetTLSCertAndSigner(ctx context.Context, ca types.CertAuthority) ([]byte, crypto.Signer, error) {
+	cert, signer, err := m.getTLSCertAndSigner(ctx, ca.GetActiveKeys())
 	return cert, signer, trace.Wrap(err)
 }
 
 // GetAdditionalTrustedTLSCertAndSigner selects a usable TLS keypair from the given CA
 // and returns the PEM-encoded TLS certificate and a [crypto.Signer].
-func (m *Manager) GetAdditionalTrustedTLSCertAndSigner(ca types.CertAuthority) ([]byte, crypto.Signer, error) {
-	cert, signer, err := m.getTLSCertAndSigner(ca.GetAdditionalTrustedKeys())
+func (m *Manager) GetAdditionalTrustedTLSCertAndSigner(ctx context.Context, ca types.CertAuthority) ([]byte, crypto.Signer, error) {
+	cert, signer, err := m.getTLSCertAndSigner(ctx, ca.GetAdditionalTrustedKeys())
 	return cert, signer, trace.Wrap(err)
 }
 
-func (m *Manager) getTLSCertAndSigner(keySet types.CAKeySet) ([]byte, crypto.Signer, error) {
+func (m *Manager) getTLSCertAndSigner(ctx context.Context, keySet types.CAKeySet) ([]byte, crypto.Signer, error) {
 	for _, keyPair := range keySet.TLS {
-		canSign, err := m.backend.canSignWithKey(keyPair.Key, keyPair.KeyType)
+		canSign, err := m.backend.canSignWithKey(ctx, keyPair.Key, keyPair.KeyType)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
 		if !canSign {
 			continue
 		}
-		signer, err := m.backend.getSigner(keyPair.Key)
+		signer, err := m.backend.getSigner(ctx, keyPair.Key)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -192,25 +192,25 @@ func (m *Manager) getTLSCertAndSigner(keySet types.CAKeySet) ([]byte, crypto.Sig
 
 // GetJWTSigner selects a usable JWT keypair from the given keySet and returns
 // a [crypto.Signer].
-func (m *Manager) GetJWTSigner(ca types.CertAuthority) (crypto.Signer, error) {
+func (m *Manager) GetJWTSigner(ctx context.Context, ca types.CertAuthority) (crypto.Signer, error) {
 	for _, keyPair := range ca.GetActiveKeys().JWT {
-		canSign, err := m.backend.canSignWithKey(keyPair.PrivateKey, keyPair.PrivateKeyType)
+		canSign, err := m.backend.canSignWithKey(ctx, keyPair.PrivateKey, keyPair.PrivateKeyType)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		if !canSign {
 			continue
 		}
-		signer, err := m.backend.getSigner(keyPair.PrivateKey)
+		signer, err := m.backend.getSigner(ctx, keyPair.PrivateKey)
 		return signer, trace.Wrap(err)
 	}
 	return nil, trace.NotFound("no usable JWT key pairs found")
 }
 
 // NewSSHKeyPair generates a new SSH keypair in the keystore backend and returns it.
-func (m *Manager) NewSSHKeyPair() (*types.SSHKeyPair, error) {
+func (m *Manager) NewSSHKeyPair(ctx context.Context) (*types.SSHKeyPair, error) {
 	// The default hash length for SSH signers is 512 bits.
-	sshKey, cryptoSigner, err := m.backend.generateRSA(WithDigestAlgorithm(crypto.SHA512))
+	sshKey, cryptoSigner, err := m.backend.generateRSA(ctx, WithDigestAlgorithm(crypto.SHA512))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -227,8 +227,8 @@ func (m *Manager) NewSSHKeyPair() (*types.SSHKeyPair, error) {
 }
 
 // NewTLSKeyPair creates a new TLS keypair in the keystore backend and returns it.
-func (m *Manager) NewTLSKeyPair(clusterName string) (*types.TLSKeyPair, error) {
-	tlsKey, signer, err := m.backend.generateRSA()
+func (m *Manager) NewTLSKeyPair(ctx context.Context, clusterName string) (*types.TLSKeyPair, error) {
+	tlsKey, signer, err := m.backend.generateRSA(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -250,8 +250,8 @@ func (m *Manager) NewTLSKeyPair(clusterName string) (*types.TLSKeyPair, error) {
 
 // New JWTKeyPair create a new JWT keypair in the keystore backend and returns
 // it.
-func (m *Manager) NewJWTKeyPair() (*types.JWTKeyPair, error) {
-	jwtKey, signer, err := m.backend.generateRSA()
+func (m *Manager) NewJWTKeyPair(ctx context.Context) (*types.JWTKeyPair, error) {
+	jwtKey, signer, err := m.backend.generateRSA(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -267,21 +267,21 @@ func (m *Manager) NewJWTKeyPair() (*types.JWTKeyPair, error) {
 }
 
 // HasUsableActiveKeys returns true if the given CA has any usable active keys.
-func (m *Manager) HasUsableActiveKeys(ca types.CertAuthority) (bool, error) {
-	usable, err := m.hasUsableKeys(ca.GetActiveKeys())
+func (m *Manager) HasUsableActiveKeys(ctx context.Context, ca types.CertAuthority) (bool, error) {
+	usable, err := m.hasUsableKeys(ctx, ca.GetActiveKeys())
 	return usable, trace.Wrap(err)
 }
 
 // HasUsableActiveKeys returns true if the given CA has any usable additional
 // trusted keys.
-func (m *Manager) HasUsableAdditionalKeys(ca types.CertAuthority) (bool, error) {
-	usable, err := m.hasUsableKeys(ca.GetAdditionalTrustedKeys())
+func (m *Manager) HasUsableAdditionalKeys(ctx context.Context, ca types.CertAuthority) (bool, error) {
+	usable, err := m.hasUsableKeys(ctx, ca.GetAdditionalTrustedKeys())
 	return usable, trace.Wrap(err)
 }
 
-func (m *Manager) hasUsableKeys(keySet types.CAKeySet) (bool, error) {
+func (m *Manager) hasUsableKeys(ctx context.Context, keySet types.CAKeySet) (bool, error) {
 	for _, sshKeyPair := range keySet.SSH {
-		usable, err := m.backend.canSignWithKey(sshKeyPair.PrivateKey, sshKeyPair.PrivateKeyType)
+		usable, err := m.backend.canSignWithKey(ctx, sshKeyPair.PrivateKey, sshKeyPair.PrivateKeyType)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}
@@ -290,7 +290,7 @@ func (m *Manager) hasUsableKeys(keySet types.CAKeySet) (bool, error) {
 		}
 	}
 	for _, tlsKeyPair := range keySet.TLS {
-		usable, err := m.backend.canSignWithKey(tlsKeyPair.Key, tlsKeyPair.KeyType)
+		usable, err := m.backend.canSignWithKey(ctx, tlsKeyPair.Key, tlsKeyPair.KeyType)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}
@@ -299,7 +299,7 @@ func (m *Manager) hasUsableKeys(keySet types.CAKeySet) (bool, error) {
 		}
 	}
 	for _, jwtKeyPair := range keySet.JWT {
-		usable, err := m.backend.canSignWithKey(jwtKeyPair.PrivateKey, jwtKeyPair.PrivateKeyType)
+		usable, err := m.backend.canSignWithKey(ctx, jwtKeyPair.PrivateKey, jwtKeyPair.PrivateKeyType)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}

--- a/lib/auth/keystore/software.go
+++ b/lib/auth/keystore/software.go
@@ -53,12 +53,12 @@ func newSoftwareKeyStore(config *SoftwareConfig, logger logrus.FieldLogger) *sof
 // crypto.Signer. The returned identifier for softwareKeyStore is a pem-encoded
 // private key, and can be passed to getSigner later to get the same
 // crypto.Signer.
-func (s *softwareKeyStore) generateRSA(_ ...RSAKeyOption) ([]byte, crypto.Signer, error) {
+func (s *softwareKeyStore) generateRSA(ctx context.Context, _ ...RSAKeyOption) ([]byte, crypto.Signer, error) {
 	priv, _, err := s.rsaKeyPairSource()
 	if err != nil {
 		return nil, nil, err
 	}
-	signer, err := s.getSigner(priv)
+	signer, err := s.getSigner(ctx, priv)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -66,13 +66,13 @@ func (s *softwareKeyStore) generateRSA(_ ...RSAKeyOption) ([]byte, crypto.Signer
 }
 
 // GetSigner returns a crypto.Signer for the given pem-encoded private key.
-func (s *softwareKeyStore) getSigner(rawKey []byte) (crypto.Signer, error) {
+func (s *softwareKeyStore) getSigner(ctx context.Context, rawKey []byte) (crypto.Signer, error) {
 	signer, err := utils.ParsePrivateKeyPEM(rawKey)
 	return signer, trace.Wrap(err)
 }
 
 // canSignWithKey returns true if the given key is a raw key.
-func (s *softwareKeyStore) canSignWithKey(_ []byte, keyType types.PrivateKeyType) (bool, error) {
+func (s *softwareKeyStore) canSignWithKey(ctx context.Context, _ []byte, keyType types.PrivateKeyType) (bool, error) {
 	return keyType == types.PrivateKeyType_RAW, nil
 }
 

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -140,7 +140,7 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 		return nil, trace.Wrap(err)
 	}
 	// generate TLS certificate
-	cert, signer, err := s.GetKeyStore().GetTLSCertAndSigner(userCA)
+	cert, signer, err := s.GetKeyStore().GetTLSCertAndSigner(ctx, userCA)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -223,7 +223,7 @@ func (a *Server) RotateCertAuthority(ctx context.Context, req RotateRequest) err
 			return trace.BadParameter("CAs list doesn't contain %q certificate", caType)
 		}
 
-		rotated, err := a.processRotationRequest(rotationReq{
+		rotated, err := a.processRotationRequest(ctx, rotationReq{
 			ca:          existing,
 			clock:       a.clock,
 			targetPhase: req.TargetPhase,
@@ -324,7 +324,7 @@ func (a *Server) autoRotateCertAuthorities(ctx context.Context) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := a.autoRotate(ca); err != nil {
+		if err := a.autoRotate(ctx, ca); err != nil {
 			return trace.Wrap(err)
 		}
 		// make sure there are local AdditionalKeys during init phase of rotation
@@ -337,7 +337,7 @@ func (a *Server) autoRotateCertAuthorities(ctx context.Context) error {
 	return nil
 }
 
-func (a *Server) autoRotate(ca types.CertAuthority) error {
+func (a *Server) autoRotate(ctx context.Context, ca types.CertAuthority) error {
 	rotation := ca.GetRotation()
 	// rotation mode is not automatic, nothing to do
 	if rotation.Mode != types.RotationModeAuto {
@@ -390,7 +390,7 @@ func (a *Server) autoRotate(ca types.CertAuthority) error {
 		return trace.BadParameter("phase is not supported: %q", rotation.Phase)
 	}
 	logger.Infof("Setting rotation phase to %q", req.targetPhase)
-	rotated, err := a.processRotationRequest(*req)
+	rotated, err := a.processRotationRequest(ctx, *req)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -497,7 +497,7 @@ func findDuplicatedCertificates(caTypes []types.CertAuthType, allCerts CertAutho
 
 // processRotationRequest processes rotation request based on the target and
 // current phase and state.
-func (a *Server) processRotationRequest(req rotationReq) (types.CertAuthority, error) {
+func (a *Server) processRotationRequest(ctx context.Context, req rotationReq) (types.CertAuthority, error) {
 	rotation := req.ca.GetRotation()
 	ca := req.ca.Clone()
 
@@ -510,7 +510,7 @@ func (a *Server) processRotationRequest(req rotationReq) (types.CertAuthority, e
 		default:
 			return nil, trace.BadParameter("can not initiate rotation while another is in progress")
 		}
-		if err := a.startNewRotation(req, ca); err != nil {
+		if err := a.startNewRotation(ctx, req, ca); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return ca, nil
@@ -575,7 +575,7 @@ func (a *Server) processRotationRequest(req rotationReq) (types.CertAuthority, e
 // startNewRotation starts new rotation. In this phase requests will continue
 // to be signed by the old CAKeySet, but a new CAKeySet will be added. This new
 // CA can be used to verify requests.
-func (a *Server) startNewRotation(req rotationReq, ca types.CertAuthority) error {
+func (a *Server) startNewRotation(ctx context.Context, req rotationReq, ca types.CertAuthority) error {
 	clock := req.clock
 	gracePeriod := req.gracePeriod
 
@@ -650,7 +650,7 @@ func (a *Server) startNewRotation(req rotationReq, ca types.CertAuthority) error
 			// invalidating the current Admin identity.
 			newKeys = additionalKeys.Clone()
 		}
-		hasUsableAdditionalKeys, err := a.keyStore.HasUsableAdditionalKeys(ca)
+		hasUsableAdditionalKeys, err := a.keyStore.HasUsableAdditionalKeys(ctx, ca)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -661,7 +661,7 @@ func (a *Server) startNewRotation(req rotationReq, ca types.CertAuthority) error
 			// 2. There are AdditionalTrustedKeys which were added by a
 			//    different HSM-enabled auth server.
 			// In either case, we need to add newly generated local keys.
-			newLocalKeys, err := newKeySet(a.keyStore, ca.GetID())
+			newLocalKeys, err := newKeySet(ctx, a.keyStore, ca.GetID())
 			if err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -216,7 +216,7 @@ func (s *Server) generateAppToken(ctx context.Context, username string, roles []
 	}
 
 	// Extract the JWT signing key and sign the claims.
-	signer, err := s.GetKeyStore().GetJWTSigner(ca)
+	signer, err := s.GetKeyStore().GetJWTSigner(ctx, ca)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -2265,7 +2265,7 @@ func TestGenerateAppToken(t *testing.T) {
 	}, true)
 	require.NoError(t, err)
 
-	signer, err := tt.server.AuthServer.AuthServer.GetKeyStore().GetJWTSigner(ca)
+	signer, err := tt.server.AuthServer.AuthServer.GetKeyStore().GetJWTSigner(ctx, ca)
 	require.NoError(t, err)
 	key, err := services.GetJWTSigner(signer, ca.GetClusterName(), tt.clock)
 	require.NoError(t, err)
@@ -2416,7 +2416,7 @@ func TestClusterConfigContext(t *testing.T) {
 
 	// try and generate a host cert, this should fail because we are recording
 	// at the nodes not at the proxy
-	_, err = proxy.GenerateHostCert(pub,
+	_, err = proxy.GenerateHostCert(ctx, pub,
 		"a", "b", nil,
 		"localhost", types.RoleProxy, 0)
 	require.True(t, trace.IsAccessDenied(err))
@@ -2431,7 +2431,7 @@ func TestClusterConfigContext(t *testing.T) {
 
 	// try and generate a host cert, now the proxy should be able to generate a
 	// host cert because it's in recording mode.
-	_, err = proxy.GenerateHostCert(pub,
+	_, err = proxy.GenerateHostCert(ctx, pub,
 		"a", "b", nil,
 		"localhost", types.RoleProxy, 0)
 	require.NoError(t, err)

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -287,13 +287,13 @@ func (c *testContext) genTestKubeClientTLSCert(t *testing.T, userName, kubeClust
 
 	ttl := roles.AdjustSessionTTL(10 * time.Minute)
 
-	ca, err := authServer.GetCertAuthority(context.Background(), types.CertAuthID{
+	ca, err := authServer.GetCertAuthority(c.ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)
 	require.NoError(t, err)
 
-	caCert, signer, err := authServer.GetKeyStore().GetTLSCertAndSigner(ca)
+	caCert, signer, err := authServer.GetKeyStore().GetTLSCertAndSigner(c.ctx, ca)
 	require.NoError(t, err)
 
 	tlsCA, err := tlsca.FromCertAndSigner(caCert, signer)

--- a/lib/reversetunnel/cache.go
+++ b/lib/reversetunnel/cache.go
@@ -63,7 +63,7 @@ func newHostCertificateCache(keygen sshca.Authority, authClient auth.ClientI) (*
 // Multiple callers can arrive and generate a host certificate at the same time.
 // This is a tradeoff to prevent long delays here due to the expensive
 // certificate generation call.
-func (c *certificateCache) getHostCertificate(addr string, additionalPrincipals []string) (ssh.Signer, error) {
+func (c *certificateCache) getHostCertificate(ctx context.Context, addr string, additionalPrincipals []string) (ssh.Signer, error) {
 	var certificate ssh.Signer
 	var err error
 	var ok bool
@@ -74,7 +74,7 @@ func (c *certificateCache) getHostCertificate(addr string, additionalPrincipals 
 
 	certificate, ok = c.get(strings.Join(principals, "."))
 	if !ok {
-		certificate, err = c.generateHostCert(principals)
+		certificate, err = c.generateHostCert(ctx, principals)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -123,7 +123,7 @@ func (c *certificateCache) set(addr string, certificate ssh.Signer, ttl time.Dur
 
 // generateHostCert will generate a SSH host certificate for a given
 // principal.
-func (c *certificateCache) generateHostCert(principals []string) (ssh.Signer, error) {
+func (c *certificateCache) generateHostCert(ctx context.Context, principals []string) (ssh.Signer, error) {
 	if len(principals) == 0 {
 		return nil, trace.BadParameter("at least one principal must be provided")
 	}
@@ -141,6 +141,7 @@ func (c *certificateCache) generateHostCert(principals []string) (ssh.Signer, er
 	}
 
 	certBytes, err := c.authClient.GenerateHostCert(
+		ctx,
 		pubBytes,
 		principals[0],
 		principals[0],

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -305,7 +305,7 @@ func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 	}
 
 	// Get a host certificate for the forwarding node from the cache.
-	hostCertificate, err := s.certificateCache.getHostCertificate(params.Address, params.Principals)
+	hostCertificate, err := s.certificateCache.getHostCertificate(context.TODO(), params.Address, params.Principals)
 	if err != nil {
 		return nil, trace.NewAggregate(trace.Wrap(err), userAgent.Close())
 	}

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -762,7 +762,7 @@ func (s *remoteSite) dialWithAgent(params DialParams) (net.Conn, error) {
 	}
 
 	// Get a host certificate for the forwarding node from the cache.
-	hostCertificate, err := s.certificateCache.getHostCertificate(params.Address, params.Principals)
+	hostCertificate, err := s.certificateCache.getHostCertificate(s.ctx, params.Address, params.Principals)
 	if err != nil {
 		userAgent.Close()
 		return nil, trace.Wrap(err)

--- a/lib/tbot/config/configtemplate_ssh_host_cert.go
+++ b/lib/tbot/config/configtemplate_ssh_host_cert.go
@@ -146,7 +146,7 @@ func (c *TemplateSSHHostCert) Render(ctx context.Context, bot Bot, currentIdenti
 	// For now, we'll reuse the bot's regular TTL, and hostID and nodeName are
 	// left unset.
 	botCfg := bot.Config()
-	key.Cert, err = authClient.GenerateHostCert(key.MarshalSSHPublicKey(),
+	key.Cert, err = authClient.GenerateHostCert(ctx, key.MarshalSSHPublicKey(),
 		"", "", c.Principals,
 		clusterName, types.RoleNode, botCfg.CertificateTTL)
 	if err != nil {

--- a/lib/tbot/config/configtemplate_ssh_host_cert_test.go
+++ b/lib/tbot/config/configtemplate_ssh_host_cert_test.go
@@ -35,6 +35,7 @@ type mockHostCertAuth struct {
 }
 
 func (m *mockHostCertAuth) GenerateHostCert(
+	ctx context.Context,
 	key []byte, hostID, nodeName string, principals []string,
 	clusterName string, role types.SystemRole, ttl time.Duration,
 ) ([]byte, error) {

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -341,7 +341,7 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI auth.Clie
 	}
 	clusterName := cn.GetClusterName()
 
-	key.Cert, err = clusterAPI.GenerateHostCert(key.MarshalSSHPublicKey(),
+	key.Cert, err = clusterAPI.GenerateHostCert(ctx, key.MarshalSSHPublicKey(),
 		"", "", principals,
 		clusterName, types.RoleNode, 0)
 	if err != nil {


### PR DESCRIPTION
Contexts are more relevant now with the GCP KMS keystore which makes gRPC requests, this commit makes sure they are passed everywhere they are needed, with only a few `context.TODO`s sprinkled in.

Follow-up to https://github.com/gravitational/teleport/pull/17933