### PR TITLE
Correct the guide to use correct `--format` value.

### DIFF
--- a/docs/pages/database-access/guides/elastic.mdx
+++ b/docs/pages/database-access/guides/elastic.mdx
@@ -208,7 +208,7 @@ For example, if your Elasticsearch server is accessible at `elastic.example.com`
 run:
 
 ```code
-$ tctl auth sign --format=elastic --host=elastic.example.com --out=elastic --ttl=2160h
+$ tctl auth sign --format=elasticsearch --host=elastic.example.com --out=elastic --ttl=2160h
 Database credentials have been written to elastic.key, elastic.crt, elastic.cas.
 ```
 


### PR DESCRIPTION
Spotted by @benarent https://github.com/gravitational/teleport/pull/16795#issuecomment-1299552113, the docs are using an incorrect format.