### PR TITLE
WebAPI: Get database endpoint

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -561,6 +561,7 @@ func (h *Handler) bindDefaultEndpoints(challengeLimiter *limiter.RateLimiter) {
 	h.GET("/webapi/sites/:site/databases", h.WithClusterAuth(h.clusterDatabasesGet))
 	h.POST("/webapi/sites/:site/databases", h.WithClusterAuth(h.handleDatabaseCreate))
 	h.PUT("/webapi/sites/:site/databases/:database", h.WithClusterAuth(h.handleDatabaseUpdate))
+	h.GET("/webapi/sites/:site/databases/:database", h.WithClusterAuth(h.clusterDatabaseGet))
 	h.GET("/webapi/sites/:site/databases/:database/iam/policy", h.WithClusterAuth(h.handleDatabaseGetIAMPolicy))
 
 	// Kube access handlers.

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -98,7 +98,7 @@ func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p
 		return nil, trace.Wrap(err)
 	}
 
-	return ui.MakeDatabase(database), nil
+	return ui.MakeDatabase(database, nil /* dbUsers */, nil /* dbNames */), nil
 }
 
 // updateDatabaseRequest contains some updatable fields of a database resource.
@@ -150,7 +150,7 @@ func (h *Handler) handleDatabaseUpdate(w http.ResponseWriter, r *http.Request, p
 		return nil, trace.Wrap(err)
 	}
 
-	return ui.MakeDatabase(database), nil
+	return ui.MakeDatabase(database, nil /* dbUsers */, nil /* dbNames */), nil
 }
 
 // databaseIAMPolicyResponse is the response type for handleDatabaseGetIAMPolicy.

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -79,10 +79,50 @@ func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p 
 	}
 
 	return listResourcesGetResponse{
-		Items:      ui.MakeDatabases(h.auth.clusterName, databases),
+		Items:      ui.MakeDatabases(databases),
 		StartKey:   resp.NextKey,
 		TotalCount: resp.TotalCount,
 	}, nil
+}
+
+// clusterDatabaseGet returns a list of db servers in a form the UI can present.
+func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	databaseName := p.ByName("database")
+	if databaseName == "" {
+		return nil, trace.BadParameter("database name is required")
+	}
+
+	clt, err := ctx.GetUserClient(site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	db, err := clt.GetDatabase(r.Context(), databaseName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	accessChecker, err := ctx.GetUserAccessChecker()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	dbNames, dbUsers, err := accessChecker.CheckDatabaseNamesAndUsers(0, true /* force ttl override*/)
+	if err != nil {
+		// if NotFound error:
+		// This user cannot request database access, has no assigned database names or users
+		//
+		// Every other error should be reported upstream.
+		if !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
+
+		// We proceed with an empty list of DBUsers and DBNames
+		dbUsers = []string{}
+		dbNames = []string{}
+	}
+
+	return ui.MakeDatabase(db, dbUsers, dbNames), nil
 }
 
 // clusterDesktopsGet returns a list of desktops in a form the UI can present.

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -97,7 +97,7 @@ func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	db, err := clt.GetDatabase(r.Context(), databaseName)
+	database, err := fetchDatabaseWithName(r.Context(), clt, r, databaseName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -122,7 +122,7 @@ func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p h
 		dbNames = []string{}
 	}
 
-	return ui.MakeDatabase(db, dbUsers, dbNames), nil
+	return ui.MakeDatabase(database, dbUsers, dbNames), nil
 }
 
 // clusterDesktopsGet returns a list of desktops in a form the UI can present.

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -228,10 +228,26 @@ type Database struct {
 	Type string `json:"type"`
 	// Labels is a map of static and dynamic labels associated with a database.
 	Labels []Label `json:"labels"`
+	// DatabaseUsers is the list of allowed Database RBAC users that the user can login.
+	DatabaseUsers []string `json:"database_users,omitempty"`
+	// DatabaseNames is the list of allowed Database RBAC names that the user can login.
+	DatabaseNames []string `json:"database_names,omitempty"`
 }
 
-// MakeDatabase creates a database object.
-func MakeDatabase(database types.Database) Database {
+// MakeDatabases creates database objects.
+func MakeDatabases(databases []types.Database) []Database {
+	uiServers := make([]Database, 0, len(databases))
+	for _, database := range databases {
+		db := MakeDatabase(database, nil /* database Users */, nil /* database Names */)
+		uiServers = append(uiServers, db)
+	}
+
+	return uiServers
+}
+
+// MakeDatabase creates database objects.
+func MakeDatabase(database types.Database, dbUsers, dbNames []string) Database {
+
 	uiLabels := []Label{}
 
 	for name, value := range database.GetAllLabels() {
@@ -244,22 +260,14 @@ func MakeDatabase(database types.Database) Database {
 	sort.Sort(sortedLabels(uiLabels))
 
 	return Database{
-		Name:     database.GetName(),
-		Desc:     database.GetDescription(),
-		Protocol: database.GetProtocol(),
-		Type:     database.GetType(),
-		Labels:   uiLabels,
+		Name:          database.GetName(),
+		Desc:          database.GetDescription(),
+		Protocol:      database.GetProtocol(),
+		Type:          database.GetType(),
+		Labels:        uiLabels,
+		DatabaseUsers: dbUsers,
+		DatabaseNames: dbNames,
 	}
-}
-
-// MakeDatabases creates database objects.
-func MakeDatabases(clusterName string, databases []types.Database) []Database {
-	uiServers := make([]Database, 0, len(databases))
-	for _, database := range databases {
-		uiServers = append(uiServers, MakeDatabase(database))
-	}
-
-	return uiServers
 }
 
 // Desktop describes a desktop to pass to the ui.

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -234,17 +234,6 @@ type Database struct {
 	DatabaseNames []string `json:"database_names,omitempty"`
 }
 
-// MakeDatabases creates database objects.
-func MakeDatabases(databases []types.Database) []Database {
-	uiServers := make([]Database, 0, len(databases))
-	for _, database := range databases {
-		db := MakeDatabase(database, nil /* database Users */, nil /* database Names */)
-		uiServers = append(uiServers, db)
-	}
-
-	return uiServers
-}
-
 // MakeDatabase creates database objects.
 func MakeDatabase(database types.Database, dbUsers, dbNames []string) Database {
 
@@ -268,6 +257,17 @@ func MakeDatabase(database types.Database, dbUsers, dbNames []string) Database {
 		DatabaseUsers: dbUsers,
 		DatabaseNames: dbNames,
 	}
+}
+
+// MakeDatabases creates database objects.
+func MakeDatabases(databases []types.Database) []Database {
+	uiServers := make([]Database, 0, len(databases))
+	for _, database := range databases {
+		db := MakeDatabase(database, nil /* database Users */, nil /* database Names */)
+		uiServers = append(uiServers, db)
+	}
+
+	return uiServers
 }
 
 // Desktop describes a desktop to pass to the ui.


### PR DESCRIPTION
This commit creates a new endpoint to return a single database by its name.

```
GET /webapi/sites/:site/databases/:database

{
  "name": "<database_name>",
  "desc": "<description>",
  "protocol": "<protocol>",
  "type": "<type>",
  "labels": [
    {"name": "<name>", "value": "<value>"},
    ...
  ],
  "database_users": ["<db_user1>", ...],
  "database_names": ["<db_name1>", ...],
}
```

The `database_users` and `database_names` will list the available Database User and Names for the current user, based on its roles.