### PR TITLE
WIP: improve platform prompt

### DIFF
--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -37,8 +37,9 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/gravitational/trace"
 
-	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 	log "github.com/sirupsen/logrus"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 )
 
 var (
@@ -49,6 +50,8 @@ var (
 	PromptWriter io.Writer = os.Stderr
 )
 
+// TODO(tobiaszheller): define new platform propmpt in webauthnprompt package and use it here
+// based on promptOpts.
 func defaultPrompt() {
 	fmt.Fprintln(PromptWriter, "Using platform authenticator, follow the OS prompt")
 }
@@ -546,7 +549,8 @@ func Login(origin, user string, assertion *wanlib.CredentialAssertion, picker Cr
 func pickCredential(
 	actx AuthContext,
 	infos []CredentialInfo, allowedCredentials []protocol.CredentialDescriptor,
-	picker CredentialPicker, promptOnce func(), userRequested bool) (*CredentialInfo, error) {
+	picker CredentialPicker, promptOnce func(), userRequested bool,
+) (*CredentialInfo, error) {
 	// Handle early exits.
 	switch l := len(infos); {
 	// MFA.

--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -45,16 +45,20 @@ var (
 	ErrCredentialNotFound = errors.New("credential not found")
 	ErrNotAvailable       = errors.New("touch ID not available")
 
-	// PromptPlatformMessage is the message shown before Touch ID prompts.
-	PromptPlatformMessage = "Using platform authenticator, follow the OS prompt"
 	// PromptWriter is the writer used for prompt messages.
 	PromptWriter io.Writer = os.Stderr
 )
 
-func promptPlatform() {
-	if PromptPlatformMessage != "" {
-		fmt.Fprintln(PromptWriter, PromptPlatformMessage)
-	}
+func defaultPrompt() {
+	fmt.Fprintln(PromptWriter, "Using platform authenticator, follow the OS prompt")
+}
+
+func loginPrompt() {
+	fmt.Fprintln(PromptWriter, "Using platform authenticator, follow the OS prompt and use *registered* Touch ID")
+}
+
+func registerPrompt() {
+	fmt.Fprintln(PromptWriter, "Using platform authenticator, follow the OS prompt to register *new* Touch ID")
 }
 
 // AuthContext is an optional, shared authentication context.
@@ -292,7 +296,7 @@ func Register(origin string, cc *wanlib.CredentialCreation) (*Registration, erro
 		return nil, trace.Wrap(err)
 	}
 
-	promptPlatform()
+	registerPrompt()
 	sig, err := native.Authenticate(nil /* actx */, credentialID, attData.digest)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -496,7 +500,7 @@ func Login(origin, user string, assertion *wanlib.CredentialAssertion, picker Cr
 		if prompted {
 			return
 		}
-		promptPlatform()
+		loginPrompt()
 		prompted = true
 	}
 
@@ -610,7 +614,7 @@ func ListCredentials() ([]CredentialInfo, error) {
 		return nil, ErrNotAvailable
 	}
 
-	promptPlatform()
+	defaultPrompt()
 	infos, err := native.ListCredentials()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -637,6 +641,6 @@ func DeleteCredential(credentialID string) error {
 		return ErrNotAvailable
 	}
 
-	promptPlatform()
+	defaultPrompt()
 	return native.DeleteCredential(credentialID)
 }

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -37,6 +37,7 @@ import (
 
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	"github.com/gravitational/teleport/lib/auth/webauthncli/webauthnprompt"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -93,7 +94,7 @@ func isLibfido2Enabled() bool {
 // fido2Login implements FIDO2Login.
 func fido2Login(
 	ctx context.Context,
-	origin string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt, opts *LoginOpts,
+	origin string, assertion *wanlib.CredentialAssertion, prompt webauthnprompt.LoginPrompt, opts *LoginOpts,
 ) (*proto.MFAAuthenticateResponse, string, error) {
 	switch {
 	case origin == "":
@@ -275,7 +276,7 @@ func discoverRPID(dev FIDODevice, info *deviceInfo, pin, rpID, appID string, all
 }
 
 func pickAssertion(
-	assertions []*libfido2.Assertion, prompt LoginPrompt, user string, passwordless bool) (*libfido2.Assertion, error) {
+	assertions []*libfido2.Assertion, prompt webauthnprompt.LoginPrompt, user string, passwordless bool) (*libfido2.Assertion, error) {
 	switch l := len(assertions); {
 	// Shouldn't happen, but let's be safe and handle it anyway.
 	case l == 0:
@@ -300,12 +301,12 @@ func pickAssertion(
 	}
 
 	// Prepare credentials and show picker.
-	creds := make([]*CredentialInfo, len(assertions))
-	credToAssertion := make(map[*CredentialInfo]*libfido2.Assertion)
+	creds := make([]*webauthnprompt.CredentialInfo, len(assertions))
+	credToAssertion := make(map[*webauthnprompt.CredentialInfo]*libfido2.Assertion)
 	for i, assertion := range assertions {
-		cred := &CredentialInfo{
+		cred := &webauthnprompt.CredentialInfo{
 			ID: assertion.CredentialID,
-			User: UserInfo{
+			User: webauthnprompt.UserInfo{
 				UserHandle: assertion.User.ID,
 				Name:       assertion.User.Name,
 			},

--- a/lib/auth/webauthncli/fido2_other.go
+++ b/lib/auth/webauthncli/fido2_other.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	"github.com/gravitational/teleport/lib/auth/webauthncli/webauthnprompt"
 )
 
 var errFIDO2Unavailable = errors.New("FIDO2 unavailable in current build")
@@ -35,7 +36,7 @@ func isLibfido2Enabled() bool {
 
 func fido2Login(
 	ctx context.Context,
-	origin string, assertion *wanlib.CredentialAssertion, prompt LoginPrompt, opts *LoginOpts,
+	origin string, assertion *wanlib.CredentialAssertion, prompt webauthnprompt.LoginPrompt, opts *LoginOpts,
 ) (*proto.MFAAuthenticateResponse, string, error) {
 	return nil, "", errFIDO2Unavailable
 }

--- a/lib/auth/webauthncli/prompt.go
+++ b/lib/auth/webauthncli/prompt.go
@@ -15,106 +15,15 @@
 package webauthncli
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"io"
-	"sort"
-	"strconv"
 
 	"github.com/gravitational/teleport/lib/auth/touchid"
-	"github.com/gravitational/teleport/lib/utils/prompt"
+	"github.com/gravitational/teleport/lib/auth/webauthncli/webauthnprompt"
 	"github.com/gravitational/trace"
 )
 
-// DefaultPrompt is a default implementation for LoginPrompt and
-// RegistrationPrompt.
-type DefaultPrompt struct {
-	PINMessage                            string
-	FirstTouchMessage, SecondTouchMessage string
-	PromptCredentialMessage               string
-
-	ctx context.Context
-	out io.Writer
-
-	count int
-}
-
-// NewDefaultPrompt creates a new default prompt.
-// Default messages are suitable for login / authorization. Messages may be
-// customized by setting the appropriate fields.
-func NewDefaultPrompt(ctx context.Context, out io.Writer) *DefaultPrompt {
-	return &DefaultPrompt{
-		PINMessage:              "Enter your security key PIN",
-		FirstTouchMessage:       "Tap your security key",
-		SecondTouchMessage:      "Tap your security key again to complete login",
-		PromptCredentialMessage: "Choose the user for login",
-		ctx:                     ctx,
-		out:                     out,
-	}
-}
-
-// PromptPIN prompts the user for a PIN.
-func (p *DefaultPrompt) PromptPIN() (string, error) {
-	return prompt.Password(p.ctx, p.out, prompt.Stdin(), p.PINMessage)
-}
-
-// PromptTouch prompts the user for a security key touch, using different
-// messages for first and second prompts. Error is always nil.
-func (p *DefaultPrompt) PromptTouch() error {
-	if p.count == 0 {
-		p.count++
-		if p.FirstTouchMessage != "" {
-			fmt.Fprintln(p.out, p.FirstTouchMessage)
-		}
-		return nil
-	}
-	if p.SecondTouchMessage != "" {
-		fmt.Fprintln(p.out, p.SecondTouchMessage)
-	}
-	return nil
-}
-
-// PromptCredential prompts the user to choose a credential, in case multiple
-// credentials are available.
-func (p *DefaultPrompt) PromptCredential(creds []*CredentialInfo) (*CredentialInfo, error) {
-	// Shouldn't happen, but let's check just in case.
-	if len(creds) == 0 {
-		return nil, errors.New("attempted to prompt credential with empty credentials")
-	}
-
-	sort.Slice(creds, func(i, j int) bool {
-		c1 := creds[i]
-		c2 := creds[j]
-		return c1.User.Name < c2.User.Name
-	})
-	for i, cred := range creds {
-		fmt.Fprintf(p.out, "[%v] %v\n", i+1, cred.User.Name)
-	}
-
-	for {
-		numOrName, err := prompt.Input(p.ctx, p.out, prompt.Stdin(), p.PromptCredentialMessage)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		switch num, err := strconv.Atoi(numOrName); {
-		case err != nil: // See if a name was typed instead.
-			for _, cred := range creds {
-				if cred.User.Name == numOrName {
-					return cred, nil
-				}
-			}
-		case num >= 1 && num <= len(creds): // Valid number.
-			return creds[num-1], nil
-		}
-
-		fmt.Fprintf(p.out, "Invalid user choice: %q\n", numOrName)
-	}
-}
-
 type credentialPicker interface {
-	PromptCredential([]*CredentialInfo) (*CredentialInfo, error)
+	PromptCredential([]*webauthnprompt.CredentialInfo) (*webauthnprompt.CredentialInfo, error)
 }
 
 // ToTouchIDCredentialPicker adapts a wancli credential picker, such as
@@ -128,12 +37,12 @@ type tidPickerAdapter struct {
 }
 
 func (p tidPickerAdapter) PromptCredential(creds []*touchid.CredentialInfo) (*touchid.CredentialInfo, error) {
-	credMap := make(map[*CredentialInfo]*touchid.CredentialInfo)
-	wcreds := make([]*CredentialInfo, len(creds))
+	credMap := make(map[*webauthnprompt.CredentialInfo]*touchid.CredentialInfo)
+	wcreds := make([]*webauthnprompt.CredentialInfo, len(creds))
 	for i, c := range creds {
-		cred := &CredentialInfo{
+		cred := &webauthnprompt.CredentialInfo{
 			ID: []byte(c.CredentialID),
-			User: UserInfo{
+			User: webauthnprompt.UserInfo{
 				UserHandle: c.User.UserHandle,
 				Name:       c.User.Name,
 			},

--- a/lib/auth/webauthncli/webauthnprompt/prompt.go
+++ b/lib/auth/webauthncli/webauthnprompt/prompt.go
@@ -1,0 +1,171 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthnprompt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils/prompt"
+)
+
+// LoginPrompt is the user interface for FIDO2Login.
+//
+// Prompts can have remote implementations, thus all methods may error.
+type LoginPrompt interface {
+	// PromptPIN prompts the user for their PIN.
+	PromptPIN() (string, error)
+	// PromptTouch prompts the user for a security key touch.
+	// In certain situations multiple touches may be required (PIN-protected
+	// devices, passwordless flows, etc).
+	PromptTouch() error
+	// PromptCredential prompts the user to choose a credential, in case multiple
+	// credentials are available.
+	// Callers are free to modify the slice, such as by sorting the credentials,
+	// but must return one of the pointers contained within.
+	PromptCredential(creds []*CredentialInfo) (*CredentialInfo, error)
+}
+
+// CredentialInfo holds information about a WebAuthn credential, typically a
+// resident public key credential.
+type CredentialInfo struct {
+	ID   []byte
+	User UserInfo
+}
+
+// UserInfo holds information about a credential owner.
+type UserInfo struct {
+	// UserHandle is the WebAuthn user handle (also referred as user ID).
+	UserHandle []byte
+	Name       string
+}
+
+// DefaultPrompt is a default implementation for LoginPrompt and
+// RegistrationPrompt.
+type DefaultPrompt struct {
+	pinMessage                            string
+	firstTouchMessage, secondTouchMessage string
+	promptCredentialMessage               string
+
+	ctx context.Context
+	out io.Writer
+
+	count int
+}
+
+type PromptOptions struct {
+	HasTOTP          bool
+	Quiet            bool
+	WithDevicePrefix string
+	Out              io.Writer
+	// CustomLoginPrompt is used when you want to pass your custom login prompt.
+	CustomLoginPrompt LoginPrompt
+}
+
+// NewDefaultPrompt creates a new default prompt.
+// Default messages are suitable for login / authorization. Messages may be
+// customized by setting PromptOptions.
+func NewDefaultPrompt(ctx context.Context, opts PromptOptions) *DefaultPrompt {
+	p := &DefaultPrompt{
+		pinMessage:              "Enter your security key PIN",
+		firstTouchMessage:       "Tap your security key",
+		secondTouchMessage:      "Tap your security key again to complete login",
+		promptCredentialMessage: "Choose the user for login",
+		ctx:                     ctx,
+		out:                     opts.Out,
+	}
+
+	if opts.Quiet {
+		p.firstTouchMessage = ""
+		p.secondTouchMessage = ""
+		return p
+	}
+
+	if opts.WithDevicePrefix != "" {
+		p.firstTouchMessage = fmt.Sprintf("Tap any %ssecurity key", opts.WithDevicePrefix)
+		p.secondTouchMessage = fmt.Sprintf("Tap your %ssecurity key to complete login", opts.WithDevicePrefix)
+	}
+
+	if opts.HasTOTP {
+		p.firstTouchMessage = fmt.Sprintf("Tap any %ssecurity key or enter a code from a %sOTP device", opts.WithDevicePrefix, opts.WithDevicePrefix)
+	}
+
+	return p
+}
+
+// PromptPIN prompts the user for a PIN.
+func (p *DefaultPrompt) PromptPIN() (string, error) {
+	return prompt.Password(p.ctx, p.out, prompt.Stdin(), p.pinMessage)
+}
+
+// PromptTouch prompts the user for a security key touch, using different
+// messages for first and second prompts. Error is always nil.
+func (p *DefaultPrompt) PromptTouch() error {
+	if p.count == 0 {
+		p.count++
+		if p.firstTouchMessage != "" {
+			fmt.Fprintln(p.out, p.firstTouchMessage)
+		}
+		return nil
+	}
+	if p.secondTouchMessage != "" {
+		fmt.Fprintln(p.out, p.secondTouchMessage)
+	}
+	return nil
+}
+
+// PromptCredential prompts the user to choose a credential, in case multiple
+// credentials are available.
+func (p *DefaultPrompt) PromptCredential(creds []*CredentialInfo) (*CredentialInfo, error) {
+	// Shouldn't happen, but let's check just in case.
+	if len(creds) == 0 {
+		return nil, errors.New("attempted to prompt credential with empty credentials")
+	}
+
+	sort.Slice(creds, func(i, j int) bool {
+		c1 := creds[i]
+		c2 := creds[j]
+		return c1.User.Name < c2.User.Name
+	})
+	for i, cred := range creds {
+		fmt.Fprintf(p.out, "[%v] %v\n", i+1, cred.User.Name)
+	}
+
+	for {
+		numOrName, err := prompt.Input(p.ctx, p.out, prompt.Stdin(), p.promptCredentialMessage)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		switch num, err := strconv.Atoi(numOrName); {
+		case err != nil: // See if a name was typed instead.
+			for _, cred := range creds {
+				if cred.User.Name == numOrName {
+					return cred, nil
+				}
+			}
+		case num >= 1 && num <= len(creds): // Valid number.
+			return creds[num-1], nil
+		}
+
+		fmt.Fprintf(p.out, "Invalid user choice: %q\n", numOrName)
+	}
+}

--- a/lib/auth/webauthnwin/api.go
+++ b/lib/auth/webauthnwin/api.go
@@ -27,9 +27,10 @@ import (
 
 	"github.com/duo-labs/webauthn/protocol"
 	"github.com/duo-labs/webauthn/protocol/webauthncose"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/client/proto"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
-	"github.com/gravitational/trace"
 )
 
 // LoginOpts groups non-mandatory options for Login.
@@ -161,11 +162,11 @@ func Register(
 	}, nil
 }
 
-var (
-	// PromptWriter is the writer used for prompt messages.
-	PromptWriter io.Writer = os.Stderr
-)
+// PromptWriter is the writer used for prompt messages.
+var PromptWriter io.Writer = os.Stderr
 
+// TODO(tobiaszheller): define new platform propmpt in webauthnprompt package and use it here
+// based on promptOpts.
 func loginPrompt() {
 	fmt.Fprintln(PromptWriter, "Using platform authenticator, follow the OS dialogs and use *registered* device")
 }

--- a/lib/auth/webauthnwin/api.go
+++ b/lib/auth/webauthnwin/api.go
@@ -91,7 +91,7 @@ func Login(ctx context.Context, origin string, assertion *wanlib.CredentialAsser
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	promptPlatform()
+	loginPrompt()
 	resp, err := native.GetAssertion(origin, &getAssertionRequest{
 		rpID:                  rpid,
 		clientData:            cd,
@@ -141,7 +141,7 @@ func Register(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	promptPlatform()
+	registerPrompt()
 	resp, err := native.MakeCredential(origin, &makeCredentialRequest{
 		rp:                    rp,
 		user:                  u,
@@ -162,16 +162,16 @@ func Register(
 }
 
 var (
-	// PromptPlatformMessage is the message shown before Touch ID prompts.
-	PromptPlatformMessage = "Using platform authenticator, follow the OS dialogs"
 	// PromptWriter is the writer used for prompt messages.
 	PromptWriter io.Writer = os.Stderr
 )
 
-func promptPlatform() {
-	if PromptPlatformMessage != "" {
-		fmt.Fprintln(PromptWriter, PromptPlatformMessage)
-	}
+func loginPrompt() {
+	fmt.Fprintln(PromptWriter, "Using platform authenticator, follow the OS dialogs and use *registered* device")
+}
+
+func registerPrompt() {
+	fmt.Fprintln(PromptWriter, "Using platform authenticator, follow the OS dialogs to register *new* device")
 }
 
 // CheckSupport is the result from a Windows webauthn support check.

--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
-	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
+	"github.com/gravitational/teleport/lib/auth/webauthncli/webauthnprompt"
 	"github.com/gravitational/teleport/lib/client"
 	dbprofile "github.com/gravitational/teleport/lib/client/db"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
@@ -315,7 +315,7 @@ func (p *pwdlessLoginPrompt) PromptTouch() error {
 }
 
 // PromptCredential prompts the user to select a login name in the list of logins.
-func (p *pwdlessLoginPrompt) PromptCredential(deviceCreds []*wancli.CredentialInfo) (*wancli.CredentialInfo, error) {
+func (p *pwdlessLoginPrompt) PromptCredential(deviceCreds []*webauthnprompt.CredentialInfo) (*webauthnprompt.CredentialInfo, error) {
 	// Shouldn't happen, but let's check just in case.
 	if len(deviceCreds) == 0 {
 		return nil, errors.New("attempted to prompt credential with empty credentials")

--- a/lib/teleterm/clusters/cluster_auth_test.go
+++ b/lib/teleterm/clusters/cluster_auth_test.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"testing"
 
-	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
-	api "github.com/gravitational/teleport/lib/teleterm/api/protogen/golang/v1"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/auth/webauthncli/webauthnprompt"
+	api "github.com/gravitational/teleport/lib/teleterm/api/protogen/golang/v1"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -39,7 +40,8 @@ func TestPwdlessLoginPrompt_PromptPIN(t *testing.T) {
 	stream.serverReq = func() (*api.LoginPasswordlessRequest, error) {
 		return &api.LoginPasswordlessRequest{Request: &api.LoginPasswordlessRequest_Pin{
 			Pin: &api.LoginPasswordlessRequest_LoginPasswordlessPINResponse{
-				Pin: "1234"},
+				Pin: "1234",
+			},
 		}}, nil
 	}
 
@@ -52,7 +54,8 @@ func TestPwdlessLoginPrompt_PromptPIN(t *testing.T) {
 	stream.serverReq = func() (*api.LoginPasswordlessRequest, error) {
 		return &api.LoginPasswordlessRequest{Request: &api.LoginPasswordlessRequest_Pin{
 			Pin: &api.LoginPasswordlessRequest_LoginPasswordlessPINResponse{
-				Pin: ""},
+				Pin: "",
+			},
 		}}, nil
 	}
 
@@ -76,11 +79,11 @@ func TestPwdlessLoginPrompt_PromptTouch(t *testing.T) {
 func TestPwdlessLoginPrompt_PromptCredential(t *testing.T) {
 	stream := &mockLoginPwdlessStream{}
 
-	unsortedCreds := []*wancli.CredentialInfo{
-		{User: wancli.UserInfo{Name: "foo"}}, // will select
-		{User: wancli.UserInfo{Name: "bar"}},
-		{User: wancli.UserInfo{Name: "ape"}},
-		{User: wancli.UserInfo{Name: "llama"}},
+	unsortedCreds := []*webauthnprompt.CredentialInfo{
+		{User: webauthnprompt.UserInfo{Name: "foo"}}, // will select
+		{User: webauthnprompt.UserInfo{Name: "bar"}},
+		{User: webauthnprompt.UserInfo{Name: "ape"}},
+		{User: webauthnprompt.UserInfo{Name: "llama"}},
 	}
 
 	expectedCredResponse := []*api.CredentialInfo{
@@ -99,7 +102,8 @@ func TestPwdlessLoginPrompt_PromptCredential(t *testing.T) {
 	stream.serverReq = func() (*api.LoginPasswordlessRequest, error) {
 		return &api.LoginPasswordlessRequest{Request: &api.LoginPasswordlessRequest_Credential{
 			Credential: &api.LoginPasswordlessRequest_LoginPasswordlessCredentialResponse{
-				Index: 2},
+				Index: 2,
+			},
 		}}, nil
 	}
 
@@ -112,7 +116,8 @@ func TestPwdlessLoginPrompt_PromptCredential(t *testing.T) {
 	stream.serverReq = func() (*api.LoginPasswordlessRequest, error) {
 		return &api.LoginPasswordlessRequest{Request: &api.LoginPasswordlessRequest_Credential{
 			Credential: &api.LoginPasswordlessRequest_LoginPasswordlessCredentialResponse{
-				Index: 4},
+				Index: 4,
+			},
 		}}, nil
 	}
 	_, err = prompt.PromptCredential(unsortedCreds)


### PR DESCRIPTION
Problems:
- platform authenticators don't use webauthn prompt and have no context if on login request this is part of standard login or adding new device
- webauthn prompt setup is done before selecting webauthn client
- prompt cannot be imported into touch_id/webauthnwin package due to cyclic dependencies.

This Draft PR tries to solve it by:
- creating new package webauthnprompt
- building `promptOpts` instead of prompt before webauthn client is selected.
- webatuhn client can select defaultClient, customPrompt (comming from promptOpts) or platformClient