### PR TITLE
Remove preview release page for non-maintained branches

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -976,16 +976,6 @@
       ]
     },
     {
-      "icon": "wand",
-      "title": "Preview",
-      "entries": [
-        {
-          "title": "Upcoming Releases",
-          "slug": "/preview/upcoming-releases/"
-        }
-      ]
-    },
-    {
       "icon": "book",
       "title": "Reference",
       "entries": [


### PR DESCRIPTION
Only the current active major version is maintained for preview releases content.  Removing this will remove non-maintained content.