### PR TITLE
[v11] For config v3, improve the error message when failing to connect to the auth service

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -117,7 +117,7 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			process.log.Error("Can not join the cluster as node, the token expired or not found. Regenerate the token and try again.")
 		case connectErr != nil:
 			process.log.Errorf("%v failed to establish connection to cluster: %v.", role, connectErr)
-			if process.Config.Version == defaults.TeleportConfigVersionV3 {
+			if process.Config.Version == defaults.TeleportConfigVersionV3 && process.Config.ProxyServer.IsEmpty() {
 				process.log.Errorf("Check to see if the config has auth_server pointing to a Teleport Proxy. If it does, use proxy_server instead of auth_server.")
 			}
 		}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -117,6 +117,9 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			process.log.Error("Can not join the cluster as node, the token expired or not found. Regenerate the token and try again.")
 		case connectErr != nil:
 			process.log.Errorf("%v failed to establish connection to cluster: %v.", role, connectErr)
+			if process.Config.Version == defaults.TeleportConfigVersionV3 {
+				process.log.Errorf("Check to see if the config has auth_server pointing to a Teleport Proxy. If it does, use proxy_server instead of auth_server.")
+			}
 		}
 
 		// Used for testing that auth service will attempt to reconnect in the provided duration.


### PR DESCRIPTION
Backport #17847 to branch/v11