### PR TITLE
Helm repo add updates for k8s docs

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-jira-cloud.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-jira-cloud.mdx
@@ -110,9 +110,7 @@ Run `./install` from `teleport-jira` or place the executable in `/usr/bin` or `/
   ```
 </TabItem>
 <TabItem label="Helm Chart">
-  ```code
-  $ helm repo add teleport https://charts.releases.teleport.dev/
-  ```
+  (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-jira-server.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-jira-server.mdx
@@ -122,15 +122,12 @@ Run `./install` from `teleport-jira` or place the executable in the appropriate 
   ```
 </TabItem>
 <TabItem label="Helm Chart">
-  ```code
-  $ helm repo add teleport https://charts.releases.teleport.dev/
-  ```
+  (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 </TabItem>
 </Tabs>
 
 <Details title="Installing via Helm?">
   ```code
-  $ helm repo add teleport https://charts.releases.teleport.dev/
   $ helm install teleport-plugin-jira teleport/teleport-plugin-jira --values teleport-jira-helm.yaml
   ```
 </Details>

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -69,10 +69,7 @@ Run `./install` from `teleport-mattermost` or place the executable in the approp
   ```
 </TabItem>
 <TabItem label="Helm Chart">
-  ```code
-  $ helm repo add teleport (=teleport.helm_repo_url=)
-  $ helm repo update
-  ```
+(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -421,10 +421,7 @@ Run `./install` from `teleport-pagerduty`.
   ```
 </TabItem>
 <TabItem label="Helm Chart">
-  ```code
-  $ helm repo add teleport https://charts.releases.teleport.dev/
-  $ helm repo update
-  ```
+  (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
@@ -97,10 +97,7 @@ and will require access to both the public internet and the Teleport Auth Servic
 
 </TabItem>
 <TabItem label="Helm Chart">
-  ```code
-  $ helm repo add teleport https://charts.releases.teleport.dev/
-  $ helm repo update
-  ```
+  (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -45,11 +45,7 @@ While the Kubernetes cluster is being provisioned, follow the "Getting Started" 
 
 ## Step 2/4. Install Teleport 
 
-Add the Teleport repository to Helm.
-
-```code
-$ helm repo add teleport https://charts.releases.teleport.dev
-```
+(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 
 Install Teleport in your Kubernetes cluster using the `teleport-cluster` Helm chart.
 ```code

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -50,13 +50,13 @@ Teleport also supports Kubernetes in on-premise and air-gapped environments. If 
 
 Let's start with a single-pod Teleport deployment using a persistent volume as a backend. Modify the values of `CLUSTER_NAME` and `EMAIL` according to your environment, where `CLUSTER_NAME` is the domain name you are using for your Teleport deployment and `EMAIL` is an email address used for notifications.
 
+(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
+
 <Tabs>
   <TabItem label="Open Source">
     ```code
     $ CLUSTER_NAME="tele.example.com"
     $ EMAIL="mail@example.com"
-    $ helm repo add teleport https://charts.releases.teleport.dev
-    $ helm repo update
 
     # Install a single node teleport cluster and provision a cert using ACME.
     # Set clusterName to unique hostname, for example tele.example.com
@@ -70,8 +70,6 @@ Let's start with a single-pod Teleport deployment using a persistent volume as a
     ```code
     $ CLUSTER_NAME="tele.example.com"
     $ EMAIL="mail@example.com"
-    $ helm repo add teleport https://charts.releases.teleport.dev
-    $ helm repo update
 
     # Create a namespace for a deployment.
     $ kubectl create namespace teleport-cluster-ent

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -56,6 +56,7 @@ Let's start with a single-pod Teleport deployment using a persistent volume as a
     $ CLUSTER_NAME="tele.example.com"
     $ EMAIL="mail@example.com"
     $ helm repo add teleport https://charts.releases.teleport.dev
+    $ helm repo update
 
     # Install a single node teleport cluster and provision a cert using ACME.
     # Set clusterName to unique hostname, for example tele.example.com
@@ -70,6 +71,7 @@ Let's start with a single-pod Teleport deployment using a persistent volume as a
     $ CLUSTER_NAME="tele.example.com"
     $ EMAIL="mail@example.com"
     $ helm repo add teleport https://charts.releases.teleport.dev
+    $ helm repo update
 
     # Create a namespace for a deployment.
     $ kubectl create namespace teleport-cluster-ent

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -108,9 +108,8 @@ For instructions on running containers with these images, see
 We host our own Helm chart repository, which you can add with the following
 command:
 
-```code
-$ helm repo add teleport https://charts.releases.teleport.dev
-```
+(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
+
 
 There are two charts available to install. Please see our guide for using each
 chart.

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -105,11 +105,7 @@ For instructions on running containers with these images, see
 
 ## Helm
 
-We host our own Helm chart repository, which you can add with the following
-command:
-
 (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
-
 
 There are two charts available to install. Please see our guide for using each
 chart.

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -59,7 +59,6 @@ commands, assigning `PROXY_ADDR` to the address of your Auth Service or Proxy
 Service.
 
 ```code
-# Add teleport-agent chart to charts repository
 $ PROXY_ADDR=tele.example.com:443
 
 # Install Kubernetes agent. It dials back to the Teleport cluster at $PROXY_ADDR

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -74,7 +74,6 @@ Switch `kubectl` to the Kubernetes cluster `cookie` and run the following
 commands, assigning `PROXY_ADDR` to the address of your Teleport Cloud tenant.
 
 ```code
-# Add teleport-agent chart to charts repository
 $ PROXY_ADDR=mytenant.teleport.sh:443
 
 # Install Kubernetes agent. It dials back to the Teleport cluster at $PROXY_ADDR

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -49,6 +49,8 @@ or up to one major version back. You can set the version override with the overr
 
 </Notice>
 
+(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
+
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
@@ -59,8 +61,6 @@ Service.
 ```code
 # Add teleport-agent chart to charts repository
 $ PROXY_ADDR=tele.example.com:443
-$ helm repo add teleport https://charts.releases.teleport.dev
-$ helm repo update
 
 # Install Kubernetes agent. It dials back to the Teleport cluster at $PROXY_ADDR
 $ CLUSTER='cookie'
@@ -77,8 +77,6 @@ commands, assigning `PROXY_ADDR` to the address of your Teleport Cloud tenant.
 ```code
 # Add teleport-agent chart to charts repository
 $ PROXY_ADDR=mytenant.teleport.sh:443
-$ helm repo add teleport https://charts.releases.teleport.dev
-$ helm repo update
 
 # Install Kubernetes agent. It dials back to the Teleport cluster at $PROXY_ADDR
 $ CLUSTER='cookie'

--- a/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
+++ b/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
@@ -45,12 +45,11 @@ $ TOKEN=$(kubectl exec -ti "${POD?}" -- tctl nodes add --roles=kube --ttl=10000h
 $ echo $TOKEN
 ```
 
+(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
+
 Switch `kubectl` to the Kubernetes cluster `cookie` and run:
 
 ```code
-# Add Teleport chart repository
-$ helm repo add teleport https://charts.releases.teleport.dev
-
 # Deploy a Kubernetes agent. It dials back to the Teleport cluster tele.example.com.
 $ CLUSTER='cookie'
 $ PROXY='tele.example.com:443'
@@ -95,12 +94,11 @@ $ TOKEN=$(tctl nodes add --roles=kube --ttl=10000h --format=json | jq -r '.[0]')
 $ echo $TOKEN
 ```
 
+(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
+
 Switch `kubectl` to the Kubernetes cluster `cookie` and run:
 
 ```code
-# Add Teleport chart repository
-$ helm repo add teleport https://charts.releases.teleport.dev
-
 # Deploy a Kubernetes agent. It dials back to the Teleport cluster mytenant.teleport.sh.
 $ CLUSTER='cookie'
 $ PROXY='mytenant.teleport.sh'

--- a/docs/pages/management/guides/fluentd.mdx
+++ b/docs/pages/management/guides/fluentd.mdx
@@ -58,9 +58,7 @@ from Teleport's events API, and forwards them to Fluentd.
   </TabItem>
 
   <TabItem label="Helm">
-  ```code
-  $ helm repo add teleport https://charts.releases.teleport.dev/
-  ```
+  (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
   </TabItem>
   <TabItem label="From Source">
   Ensure that you have Docker installed and running.

--- a/docs/pages/management/guides/teleport-operator.mdx
+++ b/docs/pages/management/guides/teleport-operator.mdx
@@ -50,11 +50,7 @@ $ kubectl cluster-info
 
 ## Step 1/3. Install teleport-cluster Helm chart with the operator
 
-Add the Teleport Helm Chart repo:
-```code
-$ helm repo add teleport https://charts.releases.teleport.dev
-$ helm repo update
-```
+(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 
 Install the Helm chart for the Teleport Cluster with `operator.enabled=true`.
 

--- a/docs/pages/try-out-teleport/local-kubernetes.mdx
+++ b/docs/pages/try-out-teleport/local-kubernetes.mdx
@@ -59,9 +59,6 @@ Start minikube with the Docker driver:
 $ minikube start --driver=docker
 ```
 
-Add the Teleport Helm repository. Our Helm charts make it easier to deploy
-Teleport on your local Kubernetes cluster:
-
 (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 
 ### Install the Teleport Auth Service and Proxy Service

--- a/docs/pages/try-out-teleport/local-kubernetes.mdx
+++ b/docs/pages/try-out-teleport/local-kubernetes.mdx
@@ -62,9 +62,7 @@ $ minikube start --driver=docker
 Add the Teleport Helm repository. Our Helm charts make it easier to deploy
 Teleport on your local Kubernetes cluster:
 
-```code
-$ helm repo add teleport https://charts.releases.teleport.dev
-```
+(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 
 ### Install the Teleport Auth Service and Proxy Service
 


### PR DESCRIPTION
Use repo add to keep consistent across helm deployment docs.   This can also lead to issues since these two examples did not have the `helm repo update` which will prevent getting the latest teleport helm version.