### PR TITLE
Add a comment to the configure-ad script warning the user about extra whitespace

### DIFF
--- a/lib/web/scripts/desktop/configure-ad.ps1
+++ b/lib/web/scripts/desktop/configure-ad.ps1
@@ -140,8 +140,6 @@ $COMPUTER_IP = (Resolve-DnsName -Type A $Env:COMPUTERNAME).Address
 $LDAP_ADDR="$COMPUTER_IP" + ":636"
 
 $DESKTOP_ACCESS_CONFIG_YAML=@'
-# NOTE:
-# If you are using PowerShell ISE: when copying and pasting the config from below there will be whitespace at the start - delete this before you save the config.
 version: v3
 teleport:
   auth_token: {0}
@@ -181,6 +179,16 @@ https://goteleport.com/docs/desktop-access/reference/configuration/
 {0}
 
 '@ -f $DESKTOP_ACCESS_CONFIG_YAML
+
+$WHITESPACE_WARNING=@'
+# WARNING:
+# When copying and pasting the config from below, PowerShell ISE will add whitespace to the start - delete this before you save the config.
+'@
+
+if ($host.name -match 'ISE')
+{
+  Write-Output $WHITESPACE_WARNING
+}
 
 Write-Output $OUTPUT
 

--- a/lib/web/scripts/desktop/configure-ad.ps1
+++ b/lib/web/scripts/desktop/configure-ad.ps1
@@ -140,6 +140,8 @@ $COMPUTER_IP = (Resolve-DnsName -Type A $Env:COMPUTERNAME).Address
 $LDAP_ADDR="$COMPUTER_IP" + ":636"
 
 $DESKTOP_ACCESS_CONFIG_YAML=@'
+# NOTE:
+# If you are using PowerShell ISE: when copying and pasting the config from below there will be whitespace at the start - delete this before you save the config.
 version: v3
 teleport:
   auth_token: {0}


### PR DESCRIPTION
When using PowerShell ISE to run the desktop setup scripts, it'll add an extra space to the start of whatever is being copied from the output.

This causes an incorrect Teleport config, as it'll add an extra space before `version` (or `teleport` for v10).

I've added a comment above the outputted Teleport config that'll prompt the user about the possible extra whitespace, if they're running the script in PowerShell ISE.