### PR TITLE
Fix caching of client credentials when users re-login to incorporate new attributes

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -327,6 +327,8 @@ type authContext struct {
 	// disconnectExpiredCert if set, controls the time when the connection
 	// should be disconnected because the client cert expires
 	disconnectExpiredCert time.Time
+	// certExpires is the client certificate expiration timestamp.
+	certExpires time.Time
 	// sessionTTL specifies the duration of the user's session
 	sessionTTL time.Duration
 }
@@ -338,7 +340,7 @@ func (c authContext) String() string {
 func (c *authContext) key() string {
 	// it is important that the context key contains user, kubernetes groups and certificate expiry,
 	// so that new logins with different parameters will not reuse this context
-	return fmt.Sprintf("%v:%v:%v:%v:%v:%v", c.teleportCluster.name, c.User.GetName(), c.kubeUsers, c.kubeGroups, c.kubeCluster, c.disconnectExpiredCert.UTC().Unix())
+	return fmt.Sprintf("%v:%v:%v:%v:%v:%v", c.teleportCluster.name, c.User.GetName(), c.kubeUsers, c.kubeGroups, c.kubeCluster, c.certExpires.Unix())
 }
 
 func (c *authContext) eventClusterMeta() apievents.KubernetesClusterMetadata {
@@ -672,6 +674,7 @@ func (f *Forwarder) setupContext(ctx auth.Context, req *http.Request, isRemoteUs
 		kubeClusterLabels: kubeLabels,
 		recordingConfig:   recordingConfig,
 		kubeCluster:       kubeCluster,
+		certExpires:       certExpires,
 		teleportCluster: teleportClusterClient{
 			name:           teleportClusterName,
 			remoteAddr:     utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
@@ -708,7 +711,8 @@ type kubeAccessDetails struct {
 func (f *Forwarder) getKubeAccessDetails(
 	roles services.AccessChecker,
 	kubeClusterName string,
-	sessionTTL time.Duration) (kubeAccessDetails, error) {
+	sessionTTL time.Duration,
+) (kubeAccessDetails, error) {
 	kubeServers, err := f.cfg.CachingAuthClient.GetKubernetesServers(f.ctx)
 	if err != nil {
 		return kubeAccessDetails{}, trace.Wrap(err)
@@ -1124,7 +1128,6 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, w http.ResponseWriter, 
 		if err := f.cfg.StreamEmitter.EmitAuditEvent(f.ctx, sessionEndEvent); err != nil {
 			f.log.WithError(err).Warn("Failed to emit session end event.")
 		}
-
 	}()
 
 	executor, err := f.getExecutor(*ctx, sess, req)
@@ -1898,12 +1901,14 @@ func (f *Forwarder) getClientCreds(ctx authContext) *tls.Config {
 	if !validClientCreds(f.cfg.Clock, c) {
 		return nil
 	}
+	f.log.Debugf("Returning cached client credentials with key: %v", ctx.key())
 	return c
 }
 
 func (f *Forwarder) saveClientCreds(ctx authContext, c *tls.Config) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.log.Debugf("Caching client credentials with key: %v", ctx.key())
 	return f.clientCredentials.Set(ctx.key(), c, ctx.sessionTTL)
 }
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1901,14 +1901,12 @@ func (f *Forwarder) getClientCreds(ctx authContext) *tls.Config {
 	if !validClientCreds(f.cfg.Clock, c) {
 		return nil
 	}
-	f.log.Debugf("Returning cached client credentials with key: %v", ctx.key())
 	return c
 }
 
 func (f *Forwarder) saveClientCreds(ctx authContext, c *tls.Config) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.log.Debugf("Caching client credentials with key: %v", ctx.key())
 	return f.clientCredentials.Set(ctx.key(), c, ctx.sessionTTL)
 }
 

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -135,7 +135,12 @@ func TestAuthenticate(t *testing.T) {
 		authPref:        authPref,
 	}
 
-	user, err := types.NewUser("user-a")
+	const (
+		username = "user-a"
+	)
+	certExpiration := time.Now().Add(time.Hour)
+
+	user, err := types.NewUser(username)
 	require.NoError(t, err)
 
 	tun := mockRevTunnel{
@@ -144,7 +149,6 @@ func TestAuthenticate(t *testing.T) {
 			"local":  mockRemoteSite{name: "local"},
 		},
 	}
-
 	f := &Forwarder{
 		log: logrus.NewEntry(logrus.New()),
 		cfg: ForwarderConfig{
@@ -201,6 +205,7 @@ func TestAuthenticate(t *testing.T) {
 					"static_label1": "static_value1",
 					"static_label2": "static_value2",
 				},
+				certExpires: certExpiration,
 				teleportCluster: teleportClusterClient{
 					name:       "local",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -232,6 +237,7 @@ func TestAuthenticate(t *testing.T) {
 				kubeGroups:        utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
 				kubeCluster:       "local",
 				kubeClusterLabels: make(map[string]string),
+				certExpires:       certExpiration,
 				teleportCluster: teleportClusterClient{
 					name:       "local",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -261,6 +267,7 @@ func TestAuthenticate(t *testing.T) {
 				kubeUsers:         utils.StringsSet([]string{"user-a"}),
 				kubeGroups:        utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
 				kubeCluster:       "local",
+				certExpires:       certExpiration,
 				kubeClusterLabels: make(map[string]string),
 				teleportCluster: teleportClusterClient{
 					name:       "local",
@@ -277,8 +284,9 @@ func TestAuthenticate(t *testing.T) {
 			tunnel:         tun,
 
 			wantCtx: &authContext{
-				kubeUsers:  utils.StringsSet([]string{"user-a"}),
-				kubeGroups: utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
+				kubeUsers:   utils.StringsSet([]string{"user-a"}),
+				kubeGroups:  utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
+				certExpires: certExpiration,
 				teleportCluster: teleportClusterClient{
 					name:       "remote",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -295,8 +303,9 @@ func TestAuthenticate(t *testing.T) {
 			tunnel:         tun,
 
 			wantCtx: &authContext{
-				kubeUsers:  utils.StringsSet([]string{"user-a"}),
-				kubeGroups: utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
+				kubeUsers:   utils.StringsSet([]string{"user-a"}),
+				kubeGroups:  utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
+				certExpires: certExpiration,
 				teleportCluster: teleportClusterClient{
 					name:       "remote",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -313,8 +322,9 @@ func TestAuthenticate(t *testing.T) {
 			tunnel:         tun,
 
 			wantCtx: &authContext{
-				kubeUsers:  utils.StringsSet([]string{"user-a"}),
-				kubeGroups: utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
+				kubeUsers:   utils.StringsSet([]string{"user-a"}),
+				kubeGroups:  utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
+				certExpires: certExpiration,
 				teleportCluster: teleportClusterClient{
 					name:       "remote",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -359,6 +369,7 @@ func TestAuthenticate(t *testing.T) {
 				kubeGroups:        utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
 				kubeCluster:       "local",
 				kubeClusterLabels: make(map[string]string),
+				certExpires:       certExpiration,
 				teleportCluster: teleportClusterClient{
 					name:       "local",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -406,6 +417,7 @@ func TestAuthenticate(t *testing.T) {
 				kubeGroups:        utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
 				kubeCluster:       "local",
 				kubeClusterLabels: make(map[string]string),
+				certExpires:       certExpiration,
 				teleportCluster: teleportClusterClient{
 					name:       "local",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -459,6 +471,7 @@ func TestAuthenticate(t *testing.T) {
 				kubeUsers:   utils.StringsSet([]string{"user-a"}),
 				kubeGroups:  utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
 				kubeCluster: "foo",
+				certExpires: certExpiration,
 				kubeClusterLabels: map[string]string{
 					"static_label1": "static_value1",
 					"static_label2": "static_value2",
@@ -482,6 +495,7 @@ func TestAuthenticate(t *testing.T) {
 				kubeUsers:   utils.StringsSet([]string{"user-a"}),
 				kubeGroups:  utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
 				kubeCluster: "foo",
+				certExpires: certExpiration,
 				teleportCluster: teleportClusterClient{
 					name:       "remote",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -523,7 +537,7 @@ func TestAuthenticate(t *testing.T) {
 				RemoteAddr: remoteAddr,
 				TLS: &tls.ConnectionState{
 					PeerCertificates: []*x509.Certificate{
-						{NotAfter: time.Now().Add(time.Hour)},
+						{NotAfter: certExpiration},
 					},
 				},
 			}
@@ -549,6 +563,19 @@ func TestAuthenticate(t *testing.T) {
 				cmpopts.IgnoreFields(authContext{}, "clientIdleTimeout", "sessionTTL", "Context", "recordingConfig", "disconnectExpiredCert"),
 				cmpopts.IgnoreFields(teleportClusterClient{}, "dial", "isRemoteClosed"),
 			))
+
+			// validate authCtx.key() to make sure it includes certExpires timestamp.
+			// this is important to make sure user's credentials are correctly cached
+			// and once user's re-login, Teleport won't reuse their previous cache entry.
+			ctxKey := fmt.Sprintf("%v:%v:%v:%v:%v:%v",
+				tt.wantCtx.teleportCluster.name,
+				username,
+				tt.wantCtx.kubeUsers,
+				tt.wantCtx.kubeGroups,
+				tt.wantCtx.kubeCluster,
+				certExpiration.Unix(),
+			)
+			require.Equal(t, ctxKey, gotCtx.key())
 		})
 	}
 }
@@ -1249,4 +1276,180 @@ func newKubeServersFromKubeClusters(t *testing.T, kubeClusters ...*types.Kuberne
 		kubeServers = append(kubeServers, kubeServer)
 	}
 	return kubeServers
+}
+
+func TestForwarder_clientCreds_cache(t *testing.T) {
+	now := time.Now()
+
+	cache, err := ttlmap.New(10)
+	require.NoError(t, err)
+
+	cl, err := newMockCSRClient()
+	require.NoError(t, err)
+
+	f := &Forwarder{
+		cfg: ForwarderConfig{
+			Keygen:     testauthority.New(),
+			AuthClient: cl,
+			Clock:      clockwork.NewFakeClockAt(time.Now().Add(-2 * time.Minute)),
+		},
+		clientCredentials: cache,
+		log:               logrus.New(),
+	}
+
+	type args struct {
+		ctx authContext
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "store first certificate",
+			args: args{
+				ctx: authContext{
+					kubeUsers:   utils.StringsSet([]string{"user-a"}),
+					kubeGroups:  utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
+					kubeCluster: "local",
+					Context: auth.Context{
+						User: &types.UserV2{
+							Metadata: types.Metadata{
+								Name: "user-a",
+							},
+						},
+						Identity:         identity,
+						UnmappedIdentity: unmappedIdentity,
+					},
+					kubeClusterLabels: make(map[string]string),
+					certExpires:       now.Add(1 * time.Hour),
+					teleportCluster: teleportClusterClient{
+						name: "local",
+					},
+					sessionTTL: 1 * time.Hour,
+				},
+			},
+		},
+		{
+			name: "store certificate with different certExpires value",
+			args: args{
+				ctx: authContext{
+					kubeUsers:   utils.StringsSet([]string{"user-a"}),
+					kubeGroups:  utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
+					kubeCluster: "local",
+					Context: auth.Context{
+						User: &types.UserV2{
+							Metadata: types.Metadata{
+								Name: "user-a",
+							},
+						},
+						Identity:         identity,
+						UnmappedIdentity: unmappedIdentity,
+					},
+					kubeClusterLabels: make(map[string]string),
+					certExpires:       now.Add(2 * time.Hour),
+					teleportCluster: teleportClusterClient{
+						name: "local",
+					},
+					sessionTTL: 1 * time.Hour,
+				},
+			},
+		},
+		{
+			name: "store certificate with different kube groups",
+			args: args{
+				ctx: authContext{
+					kubeUsers:   utils.StringsSet([]string{"user-a"}),
+					kubeGroups:  utils.StringsSet([]string{"kube-group-b", teleport.KubeSystemAuthenticated}),
+					kubeCluster: "local",
+					Context: auth.Context{
+						User: &types.UserV2{
+							Metadata: types.Metadata{
+								Name: "user-a",
+							},
+						},
+						Identity:         identity,
+						UnmappedIdentity: unmappedIdentity,
+					},
+					kubeClusterLabels: make(map[string]string),
+					certExpires:       now.Add(1 * time.Hour),
+					teleportCluster: teleportClusterClient{
+						name: "local",
+					},
+					sessionTTL: 1 * time.Hour,
+				},
+			},
+		},
+		{
+			name: "store certificate with different kube user",
+			args: args{
+				ctx: authContext{
+					kubeUsers:   utils.StringsSet([]string{"user-test"}),
+					kubeGroups:  utils.StringsSet([]string{"kube-group-b", teleport.KubeSystemAuthenticated}),
+					kubeCluster: "local",
+					Context: auth.Context{
+						User: &types.UserV2{
+							Metadata: types.Metadata{
+								Name: "user-a",
+							},
+						},
+						Identity:         identity,
+						UnmappedIdentity: unmappedIdentity,
+					},
+					kubeClusterLabels: make(map[string]string),
+					certExpires:       now.Add(1 * time.Hour),
+					teleportCluster: teleportClusterClient{
+						name: "local",
+					},
+					sessionTTL: 1 * time.Hour,
+				},
+			},
+		},
+		{
+			name: "store certificate for different user",
+			args: args{
+				ctx: authContext{
+					kubeUsers:   utils.StringsSet([]string{"user-test"}),
+					kubeGroups:  utils.StringsSet([]string{"kube-group-b", teleport.KubeSystemAuthenticated}),
+					kubeCluster: "local",
+					Context: auth.Context{
+						User: &types.UserV2{
+							Metadata: types.Metadata{
+								Name: "user-b",
+							},
+						},
+						Identity:         identity,
+						UnmappedIdentity: unmappedIdentity,
+					},
+					kubeClusterLabels: make(map[string]string),
+					certExpires:       now.Add(1 * time.Hour),
+					teleportCluster: teleportClusterClient{
+						name: "local",
+					},
+					sessionTTL: 1 * time.Hour,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// make sure cert is not cached
+			cachedTLSCfg := f.getClientCreds(tt.args.ctx)
+			require.Nil(t, cachedTLSCfg)
+
+			// request a new cert
+			tlsCfg, err := f.requestCertificate(tt.args.ctx)
+			require.NoError(t, err)
+
+			// store the certificate in cache
+			err = f.saveClientCreds(tt.args.ctx, tlsCfg)
+			require.NoError(t, err)
+
+			// make sure cache has our entry.
+			cachedTLSCfg = f.getClientCreds(tt.args.ctx)
+			require.NotNil(t, cachedTLSCfg)
+			require.Equal(t, tlsCfg, cachedTLSCfg)
+		})
+	}
 }


### PR DESCRIPTION
When users re-login after a failed attempt to access a Kubernetes cluster, Teleport may continue to use the old credentials for cluster access. This behavior results in successive failures until the credential cache expires (~1h).

This PR includes changes made by @r0mant to resolve the cache issue. It introduces certificate expiration in the cache key. Every time the user logs in again, the key will be different because the certificate expiration date is different. Thus, Teleport won't reuse the cached credentials.

Fixes #18070