### PR TITLE
Restore the Ansible Server Access guide

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -647,6 +647,10 @@
             {
               "title": "EC2 Instance Discovery (Preview)",
               "slug": "/server-access/guides/ec2-discovery/"
+            },
+            {
+              "title": "Using Teleport with Ansible",
+              "slug": "/server-access/guides/ansible/"
             }
           ]
         }

--- a/docs/pages/server-access/guides.mdx
+++ b/docs/pages/server-access/guides.mdx
@@ -13,3 +13,5 @@ layout: tocless-doc
 - [JetBrains SFTP](./guides/jetbrains-sftp.mdx): How to use a JetBrains IDE to access SFTP with Teleport.
 - [Host User Creation](./guides/host-user-creation.mdx): How to configure Teleport to automatically create transient host users.
 - [EC2 Instance Discovery (Preview)](./guides/ec2-discovery.mdx): How to configure Teleport to automatically enroll EC2 instances.
+- [Using Teleport with Ansible](./guides/ansible.mdx): How to use Ansible with
+  Teleport-issued SSH credentials. 

--- a/docs/pages/server-access/guides/ansible.mdx
+++ b/docs/pages/server-access/guides/ansible.mdx
@@ -1,0 +1,126 @@
+---
+title: Ansible
+description: Using Teleport with Ansible
+---
+
+Ansible uses the OpenSSH client by default. Teleport supports SSH protocol and
+works as SSH jumphost.
+
+In this guide we will configure OpenSSH client to work with Teleport Proxy
+and run a sample ansible playbook.
+
+## Prerequisites
+
+- Installed [Teleport Enterprise](../../deploy-a-cluster/teleport-enterprise/introduction.mdx) or [Teleport Cloud](../../deploy-a-cluster/teleport-cloud/introduction.mdx) >= (=teleport.version=)
+- `tsh` client tool  >= (=teleport.version=)
+- `ssh` openssh tool
+- `ansible` >= (=ansible.min_version=)
+- Optional tool `jq` to process `JSON` output.
+
+## Step 1/3. Login and configure SSH
+
+Log into Teleport with `tsh`:
+
+```code
+$ tsh login --proxy=example.com
+```
+
+Generate `openssh` configuration using `tsh config` shortcut:
+
+```code
+$ tsh config > ssh.cfg
+```
+
+<Admonition type="tip">
+You can edit matching patterns used in `ssh.cfg` if something
+is not working out of the box.
+</Admonition>
+
+## Step 2/3. Configure Ansible
+
+Create a folder `ansible` where we will collect all generated files:
+
+```code
+$ mkdir -p ansible
+$ cd ansible
+```
+
+Create a file `ansible.cfg`:
+
+```
+[defaults]
+host_key_checking = True
+inventory=./hosts
+remote_tmp=/tmp
+
+[ssh_connection]
+scp_if_ssh = True
+ssh_args = -F ./ssh.cfg
+```
+
+You can create an inventory file `hosts` manually or use a script below to generate it from your environment:
+
+```code
+$ tsh ls --format=json | jq -r '.[].spec.hostname' > hosts
+```
+
+## Step 3/3. Run a playbook
+
+Finally, let's create a simple ansible playbook `playbook.yaml`.
+
+The playbook below runs `hostname` on all hosts. Make sure to set the `remote_user` parameter
+to a valid SSH username that works with the target host and is allowed by Teleport:
+
+```yaml
+- hosts: all
+  remote_user: ubuntu
+  tasks:
+    - name: "hostname"
+      command: "hostname"
+```
+
+From the folder `ansible`, run the ansible playbook:
+
+```code
+$ ansible-playbook playbook.yaml 
+
+# PLAY [all] *****************************************************************************************************************************************
+# TASK [Gathering Facts] *****************************************************************************************************************************
+#
+# ok: [terminal]
+#
+# TASK [hostname] ************************************************************************************************************************************
+# changed: [terminal]
+#
+# PLAY RECAP *****************************************************************************************************************************************
+# terminal                   : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+You are all set. You are now using short-lived SSH certificates and Teleport can now record
+all ansible commands in the audit log.
+
+## Troubleshooting
+
+In case if ansible can not connect, you may see error like this one:
+
+```txt
+example.host | UNREACHABLE! => {
+    "changed": false,
+    "msg": "Failed to connect to the host via ssh: ssh: Could not resolve hostname example.host: Name or service not known",
+    "unreachable": true
+}
+```
+
+You can examine and tweak patterns matching the inventory hosts in `ssh.cfg`.
+
+Try the SSH connection using `ssh.cfg` with verbose mode to inspect the error:
+
+```code
+$ ssh -vvv -F ./ssh.cfg root@example.host
+```
+
+If `ssh` works, try running the playbook with verbose mode on:
+
+```code
+$ ansible-playbook -vvvv playbook.yaml
+```


### PR DESCRIPTION
Closes #14692

PR #10987 repurposed the Ansible Server Access guide to be a Machine ID guide. Since users still found use in the original Server Access guide, this change restores that guide.

Note that this change does not attempt to edit the Ansible Server Access guide, and simply restores it to the state it was in before #10987. The Machine ID Ansible guide is left untouched.