### PR TITLE
[v10] Bump cloud version to 10.3.6

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1107,7 +1107,7 @@
       "last_report": "August 9th, 2022"
     },
     "cloud": {
-      "version": "10.3.1",
+      "version": "10.3.6",
       "major_version": "10",
       "sla": {
         "monthly_percentage": "99.5%",


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/18106 to branch/v10