### PR TITLE
[v8] Periodically resync proxies to agents 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
 	github.com/jackc/pgproto3/v2 v2.0.7
 	github.com/johannesboyne/gofakes3 v0.0.0-20210217223559-02ffa763be97
-	github.com/jonboulle/clockwork v0.2.2
+	github.com/jonboulle/clockwork v0.3.0
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,9 @@ github.com/johannesboyne/gofakes3 v0.0.0-20210217223559-02ffa763be97/go.mod h1:J
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
-github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
+github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -23,6 +23,7 @@ package reversetunnel
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -584,17 +585,18 @@ func (a *Agent) handleDiscovery(ch ssh.Channel, reqC <-chan *ssh.Request) {
 				a.log.Infof("Connection closed, returning")
 				return
 			}
-			r, err := unmarshalDiscoveryRequest(req.Payload)
-			if err != nil {
-				a.log.Warningf("Bad payload: %v.", err)
+
+			var r discoveryRequest
+			if err := json.Unmarshal(req.Payload, &r); err != nil {
+				a.log.WithError(err).Warn("Bad payload")
 				return
 			}
-			r.ClusterAddr = a.Addr
+
+			proxies := r.ProxyNames()
+			a.log.Debugf("Received discovery request: %v", proxies)
+
 			if a.Tracker != nil {
-				// Notify tracker of all known proxies.
-				for _, p := range r.Proxies {
-					a.Tracker.TrackExpected(p.GetName())
-				}
+				a.Tracker.TrackExpected(proxies...)
 			}
 		}
 	}

--- a/lib/reversetunnel/conn.go
+++ b/lib/reversetunnel/conn.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reversetunnel
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"sync"
@@ -219,22 +220,16 @@ func (c *remoteConn) sendDiscoveryRequest(req discoveryRequest) error {
 
 	// Marshal and send the request. If the connection failed, mark the
 	// connection as invalid so it will be removed later.
-	payload, err := marshalDiscoveryRequest(req)
+	payload, err := json.Marshal(req)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// Log the discovery request being sent. Useful for debugging to know what
 	// proxies the tunnel server thinks exist.
-	names := make([]string, 0, len(req.Proxies))
-	for _, proxy := range req.Proxies {
-		names = append(names, proxy.GetName())
-	}
-	c.log.Debugf("Sending %v discovery request with proxies %q to %v.",
-		req.Type, names, c.sconn.RemoteAddr())
+	c.log.Debugf("Sending discovery request with proxies %q to %v.", req.ProxyNames(), c.sconn.RemoteAddr())
 
-	_, err = discoveryCh.SendRequest(chanDiscoveryReq, false, payload)
-	if err != nil {
+	if _, err := discoveryCh.SendRequest(chanDiscoveryReq, false, payload); err != nil {
 		c.markInvalid(err)
 		return trace.Wrap(err)
 	}

--- a/lib/reversetunnel/discovery.go
+++ b/lib/reversetunnel/discovery.go
@@ -18,8 +18,6 @@ package reversetunnel
 
 import (
 	"encoding/json"
-	"fmt"
-	"strings"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
@@ -30,71 +28,94 @@ import (
 
 // discoveryRequest is a request sent from a connected proxy with the missing proxies.
 type discoveryRequest struct {
-	// ClusterName is the name of the cluster that sends the discovery request.
-	ClusterName string `json:"cluster_name"`
-
-	// Type is the type of tunnel, is either node or proxy.
-	Type string `json:"type"`
-
-	// ClusterAddr is the address of the cluster.
-	ClusterAddr utils.NetAddr `json:"-"`
-
 	// Proxies is a list of proxies in the cluster sending the discovery request.
 	Proxies []types.Server `json:"proxies"`
 }
 
-func (r discoveryRequest) String() string {
-	proxyNames := make([]string, 0, len(r.Proxies))
+// ProxyNames returns the names of all proxies carried in the request
+func (r *discoveryRequest) ProxyNames() []string {
+	names := make([]string, 0, len(r.Proxies))
 	for _, p := range r.Proxies {
-		proxyNames = append(proxyNames, p.GetName())
+		names = append(names, p.GetName())
 	}
-	return fmt.Sprintf("discovery request, cluster name: %v, address: %v, proxies: %v",
-		r.ClusterName, r.ClusterAddr, strings.Join(proxyNames, ","))
+
+	return names
 }
 
-type discoveryRequestRaw struct {
-	ClusterName string            `json:"cluster_name"`
-	Type        string            `json:"type"`
-	Proxies     []json.RawMessage `json:"proxies"`
-}
-
-func marshalDiscoveryRequest(req discoveryRequest) ([]byte, error) {
-	var out discoveryRequestRaw
-	for _, p := range req.Proxies {
-		// Clone the server value to avoid a potential race
-		// since the proxies are shared.
-		// Marshaling attempts to enforce defaults which modifies
-		// the original value.
-		p = p.DeepCopy()
-		data, err := services.MarshalServer(p)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		out.Proxies = append(out.Proxies, data)
+// MarshalJSON creates a minimal JSON representation of a discoveryRequest
+// by converting the Proxies from types.Server to discoveryProxy.
+// The minification is useful since only the Proxy ID is to be consumed
+// by the agents. This is needed to maintain backward compatibility
+// but should be replaced in the future by a message which
+// only contains the Proxy IDs.
+func (r *discoveryRequest) MarshalJSON() ([]byte, error) {
+	var out struct {
+		Proxies []discoveryProxy `json:"proxies"`
 	}
-	out.ClusterName = req.ClusterName
-	out.Type = req.Type
+
+	out.Proxies = make([]discoveryProxy, 0, len(r.Proxies))
+
+	for _, p := range r.Proxies {
+		out.Proxies = append(out.Proxies, discoveryProxy(p.GetName()))
+	}
+
 	return json.Marshal(out)
 }
 
-func unmarshalDiscoveryRequest(data []byte) (*discoveryRequest, error) {
+func (r *discoveryRequest) UnmarshalJSON(data []byte) error {
 	if len(data) == 0 {
-		return nil, trace.BadParameter("missing payload in discovery request")
+		return trace.BadParameter("missing payload in discovery request")
 	}
-	var raw discoveryRequestRaw
-	err := utils.FastUnmarshal(data, &raw)
-	if err != nil {
-		return nil, trace.Wrap(err)
+
+	var in struct {
+		Proxies []json.RawMessage `json:"proxies"`
 	}
-	var out discoveryRequest
-	for _, bytes := range raw.Proxies {
-		proxy, err := services.UnmarshalServer([]byte(bytes), types.KindProxy)
+
+	if err := utils.FastUnmarshal(data, &in); err != nil {
+		return trace.Wrap(err)
+	}
+
+	d := discoveryRequest{
+		Proxies: make([]types.Server, 0, len(in.Proxies)),
+	}
+
+	for _, bytes := range in.Proxies {
+		proxy, err := services.UnmarshalServer(bytes, types.KindProxy)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
-		out.Proxies = append(out.Proxies, proxy)
+
+		d.Proxies = append(d.Proxies, proxy)
 	}
-	out.ClusterName = raw.ClusterName
-	out.Type = raw.Type
-	return &out, nil
+
+	*r = d
+	return nil
+}
+
+// discoveryProxy is a wrapper around a Proxy ID that
+// can be marshaled to json in the minimal representation
+// of a types.Server that will still be correctly unmarshalled
+// as a types.Server. Backwards compatibility requires a types.Server
+// to be included in a discoveryRequest when in reality only
+// the Proxy ID needs to be communicated to agents.
+//
+// This should eventually be replaced by a newer version of
+// messages used by agents to indicate they can support discovery
+// requests which only contain Proxy IDs.
+type discoveryProxy string
+
+// MarshalJSON creates a minimum representation of types.Server
+// such that (*discoveryRequest) UnmarshalJSON will successfully
+// unmarshal this as a types.Server. This allows the discoveryRequest
+// to be four and a half times smaller when marshaled.
+func (s discoveryProxy) MarshalJSON() ([]byte, error) {
+	var p struct {
+		Version  string `json:"version"`
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	p.Version = types.V2
+	p.Metadata.Name = string(s)
+	return json.Marshal(p)
 }

--- a/lib/reversetunnel/discovery_test.go
+++ b/lib/reversetunnel/discovery_test.go
@@ -1,0 +1,147 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reversetunnel
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// discoveryRequestRaw is the legacy type that was used
+// as the payload for discoveryRequests. It exists
+// here for the sake of ensuring backward compatibility.
+type discoveryRequestRaw struct {
+	ClusterName string            `json:"cluster_name"`
+	Type        string            `json:"type"`
+	Proxies     []json.RawMessage `json:"proxies"`
+}
+
+// marshalDiscoveryRequest is the legacy method of marshaling a discoveryRequest
+func marshalDiscoveryRequest(req discoveryRequest) ([]byte, error) {
+	out := discoveryRequestRaw{
+		Proxies: make([]json.RawMessage, 0, len(req.Proxies)),
+	}
+	for _, p := range req.Proxies {
+		// Clone the server value to avoid a potential race
+		// since the proxies are shared.
+		// Marshaling attempts to enforce defaults which modifies
+		// the original value.
+		p = p.DeepCopy()
+		data, err := services.MarshalServer(p)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		out.Proxies = append(out.Proxies, data)
+	}
+
+	return json.Marshal(out)
+}
+
+// unmarshalDiscoveryRequest is the legacy method of unmarshaling a discoveryRequest
+func unmarshalDiscoveryRequest(data []byte) (*discoveryRequest, error) {
+	if len(data) == 0 {
+		return nil, trace.BadParameter("missing payload in discovery request")
+	}
+
+	var raw discoveryRequestRaw
+	if err := utils.FastUnmarshal(data, &raw); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	out := discoveryRequest{
+		Proxies: make([]types.Server, 0, len(raw.Proxies)),
+	}
+	for _, bytes := range raw.Proxies {
+		proxy, err := services.UnmarshalServer(bytes, types.KindProxy)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		out.Proxies = append(out.Proxies, proxy)
+	}
+
+	return &out, nil
+}
+
+func TestDiscoveryRequestMarshalling(t *testing.T) {
+	const proxyCount = 10
+
+	// create a discovery request
+	req := discoveryRequest{
+		Proxies: make([]types.Server, 0, proxyCount),
+	}
+
+	// populate the proxies
+	for i := 0; i < proxyCount; i++ {
+		p, err := types.NewServer(uuid.New().String(), types.KindProxy, types.ServerSpecV2{})
+		require.NoError(t, err)
+		req.Proxies = append(req.Proxies, p)
+	}
+
+	// test marshaling the request with the legacy mechanism and unmarshaling
+	// with the new mechanism
+	t.Run("marshal=legacy unmarshal=new", func(t *testing.T) {
+		payload, err := marshalDiscoveryRequest(req)
+		require.NoError(t, err)
+
+		var got discoveryRequest
+		require.NoError(t, json.Unmarshal(payload, &got))
+
+		require.Empty(t, cmp.Diff(req.ProxyNames(), got.ProxyNames()))
+	})
+
+	// test marshaling the request with the new mechanism and unmarshaling
+	// with the legacy mechanism
+	t.Run("marshal=new unmarshal=legacy", func(t *testing.T) {
+		payload, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		got, err := unmarshalDiscoveryRequest(payload)
+		require.NoError(t, err)
+
+		require.Empty(t, cmp.Diff(req.ProxyNames(), got.ProxyNames()))
+	})
+
+	// test marshaling and unmarshaling the request with the new mechanism
+	t.Run("marshal=new unmarshal=new", func(t *testing.T) {
+		payload, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var got discoveryRequest
+		require.NoError(t, json.Unmarshal(payload, &got))
+
+		require.Empty(t, cmp.Diff(req.ProxyNames(), got.ProxyNames()))
+	})
+
+	// test marshaling and unmarshaling the request with the legacy mechanism
+	t.Run("marshal=legacy unmarshal=legacy", func(t *testing.T) {
+		payload, err := marshalDiscoveryRequest(req)
+		require.NoError(t, err)
+
+		got, err := unmarshalDiscoveryRequest(payload)
+		require.NoError(t, err)
+
+		require.Empty(t, cmp.Diff(req.ProxyNames(), got.ProxyNames()))
+	})
+}

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/reversetunnel/track"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/forward"
 	"github.com/gravitational/teleport/lib/utils"
@@ -39,10 +40,31 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// periodicFunctionInterval is the interval at which periodic stats are calculated.
-var periodicFunctionInterval = 3 * time.Minute
+const (
+	// periodicFunctionInterval is the interval at which periodic stats are calculated.
+	periodicFunctionInterval = 3 * time.Minute
 
-func newlocalSite(srv *server, domainName string, authServers []string) (*localSite, error) {
+	// proxySyncInterval is the interval at which the current proxies are synchronized to
+	// connected agents via a discovery request. It is a function of track.DefaultProxyExpiry
+	// to ensure that the proxies are always synced before the tracker expiry.
+	proxySyncInterval = track.DefaultProxyExpiry * 2 / 3
+)
+
+// withPeriodicFunctionInterval adjusts the periodic function interval
+func withPeriodicFunctionInterval(interval time.Duration) func(site *localSite) {
+	return func(site *localSite) {
+		site.periodicFunctionInterval = interval
+	}
+}
+
+// withProxySyncInterval adjusts the proxy sync interval
+func withProxySyncInterval(interval time.Duration) func(site *localSite) {
+	return func(site *localSite) {
+		site.proxySyncInterval = interval
+	}
+}
+
+func newlocalSite(srv *server, domainName string, authServers []string, opts ...func(*localSite)) (*localSite, error) {
 	err := utils.RegisterPrometheusCollectors(localClusterCollectors...)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -72,7 +94,13 @@ func newlocalSite(srv *server, domainName string, authServers []string) (*localS
 				"cluster": domainName,
 			},
 		}),
-		offlineThreshold: srv.offlineThreshold,
+		offlineThreshold:         srv.offlineThreshold,
+		periodicFunctionInterval: periodicFunctionInterval,
+		proxySyncInterval:        proxySyncInterval,
+	}
+
+	for _, opt := range opts {
+		opt(s)
 	}
 
 	// Start periodic functions for the the local cluster in the background.
@@ -112,6 +140,13 @@ type localSite struct {
 	// offlineThreshold is how long to wait for a keep alive message before
 	// marking a reverse tunnel connection as invalid.
 	offlineThreshold time.Duration
+
+	// periodicFunctionInterval defines the interval period functions run at
+	periodicFunctionInterval time.Duration
+
+	// proxySyncInterval defines the interval at which discovery requests are
+	// sent to keep agents in sync
+	proxySyncInterval time.Duration
 }
 
 // GetTunnelsCount always the number of tunnel connections to this cluster.
@@ -391,13 +426,16 @@ func (s *localSite) fanOutProxies(proxies []types.Server) {
 	}
 }
 
-// handleHearbeat receives heartbeat messages from the connected agent
+// handleHeartbeat receives heartbeat messages from the connected agent
 // if the agent has missed several heartbeats in a row, Proxy marks
 // the connection as invalid.
 func (s *localSite) handleHeartbeat(rconn *remoteConn, ch ssh.Channel, reqC <-chan *ssh.Request) {
+	proxyResyncTicker := s.clock.NewTicker(s.proxySyncInterval)
+
 	defer func() {
 		s.log.Debugf("Cluster connection closed.")
 		rconn.Close()
+		proxyResyncTicker.Stop()
 	}()
 
 	firstHeartbeat := true
@@ -406,14 +444,23 @@ func (s *localSite) handleHeartbeat(rconn *remoteConn, ch ssh.Channel, reqC <-ch
 		case <-s.srv.ctx.Done():
 			s.log.Infof("closing")
 			return
+		case <-proxyResyncTicker.Chan():
+			req := discoveryRequest{
+				Proxies: s.srv.proxyWatcher.GetCurrent(),
+			}
+
+			if err := rconn.sendDiscoveryRequest(req); err != nil {
+				s.log.WithError(err).Debugf("Marking connection invalid on error")
+				rconn.markInvalid(err)
+				return
+			}
 		case proxies := <-rconn.newProxiesC:
 			req := discoveryRequest{
-				ClusterName: s.srv.ClusterName,
-				Type:        rconn.tunnelType,
-				Proxies:     proxies,
+				Proxies: proxies,
 			}
+
 			if err := rconn.sendDiscoveryRequest(req); err != nil {
-				s.log.Debugf("Marking connection invalid on error: %v.", err)
+				s.log.WithError(err).Debugf("Marking connection invalid on error")
 				rconn.markInvalid(err)
 				return
 			}
@@ -446,10 +493,10 @@ func (s *localSite) handleHeartbeat(rconn *remoteConn, ch ssh.Channel, reqC <-ch
 			} else {
 				s.log.WithFields(log.Fields{"nodeID": rconn.nodeID}).Debugf("Ping <- %v", rconn.conn.RemoteAddr())
 			}
-			tm := time.Now().UTC()
+			tm := s.clock.Now().UTC()
 			rconn.setLastHeartbeat(tm)
 		// Note that time.After is re-created everytime a request is processed.
-		case <-time.After(s.offlineThreshold):
+		case <-s.clock.After(s.offlineThreshold):
 			rconn.markInvalid(trace.ConnectionProblem(nil, "no heartbeats for %v", s.offlineThreshold))
 		}
 	}
@@ -508,14 +555,14 @@ func (s *localSite) chanTransportConn(rconn *remoteConn, dreq *sshutils.DialReq)
 
 // periodicFunctions runs functions periodic functions for the local cluster.
 func (s *localSite) periodicFunctions() {
-	ticker := time.NewTicker(periodicFunctionInterval)
+	ticker := s.clock.NewTicker(s.periodicFunctionInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-s.srv.ctx.Done():
 			return
-		case <-ticker.C:
+		case <-ticker.Chan():
 			if err := s.sshTunnelStats(); err != nil {
 				s.log.Warningf("Failed to report SSH tunnel statistics for: %v: %v.", s.domainName, err)
 			}

--- a/lib/reversetunnel/localsite_test.go
+++ b/lib/reversetunnel/localsite_test.go
@@ -258,13 +258,13 @@ func (mockRemoteConnConn) RemoteAddr() net.Addr {
 
 type mockedSSHConn struct {
 	ssh.Conn
-	closed atomic.Bool
+	closed int32
 
 	channelFn func(string) ssh.Channel
 }
 
 func (c *mockedSSHConn) Close() error {
-	c.closed.Store(true)
+	atomic.CompareAndSwapInt32(&c.closed, 0, 1)
 	return nil
 }
 

--- a/lib/reversetunnel/localsite_test.go
+++ b/lib/reversetunnel/localsite_test.go
@@ -16,33 +16,39 @@ package reversetunnel
 
 import (
 	"context"
+	"encoding/json"
 	"net"
+	"sort"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestLocalSiteOverlap(t *testing.T) {
 	t.Parallel()
 
-	// to stop (*localSite).periodicFunctions()
-	ctx, ctxCancel := context.WithCancel(context.Background())
-	ctxCancel()
+	ctx := context.Background()
 
 	srv := &server{
 		ctx:             ctx,
 		localAuthClient: &mockLocalSiteClient{},
+		Config:          Config{Clock: clockwork.NewFakeClock()},
 	}
 
-	site, err := newlocalSite(srv, "clustername", nil)
+	site, err := newlocalSite(srv, "clustername", nil, withPeriodicFunctionInterval(time.Hour))
 	require.NoError(t, err)
 
 	nodeID := uuid.NewString()
@@ -83,13 +89,159 @@ func TestLocalSiteOverlap(t *testing.T) {
 	require.Nil(t, c)
 }
 
+func TestProxyResync(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clock := clockwork.NewFakeClock()
+
+	proxy1, err := types.NewServer(uuid.NewString(), types.KindProxy, types.ServerSpecV2{})
+	require.NoError(t, err)
+
+	proxy2, err := types.NewServer(uuid.NewString(), types.KindProxy, types.ServerSpecV2{})
+	require.NoError(t, err)
+
+	// set up the watcher and wait for it to be initialized
+	watcher, err := services.NewProxyWatcher(ctx, services.ProxyWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: "test",
+			Log:       utils.NewLoggerForTests(),
+			Clock:     clock,
+			Client: &mockLocalSiteClient{
+				proxies: []types.Server{proxy1, proxy2},
+			},
+		},
+		ProxiesC: make(chan []types.Server, 1),
+	})
+	require.NoError(t, err)
+
+	// wait for the watcher to be initialized
+	select {
+	case p := <-watcher.ProxiesC:
+		require.Len(t, p, 2)
+	case <-time.After(15 * time.Second):
+		t.Fatal("Timed out waiting for proxy watcher to initialize")
+	}
+
+	// set up the site
+	srv := &server{
+		ctx:              ctx,
+		Config:           Config{Clock: clock},
+		localAuthClient:  &mockLocalSiteClient{},
+		log:              utils.NewLoggerForTests(),
+		offlineThreshold: 24 * time.Hour,
+		proxyWatcher:     watcher,
+	}
+	site, err := newlocalSite(srv, "clustername", nil, withProxySyncInterval(time.Second), withPeriodicFunctionInterval(24*time.Hour))
+	require.NoError(t, err)
+
+	// create the ssh machinery to mock an agent
+	discoveryCh := make(chan *discoveryRequest)
+
+	reqHandler := func(name string, wantReply bool, payload []byte) (bool, error) {
+		assert.Equal(t, name, chanDiscoveryReq)
+
+		var req discoveryRequest
+		assert.NoError(t, json.Unmarshal(payload, &req))
+		discoveryCh <- &req
+		return true, nil
+	}
+	channelCreator := func(name string) ssh.Channel {
+		assert.Equal(t, name, chanDiscovery)
+		return &mockedSSHChannel{reqHandler: reqHandler}
+	}
+
+	rconn := &mockRemoteConnConn{}
+	sconn := &mockedSSHConn{
+		channelFn: channelCreator,
+	}
+
+	// add a connection
+	conn1, err := site.addConn(uuid.NewString(), types.NodeTunnel, rconn, sconn)
+	require.NoError(t, err)
+
+	reqs := make(chan *ssh.Request)
+
+	// terminated by canceled context
+	go func() {
+		site.handleHeartbeat(conn1, nil, reqs)
+	}()
+
+	expected := []types.Server{proxy1, proxy2}
+	sort.Slice(expected, func(i, j int) bool { return expected[i].GetName() < expected[j].GetName() })
+	for i := 0; i < 5; i++ {
+		// wait for the heartbeat loop to select
+		clock.BlockUntil(3) // periodic ticker + heart beat timer + resync ticker = 3
+
+		// advance the sync interval to force a discovery request to be sent
+		clock.Advance(time.Second)
+
+		// wait for the discovery request to be received
+		select {
+		case req := <-discoveryCh:
+			require.NotNil(t, req)
+			require.Len(t, req.Proxies, 2)
+
+			sort.Slice(req.Proxies, func(i, j int) bool { return req.Proxies[i].GetName() < req.Proxies[j].GetName() })
+
+			require.Equal(t, req.Proxies[0].GetName(), expected[0].GetName())
+			require.Equal(t, req.Proxies[1].GetName(), expected[1].GetName())
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for discovery request")
+		}
+	}
+}
+
 type mockLocalSiteClient struct {
 	auth.Client
+
+	proxies []types.Server
 }
 
 // called by (*localSite).sshTunnelStats() as part of (*localSite).periodicFunctions()
-func (mockLocalSiteClient) GetNodes(_ context.Context, _ string, _ ...services.MarshalOption) ([]types.Server, error) {
+func (*mockLocalSiteClient) GetNodes(_ context.Context, _ string, _ ...services.MarshalOption) ([]types.Server, error) {
 	return nil, nil
+}
+
+func (m *mockLocalSiteClient) GetProxies() ([]types.Server, error) {
+	return m.proxies, nil
+}
+
+type mockWatcher struct {
+	events chan types.Event
+}
+
+func newMockWatcher() mockWatcher {
+	ch := make(chan types.Event, 1)
+
+	ch <- types.Event{
+		Type: types.OpInit,
+	}
+
+	return mockWatcher{events: ch}
+}
+
+func (m mockWatcher) Events() <-chan types.Event {
+	return m.events
+}
+
+func (m mockWatcher) Done() <-chan struct{} {
+	return make(chan struct{})
+}
+
+func (m mockWatcher) Close() error {
+	return nil
+}
+
+func (m mockWatcher) Error() error {
+	return nil
+}
+
+// called by proxyWatcher
+func (mockLocalSiteClient) NewWatcher(context.Context, types.Watch) (types.Watcher, error) {
+	return newMockWatcher(), nil
 }
 
 type mockRemoteConnConn struct {
@@ -97,4 +249,57 @@ type mockRemoteConnConn struct {
 }
 
 // called for logging by (*remoteConn).markInvalid()
-func (mockRemoteConnConn) RemoteAddr() net.Addr { return nil }
+func (mockRemoteConnConn) RemoteAddr() net.Addr {
+	return &utils.NetAddr{
+		Addr:        "localhost",
+		AddrNetwork: "tcp",
+	}
+}
+
+type mockedSSHConn struct {
+	ssh.Conn
+	closed atomic.Bool
+
+	channelFn func(string) ssh.Channel
+}
+
+func (c *mockedSSHConn) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+func (c *mockedSSHConn) OpenChannel(name string, data []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	ch := make(chan *ssh.Request)
+	close(ch)
+
+	if c.channelFn != nil {
+		return c.channelFn(name), ch, nil
+	}
+
+	return &mockedSSHChannel{}, ch, nil
+}
+
+func (*mockedSSHConn) RemoteAddr() net.Addr {
+	return &utils.NetAddr{
+		Addr:        "localhost",
+		AddrNetwork: "tcp",
+	}
+}
+
+type mockedSSHChannel struct {
+	ssh.Channel
+
+	reqHandler func(name string, wantReply bool, payload []byte) (bool, error)
+}
+
+func (c *mockedSSHChannel) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {
+	if c.reqHandler == nil {
+		return true, nil
+	}
+
+	return c.reqHandler(name, wantReply, payload)
+}
+
+func (*mockedSSHChannel) Close() error {
+	return nil
+}

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -356,9 +356,7 @@ func (s *remoteSite) handleHeartbeat(conn *remoteConn, ch ssh.Channel, reqC <-ch
 			return
 		case proxies := <-conn.newProxiesC:
 			req := discoveryRequest{
-				ClusterName: s.srv.ClusterName,
-				Type:        conn.tunnelType,
-				Proxies:     proxies,
+				Proxies: proxies,
 			}
 			if err := conn.sendDiscoveryRequest(req); err != nil {
 				s.Debugf("Marking connection invalid on error: %v.", err)

--- a/lib/reversetunnel/track/tracker.go
+++ b/lib/reversetunnel/track/tracker.go
@@ -29,6 +29,12 @@ import (
 
 type Lease = workpool.Lease
 
+const (
+	// DefaultProxyExpiry is the default amount of time a tracker will attempt
+	// to successfully connect to a proxy before giving up
+	DefaultProxyExpiry = 3 * time.Minute
+)
+
 // Config configures basic Tracker parameters.
 type Config struct {
 	// ProxyExpiry is the duration an entry will be held since the last
@@ -44,7 +50,7 @@ type Config struct {
 // CheckAndSetDefaults set default values for Config.
 func (c *Config) CheckAndSetDefaults() error {
 	if c.ProxyExpiry < 1 {
-		c.ProxyExpiry = 3 * time.Minute
+		c.ProxyExpiry = DefaultProxyExpiry
 	}
 	if c.TickRate < 1 {
 		c.TickRate = 30 * time.Second

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -352,10 +352,7 @@ func (p *proxyCollector) getResourcesAndUpdateCurrent(ctx context.Context) error
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(proxies) == 0 {
-		// At least one proxy ought to exist.
-		return trace.NotFound("empty proxy list")
-	}
+
 	newCurrent := make(map[string]types.Server, len(proxies))
 	for _, proxy := range proxies {
 		newCurrent[proxy.GetName()] = proxy

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -131,14 +131,6 @@ func TestProxyWatcher(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(w.Close)
 
-	// Since no proxy is yet present, the ProxyWatcher should immediately
-	// yield back to its retry loop.
-	select {
-	case <-w.ResetC:
-	case <-time.After(time.Second):
-		t.Fatal("Timeout waiting for ProxyWatcher reset.")
-	}
-
 	// Add a proxy server.
 	proxy := newProxyServer(t, "proxy1", "127.0.0.1:2023")
 	require.NoError(t, presence.UpsertProxy(proxy))

--- a/vendor/github.com/jonboulle/clockwork/context.go
+++ b/vendor/github.com/jonboulle/clockwork/context.go
@@ -1,0 +1,25 @@
+package clockwork
+
+import (
+	"context"
+)
+
+// contextKey is private to this package so we can ensure uniqueness here. This
+// type identifies context values provided by this package.
+type contextKey string
+
+// keyClock provides a clock for injecting during tests. If absent, a real clock should be used.
+var keyClock = contextKey("clock") // clockwork.Clock
+
+// AddToContext creates a derived context that references the specified clock.
+func AddToContext(ctx context.Context, clock Clock) context.Context {
+	return context.WithValue(ctx, keyClock, clock)
+}
+
+// FromContext extracts a clock from the context. If not present, a real clock is returned.
+func FromContext(ctx context.Context) Clock {
+	if clock, ok := ctx.Value(keyClock).(Clock); ok {
+		return clock
+	}
+	return NewRealClock()
+}

--- a/vendor/github.com/jonboulle/clockwork/timer.go
+++ b/vendor/github.com/jonboulle/clockwork/timer.go
@@ -1,0 +1,97 @@
+package clockwork
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// Timer provides an interface which can be used instead of directly
+// using the timer within the time module. The real-time timer t
+// provides events through t.C which becomes now t.Chan() to make
+// this channel requirement definable in this interface.
+type Timer interface {
+	Chan() <-chan time.Time
+	Reset(d time.Duration) bool
+	Stop() bool
+}
+
+type realTimer struct {
+	*time.Timer
+}
+
+func (r realTimer) Chan() <-chan time.Time {
+	return r.C
+}
+
+type fakeTimer struct {
+	c       chan time.Time
+	clock   FakeClock
+	stop    chan struct{}
+	reset   chan reset
+	stopped uint32
+}
+
+func (f *fakeTimer) Chan() <-chan time.Time {
+	return f.c
+}
+
+func (f *fakeTimer) Reset(d time.Duration) bool {
+	stopped := f.Stop()
+
+	f.reset <- reset{t: f.clock.Now().Add(d), next: f.clock.After(d)}
+	if d > 0 {
+		atomic.StoreUint32(&f.stopped, 0)
+	}
+
+	return stopped
+}
+
+func (f *fakeTimer) Stop() bool {
+	if atomic.CompareAndSwapUint32(&f.stopped, 0, 1) {
+		f.stop <- struct{}{}
+		return true
+	}
+	return false
+}
+
+type reset struct {
+	t    time.Time
+	next <-chan time.Time
+}
+
+// run initializes a background goroutine to send the timer event to the timer channel
+// after the period. Events are discarded if the underlying ticker channel does not have
+// enough capacity.
+func (f *fakeTimer) run(initialDuration time.Duration) {
+	nextTick := f.clock.Now().Add(initialDuration)
+	next := f.clock.After(initialDuration)
+
+	waitForReset := func() (time.Time, <-chan time.Time) {
+		for {
+			select {
+			case <-f.stop:
+				continue
+			case r := <-f.reset:
+				return r.t, r.next
+			}
+		}
+	}
+
+	go func() {
+		for {
+			select {
+			case <-f.stop:
+			case <-next:
+				atomic.StoreUint32(&f.stopped, 1)
+				select {
+				case f.c <- nextTick:
+				default:
+				}
+
+				next = nil
+			}
+
+			nextTick, next = waitForReset()
+		}
+	}()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -573,7 +573,7 @@ github.com/johannesboyne/gofakes3
 github.com/johannesboyne/gofakes3/backend/s3mem
 github.com/johannesboyne/gofakes3/internal/goskipiter
 github.com/johannesboyne/gofakes3/internal/s3io
-# github.com/jonboulle/clockwork v0.2.2
+# github.com/jonboulle/clockwork v0.3.0
 ## explicit; go 1.13
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.12


### PR DESCRIPTION
Backports #18050 to branch/v8


Note: This also bumps clockwork on v8. It was discovered that the current version leaked blockers when using fake clocks which made `clock.BlockUntil` only work if you accounted for the number of leaked blockers.