### PR TITLE
Sign tsh for teleport connect on windows builder

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -753,7 +753,23 @@ steps:
   - Enable-Go -ToolchainDir "$Workspace/toolchains"
   - cd $TeleportSrc
   - $Env:GCO_ENABLED=1
-  - go build -o build/tsh.exe ./tool/tsh
+  - go build -o build/tsh-unsigned.exe ./tool/tsh
+  environment:
+    WORKSPACE_DIR: C:/Drone/Workspace/push-build-native-windows-amd64
+- name: Sign tsh
+  commands:
+  - $ErrorActionPreference = 'Stop'
+  - $Workspace = "$Env:WORKSPACE_DIR/$Env:DRONE_BUILD_NUMBER"
+  - $TeleportSrc = "$Workspace/go/src/github.com/gravitational/teleport"
+  - . "$TeleportSrc/build.assets/windows/build.ps1"
+  - cd $TeleportSrc
+  - ([System.Convert]::FromBase64String($ENV:WINDOWS_SIGNING_CERT)) | Set-Content
+    windows-signing-cert.pfx -Encoding Byte
+  - '& ''C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe''
+    sign /f windows-signing-cert.pfx /d Teleport /t http://timestamp.digicert.com
+    /du https://goteleport.com /fd sha256 build\tsh-unsigned.exe'
+  - mv build\tsh-unsigned.exe build\tsh.exe
+  - rm -r windows-signing-cert.pfx
   environment:
     WINDOWS_SIGNING_CERT:
       from_secret: WINDOWS_SIGNING_CERT
@@ -1026,7 +1042,23 @@ steps:
   - Enable-Go -ToolchainDir "$Workspace/toolchains"
   - cd $TeleportSrc
   - $Env:GCO_ENABLED=1
-  - go build -o build/tsh.exe ./tool/tsh
+  - go build -o build/tsh-unsigned.exe ./tool/tsh
+  environment:
+    WORKSPACE_DIR: C:/Drone/Workspace/build-native-windows-amd64
+- name: Sign tsh
+  commands:
+  - $ErrorActionPreference = 'Stop'
+  - $Workspace = "$Env:WORKSPACE_DIR/$Env:DRONE_BUILD_NUMBER"
+  - $TeleportSrc = "$Workspace/go/src/github.com/gravitational/teleport"
+  - . "$TeleportSrc/build.assets/windows/build.ps1"
+  - cd $TeleportSrc
+  - ([System.Convert]::FromBase64String($ENV:WINDOWS_SIGNING_CERT)) | Set-Content
+    windows-signing-cert.pfx -Encoding Byte
+  - '& ''C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe''
+    sign /f windows-signing-cert.pfx /d Teleport /t http://timestamp.digicert.com
+    /du https://goteleport.com /fd sha256 build\tsh-unsigned.exe'
+  - mv build\tsh-unsigned.exe build\tsh.exe
+  - rm -r windows-signing-cert.pfx
   environment:
     WINDOWS_SIGNING_CERT:
       from_secret: WINDOWS_SIGNING_CERT
@@ -18166,6 +18198,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 5bb158520950e163e5978eee73f7c8ef1ae3da426602374d3064a7a79b69e340
+hmac: a2b3e028a12e4a089c407c03cf72c16225058546eb6782ee379d549f62e7283f
 
 ...

--- a/dronegen/windows.go
+++ b/dronegen/windows.go
@@ -50,6 +50,7 @@ func windowsTagPipeline() pipeline {
 		installWindowsNodeToolchainStep(p.Workspace.Path),
 		installWindowsGoToolchainStep(p.Workspace.Path),
 		buildWindowsTshStep(p.Workspace.Path),
+		signTshStep(p.Workspace.Path),
 		buildWindowsTeleportConnectStep(p.Workspace.Path),
 		{
 			Name: "Assume AWS Role",
@@ -113,6 +114,7 @@ func windowsPushPipeline() pipeline {
 		installWindowsNodeToolchainStep(p.Workspace.Path),
 		installWindowsGoToolchainStep(p.Workspace.Path),
 		buildWindowsTshStep(p.Workspace.Path),
+		signTshStep(p.Workspace.Path),
 		buildWindowsTeleportConnectStep(p.Workspace.Path),
 		cleanUpWindowsWorkspaceStep(p.Workspace.Path),
 		{
@@ -222,8 +224,7 @@ func buildWindowsTshStep(workspace string) step {
 	return step{
 		Name: "Build tsh",
 		Environment: map[string]value{
-			"WORKSPACE_DIR":        {raw: workspace},
-			"WINDOWS_SIGNING_CERT": {fromSecret: "WINDOWS_SIGNING_CERT"},
+			"WORKSPACE_DIR": {raw: workspace},
 		},
 		Commands: []string{
 			`$ErrorActionPreference = 'Stop'`,
@@ -234,7 +235,28 @@ func buildWindowsTshStep(workspace string) step {
 			`Enable-Go -ToolchainDir "$Workspace` + toolchainDir + `"`,
 			`cd $TeleportSrc`,
 			`$Env:GCO_ENABLED=1`,
-			`go build -o build/tsh.exe ./tool/tsh`,
+			`go build -o build/tsh-unsigned.exe ./tool/tsh`,
+		},
+	}
+}
+
+func signTshStep(workspace string) step {
+	return step{
+		Name: "Sign tsh",
+		Environment: map[string]value{
+			"WORKSPACE_DIR":        {raw: workspace},
+			"WINDOWS_SIGNING_CERT": {fromSecret: "WINDOWS_SIGNING_CERT"},
+		},
+		Commands: []string{
+			`$ErrorActionPreference = 'Stop'`,
+			`$Workspace = "` + perBuildWorkspace + `"`,
+			`$TeleportSrc = "$Workspace` + teleportSrc + `"`,
+			`. "$TeleportSrc/build.assets/windows/build.ps1"`,
+			`cd $TeleportSrc`,
+			`([System.Convert]::FromBase64String($ENV:WINDOWS_SIGNING_CERT)) | Set-Content windows-signing-cert.pfx -Encoding Byte`,
+			`& 'C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe' sign /f windows-signing-cert.pfx /d Teleport /t http://timestamp.digicert.com /du https://goteleport.com /fd sha256 build\tsh-unsigned.exe`,
+			`mv build\tsh-unsigned.exe build\tsh.exe`,
+			`rm -r windows-signing-cert.pfx`,
 		},
 	}
 }


### PR DESCRIPTION
## Background

Currently we are building tsh for windows on linux machine using cross-compiling and there we are using osslsigncode to sign it.
However tsh is also built for teleport connect on windows builder, and there executable is not signed at all. It results in poor UX when using windows hello/fido2 as MFA in Teleport Connect.

## Solution

I have setup new step in windows builder to sign tsh executables. I am using windows signtool to sign it. 

Working pipeline: https://drone.platform.teleport.sh/gravitational/teleport/17291/27/9
Built executable: https://get.gravitational.com/Teleport%20Connect%20Setup-12.0.0-dev.tobiaszheller.7.exe

## Why signtool instead of osslsigncode

I have tried setting up new step for signing tsh using osslsigncode however it resulted in following error:
```
Failed to parse PKCS#12 file: 
digital envelope routines:inner_evp_generic_fetch:unsupported
```
It seems that static build of osslsigncode for windows is using openssl 3.0 which fails on parsing PKCS12 (more details: https://github.com/mtrojnar/osslsigncode/issues/178)

It turned out that windows native tool `signtool` is already installed on windows builder and it can handler PKCS12 without any issues.

## Future todo

- remove osslsigncode from windows builder or  use format supported by openssl 3.0 for signing code. 
