### PR TITLE
Close the two way TCP server in app access integration tests.

### DIFF
--- a/integration/appaccess/fixtures.go
+++ b/integration/appaccess/fixtures.go
@@ -167,7 +167,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 		}
 		c.Close()
 	})
-	t.Cleanup(func() { rootTCPServer.Close() })
+	t.Cleanup(func() { rootTCPTwoWayServer.Close() })
 	// HTTP server in leaf cluster.
 	leafServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, p.leafMessage)


### PR DESCRIPTION
The two way TCP server was not being properly closed at the end of app access integration tests.