### PR TITLE
Remove references to party initiated limits for SAML

### DIFF
--- a/docs/pages/access-controls/sso/adfs.mdx
+++ b/docs/pages/access-controls/sso/adfs.mdx
@@ -175,15 +175,6 @@ automatically in a browser.
   can be passed via `tsh login --auth=connector_name`
 </Admonition>
 
-<Admonition
-  type="note"
-  title="IMPORTANT"
->
-  Teleport only supports sending party-initiated flows for SAML 2.0. This means
-  that you cannot initiate login from your identity provider, and must do so
-  from either the Teleport Web UI or CLI.
-  </Admonition>
-
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)

--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -161,15 +161,6 @@ automatically in a browser).
   can be passed via `tsh login --auth=connector_name`
 </Admonition>
 
-<Admonition
-  type="note"
-  title="IMPORTANT"
->
-  Teleport only supports sending party initiated flows for SAML 2.0. This
-  means you can not initiate login from your identity provider, you have to
-  initiate login from either the Teleport Web UI or CLI.
-</Admonition>
-
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)

--- a/docs/pages/access-controls/sso/one-login.mdx
+++ b/docs/pages/access-controls/sso/one-login.mdx
@@ -38,14 +38,6 @@ section:
 - [Square Icon](../../../img/sso/onelogin/teleport.png)
 - [Rectangular Icon](../../../img/sso/onelogin/teleportlogo@2x.png)
 
-<Admonition
-  type="tip"
-  title="Important"
->
-  Make sure to pick `SAML Test Connector (SP)` and not `SAML Test Connector (IdP)`,
-  because teleport only supports `SP` - service provider initiated SAML flows.
-</Admonition>
-
 Set `Audience`, `Recipient` and `ACS (Consumer) URL Validator` to the same value:
 
 `https://teleport.example.com:3080/v1/webapi/saml/acs` where `teleport.example.com` is the
@@ -143,15 +135,6 @@ automatically in a browser).
 >
   Teleport can use multiple SAML connectors. In this case a connector name
   can be passed via `tsh login --auth=connector_name`
-</Admonition>
-
-<Admonition
-  type="note"
-  title="IMPORTANT"
->
-  Teleport only supports sending party initiated flows for SAML 2.0. This
-  means you can not initiate login from your identity provider, you have to
-  initiate login from either the Teleport Web UI or CLI.
 </Admonition>
 
 ![Teleport](../../../img/sso/onelogin/onelogin-saml-8.png)

--- a/examples/resources/adfs-connector.yaml
+++ b/examples/resources/adfs-connector.yaml
@@ -14,6 +14,9 @@ spec:
   # as a provider
   provider: adfs
 
+  # Controls whether IdP-initiated SSO is allowed. If false, all such requests will be rejected with an error.
+  allow_idp_initiated: false
+
   # entity_descriptor XML can either be copied into connector or fetched from a URL
   entity_descriptor: |
     <EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">

--- a/examples/resources/onelogin-connector.yaml
+++ b/examples/resources/onelogin-connector.yaml
@@ -4,6 +4,8 @@ metadata:
   name: OneLogin
 spec:
   acs: https://<cluster-url>/v1/webapi/saml/acs
+  # Controls whether IdP-initiated SSO is allowed. If false, all such requests will be rejected with an error.
+  allow_idp_initiated: false
   attributes_to_roles:
     - {name: "groups", value: "admin", roles: ["editor"]}
     - {name: "groups", value: "dev", roles: ["access"]}


### PR DESCRIPTION
- Removes references to party initiated limits for SAML
- Includes `allow_idp_initiated` in SAML examples

Closes #18184