### PR TITLE
[v9] Add option to disable the `ServiceAccount` creation for `teleport-kube-agent chart` (#16876) (#16983)

### DIFF
--- a/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
@@ -863,27 +863,51 @@ Ensures that this number of replicas is available during voluntary disruptions, 
   </TabItem>
 </Tabs>
 
-## `serviceAccountName`
+## `serviceAccount.create`
 
-<Admonition type="note">
-  Most users will not need to change this.
-</Admonition>
+| Type | Default value | Required? | Can be used in `custom` mode? |
+| - | - | - | - |
+| `boolean` | `true` | No | ✅ |
 
-| Type | Default value |
-| - | - |
-| `string` | `nil` |
+[Kubernetes reference](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
 
-`serviceAccountName` can be optionally used to override the name of the Kubernetes `ServiceAccount` used by the `teleport-kube-agent` chart.
+Boolean value to control whether Helm Chart should create the `ServiceAccount`.
+When off, the `serviceAccount.name` parameter should be set to the existing `ServiceAccount` name.
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  serviceAccountName: kubernetes-serviceaccount
+  serviceAccount:
+    create: false
+    name: kubernetes-serviceaccount
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set serviceAccountName=kubernetes-serviceaccount
+  $ --set serviceAccount.create=false
+  $ --set serviceAccount.name=kubernetes-serviceaccount
+  ```
+  </TabItem>
+</Tabs>
+
+## `serviceAccount.name`
+
+| Type | Default value | Required? | Can be used in `custom` mode? |
+| - | - | - | - |
+| `string` | `""` | No | ✅ |
+
+`serviceAccount.name` can be optionally used to override the name of the Kubernetes `ServiceAccount` used by the `teleport-kube-agent` chart.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  serviceAccount:
+    name: kubernetes-serviceaccount
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set serviceAccount.name=kubernetes-serviceaccount
   ```
   </TabItem>
 </Tabs>

--- a/examples/chart/teleport-kube-agent/templates/_helpers.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{/*
+Create the name of the service account to use
+if serviceAccount is not defined or serviceAccount.name is empty, use .Release.Name
+*/}}
+{{- define "teleport.serviceAccountName" -}}
+{{- coalesce .Values.serviceAccount.name .Values.serviceAccountName .Release.Name -}}
+{{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
   name: {{ .Values.clusterRoleName | default .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccountName | default .Release.Name }}
+  name: {{ template "teleport.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -196,5 +196,5 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-      serviceAccountName: {{ .Values.serviceAccountName | default .Release.Name }}
+      serviceAccountName: {{ template "teleport.serviceAccountName" . }}
 {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/psp.yaml
+++ b/examples/chart/teleport-kube-agent/templates/psp.yaml
@@ -62,5 +62,5 @@ roleRef:
   name: {{ .Release.Name }}-psp
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccountName | default .Release.Name }}
+  name: {{ template "teleport.serviceAccountName" . }}
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
+++ b/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccountName | default .Release.Name }}
+  name: {{ template "teleport.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- if .Values.extraLabels.serviceAccount }}
   labels:
@@ -10,4 +11,5 @@ metadata:
 {{- if .Values.annotations.serviceAccount }}
   annotations:
 {{- toYaml .Values.annotations.serviceAccount | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -115,7 +115,7 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-      serviceAccountName: {{ .Values.serviceAccountName | default .Release.Name }}
+      serviceAccountName: {{ template "teleport.serviceAccountName" . }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -146,7 +146,17 @@ clusterRoleName: ""
 # (optional) Override the name of the ClusterRoleBinding used by the agent's service account.
 clusterRoleBindingName: ""
 # (optional) Override the name of the service account used by the agent.
+# DEPRECATED Use serviceAccount:name instead
 serviceAccountName: ""
+# (optional) Kubernetes service account to create/use.
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true 
+  # The name of the ServiceAccount to use.
+  # If not set and serviceAccount.create is true, the name is generated using the release name.
+  # If create is false, the name will be used to reference an existing service account.
+  name: ""
+
 # Name of the Secret to store the teleport join token.
 secretName: teleport-kube-agent-join-token
 


### PR DESCRIPTION
Backport of #16876 to V9