### PR TITLE
[v9] Add in app access connection monitoring.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -157,6 +157,8 @@ func (s *InstanceSecrets) String() string {
 
 // InstanceConfig is an instance configuration
 type InstanceConfig struct {
+	// Clock is an optional clock to use
+	Clock clockwork.Clock
 	// ClusterName is a cluster name of the instance
 	ClusterName string
 	// HostID is a host id of the instance

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -890,6 +890,10 @@ type AppsConfig struct {
 
 	// ResourceMatchers match cluster database resources.
 	ResourceMatchers []services.ResourceMatcher
+
+	// MonitorCloseChannel will be signaled when a monitor closes a connection.
+	// Used only for testing. Optional.
+	MonitorCloseChannel chan struct{}
 }
 
 // App is the specific application that will be proxied by the application

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3861,21 +3861,23 @@ func (process *TeleportProcess) initApps() {
 			return trace.Wrap(err)
 		}
 		appServer, err := app.New(process.ExitContext(), &app.Config{
-			DataDir:          process.Config.DataDir,
-			AuthClient:       conn.Client,
-			AccessPoint:      accessPoint,
-			Authorizer:       authorizer,
-			TLSConfig:        tlsConfig,
-			CipherSuites:     process.Config.CipherSuites,
-			HostID:           process.Config.HostUUID,
-			Hostname:         process.Config.Hostname,
-			GetRotation:      process.getRotation,
-			Apps:             applications,
-			CloudLabels:      process.cloudLabels,
-			ResourceMatchers: process.Config.Apps.ResourceMatchers,
-			OnHeartbeat:      process.onHeartbeat(teleport.ComponentApp),
-			LockWatcher:      lockWatcher,
-			Emitter:          asyncEmitter,
+			Clock:               process.Config.Clock,
+			DataDir:             process.Config.DataDir,
+			AuthClient:          conn.Client,
+			AccessPoint:         accessPoint,
+			Authorizer:          authorizer,
+			TLSConfig:           tlsConfig,
+			CipherSuites:        process.Config.CipherSuites,
+			HostID:              process.Config.HostUUID,
+			Hostname:            process.Config.Hostname,
+			GetRotation:         process.getRotation,
+			Apps:                applications,
+			CloudLabels:         process.cloudLabels,
+			ResourceMatchers:    process.Config.Apps.ResourceMatchers,
+			OnHeartbeat:         process.onHeartbeat(teleport.ComponentApp),
+			LockWatcher:         lockWatcher,
+			Emitter:             asyncEmitter,
+			MonitorCloseChannel: process.Config.Apps.MonitorCloseChannel,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -116,6 +116,10 @@ type Config struct {
 
 	// Emitter is an event emitter.
 	Emitter events.Emitter
+
+	// MonitorCloseChannel will be signaled when the monitor closes a connection.
+	// Used only for testing. Optional.
+	MonitorCloseChannel chan struct{}
 }
 
 // CheckAndSetDefaults makes sure the configuration has the minimum required
@@ -658,6 +662,7 @@ func (s *Server) monitorConn(parentCtx context.Context, conn net.Conn, authCtx *
 		TeleportUser:          identity.Username,
 		Emitter:               s.c.Emitter,
 		Entry:                 s.log,
+		MonitorCloseChannel:   s.c.MonitorCloseChannel,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -268,6 +268,8 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		apps = config.Apps
 	}
 
+	discard := events.NewDiscardEmitter()
+
 	s.appServer, err = New(s.closeContext, &Config{
 		Clock:            s.clock,
 		DataDir:          s.dataDir,
@@ -284,6 +286,8 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		Cloud:            &testCloud{},
 		ResourceMatchers: config.ResourceMatchers,
 		OnReconcile:      config.OnReconcile,
+		LockWatcher:      lockWatcher,
+		Emitter:          discard,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/17436 to branch/v9

Note: This ended up needing a good amount of rework because Teleport didn't support TCP apps here. While at face value you might think that we could avoid having a connection monitor here, websockets still benefit from the connection monitor since they're long lived.

The integration tests have been re-oriented to target websockets instead of TCP applications. The certification duration used `apidefaults.CertDuration`, so the only way to alter this without significantly altering a lot of the underlying plumbing was to set a max TTL for the role associated with the user.

Rather than track errors in the application server like the v10 and v11 implementations, this actually tracks whether a monitor was set up for a given connection and sets it up in the HTTP server itself. This is necessary because the function signature of `HandleConnection` doesn't include an error, so there's no real way to pass errors up the stack if authentication fails during `HandleConnection`.

Basically, please take a good look at this one since it's changed a good bit from the other backports.