### PR TITLE
Cloud Build workflows moved to Github Actions

### DIFF
--- a/.github/actions/auth-to-gcloud/action.yml
+++ b/.github/actions/auth-to-gcloud/action.yml
@@ -1,0 +1,21 @@
+name: Authenticate to Google Gloud
+description: Authenticates to Google Cloud
+inputs:
+  workload_identity_provider:
+    description: Google Cloud identity provider
+    required: false
+    default: projects/671314886056/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+
+  service_account:
+    description: Google Cloud Storage service account name
+    required: false
+    default: teleport-storage@just-terminus-366813.iam.gserviceaccount.com
+
+runs:
+  using: "composite"
+  steps:
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v0
+      with:
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.service_account }}

--- a/.github/actions/prepare-workspace/action.yml
+++ b/.github/actions/prepare-workspace/action.yml
@@ -1,0 +1,47 @@
+name: Prepare Teleport workspace
+description: Prepares Teleport workspace folder
+inputs:
+  cache_key:
+    description: Cache infix used in cache actions
+    required: false
+    default: ${{ github.workflow }}
+  
+runs:
+  using: "composite"
+  steps:
+    - name: Mark workspace as git safe.directory
+      shell: bash
+      run: |
+        git config --global --add safe.directory ${GITHUB_WORKSPACE}
+        git config --global --add safe.directory ${GITHUB_WORKSPACE}/webassets
+
+    - name: Fetch go cache paths
+      id: go-cache-paths
+      shell: bash
+      run: |
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+
+    - name: Go build cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-build-${{ inputs.cache_key }}-
+
+    - name: Go mod cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-mod-${{ inputs.cache_key }}-
+
+    - name: Rust cargo cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ github.workspace }}/target
+          /usr/local/cargo/registry
+          /usr/local/cargo/git
+        key: ${{ runner.os }}-cargo-${{ inputs.cache_key }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-${{ inputs.cache_key }}-

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -1,0 +1,17 @@
+name: Upload test artifacts
+description: Upload test artifacts
+inputs:
+  bucket_name:
+    description: Google Cloud bucket name
+    required: false
+    default: teleport-test-logs
+
+runs:
+  using: "composite"
+  steps:
+    - name: Upload artifacts
+      uses: google-github-actions/upload-cloud-storage@v0
+      with:
+        path: ${{ github.workspace }}/test-logs
+        destination: ${{ inputs.bucket_name }}/${{ github.workflow }}-${{ github.run_id }}
+        parent: false

--- a/.github/services/Dockerfile.etcd
+++ b/.github/services/Dockerfile.etcd
@@ -1,0 +1,20 @@
+ARG BUILDARCH
+ARG ETCD_VERSION
+
+FROM bitnami/etcd:${ETCD_VERSION}
+
+COPY examples/etcd/certs /certs
+
+HEALTHCHECK CMD etcdctl --insecure-discovery --endpoint=https://etcd0:2379 --key-file /certs/client-key.pem --cert-file /certs/client-cert.pem --ca-file /certs/ca-cert.pem cluster-health
+
+EXPOSE 2379 2380
+
+ENTRYPOINT /opt/bitnami/etcd/bin/etcd --name teleportstorage \
+    --initial-cluster-state new \
+    --cert-file /certs/server-cert.pem \
+    --key-file /certs/server-key.pem \
+    --trusted-ca-file /certs/ca-cert.pem \
+    --advertise-client-urls=https://127.0.0.1:2379 \
+    --listen-client-urls=https://0.0.0.0:2379 \
+    --client-cert-auth \
+    --debug

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -1,0 +1,64 @@
+name: Build CI service images
+run-name: Build CI service images
+on:
+  push:
+    paths:
+      - .github/services/Dockerfile.*
+      - examples/etcd/certs/*.pem
+    branches:
+      - master
+  pull_request:
+    paths:
+      - .github/services/Dockerfile.*
+      - examples/etcd/certs/*.pem
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: gravitational/ci-etcd
+  ETCD_VERSION: 3.3.9
+
+jobs:
+  build:
+    name: Build CI services Docker images
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build etcd image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ github.workspace }}
+          file: .github/services/Dockerfile.etcd
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.ETCD_VERSION }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ETCD_VERSION=${{ env.ETCD_VERSION }}
+          push: true
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -1,0 +1,24 @@
+name: markdown-lint
+run-name: yarn markdown-lint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  doc-tests:
+    name: yarn markdown-lint
+    runs-on: ubuntu-latest
+
+    container:
+      image: public.ecr.aws/gravitational/docs:latest
+      volumes:
+        - ${{ github.workspace }}:/src/content
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        run: cd /src/content && yarn markdown-lint

--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -1,0 +1,68 @@
+name: integration-tests-non-root
+run-name: Integration tests (non-root) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  test:
+    name: Integration tests (non-root)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+
+    container: 
+      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      env:
+        TELEPORT_ETCD_TEST: yes
+        TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379
+      options: --cap-add=SYS_ADMIN --privileged
+
+    services:
+      etcd0:
+        image: ghcr.io/gzigzigzeo/teleport-ci-etcd:3.3.9
+        options: >-
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --add-host etcd0:127.0.0.1
+        ports:
+          - 2379:2379
+          - 2380:2380
+          - 3379:3379
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Authenticate to Google Cloud
+        if: github.repository	== 'gravitational/teleport'
+        uses: ./.github/actions/auth-to-gcloud
+
+      - name: Prepare workspace
+        uses: ./.github/actions/prepare-workspace
+
+      - name: Chown
+        run: |
+          mkdir -p $(go env GOMODCACHE)
+          mkdir -p $(go env GOCACHE)
+          chown -Rf ci:ci ${GITHUB_WORKSPACE} $(go env GOMODCACHE) $(go env GOCACHE)
+        continue-on-error: true
+
+      - name: Run tests
+        timeout-minutes: 40
+        run: runuser -u ci -g ci make rdpclient integration
+
+      - name: Upload artifacts
+        if: always() && github.repository	== 'gravitational/teleport'
+        uses: ./.github/actions/upload-artifacts

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -1,0 +1,45 @@
+name: integration-tests-root
+run-name: Integration tests (root) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  test:
+    name: Integration tests (root)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    container: 
+      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      options: --cap-add=SYS_ADMIN --privileged
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Authenticate to Google Cloud
+        if: github.repository	== 'gravitational/teleport'
+        uses: ./.github/actions/auth-to-gcloud
+
+      - name: Prepare workspace
+        uses: ./.github/actions/prepare-workspace
+
+      - name: Run tests
+        timeout-minutes: 40
+        run: |
+          make rdpclient integration-root
+
+      - name: Upload artifacts
+        if: always() && github.repository	== 'gravitational/teleport'
+        uses: ./.github/actions/upload-artifacts

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,24 @@
+name: go-lint
+run-name: make lint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  lint:
+    name: make lint
+    runs-on: ubuntu-latest
+
+    container:
+      image: public.ecr.aws/gravitational/teleport-buildbox:teleport11
+      env:
+        GO_LINT_FLAGS: --timeout=15m
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run linter
+        run: make lint

--- a/.github/workflows/os-compability-test.yaml
+++ b/.github/workflows/os-compability-test.yaml
@@ -1,0 +1,60 @@
+name: os-compability-test
+run-name: OS compability test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: make build/*
+    runs-on: ubuntu-latest
+    container: 
+      image: public.ecr.aws/gravitational/teleport-buildbox-centos7:teleport12
+      env:
+        GOCACHE: /tmp/gocache
+
+    steps:
+      # https://github.com/gravitational/teleport/pull/18573
+      - name: Install git 1.18+
+        run: |
+          yum -y install git
+
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Prepare workspace
+        uses: ./.github/actions/prepare-workspace
+
+      - name: Run make
+        run: |
+          make build/tctl build/tsh build/tbot build/teleport
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: ${{ github.workspace }}/build/
+
+  test-compat:
+    needs: build
+    name: test-compat
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: ${{ github.workspace }}/build
+
+      - name: chmod +x
+        run: chmod +x ${GITHUB_WORKSPACE}/build/*
+
+      - name: Run compat matrix
+        # timeout-minutes: 10 TODO: Uncomment on production runner
+        run: |
+          cd ${GITHUB_WORKSPACE} && ./build.assets/build-test-compat.sh

--- a/.github/workflows/unit-tests-code-bypass.yaml
+++ b/.github/workflows/unit-tests-code-bypass.yaml
@@ -1,0 +1,14 @@
+name: unit-tests-code
+run-name: Unit tests (code) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.go'
+
+jobs:
+  test:
+    name: Unit tests (code)
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes to verify"'

--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -1,0 +1,65 @@
+name: unit-tests-code
+run-name: Unit tests (code) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  test:
+    name: Unit tests (code)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    container: 
+      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      env:
+        TELEPORT_ETCD_TEST: yes
+        TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379
+        TELEPORT_XAUTH_TEST: yes
+        TELEPORT_BPF_TEST: yes
+      options: --cap-add=SYS_ADMIN --privileged
+
+    services:
+      etcd0:
+        image: ghcr.io/gzigzigzeo/teleport-ci-etcd:3.3.9
+        options: >-
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --add-host etcd0:127.0.0.1
+        ports:
+          - 2379:2379
+          - 2380:2380
+          - 3379:3379
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Authenticate to Google Cloud
+        if: github.repository	== 'gravitational/teleport'
+        uses: ./.github/actions/auth-to-gcloud
+
+      - name: Prepare workspace
+        uses: ./.github/actions/prepare-workspace
+
+      - name: Mount debugfs
+        run: mount -t debugfs none /sys/kernel/debug/
+
+      - name: Run tests
+        timeout-minutes: 40
+        run: make test-go test-sh test-api
+
+      - name: Upload artifacts
+        if: always() && github.repository	== 'gravitational/teleport'
+        uses: ./.github/actions/upload-artifacts

--- a/.github/workflows/unit-tests-helm-bypass.yaml
+++ b/.github/workflows/unit-tests-helm-bypass.yaml
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: unit-tests-helm
+run-name: Unit tests (helm) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'examples/chart/**'
+
+jobs:
+  test:
+    name: Unit tests (helm)
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes to verify"'

--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -1,0 +1,28 @@
+name: unit-tests-helm
+run-name: Unit tests (helm) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'examples/chart/**'
+
+jobs:
+  test:
+    name: Unit tests (helm)
+    runs-on: ubuntu-latest
+
+    container: 
+      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      env:
+        HELM_PLUGINS: /root/.local/share/helm/plugins
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        timeout-minutes: 40
+        run: make test-helm

--- a/.github/workflows/unit-tests-operator-bypass.yaml
+++ b/.github/workflows/unit-tests-operator-bypass.yaml
@@ -1,0 +1,18 @@
+name: unit-tests-operator
+run-name: Unit tests (operator) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  pull_request:
+    paths-ignore:
+      - /go.mod
+      - /go.sum
+      - operator/**
+      - api/types/**
+      - lib/tbot/**
+
+jobs:
+  test:
+    name: Unit tests (operator)
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes to verify"'

--- a/.github/workflows/unit-tests-operator.yaml
+++ b/.github/workflows/unit-tests-operator.yaml
@@ -1,0 +1,34 @@
+name: unit-tests-operator
+run-name: Unit tests (operator) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - /go.mod
+      - /go.sum
+      - operator/**
+      - api/types/**
+      - lib/tbot/**
+
+jobs:
+  test:
+    name: Unit tests (operator)
+    runs-on: ubuntu-latest
+
+    container: 
+      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      options: --cap-add=SYS_ADMIN --privileged
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Prepare workspace
+        uses: ./.github/actions/prepare-workspace
+
+      - name: Run tests
+        timeout-minutes: 40
+        run: make test-operator

--- a/.github/workflows/unit-tests-rust-bypass.yaml
+++ b/.github/workflows/unit-tests-rust-bypass.yaml
@@ -1,0 +1,16 @@
+name: unit-tests-rust
+run-name: Unit tests (rust) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+
+jobs:
+  test:
+    name: Unit tests (rust)
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes to verify"'

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -1,0 +1,38 @@
+name: unit-tests-rust
+run-name: Unit tests (rust) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+
+jobs:
+  test:
+    name: Unit tests (rust)
+    runs-on: ubuntu-latest
+    container: 
+      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      options: --cap-add=SYS_ADMIN --privileged
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Rust cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/target
+            /usr/local/cargo/registry
+            /usr/local/cargo/git
+          key: ${{ runner.os }}-cargo-${{ github.workflow }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-${{ github.workflow }}-
+
+      - name: Run tests
+        timeout-minutes: 40
+        run: make test-rust

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -306,7 +306,7 @@ func etcdBackendConfig(t *testing.T) *backend.Config {
 	cfg := &backend.Config{
 		Type: "etcd",
 		Params: backend.Params{
-			"peers":         []string{"https://127.0.0.1:2379"},
+			"peers":         []string{etcdTestEndpoint()},
 			"prefix":        prefix,
 			"tls_key_file":  "../../examples/etcd/certs/client-key.pem",
 			"tls_cert_file": "../../examples/etcd/certs/client-cert.pem",
@@ -321,6 +321,17 @@ func etcdBackendConfig(t *testing.T) *backend.Config {
 			"failed to clean up etcd backend")
 	})
 	return cfg
+}
+
+// Returns etcd host used in tests
+func etcdTestEndpoint() string {
+	host := os.Getenv("TELEPORT_ETCD_TEST_ENDPOINT")
+
+	if host != "" {
+		return host
+	}
+
+	return "https://127.0.0.1:2379"
 }
 
 func liteBackendConfig(t *testing.T) *backend.Config {

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 
 // commonEtcdParams holds the common etcd configuration for all tests.
 var commonEtcdParams = backend.Params{
-	"peers":         []string{"https://127.0.0.1:2379"},
+	"peers":         []string{etcdTestEndpoint()},
 	"prefix":        examplePrefix,
 	"tls_key_file":  "../../../examples/etcd/certs/client-key.pem",
 	"tls_cert_file": "../../../examples/etcd/certs/client-cert.pem",
@@ -174,7 +174,8 @@ func TestCompareAndSwapOversizedValue(t *testing.T) {
 	// setup
 	const maxClientMsgSize = 128
 	bk, err := New(context.Background(), backend.Params{
-		"peers":                          []string{"https://127.0.0.1:2379"},
+		// temp change to etcd
+		"peers":                          []string{etcdTestEndpoint()},
 		"prefix":                         "/teleport",
 		"tls_key_file":                   "../../../examples/etcd/certs/client-key.pem",
 		"tls_cert_file":                  "../../../examples/etcd/certs/client-cert.pem",
@@ -245,6 +246,17 @@ func TestLeaseBucketing(t *testing.T) {
 
 func etcdTestEnabled() bool {
 	return os.Getenv("TELEPORT_ETCD_TEST") != ""
+}
+
+// Returns etcd host used in tests
+func etcdTestEndpoint() string {
+	host := os.Getenv("TELEPORT_ETCD_TEST_ENDPOINT")
+
+	if host != "" {
+		return host
+	}
+
+	return "https://127.0.0.1:2379"
 }
 
 func (r blockingFakeClock) Advance(d time.Duration) {


### PR DESCRIPTION
# Update builds to GitHub actions

We need to move CI from Google Cloud Build to Github Actions to enable merge workflow.

## `.cloudbuild/scripts`

All tests are run by go scripts located in `.cloudbuild/scripts`. Each script performs the following:

1. Detects a changed file group: code, helm, operator, sh, rust, docs, CI.
2. Starts `etcd` service, mounts debugfs, chowns if required.
3. Runs tests related to a changed group.
4. Uploads build artefacts (JSON logs) to the Google storage bucket, regardless of a test result.

## GitHub Actions

GitHub Actions has the implementations for most of the steps described above as a separate recipes (actions). GHA internal changes detector plays with GitHub better than a DIY script. Standard action errors are easier to analyse. Integration tests are a bit faster because they can be split into two workflows and run in parallel.

## etcd

Some tests require `etcd` service up and running. The most reliable way to use it with GitHub Actions is to start `etcd` in a [service container](https://docs.github.com/en/actions/using-containerized-services/about-service-containers). 

Tests use mTLS auth. Certificates are stored in the repo (`examples/etcd/certs`). Unfortunately, a service container can not access a repository files during the startup. Service containers are self-isolated by design.

To overcome this, I’ve built a tiny Docker image, which embeds `etcd` and a required certs from the repo. I also implemented the workflow, which builds this image on CI and uploads it to the registry. It runs only if certificates or Dockerfile get changed.

`TELEPORT_ETCD_TEST_ENDPOINT` environment variable is now used to set `etcd` endpoint in CI tests. 

## Resulting workflows

Workflows:

* `doc-tests.yaml` - runs markdown linting.
* `lint.yaml` - runs go lint.
* `os-compability-test.yaml` - ensures that built binaries would start in different OS.
* `integration-tests-root.yaml` - runs integration tests as root user.
* `integration-tests-non-root.yaml` - runs integration tests as a regular user.
* `unit-tests-helm.yaml` - runs Helm tests.
* `unit-tests-rust.yaml` - runs Rust tests.
* `unit-tests-operator.yaml` - runs k8s operator tests.
* `unit-tests-code.yaml` - runs go unit tests.
* `build-ci-service-images.yaml` - builds and uploads `etcd` service container image.

Actions:

* `prepare-workspace` - adds /workspace to git.safe, logs in to Google Cloud and handles caching.
* `upload-artifacts` - uploads artifacts to Google cache.

## Skipped, but required checks

A pull request may not contain changes which trigger a workflow required to merge. For example, a pull request may not change Rust code, but Rust unit tests are required by branch protection rules. [The GitHub recommended method](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks) is used to overcome this. 

Bypass workflows are defined in `*-bypass.yaml` files.

## Required credentials

For now, all steps use temporary credentials.

- To make artifacts uploader work - please, [follow the setup instructions](https://github.com/google-github-actions/auth). Service account must be created and must have `storage.objects.`create and `storage.objects.delete` permissions. `workload_identity_provider` and `service_account` names must be set in `.github/actions/prepare-workspace`. You'll get this values after setup.
- Bucket name must be set in `.github/actions/upload-artifacts`
- `build-ci-service-images.yaml` pushes etcd Docker image to the registry. Please, modify it according to your registry settings (see https://github.com/docker/login-action) and define required secrets in the repo settings.

## Known issues

- [ ] #18252 must be merged to eliminate git update steps all across the current workflows.
- [ ] non-root integration tests fail. It is clear that some of the tests are failing because of default runners are slow.
- [ ] (improvement) I guess, that `os-compat-test.sh` could be turned into GitHub Actions matrix step, which would run everything in parralel. However, I am not 100% sure that container image can be taken from a param. Will investigate.
- [ ] `on` section (workflow triggers) might require minor adjustments for `unit-tests`.