### PR TITLE
Make TestTCP* tests in appaccess more deterministic.

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -596,7 +596,11 @@ func TestTCPLock(t *testing.T) {
 	clock.Advance(10 * time.Second)
 
 	// Wait for the channel closure signal
-	<-mCloseChannel
+	select {
+	case <-mCloseChannel:
+	case <-time.After(time.Second * 5):
+		require.Fail(t, "timeout waiting for monitor channel signal")
+	}
 	_, err = conn.Write(msg)
 	require.NoError(t, err)
 
@@ -651,7 +655,11 @@ func TestTCPCertExpiration(t *testing.T) {
 	// Let the cert expire.
 	clock.Advance(30 * time.Second)
 	// Wait for the channel closure signal
-	<-mCloseChannel
+	select {
+	case <-mCloseChannel:
+	case <-time.After(time.Second * 5):
+		require.Fail(t, "timeout waiting for monitor channel signal")
+	}
 	_, err = conn.Write(msg)
 	require.NoError(t, err)
 

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/oxy/forward"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -559,58 +560,11 @@ func TestTCP(t *testing.T) {
 
 // TestTCPLock tests locking TCP applications.
 func TestTCPLock(t *testing.T) {
-	pack := Setup(t)
-
-	msg := []byte(uuid.New().String())
-
-	// Start the proxy to the two way communication app.
-	address := pack.startLocalProxy(t, pack.rootTCPTwoWayPublicAddr, pack.rootAppClusterName)
-	conn, err := net.Dial("tcp", address)
-	require.NoError(t, err)
-
-	// Read, write, and read again to make sure its working as expected.
-	buf := make([]byte, 1024)
-	n, err := conn.Read(buf)
-	require.NoError(t, err, buf)
-
-	resp := strings.TrimSpace(string(buf[:n]))
-	require.Equal(t, pack.rootTCPTwoWayMessage, resp)
-
-	_, err = conn.Write(msg)
-	require.NoError(t, err)
-
-	n, err = conn.Read(buf)
-	require.NoError(t, err, buf)
-
-	resp = strings.TrimSpace(string(buf[:n]))
-	require.Equal(t, pack.rootTCPTwoWayMessage, resp)
-
-	// Lock the user and try to write
-	pack.LockUser(t)
-	require.Eventually(t, func() bool {
-		_, err := conn.Write(msg)
-		if err != nil {
-			return false
-		}
-
-		_, err = conn.Read(buf)
-		return err != nil
-	}, 5*time.Second, 100*time.Millisecond)
-	// Close and re-open the connection
-	require.NoError(t, conn.Close())
-
-	conn, err = net.Dial("tcp", address)
-	require.NoError(t, err)
-
-	// Try to read again, expect a failure.
-	_, err = conn.Read(buf)
-	require.Error(t, err, buf)
-}
-
-// TestTCPCertExpiration tests TCP application with certs expiring.
-func TestTCPCertExpiration(t *testing.T) {
+	clock := clockwork.NewFakeClockAt(time.Now())
+	mCloseChannel := make(chan struct{})
 	pack := SetupWithOptions(t, AppTestOptions{
-		CertificateTTL: 5 * time.Second,
+		Clock:               clock,
+		MonitorCloseChannel: mCloseChannel,
 	})
 
 	msg := []byte(uuid.New().String())
@@ -638,15 +592,72 @@ func TestTCPCertExpiration(t *testing.T) {
 	require.Equal(t, pack.rootTCPTwoWayMessage, resp)
 
 	// Lock the user and try to write
-	require.Eventually(t, func() bool {
-		_, err := conn.Write(msg)
-		if err != nil {
-			return false
-		}
+	pack.LockUser(t)
+	clock.Advance(10 * time.Second)
 
-		_, err = conn.Read(buf)
-		return err != nil
-	}, 5*time.Second, 100*time.Millisecond)
+	// Wait for the channel closure signal
+	<-mCloseChannel
+	_, err = conn.Write(msg)
+	require.NoError(t, err)
+
+	_, err = conn.Read(buf)
+	require.Error(t, err)
+
+	// Close and re-open the connection
+	require.NoError(t, conn.Close())
+
+	conn, err = net.Dial("tcp", address)
+	require.NoError(t, err)
+
+	// Try to read again, expect a failure.
+	_, err = conn.Read(buf)
+	require.Error(t, err, buf)
+}
+
+// TestTCPCertExpiration tests TCP application with certs expiring.
+func TestTCPCertExpiration(t *testing.T) {
+	clock := clockwork.NewFakeClockAt(time.Now())
+	mCloseChannel := make(chan struct{})
+	pack := SetupWithOptions(t, AppTestOptions{
+		CertificateTTL:      5 * time.Second,
+		Clock:               clock,
+		MonitorCloseChannel: mCloseChannel,
+	})
+
+	msg := []byte(uuid.New().String())
+
+	// Start the proxy to the two way communication app.
+	address := pack.startLocalProxy(t, pack.rootTCPTwoWayPublicAddr, pack.rootAppClusterName)
+	conn, err := net.Dial("tcp", address)
+	require.NoError(t, err)
+
+	// Read, write, and read again to make sure its working as expected.
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	require.NoError(t, err, buf)
+
+	resp := strings.TrimSpace(string(buf[:n]))
+	require.Equal(t, pack.rootTCPTwoWayMessage, resp)
+
+	_, err = conn.Write(msg)
+	require.NoError(t, err)
+
+	n, err = conn.Read(buf)
+	require.NoError(t, err, buf)
+
+	resp = strings.TrimSpace(string(buf[:n]))
+	require.Equal(t, pack.rootTCPTwoWayMessage, resp)
+
+	// Let the cert expire.
+	clock.Advance(30 * time.Second)
+	// Wait for the channel closure signal
+	<-mCloseChannel
+	_, err = conn.Write(msg)
+	require.NoError(t, err)
+
+	_, err = conn.Read(buf)
+	require.Error(t, err)
+
 	// Close and re-open the connection
 	require.NoError(t, conn.Close())
 
@@ -681,7 +692,7 @@ func testServersHA(p *Pack, t *testing.T) {
 				}
 			},
 			startAppServers: func(pack *Pack, count int) []*service.TeleportProcess {
-				return pack.startRootAppServers(t, count, []service.App{})
+				return pack.startRootAppServers(t, count, AppTestOptions{})
 			},
 			waitForTunnelConn: func(t *testing.T, pack *Pack, count int) {
 				helpers.WaitForActiveTunnelConnections(t, pack.rootCluster.Tunnel, pack.rootCluster.Secrets.SiteName, count)
@@ -697,7 +708,7 @@ func testServersHA(p *Pack, t *testing.T) {
 				}
 			},
 			startAppServers: func(pack *Pack, count int) []*service.TeleportProcess {
-				return pack.startLeafAppServers(t, count, []service.App{})
+				return pack.startLeafAppServers(t, count, AppTestOptions{})
 			},
 			waitForTunnelConn: func(t *testing.T, pack *Pack, count int) {
 				helpers.WaitForActiveTunnelConnections(t, pack.leafCluster.Tunnel, pack.leafCluster.Secrets.SiteName, count)

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -598,7 +598,7 @@ func TestTCPLock(t *testing.T) {
 	// Wait for the channel closure signal
 	select {
 	case <-mCloseChannel:
-	case <-time.After(time.Second * 5):
+	case <-time.After(time.Second * 10):
 		require.Fail(t, "timeout waiting for monitor channel signal")
 	}
 	_, err = conn.Write(msg)
@@ -657,7 +657,7 @@ func TestTCPCertExpiration(t *testing.T) {
 	// Wait for the channel closure signal
 	select {
 	case <-mCloseChannel:
-	case <-time.After(time.Second * 5):
+	case <-time.After(time.Second * 10):
 		require.Fail(t, "timeout waiting for monitor channel signal")
 	}
 	_, err = conn.Write(msg)

--- a/integration/appaccess/fixtures.go
+++ b/integration/appaccess/fixtures.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -42,6 +43,8 @@ type AppTestOptions struct {
 	RootClusterListeners helpers.InstanceListenerSetupFunc
 	LeafClusterListeners helpers.InstanceListenerSetupFunc
 	CertificateTTL       time.Duration
+	Clock                clockwork.FakeClock
+	MonitorCloseChannel  chan struct{}
 
 	RootConfig func(config *service.Config)
 	LeafConfig func(config *service.Config)
@@ -167,7 +170,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 		}
 		c.Close()
 	})
-	t.Cleanup(func() { rootTCPServer.Close() })
+	t.Cleanup(func() { rootTCPTwoWayServer.Close() })
 	// HTTP server in leaf cluster.
 	leafServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, p.leafMessage)
@@ -257,6 +260,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 
 	// Create a new Teleport instance with passed in configuration.
 	rootCfg := helpers.InstanceConfig{
+		Clock:       opts.Clock,
 		ClusterName: "example.com",
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Host,
@@ -271,6 +275,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 
 	// Create a new Teleport instance with passed in configuration.
 	leafCfg := helpers.InstanceConfig{
+		Clock:       opts.Clock,
 		ClusterName: "leaf.example.com",
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Host,
@@ -299,6 +304,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 	if opts.RootConfig != nil {
 		opts.RootConfig(rcConf)
 	}
+	rcConf.Clock = opts.Clock
 
 	lcConf := service.MakeDefaultConfig()
 	lcConf.Console = nil
@@ -316,6 +322,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 	if opts.RootConfig != nil {
 		opts.RootConfig(lcConf)
 	}
+	lcConf.Clock = opts.Clock
 
 	err = p.leafCluster.CreateEx(t, p.rootCluster.Secrets.AsSlice(), lcConf)
 	require.NoError(t, err)
@@ -331,11 +338,11 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 
 	// At least one rootAppServer should start during the setup
 	rootAppServersCount := 1
-	p.rootAppServers = p.startRootAppServers(t, rootAppServersCount, opts.ExtraRootApps)
+	p.rootAppServers = p.startRootAppServers(t, rootAppServersCount, opts)
 
 	// At least one leafAppServer should start during the setup
 	leafAppServersCount := 1
-	p.leafAppServers = p.startLeafAppServers(t, leafAppServersCount, opts.ExtraLeafApps)
+	p.leafAppServers = p.startLeafAppServers(t, leafAppServersCount, opts)
 
 	// Create user for tests.
 	p.initUser(t)

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -567,13 +567,14 @@ func (p *Pack) waitForLogout(appCookie string) (int, error) {
 	}
 }
 
-func (p *Pack) startRootAppServers(t *testing.T, count int, extraApps []service.App) []*service.TeleportProcess {
+func (p *Pack) startRootAppServers(t *testing.T, count int, opts AppTestOptions) []*service.TeleportProcess {
 	log := utils.NewLoggerForTests()
 
 	configs := make([]*service.Config, count)
 
 	for i := 0; i < count; i++ {
 		raConf := service.MakeDefaultConfig()
+		raConf.Clock = opts.Clock
 		raConf.Console = nil
 		raConf.Log = log
 		raConf.DataDir = t.TempDir()
@@ -587,6 +588,7 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, extraApps []service.
 		raConf.SSH.Enabled = false
 		raConf.Apps.Enabled = true
 		raConf.CircuitBreakerConfig = breaker.NoopBreakerConfig()
+		raConf.Apps.MonitorCloseChannel = opts.MonitorCloseChannel
 		raConf.Apps.Apps = append([]service.App{
 			{
 				Name:       p.rootAppName,
@@ -698,7 +700,7 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, extraApps []service.
 					},
 				},
 			},
-		}, extraApps...)
+		}, opts.ExtraRootApps...)
 
 		configs[i] = raConf
 	}
@@ -724,12 +726,13 @@ func waitForAppServer(t *testing.T, tunnel reversetunnel.Server, name string, ho
 	waitForAppRegInRemoteSiteCache(t, tunnel, name, apps, hostUUID)
 }
 
-func (p *Pack) startLeafAppServers(t *testing.T, count int, extraApps []service.App) []*service.TeleportProcess {
+func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions) []*service.TeleportProcess {
 	log := utils.NewLoggerForTests()
 	configs := make([]*service.Config, count)
 
 	for i := 0; i < count; i++ {
 		laConf := service.MakeDefaultConfig()
+		laConf.Clock = opts.Clock
 		laConf.Console = nil
 		laConf.Log = log
 		laConf.DataDir = t.TempDir()
@@ -743,6 +746,7 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, extraApps []service.
 		laConf.SSH.Enabled = false
 		laConf.Apps.Enabled = true
 		laConf.CircuitBreakerConfig = breaker.NoopBreakerConfig()
+		laConf.Apps.MonitorCloseChannel = opts.MonitorCloseChannel
 		laConf.Apps.Apps = append([]service.App{
 			{
 				Name:       p.leafAppName,
@@ -830,7 +834,7 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, extraApps []service.
 					},
 				},
 			},
-		}, extraApps...)
+		}, opts.ExtraLeafApps...)
 
 		configs[i] = laConf
 	}

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -252,6 +252,8 @@ type TeleInstance struct {
 
 // InstanceConfig is an instance configuration
 type InstanceConfig struct {
+	// Clock is an optional clock to use
+	Clock clockwork.Clock
 	// ClusterName is a cluster name of the instance
 	ClusterName string
 	// HostID is a host id of the instance
@@ -320,7 +322,10 @@ func NewInstance(t *testing.T, cfg InstanceConfig) *TeleInstance {
 		Username: fmt.Sprintf("%v.%v", cfg.HostID, cfg.ClusterName),
 		Groups:   []string{string(types.RoleAdmin)},
 	}
-	clock := clockwork.NewRealClock()
+	clock := cfg.Clock
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
 	subject, err := identity.Subject()
 	fatalIf(err)
 	tlsCert, err := tlsCA.GenerateCertificate(tlsca.CertificateRequest{

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -1044,6 +1044,10 @@ type AppsConfig struct {
 
 	// ResourceMatchers match cluster database resources.
 	ResourceMatchers []services.ResourceMatcher
+
+	// MonitorCloseChannel will be signaled when a monitor closes a connection.
+	// Used only for testing. Optional.
+	MonitorCloseChannel chan struct{}
 }
 
 // App is the specific application that will be proxied by the application

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4432,6 +4432,7 @@ func (process *TeleportProcess) initApps() {
 		proxyGetter := reversetunnel.NewConnectedProxyGetter()
 
 		appServer, err := app.New(process.ExitContext(), &app.Config{
+			Clock:                process.Config.Clock,
 			DataDir:              process.Config.DataDir,
 			AuthClient:           conn.Client,
 			AccessPoint:          accessPoint,
@@ -4448,6 +4449,7 @@ func (process *TeleportProcess) initApps() {
 			ConnectedProxyGetter: proxyGetter,
 			LockWatcher:          lockWatcher,
 			Emitter:              asyncEmitter,
+			MonitorCloseChannel:  process.Config.Apps.MonitorCloseChannel,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -118,6 +118,10 @@ type Config struct {
 
 	// Emitter is an event emitter.
 	Emitter events.Emitter
+
+	// MonitorCloseChannel will be signaled when the monitor closes a connection.
+	// Used only for testing. Optional.
+	MonitorCloseChannel chan struct{}
 }
 
 // CheckAndSetDefaults makes sure the configuration has the minimum required
@@ -723,6 +727,7 @@ func (s *Server) monitorConn(ctx context.Context, tc *srv.TrackingReadConn, auth
 		TeleportUser:          identity.Username,
 		Emitter:               s.c.Emitter,
 		Entry:                 s.log,
+		MonitorCloseChannel:   s.c.MonitorCloseChannel,
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
The appaccess TestTCP* tests are highly reliant on time. This has been reduced (but not eliminated) by using a fakeClock and a channel for signaling monitor triggered connection closures.