### PR TITLE
Minor tweaks for GitHub Machine ID integration docs

### DIFF
--- a/docs/pages/includes/machine-id/guides.mdx
+++ b/docs/pages/includes/machine-id/guides.mdx
@@ -1,6 +1,6 @@
 - [Using Machine ID with Ansible](../../machine-id/guides/ansible.mdx): How to integrate Machine ID with Ansible.
 - [Using Machine ID with Applications](../../machine-id/guides/applications.mdx): How to use Machine ID to connect automated services to applications.
 - [Using Machine ID with Databases](../../machine-id/guides/databases.mdx): How to use Machine ID to connect custom applications to your databases.
-- [Using Machine ID With GitHub Actions](../../machine-id/guides/github-actions.mdx): How to use Machine ID to to access Teleport resources from GitHub Actions.
+- [Using Machine ID with GitHub Actions](../../machine-id/guides/github-actions.mdx): How to use Machine ID to to access Teleport resources from GitHub Actions.
 - [Using Machine ID with Jenkins](../../machine-id/guides/jenkins.mdx): How to integrate Machine ID with Jenkins.
 - [Using Machine ID with Kubernetes](../../machine-id/guides/kubernetes.mdx): How to use Machine ID to connect automated services to Kubernetes clusters.

--- a/docs/pages/includes/machine-id/guides.mdx
+++ b/docs/pages/includes/machine-id/guides.mdx
@@ -1,6 +1,6 @@
-- [Using Teleport Machine ID with Ansible](../../machine-id/guides/ansible.mdx): How to integrate Teleport Machine ID with Ansible.
-- [Using Teleport Machine ID with Applications](../../machine-id/guides/applications.mdx): How to use Machine ID to connect automated services to applications.
-- [Using Teleport Machine ID with Databases](../../machine-id/guides/databases.mdx): How to use Machine ID to connect custom applications to your databases.
-- [Using Machine ID With GitHub Actions](../../machine-id/guides/github-actions.mdx): How to use Machine ID to securely run GitHub Actions.
-- [Using Teleport Machine ID with Jenkins](../../machine-id/guides/jenkins.mdx): How to integrate Teleport Machine ID with Jenkins.
-- [Using Teleport Machine ID with Kubernetes](../../machine-id/guides/kubernetes.mdx): How to use Machine ID to connect automated services to Kubernetes clusters.
+- [Using Machine ID with Ansible](../../machine-id/guides/ansible.mdx): How to integrate Machine ID with Ansible.
+- [Using Machine ID with Applications](../../machine-id/guides/applications.mdx): How to use Machine ID to connect automated services to applications.
+- [Using Machine ID with Databases](../../machine-id/guides/databases.mdx): How to use Machine ID to connect custom applications to your databases.
+- [Using Machine ID With GitHub Actions](../../machine-id/guides/github-actions.mdx): How to use Machine ID to to access Teleport resources from GitHub Actions.
+- [Using Machine ID with Jenkins](../../machine-id/guides/jenkins.mdx): How to integrate Machine ID with Jenkins.
+- [Using Machine ID with Kubernetes](../../machine-id/guides/kubernetes.mdx): How to use Machine ID to connect automated services to Kubernetes clusters.

--- a/docs/pages/machine-id/faq.mdx
+++ b/docs/pages/machine-id/faq.mdx
@@ -12,10 +12,9 @@ following situations:
    joining.
  - Long-lived worker nodes, like self-hosted Jenkins workers, using token-based
    joining.
-
-We are working to support SaaS-based CI/CD providers like GitHub Actions in the
-the near future, but cannot currently recommend using Machine ID on these
-providers.
+ - You use a supported SaaS CI/CD Provider:
+   - GitHub Actions (Teleport 11)
+   - CircleCI (coming in Teleport 11.1)
 
 ## Can Machine ID be used with Trusted Clusters ?
 

--- a/docs/pages/machine-id/guides/github-actions.mdx
+++ b/docs/pages/machine-id/guides/github-actions.mdx
@@ -3,6 +3,16 @@ title: Using Machine ID With GitHub Actions
 description: A tutorial for using Machine ID with GitHub Actions
 ---
 
+<Details
+  title="Version warning"
+  opened={true}
+  scope={["oss", "enterprise"]}
+  scopeOnly={true}
+  min="11.0"
+>
+  Machine ID for GitHub Actions is available starting from Teleport `v11.0`.
+</Details>
+
 GitHub Actions are a popular CI/CD platform that works as a larger part of the GitHub
 ecosystem. Teleport, with the help of Machine ID, allows for GitHub Actions to
 securely interact with Teleport Protected resources without the need for long lived
@@ -23,7 +33,6 @@ or self-hosted runners.
 - A local workstation with `tsh` access to the cluster.
 - A GitHub repository with GitHub Actions enabled. This guide uses the example `gravitational/example`
 repo, however this value should be replaced with your own unique repo.
-- A Teleport cluster running at least version 11.
 
 ## Step 1/3. Create a join Token for GitHub Actions
 

--- a/docs/pages/machine-id/guides/github-actions.mdx
+++ b/docs/pages/machine-id/guides/github-actions.mdx
@@ -11,7 +11,7 @@ GitHub Actions with Teleport can be applied as both a viable and secure solution
 CI/CD platform is needed.
 
 <Admonition type="note">
-Currently GitHub Actions with Machine ID are unsupported on GitHub Enterprise
+Currently GitHub Actions with Machine ID is unsupported on GitHub Enterprise
 or self-hosted runners.
 </Admonition>
 
@@ -21,12 +21,13 @@ or self-hosted runners.
 
 - A node that is a part of the Teleport cluster with [Server Access](https://goteleport.com/docs/server-access/introduction/).
 - A local workstation with `tsh` access to the cluster.
-- A Github repository with Github actions enabled. This guide uses the example `gravitational/example`
+- A GitHub repository with GitHub Actions enabled. This guide uses the example `gravitational/example`
 repo, however this value should be replaced with your own unique repo.
+- A Teleport cluster running at least version 11.
 
 ## Step 1/3. Create a join Token for GitHub Actions
 
-Github Actions will need it's own join token in order to join the cluster.
+GitHub Actions will need its own join token in order to join the cluster.
 Using a text editor of your choice, create the configuration YAML file `tokenconfig.yaml` for the
 join token that resembles the following:
 
@@ -66,7 +67,7 @@ repository is used, and this example repository should be replaced with your own
 
 Most of the configuration settings used in the example configuration file `tokenconfig.yaml`
 do not have any variable settings, however the `allow` block of `spec.github.allow` has additional
-configuration options to more strictly define which GitHub actions tokens will be granted access to:
+configuration options to more strictly define which GitHub Actions tokens will be granted access to:
 
 | **Setting** | **Behavior** | **Example** |
 | ----------- | ----------- | ----------- |
@@ -102,7 +103,7 @@ github-token Bot         01 Jan 00 00:00 UTC (2562047h47m16.854775807s)
 
 ## Step 2/3. Creating your Machine ID bot
 
-With the join token for Github Actions created, the next step is to create the Machine ID bot,
+With the join token for GitHub Actions created, the next step is to create the Machine ID bot,
 and ensure that it is configured to use the newly created token. This bot can be created using a Teleport
 `configuration.yaml` file, however for the purposes of this guide you will create a simple configuration
 using `tctl` with any required configuration flags.
@@ -122,9 +123,9 @@ $ tctl bots add github-demo --roles=access --token=github-token –logins=userna
 
 ## Step 3/3. Configuring GitHub Actions
 
-Now that the bot has been successfully created, github actions can function as part of the Teleport cluster.
+Now that the bot has been successfully created, GitHub Actions can function as part of the Teleport cluster.
 
-In the Github workflows directory of your repo (`.github/workflows/`) create a new workflow YAML file,
+In the GitHub workflows directory of your repo (`.github/workflows/`) create a new workflow YAML file,
 in this case `actionstest.yml`, that will reflect the action you'd like to configure. This guide will create an action that
 will both list nodes within the cluster using `tsh ls`, as well as write the commit SHA that triggered the workflow to
 a file within the bot node. To create this configuration, use the following YAML file:
@@ -183,7 +184,7 @@ Add, commit, and push your changes to the `main` branch of the repository.
 
 Navigate to the **Actions** tab of your GitHub repository in your web browser. Select
 the **Workflow** that has now been created and triggered by the change, and select the `guide-demo` job.
-The Github action may take some time to complete, and will resemble the following once successful.
+The GitHub action may take some time to complete, and will resemble the following once successful.
 
 
 ![GitHub Actions](../../../img/machine-id/github-actions.png)

--- a/docs/pages/machine-id/guides/github-actions.mdx
+++ b/docs/pages/machine-id/guides/github-actions.mdx
@@ -13,9 +13,9 @@ description: A tutorial for using Machine ID with GitHub Actions
   Machine ID for GitHub Actions is available starting from Teleport `v11.0`.
 </Details>
 
-GitHub Actions are a popular CI/CD platform that works as a larger part of the GitHub
+GitHub Actions are a popular CI/CD platform that works as a part of the larger GitHub
 ecosystem. Teleport, with the help of Machine ID, allows for GitHub Actions to
-securely interact with Teleport Protected resources without the need for long lived
+securely interact with Teleport protected resources without the need for long lived
 credentials. By ensuring that rotated Machine ID credentials are additionally limited by RBAC,
 GitHub Actions with Teleport can be applied as both a viable and secure solution whenever a
 CI/CD platform is needed.


### PR DESCRIPTION
Ensures we correctly capitalise GitHub Actions for consistency with GitHub's branding and adds a note regarding Teleport 11 being required (as per discussion on slack with @stevenGravy.
