### PR TITLE
[v9] Adds backwards compatibility querying leaf resources in the web UI

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -557,7 +557,6 @@ func (h *Handler) getUserStatus(w http.ResponseWriter, r *http.Request, _ httpro
 // getUserContext returns user context
 //
 // GET /webapi/sites/:site/context
-//
 func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httprouter.Params, c *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	cn, err := h.cfg.AccessPoint.GetClusterName()
 	if err != nil {
@@ -1419,10 +1418,9 @@ func newSessionResponse(ctx *SessionContext) (*CreateSessionResponse, error) {
 //
 // {"user": "alex", "pass": "abc123", "second_factor_token": "token", "second_factor_type": "totp"}
 //
-// Response
+// # Response
 //
 // {"type": "bearer", "token": "bearer token", "user": {"name": "alex", "allowed_logins": ["admin", "bob"]}, "expires_in": 20}
-//
 func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
 	var req *CreateSessionReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
@@ -1489,7 +1487,6 @@ func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p htt
 // Response:
 //
 // {"message": "ok"}
-//
 func (h *Handler) deleteSession(w http.ResponseWriter, r *http.Request, _ httprouter.Params, ctx *SessionContext) (interface{}, error) {
 	err := h.logout(r.Context(), w, ctx)
 	if err != nil {
@@ -1698,7 +1695,6 @@ func (h *Handler) getResetPasswordToken(ctx context.Context, tokenID string) (in
 // Response:
 //
 // {"version":"U2F_V2","challenge":"randombase64string","appId":"https://mycorp.com:3080"}
-//
 func (h *Handler) u2fRegisterRequest(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
 	res, err := h.auth.proxyClient.CreateRegisterChallenge(r.Context(), &proto.CreateRegisterChallengeRequest{
 		TokenID:    p.ByName("token"),
@@ -1750,7 +1746,7 @@ func (h *Handler) mfaLoginBegin(w http.ResponseWriter, r *http.Request, p httpro
 // { "user": "bob", "password": "pass", "pub_key": "key to sign", "ttl": 1000000000 }                   # password-only
 // { "user": "bob", "webauthn_challenge_response": {...}, "pub_key": "key to sign", "ttl": 1000000000 } # mfa
 //
-// Success response
+// # Success response
 //
 // { "cert": "base64 encoded signed cert", "host_signers": [{"domain_name": "example.com", "checking_keys": ["base64 encoded public signing key"]}] }
 func (h *Handler) mfaLoginFinish(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
@@ -1804,7 +1800,6 @@ func (h *Handler) mfaLoginFinishSession(w http.ResponseWriter, r *http.Request, 
 // Successful response:
 //
 // {"sites": {"name": "localhost", "last_connected": "RFC3339 time", "status": "active"}}
-//
 func (h *Handler) getClusters(w http.ResponseWriter, r *http.Request, p httprouter.Params, c *SessionContext) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in users identity. The
 	// identity of the logged in user is used to fetch the list of nodes.
@@ -1870,26 +1865,17 @@ func (h *Handler) clusterNodesGet(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindNode)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	servers, err := types.ResourcesWithLabels(resp.Resources).AsServers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	userRoles, err := ctx.GetUserRoles()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return listResourcesGetResponse{
-		Items:      ui.MakeServers(site.GetName(), servers, userRoles),
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
-	}, nil
+	res, err := handleClusterNodesGet(clt, r, site.GetName(), userRoles)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return res, nil
 }
 
 // siteNodeConnect connect to the site node
@@ -1901,10 +1887,9 @@ func (h *Handler) clusterNodesGet(w http.ResponseWriter, r *http.Request, p http
 //
 // {"server_id": "uuid", "login": "admin", "term": {"h": 120, "w": 100}, "sid": "123"}
 //
-// Session id can be empty
+// # Session id can be empty
 //
 // Successful response is a websocket stream that allows read write to the server
-//
 func (h *Handler) siteNodeConnect(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -2050,7 +2035,6 @@ func (h *Handler) siteSessionsGet(w http.ResponseWriter, r *http.Request, p http
 // Response body:
 //
 // {"session": {"id": "sid", "terminal_params": {"w": 100, "h": 100}, "parties": [], "login": "bob"}}
-//
 func (h *Handler) siteSessionGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	sessionID, err := session.ParseID(p.ByName("sid"))
 	if err != nil {
@@ -2101,16 +2085,17 @@ func toFieldsSlice(rawEvents []apievents.AuditEvent) ([]events.EventFields, erro
 // GET /v1/webapi/sites/:site/events/search
 //
 // Query parameters:
-//   "from"    : date range from, encoded as RFC3339
-//   "to"      : date range to, encoded as RFC3339
-//   "limit"   : optional maximum number of events to return on each fetch
-//   "startKey": resume events search from the last event received,
-//               empty string means start search from beginning
-//   "include" : optional comma-separated list of event names to return e.g.
-//               include=session.start,session.end, all are returned if empty
-//   "order":    optional ordering of events. Can be either "asc" or "desc"
-//               for ascending and descending respectively.
-//               If no order is provided it defaults to descending.
+//
+//	"from"    : date range from, encoded as RFC3339
+//	"to"      : date range to, encoded as RFC3339
+//	"limit"   : optional maximum number of events to return on each fetch
+//	"startKey": resume events search from the last event received,
+//	            empty string means start search from beginning
+//	"include" : optional comma-separated list of event names to return e.g.
+//	            include=session.start,session.end, all are returned if empty
+//	"order":    optional ordering of events. Can be either "asc" or "desc"
+//	            for ascending and descending respectively.
+//	            If no order is provided it defaults to descending.
 func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	values := r.URL.Query()
 
@@ -2130,14 +2115,15 @@ func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p 
 // GET /v1/webapi/sites/:site/sessions/search
 //
 // Query parameters:
-//   "from"    : date range from, encoded as RFC3339
-//   "to"      : date range to, encoded as RFC3339
-//   "limit"   : optional maximum number of events to return on each fetch
-//   "startKey": resume events search from the last event received,
-//               empty string means start search from beginning
-//   "order":    optional ordering of events. Can be either "asc" or "desc"
-//               for ascending and descending respectively.
-//               If no order is provided it defaults to descending.
+//
+//	"from"    : date range from, encoded as RFC3339
+//	"to"      : date range to, encoded as RFC3339
+//	"limit"   : optional maximum number of events to return on each fetch
+//	"startKey": resume events search from the last event received,
+//	            empty string means start search from beginning
+//	"order":    optional ordering of events. Can be either "asc" or "desc"
+//	            for ascending and descending respectively.
+//	            If no order is provided it defaults to descending.
 func (h *Handler) clusterSearchSessionEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	searchSessionEvents := func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error) {
 		return clt.SearchSessionEvents(from, to, limit, order, startKey, nil, "")
@@ -2241,8 +2227,9 @@ func queryOrder(query url.Values, name string, def types.EventOrder) (types.Even
 // GET /v1/webapi/sites/:site/namespaces/:namespace/sessions/:sid/stream?query
 //
 // Query parameters:
-//   "offset"   : bytes from the beginning
-//   "bytes"    : number of bytes to read (it won't return more than 512Kb)
+//
+//	"offset"   : bytes from the beginning
+//	"bytes"    : number of bytes to read (it won't return more than 512Kb)
 //
 // Unlike other request handlers, this one does not return JSON.
 // It returns the binary stream unencoded, directly in the respose body,
@@ -2351,13 +2338,13 @@ type eventsListGetResponse struct {
 // GET /v1/webapi/sites/:site/namespaces/:namespace/sessions/:sid/events?after=N
 //
 // Query:
-//    "after" : cursor value of an event to return "newer than" events
-//              good for repeated polling
+//
+//	"after" : cursor value of an event to return "newer than" events
+//	          good for repeated polling
 //
 // Response body (each event is an arbitrary JSON structure)
 //
 // {"events": [{...}, {...}, ...}
-//
 func (h *Handler) siteSessionEventsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	sessionID, err := session.ParseID(p.ByName("sid"))
 	if err != nil {
@@ -2412,10 +2399,9 @@ func (h *Handler) hostCredentials(w http.ResponseWriter, r *http.Request, p http
 //
 // { "user": "bob", "password": "pass", "otp_token": "tok", "pub_key": "key to sign", "ttl": 1000000000 }
 //
-// Success response
+// # Success response
 //
 // { "cert": "base64 encoded signed cert", "host_signers": [{"domain_name": "example.com", "checking_keys": ["base64 encoded public signing key"]}] }
-//
 func (h *Handler) createSSHCert(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
 	var req *client.CreateSSHCertReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
@@ -2455,16 +2441,16 @@ func (h *Handler) createSSHCert(w http.ResponseWriter, r *http.Request, p httpro
 //
 // * Request body:
 //
-// {
-//     "token": "foo",
-//     "certificate_authorities": ["AQ==", "Ag=="]
-// }
+//	{
+//	    "token": "foo",
+//	    "certificate_authorities": ["AQ==", "Ag=="]
+//	}
 //
 // * Response:
 //
-// {
-//     "certificate_authorities": ["AQ==", "Ag=="]
-// }
+//	{
+//	    "certificate_authorities": ["AQ==", "Ag=="]
+//	}
 func (h *Handler) validateTrustedCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
 	var validateRequestRaw auth.ValidateTrustedClusterRequestRaw
 	if err := httplib.ReadJSON(r, &validateRequestRaw); err != nil {

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -53,32 +53,16 @@ func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httpr
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindAppServer)
+	res, err := handleClusterAppsGet(clt, r, ui.MakeAppsConfig{
+		LocalClusterName:  h.auth.clusterName,
+		LocalProxyDNSName: h.proxyDNSName(),
+		AppClusterName:    appClusterName,
+		Identity:          identity,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	appServers, err := types.ResourcesWithLabels(resp.Resources).AsAppServers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	var apps types.Apps
-	for _, server := range appServers {
-		apps = append(apps, server.GetApp())
-	}
-
-	return listResourcesGetResponse{
-		Items: ui.MakeApps(ui.MakeAppsConfig{
-			LocalClusterName:  h.auth.clusterName,
-			LocalProxyDNSName: h.proxyDNSName(),
-			AppClusterName:    appClusterName,
-			Identity:          identity,
-			Apps:              apps,
-		}),
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
-	}, nil
+	return res, nil
 }
 
 type GetAppFQDNRequest resolveAppParams

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -22,8 +22,11 @@ import (
 	"testing"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/web/ui"
 
 	"github.com/gravitational/trace"
@@ -418,6 +421,9 @@ func TestListResources(t *testing.T) {
 				}
 				return nil, nil
 			}
+			m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
+				return proto.PingResponse{ServerVersion: "9.1"}, nil
+			}
 
 			_, err = listResources(m, httpReq, types.KindNode)
 			if tc.wantBadParamErr {
@@ -427,6 +433,311 @@ func TestListResources(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListResourcesPing(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+
+	m.mockListResources = func(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+		return nil, trace.NotImplemented("not implemented")
+	}
+
+	// Test v8 ping.
+	mockPingCalled := 0
+	m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
+		mockPingCalled += 1
+		return proto.PingResponse{ServerVersion: "8.3.1"}, nil
+	}
+	mockHTTPReq, err := http.NewRequest("", "", nil)
+	require.NoError(t, err)
+	_, err = listResources(m, mockHTTPReq, types.KindNode)
+	require.True(t, trace.IsNotImplemented(err))
+	require.Equal(t, 1, mockPingCalled)
+
+	// Test v9.0 ping.
+	mockPingCalled = 0
+	m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
+		mockPingCalled += 1
+		return proto.PingResponse{ServerVersion: "9.0.1"}, nil
+	}
+	_, err = listResources(m, mockHTTPReq, types.KindNode)
+	require.True(t, trace.IsNotImplemented(err))
+	require.Equal(t, 1, mockPingCalled)
+
+	// Test v9.1 ping.
+	mockPingCalled = 0
+	m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
+		mockPingCalled += 1
+		return proto.PingResponse{ServerVersion: "9.1.4"}, nil
+	}
+	m.mockListResources = func(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+		return nil, nil
+	}
+	_, err = listResources(m, mockHTTPReq, types.KindNode)
+	require.NoError(t, err)
+	require.Equal(t, 1, mockPingCalled)
+}
+
+func TestHandleClusterNodesGetFallback(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+
+	// Create mock servers.
+	server1, err := types.NewServer("server1", types.KindNode, types.ServerSpecV2{})
+	require.NoError(t, err)
+	server2, err := types.NewServer("server2", types.KindNode, types.ServerSpecV2{})
+	require.NoError(t, err)
+
+	m.mockListResources = func(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+		return nil, trace.NotImplemented("not implemented")
+	}
+	m.mockGetNodes = func(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]types.Server, error) {
+		return []types.Server{server1, server2}, nil
+	}
+	m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
+		return proto.PingResponse{ServerVersion: "9.1"}, nil
+	}
+
+	mockHTTPReq, err := http.NewRequest("", "", nil)
+	require.NoError(t, err)
+
+	teleUser, err := types.NewUser("foo")
+	require.NoError(t, err)
+	mockUserRoles := []types.Role{defaultRoleForNewUser(teleUser, "llama")}
+
+	res, err := handleClusterNodesGet(m, mockHTTPReq, "cluster-name", mockUserRoles)
+	require.NoError(t, err)
+	require.Nil(t, res.StartKey)
+	require.Nil(t, res.TotalCount)
+	require.ElementsMatch(t, res.Items, []ui.Server{
+		{ClusterName: "cluster-name",
+			Labels:    []ui.Label{},
+			Name:      "server1",
+			Tunnel:    false,
+			SSHLogins: []string{"llama"}},
+		{ClusterName: "cluster-name",
+			Labels:    []ui.Label{},
+			Name:      "server2",
+			Tunnel:    false,
+			SSHLogins: []string{"llama"}}})
+}
+
+func TestHandleClusterAppsGetFallback(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+
+	// Create mocks with duplicates.
+	server1, err := types.NewAppServerV3(types.Metadata{Name: "server1"}, types.AppServerSpecV3{
+		HostID: "hostid",
+		App: &types.AppV3{
+			Metadata: types.Metadata{Name: "app1"},
+			Spec:     types.AppSpecV3{URI: "uri"},
+		}})
+	require.NoError(t, err)
+	server2, err := types.NewAppServerV3(types.Metadata{Name: "server2"}, types.AppServerSpecV3{
+		HostID: "hostid",
+		App: &types.AppV3{
+			Metadata: types.Metadata{Name: "app2"},
+			Spec:     types.AppSpecV3{URI: "uri"},
+		}})
+	require.NoError(t, err)
+	serverDup, err := types.NewAppServerV3(types.Metadata{Name: "server3"}, types.AppServerSpecV3{
+		HostID: "hostid",
+		App: &types.AppV3{
+			Metadata: types.Metadata{Name: "app2"},
+			Spec:     types.AppSpecV3{URI: "uri"},
+		}})
+	require.NoError(t, err)
+
+	m.mockListResources = func(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+		return nil, trace.NotImplemented("not implemented")
+	}
+	m.mockGetApplicationServers = func(context.Context, string) ([]types.AppServer, error) {
+		return []types.AppServer{server1, server2, serverDup}, nil
+	}
+	m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
+		return proto.PingResponse{ServerVersion: "9.1"}, nil
+	}
+
+	mockHTTPReq, err := http.NewRequest("", "", nil)
+	require.NoError(t, err)
+
+	res, err := handleClusterAppsGet(m, mockHTTPReq, ui.MakeAppsConfig{
+		LocalClusterName:  "cluster-name",
+		LocalProxyDNSName: "dns-name",
+		AppClusterName:    "cluster-name",
+		Identity: &tlsca.Identity{
+			AWSRoleARNs: []string{"aws"},
+		},
+	})
+	require.NoError(t, err)
+	require.Nil(t, res.StartKey)
+	require.Nil(t, res.TotalCount)
+	require.ElementsMatch(t, res.Items, []ui.App{
+		{
+			Name:       "app1",
+			URI:        "uri",
+			Labels:     []ui.Label{},
+			ClusterID:  "cluster-name",
+			FQDN:       "app1.dns-name",
+			AWSConsole: false,
+		},
+		{
+			Name:       "app2",
+			URI:        "uri",
+			Labels:     []ui.Label{},
+			ClusterID:  "cluster-name",
+			FQDN:       "app2.dns-name",
+			AWSConsole: false,
+		}})
+}
+
+func TestHandleClusterDatabasesGetFallback(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+
+	// Create mocks with duplicates.
+	server1, err := types.NewDatabaseServerV3(types.Metadata{Name: "db1"}, types.DatabaseServerSpecV3{
+		Hostname: "test-hostname",
+		HostID:   "test-hostID",
+	})
+	require.NoError(t, err)
+	server2, err := types.NewDatabaseServerV3(types.Metadata{Name: "db2"}, types.DatabaseServerSpecV3{
+		Hostname: "test-hostname",
+		HostID:   "test-hostID"})
+	require.NoError(t, err)
+	serverDup, err := types.NewDatabaseServerV3(types.Metadata{Name: "db2"}, types.DatabaseServerSpecV3{
+		Hostname: "test-hostname",
+		HostID:   "test-hostID"})
+	require.NoError(t, err)
+
+	m.mockListResources = func(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+		return nil, trace.NotImplemented("not implemented")
+	}
+	m.mockGetDatabaseServers = func(context.Context, string, ...services.MarshalOption) ([]types.DatabaseServer, error) {
+		return []types.DatabaseServer{server1, server2, serverDup}, nil
+	}
+	m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
+		return proto.PingResponse{ServerVersion: "9.1"}, nil
+	}
+
+	mockHTTPReq, err := http.NewRequest("", "", nil)
+	require.NoError(t, err)
+
+	res, err := handleClusterDatabasesGet(m, mockHTTPReq, "cluster-name")
+	require.NoError(t, err)
+	require.Nil(t, res.StartKey)
+	require.Nil(t, res.TotalCount)
+	require.ElementsMatch(t, res.Items, []ui.Database{
+		{
+			Name:   "db1",
+			Type:   types.DatabaseTypeSelfHosted,
+			Labels: []ui.Label{},
+		},
+		{
+			Name:   "db2",
+			Type:   types.DatabaseTypeSelfHosted,
+			Labels: []ui.Label{},
+		}})
+}
+
+func TestHandleClusterWindowsGetFallback(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+
+	// Create mocks with duplicates.
+	server1, err := types.NewWindowsDesktopV3("desktop1", nil, types.WindowsDesktopSpecV3{
+		HostID: "test-hostID",
+		Addr:   "addr",
+	})
+	require.NoError(t, err)
+	server2, err := types.NewWindowsDesktopV3("desktop2", nil, types.WindowsDesktopSpecV3{
+		HostID: "test-hostID",
+		Addr:   "addr"})
+	require.NoError(t, err)
+	serverDup, err := types.NewWindowsDesktopV3("desktop2", nil, types.WindowsDesktopSpecV3{
+		HostID: "test-hostID",
+		Addr:   "addr"})
+	require.NoError(t, err)
+
+	m.mockListResources = func(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+		return nil, trace.NotImplemented("not implemented")
+	}
+	m.mockGetWindowsDesktops = func(context.Context, types.WindowsDesktopFilter) ([]types.WindowsDesktop, error) {
+		return []types.WindowsDesktop{server1, server2, serverDup}, nil
+	}
+	m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
+		return proto.PingResponse{ServerVersion: "9.1"}, nil
+	}
+
+	mockHTTPReq, err := http.NewRequest("", "", nil)
+	require.NoError(t, err)
+
+	res, err := handleClusterDesktopsGet(m, mockHTTPReq)
+	require.NoError(t, err)
+	require.Nil(t, res.StartKey)
+	require.Nil(t, res.TotalCount)
+	require.ElementsMatch(t, res.Items, []ui.Desktop{
+		{
+			OS:     constants.WindowsOS,
+			Name:   "desktop1",
+			Addr:   "addr",
+			Labels: []ui.Label{},
+		},
+		{
+			OS:     constants.WindowsOS,
+			Name:   "desktop2",
+			Addr:   "addr",
+			Labels: []ui.Label{},
+		}})
+}
+
+func TestHandleClusterKubesGetFallback(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+
+	// Create mocks with duplicates.
+	server1, err := types.NewServer("ksvc1", types.KindKubeService, types.ServerSpecV2{
+		KubernetesClusters: []*types.KubernetesCluster{
+			{Name: "cluster1"},
+			{Name: "cluster1"},
+			{Name: "cluster2"},
+		},
+	})
+	require.NoError(t, err)
+	server2, err := types.NewServer("ksvc2", types.KindKubeService, types.ServerSpecV2{
+		KubernetesClusters: []*types.KubernetesCluster{
+			{Name: "cluster2"},
+			{Name: "cluster3"},
+		},
+	})
+	require.NoError(t, err)
+
+	m.mockListResources = func(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+		return nil, trace.NotImplemented("not implemented")
+	}
+	m.mockGetKubeServices = func(context.Context) ([]types.Server, error) {
+		return []types.Server{server1, server2}, nil
+	}
+	m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
+		return proto.PingResponse{ServerVersion: "9.1"}, nil
+	}
+
+	mockHTTPReq, err := http.NewRequest("", "", nil)
+	require.NoError(t, err)
+
+	res, err := handleClusterKubesGet(m, mockHTTPReq)
+	require.NoError(t, err)
+	require.Nil(t, res.StartKey)
+	require.Nil(t, res.TotalCount)
+	require.ElementsMatch(t, res.Items, []ui.KubeCluster{
+		{
+			Name:   "cluster1",
+			Labels: []ui.Label{},
+		},
+		{
+			Name:   "cluster2",
+			Labels: []ui.Label{},
+		},
+		{
+			Name:   "cluster3",
+			Labels: []ui.Label{},
+		}})
 }
 
 type mockedResourceAPIGetter struct {
@@ -442,6 +753,13 @@ type mockedResourceAPIGetter struct {
 	mockGetTrustedClusters    func(ctx context.Context) ([]types.TrustedCluster, error)
 	mockDeleteTrustedCluster  func(ctx context.Context, name string) error
 	mockListResources         func(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
+
+	mockGetApplicationServers func(context.Context, string) ([]types.AppServer, error)
+	mockGetDatabaseServers    func(context.Context, string, ...services.MarshalOption) ([]types.DatabaseServer, error)
+	mockGetWindowsDesktops    func(context.Context, types.WindowsDesktopFilter) ([]types.WindowsDesktop, error)
+	mockGetKubeServices       func(context.Context) ([]types.Server, error)
+	mockGetNodes              func(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]types.Server, error)
+	mockPing                  func(ctx context.Context) (proto.PingResponse, error)
 }
 
 func (m *mockedResourceAPIGetter) GetRole(ctx context.Context, name string) (types.Role, error) {
@@ -536,4 +854,52 @@ func (m *mockedResourceAPIGetter) ListResources(ctx context.Context, req proto.L
 	}
 
 	return nil, trace.NotImplemented("mockListResources not implemented")
+}
+
+func (m *mockedResourceAPIGetter) GetNodes(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]types.Server, error) {
+	if m.mockGetNodes != nil {
+		return m.mockGetNodes(ctx, namespace)
+	}
+
+	return nil, trace.NotImplemented("mockGetNodes not implemented")
+}
+
+func (m *mockedResourceAPIGetter) GetKubeServices(ctx context.Context) ([]types.Server, error) {
+	if m.mockGetKubeServices != nil {
+		return m.mockGetKubeServices(ctx)
+	}
+
+	return nil, trace.NotImplemented("mockGetKubeServices not implemented")
+}
+
+func (m *mockedResourceAPIGetter) GetWindowsDesktops(ctx context.Context, filter types.WindowsDesktopFilter) ([]types.WindowsDesktop, error) {
+	if m.mockGetWindowsDesktops != nil {
+		return m.mockGetWindowsDesktops(ctx, filter)
+	}
+
+	return nil, trace.NotImplemented("mockGetWindowsDesktops not implemented")
+}
+
+func (m *mockedResourceAPIGetter) GetDatabaseServers(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]types.DatabaseServer, error) {
+	if m.mockGetDatabaseServers != nil {
+		return m.mockGetDatabaseServers(ctx, namespace)
+	}
+
+	return nil, trace.NotImplemented("mockGetDatabaseServers not implemented")
+}
+
+func (m *mockedResourceAPIGetter) GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error) {
+	if m.mockGetApplicationServers != nil {
+		return m.mockGetApplicationServers(ctx, namespace)
+	}
+
+	return nil, trace.NotImplemented("mockGetApplicationServers not implemented")
+}
+
+func (m *mockedResourceAPIGetter) Ping(ctx context.Context) (proto.PingResponse, error) {
+	if m.mockPing != nil {
+		return m.mockPing(ctx)
+	}
+
+	return proto.PingResponse{}, trace.NotImplemented("mockPing not implemented")
 }

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -435,9 +435,9 @@ func TestListResources(t *testing.T) {
 	}
 }
 
-// TestListResourcesPing tests for supported and unsupported server versions
+// TestAttemptListResources tests for supported and unsupported server versions
 // returned by ping. Unsupported versions should return an error.
-func TestListResourcesPing(t *testing.T) {
+func TestAttemptListResources(t *testing.T) {
 	m := &mockedResourceAPIGetter{}
 
 	m.mockListResources = func(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
@@ -450,22 +450,22 @@ func TestListResourcesPing(t *testing.T) {
 	}
 	mockHTTPReq, err := http.NewRequest("", "", nil)
 	require.NoError(t, err)
-	_, err = listResources(m, mockHTTPReq, types.KindNode)
+	_, err = attemptListResources(m, mockHTTPReq, types.KindNode)
 	require.NoError(t, err)
 
 	// Test unsupported v8 ping.
 	m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
 		return proto.PingResponse{ServerVersion: "8.3.1"}, nil
 	}
-	_, err = listResources(m, mockHTTPReq, types.KindNode)
-	require.True(t, trace.IsNotImplemented(err))
+	_, err = attemptListResources(m, mockHTTPReq, types.KindNode)
+	require.True(t, trace.IsNotImplemented(err), "attemptListResources returned an unexpected error: %v (want not implemented)", err)
 
 	// Test unsupported v9.0 ping.
 	m.mockPing = func(ctx context.Context) (proto.PingResponse, error) {
 		return proto.PingResponse{ServerVersion: "9.0.1"}, nil
 	}
-	_, err = listResources(m, mockHTTPReq, types.KindNode)
-	require.True(t, trace.IsNotImplemented(err))
+	_, err = attemptListResources(m, mockHTTPReq, types.KindNode)
+	require.True(t, trace.IsNotImplemented(err), "attemptListResources returned an unexpected error: %v (want not implemented)", err)
 }
 
 func TestHandleClusterNodesGetFallback(t *testing.T) {

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -34,21 +34,12 @@ func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindKubernetesCluster)
+	resp, err := handleClusterKubesGet(clt, r)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	return resp, nil
 
-	clusters, err := types.ResourcesWithLabels(resp.Resources).AsKubeClusters()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return listResourcesGetResponse{
-		Items:      ui.MakeKubeClusters(clusters),
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
-	}, nil
 }
 
 // clusterDatabasesGet returns a list of db servers in a form the UI can present.
@@ -58,27 +49,11 @@ func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p 
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindDatabaseServer)
+	res, err := handleClusterDatabasesGet(clt, r, h.auth.clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	servers, err := types.ResourcesWithLabels(resp.Resources).AsDatabaseServers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Make a list of all proxied databases.
-	var databases []types.Database
-	for _, server := range servers {
-		databases = append(databases, server.GetDatabase())
-	}
-
-	return listResourcesGetResponse{
-		Items:      ui.MakeDatabases(h.auth.clusterName, databases),
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
-	}, nil
+	return res, nil
 }
 
 // clusterDesktopsGet returns a list of desktops in a form the UI can present.
@@ -88,21 +63,12 @@ func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindWindowsDesktop)
+	res, err := handleClusterDesktopsGet(clt, r)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	return res, nil
 
-	windowsDesktops, err := types.ResourcesWithLabels(resp.Resources).AsWindowsDesktops()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return listResourcesGetResponse{
-		Items:      ui.MakeDesktops(windowsDesktops),
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
-	}, nil
 }
 
 // getDesktopHandle returns a desktop.

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -152,6 +152,46 @@ func MakeKubeClusters(clusters []types.KubeCluster) []KubeCluster {
 	return uiKubeClusters
 }
 
+func MakeLegacyKubeClusters(servers []types.Server) []KubeCluster {
+	kubeClusters := map[string]*types.KubernetesCluster{}
+
+	// Get unique kube clusters
+	for _, server := range servers {
+		// Process each kube cluster.
+		for _, cluster := range server.GetKubernetesClusters() {
+			kubeClusters[cluster.Name] = cluster
+		}
+	}
+
+	uiKubeClusters := make([]KubeCluster, 0, len(kubeClusters))
+	for _, cluster := range kubeClusters {
+		uiLabels := []Label{}
+
+		for name, value := range cluster.StaticLabels {
+			uiLabels = append(uiLabels, Label{
+				Name:  name,
+				Value: value,
+			})
+		}
+
+		for name, cmd := range cluster.DynamicLabels {
+			uiLabels = append(uiLabels, Label{
+				Name:  name,
+				Value: cmd.GetResult(),
+			})
+		}
+
+		sort.Sort(sortedLabels(uiLabels))
+
+		uiKubeClusters = append(uiKubeClusters, KubeCluster{
+			Name:   cluster.Name,
+			Labels: uiLabels,
+		})
+	}
+
+	return uiKubeClusters
+}
+
 // Database describes a database server.
 type Database struct {
 	// Name is the name of the database.


### PR DESCRIPTION
part of bug fix https://github.com/gravitational/teleport/issues/18171
requires changes to web UI to completely fix https://github.com/gravitational/webapps/pull/1340

#### Description
The CLI tools does not support pagination so it took a different route from the web UI and has fallback supports for the new api `ListResources`, the web UI in other hand, i completely missed adding fallback support for when user navigates to a v8/v9.0 leaf cluster.

This PR adds that missing fallback support and adds test for the fallback logic. The non-fallback logic has already been tested in `apiserver_test.go`, testing for desktops was missing so I added that as well.

#### TODO
- requires forward porting to v10, since the required features the web UI needs is starting from `v9.1`, this PR is needed to cover `v9.0`)
- update test plan to click through screens with a leaf cluster that is current version - 1
- update tests in master for `web/apiserver_test.go` with the tests added in this PR

#### Manual testing on web UI
v9 cluster works as is
- [x] apps
- [x] databases
- [x] kubes
- [x] desktops
- [x] nodes

v8 auth with v9 proxy
- [x] apps
- [x] databases
- [x] kubes
- [x] desktops
- [x] nodes