### PR TITLE
Fix kernel version parsing on WSL2

### DIFF
--- a/lib/utils/kernel.go
+++ b/lib/utils/kernel.go
@@ -17,12 +17,11 @@ limitations under the License.
 package utils
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"runtime"
-	"strings"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
@@ -51,6 +50,12 @@ func KernelVersion() (*semver.Version, error) {
 	return ver, nil
 }
 
+// kernelVersionRegex extracts the first three digits of a version from
+// a kernel version - this strips off any additional digits or additional
+// information appended to the kernel version e.g:
+// 5.15.68.1-microsoft-standard-WSL2 => 5.15.68
+var kernelVersionRegex = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
 // kernelVersion reads in the kernel version from the reader and returns
 // a *semver.Version.
 func kernelVersion(reader io.Reader) (*semver.Version, error) {
@@ -59,10 +64,13 @@ func kernelVersion(reader io.Reader) (*semver.Version, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// Only keep the major, minor, and patch, throw away everything after "-".
-	parts := bytes.Split(buf, []byte("-"))
-	s := strings.TrimSpace(string(parts[0]))
-
+	s := kernelVersionRegex.FindString(string(buf))
+	if s == "" {
+		return nil, trace.BadParameter(
+			"unable to extract kernel semver from string %q",
+			string(buf),
+		)
+	}
 	ver, err := semver.NewVersion(s)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/utils/kernel.go
+++ b/lib/utils/kernel.go
@@ -54,7 +54,7 @@ func KernelVersion() (*semver.Version, error) {
 // a kernel version - this strips off any additional digits or additional
 // information appended to the kernel version e.g:
 // 5.15.68.1-microsoft-standard-WSL2 => 5.15.68
-var kernelVersionRegex = regexp.MustCompile(`\d+\.\d+\.\d+`)
+var kernelVersionRegex = regexp.MustCompile(`^\d+\.\d+\.\d+`)
 
 // kernelVersion reads in the kernel version from the reader and returns
 // a *semver.Version.

--- a/lib/utils/kernel_test.go
+++ b/lib/utils/kernel_test.go
@@ -70,20 +70,39 @@ func TestKernelVersion(t *testing.T) {
 			inMax:      "5.1.0",
 			outRelease: "5.0.0",
 		},
+		// Windows WSL2
+		{
+			inRelease:  "5.15.68.1-microsoft-standard-WSL2",
+			inMin:      "5.14.0",
+			inMax:      "5.16.0",
+			outRelease: "5.15.68",
+		},
 	}
 
 	for _, tt := range tests {
-		// Check the version is parsed correctly.
-		version, err := kernelVersion(strings.NewReader(tt.inRelease))
-		require.NoError(t, err)
-		require.Equal(t, version.String(), tt.outRelease)
+		t.Run(tt.inRelease, func(t *testing.T) {
+			// Check the version is parsed correctly.
+			version, err := kernelVersion(strings.NewReader(tt.inRelease))
+			require.NoError(t, err)
+			require.Equal(t, version.String(), tt.outRelease)
 
-		// Check that version comparisons work.
-		min, err := semver.NewVersion(tt.inMin)
-		require.NoError(t, err)
-		max, err := semver.NewVersion(tt.inMax)
-		require.NoError(t, err)
-		require.Equal(t, version.LessThan(*max), true)
-		require.Equal(t, version.LessThan(*min), false)
+			// Check that version comparisons work.
+			min, err := semver.NewVersion(tt.inMin)
+			require.NoError(t, err)
+			max, err := semver.NewVersion(tt.inMax)
+			require.NoError(t, err)
+			require.Equal(t, version.LessThan(*max), true)
+			require.Equal(t, version.LessThan(*min), false)
+		})
 	}
+
+	t.Run("invalid kernel version", func(t *testing.T) {
+		v, err := kernelVersion(strings.NewReader("10.23"))
+		require.Nil(t, v)
+		require.EqualError(
+			t,
+			err,
+			`unable to extract kernel semver from string "10.23"`,
+		)
+	})
 }


### PR DESCRIPTION
Our existing Kernel version parsing cannot handle WSL2 kernel versions which include a fourth digit within the semantic version to indicate the patches made by Microsoft to the Linux kernel.

See https://github.com/gravitational/teleport/issues/18210 for more information about the bug experienced on WSL2.

Closes https://github.com/gravitational/teleport/issues/18210