### PR TITLE
Support debug builds with TELEPORT_DEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,15 @@ ADDFLAGS ?=
 PWD ?= `pwd`
 TELEPORT_DEBUG ?= false
 GITTAG=v$(VERSION)
-BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s' -trimpath
 CGOFLAG ?= CGO_ENABLED=1
+
+# When TELEPORT_DEBUG is true, set flags to produce
+# debugger-friendly builds.
+ifeq ("$(TELEPORT_DEBUG)","true")
+BUILDFLAGS ?= $(ADDFLAGS) -gcflags=all="-N -l"
+else
+BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s' -trimpath
+endif
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)


### PR DESCRIPTION
For debug builds, we don't want to strip the symbol table of DWARF debug information. Additionally, disable inlining and other optimizations that may interfere with debugging.

See https://go.googlesource.com/vscode-go/+/HEAD/docs/debugging.md

Corresponding e PR is here if reviewers don't mind looking at both: https://github.com/gravitational/teleport.e/pull/600