### PR TITLE
[v10] Binds Teleport Connect builds to a versioned builder

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -666,6 +666,8 @@ workspace:
 platform:
   os: windows
   arch: amd64
+nodes:
+  buildbox_version: teleport10
 clone:
   disable: true
 concurrency:
@@ -919,6 +921,8 @@ workspace:
 platform:
   os: windows
   arch: amd64
+nodes:
+  buildbox_version: teleport10
 clone:
   disable: true
 depends_on:
@@ -1080,7 +1084,6 @@ steps:
     RELEASES_KEY:
       from_secret: RELEASES_KEY
     WORKSPACE_DIR: C:/Drone/Workspace/build-native-windows-amd64
-  failure: ignore
 - name: Clean up workspace (post)
   commands:
   - $ErrorActionPreference = 'Continue'
@@ -8673,6 +8676,6 @@ steps:
     WORKSPACE_DIR: /tmp/build-darwin-amd64-connect
 ---
 kind: signature
-hmac: 85cc594714ff84ff91bd9c76d58aafe54a00b8d16231851f77e2cc04d88f3bdb
+hmac: b447e14f67d454ee5e10003af00ce14dadfb59fd8111d00d49556661ac992c0e
 
 ...

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -36,6 +36,7 @@ type pipeline struct {
 	Trigger     trigger          `yaml:"trigger"`
 	Workspace   workspace        `yaml:"workspace,omitempty"`
 	Platform    platform         `yaml:"platform,omitempty"`
+	Nodes       map[string]value `yaml:"nodes,omitempty"`
 	Clone       clone            `yaml:"clone,omitempty"`
 	DependsOn   []string         `yaml:"depends_on,omitempty"`
 	Concurrency concurrency      `yaml:"concurrency,omitempty"`

--- a/dronegen/windows.go
+++ b/dronegen/windows.go
@@ -31,6 +31,10 @@ func newWindowsPipeline(name string) pipeline {
 	p.Workspace.Path = path.Join("C:/Drone/Workspace", name)
 	p.Concurrency.Limit = 1
 	p.Platform = platform{OS: "windows", Arch: "amd64"}
+	p.Nodes = map[string]value{
+		"buildbox_version": buildboxVersion,
+	}
+
 	return p
 }
 
@@ -265,7 +269,6 @@ func windowsRegisterArtifactsStep(workspace string) step {
 			`Get-Relcli -Url $relcliUrl -Sha256 $relcliSha256 -Workspace $Workspace`,
 			`Register-Artifacts -Workspace $Workspace -Outputs $OutputsDir`,
 		},
-		Failure: "ignore",
 	}
 }
 


### PR DESCRIPTION
The build environments for Teleport Connect  have started to diverge, and so this patch
binds the drone pipeline to a versioned buildbox.