### PR TITLE
[v11] Binds Teleport Connect builds to a versioned builder

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -676,6 +676,8 @@ workspace:
 platform:
   os: windows
   arch: amd64
+nodes:
+  buildbox_version: teleport11
 clone:
   disable: true
 concurrency:
@@ -945,6 +947,8 @@ workspace:
 platform:
   os: windows
   arch: amd64
+nodes:
+  buildbox_version: teleport11
 clone:
   disable: true
 depends_on:
@@ -18193,6 +18197,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: aa1dd8dd1ad2d28ad9fbf4c096f3e1782d8fceee98f00ecbff53e38f52250973
+hmac: 5cd960df0567481f68f34595742abb6460a914665d896306debea0e183fb5259
 
 ...

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -36,6 +36,7 @@ type pipeline struct {
 	Trigger     trigger          `yaml:"trigger"`
 	Workspace   workspace        `yaml:"workspace,omitempty"`
 	Platform    platform         `yaml:"platform,omitempty"`
+	Nodes       map[string]value `yaml:"nodes,omitempty"`
 	Clone       clone            `yaml:"clone,omitempty"`
 	DependsOn   []string         `yaml:"depends_on,omitempty"`
 	Concurrency concurrency      `yaml:"concurrency,omitempty"`

--- a/dronegen/windows.go
+++ b/dronegen/windows.go
@@ -33,6 +33,9 @@ func newWindowsPipeline(name string) pipeline {
 	p.Workspace.Path = path.Join("C:/Drone/Workspace", name)
 	p.Concurrency.Limit = 1
 	p.Platform = platform{OS: "windows", Arch: "amd64"}
+	p.Nodes = map[string]value{
+		"buildbox_version": buildboxVersion,
+	}
 	return p
 }
 


### PR DESCRIPTION
The build environments for Teleport Connect have started to diverge, and so this patch
binds the drone pipeline to a versioned buildbox.