### PR TITLE
Adds drone builbox selector for Windows Builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -676,10 +676,10 @@ workspace:
 platform:
   os: windows
   arch: amd64
+node:
+  buildbox_version: teleport11
 clone:
   disable: true
-concurrency:
-  limit: 1
 steps:
 - name: Check out Teleport
   commands:
@@ -945,6 +945,8 @@ workspace:
 platform:
   os: windows
   arch: amd64
+node:
+  buildbox_version: teleport11
 clone:
   disable: true
 depends_on:
@@ -18193,6 +18195,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: c805c4e2e9fe7b827500f7e149e85921c9ede5798d41b60019c032142cf74f18
+hmac: 84bece0a4d5fedac22a6c32fb220634559bc3f1934518c10134e1a4a140d50c3
 
 ...

--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -129,7 +129,7 @@ function Install-Node {
         Expand-Archive -Path $NodeZipfile -DestinationPath $ToolchainDir
         Rename-Item -Path "$ToolchainDir/node-v$NodeVersion-win-x64" -NewName "$ToolchainDir/node"
         Enable-Node -ToolchainDir $ToolchainDir
-        npm config set msvs_version 2017
+        npm config set msvs_version 2022
         corepack enable yarn
     }
 }

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -36,6 +36,7 @@ type pipeline struct {
 	Trigger     trigger          `yaml:"trigger"`
 	Workspace   workspace        `yaml:"workspace,omitempty"`
 	Platform    platform         `yaml:"platform,omitempty"`
+	Nodes       map[string]value `yaml:"nodes,omitempty"`
 	Clone       clone            `yaml:"clone,omitempty"`
 	DependsOn   []string         `yaml:"depends_on,omitempty"`
 	Concurrency concurrency      `yaml:"concurrency,omitempty"`

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -36,7 +36,7 @@ type pipeline struct {
 	Trigger     trigger          `yaml:"trigger"`
 	Workspace   workspace        `yaml:"workspace,omitempty"`
 	Platform    platform         `yaml:"platform,omitempty"`
-	Nodes       map[string]value `yaml:"nodes,omitempty"`
+	Node        map[string]value `yaml:"node,omitempty"`
 	Clone       clone            `yaml:"clone,omitempty"`
 	DependsOn   []string         `yaml:"depends_on,omitempty"`
 	Concurrency concurrency      `yaml:"concurrency,omitempty"`

--- a/dronegen/windows.go
+++ b/dronegen/windows.go
@@ -31,9 +31,8 @@ const (
 func newWindowsPipeline(name string) pipeline {
 	p := newExecPipeline(name)
 	p.Workspace.Path = path.Join("C:/Drone/Workspace", name)
-	p.Concurrency.Limit = 1
 	p.Platform = platform{OS: "windows", Arch: "amd64"}
-	p.Nodes = map[string]value{
+	p.Node = map[string]value{
 		"buildbox_version": buildboxVersion,
 	}
 	return p
@@ -41,7 +40,7 @@ func newWindowsPipeline(name string) pipeline {
 
 func windowsTagPipeline() pipeline {
 	p := newWindowsPipeline("build-native-windows-amd64")
-
+	p.Concurrency.Limit = 1
 	p.DependsOn = []string{tagCleanupPipelineName}
 	p.Trigger = triggerTag
 

--- a/dronegen/windows.go
+++ b/dronegen/windows.go
@@ -33,6 +33,9 @@ func newWindowsPipeline(name string) pipeline {
 	p.Workspace.Path = path.Join("C:/Drone/Workspace", name)
 	p.Concurrency.Limit = 1
 	p.Platform = platform{OS: "windows", Arch: "amd64"}
+	p.Nodes = map[string]value{
+		"buildbox_version": buildboxVersion,
+	}
 	return p
 }
 


### PR DESCRIPTION
Adds a drone node selector so builds will be routed to the correct buildbox

Also
1.  changes the version of Visual Studio expected by npm to vs 2022 to match buildbox installation
2. Removes the concurrency limit for window push builds. As there are separate builders for v10, v11 
   and v12. Given that the concurrency limits are enforced across all builds with the same name, they 
   serialise builds from different teleport versions. it seems wasteful to have a builder for v10 sit idle 
   while waiting a v11 build completes.

   The concurrent limits have been left for tag builds, as there are flow-on concurrency concern due to artifact
   uploading, etc.
