### PR TITLE
[v11] fix node selection

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -671,7 +671,7 @@ trigger:
     include:
     - master
     - branch/*
-    - tcsc/branch/v11*
+    - tcsc/branch/v11/*
 workspace:
   path: C:/Drone/Workspace/push-build-native-windows-amd64
 platform:
@@ -18196,6 +18196,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 67b6ab8421a4d29d95b87d364a8dbbec9ea92b5b83d2cd751fedf86ed7a5150f
+hmac: 08f91cd9e43a740c4dcf0f6f295ded32f258b7cfa3ea24ddabe72c8b78548a45
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -671,12 +671,13 @@ trigger:
     include:
     - master
     - branch/*
+    - tcsc/branch/v11*
 workspace:
   path: C:/Drone/Workspace/push-build-native-windows-amd64
 platform:
   os: windows
   arch: amd64
-nodes:
+node:
   buildbox_version: teleport11
 clone:
   disable: true
@@ -947,14 +948,12 @@ workspace:
 platform:
   os: windows
   arch: amd64
-nodes:
+node:
   buildbox_version: teleport11
 clone:
   disable: true
 depends_on:
 - clean-up-previous-build
-concurrency:
-  limit: 1
 steps:
 - name: Check out Teleport
   commands:
@@ -18197,6 +18196,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 5cd960df0567481f68f34595742abb6460a914665d896306debea0e183fb5259
+hmac: 67b6ab8421a4d29d95b87d364a8dbbec9ea92b5b83d2cd751fedf86ed7a5150f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -671,7 +671,6 @@ trigger:
     include:
     - master
     - branch/*
-    - tcsc/branch/v11/*
 workspace:
   path: C:/Drone/Workspace/push-build-native-windows-amd64
 platform:
@@ -18196,6 +18195,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 08f91cd9e43a740c4dcf0f6f295ded32f258b7cfa3ea24ddabe72c8b78548a45
+hmac: 67b6ab8421a4d29d95b87d364a8dbbec9ea92b5b83d2cd751fedf86ed7a5150f
 
 ...

--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -129,7 +129,7 @@ function Install-Node {
         Expand-Archive -Path $NodeZipfile -DestinationPath $ToolchainDir
         Rename-Item -Path "$ToolchainDir/node-v$NodeVersion-win-x64" -NewName "$ToolchainDir/node"
         Enable-Node -ToolchainDir $ToolchainDir
-        npm config set msvs_version 2017
+        npm config set msvs_version 2022
         corepack enable yarn
     }
 }

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -36,7 +36,7 @@ type pipeline struct {
 	Trigger     trigger          `yaml:"trigger"`
 	Workspace   workspace        `yaml:"workspace,omitempty"`
 	Platform    platform         `yaml:"platform,omitempty"`
-	Nodes       map[string]value `yaml:"nodes,omitempty"`
+	Node        map[string]value `yaml:"node,omitempty"`
 	Clone       clone            `yaml:"clone,omitempty"`
 	DependsOn   []string         `yaml:"depends_on,omitempty"`
 	Concurrency concurrency      `yaml:"concurrency,omitempty"`

--- a/dronegen/windows.go
+++ b/dronegen/windows.go
@@ -31,9 +31,8 @@ const (
 func newWindowsPipeline(name string) pipeline {
 	p := newExecPipeline(name)
 	p.Workspace.Path = path.Join("C:/Drone/Workspace", name)
-	p.Concurrency.Limit = 1
 	p.Platform = platform{OS: "windows", Arch: "amd64"}
-	p.Nodes = map[string]value{
+	p.Node = map[string]value{
 		"buildbox_version": buildboxVersion,
 	}
 	return p
@@ -102,6 +101,7 @@ func windowsTagPipeline() pipeline {
 
 func windowsPushPipeline() pipeline {
 	p := newWindowsPipeline("push-build-native-windows-amd64")
+	p.Concurrency.Limit = 1
 	p.Trigger = trigger{
 		Event:  triggerRef{Include: []string{"push"}, Exclude: []string{"pull_request"}},
 		Branch: triggerRef{Include: []string{"master", "branch/*"}},


### PR DESCRIPTION
The Drone node selector was improperly specified as nodes instead of node, causing Drone to stall builds.

Also removes the concurrency limit on Windows push builds. As there are separate builders for v10, v11 and v12. Given that the concurrency limits are enforced across all builds with the same name, they serialise builds from different teleport versions. it seems wasteful to have a builder for v10 sit idle while waiting a v11 build completes.

The concurrent limits have been left for tag builds, as there are flow-on concurrency concern due to artifact uploading, etc.

Also updates the version of Visual Studio that `npm` looks for to 2022 in order to match buildbox