### PR TITLE
add scalability helpers

### DIFF
--- a/api/internalutils/doc.go
+++ b/api/internalutils/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// packages under `api/internalutils` hold helpers that aren't intended to be part of the
+// public api, but need to be importable by both `api` and `lib`.
+package internal

--- a/api/internalutils/stream/stream.go
+++ b/api/internalutils/stream/stream.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stream
+
+import (
+	"github.com/gravitational/trace"
+)
+
+// Stream is a generic interface for streaming APIs. This package was built with the
+// intention of making it easier to write streaming resource getters, and may not be
+// be suitable for applications outside of that specific usecase. Streams may panic if
+// misused. See the Collect function for an example of the correct consumption pattern.
+//
+// NOTE: streams almost always perform worse than slices in go. unless you're dealing
+// with a resource that scales linearly with cluster size, you are probably better off
+// just working with slices.
+type Stream[T any] interface {
+	// Next attempts to advance the stream to the next item. If false is returned,
+	// then no more items are available. Next() and Item() must not be called after the
+	// first time Next() returns false.
+	Next() bool
+	// Item gets the current item. Invoking Item() is only safe if Next was previously
+	// invoked *and* returned true. Invoking Item() before invoking Next(), or after Next()
+	// returned false may cause panics or other unpredictable behavior. Whether or not the
+	// item returned is safe for access after the stream is advanced again is dependent
+	// on the implementation and should be documented (e.g. an I/O based stream might
+	// re-use an underlying buffer).
+	Item() T
+	// Done checks for any errors that occurred during streaming and informs the stream
+	// that we've finished consuming items from it. Invoking Next() or Item() after Done()
+	// has been called is not permitted. Done may trigger cleanup operations, but unlike Close()
+	// the error reported is specifically related to failures that occurred *during* streaming,
+	// meaning that if Done() returns an error, there is a high likelihood that the complete
+	// set of values was not observed. For this reason, Done() should always be checked explicitly
+	// rather than deferred as Close() might be.
+	Done() error
+}
+
+// streamFunc is a wrapper that converts a closure into a stream.
+type streamFunc[T any] struct {
+	fn        func() (T, error)
+	doneFuncs []func()
+	item      T
+	err       error
+}
+
+func (stream *streamFunc[T]) Next() bool {
+	stream.item, stream.err = stream.fn()
+	return stream.err == nil
+}
+
+func (stream *streamFunc[T]) Item() T {
+	return stream.item
+}
+
+func (stream *streamFunc[T]) Done() error {
+	for _, fn := range stream.doneFuncs {
+		fn()
+	}
+	if trace.IsEOF(stream.err) {
+		return nil
+	}
+	return stream.err
+}
+
+// Func builds a stream from a closure. The supplied closure *must*
+// return io.EOF if no more items are available. Failure to return io.EOF
+// (or some other error) may cause infinite loops. Cleanup functions may
+// be optionally provided which will be run on close. If wrapping a
+// paginated API, consider using PageFunc instead.
+func Func[T any](fn func() (T, error), doneFuncs ...func()) Stream[T] {
+	return &streamFunc[T]{
+		fn:        fn,
+		doneFuncs: doneFuncs,
+	}
+}
+
+// Collect aggregates a stream into a slice. If an error is hit, the
+// items observed thus far are still returned, but they may not represent
+// the complete set.
+func Collect[T any](stream Stream[T]) ([]T, error) {
+	var c []T
+	for stream.Next() {
+		c = append(c, stream.Item())
+	}
+	return c, trace.Wrap(stream.Done())
+}
+
+// CollectPages aggregates a paginated stream into a slice. If an error
+// is hit, the pages observed thus far are still returned, but they may not
+// represent the complete set.
+func CollectPages[T any](stream Stream[[]T]) ([]T, error) {
+	var c []T
+	for stream.Next() {
+		c = append(c, stream.Item()...)
+	}
+	return c, trace.Wrap(stream.Done())
+}
+
+// filterMap is a stream that performs a FilterMap operation.
+type filterMap[A, B any] struct {
+	inner Stream[A]
+	fn    func(A) (B, bool)
+	item  B
+}
+
+func (stream *filterMap[A, B]) Next() bool {
+	for {
+		if !stream.inner.Next() {
+			return false
+		}
+		var ok bool
+		stream.item, ok = stream.fn(stream.inner.Item())
+		if !ok {
+			continue
+		}
+		return true
+	}
+}
+
+func (stream *filterMap[A, B]) Item() B {
+	return stream.item
+}
+
+func (stream *filterMap[A, B]) Done() error {
+	return stream.inner.Done()
+}
+
+// FilterMap maps a stream of type A into a stream of type B, filtering out
+// items when fn returns false.
+func FilterMap[A, B any](stream Stream[A], fn func(A) (B, bool)) Stream[B] {
+	return &filterMap[A, B]{
+		inner: stream,
+		fn:    fn,
+	}
+}
+
+// mapWhile is a stream that performs a MapWhile operation.
+type mapWhile[A, B any] struct {
+	inner Stream[A]
+	fn    func(A) (B, bool)
+	item  B
+}
+
+func (stream *mapWhile[A, B]) Next() bool {
+	if !stream.inner.Next() {
+		return false
+	}
+
+	var ok bool
+	stream.item, ok = stream.fn(stream.inner.Item())
+	return ok
+}
+
+func (stream *mapWhile[A, B]) Item() B {
+	return stream.item
+}
+
+func (stream *mapWhile[A, B]) Done() error {
+	return stream.inner.Done()
+}
+
+// MapWhile maps a stream of type A into a stream of type B, halting early
+// if fn returns false.
+func MapWhile[A, B any](stream Stream[A], fn func(A) (B, bool)) Stream[B] {
+	return &mapWhile[A, B]{
+		inner: stream,
+		fn:    fn,
+	}
+}
+
+// empty is a stream that halts immediately
+type empty[T any] struct {
+	err error
+}
+
+func (stream empty[T]) Next() bool {
+	return false
+}
+
+func (stream empty[T]) Item() T {
+	panic("Item() called on empty/failed stream")
+}
+
+func (stream empty[T]) Done() error {
+	return stream.err
+}
+
+// Fail creates an empty stream that fails immediately with the supplied error.
+func Fail[T any](err error) Stream[T] {
+	return empty[T]{err}
+}
+
+// Empty creates an empty stream (equivalent to Fail(nil)).
+func Empty[T any]() Stream[T] {
+	return empty[T]{}
+}
+
+// once is a stream that yields a single item
+type once[T any] struct {
+	yielded bool
+	item    T
+}
+
+func (stream *once[T]) Next() bool {
+	if stream.yielded {
+		return false
+	}
+	stream.yielded = true
+	return true
+}
+
+func (stream *once[T]) Item() T {
+	return stream.item
+}
+
+func (stream *once[T]) Done() error {
+	return nil
+}
+
+// Once creates a stream that yields a single item.
+func Once[T any](item T) Stream[T] {
+	return &once[T]{
+		item: item,
+	}
+}
+
+// Drain consumes a stream to completion.
+func Drain[T any](stream Stream[T]) error {
+	for stream.Next() {
+	}
+	return trace.Wrap(stream.Done())
+}
+
+// slice streams the elements of a slice
+type slice[T any] struct {
+	items []T
+	idx   int
+}
+
+func (s *slice[T]) Next() bool {
+	s.idx++
+	return len(s.items) > s.idx
+}
+
+func (s *slice[T]) Item() T {
+	return s.items[s.idx]
+}
+
+func (s *slice[T]) Done() error {
+	return nil
+}
+
+// Slice constructs a stream from a slice.
+func Slice[T any](items []T) Stream[T] {
+	return &slice[T]{
+		items: items,
+		idx:   -1,
+	}
+}
+
+type pageFunc[T any] struct {
+	inner streamFunc[[]T]
+	page  slice[T]
+}
+
+func (d *pageFunc[T]) Next() bool {
+	for {
+		if d.page.Next() {
+			return true
+		}
+		if !d.inner.Next() {
+			return false
+		}
+		d.page = slice[T]{
+			items: d.inner.Item(),
+			idx:   -1,
+		}
+	}
+}
+
+func (d *pageFunc[T]) Item() T {
+	return d.page.Item()
+}
+
+func (d *pageFunc[T]) Done() error {
+	return d.inner.Done()
+}
+
+// PageFunc is equivalent to Func except that it performs internal depagination. As with
+// Func, the supplied closure *must* return io.EOF if no more items are available. Failure
+// to return io.EOF (or some other error) may result in infinite loops.
+func PageFunc[T any](fn func() ([]T, error), doneFuncs ...func()) Stream[T] {
+	return &pageFunc[T]{
+		inner: streamFunc[[]T]{
+			fn:        fn,
+			doneFuncs: doneFuncs,
+		},
+	}
+}

--- a/api/internalutils/stream/stream_test.go
+++ b/api/internalutils/stream/stream_test.go
@@ -1,0 +1,350 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stream
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSlice tests the slice stream.
+func TestSlice(t *testing.T) {
+	// normal usage
+	s, err := Collect(Slice([]int{1, 2, 3}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, s)
+
+	// single-element slice
+	s, err = Collect(Slice([]int{100}))
+	require.NoError(t, err)
+	require.Equal(t, []int{100}, s)
+
+	// nil slice
+	s, err = Collect(Slice[int](nil))
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+}
+
+// TestFilterMap tests the FilterMap combinator.
+func TestFilterMap(t *testing.T) {
+	// normal usage
+	s, err := Collect(FilterMap(Slice([]int{1, 2, 3, 4}), func(i int) (string, bool) {
+		if i%2 == 0 {
+			return fmt.Sprintf("%d", i*10), true
+		}
+		return "", false
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []string{"20", "40"}, s)
+
+	// single-match
+	s, err = Collect(FilterMap(Slice([]int{1, 2, 3, 4}), func(i int) (string, bool) {
+		if i == 3 {
+			return "three", true
+		}
+		return "", false
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []string{"three"}, s)
+
+	// no matches
+	s, err = Collect(FilterMap(Slice([]int{1, 2, 3, 4}), func(i int) (string, bool) {
+		return "", false
+	}))
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+
+	// empty stream
+	s, err = Collect(FilterMap(Empty[int](), func(_ int) (string, bool) { panic("unreachable") }))
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+
+	// failure
+	err = Drain(FilterMap(Fail[int](fmt.Errorf("unexpected error")), func(_ int) (string, bool) { panic("unreachable") }))
+	require.Error(t, err)
+}
+
+// TestMapWhile tests the MapWhile combinator.
+func TestMapWhile(t *testing.T) {
+	// normal usage
+	s, err := Collect(MapWhile(Slice([]int{1, 2, 3, 4}), func(i int) (string, bool) {
+		if i == 3 {
+			return "", false
+		}
+		return fmt.Sprintf("%d", i*10), true
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []string{"10", "20"}, s)
+
+	// halt after 1 element
+	s, err = Collect(MapWhile(Slice([]int{1, 2, 3, 4}), func(i int) (string, bool) {
+		if i == 1 {
+			return "one", true
+		}
+		return "", false
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []string{"one"}, s)
+
+	// halt immediately
+	s, err = Collect(MapWhile(Slice([]int{1, 2, 3, 4}), func(_ int) (string, bool) {
+		return "", false
+	}))
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+
+	// empty stream
+	s, err = Collect(MapWhile(Empty[int](), func(_ int) (string, bool) { panic("unreachable") }))
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+
+	// failure
+	err = Drain(MapWhile(Fail[int](fmt.Errorf("unexpected error")), func(_ int) (string, bool) { panic("unreachable") }))
+	require.Error(t, err)
+}
+
+// TestFunc tests the Func stream.
+func TestFunc(t *testing.T) {
+	// normal usage
+	var n int
+	s, err := Collect(Func(func() (int, error) {
+		n++
+		if n > 3 {
+			return 0, io.EOF
+		}
+		return n, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, s)
+
+	// single-element
+	var once bool
+	s, err = Collect(Func(func() (int, error) {
+		if once {
+			return 0, io.EOF
+		}
+		once = true
+		return 100, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{100}, s)
+
+	// no element
+	s, err = Collect(Func(func() (int, error) {
+		return 0, io.EOF
+	}))
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+
+	// immediate error
+	err = Drain(Func(func() (int, error) {
+		return 0, fmt.Errorf("unexpected error")
+	}))
+	require.Error(t, err)
+
+	// error after a few streamations
+	n = 0
+	err = Drain(Func(func() (int, error) {
+		n++
+		if n > 10 {
+			return 0, fmt.Errorf("unexpected error")
+		}
+		return n, nil
+	}))
+	require.Error(t, err)
+}
+
+func TestPageFunc(t *testing.T) {
+	// basic pages
+	var n int
+	s, err := Collect(PageFunc(func() ([]int, error) {
+		n++
+		if n > 3 {
+			return nil, io.EOF
+		}
+		return []int{
+			n,
+			n * 10,
+			n * 100,
+		}, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 10, 100, 2, 20, 200, 3, 30, 300}, s)
+
+	// single page
+	var once bool
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		if once {
+			return nil, io.EOF
+		}
+		once = true
+		return []int{1, 2, 3}, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, s)
+
+	// single element
+	once = false
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		if once {
+			return nil, io.EOF
+		}
+		once = true
+		return []int{100}, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{100}, s)
+
+	// no pages
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		return nil, io.EOF
+	}))
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+
+	// lots of empty pages
+	n = 0
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		n++
+		switch n {
+		case 5:
+			return []int{1, 2, 3}, nil
+		case 10:
+			return []int{4, 5, 6}, nil
+		case 15:
+			return nil, io.EOF
+		default:
+			return nil, nil
+		}
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4, 5, 6}, s)
+
+	// only empty and/or nil pages
+	n = 0
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		n++
+		if n > 20 {
+			return nil, io.EOF
+		}
+		if n%2 == 0 {
+			return []int{}, nil
+		}
+		return nil, nil
+	}))
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+
+	// eventual failure
+	n = 0
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		n++
+		if n > 3 {
+			return nil, fmt.Errorf("bad things")
+		}
+		return []int{1, 2, 3}, nil
+	}))
+	require.Error(t, err)
+	require.Equal(t, []int{1, 2, 3, 1, 2, 3, 1, 2, 3}, s)
+
+	// immediate failure
+	err = Drain(PageFunc(func() ([]int, error) {
+		return nil, fmt.Errorf("very bad things")
+	}))
+	require.Error(t, err)
+}
+
+// TestEmpty tests the Empty/Fail stream.
+func TestEmpty(t *testing.T) {
+	// empty case
+	s, err := Collect(Empty[int]())
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+
+	// normal error case
+	s, err = Collect(Fail[int](fmt.Errorf("unexpeced error")))
+	require.Error(t, err)
+	require.Len(t, s, 0)
+
+	// nil error case
+	s, err = Collect(Fail[int](nil))
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+}
+
+func TestCollectPages(t *testing.T) {
+	tts := []struct {
+		pages  [][]string
+		expect []string
+		err    error
+		desc   string
+	}{
+		{
+			pages: [][]string{
+				{"foo", "bar"},
+				{},
+				{"bin", "baz"},
+			},
+			expect: []string{
+				"foo",
+				"bar",
+				"bin",
+				"baz",
+			},
+			desc: "basic-depagination",
+		},
+		{
+			pages: [][]string{
+				{"one"},
+			},
+			expect: []string{"one"},
+			desc:   "single-element-case",
+		},
+		{
+			desc: "empty-case",
+		},
+		{
+			err:  fmt.Errorf("failure"),
+			desc: "error-case",
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.desc, func(t *testing.T) {
+			var stream Stream[[]string]
+			if tt.err == nil {
+				stream = Slice(tt.pages)
+			} else {
+				stream = Fail[[]string](tt.err)
+			}
+			collected, err := CollectPages(stream)
+			if tt.err == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			if len(tt.expect) == 0 {
+				require.Len(t, collected, 0)
+			} else {
+				require.Equal(t, tt.expect, collected)
+			}
+		})
+	}
+}

--- a/api/utils/retryutils/jitter.go
+++ b/api/utils/retryutils/jitter.go
@@ -17,6 +17,7 @@ package retryutils
 import (
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -39,8 +40,15 @@ func NewJitter() Jitter {
 // extent possible (e.g. when retrying a CompareAndSwap operation), a full jitter
 // may be appropriate.
 func NewFullJitter() Jitter {
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	jitter, _ := newJitter(1, rng)
+	jitter, _ := newJitter(1, newDefaultRng())
+	return jitter
+}
+
+// NewShardedFullJitter is equivalent to NewFullJitter except that it
+// performs better under high concurrency at the cost of having a larger
+// footprint in memory.
+func NewShardedFullJitter() Jitter {
+	jitter, _ := newShardedJitter(1, newDefaultRng)
 	return jitter
 }
 
@@ -48,8 +56,15 @@ func NewFullJitter() Jitter {
 // a large range and most suitable for jittering things like backoff
 // operations where breaking cycles quickly is a priority.
 func NewHalfJitter() Jitter {
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	jitter, _ := newJitter(2, rng)
+	jitter, _ := newJitter(2, newDefaultRng())
+	return jitter
+}
+
+// NewShardedHalfJitter is equivalent to NewHalfJitter except that it
+// performs better under high concurrency at the cost of having a larger
+// footprint in memory.
+func NewShardedHalfJitter() Jitter {
+	jitter, _ := newShardedJitter(2, newDefaultRng)
 	return jitter
 }
 
@@ -57,9 +72,20 @@ func NewHalfJitter() Jitter {
 // jitters such as this when jittering periodic operations (e.g. cert rotation
 // checks) since large jitters result in significantly increased load.
 func NewSeventhJitter() Jitter {
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	jitter, _ := newJitter(7, rng)
+	jitter, _ := newJitter(7, newDefaultRng())
 	return jitter
+}
+
+// NewShardedSeventhJitter is equivalent to NewSeventhJitter except that it
+// performs better under high concurrency at the cost of having a larger
+// footprint in memory.
+func NewShardedSeventhJitter() Jitter {
+	jitter, _ := newShardedJitter(7, newDefaultRng)
+	return jitter
+}
+
+func newDefaultRng() rng {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 // rng is an interface implemented by math/rand.Rand. This interface
@@ -86,5 +112,44 @@ func newJitter(n time.Duration, rng rng) (Jitter, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		return d*(n-1)/n + time.Duration(rng.Int63n(int64(d))/int64(n))
+	}, nil
+}
+
+// newShardedJitter constructs a new sharded jitter instance on the range [d*(n-1)/n,d)
+// newShardedJitter only returns an error if n < 1.
+func newShardedJitter(n time.Duration, mkrng func() rng) (Jitter, error) {
+	// the shard count here is pretty arbitrary. it was selected based on
+	// fiddling with some benchmarks. seems to be a good balance between
+	// limiting size and maximing perf under 100k concurrent calls
+	const shards = 64
+
+	if n < 1 {
+		return nil, trace.BadParameter("newShardedJitter expects n>=1, but got %v", n)
+	}
+
+	var rngs [shards]rng
+	var mus [shards]sync.Mutex
+	var ctr atomic.Uint64
+	var initOnce sync.Once
+
+	return func(d time.Duration) time.Duration {
+		// rng's allocate >4kb each during init, which is a bit annoying if the jitter
+		// isn't actually being used (e.g. when importing a package that has a global jitter).
+		// best to allocate lazily (this has no measurable impact on benchmarks).
+		initOnce.Do(func() {
+			for i := range rngs {
+				rngs[i] = mkrng()
+			}
+		})
+		// values less than 1 cause rng to panic, and some logic
+		// relies on treating zero duration as non-blocking case.
+		if d < 1 {
+			return 0
+		}
+		idx := ctr.Add(1) % shards
+		mus[idx].Lock()
+		r := d*(n-1)/n + time.Duration(rngs[idx].Int63n(int64(d))/int64(n))
+		mus[idx].Unlock()
+		return r
 	}, nil
 }

--- a/api/utils/retryutils/jitter_test.go
+++ b/api/utils/retryutils/jitter_test.go
@@ -18,6 +18,7 @@ package retryutils
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -55,6 +56,8 @@ func TestNewJitterBadParameter(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("n=%v", tc.n), func(t *testing.T) {
 			_, err := newJitter(tc.n, nil)
+			tc.assertErr(t, err)
+			_, err = newShardedJitter(tc.n, nil)
 			tc.assertErr(t, err)
 		})
 	}
@@ -100,7 +103,15 @@ func TestNewJitter(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expectFloor, testFloorJitter(baseDuration))
 
+			testFloorJitter, err = newShardedJitter(tc.n, func() rng { return mockInt63nFloor })
+			require.NoError(t, err)
+			require.Equal(t, tc.expectFloor, testFloorJitter(baseDuration))
+
 			testCeilingJitter, err := newJitter(tc.n, mockInt63nCeiling)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectCeiling, testCeilingJitter(baseDuration))
+
+			testCeilingJitter, err = newShardedJitter(tc.n, func() rng { return mockInt63nCeiling })
 			require.NoError(t, err)
 			require.Equal(t, tc.expectCeiling, testCeilingJitter(baseDuration))
 		})
@@ -111,4 +122,35 @@ type mockInt63n func(n int64) int64
 
 func (m mockInt63n) Int63n(n int64) int64 {
 	return m(n)
+}
+
+// BenchmarkJitter is an attempt to check the effect of concurrency on the performance
+// of a global jitter instance. I'm a bit skeptical of how "true to life" this benchmark
+// really is, but the results would seem to indicate that >100k concurrent jitters would
+// still all complete in <1s, which is very good for our purposes.
+func BenchmarkSingleJitter(b *testing.B) {
+	benchmarkSharedJitter(b, NewHalfJitter())
+}
+
+func BenchmarkShardedJitter(b *testing.B) {
+	benchmarkSharedJitter(b, NewShardedHalfJitter())
+}
+
+func benchmarkSharedJitter(b *testing.B, jitter Jitter) {
+	benchmarkJitter(b, func() Jitter { return jitter })
+}
+
+func benchmarkJitter(b *testing.B, mkjitter func() Jitter) {
+	procs := runtime.GOMAXPROCS(0)
+	for n := procs; n < 200_000; n = n * 2 {
+		b.Run(fmt.Sprintf("n%d", n), func(b *testing.B) {
+			b.SetParallelism(n / procs)
+			b.RunParallel(func(pb *testing.PB) {
+				jitter := mkjitter()
+				for pb.Next() {
+					jitter(time.Hour)
+				}
+			})
+		})
+	}
 }

--- a/lib/utils/interval/interval_test.go
+++ b/lib/utils/interval/interval_test.go
@@ -29,6 +29,7 @@ import (
 func TestIntervalReset(t *testing.T) {
 	const iterations = 1_000
 	const duration = time.Millisecond * 666
+	t.Parallel()
 
 	var success, failure atomic.Uint64
 	var wg sync.WaitGroup
@@ -75,12 +76,11 @@ func TestIntervalReset(t *testing.T) {
 
 	wg.Wait()
 
-	t.Logf("success=%d, failure=%d", success.Load(), failure.Load())
-
-	require.True(t, success.Load() > failure.Load())
+	require.Greater(t, success.Load(), failure.Load())
 }
 
 func TestNewNoop(t *testing.T) {
+	t.Parallel()
 	i := NewNoop()
 	ch := i.Next()
 	select {

--- a/lib/utils/interval/multi.go
+++ b/lib/utils/interval/multi.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interval
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/gravitational/teleport/api/utils/retryutils"
+)
+
+// MultiInterval is equivalent to Interval except that it supports multiple intervals simultanesouly,
+// distinguishing them by key. The only real benefit to using this type instead of using multiple
+// Intervals is that it only allocates one timer and one background goroutine regardless of the number
+// of intervals. There are very few cases where this distinction matters. An example of a place where this
+// *does* matter is when you need multiple intervals *per* connected instance on an auth or proxy server.
+// In such a case, allocating only one timer and one goroutine per connected instance can be a significant
+// saving (see the lib/inventory for an example of this usecase).
+//
+// Note that MultiInterval behaves differently than time.Ticker or Interval in that it may yield the same
+// timestamp multiple times. It will only do this for *different* keys (i.e. K1 and K2 may both tick at T0)
+// but it is still a potential source of bugs/confusion when transitioning to using this type from one
+// of the single-interval alternatives.
+type MultiInterval[T comparable] struct {
+	subs      []subIntervalEntry[T]
+	push      chan subIntervalEntry[T]
+	ch        chan Tick[T]
+	reset     chan T
+	fire      chan T
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+// Tick represents a firing of the interval. The Key field denominates the sub-interval that
+// fired, and the Time field represents the time at which the firing occurred.
+type Tick[T any] struct {
+	Key  T
+	Time time.Time
+}
+
+// SubInterval configures an interval.  The only required parameters are the Duration
+// field which *must* be a positive duration, and the Key field which can be any comparable
+// value.
+type SubInterval[T any] struct {
+	// Key is the key that will uniquely identify this sub-interval.
+	Key T
+	// Duration is the duration on which the interval "ticks" (if a jitter is
+	// applied, this represents the upper bound of the range).
+	Duration time.Duration
+
+	// FirstDuration is an optional special duration to be used for the first
+	// "tick" of the interval.  This duration is not jittered.
+	FirstDuration time.Duration
+
+	// Jitter is an optional jitter to be applied to each step of the interval.
+	// It is usually preferable to use a smaller jitter (e.g. NewSeventhJitter())
+	// for this parameter, since periodic operations are typically costly and the
+	// effect of the jitter is cumulative.
+	Jitter retryutils.Jitter
+}
+
+// subIntervalEntry wraps a SubInterval with some internal state.
+type subIntervalEntry[T comparable] struct {
+	SubInterval[T]
+	next time.Time
+}
+
+func (s *subIntervalEntry[T]) init(now time.Time) {
+	d := s.Duration
+	if s.FirstDuration != 0 {
+		d = s.FirstDuration
+	} else if s.Jitter != nil {
+		// jitter is only applied if we aren't using
+		// a custom FirstDuration value.
+		d = s.Jitter(d)
+	}
+	s.next = now.Add(d)
+}
+
+func (s *subIntervalEntry[T]) duration(now time.Time) time.Duration {
+	if now.After(s.next) {
+		// we use the smallest possible duration to represent "fire now".
+		return time.Duration(1)
+	}
+	return s.next.Sub(now)
+}
+
+func (s *subIntervalEntry[T]) reset(now time.Time) {
+	d := s.Duration
+	if s.Jitter != nil {
+		d = s.Jitter(d)
+	}
+	s.next = now.Add(d)
+}
+
+func (s *subIntervalEntry[T]) increment() {
+	s.reset(s.next)
+}
+
+// NewMulti creates a new multi-interval instance.  This function panics on non-positive
+// interval durations (equivalent to time.NewTicker) or if no sub-intervals are provided.
+func NewMulti[T comparable](intervals ...SubInterval[T]) *MultiInterval[T] {
+	if len(intervals) == 0 {
+		panic(errors.New("empty sub-interval set for interval.NewMulti"))
+	}
+
+	interval := &MultiInterval[T]{
+		subs:  make([]subIntervalEntry[T], 0, len(intervals)),
+		push:  make(chan subIntervalEntry[T]),
+		ch:    make(chan Tick[T], 1),
+		reset: make(chan T),
+		fire:  make(chan T),
+		done:  make(chan struct{}),
+	}
+
+	// check and initialize our sub-intervals.
+	now := time.Now()
+	for _, sub := range intervals {
+		if sub.Duration <= 0 {
+			panic(errors.New("non-positive sub interval for interval.NewMulti"))
+		}
+		entry := subIntervalEntry[T]{
+			SubInterval: sub,
+		}
+		entry.init(now)
+		interval.pushEntry(entry)
+	}
+
+	key, d := interval.duration(now)
+
+	// start the timer in this goroutine to improve
+	// consistency of first tick.
+	timer := time.NewTimer(d)
+
+	go interval.run(timer, key)
+
+	return interval
+}
+
+// Push adds a new sub-interval, potentially overwriting an existing sub-interval with the same key.
+// This method panics on non-positive durations (equivalent to time.NewTicker).
+func (i *MultiInterval[T]) Push(sub SubInterval[T]) {
+	if sub.Duration <= 0 {
+		panic(errors.New("non-positive sub interval for MultiInterval.Push"))
+	}
+	entry := subIntervalEntry[T]{
+		SubInterval: sub,
+	}
+	// we initialize here in order to improve consistency of start time
+	entry.init(time.Now())
+	select {
+	case i.push <- entry:
+	case <-i.done:
+	}
+}
+
+// Stop permanently stops the interval.  Note that stopping an interval does not
+// close its output channel.  This is done in order to prevent concurrent stops
+// from generating erroneous "ticks" and is consistent with the behavior of
+// time.Ticker.
+func (i *MultiInterval[T]) Stop() {
+	i.closeOnce.Do(func() {
+		close(i.done)
+	})
+}
+
+// Reset resets the interval without pausing it (i.e. it will now fire in
+// jitter(duration) regardless of current timer progress).
+func (i *MultiInterval[T]) Reset(key T) {
+	select {
+	case i.reset <- key:
+	case <-i.done:
+	}
+}
+
+// FireNow forces the sub-interval to fire immediately regardless of how much time is left on
+// the current interval. This also effectively resets the sub-interval.
+func (i *MultiInterval[T]) FireNow(key T) {
+	select {
+	case i.fire <- key:
+	case <-i.done:
+	}
+}
+
+// Next is the channel over which interval ticks are delivered.
+func (i *MultiInterval[T]) Next() <-chan Tick[T] {
+	return i.ch
+}
+
+// duration gets the next duration and its associated key.
+func (i *MultiInterval[T]) duration(now time.Time) (key T, d time.Duration) {
+	for idx := range i.subs {
+		sd := i.subs[idx].duration(now)
+		if d == 0 || sd < d {
+			key = i.subs[idx].Key
+			d = sd
+		}
+	}
+	return
+}
+
+// increment increments the sub-interval with the provided key.
+func (i *MultiInterval[T]) increment(key T) {
+	for idx := range i.subs {
+		if i.subs[idx].Key == key {
+			i.subs[idx].increment()
+			return
+		}
+	}
+}
+
+// resetEntry resets the sub-interval entry with the provided key.
+func (i *MultiInterval[T]) resetEntry(now time.Time, key T) {
+	for idx := range i.subs {
+		if i.subs[idx].Key == key {
+			i.subs[idx].reset(now)
+			return
+		}
+	}
+}
+
+// pushEntry adds a new subinterval, overwriting any previous sub-intervals with the
+// same key.
+func (i *MultiInterval[T]) pushEntry(entry subIntervalEntry[T]) {
+	for idx := range i.subs {
+		if i.subs[idx].Key == entry.Key {
+			i.subs[idx] = entry
+			return
+		}
+	}
+	i.subs = append(i.subs, entry)
+}
+
+func (i *MultiInterval[T]) run(timer *time.Timer, key T) {
+	defer timer.Stop()
+
+	var pending pendingTicks[T]
+	var ch chan Tick[T]
+	for {
+
+		// get the next pending tick if one exists
+		tick, ok := pending.next()
+
+		// set up outbound channel so that we don't send
+		// unless we have a valid tick.
+		if ok {
+			ch = i.ch
+		} else {
+			ch = nil
+		}
+
+		select {
+		case t := <-timer.C:
+			// increment the sub-interval for the current key
+			i.increment(key)
+
+			// add a pending tick for the current key
+			pending.add(t, key)
+
+			// calculate next key+duration
+			var d time.Duration
+			key, d = i.duration(t)
+
+			// timer has fired, so we can safely reset it without
+			// stop and drain.
+			timer.Reset(d)
+
+		case resetKey := <-i.reset:
+			now := time.Now()
+
+			// reset the sub-interval for the target key
+			i.resetEntry(now, resetKey)
+
+			// remove any pending tick for the target key
+			pending.remove(resetKey)
+
+			// recalulate our next key+duration in case resetting
+			// the sub-interval changed things.
+			var d time.Duration
+			key, d = i.duration(now)
+
+			// stop and drain timer
+			if !timer.Stop() {
+				<-timer.C
+			}
+
+			// apply the new duration
+			timer.Reset(d)
+
+		case fireKey := <-i.fire:
+			now := time.Now()
+
+			// reset the sub-interval for the key we are firing
+			i.resetEntry(now, fireKey)
+
+			// push an "artificial" tick.
+			pending.add(now, fireKey)
+
+			// recalculate our next key+duration in case resetting
+			// the fired key changes things.
+			var d time.Duration
+			key, d = i.duration(now)
+
+			// stop and drain timer.
+			if !timer.Stop() {
+				<-timer.C
+			}
+
+			// re-set the timer
+			timer.Reset(d)
+		case entry := <-i.push:
+			now := time.Now()
+
+			// add the new sub-interval entry
+			i.pushEntry(entry)
+
+			// remove any pending ticks that may be invalidated
+			// by this new entry overwriting an old one.
+			pending.remove(entry.Key)
+
+			// recalulate our next key+duration in case adding/overwriting the
+			// new entry changes things.
+			var d time.Duration
+			key, d = i.duration(now)
+
+			// stop and drain timer
+			if !timer.Stop() {
+				<-timer.C
+			}
+
+			// apply the new duration
+			timer.Reset(d)
+
+		case ch <- tick:
+			// remove the fired tick from pending
+			pending.remove(tick.Key)
+
+		case <-i.done:
+			// interval has been stopped.
+			return
+		}
+	}
+}
+
+// pendingTicks is a helper for managing a backlog of pending ticks. Ideally, there shouldn't be
+// a backlog, but its important to not miss a tick if two sub-intervals happen to fire at the
+// same time. This helper preserves tick order, but does not store duplicates (i.e. if the tick
+// order is A,B,B,C,A, this will result in the sequence A,B,C). All ticks are yielded with the
+// most recently observed timestamp.
+type pendingTicks[T comparable] struct {
+	time time.Time
+	keys []T
+}
+
+func (p *pendingTicks[T]) add(now time.Time, key T) {
+	p.time = now
+	for _, k := range p.keys {
+		if k == key {
+			return
+		}
+	}
+	p.keys = append(p.keys, key)
+}
+
+func (p *pendingTicks[T]) next() (tick Tick[T], ok bool) {
+	if len(p.keys) == 0 {
+		return Tick[T]{}, false
+	}
+	return Tick[T]{
+		Key:  p.keys[0],
+		Time: p.time,
+	}, true
+}
+
+func (p *pendingTicks[T]) remove(key T) {
+	for idx := range p.keys {
+		if p.keys[idx] == key {
+			p.keys = append(p.keys[:idx], p.keys[idx+1:]...)
+			return
+		}
+	}
+}

--- a/lib/utils/interval/multi_test.go
+++ b/lib/utils/interval/multi_test.go
@@ -1,0 +1,284 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interval
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiIntervalReset verifies the basic behavior of the multi interval reset functionality.
+// Since time based tests tend to be flaky, this test passes if it has a >50% success
+// rate (i.e. >50% of resets seemed to have actually extended the timer successfully).
+func TestMultiIntervalReset(t *testing.T) {
+	const iterations = 1_000
+	const duration = time.Millisecond * 666
+	t.Parallel()
+
+	var success, failure atomic.Uint64
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			resetTimer := time.NewTimer(duration / 3)
+			defer resetTimer.Stop()
+
+			interval := NewMulti[string](SubInterval[string]{
+				Key:      "key",
+				Duration: duration,
+			})
+			defer interval.Stop()
+
+			start := time.Now()
+
+			for i := 0; i < 6; i++ {
+				select {
+				case <-interval.Next():
+					failure.Add(1)
+					return
+				case <-resetTimer.C:
+					interval.Reset("key")
+					resetTimer.Reset(duration / 3)
+				}
+			}
+
+			<-interval.Next()
+			elapsed := time.Since(start)
+			// we expect this test to produce elapsed times of
+			// 3*duration if it is working properly. we accept a
+			// margin or error of +/- 1 duration in order to
+			// minimize flakiness.
+			if elapsed > duration*2 && elapsed < duration*4 {
+				success.Add(1)
+			} else {
+				failure.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	require.Greater(t, success.Load(), failure.Load())
+}
+
+// TestMultiIntervalBasics verifies basic expected multiinterval behavior. Due to the general
+// flakiness of time-based tests, this test is designed to only care about which sub-intervals
+// tick *more* relative to one another, and not about the specific relative frequency of observed
+// ticks.
+func TestMultiIntervalBasics(t *testing.T) {
+	t.Parallel()
+	interval := NewMulti[string](
+		SubInterval[string]{
+			Key:      "fast",
+			Duration: time.Millisecond * 8,
+		},
+		SubInterval[string]{
+			Key:      "slow",
+			Duration: time.Millisecond * 16,
+		},
+		SubInterval[string]{
+			Key:           "once",
+			Duration:      time.Hour,
+			FirstDuration: time.Millisecond,
+		},
+	)
+	defer interval.Stop()
+
+	var fast, slow, once int
+	var prevT time.Time
+	for i := 0; i < 60; i++ {
+		tick := <-interval.Next()
+		require.True(t, !tick.Time.IsZero())
+		require.True(t, tick.Time.After(prevT) || tick.Time == prevT)
+		prevT = tick.Time
+		switch tick.Key {
+		case "fast":
+			fast++
+		case "slow":
+			slow++
+		case "once":
+			once++
+		}
+	}
+	require.Equal(t, 1, once)
+	require.Greater(t, slow, once)
+	require.Greater(t, fast, slow)
+}
+
+// TestMultiIntervalPush verifies the expected behavior of MultiInterval.Push, both in terms of
+// its ability to add new sub-intervals, and to overwrite existing sub-intervals.
+func TestMultiIntervalPush(t *testing.T) {
+	t.Parallel()
+	interval := NewMulti[string](
+		SubInterval[string]{
+			Key:      "foo",
+			Duration: time.Millisecond * 6,
+		},
+	)
+	defer interval.Stop()
+
+	// verify that single-interval is working
+	for i := 0; i < 3; i++ {
+		tick := <-interval.Next()
+		require.Equal(t, "foo", tick.Key)
+	}
+
+	// push a new slower sub-interval
+	interval.Push(SubInterval[string]{
+		Key:      "bar",
+		Duration: time.Millisecond * 12,
+	})
+
+	// aggregate rates of both sub-intervals
+	var foo, bar int
+	for i := 0; i < 60; i++ {
+		tick := <-interval.Next()
+		switch tick.Key {
+		case "foo":
+			foo++
+		case "bar":
+			bar++
+		}
+	}
+	// verify that both sub-intervals are firing, and that
+	// foo is firing more frequently.
+	require.NotZero(t, foo)
+	require.NotZero(t, bar)
+	require.Greater(t, foo, bar)
+
+	// overwrite the old sub-intervals, inverting their respective
+	// tick rates.
+	interval.Push(SubInterval[string]{
+		Key:      "foo",
+		Duration: time.Millisecond * 12,
+	})
+	interval.Push(SubInterval[string]{
+		Key:      "bar",
+		Duration: time.Millisecond * 6,
+	})
+
+	// aggregate new rates for both sub-intervals
+	foo = 0
+	bar = 0
+	for i := 0; i < 60; i++ {
+		tick := <-interval.Next()
+		switch tick.Key {
+		case "foo":
+			foo++
+		case "bar":
+			bar++
+		}
+	}
+	// verify that both sub-intervals are firing, and that
+	// foo their relative rates have flipped, with bar now
+	// firing more frequently.
+	require.NotZero(t, foo)
+	require.NotZero(t, bar)
+	require.Greater(t, bar, foo)
+}
+
+// TestMultiIntervalFireNow verifies the expected behavior of MultiInterval.FireNow.
+func TestMultiIntervalFireNow(t *testing.T) {
+	t.Parallel()
+	// set up one sub-interval that fires frequently, and another that will never
+	// fire during this test unless we trigger with FireNow.
+	interval := NewMulti[string](
+		SubInterval[string]{
+			Key:      "slow",
+			Duration: time.Hour,
+		},
+		SubInterval[string]{
+			Key:      "fast",
+			Duration: time.Millisecond * 10,
+		},
+	)
+	defer interval.Stop()
+
+	// verify that only the 'fast' interval is firing
+	for i := 0; i < 10; i++ {
+		tick := <-interval.Next()
+		require.Equal(t, "fast", tick.Key)
+	}
+
+	// trigger the slow interval
+	interval.FireNow("slow")
+
+	// make sure that we observe slow interval firing
+	var seenSlow bool
+	for i := 0; i < 60; i++ {
+		tick := <-interval.Next()
+		if tick.Key == "slow" {
+			seenSlow = true
+			break
+		}
+	}
+
+	require.True(t, seenSlow)
+}
+
+// TestPendingTicks tests the expected behavior of the pendingTicks helper.
+func TestPendingTicks(t *testing.T) {
+	// "backlog" of fake ticks with lots of duplicates
+	tks := []string{
+		"foo",
+		"bar",
+		"foo",
+		"foo",
+		"bin",
+		"bar",
+		"bar",
+		"baz",
+		"foo",
+	}
+
+	var pending pendingTicks[string]
+
+	// insert out fake ticks
+	for _, tk := range tks {
+		pending.add(time.Now(), tk)
+	}
+
+	// we expect to have not stored any duplicate keys (important for
+	// preventing runaway memory growth due to neglected interval).
+	require.Len(t, pending.keys, 4)
+
+	// expected order of ticks to be emitted
+	expect := []string{
+		"foo",
+		"bar",
+		"bin",
+		"baz",
+	}
+
+	// verify that we see the ticks in the order we expect
+	for _, exp := range expect {
+		tick, ok := pending.next()
+		require.True(t, ok)
+		require.Equal(t, exp, tick.Key)
+		pending.remove(exp)
+	}
+
+	// verify that no more ticks are available
+	_, ok := pending.next()
+	require.False(t, ok)
+}

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -24,17 +24,20 @@ import (
 
 // HalfJitter is a global jitter instance used for one-off jitters.
 // Prefer instantiating a new jitter instance for operations that require
-// repeated calls.
+// repeated calls, and use a dedicated sharded jitter instance for
+// any usecases that might scale with cluster size or request count.
 var HalfJitter = retryutils.NewHalfJitter()
 
 // SeventhJitter is a global jitter instance used for one-off jitters.
 // Prefer instantiating a new jitter instance for operations that require
-// repeated calls.
+// repeated calls, and use a dedicated sharded jitter instance for
+// any usecases that might scale with cluster size or request count.
 var SeventhJitter = retryutils.NewSeventhJitter()
 
 // FullJitter is a global jitter instance used for one-off jitters.
 // Prefer instantiating a new jitter instance for operations that require
-// repeated calls
+// repeated calls, and use a dedicated sharded jitter instance for
+// any usecases that might scale with cluster size or request count.
 var FullJitter = retryutils.NewFullJitter()
 
 // NewDefaultLinear creates a linear retry using a half jitter, 10s step, and maxing out


### PR DESCRIPTION
This PR adds a handful of helpers required to ensure scalability of the upcoming instance heartbeat logic.

This PR is a subset of https://github.com/gravitational/teleport/pull/18313 that has been broken out for easier reviewing.  See the description of that PR for an explanation of why these helpers are necessary.