### PR TITLE
Wire the Device Trust client into API/Auth clients

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
@@ -586,6 +587,15 @@ func (c *Client) WithCallOptions(opts ...grpc.CallOption) *Client {
 	clt := *c
 	clt.callOpts = append(clt.callOpts, opts...)
 	return &clt
+}
+
+// DevicesClient returns an unadorned Device Trust client, using the underlying
+// Auth gRPC connection.
+// Clients connecting to non-Enterprise clusters, or older Teleport versions,
+// still get a devices client when calling this method, but all RPCs will return
+// "not implemented" errors (as per the default gRPC behavior).
+func (c *Client) DevicesClient() devicepb.DeviceTrustServiceClient {
+	return devicepb.NewDeviceTrustServiceClient(c.conn)
 }
 
 // Ping gets basic info about the auth server.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
@@ -246,6 +247,12 @@ func hasRemoteUserRole(authContext Context) bool {
 func hasLocalUserRole(authContext Context) bool {
 	_, ok := authContext.UnmappedIdentity.(LocalUser)
 	return ok
+}
+
+// DevicesClient allows ServerWithRoles to implement ClientI.
+// It should not be called through ServerWithRoles and will always panic.
+func (a *ServerWithRoles) DevicesClient() devicepb.DeviceTrustServiceClient {
+	panic("DevicesClient not implemented by ServerWithRoles")
 }
 
 // CreateSessionTracker creates a tracker resource for an active session.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -1610,6 +1611,12 @@ type ClientI interface {
 
 	types.WebSessionsGetter
 	types.WebTokensGetter
+
+	// DevicesClient returns a Device Trust client.
+	// Clients connecting to non-Enterprise clusters, or older Teleport versions,
+	// still get a client when calling this method, but all RPCs will return
+	// "not implemented" errors (as per the default gRPC behavior).
+	DevicesClient() devicepb.DeviceTrustServiceClient
 
 	// NewKeepAliver returns a new instance of keep aliver
 	NewKeepAliver(ctx context.Context) (types.KeepAliver, error)

--- a/lib/devicetrust/friendly_enums.go
+++ b/lib/devicetrust/friendly_enums.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicetrust
+
+import devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+
+// FriendlyOSType returns a user-friendly OSType representation.
+// Recommended for user-facing messages.
+func FriendlyOSType(osType devicepb.OSType) string {
+	switch osType {
+	case devicepb.OSType_OS_TYPE_LINUX:
+		return "Linux"
+	case devicepb.OSType_OS_TYPE_MACOS:
+		return "macOS"
+	case devicepb.OSType_OS_TYPE_WINDOWS:
+		return "Windows"
+	default:
+		return osType.String()
+	}
+}
+
+// FriendlyOSType returns a user-friendly DeviceEnrollStatus representation.
+// Recommended for user-facing messages.
+func FriendlyDeviceEnrollStatus(enrollStatus devicepb.DeviceEnrollStatus) string {
+	switch enrollStatus {
+	case devicepb.DeviceEnrollStatus_DEVICE_ENROLL_STATUS_ENROLLED:
+		return "enrolled"
+	case devicepb.DeviceEnrollStatus_DEVICE_ENROLL_STATUS_NOT_ENROLLED:
+		return "not enrolled"
+	default:
+		return enrollStatus.String()
+	}
+}


### PR DESCRIPTION
Wire the Device Trust client into existing clients, a necessity for implementing device-related commands.

A few user-friendly enum conversions are added as well, as these are useful to write said commands.

https://github.com/gravitational/teleport.e/issues/514