### PR TITLE
Propagate clocks throughout Teleport, adjust TestTCP tests.

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -524,7 +524,10 @@ func testInvalidateAppSessionsOnLogout(p *Pack, t *testing.T) {
 
 // TestTCP tests proxying of plain TCP applications through app access.
 func TestTCP(t *testing.T) {
-	pack := Setup(t)
+	clock := clockwork.NewFakeClockAt(time.Now())
+	pack := SetupWithOptions(t, AppTestOptions{
+		Clock: clock,
+	})
 
 	tests := []struct {
 		description string
@@ -623,7 +626,6 @@ func TestTCPCertExpiration(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(time.Now())
 	mCloseChannel := make(chan struct{})
 	pack := SetupWithOptions(t, AppTestOptions{
-		CertificateTTL:      5 * time.Second,
 		Clock:               clock,
 		MonitorCloseChannel: mCloseChannel,
 	})

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -242,9 +242,8 @@ func (p *Pack) initWebSession(t *testing.T) {
 // credentials.
 func (p *Pack) initTeleportClient(t *testing.T, opts AppTestOptions) {
 	creds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{
-		Process:        p.rootCluster.Process,
-		Username:       p.user.GetName(),
-		CertificateTTL: opts.CertificateTTL,
+		Process:  p.rootCluster.Process,
+		Username: p.user.GetName(),
 	})
 	require.NoError(t, err)
 
@@ -586,6 +585,7 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, opts AppTestOptions)
 		raConf.Auth.Enabled = false
 		raConf.Proxy.Enabled = false
 		raConf.SSH.Enabled = false
+		raConf.Discovery.Enabled = false
 		raConf.Apps.Enabled = true
 		raConf.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 		raConf.Apps.MonitorCloseChannel = opts.MonitorCloseChannel
@@ -709,6 +709,9 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, opts AppTestOptions)
 	require.NoError(t, err)
 	require.Equal(t, len(configs), len(servers))
 
+	if opts.Clock != nil {
+		opts.Clock.Advance(1 * time.Millisecond)
+	}
 	for i, appServer := range servers {
 		srv := appServer
 		t.Cleanup(func() {
@@ -744,6 +747,7 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions)
 		laConf.Auth.Enabled = false
 		laConf.Proxy.Enabled = false
 		laConf.SSH.Enabled = false
+		laConf.Discovery.Enabled = false
 		laConf.Apps.Enabled = true
 		laConf.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 		laConf.Apps.MonitorCloseChannel = opts.MonitorCloseChannel

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh/agent"
 
@@ -235,9 +236,9 @@ func WaitForProxyCount(t *TeleInstance, clusterName string, count int) error {
 	return trace.BadParameter("proxy count on %v: %v (wanted %v)", clusterName, counts[clusterName], count)
 }
 
-func WaitForAuditEventTypeWithBackoff(t *testing.T, cli *auth.Server, startTime time.Time, eventType string) []apievents.AuditEvent {
+func WaitForAuditEventTypeWithBackoff(t *testing.T, cli *auth.Server, startTime time.Time, clock clockwork.Clock, eventType string) []apievents.AuditEvent {
 	max := time.Second
-	timeout := time.After(max)
+	timeout := clock.After(max)
 	bf, err := retryutils.NewLinear(retryutils.LinearConfig{
 		Step: max / 10,
 		Max:  max,

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -252,7 +252,7 @@ type TeleInstance struct {
 
 // InstanceConfig is an instance configuration
 type InstanceConfig struct {
-	// Clock is an optional clock to use
+	// Clock is a mock-able clock.
 	Clock clockwork.Clock
 	// ClusterName is a cluster name of the instance
 	ClusterName string

--- a/integration/helpers/internal.go
+++ b/integration/helpers/internal.go
@@ -19,14 +19,48 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
 
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+const (
+	fakeClockTickDuration = 10 * time.Millisecond
+)
+
 func nullImpersonationCheck(context.Context, string, authztypes.SelfSubjectAccessReviewInterface) error {
 	return nil
+}
+
+// TickFakeClock will start a goroutine to tick a fake clock periodically.
+// This is intended to be run temporarily during integration tests so that
+// the starting of a Teleport process proceeds normally.
+func TickFakeClock(clock clockwork.Clock) (cleanup func()) {
+	emptyFunc := func() {}
+	if clock == nil {
+		return emptyFunc
+	}
+
+	if fakeClock, ok := clock.(clockwork.FakeClock); ok {
+		tickerDone := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(fakeClockTickDuration)
+			for {
+				select {
+				case <-ticker.C:
+					fakeClock.Advance(fakeClockTickDuration)
+				case <-tickerDone:
+					ticker.Stop()
+					return
+				}
+			}
+		}()
+		return func() { close(tickerDone) }
+	}
+
+	return emptyFunc
 }
 
 func StartAndWait(process *service.TeleportProcess, expectedEvents []string) ([]service.Event, error) {
@@ -39,8 +73,9 @@ func StartAndWait(process *service.TeleportProcess, expectedEvents []string) ([]
 	// wait for all events to arrive or a timeout. if all the expected events
 	// from above are not received, this instance will not start
 	receivedEvents := make([]service.Event, 0, len(expectedEvents))
-	ctx, cancel := context.WithTimeout(process.ExitContext(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(process.ExitContext(), 20*time.Second)
 	defer cancel()
+
 	for _, eventName := range expectedEvents {
 		if event, err := process.WaitForEvent(ctx, eventName); err == nil {
 			receivedEvents = append(receivedEvents, event)

--- a/integration/helpers/usercreds.go
+++ b/integration/helpers/usercreds.go
@@ -98,8 +98,6 @@ type UserCredsRequest struct {
 	RouteToCluster string
 	// SourceIP is an optional source IP to use in SSH certs
 	SourceIP string
-	// CertificateTTL is an optional TTL for the generated user certificate.
-	CertificateTTL time.Duration
 }
 
 // GenerateUserCreds generates key to be used by client
@@ -110,12 +108,8 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 	}
 	a := req.Process.GetAuthServer()
 	sshPub := ssh.MarshalAuthorizedKey(priv.SSHPublicKey())
-	ttl := time.Hour
-	if req.CertificateTTL != 0 {
-		ttl = req.CertificateTTL
-	}
 	sshCert, x509Cert, err := a.GenerateUserTestCerts(
-		sshPub, req.Username, ttl, constants.CertificateFormatStandard, req.RouteToCluster, req.SourceIP)
+		sshPub, req.Username, time.Hour, constants.CertificateFormatStandard, req.RouteToCluster, req.SourceIP)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -43,6 +43,7 @@ import (
 )
 
 type APIConfig struct {
+	Clock          clockwork.Clock
 	PluginRegistry plugin.Registry
 	AuthServer     *Server
 	AuditLog       events.IAuditLog
@@ -78,9 +79,13 @@ type APIServer struct {
 
 // NewAPIServer returns a new instance of APIServer HTTP handler
 func NewAPIServer(config *APIConfig) (http.Handler, error) {
+	clock := config.Clock
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
 	srv := APIServer{
 		APIConfig: *config,
-		Clock:     clockwork.NewRealClock(),
+		Clock:     clock,
 	}
 	srv.Router = *httprouter.New()
 	srv.Router.UseRawPath = true

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -239,6 +239,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 
 	closeCtx, cancelFunc := context.WithCancel(context.TODO())
 	as := Server{
+		clock:           cfg.Clock,
 		bk:              cfg.Backend,
 		limiter:         limiter,
 		Authority:       cfg.Authority,
@@ -270,7 +271,8 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		as.clock = clockwork.NewRealClock()
 	}
 	as.githubOrgSSOCache, err = utils.NewFnCache(utils.FnCacheConfig{
-		TTL: githubCacheTimeout,
+		Clock: cfg.Clock,
+		TTL:   githubCacheTimeout,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -4378,7 +4378,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	joinServiceServer := joinserver.NewJoinServiceGRPCServer(serverWithNopRole)
+	joinServiceServer := joinserver.NewJoinServiceGRPCServer(serverWithNopRole, cfg.Clock)
 	proto.RegisterJoinServiceServer(server, joinServiceServer)
 
 	return authServer, nil

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -589,6 +589,8 @@ type TestTLSServerConfig struct {
 	Listener net.Listener
 	// AcceptedUsage is a list of accepted usage restrictions
 	AcceptedUsage []string
+	// Clock is a mock-able clock.
+	Clock clockwork.Clock
 }
 
 // Auth returns auth server used by this TLS server
@@ -672,6 +674,7 @@ func NewTestTLSServer(cfg TestTLSServerConfig) (*TestTLSServer, error) {
 		APIConfig:     *srv.APIConfig,
 		LimiterConfig: *srv.Limiter,
 		AcceptedUsage: cfg.AcceptedUsage,
+		Clock:         cfg.Clock,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"golang.org/x/crypto/ssh"
@@ -197,6 +198,9 @@ type InitConfig struct {
 
 	// FIPS means FedRAMP/FIPS 140-2 compliant configuration was requested.
 	FIPS bool
+
+	// Clock is a mock-able clock.
+	Clock clockwork.Clock
 }
 
 // Init instantiates and configures an instance of AuthServer
@@ -991,7 +995,7 @@ func ReadSSHIdentityFromKeyPair(keyBytes, certBytes []byte) (*Identity, error) {
 // ReadLocalIdentity reads, parses and returns the given pub/pri key + cert from the
 // key storage (dataDir).
 func ReadLocalIdentity(dataDir string, id IdentityID) (*Identity, error) {
-	storage, err := NewProcessStorage(context.TODO(), dataDir)
+	storage, err := NewProcessStorage(context.TODO(), clockwork.NewRealClock(), dataDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/oxy/ratelimit"
 	"github.com/gravitational/trace"
 	om "github.com/grpc-ecosystem/go-grpc-middleware/providers/openmetrics/v2"
+	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
@@ -50,6 +51,8 @@ import (
 
 // TLSServerConfig is a configuration for TLS server
 type TLSServerConfig struct {
+	// Clock is a mock-able clock.
+	Clock clockwork.Clock
 	// Listener is a listener to bind to
 	Listener net.Listener
 	// TLS is a base TLS configuration
@@ -189,6 +192,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	server.mux, err = multiplexer.NewTLSListener(multiplexer.TLSListenerConfig{
 		Listener: tls.NewListener(cfg.Listener, server.cfg.TLS),
 		ID:       cfg.ID,
+		Clock:    cfg.Clock,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/state_unix.go
+++ b/lib/auth/state_unix.go
@@ -23,6 +23,7 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/kubernetes"
@@ -30,12 +31,13 @@ import (
 )
 
 // NewProcessStorage returns a new instance of the process storage.
-func NewProcessStorage(ctx context.Context, path string) (*ProcessStorage, error) {
+func NewProcessStorage(ctx context.Context, clock clockwork.Clock, path string) (*ProcessStorage, error) {
 	if path == "" {
 		return nil, trace.BadParameter("missing parameter path")
 	}
 
 	litebk, err := lite.NewWithConfig(ctx, lite.Config{
+		Clock:     clock,
 		Path:      path,
 		EventsOff: true,
 		Sync:      lite.SyncFull,

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -232,6 +232,7 @@ func NewWithConfig(ctx context.Context, cfg Config) (*Backend, error) {
 	db.SetMaxOpenConns(1)
 	buf := backend.NewCircularBuffer(
 		backend.BufferCapacity(cfg.BufferSize),
+		backend.BufferClock(cfg.Clock),
 	)
 	closeCtx, cancel := context.WithCancel(ctx)
 	l := &Backend{

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -94,6 +94,7 @@ func New(cfg Config) (*Memory, error) {
 	ctx, cancel := context.WithCancel(cfg.Context)
 	buf := backend.NewCircularBuffer(
 		backend.BufferCapacity(cfg.BufferSize),
+		backend.BufferClock(cfg.Clock),
 	)
 	buf.SetInit()
 	m := &Memory{

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -780,7 +780,7 @@ func (c *Cache) Start() error {
 	case <-c.ctx.Done():
 		c.Close()
 		return trace.Wrap(c.ctx.Err(), "context closed during cache init")
-	case <-time.After(c.Config.CacheInitTimeout):
+	case <-c.Clock.After(c.Config.CacheInitTimeout):
 		c.Warningf("Cache init is taking too long, will continue in background.")
 	}
 	return nil

--- a/lib/httplib/httplib.go
+++ b/lib/httplib/httplib.go
@@ -19,7 +19,6 @@ limitations under the License.
 package httplib
 
 import (
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"mime"
@@ -152,11 +151,7 @@ func ConvertResponse(re *roundtrip.Response, err error) (*roundtrip.Response, er
 	if err != nil {
 		var uErr *url.Error
 		if errors.As(err, &uErr) && uErr.Err != nil {
-			var hostnameErr x509.HostnameError
-			if errors.As(uErr.Err, &hostnameErr) {
-				return nil, trace.ConnectionProblem(uErr.Err, uErr.Error())
-			}
-			return nil, trace.ConnectionProblem(uErr.Err, "error parsing URL")
+			return nil, trace.ConnectionProblem(uErr.Err, uErr.Error())
 		}
 		var nErr net.Error
 		if errors.As(err, &nErr) && nErr.Timeout() {

--- a/lib/joinserver/joinserver.go
+++ b/lib/joinserver/joinserver.go
@@ -45,10 +45,13 @@ type JoinServiceGRPCServer struct {
 }
 
 // NewJoinServiceGRPCServer returns a new JoinServiceGRPCServer.
-func NewJoinServiceGRPCServer(joinServiceClient joinServiceClient) *JoinServiceGRPCServer {
+func NewJoinServiceGRPCServer(joinServiceClient joinServiceClient, clock clockwork.Clock) *JoinServiceGRPCServer {
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
 	return &JoinServiceGRPCServer{
 		joinServiceClient: joinServiceClient,
-		clock:             clockwork.NewRealClock(),
+		clock:             clock,
 	}
 }
 

--- a/lib/joinserver/joinserver_test.go
+++ b/lib/joinserver/joinserver_test.go
@@ -97,10 +97,12 @@ func newTestPack(t *testing.T) *testPack {
 
 	streamConnectionCount := &atomic.Int32{}
 
+	clock := clockwork.NewFakeClock()
+
 	// create the first instance of JoinServiceGRPCServer wrapping the mock auth
 	// server, to imitate the JoinServiceGRPCServer which runs on Auth
 	authGRPCServer, authGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(streamConnectionCount)))
-	authServer := NewJoinServiceGRPCServer(mockAuthServer)
+	authServer := NewJoinServiceGRPCServer(mockAuthServer, clock)
 	proto.RegisterJoinServiceServer(authGRPCServer, authServer)
 
 	// create a client to the "auth" gRPC service
@@ -111,7 +113,7 @@ func newTestPack(t *testing.T) *testPack {
 	// create a second instance of JoinServiceGRPCServer wrapping the "auth"
 	// gRPC client, to imitate the JoinServiceGRPCServer which runs on Proxy
 	proxyGRPCServer, proxyGRPCListener := newGRPCServer(t, grpc.ChainStreamInterceptor(ConnectionCountingStreamInterceptor(streamConnectionCount)))
-	proxyServer := NewJoinServiceGRPCServer(authJoinServiceClient)
+	proxyServer := NewJoinServiceGRPCServer(authJoinServiceClient, clock)
 	proto.RegisterJoinServiceServer(proxyGRPCServer, proxyServer)
 
 	// create a client to the "proxy" gRPC service

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -185,7 +185,7 @@ func (m *Mux) Serve() error {
 		select {
 		case <-m.context.Done():
 			return nil
-		case <-time.After(5 * time.Second):
+		case <-m.Clock.After(5 * time.Second):
 			m.WithError(err).Debugf("Backoff on accept error.")
 		}
 	}

--- a/lib/multiplexer/tls.go
+++ b/lib/multiplexer/tls.go
@@ -125,7 +125,7 @@ func (l *TLSListener) Serve() error {
 		select {
 		case <-l.context.Done():
 			return trace.Wrap(net.ErrClosed, "listener is closed")
-		case <-time.After(5 * time.Second):
+		case <-l.cfg.Clock.After(5 * time.Second):
 		}
 	}
 }
@@ -149,8 +149,8 @@ func (l *TLSListener) detectAndForward(conn *tls.Conn) {
 
 	// Log warning if TLS handshake takes more than one second to help debug
 	// latency issues.
-	if elapsed := time.Since(start); elapsed > 1*time.Second {
-		l.log.Warnf("Slow TLS handshake from %v, took %v.", conn.RemoteAddr(), time.Since(start))
+	if elapsed := l.cfg.Clock.Since(start); elapsed > 1*time.Second {
+		l.log.Warnf("Slow TLS handshake from %v, took %v.", conn.RemoteAddr(), l.cfg.Clock.Since(start))
 	}
 
 	err = conn.SetReadDeadline(time.Time{})

--- a/lib/multiplexer/web.go
+++ b/lib/multiplexer/web.go
@@ -105,7 +105,7 @@ func (l *WebListener) Serve() error {
 			select {
 			case <-l.context.Done():
 				return trace.Wrap(net.ErrClosed, "listener is closed")
-			case <-time.After(5 * time.Second):
+			case <-l.cfg.Clock.After(5 * time.Second):
 				l.log.WithError(err).Warn("Backoff on accept error.")
 			}
 			continue

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -174,13 +174,13 @@ func (p *resourceWatcher) IsInitialized() bool {
 // the resources presented in auth server.
 func (p *resourceWatcher) WaitInitialization() error {
 	// wait for resourceWatcher to complete initialization.
-	t := time.NewTicker(5 * time.Second)
+	t := p.Clock.NewTicker(5 * time.Second)
 	defer t.Stop()
 	for {
 		select {
 		case <-p.collector.initializationChan():
 			return nil
-		case <-t.C:
+		case <-t.Chan():
 			p.Log.Debugf("ResourceWatcher %s is not yet initialized.", p.collector.resourceKind())
 		case <-p.ctx.Done():
 			return trace.BadParameter("ResourceWatcher %s failed to initialize.", p.collector.resourceKind())

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -121,6 +121,7 @@ func TestProxyWatcher(t *testing.T) {
 	presence := local.NewPresenceService(bk)
 	w, err := services.NewProxyWatcher(ctx, services.ProxyWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Clock:          clock,
 			Component:      "test",
 			MaxRetryPeriod: 200 * time.Millisecond,
 			Client: &client{
@@ -138,7 +139,9 @@ func TestProxyWatcher(t *testing.T) {
 	proxy := newProxyServer(t, "proxy1", "127.0.0.1:2023")
 	require.NoError(t, presence.UpsertProxy(proxy))
 
-	// The first event is always the current list of proxies.
+	clock.Advance(10 * time.Second)
+
+	// Detect the new proxy.
 	select {
 	case changeset := <-w.ProxiesC:
 		require.Len(t, changeset, 1)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -384,6 +384,7 @@ func (s *Server) stopDynamicLabels(name string) {
 // startHeartbeat starts the registration heartbeat to the auth server.
 func (s *Server) startHeartbeat(ctx context.Context, app types.Application) error {
 	heartbeat, err := srv.NewHeartbeat(srv.HeartbeatConfig{
+		Clock:           s.c.Clock,
 		Context:         s.closeContext,
 		Component:       teleport.ComponentApp,
 		Mode:            srv.HeartbeatModeApp,

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -510,6 +510,7 @@ func (s *Server) getProxiedDatabases() (databases types.Databases) {
 // startHeartbeat starts the registration heartbeat to the auth server.
 func (s *Server) startHeartbeat(ctx context.Context, database types.Database) error {
 	heartbeat, err := srv.NewHeartbeat(srv.HeartbeatConfig{
+		Clock:           s.cfg.Clock,
 		Context:         s.closeContext,
 		Component:       teleport.ComponentDatabase,
 		Mode:            srv.HeartbeatModeDB,

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -545,6 +545,7 @@ func (s *WindowsService) scheduleNextLDAPCertRenewalLocked(after time.Duration) 
 
 func (s *WindowsService) startServiceHeartbeat() error {
 	heartbeat, err := srv.NewHeartbeat(srv.HeartbeatConfig{
+		Clock:           s.cfg.Clock,
 		Context:         s.closeCtx,
 		Component:       teleport.ComponentWindowsDesktop,
 		Mode:            srv.HeartbeatModeWindowsDesktopService,
@@ -577,6 +578,7 @@ func (s *WindowsService) startServiceHeartbeat() error {
 func (s *WindowsService) startStaticHostHeartbeats() error {
 	for _, host := range s.cfg.Heartbeat.StaticHosts {
 		heartbeat, err := srv.NewHeartbeat(srv.HeartbeatConfig{
+			Clock:           s.cfg.Clock,
 			Context:         s.closeCtx,
 			Component:       teleport.ComponentWindowsDesktop,
 			Mode:            srv.HeartbeatModeWindowsDesktop,

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -108,7 +108,7 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 
 	// Create a new session cache, this holds sessions that can be used to
 	// forward requests.
-	h.cache, err = newSessionCache(ctx, h.log)
+	h.cache, err = newSessionCache(ctx, h.c.Clock, h.log)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
The TestTCP tests were flaky because a great deal of Teleport still relies on `clockwork.NewRealClock()` even if the root process clock is set to a fake clock. This does a first pass of propagating clocks throughout our various Teleport services and adjusts the TestTCP tests to deal with some of the after effects of that.

This touches a lot of different pieces because it's hard to do this in a piecemeal manner. When a fake clock is used for one service, it introduces issues with other services because there have been implicit, inadvertent dependencies on real clocks in many of our tests. Additionally, propagating clocks accidentally caused a few flaky tests to reliably fail, as they suddenly became deterministic. As a result, I had to alter a few of those tests as well to make them behave.

The last odd thing is the `TickFakeClock` function, which, as you read correctly, takes a fake clock and makes it tick (mostly) like a regular clock. While this is odd, Teleport initialization depends on several things like heartbeats and events, all of which require an active clock. This is not an ideal change, but the startup of Teleport in integration tests will fail pretty reliably without this.