### PR TITLE
Add device trust specific verbs

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -318,6 +318,14 @@ const (
 	// VerbRotate is used to rotate certificate authorities
 	// used only internally
 	VerbRotate = "rotate"
+
+	// VerbCreateEnrollToken allows the creation of device enrollment tokens.
+	// Device Trust is a Teleport Enterprise feature.
+	VerbCreateEnrollToken = "create_enroll_token"
+
+	// VerbEnroll allows enrollment of trusted devices.
+	// Device Trust is a Teleport Enterprise feature.
+	VerbEnroll = "enroll"
 )
 
 const (

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -72,6 +72,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindConnectionDiagnostic, RW()),
 					types.NewRule(types.KindDatabaseCertificate, RW()),
 					types.NewRule(types.KindInstaller, RW()),
+					types.NewRule(types.KindDevice, append(RW(), types.VerbCreateEnrollToken, types.VerbEnroll)),
 					// Please see defaultAllowRules when adding a new rule.
 				},
 			},


### PR DESCRIPTION
Add verbs specific to Device Trust ("create_enroll_token" and "enroll") and change the editor preset to have full device administration powers.

I'll be conservative here and not retrofit permissions into editor, a fact to be called out in our to-be-written user-facing documentation.

https://github.com/gravitational/teleport.e/issues/514