### PR TITLE
changes docs from `desktop.directory.start` to `desktop.directory.share`

### DIFF
--- a/docs/pages/desktop-access/reference/audit.mdx
+++ b/docs/pages/desktop-access/reference/audit.mdx
@@ -156,7 +156,7 @@ were received.
 }
 ```
 
-## desktop.directory.start (TDP04I/W)
+## desktop.directory.share (TDP04I/W)
 
 Emitted when Teleport starts sharing a directory on a local machine to the remote desktop.
 
@@ -169,7 +169,7 @@ Emitted when Teleport starts sharing a directory on a local machine to the remot
   "directory_id": 2,
   "directory_name": "local-files",
   "ei": 0,
-  "event": "desktop.directory.start",
+  "event": "desktop.directory.share",
   "proto": "tdp",
   "sid": "4a0ed655-1e0b-412b-b14a-348e840e7fa2",
   "success": true, // false if the operation failed


### PR DESCRIPTION
I mistakenly forgot to swap this before merging https://github.com/gravitational/teleport/pull/17910