### PR TITLE
[v9] Fix concurrency issues when `tsh login` is invoked in parallel tests

### DIFF
--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -1032,7 +1032,11 @@ func updateKubeConfig(cf *CLIConf, tc *client.TeleportClient, path string) error
 		return trace.Wrap(err)
 	}
 
-	if path == "" {
+	// cf.kubeConfigPath is used in tests to allow Teleport to run tsh login commands
+	// in parallel. If defined, it should take precedence over kubeconfig.PathFromEnv().
+	if path == "" && cf.kubeConfigPath != "" {
+		path = cf.kubeConfigPath
+	} else if path == "" {
 		path = kubeconfig.PathFromEnv()
 	}
 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -335,6 +335,12 @@ type CLIConf struct {
 
 	// TracingProvider is the provider to use to create tracers, from which spans can be created.
 	TracingProvider oteltrace.TracerProvider
+
+	// kubeConfigPath is the location of the Kubeconfig for the current test.
+	// Setting this value allows Teleport tests to run `tsh login` commands in
+	// parallel.
+	// It shouldn't be used outside testing.
+	kubeConfigPath string
 }
 
 // Stdout returns the stdout writer.

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -1494,6 +1494,13 @@ func setHomePath(path string) cliOption {
 	}
 }
 
+func setKubeConfigPath(path string) cliOption {
+	return func(cf *CLIConf) error {
+		cf.kubeConfigPath = path
+		return nil
+	}
+}
+
 func setIdentity(path string) cliOption {
 	return func(cf *CLIConf) error {
 		cf.IdentityFileIn = path


### PR DESCRIPTION
Backport #18333 to branch/v9