### PR TITLE
[v11] Remove deprecated `kinds` field from `tbot` config

### DIFF
--- a/lib/tbot/config/config_destination.go
+++ b/lib/tbot/config/config_destination.go
@@ -116,11 +116,6 @@ type DestinationConfig struct {
 	Roles   []string         `yaml:"roles,omitempty"`
 	Configs []TemplateConfig `yaml:"configs,omitempty"`
 
-	// Kinds is a deprecated and unused field that remains for compatibility
-	// reasons.
-	// DELETE IN 11.0.0: Kinds should be removed after a grace period.
-	Kinds []string `yaml:"kinds,omitempty"`
-
 	// Database is a database to request access to. Mutually exclusive with
 	// `kubernetes_cluster` and other special cert requests.
 	Database *Database `yaml:"database,omitempty"`
@@ -214,12 +209,6 @@ func (dc *DestinationConfig) CheckAndSetDefaults() error {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-
-	if len(dc.Kinds) > 0 {
-		log.Warnf("The `kinds` configuration field has been deprecated and " +
-			"will be removed in a future release. It is now a no-op and can " +
-			"safely be removed from the configuration file.")
 	}
 
 	return nil


### PR DESCRIPTION
Backport #18439 to branch/v11