### PR TITLE
[v11] Remove CertificateTTL from appaccess integration tests.

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -623,7 +623,6 @@ func TestTCPCertExpiration(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(time.Now())
 	mCloseChannel := make(chan struct{})
 	pack := SetupWithOptions(t, AppTestOptions{
-		CertificateTTL:      5 * time.Second,
 		Clock:               clock,
 		MonitorCloseChannel: mCloseChannel,
 	})

--- a/integration/appaccess/fixtures.go
+++ b/integration/appaccess/fixtures.go
@@ -43,7 +43,6 @@ type AppTestOptions struct {
 	ExtraLeafApps        []service.App
 	RootClusterListeners helpers.InstanceListenerSetupFunc
 	LeafClusterListeners helpers.InstanceListenerSetupFunc
-	CertificateTTL       time.Duration
 	Clock                clockwork.FakeClock
 	MonitorCloseChannel  chan struct{}
 

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -242,9 +242,8 @@ func (p *Pack) initWebSession(t *testing.T) {
 // credentials.
 func (p *Pack) initTeleportClient(t *testing.T, opts AppTestOptions) {
 	creds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{
-		Process:        p.rootCluster.Process,
-		Username:       p.user.GetName(),
-		CertificateTTL: opts.CertificateTTL,
+		Process:  p.rootCluster.Process,
+		Username: p.user.GetName(),
 	})
 	require.NoError(t, err)
 

--- a/integration/helpers/usercreds.go
+++ b/integration/helpers/usercreds.go
@@ -97,8 +97,6 @@ type UserCredsRequest struct {
 	RouteToCluster string
 	// SourceIP is an optional source IP to use in SSH certs
 	SourceIP string
-	// CertificateTTL is an optional TTL for the generated user certificate.
-	CertificateTTL time.Duration
 }
 
 // GenerateUserCreds generates key to be used by client
@@ -109,12 +107,8 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 	}
 	a := req.Process.GetAuthServer()
 	sshPub := ssh.MarshalAuthorizedKey(priv.SSHPublicKey())
-	ttl := time.Hour
-	if req.CertificateTTL != 0 {
-		ttl = req.CertificateTTL
-	}
 	sshCert, x509Cert, err := a.GenerateUserTestCerts(
-		sshPub, req.Username, ttl, constants.CertificateFormatStandard, req.RouteToCluster, req.SourceIP)
+		sshPub, req.Username, time.Hour, constants.CertificateFormatStandard, req.RouteToCluster, req.SourceIP)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport #18395 to branch/v11