### PR TITLE
[v9] Fix regression from multiarch containers where `{DRONE_TAG}` is replaced with `(echo v1.2.3-fred.1)`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5910,7 +5910,7 @@ steps:
       - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
       - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
       # set version
-      - if [[ "$(echo v1.2.3-fred.1)" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
   - name: Assume Download AWS Role
     image: amazon/aws-cli
@@ -5948,7 +5948,7 @@ steps:
         path: /root/.aws
     commands:
       - export VERSION=$(cat /go/.version.txt)
-      - if [[ "$(echo v1.2.3-fred.1)" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
+      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
       - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/src/github.com/gravitational/teleport/assets/aws/files
 
   - name: Assume Packer AWS Role
@@ -6084,7 +6084,7 @@ steps:
       - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
       - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
       # set version
-      - if [[ "$(echo v1.2.3-fred.1)" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
   - name: Assume Download AWS Role
     image: amazon/aws-cli
@@ -6122,7 +6122,7 @@ steps:
         path: /root/.aws
     commands:
       - export VERSION=$(cat /go/.version.txt)
-      - if [[ "$(echo v1.2.3-fred.1)" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
+      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
       - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/src/github.com/gravitational/teleport/assets/aws/files
       - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/src/github.com/gravitational/teleport/assets/aws/files
 
@@ -6860,7 +6860,7 @@ steps:
   - name: Check if commit is tagged
     image: alpine
     commands:
-      - "[ -n $(echo v1.2.3-fred.1) ] || (echo 'DRONE_TAG is not set. Is the commit tagged?' && exit 1)"
+      - "[ -n ${DRONE_TAG} ] || (echo 'DRONE_TAG is not set. Is the commit tagged?' && exit 1)"
 
   - name: Assume Download AWS Role
     image: amazon/aws-cli
@@ -6945,7 +6945,7 @@ steps:
         mkdir -p /go/src/github.com/gravitational/teleport
         cd /go/src/github.com/gravitational/teleport
         git init && git remote add origin ${DRONE_REMOTE_URL}
-        git fetch origin +refs/tags/$(echo v1.2.3-fred.1):
+        git fetch origin +refs/tags/${DRONE_TAG}:
         git checkout -qf FETCH_HEAD
 
   - name: Assume AMI Download AWS Role
@@ -7129,7 +7129,7 @@ steps:
     image: golang:1.17-alpine
     commands:
       - cd /go/src/github.com/gravitational/teleport/build.assets/tooling
-      - go run ./cmd/check -tag $(echo v1.2.3-fred.1) -check prerelease || (echo '---> Not publishing $(echo v1.2.3-fred.1) packages to RPM and DEB repos' && exit 78)
+      - go run ./cmd/check -tag ${DRONE_TAG} -check prerelease || (echo '---> Not publishing ${DRONE_TAG} packages to RPM and DEB repos' && exit 78)
 
   - name: Assume RPM Repo AWS Role
     image: amazon/aws-cli
@@ -7231,7 +7231,7 @@ steps:
     image: golang:1.17-alpine
     commands:
       - cd /go/src/github.com/gravitational/teleport/build.assets/tooling
-      - go run ./cmd/check -tag $(echo v1.2.3-fred.1) -check latest || (echo '---> Not publishing ${DRONE_REPO} packages to DEB repo' && exit 78)
+      - go run ./cmd/check -tag ${DRONE_TAG} -check latest || (echo '---> Not publishing ${DRONE_REPO} packages to DEB repo' && exit 78)
 
   - name: Assume Deb Repo AWS Role
     image: amazon/aws-cli
@@ -15643,6 +15643,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: b30633d3f0e5dbc82a7d4fa2e691b17c9931d6c81ea03bd889f9ef1abc1d769c
+hmac: 5779deb94b44a32b78bb1910377c31d5feac4d715e945aff64c67934769aceca
 
 ...


### PR DESCRIPTION
Backport PR https://github.com/gravitational/teleport/pull/18279 added a regression that replaced `DRONE_TAG` with a testing tag. This PR fixes the bug.