### PR TITLE
Adds a `tdpMaxFileReadWriteLength` and tests to ensure size limit violations are non-fatal errors

### DIFF
--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -129,5 +129,8 @@ func IsNonFatalErr(err error) bool {
 		return false
 	}
 
-	return errors.Is(err, trace.LimitExceeded(clipDataMaxLenErr))
+	return errors.Is(err, trace.LimitExceeded(clipDataMaxLenErr)) ||
+		errors.Is(err, trace.LimitExceeded(stringMaxLenError)) ||
+		errors.Is(err, trace.LimitExceeded(fileReadWriteMaxLenError)) ||
+		errors.Is(err, trace.LimitExceeded(mfaDataMaxLenError))
 }

--- a/lib/srv/desktop/tdp/proto.go
+++ b/lib/srv/desktop/tdp/proto.go
@@ -1474,6 +1474,10 @@ func writeUint64(b *bytes.Buffer, v uint64) {
 // tdpMaxNotificationMessageLength is somewhat arbitrary, as it is only sent *to*
 // the browser (Teleport never receives this message, so won't be decoding it)
 const tdpMaxNotificationMessageLength = 10240
+
+// tdpMaxPathLength is currently just an arbitrary value, more research is required
+// (see https://github.com/gravitational/teleport/issues/14950)
 const tdpMaxPathLength = 10240
+
 const maxClipboardDataLength = 1024 * 1024    // 1MB
 const tdpMaxFileReadWriteLength = 1024 * 1024 // 1MB


### PR DESCRIPTION
* Adds a `tdpMaxFileReadWriteLength` that's used as a limit when decoding `SharedDirectoryReadResponse` and `SharedDirectoryWriteRequest`.
* Adds all the error messages that get returned from a max size limit violation to `IsNonFatalError`
* Creates a single test for testing that such boundaries are respected and are considered non-fatal (see description of `TestSizeLimitsAreNonFatal` for why these being non-fatal makes sense).

Fixes https://github.com/gravitational/teleport-private/issues/171