### PR TITLE
Added post-install scriplet on RPM packages

### DIFF
--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -212,9 +212,9 @@ else
     if [[ "${PACKAGE_TYPE}" == "rpm" ]]; then
         PACKAGE_ARCH="${RPM_PACKAGE_ARCH}"
         OUTPUT_FILENAME="${TAR_PATH}-${TELEPORT_VERSION}-1${OPTIONAL_RUNTIME_SECTION}.${RPM_OUTPUT_ARCH}.rpm"
-        FILE_PERMISSIONS_STANZA="--rpm-user root --rpm-group root --rpm-use-file-permissions "
+        FILE_PERMISSIONS_STANZA="--rpm-user root --rpm-group root --rpm-use-file-permissions --after-install /rpm/artifacts/posttrans.sh "
         # the rpm/rpmmacros file suppresses the creation of .build-id files (see https://github.com/gravitational/teleport/issues/7040)
-        EXTRA_DOCKER_OPTIONS="-v $(pwd)/rpm/rpmmacros:/root/.rpmmacros"
+        EXTRA_DOCKER_OPTIONS="-v $(pwd)/rpm/rpmmacros:/root/.rpmmacros -v $(pwd)/rpm/posttrans.sh:/rpm/artifacts/posttrans.sh "
         # if we set this environment variable, don't sign RPMs (can be useful for building test RPMs
         # without having the signing keys)
         if [ "${UNSIGNED_RPM}" == "true" ]; then
@@ -224,7 +224,7 @@ else
             # with pubring.kbx and trustdb.gpg files, plus a private-keys-v1.d directory with signing keys
             # it needs to contain the "Gravitational, Inc" private key and signing key.
             # we also use the rpm-sign/rpmmacros file instead which contains extra directives used for signing.
-            EXTRA_DOCKER_OPTIONS="-v $(pwd)/rpm-sign/rpmmacros:/root/.rpmmacros -v $(pwd)/rpm-sign/popt-override:/etc/popt.d/rpmsign-override -v ${GNUPG_DIR}:/root/.gnupg"
+            EXTRA_DOCKER_OPTIONS="-v $(pwd)/rpm/posttrans.sh:/rpm/artifacts/posttrans.sh -v $(pwd)/rpm-sign/rpmmacros:/root/.rpmmacros -v $(pwd)/rpm-sign/popt-override:/etc/popt.d/rpmsign-override -v ${GNUPG_DIR}:/root/.gnupg"
             RPM_SIGN_STANZA="--rpm-sign"
         fi
     elif [[ "${PACKAGE_TYPE}" == "deb" ]]; then

--- a/build.assets/rpm/posttrans.sh
+++ b/build.assets/rpm/posttrans.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+systemctl daemon-reload


### PR DESCRIPTION
Automatically reload systemd manager configuration after an RPM install/upgrade.

```bash
$ make release
$ make rpm
mkdir -p build/
cp ./build.assets/build-package.sh ./build.assets/build-common.sh build/
chmod +x build/build-package.sh
cp -a ./build.assets/rpm build/
cp -a ./build.assets/rpm-sign build/
cd build && ./build-package.sh -t oss -v 12.0.0-dev -p rpm -a amd64  
[....SNIP....]

# now we can see the scriptlet being added 
$ rpm -qpil build/teleport-12.0.0-dev-1.x86_64.rpm --scripts
Name        : teleport
Version     : 12.0.0_dev
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : default
Size        : 418167181
License     : Apache-2.0
Signature   : (none)
Source RPM  : teleport-12.0.0_dev-1.src.rpm
Build Date  : Tue 15 Nov 2022 01:49:33 AM EST
Build Host  : 2d57bd61ea5f
Relocations : / 
Packager    : info@goteleport.com
Vendor      : Gravitational
URL         : https://goteleport.com/docs
Summary     : Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API [64-bit x86 Open source edition]
Description :
Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API [64-bit x86 Open source edition]
postinstall scriptlet (using /bin/sh):
#!/bin/bash                               <=== here
systemctl daemon-reload        <==== here
/lib/systemd/system/teleport.service
/usr/local/bin/tbot
/usr/local/bin/tctl
/usr/local/bin/teleport
/usr/local/bin/tsh
/var/lib/teleport


```


Signed-off-by: Marcelo Moreira de Mello <tchello.mello@gmail.com>