### PR TITLE
Use temp files location instead of current dir for Active Dir Install

### DIFF
--- a/lib/web/scripts/desktop/configure-ad.ps1
+++ b/lib/web/scripts/desktop/configure-ad.ps1
@@ -1,28 +1,5 @@
 $ErrorActionPreference = "Stop"
 
-# Test that we can create and remove the required files 
-# If the directory prevents writing and removing files the script can fail.
-Try
-{
- $file_array = @('teleport.pem','windows.der','windows.pem')
- for($i = 0; $i -lt $file_array.length; $i++){ 
- Write-Output ""| Out-File -FilePath $file_array[$i]
- Remove-Item $file_array[$i] -Recurse
- }
-}
-Catch 
-{
-$FILE_ERROR=@'
-Teleport Active Directory Script requires create and delete permission for files in the execution directory.
-Check that you aren't running the script in a directory that denies creating and deleting files.
-'@
-
-Write-Output $FILE_ERROR
-# Exit running script throwing the error
-throw $_
-
-} 
-
 $TELEPORT_CA_CERT_PEM = "{{.caCertPEM}}"
 $TELEPORT_CA_CERT_SHA1 = "{{.caCertSHA1}}"
 $TELEPORT_CA_CERT_BLOB_BASE64 = "{{.caCertBase64}}"
@@ -96,11 +73,11 @@ New-GPO -Name $ACCESS_GPO_NAME | New-GPLink -Target $DOMAIN_DN
 $CERT = [System.Convert]::FromBase64String($TELEPORT_CA_CERT_BLOB_BASE64)
 Set-GPRegistryValue -Name $ACCESS_GPO_NAME -Key "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\SystemCertificates\Root\Certificates\$TELEPORT_CA_CERT_SHA1" -ValueName "Blob" -Type Binary -Value $CERT
 
+$TeleportPEMFile = $env:TEMP + "\teleport.pem"
+Write-Output $TELEPORT_CA_CERT_PEM | Out-File -FilePath $TeleportPEMFile
 
-Write-Output $TELEPORT_CA_CERT_PEM | Out-File -FilePath teleport.pem
-
-certutil -dspublish -f teleport.pem RootCA
-certutil -dspublish -f teleport.pem NTAuthCA
+certutil -dspublish -f $TeleportPEMFile RootCA
+certutil -dspublish -f $TeleportPEMFile NTAuthCA
 certutil -pulse
 
 $ACCESS_SECURITY_TEMPLATE=@'
@@ -146,12 +123,14 @@ Set-GPRegistryValue -Name $ACCESS_GPO_NAME -Key "HKEY_LOCAL_MACHINE\Software\Pol
 
 
 # # Step 5/7. Export your LDAP CA certificate
-certutil "-ca.cert" windows.der
-certutil -encode windows.der windows.pem
+$WindowsDERFile = $env:TEMP + "\windows.der"
+$WindowsPEMFile = $env:TEMP + "\windows.pem"
+certutil "-ca.cert" $WindowsDERFile 
+certutil -encode $WindowsDERFile $WindowsPEMFile
 
 gpupdate.exe /force
 
-$CA_CERT_PEM = Get-Content -Path windows.pem
+$CA_CERT_PEM = Get-Content -Path $WindowsPEMFile
 $CA_CERT_YAML = $CA_CERT_PEM | ForEach-Object { "        " + $_  } | Out-String
 
 
@@ -216,7 +195,7 @@ if ($host.name -match 'ISE')
 Write-Output $OUTPUT
 
 # cleanup files that were created during execution of this script
-Remove-Item teleport.pem -Recurse
-Remove-Item windows.der -Recurse
-Remove-Item windows.pem -Recurse
+Remove-Item $TeleportPEMFile -Recurse
+Remove-Item $WindowsDERFile -Recurse
+Remove-Item $WindowsPEMFile -Recurse
 

--- a/lib/web/scripts/desktop/configure-ad.ps1
+++ b/lib/web/scripts/desktop/configure-ad.ps1
@@ -1,5 +1,28 @@
 $ErrorActionPreference = "Stop"
 
+# Test that we can create and remove the required files 
+# If the directory prevents writing and removing files the script can fail.
+Try
+{
+ $file_array = @('teleport.pem','windows.der','windows.pem')
+ for($i = 0; $i -lt $file_array.length; $i++){ 
+ Write-Output ""| Out-File -FilePath $file_array[$i]
+ Remove-Item $file_array[$i] -Recurse
+ }
+}
+Catch 
+{
+$FILE_ERROR=@'
+Teleport Active Directory Script requires create and delete permission for files in the execution directory.
+Check that you aren't running the script in a directory that denies creating and deleting files.
+'@
+
+Write-Output $FILE_ERROR
+# Exit running script throwing the error
+throw $_
+
+} 
+
 $TELEPORT_CA_CERT_PEM = "{{.caCertPEM}}"
 $TELEPORT_CA_CERT_SHA1 = "{{.caCertSHA1}}"
 $TELEPORT_CA_CERT_BLOB_BASE64 = "{{.caCertBase64}}"


### PR DESCRIPTION
Addresses https://github.com/gravitational/teleport/issues/18346 so that it doesn't matter where you run the script.  This can happen easily if a user does a Run as Admin and it opens in a dir like c:\Windows\System32 that denies all writing. 