### PR TITLE
Take cloud labels into account for application access permissions calculation.

### DIFF
--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -362,17 +362,6 @@ func (s *Server) startDynamicLabels(ctx context.Context, app types.Application) 
 	return nil
 }
 
-// getDynamicLabels returns dynamic labels for the specified app.
-func (s *Server) getDynamicLabels(name string) *labels.Dynamic {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	dynamic, ok := s.dynamicLabels[name]
-	if !ok {
-		return nil
-	}
-	return dynamic
-}
-
 // stopDynamicLabels stops dynamic labels for the specified app.
 func (s *Server) stopDynamicLabels(name string) {
 	s.mu.Lock()
@@ -434,16 +423,8 @@ func (s *Server) getServerInfo(app types.Application) (types.Resource, error) {
 	// Make sure to return a new object, because it gets cached by
 	// heartbeat and will always compare as equal otherwise.
 	s.mu.RLock()
-	copy := app.Copy()
+	copy := s.appWithUpdatedLabels(app)
 	s.mu.RUnlock()
-	// Update dynamic labels if the app has them.
-	labels := s.getDynamicLabels(copy.GetName())
-	if labels != nil {
-		copy.SetDynamicLabels(labels.Get())
-	}
-	if s.c.CloudLabels != nil {
-		s.c.CloudLabels.Apply(copy)
-	}
 	expires := s.c.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL)
 	server, err := types.NewAppServerV3(types.Metadata{
 		Name:    copy.GetName(),
@@ -956,10 +937,29 @@ func (s *Server) getApp(ctx context.Context, publicAddr string) (types.Applicati
 
 	for _, a := range s.getApps() {
 		if publicAddr == a.GetPublicAddr() {
-			return a, nil
+			return s.appWithUpdatedLabels(a), nil
 		}
 	}
 	return nil, trace.NotFound("no application at %v found", publicAddr)
+}
+
+func (s *Server) appWithUpdatedLabels(app types.Application) *types.AppV3 {
+	// Create a copy of the application to modify
+	copy := app.Copy()
+
+	// Update dynamic labels if the app has them.
+	labels := s.dynamicLabels[copy.GetName()]
+
+	if labels != nil {
+		copy.SetDynamicLabels(labels.Get())
+	}
+
+	// Add in the cloud labels if the app has them.
+	if s.c.CloudLabels != nil {
+		s.c.CloudLabels.Apply(copy)
+	}
+
+	return copy
 }
 
 // newHTTPServer creates an *http.Server that can authorize and forward

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -943,6 +943,8 @@ func (s *Server) getApp(ctx context.Context, publicAddr string) (types.Applicati
 	return nil, trace.NotFound("no application at %v found", publicAddr)
 }
 
+// appWithUpdatedLabels will inject updated dynamic and cloud labels into an application
+// object. The caller must invoke an RLock on `s.mu` before calling this function.
 func (s *Server) appWithUpdatedLabels(app types.Application) *types.AppV3 {
 	// Create a copy of the application to modify
 	copy := app.Copy()

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/services"
 	libsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/app/common"
@@ -116,6 +117,12 @@ type suiteConfig struct {
 	ValidateRequest func(*Suite, *http.Request)
 	// UseWebsockets will make the application server use a websocket for connection.
 	UseWebsockets bool
+	// CloudImporter will use the given cloud importer for the app server.
+	CloudImporter labels.Importer
+	// AppLabels are the labels assigned to the application.
+	AppLabels map[string]string
+	// RoleAppLabels are the labels set to allow for the user role.
+	RoleAppLabels types.Labels
 }
 
 func SetUpSuite(t *testing.T) *Suite {
@@ -154,22 +161,37 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		s.tlsServer.Close()
 	})
 
-	// Create user and role.
-	s.user, s.role, err = auth.CreateUserAndRole(s.tlsServer.Auth(), "foo", []string{"foo-login"})
-	require.NoError(t, err)
-
-	// Grant the user's role access to the application label "bar: baz".
-	s.role.SetAppLabels(types.Allow, types.Labels{"bar": []string{"baz"}})
-	s.role.SetAWSRoleARNs(types.Allow, []string{"readonly"})
-	err = s.tlsServer.Auth().UpsertRole(context.Background(), s.role)
-	require.NoError(t, err)
-
+	// Set up the host cert pool.
 	rootCA, err := s.tlsServer.Auth().GetCertAuthority(context.Background(), types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: "root.example.com",
 	}, false)
 	require.NoError(t, err)
 	s.hostCertPool, err = services.CertPool(rootCA)
+	require.NoError(t, err)
+
+	roleAppLabels := config.RoleAppLabels
+	// Default to something that matches the staticLabels package level variable.
+	if roleAppLabels == nil {
+		roleAppLabels = types.Labels{
+			"bar": []string{"baz"},
+		}
+	}
+
+	// Grant the user's role access to the application label "bar: baz".
+	s.role = &types.RoleV5{
+		Metadata: types.Metadata{
+			Name: "foo",
+		},
+		Spec: types.RoleSpecV5{
+			Allow: types.RoleConditions{
+				AppLabels:   roleAppLabels,
+				AWSRoleARNs: []string{"readonly"},
+			},
+		},
+	}
+	// Create user for regular tests.
+	s.user, err = auth.CreateUser(s.tlsServer.Auth(), "foo", s.role)
 	require.NoError(t, err)
 
 	s.closeContext, s.closeFunc = context.WithCancel(context.Background())
@@ -209,10 +231,16 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	s.hostport = u.Host
 	s.serverPort = u.Port()
 
+	// Default to staticLabels.
+	appLabels := config.AppLabels
+	if appLabels == nil {
+		appLabels = staticLabels
+	}
+
 	// Create apps that will be used for each test.
 	appFoo, err := types.NewAppV3(types.Metadata{
 		Name:   "foo",
-		Labels: staticLabels,
+		Labels: appLabels,
 	}, types.AppSpecV3{
 		URI:           s.testhttp.URL,
 		PublicAddr:    "foo.example.com",
@@ -243,33 +271,10 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	tlsConfig.Time = s.clock.Now
 
 	// Generate certificate for user.
-	privateKey, publicKey, err := testauthority.New().GenerateKeyPair()
-	require.NoError(t, err)
-	certificate, err := s.tlsServer.Auth().GenerateUserAppTestCert(auth.AppTestCertRequest{
-		PublicKey:   publicKey,
-		Username:    s.user.GetName(),
-		TTL:         1 * time.Hour,
-		PublicAddr:  "foo.example.com",
-		ClusterName: "root.example.com",
-	})
-	require.NoError(t, err)
-	s.clientCertificate, err = tls.X509KeyPair(certificate, privateKey)
-	require.NoError(t, err)
+	s.clientCertificate = s.generateCertificate(t, s.user, "foo.example.com", "")
 
 	// Generate certificate for AWS console application.
-	privateKey, publicKey, err = testauthority.New().GenerateKeyPair()
-	require.NoError(t, err)
-	certificate, err = s.tlsServer.Auth().GenerateUserAppTestCert(auth.AppTestCertRequest{
-		PublicKey:   publicKey,
-		Username:    s.user.GetName(),
-		TTL:         1 * time.Hour,
-		PublicAddr:  "aws.example.com",
-		ClusterName: "root.example.com",
-		AWSRoleARN:  "readonly",
-	})
-	require.NoError(t, err)
-	s.awsConsoleCertificate, err = tls.X509KeyPair(certificate, privateKey)
-	require.NoError(t, err)
+	s.awsConsoleCertificate = s.generateCertificate(t, s.user, "aws.example.com", "readonly")
 
 	// Make sure the upload directory is created.
 	err = os.MkdirAll(filepath.Join(
@@ -317,6 +322,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		OnReconcile:      config.OnReconcile,
 		LockWatcher:      lockWatcher,
 		Emitter:          discard,
+		CloudLabels:      config.CloudImporter,
 	})
 	require.NoError(t, err)
 
@@ -333,6 +339,27 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	})
 
 	return s
+}
+
+func (s *Suite) generateCertificate(t *testing.T, user types.User, publicAddr, AWSRoleARN string) tls.Certificate {
+	privateKey, publicKey, err := testauthority.New().GenerateKeyPair()
+	require.NoError(t, err)
+	req := auth.AppTestCertRequest{
+		PublicKey:   publicKey,
+		Username:    user.GetName(),
+		TTL:         1 * time.Hour,
+		PublicAddr:  publicAddr,
+		ClusterName: "root.example.com",
+	}
+	if AWSRoleARN != "" {
+		req.AWSRoleARN = AWSRoleARN
+	}
+	certificate, err := s.tlsServer.Auth().GenerateUserAppTestCert(req)
+	require.NoError(t, err)
+	tlsCertificate, err := tls.X509KeyPair(certificate, privateKey)
+	require.NoError(t, err)
+
+	return tlsCertificate
 }
 
 // TestStart makes sure that after the server has started, a correct services.App
@@ -408,6 +435,150 @@ func TestWaitStop(t *testing.T) {
 	require.Equal(t, err, context.Canceled)
 }
 
+func TestAppWithUpdatedLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		app           types.Application
+		dynamicLabels map[string]*labels.Dynamic
+		cloudLabels   labels.Importer
+
+		expectedDynamicLabels map[string]string
+		expectedCloudLabels   map[string]string
+	}{
+		{
+			name: "no dynamic labels or cloud labels",
+			app: &types.AppV3{
+				Metadata: types.Metadata{
+					Labels: map[string]string{
+						"test1": "value1",
+					},
+				},
+			},
+			expectedDynamicLabels: map[string]string{},
+			expectedCloudLabels:   map[string]string{},
+		},
+		{
+			name: "only dynamic labels",
+			app: &types.AppV3{
+				Metadata: types.Metadata{
+					Name: "app1",
+					Labels: map[string]string{
+						"test1": "value1",
+					},
+				},
+				Spec: types.AppSpecV3{
+					DynamicLabels: map[string]types.CommandLabelV2{
+						"something": {
+							Command: []string{"echo", "blah"},
+							Result:  "blah",
+						},
+					},
+				},
+			},
+			expectedDynamicLabels: map[string]string{
+				"something": "blah",
+			},
+			expectedCloudLabels: map[string]string{},
+		},
+		{
+			name: "dynamic and cloud labels",
+			app: &types.AppV3{
+				Metadata: types.Metadata{
+					Name: "app1",
+					Labels: map[string]string{
+						"test1": "value1",
+					},
+				},
+				Spec: types.AppSpecV3{
+					DynamicLabels: map[string]types.CommandLabelV2{
+						"something": {
+							Command: []string{"echo", "blah"},
+							Result:  "blah",
+						},
+					},
+				},
+			},
+			cloudLabels: mustNewCloudImporter(t, &labels.CloudConfig{
+				Client: newTestIMClient("1", "host", map[string]string{
+					"cloud1": "value1",
+					"cloud2": "value2",
+				}),
+			}),
+			expectedDynamicLabels: map[string]string{
+				"something": "blah",
+			},
+			expectedCloudLabels: map[string]string{
+				"aws/cloud1": "value1",
+				"aws/cloud2": "value2",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := SetUpSuiteWithConfig(t, suiteConfig{
+				CloudImporter: test.cloudLabels,
+			})
+
+			if test.cloudLabels != nil {
+				require.NoError(t, test.cloudLabels.Sync(context.Background()))
+			}
+
+			updatedApp := s.appServer.appWithUpdatedLabels(test.app)
+
+			for key, value := range test.expectedDynamicLabels {
+				require.Equal(t, value, updatedApp.GetDynamicLabels()[key].GetResult())
+			}
+
+			for key, value := range test.expectedCloudLabels {
+				require.Equal(t, value, updatedApp.GetStaticLabels()[key])
+			}
+		})
+	}
+}
+
+// testIMClient is a test instance metadata client for exercising cloud labels.
+type testIMClient struct {
+	id       string
+	hostname string
+	labels   map[string]string
+}
+
+func newTestIMClient(id, hostname string, labels map[string]string) *testIMClient {
+	return &testIMClient{
+		id:       id,
+		hostname: hostname,
+		labels:   labels,
+	}
+}
+
+func (i *testIMClient) IsAvailable(_ context.Context) bool {
+	return true
+}
+
+func (i *testIMClient) GetTags(_ context.Context) (map[string]string, error) {
+	return i.labels, nil
+}
+
+func (i *testIMClient) GetHostname(_ context.Context) (string, error) {
+	return i.hostname, nil
+}
+
+func (i *testIMClient) GetType() types.InstanceMetadataType {
+	return types.InstanceMetadataTypeEC2
+}
+
+func (i *testIMClient) GetID(ctx context.Context) (string, error) {
+	return i.id, nil
+}
+
+func mustNewCloudImporter(t *testing.T, config *labels.CloudConfig) labels.Importer {
+	importer, err := labels.NewCloudImporter(context.Background(), config)
+	require.NoError(t, err)
+
+	return importer
+}
+
 // TestHandleConnection verifies that requests with valid certificates are forwarded and the
 // request had headers rewritten as expected.
 func TestHandleConnection(t *testing.T) {
@@ -446,8 +617,72 @@ func TestHandleConnectionWS(t *testing.T) {
 
 // TestAuthorize verifies that only authorized requests are handled.
 func TestAuthorize(t *testing.T) {
-	// TODO(r0mant): Implement this.
-	t.Skip("Not implemented")
+	tests := []struct {
+		name           string
+		cloudLabels    labels.Importer
+		roleAppLabels  types.Labels
+		appLabels      map[string]string
+		message        string
+		expectedStatus int
+	}{
+		{
+			name: "no cloud labels",
+			roleAppLabels: types.Labels{
+				"bar": []string{"baz"},
+			},
+			appLabels: map[string]string{
+				"bar": "baz",
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "cloud labels",
+			cloudLabels: mustNewCloudImporter(t, &labels.CloudConfig{
+				Client: newTestIMClient("foo", "host", map[string]string{
+					"test": "value",
+				}),
+			}),
+			roleAppLabels: types.Labels{
+				"aws/test": []string{"value"},
+			},
+			appLabels:      map[string]string{},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:          "no access",
+			roleAppLabels: types.Labels{},
+			appLabels: map[string]string{
+				"bar": "baz",
+			},
+			message:        "Not Found",
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := SetUpSuiteWithConfig(t, suiteConfig{
+				CloudImporter: test.cloudLabels,
+				AppLabels:     test.appLabels,
+				RoleAppLabels: test.roleAppLabels,
+			})
+
+			if test.cloudLabels != nil {
+				require.NoError(t, s.appServer.c.CloudLabels.Sync(context.Background()))
+			}
+
+			s.checkHTTPResponse(t, s.clientCertificate, func(resp *http.Response) {
+				require.Equal(t, test.expectedStatus, resp.StatusCode)
+				buf, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				message := s.message
+				if test.message != "" {
+					message = test.message
+				}
+				require.Equal(t, message, strings.TrimSpace(string(buf)))
+			})
+		})
+	}
 }
 
 // TestAuthorizeWithLocks verifies that requests are forbidden when there is
@@ -500,7 +735,7 @@ func TestSessionClose(t *testing.T) {
 func TestAWSConsoleRedirect(t *testing.T) {
 	s := SetUpSuite(t)
 	s.checkHTTPResponse(t, s.awsConsoleCertificate, func(resp *http.Response) {
-		require.Equal(t, resp.StatusCode, http.StatusFound)
+		require.Equal(t, http.StatusFound, resp.StatusCode)
 		location, err := resp.Location()
 		require.NoError(t, err)
 		require.Equal(t, location.String(), "https://signin.aws.amazon.com")


### PR DESCRIPTION
The app access service now takes cloud labels into account for determining permissions to an application. Previously, the app service didn't recognize cloud labels w/r/t determining whether users had access to a particular application. This was particularly confusing because this worked in the UI, i.e. the application would show in the list of applications the user had permissions to, but the app service itself would reject them. This is because the dynamic and cloud labels were not being properly injected into the application before running authorize within the app service.

Closes https://github.com/gravitational/teleport/issues/17929