### PR TITLE
Minor logging language tweak in `tbot`

### DIFF
--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -649,17 +649,13 @@ func (b *Bot) renew(
 	// Purge the CA cache. We could be smarter about this in the future if
 	// desired, since generally CAs don't change that often.
 	b.clearCertAuthorities()
-
-	b.log.Infof("Persisted new certificates to disk. Next renewal in approximately %s", b.cfg.RenewalInterval)
 	return nil
 }
 
 const renewalRetryLimit = 5
 
 func (b *Bot) renewLoop(ctx context.Context) error {
-	// TODO: what should this interval be? should it be user configurable?
-	// Also, must be < the validity period.
-	// TODO: validate that cert is actually renewable.
+	// TODO: validate that bot certificates are valid before attempting renewal
 
 	b.log.Infof(
 		"Beginning renewal loop: ttl=%s interval=%s",
@@ -715,9 +711,10 @@ func (b *Bot) renewLoop(ctx context.Context) error {
 		}
 
 		if b.cfg.Oneshot {
-			b.log.Info("Oneshot mode enabled, exiting successfully.")
+			b.log.Info("Persisted certificates successfully. One-shot mode enabled so exiting.")
 			break
 		}
+		b.log.Infof("Persisted certificates successfully. Next renewal in approximately %s.", b.cfg.RenewalInterval)
 
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Previously logging was confusing when using `--oneshot` because it mentioned renewing in X minutes, before then stating that it was exiting due to one shot mode. Now only a single log message is output.

I've also modified the language to remove mentions of disk, we are looking to introduce non-filesystem output for certificates and once thats introduced, this will be misleading.