### PR TITLE
[docs] Swaps `Allow remote RDP connections` and `Open firewall to inbound RDP connections` steps

### DIFF
--- a/docs/pages/desktop-access/manual-setup.mdx
+++ b/docs/pages/desktop-access/manual-setup.mdx
@@ -288,30 +288,6 @@ Computer Configuration > Policies > Windows Settings > Security Settings > Syste
   ![Enable Smartcard](../../img/desktop-access/smartcard.png)
 </Figure>
 
-### Open firewall to inbound RDP connections
-
-<Admonition type="warning" title="Warning">
-  During testing on a Windows Server 2012 R2 server, we found that the following
-  firewall rule would sometimes mysteriously disappear. If connections through
-  Teleport later appear to be hanging for a few seconds and then failing, double
-  check that this rule is still in effect.
-</Admonition>
-
-1. Select:
-
-```text
-Computer Configuration > Policies > Windows Settings > Security Settings > Windows Firewall with Advanced Security (x2)
-```
-
-2. Right click on `Inbound Rules` and select `New Rule...`.
-3. Under `Predefined` select `Remote Desktop`.
-4. Only select the rule for `User Mode (TCP-in)`.
-5. On the next screen, select `Allow the connection` and finish.
-
-<Figure align="left" bordered caption="Open the Firewall">
-  ![Open the Firewall](../../img/desktop-access/firewall.png)
-</Figure>
-
 ### Allow remote RDP connections
 
 1. Next, select:
@@ -331,6 +307,23 @@ Computer Configuration > Policies > Administrative Templates > Windows Component
 
 <Figure align="left" bordered caption="Disable Require user authentication...">
   ![Disable Require](../../img/desktop-access/disable.png)
+</Figure>
+
+### Open firewall to inbound RDP connections
+
+1. Select:
+
+```text
+Computer Configuration > Policies > Windows Settings > Security Settings > Windows Firewall with Advanced Security (x2)
+```
+
+2. Right click on `Inbound Rules` and select `New Rule...`.
+3. Under `Predefined` select `Remote Desktop`.
+4. Only select the rule for `User Mode (TCP-in)`.
+5. On the next screen, select `Allow the connection` and finish.
+
+<Figure align="left" bordered caption="Open the Firewall">
+  ![Open the Firewall](../../img/desktop-access/firewall.png)
 </Figure>
 
 ### Ensure your GPO is updated


### PR DESCRIPTION
The `Allow remote RDP connections` steps seem to reliably undo the `Open firewall to inbound RDP connections` step (on both 2012R and 2019) so I've switched them around.