### PR TITLE
Fix CodeQL Integer Conversion Warnings

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1967,12 +1967,16 @@ func (c *Client) StreamSessionEvents(ctx context.Context, sessionID string, star
 
 // SearchEvents allows searching for events with a full pagination support.
 func (c *Client) SearchEvents(ctx context.Context, fromUTC, toUTC time.Time, namespace string, eventTypes []string, limit int, order types.EventOrder, startKey string) ([]events.AuditEvent, string, error) {
+	i32Limit, err := utils.IntToInt32(limit)
+	if err != nil {
+		return nil, "", err
+	}
 	request := &proto.GetEventsRequest{
 		Namespace:  namespace,
 		StartDate:  fromUTC,
 		EndDate:    toUTC,
 		EventTypes: eventTypes,
-		Limit:      int32(limit),
+		Limit:      i32Limit,
 		StartKey:   startKey,
 		Order:      proto.Order(order),
 	}
@@ -1996,10 +2000,14 @@ func (c *Client) SearchEvents(ctx context.Context, fromUTC, toUTC time.Time, nam
 
 // SearchSessionEvents allows searching for session events with a full pagination support.
 func (c *Client) SearchSessionEvents(ctx context.Context, fromUTC time.Time, toUTC time.Time, limit int, order types.EventOrder, startKey string) ([]events.AuditEvent, string, error) {
+	i32Limit, err := utils.IntToInt32(limit)
+	if err != nil {
+		return nil, "", err
+	}
 	request := &proto.GetSessionEventsRequest{
 		StartDate: fromUTC,
 		EndDate:   toUTC,
-		Limit:     int32(limit),
+		Limit:     i32Limit,
 		StartKey:  startKey,
 		Order:     proto.Order(order),
 	}

--- a/api/utils/conv.go
+++ b/api/utils/conv.go
@@ -20,9 +20,87 @@ package utils
 import (
 	"bytes"
 	"encoding/json"
+	"math"
+	"strconv"
 
 	"github.com/gravitational/trace"
 )
+
+// IntToUInt16 converts an int to uint16, checking for possible overflow or underflow issues.
+func IntToUInt16(i int) (uint16, error) {
+	if i > math.MaxUint16 {
+		return uint16(math.MaxUint16), trace.Errorf("value too large to cast to uint16: %v", i)
+	} else if i < 0 {
+		return 0, trace.Errorf("can't cast negative value to uint16: %v", i)
+	}
+	return uint16(i), nil
+}
+
+// IntToUInt32 converts an int to uint32, checking for possible overflow or underflow issues.
+func IntToUInt32(i int) (uint32, error) {
+	if i > math.MaxUint32 {
+		return uint32(math.MaxUint32), trace.Errorf("value too large to cast to uint32: %v", i)
+	} else if i < 0 {
+		return 0, trace.Errorf("can't cast negative value to uint32: %v", i)
+	}
+	return uint32(i), nil
+}
+
+// IntToInt16 converts an int to int16, checking for possible overflow or underflow issues.
+func IntToInt16(i int) (int16, error) {
+	if i > math.MaxInt16 {
+		return int16(math.MaxInt16), trace.Errorf("value too large to cast to int16: %v", i)
+	} else if i < math.MinInt16 {
+		return int16(math.MinInt16), trace.Errorf("value too small to cast to int16: %v", i)
+	}
+	return int16(i), nil
+}
+
+// IntToInt32 converts an int to int32, checking for possible overflow or underflow issues.
+func IntToInt32(i int) (int32, error) {
+	if i > math.MaxInt32 {
+		return int32(math.MaxInt32), trace.Errorf("value too large to cast to int32: %v", i)
+	} else if i < math.MinInt32 {
+		return int32(math.MinInt32), trace.Errorf("value too small to cast to int32: %v", i)
+	}
+	return int32(i), nil
+}
+
+// StrToUInt16 converts a string to uint16, checking for possible overflow or underflow issues.
+func StrToUInt16(str string) (uint16, error) {
+	i, err := strconv.Atoi(str)
+	if err != nil {
+		return uint16(0), trace.Errorf("Failed to parse int from string: %s", str)
+	}
+	return IntToUInt16(i)
+}
+
+// StrToUInt32 converts a string to uint32, checking for possible overflow or underflow issues.
+func StrToUInt32(str string) (uint32, error) {
+	i, err := strconv.Atoi(str)
+	if err != nil {
+		return uint32(0), trace.Errorf("Failed to parse int from string: %s", str)
+	}
+	return IntToUInt32(i)
+}
+
+// StrToInt16 converts a string to int16, checking for possible overflow or underflow issues.
+func StrToInt16(str string) (int16, error) {
+	i, err := strconv.Atoi(str)
+	if err != nil {
+		return int16(0), trace.Errorf("Failed to parse int from string: %s", str)
+	}
+	return IntToInt16(i)
+}
+
+// StrToInt32 converts a string to int32, checking for possible overflow or underflow issues.
+func StrToInt32(str string) (int32, error) {
+	i, err := strconv.Atoi(str)
+	if err != nil {
+		return int32(0), trace.Errorf("Failed to parse int from string: %s", str)
+	}
+	return IntToInt32(i)
+}
 
 // ObjectToStruct is converts any structure into JSON and then unmarshalls it into
 // another structure.

--- a/api/utils/conv_test.go
+++ b/api/utils/conv_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package utils
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConv_IntToInt32(t *testing.T) {
+	t.Run("simpleCast", func(t *testing.T) {
+		for i := -10; i <= 10; i++ {
+			castI, err := IntToInt32(i)
+			require.Nil(t, err)
+			require.Equal(t, int32(i), castI)
+		}
+	})
+	// range tests for 32bit excluded to support 32bit platform test execution
+}
+
+func TestConv_IntToInt16(t *testing.T) {
+	t.Run("simpleCast", func(t *testing.T) {
+		for i := -10; i <= 10; i++ {
+			castI, err := IntToInt16(i)
+			require.Nil(t, err)
+			require.Equal(t, int16(i), castI)
+		}
+	})
+	t.Run("aboveRange", func(t *testing.T) {
+		i, err := IntToInt16(math.MaxInt16 + 1)
+		require.NotNil(t, err)
+		require.Equal(t, int16(math.MaxInt16), i)
+	})
+	t.Run("belowRange", func(t *testing.T) {
+		i, err := IntToInt16(math.MinInt16 - 1)
+		require.NotNil(t, err)
+		require.Equal(t, int16(math.MinInt16), i)
+	})
+}
+
+func TestConv_IntToUInt32(t *testing.T) {
+	t.Run("simpleCast", func(t *testing.T) {
+		for i := 0; i <= 10; i++ {
+			castI, err := IntToUInt32(i)
+			require.Nil(t, err)
+			require.Equal(t, uint32(i), castI)
+		}
+	})
+	// above range test for 32bit excluded for 32bit platform capability
+	t.Run("negative", func(t *testing.T) {
+		i, err := IntToUInt32(-1)
+		require.NotNil(t, err)
+		require.Equal(t, uint32(0), i)
+	})
+}
+
+func TestConv_IntToUInt16(t *testing.T) {
+	t.Run("simpleCast", func(t *testing.T) {
+		for i := 0; i <= 10; i++ {
+			castI, err := IntToUInt16(i)
+			require.Nil(t, err)
+			require.Equal(t, uint16(i), castI)
+		}
+	})
+	t.Run("aboveRange", func(t *testing.T) {
+		i, err := IntToUInt16(math.MaxUint16 + 1)
+		require.NotNil(t, err)
+		require.Equal(t, uint16(math.MaxUint16), i)
+	})
+	t.Run("negative", func(t *testing.T) {
+		i, err := IntToUInt16(-1)
+		require.NotNil(t, err)
+		require.Equal(t, uint16(0), i)
+	})
+}

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -695,7 +694,7 @@ func (c *ServerContext) OpenXServerListener(x11Req x11.ForwardRequestPayload, di
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	originPortI, err := strconv.Atoi(originPort)
+	originPortI, err := apiutils.StrToUInt16(originPort)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -36,6 +36,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auditd"
 	"github.com/gravitational/teleport/lib/pam"
 	"github.com/gravitational/teleport/lib/shell"
@@ -875,11 +876,11 @@ func newParker(ctx context.Context, credential syscall.Credential) error {
 // getCmdCredentials parses the uid, gid, and groups of the
 // given user into a credential object for a command to use.
 func getCmdCredential(localUser *user.User) (*syscall.Credential, error) {
-	uid, err := strconv.Atoi(localUser.Uid)
+	uid, err := apiutils.StrToUInt32(localUser.Uid)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	gid, err := strconv.Atoi(localUser.Gid)
+	gid, err := apiutils.StrToUInt32(localUser.Gid)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -891,20 +892,20 @@ func getCmdCredential(localUser *user.User) (*syscall.Credential, error) {
 	}
 	groups := make([]uint32, 0)
 	for _, sgid := range userGroups {
-		igid, err := strconv.Atoi(sgid)
+		igid, err := apiutils.StrToUInt32(sgid)
 		if err != nil {
 			log.Warnf("Cannot interpret user group: '%v'", sgid)
 		} else {
-			groups = append(groups, uint32(igid))
+			groups = append(groups, igid)
 		}
 	}
 	if len(groups) == 0 {
-		groups = append(groups, uint32(gid))
+		groups = append(groups, gid)
 	}
 
 	return &syscall.Credential{
-		Uid:    uint32(uid),
-		Gid:    uint32(gid),
+		Uid:    uid,
+		Gid:    gid,
 		Groups: groups,
 	}, nil
 }

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -29,7 +29,6 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -40,6 +39,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
@@ -118,11 +118,11 @@ func (h *Handler) createDesktopConnection(
 	if username == "" {
 		return sendTDPError(ws, trace.BadParameter("missing username"))
 	}
-	width, err := strconv.Atoi(q.Get("width"))
+	width, err := apiutils.StrToUInt32(q.Get("width"))
 	if err != nil {
 		return sendTDPError(ws, trace.BadParameter("width missing or invalid"))
 	}
-	height, err := strconv.Atoi(q.Get("height"))
+	height, err := apiutils.StrToUInt32(q.Get("height"))
 	if err != nil {
 		return sendTDPError(ws, trace.BadParameter("height missing or invalid"))
 	}
@@ -200,7 +200,7 @@ func (h *Handler) createDesktopConnection(
 	if err != nil {
 		return sendTDPError(ws, err)
 	}
-	err = tdpConn.WriteMessage(tdp.ClientScreenSpec{Width: uint32(width), Height: uint32(height)})
+	err = tdpConn.WriteMessage(tdp.ClientScreenSpec{Width: width, Height: height})
 	if err != nil {
 		return sendTDPError(ws, err)
 	}


### PR DESCRIPTION
These warnings are fairly pedantic in most cases, but it was easiest to just fix them as I reviewed them. I added to `api/utils/conv,go` the boundary checks for doing this casting.  In many cases this allowed a drop in replacement of one of the newly added functions.

Example CodeQL findings fixed by this:
https://github.com/gravitational/teleport/security/code-scanning/81
https://github.com/gravitational/teleport/security/code-scanning/80
https://github.com/gravitational/teleport/security/code-scanning/79
https://github.com/gravitational/teleport/security/code-scanning/78
https://github.com/gravitational/teleport/security/code-scanning/77
https://github.com/gravitational/teleport/security/code-scanning/70
https://github.com/gravitational/teleport/security/code-scanning/69