### PR TITLE
SQL Server guide updates

### DIFF
--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -38,6 +38,7 @@ Directory authentication.
 ## Prerequisites
 
 - A SQL Server database with Active Directory authentication enabled.
+- A SQL Server network listener configured with a Certificate using Subject Alternative Names
 - A Windows machine joined to the same Active Directory domain as the database.
 - A Linux node joined to the same Active Directory domain as the database. This
   guide will walk you through the joining steps if you don't have one.
@@ -228,13 +229,15 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 <ScopedBlock scope={["oss", "enterprise"]}>
 
-Start the Teleport Database Service. Make sure to update `--auth-server` to point to
-your Teleport Proxy Service address and `--uri` to the SQL Server endpoint.
+Configure the Teleport Database Service. Make sure to update `--proxy` to
+point to your Teleport Proxy Service address and `--uri` to the SQL Server
+endpoint.
 
   ```code
-  $ teleport db start \
+  $ sudo teleport db configure create \
+    -o file \
     --token=/tmp/token \
-    --auth-server=teleport.example.com:3080 \
+    --proxy=teleport.example.com:443 \
     --name=sqlserver \
     --protocol=sqlserver \
     --uri=sqlserver.example.com:1433 \
@@ -247,14 +250,15 @@ your Teleport Proxy Service address and `--uri` to the SQL Server endpoint.
 </ScopedBlock>
 <ScopedBlock scope={["cloud"]}>
 
-Start the Teleport Database Service. Make sure to update `--auth-server` to
+Configure the Teleport Database Service. Make sure to update `--proxy` to
 point to your Teleport Cloud tenant address and `--uri` to the SQL Server
 endpoint.
 
   ```code
-  $ teleport db start \
+  $ sudo teleport db configure create \
+    -o file \
     --token=/tmp/token \
-    --auth-server=mytenant.teleport.sh:443 \
+    --proxy=mytenant.teleport.sh:443:443 \
     --name=sqlserver \
     --protocol=sqlserver \
     --uri=sqlserver.example.com:1433 \
@@ -274,10 +278,7 @@ Provide Active Directory parameters:
 | `--ad-domain` | Active Directory domain (Kerberos realm) that SQL Server is joined. |
 | `--ad-spn` | Service Principal Name for SQL Server to fetch Kerberos tickets for. |
 
-<Admonition type="tip">
-  You can start the Teleport Database Service using a configuration file instead of
-  CLI flags. See the [YAML reference](../reference/configuration.mdx).
-</Admonition>
+
 
 ### Service Principal Name
 
@@ -309,7 +310,15 @@ object typically resides under the AWS Reserved / RDS path:
   toggle is enabled.
 </Admonition>
 
-## Step 6/7. Create SQL Server AD users
+## Step 6/8. Start the Database Service
+Start the Database Service:
+
+```code
+$ teleport start --config=/etc/teleport.yaml
+```
+
+
+## Step 7/8. Create SQL Server AD users
 
 <Admonition type="note">
   You can skip this step if you already have Active Directory logins in your
@@ -323,7 +332,7 @@ logins that will use Active Directory authentication:
 master> CREATE LOGIN [EXAMPLE\alice] FROM WINDOWS WITH DEFAULT_DATABASE = [master], DEFAULT_LANGUAGE = [us_english];
 ```
 
-## Step 7/7. Connect
+## Step 8/8. Connect
 
 Log in to your Teleport cluster. Your SQL Server database should appear in the
 list of available databases:
@@ -359,13 +368,42 @@ $ tsh db connect --db-user=teleport sqlserver
 
 <Admonition type="note">
   The `mssql-cli` command-line client should be available in `PATH` of the machine
-  you're running `tsh db connect` from.
+  you're running `tsh db connect` from.  
+  
+  `mssql-cli` is not required for SQL Server connections.  Use `tsh proxy db --db-user=teleport --tunnel sqlserver`
+   to connect from other DB Clients such as Microsoft SQL Server Management Studio.
 </Admonition>
 
 To log out of the database and remove credentials:
 
 ```code
 $ tsh db logout sqlserver
+```
+
+## Troubleshooting
+
+### Certificate error
+
+If your `tsh db connect` error includes the following text, the certificate used by SQL Server is not a known Certificate Authority.
+
+```code
+Error message: TLS Handshake failed: x509: certificate signed by unknown authority
+```
+
+Add the Certificate Authority (CA) `ca_cert_file` into the `tls` section so Teleport can validate the certificate. 
+```yaml
+  databases:
+  - name: sqlserver
+    protocol: sqlserver
+    uri: sqlserver.example.com:1433
+    ad:
+      keytab_file: /path/to/teleport.keytab
+      domain: EXAMPLE.COM
+      spn: MSSQLSvc/sqlserver.example.com:1433
+    static_labels:
+      "env": "dev"
+    tls:
+      ca_cert_file: /var/lib/teleport/cert.pem
 ```
 
 ## Next steps


### PR DESCRIPTION
- use `db configure create` to create teleport yaml instead of `teleport db start`
- highlight that a DB tool can be used separate from `mssql-cli`
- certificate troubleshooting that is common in a non-AWS AD env