### PR TITLE
Add warning about /x/crypto v0.3.0+ updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,11 @@ updates:
       # TODO(xacrimon): Update Firestore and solve deprecations.
       - dependency-name: cloud.google.com/go/firestore
       # Breaks backwards compatibility
+      - dependency-name: github.com/gravitational/ttlmap
       # TODO(greedy52): Update mongo-driver and fix API changes.
       - dependency-name: go.mongodb.org/mongo-driver
-      - dependency-name: github.com/gravitational/ttlmap
+      # TODO(codingllama): Allow /x/crypto updates after upstream patch.
+      - dependency-name: golang.org/x/crypto
       # Must be kept in-sync with libbpf
       - dependency-name: github.com/aquasecurity/libbpfgo
       # Forked/replaced dependencies

--- a/api/go.mod
+++ b/api/go.mod
@@ -19,7 +19,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.11.1
 	go.opentelemetry.io/otel/trace v1.11.1
 	go.opentelemetry.io/proto/otlp v0.19.0
-	golang.org/x/crypto v0.2.0
 	golang.org/x/exp v0.0.0-20221114191408-850992195362
 	golang.org/x/net v0.2.0
 	google.golang.org/genproto v0.0.0-20221116193143-41c2ba794472
@@ -27,6 +26,12 @@ require (
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+// DO NOT UPDATE crypto beyond v0.2.0, the commit below breaks compatibility
+// with OpenSSH <= 7.6.
+// We are working on landing a patch upstream.
+// https://github.com/golang/crypto/commit/6fad3dfc18918c2ac9c112e46b32473bd2e5e2f9
+require golang.org/x/crypto v0.2.0 // DO NOT UPDATE
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.11.1
 	go.opentelemetry.io/otel/trace v1.11.1
 	go.opentelemetry.io/proto/otlp v0.19.0
-	golang.org/x/crypto v0.2.0
 	golang.org/x/exp v0.0.0-20221114191408-850992195362
 	golang.org/x/mod v0.7.0
 	golang.org/x/net v0.2.0
@@ -153,6 +152,12 @@ require (
 	sigs.k8s.io/controller-tools v0.10.0
 	sigs.k8s.io/yaml v1.3.0
 )
+
+// DO NOT UPDATE crypto beyond v0.2.0, the commit below breaks compatibility
+// with OpenSSH <= 7.6.
+// We are working on landing a patch upstream.
+// https://github.com/golang/crypto/commit/6fad3dfc18918c2ac9c112e46b32473bd2e5e2f9
+require golang.org/x/crypto v0.2.0 // DO NOT UPDATE
 
 // Indirect mailgun dependencies.
 // Updating causes breaking changes.


### PR DESCRIPTION
[A recent /x/crypto commit][1] breaks compatibility with OpenSSH <=7.6, so we are adding a warning to avoid bumping crypto until that is solved.

As a last resort we have https://github.com/gravitational/crypto, but we are not using it yet.

[1]: https://github.com/golang/crypto/commit/6fad3dfc18918c2ac9c112e46b32473bd2e5e2f9