### PR TITLE
Fixes yum git install in centos-7

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -156,7 +156,8 @@ RUN yum groupinstall -y 'Development Tools' && \
     zip \
     # required by libbpf
     zlib-static && \
-    yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm git && \
+    yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && \
+    yum -y install git && \
     yum clean all
 
 # Install etcd.


### PR DESCRIPTION
Fixes git 2.18+ install command. It does not work when specified in the same sequence. Please, update centos7:teleport12 when this gets merged.