### PR TITLE
saml: Don't check existence of templated role names

### DIFF
--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -103,6 +103,10 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 	if rg != nil {
 		for _, mapping := range sc.GetAttributesToRoles() {
 			for _, role := range mapping.Roles {
+				if strings.ContainsRune(role, '$') {
+					// Role is a template so we cannot check for existence of that literal name.
+					continue
+				}
 				_, err := rg.GetRole(context.Background(), role)
 				switch {
 				case trace.IsNotFound(err):

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -103,10 +103,11 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 	if rg != nil {
 		for _, mapping := range sc.GetAttributesToRoles() {
 			for _, role := range mapping.Roles {
-				if strings.ContainsRune(role, '$') {
+				if utils.ContainsExpansion(role) {
 					// Role is a template so we cannot check for existence of that literal name.
 					continue
 				}
+				role = strings.ReplaceAll(role, "$$", "$")
 				_, err := rg.GetRole(context.Background(), role)
 				switch {
 				case trace.IsNotFound(err):

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -107,7 +107,6 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 					// Role is a template so we cannot check for existence of that literal name.
 					continue
 				}
-				role = strings.ReplaceAll(role, "$$", "$")
 				_, err := rg.GetRole(context.Background(), role)
 				switch {
 				case trace.IsNotFound(err):

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -96,14 +96,6 @@ func TestValidateRoles(t *testing.T) {
 			roles: []string{"foo", "$1", "$baz", "admin_${baz}"},
 		},
 		{
-			desc:  "dollar literal",
-			roles: []string{"big$$"},
-		},
-		{
-			desc:  "dollar literal and expansion",
-			roles: []string{"big$$${baz}"},
-		},
-		{
 			desc:        "missing role",
 			roles:       []string{"baz"},
 			expectedErr: trace.BadParameter(`role "baz" specified in attributes_to_roles not found`),

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -17,13 +17,16 @@ limitations under the License.
 package services
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 )
@@ -65,4 +68,70 @@ func TestCheckSAMLEntityDescriptor(t *testing.T) {
 	certs, err := CheckSAMLEntityDescriptor(ed)
 	require.NoError(t, err)
 	require.Len(t, certs, 1)
+}
+
+func TestValidateRoles(t *testing.T) {
+	t.Parallel()
+
+	// Create a roleSet with <nil> role values as ValidateSAMLRole does
+	// not care what the role value is, just that it exists and that
+	// the RoleGetter does not return an error.
+	var validRoles roleSet = map[string]types.Role{
+		"foo": nil,
+		"bar": nil,
+	}
+
+	testCases := []struct {
+		desc      string
+		roles     []string
+		expectErr bool
+	}{
+		{
+			desc:  "valid roles",
+			roles: []string{"foo", "bar"},
+		},
+		{
+			desc:  "role templates",
+			roles: []string{"foo", "$1", "$baz", "admin_${baz}"},
+		},
+		{
+			desc:      "missing role",
+			roles:     []string{"baz"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			connector, err := types.NewSAMLConnector("test_connector", types.SAMLConnectorSpecV2{
+				AssertionConsumerService: "http://localhost:65535/acs", // not called
+				Issuer:                   "test",
+				SSO:                      "https://localhost:65535/sso", // not called
+				AttributesToRoles: []types.AttributeMapping{
+					// not used. can be any name, value but role must exist
+					{Name: "groups", Value: "admin", Roles: tc.roles},
+				},
+			})
+			require.NoError(t, err)
+
+			err = ValidateSAMLConnector(connector, validRoles)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// roleSet is a basic set of roles keyed by role name. It implements the
+// RoleGetter interface, returning the role if it exists, or a trace.NotFound
+// error if it does not exist.
+type roleSet map[string]types.Role
+
+func (rs roleSet) GetRole(ctx context.Context, name string) (types.Role, error) {
+	if r, ok := rs[name]; ok {
+		return r, nil
+	}
+	return nil, trace.NotFound("unknown role: %s", name)
 }

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -124,7 +124,7 @@ func TestValidateRoles(t *testing.T) {
 			require.NoError(t, err)
 
 			err = ValidateSAMLConnector(connector, validRoles)
-			require.ErrorIs(t, tc.expectedErr, err)
+			require.ErrorIs(t, err, tc.expectedErr)
 		})
 	}
 }


### PR DESCRIPTION
Do not check that a role exists when validating a SAML connector if that
role name contains an expansion - that is, it is a template name using regular
expression capture groups matching against SAML assertion values.

Issue: https://github.com/gravitational/teleport/issues/18593