### PR TITLE
Docs: Update Terraform suggested role

### DIFF
--- a/docs/pages/management/guides/terraform-provider.mdx
+++ b/docs/pages/management/guides/terraform-provider.mdx
@@ -86,8 +86,24 @@ metadata:
   name: terraform
 spec:
   allow:
+    db_labels:
+      '*': '*'
+    app_labels:
+      '*': '*'
     rules:
-      - resources: ['user', 'role', 'token', 'trusted_cluster', 'github', 'oidc', 'saml']
+      - resources:
+        - app
+        - cluster_auth_preference
+        - cluster_networking_config
+        - db
+        - github
+        - oidc
+        - role
+        - saml
+        - session_recording_config
+        - token
+        - trusted_cluster
+        - user
         verbs: ['list','create','read','update','delete']
 version: v5
 ---


### PR DESCRIPTION
We support the following resources

https://github.com/gravitational/teleport-plugins/blob/236706003e176f9835a0bb92d1317b84048ad0d1/terraform/provider/provider.go#LL557C25-L557C25

Updating the suggested role to include all of them.
Note: even though the `bot` resource is manageable in Terraform, the API does not require it as a resource - it requires `User,Role,Token` resources