### PR TITLE
Do not run parker process for all SSH sessions

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -174,7 +174,7 @@ type Server interface {
 	// temporary teleport users or not
 	GetCreateHostUser() bool
 
-	// GetHostUser returns the HostUsers instance being used to manage
+	// GetHostUsers returns the HostUsers instance being used to manage
 	// host user provisioning
 	GetHostUsers() HostUsers
 

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -429,12 +429,12 @@ func startNewParker(parkerCtx context.Context, cmd *exec.Cmd, login string, loca
 		return trace.Wrap(err)
 	}
 
-	guid, err := strconv.Atoi(group.Gid)
+	guid, err := strconv.ParseUint(group.Gid, 10, 32)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	if cmd.SysProcAttr.Credential.Gid != uint32(guid) {
+	if uint64(cmd.SysProcAttr.Credential.Gid) != guid {
 		// Check if the new user guid matches the TeleportServiceGroup. If not
 		// this user hasn't been created by Teleport, and we don't need the parker.
 		return nil

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -432,8 +432,8 @@ func newOsWrapper() *osWrapper {
 // userInfo wraps user.User data into an interface, so we can override
 // returned results in tests.
 type userInfo interface {
-	Gid() string
-	Uid() string
+	GID() string
+	UID() string
 	GroupIds() ([]string, error)
 }
 
@@ -441,11 +441,11 @@ type systemUser struct {
 	u *user.User
 }
 
-func (s *systemUser) Gid() string {
+func (s *systemUser) GID() string {
 	return s.u.Gid
 }
 
-func (s *systemUser) Uid() string {
+func (s *systemUser) UID() string {
 	return s.u.Uid
 }
 
@@ -499,7 +499,7 @@ func (o *osWrapper) startNewParker(ctx context.Context, credential *syscall.Cred
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if localUser.Uid() != localUserCheck.Uid || localUser.Gid() != localUserCheck.Gid {
+	if localUser.UID() != localUserCheck.Uid || localUser.GID() != localUserCheck.Gid {
 		return trace.BadParameter("user %q has been changed", loginAsUser)
 	}
 

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -1,0 +1,151 @@
+/*
+ *
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package srv
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestStartNewParker(t *testing.T) {
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+	currentUID, err := strconv.ParseUint(currentUser.Uid, 10, 32)
+	require.NoError(t, err)
+	currentGID, err := strconv.ParseUint(currentUser.Gid, 10, 32)
+	require.NoError(t, err)
+
+	t.Parallel()
+
+	type args struct {
+		credential  *syscall.Credential
+		loginAsUser string
+		localUser   *user.User
+	}
+	tests := []struct {
+		name      string
+		args      args
+		newOsPack func(t *testing.T) (*osWrapper, func())
+		wantErr   require.ErrorAssertionFunc
+	}{
+		{
+			name:    "empty credentials does nothing",
+			wantErr: require.NoError,
+			newOsPack: func(t *testing.T) (*osWrapper, func()) {
+				return &osWrapper{}, func() {}
+			},
+		},
+		{
+			name:    "missing Teleport group returns no error",
+			wantErr: require.NoError,
+			newOsPack: func(t *testing.T) (*osWrapper, func()) {
+				return &osWrapper{
+					LookupGroup: func(name string) (*user.Group, error) {
+						require.Equal(t, types.TeleportServiceGroup, name)
+						return nil, user.UnknownGroupError(types.TeleportServiceGroup)
+					},
+				}, func() {}
+			},
+		},
+		{
+			name:    "different group doesn't start parker",
+			wantErr: require.NoError,
+			newOsPack: func(t *testing.T) (*osWrapper, func()) {
+				return &osWrapper{
+					LookupGroup: func(name string) (*user.Group, error) {
+						require.Equal(t, types.TeleportServiceGroup, name)
+						return &user.Group{Gid: "1234"}, nil
+					},
+					CommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+						require.FailNow(t, "CommandContext should not be called")
+						return nil
+					},
+				}, func() {}
+			},
+			args: args{
+				credential: &syscall.Credential{Gid: 1000},
+			},
+		},
+		{
+			name:    "parker is started",
+			wantErr: require.NoError,
+			newOsPack: func(t *testing.T) (*osWrapper, func()) {
+				parkerStarted := false
+
+				return &osWrapper{
+						LookupGroup: func(name string) (*user.Group, error) {
+							require.Equal(t, types.TeleportServiceGroup, name)
+							return &user.Group{Gid: currentUser.Gid}, nil
+						},
+						CommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+							require.NotNil(t, ctx)
+							require.Len(t, arg, 1)
+							require.Equal(t, arg[0], teleport.ParkSubCommand)
+							parkerStarted = true
+							return exec.CommandContext(ctx, name, arg...)
+						},
+						LookupUser: func(username string) (*user.User, error) {
+							return &user.User{Uid: currentUser.Uid, Gid: currentUser.Gid}, nil
+						},
+					}, func() {
+						require.True(t, parkerStarted, "parker process didn't start")
+					}
+			},
+			args: args{
+				credential: &syscall.Credential{
+					Uid: uint32(currentUID),
+					Gid: uint32(currentGID),
+					// Changing to false causes "fork/exec /proc/self/exe: operation not permitted"
+					// to be returned when creating the park process.
+					NoSetGroups: true,
+				},
+				localUser: &user.User{
+					Uid: currentUser.Uid,
+					Gid: currentUser.Gid,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			osPack, assertExpected := tt.newOsPack(t)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel) // cancel to stop the park process.
+
+			err := osPack.startNewParker(ctx, tt.args.credential, tt.args.loginAsUser, tt.args.localUser)
+			tt.wantErr(t, err, fmt.Sprintf("startNewParker(%v, %+v, %v, %+v)", ctx, tt.args.credential, tt.args.loginAsUser, tt.args.localUser))
+
+			assertExpected()
+		})
+	}
+}

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -33,6 +33,24 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+type stubUser struct {
+	gid      string
+	uid      string
+	groupIDS []string
+}
+
+func (s *stubUser) Gid() string {
+	return s.gid
+}
+
+func (s *stubUser) Uid() string {
+	return s.uid
+}
+
+func (s *stubUser) GroupIds() ([]string, error) {
+	return s.groupIDS, nil
+}
+
 func TestStartNewParker(t *testing.T) {
 	currentUser, err := user.Current()
 	require.NoError(t, err)
@@ -46,7 +64,7 @@ func TestStartNewParker(t *testing.T) {
 	type args struct {
 		credential  *syscall.Credential
 		loginAsUser string
-		localUser   *user.User
+		localUser   *stubUser
 	}
 	tests := []struct {
 		name      string
@@ -90,6 +108,11 @@ func TestStartNewParker(t *testing.T) {
 			},
 			args: args{
 				credential: &syscall.Credential{Gid: 1000},
+				localUser: &stubUser{
+					uid:      "1001",
+					gid:      "1003",
+					groupIDS: []string{"1003"},
+				},
 			},
 		},
 		{
@@ -125,9 +148,10 @@ func TestStartNewParker(t *testing.T) {
 					// to be returned when creating the park process.
 					NoSetGroups: true,
 				},
-				localUser: &user.User{
-					Uid: currentUser.Uid,
-					Gid: currentUser.Gid,
+				localUser: &stubUser{
+					uid:      currentUser.Uid,
+					gid:      currentUser.Gid,
+					groupIDS: []string{currentUser.Gid},
 				},
 			},
 		},

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -39,11 +39,11 @@ type stubUser struct {
 	groupIDS []string
 }
 
-func (s *stubUser) Gid() string {
+func (s *stubUser) GID() string {
 	return s.gid
 }
 
-func (s *stubUser) Uid() string {
+func (s *stubUser) UID() string {
 	return s.uid
 }
 

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -118,7 +118,7 @@ type HostUsers interface {
 	doWithUserLock(func(types.SemaphoreLease) error) error
 
 	// SetHostUserDeletionGrace sets the grace period before a user
-	// can be deleted, used so integration tests dont need to sleep
+	// can be deleted, used so integration tests don't need to sleep
 	SetHostUserDeletionGrace(time.Duration)
 }
 


### PR DESCRIPTION
Parker process is only needed when a user is auto-provision by Teleport. Currently, this process always starts, which causes some problems when SELinux is enabled and may also cause issues with a similar mechanism as AppArmor.
This PR runs only the parker process only when it's really needed not for every SSH session reducing the problem mentioned above.