### PR TITLE
[v9] fix aws rds discovery invalid engine filter

### DIFF
--- a/lib/srv/db/cloud/mocks.go
+++ b/lib/srv/db/cloud/mocks.go
@@ -31,9 +31,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/redshift/redshiftiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
-	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/trace"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+
+	"github.com/gravitational/teleport/lib/srv/db/common"
 )
 
 // STSMock mocks AWS STS API.
@@ -51,17 +52,25 @@ func (m *STSMock) GetCallerIdentityWithContext(aws.Context, *sts.GetCallerIdenti
 // RDSMock mocks AWS RDS API.
 type RDSMock struct {
 	rdsiface.RDSAPI
-	DBInstances []*rds.DBInstance
-	DBClusters  []*rds.DBCluster
+	DBInstances      []*rds.DBInstance
+	DBClusters       []*rds.DBCluster
+	DBEngineVersions []*rds.DBEngineVersion
 }
 
 func (m *RDSMock) DescribeDBInstancesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, options ...request.Option) (*rds.DescribeDBInstancesOutput, error) {
+	if err := checkEngineFilters(input.Filters, m.DBEngineVersions); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	instances, err := applyInstanceFilters(m.DBInstances, input.Filters)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if aws.StringValue(input.DBInstanceIdentifier) == "" {
 		return &rds.DescribeDBInstancesOutput{
-			DBInstances: m.DBInstances,
+			DBInstances: instances,
 		}, nil
 	}
-	for _, instance := range m.DBInstances {
+	for _, instance := range instances {
 		if aws.StringValue(instance.DBInstanceIdentifier) == aws.StringValue(input.DBInstanceIdentifier) {
 			return &rds.DescribeDBInstancesOutput{
 				DBInstances: []*rds.DBInstance{instance},
@@ -72,19 +81,33 @@ func (m *RDSMock) DescribeDBInstancesWithContext(ctx aws.Context, input *rds.Des
 }
 
 func (m *RDSMock) DescribeDBInstancesPagesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, fn func(*rds.DescribeDBInstancesOutput, bool) bool, options ...request.Option) error {
+	if err := checkEngineFilters(input.Filters, m.DBEngineVersions); err != nil {
+		return trace.Wrap(err)
+	}
+	instances, err := applyInstanceFilters(m.DBInstances, input.Filters)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	fn(&rds.DescribeDBInstancesOutput{
-		DBInstances: m.DBInstances,
+		DBInstances: instances,
 	}, true)
 	return nil
 }
 
 func (m *RDSMock) DescribeDBClustersWithContext(ctx aws.Context, input *rds.DescribeDBClustersInput, options ...request.Option) (*rds.DescribeDBClustersOutput, error) {
+	if err := checkEngineFilters(input.Filters, m.DBEngineVersions); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	clusters, err := applyClusterFilters(m.DBClusters, input.Filters)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if aws.StringValue(input.DBClusterIdentifier) == "" {
 		return &rds.DescribeDBClustersOutput{
-			DBClusters: m.DBClusters,
+			DBClusters: clusters,
 		}, nil
 	}
-	for _, cluster := range m.DBClusters {
+	for _, cluster := range clusters {
 		if aws.StringValue(cluster.DBClusterIdentifier) == aws.StringValue(input.DBClusterIdentifier) {
 			return &rds.DescribeDBClustersOutput{
 				DBClusters: []*rds.DBCluster{cluster},
@@ -95,8 +118,15 @@ func (m *RDSMock) DescribeDBClustersWithContext(ctx aws.Context, input *rds.Desc
 }
 
 func (m *RDSMock) DescribeDBClustersPagesWithContext(aws aws.Context, input *rds.DescribeDBClustersInput, fn func(*rds.DescribeDBClustersOutput, bool) bool, options ...request.Option) error {
+	if err := checkEngineFilters(input.Filters, m.DBEngineVersions); err != nil {
+		return trace.Wrap(err)
+	}
+	clusters, err := applyClusterFilters(m.DBClusters, input.Filters)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	fn(&rds.DescribeDBClustersOutput{
-		DBClusters: m.DBClusters,
+		DBClusters: clusters,
 	}, true)
 	return nil
 }
@@ -352,4 +382,82 @@ func (g *GCPSQLAdminClientMock) GetDatabaseInstance(ctx context.Context, session
 
 func (g *GCPSQLAdminClientMock) GenerateEphemeralCert(ctx context.Context, sessionCtx *common.Session) (*tls.Certificate, error) {
 	return g.EphemeralCert, nil
+}
+
+// checkEngineFilters checks RDS filters to detect unrecognized engine filters.
+func checkEngineFilters(filters []*rds.Filter, engineVersions []*rds.DBEngineVersion) error {
+	if len(filters) == 0 {
+		return nil
+	}
+	recognizedEngines := make(map[string]struct{})
+	for _, e := range engineVersions {
+		recognizedEngines[aws.StringValue(e.Engine)] = struct{}{}
+	}
+	for _, f := range filters {
+		if aws.StringValue(f.Name) != "engine" {
+			continue
+		}
+		for _, v := range f.Values {
+			if _, ok := recognizedEngines[aws.StringValue(v)]; !ok {
+				return trace.Errorf("unrecognized engine name %q", aws.StringValue(v))
+			}
+		}
+	}
+	return nil
+}
+
+// applyInstanceFilters filters RDS DBInstances using the provided RDS filters.
+func applyInstanceFilters(in []*rds.DBInstance, filters []*rds.Filter) ([]*rds.DBInstance, error) {
+	if len(filters) == 0 {
+		return in, nil
+	}
+	var out []*rds.DBInstance
+	efs := engineFilterSet(filters)
+	for _, instance := range in {
+		if instanceEngineMatches(instance, efs) {
+			out = append(out, instance)
+		}
+	}
+	return out, nil
+}
+
+// applyClusterFilters filters RDS DBClusters using the provided RDS filters.
+func applyClusterFilters(in []*rds.DBCluster, filters []*rds.Filter) ([]*rds.DBCluster, error) {
+	if len(filters) == 0 {
+		return in, nil
+	}
+	var out []*rds.DBCluster
+	efs := engineFilterSet(filters)
+	for _, cluster := range in {
+		if clusterEngineMatches(cluster, efs) {
+			out = append(out, cluster)
+		}
+	}
+	return out, nil
+}
+
+// engineFilterSet builds a string set of engine names from a list of RDS filters.
+func engineFilterSet(filters []*rds.Filter) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, f := range filters {
+		if aws.StringValue(f.Name) != "engine" {
+			continue
+		}
+		for _, v := range f.Values {
+			out[aws.StringValue(v)] = struct{}{}
+		}
+	}
+	return out
+}
+
+// instanceEngineMatches returns whether an RDS DBInstance engine matches any engine name in a filter set.
+func instanceEngineMatches(instance *rds.DBInstance, filterSet map[string]struct{}) bool {
+	_, ok := filterSet[aws.StringValue(instance.Engine)]
+	return ok
+}
+
+// clusterEngineMatches returns whether an RDS DBCluster engine matches any engine name in a filter set.
+func clusterEngineMatches(cluster *rds.DBCluster, filterSet map[string]struct{}) bool {
+	_, ok := filterSet[aws.StringValue(cluster.Engine)]
+	return ok
 }

--- a/lib/srv/db/cloud/watchers/rds.go
+++ b/lib/srv/db/cloud/watchers/rds.go
@@ -20,16 +20,15 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/srv/db/common"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
-
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/common"
 )
 
 // rdsFetcherConfig is the RDS databases fetcher configuration.

--- a/lib/srv/db/cloud/watchers/rds.go
+++ b/lib/srv/db/cloud/watchers/rds.go
@@ -100,7 +100,7 @@ func (f *rdsDBInstancesFetcher) Get(ctx context.Context) (types.Databases, error
 
 // getRDSDatabases returns a list of database resources representing RDS instances.
 func (f *rdsDBInstancesFetcher) getRDSDatabases(ctx context.Context) (types.Databases, error) {
-	instances, err := getAllDBInstances(ctx, f.cfg.RDS, maxPages)
+	instances, err := getAllDBInstances(ctx, f.cfg.RDS, maxPages, f.log)
 	if err != nil {
 		return nil, common.ConvertError(err)
 	}
@@ -134,16 +134,25 @@ func (f *rdsDBInstancesFetcher) getRDSDatabases(ctx context.Context) (types.Data
 
 // getAllDBInstances fetches all RDS instances using the provided client, up
 // to the specified max number of pages.
-func getAllDBInstances(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int) (instances []*rds.DBInstance, err error) {
-	var pageNum int
-	err = rdsClient.DescribeDBInstancesPagesWithContext(ctx, &rds.DescribeDBInstancesInput{
-		Filters: rdsFilters(),
-	}, func(ddo *rds.DescribeDBInstancesOutput, lastPage bool) bool {
-		pageNum++
-		instances = append(instances, ddo.DBInstances...)
-		return pageNum <= maxPages
+func getAllDBInstances(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int, log logrus.FieldLogger) ([]*rds.DBInstance, error) {
+	var instances []*rds.DBInstance
+	err := retryWithIndividualEngineFilters(log, rdsInstanceEngines(), func(filters []*rds.Filter) error {
+		var pageNum int
+		var out []*rds.DBInstance
+		err := rdsClient.DescribeDBInstancesPagesWithContext(ctx, &rds.DescribeDBInstancesInput{
+			Filters: filters,
+		}, func(ddo *rds.DescribeDBInstancesOutput, lastPage bool) bool {
+			pageNum++
+			instances = append(instances, ddo.DBInstances...)
+			return pageNum <= maxPages
+		})
+		if err == nil {
+			// only append to instances on nil error, just in case we have to retry.
+			instances = append(instances, out...)
+		}
+		return trace.Wrap(err)
 	})
-	return instances, common.ConvertError(err)
+	return instances, trace.Wrap(err)
 }
 
 // String returns the fetcher's string description.
@@ -196,7 +205,7 @@ func (f *rdsAuroraClustersFetcher) Get(ctx context.Context) (types.Databases, er
 
 // getAuroraDatabases returns a list of database resources representing RDS clusters.
 func (f *rdsAuroraClustersFetcher) getAuroraDatabases(ctx context.Context) (types.Databases, error) {
-	clusters, err := getAllDBClusters(ctx, f.cfg.RDS, maxPages)
+	clusters, err := getAllDBClusters(ctx, f.cfg.RDS, maxPages, f.log)
 	if err != nil {
 		return nil, common.ConvertError(err)
 	}
@@ -271,16 +280,25 @@ func (f *rdsAuroraClustersFetcher) getAuroraDatabases(ctx context.Context) (type
 
 // getAllDBClusters fetches all RDS clusters using the provided client, up to
 // the specified max number of pages.
-func getAllDBClusters(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int) (clusters []*rds.DBCluster, err error) {
-	var pageNum int
-	err = rdsClient.DescribeDBClustersPagesWithContext(ctx, &rds.DescribeDBClustersInput{
-		Filters: auroraFilters(),
-	}, func(ddo *rds.DescribeDBClustersOutput, lastPage bool) bool {
-		pageNum++
-		clusters = append(clusters, ddo.DBClusters...)
-		return pageNum <= maxPages
+func getAllDBClusters(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int, log logrus.FieldLogger) ([]*rds.DBCluster, error) {
+	var clusters []*rds.DBCluster
+	err := retryWithIndividualEngineFilters(log, auroraEngines(), func(filters []*rds.Filter) error {
+		var pageNum int
+		var out []*rds.DBCluster
+		err := rdsClient.DescribeDBClustersPagesWithContext(ctx, &rds.DescribeDBClustersInput{
+			Filters: filters,
+		}, func(ddo *rds.DescribeDBClustersOutput, lastPage bool) bool {
+			pageNum++
+			out = append(out, ddo.DBClusters...)
+			return pageNum <= maxPages
+		})
+		if err == nil {
+			// only append to clusters on nil error, just in case we have to retry.
+			clusters = append(clusters, out...)
+		}
+		return trace.Wrap(err)
 	})
-	return clusters, common.ConvertError(err)
+	return clusters, trace.Wrap(err)
 }
 
 // String returns the fetcher's string description.
@@ -289,28 +307,62 @@ func (f *rdsAuroraClustersFetcher) String() string {
 		f.cfg.Region, f.cfg.Labels)
 }
 
-// rdsFilters returns filters to make sure DescribeDBInstances call returns
+// rdsInstanceEngines returns engines to make sure DescribeDBInstances call returns
 // only databases with engines Teleport supports.
-func rdsFilters() []*rds.Filter {
+func rdsInstanceEngines() []string {
+	return []string{
+		services.RDSEnginePostgres,
+		services.RDSEngineMySQL,
+		services.RDSEngineMariaDB,
+	}
+}
+
+// auroraEngines returns engines to make sure DescribeDBClusters call returns
+// only databases with engines Teleport supports.
+func auroraEngines() []string {
+	return []string{
+		services.RDSEngineAurora,
+		services.RDSEngineAuroraMySQL,
+		services.RDSEngineAuroraPostgres,
+	}
+}
+
+// rdsEngineFilter is a helper func to construct an RDS filter for engine names.
+func rdsEngineFilter(engines []string) []*rds.Filter {
 	return []*rds.Filter{{
-		Name: aws.String("engine"),
-		Values: aws.StringSlice([]string{
-			services.RDSEnginePostgres,
-			services.RDSEngineMySQL,
-			services.RDSEngineMariaDB}),
+		Name:   aws.String("engine"),
+		Values: aws.StringSlice(engines),
 	}}
 }
 
-// auroraFilters returns filters to make sure DescribeDBClusters call returns
-// only databases with engines Teleport supports.
-func auroraFilters() []*rds.Filter {
-	return []*rds.Filter{{
-		Name: aws.String("engine"),
-		Values: aws.StringSlice([]string{
-			services.RDSEngineAurora,
-			services.RDSEngineAuroraMySQL,
-			services.RDSEngineAuroraPostgres}),
-	}}
+// rdsFilterFn is a function that takes RDS filters and performs some operation with them, returning any error encountered.
+type rdsFilterFn func([]*rds.Filter) error
+
+// retryWithIndividualEngineFilters is a helper error handling function for AWS RDS unrecognized engine name filter errors,
+// that will call the provided RDS querying function with filters, check the returned error,
+// and if the error is an AWS unrecognized engine name error then it will retry once by calling the function with one filter
+// at a time. If any error other than an AWS unrecognized engine name error occurs, this function will return that error
+// without retrying, or skip retrying subsequent filters if it has already started to retry.
+func retryWithIndividualEngineFilters(log logrus.FieldLogger, engines []string, fn rdsFilterFn) error {
+	err := fn(rdsEngineFilter(engines))
+	if err == nil {
+		return nil
+	}
+	if !common.IsUnrecognizedAWSEngineNameError(err) {
+		return trace.Wrap(err)
+	}
+	log.WithError(err).Warn("Teleport supports an engine which is unrecognized in this AWS region. Querying engines individually.")
+	for _, engine := range engines {
+		err := fn(rdsEngineFilter([]string{engine}))
+		if err == nil {
+			continue
+		}
+		if !common.IsUnrecognizedAWSEngineNameError(err) {
+			return trace.Wrap(err)
+		}
+		// skip logging unrecognized engine name error here, we already logged it in the initial attempt.
+	}
+	return nil
 }
 
 // maxPages is the maximum number of pages to iterate over when fetching databases.

--- a/lib/srv/db/cloud/watchers/watcher_test.go
+++ b/lib/srv/db/cloud/watchers/watcher_test.go
@@ -44,8 +44,11 @@ func TestWatcher(t *testing.T) {
 	rdsInstance2, _ := makeRDSInstance(t, "instance-2", "us-east-2", map[string]string{"env": "prod"})
 	rdsInstance3, _ := makeRDSInstance(t, "instance-3", "us-east-1", map[string]string{"env": "dev"})
 	rdsInstance4, rdsDatabase4 := makeRDSInstance(t, "instance-4", "us-west-1", nil)
+	rdsInstance5, rdsDatabase5 := makeRDSInstance(t, "instance-5", "us-east-2", map[string]string{"env": "dev"})
 	rdsInstanceUnavailable, _ := makeRDSInstance(t, "instance-5", "us-west-1", nil, withRDSInstanceStatus("stopped"))
 	rdsInstanceUnknownStatus, rdsDatabaseUnknownStatus := makeRDSInstance(t, "instance-5", "us-west-6", nil, withRDSInstanceStatus("status-does-not-exist"))
+	auroraMySQLEngine := &rds.DBEngineVersion{Engine: aws.String(services.RDSEngineAuroraMySQL)}
+	postgresEngine := &rds.DBEngineVersion{Engine: aws.String(services.RDSEnginePostgres)}
 
 	auroraCluster1, auroraDatabase1 := makeRDSCluster(t, "cluster-1", "us-east-1", map[string]string{"env": "prod"})
 	auroraCluster2, auroraDatabases2 := makeRDSClusterWithExtraEndpoints(t, "cluster-2", "us-east-2", map[string]string{"env": "dev"}, true)
@@ -83,16 +86,48 @@ func TestWatcher(t *testing.T) {
 			clients: &common.TestCloudClients{
 				RDSPerRegion: map[string]rdsiface.RDSAPI{
 					"us-east-1": &cloud.RDSMock{
-						DBInstances: []*rds.DBInstance{rdsInstance1, rdsInstance3},
-						DBClusters:  []*rds.DBCluster{auroraCluster1},
+						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3},
+						DBClusters:       []*rds.DBCluster{auroraCluster1},
+						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
 					},
 					"us-east-2": &cloud.RDSMock{
-						DBInstances: []*rds.DBInstance{rdsInstance2},
-						DBClusters:  []*rds.DBCluster{auroraCluster2, auroraCluster3},
+						DBInstances:      []*rds.DBInstance{rdsInstance2},
+						DBClusters:       []*rds.DBCluster{auroraCluster2, auroraCluster3},
+						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
 					},
 				},
 			},
 			expectedDatabases: append(types.Databases{rdsDatabase1, auroraDatabase1}, auroraDatabases2...),
+		},
+		{
+			name: "RDS unrecognized engines are skipped",
+			awsMatchers: []services.AWSMatcher{
+				{
+					Types:   []string{services.AWSMatcherRDS},
+					Regions: []string{"us-east-1"},
+					Tags:    types.Labels{"env": []string{"prod"}},
+				},
+				{
+					Types:   []string{services.AWSMatcherRDS},
+					Regions: []string{"us-east-2"},
+					Tags:    types.Labels{"env": []string{"dev"}},
+				},
+			},
+			clients: &common.TestCloudClients{
+				RDSPerRegion: map[string]rdsiface.RDSAPI{
+					"us-east-1": &cloud.RDSMock{
+						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3},
+						DBClusters:       []*rds.DBCluster{auroraCluster1},
+						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
+					},
+					"us-east-2": &cloud.RDSMock{
+						DBInstances:      []*rds.DBInstance{rdsInstance5},
+						DBClusters:       []*rds.DBCluster{auroraCluster2, auroraCluster3},
+						DBEngineVersions: []*rds.DBEngineVersion{postgresEngine},
+					},
+				},
+			},
+			expectedDatabases: types.Databases{auroraDatabase1, rdsDatabase5},
 		},
 		{
 			name: "RDS unsupported databases are skipped",
@@ -104,7 +139,8 @@ func TestWatcher(t *testing.T) {
 			clients: &common.TestCloudClients{
 				RDSPerRegion: map[string]rdsiface.RDSAPI{
 					"us-east-1": &cloud.RDSMock{
-						DBClusters: []*rds.DBCluster{auroraCluster1, auroraClusterUnsupported},
+						DBClusters:       []*rds.DBCluster{auroraCluster1, auroraClusterUnsupported},
+						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
 					},
 				},
 			},
@@ -119,8 +155,9 @@ func TestWatcher(t *testing.T) {
 			}},
 			clients: &common.TestCloudClients{
 				RDS: &cloud.RDSMock{
-					DBInstances: []*rds.DBInstance{rdsInstance1, rdsInstanceUnavailable, rdsInstanceUnknownStatus},
-					DBClusters:  []*rds.DBCluster{auroraCluster1, auroraClusterUnavailable, auroraClusterUnknownStatus},
+					DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstanceUnavailable, rdsInstanceUnknownStatus},
+					DBClusters:       []*rds.DBCluster{auroraCluster1, auroraClusterUnavailable, auroraClusterUnknownStatus},
+					DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
 				},
 			},
 			expectedDatabases: types.Databases{rdsDatabase1, rdsDatabaseUnknownStatus, auroraDatabase1, auroraDatabaseUnknownStatus},
@@ -134,7 +171,8 @@ func TestWatcher(t *testing.T) {
 			}},
 			clients: &common.TestCloudClients{
 				RDS: &cloud.RDSMock{
-					DBClusters: []*rds.DBCluster{auroraClusterNoWriter},
+					DBClusters:       []*rds.DBCluster{auroraClusterNoWriter},
+					DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
 				},
 			},
 			expectedDatabases: auroraDatabasesNoWriter,
@@ -150,12 +188,18 @@ func TestWatcher(t *testing.T) {
 				RDSPerRegion: map[string]rdsiface.RDSAPI{
 					"ca-central-1": &cloud.RDSMockUnauth{},
 					"us-west-1": &cloud.RDSMockByDBType{
-						DBInstances: &cloud.RDSMock{DBInstances: []*rds.DBInstance{rdsInstance4}},
-						DBClusters:  &cloud.RDSMockUnauth{},
+						DBInstances: &cloud.RDSMock{
+							DBInstances:      []*rds.DBInstance{rdsInstance4},
+							DBEngineVersions: []*rds.DBEngineVersion{postgresEngine},
+						},
+						DBClusters: &cloud.RDSMockUnauth{},
 					},
 					"us-east-1": &cloud.RDSMockByDBType{
 						DBInstances: &cloud.RDSMockUnauth{},
-						DBClusters:  &cloud.RDSMock{DBClusters: []*rds.DBCluster{auroraCluster1}},
+						DBClusters: &cloud.RDSMock{
+							DBClusters:       []*rds.DBCluster{auroraCluster1},
+							DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
+						},
 					},
 				},
 			},
@@ -204,7 +248,8 @@ func TestWatcher(t *testing.T) {
 			},
 			clients: &common.TestCloudClients{
 				RDS: &cloud.RDSMock{
-					DBClusters: []*rds.DBCluster{auroraCluster1},
+					DBClusters:       []*rds.DBCluster{auroraCluster1},
+					DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
 				},
 				Redshift: &cloud.RedshiftMock{
 					Clusters: []*redshift.Cluster{redshiftUse1Prod},

--- a/lib/srv/db/cloud/watchers/watcher_test.go
+++ b/lib/srv/db/cloud/watchers/watcher_test.go
@@ -22,18 +22,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/srv/db/cloud"
-	"github.com/gravitational/teleport/lib/srv/db/common"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/aws/aws-sdk-go/service/redshift"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/cloud"
+	"github.com/gravitational/teleport/lib/srv/db/common"
 )
 
 // TestWatcher tests cloud databases watcher.

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -100,4 +101,13 @@ type causer interface {
 // pgError defines an interface for errors wrapped by Postgres driver.
 type pgError interface {
 	Unwrap() error
+}
+
+// IsUnrecognizedAWSEngineNameError checks if the err is non-nil and came from using an engine filter that the
+// AWS region does not recognize.
+func IsUnrecognizedAWSEngineNameError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "unrecognized engine name")
 }


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/18328 to v9