### PR TITLE
auth: Remove Upsert/Delete from SAMLService interface

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2822,7 +2822,7 @@ func (a *ServerWithRoles) UpsertSAMLConnector(ctx context.Context, connector typ
 		return trace.Wrap(err)
 	}
 	if !modules.GetModules().Features().SAML {
-		return trace.AccessDenied("SAML is only available in enterprise subscriptions")
+		return trace.Wrap(ErrSAMLRequiresEnterprise)
 	}
 	return a.authServer.UpsertSAMLConnector(ctx, connector)
 }

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -46,7 +46,7 @@ import (
 
 // ErrSAMLRequiresEnterprise is the error returned by the SAML methods when not
 // using the Enterprise edition of Teleport.
-var ErrSAMLRequiresEnterprise = trace.AccessDenied("SAML is only available in enterprise subscriptions")
+var ErrSAMLRequiresEnterprise = fmt.Errorf("SAML: %w", ErrRequiresEnterprise)
 
 // SAMLService are the methods that the auth server delegates to a plugin for
 // implementing the SAML connector. These are the core functions of SAML


### PR DESCRIPTION
Remove the Upsert and Delete methods from the SAMLService interface. It
was intended for these to be part of the SAML "plugin", however they are
needed for the operator tests to be able to create and delete the SAML
connectors.

The methods are back to being implemented directly in the `auth.Server`.
This does not cause any real issues with the rest in the enterprise repo
as the upsert/delete logic is just manipulating the local backend with
no actual SAML logic in it. The `Get*` methods had already been kept in
the `auth.Server` for the same reason.

This narrows the `SAMLService` interface to just creating the SAML auth
request and validating the response that comes back from the SAML
identity provider. This is the core of the SAML-specific logic.

Issue: https://github.com/gravitational/teleport.e/issues/525