### PR TITLE
[Docs] update docs vars for master

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1235,14 +1235,14 @@
     },
     "teleport": {
       "major_version": "11",
-      "version": "9.0.4",
-      "golang": "1.17",
+      "version": "11.0.3",
+      "golang": "1.19",
       "plugin": {
-        "version": "10.2.6"
+        "version": "11.0.3"
       },
       "helm_repo_url": "https://charts.releases.teleport.dev",
-      "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport:9.1.2",
-      "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent:9.1.2"
+      "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport:11.0.3",
+      "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent:11.0.3"
     },
     "terraform": {
       "version": "1.0.0"


### PR DESCRIPTION
It was brought up in discussions that the Teleport version vars are updated per release branch. This can be confusing for folks writing docs while working off the master branch. This PR updates the Teleport versions for the master branch to avoid this confusion.

Perhaps in the future we should update the versions to master first, then backport and adjust as needed. With this method all branches remain up-to-date respectively.

This convention could also be applied to the CHANGELOG.