### PR TITLE
docs: improve wording on free cloud trials

### DIFF
--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -30,7 +30,7 @@ Teleport Cloud is a deployment of the Auth Service and Proxy Service,
 managed by a dedicated team at Teleport.
 
 - [Learn More](./deploy-a-cluster/teleport-cloud/getting-started.mdx): Learn how to start using Teleport Cloud.
-- [Start your Free Trial](https://goteleport.com/signup): Try Teleport hosted by us in the cloud for free.
+- [Start your Free Trial](https://goteleport.com/signup): Try Teleport Cloud.
 </TabItem>
 <TabItem scope="enterprise" label="Teleport Enterprise">
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -32,7 +32,7 @@ You can also [compare Teleport editions](faq.mdx#how-is-open-source-different-fr
 
 - [Open Source Teleport](./deploy-a-cluster/open-source.mdx): Learn how to host your own open source Teleport deployment on a standalone Linux server.
 - [Teleport Enterprise](./deploy-a-cluster/teleport-enterprise/introduction.mdx): Get started with a self-hosted Teleport Enterprise deployment, which gives you more advanced features and full customization.
-- [Teleport Cloud](./deploy-a-cluster/teleport-cloud/getting-started.mdx): Try Teleport hosted by us in the cloud for free.
+- [Teleport Cloud](./deploy-a-cluster/teleport-cloud/getting-started.mdx): Try our cloud-hosted version for free.
 
 ## Configure access
 


### PR DESCRIPTION
Make it clear that the trial is free, not the hosting.