### PR TITLE
Make 'tsh scp' error messages more useful

### DIFF
--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -2014,12 +2014,6 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 	}
 }
 
-// TODO: tsh scp will display neither the message sent in stderr or in
-// the reply; github.com/pkg/sftp ignores the SSH channel stderr, and
-// golang.org/x/crypto/ssh.channel.SendRequest ignores the message in
-// a channel reply. This is bad UX for users, as
-// 'ssh: subsystem request failed' will be the only error displayed when
-// access is denied.
 func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
 	s.Logger.WithError(err).Errorf("failure handling SSH %q request", req.Type)
 	// Terminate the error with a newline when writing to remote channel's
@@ -2050,7 +2044,6 @@ func (s *Server) parseSubsystemRequest(req *ssh.Request, ch ssh.Channel, ctx *sr
 		return newHomeDirSubsys(), nil
 	case r.Name == sftpSubsystem:
 		if err := ctx.CheckSFTPAllowed(s.reg); err != nil {
-			s.replyError(ch, req, err)
 			return nil, trace.Wrap(err)
 		}
 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -3241,7 +3241,6 @@ func onSCP(cf *CLIConf) error {
 	if err == nil || (err != nil && errors.Is(err, context.Canceled)) {
 		return nil
 	}
-	fmt.Fprintln(os.Stderr, utils.UserMessageFromError(err))
 
 	return trace.Wrap(err)
 }


### PR DESCRIPTION
When the `ssh_file_copy` role option being set to `false` prevented a user from copying files, this is the current output:

```
ERROR: ssh: subsystem request failed

ERROR: ssh: subsystem request failed
```

After this change, the output is:

```
ERROR: file copying via SCP or SFTP is not permitted
```

Fixes https://github.com/gravitational/teleport/issues/15621.