### PR TITLE
[Docs] remove tf language from codeblocks

### DIFF
--- a/docs/pages/reference/terraform-provider.mdx
+++ b/docs/pages/reference/terraform-provider.mdx
@@ -284,7 +284,7 @@ Options specify session, connection and auditing permissions of the role.
 
 Example:
 
-```tf
+```
 resource "teleport_role" "example" {
   metadata = {
     name = "example"


### PR DESCRIPTION
`tf` is not currently a registered language with our setup. We might be able to add it in, but seems to be a bit trickier than adding a couple lines. I've opted to just remove this highlight here (which also matches the code blocks in the rest of this same file already) and put up a future PR to add this syntax highlighting if wanted. Without the `tf` tag, we still receive the default code block syntax highlighting. 