### PR TITLE
Remove unused CheckPassword Auth HTTP endpoint

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -1334,9 +1334,3 @@ func (s *APIServer) processKubeCSR(auth ClientI, w http.ResponseWriter, r *http.
 func message(msg string) map[string]interface{} {
 	return map[string]interface{}{"message": msg}
 }
-
-type contextParamsKey string
-
-// contextParams is the name of of the key that holds httprouter.Params in
-// a context.
-const contextParams contextParamsKey = "params"

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -17,7 +17,6 @@ limitations under the License.
 package auth
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -33,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/plugin"
@@ -106,7 +104,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	// Passwords and sessions
 	srv.POST("/:version/users", srv.WithAuth(srv.upsertUser))
 	srv.PUT("/:version/users/:user/web/password", srv.WithAuth(srv.changePassword))
-	srv.POST("/:version/users/:user/web/password/check", srv.withRate(srv.WithAuth(srv.checkPassword)))
 	srv.POST("/:version/users/:user/web/sessions", srv.WithAuth(srv.createWebSession))
 	srv.POST("/:version/users/:user/web/authenticate", srv.WithAuth(srv.authenticateWebUser))
 	srv.POST("/:version/users/:user/ssh/authenticate", srv.WithAuth(srv.authenticateSSHUser))
@@ -222,33 +219,6 @@ func (s *APIServer) WithAuth(handler HandlerWithAuthFunc) httprouter.Handle {
 		}
 		return handler(auth, w, r, p, version)
 	})
-}
-
-// withRate wrap a rate limiter around the passed in httprouter.Handle and
-// returns a httprouter.Handle. Because the rate limiter wraps a http.Handler,
-// internally withRate converts to the standard handler and back.
-func (s *APIServer) withRate(handle httprouter.Handle) httprouter.Handle {
-	limiter := defaults.CheckPasswordLimiter()
-
-	fromStandard := func(h http.Handler) httprouter.Handle {
-		return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-			ctx := context.WithValue(r.Context(), contextParams, p)
-			r = r.WithContext(ctx)
-			h.ServeHTTP(w, r)
-		}
-	}
-	toStandard := func(handle httprouter.Handle) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			p, ok := r.Context().Value(contextParams).(httprouter.Params)
-			if !ok {
-				trace.WriteError(w, trace.BadParameter("parameters missing from request"))
-				return
-			}
-			handle(w, r, p)
-		})
-	}
-	limiter.WrapHandle(toStandard(handle))
-	return fromStandard(limiter)
 }
 
 type upsertServerRawReq struct {
@@ -574,25 +544,6 @@ func (s *APIServer) upsertUser(auth ClientI, w http.ResponseWriter, r *http.Requ
 		return nil, trace.Wrap(err)
 	}
 	return message(fmt.Sprintf("'%v' user upserted", user.GetName())), nil
-}
-
-type checkPasswordReq struct {
-	Password string `json:"password"`
-	OTPToken string `json:"otp_token"`
-}
-
-func (s *APIServer) checkPassword(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	var req checkPasswordReq
-	if err := httplib.ReadJSON(r, &req); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	user := p.ByName("user")
-	if err := auth.CheckPassword(user, []byte(req.Password), req.OTPToken); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return message(fmt.Sprintf("%q user password matches", user)), nil
 }
 
 func (s *APIServer) getUser(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1685,14 +1685,6 @@ func (a *ServerWithRoles) ChangePassword(req services.ChangePasswordReq) error {
 	return a.authServer.ChangePassword(req)
 }
 
-func (a *ServerWithRoles) CheckPassword(user string, password []byte, otpToken string) error {
-	if err := a.currentUserAction(user); err != nil {
-		return trace.Wrap(err)
-	}
-	_, err := a.authServer.checkPassword(user, password, otpToken)
-	return trace.Wrap(err)
-}
-
 func (a *ServerWithRoles) PreAuthenticatedSignIn(ctx context.Context, user string) (types.WebSession, error) {
 	if err := a.currentUserAction(user); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -776,18 +776,6 @@ func (c *Client) ChangePassword(req services.ChangePasswordReq) error {
 	return trace.Wrap(err)
 }
 
-// CheckPassword checks if the suplied web access password is valid.
-func (c *Client) CheckPassword(user string, password []byte, otpToken string) error {
-	_, err := c.PostJSON(
-		context.TODO(),
-		c.Endpoint("users", user, "web", "password", "check"),
-		checkPasswordReq{
-			Password: string(password),
-			OTPToken: otpToken,
-		})
-	return trace.Wrap(err)
-}
-
 // ExtendWebSession creates a new web session for a user based on another
 // valid web session
 func (c *Client) ExtendWebSession(ctx context.Context, req WebSessionReq) (types.WebSession, error) {
@@ -1461,9 +1449,6 @@ type IdentityService interface {
 
 	// ChangePassword changes user password
 	ChangePassword(req services.ChangePasswordReq) error
-
-	// CheckPassword checks if the suplied web access password is valid.
-	CheckPassword(user string, password []byte, otpToken string) error
 
 	// GenerateToken creates a special provisioning token for a new SSH server
 	// that is valid for ttl period seconds.

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -756,26 +756,6 @@ var (
 	}
 )
 
-// CheckPasswordLimiter creates a rate limit that can be used to slow down
-// requests that come to the check password endpoint.
-func CheckPasswordLimiter() *limiter.Limiter {
-	limiter, err := limiter.NewLimiter(limiter.Config{
-		MaxConnections:   LimiterMaxConnections,
-		MaxNumberOfUsers: LimiterMaxConcurrentUsers,
-		Rates: []limiter.Rate{
-			{
-				Period:  1 * time.Second,
-				Average: 10,
-				Burst:   10,
-			},
-		},
-	})
-	if err != nil {
-		panic(fmt.Sprintf("Failed to create limiter: %v.", err))
-	}
-	return limiter
-}
-
 // Transport returns a new http.Client with sensible defaults.
 func HTTPClient() (*http.Client, error) {
 	transport, err := Transport()


### PR DESCRIPTION
As far as I can tell from a cursory check with `git log -S 'CheckPassword('`, we haven't called this endpoint in the last few years. If this is wrong, let me know !