### PR TITLE
Add info to docs about working with github enterprise server

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -239,7 +239,8 @@
           "entries": [
             {
               "title": "GitHub SSO",
-              "slug": "/access-controls/sso/github-sso/"
+              "slug": "/access-controls/sso/github-sso/",
+              "forScopes": ["enterprise", "cloud", "oss"]
             },
             {
               "title": "Azure Active Directory (AD)",

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -41,7 +41,8 @@ Instructions for creating a GitHub OAuth app are available here:
 Define a GitHub authentication connector by creating a file called `github.yaml`
 with the following content:
 
-<ScopedBlock scope="oss">
+<Tabs>
+<TabItem label="Open Source" scope="oss">
 
 ```yaml
 kind: github
@@ -67,8 +68,8 @@ spec:
         - access
 ```
 
-</ScopedBlock>
-<ScopedBlock scope="enterprise">
+</TabItem>
+<TabItem label="Enterprise / Cloud" scope={["enterprise", "cloud"]}>
 
 ```yaml
 kind: github
@@ -96,7 +97,8 @@ spec:
         - access
 ```
 
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 The values of `client_id`, `client_secret`, and `redirect_url` come from the
 GitHub OAuth App you created earlier.

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -11,7 +11,8 @@ Teleport.
 ## Prerequisites
 
 - A GitHub organization with at least one team. <ScopedBlock scope="oss">This organization must not have external SSO set up, or Teleport
-will refuse to create the GitHub authentication connector.</ScopedBlock>
+will refuse to create the GitHub authentication connector.</ScopedBlock><ScopedBlock scope="enterprise">This organization can be hosted
+from either GitHub Cloud or Github Enterprise Server.</ScopedBlock>
 - Teleport role with access to maintaining `github` resources for using `tctl` from the Desktop. This is available in the default `editor` role.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
@@ -40,6 +41,8 @@ Instructions for creating a GitHub OAuth app are available here:
 Define a GitHub authentication connector by creating a file called `github.yaml`
 with the following content:
 
+<ScopedBlock scope="oss">
+
 ```yaml
 kind: github
 version: v3
@@ -63,6 +66,37 @@ spec:
       roles:
         - access
 ```
+
+</ScopedBlock>
+<ScopedBlock scope="enterprise">
+
+```yaml
+kind: github
+version: v3
+metadata:
+  # Connector name that will be used with `tsh --auth=github login`
+  name: github
+spec:
+  # Client ID of your GitHub OAuth App
+  client_id: <client-id>
+  # Client secret of your GitHub OAuth App
+  client_secret: <client-secret>
+  # Connector display name that will be shown on the Web UI login screen
+  display: GitHub
+  # URL of your GitHub Enterprise Server instance (if applicable)
+  endpoint_url: https://<github-enterprise-server-address>
+  # Callback URL that will be called after successful authentication
+  redirect_url: https://<proxy-address>/v1/webapi/github/callback
+  # Mapping of org/team memberships onto allowed roles
+  teams_to_roles:
+    - organization: octocats # GitHub organization name
+      team: admins # GitHub team name within that organization
+      # Maps octocats/admins to the "access" Teleport role
+      roles:
+        - access
+```
+
+</ScopedBlock>
 
 The values of `client_id`, `client_secret`, and `redirect_url` come from the
 GitHub OAuth App you created earlier.

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -11,7 +11,7 @@ Teleport.
 ## Prerequisites
 
 - A GitHub organization with at least one team. <ScopedBlock scope="oss">This organization must not have external SSO set up, or Teleport
-will refuse to create the GitHub authentication connector.</ScopedBlock><ScopedBlock scope="enterprise">This organization can be hosted
+will refuse to create the GitHub authentication connector.</ScopedBlock><ScopedBlock scope={["enterprise", "cloud"]}>This organization can be hosted
 from either GitHub Cloud or Github Enterprise Server.</ScopedBlock>
 - Teleport role with access to maintaining `github` resources for using `tctl` from the Desktop. This is available in the default `editor` role.
 


### PR DESCRIPTION
Document added field in the GitHub Authentication Connector added in #17293 and https://github.com/gravitational/teleport.e/pull/527.