### PR TITLE
Ensure app session is in backend in app access integration tests.

### DIFF
--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -42,7 +42,6 @@ import (
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
-	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/httplib/csrf"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -393,9 +392,10 @@ func (p *Pack) makeTLSConfig(t *testing.T, publicAddr, clusterName string) *tls.
 	require.NoError(t, err)
 
 	// Make sure the session ID can be seen in the backend before we continue onward.
-	backendKey := backend.Key("apps", "sessions", ws.GetMetadata().Name)
 	require.Eventually(t, func() bool {
-		_, err := p.rootCluster.Process.GetBackend().Get(context.Background(), backendKey)
+		_, err := p.rootCluster.Process.GetAuthServer().GetAppSession(context.Background(), types.GetAppSessionRequest{
+			SessionID: ws.GetMetadata().Name,
+		})
 		return err == nil
 	}, 5*time.Second, 100*time.Millisecond)
 


### PR DESCRIPTION
There is an occasional race condition where the app session does not appear to be reflected in the backend after it's created by the time the test logic in the app access integration tests is run. This will (hopefully) address this issue.

Note: I realize that `require.Eventually` isn't well liked, but I think in this case it makes sense as I would expect the delta between the call to create the app session and the call to retrieve the app session successfully from the backend to be very small.