### PR TITLE
Securely delete OTP QR code

### DIFF
--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -27,10 +27,9 @@ import (
 
 	"github.com/gofrs/flock"
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // ErrUnsuccessfulLockTry designates an error when we temporarily couldn't acquire lock

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -29,6 +29,8 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // ErrUnsuccessfulLockTry designates an error when we temporarily couldn't acquire lock
@@ -228,10 +230,14 @@ func overwriteFile(filePath string) error {
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.WithError(err).Warningf("Failed to close %v.", f.Name())
+		}
+	}()
 
 	fi, err := f.Stat()
 	if err != nil {
-		f.Close()
 		return trace.ConvertSystemError(err)
 	}
 
@@ -242,10 +248,6 @@ func overwriteFile(filePath string) error {
 		size += block
 	}
 
-	if _, err := io.CopyN(f, rand.Reader, size); err != nil {
-		f.Close()
-		return trace.Wrap(err)
-	}
-
-	return trace.ConvertSystemError(f.Close())
+	_, err = io.CopyN(f, rand.Reader, size)
+	return trace.Wrap(err)
 }

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -225,13 +225,13 @@ func RemoveSecure(filePath string, iterations int) error {
 			return trace.Wrap(err)
 		}
 	}
-	return trace.Wrap(os.Remove(filePath))
+	return trace.ConvertSystemError(os.Remove(filePath))
 }
 
 func overwriteFile(filePath string) error {
 	f, err := os.OpenFile(filePath, os.O_WRONLY, 0)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.ConvertSystemError(err)
 	}
 	defer f.Close()
 

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -212,15 +212,10 @@ func FSTryReadLockTimeout(ctx context.Context, filePath string, timeout time.Dur
 	return unlockWrapper(fileLock.Unlock, fileLock.Path()), nil
 }
 
-// RemoveSecure attempts to securely delete the file by first overwriting the file with random data followed by
-// calling os.Remove(filePath). The number of times to overwrite the data is set by iterations. Iterations must
-// be > 0 or a trace.BadParameterError will be returned.
-func RemoveSecure(filePath string, iterations int) error {
-	if iterations < 1 {
-		return trace.BadParameter("iterations must be greater than 0")
-	}
-
-	for i := 0; i < iterations; i++ {
+// RemoveSecure attempts to securely delete the file by first overwriting the file with random data three times
+// followed by calling os.Remove(filePath).
+func RemoveSecure(filePath string) error {
+	for i := 0; i < 3; i++ {
 		if err := overwriteFile(filePath); err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -233,11 +233,11 @@ func overwriteFile(filePath string) error {
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
-	defer f.Close()
 
 	fi, err := f.Stat()
 	if err != nil {
-		return trace.Wrap(err)
+		f.Close()
+		return trace.ConvertSystemError(err)
 	}
 
 	// Rounding up to 4k to hide the original file size. 4k was chosen because it's a common block size.
@@ -247,6 +247,10 @@ func overwriteFile(filePath string) error {
 		size += block
 	}
 
-	_, err = io.CopyN(f, rand.Reader, size)
-	return trace.Wrap(err)
+	if _, err := io.CopyN(f, rand.Reader, size); err != nil {
+		f.Close()
+		return trace.Wrap(err)
+	}
+
+	return trace.ConvertSystemError(f.Close())
 }

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -239,17 +240,13 @@ func overwriteFile(filePath string) error {
 		return trace.Wrap(err)
 	}
 
-	b := make([]byte, 4096)
-	var size int64
-	for size < fi.Size() {
-		if _, err := rand.Read(b); err != nil {
-			return trace.Wrap(err)
-		}
-		n, err := f.Write(b)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		size += int64(n)
+	// Rounding up to 4k to hide the original file size. 4k was chosen because it's a common block size.
+	var block int64 = 4096
+	size := fi.Size() / block * block
+	if fi.Size()%block != 0 {
+		size += block
 	}
-	return nil
+
+	_, err = io.CopyN(f, rand.Reader, size)
+	return trace.Wrap(err)
 }

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -241,7 +241,7 @@ func overwriteFile(filePath string) error {
 	}
 
 	// Rounding up to 4k to hide the original file size. 4k was chosen because it's a common block size.
-	var block int64 = 4096
+	const block = 4096
 	size := fi.Size() / block * block
 	if fi.Size()%block != 0 {
 		size += block

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -224,14 +224,18 @@ func RemoveSecure(filePath string) error {
 	return trace.ConvertSystemError(os.Remove(filePath))
 }
 
-func overwriteFile(filePath string) error {
+func overwriteFile(filePath string) (err error) {
 	f, err := os.OpenFile(filePath, os.O_WRONLY, 0)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
 	defer func() {
-		if err := f.Close(); err != nil {
-			log.WithError(err).Warningf("Failed to close %v.", f.Name())
+		if closeErr := f.Close(); closeErr != nil {
+			if err == nil {
+				err = trace.ConvertSystemError(closeErr)
+			} else {
+				log.WithError(closeErr).Warningf("Failed to close %v.", f.Name())
+			}
 		}
 	}()
 

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"os"
 	"path/filepath"
@@ -208,4 +209,47 @@ func FSTryReadLockTimeout(ctx context.Context, filePath string, timeout time.Dur
 	}
 
 	return unlockWrapper(fileLock.Unlock, fileLock.Path()), nil
+}
+
+// RemoveSecure attempts to securely delete the file by first overwriting the file with random data followed by
+// calling os.Remove(filePath). The number of times to overwrite the data is set by iterations. Iterations must
+// be > 0 or a trace.BadParameterError will be returned.
+func RemoveSecure(filePath string, iterations int) error {
+	if iterations < 1 {
+		return trace.BadParameter("iterations must be greater than 0")
+	}
+
+	for i := 0; i < iterations; i++ {
+		if err := overwriteFile(filePath); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return trace.Wrap(os.Remove(filePath))
+}
+
+func overwriteFile(filePath string) error {
+	f, err := os.OpenFile(filePath, os.O_WRONLY, 0)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	b := make([]byte, 4096)
+	var size int64
+	for size < fi.Size() {
+		if _, err := rand.Read(b); err != nil {
+			return trace.Wrap(err)
+		}
+		n, err := f.Write(b)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		size += int64(n)
+	}
+	return nil
 }

--- a/lib/utils/fs_test.go
+++ b/lib/utils/fs_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -109,6 +108,5 @@ func TestRemoveSecure(t *testing.T) {
 	f, err := os.Create(filepath.Join(t.TempDir(), "teleport-remove-secure-test"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	require.True(t, trace.IsBadParameter(RemoveSecure(f.Name(), 0)))
-	require.NoError(t, RemoveSecure(f.Name(), 1))
+	require.NoError(t, RemoveSecure(f.Name()))
 }

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -669,7 +669,7 @@ func showOTPQRCode(k *otp.Key) (cleanup func(), retErr error) {
 	}
 	log.Debugf("Opened QR code via %q", imageViewer)
 	return func() {
-		if err := os.Remove(imageFile.Name()); err != nil {
+		if err := utils.RemoveSecure(imageFile.Name(), 3); err != nil {
 			log.WithError(err).Debugf("Failed to clean up temporary QR code file %q", imageFile.Name())
 		}
 		if err := cmd.Process.Kill(); err != nil {

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -669,7 +669,7 @@ func showOTPQRCode(k *otp.Key) (cleanup func(), retErr error) {
 	}
 	log.Debugf("Opened QR code via %q", imageViewer)
 	return func() {
-		if err := utils.RemoveSecure(imageFile.Name(), 3); err != nil {
+		if err := utils.RemoveSecure(imageFile.Name()); err != nil {
 			log.WithError(err).Debugf("Failed to clean up temporary QR code file %q", imageFile.Name())
 		}
 		if err := cmd.Process.Kill(); err != nil {


### PR DESCRIPTION
### Purpose
Make sure the OTP QR code can't be recovered after being deleted. Fixes gravitational/teleport-private#182.

### Implementation
Before deleting the OTP QR code overwrite the file with random data.