### PR TITLE
[v11] saml: Don't check existence of templated role names

### DIFF
--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -103,6 +103,10 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 	if rg != nil {
 		for _, mapping := range sc.GetAttributesToRoles() {
 			for _, role := range mapping.Roles {
+				if utils.ContainsExpansion(role) {
+					// Role is a template so we cannot check for existence of that literal name.
+					continue
+				}
 				_, err := rg.GetRole(context.Background(), role)
 				switch {
 				case trace.IsNotFound(err):

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -17,13 +17,16 @@ limitations under the License.
 package services
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 )
@@ -67,4 +70,67 @@ func TestCheckSAMLEntityDescriptor(t *testing.T) {
 	certs, err := CheckSAMLEntityDescriptor(ed)
 	require.NoError(t, err)
 	require.Len(t, certs, 1)
+}
+
+func TestValidateRoles(t *testing.T) {
+	t.Parallel()
+
+	// Create a roleSet with <nil> role values as ValidateSAMLRole does
+	// not care what the role value is, just that it exists and that
+	// the RoleGetter does not return an error.
+	var validRoles roleSet = map[string]types.Role{
+		"foo":  nil,
+		"bar":  nil,
+		"big$": nil,
+	}
+
+	testCases := []struct {
+		desc        string
+		roles       []string
+		expectedErr error
+	}{
+		{
+			desc:  "valid roles",
+			roles: []string{"foo", "bar"},
+		},
+		{
+			desc:  "role templates",
+			roles: []string{"foo", "$1", "$baz", "admin_${baz}"},
+		},
+		{
+			desc:        "missing role",
+			roles:       []string{"baz"},
+			expectedErr: trace.BadParameter(`role "baz" specified in attributes_to_roles not found`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			connector, err := types.NewSAMLConnector("test_connector", types.SAMLConnectorSpecV2{
+				AssertionConsumerService: "http://localhost:65535/acs", // not called
+				Issuer:                   "test",
+				SSO:                      "https://localhost:65535/sso", // not called
+				AttributesToRoles: []types.AttributeMapping{
+					// not used. can be any name, value but role must exist
+					{Name: "groups", Value: "admin", Roles: tc.roles},
+				},
+			})
+			require.NoError(t, err)
+
+			err = ValidateSAMLConnector(connector, validRoles)
+			require.ErrorIs(t, err, tc.expectedErr)
+		})
+	}
+}
+
+// roleSet is a basic set of roles keyed by role name. It implements the
+// RoleGetter interface, returning the role if it exists, or a trace.NotFound
+// error if it does not exist.
+type roleSet map[string]types.Role
+
+func (rs roleSet) GetRole(ctx context.Context, name string) (types.Role, error) {
+	if r, ok := rs[name]; ok {
+		return r, nil
+	}
+	return nil, trace.NotFound("unknown role: %s", name)
 }


### PR DESCRIPTION
Do not check that a role exists when validating a SAML connector if that
role name contains an expansion - that is, it is a template name using regular
expression capture groups matching against SAML assertion values.

Backport: https://github.com/gravitational/teleport/pull/18594
Issue: https://github.com/gravitational/teleport/issues/18593