### PR TITLE
Fix for Teleport start config file log

### DIFF
--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -446,10 +446,17 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 
 // OnStart is the handler for "start" CLI command
 func OnStart(clf config.CommandLineFlags, config *service.Config) error {
-	if clf.ConfigFile != "" {
+        //check to see if the config file is not passed and if the
+        // default config file is available. If available it will be used
+        configFileUsed := clf.ConfigFile
+        if clf.ConfigFile == "" && utils.FileExists(defaults.ConfigFilePath) {
+                configFileUsed = defaults.ConfigFilePath
+        }
+    
+	if configFileUsed  == "" {
 		config.Log.Infof("Starting Teleport v%s", teleport.Version)
 	} else {
-		config.Log.Infof("Starting Teleport v%s with a config file located at %q", teleport.Version, clf.ConfigFile)
+		config.Log.Infof("Starting Teleport v%s with a config file located at %q", teleport.Version, configFileUsed)
 	}
 	return service.Run(context.TODO(), *config, nil)
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -446,14 +446,14 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 
 // OnStart is the handler for "start" CLI command
 func OnStart(clf config.CommandLineFlags, config *service.Config) error {
-        //check to see if the config file is not passed and if the
-        // default config file is available. If available it will be used
-        configFileUsed := clf.ConfigFile
-        if clf.ConfigFile == "" && utils.FileExists(defaults.ConfigFilePath) {
-                configFileUsed = defaults.ConfigFilePath
-        }
-    
-	if configFileUsed  == "" {
+	//check to see if the config file is not passed and if the
+	// default config file is available. If available it will be used
+	configFileUsed := clf.ConfigFile
+	if clf.ConfigFile == "" && utils.FileExists(defaults.ConfigFilePath) {
+		configFileUsed = defaults.ConfigFilePath
+	}
+
+	if configFileUsed == "" {
 		config.Log.Infof("Starting Teleport v%s", teleport.Version)
 	} else {
 		config.Log.Infof("Starting Teleport v%s with a config file located at %q", teleport.Version, configFileUsed)


### PR DESCRIPTION
Logging was giving config file as blank even if specified. Updated to give config file if specified and default config file if exists and non given.

Current:
```bash
Starting Teleport v11.0.3 with a config file located at ""
```

Now with `teleport start` and `/etc/teleport.yaml` exists:
```bash
Starting Teleport v11.0.3 with a config file located at "/etc/teleport.yaml"
```

Now with `teleport start` and `/etc/teleport.yaml` does not exist:
```bash
Starting Teleport v11.0.3
```

Now with `teleport start -c /etc/runteleport.yaml`:
```bash
Starting Teleport v11.0.3 with a config file located at " /etc/runteleport.yaml"
```
