### PR TITLE
GHA improvements

### DIFF
--- a/.github/actions/prepare-workspace/action.yml
+++ b/.github/actions/prepare-workspace/action.yml
@@ -5,6 +5,11 @@ inputs:
     description: Cache infix used in cache actions
     required: false
     default: ${{ github.workflow }}
+    
+  go_version:
+    description: Golang version for cache keys
+    required: false
+    default: go1.19.2
 
 runs:
   using: "composite"
@@ -26,15 +31,15 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-build-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-build-${{ inputs.cache_key }}-
+        key: ${{ runner.os }}-go-build-${{ inputs.go_version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-build-${{ inputs.go_version }}-${{ inputs.cache_key }}-
 
     - name: Go mod cache
       uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
-        key: ${{ runner.os }}-go-mod-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-mod-${{ inputs.cache_key }}-
+        key: ${{ runner.os }}-go-mod-${{ inputs.go_version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-mod-${{ inputs.go_version }}-${{ inputs.cache_key }}-
 
     - name: Rust cargo cache
       uses: actions/cache@v3

--- a/.github/actions/prepare-workspace/action.yml
+++ b/.github/actions/prepare-workspace/action.yml
@@ -6,11 +6,6 @@ inputs:
     required: false
     default: ${{ github.workflow }}
     
-  go_version:
-    description: Golang version for cache keys
-    required: false
-    default: go1.19.2
-
 runs:
   using: "composite"
   steps:
@@ -27,19 +22,23 @@ runs:
         echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
         echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
 
+    - name: Get go version
+      id: go-version
+      run: echo "go-version=$(go version | { read _ _ v _; echo ${v#go}; })" >> $GITHUB_OUTPUT
+
     - name: Go build cache
       uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-build-${{ inputs.go_version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-build-${{ inputs.go_version }}-${{ inputs.cache_key }}-
+        key: ${{ runner.os }}-go-build-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-build-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-
 
     - name: Go mod cache
       uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
-        key: ${{ runner.os }}-go-mod-${{ inputs.go_version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-mod-${{ inputs.go_version }}-${{ inputs.cache_key }}-
+        key: ${{ runner.os }}-go-mod-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-mod-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-
 
     - name: Rust cargo cache
       uses: actions/cache@v3

--- a/.github/workflows/build-ci-buildbox-images.yaml
+++ b/.github/workflows/build-ci-buildbox-images.yaml
@@ -1,0 +1,80 @@
+name: Build CI buildbox Images
+run-name: Build CI buildbox Images
+on:
+  push:
+    paths:
+      - build.assets/Dockerfile
+      - build.assets/Dockerfile-centos7
+      - build.assets/Makefile
+      - build.assets/images.mk    
+    branches:
+      - master
+  pull_request:
+    paths:
+      - build.assets/Dockerfile    
+      - build.assets/Dockerfile-centos7
+      - build.assets/Makefile
+      - build.assets/images.mk
+
+env:
+  REGISTRY: ghcr.io
+  BUILDBOX_BASE_NAME: ghcr.io/gzigzigzeo/teleport-buildbox
+
+jobs:
+  buildbox:
+    name: Build buildbox ubuntu image
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # We need to keep env vars in sync, so, we can't use standard build actions
+      - name: Build buildbox image
+        run: cd build.assets && make buildbox
+
+      - name: Docker push the latest built image
+        run: docker push $(docker images -a --format '{{.Repository}}:{{.Tag}}'| head -1)
+
+  buildbox-centos7:
+    name: Build buildbox centos7 image
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # We need to keep env vars in sync, so, we can't use standard build actions
+      - name: Build buildbox image
+        run: cd build.assets && make buildbox-centos7
+
+      - name: Docker push the latest built image
+        run: docker push $(docker images -a --format '{{.Repository}}:{{.Tag}}'| head -1)

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -11,8 +11,6 @@ on:
     paths:
       - .github/services/Dockerfile.*
       - examples/etcd/certs/*.pem
-    branches:
-      - master
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -21,7 +21,7 @@ jobs:
       packages: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       env:
         GO_LINT_FLAGS: --timeout=15m
 

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox-centos7:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport12
       env:
         GOCACHE: /tmp/gocache
 

--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -21,7 +21,7 @@ jobs:
       packages: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       env:
         HELM_PLUGINS: /root/.local/share/helm/plugins
 

--- a/.github/workflows/unit-tests-operator.yaml
+++ b/.github/workflows/unit-tests-operator.yaml
@@ -22,7 +22,7 @@ jobs:
       contents: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/build.assets/images.mk
+++ b/build.assets/images.mk
@@ -3,11 +3,12 @@
 # These values may need to be updated in `dronegen/container_image_products.go` if
 # they change here
 BUILDBOX_VERSION ?= teleport12
+BUILDBOX_BASE_NAME ?= public.ecr.aws/gravitational/teleport-buildbox
 
-BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:$(BUILDBOX_VERSION)
-BUILDBOX_FIPS=public.ecr.aws/gravitational/teleport-buildbox-fips:$(BUILDBOX_VERSION)
-BUILDBOX_CENTOS7=public.ecr.aws/gravitational/teleport-buildbox-centos7:$(BUILDBOX_VERSION)
-BUILDBOX_CENTOS7_FIPS=public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$(BUILDBOX_VERSION)
-BUILDBOX_ARM=public.ecr.aws/gravitational/teleport-buildbox-arm:$(BUILDBOX_VERSION)
-BUILDBOX_ARM_FIPS=public.ecr.aws/gravitational/teleport-buildbox-arm-fips:$(BUILDBOX_VERSION)
-BUILDBOX_TELETERM=public.ecr.aws/gravitational/teleport-buildbox-teleterm:$(BUILDBOX_VERSION)
+BUILDBOX=$(BUILDBOX_BASE_NAME):$(BUILDBOX_VERSION)
+BUILDBOX_FIPS=$(BUILDBOX_BASE_NAME)-fips:$(BUILDBOX_VERSION)
+BUILDBOX_CENTOS7=$(BUILDBOX_BASE_NAME)-centos7:$(BUILDBOX_VERSION)
+BUILDBOX_CENTOS7_FIPS=$(BUILDBOX_BASE_NAME)-centos7-fips:$(BUILDBOX_VERSION)
+BUILDBOX_ARM=$(BUILDBOX_BASE_NAME)-arm:$(BUILDBOX_VERSION)
+BUILDBOX_ARM_FIPS=$(BUILDBOX_BASE_NAME)-arm-fips:$(BUILDBOX_VERSION)
+BUILDBOX_TELETERM=$(BUILDBOX_BASE_NAME)-teleterm:$(BUILDBOX_VERSION)


### PR DESCRIPTION
What's inside:
- [x] Added go version to prepare-workflow cache keys
- [x] Added workflow, which builds buildbox and buildbox-centos7 images, and uses them as the container in all other workflows. Updated to use `make buildbox` instead of standard docker build action.