### PR TITLE
Move database discovery from database access to discovery service part 1

### DIFF
--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -160,6 +160,19 @@ func (r ResourcesWithLabels) AsDatabaseServers() ([]DatabaseServer, error) {
 	return dbs, nil
 }
 
+// AsDatabases converts each resource into type Database.
+func (r ResourcesWithLabels) AsDatabases() (Databases, error) {
+	dbs := make(Databases, 0, len(r))
+	for _, resource := range r {
+		db, ok := resource.(Database)
+		if !ok {
+			return nil, trace.BadParameter("expected types.Database, got: %T", resource)
+		}
+		dbs = append(dbs, db)
+	}
+	return dbs, nil
+}
+
 // AsWindowsDesktops converts each resource into type WindowsDesktop.
 func (r ResourcesWithLabels) AsWindowsDesktops() ([]WindowsDesktop, error) {
 	desktops := make([]WindowsDesktop, 0, len(r))

--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -19,6 +19,7 @@ package aws
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -78,4 +79,13 @@ func parseMetadataClientError(err error) error {
 		return trace.ReadError(httpError.HTTPStatusCode(), nil)
 	}
 	return trace.Wrap(err)
+}
+
+// IsUnrecognizedAWSEngineNameError checks if the err is non-nil and came from
+// using an engine filter that the AWS region does not recognize.
+func IsUnrecognizedAWSEngineNameError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "unrecognized engine name")
 }

--- a/lib/srv/db/cloud/watchers/watcher.go
+++ b/lib/srv/db/cloud/watchers/watcher.go
@@ -131,7 +131,7 @@ func (w *Watcher) fetchAndSend() {
 		}
 		databases, err := resources.AsDatabases()
 		if err != nil {
-			w.log.WithError(err).Errorf("Failed to convert types.ResourceWithLabels to types.Databases for fetcher %v.", fetcher)
+			w.log.WithError(err).Errorf("Failed to convert types.ResourcesWithLabels to types.Databases for fetcher %v.", fetcher)
 			return
 		}
 		result = append(result, databases...)

--- a/lib/srv/discovery/common/interfaces.go
+++ b/lib/srv/discovery/common/interfaces.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fetchers
+package common
 
 import (
 	"context"

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers"
 	"github.com/gravitational/teleport/lib/srv/server"
 )
@@ -96,7 +97,7 @@ type Server struct {
 	// azureWatcher periodically retrieves Azure virtual machines.
 	azureWatcher *server.Watcher
 	// kubeFetchers holds all kubernetes fetchers for Azure and other clouds.
-	kubeFetchers []fetchers.Fetcher
+	kubeFetchers []common.Fetcher
 }
 
 // New initializes a discovery Server

--- a/lib/srv/discovery/fetchers/aks.go
+++ b/lib/srv/discovery/fetchers/aks.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
 type aksFetcher struct {
@@ -66,7 +67,7 @@ func (c *AKSFetcherConfig) CheckAndSetDefaults() error {
 }
 
 // NewAKSFetcher creates a new AKS fetcher configuration.
-func NewAKSFetcher(cfg AKSFetcherConfig) (Fetcher, error) {
+func NewAKSFetcher(cfg AKSFetcherConfig) (common.Fetcher, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/aws.go
+++ b/lib/srv/discovery/fetchers/db/aws.go
@@ -156,7 +156,7 @@ func (f awsFetcher) ResourceType() string {
 }
 
 // Cloud returns the cloud the fetcher is operating.
-func (a awsFetcher) Cloud() string {
+func (f awsFetcher) Cloud() string {
 	return types.CloudAWS
 }
 

--- a/lib/srv/discovery/fetchers/db/aws.go
+++ b/lib/srv/discovery/fetchers/db/aws.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package db
+
+import (
+	"github.com/gravitational/trace"
+	"golang.org/x/exp/slices"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
+)
+
+// MakeAWSFetchers creates fetchers for AWS-hosted databases.
+func MakeAWSFetchers(clients cloud.Clients, matchers []services.AWSMatcher) (result []common.Fetcher, err error) {
+	type makeFetcherFunc func(cloud.Clients, string, types.Labels) (common.Fetcher, error)
+	makeFetcherFuncs := map[string][]makeFetcherFunc{
+		services.AWSMatcherRDS:         {makeRDSInstanceFetcher, makeRDSAuroraFetcher},
+		services.AWSMatcherRDSProxy:    {makeRDSProxyFetcher},
+		services.AWSMatcherRedshift:    {makeRedshiftFetcher},
+		services.AWSMatcherElastiCache: {makeElastiCacheFetcher},
+		services.AWSMatcherMemoryDB:    {makeMemoryDBFetcher},
+	}
+
+	for _, matcher := range matchers {
+		for _, region := range matcher.Regions {
+			for matcherType, makeFetchers := range makeFetcherFuncs {
+				if !slices.Contains(matcher.Types, matcherType) {
+					continue
+				}
+
+				for _, makeFetcher := range makeFetchers {
+					fetcher, err := makeFetcher(clients, region, matcher.Tags)
+					if err != nil {
+						return nil, trace.Wrap(err)
+					}
+					result = append(result, fetcher)
+				}
+			}
+		}
+	}
+	return result, nil
+}
+
+// makeRDSInstanceFetcher returns RDS instance fetcher for the provided region and tags.
+func makeRDSInstanceFetcher(clients cloud.Clients, region string, tags types.Labels) (common.Fetcher, error) {
+	rds, err := clients.GetAWSRDSClient(region)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	fetcher, err := newRDSDBInstancesFetcher(rdsFetcherConfig{
+		Region: region,
+		Labels: tags,
+		RDS:    rds,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return fetcher, nil
+}
+
+// makeRDSAuroraFetcher returns RDS Aurora fetcher for the provided region and tags.
+func makeRDSAuroraFetcher(clients cloud.Clients, region string, tags types.Labels) (common.Fetcher, error) {
+	rds, err := clients.GetAWSRDSClient(region)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	fetcher, err := newRDSAuroraClustersFetcher(rdsFetcherConfig{
+		Region: region,
+		Labels: tags,
+		RDS:    rds,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return fetcher, nil
+}
+
+// makeRDSProxyFetcher returns RDS proxy fetcher for the provided region and tags.
+func makeRDSProxyFetcher(clients cloud.Clients, region string, tags types.Labels) (common.Fetcher, error) {
+	rds, err := clients.GetAWSRDSClient(region)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return newRDSDBProxyFetcher(rdsFetcherConfig{
+		Region: region,
+		Labels: tags,
+		RDS:    rds,
+	})
+}
+
+// makeRedshiftFetcher returns Redshift fetcher for the provided region and tags.
+func makeRedshiftFetcher(clients cloud.Clients, region string, tags types.Labels) (common.Fetcher, error) {
+	redshift, err := clients.GetAWSRedshiftClient(region)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return newRedshiftFetcher(redshiftFetcherConfig{
+		Region:   region,
+		Labels:   tags,
+		Redshift: redshift,
+	})
+}
+
+// makeElastiCacheFetcher returns ElastiCache fetcher for the provided region and tags.
+func makeElastiCacheFetcher(clients cloud.Clients, region string, tags types.Labels) (common.Fetcher, error) {
+	elastiCache, err := clients.GetAWSElastiCacheClient(region)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return newElastiCacheFetcher(elastiCacheFetcherConfig{
+		Region:      region,
+		Labels:      tags,
+		ElastiCache: elastiCache,
+	})
+}
+
+// makeMemoryDBFetcher returns MemoryDB fetcher for the provided region and tags.
+func makeMemoryDBFetcher(clients cloud.Clients, region string, tags types.Labels) (common.Fetcher, error) {
+	memorydb, err := clients.GetAWSMemoryDBClient(region)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return newMemoryDBFetcher(memoryDBFetcherConfig{
+		Region:   region,
+		Labels:   tags,
+		MemoryDB: memorydb,
+	})
+}
+
+// awsFetcher is a common base struct for all AWS database fetchers.
+type awsFetcher struct {
+}
+
+// ResourceType identifies the resource type the fetcher is returning.
+func (f awsFetcher) ResourceType() string {
+	return types.KindDatabase
+}
+
+// Cloud returns the cloud the fetcher is operating.
+func (a awsFetcher) Cloud() string {
+	return types.CloudAWS
+}
+
+// maxAWSPages is the maximum number of pages to iterate over when fetching AWS databases.
+const maxAWSPages = 10

--- a/lib/srv/discovery/fetchers/db/aws_memorydb.go
+++ b/lib/srv/discovery/fetchers/db/aws_memorydb.go
@@ -17,6 +17,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/memorydb"
@@ -136,6 +137,12 @@ func (f *memoryDBFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, e
 		}
 	}
 	return filterDatabasesByLabels(databases, f.cfg.Labels, f.log), nil
+}
+
+// String returns the fetcher's string description.
+func (f *memoryDBFetcher) String() string {
+	return fmt.Sprintf("memoryDBFetcher(Region=%v, Labels=%v)",
+		f.cfg.Region, f.cfg.Labels)
 }
 
 // getMemoryDBClusters fetches all MemoryDB clusters.

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
@@ -15,6 +15,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -60,6 +61,12 @@ func (f *rdsDBProxyFetcher) Get(ctx context.Context) (types.ResourcesWithLabels,
 	}
 
 	return filterDatabasesByLabels(databases, f.cfg.Labels, f.log), nil
+}
+
+// String returns the fetcher's string description.
+func (f *rdsDBProxyFetcher) String() string {
+	return fmt.Sprintf("rdsDBProxyFetcher(Region=%v, Labels=%v)",
+		f.cfg.Region, f.cfg.Labels)
 }
 
 // getRDSProxyDatabases returns a list of database resources representing RDS

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package watchers
+package db
 
 import (
 	"context"
@@ -23,18 +23,21 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
+	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
 // rdsDBProxyFetcher retrieves RDS Proxies and their custom endpoints.
 type rdsDBProxyFetcher struct {
+	awsFetcher
+
 	cfg rdsFetcherConfig
 	log logrus.FieldLogger
 }
 
 // newRDSDBProxyFetcher returns a new RDS Proxy fetcher instance.
-func newRDSDBProxyFetcher(config rdsFetcherConfig) (Fetcher, error) {
+func newRDSDBProxyFetcher(config rdsFetcherConfig) (common.Fetcher, error) {
 	if err := config.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -50,7 +53,7 @@ func newRDSDBProxyFetcher(config rdsFetcherConfig) (Fetcher, error) {
 
 // Get returns RDS Proxies and proxy endpoints matching the watcher's
 // selectors.
-func (f *rdsDBProxyFetcher) Get(ctx context.Context) (types.Databases, error) {
+func (f *rdsDBProxyFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, error) {
 	databases, err := f.getRDSProxyDatabases(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -64,14 +67,14 @@ func (f *rdsDBProxyFetcher) Get(ctx context.Context) (types.Databases, error) {
 func (f *rdsDBProxyFetcher) getRDSProxyDatabases(ctx context.Context) (types.Databases, error) {
 	// Get a list of all RDS Proxies. Each RDS Proxy has one "default"
 	// endpoint.
-	rdsProxies, err := getRDSProxies(ctx, f.cfg.RDS, common.MaxPages)
+	rdsProxies, err := getRDSProxies(ctx, f.cfg.RDS, maxAWSPages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Get all RDS Proxy custom endpoints sorted by the name of the RDS Proxy
 	// that owns the custom endpoints.
-	customEndpointsByProxyName, err := getRDSProxyCustomEndpoints(ctx, f.cfg.RDS, common.MaxPages)
+	customEndpointsByProxyName, err := getRDSProxyCustomEndpoints(ctx, f.cfg.RDS, maxAWSPages)
 	if err != nil {
 		f.log.Debugf("Failed to get RDS Proxy endpoints: %v.", err)
 	}
@@ -160,7 +163,7 @@ func getRDSProxies(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int)
 			return pageNum <= maxPages
 		},
 	)
-	return rdsProxies, common.ConvertError(err)
+	return rdsProxies, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
 }
 
 // getRDSProxyCustomEndpoints fetches all RDS Proxy custom endpoints using the
@@ -179,7 +182,7 @@ func getRDSProxyCustomEndpoints(ctx context.Context, rdsClient rdsiface.RDSAPI, 
 			return pageNum <= maxPages
 		},
 	)
-	return customEndpointsByProxyName, common.ConvertError(err)
+	return customEndpointsByProxyName, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
 }
 
 // getRDSProxyTargetPort gets the port number that the targets of the RDS Proxy
@@ -189,7 +192,7 @@ func getRDSProxyTargetPort(ctx context.Context, rdsClient rdsiface.RDSAPI, dbPro
 		DBProxyName: dbProxyName,
 	})
 	if err != nil {
-		return 0, common.ConvertError(err)
+		return 0, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
 	}
 
 	// The proxy may have multiple targets but they should have the same port.
@@ -207,7 +210,7 @@ func listRDSResourceTags(ctx context.Context, rdsClient rdsiface.RDSAPI, resourc
 		ResourceName: resourceName,
 	})
 	if err != nil {
-		return nil, common.ConvertError(err)
+		return nil, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
 	}
 	return output.TagList, nil
 }

--- a/lib/srv/discovery/fetchers/db/azure_dbserver.go
+++ b/lib/srv/discovery/fetchers/db/azure_dbserver.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package watchers
+package db
 
 import (
 	"github.com/gravitational/trace"
@@ -23,15 +23,16 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
 // newAzureMySQLFetcher creates a fetcher for Azure MySQL.
-func newAzureMySQLFetcher(config azureFetcherConfig) (Fetcher, error) {
+func newAzureMySQLFetcher(config azureFetcherConfig) (common.Fetcher, error) {
 	return newAzureFetcher[*azure.DBServer, azure.DBServersClient](config, &azureDBServerPlugin{})
 }
 
 // newAzureMySQLFetcher creates a fetcher for Azure PostgresSQL.
-func newAzurePostgresFetcher(config azureFetcherConfig) (Fetcher, error) {
+func newAzurePostgresFetcher(config azureFetcherConfig) (common.Fetcher, error) {
 	return newAzureFetcher[*azure.DBServer, azure.DBServersClient](config, &azureDBServerPlugin{})
 }
 

--- a/lib/srv/discovery/fetchers/db/azure_redis.go
+++ b/lib/srv/discovery/fetchers/db/azure_redis.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package watchers
+package db
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v2"
@@ -24,10 +24,11 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
 // newAzureRedisFetcher creates a fetcher for Azure Redis.
-func newAzureRedisFetcher(config azureFetcherConfig) (Fetcher, error) {
+func newAzureRedisFetcher(config azureFetcherConfig) (common.Fetcher, error) {
 	return newAzureFetcher[*armredis.ResourceInfo, azure.RedisClient](config, &azureRedisPlugin{})
 }
 

--- a/lib/srv/discovery/fetchers/db/azure_redis_enterprise.go
+++ b/lib/srv/discovery/fetchers/db/azure_redis_enterprise.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package watchers
+package db
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise"
@@ -24,9 +24,10 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
-func newAzureRedisEnterpriseFetcher(config azureFetcherConfig) (Fetcher, error) {
+func newAzureRedisEnterpriseFetcher(config azureFetcherConfig) (common.Fetcher, error) {
 	return newAzureFetcher[*azure.RedisEnterpriseDatabase, azure.RedisEnterpriseClient](config, &azureRedisEnterprisePlugin{})
 }
 

--- a/lib/srv/discovery/fetchers/db/db.go
+++ b/lib/srv/discovery/fetchers/db/db.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package db
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// filterDatabasesByLabels filters input databases with provided labels and
+// converts the databases to types.ResourcesWithLabels.
+func filterDatabasesByLabels(databases types.Databases, labels types.Labels, log logrus.FieldLogger) types.ResourcesWithLabels {
+	var matchedDatabases types.Databases
+	for _, database := range databases {
+		match, _, err := services.MatchLabels(labels, database.GetAllLabels())
+		if err != nil {
+			log.Warnf("Failed to match %v against selector: %v.", database, err)
+		} else if match {
+			matchedDatabases = append(matchedDatabases, database)
+		} else {
+			log.Debugf("%v doesn't match selector.", database)
+		}
+	}
+	return matchedDatabases.AsResources()
+}

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
 const (
@@ -71,7 +72,7 @@ func (c *EKSFetcherConfig) CheckAndSetDefaults() error {
 }
 
 // NewEKSFetcher creates a new EKS fetcher configuration.
-func NewEKSFetcher(cfg EKSFetcherConfig) (Fetcher, error) {
+func NewEKSFetcher(cfg EKSFetcherConfig) (common.Fetcher, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/gke.go
+++ b/lib/srv/discovery/fetchers/gke.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
 // GKEFetcherConfig configures the GKE fetcher.
@@ -68,7 +69,7 @@ type gkeFetcher struct {
 }
 
 // NewGKEFetcher creates a new GKE fetcher configuration.
-func NewGKEFetcher(cfg GKEFetcherConfig) (Fetcher, error) {
+func NewGKEFetcher(cfg GKEFetcherConfig) (common.Fetcher, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Implements #18742 

note: db discovery and discovery service currently share the same matcher types for configuration so no need to refactor that part.

Please feel free to give any naming suggestions!

Part 1 Changes:
- Move discovery's `Fetcher` interface to `discovery/common`
- Move db fetchers from `lib/srv/db/cloud/watchers` to `lib/srv/discovery/fetchers/db`
- Update db fetchers to implement discovery's `Fetcher` interface
- Update current database watcher to use discovery's `Fetcher`
Note that there is no function change yet.

Testing:
- [x] auto-discover an AWS RDS from db agent
- [x] auto-discover an Azure Redis from db agent

Coming in p2:
- Move common mocks from `lib/srv/db/cloud` to `lib/cloud/test
- Move database watcher to `lib/srv/discovery/watchers/`
- Add tests for new fetchers in `lib/srv/discovery/fetchers/db`

Coming in p3:
- Enable database matchers in discovery service
