### PR TITLE
[v9] Ensure app session is in backend in app access integration tests.

### DIFF
--- a/integration/app_integration_test.go
+++ b/integration/app_integration_test.go
@@ -1564,6 +1564,14 @@ func (p *pack) makeTLSConfig(t *testing.T, publicAddr, clusterName string) *tls.
 	})
 	require.NoError(t, err)
 
+	// Make sure the session ID can be seen in the backend before we continue onward.
+	require.Eventually(t, func() bool {
+		_, err := p.rootCluster.Process.GetAuthServer().GetAppSession(context.Background(), types.GetAppSessionRequest{
+			SessionID: ws.GetMetadata().Name,
+		})
+		return err == nil
+	}, 5*time.Second, 100*time.Millisecond)
+
 	certificate, err := p.rootCluster.Process.GetAuthServer().GenerateUserAppTestCert(
 		auth.AppTestCertRequest{
 			PublicKey:   publicKey,


### PR DESCRIPTION
Backport #18744 to branch/v9