### PR TITLE
[v11] Do not run parker process for all SSH sessions

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -174,7 +174,7 @@ type Server interface {
 	// temporary teleport users or not
 	GetCreateHostUser() bool
 
-	// GetHostUser returns the HostUsers instance being used to manage
+	// GetHostUsers returns the HostUsers instance being used to manage
 	// host user provisioning
 	GetHostUsers() HostUsers
 

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -36,6 +36,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auditd"
 	"github.com/gravitational/teleport/lib/pam"
 	"github.com/gravitational/teleport/lib/shell"
@@ -317,18 +318,11 @@ func RunCommand() (errw io.Writer, code int, err error) {
 	// again, to avoid it getting deleted under our nose.
 	parkerCtx, parkerCancel := context.WithCancel(context.Background())
 	defer parkerCancel()
-	if cmd.SysProcAttr.Credential != nil {
-		if err := newParker(parkerCtx, *cmd.SysProcAttr.Credential); err != nil {
-			return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
-		}
 
-		localUserCheck, err := user.Lookup(c.Login)
-		if err != nil {
-			return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
-		}
-		if localUser.Uid != localUserCheck.Uid || localUser.Gid != localUserCheck.Gid {
-			return errorWriter, teleport.RemoteCommandFailure, trace.BadParameter("user %q has been changed", c.Login)
-		}
+	osPack := newOsWrapper()
+	if err := osPack.startNewParker(parkerCtx, cmd.SysProcAttr.Credential,
+		c.Login, &systemUser{u: localUser}); err != nil {
+		return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
 	}
 
 	if c.X11Config.XServerUnixSocket != "" {
@@ -418,6 +412,98 @@ func RunCommand() (errw io.Writer, code int, err error) {
 	}
 
 	return io.Discard, exitCode(err), trace.Wrap(err)
+}
+
+// osWrapper wraps system calls, so we can replace them in tests.
+type osWrapper struct {
+	LookupGroup    func(name string) (*user.Group, error)
+	LookupUser     func(username string) (*user.User, error)
+	CommandContext func(ctx context.Context, name string, arg ...string) *exec.Cmd
+}
+
+func newOsWrapper() *osWrapper {
+	return &osWrapper{
+		LookupGroup:    user.LookupGroup,
+		LookupUser:     user.Lookup,
+		CommandContext: exec.CommandContext,
+	}
+}
+
+// userInfo wraps user.User data into an interface, so we can override
+// returned results in tests.
+type userInfo interface {
+	GID() string
+	UID() string
+	GroupIds() ([]string, error)
+}
+
+type systemUser struct {
+	u *user.User
+}
+
+func (s *systemUser) GID() string {
+	return s.u.Gid
+}
+
+func (s *systemUser) UID() string {
+	return s.u.Uid
+}
+
+func (s *systemUser) GroupIds() ([]string, error) {
+	return s.u.GroupIds()
+}
+
+// startNewParker starts a new parker process only if the requested user has been created
+// by Teleport. Otherwise, does nothing.
+func (o *osWrapper) startNewParker(ctx context.Context, credential *syscall.Credential,
+	loginAsUser string, localUser userInfo,
+) error {
+	if credential == nil {
+		// Empty credential, no reason to start the parker.
+		return nil
+	}
+
+	group, err := o.LookupGroup(types.TeleportServiceGroup)
+	if errors.Is(err, user.UnknownGroupError(types.TeleportServiceGroup)) {
+		// The service group doesn't exist. Auto-provision is disabled, do nothing.
+		return nil
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	groups, err := localUser.GroupIds()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	found := false
+	for _, localUserGroup := range groups {
+		if localUserGroup == group.Gid {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		// Check if the new user guid matches the TeleportServiceGroup. If not
+		// this user hasn't been created by Teleport, and we don't need the parker.
+		return nil
+	}
+
+	if err := o.newParker(ctx, *credential); err != nil {
+		return trace.Wrap(err)
+	}
+
+	localUserCheck, err := o.LookupUser(loginAsUser)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if localUser.UID() != localUserCheck.Uid || localUser.GID() != localUserCheck.Gid {
+		return trace.BadParameter("user %q has been changed", loginAsUser)
+	}
+
+	return nil
 }
 
 // RunForward reads in the command to run from the parent process (over a
@@ -847,13 +933,13 @@ func CheckHomeDir(localUser *user.User) (bool, error) {
 }
 
 // Spawns a process with the given credentials, outliving the context.
-func newParker(ctx context.Context, credential syscall.Credential) error {
+func (o *osWrapper) newParker(ctx context.Context, credential syscall.Credential) error {
 	executable, err := os.Executable()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	cmd := exec.CommandContext(ctx, executable, teleport.ParkSubCommand)
+	cmd := o.CommandContext(ctx, executable, teleport.ParkSubCommand)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Credential: &credential,
 	}
@@ -865,7 +951,7 @@ func newParker(ctx context.Context, credential syscall.Credential) error {
 		return trace.Wrap(err)
 	}
 
-	// the process will get killed when the context ends but we still need to
+	// the process will get killed when the context ends, but we still need to
 	// Wait on it
 	go cmd.Wait()
 

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -1,0 +1,175 @@
+/*
+ *
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package srv
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+)
+
+type stubUser struct {
+	gid      string
+	uid      string
+	groupIDS []string
+}
+
+func (s *stubUser) GID() string {
+	return s.gid
+}
+
+func (s *stubUser) UID() string {
+	return s.uid
+}
+
+func (s *stubUser) GroupIds() ([]string, error) {
+	return s.groupIDS, nil
+}
+
+func TestStartNewParker(t *testing.T) {
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+	currentUID, err := strconv.ParseUint(currentUser.Uid, 10, 32)
+	require.NoError(t, err)
+	currentGID, err := strconv.ParseUint(currentUser.Gid, 10, 32)
+	require.NoError(t, err)
+
+	t.Parallel()
+
+	type args struct {
+		credential  *syscall.Credential
+		loginAsUser string
+		localUser   *stubUser
+	}
+	tests := []struct {
+		name      string
+		args      args
+		newOsPack func(t *testing.T) (*osWrapper, func())
+		wantErr   require.ErrorAssertionFunc
+	}{
+		{
+			name:    "empty credentials does nothing",
+			wantErr: require.NoError,
+			newOsPack: func(t *testing.T) (*osWrapper, func()) {
+				return &osWrapper{}, func() {}
+			},
+		},
+		{
+			name:    "missing Teleport group returns no error",
+			wantErr: require.NoError,
+			newOsPack: func(t *testing.T) (*osWrapper, func()) {
+				return &osWrapper{
+					LookupGroup: func(name string) (*user.Group, error) {
+						require.Equal(t, types.TeleportServiceGroup, name)
+						return nil, user.UnknownGroupError(types.TeleportServiceGroup)
+					},
+				}, func() {}
+			},
+		},
+		{
+			name:    "different group doesn't start parker",
+			wantErr: require.NoError,
+			newOsPack: func(t *testing.T) (*osWrapper, func()) {
+				return &osWrapper{
+					LookupGroup: func(name string) (*user.Group, error) {
+						require.Equal(t, types.TeleportServiceGroup, name)
+						return &user.Group{Gid: "1234"}, nil
+					},
+					CommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+						require.FailNow(t, "CommandContext should not be called")
+						return nil
+					},
+				}, func() {}
+			},
+			args: args{
+				credential: &syscall.Credential{Gid: 1000},
+				localUser: &stubUser{
+					uid:      "1001",
+					gid:      "1003",
+					groupIDS: []string{"1003"},
+				},
+			},
+		},
+		{
+			name:    "parker is started",
+			wantErr: require.NoError,
+			newOsPack: func(t *testing.T) (*osWrapper, func()) {
+				parkerStarted := false
+
+				return &osWrapper{
+						LookupGroup: func(name string) (*user.Group, error) {
+							require.Equal(t, types.TeleportServiceGroup, name)
+							return &user.Group{Gid: currentUser.Gid}, nil
+						},
+						CommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+							require.NotNil(t, ctx)
+							require.Len(t, arg, 1)
+							require.Equal(t, arg[0], teleport.ParkSubCommand)
+							parkerStarted = true
+							return exec.CommandContext(ctx, name, arg...)
+						},
+						LookupUser: func(username string) (*user.User, error) {
+							return &user.User{Uid: currentUser.Uid, Gid: currentUser.Gid}, nil
+						},
+					}, func() {
+						require.True(t, parkerStarted, "parker process didn't start")
+					}
+			},
+			args: args{
+				credential: &syscall.Credential{
+					Uid: uint32(currentUID),
+					Gid: uint32(currentGID),
+					// Changing to false causes "fork/exec /proc/self/exe: operation not permitted"
+					// to be returned when creating the park process.
+					NoSetGroups: true,
+				},
+				localUser: &stubUser{
+					uid:      currentUser.Uid,
+					gid:      currentUser.Gid,
+					groupIDS: []string{currentUser.Gid},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			osPack, assertExpected := tt.newOsPack(t)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel) // cancel to stop the park process.
+
+			err := osPack.startNewParker(ctx, tt.args.credential, tt.args.loginAsUser, tt.args.localUser)
+			tt.wantErr(t, err, fmt.Sprintf("startNewParker(%v, %+v, %v, %+v)", ctx, tt.args.credential, tt.args.loginAsUser, tt.args.localUser))
+
+			assertExpected()
+		})
+	}
+}

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -118,7 +118,7 @@ type HostUsers interface {
 	doWithUserLock(func(types.SemaphoreLease) error) error
 
 	// SetHostUserDeletionGrace sets the grace period before a user
-	// can be deleted, used so integration tests dont need to sleep
+	// can be deleted, used so integration tests don't need to sleep
 	SetHostUserDeletionGrace(time.Duration)
 }
 


### PR DESCRIPTION
Parker process is only needed when a user is auto-provision by Teleport. Currently, this process always starts, which causes some problems when SELinux is enabled and may also cause issues with a similar mechanism as AppArmor. This PR runs only the parker process only when it's really needed not for every SSH session reducing the problem mentioned above.

Backport of #18604