### PR TITLE
[v9] Add `tctl windows_desktops` as the default and keep `tctl desktops` as an alias

### DIFF
--- a/tool/tctl/common/desktop_command.go
+++ b/tool/tctl/common/desktop_command.go
@@ -47,7 +47,7 @@ type DesktopCommand struct {
 func (c *DesktopCommand) Initialize(app *kingpin.Application, config *service.Config) {
 	c.config = config
 
-	desktop := app.Command("desktops", "Operate on registered desktops.")
+	desktop := app.Command("windows_desktops", "Operate on registered desktops.").Alias("desktops")
 	c.desktopList = desktop.Command("ls", "List all desktops registered with the cluster.")
 	c.desktopList.Flag("format", "Output format, 'text', 'json' or 'yaml'").Default(teleport.Text).StringVar(&c.format)
 	c.desktopList.Flag("verbose", "Verbose table output, shows full label output").Short('v').BoolVar(&c.verbose)


### PR DESCRIPTION
Backport #18769 to branch/v9