### PR TITLE
tctl: add edit command

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2769,7 +2769,10 @@ func (a *ServerWithRoles) UpsertOIDCConnector(ctx context.Context, connector typ
 		return trace.Wrap(err)
 	}
 	if !modules.GetModules().Features().OIDC {
-		return trace.AccessDenied("OIDC is only available in enterprise subscriptions")
+		// TODO(zmb3): ideally we would wrap ErrREquiresEnterprise here, but
+		// we can't currently propagate wrapped errors across the gRPC boundary,
+		// and we want tctl to display a clean user-facing messasge in this case
+		return trace.AccessDenied("OIDC is only available in Teleport Enterprise")
 	}
 
 	return a.authServer.UpsertOIDCConnector(ctx, connector)
@@ -2846,15 +2849,20 @@ func (a *ServerWithRoles) DeleteOIDCConnector(ctx context.Context, connectorID s
 
 // UpsertSAMLConnector creates or updates a SAML connector.
 func (a *ServerWithRoles) UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) error {
+	if !modules.GetModules().Features().SAML {
+		// TODO(zmb3): ideally we would wrap ErrREquiresEnterprise here, but
+		// we can't currently propagate wrapped errors across the gRPC boundary,
+		// and we want tctl to display a clean user-facing messasge in this case
+		return trace.Wrap(ErrSAMLRequiresEnterprise)
+	}
+
 	if err := a.authConnectorAction(apidefaults.Namespace, types.KindSAML, types.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.authConnectorAction(apidefaults.Namespace, types.KindSAML, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	if !modules.GetModules().Features().SAML {
-		return trace.Wrap(ErrSAMLRequiresEnterprise)
-	}
+
 	return a.authServer.UpsertSAMLConnector(ctx, connector)
 }
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2769,9 +2769,9 @@ func (a *ServerWithRoles) UpsertOIDCConnector(ctx context.Context, connector typ
 		return trace.Wrap(err)
 	}
 	if !modules.GetModules().Features().OIDC {
-		// TODO(zmb3): ideally we would wrap ErrREquiresEnterprise here, but
+		// TODO(zmb3): ideally we would wrap ErrRequiresEnterprise here, but
 		// we can't currently propagate wrapped errors across the gRPC boundary,
-		// and we want tctl to display a clean user-facing messasge in this case
+		// and we want tctl to display a clean user-facing message in this case
 		return trace.AccessDenied("OIDC is only available in Teleport Enterprise")
 	}
 
@@ -2850,9 +2850,6 @@ func (a *ServerWithRoles) DeleteOIDCConnector(ctx context.Context, connectorID s
 // UpsertSAMLConnector creates or updates a SAML connector.
 func (a *ServerWithRoles) UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) error {
 	if !modules.GetModules().Features().SAML {
-		// TODO(zmb3): ideally we would wrap ErrREquiresEnterprise here, but
-		// we can't currently propagate wrapped errors across the gRPC boundary,
-		// and we want tctl to display a clean user-facing messasge in this case
 		return trace.Wrap(ErrSAMLRequiresEnterprise)
 	}
 

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -19,7 +19,6 @@ package auth
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/gravitational/trace"
 
@@ -31,7 +30,11 @@ import (
 
 // ErrSAMLRequiresEnterprise is the error returned by the SAML methods when not
 // using the Enterprise edition of Teleport.
-var ErrSAMLRequiresEnterprise = fmt.Errorf("SAML: %w", ErrRequiresEnterprise)
+//
+// TODO(zmb3): ideally we would wrap ErrRequiresEnterprise here, but
+// we can't currently propagate wrapped errors across the gRPC boundary,
+// and we want tctl to display a clean user-facing messasge in this case
+var ErrSAMLRequiresEnterprise = trace.AccessDenied("SAML is only available in Teleport Enterprise")
 
 // SAMLService are the methods that the auth server delegates to a plugin for
 // implementing the SAML connector. These are the core functions of SAML

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -33,7 +33,7 @@ import (
 //
 // TODO(zmb3): ideally we would wrap ErrRequiresEnterprise here, but
 // we can't currently propagate wrapped errors across the gRPC boundary,
-// and we want tctl to display a clean user-facing messasge in this case
+// and we want tctl to display a clean user-facing message in this case
 var ErrSAMLRequiresEnterprise = trace.AccessDenied("SAML is only available in Teleport Enterprise")
 
 // SAMLService are the methods that the auth server delegates to a plugin for

--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -40,6 +40,8 @@ func Commands() []CLICommand {
 		&RecordingsCommand{},
 		&AlertCommand{},
 		&ProxyCommand{},
+		&ResourceCommand{},
+		&EditCommand{},
 	}
 }
 
@@ -47,7 +49,6 @@ func Commands() []CLICommand {
 // for oss and ent.
 func OSSCommands() []CLICommand {
 	return []CLICommand{
-		&ResourceCommand{},
 		&configure.SSOConfigureCommand{},
 		&tester.SSOTestCommand{},
 	}

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/gravitational/kingpin"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// EditCommand implements the `tctl edit` command for modifying
+// Teleport resources.
+type EditCommand struct {
+	app    *kingpin.Application
+	cmd    *kingpin.CmdClause
+	config *service.Config
+	ref    services.Ref
+}
+
+func (e *EditCommand) Initialize(app *kingpin.Application, config *service.Config) {
+	e.app = app
+	e.config = config
+	e.cmd = app.Command("edit", "Edit a Teleport resource")
+	e.cmd.Arg("resource type/resource name", `Resource to update
+	<resource type>  Type of a resource [for example: rc]
+	<resource name>  Resource name to update
+	
+	Example:
+	$ tctl edit rc/remote`).SetValue(&e.ref)
+}
+
+func (e *EditCommand) TryRun(ctx context.Context, cmd string, client auth.ClientI) (match bool, err error) {
+	if cmd != e.cmd.FullCommand() {
+		return false, nil
+	}
+
+	f, err := os.CreateTemp("", "teleport-resource*.yaml")
+	if err != nil {
+		return true, trace.Wrap(err)
+	}
+
+	defer func() {
+		if err := os.Remove(f.Name()); err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: could not remove temporary file %v\n", f.Name())
+		}
+	}()
+
+	rc := &ResourceCommand{
+		refs:     services.Refs{e.ref},
+		format:   teleport.YAML,
+		stdout:   f,
+		filename: f.Name(),
+		force:    true,
+	}
+	rc.Initialize(e.app, e.config)
+
+	err = rc.Get(ctx, client)
+	if closeErr := f.Close(); closeErr != nil {
+		return true, trace.Wrap(err)
+	}
+	if err != nil {
+		return true, trace.Wrap(err, "could not get resource %v: %v", rc.ref.String(), err)
+	}
+
+	args := strings.Fields(editor())
+	editorCmd := exec.CommandContext(ctx, args[0], append(args[1:], f.Name())...)
+	editorCmd.Stdin = os.Stdin
+	editorCmd.Stdout = os.Stdout
+	editorCmd.Stderr = os.Stderr
+	if err := editorCmd.Start(); err != nil {
+		return true, trace.BadParameter("could not start editor %v: %v", editor(), err)
+	}
+	if err := editorCmd.Wait(); err != nil {
+		return true, trace.BadParameter("skipping resource update, editor did not complete successfully: %v", err)
+	}
+
+	// TODO(zmb3): consider skipping this step if the file hasn't changed
+	if err := rc.Create(ctx, client); err != nil {
+		return true, trace.Wrap(err)
+	}
+
+	return true, nil
+}
+
+// editor gets the text editor to be used for editing the resource
+func editor() string {
+	for _, v := range []string{"TELEPORT_EDITOR", "VISUAL", "EDITOR"} {
+		if value := os.Getenv(v); value != "" {
+			return value
+		}
+	}
+	return "vi"
+}

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -116,7 +116,7 @@ func (e *EditCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 
 	// nothing to do if the resource was not modified
 	if newSum == originalSum {
-		fmt.Println("edit cancelled, no changes made")
+		fmt.Println("edit canceled, no changes made")
 		return true, nil
 	}
 

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -115,7 +115,8 @@ func (e *EditCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 	}
 
 	// nothing to do if the resource was not modified
-	if changed := newSum != originalSum; !changed {
+	if newSum == originalSum {
+		fmt.Println("edit cancelled, no changes made")
 		return true, nil
 	}
 

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -110,6 +110,8 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *service.
 		types.KindToken:                   rc.createToken,
 		types.KindInstaller:               rc.createInstaller,
 		types.KindNode:                    rc.createNode,
+		types.KindOIDCConnector:           rc.createConnector,
+		types.KindSAMLConnector:           rc.createConnector,
 	}
 	rc.config = config
 
@@ -123,7 +125,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *service.
 	<resource type>  Type of a resource [for example: rc]
 	<resource name>  Resource name to update
 
-	Examples:
+	Example:
 	$ tctl update rc/remote`).SetValue(&rc.ref)
 	rc.updateCmd.Flag("set-labels", "Set labels").StringVar(&rc.labels)
 	rc.updateCmd.Flag("set-ttl", "Set TTL").StringVar(&rc.ttl)
@@ -278,7 +280,7 @@ func (rc *ResourceCommand) Create(ctx context.Context, client auth.ClientI) (err
 		if !found {
 			// if we're trying to create an OIDC/SAML connector with the OSS version of tctl, return a specific error
 			if raw.Kind == "oidc" || raw.Kind == "saml" {
-				return trace.BadParameter("creating resources of type %q is only supported in Teleport Enterprise. If you are connecting to a Teleport Enterprise Cluster you must install the enterprise version of tctl. https://goteleport.com/teleport/docs/enterprise/", raw.Kind)
+				return trace.BadParameter("creating resources of type %q is only supported in Teleport Enterprise. If you are connecting to a Teleport Enterprise Cluster you must install the enterprise version of tctl. https://goteleport.com/docs/deploy-a-cluster/teleport-enterprise/introduction/", raw.Kind)
 			}
 			return trace.BadParameter("creating resources of type %q is not supported", raw.Kind)
 		}
@@ -642,6 +644,76 @@ func (rc *ResourceCommand) createNode(ctx context.Context, client auth.ClientI, 
 
 	_, err = client.UpsertNode(ctx, server)
 	return trace.Wrap(err)
+}
+
+func (rc *ResourceCommand) createConnector(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+	var (
+		connectorName string
+		exists        bool
+	)
+	switch raw.Kind {
+	case types.KindSAMLConnector:
+		// Create services.SAMLConnector from raw YAML to extract the connector name.
+		conn, err := services.UnmarshalSAMLConnector(raw.Raw)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		connectorName = conn.GetName()
+
+		// Check if this connector is already in the backend. If it is, and the force
+		// flag was not supplied, return an "connector already exists" error.
+		foundConn, err := client.GetSAMLConnector(ctx, connectorName, true)
+		if err != nil && !trace.IsNotFound(err) {
+			return trace.Wrap(err)
+		}
+		exists = (err == nil)
+		if !rc.IsForced() && exists {
+			return trace.AlreadyExists("connector '%s' already exists, use -f flag to override", connectorName)
+		}
+
+		// If the connector being pushed to the backend does not have a signing key
+		// in it and an existing connector was found in the backend, extract the
+		// signing key from the found connector and inject it into the connector
+		// being injected into the backend.
+		if conn.GetSigningKeyPair() == nil && exists {
+			conn.SetSigningKeyPair(foundConn.GetSigningKeyPair())
+		}
+		if err := conn.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
+
+		if err = client.UpsertSAMLConnector(ctx, conn); err != nil {
+			return trace.Wrap(err)
+		}
+
+	case types.KindOIDCConnector:
+		conn, err := services.UnmarshalOIDCConnector(raw.Raw)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if err := conn.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
+		connectorName = conn.GetName()
+		_, err = client.GetOIDCConnector(ctx, connectorName, false)
+		if err != nil && !trace.IsNotFound(err) {
+			return trace.Wrap(err)
+		}
+		exists = (err == nil)
+		if !rc.IsForced() && exists {
+			return trace.AlreadyExists("connector '%s' already exists, use -f flag to override", connectorName)
+		}
+		if err = client.UpsertOIDCConnector(ctx, conn); err != nil {
+			return trace.Wrap(err)
+		}
+
+	// unknown connector type
+	default:
+		return trace.BadParameter("unknown connector type: '%s'", raw.Kind)
+	}
+
+	fmt.Printf("authentication connector '%s' has been %s\n", connectorName, UpsertVerb(exists, rc.IsForced()))
+	return nil
 }
 
 // Delete deletes resource by name

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -278,10 +278,6 @@ func (rc *ResourceCommand) Create(ctx context.Context, client auth.ClientI) (err
 		// locate the creator function for a given resource kind:
 		creator, found := rc.CreateHandlers[ResourceKind(raw.Kind)]
 		if !found {
-			// if we're trying to create an OIDC/SAML connector with the OSS version of tctl, return a specific error
-			if raw.Kind == "oidc" || raw.Kind == "saml" {
-				return trace.BadParameter("creating resources of type %q is only supported in Teleport Enterprise. If you are connecting to a Teleport Enterprise Cluster you must install the enterprise version of tctl. https://goteleport.com/docs/deploy-a-cluster/teleport-enterprise/introduction/", raw.Kind)
-			}
 			return trace.BadParameter("creating resources of type %q is not supported", raw.Kind)
 		}
 		// only return in case of error, to create multiple resources


### PR DESCRIPTION
This command allows you to modify a resource in place by opening the resource YAML in your text editor.

The editor is selected by checking the following, in order of precedence:

- the TELEPORT_EDITOR environment variable
- the VISUAL environment variable
- the EDITOR environment variable
- defaulting to 'vi'