### PR TITLE
Improve the Kubernetes Dynamic Registration guide

### DIFF
--- a/docs/pages/kubernetes-access/guides/dynamic-registration.mdx
+++ b/docs/pages/kubernetes-access/guides/dynamic-registration.mdx
@@ -160,10 +160,14 @@ manager or via a TAR archive:
 ```code
 $ sudo systemctl start teleport
 ```
+
 </TabItem>
 <TabItem label="TAR archive">
+
 ```code
-$ sudo teleport start
+$ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
+$ sudo systemctl enable teleport; 
+$ sudo systemctl start teleport; 
 ```
 </TabItem>
 </Tabs>
@@ -279,7 +283,7 @@ will use to generate the kubeconfig:
 
 ```code
 $ curl -OL \
-https://raw.githubusercontent.com/gravitational/teleport/master/examples/k8s-auth/get-kubeconfig.sh
+https://raw.githubusercontent.com/gravitational/teleport/v(=teleport.version=)/examples/k8s-auth/get-kubeconfig.sh
 ```
 
 The script creates a service account for the Teleport Kubernetes Service that

--- a/docs/pages/kubernetes-access/guides/dynamic-registration.mdx
+++ b/docs/pages/kubernetes-access/guides/dynamic-registration.mdx
@@ -169,6 +169,7 @@ $ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
 $ sudo systemctl enable teleport; 
 $ sudo systemctl start teleport; 
 ```
+
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Some review comments for an earlier PR that edited the Standalone Kubernetes guide (#18608) also apply to this one:

- Use systemctl to start TAR-based Teleport installations
- Edit the `curl` command that fetches the kubeconfig script so it uses the Teleport release specified in the docs