### PR TITLE
(buddy) Add Go version to GHA cache key and CI image workflow

### DIFF
--- a/.github/actions/prepare-workspace/action.yml
+++ b/.github/actions/prepare-workspace/action.yml
@@ -5,6 +5,11 @@ inputs:
     description: Cache infix used in cache actions
     required: false
     default: ${{ github.workflow }}
+    
+  go_version:
+    description: Golang version for cache keys
+    required: false
+    default: go1.19.2
 
 runs:
   using: "composite"
@@ -26,15 +31,15 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-build-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-build-${{ inputs.cache_key }}-
+        key: ${{ runner.os }}-go-build-${{ inputs.go_version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-build-${{ inputs.go_version }}-${{ inputs.cache_key }}-
 
     - name: Go mod cache
       uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
-        key: ${{ runner.os }}-go-mod-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-mod-${{ inputs.cache_key }}-
+        key: ${{ runner.os }}-go-mod-${{ inputs.go_version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-mod-${{ inputs.go_version }}-${{ inputs.cache_key }}-
 
     - name: Rust cargo cache
       uses: actions/cache@v3

--- a/.github/workflows/build-ci-buildbox-images.yaml
+++ b/.github/workflows/build-ci-buildbox-images.yaml
@@ -1,0 +1,82 @@
+name: Build CI Buildbox Images
+run-name: Build CI Buildbox Images
+on:
+  push:
+    paths:
+      - build.assets/Dockerfile
+      - build.assets/Dockerfile-centos7
+      - build.assets/Makefile
+      - build.assets/images.mk
+    branches:
+      - master
+  pull_request:
+    paths:
+      - build.assets/Dockerfile
+      - build.assets/Dockerfile-centos7
+      - build.assets/Makefile
+      - build.assets/images.mk
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  BUILDBOX_BASE_NAME: ghcr.io/gravitational/teleport-buildbox
+
+jobs:
+  buildbox:
+    name: Build Ubuntu Buildbox
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # We need to keep env vars in sync, so, we can't use standard build actions
+      - name: Build buildbox image
+        run: cd build.assets && make buildbox
+
+      - name: Docker push the latest built image
+        run: docker push $(docker images -a --format '{{.Repository}}:{{.Tag}}'| head -1)
+
+  buildbox-centos7:
+    name: Build CentOS 7 Buildbox
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # We need to keep env vars in sync, so, we can't use standard build actions
+      - name: Build buildbox image
+        run: cd build.assets && make buildbox-centos7
+
+      - name: Docker push the latest built image
+        run: docker push $(docker images -a --format '{{.Repository}}:{{.Tag}}'| head -1)

--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -21,7 +21,7 @@ jobs:
       packages: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -18,9 +18,10 @@ jobs:
 
     permissions:
       contents: read
+      packages: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,9 +13,10 @@ jobs:
 
     permissions:
       contents: read
+      packages: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       env:
         GO_LINT_FLAGS: --timeout=15m
 

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -13,9 +13,10 @@ jobs:
 
     permissions:
       contents: read
+      packages: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox-centos7:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport12
       env:
         GOCACHE: /tmp/gocache
 

--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -21,7 +21,7 @@ jobs:
       packages: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -16,9 +16,10 @@ jobs:
 
     permissions:
       contents: read
+      packages: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       env:
         HELM_PLUGINS: /root/.local/share/helm/plugins
 

--- a/.github/workflows/unit-tests-operator.yaml
+++ b/.github/workflows/unit-tests-operator.yaml
@@ -16,13 +16,14 @@ on:
 jobs:
   test:
     name: Unit Tests (Operator)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-16core
 
     permissions:
       contents: read
+      packages: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -18,9 +18,10 @@ jobs:
 
     permissions:
       contents: read
+      packages: read
 
     container:
-      image: public.ecr.aws/gravitational/teleport-buildbox:teleport12
+      image: ghcr.io/gravitational/teleport-buildbox:teleport12
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/api/types/app.go
+++ b/api/types/app.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 )
 
-// Application represents a web app.
+// Application represents a web, TCP or cloud console application.
 type Application interface {
 	// ResourceWithLabels provides common resource methods.
 	ResourceWithLabels

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -59,8 +59,11 @@ ifneq ("$(KUBECONFIG)","")
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(KUBECONFIG):/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=$(TEST_KUBE)
 endif
 
-# conditionally force the use of UID/GID 1000:1000 if we're running in Drone
+# conditionally force the use of UID/GID 1000:1000 if we're running in Drone or Github Actions (in which case CI env var will be set)
 ifeq ("$(DRONE)","true")
+CI := true
+endif
+ifeq ("$(CI)","true")
 UID := 1000
 GID := 1000
 NOROOT := -u 1000:1000

--- a/build.assets/images.mk
+++ b/build.assets/images.mk
@@ -3,11 +3,12 @@
 # These values may need to be updated in `dronegen/container_image_products.go` if
 # they change here
 BUILDBOX_VERSION ?= teleport12
+BUILDBOX_BASE_NAME ?= public.ecr.aws/gravitational/teleport-buildbox
 
-BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:$(BUILDBOX_VERSION)
-BUILDBOX_FIPS=public.ecr.aws/gravitational/teleport-buildbox-fips:$(BUILDBOX_VERSION)
-BUILDBOX_CENTOS7=public.ecr.aws/gravitational/teleport-buildbox-centos7:$(BUILDBOX_VERSION)
-BUILDBOX_CENTOS7_FIPS=public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$(BUILDBOX_VERSION)
-BUILDBOX_ARM=public.ecr.aws/gravitational/teleport-buildbox-arm:$(BUILDBOX_VERSION)
-BUILDBOX_ARM_FIPS=public.ecr.aws/gravitational/teleport-buildbox-arm-fips:$(BUILDBOX_VERSION)
-BUILDBOX_TELETERM=public.ecr.aws/gravitational/teleport-buildbox-teleterm:$(BUILDBOX_VERSION)
+BUILDBOX=$(BUILDBOX_BASE_NAME):$(BUILDBOX_VERSION)
+BUILDBOX_FIPS=$(BUILDBOX_BASE_NAME)-fips:$(BUILDBOX_VERSION)
+BUILDBOX_CENTOS7=$(BUILDBOX_BASE_NAME)-centos7:$(BUILDBOX_VERSION)
+BUILDBOX_CENTOS7_FIPS=$(BUILDBOX_BASE_NAME)-centos7-fips:$(BUILDBOX_VERSION)
+BUILDBOX_ARM=$(BUILDBOX_BASE_NAME)-arm:$(BUILDBOX_VERSION)
+BUILDBOX_ARM_FIPS=$(BUILDBOX_BASE_NAME)-arm-fips:$(BUILDBOX_VERSION)
+BUILDBOX_TELETERM=$(BUILDBOX_BASE_NAME)-teleterm:$(BUILDBOX_VERSION)

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -5,7 +5,7 @@
 # clusterName is a unique cluster name.
 # This value cannot be changed after your cluster starts without rebuilding it from scratch.
 # We recommend using the fully qualified domain name that you use to access your cluster,
-# for example: teleport.example.com
+# for example: teleport.example.com.
 clusterName: ""
 
 # Name for this kubernetes cluster to be used by teleport users.

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -32,9 +32,10 @@
 //!    it didn't allocate but needs to hold on to, is responsible for copying it to its
 //!    own respective heap.
 //!
-//! In practice, this means that all the functions called from Go (those prefixed with
-//! `pub unsafe extern "C"`) MUST NOT hang on to any of the pointers passed in to them after
-//! they return. All pointer data that needs to persist MUST be copied into Rust-owned memory.
+//! In practice, this means that all the functions called from Go (those
+//! prefixed with `pub unsafe extern "C"`) MUST NOT hang on to any of the
+//! pointers passed in to them after they return. All pointer data that needs to
+//! persist MUST be copied into Rust-owned memory.
 
 mod cliprdr;
 mod errors;


### PR DESCRIPTION
Buddy PR for https://github.com/gravitational/teleport/pull/18781.

We're publishing our buildboxes to ghcr now which should fix the issue with ECR throttling.