### PR TITLE
Add the `--version` flag to `helm install`

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
@@ -237,7 +237,9 @@ $ teleport-jira start
 </TabItem>
 <TabItem label="Helm Chart" scopes={["oss", "enterprise", "cloud"]}>
 ```code
-$ helm install teleport-plugin-jira teleport/teleport-plugin-jira --values teleport-jira-helm.yaml
+$ helm install teleport-plugin-jira teleport/teleport-plugin-jira \
+  --values teleport-jira-helm.yaml \
+  --version (=teleport.plugin.version=)
 ```
 </TabItem>
 </Tabs>

--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -51,10 +51,13 @@ Install Teleport in your Kubernetes cluster using the `teleport-cluster` Helm ch
 ```code
 $ CLUSTERNAME=tele.example.com # replace with your preferred domain name
 $ EMAIL_ADDR=dodemo@goteleport.com # replace with your email
-$ helm install teleport-cluster teleport/teleport-cluster --create-namespace --namespace=teleport-cluster \
+$ helm install teleport-cluster teleport/teleport-cluster \
+  --create-namespace \
+  --namespace=teleport-cluster \
   --set clusterName=$CLUSTERNAME \
   --set acme=true \
-  --set acmeEmail=$EMAIL_ADDR
+  --set acmeEmail=$EMAIL_ADDR \
+  --version (=teleport.version=)
 NAME: teleport-cluster
 LAST DEPLOYED: Tue Oct 26 17:01:21 2021
 NAMESPACE: teleport-cluster

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -61,8 +61,13 @@ Let's start with a single-pod Teleport deployment using a persistent volume as a
     # Install a single node teleport cluster and provision a cert using ACME.
     # Set clusterName to unique hostname, for example tele.example.com
     # Set acmeEmail to receive correspondence from Letsencrypt certificate authority.
-    $ helm install teleport-cluster teleport/teleport-cluster --create-namespace --namespace=teleport-cluster \
-      --set clusterName=${CLUSTER_NAME?} --set acme=true --set acmeEmail=${EMAIL?}
+    $ helm install teleport-cluster teleport/teleport-cluster \
+      --create-namespace \
+      --namespace=teleport-cluster \
+      --set clusterName=${CLUSTER_NAME?} \
+      --set acme=true \
+      --set acmeEmail=${EMAIL?} \
+      --version (=teleport.version=)
     ```
   </TabItem>
 
@@ -82,8 +87,13 @@ Let's start with a single-pod Teleport deployment using a persistent volume as a
     $ kubectl create secret generic license --from-file=license.pem
 
     # Install Teleport
-    $ helm install teleport-cluster teleport/teleport-cluster --namespace=teleport-cluster-ent \
-      --set clusterName=${CLUSTER_NAME?} --set acme=true --set acmeEmail=${EMAIL?} --set enterprise=true
+    $ helm install teleport-cluster teleport/teleport-cluster \
+      --namespace=teleport-cluster-ent \
+      --version (=teleport.version=) \
+      --set clusterName=${CLUSTER_NAME?} \
+      --set acme=true \
+      --set enterprise=true \
+      --set acmeEmail=${EMAIL?}
     ```
   </TabItem>
 </Tabs>

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -78,8 +78,13 @@ $ PROXY_ADDR=tele.example.com:443
 
 # Install Kubernetes agent. It dials back to the Teleport cluster at $PROXY_ADDR
 $ CLUSTER=cookie
-$ helm install teleport-agent teleport/teleport-kube-agent --set kubeClusterName=${CLUSTER?} \
-  --set proxyAddr=${PROXY_ADDR?} --set authToken=${TOKEN?} --create-namespace --namespace=teleport-agent
+$ helm install teleport-agent teleport/teleport-kube-agent \
+  --set kubeClusterName=${CLUSTER?} \
+  --set proxyAddr=${PROXY_ADDR?} \
+  --set authToken=${TOKEN?} \
+  --create-namespace \
+  --namespace=teleport-agent \
+  --version (=teleport.version=) 
 ```
 
 </TabItem>
@@ -94,9 +99,13 @@ $ PROXY_ADDR=mytenant.teleport.sh:443
 # Install Kubernetes agent. It dials back to the Teleport cluster at $PROXY_ADDR
 $ CLUSTER=cookie
 # Run the helm install specifying to match to the Teleport Cloud version of Teleport
-$ helm install teleport-agent teleport/teleport-kube-agent --set kubeClusterName=${CLUSTER?} \
-  --set proxyAddr=${PROXY_ADDR?} --set authToken=${TOKEN?} --create-namespace --namespace=teleport-agent \
-  --set teleportVersionOverride=(=cloud.version=)
+$ helm install teleport-agent teleport/teleport-kube-agent \
+  --set kubeClusterName=${CLUSTER?} \
+  --set proxyAddr=${PROXY_ADDR?} \
+  --set authToken=${TOKEN?} \
+  --create-namespace \
+  --namespace=teleport-agent \
+  --version (=cloud.version=)
 ```
 
 </TabItem>

--- a/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
+++ b/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
@@ -53,8 +53,13 @@ Switch `kubectl` to the Kubernetes cluster `cookie` and run:
 # Deploy a Kubernetes agent. It dials back to the Teleport cluster tele.example.com.
 $ CLUSTER=cookie
 $ PROXY=tele.example.com:443
-$ helm install teleport-agent teleport/teleport-kube-agent --set kubeClusterName=${CLUSTER?} \
-  --set proxyAddr=${PROXY?} --set authToken=${TOKEN?} --create-namespace --namespace=teleport-agent
+$ helm install teleport-agent teleport/teleport-kube-agent \
+  --set kubeClusterName=${CLUSTER?} \
+  --set proxyAddr=${PROXY?} \
+  --set authToken=${TOKEN?} \
+  --create-namespace \
+  --namespace=teleport-agent \
+  --version (=teleport.version=)
 ```
 
 List connected clusters using `tsh kube ls` and switch between
@@ -102,8 +107,13 @@ Switch `kubectl` to the Kubernetes cluster `cookie` and run:
 # Deploy a Kubernetes agent. It dials back to the Teleport cluster mytenant.teleport.sh.
 $ CLUSTER=cookie
 $ PROXY=mytenant.teleport.sh
-$ helm install teleport-agent teleport/teleport-kube-agent --set kubeClusterName=${CLUSTER?} \
-  --set proxyAddr=${PROXY?} --set authToken=${TOKEN?} --create-namespace --namespace=teleport-agent
+$ helm install teleport-agent teleport/teleport-kube-agent \
+  --set kubeClusterName=${CLUSTER?} \
+  --set proxyAddr=${PROXY?} \
+  --set authToken=${TOKEN?} \
+  --create-namespace \
+  --namespace=teleport-agent \
+  --version (=teleport.version=)
 ```
 
 List connected clusters using `tsh kube ls` and switch between

--- a/docs/pages/management/guides/fluentd.mdx
+++ b/docs/pages/management/guides/fluentd.mdx
@@ -430,7 +430,9 @@ persistentVolumeClaim:
 To start the event handler in Kubernetes, run the following command:
 
 ```code
-$ helm install teleport-plugin-event-handler teleport/teleport-plugin-event-handler --values teleport-plugin-event-handler-values.yaml
+$ helm install teleport-plugin-event-handler teleport/teleport-plugin-event-handler \
+  --values teleport-plugin-event-handler-values.yaml \
+  --version (=teleport.plugin.version=)
 ```
 
 </TabItem>

--- a/docs/pages/management/guides/teleport-operator.mdx
+++ b/docs/pages/management/guides/teleport-operator.mdx
@@ -59,7 +59,7 @@ $ helm install teleport-cluster teleport/teleport-cluster \
         --create-namespace --namespace teleport-cluster \
         --set clusterName=teleport-cluster.teleport-cluster.svc.cluster.local \
         --set operator.enabled=true \
-        --set teleportVersionOverride=(=teleport.version=)
+        --version (=teleport.version=)
 ```
 
 This command installs the required Kubernetes CRDs and deploys the Teleport Kubernetes Operator next to the Teleport

--- a/docs/pages/try-out-teleport/local-kubernetes.mdx
+++ b/docs/pages/try-out-teleport/local-kubernetes.mdx
@@ -70,9 +70,10 @@ You will deploy the Auth Service and Proxy Service by installing the
 # This is the DNS name Kubernetes will assign to the Proxy Service
 $ CLUSTER_NAME="teleport-cluster.teleport-cluster.svc.cluster.local"
 $ helm install teleport-cluster teleport/teleport-cluster \
---create-namespace \
---namespace=teleport-cluster \
---set clusterName=${CLUSTER_NAME?}
+  --create-namespace \
+  --namespace=teleport-cluster \
+  --set clusterName=${CLUSTER_NAME?} \
+  --version (=teleport.version=)
 $ kubectl config set-context --current --namespace teleport-cluster
 ```
 
@@ -316,7 +317,8 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
   --set authToken=${INVITE_TOKEN?} \
   --set "apps[0].name"="kube-dash" \
   --set "apps[0].uri"=https://${DASH_ADDR?} \
-  --set insecureSkipProxyTLSVerify=true
+  --set insecureSkipProxyTLSVerify=true \
+  --version (=teleport.version=)
 ```
 
 <Details title="Why do we skip certificate verification here?">


### PR DESCRIPTION
Closes #18304

- This applies to installing `teleport-cluster`, `teleport-kube-agent`, and plugins, using the appropriate version variable for each.
- Some pages use the `--teleportVersionOverride` values setting instead of `--version`. I've replaced this with `--version` for consistency.

Used this `awk` script to find `helm install` instructions that were missing the `--version` flag:

```awk
find docs/pages -name "*.mdx" -exec awk '
BEGIN{v=0;i=0}
/helm install teleport-/{i++}
/--version \(=/{v++}
END{if(i>0 && i!=v) print FILENAME}' {} \;
```