### PR TITLE
Implicitly set go version in prepare-workspace

### DIFF
--- a/.github/actions/prepare-workspace/action.yml
+++ b/.github/actions/prepare-workspace/action.yml
@@ -5,11 +5,6 @@ inputs:
     description: Cache infix used in cache actions
     required: false
     default: ${{ github.workflow }}
-    
-  go_version:
-    description: Golang version for cache keys
-    required: false
-    default: go1.19.2
 
 runs:
   using: "composite"
@@ -27,19 +22,24 @@ runs:
         echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
         echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
 
+    - name: Get go version
+      id: go-version
+      shell: bash      
+      run: echo "go-version=$(go version | { read _ _ v _; echo ${v#go}; })" >> $GITHUB_OUTPUT
+
     - name: Go build cache
       uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-build-${{ inputs.go_version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-build-${{ inputs.go_version }}-${{ inputs.cache_key }}-
+        key: ${{ runner.os }}-go-build-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-build-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-
 
     - name: Go mod cache
       uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
-        key: ${{ runner.os }}-go-mod-${{ inputs.go_version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-mod-${{ inputs.go_version }}-${{ inputs.cache_key }}-
+        key: ${{ runner.os }}-go-mod-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-mod-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-
 
     - name: Rust cargo cache
       uses: actions/cache@v3

--- a/.github/workflows/build-ci-buildbox-images.yaml
+++ b/.github/workflows/build-ci-buildbox-images.yaml
@@ -9,15 +9,8 @@ on:
       - build.assets/images.mk
     branches:
       - master
-  pull_request:
-    paths:
-      - build.assets/Dockerfile
-      - build.assets/Dockerfile-centos7
-      - build.assets/Makefile
-      - build.assets/images.mk
-    branches:
-      - master
-
+  workflow_dispatch:
+  
 env:
   REGISTRY: ghcr.io
   BUILDBOX_BASE_NAME: ghcr.io/gravitational/teleport-buildbox

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -7,12 +7,6 @@ on:
       - examples/etcd/certs/*.pem
     branches:
       - master
-  pull_request:
-    paths:
-      - .github/services/Dockerfile.*
-      - examples/etcd/certs/*.pem
-    branches:
-      - master
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
As we discussed in #18877.

What's inside:
- [x] Go version for cache keys is set from `go version` output in prepare-workspace.
- [x] Removed `on.pull_request.branches` for image build actions.