### PR TITLE
Properly check err from EmitAuditEvent.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1462,7 +1462,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 
 	eventIdentity := identity.GetEventIdentity()
 	eventIdentity.Expires = certRequest.NotAfter
-	if a.emitter.EmitAuditEvent(a.closeCtx, &apievents.CertificateCreate{
+	if err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.CertificateCreate{
 		Metadata: apievents.Metadata{
 			Type: events.CertificateCreateEvent,
 			Code: events.CertificateCreateCode,


### PR DESCRIPTION
Fix missing assignment to `err`, which made the condition impossible to reach.