### PR TITLE
Remove DEBUG env var from Connect macOS dronegen

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -593,7 +593,6 @@ steps:
   - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
   - security find-identity -v
   - export CSC_NAME=0FFD3E3413AB4C599C53FBB1D8CA690915E33D83
-  - export DEBUG="electron-*"
   - export CONNECT_TSH_BIN_PATH=$WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build/tsh
   - cd $WORKSPACE_DIR/go/src/github.com/gravitational/webapps
   - yarn install && yarn build-term && yarn package-term -c.extraMetadata.version=$VERSION
@@ -8043,7 +8042,6 @@ steps:
   - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
   - security find-identity -v
   - export CSC_NAME=0FFD3E3413AB4C599C53FBB1D8CA690915E33D83
-  - export DEBUG="electron-*"
   - cd $WORKSPACE_DIR/go/src/github.com/gravitational
   - pkgutil --expand-full tsh-$${VERSION}.pkg tsh
   - export CONNECT_TSH_APP_PATH=$WORKSPACE_DIR/go/src/github.com/gravitational/tsh/Payload/tsh.app
@@ -18269,6 +18267,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: c50cecb03e9ca4c1a58759cd017fb8555b386f1f45938ae84b56bbb396b36ad3
+hmac: 88e09acfb6869d0ff016262f4beb5fbf66b791abcf6513565f6d3ca1eebb09c3
 
 ...

--- a/dronegen/mac.go
+++ b/dronegen/mac.go
@@ -557,8 +557,6 @@ func darwinBuildCommands(toolchainConfig toolchainConfig, artifactConfig darwinA
 			// available.
 			// https://www.electron.build/code-signing
 			`export CSC_NAME=0FFD3E3413AB4C599C53FBB1D8CA690915E33D83`,
-
-			`export DEBUG="electron-*"`,
 		)
 
 		if artifactConfig == binariesWithConnect {


### PR DESCRIPTION
It was added in an effort to debug flaky Connect builds (#15836).

However, we discovered that the v11.1.0 macOS version of Connect stopped working. This was likely due to upgrade of electron-builder which recently updated its process of building native deps
(electron-userland/electron-builder#7196).

In the Node.js ecosystem, the DEBUG env var is typically used to control which packages emit debug messages [1]. However, after the update of electron-builder, the env var also changed the behavior of one of the packages responsible for building the apps.

This was confirmed by inspecting file tree between different app bundles and running the build locally with DEBUG set to electron-*.

[1] https://www.npmjs.com/package/debug

---

Although we did run a CI build after upgrading electron-builder to test if everything is working, we didn't actually execute the artifact built by drone, so we missed the fact that the build was broken.