### PR TITLE
[v10] Connect: Set TeleportClient.AuthConnector before logging in

### DIFF
--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -90,6 +90,7 @@ func (c *Cluster) LocalLogin(ctx context.Context, user, password, otpToken strin
 		return trace.Wrap(err)
 	}
 
+	c.clusterClient.AuthConnector = constants.LocalConnector
 	// TODO(alex-kovoy): SiteName needs to be reset if trying to login to a cluster with
 	// existing profile for the first time (investigate why)
 	c.clusterClient.SiteName = ""
@@ -138,6 +139,8 @@ func (c *Cluster) SSOLogin(ctx context.Context, providerType, providerName strin
 	if _, err := c.clusterClient.Ping(ctx); err != nil {
 		return trace.Wrap(err)
 	}
+
+	c.clusterClient.AuthConnector = providerName
 
 	key, err := client.GenerateRSAKey()
 	if err != nil {


### PR DESCRIPTION
Backport #18811.

v10 doesn't support passwordless, so we have to set AuthConnector in only two places. I compiled v10 locally and verified that auth_connector in the profile yaml file gets set to a correct value for SSO and local login.