### PR TITLE
Fix web ssh session with proxy recording mode

### DIFF
--- a/api/utils/sshutils/callback.go
+++ b/api/utils/sshutils/callback.go
@@ -18,6 +18,7 @@ package sshutils
 
 import (
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 )
@@ -35,12 +36,17 @@ type HostKeyCallbackConfig struct {
 	FIPS bool
 	// OnCheckCert is called on SSH certificate validation.
 	OnCheckCert func(*ssh.Certificate)
+	// Clock is used to set the Checker Time
+	Clock clockwork.Clock
 }
 
 // Check validates the config.
 func (c *HostKeyCallbackConfig) Check() error {
 	if c.GetHostCheckers == nil {
 		return trace.BadParameter("missing GetHostCheckers")
+	}
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
 	}
 	return nil
 }
@@ -54,6 +60,7 @@ func NewHostKeyCallback(conf HostKeyCallbackConfig) (ssh.HostKeyCallback, error)
 		CertChecker: ssh.CertChecker{
 			IsHostAuthority: makeIsHostAuthorityFunc(conf.GetHostCheckers),
 			HostKeyFallback: conf.HostKeyFallback,
+			Clock:           conf.Clock.Now,
 		},
 		FIPS:        conf.FIPS,
 		OnCheckCert: conf.OnCheckCert,

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -333,6 +333,7 @@ func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 		TargetID:        params.ServerID,
 		TargetAddr:      params.To.String(),
 		TargetHostname:  params.Address,
+		Clock:           s.clock,
 	}
 	remoteServer, err := forward.New(serverConfig)
 	if err != nil {

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -856,6 +856,7 @@ func (s *remoteSite) dialWithAgent(params DialParams) (net.Conn, error) {
 		TargetID:        params.ServerID,
 		TargetAddr:      params.To.String(),
 		TargetHostname:  params.Address,
+		Clock:           s.clock,
 	}
 	remoteServer, err := forward.New(serverConfig)
 	if err != nil {

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -877,6 +877,9 @@ func (s *server) checkClientCert(logger *log.Entry, user string, clusterName str
 	}
 
 	checker := apisshutils.CertChecker{
+		CertChecker: ssh.CertChecker{
+			Clock: s.Clock.Now,
+		},
 		FIPS: s.FIPS,
 	}
 	if err := checker.CheckCert(user, cert); err != nil {

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
@@ -56,7 +57,8 @@ func TestServerKeyAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	s := &server{
-		log: utils.NewLoggerForTests(),
+		log:    utils.NewLoggerForTests(),
+		Config: Config{Clock: clockwork.NewRealClock()},
 		localAccessPoint: mockAccessPoint{
 			ca: ca,
 		},

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1976,7 +1976,7 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 // 'ssh: subsystem request failed' will be the only error displayed when
 // access is denied.
 func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
-	s.Logger.Error(err)
+	s.Logger.WithError(err).Errorf("failure handling SSH %q request", req.Type)
 	// Terminate the error with a newline when writing to remote channel's
 	// stderr so the output does not mix with the rest of the output if the remote
 	// side is not doing additional formatting for extended data.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3327,6 +3327,7 @@ func makeTeleportClientConfig(ctx context.Context, sesCtx *SessionContext) (*cli
 	callback, err := apisshutils.NewHostKeyCallback(
 		apisshutils.HostKeyCallbackConfig{
 			GetHostCheckers: sesCtx.getCheckers,
+			Clock:           sesCtx.parent.clock,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1315,11 +1315,11 @@ func TestTerminal(t *testing.T) {
 			termHandler := newTerminalHandler()
 			stream := termHandler.asTerminalStream(ws)
 
-			_, err = io.WriteString(stream, "echo vinsong\r\n")
+			// here we intentionally run a command where the output we're looking
+			// for is not present in the command itself
+			_, err = io.WriteString(stream, "echo txlxport | sed 's/x/e/g'\r\n")
 			require.NoError(t, err)
-
-			err = waitForOutput(stream, "vinsong")
-			require.NoError(t, err)
+			require.NoError(t, waitForOutput(stream, "teleport"))
 		})
 	}
 }

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -51,7 +51,6 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/session"
-	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
 )


### PR DESCRIPTION
The agent was not being propagated when establishing an ssh session via the web which resulted in the error described in #18850. Providing the agent was straightforward, however, due to the changes from #18656 when using the forward server, as is required with proxy recording mode, the ssh connection is now being performed directly over a `net.Pipe`. Due to the synchronous nature of `net.Pipe` this causes a deadlock when performing the ssh handshake. To mitigate the deadlocks, `DualPipeNetConn` was changed to leverage `syscall.Socketpair` instead of `net.Pipe`.

`TestTerminal` now has two cases, one for node recording mode and another for proxy recording mode. In order for the proxy recording mode test to pass the fake clock used in the test needed to be properly propagated to the `ssh.CertChecker` and `forward.ServerConfig`.

Fixes #18850