### PR TITLE
[v9] Update go crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.7.0
 	go.opentelemetry.io/proto/otlp v0.16.0
 	go.uber.org/atomic v1.7.0
-	golang.org/x/crypto v0.0.0-20220126234351-aa10faf2a1f8
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 	golang.org/x/net v0.0.0-20221002022538-bcab6841153b
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2

--- a/go.sum
+++ b/go.sum
@@ -1203,6 +1203,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220126234351-aa10faf2a1f8 h1:kACShD3qhmr/3rLmg1yXyt+N4HcwutKyPRB93s54TIU=
 golang.org/x/crypto v0.0.0-20220126234351-aa10faf2a1f8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4405,12 +4405,12 @@ func testRotateChangeSigningAlg(t *testing.T, suite *integrationTestSuite) {
 
 	t.Log("change signature algorithm with custom config value and manual rotation")
 	// Change the signing algorithm in config file.
-	signingAlg := ssh.SigAlgoRSA
+	signingAlg := ssh.KeyAlgoRSA
 	config.CASignatureAlgorithm = &signingAlg
 	svc, cancel = restart(svc, cancel)
 	// Do a manual rotation - this should change the signing algorithm.
 	svc = rotate(svc, types.RotationModeManual)
-	assertSigningAlg(svc, ssh.SigAlgoRSA)
+	assertSigningAlg(svc, ssh.KeyAlgoRSA)
 
 	t.Log("preserve signature algorithm with empty config value and manual rotation")
 	// Unset the config value.
@@ -4420,7 +4420,7 @@ func testRotateChangeSigningAlg(t *testing.T, suite *integrationTestSuite) {
 	// Do a manual rotation - this should leave the signing algorithm
 	// unaffected because config value is not set.
 	svc = rotate(svc, types.RotationModeManual)
-	assertSigningAlg(svc, ssh.SigAlgoRSA)
+	assertSigningAlg(svc, ssh.KeyAlgoRSA)
 
 	// shut down the service
 	cancel()

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -465,7 +465,7 @@ func TestCASigningAlg(t *testing.T) {
 	auth, err := Init(conf)
 	require.NoError(t, err)
 	defer auth.Close()
-	verifyCAs(auth, ssh.SigAlgoRSASHA2512)
+	verifyCAs(auth, ssh.KeyAlgoRSASHA512)
 
 	require.NoError(t, auth.Close())
 
@@ -475,19 +475,19 @@ func TestCASigningAlg(t *testing.T) {
 	conf.DataDir = t.TempDir()
 
 	// Start a new server with non-default signing alg.
-	signingAlg := ssh.SigAlgoRSA
+	signingAlg := ssh.KeyAlgoRSA
 	conf.CASigningAlg = &signingAlg
 	auth, err = Init(conf)
 	require.NoError(t, err)
 	defer auth.Close()
-	verifyCAs(auth, ssh.SigAlgoRSA)
+	verifyCAs(auth, ssh.KeyAlgoRSA)
 
 	// Start again, using a different alg. This should not change the existing
 	// CA.
-	signingAlg = ssh.SigAlgoRSASHA2256
+	signingAlg = ssh.KeyAlgoRSASHA256
 	auth, err = Init(conf)
 	require.NoError(t, err)
-	verifyCAs(auth, ssh.SigAlgoRSA)
+	verifyCAs(auth, ssh.KeyAlgoRSA)
 }
 
 // TestPresets tests behavior of presets

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -55,9 +55,9 @@ import (
 )
 
 var validCASigAlgos = []string{
-	ssh.SigAlgoRSA,
-	ssh.SigAlgoRSASHA2256,
-	ssh.SigAlgoRSASHA2512,
+	ssh.KeyAlgoRSA,
+	ssh.KeyAlgoRSASHA256,
+	ssh.KeyAlgoRSASHA512,
 }
 
 // FileConfig structre represents the teleport configuration stored in a config file

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -417,7 +417,7 @@ var (
 
 	// CASignatureAlgorithm is the default signing algorithm to use when
 	// creating new SSH CAs.
-	CASignatureAlgorithm = ssh.SigAlgoRSASHA2512
+	CASignatureAlgorithm = ssh.KeyAlgoRSASHA512
 
 	// SessionControlTimeout is the maximum amount of time a controlled session
 	// may persist after contact with the auth server is lost (sessctl semaphore

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -60,10 +60,12 @@ func TestDefaultConfig(t *testing.T) {
 		"aes256-ctr",
 	})
 	require.Equal(t, config.KEXAlgorithms, []string{
+		"curve25519-sha256",
 		"curve25519-sha256@libssh.org",
 		"ecdh-sha2-nistp256",
 		"ecdh-sha2-nistp384",
 		"ecdh-sha2-nistp521",
+		"diffie-hellman-group14-sha256",
 	})
 	require.Equal(t, config.MACAlgorithms, []string{
 		"hmac-sha2-256-etm@openssh.com",

--- a/lib/sshutils/authority.go
+++ b/lib/sshutils/authority.go
@@ -79,11 +79,11 @@ func GetSigningAlgName(ca types.CertAuthority) string {
 	// field was added. Default to RSA-SHA1 to match the implicit algorithm
 	// used in those clusters.
 	case types.CertAuthoritySpecV2_RSA_SHA1, types.CertAuthoritySpecV2_UNKNOWN:
-		return ssh.SigAlgoRSA
+		return ssh.KeyAlgoRSA
 	case types.CertAuthoritySpecV2_RSA_SHA2_256:
-		return ssh.SigAlgoRSASHA2256
+		return ssh.KeyAlgoRSASHA256
 	case types.CertAuthoritySpecV2_RSA_SHA2_512:
-		return ssh.SigAlgoRSASHA2512
+		return ssh.KeyAlgoRSASHA512
 	default:
 		return ""
 	}
@@ -101,11 +101,11 @@ func SetSigningAlgName(ca types.CertAuthority, alg string) {
 // constants, types.CertAuthoritySpecV2_UNKNOWN is returned.
 func ParseSigningAlg(alg string) types.CertAuthoritySpecV2_SigningAlgType {
 	switch alg {
-	case ssh.SigAlgoRSA:
+	case ssh.KeyAlgoRSA:
 		return types.CertAuthoritySpecV2_RSA_SHA1
-	case ssh.SigAlgoRSASHA2256:
+	case ssh.KeyAlgoRSASHA256:
 		return types.CertAuthoritySpecV2_RSA_SHA2_256
-	case ssh.SigAlgoRSASHA2512:
+	case ssh.KeyAlgoRSASHA512:
 		return types.CertAuthoritySpecV2_RSA_SHA2_512
 	default:
 		return types.CertAuthoritySpecV2_UNKNOWN


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/18884 requires an updated version of go/crypto. The updated version deprecated some of the symbols that make our linter fail. 
I decided to update them as a separate PR to make the history cleaner.