### PR TITLE
Security Response Header Uniformity Improvements

### DIFF
--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -165,10 +165,13 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	cfg.TLS.ClientAuth = tls.VerifyClientCertIfGiven
 	cfg.TLS.NextProtos = []string{http2.NextProtoTLS}
 
+	tracingHandler := httplib.MakeTracingHandler(limiter, teleport.ComponentAuth)
+	securityHeaderHandler := httplib.MakeSecurityHeaderHandler(tracingHandler)
+
 	server := &TLSServer{
 		cfg: cfg,
 		httpServer: &http.Server{
-			Handler:           httplib.MakeTracingHandler(limiter, teleport.ComponentAuth),
+			Handler:           securityHeaderHandler,
 			ReadHeaderTimeout: apidefaults.DefaultDialTimeout,
 		},
 		log: logrus.WithFields(logrus.Fields{

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -165,13 +165,13 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	cfg.TLS.ClientAuth = tls.VerifyClientCertIfGiven
 	cfg.TLS.NextProtos = []string{http2.NextProtoTLS}
 
-	tracingHandler := httplib.MakeTracingHandler(limiter, teleport.ComponentAuth)
-	securityHeaderHandler := httplib.MakeSecurityHeaderHandler(tracingHandler)
+	securityHeaderHandler := httplib.MakeSecurityHeaderHandler(limiter)
+	tracingHandler := httplib.MakeTracingHandler(securityHeaderHandler, teleport.ComponentAuth)
 
 	server := &TLSServer{
 		cfg: cfg,
 		httpServer: &http.Server{
-			Handler:           securityHeaderHandler,
+			Handler:           tracingHandler,
 			ReadHeaderTimeout: apidefaults.DefaultDialTimeout,
 		},
 		log: logrus.WithFields(logrus.Fields{

--- a/lib/httplib/httpheaders.go
+++ b/lib/httplib/httpheaders.go
@@ -30,6 +30,8 @@ func SetNoCacheHeaders(h http.Header) {
 	h.Set("Expires", "0")
 }
 
+// SetDefaultSecurityHeaders adds headers that should generally be considered safe defaults.  It is expected that all
+// responses should be able to add these headers without negative impact.
 func SetDefaultSecurityHeaders(h http.Header) {
 	// Prevent web browsers from using content sniffing to discover a file’s MIME type
 	h.Set("X-Content-Type-Options", "nosniff")
@@ -49,9 +51,6 @@ func SetDefaultSecurityHeaders(h http.Header) {
 	// being sent over HTTP to the specified domain and will instead send all communications over HTTPS.
 	// It also prevents HTTPS click through prompts on browsers
 	h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
-
-	// Prevent web browsers from using content sniffing to discover a file’s MIME type
-	h.Set("X-Content-Type-Options", "nosniff")
 }
 
 // SetIndexContentSecurityPolicy sets the Content-Security-Policy header for main index.html page

--- a/lib/httplib/httpheaders.go
+++ b/lib/httplib/httpheaders.go
@@ -30,25 +30,16 @@ func SetNoCacheHeaders(h http.Header) {
 	h.Set("Expires", "0")
 }
 
-// SetStaticFileHeaders sets security header flags for static non-html resources
-func SetStaticFileHeaders(h http.Header) {
-	SetNoSniff(h)
-	SetReferrerPolicyOrigin(h)
-	SetSameOriginIFrame(h)
-	SetStrictTransportSecurity(h)
-}
-
-// SetIndexHTMLHeaders sets security header flags for main index.html page
-func SetIndexHTMLHeaders(h http.Header) {
-	SetNoCacheHeaders(h)
-	SetNoSniff(h)
+func SetDefaultSecurityHeaders(h http.Header) {
+	// Prevent web browsers from using content sniffing to discover a file’s MIME type
+	h.Set("X-Content-Type-Options", "nosniff")
 
 	// Only send the origin of the document as the referrer in all cases.
 	// The document https://example.com/page.html will send the referrer https://example.com/.
-	SetReferrerPolicyOrigin(h)
+	h.Set("Referrer-Policy", "origin")
 
 	// X-Frame-Options indicates that the page can only be displayed in iframe on the same origin as the page itself
-	SetSameOriginIFrame(h)
+	h.Set("X-Frame-Options", "SAMEORIGIN")
 
 	// X-XSS-Protection is a feature of Internet Explorer, Chrome and Safari that stops pages
 	// from loading when they detect reflected cross-site scripting (XSS) attacks.
@@ -57,12 +48,14 @@ func SetIndexHTMLHeaders(h http.Header) {
 	// Once a supported browser receives this header that browser will prevent any communications from
 	// being sent over HTTP to the specified domain and will instead send all communications over HTTPS.
 	// It also prevents HTTPS click through prompts on browsers
-	SetStrictTransportSecurity(h)
+	h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 
 	// Prevent web browsers from using content sniffing to discover a file’s MIME type
 	h.Set("X-Content-Type-Options", "nosniff")
+}
 
-	// Set content policy flags
+// SetIndexContentSecurityPolicy sets the Content-Security-Policy header for main index.html page
+func SetIndexContentSecurityPolicy(h http.Header) {
 	var cspValue = strings.Join([]string{
 		GetDefaultContentSecurityPolicy(),
 		// 'unsafe-inline' is required by CSS-in-JS to work
@@ -88,38 +81,12 @@ func GetDefaultContentSecurityPolicy() string {
 	}, ";")
 }
 
-// SetStrictTransportSecurity sets the Strict-Transport-Security header as a security best practice to reduce the risk
-// of clients attempting any unencrypted requests.
-func SetStrictTransportSecurity(h http.Header) {
-	h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
-}
-
-// SetSameOriginIFrame sets X-Frame-Options flag
-func SetSameOriginIFrame(h http.Header) {
-	// X-Frame-Options indicates that the page can only be displayed in iframe on the same origin as the page itself
-	h.Set("X-Frame-Options", "SAMEORIGIN")
-}
-
-// SetNoSniff sets X-Content-Type-Options flag
-func SetNoSniff(h http.Header) {
-	// Prevent web browsers from using content sniffing to discover a file’s MIME type
-	h.Set("X-Content-Type-Options", "nosniff")
-}
-
 // SetWebConfigHeaders sets headers for webConfig.js
 func SetWebConfigHeaders(h http.Header) {
-	SetStaticFileHeaders(h)
 	h.Set("Content-Type", "application/javascript")
 }
 
 // SetScriptHeaders sets headers for the teleport install script
 func SetScriptHeaders(h http.Header) {
-	SetStaticFileHeaders(h)
 	h.Set("Content-Type", "text/x-shellscript")
-}
-
-// SetReferrerPolicyOrigin sets the Referrer-Policy header to only provide referrer request headers when requests are going
-// to the same origin.
-func SetReferrerPolicyOrigin(h http.Header) {
-	h.Set("Referrer-Policy", "origin")
 }

--- a/lib/httplib/httplib.go
+++ b/lib/httplib/httplib.go
@@ -116,11 +116,6 @@ func MakeHandlerWithErrorWriter(fn HandlerFunc, errWriter ErrorWriter) httproute
 	}
 }
 
-// MakeStdHandler returns a new http.Handle func from http.HandlerFunc
-func MakeStdHandler(fn StdHandlerFunc) http.HandlerFunc {
-	return MakeStdHandlerWithErrorWriter(fn, trace.WriteError)
-}
-
 // MakeStdHandlerWithErrorWriter returns a http.HandlerFunc from the
 // StdHandlerFunc, and sends all errors to ErrorWriter.
 func MakeStdHandlerWithErrorWriter(fn StdHandlerFunc, errWriter ErrorWriter) http.HandlerFunc {

--- a/lib/httplib/httplib.go
+++ b/lib/httplib/httplib.go
@@ -59,6 +59,17 @@ func MakeHandler(fn HandlerFunc) httprouter.Handle {
 	return MakeHandlerWithErrorWriter(fn, trace.WriteError)
 }
 
+// MakeSecurityHeaderHandler returns a new httprouter.Handle func that wraps the provided handler func
+// with one that will ensure the headers from SetDefaultSecurityHeaders are applied.
+func MakeSecurityHeaderHandler(h http.Handler) http.Handler {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		SetDefaultSecurityHeaders(w.Header())
+
+		h.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(handler)
+}
+
 // MakeTracingHandler returns a new httprouter.Handle func that wraps the provided handler func
 // with one that will add a tracing span for each request.
 func MakeTracingHandler(h http.Handler, component string) http.Handler {
@@ -91,6 +102,8 @@ func MakeHandlerWithErrorWriter(fn HandlerFunc, errWriter ErrorWriter) httproute
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		// ensure that neither proxies nor browsers cache http traffic
 		SetNoCacheHeaders(w.Header())
+		// ensure that default security headers are set
+		SetDefaultSecurityHeaders(w.Header())
 
 		out, err := fn(w, r, p)
 		if err != nil {
@@ -114,6 +127,8 @@ func MakeStdHandlerWithErrorWriter(fn StdHandlerFunc, errWriter ErrorWriter) htt
 	return func(w http.ResponseWriter, r *http.Request) {
 		// ensure that neither proxies nor browsers cache http traffic
 		SetNoCacheHeaders(w.Header())
+		// ensure that default security headers are set
+		SetDefaultSecurityHeaders(w.Header())
 
 		out, err := fn(w, r)
 		if err != nil {

--- a/lib/sshutils/scp/http.go
+++ b/lib/sshutils/scp/http.go
@@ -192,7 +192,7 @@ func (l *httpFileSystem) CreateFile(filePath string, length uint64) (io.WriteClo
 	header := l.writer.Header()
 
 	httplib.SetNoCacheHeaders(header)
-	httplib.SetNoSniff(header)
+	httplib.SetDefaultSecurityHeaders(header)
 	header.Set("Content-Length", contentLength)
 	header.Set("Content-Type", "application/octet-stream")
 	filename = url.QueryEscape(filename)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -357,6 +357,9 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 	}
 
 	routingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// ensure security headers are set for all responses
+		httplib.SetDefaultSecurityHeaders(w.Header())
+
 		// request is going to the API?
 		if strings.HasPrefix(r.URL.Path, apiPrefix) {
 			http.StripPrefix(apiPrefix, h).ServeHTTP(w, r)
@@ -391,6 +394,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 			}
 			session.XCSRF = csrfToken
 
+			httplib.SetNoCacheHeaders(w.Header())
 			httplib.SetIndexContentSecurityPolicy(w.Header())
 			if err := indexPage.Execute(w, session); err != nil {
 				h.log.WithError(err).Error("Failed to execute index page template.")

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -371,6 +371,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 
 		// redirect to "/web" when someone hits "/"
 		if r.URL.Path == "/" {
+			app.SetRedirectPageHeaders(w.Header(), "")
 			http.Redirect(w, r, "/web", http.StatusFound)
 			return
 		}

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -25,10 +25,10 @@ import (
 )
 
 func SetRedirectPageHeaders(h http.Header, nonce string) {
-	// SetIndexHTMLHeaders will set safe initial defaults
-	httplib.SetIndexHTMLHeaders(h)
+	httplib.SetNoCacheHeaders(h)
+	httplib.SetDefaultSecurityHeaders(h)
 
-	// Replace content security policy flags
+	// Set content security policy flags
 	scriptSrc := "none"
 	if nonce != "" {
 		// Should match the <script> tab nonce (random value).

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -25,22 +25,21 @@ import (
 )
 
 func SetRedirectPageHeaders(h http.Header, nonce string) {
+	// SetIndexHTMLHeaders will set safe initial defaults
 	httplib.SetIndexHTMLHeaders(h)
-	// Set content policy flags
+
+	// Replace content security policy flags
 	scriptSrc := "none"
 	if nonce != "" {
 		// Should match the <script> tab nonce (random value).
 		scriptSrc = fmt.Sprintf("nonce-%v", nonce)
 	}
 	var csp = strings.Join([]string{
+		httplib.GetDefaultContentSecurityPolicy(),
 		fmt.Sprintf("script-src '%v'", scriptSrc),
 		"style-src 'self'",
-		"object-src 'none'",
 		"img-src 'self'",
-		"base-uri 'self'",
 	}, ";")
-
-	h.Set("Referrer-Policy", "no-referrer")
 	h.Set("Content-Security-Policy", csp)
 }
 

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -28,13 +28,10 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/lib/httplib"
 )
 
 // SetScriptHeaders sets response headers to plain text.
 func SetScriptHeaders(h http.Header) {
-	httplib.SetNoCacheHeaders(h)
-	httplib.SetNoSniff(h)
 	h.Set("Content-Type", "text/plain")
 }
 


### PR DESCRIPTION
When investigating how to resolve #12529 several discoveries were made:

1) We were in some cases already applying the Strict Transport response header: https://github.com/gravitational/teleport/blob/master/lib/httplib/httpheaders.go#L59

2) We had logic for redirects which deferred to the above function, and then replaced the Content-Security-Policy and the Referrer-Policy: https://github.com/gravitational/teleport/blob/master/lib/web/app/redirect.go#L28

3) Neither of which were uniformly applied across the service, resulting in the initially mentioned issue

Our need for customizing our security response headers primarily exists within the Content-Security-Policy.  Other headers can be applied more broadly to provide safe defaults across our service.  For that reason this PR attempts to centralize the logic for these "default" security headers.

At a high level what I have done here is:
* Change `httpheaders.go` to allow for the CSP to be applied separate from the other headers.  Then the changes to `httplib.go` 's handlers as the primary method of making sure these defaults are applied in a common way (similar to how we were already doing for caching directives).
* Change the redirect logic to better fit this model and fix a few places where redirects were returned but without the redirect header logic being applied.
* Simplified several cases where this logic was being handled as a one off but is now being handled centrally

I have added some testing to `apiserver_test.go` but I believe we likely will want this verification in more places.