### PR TITLE
(buddy) Implicitly set go version in prepare-workspace

### DIFF
--- a/.github/actions/prepare-workspace/action.yml
+++ b/.github/actions/prepare-workspace/action.yml
@@ -5,11 +5,6 @@ inputs:
     description: Cache infix used in cache actions
     required: false
     default: ${{ github.workflow }}
-    
-  go_version:
-    description: Golang version for cache keys
-    required: false
-    default: go1.19.2
 
 runs:
   using: "composite"
@@ -20,26 +15,31 @@ runs:
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
         git config --global --add safe.directory ${GITHUB_WORKSPACE}/webassets
 
-    - name: Fetch go cache paths
+    - name: Fetch Go cache paths
       id: go-cache-paths
       shell: bash
       run: |
         echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
         echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
 
+    - name: Get Go version
+      id: go-version
+      shell: bash
+      run: echo "go-version=$(go version | { read _ _ v _; echo ${v#go}; })" >> $GITHUB_OUTPUT
+
     - name: Go build cache
       uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-build-${{ inputs.go_version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-build-${{ inputs.go_version }}-${{ inputs.cache_key }}-
+        key: ${{ runner.os }}-go-build-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-build-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-
 
     - name: Go mod cache
       uses: actions/cache@v3
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
-        key: ${{ runner.os }}-go-mod-${{ inputs.go_version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-mod-${{ inputs.go_version }}-${{ inputs.cache_key }}-
+        key: ${{ runner.os }}-go-mod-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-go-mod-${{ steps.go-version.outputs.go-version }}-${{ inputs.cache_key }}-
 
     - name: Rust cargo cache
       uses: actions/cache@v3

--- a/.github/workflows/build-ci-buildbox-images.yaml
+++ b/.github/workflows/build-ci-buildbox-images.yaml
@@ -9,14 +9,7 @@ on:
       - build.assets/images.mk
     branches:
       - master
-  pull_request:
-    paths:
-      - build.assets/Dockerfile
-      - build.assets/Dockerfile-centos7
-      - build.assets/Makefile
-      - build.assets/images.mk
-    branches:
-      - master
+      - branch/**
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -7,12 +7,6 @@ on:
       - examples/etcd/certs/*.pem
     branches:
       - master
-  pull_request:
-    paths:
-      - .github/services/Dockerfile.*
-      - examples/etcd/certs/*.pem
-    branches:
-      - master
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -18,7 +18,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: read
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport12

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: read
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport12

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -13,7 +13,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: read
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport12

--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -16,7 +16,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: read
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport12

--- a/.github/workflows/unit-tests-operator.yaml
+++ b/.github/workflows/unit-tests-operator.yaml
@@ -20,7 +20,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: read
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport12

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -18,7 +18,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: read
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport12

--- a/api/client/events.go
+++ b/api/client/events.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-// EventToGRPC converts types.Event to proto.Event
+// EventToGRPC converts types.Event to proto.Event.
 func EventToGRPC(in types.Event) (*proto.Event, error) {
 	eventType, err := EventTypeToGRPC(in.Type)
 	if err != nil {

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -30,7 +30,7 @@ authentication:
   connectorName: ""
 
   # Enable/disable local authentication by setting `authentication.local_auth` in `teleport.yaml`.
-  # Disabling local auth is required for FedRAMP / FIPS; see https://gravitational.com/teleport/docs/enterprise/ssh-kubernetes-fedramp/
+  # Disabling local auth is required for FedRAMP / FIPS; see https://gravitational.com/teleport/docs/enterprise/ssh-kubernetes-fedramp/.
   localAuth: true
 
   # Controls the locking mode: in case of network split should Teleport guarantee availability or integrity ?

--- a/lib/srv/desktop/rdp/rdpclient/src/piv.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/piv.rs
@@ -26,7 +26,7 @@ use std::fmt::Write as _;
 use std::io::{Cursor, Read};
 use uuid::Uuid;
 
-// AID (Application ID) of PIV application, per
+// AID (Application ID) of PIV application, per:
 // https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf
 const PIV_AID: Aid = Aid::new_truncatable(
     &[


### PR DESCRIPTION
Buddy PR for https://github.com/gravitational/teleport/pull/18893 plus a couple other tweaks.

- Determine Go version for cache key automatically instead of hardcoding.
- Do not build ghcr CI images (etcd and buildboxes) on PRs to avoid unintended breakages.
  - Only build/push them on push events which mirrors our current Drone setup.
  - We might add ability to trigger them manually via workflow_dispatch events later.
- Add release branches pattern for buildbox images trigger as well.
- Remove `packages: read` permission from test jobs since buildbox images are now public.
