### PR TITLE
Fix `teleport-kube-agent` v9 bug, generating invalid join_params config

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -15,9 +15,13 @@ metadata:
 data:
   teleport.yaml: |
     teleport:
+      {{- if eq .Values.joinParams.method "token" }}
+      auth_token: "/etc/teleport-secrets/auth-token"
+      {{- else }}
       join_params:
         method: "{{ .Values.joinParams.method }}"
         token_name: "/etc/teleport-secrets/auth-token"
+      {{- end }}
       auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
       log:
         severity: {{ $logLevel }}


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/18970

Teleport v9 supports `join_params` but not with `method: token`. This PR handles this case to ensure backward compatibility.