### PR TITLE
Eventually require connection failure in TestTCPCertExpiration tests.

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -669,12 +669,16 @@ func TestTCPCertExpiration(t *testing.T) {
 	// Close and re-open the connection
 	require.NoError(t, conn.Close())
 
-	conn, err = net.Dial("tcp", address)
-	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		conn, err := net.Dial("tcp", address)
+		if err != nil {
+			return false
+		}
 
-	// Try to read again, expect a failure.
-	_, err = conn.Read(buf)
-	require.Error(t, err, buf)
+		// Try to read again, expect a failure.
+		_, err = conn.Read(buf)
+		return err != nil
+	}, time.Second*5, time.Millisecond*100)
 }
 
 func testServersHA(p *Pack, t *testing.T) {

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -561,7 +561,7 @@ func TestTCP(t *testing.T) {
 // TestTCPLock tests locking TCP applications.
 func TestTCPLock(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(time.Now())
-	mCloseChannel := make(chan struct{})
+	mCloseChannel := make(chan struct{}, 1)
 	pack := SetupWithOptions(t, AppTestOptions{
 		Clock:               clock,
 		MonitorCloseChannel: mCloseChannel,


### PR DESCRIPTION
The TestTCPCertExpiration test may have a race condition where the connection made to the test application immediately after the cert expiry may succeed. Due to the wonky nature of using the fake clock in this test, I'm introducing a requires.Eventually here to hopefully mitigate this race.

Note: I'm not 100% sure this will solve this flake, but it seems to be pretty rare.