### PR TITLE
[Docs] Hotfix: Broken download link on Intro to Teleport Clients

### DIFF
--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -13,7 +13,7 @@ Teleport, and includes links to more detailed documentation at the end.
 
 ### tsh
 
-`tsh` lets you authenticate to Teleport and list and connect to resources. After [downloading](/downloads)
+`tsh` lets you authenticate to Teleport and list and connect to resources. After [downloading](https://goteleport.com/downloads)
 and installing `tsh`, sign in to your Teleport cluster:
 
 <Tabs>


### PR DESCRIPTION
Makes the link to the Downloads page a full (not relative) link.