### PR TITLE
[v11] fix heading level for 11.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,13 +86,13 @@ This release of Teleport contains multiple improvements and bug fixes.
 
 This release of Teleport contains a security fix and multiple bug fixes.
 
-## Block SFTP in Moderated Sessions
+### Block SFTP in Moderated Sessions
 
 Teleport did not block SFTP protocol in Moderated Sessions.
 
 [#17727](https://github.com/gravitational/teleport/pull/17727)
 
-## Other fixes
+### Other fixes
 
 * Fixed issue with agent forwarding not working for auto-created users. [#17586](https://github.com/gravitational/teleport/pull/17586)
 * Fixed "traits missing" error in Application Access. [#17737](https://github.com/gravitational/teleport/pull/17737)


### PR DESCRIPTION
fixes issue with table of contents

<img width="225" alt="image" src="https://user-images.githubusercontent.com/60704961/205217850-545f87f5-9e19-4ab5-a5eb-d7362229d77a.png">
