### PR TITLE
Fetch and buffer all entries from LDAP search

### DIFF
--- a/lib/auth/windows/ldap.go
+++ b/lib/auth/windows/ldap.go
@@ -103,6 +103,11 @@ const (
 	AttrOSVersion = "operatingSystemVersion"
 	// AttrPrimaryGroupID is the primary group id of an LDAP object
 	AttrPrimaryGroupID = "primaryGroupID"
+
+	// searchPageSize is desired page size for LDAP search. In Active Directory the default search size limit is 1000 entries,
+	// so in most cases the 1000 search page size will result in the optimal amount of requests made to
+	// LDAP server.
+	searchPageSize = 1000
 )
 
 // Note: if you want to browse LDAP on the Windows machine, run ADSIEdit.msc.
@@ -151,7 +156,7 @@ func (c *LDAPClient) ReadWithFilter(dn string, filter string, attrs []string) ([
 	)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	res, err := c.client.Search(req)
+	res, err := c.client.SearchWithPaging(req, searchPageSize)
 	if ldap.IsErrorWithCode(err, ldap.ErrorNetwork) {
 		return nil, trace.ConnectionProblem(err, "fetching LDAP object %q", dn)
 	} else if err != nil {


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/17797.

Before it would throw  an `Size Limit Exceeded` error when there were more search results than the search size limit.

Now, it will make as many calls as needed to fetch all the results without throwing an error.

In some cases, if there is a lot of entries, the search might slow down a bit as there will be more requests made to fetch all entries. 