### PR TITLE
Fix desktop access setup docs

### DIFF
--- a/docs/pages/desktop-access/manual-setup.mdx
+++ b/docs/pages/desktop-access/manual-setup.mdx
@@ -382,7 +382,7 @@ Start > Control Panel > Administrative Tools > Certificate Authority
 7. In the `Cryptography` tab change `Provider Category` to `Key Storage Provider`, then `Algorithm name` to `ECDH_P384`. Also, change `Request hash` to `SHA384`.
 8. Next, in the `Extensions` tab select `Application Polices` and click the `Edit` button.
 9. Remove all entries from the list.
-10. Go to the `Security` tab, select `Domain Controllers` and give the group `Read` and `Enroll` permissions.
+10. Go to the `Security` tab, select `Domain Computers` and give the group `Read` and `Enroll` permissions.
 11. Finally, create a template by clicking `OK`.
 12. Go back to the Certificate Authority window and right-click on `Certificate Templates`. Then:
 

--- a/lib/web/scripts/desktop/install-ad-cs.ps1
+++ b/lib/web/scripts/desktop/install-ad-cs.ps1
@@ -1,5 +1,5 @@
 $ErrorActionPreference = "Stop"
 
 Add-WindowsFeature Adcs-Cert-Authority -IncludeManagementTools
-Install-AdcsCertificationAuthority -CAType EnterpriseRootCA -Force
+Install-AdcsCertificationAuthority -CAType EnterpriseRootCA -HashAlgorithmName SHA384 -Force
 Restart-Computer -Force


### PR DESCRIPTION
Documentation of the desktop access setup were missing some parameters or was using different words that were confusing. It fixes all of it.