### PR TITLE
Prevent race from causing remote clients from being closed

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -747,7 +747,7 @@ func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httpr
 
 	// The following section is similar to
 	// https://github.com/gravitational/teleport/blob/ea810d30d99f26e58a190edc5facfbe0c09ea5e5/lib/srv/desktop/windows_server.go#L757-L769
-	recConfig, err := c.unsafeCachedAuthClient.GetSessionRecordingConfig(r.Context())
+	recConfig, err := c.cfg.UnsafeCachedAuthClient.GetSessionRecordingConfig(r.Context())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -776,7 +776,7 @@ func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httpr
 		return nil, trace.Wrap(err)
 	}
 
-	userContext.ConsumedAccessRequestID = c.session.GetConsumedAccessRequestID()
+	userContext.ConsumedAccessRequestID = c.cfg.Session.GetConsumedAccessRequestID()
 
 	return userContext, nil
 }
@@ -1607,8 +1607,8 @@ type CreateSessionResponse struct {
 	SessionInactiveTimeoutMS int `json:"sessionInactiveTimeout"`
 }
 
-func newSessionResponse(ctx *SessionContext) (*CreateSessionResponse, error) {
-	accessChecker, err := ctx.GetUserAccessChecker()
+func newSessionResponse(scx *SessionContext) (*CreateSessionResponse, error) {
+	accessChecker, err := scx.GetUserAccessChecker()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1617,7 +1617,7 @@ func newSessionResponse(ctx *SessionContext) (*CreateSessionResponse, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	token, err := ctx.getToken()
+	token, err := scx.getToken()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1625,8 +1625,8 @@ func newSessionResponse(ctx *SessionContext) (*CreateSessionResponse, error) {
 	return &CreateSessionResponse{
 		TokenType:                roundtrip.AuthBearer,
 		Token:                    token.GetName(),
-		TokenExpiresIn:           int(token.Expiry().Sub(ctx.parent.clock.Now()) / time.Second),
-		SessionInactiveTimeoutMS: int(ctx.session.GetIdleTimeout().Milliseconds()),
+		TokenExpiresIn:           int(token.Expiry().Sub(scx.cfg.Parent.clock.Now()) / time.Second),
+		SessionInactiveTimeoutMS: int(scx.cfg.Session.GetIdleTimeout().Milliseconds()),
 	}, nil
 }
 
@@ -1892,7 +1892,7 @@ func (h *Handler) trySettingConnectorNameToPasswordless(ctx context.Context, ses
 		return nil
 	}
 
-	authPreference, err := sessCtx.clt.GetAuthPreference(ctx)
+	authPreference, err := sessCtx.cfg.RootClient.GetAuthPreference(ctx)
 	if err != nil {
 		return nil
 	}
@@ -1912,7 +1912,7 @@ func (h *Handler) trySettingConnectorNameToPasswordless(ctx context.Context, ses
 
 	authPreference.SetConnectorName(constants.PasswordlessConnector)
 
-	err = sessCtx.clt.SetAuthPreference(ctx, authPreference)
+	err = sessCtx.cfg.RootClient.SetAuthPreference(ctx, authPreference)
 	return trace.Wrap(err)
 }
 
@@ -2156,7 +2156,7 @@ func (h *Handler) getSiteNamespaces(w http.ResponseWriter, r *http.Request, _ ht
 func (h *Handler) clusterNodesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of nodes.
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2191,7 +2191,7 @@ type getLoginAlertsResponse struct {
 func (h *Handler) clusterLoginAlertsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of alerts.
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2235,7 +2235,7 @@ func createIdentityContext(login string, sessionCtx *SessionContext) (srv.Identi
 
 	return srv.IdentityContext{
 		AccessChecker:  accessChecker,
-		TeleportUser:   sessionCtx.user,
+		TeleportUser:   sessionCtx.GetUser(),
 		Login:          login,
 		Certificate:    sshCert,
 		UnmappedRoles:  unmappedRoles,
@@ -2271,7 +2271,7 @@ func (h *Handler) siteNodeConnect(
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := sessionCtx.GetUserClient(site)
+	clt, err := sessionCtx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2436,7 +2436,7 @@ type siteSessionGenerateResponse struct {
 // siteSessionCreate generates a new site session that can be used by UI
 // The ServerID from request can be in the form of hostname, uuid, or ip address.
 func (h *Handler) siteSessionGenerate(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2520,7 +2520,7 @@ func trackerToLegacySession(tracker types.SessionTracker, clusterName string) se
 //
 // {"sessions": [{"id": "sid", "terminal_params": {"w": 100, "h": 100}, "parties": [], "login": "bob"}, ...] }
 func (h *Handler) siteSessionsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2554,7 +2554,7 @@ func (h *Handler) siteSessionGet(w http.ResponseWriter, r *http.Request, p httpr
 	}
 	h.log.Infof("web.getSession(%v)", sessionID)
 
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2613,7 +2613,7 @@ func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p 
 	searchEvents := func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error) {
 		return clt.SearchEvents(from, to, apidefaults.Namespace, eventTypes, limit, order, startKey)
 	}
-	return clusterEventsList(ctx, site, r.URL.Query(), searchEvents)
+	return clusterEventsList(r.Context(), ctx, site, r.URL.Query(), searchEvents)
 }
 
 // clusterSearchSessionEvents returns session events matching the criteria.
@@ -2634,12 +2634,12 @@ func (h *Handler) clusterSearchSessionEvents(w http.ResponseWriter, r *http.Requ
 	searchSessionEvents := func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error) {
 		return clt.SearchSessionEvents(from, to, limit, order, startKey, nil, "")
 	}
-	return clusterEventsList(ctx, site, r.URL.Query(), searchSessionEvents)
+	return clusterEventsList(r.Context(), ctx, site, r.URL.Query(), searchSessionEvents)
 }
 
 // clusterEventsList returns a list of audit events obtained using the provided
 // searchEvents method.
-func clusterEventsList(ctx *SessionContext, site reversetunnel.RemoteSite, values url.Values, searchEvents func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error)) (interface{}, error) {
+func clusterEventsList(ctx context.Context, sctx *SessionContext, site reversetunnel.RemoteSite, values url.Values, searchEvents func(clt auth.ClientI, from, to time.Time, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error)) (interface{}, error) {
 	from, err := queryTime(values, "from", time.Now().UTC().AddDate(0, -1, 0))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2662,7 +2662,7 @@ func clusterEventsList(ctx *SessionContext, site reversetunnel.RemoteSite, value
 
 	startKey := values.Get("startKey")
 
-	clt, err := ctx.GetUserClient(site)
+	clt, err := sctx.GetUserClient(ctx, site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2803,7 +2803,7 @@ func (h *Handler) siteSessionStreamGet(w http.ResponseWriter, r *http.Request, p
 		onError(trace.Wrap(err))
 		return
 	}
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		onError(trace.Wrap(err))
 		return
@@ -2873,7 +2873,7 @@ func (h *Handler) siteSessionEventsGet(w http.ResponseWriter, r *http.Request, p
 		return nil, trace.BadParameter("invalid session ID %q", p.ByName("sid"))
 	}
 
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3063,7 +3063,7 @@ type ClusterClientProvider interface {
 	// UserClientForCluster returns a client to the local or remote cluster
 	// identified by clusterName and is authenticated with the identity of the
 	// user.
-	UserClientForCluster(clusterName string) (auth.ClientI, error)
+	UserClientForCluster(ctx context.Context, clusterName string) (auth.ClientI, error)
 }
 
 type clusterClientProvider struct {
@@ -3073,13 +3073,13 @@ type clusterClientProvider struct {
 
 // UserClientForCluster returns a client to the local or remote cluster
 // identified by clusterName and is authenticated with the identity of the user.
-func (r clusterClientProvider) UserClientForCluster(clusterName string) (auth.ClientI, error) {
+func (r clusterClientProvider) UserClientForCluster(ctx context.Context, clusterName string) (auth.ClientI, error) {
 	site, err := r.h.getSite(r.ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := r.ctx.GetUserClient(site)
+	clt, err := r.ctx.GetUserClient(ctx, site)
 	return clt, trace.Wrap(err)
 }
 
@@ -3324,7 +3324,7 @@ func makeTeleportClientConfig(ctx context.Context, sesCtx *SessionContext) (*cli
 		return nil, trace.BadParameter("failed to get user credentials: %v", err)
 	}
 
-	tlsConfig, err := sesCtx.ClientTLSConfig()
+	tlsConfig, err := sesCtx.ClientTLSConfig(ctx)
 	if err != nil {
 		return nil, trace.BadParameter("failed to get client TLS config: %v", err)
 	}
@@ -3344,7 +3344,7 @@ func makeTeleportClientConfig(ctx context.Context, sesCtx *SessionContext) (*cli
 	}
 
 	config := &client.Config{
-		Username:          sesCtx.user,
+		Username:          sesCtx.GetUser(),
 		Agent:             agent,
 		SkipLocalAuth:     true,
 		TLS:               tlsConfig,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1607,8 +1607,8 @@ type CreateSessionResponse struct {
 	SessionInactiveTimeoutMS int `json:"sessionInactiveTimeout"`
 }
 
-func newSessionResponse(scx *SessionContext) (*CreateSessionResponse, error) {
-	accessChecker, err := scx.GetUserAccessChecker()
+func newSessionResponse(sctx *SessionContext) (*CreateSessionResponse, error) {
+	accessChecker, err := sctx.GetUserAccessChecker()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1617,7 +1617,7 @@ func newSessionResponse(scx *SessionContext) (*CreateSessionResponse, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	token, err := scx.getToken()
+	token, err := sctx.getToken()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1625,8 +1625,8 @@ func newSessionResponse(scx *SessionContext) (*CreateSessionResponse, error) {
 	return &CreateSessionResponse{
 		TokenType:                roundtrip.AuthBearer,
 		Token:                    token.GetName(),
-		TokenExpiresIn:           int(token.Expiry().Sub(scx.cfg.Parent.clock.Now()) / time.Second),
-		SessionInactiveTimeoutMS: int(scx.cfg.Session.GetIdleTimeout().Milliseconds()),
+		TokenExpiresIn:           int(token.Expiry().Sub(sctx.cfg.Parent.clock.Now()) / time.Second),
+		SessionInactiveTimeoutMS: int(sctx.cfg.Session.GetIdleTimeout().Milliseconds()),
 	}, nil
 }
 
@@ -1731,8 +1731,8 @@ func (h *Handler) deleteSession(w http.ResponseWriter, r *http.Request, _ httpro
 	return OK(), nil
 }
 
-func (h *Handler) logout(ctx context.Context, w http.ResponseWriter, scx *SessionContext) error {
-	if err := scx.Invalidate(ctx); err != nil {
+func (h *Handler) logout(ctx context.Context, w http.ResponseWriter, sctx *SessionContext) error {
+	if err := sctx.Invalidate(ctx); err != nil {
 		return trace.Wrap(err)
 	}
 	ClearSession(w)

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -39,16 +39,16 @@ import (
 )
 
 // clusterAppsGet returns a list of applications in a form the UI can present.
-func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	appClusterName := p.ByName("site")
 
-	identity, err := ctx.GetIdentity()
+	identity, err := sctx.GetIdentity()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Get a list of application servers and their proxied apps.
-	clt, err := ctx.GetUserClient(r.Context(), site)
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -48,7 +48,7 @@ func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httpr
 	}
 
 	// Get a list of application servers and their proxied apps.
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/connection_diagnostic.go
+++ b/lib/web/connection_diagnostic.go
@@ -30,7 +30,7 @@ import (
 
 // getConnectionDiagnostic returns a connection diagnostic connection diagnostics.
 func (h *Handler) getConnectionDiagnostic(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -60,7 +60,7 @@ func (h *Handler) diagnoseConnection(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	userClt, err := ctx.GetUserClient(site)
+	userClt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/connection_diagnostic.go
+++ b/lib/web/connection_diagnostic.go
@@ -29,8 +29,8 @@ import (
 )
 
 // getConnectionDiagnostic returns a connection diagnostic connection diagnostics.
-func (h *Handler) getConnectionDiagnostic(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(r.Context(), site)
+func (h *Handler) getConnectionDiagnostic(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -50,7 +50,7 @@ func (h *Handler) getConnectionDiagnostic(w http.ResponseWriter, r *http.Request
 }
 
 // diagnoseConnection executes and returns a connection diagnostic.
-func (h *Handler) diagnoseConnection(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) diagnoseConnection(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	req := conntest.TestConnectionRequest{}
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -60,7 +60,7 @@ func (h *Handler) diagnoseConnection(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	userClt, err := ctx.GetUserClient(r.Context(), site)
+	userClt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -89,7 +89,7 @@ func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -134,7 +134,7 @@ func (h *Handler) handleDatabaseUpdate(w http.ResponseWriter, r *http.Request, p
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -176,7 +176,7 @@ func (h *Handler) handleDatabaseGetIAMPolicy(w http.ResponseWriter, r *http.Requ
 		return nil, trace.BadParameter("missing database name")
 	}
 
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -61,7 +61,7 @@ func (r *createDatabaseRequest) checkAndSetDefaults() error {
 }
 
 // handleDatabaseCreate creates a database's metadata.
-func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	var req *createDatabaseRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -89,7 +89,7 @@ func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := ctx.GetUserClient(r.Context(), site)
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -119,7 +119,7 @@ func (r *updateDatabaseRequest) checkAndSetDefaults() error {
 }
 
 // handleDatabaseUpdate updates the database
-func (h *Handler) handleDatabaseUpdate(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) handleDatabaseUpdate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	databaseName := p.ByName("database")
 	if databaseName == "" {
 		return nil, trace.BadParameter("a database name is required")
@@ -134,7 +134,7 @@ func (h *Handler) handleDatabaseUpdate(w http.ResponseWriter, r *http.Request, p
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := ctx.GetUserClient(r.Context(), site)
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -170,13 +170,13 @@ type databaseIAMPolicyAWS struct {
 }
 
 // handleDatabaseGetIAMPolicy returns the required IAM policy for database.
-func (h *Handler) handleDatabaseGetIAMPolicy(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) handleDatabaseGetIAMPolicy(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	databaseName := p.ByName("database")
 	if databaseName == "" {
 		return nil, trace.BadParameter("missing database name")
 	}
 
-	clt, err := ctx.GetUserClient(r.Context(), site)
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -56,7 +56,7 @@ func (h *Handler) desktopConnectHandle(
 	w http.ResponseWriter,
 	r *http.Request,
 	p httprouter.Params,
-	ctx *SessionContext,
+	scx *SessionContext,
 	site reversetunnel.RemoteSite,
 ) (interface{}, error) {
 	desktopName := p.ByName("desktopName")
@@ -64,10 +64,10 @@ func (h *Handler) desktopConnectHandle(
 		return nil, trace.BadParameter("missing desktopName in request URL")
 	}
 
-	log := ctx.log.WithField("desktop-name", desktopName)
+	log := scx.cfg.Log.WithField("desktop-name", desktopName)
 	log.Debug("New desktop access websocket connection")
 
-	if err := h.createDesktopConnection(w, r, desktopName, log, ctx, site); err != nil {
+	if err := h.createDesktopConnection(w, r, desktopName, log, scx, site); err != nil {
 		// createDesktopConnection makes a best effort attempt to send an error to the user
 		// (via websocket) before terminating the connection. We log the error here, but
 		// return nil because our HTTP middleware will try to write the returned error in JSON
@@ -89,7 +89,7 @@ func (h *Handler) createDesktopConnection(
 	r *http.Request,
 	desktopName string,
 	log *logrus.Entry,
-	ctx *SessionContext,
+	scx *SessionContext,
 	site reversetunnel.RemoteSite,
 ) error {
 	upgrader := websocket.Upgrader{
@@ -142,12 +142,11 @@ func (h *Handler) createDesktopConnection(
 	//
 	// In the future, we may want to do something smarter like latency-based
 	// routing.
-	clt, err := ctx.GetUserClient(site)
+	clt, err := scx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return sendTDPError(ws, trace.Wrap(err))
 	}
-	winDesktops, err := clt.GetWindowsDesktops(r.Context(),
-		types.WindowsDesktopFilter{Name: desktopName})
+	winDesktops, err := clt.GetWindowsDesktops(r.Context(), types.WindowsDesktopFilter{Name: desktopName})
 	if err != nil {
 		return sendTDPError(ws, trace.Wrap(err, "cannot get Windows desktops"))
 	}
@@ -173,19 +172,19 @@ func (h *Handler) createDesktopConnection(
 		site:     site,
 		userAddr: r.RemoteAddr,
 	}
-	serviceConn, err := c.connectToWindowsService(ctx.parent.clusterName, validServiceIDs)
+	serviceConn, err := c.connectToWindowsService(scx.cfg.RootClusterName, validServiceIDs)
 	if err != nil {
 		return sendTDPError(ws, trace.Wrap(err, "cannot connect to Windows Desktop Service"))
 	}
 	defer serviceConn.Close()
 
-	pc, err := proxyClient(r.Context(), ctx, h.ProxyHostPort(), username)
+	pc, err := proxyClient(r.Context(), scx, h.ProxyHostPort(), username)
 	if err != nil {
 		return sendTDPError(ws, trace.Wrap(err))
 	}
 	defer pc.Close()
 
-	tlsConfig, err := desktopTLSConfig(r.Context(), ws, pc, ctx, desktopName, username, site.GetName())
+	tlsConfig, err := desktopTLSConfig(r.Context(), ws, pc, scx, desktopName, username, site.GetName())
 	if err != nil {
 		return sendTDPError(ws, err)
 	}
@@ -238,7 +237,7 @@ func proxyClient(ctx context.Context, sessCtx *SessionContext, addr, windowsUser
 }
 
 func desktopTLSConfig(ctx context.Context, ws *websocket.Conn, pc *client.ProxyClient, sessCtx *SessionContext, desktopName, username, siteName string) (*tls.Config, error) {
-	pk, err := keys.ParsePrivateKey(sessCtx.session.GetPriv())
+	pk, err := keys.ParsePrivateKey(sessCtx.cfg.Session.GetPriv())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -252,8 +251,8 @@ func desktopTLSConfig(ctx context.Context, ws *websocket.Conn, pc *client.ProxyC
 		RouteToCluster: siteName,
 		ExistingCreds: &client.Key{
 			PrivateKey:          pk,
-			Cert:                sessCtx.session.GetPub(),
-			TLSCert:             sessCtx.session.GetTLSCert(),
+			Cert:                sessCtx.cfg.Session.GetPub(),
+			TLSCert:             sessCtx.cfg.Session.GetTLSCert(),
 			WindowsDesktopCerts: make(map[string][]byte),
 		},
 	}, promptMFAChallenge(ws, &wsLock, tdpMFACodec{}))
@@ -268,7 +267,7 @@ func desktopTLSConfig(ctx context.Context, ws *websocket.Conn, pc *client.ProxyC
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tlsConfig, err := sessCtx.ClientTLSConfig()
+	tlsConfig, err := sessCtx.ClientTLSConfig(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -39,7 +39,7 @@ func (h *Handler) desktopPlaybackHandle(
 		return nil, trace.BadParameter("missing sid in request URL")
 	}
 
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -57,7 +57,7 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 		namespace:      defaults.Namespace,
 	}
 
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -46,7 +46,7 @@ type fileTransferRequest struct {
 	filename string
 }
 
-func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	query := r.URL.Query()
 	req := fileTransferRequest{
 		cluster:        p.ByName("site"),
@@ -57,13 +57,13 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 		namespace:      defaults.Namespace,
 	}
 
-	clt, err := ctx.GetUserClient(r.Context(), site)
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	ft := fileTransfer{
-		ctx:           ctx,
+		ctx:           sctx,
 		authClient:    clt,
 		proxyHostPort: h.ProxyHostPort(),
 	}

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -39,7 +39,7 @@ import (
 func (h *Handler) checkAccessToRegisteredResource(w http.ResponseWriter, r *http.Request, p httprouter.Params, c *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of resources.
-	clt, err := c.GetUserClient(site)
+	clt, err := c.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -28,8 +28,8 @@ import (
 )
 
 // clusterKubesGet returns a list of kube clusters in a form the UI can present.
-func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(r.Context(), site)
+func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -43,7 +43,7 @@ func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p http
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessChecker, err := ctx.GetUserAccessChecker()
+	accessChecker, err := sctx.GetUserAccessChecker()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -56,8 +56,8 @@ func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p http
 }
 
 // clusterDatabasesGet returns a list of db servers in a form the UI can present.
-func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(r.Context(), site)
+func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -86,13 +86,13 @@ func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p 
 }
 
 // clusterDatabaseGet returns a list of db servers in a form the UI can present.
-func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	databaseName := p.ByName("database")
 	if databaseName == "" {
 		return nil, trace.BadParameter("database name is required")
 	}
 
-	clt, err := ctx.GetUserClient(r.Context(), site)
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -102,7 +102,7 @@ func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	accessChecker, err := ctx.GetUserAccessChecker()
+	accessChecker, err := sctx.GetUserAccessChecker()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -126,8 +126,8 @@ func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p h
 }
 
 // clusterDesktopsGet returns a list of desktops in a form the UI can present.
-func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(r.Context(), site)
+func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -150,10 +150,10 @@ func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p h
 }
 
 // clusterDesktopServicesGet returns a list of desktop services in a form the UI can present.
-func (h *Handler) clusterDesktopServicesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterDesktopServicesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of desktop services.
-	clt, err := ctx.GetUserClient(r.Context(), site)
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -176,8 +176,8 @@ func (h *Handler) clusterDesktopServicesGet(w http.ResponseWriter, r *http.Reque
 }
 
 // getDesktopHandle returns a desktop.
-func (h *Handler) getDesktopHandle(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(r.Context(), site)
+func (h *Handler) getDesktopHandle(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -205,7 +205,7 @@ func (h *Handler) getDesktopHandle(w http.ResponseWriter, r *http.Request, p htt
 // Response body:
 //
 // {"active": bool}
-func (h *Handler) desktopIsActive(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) desktopIsActive(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	desktopName := p.ByName("desktopName")
 	trackers, err := h.auth.proxyClient.GetActiveSessionTrackersWithFilter(r.Context(), &types.SessionTrackerFilter{
 		Kind: string(types.WindowsDesktopSessionKind),
@@ -219,7 +219,7 @@ func (h *Handler) desktopIsActive(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := ctx.GetUserClient(r.Context(), site)
+	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -29,7 +29,7 @@ import (
 
 // clusterKubesGet returns a list of kube clusters in a form the UI can present.
 func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -57,7 +57,7 @@ func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p http
 
 // clusterDatabasesGet returns a list of db servers in a form the UI can present.
 func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -92,7 +92,7 @@ func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.BadParameter("database name is required")
 	}
 
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -127,7 +127,7 @@ func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p h
 
 // clusterDesktopsGet returns a list of desktops in a form the UI can present.
 func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -153,7 +153,7 @@ func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p h
 func (h *Handler) clusterDesktopServicesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	// Get a client to the Auth Server with the logged in user's identity. The
 	// identity of the logged in user is used to fetch the list of desktop services.
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -177,7 +177,7 @@ func (h *Handler) clusterDesktopServicesGet(w http.ResponseWriter, r *http.Reque
 
 // getDesktopHandle returns a desktop.
 func (h *Handler) getDesktopHandle(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -219,7 +219,7 @@ func (h *Handler) desktopIsActive(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := ctx.GetUserClient(site)
+	clt, err := ctx.GetUserClient(r.Context(), site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -121,9 +121,10 @@ func (c *SessionContextConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = logrus.WithFields(logrus.Fields{
-			"user":    c.User,
-			"session": c.Session.GetShortName(),
+		c.Log = newPackageLogger().WithFields(logrus.Fields{
+			trace.Component: teleport.ComponentWeb,
+			"user":          c.User,
+			"session":       c.Session.GetShortName(),
 		})
 	}
 

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc"
 
 	"github.com/gravitational/teleport"
@@ -55,72 +56,137 @@ import (
 // each web session generated for the user and provides
 // a basic client cache for remote auth server connections.
 type SessionContext struct {
-	log  logrus.FieldLogger
-	user string
-
-	// clt holds a connection to the root auth. Note that requests made using this
-	// client are made with the identity of the user and are NOT cached.
-	clt *auth.Client
+	// SessionContextConfig contains dependency injected configurations
+	cfg SessionContextConfig
 	// remoteClientCache holds the remote clients that have been used in this
 	// session.
 	remoteClientCache
+	// remoteClientGroup prevents duplicate requests to create remote clients
+	// for a given site
+	remoteClientGroup singleflight.Group
+}
 
-	// unsafeCachedAuthClient holds a read-only cache to root auth. Note this access
+type SessionContextConfig struct {
+	// Log is used to emit logs
+	Log *logrus.Entry
+	// User is the name of the current user
+	User string
+
+	// RootClusterName is the name of the root cluster
+	RootClusterName string
+
+	// RootClient holds a connection to the root auth. Note that requests made using this
+	// client are made with the identity of the user and are NOT cached.
+	RootClient *auth.Client
+
+	// UnsafeCachedAuthClient holds a read-only cache to root auth. Note this access
 	// point cache is authenticated with the identity of the node, not of the
 	// user. This is why its prefixed with "unsafe".
 	//
 	// This access point should only be used if the identity of the caller will
 	// not affect the result of the RPC. For example, never use it to call
 	// "GetNodes".
-	unsafeCachedAuthClient auth.ReadProxyAccessPoint
+	UnsafeCachedAuthClient auth.ReadProxyAccessPoint
 
-	parent *sessionCache
-	// resources is persistent resource store this context is bound to.
+	Parent *sessionCache
+	// Resources is a persistent resource store this context is bound to.
 	// The store maintains a list of resources between session renewals
-	resources *sessionResources
-	// session refers the web session created for the user.
-	session types.WebSession
+	Resources *sessionResources
+	// Session refers the web session created for the user.
+	Session types.WebSession
+
+	// newRemoteClient is used by tests to override how remote clients are constructed to allow for fake sites
+	newRemoteClient func(ctx context.Context, sessionContext *SessionContext, site reversetunnel.RemoteSite) (auth.ClientI, error)
+}
+
+func (c *SessionContextConfig) CheckAndSetDefaults() error {
+	if c.RootClient == nil {
+		return trace.BadParameter("RootClient required")
+	}
+
+	if c.UnsafeCachedAuthClient == nil {
+		return trace.BadParameter("UnsafeCachedAuthClient required")
+	}
+
+	if c.Parent == nil {
+		return trace.BadParameter("Parent required")
+	}
+
+	if c.Resources == nil {
+		return trace.BadParameter("Resources required")
+	}
+
+	if c.Session == nil {
+		return trace.BadParameter("Session required")
+	}
+
+	if c.Log == nil {
+		c.Log = logrus.WithFields(logrus.Fields{
+			"user":    c.User,
+			"session": c.Session.GetShortName(),
+		})
+	}
+
+	if c.newRemoteClient == nil {
+		c.newRemoteClient = newRemoteClient
+	}
+
+	if c.RootClusterName == "" {
+		c.RootClusterName = c.Parent.clusterName
+	}
+
+	return nil
+}
+
+func NewSessionContext(cfg SessionContextConfig) (*SessionContext, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &SessionContext{
+		cfg: cfg,
+	}, nil
 }
 
 // String returns the text representation of this context
 func (c *SessionContext) String() string {
 	return fmt.Sprintf("WebSession(user=%v,id=%v,expires=%v,bearer=%v,bearer_expires=%v)",
-		c.user,
-		c.session.GetName(),
-		c.session.GetExpiryTime(),
-		c.session.GetBearerToken(),
-		c.session.GetBearerTokenExpiryTime(),
+		c.cfg.User,
+		c.cfg.Session.GetName(),
+		c.cfg.Session.GetExpiryTime(),
+		c.cfg.Session.GetBearerToken(),
+		c.cfg.Session.GetBearerTokenExpiryTime(),
 	)
 }
 
 // AddClosers adds the specified closers to this context
 func (c *SessionContext) AddClosers(closers ...io.Closer) {
-	c.resources.addClosers(closers...)
+	c.cfg.Resources.addClosers(closers...)
 }
 
 // RemoveCloser removes the specified closer from this context
 func (c *SessionContext) RemoveCloser(closer io.Closer) {
-	c.resources.removeCloser(closer)
+	c.cfg.Resources.removeCloser(closer)
 }
 
 // Invalidate invalidates this context by removing the underlying session
 // and closing all underlying closers
 func (c *SessionContext) Invalidate(ctx context.Context) error {
-	return c.parent.invalidateSession(ctx, c)
+	return c.cfg.Parent.invalidateSession(ctx, c)
 }
 
 func (c *SessionContext) validateBearerToken(ctx context.Context, token string) error {
-	fetchedToken, err := c.parent.readBearerToken(ctx, types.GetWebTokenRequest{
-		User:  c.user,
+	fetchedToken, err := c.cfg.Parent.readBearerToken(ctx, types.GetWebTokenRequest{
+		User:  c.cfg.User,
 		Token: token,
 	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	if fetchedToken.GetUser() != c.user {
-		c.log.Warnf("Failed validating bearer token: the user[%s] in bearer token[%s] did not match the user[%s] for session[%s]",
-			fetchedToken.GetUser(), token, c.user, c.GetSessionID())
+	if fetchedToken.GetUser() != c.cfg.User {
+		c.cfg.Log.Warnf("Failed validating bearer token: the user[%s] in bearer token[%s] did not match the user[%s] for session[%s]",
+			fetchedToken.GetUser(), token, c.cfg.User, c.GetSessionID())
 		return trace.AccessDenied("access denied")
 	}
 
@@ -129,34 +195,45 @@ func (c *SessionContext) validateBearerToken(ctx context.Context, token string) 
 
 // GetClient returns the client connected to the auth server
 func (c *SessionContext) GetClient() (auth.ClientI, error) {
-	return c.clt, nil
+	return c.cfg.RootClient, nil
 }
 
 // GetClientConnection returns a connection to Auth Service
 func (c *SessionContext) GetClientConnection() *grpc.ClientConn {
-	return c.clt.GetConnection()
+	return c.cfg.RootClient.GetConnection()
 }
 
 // GetUserClient will return an auth.ClientI with the role of the user at
 // the requested site. If the site is local a client with the users local role
 // is returned. If the site is remote a client with the users remote role is
 // returned.
-func (c *SessionContext) GetUserClient(site reversetunnel.RemoteSite) (auth.ClientI, error) {
-	// get the name of the current cluster
-	clusterName, err := c.clt.GetClusterName()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func (c *SessionContext) GetUserClient(ctx context.Context, site reversetunnel.RemoteSite) (auth.ClientI, error) {
 	// if we're trying to access the local cluster, pass back the local client.
-	if clusterName.GetClusterName() == site.GetName() {
-		return c.clt, nil
+	if c.cfg.RootClusterName == site.GetName() {
+		return c.cfg.RootClient, nil
 	}
 
-	// check if we already have a connection to this cluster
-	remoteClt, ok := c.getRemoteClient(site)
-	if !ok {
-		rClt, err := c.newRemoteClient(site)
+	// return the client for the requested remote site
+	clt, err := c.remoteClient(ctx, site)
+	return clt, trace.Wrap(err)
+}
+
+// remoteClient returns an auth.ClientI with the role of the user at
+// the requested [site]. All remote clients are lazily created
+// when they are first requested and then cached. Subsequent requests
+// will return the previously created client to prevent having more than
+// a single auth.ClientI per site for a user.
+//
+// A [singleflight.Group] is leveraged to prevent duplicate requests for remote
+// clients at the same time to race.
+func (c *SessionContext) remoteClient(ctx context.Context, site reversetunnel.RemoteSite) (auth.ClientI, error) {
+	cltI, err, _ := c.remoteClientGroup.Do(site.GetName(), func() (interface{}, error) {
+		// check if we already have a connection to this cluster
+		if clt, ok := c.remoteClientCache.getRemoteClient(site); ok {
+			return clt, nil
+		}
+
+		rClt, err := c.cfg.newRemoteClient(ctx, c, site)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -164,24 +241,40 @@ func (c *SessionContext) GetUserClient(site reversetunnel.RemoteSite) (auth.Clie
 		// we'll save the remote client in our session context so we don't have to
 		// build a new connection next time. all remote clients will be closed when
 		// the session context is closed.
-		err = c.addRemoteClient(site, rClt)
+		err = c.remoteClientCache.addRemoteClient(site, rClt)
 		if err != nil {
-			c.log.WithError(err).Info("Failed closing stale remote client for site: ", site.GetName())
+			c.cfg.Log.WithError(err).Info("Failed closing stale remote client for site: ", site.GetName())
 		}
 
 		return rClt, nil
-	}
+	})
 
-	return remoteClt, nil
-}
-
-// newRemoteClient returns a client to a remote cluster with the role of
-// the logged in user.
-func (c *SessionContext) newRemoteClient(cluster reversetunnel.RemoteSite) (auth.ClientI, error) {
-	clt, err := c.tryRemoteTLSClient(cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	clt, ok := cltI.(auth.ClientI)
+	if !ok {
+		return nil, trace.BadParameter("unexpected type %T received for auth client", cltI)
+	}
+
+	return clt, nil
+}
+
+// newRemoteClient returns a client to a remote cluster with the role of current user.
+func newRemoteClient(ctx context.Context, scx *SessionContext, site reversetunnel.RemoteSite) (auth.ClientI, error) {
+	clt, err := scx.newRemoteTLSClient(ctx, site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Clients lazily dial, so attempt an RPC to determine if this client
+	// is functional or not.
+	_, err = clt.GetDomainName(ctx)
+	if err != nil {
+		return nil, trace.NewAggregate(err, clt.Close())
+	}
+
 	return clt, nil
 }
 
@@ -192,27 +285,12 @@ func clusterDialer(remoteCluster reversetunnel.RemoteSite) apiclient.ContextDial
 	})
 }
 
-// tryRemoteTLSClient tries creating TLS client and using it (the client may not be available
-// due to older clusters), returns client if it is working properly
-func (c *SessionContext) tryRemoteTLSClient(cluster reversetunnel.RemoteSite) (auth.ClientI, error) {
-	clt, err := c.newRemoteTLSClient(cluster)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	_, err = clt.GetDomainName(context.TODO())
-	if err != nil {
-		return nil, trace.NewAggregate(err, clt.Close())
-	}
-	return clt, nil
-}
-
 // ClientTLSConfig returns client TLS authentication associated
 // with the web session context
-func (c *SessionContext) ClientTLSConfig(clusterName ...string) (*tls.Config, error) {
-	ctx := context.TODO()
+func (c *SessionContext) ClientTLSConfig(ctx context.Context, clusterName ...string) (*tls.Config, error) {
 	var certPool *x509.CertPool
 	if len(clusterName) == 0 {
-		certAuthorities, err := c.parent.proxyClient.GetCertAuthorities(ctx, types.HostCA, false)
+		certAuthorities, err := c.cfg.Parent.proxyClient.GetCertAuthorities(ctx, types.HostCA, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -221,7 +299,7 @@ func (c *SessionContext) ClientTLSConfig(clusterName ...string) (*tls.Config, er
 			return nil, trace.Wrap(err)
 		}
 	} else {
-		certAuthority, err := c.parent.proxyClient.GetCertAuthority(ctx, types.CertAuthID{
+		certAuthority, err := c.cfg.Parent.proxyClient.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,
 			DomainName: clusterName[0],
 		}, false)
@@ -234,25 +312,27 @@ func (c *SessionContext) ClientTLSConfig(clusterName ...string) (*tls.Config, er
 		}
 	}
 
-	tlsConfig := utils.TLSConfig(c.parent.cipherSuites)
-	tlsCert, err := tls.X509KeyPair(c.session.GetTLSCert(), c.session.GetPriv())
+	tlsConfig := utils.TLSConfig(c.cfg.Parent.cipherSuites)
+	tlsCert, err := tls.X509KeyPair(c.cfg.Session.GetTLSCert(), c.cfg.Session.GetPriv())
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to parse TLS cert and key")
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	tlsConfig.RootCAs = certPool
-	tlsConfig.ServerName = apiutils.EncodeClusterName(c.parent.clusterName)
-	tlsConfig.Time = c.parent.clock.Now
+	tlsConfig.ServerName = apiutils.EncodeClusterName(c.cfg.Parent.clusterName)
+	tlsConfig.Time = c.cfg.Parent.clock.Now
 	return tlsConfig, nil
 }
 
-func (c *SessionContext) newRemoteTLSClient(cluster reversetunnel.RemoteSite) (auth.ClientI, error) {
-	tlsConfig, err := c.ClientTLSConfig(cluster.GetName())
+func (c *SessionContext) newRemoteTLSClient(ctx context.Context, cluster reversetunnel.RemoteSite) (auth.ClientI, error) {
+	tlsConfig, err := c.ClientTLSConfig(ctx, cluster.GetName())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	return auth.NewClient(apiclient.Config{
-		Dialer: clusterDialer(cluster),
+		Context: ctx,
+		Dialer:  clusterDialer(cluster),
 		Credentials: []apiclient.Credentials{
 			apiclient.LoadTLS(tlsConfig),
 		},
@@ -262,15 +342,15 @@ func (c *SessionContext) newRemoteTLSClient(cluster reversetunnel.RemoteSite) (a
 
 // GetUser returns the authenticated teleport user
 func (c *SessionContext) GetUser() string {
-	return c.user
+	return c.cfg.User
 }
 
 // extendWebSession creates a new web session for this user
 // based on the previous session
 func (c *SessionContext) extendWebSession(ctx context.Context, req renewSessionRequest) (types.WebSession, error) {
-	session, err := c.clt.ExtendWebSession(ctx, auth.WebSessionReq{
-		User:            c.user,
-		PrevSessionID:   c.session.GetName(),
+	session, err := c.cfg.RootClient.ExtendWebSession(ctx, auth.WebSessionReq{
+		User:            c.cfg.User,
+		PrevSessionID:   c.cfg.Session.GetName(),
 		AccessRequestID: req.AccessRequestID,
 		Switchback:      req.Switchback,
 		ReloadUser:      req.ReloadUser,
@@ -292,7 +372,7 @@ func (c *SessionContext) GetAgent() (agent.ExtendedAgent, *ssh.Certificate, erro
 	if len(cert.ValidPrincipals) == 0 {
 		return nil, nil, trace.BadParameter("expected at least valid principal in certificate")
 	}
-	privateKey, err := ssh.ParseRawPrivateKey(c.session.GetPriv())
+	privateKey, err := ssh.ParseRawPrivateKey(c.cfg.Session.GetPriv())
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "failed to parse SSH private key")
 	}
@@ -313,7 +393,7 @@ func (c *SessionContext) GetAgent() (agent.ExtendedAgent, *ssh.Certificate, erro
 
 func (c *SessionContext) getCheckers() ([]ssh.PublicKey, error) {
 	ctx := context.TODO()
-	cas, err := c.unsafeCachedAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
+	cas, err := c.cfg.UnsafeCachedAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -330,12 +410,12 @@ func (c *SessionContext) getCheckers() ([]ssh.PublicKey, error) {
 
 // GetSSHCertificate returns the *ssh.Certificate associated with this session.
 func (c *SessionContext) GetSSHCertificate() (*ssh.Certificate, error) {
-	return apisshutils.ParseCertificate(c.session.GetPub())
+	return apisshutils.ParseCertificate(c.cfg.Session.GetPub())
 }
 
 // GetX509Certificate returns the *x509.Certificate associated with this session.
 func (c *SessionContext) GetX509Certificate() (*x509.Certificate, error) {
-	tlsCert, err := tlsca.ParseCertificatePEM(c.session.GetTLSCert())
+	tlsCert, err := tlsca.ParseCertificatePEM(c.cfg.Session.GetTLSCert())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -349,24 +429,19 @@ func (c *SessionContext) GetUserAccessChecker() (services.AccessChecker, error) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	accessInfo, err := services.AccessInfoFromLocalCertificate(cert)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clusterName, err := c.unsafeCachedAuthClient.GetClusterName()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	accessChecker, err := services.NewAccessChecker(accessInfo, clusterName.GetClusterName(), c.unsafeCachedAuthClient)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return accessChecker, nil
+
+	accessChecker, err := services.NewAccessChecker(accessInfo, c.cfg.RootClusterName, c.cfg.UnsafeCachedAuthClient)
+	return accessChecker, trace.Wrap(err)
 }
 
 // GetProxyListenerMode returns cluster proxy listener mode form cluster networking config.
 func (c *SessionContext) GetProxyListenerMode(ctx context.Context) (types.ProxyListenerMode, error) {
-	resp, err := c.unsafeCachedAuthClient.GetClusterNetworkingConfig(ctx)
+	resp, err := c.cfg.UnsafeCachedAuthClient.GetClusterNetworkingConfig(ctx)
 	if err != nil {
 		return types.ProxyListenerMode_Separate, trace.Wrap(err)
 	}
@@ -388,13 +463,13 @@ func (c *SessionContext) GetIdentity() (*tlsca.Identity, error) {
 
 // GetSessionID returns the ID of the underlying user web session.
 func (c *SessionContext) GetSessionID() string {
-	return c.session.GetName()
+	return c.cfg.Session.GetName()
 }
 
 // Close cleans up resources associated with this context and removes it
 // from the user context
 func (c *SessionContext) Close() error {
-	return trace.NewAggregate(c.remoteClientCache.Close(), c.clt.Close())
+	return trace.NewAggregate(c.remoteClientCache.Close(), c.cfg.RootClient.Close())
 }
 
 // getToken returns the bearer token associated with the underlying
@@ -402,9 +477,9 @@ func (c *SessionContext) Close() error {
 // is only useful immediately after a session has been created to query
 // the token.
 func (c *SessionContext) getToken() (types.WebToken, error) {
-	t, err := types.NewWebToken(c.session.GetBearerTokenExpiryTime(), types.WebTokenSpecV3{
-		User:  c.session.GetUser(),
-		Token: c.session.GetBearerToken(),
+	t, err := types.NewWebToken(c.cfg.Session.GetBearerTokenExpiryTime(), types.WebTokenSpecV3{
+		User:  c.cfg.Session.GetUser(),
+		Token: c.cfg.Session.GetBearerToken(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -421,9 +496,9 @@ func (c *SessionContext) getToken() (types.WebToken, error) {
 // considered expired when its bearer token TTL is in the past (subject to
 // lingering threshold)
 func (c *SessionContext) expired(ctx context.Context) bool {
-	_, err := c.parent.readSession(ctx, types.GetWebSessionRequest{
-		User:      c.user,
-		SessionID: c.session.GetName(),
+	_, err := c.cfg.Parent.readSession(ctx, types.GetWebSessionRequest{
+		User:      c.cfg.User,
+		SessionID: c.cfg.Session.GetName(),
 	})
 
 	// If looking up the session in the cache or backend succeeds, then
@@ -434,13 +509,13 @@ func (c *SessionContext) expired(ctx context.Context) bool {
 
 	// If the session has no expiry time, then also by definition it
 	// cannot be expired
-	expiry := c.session.GetBearerTokenExpiryTime()
+	expiry := c.cfg.Session.GetBearerTokenExpiryTime()
 	if expiry.IsZero() {
 		return false
 	}
 
 	if !trace.IsNotFound(err) {
-		c.log.WithError(err).Debug("Failed to query web session.")
+		c.cfg.Log.WithError(err).Debug("Failed to query web session.")
 	}
 	// Give the session some time to linger so existing users of the context
 	// have successfully disposed of them.
@@ -448,7 +523,7 @@ func (c *SessionContext) expired(ctx context.Context) bool {
 	// cached site clients.
 	// This is a cheaper way to avoid race without introducing object
 	// reference counters.
-	return c.parent.clock.Since(expiry) > c.parent.sessionLingeringThreshold
+	return c.cfg.Parent.clock.Since(expiry) > c.cfg.Parent.sessionLingeringThreshold
 }
 
 // cachedSessionLingeringThreshold specifies the maximum amount of time the session cache
@@ -551,7 +626,7 @@ func (s *sessionCache) clearExpiredSessions(ctx context.Context) {
 		if !c.expired(ctx) {
 			continue
 		}
-		s.removeSessionContextLocked(c.session.GetUser(), c.session.GetName())
+		s.removeSessionContextLocked(c.cfg.Session.GetUser(), c.cfg.Session.GetName())
 		s.log.WithField("ctx", c.String()).Debug("Context expired.")
 	}
 }
@@ -706,16 +781,16 @@ func (s *sessionCache) invalidateSession(ctx context.Context, scx *SessionContex
 	// Delete just the session - leave the bearer token to linger to avoid
 	// failing a client query still using the old token.
 	err = clt.WebSessions().Delete(ctx, types.DeleteWebSessionRequest{
-		User:      scx.user,
-		SessionID: scx.session.GetName(),
+		User:      scx.GetUser(),
+		SessionID: scx.GetSessionID(),
 	})
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
-	if err := clt.DeleteUserAppSessions(ctx, &proto.DeleteUserAppSessionsRequest{Username: scx.user}); err != nil {
+	if err := clt.DeleteUserAppSessions(ctx, &proto.DeleteUserAppSessionsRequest{Username: scx.GetUser()}); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := s.releaseResources(scx.GetUser(), scx.session.GetName()); err != nil {
+	if err := s.releaseResources(scx.GetUser(), scx.GetSessionID()); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -732,14 +807,14 @@ func (s *sessionCache) getContext(user, sessionID string) (*SessionContext, erro
 		user, sessionID)
 }
 
-func (s *sessionCache) insertContext(user string, ctx *SessionContext) (exists bool) {
+func (s *sessionCache) insertContext(user string, scx *SessionContext) (exists bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	id := sessionKey(user, ctx.session.GetName())
+	id := sessionKey(user, scx.GetSessionID())
 	if _, exists := s.sessions[id]; exists {
 		return true
 	}
-	s.sessions[id] = ctx
+	s.sessions[id] = scx
 	return false
 }
 
@@ -828,28 +903,30 @@ func (s *sessionCache) newSessionContextFromSession(session types.WebSession) (*
 		return nil, trace.Wrap(err)
 	}
 
-	ctx := &SessionContext{
-		clt:                    userClient,
-		unsafeCachedAuthClient: s.accessPoint,
-		user:                   session.GetUser(),
-		session:                session,
-		parent:                 s,
-		resources:              s.upsertSessionContext(session.GetUser()),
-		log: s.log.WithFields(logrus.Fields{
+	scx, err := NewSessionContext(SessionContextConfig{
+		Log: s.log.WithFields(logrus.Fields{
 			"user":    session.GetUser(),
 			"session": session.GetShortName(),
 		}),
-	}
+		User:                   session.GetUser(),
+		RootClient:             userClient,
+		UnsafeCachedAuthClient: s.accessPoint,
+		Parent:                 s,
+		Resources:              s.upsertSessionContext(session.GetUser()),
+		Session:                session,
+		RootClusterName:        s.clusterName,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if exists := s.insertContext(session.GetUser(), ctx); exists {
+
+	if exists := s.insertContext(session.GetUser(), scx); exists {
 		// this means that someone has just inserted the context, so
 		// close our extra context and return
-		ctx.Close()
+		scx.Close()
 	}
 
-	return ctx, nil
+	return scx, nil
 }
 
 func (s *sessionCache) tlsConfig(cert, privKey []byte) (*tls.Config, error) {

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -121,10 +121,9 @@ func (c *SessionContextConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.Log == nil {
-		c.Log = newPackageLogger().WithFields(logrus.Fields{
-			trace.Component: teleport.ComponentWeb,
-			"user":          c.User,
-			"session":       c.Session.GetShortName(),
+		c.Log = log.WithFields(logrus.Fields{
+			"user":    c.User,
+			"session": c.Session.GetShortName(),
 		})
 	}
 

--- a/lib/web/sessions_test.go
+++ b/lib/web/sessions_test.go
@@ -15,8 +15,11 @@
 package web
 
 import (
+	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -28,7 +31,7 @@ import (
 func TestRemoteClientCache(t *testing.T) {
 	t.Parallel()
 
-	openCount := 0
+	var openCount atomic.Int32
 	cache := remoteClientCache{}
 
 	sa1 := newMockRemoteSite("a")
@@ -39,19 +42,19 @@ func TestRemoteClientCache(t *testing.T) {
 	err2 := errors.New("c2")
 
 	require.NoError(t, cache.addRemoteClient(sa1, newMockClientI(&openCount, err1)))
-	require.Equal(t, 1, openCount)
+	require.Equal(t, int32(1), openCount.Load())
 
 	require.ErrorIs(t, cache.addRemoteClient(sa2, newMockClientI(&openCount, nil)), err1)
-	require.Equal(t, 1, openCount)
+	require.Equal(t, int32(1), openCount.Load())
 
 	require.NoError(t, cache.addRemoteClient(sb, newMockClientI(&openCount, err2)))
-	require.Equal(t, 2, openCount)
+	require.Equal(t, int32(2), openCount.Load())
 
 	var aggrErr trace.Aggregate
 	require.ErrorAs(t, cache.Close(), &aggrErr)
 	require.ElementsMatch(t, []error{err2}, aggrErr.Errors())
 
-	require.Zero(t, openCount)
+	require.Zero(t, openCount.Load())
 }
 
 func newMockRemoteSite(name string) reversetunnel.RemoteSite {
@@ -67,18 +70,108 @@ func (m *mockRemoteSite) GetName() string {
 	return m.name
 }
 
-func newMockClientI(openCount *int, closeErr error) auth.ClientI {
-	*openCount++
+func newMockClientI(openCount *atomic.Int32, closeErr error) auth.ClientI {
+	openCount.Add(1)
 	return &mockClientI{openCount: openCount, closeErr: closeErr}
 }
 
 type mockClientI struct {
 	auth.ClientI
-	openCount *int
+	openCount *atomic.Int32
 	closeErr  error
 }
 
 func (m *mockClientI) Close() error {
-	*m.openCount--
+	m.openCount.Add(-1)
 	return m.closeErr
+}
+
+func (m *mockClientI) GetDomainName(ctx context.Context) (string, error) {
+	return "test", nil
+}
+
+func TestGetUserClient(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	var openCount atomic.Int32
+	scx := SessionContext{
+		cfg: SessionContextConfig{
+			RootClusterName: "local",
+			newRemoteClient: func(ctx context.Context, sessionContext *SessionContext, site reversetunnel.RemoteSite) (auth.ClientI, error) {
+				return newMockClientI(&openCount, nil), nil
+			},
+		},
+	}
+
+	localSite := &mockRemoteSite{name: "local"}
+	remoteSite := &mockRemoteSite{name: "remote"}
+
+	// getting a client for the local site should return
+	// the RootClient from SessionContextConfig
+	clt, err := scx.GetUserClient(ctx, localSite)
+	require.NoError(t, err)
+	require.Nil(t, clt)
+	require.Zero(t, openCount.Load())
+
+	// getting a client a remote site for the first time
+	// should call newRemoteClient from SessionContextConfig
+	// and increment openCount
+	clt, err = scx.GetUserClient(ctx, remoteSite)
+	require.NoError(t, err)
+	require.NotNil(t, clt)
+	require.Equal(t, int32(1), openCount.Load())
+
+	// getting a client a remote site a second time
+	// should return the cached client and not call
+	// newRemoteClient from SessionContextConfig
+	clt, err = scx.GetUserClient(ctx, remoteSite)
+	require.NoError(t, err)
+	require.NotNil(t, clt)
+	require.Equal(t, int32(1), openCount.Load())
+
+	// clear the remote cache
+	require.NoError(t, scx.remoteClientCache.Close())
+	require.Zero(t, openCount.Load())
+
+	// now attempt to get the same remote site concurrently
+	// and ensure that the first request creates the client
+	// and the second request is provided the cached value
+	type result struct {
+		clt auth.ClientI
+		err error
+	}
+
+	resultCh := make(chan result, 2)
+	go func() {
+		clt, err := scx.GetUserClient(ctx, remoteSite)
+		resultCh <- result{clt: clt, err: err}
+	}()
+
+	go func() {
+		clt, err := scx.GetUserClient(ctx, remoteSite)
+		resultCh <- result{clt: clt, err: err}
+	}()
+
+	timeout := time.After(10 * time.Second)
+	clients := make([]auth.ClientI, 2)
+	for i := 0; i < 2; i++ {
+		select {
+		case res := <-resultCh:
+			require.NoError(t, res.err)
+			require.NotNil(t, res.clt)
+			clients[i] = res.clt
+		case <-timeout:
+			t.Fatalf("Timed out waiting for user client results")
+		}
+	}
+
+	// ensure that only one client was created and that
+	// both clients returned are functional
+	require.Equal(t, int32(1), openCount.Load())
+	for i := 0; i < 2; i++ {
+		domain, err := clients[i].GetDomainName(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "test", domain)
+	}
 }

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -481,15 +481,15 @@ func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.T
 		stream.Recv()
 	}()
 
-	pk, err := keys.ParsePrivateKey(t.ctx.session.GetPriv())
+	pk, err := keys.ParsePrivateKey(t.ctx.cfg.Session.GetPriv())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	key := &client.Key{
 		PrivateKey: pk,
-		Cert:       t.ctx.session.GetPub(),
-		TLSCert:    t.ctx.session.GetTLSCert(),
+		Cert:       t.ctx.cfg.Session.GetPub(),
+		TLSCert:    t.ctx.cfg.Session.GetTLSCert(),
 	}
 
 	tlsCert, err := key.TeleportTLSCertificate()


### PR DESCRIPTION
`web.SessionContext` was susceptible to races retrieving `auth.ClientI` for remote sites. The mutex on the remote client cache was not held for the duration of the `GetUserClient` which meant two simultaneous requests could find no client existed in the cache, create one and then add it to the cache. When the second client is added to the cache it would close the first client created, which results in the `use of closed network connection` error displaying on the web UI as described in #17173.

To remedy this the portion of `GetUserClient` that retrieves the remote client is now protected by a `singleflight.Group`. This ensures that races on creating a client no longer happen.

`web.SessionContext` was slightly refactored to make it easier to test, to remove some unnecessary operations, and to provide `context.Context` to `GetUserClient`. Additionally, all `web.SessionContext` variables which were named `ctx` in `lib/web` have been renamed to avoid confusion as that often refers to a `context.Context`.

Fixes #17173