### PR TITLE
uploader: move corrupted uploads to separate directory

### DIFF
--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -302,7 +302,6 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 	)
 	require.NoError(t, err)
 	s.srv = srv
-	require.NoError(t, auth.CreateUploaderDirs(nodeDir))
 	require.NoError(t, s.srv.Start())
 	return s
 }

--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -302,7 +302,7 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 	)
 	require.NoError(t, err)
 	s.srv = srv
-	require.NoError(t, auth.CreateUploaderDir(nodeDir))
+	require.NoError(t, auth.CreateUploaderDirs(nodeDir))
 	require.NoError(t, s.srv.Start())
 	return s
 }

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -21,8 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"net"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -35,7 +33,6 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/keystore"
@@ -100,18 +97,6 @@ func (cfg *TestAuthServerConfig) CheckAndSetDefaults() error {
 		}
 	}
 	return nil
-}
-
-// CreateUploaderDirs creates the directory structure for the file uploader service.
-func CreateUploaderDirs(dir string) error {
-	var errs []error
-
-	for _, dirname := range []string{events.StreamingSessionsDir, events.CorruptedSessionsDir} {
-		path := filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload, dirname, apidefaults.Namespace)
-		errs = append(errs, trace.ConvertSystemError(os.MkdirAll(path, teleport.SharedDirMode)))
-	}
-
-	return trace.NewAggregate(errs...)
 }
 
 // TestServer defines the set of server components for a test

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -102,14 +102,16 @@ func (cfg *TestAuthServerConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-// CreateUploaderDir creates directory for file uploader service
-func CreateUploaderDir(dir string) error {
-	if err := os.MkdirAll(filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, apidefaults.Namespace), teleport.SharedDirMode); err != nil {
-		return trace.ConvertSystemError(err)
+// CreateUploaderDirs creates the directory structure for the file uploader service.
+func CreateUploaderDirs(dir string) error {
+	var errs []error
+
+	for _, dirname := range []string{events.StreamingSessionsDir, events.CorruptedSessionsDir} {
+		path := filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload, dirname, apidefaults.Namespace)
+		errs = append(errs, trace.ConvertSystemError(os.MkdirAll(path, teleport.SharedDirMode)))
 	}
 
-	return nil
+	return trace.NewAggregate(errs...)
 }
 
 // TestServer defines the set of server components for a test

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -52,11 +52,17 @@ const (
 	// in /var/lib/teleport/log/sessions
 	SessionLogsDir = "sessions"
 
-	// StreamingLogsDir is a subdirectory of sessions /var/lib/teleport/log/streaming
-	// is used in new versions of the uploader. This directory is used in asynchronous
+	// StreamingSessionsDir is a subdirectory of sessions (/var/lib/teleport/log/upload/streaming)
+	// that is used in new versions of the uploader. This directory is used in asynchronous
 	// recording modes where recordings are buffered to disk before being uploaded
 	// to the auth server.
-	StreamingLogsDir = "streaming"
+	StreamingSessionsDir = "streaming"
+
+	// CorruptedSessionsDir is a subdirectory of sessions (/var/lib/teleport/log/upload/corrupted)
+	// where corrupted session recordings are placed. This ensures that the uploader doesn't
+	// continue to try to upload corrupted sessions, but preserves the recording in case it contains
+	// valuable info.
+	CorruptedSessionsDir = "corrupted"
 
 	// RecordsDir is an auth server subdirectory with session recordings that is used
 	// when the auth server is not configured for external cloud storage. It is not

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -43,6 +43,8 @@ import (
 type UploaderConfig struct {
 	// ScanDir is data directory with the uploads
 	ScanDir string
+	// CorruptedDir is the directory to store corrupted uploads in.
+	CorruptedDir string
 	// Clock is the clock replacement
 	Clock clockwork.Clock
 	// ScanPeriod is a uploader dir scan period
@@ -65,6 +67,9 @@ func (cfg *UploaderConfig) CheckAndSetDefaults() error {
 	}
 	if cfg.ScanDir == "" {
 		return trace.BadParameter("missing parameter ScanDir")
+	}
+	if cfg.CorruptedDir == "" {
+		return trace.BadParameter("missing parameter CorruptedDir")
 	}
 	if cfg.ConcurrentUploads <= 0 {
 		cfg.ConcurrentUploads = defaults.UploaderConcurrentUploads
@@ -214,6 +219,9 @@ type ScanStats struct {
 	Scanned int
 	// Started is how many uploads have been started
 	Started int
+	// Corrupted is how many corrupted uploads have been
+	// moved out of the scan dir.
+	Corrupted int
 }
 
 // Scan scans the streaming directory and uploads recordings
@@ -244,6 +252,7 @@ func (u *Uploader) Scan(ctx context.Context) (*ScanStats, error) {
 			}
 			if isSessionError(err) {
 				u.log.WithError(err).Warningf("Skipped session recording %v.", fi.Name())
+				stats.Corrupted++
 				continue
 			}
 			return nil, trace.Wrap(err)
@@ -251,7 +260,8 @@ func (u *Uploader) Scan(ctx context.Context) (*ScanStats, error) {
 		stats.Started++
 	}
 	if stats.Scanned > 0 {
-		u.log.Debugf("Scanned %v uploads, started %v in %v.", stats.Scanned, stats.Started, u.cfg.ScanDir)
+		u.log.Debugf("Scanned %v uploads, started %v, found %v corrupted in %v.",
+			stats.Scanned, stats.Started, stats.Corrupted, u.cfg.ScanDir)
 	}
 	return &stats, nil
 }
@@ -348,10 +358,24 @@ func (u *Uploader) startUpload(ctx context.Context, fileName string) error {
 		return trace.Wrap(err)
 	}
 	if isSessionError {
+		errorFilePath := u.sessionErrorFilePath(sessionID)
+		// move the corrupted recording and the error marker to a separate directory
+		// to prevent the uploader from spinning on the same corrupted upload
+		var moveErrs []error
+		if err := os.Rename(sessionFilePath, filepath.Join(u.cfg.CorruptedDir, filepath.Base(sessionFilePath))); err != nil {
+			moveErrs = append(moveErrs, trace.Wrap(err, "moving %v to %v", sessionFilePath, u.cfg.CorruptedDir))
+		}
+		if err := os.Rename(errorFilePath, filepath.Join(u.cfg.CorruptedDir, filepath.Base(errorFilePath))); err != nil {
+			moveErrs = append(moveErrs, trace.Wrap(err, "moving %v to %v", errorFilePath, u.cfg.CorruptedDir))
+		}
+		if len(moveErrs) > 0 {
+			u.log.Errorf("Failed to move corrupted recording: %v", trace.NewAggregate(moveErrs...))
+		}
+
 		return sessionError{
 			err: trace.BadParameter(
-				"session recording %v is either corrupted or is using unsupported format, remove the file %v to correct the problem, remove the %v file to retry the upload",
-				sessionID, sessionFilePath, u.sessionErrorFilePath(sessionID)),
+				"session recording %v; check the %v directory for artifacts",
+				sessionID, u.cfg.CorruptedDir),
 		}
 	}
 

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -92,6 +92,13 @@ func NewUploader(cfg UploaderConfig) (*Uploader, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	if err := os.MkdirAll(cfg.ScanDir, teleport.SharedDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	if err := os.MkdirAll(cfg.CorruptedDir, teleport.SharedDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
 	uploader := &Uploader{
 		cfg: cfg,
 		log: log.WithFields(log.Fields{

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -62,9 +62,8 @@ func TestChaosUpload(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	scanDir, err := os.MkdirTemp("", "teleport-streams")
-	require.NoError(t, err)
-	defer os.RemoveAll(scanDir)
+	scanDir := t.TempDir()
+	corruptedDir := t.TempDir()
 
 	var terminateConnection, failCreateAuditStream, failResumeAuditStream atomic.Uint64
 
@@ -113,10 +112,11 @@ func TestChaosUpload(t *testing.T) {
 
 	scanPeriod := 10 * time.Second
 	uploader, err := NewUploader(UploaderConfig{
-		ScanDir:    scanDir,
-		ScanPeriod: scanPeriod,
-		Streamer:   faultyStreamer,
-		Clock:      clock,
+		ScanDir:      scanDir,
+		CorruptedDir: corruptedDir,
+		ScanPeriod:   scanPeriod,
+		Streamer:     faultyStreamer,
+		Clock:        clock,
 	})
 	require.NoError(t, err)
 	go uploader.Serve(ctx)

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -69,9 +69,7 @@ const minUploadBytes = events.MaxProtoMessageSizeBytes * 2
 
 // NewStreamer creates a streamer sending uploads to disk
 func NewStreamer(dir string) (*events.ProtoStreamer, error) {
-	handler, err := NewHandler(Config{
-		Directory: dir,
-	})
+	handler, err := NewHandler(Config{Directory: dir})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -62,6 +62,10 @@ func (s *Config) CheckAndSetDefaults() error {
 
 // NewHandler returns new file sessions handler
 func NewHandler(cfg Config) (*Handler, error) {
+	if err := os.MkdirAll(cfg.Directory, teleport.SharedDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -802,10 +802,10 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 // async streamer buffers the events to disk and uploads the events later
 func (f *Forwarder) newStreamer(ctx *authContext) (events.Streamer, error) {
 	if services.IsRecordSync(ctx.recordingConfig.GetMode()) {
-		f.log.Debugf("Using sync streamer for session.")
+		f.log.Debug("Using sync streamer for session.")
 		return f.cfg.AuthClient, nil
 	}
-	f.log.Debugf("Using async streamer for session.")
+	f.log.Debug("Using async streamer for session.")
 	dir := filepath.Join(
 		f.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
 		events.StreamingSessionsDir, apidefaults.Namespace,

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -808,7 +808,7 @@ func (f *Forwarder) newStreamer(ctx *authContext) (events.Streamer, error) {
 	f.log.Debugf("Using async streamer for session.")
 	dir := filepath.Join(
 		f.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, apidefaults.Namespace,
+		events.StreamingSessionsDir, apidefaults.Namespace,
 	)
 	fileStreamer, err := filesessions.NewStreamer(dir)
 	if err != nil {

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -212,7 +212,16 @@ func setupTestContext(ctx context.Context, t *testing.T, cfg testConfig) *testCo
 			testCtx.kubeServer.DataDir,
 			teleport.LogsDir,
 			teleport.ComponentUpload,
-			events.StreamingLogsDir,
+			events.StreamingSessionsDir,
+			apidefaults.Namespace,
+		), os.ModePerm)
+	require.NoError(t, err)
+	err = os.MkdirAll(
+		filepath.Join(
+			testCtx.kubeServer.DataDir,
+			teleport.LogsDir,
+			teleport.ComponentUpload,
+			events.CorruptedSessionsDir,
 			apidefaults.Namespace,
 		), os.ModePerm)
 	require.NoError(t, err)

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -45,7 +44,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
-	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
 	"github.com/gravitational/teleport/lib/limiter"
@@ -204,26 +202,6 @@ func setupTestContext(ctx context.Context, t *testing.T, cfg testConfig) *testCo
 		ResourceMatchers: cfg.resourceMatchers,
 		OnReconcile:      cfg.onReconcile,
 	})
-	require.NoError(t, err)
-	// create session recording path
-	// testCtx.kubeServer.DataDir/log/upload/streaming/default
-	err = os.MkdirAll(
-		filepath.Join(
-			testCtx.kubeServer.DataDir,
-			teleport.LogsDir,
-			teleport.ComponentUpload,
-			events.StreamingSessionsDir,
-			apidefaults.Namespace,
-		), os.ModePerm)
-	require.NoError(t, err)
-	err = os.MkdirAll(
-		filepath.Join(
-			testCtx.kubeServer.DataDir,
-			teleport.LogsDir,
-			teleport.ComponentUpload,
-			events.CorruptedSessionsDir,
-			apidefaults.Namespace,
-		), os.ModePerm)
 	require.NoError(t, err)
 
 	// Waits for len(clusters) heartbeats to start

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2482,33 +2482,38 @@ func (process *TeleportProcess) initUploaderService() error {
 		return trace.Wrap(err)
 	}
 
-	// prepare dir for uploader
-	path := []string{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.StreamingLogsDir, apidefaults.Namespace}
-	for i := 1; i < len(path); i++ {
-		dir := filepath.Join(path[:i+1]...)
-		log.Infof("Creating directory %v.", dir)
-		err := os.Mkdir(dir, 0o755)
-		err = trace.ConvertSystemError(err)
-		if err != nil {
-			if !trace.IsAlreadyExists(err) {
+	// prepare directories for uploader
+	paths := [][]string{
+		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.StreamingSessionsDir, apidefaults.Namespace},
+		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.CorruptedSessionsDir, apidefaults.Namespace},
+	}
+	for _, path := range paths {
+		for i := 1; i < len(path); i++ {
+			dir := filepath.Join(path[:i+1]...)
+			log.Infof("Creating directory %v.", dir)
+			err := os.Mkdir(dir, 0o755)
+			err = trace.ConvertSystemError(err)
+			if err != nil && !trace.IsAlreadyExists(err) {
 				return trace.Wrap(err)
 			}
-		}
-		if uid != nil && gid != nil {
-			log.Infof("Setting directory %v owner to %v:%v.", dir, *uid, *gid)
-			err := os.Chown(dir, *uid, *gid)
-			if err != nil {
-				return trace.ConvertSystemError(err)
+			if uid != nil && gid != nil {
+				log.Infof("Setting directory %v owner to %v:%v.", dir, *uid, *gid)
+				err := os.Chown(dir, *uid, *gid)
+				if err != nil {
+					return trace.ConvertSystemError(err)
+				}
 			}
 		}
 	}
 
-	uploadsDir := filepath.Join(path...)
+	uploadsDir := filepath.Join(paths[0]...)
+	corruptedDir := filepath.Join(paths[1]...)
 
 	fileUploader, err := filesessions.NewUploader(filesessions.UploaderConfig{
-		Streamer: conn.Client,
-		ScanDir:  uploadsDir,
-		EventsC:  process.Config.UploadEventsC,
+		Streamer:     conn.Client,
+		ScanDir:      uploadsDir,
+		CorruptedDir: corruptedDir,
+		EventsC:      process.Config.UploadEventsC,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -27,7 +27,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -275,18 +274,6 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 
 	// Generate certificate for AWS console application.
 	s.awsConsoleCertificate = s.generateCertificate(t, s.user, "aws.example.com", "readonly")
-
-	// Make sure the upload directory is created.
-	err = os.MkdirAll(filepath.Join(
-		s.dataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingSessionsDir, defaults.Namespace,
-	), 0o755)
-	require.NoError(t, err)
-	err = os.MkdirAll(filepath.Join(
-		s.dataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.CorruptedSessionsDir, defaults.Namespace,
-	), 0o755)
-	require.NoError(t, err)
 
 	lockWatcher, err := services.NewLockWatcher(s.closeContext, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -279,7 +279,12 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	// Make sure the upload directory is created.
 	err = os.MkdirAll(filepath.Join(
 		s.dataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, defaults.Namespace,
+		events.StreamingSessionsDir, defaults.Namespace,
+	), 0o755)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(
+		s.dataDir, teleport.LogsDir, teleport.ComponentUpload,
+		events.CorruptedSessionsDir, defaults.Namespace,
 	), 0o755)
 	require.NoError(t, err)
 

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -323,7 +323,7 @@ func (s *Server) newStreamer(app types.Application, chunkID string, recConfig ty
 	s.log.Debugf("Using async streamer for session chunk %v.", chunkID)
 	uploadDir := filepath.Join(
 		s.c.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, apidefaults.Namespace,
+		events.StreamingSessionsDir, apidefaults.Namespace,
 	)
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {

--- a/lib/srv/db/streamer.go
+++ b/lib/srv/db/streamer.go
@@ -78,18 +78,25 @@ func (s *Server) newStreamer(ctx context.Context, sessionID string, recConfig ty
 	s.log.Debugf("Using async streamer for session %v.", sessionID)
 	uploadDir := filepath.Join(
 		s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		libevents.StreamingLogsDir, apidefaults.Namespace)
-	// Make sure the upload dir exists, otherwise file streamer will fail.
-	_, err := utils.StatDir(uploadDir)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
-	if trace.IsNotFound(err) {
-		s.log.Debugf("Creating upload dir %v.", uploadDir)
-		if err := os.MkdirAll(uploadDir, 0755); err != nil {
+		libevents.StreamingSessionsDir, apidefaults.Namespace)
+	corruptedDir := filepath.Join(
+		s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
+		libevents.CorruptedSessionsDir, apidefaults.Namespace)
+
+	for _, dir := range []string{uploadDir, corruptedDir} {
+		// Make sure the upload dir exists, otherwise file streamer will fail.
+		_, err := utils.StatDir(dir)
+		if err != nil && !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
+		if trace.IsNotFound(err) {
+			s.log.Debugf("Creating upload dir %v.", uploadDir)
+			if err := os.MkdirAll(uploadDir, 0755); err != nil {
+				return nil, trace.Wrap(err)
+			}
+		}
 	}
+
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/db/streamer.go
+++ b/lib/srv/db/streamer.go
@@ -18,7 +18,6 @@ package db
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 
 	"github.com/gravitational/trace"
@@ -31,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/db/common"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 // newStreamWriter creates a streamer that will be used to stream the
@@ -79,24 +77,6 @@ func (s *Server) newStreamer(ctx context.Context, sessionID string, recConfig ty
 	uploadDir := filepath.Join(
 		s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
 		libevents.StreamingSessionsDir, apidefaults.Namespace)
-	corruptedDir := filepath.Join(
-		s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		libevents.CorruptedSessionsDir, apidefaults.Namespace)
-
-	for _, dir := range []string{uploadDir, corruptedDir} {
-		// Make sure the upload dir exists, otherwise file streamer will fail.
-		_, err := utils.StatDir(dir)
-		if err != nil && !trace.IsNotFound(err) {
-			return nil, trace.Wrap(err)
-		}
-		if trace.IsNotFound(err) {
-			s.log.Debugf("Creating upload dir %v.", uploadDir)
-			if err := os.MkdirAll(uploadDir, 0755); err != nil {
-				return nil, trace.Wrap(err)
-			}
-		}
-	}
-
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -407,22 +406,6 @@ func (s *WindowsService) newStreamer(ctx context.Context, recConfig types.Sessio
 	s.cfg.Log.Debugf("using async streamer (for mode %v)", recConfig.GetMode())
 	uploadDir := filepath.Join(s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
 		libevents.StreamingSessionsDir, apidefaults.Namespace)
-	corruptedDir := filepath.Join(s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		libevents.CorruptedSessionsDir, apidefaults.Namespace)
-
-	// ensure uploader directories exist
-	for _, dir := range []string{uploadDir, corruptedDir} {
-		_, err := utils.StatDir(dir)
-		if trace.IsNotFound(err) {
-			s.cfg.Log.Debugf("Creating upload dir %v.", dir)
-			if err := os.MkdirAll(dir, 0755); err != nil {
-				return nil, trace.Wrap(err)
-			}
-		} else if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -406,17 +406,21 @@ func (s *WindowsService) newStreamer(ctx context.Context, recConfig types.Sessio
 	}
 	s.cfg.Log.Debugf("using async streamer (for mode %v)", recConfig.GetMode())
 	uploadDir := filepath.Join(s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		libevents.StreamingLogsDir, apidefaults.Namespace)
+		libevents.StreamingSessionsDir, apidefaults.Namespace)
+	corruptedDir := filepath.Join(s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
+		libevents.CorruptedSessionsDir, apidefaults.Namespace)
 
-	// ensure upload dir exists
-	_, err := utils.StatDir(uploadDir)
-	if trace.IsNotFound(err) {
-		s.cfg.Log.Debugf("Creating upload dir %v.", uploadDir)
-		if err := os.MkdirAll(uploadDir, 0755); err != nil {
+	// ensure uploader directories exist
+	for _, dir := range []string{uploadDir, corruptedDir} {
+		_, err := utils.StatDir(dir)
+		if trace.IsNotFound(err) {
+			s.cfg.Log.Debugf("Creating upload dir %v.", dir)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return nil, trace.Wrap(err)
+			}
+		} else if err != nil {
 			return nil, trace.Wrap(err)
 		}
-	} else if err != nil {
-		return nil, trace.Wrap(err)
 	}
 
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -136,6 +136,7 @@ func newMockServer(t *testing.T) *mockServer {
 
 	return &mockServer{
 		auth:        authServer,
+		datadir:     t.TempDir(),
 		MockEmitter: &eventstest.MockEmitter{},
 		clock:       clock,
 	}
@@ -143,6 +144,7 @@ func newMockServer(t *testing.T) *mockServer {
 
 type mockServer struct {
 	*eventstest.MockEmitter
+	datadir   string
 	auth      *auth.Server
 	component string
 	clock     clockwork.FakeClock
@@ -187,7 +189,7 @@ func (m *mockServer) GetAccessPoint() AccessPoint {
 
 // GetDataDir returns data directory of the server
 func (m *mockServer) GetDataDir() string {
-	return "testDataDir"
+	return m.datadir
 }
 
 // GetPAM returns PAM configuration for this server.

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -263,7 +263,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 		nodeClient,
 		serverOptions...)
 	require.NoError(t, err)
-	require.NoError(t, auth.CreateUploaderDir(nodeDir))
+	require.NoError(t, auth.CreateUploaderDirs(nodeDir))
 	require.NoError(t, sshSrv.Start())
 	t.Cleanup(func() {
 		require.NoError(t, sshSrv.Close())
@@ -1781,7 +1781,7 @@ func TestLimiter(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, srv.Start())
 
-	require.NoError(t, auth.CreateUploaderDir(nodeStateDir))
+	require.NoError(t, auth.CreateUploaderDirs(nodeStateDir))
 	defer srv.Close()
 
 	config := &ssh.ClientConfig{

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -263,7 +263,6 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 		nodeClient,
 		serverOptions...)
 	require.NoError(t, err)
-	require.NoError(t, auth.CreateUploaderDirs(nodeDir))
 	require.NoError(t, sshSrv.Start())
 	t.Cleanup(func() {
 		require.NoError(t, sshSrv.Close())
@@ -1781,7 +1780,6 @@ func TestLimiter(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, srv.Start())
 
-	require.NoError(t, auth.CreateUploaderDirs(nodeStateDir))
 	defer srv.Close()
 
 	config := &ssh.ClientConfig{

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1238,7 +1238,7 @@ func (s *session) newStreamer(ctx *ServerContext) (events.Streamer, error) {
 func sessionsStreamingUploadDir(ctx *ServerContext) string {
 	return filepath.Join(
 		ctx.srv.GetDataDir(), teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, ctx.srv.GetNamespace(),
+		events.StreamingSessionsDir, ctx.srv.GetNamespace(),
 	)
 }
 

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -101,11 +101,6 @@ func TestSession_newRecorder(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	nodeRecording, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
-		Mode: types.RecordAtNode,
-	})
-	require.NoError(t, err)
-
 	nodeRecordingSync, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
 		Mode: types.RecordAtNodeSync,
 	})
@@ -167,28 +162,6 @@ func TestSession_newRecorder(t *testing.T) {
 				_, ok := i.(*events.DiscardStream)
 				require.True(t, ok)
 			},
-		},
-		{
-			desc: "err-new-streamer-fails",
-			sess: &session{
-				id:  "test",
-				log: logger,
-				registry: &SessionRegistry{
-					SessionRegistryConfig: SessionRegistryConfig{
-						Srv: &mockServer{
-							component: teleport.ComponentNode,
-						},
-					},
-				},
-			},
-			sctx: &ServerContext{
-				SessionRecordingConfig: nodeRecording,
-				srv: &mockServer{
-					component: teleport.ComponentNode,
-				},
-			},
-			errAssertion: require.Error,
-			recAssertion: require.Nil,
 		},
 		{
 			desc: "strict-err-new-audit-writer-fails",

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -290,7 +290,6 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	s.node = node
 	s.srvID = node.ID()
 	require.NoError(t, s.node.Start())
-	require.NoError(t, auth.CreateUploaderDirs(nodeDataDir))
 
 	// create reverse tunnel service:
 	proxyID := "proxy"
@@ -6052,7 +6051,6 @@ func newWebPack(t *testing.T, numProxies int) *webPack {
 
 	require.NoError(t, node.Start())
 	t.Cleanup(func() { require.NoError(t, node.Close()) })
-	require.NoError(t, auth.CreateUploaderDirs(nodeDataDir))
 
 	var proxies []*testProxy
 	for p := 0; p < numProxies; p++ {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -290,7 +290,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	s.node = node
 	s.srvID = node.ID()
 	require.NoError(t, s.node.Start())
-	require.NoError(t, auth.CreateUploaderDir(nodeDataDir))
+	require.NoError(t, auth.CreateUploaderDirs(nodeDataDir))
 
 	// create reverse tunnel service:
 	proxyID := "proxy"
@@ -6052,7 +6052,7 @@ func newWebPack(t *testing.T, numProxies int) *webPack {
 
 	require.NoError(t, node.Start())
 	t.Cleanup(func() { require.NoError(t, node.Close()) })
-	require.NoError(t, auth.CreateUploaderDir(nodeDataDir))
+	require.NoError(t, auth.CreateUploaderDirs(nodeDataDir))
 
 	var proxies []*testProxy
 	for p := 0; p < numProxies; p++ {


### PR DESCRIPTION
This ensures that the uploader won't busy loop over the same corrupted upload file, while ensuring that the file is still preserved.

Fixes #18936
Fixes #8173