### PR TITLE
[v9] docs: Add warnings about using layer 7 LBs with TLS routing

### DIFF
--- a/docs/pages/architecture/tls-routing.mdx
+++ b/docs/pages/architecture/tls-routing.mdx
@@ -25,6 +25,17 @@ To implement TLS routing, Teleport uses SNI ([Server Name Indication](https://en
 and ALPN ([Application-Level Protocol Negotiation](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation))
 TLS extensions.
 
+<Admonition
+  type="warning"
+  title="TLS routing is incompatible with layer 7 load balancers and reverse proxies"
+>
+TLS routing will not work in environments where layer 7 load balancers or reverse proxies are used. See further information in the [When to use TLS routing](#when-to-use-tls-routing) section below.
+</Admonition>
+
+## When to use TLS routing
+
+(!docs/pages/includes/tls-multiplexing-warnings.mdx!)
+
 ## How it works
 
 Starting from version `8.0` Teleport proxy listens for all client connections

--- a/docs/pages/includes/tls-multiplexing-warnings.mdx
+++ b/docs/pages/includes/tls-multiplexing-warnings.mdx
@@ -1,0 +1,26 @@
+Using Teleport's TLS routing mode behind a layer 7 (HTTP/HTTPS) proxy is generally not supported, due to
+these proxies terminating TLS themselves and then rewriting their requests to the upstream service, stripping
+the additional SNI/ALPN parts of the request in the process. In order for ALPN to work correctly, the Teleport
+proxy must terminate TLS itself.
+
+Broadly, this means that Teleport's TLS routing functionality is incompatible with:
+- AWS ALBs (Application Load Balancers)
+- AWS NLBs (Network Load Balancers), when using a TLS listener and a public ACM (Amazon Certificate Manager) certificate
+- Commonly used HTTP reverse proxies including nginx, Apache, Caddy, Traefik, HAProxy and many others
+- Cloudflare tunnels in their default configuration
+
+Deploying Teleport in TLS routing mode behind an HTTP proxy will result in a Teleport Web UI experience that seems
+to work perfectly, but the use of `tsh`, `tctl` and attempting to join remote Teleport services to the cluster will fail
+with errors like `ssh: overflow reading version string` and `EOF`. A functioning Teleport Web UI is not always an indication
+of a correctly configured Teleport cluster.
+
+If in doubt, remove all load balancers/proxies from the equation and connect Teleport clients or agent processes directly to
+Teleport's web port to isolate the issue.
+
+To use Teleport behind a reverse proxy, you should either:
+- use a layer 4 (TCP) proxy which forwards TCP streams directly to Teleport (which will in turn handle TLS termination itself)
+- disable Teleport's TLS routing mode by adding `version: v1` to your config file and removing `proxy_listener_mode: multiplex`
+ 
+You can get an example `v1` config file using `teleport configure --version=v1 --public-addr=teleport.example.com:443` (change the public address to your own domain)
+
+If disabling TLS routing, you can find the list of default ports to use for connecting different Teleport services at [ports without TLS routing](../reference/networking.mdx#ports-without-tls-routing)

--- a/docs/pages/includes/tls-multiplexing-warnings.mdx
+++ b/docs/pages/includes/tls-multiplexing-warnings.mdx
@@ -20,7 +20,7 @@ Teleport's web port to isolate the issue.
 To use Teleport behind a reverse proxy, you should either:
 - use a layer 4 (TCP) proxy which forwards TCP streams directly to Teleport (which will in turn handle TLS termination itself)
 - disable Teleport's TLS routing mode by adding `version: v1` to your config file and removing `proxy_listener_mode: multiplex`
- 
+
 You can get an example `v1` config file using `teleport configure --version=v1 --public-addr=teleport.example.com:443` (change the public address to your own domain)
 
-If disabling TLS routing, you can find the list of default ports to use for connecting different Teleport services at [ports without TLS routing](../reference/networking.mdx#ports-without-tls-routing)
+If disabling TLS routing, you can find the list of default ports to use for connecting different Teleport services in the [ports reference](../setup/reference/networking.mdx#ports)

--- a/docs/pages/setup/admin/troubleshooting.mdx
+++ b/docs/pages/setup/admin/troubleshooting.mdx
@@ -119,11 +119,11 @@ command:
 
 ```code
 $ tctl status
-Cluster  mytenant.teleport.sh                                          
-Version  (=cloud.version=)                                                                   
-Host CA  never updated                                                           
-User CA  never updated                                                           
-Jwt CA   never updated                                                           
+Cluster  mytenant.teleport.sh
+Version  (=cloud.version=)
+Host CA  never updated
+User CA  never updated
+Jwt CA   never updated
 CA pin   (=presets.ca_pin=)
 ```
 
@@ -171,19 +171,23 @@ purposes and seeing it within your logs is not necessarily an indication that
 anything is incorrect.
 
 Firstly, Teleport uses this value within certificates (as a DNS Subject
-Alternative Name) issued to the Auth and Proxy Service. Teleport clients can 
-then use this value to validate the service's certificates during the TLS 
-handshake regardless of the service address as long as the client already has a 
+Alternative Name) issued to the Auth and Proxy Service. Teleport clients can
+then use this value to validate the service's certificates during the TLS
+handshake regardless of the service address as long as the client already has a
 copy of the cluster's certificate authorities. This is important as there are
 often multiple different ways that a client can connect to the Auth Service and
 these are not always via the same address.
 
-Secondly, this value is used by clients as part of the URL when making gRPC or 
+Secondly, this value is used by clients as part of the URL when making gRPC or
 HTTP requests to the Teleport API. This is because the Teleport API client uses
 special logic to open the connection to the Auth Service to make the request,
-rather than connecting to a single address as a typical client may do. This 
-special logic is necessary for the client to be able to support connecting to a 
-list of Auth Services or to be able to connect to the Auth Service through a 
-tunnel via the Proxy Service. This means that `teleport.cluster.local` appears 
-in log messages that show the URL of a request made to the Auth Service, and 
+rather than connecting to a single address as a typical client may do. This
+special logic is necessary for the client to be able to support connecting to a
+list of Auth Services or to be able to connect to the Auth Service through a
+tunnel via the Proxy Service. This means that `teleport.cluster.local` appears
+in log messages that show the URL of a request made to the Auth Service, and
 does not explicitly indicate that something is misconfigured.
+
+## `ssh: overflow reading version string`
+
+(!docs/pages/includes/tls-multiplexing-warnings.mdx!)

--- a/docs/pages/setup/operations/tls-routing.mdx
+++ b/docs/pages/setup/operations/tls-routing.mdx
@@ -15,7 +15,7 @@ description: How to upgrade an existing Teleport cluster to single-port TLS rout
 
 <Admonition scope={["cloud"]} type="tip" scopeOnly>
 
-Teleport Cloud manages the Proxy Service's networking configuration for you. 
+Teleport Cloud manages the Proxy Service's networking configuration for you.
 
 To see which ports and networking settings the Proxy Service is configured to
 use in your Teleport Cloud tenant, run the following command, replacing
@@ -24,8 +24,6 @@ use in your Teleport Cloud tenant, run the following command, replacing
 ```code
 $ curl https://mytenant.teleport.sh/webapi/ping | jq '.proxy'
 ```
-
-TLS routing is not currently supported in Teleport Cloud.
 
 </Admonition>
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/18823 to branch/v9