### PR TITLE
Edit the Database Access introduction

### DIFF
--- a/docs/pages/database-access/introduction.mdx
+++ b/docs/pages/database-access/introduction.mdx
@@ -8,24 +8,11 @@ access control and visibility.
 
 Some of the things you can do with Database Access:
 
-- Users can retrieve short-lived database certificates using a Single Sign-On
+- Enable users to retrieve short-lived database certificates using a Single Sign-On
   flow, thus maintaining their organization-wide identity.
 - Configure role-based access controls for databases and implement custom
   [Access Request](../access-controls/access-requests.mdx) workflows.
 - Capture database activity in the Teleport audit log.
-
-Database Access currently supports the following databases:
-
-- CockroachDB
-- Elasticsearch
-- MariaDB
-- Microsoft SQL Server
-- MongoDB
-- MySQL
-- PostgreSQL
-- Redis
-- Cassandra
-- ScyllaDB
 
 ## Demo
 

--- a/docs/pages/includes/database-access/guides.mdx
+++ b/docs/pages/includes/database-access/guides.mdx
@@ -1,4 +1,4 @@
-## Database guides
+## How to connect your database to Teleport 
 
 - [Active Directory SQL Server (Preview)](../../database-access/guides/sql-server-ad.mdx): Connect Microsoft SQL Server with Active Directory authentication.
 - [AWS DynamoDB](../../database-access/guides/dynamodb.mdx): Connect AWS DynamoDB database.


### PR DESCRIPTION
Closes #17092

The Database Access introduction lists the databases that Teleport supports, but also includes a list of links to all of our Database Access guides.

So we don't have to maintain two separate lists, I have removed the first list of supported databases.

I have also edited the heading of the section that lists our database-specific guides so it's clearer that they are about specific databases.