### PR TITLE
Add the `tsh device enroll` command

### DIFF
--- a/tool/tsh/device.go
+++ b/tool/tsh/device.go
@@ -1,0 +1,91 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/gravitational/kingpin"
+	"github.com/gravitational/trace"
+
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/devicetrust"
+	"github.com/gravitational/teleport/lib/devicetrust/enroll"
+)
+
+type deviceCommand struct {
+	enroll *deviceEnrollCommand
+}
+
+func newDeviceCommand(app *kingpin.Application) *deviceCommand {
+	root := &deviceCommand{
+		enroll: &deviceEnrollCommand{},
+	}
+
+	// "tsh device" command.
+	parentCmd := app.Command(
+		"device", "Manage your device. Requires Teleport Enterprise.")
+
+	// "tsh device enroll" command.
+	root.enroll.CmdClause = parentCmd.Command(
+		"enroll", "Enroll your device as a trusted device. Requires Teleport Enteprise")
+	root.enroll.Flag("token", "Device enrollment token").
+		Required().
+		StringVar(&root.enroll.token)
+
+	return root
+}
+
+type deviceEnrollCommand struct {
+	*kingpin.CmdClause
+
+	token string
+}
+
+func (c *deviceEnrollCommand) run(cf *CLIConf) error {
+	teleportClient, err := makeClient(cf, true /* useProfileLogin */)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var dev *devicepb.Device
+	ctx := cf.Context
+	if err := client.RetryWithRelogin(ctx, teleportClient, func() error {
+		proxyClient, err := teleportClient.ConnectToProxy(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer proxyClient.Close()
+
+		authClient, err := proxyClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer authClient.Close()
+
+		devices := authClient.DevicesClient()
+		dev, err = enroll.RunCeremony(ctx, devices, c.token)
+		return trace.Wrap(err)
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf(
+		"Device %q/%v enrolled\n",
+		dev.AssetTag, devicetrust.FriendlyOSType(dev.OsType),
+	)
+	return nil
+}

--- a/tool/tsh/device.go
+++ b/tool/tsh/device.go
@@ -41,7 +41,7 @@ func newDeviceCommand(app *kingpin.Application) *deviceCommand {
 
 	// "tsh device enroll" command.
 	root.enroll.CmdClause = parentCmd.Command(
-		"enroll", "Enroll your device as a trusted device. Requires Teleport Enteprise")
+		"enroll", "Enroll your device as a trusted device. Requires Teleport Enterprise")
 	root.enroll.Flag("token", "Device enrollment token").
 		Required().
 		StringVar(&root.enroll.token)

--- a/tool/tsh/device.go
+++ b/tool/tsh/device.go
@@ -37,11 +37,11 @@ func newDeviceCommand(app *kingpin.Application) *deviceCommand {
 
 	// "tsh device" command.
 	parentCmd := app.Command(
-		"device", "Manage your device. Requires Teleport Enterprise.")
+		"device", "Manage this device. Requires Teleport Enterprise.")
 
 	// "tsh device enroll" command.
 	root.enroll.CmdClause = parentCmd.Command(
-		"enroll", "Enroll your device as a trusted device. Requires Teleport Enterprise")
+		"enroll", "Enroll this device as a trusted device. Requires Teleport Enterprise")
 	root.enroll.Flag("token", "Device enrollment token").
 		Required().
 		StringVar(&root.enroll.token)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -845,6 +845,9 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 
 	webauthnwin := newWebauthnwinCommand(app)
 
+	// Device Trust commands.
+	deviceCmd := newDeviceCommand(app)
+
 	if runtime.GOOS == constants.WindowsOS {
 		bench.Hidden()
 	}
@@ -1087,6 +1090,8 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 		err = tid.diag.run(&cf)
 	case webauthnwin.diag.FullCommand():
 		err = webauthnwin.diag.run(&cf)
+	case deviceCmd.enroll.FullCommand():
+		err = deviceCmd.enroll.run(&cf)
 	default:
 		// Handle commands that might not be available.
 		switch {


### PR DESCRIPTION
Wire the device enrollment ceremony, implemented by lib/devicetrust/enroll, to `tsh`.

https://github.com/gravitational/teleport.e/issues/514