### PR TITLE
Fix a link with a long redirect chain

### DIFF
--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -13,8 +13,9 @@ Teleport, and includes links to more detailed documentation at the end.
 
 ### tsh
 
-`tsh` lets you authenticate to Teleport and list and connect to resources. After [downloading](https://goteleport.com/downloads)
-and installing `tsh`, sign in to your Teleport cluster:
+`tsh` lets you authenticate to Teleport and list and connect to resources. After
+[downloading](https://goteleport.com/download/) and installing `tsh`, sign in to
+your Teleport cluster:
 
 <Tabs>
 <TabItem label="Local user">


### PR DESCRIPTION
One link to the Teleport Downloads page in the Connect your Client section introduction was being redirected multiple times. This change fixes the link.