### PR TITLE
Return user-friendly messages for common enroll errors

### DIFF
--- a/lib/devicetrust/enroll/enroll.go
+++ b/lib/devicetrust/enroll/enroll.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gravitational/trace"
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	"github.com/gravitational/teleport/lib/devicetrust"
 	"github.com/gravitational/teleport/lib/devicetrust/native"
 )
 
@@ -33,6 +34,14 @@ var (
 
 // RunCeremony performs the client-side device enrollment ceremony.
 func RunCeremony(ctx context.Context, devicesClient devicepb.DeviceTrustServiceClient, enrollToken string) (*devicepb.Device, error) {
+	dev, err := runCeremony(ctx, devicesClient, enrollToken)
+	if err != nil {
+		return nil, trace.Wrap(devicetrust.HandleUnimplemented(err))
+	}
+	return dev, err
+}
+
+func runCeremony(ctx context.Context, devicesClient devicepb.DeviceTrustServiceClient, enrollToken string) (*devicepb.Device, error) {
 	// Start by checking the OSType, this lets us exit early with a nicer message
 	// for non-supported OSes.
 	if getOSType() != devicepb.OSType_OS_TYPE_MACOS {

--- a/lib/devicetrust/errors.go
+++ b/lib/devicetrust/errors.go
@@ -1,0 +1,40 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicetrust
+
+import (
+	"errors"
+
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// HandleUnimplemented turns remote unimplemented errors to a more user-friendly
+// error.
+func HandleUnimplemented(err error) error {
+	for e := err; e != nil; {
+		switch s, ok := status.FromError(e); {
+		case ok && s.Code() == codes.Unimplemented:
+			log.WithError(err).Debug("Device Trust: interpreting error as OSS or older Enterprise cluster")
+			return errors.New("device trust not supported by remote cluster")
+		case ok:
+			return err // Unexpected status error.
+		default:
+			e = errors.Unwrap(e)
+		}
+	}
+	return err
+}

--- a/lib/devicetrust/errors_test.go
+++ b/lib/devicetrust/errors_test.go
@@ -1,0 +1,70 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicetrust_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/gravitational/teleport/lib/devicetrust"
+)
+
+func TestHandleUnimplemented(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantChanged bool
+	}{
+		{
+			name: "unrelated err",
+			err:  errors.New("something bad"),
+		},
+		{
+			name: "trace.NotImplemented",
+			err:  trace.NotImplemented("not implemented"), // ignored, we want a gRPC not implemented error.
+		},
+		{
+			name:        "status with codes.Unimplemented",
+			err:         status.Errorf(codes.Unimplemented, "method not implemented"),
+			wantChanged: true,
+		},
+		{
+			name:        "wrapped status with codes.Unimplemented",
+			err:         trace.Wrap(fmt.Errorf("wrapped: %w", status.Errorf(codes.Unimplemented, "method not implemented"))),
+			wantChanged: true,
+		},
+		{
+			name: "unrelated status error",
+			err:  status.Errorf(codes.InvalidArgument, "llamas required"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := devicetrust.HandleUnimplemented(test.err)
+			if test.wantChanged {
+				assert.ErrorContains(t, got, "device trust not supported")
+			} else {
+				assert.Equal(t, test.err, got,
+					"HandleUnimplemented returned a modified error, wanted the same as the original")
+			}
+		})
+	}
+}

--- a/lib/devicetrust/native/status_error.go
+++ b/lib/devicetrust/native/status_error.go
@@ -34,7 +34,7 @@ type statusError struct {
 func (e *statusError) Error() string {
 	switch e.status {
 	case errSecItemNotFound:
-		return "device key not found"
+		return "device key not found, was the device enrolled?"
 	case errSecMissingEntitlement:
 		return "binary missing signature or entitlements, download the client binaries from https://goteleport.com/download/"
 	default:

--- a/lib/devicetrust/native/status_error.go
+++ b/lib/devicetrust/native/status_error.go
@@ -1,0 +1,43 @@
+//go:build darwin
+
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package native
+
+import "fmt"
+
+const (
+	// https://www.osstatus.com/search/results?framework=Security&search=-25300
+	errSecItemNotFound = -25300
+	// https://www.osstatus.com/search/results?framework=Security&search=-34018
+	errSecMissingEntitlement = -34018
+)
+
+// statusError represents a native error that contains a status code, typically
+// an OSStatus value.
+type statusError struct {
+	status int32
+}
+
+func (e *statusError) Error() string {
+	switch e.status {
+	case errSecItemNotFound:
+		return "device key not found"
+	case errSecMissingEntitlement:
+		return "binary missing signature or entitlements, download the client binaries from https://goteleport.com/download/"
+	default:
+		return fmt.Sprintf("status %d", e.status)
+	}
+}


### PR DESCRIPTION
Handle a few common macOS errors, as well as gRPC unimplemented errors, and return more user-friendly messages in their place.

https://github.com/gravitational/teleport.e/issues/514