### PR TITLE
Properly escape maps in log entries

### DIFF
--- a/lib/utils/formatter.go
+++ b/lib/utils/formatter.go
@@ -326,7 +326,7 @@ func (w *writer) writeMap(m map[string]interface{}) {
 			continue
 		}
 		switch value := m[key].(type) {
-		case log.Fields:
+		case map[string]interface{}:
 			w.writeMap(value)
 		default:
 			w.writeKeyValue(key, value)

--- a/lib/utils/formatter.go
+++ b/lib/utils/formatter.go
@@ -312,7 +312,7 @@ func (w *writer) writeValue(value interface{}, color int) {
 	w.WriteString(s)
 }
 
-func (w *writer) writeMap(m map[string]interface{}) {
+func (w *writer) writeMap(m map[string]any) {
 	if len(m) == 0 {
 		return
 	}
@@ -326,7 +326,9 @@ func (w *writer) writeMap(m map[string]interface{}) {
 			continue
 		}
 		switch value := m[key].(type) {
-		case map[string]interface{}:
+		case map[string]any:
+			w.writeMap(value)
+		case log.Fields:
 			w.writeMap(value)
 		default:
 			w.writeKeyValue(key, value)


### PR DESCRIPTION
### Purpose

Properly escape strings in log entries when the strings are inside maps. Fixes https://github.com/gravitational/teleport-private/issues/183.

### Implementation

Check for the proper type (map[string]interface{}) in the log writer.

Output log before:

```
2022-12-05T15:05:36-06:00 INFO [AUDIT]     cert.create cert_type:user cluster_name:tele.example.org code:TC000I ei:0 event:cert.create identity:map[expires:2022-12-06T08:56:08.00141Z logins:[-teleport-nologin-99eba9e0-4d5e-437f-b975-63d52a0d978b -teleport-internal-join] roles:[access editor auditor] route_to_cluster:Samuels-MBP.localdomain route_to_database:map[protocol:redis service_name:teleport username:
2022-09-02T12:33:21+02:00 INFO [AUDIT]     This is a fake log entry.] teleport_cluster:Samuels-MBP.localdomain traits:map[logins:<nil>] usage:[usage:db] user:sfreiberg] time:2022-12-05T21:05:36.378Z uid:02366e4b-7b21-458b-9554-84e6c3c86863 events/emitter.go:265
```

Notice the user supplied newline causes it to look like the fake log entry is real.

Output log after:

```
2022-12-07T10:05:16-06:00 INFO [AUDIT]     cert.create cert_type:user cluster_name:tele.example.org code:TC000I ei:0 event:cert.create expires:2022-12-08T04:03:29.001357Z logins:[-teleport-nologin-8518a6a1-2f5a-4c1e-aeb0-6d96c9b457f2 -teleport-internal-join] roles:[access editor auditor] route_to_cluster:Samuels-MBP.localdomain protocol:redis service_name:teleport username:"\n2022-09-02T12:33:21+02:00 INFO [AUDIT]     This is a fake log entry." teleport_cluster:Samuels-MBP.localdomain logins:<nil> usage:[usage:db] user:sfreiberg time:2022-12-07T16:05:16.377Z uid:08f24c30-7c2f-4ab7-b1c9-eebaa86d4d95 events/emitter.go:265
```