### PR TITLE
[v10] Update Go to 1.19.4

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ name: push-build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
   UID: "1000"
 trigger:
   event:
@@ -152,7 +152,7 @@ name: push-build-linux-386
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
   UID: "1000"
 trigger:
   event:
@@ -257,7 +257,7 @@ name: push-build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
   UID: "1000"
 trigger:
   event:
@@ -366,7 +366,7 @@ name: push-build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
   UID: "1000"
 trigger:
   event:
@@ -533,7 +533,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.18.9
+    RUNTIME: go1.19.4
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -1114,7 +1114,7 @@ name: push-build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
   UID: "1000"
 trigger:
   event:
@@ -1219,7 +1219,7 @@ name: push-build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
   UID: "1000"
 trigger:
   event:
@@ -1660,7 +1660,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
 trigger:
   event:
     include:
@@ -1849,7 +1849,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
 trigger:
   event:
     include:
@@ -2037,7 +2037,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
 trigger:
   event:
     include:
@@ -2238,7 +2238,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
 trigger:
   event:
     include:
@@ -3452,7 +3452,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
 trigger:
   event:
     include:
@@ -4212,7 +4212,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.18.9
+    RUNTIME: go1.19.4
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -4783,7 +4783,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
 trigger:
   event:
     include:
@@ -4969,7 +4969,7 @@ type: kubernetes
 name: build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
 trigger:
   event:
     include:
@@ -6183,7 +6183,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.18.9
+  RUNTIME: go1.19.4
 trigger:
   event:
     include:
@@ -18264,6 +18264,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: a1b56ad487d98821ff1b5f7b8441e094ba840c85c0af2e1a6b7c299714d4132b
+hmac: 4465f8038b3e6d86e2f5050f5cd2407ab02c26ed91dae95a952186ba3e8d3f5b
 
 ...

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/api
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -34,9 +34,6 @@ ENV LANGUAGE=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LC_CTYPE=en_US.UTF-8
 
-ARG BORINGCRYPTO_RUNTIME
-ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
-
 ARG UID
 ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
@@ -70,22 +67,17 @@ RUN yum groupinstall -y 'Development Tools' && \
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
-# BoringCrypto (unlike regular Go) requires glibc 2.14, so we have to build from source.
-# 1) Install older binary Go runtime for bootstrapping
-# 2) Get source for the correct Go boringcrypto runtime and compile it with Go bootstrap runtime
-# 3) Erase Go bootstrap runtime and create build directories
-# 4) Print compiled Go version
-RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
-    mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${BORINGCRYPTO_RUNTIME}.src.tar.gz | tar xz && \
-    cd /opt/go/src && GOROOT_BOOTSTRAP=/go-bootstrap/go ./make.bash && \
-    rm -rf /go-bootstrap && \
+# Install Go.
+ARG GOLANG_VERSION
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-amd64.tar.gz | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
     chmod a-w / && \
     /opt/go/bin/go version
 
-ENV GOPATH="/go" \
+ENV GOEXPERIMENT=boringcrypto \
+    GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="/opt/llvm/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -56,13 +56,14 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # Install Go.
-ARG BORINGCRYPTO_RUNTIME
-RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${BORINGCRYPTO_RUNTIME}.linux-amd64.tar.gz | tar xz && \
+ARG GOLANG_VERSION
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-amd64.tar.gz | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
     chmod a-w /
-ENV GOPATH="/go" \
+ENV GOEXPERIMENT=boringcrypto \
+    GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -21,7 +21,7 @@ TEST_KUBE ?=
 
 OS ?= linux
 ARCH ?= amd64
-GOLANG_VERSION ?= go1.18.9
+GOLANG_VERSION ?= go1.19.4
 RUST_VERSION ?= 1.63.0 # don't bump this without checking GLIBC compatibility
 NODE_VERSION ?= 16.13.2
 BORINGCRYPTO_RUNTIME=$(GOLANG_VERSION)b7

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -24,7 +24,6 @@ ARCH ?= amd64
 GOLANG_VERSION ?= go1.19.4
 RUST_VERSION ?= 1.63.0 # don't bump this without checking GLIBC compatibility
 NODE_VERSION ?= 16.13.2
-BORINGCRYPTO_RUNTIME=$(GOLANG_VERSION)b7
 LIBBPF_VERSION ?= 0.7.0-teleport
 
 UID := $$(id -u)
@@ -143,7 +142,7 @@ buildbox-fips:
 		docker build \
 			--build-arg UID=$(UID) \
 			--build-arg GID=$(GID) \
-			--build-arg BORINGCRYPTO_RUNTIME=$(BORINGCRYPTO_RUNTIME) \
+			--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 			--cache-from $(BUILDBOX_FIPS) \
 			--tag $(BUILDBOX_FIPS) -f Dockerfile-fips . ; \
@@ -175,7 +174,7 @@ buildbox-centos7-fips:
 	docker build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
-		--build-arg BORINGCRYPTO_RUNTIME=$(BORINGCRYPTO_RUNTIME) \
+		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--cache-from $(BUILDBOX_CENTOS7_FIPS) \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/firestore v1.6.1


### PR DESCRIPTION
Update the v10 branches to the latest Go minor release.

FIPS image changes cloned from https://github.com/gravitational/teleport/pull/16479.