### PR TITLE
Bump Buf to v1.10.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -223,7 +223,7 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1 && \
 
 # Install buf
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.9.0" && \
+    VERSION="1.10.0" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Bump Buf to the latest version (housekeeping so we keep up with the releases). No lint/format/generate changes.

See https://github.com/bufbuild/buf/releases/tag/v1.10.0.