### PR TITLE
Add `tsh device` debug commands

### DIFF
--- a/lib/devicetrust/native/api.go
+++ b/lib/devicetrust/native/api.go
@@ -34,3 +34,8 @@ func CollectDeviceData() (*devicepb.DeviceCollectedData, error) {
 func SignChallenge(chal []byte) (sig []byte, err error) {
 	return signChallenge(chal)
 }
+
+// GetDeviceCredential returns the current device credential, if it exists.
+func GetDeviceCredential() (*devicepb.DeviceCredential, error) {
+	return getDeviceCredential()
+}

--- a/lib/devicetrust/native/others.go
+++ b/lib/devicetrust/native/others.go
@@ -37,3 +37,7 @@ func collectDeviceData() (*devicepb.DeviceCollectedData, error) {
 func signChallenge(chal []byte) (sig []byte, err error) {
 	return nil, errPlatformNotSupported
 }
+
+func getDeviceCredential() (*devicepb.DeviceCredential, error) {
+	return nil, errPlatformNotSupported
+}

--- a/lib/devicetrust/native/status_error.go
+++ b/lib/devicetrust/native/status_error.go
@@ -34,6 +34,10 @@ type statusError struct {
 func (e *statusError) Error() string {
 	switch e.status {
 	case errSecItemNotFound:
+		// errSecItemNotFound can also occur because of an unsigned binary - it
+		// cannot read the correct key, so it appears the same as not finding any.
+		// TODO(codingllama): Consider adding a signature check to client-side
+		//  Device Trust, like lib/auth/touchid.
 		return "device key not found, was the device enrolled?"
 	case errSecMissingEntitlement:
 		return "binary missing signature or entitlements, download the client binaries from https://goteleport.com/download/"

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1092,6 +1092,10 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 		err = webauthnwin.diag.run(&cf)
 	case deviceCmd.enroll.FullCommand():
 		err = deviceCmd.enroll.run(&cf)
+	case deviceCmd.collect.FullCommand():
+		err = deviceCmd.collect.run(&cf)
+	case deviceCmd.keyget.FullCommand():
+		err = deviceCmd.keyget.run(&cf)
 	default:
 		// Handle commands that might not be available.
 		switch {


### PR DESCRIPTION
Add `tsh device collect` and `tsh device keyget`, which are useful to debug device trust functionality.

https://github.com/gravitational/teleport.e/issues/514
