### PR TITLE
Support tctl auth sign --format=windows

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5160,7 +5160,8 @@ func (a *ServerWithRoles) checkAccessToWindowsDesktop(w types.WindowsDesktop) er
 // authentication.
 func (a *ServerWithRoles) GenerateWindowsDesktopCert(ctx context.Context, req *proto.WindowsDesktopCertRequest) (*proto.WindowsDesktopCertResponse, error) {
 	// Only windows_desktop_service should be requesting Windows certificates.
-	if !a.hasBuiltinRole(types.RoleWindowsDesktop) {
+	// (We also allow RoleAdmin for tctl auth sign)
+	if !a.hasBuiltinRole(types.RoleWindowsDesktop, types.RoleAdmin) {
 		return nil, trace.AccessDenied("access denied")
 	}
 	return a.authServer.GenerateWindowsDesktopCert(ctx, req)

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -182,6 +182,10 @@ func TestWriteAllFormats(t *testing.T) {
 		t.Run(string(format), func(t *testing.T) {
 			key := newClientKey(t)
 
+			key.WindowsDesktopCerts = map[string][]byte{
+				"windows-user": []byte("cert data"),
+			}
+
 			cfg := WriteConfig{
 				OutputPath: path.Join(t.TempDir(), "identity"),
 				Key:        key,


### PR DESCRIPTION
User certs for desktop access are only valid for a few minutes and are never written to disk. This can make it difficult to troubleshoot cert validity.

This commit adds support for generating Windows user certificates which can be exported to the Windows environment for validation.

Note: at this time, we only write the certificate and not the corresponding private key, making it impossible to use the generated cert for any real purpose.