### PR TITLE
[v9] Eventually require connection failure in TestWSSCertExpiration tests.

### DIFF
--- a/integration/app_integration_test.go
+++ b/integration/app_integration_test.go
@@ -190,13 +190,12 @@ func TestWSSLock(t *testing.T) {
 
 	// Try to read for a short amount of time.
 	require.Eventually(t, func() bool {
+		// These are closed outside of the scope of this function.
+		//nolint:bodyclose
 		conn, httpResponse, err = dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
-		require.NoError(t, err)
 		if err != nil {
 			return false
 		}
-
-		// Try to read
 
 		// Read, write, and read again to make sure its working as expected.
 		stream = &web.WebsocketIO{Conn: conn}
@@ -243,7 +242,13 @@ func TestWSSLock(t *testing.T) {
 	_ = conn.Close()
 
 	require.Eventually(t, func() bool {
+		// These are closed outside of the scope of this function.
+		//nolint:bodyclose
 		conn, httpResponse, err = dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
+		if err == nil {
+			conn.Close()
+			httpResponse.Body.Close()
+		}
 		return err != nil
 	}, time.Second*5, time.Millisecond*100)
 
@@ -290,13 +295,12 @@ func TestWSSCertExpiration(t *testing.T) {
 
 	// Try to read for a short amount of time.
 	require.Eventually(t, func() bool {
+		// These are closed outside of the scope of this function.
+		//nolint:bodyclose
 		conn, httpResponse, err = dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
-		require.NoError(t, err)
 		if err != nil {
 			return false
 		}
-
-		// Try to read
 
 		// Read, write, and read again to make sure its working as expected.
 		stream = &web.WebsocketIO{Conn: conn}
@@ -343,7 +347,13 @@ func TestWSSCertExpiration(t *testing.T) {
 	_ = conn.Close()
 
 	require.Eventually(t, func() bool {
+		// These are closed outside of the scope of this function.
+		//nolint:bodyclose
 		conn, httpResponse, err = dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
+		if err == nil {
+			conn.Close()
+			httpResponse.Body.Close()
+		}
 		return err != nil
 	}, time.Second*5, time.Millisecond*100)
 

--- a/integration/app_integration_test.go
+++ b/integration/app_integration_test.go
@@ -159,7 +159,7 @@ func TestAppAccessWebsockets(t *testing.T) {
 // TestWSSLock tests locks with WSS connections.
 func TestWSSLock(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(time.Now())
-	mCloseChannel := make(chan struct{})
+	mCloseChannel := make(chan struct{}, 1)
 
 	pack := setupWithOptions(t, appTestOptions{
 		clock:               clock,
@@ -180,21 +180,41 @@ func TestWSSLock(t *testing.T) {
 	dialer.TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: true,
 	}
-	conn, httpResponse, err := dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
-	require.NoError(t, err)
+
+	var conn *websocket.Conn
+	var err error
+	var httpResponse *http.Response
+	var n int
+	var stream *web.WebsocketIO
+	buf := make([]byte, 1024)
+
+	// Try to read for a short amount of time.
+	require.Eventually(t, func() bool {
+		conn, httpResponse, err = dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
+		require.NoError(t, err)
+		if err != nil {
+			return false
+		}
+
+		// Try to read
+
+		// Read, write, and read again to make sure its working as expected.
+		stream = &web.WebsocketIO{Conn: conn}
+		n, err = stream.Read(buf)
+		if err != nil {
+			conn.Close()
+			httpResponse.Body.Close()
+		}
+		return err == nil
+	}, time.Second*5, time.Millisecond*100)
 
 	defer conn.Close()
 	defer httpResponse.Body.Close()
-	stream := &web.WebsocketIO{Conn: conn}
-
-	// Read, write, and read again to make sure its working as expected.
-	buf := make([]byte, 1024)
-	n, err := stream.Read(buf)
-	require.NoError(t, err)
 
 	resp := strings.TrimSpace(string(buf[:n]))
 	require.Equal(t, pack.rootWSSTwoWayMessage, resp)
 
+	// Once we've read successfully, write, and then read again to verify the connection
 	_, err = stream.Write(msg)
 	require.NoError(t, err)
 
@@ -222,8 +242,10 @@ func TestWSSLock(t *testing.T) {
 	// Close and re-open the connection. We don't care about the error message here.
 	_ = conn.Close()
 
-	conn, httpResponse, err = dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
-	require.Error(t, err)
+	require.Eventually(t, func() bool {
+		conn, httpResponse, err = dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
+		return err != nil
+	}, time.Second*5, time.Millisecond*100)
 
 	if conn != nil {
 		defer conn.Close()
@@ -237,7 +259,7 @@ func TestWSSLock(t *testing.T) {
 // TestWSSCertExpiration tests WSS application with certs expiring.
 func TestWSSCertExpiration(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(time.Now())
-	mCloseChannel := make(chan struct{})
+	mCloseChannel := make(chan struct{}, 1)
 
 	pack := setupWithOptions(t, appTestOptions{
 		clock:               clock,
@@ -258,21 +280,41 @@ func TestWSSCertExpiration(t *testing.T) {
 	dialer.TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: true,
 	}
-	conn, httpResponse, err := dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
-	require.NoError(t, err)
+
+	var conn *websocket.Conn
+	var err error
+	var httpResponse *http.Response
+	var n int
+	var stream *web.WebsocketIO
+	buf := make([]byte, 1024)
+
+	// Try to read for a short amount of time.
+	require.Eventually(t, func() bool {
+		conn, httpResponse, err = dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
+		require.NoError(t, err)
+		if err != nil {
+			return false
+		}
+
+		// Try to read
+
+		// Read, write, and read again to make sure its working as expected.
+		stream = &web.WebsocketIO{Conn: conn}
+		n, err = stream.Read(buf)
+		if err != nil {
+			conn.Close()
+			httpResponse.Body.Close()
+		}
+		return err == nil
+	}, time.Second*5, time.Millisecond*100)
 
 	defer conn.Close()
 	defer httpResponse.Body.Close()
-	stream := &web.WebsocketIO{Conn: conn}
-
-	// Read, write, and read again to make sure its working as expected.
-	buf := make([]byte, 1024)
-	n, err := stream.Read(buf)
-	require.NoError(t, err)
 
 	resp := strings.TrimSpace(string(buf[:n]))
 	require.Equal(t, pack.rootWSSTwoWayMessage, resp)
 
+	// Once we've read successfully, write, and then read again to verify the connection
 	_, err = stream.Write(msg)
 	require.NoError(t, err)
 
@@ -300,8 +342,10 @@ func TestWSSCertExpiration(t *testing.T) {
 	// Close and re-open the connection. We don't care about the error message here.
 	_ = conn.Close()
 
-	conn, httpResponse, err = dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
-	require.Error(t, err)
+	require.Eventually(t, func() bool {
+		conn, httpResponse, err = dialer.Dial(fmt.Sprintf("wss://%s%s", net.JoinHostPort(Loopback, pack.rootCluster.GetPortWeb()), "/"), header)
+		return err != nil
+	}, time.Second*5, time.Millisecond*100)
 
 	if conn != nil {
 		defer conn.Close()


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/18978 to branch/v9