### PR TITLE
[v11] Bump Buf to v1.10.0 and protoc to 3.20.3

### DIFF
--- a/api/proto/teleport/legacy/client/proto/authservice.proto
+++ b/api/proto/teleport/legacy/client/proto/authservice.proto
@@ -1827,9 +1827,9 @@ message UpstreamInventoryHello {
   // active.
   repeated string Services = 3 [(gogoproto.casttype) = "github.com/gravitational/teleport/api/types.SystemRole"];
 
-// TODO(fspmarshall): look into what other info can safely be stated here once, instead of
-// being repeatedly announced (e.g. addrs, static labels, etc). may be able to achieve a
-// non-trivial reduction in network usage by doing this.
+  // TODO(fspmarshall): look into what other info can safely be stated here once, instead of
+  // being repeatedly announced (e.g. addrs, static labels, etc). may be able to achieve a
+  // non-trivial reduction in network usage by doing this.
 }
 
 // DownstreamInventoryHello is the hello message sent down the inventory control stream.

--- a/api/proto/teleport/legacy/types/webauthn/webauthn.proto
+++ b/api/proto/teleport/legacy/types/webauthn/webauthn.proto
@@ -234,8 +234,8 @@ message CredentialDescriptor {
   // Raw Credential ID.
   bytes id = 2;
 
-// Notes:
-// * Transport hints omitted (assume no restrictions).
+  // Notes:
+  // * Transport hints omitted (assume no restrictions).
 }
 
 // Parameters for credential creation.

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -203,7 +203,7 @@ RUN (git clone https://github.com/gogo/protobuf.git --branch ${GOGO_PROTO_TAG} -
 
 # Install buf
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.8.0" && \
+    VERSION="1.10.0" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -42,7 +42,7 @@ RUNTIME_ARCH := $(RUNTIME_ARCH_$(HOST_ARCH))
 
 # Newer version of protoc have removed JS support that breaks our Teleterm build.
 # Related issue: https://github.com/protocolbuffers/protobuf-javascript/issues/105
-PROTOC_VER ?= 3.20.1
+PROTOC_VER ?= 3.20.3
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 

--- a/lib/prehog/proto/prehog/v1alpha/teleport.proto
+++ b/lib/prehog/proto/prehog/v1alpha/teleport.proto
@@ -24,7 +24,7 @@ message UserLoginEvent {
   // empty for local or github/saml/oidc
   string connector_type = 2;
 
-// TODO(espadolini): should passwordless be a flag?
+  // TODO(espadolini): should passwordless be a flag?
 }
 
 message SSOCreateEvent {
@@ -37,7 +37,7 @@ message ResourceCreateEvent {
   // databases/desktops/kube clusters accessed through it?
   string resource_type = 1;
 
-// TODO(espadolini): flags for Discover, autodiscovery, join scripts?
+  // TODO(espadolini): flags for Discover, autodiscovery, join scripts?
 }
 
 message SessionStartEvent {


### PR DESCRIPTION
Backport #19162 and, additionally, update protoc and reformat protos.

No lint/generate changes for protos.

See https://github.com/bufbuild/buf/blob/main/CHANGELOG.md.