### PR TITLE
[v10] Bump Buf to v1.10.0 and protoc to 3.20.3

### DIFF
--- a/.cloudbuild/scripts/cmd/integration-tests/main.go
+++ b/.cloudbuild/scripts/cmd/integration-tests/main.go
@@ -37,9 +37,9 @@ import (
 )
 
 const (
-	gomodcacheDir = ".gomodcache-ci"
-	nonrootUID    = 1000
-	nonrootGID    = 1000
+	goCachesRootName = "gocache"
+	nonrootUID       = 1000
+	nonrootGID       = 1000
 )
 
 // main is just a stub that prints out an error message and sets a nonzero exit
@@ -78,8 +78,11 @@ func innerMain() error {
 		}
 	}
 
-	moduleCacheDir := filepath.Join(os.TempDir(), gomodcacheDir)
-	gomodcache := fmt.Sprintf("GOMODCACHE=%s", moduleCacheDir)
+	goCacheRoot := filepath.Join(os.TempDir(), goCachesRootName)
+	env := map[string]string{
+		"GOCACHE":    filepath.Join(goCacheRoot, "go-build"),
+		"GOMODCACHE": filepath.Join(goCacheRoot, "pkg"),
+	}
 
 	log.Println("Analysing code changes")
 	ch, err := changes.Analyze(args.workspace, args.targetBranch, args.commitSHA)
@@ -102,7 +105,7 @@ func innerMain() error {
 	}()
 
 	log.Printf("Running root-only integration tests...")
-	err = runRootIntegrationTests(args.workspace, gomodcache)
+	err = runRootIntegrationTests(args.workspace, env)
 	if err != nil {
 		return trace.Wrap(err, "Root-only integration tests failed")
 	}
@@ -121,7 +124,7 @@ func innerMain() error {
 		}
 
 		log.Printf("Reconfiguring module cache for nonroot user")
-		err = chownR(moduleCacheDir, nonrootUID, nonrootGID)
+		err = chownR(goCacheRoot, nonrootUID, nonrootGID)
 		if err != nil {
 			return trace.Wrap(err, "failed reconfiguring module cache")
 		}
@@ -142,7 +145,7 @@ func innerMain() error {
 	defer etcdSvc.Stop()
 
 	log.Printf("Running nonroot integration tests...")
-	err = runNonrootIntegrationTests(args.workspace, nonrootUID, nonrootGID, gomodcache)
+	err = runNonrootIntegrationTests(args.workspace, nonrootUID, nonrootGID, env)
 	if err != nil {
 		return trace.Wrap(err, "Nonroot integration tests failed")
 	}
@@ -152,12 +155,13 @@ func innerMain() error {
 	return nil
 }
 
-func runRootIntegrationTests(workspace string, env ...string) error {
+func runRootIntegrationTests(workspace string, env map[string]string) error {
 	// Run root integration tests
 	cmd := exec.Command("make", "rdpclient", "integration-root")
 	cmd.Dir = workspace
-	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%v=%v", k, v))
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -165,10 +169,13 @@ func runRootIntegrationTests(workspace string, env ...string) error {
 	return cmd.Run()
 }
 
-func runNonrootIntegrationTests(workspace string, uid, gid int, env ...string) error {
+func runNonrootIntegrationTests(workspace string, uid, gid int, env map[string]string) error {
 	cmd := exec.Command("make", "integration")
 	cmd.Dir = workspace
-	cmd.Env = append(append(os.Environ(), "TELEPORT_ETCD_TEST=yes"), env...)
+	cmd.Env = append(os.Environ(), "TELEPORT_ETCD_TEST=yes")
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%v=%v", k, v))
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/api/client/proto/authservice.pb.go
+++ b/api/client/proto/authservice.pb.go
@@ -9141,8 +9141,8 @@ func (m *RecoveryCodes) GetCreated() time.Time {
 // CreateAccountRecoveryCodesRequest is a request to create new set of recovery codes for a user,
 // replacing and invalidating any previously existing codes. Recovery codes can only be given to
 // users who meet the following requirements:
-//  - cloud feature is enabled
-//  - username is in valid email format
+//   - cloud feature is enabled
+//   - username is in valid email format
 type CreateAccountRecoveryCodesRequest struct {
 	// TokenID is the ID of a user token that will be used to verify this request.
 	// Token types accepted are:
@@ -9830,11 +9830,11 @@ func (*PaginatedResource) XXX_OneofWrappers() []interface{} {
 //
 // NOTE: There are two paths this request can take:
 //  1. ListResources: the more efficient path that retrieves resources by subset
-//  at a time defined by field 'Limit'. Does NOT de-duplicate matches.
+//     at a time defined by field 'Limit'. Does NOT de-duplicate matches.
 //  2. listResourcesWithSort: the less efficient path that retrieves all resources
-//  upfront by falling back to the traditional GetXXX calls. Used when sorting (SortBy),
-//  total count of resources (NeedTotalCount), or ResourceType `KindKubernetesCluster`
-//  is requested. Matches are de-duplicated.
+//     upfront by falling back to the traditional GetXXX calls. Used when sorting (SortBy),
+//     total count of resources (NeedTotalCount), or ResourceType `KindKubernetesCluster`
+//     is requested. Matches are de-duplicated.
 type ListResourcesRequest struct {
 	// ResourceType is the resource that is going to be retrieved.
 	// This only needs to be set explicitly for the `ListResources` rpc.

--- a/api/proto/teleport/legacy/client/proto/authservice.proto
+++ b/api/proto/teleport/legacy/client/proto/authservice.proto
@@ -1952,9 +1952,9 @@ message UpstreamInventoryHello {
   // active.
   repeated string Services = 3 [(gogoproto.casttype) = "github.com/gravitational/teleport/api/types.SystemRole"];
 
-// TODO(fspmarshall): look into what other info can safely be stated here once, instead of
-// being repeatedly announced (e.g. addrs, static labels, etc). may be able to achieve a
-// non-trivial reduction in network usage by doing this.
+  // TODO(fspmarshall): look into what other info can safely be stated here once, instead of
+  // being repeatedly announced (e.g. addrs, static labels, etc). may be able to achieve a
+  // non-trivial reduction in network usage by doing this.
 }
 
 // DownstreamInventoryHello is the hello message sent down the inventory control stream.

--- a/api/proto/teleport/legacy/types/webauthn/webauthn.proto
+++ b/api/proto/teleport/legacy/types/webauthn/webauthn.proto
@@ -234,8 +234,8 @@ message CredentialDescriptor {
   // Raw Credential ID.
   bytes id = 2;
 
-// Notes:
-// * Transport hints omitted (assume no restrictions).
+  // Notes:
+  // * Transport hints omitted (assume no restrictions).
 }
 
 // Parameters for credential creation.

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -6043,6 +6043,7 @@ type MFADevice struct {
 	AddedAt  time.Time `protobuf:"bytes,6,opt,name=added_at,json=addedAt,proto3,stdtime" json:"added_at"`
 	LastUsed time.Time `protobuf:"bytes,7,opt,name=last_used,json=lastUsed,proto3,stdtime" json:"last_used"`
 	// Types that are valid to be assigned to Device:
+	//
 	//	*MFADevice_Totp
 	//	*MFADevice_U2F
 	//	*MFADevice_Webauthn

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -179,7 +179,7 @@ RUN (git clone https://github.com/gogo/protobuf.git ${GOPATH}/src/github.com/gog
 
 # Install buf
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.7.0" && \
+    VERSION="1.10.0" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -36,7 +36,7 @@ RUNTIME_ARCH_arm64 := arm64
 RUNTIME_ARCH_aarch64 := arm64
 RUNTIME_ARCH := $(RUNTIME_ARCH_$(HOST_ARCH))
 
-PROTOC_VER ?= 3.13.0
+PROTOC_VER ?= 3.20.3
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 

--- a/lib/teleterm/api/protogen/golang/v1/service.pb.go
+++ b/lib/teleterm/api/protogen/golang/v1/service.pb.go
@@ -357,6 +357,7 @@ type LoginPasswordlessRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Request:
+	//
 	//	*LoginPasswordlessRequest_Init
 	//	*LoginPasswordlessRequest_Pin
 	//	*LoginPasswordlessRequest_Credential
@@ -454,6 +455,7 @@ type LoginRequest struct {
 	// cluster_uri is the cluster uri
 	ClusterUri string `protobuf:"bytes,1,opt,name=cluster_uri,json=clusterUri,proto3" json:"cluster_uri,omitempty"`
 	// Types that are assignable to Params:
+	//
 	//	*LoginRequest_Local
 	//	*LoginRequest_Sso
 	Params isLoginRequest_Params `protobuf_oneof:"params"`

--- a/lib/teleterm/api/protogen/js/v1/app_pb.js
+++ b/lib/teleterm/api/protogen/js/v1/app_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 var v1_label_pb = require('../v1/label_pb.js');
 goog.object.extend(proto, v1_label_pb);

--- a/lib/teleterm/api/protogen/js/v1/auth_settings_pb.js
+++ b/lib/teleterm/api/protogen/js/v1/auth_settings_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 goog.exportSymbol('proto.teleport.terminal.v1.AuthProvider', null, global);
 goog.exportSymbol('proto.teleport.terminal.v1.AuthSettings', null, global);

--- a/lib/teleterm/api/protogen/js/v1/cluster_pb.js
+++ b/lib/teleterm/api/protogen/js/v1/cluster_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 goog.exportSymbol('proto.teleport.terminal.v1.ACL', null, global);
 goog.exportSymbol('proto.teleport.terminal.v1.Cluster', null, global);

--- a/lib/teleterm/api/protogen/js/v1/database_pb.js
+++ b/lib/teleterm/api/protogen/js/v1/database_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 var v1_label_pb = require('../v1/label_pb.js');
 goog.object.extend(proto, v1_label_pb);

--- a/lib/teleterm/api/protogen/js/v1/gateway_pb.js
+++ b/lib/teleterm/api/protogen/js/v1/gateway_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 goog.exportSymbol('proto.teleport.terminal.v1.Gateway', null, global);
 /**

--- a/lib/teleterm/api/protogen/js/v1/kube_pb.js
+++ b/lib/teleterm/api/protogen/js/v1/kube_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 var v1_label_pb = require('../v1/label_pb.js');
 goog.object.extend(proto, v1_label_pb);

--- a/lib/teleterm/api/protogen/js/v1/label_pb.js
+++ b/lib/teleterm/api/protogen/js/v1/label_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 goog.exportSymbol('proto.teleport.terminal.v1.Label', null, global);
 /**

--- a/lib/teleterm/api/protogen/js/v1/server_pb.js
+++ b/lib/teleterm/api/protogen/js/v1/server_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 var v1_label_pb = require('../v1/label_pb.js');
 goog.object.extend(proto, v1_label_pb);

--- a/lib/teleterm/api/protogen/js/v1/service_pb.js
+++ b/lib/teleterm/api/protogen/js/v1/service_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 var v1_app_pb = require('../v1/app_pb.js');
 goog.object.extend(proto, v1_app_pb);


### PR DESCRIPTION
Backport #19162 and, additionally, update protoc, reformat and regenerate protos. No lint changes for protos.

Backport #16523 to fix integration tests.

See https://github.com/bufbuild/buf/blob/main/CHANGELOG.md.