### PR TITLE
[v11] Add `license` and `download` verbs to user context ACL and default editor role

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -273,6 +273,12 @@ const (
 	// KindClusterAlert is a resource that conveys a cluster-level alert message.
 	KindClusterAlert = "cluster_alert"
 
+	// KindDevice represents a registered or trusted device.
+	KindDevice = "device"
+
+	// KindDownload represents Teleport binaries downloads.
+	KindDownload = "download"
+
 	// KindUsageEvent is an external cluster usage event. Similar to
 	// KindHostCert, this kind is not backed by a real resource.
 	KindUsageEvent = "usage_event"

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -72,6 +72,8 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindConnectionDiagnostic, RW()),
 					types.NewRule(types.KindDatabaseCertificate, RW()),
 					types.NewRule(types.KindInstaller, RW()),
+					types.NewRule(types.KindLicense, RO()),
+					types.NewRule(types.KindDownload, RO()),
 					// Please see defaultAllowRules when adding a new rule.
 				},
 			},

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -90,6 +90,10 @@ type userACL struct {
 	DesktopSessionRecording bool `json:"desktopSessionRecording"`
 	// DirectorySharing defines whether a user is permitted to share a directory during windows desktop sessions.
 	DirectorySharing bool `json:"directorySharing"`
+	// Download defines whether the user has access to download Teleport Enterprise Binaries
+	Download access `json:"download"`
+	// Download defines whether the user has access to download the license
+	License access `json:"license"`
 }
 
 type authType string
@@ -212,6 +216,8 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 	clipboard := userRoles.DesktopClipboard()
 	desktopSessionRecording := desktopRecordingEnabled && userRoles.RecordDesktopSession()
 	directorySharing := userRoles.DesktopDirectorySharing()
+	download := newAccess(userRoles, ctx, types.KindDownload)
+	license := newAccess(userRoles, ctx, types.KindLicense)
 
 	acl := userACL{
 		AccessRequests:          requestAccess,
@@ -234,6 +240,8 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 		Clipboard:               clipboard,
 		DesktopSessionRecording: desktopSessionRecording,
 		DirectorySharing:        directorySharing,
+		Download:                download,
+		License:                 license,
 	}
 
 	// local user

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -109,6 +109,8 @@ func TestNewUserContext(t *testing.T) {
 	require.Empty(t, cmp.Diff(userContext.ACL.Billing, denied))
 	require.Equal(t, userContext.ACL.Clipboard, true)
 	require.Equal(t, userContext.ACL.DesktopSessionRecording, true)
+	require.Empty(t, cmp.Diff(userContext.ACL.License, denied))
+	require.Empty(t, cmp.Diff(userContext.ACL.Download, denied))
 
 	// test local auth type
 	require.Equal(t, userContext.AuthType, authLocal)


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/19049