### PR TITLE
Terraform code git clone to use branch, not master

### DIFF
--- a/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
@@ -74,7 +74,7 @@ level of AWS permissions.
 Firstly, you'll need to clone the Teleport repo to get the Terraform code available on your system:
 
 ```code
-$ git clone https://github.com/gravitational/teleport
+$ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 # Cloning into 'teleport'...
 # remote: Enumerating objects: 106, done.
 # remote: Counting objects: 100% (106/106), done.


### PR DESCRIPTION
The current version had the retrieval of the current `master`, not the branch that matches to the version being used.