### PR TITLE
CodeQL: Set a timeout limit to ensure jobs don't hang

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,10 +42,12 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+      timeout-minutes: 10
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
       if: ${{ matrix.language != 'go' }}
+      timeout-minutes: 15
 
     - name: Build Teleport OSS
       run: |
@@ -56,3 +58,4 @@ jobs:
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"
+      timeout-minutes: 15

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
       if: ${{ matrix.language != 'go' }}
-      timeout-minutes: 15
+      timeout-minutes: 30
 
     - name: Build Teleport OSS
       run: |
@@ -58,4 +58,4 @@ jobs:
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"
-      timeout-minutes: 15
+      timeout-minutes: 30


### PR DESCRIPTION
Recently the CodeQL jobs started hanging, this is a stop gap measure to make sure action costs remain under control.