### PR TITLE
(buddy) Add workflows that build tools on Mac OS and Windows

### DIFF
--- a/.github/workflows/build-macos-bypass.yaml
+++ b/.github/workflows/build-macos-bypass.yaml
@@ -1,5 +1,5 @@
 # This workflow is required to ensure that required Github check passes even if
-# the actual "Unit Tests (Operator)" workflow skipped due to path filtering. Otherwise
+# the actual "Build on Mac OS" workflow skipped due to path filtering. Otherwise
 # it will stay forever pending.
 #
 # See "Handling skipped but required checks" for more info:
@@ -8,25 +8,26 @@
 #
 # Note both workflows must have the same name.
 
-name: Unit Tests (Operator)
-run-name: Skip Unit Tests (Operator) - ${{ github.run_id }} - @${{ github.actor }}
+name: Build on Mac OS
+run-name: Skip Build on Mac OS
 
 on:
   pull_request:
     paths-ignore:
-      - /go.mod
-      - /go.sum
-      - operator/**
-      - api/types/**
-      - lib/tbot/**
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
 
 jobs:
-  test:
+  build:
     name: Skipped
-    runs-on: ubuntu-latest
+    runs-on: macos-12
 
     permissions:
       contents: none
 
     steps:
-      - run: 'echo "No changes to verify"'
+      - run: 'echo "No code changes"'

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -1,0 +1,40 @@
+name: Build on Mac OS
+run-name: Build on Mac OS
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+
+jobs:
+  build:
+    name: Build all tools on Mac OS
+    runs-on: macos-12 # TODO(r0mant): Update with large runner when it's available
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Get Go version
+        id: go-version
+        shell: bash
+        run: echo "go-version=$(make --no-print-directory print-go-version | tr -d '\n')" >> $GITHUB_OUTPUT
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ steps.go-version.outputs.go-version }}
+
+      - name: Build
+        run: make binaries

--- a/.github/workflows/build-windows-bypass.yaml
+++ b/.github/workflows/build-windows-bypass.yaml
@@ -1,5 +1,5 @@
 # This workflow is required to ensure that required Github check passes even if
-# the actual "Unit Tests (Operator)" workflow skipped due to path filtering. Otherwise
+# the actual "Build on Windows" workflow skipped due to path filtering. Otherwise
 # it will stay forever pending.
 #
 # See "Handling skipped but required checks" for more info:
@@ -8,25 +8,25 @@
 #
 # Note both workflows must have the same name.
 
-name: Unit Tests (Operator)
-run-name: Skip Unit Tests (Operator) - ${{ github.run_id }} - @${{ github.actor }}
+name: Build on Windows
+run-name: Skip Build on Windows
 
 on:
   pull_request:
+    # We only build tsh on Windows so only consider Go code as tsh doesn't
+    # run any Rust.
     paths-ignore:
-      - /go.mod
-      - /go.sum
-      - operator/**
-      - api/types/**
-      - lib/tbot/**
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
-  test:
+  build:
     name: Skipped
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     permissions:
       contents: none
 
     steps:
-      - run: 'echo "No changes to verify"'
+      - run: 'echo "No code changes"'

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -1,0 +1,41 @@
+name: Build on Windows
+run-name: Build on Windows
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    # We only build tsh on Windows so only consider Go code as tsh doesn't
+    # run any Rust.
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  build:
+    name: Build tsh tool on Windows
+    runs-on: windows-2022-16core
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Get Go version
+        id: go-version
+        shell: bash
+        run: echo "go-version=$(make --no-print-directory print-go-version | tr -d '\n')" >> $GITHUB_OUTPUT
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ steps.go-version.outputs.go-version }}
+
+      - name: Build
+        run: |
+          $Env:OS="windows"
+          make build/tsh

--- a/.github/workflows/integration-tests-non-root-bypass.yaml
+++ b/.github/workflows/integration-tests-non-root-bypass.yaml
@@ -1,6 +1,6 @@
 # This workflow is required to ensure that required Github check passes even if
-# the actual "Unit Tests (Operator)" workflow skipped due to path filtering. Otherwise
-# it will stay forever pending.
+# the actual "Integration Tests (Non-root)" workflow skipped due to path filtering.
+# Otherwise it will stay forever pending.
 #
 # See "Handling skipped but required checks" for more info:
 #
@@ -8,17 +8,15 @@
 #
 # Note both workflows must have the same name.
 
-name: Unit Tests (Operator)
-run-name: Skip Unit Tests (Operator) - ${{ github.run_id }} - @${{ github.actor }}
+name: Integration Tests (Non-root)
+run-name: Skip Integration Tests (Non-root) - ${{ github.run_id }} - @${{ github.actor }}
 
 on:
   pull_request:
     paths-ignore:
-      - /go.mod
-      - /go.sum
-      - operator/**
-      - api/types/**
-      - lib/tbot/**
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
   test:

--- a/.github/workflows/integration-tests-root-bypass.yaml
+++ b/.github/workflows/integration-tests-root-bypass.yaml
@@ -1,6 +1,6 @@
 # This workflow is required to ensure that required Github check passes even if
-# the actual "Unit Tests (Operator)" workflow skipped due to path filtering. Otherwise
-# it will stay forever pending.
+# the actual "Integration Tests (Root)" workflow skipped due to path filtering.
+# Otherwise it will stay forever pending.
 #
 # See "Handling skipped but required checks" for more info:
 #
@@ -8,17 +8,15 @@
 #
 # Note both workflows must have the same name.
 
-name: Unit Tests (Operator)
-run-name: Skip Unit Tests (Operator) - ${{ github.run_id }} - @${{ github.actor }}
+name: Integration Tests (Root)
+run-name: Skip Integration Tests (Root) - ${{ github.run_id }} - @${{ github.actor }}
 
 on:
   pull_request:
     paths-ignore:
-      - /go.mod
-      - /go.sum
-      - operator/**
-      - api/types/**
-      - lib/tbot/**
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-code-bypass.yaml
+++ b/.github/workflows/unit-tests-code-bypass.yaml
@@ -1,5 +1,15 @@
+# This workflow is required to ensure that required Github check passes even if
+# the actual "Unit Tests (Go)" workflow skipped due to path filtering. Otherwise
+# it will stay forever pending.
+#
+# See "Handling skipped but required checks" for more info:
+#
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Note both workflows must have the same name.
+
 name: Unit Tests (Go)
-run-name: Unit Tests (Go) - ${{ github.run_id }} - @${{ github.actor }}
+run-name: Skip Unit Tests (Go) - ${{ github.run_id }} - @${{ github.actor }}
 
 on:
   pull_request:
@@ -8,7 +18,7 @@ on:
 
 jobs:
   test:
-    name: Unit Tests (Go)
+    name: Skipped
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/unit-tests-helm-bypass.yaml
+++ b/.github/workflows/unit-tests-helm-bypass.yaml
@@ -1,6 +1,15 @@
+# This workflow is required to ensure that required Github check passes even if
+# the actual "Unit Tests (Helm)" workflow skipped due to path filtering. Otherwise
+# it will stay forever pending.
+#
+# See "Handling skipped but required checks" for more info:
+#
 # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Note both workflows must have the same name.
+
 name: Unit Tests (Helm)
-run-name: Unit Tests (Helm) - ${{ github.run_id }} - @${{ github.actor }}
+run-name: Skip Unit Tests (Helm) - ${{ github.run_id }} - @${{ github.actor }}
 
 on:
   pull_request:
@@ -9,7 +18,7 @@ on:
 
 jobs:
   test:
-    name: Unit Tests (Helm)
+    name: Skipped
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/unit-tests-rust-bypass.yaml
+++ b/.github/workflows/unit-tests-rust-bypass.yaml
@@ -1,5 +1,15 @@
+# This workflow is required to ensure that required Github check passes even if
+# the actual "Unit Tests (Rust)" workflow skipped due to path filtering. Otherwise
+# it will stay forever pending.
+#
+# See "Handling skipped but required checks" for more info:
+#
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Note both workflows must have the same name.
+
 name: Unit Tests (Rust)
-run-name: Unit Tests (Rust) - ${{ github.run_id }} - @${{ github.actor }}
+run-name: Skip Unit Tests (Rust) - ${{ github.run_id }} - @${{ github.actor }}
 
 on:
   pull_request:
@@ -10,7 +20,7 @@ on:
 
 jobs:
   test:
-    name: Unit Tests (Rust)
+    name: Skipped
     runs-on: ubuntu-latest
 
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,13 @@ all: version
 	@echo "---> Building OSS binaries."
 	$(MAKE) $(BINARIES)
 
+#
+# make binaries builds all binaries defined in the BINARIES environment variable
+#
+.PHONY: binaries
+binaries:
+	$(MAKE) $(BINARIES)
+
 # By making these 3 targets below (tsh, tctl and teleport) PHONY we are solving
 # several problems:
 # * Build will rely on go build internal caching https://golang.org/doc/go1.10 at all times
@@ -908,6 +915,13 @@ sloccount:
 .PHONY: remove-temp-files
 remove-temp-files:
 	find . -name flymake_* -delete
+
+#
+# print-go-version outputs Go version as a semver without "go" prefix
+#
+.PHONY: print-go-version
+print-go-version:
+	@$(MAKE) -C build.assets print-go-version | sed "s/go//"
 
 # Dockerized build: useful for making Linux releases on OSX
 .PHONY:docker

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 )
 
-// User represents teleport embedded user or external user
+// User represents teleport embedded user or external user.
 type User interface {
 	// ResourceWithSecrets provides common resource properties
 	ResourceWithSecrets

--- a/lib/srv/desktop/rdp/rdpclient/build.rs
+++ b/lib/srv/desktop/rdp/rdpclient/build.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 fn main() {
-    // the cwd of build scripts is the root of the crate
+    // the cwd of build scripts is the root of the crate.
     let bindings = cbindgen::Builder::new()
         .with_crate(".")
         .with_language(cbindgen::Language::C)


### PR DESCRIPTION
Buddy PR for https://github.com/gravitational/teleport/pull/19036 with a few updates:

- Tweak build on Mac/Win workflows to only run on code changes and add corresponding "bypass" workflows to make sure they succeed when we make these checks required.
- Add "bypass" workflows to integration tests too as I noticed they were missing but will be needed when we flip the switch.
- Add more verbose comments to all "bypass" workflows to explain why they exist with link to relevant Github documentation.