### PR TITLE
Fix issue "redis" engine is not registered

### DIFF
--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -17,7 +17,6 @@ limitations under the License.
 package db
 
 //nolint:goimports
-
 import (
 	"context"
 	"crypto/tls"

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package db
 
 //nolint:goimports
+
 import (
 	"context"
 	"crypto/tls"
@@ -54,6 +55,8 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/mysql"
 	// Import to register Postgres engine.
 	_ "github.com/gravitational/teleport/lib/srv/db/postgres"
+	// Import to register Redis engine.
+	_ "github.com/gravitational/teleport/lib/srv/db/redis"
 	// Import to register Snowflake engine.
 	_ "github.com/gravitational/teleport/lib/srv/db/snowflake"
 	"github.com/gravitational/teleport/lib/utils"


### PR DESCRIPTION
Error when connecting Redis database
```
Original Error: *trace.NotFoundError database engine &#34;redis&#34; is not registered
```

Related PR
- #18776

(interestingly, this is not caught by test, likely because test has different importing path)