### PR TITLE
Disable password prompt in desktop access config script

### DIFF
--- a/lib/web/scripts/desktop/configure-ad.ps1
+++ b/lib/web/scripts/desktop/configure-ad.ps1
@@ -121,6 +121,8 @@ Set-GPRegistryValue -Name $ACCESS_GPO_NAME -Type String -Key "HKEY_LOCAL_MACHINE
 Set-GPRegistryValue -Name $ACCESS_GPO_NAME -Key "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" -ValueName "fDenyTSConnections" -Type DWORD -Value 0
 Set-GPRegistryValue -Name $ACCESS_GPO_NAME -Key "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" -ValueName "UserAuthentication" -Type DWORD -Value 0
 
+# Disable "Always prompt for password upon connection"
+Set-GPRegistryValue -Name $ACCESS_GPO_NAME -Key "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" -ValueName "fPromptForPassword" -Type DWORD -Value 0
 
 # # Step 5/7. Export your LDAP CA certificate
 $WindowsDERFile = $env:TEMP + "\windows.der"


### PR DESCRIPTION
In https://github.com/gravitational/teleport/commit/399f489c3b2b2ddc248967e5ee401ed296dc8848 additional step that disables the password prompt has been added to the manual configuration.

This PR updates the automation script to be aligned with the manual configuration.
