### PR TITLE
[v10] Backport uploader fixes

### DIFF
--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -110,6 +110,17 @@ var localServiceMappings = map[SystemRole]struct{}{
 	RoleDiscovery:      {},
 }
 
+// LocalServiceMappings returns the subset of role mappings which happen
+// to be true Teleport services (e.g. db, kube, proxy, etc), excluding
+// those which represent remote service (i.e. remoteproxy).
+func LocalServiceMappings() SystemRoles {
+	var sr SystemRoles
+	for k := range localServiceMappings {
+		sr = append(sr, k)
+	}
+	return sr
+}
+
 // NewTeleportRoles return a list of teleport roles from slice of strings
 func NewTeleportRoles(in []string) (SystemRoles, error) {
 	var roles SystemRoles

--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -300,7 +300,6 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 	)
 	require.NoError(t, err)
 	s.srv = srv
-	require.NoError(t, auth.CreateUploaderDir(nodeDir))
 	require.NoError(t, s.srv.Start())
 	return s
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3110,7 +3110,7 @@ func (a *ServerWithRoles) CreateAuditStream(ctx context.Context, sid session.ID)
 	}
 	role, ok := a.context.Identity.(BuiltinRole)
 	if !ok || !role.IsServer() {
-		return nil, trace.AccessDenied("this request can be only executed by proxy, node or auth")
+		return nil, trace.AccessDenied("this request can be only executed by a Teleport server")
 	}
 	stream, err := a.authServer.CreateAuditStream(ctx, sid)
 	if err != nil {
@@ -3130,7 +3130,7 @@ func (a *ServerWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID,
 	}
 	role, ok := a.context.Identity.(BuiltinRole)
 	if !ok || !role.IsServer() {
-		return nil, trace.AccessDenied("this request can be only executed by proxy, node or auth")
+		return nil, trace.AccessDenied("this request can be only executed by a Teleport server")
 	}
 	stream, err := a.authServer.ResumeAuditStream(ctx, sid, uploadID)
 	if err != nil {
@@ -4555,18 +4555,19 @@ func (a *ServerWithRoles) StreamSessionEvents(ctx context.Context, sessionID ses
 		return nil, e
 	}
 
-	if err := a.actionForKindSession(apidefaults.Namespace, types.VerbList, sessionID); err != nil {
-		return createErrorChannel(err)
-	}
+	err := a.serverAction()
+	isTeleportServer := err == nil
 
-	// StreamSessionEvents can be called internally, and when that happens we don't want to emit an event.
-	shouldEmitAuditEvent := true
-	if role, ok := a.context.Identity.(BuiltinRole); ok {
-		if role.IsServer() {
-			shouldEmitAuditEvent = false
+	if !isTeleportServer {
+		if err := a.actionForKindSession(apidefaults.Namespace, types.VerbList, sessionID); err != nil {
+			c, e := make(chan apievents.AuditEvent), make(chan error, 1)
+			e <- trace.Wrap(err)
+			return c, e
 		}
 	}
 
+	// StreamSessionEvents can be called internally, and when that happens we don't want to emit an event.
+	shouldEmitAuditEvent := !isTeleportServer
 	if shouldEmitAuditEvent {
 		if err := a.authServer.emitter.EmitAuditEvent(a.authServer.closeCtx, &apievents.SessionRecordingAccess{
 			Metadata: apievents.Metadata{

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -3752,6 +3753,95 @@ func TestGenerateHostCert(t *testing.T) {
 
 			_, err = client.GenerateHostCert(pub, "", "", test.principals, clusterName, types.RoleNode, 0)
 			require.True(t, test.expect(err))
+		})
+	}
+}
+
+// TestLocalServiceRolesHavePermissionsForUploaderService verifies that all of Teleport's
+// builtin roles have permissions to execute the calls required by the uploader service.
+// This is because only one uploader service runs per Teleport process, and it will use
+// the first available identity.
+func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
+	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+
+	for _, role := range types.LocalServiceMappings() {
+		if role == types.RoleAuth {
+			continue
+		}
+		t.Run(role.String(), func(t *testing.T) {
+			ctx := context.Background()
+
+			identity := TestBuiltin(role)
+			authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, identity.I))
+			require.NoError(t, err)
+
+			s := &ServerWithRoles{
+				authServer: srv.AuthServer,
+				alog:       srv.AuditLog,
+				context:    *authContext,
+			}
+
+			t.Run("GetSessionTracker", func(t *testing.T) {
+				sid := session.ID("foo/" + role.String())
+				tracker, err := s.CreateSessionTracker(ctx, &types.SessionTrackerV1{
+					ResourceHeader: types.ResourceHeader{
+						Metadata: types.Metadata{
+							Name: sid.String(),
+						},
+					},
+					Spec: types.SessionTrackerSpecV1{
+						SessionID: sid.String(),
+					},
+				})
+				require.NoError(t, err)
+
+				_, err = s.GetSessionTracker(ctx, tracker.GetSessionID())
+				require.NoError(t, err)
+			})
+
+			t.Run("EmitAuditEvent", func(t *testing.T) {
+				err := s.EmitAuditEvent(ctx, &apievents.UserLogin{
+					Metadata: apievents.Metadata{
+						Type: events.UserLoginEvent,
+						Code: events.UserLocalLoginFailureCode,
+					},
+					Method: events.LoginMethodClientCert,
+					Status: apievents.Status{Success: true},
+				})
+				require.NoError(t, err)
+			})
+
+			t.Run("StreamSessionEvents", func(t *testing.T) {
+				// swap out the audit log with a discard log because we don't care if
+				// the streaming actually succeeds, we just want to make sure RBAC checks
+				// pass and allow us to enter the audit log code
+				originalLog := s.alog
+				t.Cleanup(func() { s.alog = originalLog })
+				s.alog = events.NewDiscardAuditLog()
+
+				eventC, errC := s.StreamSessionEvents(ctx, "foo", 0)
+				select {
+				case err := <-errC:
+					require.NoError(t, err)
+				default:
+					// drain eventC to prevent goroutine leak
+					for range eventC {
+					}
+				}
+			})
+
+			t.Run("CreateAuditStream", func(t *testing.T) {
+				stream, err := s.CreateAuditStream(ctx, session.ID("streamer"))
+				require.NoError(t, err)
+				require.NoError(t, stream.Close(ctx))
+			})
+
+			t.Run("ResumeAuditStream", func(t *testing.T) {
+				stream, err := s.ResumeAuditStream(ctx, session.ID("streamer"), "upload")
+				require.NoError(t, err)
+				require.NoError(t, stream.Close(ctx))
+			})
 		})
 	}
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -264,6 +264,8 @@ func (g *GRPCServer) CreateAuditStream(stream proto.AuthService_CreateAuditStrea
 			}
 			if g.APIConfig.MetadataGetter != nil {
 				sessionData := g.APIConfig.MetadataGetter.GetUploadMetadata(sessionID)
+				// TODO(zmb3): this may result in duplicate upload events, as the upload
+				// completer will emit its own session.upload
 				event := &apievents.SessionUpload{
 					Metadata: apievents.Metadata{
 						Type:        events.SessionUploadEvent,

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -21,8 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"net"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -35,7 +33,6 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/keystore"
@@ -92,16 +89,6 @@ func (cfg *TestAuthServerConfig) CheckAndSetDefaults() error {
 	if len(cfg.CipherSuites) == 0 {
 		cfg.CipherSuites = utils.DefaultCipherSuites()
 	}
-	return nil
-}
-
-// CreateUploaderDir creates directory for file uploader service
-func CreateUploaderDir(dir string) error {
-	if err := os.MkdirAll(filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, apidefaults.Namespace), teleport.SharedDirMode); err != nil {
-		return trace.ConvertSystemError(err)
-	}
-
 	return nil
 }
 

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -52,14 +52,17 @@ const (
 	SessionLogsDir = "sessions"
 
 	// StreamingLogsDir is a subdirectory of sessions /var/lib/teleport/log/streaming
-	// is used in new versions of the uploader
+	// is used in new versions of the uploader. This directory is used in asynchronous
+	// recording modes where recordings are buffered to disk before being uploaded
+	// to the auth server.
 	StreamingLogsDir = "streaming"
 
-	// RecordsDir is a subdirectory with default records /var/lib/teleport/log/records
-	// is used in new versions of the uploader
+	// RecordsDir is an auth server subdirectory with session recordings that is used
+	// when the auth server is not configured for external cloud storage. It is not
+	// used by nodes, proxies, or other Teleport services.
 	RecordsDir = "records"
 
-	// PlaybackDir is a directory for playbacks
+	// PlaybackDir is a directory for caching downloaded sessions during playback.
 	PlaybackDir = "playbacks"
 
 	// LogfileExt defines the ending of the daily event log file

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -51,11 +51,17 @@ const (
 	// in /var/lib/teleport/log/sessions
 	SessionLogsDir = "sessions"
 
-	// StreamingLogsDir is a subdirectory of sessions /var/lib/teleport/log/streaming
-	// is used in new versions of the uploader. This directory is used in asynchronous
+	// StreamingSessionsDir is a subdirectory of sessions (/var/lib/teleport/log/upload/streaming)
+	// that is used in new versions of the uploader. This directory is used in asynchronous
 	// recording modes where recordings are buffered to disk before being uploaded
 	// to the auth server.
-	StreamingLogsDir = "streaming"
+	StreamingSessionsDir = "streaming"
+
+	// CorruptedSessionsDir is a subdirectory of sessions (/var/lib/teleport/log/upload/corrupted)
+	// where corrupted session recordings are placed. This ensures that the uploader doesn't
+	// continue to try to upload corrupted sessions, but preserves the recording in case it contains
+	// valuable info.
+	CorruptedSessionsDir = "corrupted"
 
 	// RecordsDir is an auth server subdirectory with session recordings that is used
 	// when the auth server is not configured for external cloud storage. It is not

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -173,6 +173,7 @@ func (u *UploadCompleter) checkUploads(ctx context.Context) error {
 
 		switch _, err := u.cfg.SessionTracker.GetSessionTracker(ctx, upload.SessionID.String()); {
 		case err == nil: // session is still in progress, continue to other uploads
+			u.log.Debugf("session %v has active tracker and is not ready to be uploaded", upload.SessionID)
 			continue
 		case trace.IsNotFound(err): // upload abandoned, complete upload
 		case trace.IsAccessDenied(err): // upload abandoned, complete upload
@@ -193,11 +194,11 @@ func (u *UploadCompleter) checkUploads(ctx context.Context) error {
 			return trace.Wrap(err)
 		}
 
-		u.log.Debugf("Upload %v was abandoned, trying to complete.", upload.ID)
+		u.log.Debugf("Upload for session %v was abandoned, trying to complete.", upload.SessionID)
 		if err := u.cfg.Uploader.CompleteUpload(ctx, upload, parts); err != nil {
 			return trace.Wrap(err)
 		}
-		u.log.Debugf("Completed upload %v.", upload)
+		u.log.Debugf("Completed upload for session %v.", upload.SessionID)
 		completed++
 
 		if len(parts) == 0 {

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -42,6 +42,8 @@ import (
 type UploaderConfig struct {
 	// ScanDir is data directory with the uploads
 	ScanDir string
+	// CorruptedDir is the directory to store corrupted uploads in.
+	CorruptedDir string
 	// Clock is the clock replacement
 	Clock clockwork.Clock
 	// ScanPeriod is a uploader dir scan period
@@ -65,6 +67,9 @@ func (cfg *UploaderConfig) CheckAndSetDefaults() error {
 	if cfg.ScanDir == "" {
 		return trace.BadParameter("missing parameter ScanDir")
 	}
+	if cfg.CorruptedDir == "" {
+		return trace.BadParameter("missing parameter CorruptedDir")
+	}
 	if cfg.ConcurrentUploads <= 0 {
 		cfg.ConcurrentUploads = defaults.UploaderConcurrentUploads
 	}
@@ -84,6 +89,13 @@ func (cfg *UploaderConfig) CheckAndSetDefaults() error {
 func NewUploader(cfg UploaderConfig) (*Uploader, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	if err := os.MkdirAll(cfg.ScanDir, teleport.SharedDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	if err := os.MkdirAll(cfg.CorruptedDir, teleport.SharedDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
 	}
 
 	uploader := &Uploader{
@@ -213,6 +225,9 @@ type ScanStats struct {
 	Scanned int
 	// Started is how many uploads have been started
 	Started int
+	// Corrupted is how many corrupted uploads have been
+	// moved out of the scan dir.
+	Corrupted int
 }
 
 // Scan scans the streaming directory and uploads recordings
@@ -243,6 +258,7 @@ func (u *Uploader) Scan(ctx context.Context) (*ScanStats, error) {
 			}
 			if isSessionError(err) {
 				u.log.WithError(err).Warningf("Skipped session recording %v.", fi.Name())
+				stats.Corrupted++
 				continue
 			}
 			return nil, trace.Wrap(err)
@@ -250,7 +266,8 @@ func (u *Uploader) Scan(ctx context.Context) (*ScanStats, error) {
 		stats.Started++
 	}
 	if stats.Scanned > 0 {
-		u.log.Debugf("Scanned %v uploads, started %v in %v.", stats.Scanned, stats.Started, u.cfg.ScanDir)
+		u.log.Debugf("Scanned %v uploads, started %v, found %v corrupted in %v.",
+			stats.Scanned, stats.Started, stats.Corrupted, u.cfg.ScanDir)
 	}
 	return &stats, nil
 }
@@ -347,10 +364,24 @@ func (u *Uploader) startUpload(ctx context.Context, fileName string) error {
 		return trace.Wrap(err)
 	}
 	if isSessionError {
+		errorFilePath := u.sessionErrorFilePath(sessionID)
+		// move the corrupted recording and the error marker to a separate directory
+		// to prevent the uploader from spinning on the same corrupted upload
+		var moveErrs []error
+		if err := os.Rename(sessionFilePath, filepath.Join(u.cfg.CorruptedDir, filepath.Base(sessionFilePath))); err != nil {
+			moveErrs = append(moveErrs, trace.Wrap(err, "moving %v to %v", sessionFilePath, u.cfg.CorruptedDir))
+		}
+		if err := os.Rename(errorFilePath, filepath.Join(u.cfg.CorruptedDir, filepath.Base(errorFilePath))); err != nil {
+			moveErrs = append(moveErrs, trace.Wrap(err, "moving %v to %v", errorFilePath, u.cfg.CorruptedDir))
+		}
+		if len(moveErrs) > 0 {
+			u.log.Errorf("Failed to move corrupted recording: %v", trace.NewAggregate(moveErrs...))
+		}
+
 		return sessionError{
 			err: trace.BadParameter(
-				"session recording %v is either corrupted or is using unsupported format, remove the file %v to correct the problem, remove the %v file to retry the upload",
-				sessionID, sessionFilePath, u.sessionErrorFilePath(sessionID)),
+				"session recording %v; check the %v directory for artifacts",
+				sessionID, u.cfg.CorruptedDir),
 		}
 	}
 

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -55,8 +55,6 @@ type UploaderConfig struct {
 	EventsC chan events.UploadEvent
 	// Component is used for logging purposes
 	Component string
-	// AuditLog is used for storing logs
-	AuditLog events.IAuditLog
 }
 
 // CheckAndSetDefaults checks and sets default values of UploaderConfig
@@ -66,9 +64,6 @@ func (cfg *UploaderConfig) CheckAndSetDefaults() error {
 	}
 	if cfg.ScanDir == "" {
 		return trace.BadParameter("missing parameter ScanDir")
-	}
-	if cfg.AuditLog == nil {
-		return trace.BadParameter("missing parameter AuditLog")
 	}
 	if cfg.ConcurrentUploads <= 0 {
 		cfg.ConcurrentUploads = defaults.UploaderConcurrentUploads
@@ -97,7 +92,6 @@ func NewUploader(cfg UploaderConfig) (*Uploader, error) {
 			trace.Component: cfg.Component,
 		}),
 		closeC:    make(chan struct{}),
-		auditLog:  cfg.AuditLog,
 		semaphore: make(chan struct{}, cfg.ConcurrentUploads),
 		eventsCh:  make(chan events.UploadEvent, cfg.ConcurrentUploads),
 	}
@@ -121,7 +115,6 @@ type Uploader struct {
 	log *log.Entry
 
 	eventsCh chan events.UploadEvent
-	auditLog events.IAuditLog
 	closeC   chan struct{}
 }
 

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -120,7 +120,6 @@ func TestChaosUpload(t *testing.T) {
 		ScanPeriod: scanPeriod,
 		Streamer:   faultyStreamer,
 		Clock:      clock,
-		AuditLog:   &events.DiscardAuditLog{},
 	})
 	require.NoError(t, err)
 	go uploader.Serve(ctx)

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -63,9 +63,8 @@ func TestChaosUpload(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	scanDir, err := os.MkdirTemp("", "teleport-streams")
-	require.NoError(t, err)
-	defer os.RemoveAll(scanDir)
+	scanDir := t.TempDir()
+	corruptedDir := t.TempDir()
 
 	terminateConnection := atomic.NewUint64(0)
 	failCreateAuditStream := atomic.NewUint64(0)
@@ -116,10 +115,11 @@ func TestChaosUpload(t *testing.T) {
 
 	scanPeriod := 10 * time.Second
 	uploader, err := NewUploader(UploaderConfig{
-		ScanDir:    scanDir,
-		ScanPeriod: scanPeriod,
-		Streamer:   faultyStreamer,
-		Clock:      clock,
+		ScanDir:      scanDir,
+		CorruptedDir: corruptedDir,
+		ScanPeriod:   scanPeriod,
+		Streamer:     faultyStreamer,
+		Clock:        clock,
 	})
 	require.NoError(t, err)
 	go uploader.Serve(ctx)

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -20,6 +20,8 @@ package filesessions
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -117,6 +119,49 @@ func TestUploadParallel(t *testing.T) {
 
 		delete(sessions, event.SessionID)
 	}
+}
+
+// TestMovesCorruptedUploads verifies that the uploader moves corrupted uploads
+// out of the scan directory.
+func TestMovesCorruptedUploads(t *testing.T) {
+	scanDir := t.TempDir()
+	corruptedDir := t.TempDir()
+
+	uploader, err := NewUploader(UploaderConfig{
+		Streamer:     events.NewDiscardEmitter(),
+		ScanDir:      scanDir,
+		CorruptedDir: corruptedDir,
+	})
+	require.NoError(t, err)
+
+	sessionID := session.NewID()
+	uploadPath := filepath.Join(scanDir, sessionID.String()+".tar")
+	errorPath := filepath.Join(scanDir, sessionID.String()+".error")
+
+	// create a "corrupted" upload and error file in the scan dir
+	b := make([]byte, 4096)
+	rand.Read(b)
+	require.NoError(t, os.WriteFile(uploadPath, b, 0600))
+	require.NoError(t, uploader.writeSessionError(sessionID, errors.New("this is a corrupted upload")))
+
+	stats, err := uploader.Scan(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Scanned)
+	require.Equal(t, 1, stats.Corrupted)
+	require.Equal(t, 0, stats.Started)
+
+	require.NoFileExists(t, uploadPath)
+	require.NoFileExists(t, errorPath)
+
+	require.FileExists(t, filepath.Join(corruptedDir, filepath.Base(uploadPath)))
+	require.FileExists(t, filepath.Join(corruptedDir, filepath.Base(errorPath)))
+
+	// run a second scan to verify that the file is no longer processed
+	stats, err = uploader.Scan(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, stats.Scanned)
+	require.Equal(t, 0, stats.Corrupted)
+	require.Equal(t, 0, stats.Started)
 }
 
 type resumeTestCase struct {
@@ -451,6 +496,7 @@ func (u *uploaderPack) Close(t *testing.T) {
 
 func newUploaderPack(t *testing.T, wrapStreamer wrapStreamerFn) uploaderPack {
 	scanDir := t.TempDir()
+	corruptedDir := t.TempDir()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	pack := uploaderPack{
@@ -476,11 +522,12 @@ func newUploaderPack(t *testing.T, wrapStreamer wrapStreamerFn) uploaderPack {
 	}
 
 	uploader, err := NewUploader(UploaderConfig{
-		ScanDir:    pack.scanDir,
-		ScanPeriod: pack.scanPeriod,
-		Streamer:   pack.streamer,
-		Clock:      pack.clock,
-		EventsC:    pack.eventsC,
+		ScanDir:      pack.scanDir,
+		CorruptedDir: corruptedDir,
+		ScanPeriod:   pack.scanPeriod,
+		Streamer:     pack.streamer,
+		Clock:        pack.clock,
+		EventsC:      pack.eventsC,
 	})
 	require.NoError(t, err)
 	pack.uploader = uploader
@@ -508,14 +555,16 @@ func runResume(t *testing.T, testCase resumeTestCase) {
 	test := testCase.newTest(streamer)
 
 	scanDir := t.TempDir()
+	corruptedDir := t.TempDir()
 
 	scanPeriod := 10 * time.Second
 	uploader, err := NewUploader(UploaderConfig{
-		EventsC:    eventsC,
-		ScanDir:    scanDir,
-		ScanPeriod: scanPeriod,
-		Streamer:   test.streamer,
-		Clock:      clock,
+		EventsC:      eventsC,
+		ScanDir:      scanDir,
+		CorruptedDir: corruptedDir,
+		ScanPeriod:   scanPeriod,
+		Streamer:     test.streamer,
+		Clock:        clock,
 	})
 	require.Nil(t, err)
 	go uploader.Serve(ctx)

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -481,7 +481,6 @@ func newUploaderPack(t *testing.T, wrapStreamer wrapStreamerFn) uploaderPack {
 		Streamer:   pack.streamer,
 		Clock:      pack.clock,
 		EventsC:    pack.eventsC,
-		AuditLog:   &events.DiscardAuditLog{},
 	})
 	require.NoError(t, err)
 	pack.uploader = uploader
@@ -517,7 +516,6 @@ func runResume(t *testing.T, testCase resumeTestCase) {
 		ScanPeriod: scanPeriod,
 		Streamer:   test.streamer,
 		Clock:      clock,
-		AuditLog:   &events.DiscardAuditLog{},
 	})
 	require.Nil(t, err)
 	go uploader.Serve(ctx)

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -69,9 +69,7 @@ const minUploadBytes = events.MaxProtoMessageSizeBytes * 2
 
 // NewStreamer creates a streamer sending uploads to disk
 func NewStreamer(dir string) (*events.ProtoStreamer, error) {
-	handler, err := NewHandler(Config{
-		Directory: dir,
-	})
+	handler, err := NewHandler(Config{Directory: dir})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -62,6 +62,10 @@ func (s *Config) CheckAndSetDefaults() error {
 
 // NewHandler returns new file sessions handler
 func NewHandler(cfg Config) (*Handler, error) {
+	if err := os.MkdirAll(cfg.Directory, teleport.SharedDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -807,13 +807,13 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 // async streamer buffers the events to disk and uploads the events later
 func (f *Forwarder) newStreamer(ctx *authContext) (events.Streamer, error) {
 	if services.IsRecordSync(ctx.recordingConfig.GetMode()) {
-		f.log.Debugf("Using sync streamer for session.")
+		f.log.Debug("Using sync streamer for session.")
 		return f.cfg.AuthClient, nil
 	}
-	f.log.Debugf("Using async streamer for session.")
+	f.log.Debug("Using async streamer for session.")
 	dir := filepath.Join(
 		f.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, apidefaults.Namespace,
+		events.StreamingSessionsDir, apidefaults.Namespace,
 	)
 	fileStreamer, err := filesessions.NewStreamer(dir)
 	if err != nil {

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -44,7 +43,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
-	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
 	"github.com/gravitational/teleport/lib/limiter"
@@ -198,17 +196,6 @@ func setupTestContext(ctx context.Context, t *testing.T, cfg testConfig) *testCo
 			}
 		},
 	})
-	require.NoError(t, err)
-	// create session recording path
-	// testCtx.kubeServer.DataDir/log/upload/streaming/default
-	err = os.MkdirAll(
-		filepath.Join(
-			testCtx.kubeServer.DataDir,
-			teleport.LogsDir,
-			teleport.ComponentUpload,
-			events.StreamingLogsDir,
-			apidefaults.Namespace,
-		), os.ModePerm)
 	require.NoError(t, err)
 
 	testCtx.startKubeService(t)

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
@@ -72,23 +71,6 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-	}
-
-	clusterName := conn.ServerIdentity.ClusterName
-
-	// Start uploader that will scan a path on disk and upload completed
-	// sessions to the auth server.
-	uploaderCfg := filesessions.UploaderConfig{
-		Streamer: accessPoint,
-		AuditLog: conn.Client,
-	}
-	completerCfg := events.UploadCompleterConfig{
-		SessionTracker: conn.Client,
-		ClusterName:    clusterName,
-	}
-	err = process.initUploaderService(uploaderCfg, completerCfg)
-	if err != nil {
-		return trace.Wrap(err)
 	}
 
 	// Create database resources from databases defined in the static configuration.
@@ -161,6 +143,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 		return trace.Wrap(err)
 	}
 
+	clusterName := conn.ServerIdentity.ClusterName
 	authorizer, err := auth.NewAuthorizer(clusterName, accessPoint, lockWatcher)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -30,8 +30,6 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
@@ -231,19 +229,6 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 			warnOnErr(srv.Close(), log)
 		}
 	}()
-
-	if err := process.initUploaderService(
-		filesessions.UploaderConfig{
-			Streamer: accessPoint,
-			AuditLog: conn.Client,
-		},
-		events.UploadCompleterConfig{
-			SessionTracker: conn.Client,
-			GracePeriod:    defaults.UploadGracePeriod,
-			ClusterName:    conn.ServerIdentity.ClusterName,
-		}); err != nil {
-		return trace.Wrap(err)
-	}
 
 	process.RegisterCriticalFunc("windows_desktop.serve", func() error {
 		if useTunnel {

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/events/filesessions"
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -72,21 +71,6 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 	}
 
 	teleportClusterName := conn.ServerIdentity.ClusterName
-
-	// Start uploader that will scan a path on disk and upload completed
-	// sessions to the Auth Server.
-	uploaderCfg := filesessions.UploaderConfig{
-		Streamer: accessPoint,
-		AuditLog: conn.Client,
-	}
-	completerCfg := events.UploadCompleterConfig{
-		SessionTracker: conn.Client,
-		ClusterName:    teleportClusterName,
-	}
-	if err := process.initUploaderService(uploaderCfg, completerCfg); err != nil {
-		return trace.Wrap(err)
-	}
-
 	proxyGetter := reversetunnel.NewConnectedProxyGetter()
 
 	// This service can run in 2 modes:

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1143,6 +1143,11 @@ func NewTeleport(cfg *Config, opts ...NewTeleportOption) (*TeleportProcess, erro
 
 	process.RegisterFunc("common.rotate", process.periodicSyncRotationState)
 
+	// run one upload completer per-process
+	// even in sync recording modes, since the recording mode can be changed
+	// at any time with dynamic configuration
+	process.RegisterFunc("common.upload", process.initUploaderService)
+
 	if !serviceStarted {
 		return nil, trace.BadParameter("all services failed to start")
 	}
@@ -1273,8 +1278,11 @@ func adminCreds() (*int, *int, error) {
 	return &uid, &gid, nil
 }
 
-// initUploadHandler initializes upload handler based on the config settings,
-func initUploadHandler(ctx context.Context, auditConfig types.ClusterAuditConfig, dataDir string) (events.MultipartHandler, error) {
+// initAuthUploadHandler initializes the auth server's upload handler based upon the configuration.
+// When configured to store session recordings in external storage, this will be an API client for
+// cloud-provider storage. Otherwise a local file-based handler is used which stores the recordings
+// on disk.
+func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditConfig, dataDir string) (events.MultipartHandler, error) {
 	if !auditConfig.ShouldUploadSessions() {
 		recordsDir := filepath.Join(dataDir, events.RecordsDir)
 		if err := os.MkdirAll(recordsDir, teleport.SharedDirMode); err != nil {
@@ -1469,7 +1477,7 @@ func (process *TeleportProcess) initAuthService() error {
 			cfg.Auth.AuditConfig.SetUseFIPSEndpoint(types.ClusterAuditConfigSpecV2_FIPS_ENABLED)
 		}
 
-		uploadHandler, err = initUploadHandler(
+		uploadHandler, err = initAuthUploadHandler(
 			process.ExitContext(), cfg.Auth.AuditConfig, filepath.Join(cfg.DataDir, teleport.LogsDir))
 		if err != nil {
 			if !trace.IsNotFound(err) {
@@ -1626,8 +1634,10 @@ func (process *TeleportProcess) initAuthService() error {
 
 	process.setLocalAuth(authServer)
 
-	// Upload completer is responsible for checking for initiated but abandoned
-	// session uploads and completing them. it will be closed once the process exits.
+	// The auth server runs its own upload completer, which is necessary in sync recording modes where
+	// a node can abandon an upload before it is competed.
+	// (In async recording modes, auth only ever sees completed uploads, as the node's upload completer
+	// packages up the parts into a single upload before sending to auth)
 	if uploadHandler != nil {
 		err = events.StartNewUploadCompleter(process.ExitContext(), events.UploadCompleterConfig{
 			Uploader:       uploadHandler,
@@ -2368,23 +2378,6 @@ func (process *TeleportProcess) initSSH() error {
 		}
 		defer func() { warnOnErr(s.Close(), log) }()
 
-		// init uploader service for recording SSH node, if proxy is not
-		// enabled on this node, because proxy stars uploader service as well
-		if !cfg.Proxy.Enabled {
-			uploaderCfg := filesessions.UploaderConfig{
-				Streamer: authClient,
-				AuditLog: conn.Client,
-			}
-			completerCfg := events.UploadCompleterConfig{
-				SessionTracker: conn.Client,
-				GracePeriod:    defaults.UploadGracePeriod,
-				ClusterName:    conn.ServerIdentity.ClusterName,
-			}
-			if err := process.initUploaderService(uploaderCfg, completerCfg); err != nil {
-				return trace.Wrap(err)
-			}
-		}
-
 		var agentPool *reversetunnel.AgentPool
 		if !conn.UseTunnel() {
 			listener, err := process.importOrCreateListener(listenerNodeSSH, cfg.SSH.Addr.Addr)
@@ -2483,12 +2476,43 @@ func (process *TeleportProcess) registerWithAuthServer(role types.SystemRole, ev
 	})
 }
 
-// initUploadService starts a file-based uploader that scans the local streaming logs directory
+// initUploaderService starts a file-based uploader that scans the local streaming logs directory
 // (data/log/upload/streaming/default/)
-func (process *TeleportProcess) initUploaderService(uploaderCfg filesessions.UploaderConfig, completerCfg events.UploadCompleterConfig) error {
+func (process *TeleportProcess) initUploaderService() error {
 	log := process.log.WithFields(logrus.Fields{
-		trace.Component: teleport.Component(teleport.ComponentAuditLog, process.id),
+		trace.Component: teleport.Component(teleport.ComponentUpload, process.id),
 	})
+
+	if _, err := process.WaitForEvent(process.ExitContext(), TeleportReadyEvent); err != nil {
+		return trace.Wrap(err)
+	}
+
+	log.Infof("starting upload completer service")
+
+	connectors := process.getConnectors()
+	var conn *Connector
+	for _, c := range connectors {
+		if c.Client != nil {
+			conn = c
+			log.Debugf("upload completer will use role %v", c.ServerIdentity.ID.Role)
+			break
+		}
+	}
+
+	// The auth service's upload completer is initialized separately.
+	// The only circumstance in which we would expect not to have found
+	// a connector is if the auth service is the only service running in
+	// this process. In that case, there's nothing to do here and we can
+	// safely return.
+	if conn == nil {
+		for _, localService := range types.LocalServiceMappings() {
+			if localService != types.RoleAuth && process.instanceRoleExpected(localService) {
+				return trace.BadParameter("no connectors found")
+			}
+		}
+		return nil
+	}
+
 	// create folder for uploads
 	uid, gid, err := adminCreds()
 	if err != nil {
@@ -2516,9 +2540,13 @@ func (process *TeleportProcess) initUploaderService(uploaderCfg filesessions.Upl
 		}
 	}
 
-	uploaderCfg.ScanDir = filepath.Join(path...)
-	uploaderCfg.EventsC = process.Config.UploadEventsC
-	fileUploader, err := filesessions.NewUploader(uploaderCfg)
+	uploadsDir := filepath.Join(path...)
+
+	fileUploader, err := filesessions.NewUploader(filesessions.UploaderConfig{
+		Streamer: conn.Client,
+		ScanDir:  uploadsDir,
+		EventsC:  process.Config.UploadEventsC,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -2541,16 +2569,21 @@ func (process *TeleportProcess) initUploaderService(uploaderCfg filesessions.Upl
 	// upload completer scans for uploads that have been initiated, but not completed
 	// by the client (aborted or crashed) and completes them. It will be closed once
 	// the uploader context is closed.
-	handler, err := filesessions.NewHandler(filesessions.Config{
-		Directory: filepath.Join(path...),
-	})
+	handler, err := filesessions.NewHandler(filesessions.Config{Directory: uploadsDir})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	completerCfg.Uploader = handler
-	completerCfg.AuditLog = uploaderCfg.AuditLog
-	uploadCompleter, err := events.NewUploadCompleter(completerCfg)
+	uploadCompleter, err := events.NewUploadCompleter(events.UploadCompleterConfig{
+		Uploader:       handler,
+		AuditLog:       conn.Client,
+		SessionTracker: conn.Client,
+		ClusterName:    conn.ServerIdentity.ClusterName,
+		// DELETE IN 11.0.0
+		// Provide a grace period so that Auth does not prematurely upload
+		// sessions which don't have a session tracker (v9.2 and earlier)
+		GracePeriod: defaults.UploadGracePeriod,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -4040,17 +4073,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		log.Infof("Exited.")
 	})
 
-	uploaderCfg := filesessions.UploaderConfig{
-		Streamer: accessPoint,
-		AuditLog: conn.Client,
-	}
-	completerCfg := events.UploadCompleterConfig{
-		SessionTracker: conn.Client,
-		ClusterName:    clusterName,
-	}
-	if err := process.initUploaderService(uploaderCfg, completerCfg); err != nil {
-		return trace.Wrap(err)
-	}
 	return nil
 }
 
@@ -4430,20 +4452,6 @@ func (process *TeleportProcess) initApps() {
 		}
 
 		clusterName := conn.ServerIdentity.ClusterName
-
-		// Start uploader that will scan a path on disk and upload completed
-		// sessions to the Auth Server.
-		uploaderCfg := filesessions.UploaderConfig{
-			Streamer: accessPoint,
-			AuditLog: conn.Client,
-		}
-		completerCfg := events.UploadCompleterConfig{
-			SessionTracker: conn.Client,
-			ClusterName:    clusterName,
-		}
-		if err := process.initUploaderService(uploaderCfg, completerCfg); err != nil {
-			return trace.Wrap(err)
-		}
 
 		// Start header dumping debugging application if requested.
 		if process.Config.Apps.DebugApp {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2519,33 +2519,38 @@ func (process *TeleportProcess) initUploaderService() error {
 		return trace.Wrap(err)
 	}
 
-	// prepare dir for uploader
-	path := []string{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.StreamingLogsDir, apidefaults.Namespace}
-	for i := 1; i < len(path); i++ {
-		dir := filepath.Join(path[:i+1]...)
-		log.Infof("Creating directory %v.", dir)
-		err := os.Mkdir(dir, 0o755)
-		err = trace.ConvertSystemError(err)
-		if err != nil {
-			if !trace.IsAlreadyExists(err) {
+	// prepare directories for uploader
+	paths := [][]string{
+		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.StreamingSessionsDir, apidefaults.Namespace},
+		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.CorruptedSessionsDir, apidefaults.Namespace},
+	}
+	for _, path := range paths {
+		for i := 1; i < len(path); i++ {
+			dir := filepath.Join(path[:i+1]...)
+			log.Infof("Creating directory %v.", dir)
+			err := os.Mkdir(dir, 0o755)
+			err = trace.ConvertSystemError(err)
+			if err != nil && !trace.IsAlreadyExists(err) {
 				return trace.Wrap(err)
 			}
-		}
-		if uid != nil && gid != nil {
-			log.Infof("Setting directory %v owner to %v:%v.", dir, *uid, *gid)
-			err := os.Chown(dir, *uid, *gid)
-			if err != nil {
-				return trace.ConvertSystemError(err)
+			if uid != nil && gid != nil {
+				log.Infof("Setting directory %v owner to %v:%v.", dir, *uid, *gid)
+				err := os.Chown(dir, *uid, *gid)
+				if err != nil {
+					return trace.ConvertSystemError(err)
+				}
 			}
 		}
 	}
 
-	uploadsDir := filepath.Join(path...)
+	uploadsDir := filepath.Join(paths[0]...)
+	corruptedDir := filepath.Join(paths[1]...)
 
 	fileUploader, err := filesessions.NewUploader(filesessions.UploaderConfig{
-		Streamer: conn.Client,
-		ScanDir:  uploadsDir,
-		EventsC:  process.Config.UploadEventsC,
+		Streamer:     conn.Client,
+		ScanDir:      uploadsDir,
+		CorruptedDir: corruptedDir,
+		EventsC:      process.Config.UploadEventsC,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -275,10 +275,10 @@ func TestServiceInitExternalLog(t *testing.T) {
 		{events: []string{"file://localhost"}, isErr: true},
 	}
 
-	backend, err := memory.New(memory.Config{})
-	require.NoError(t, err)
-
 	for _, tt := range tts {
+		backend, err := memory.New(memory.Config{})
+		require.NoError(t, err)
+
 		t.Run(strings.Join(tt.events, ","), func(t *testing.T) {
 			// isErr implies isNil.
 			if tt.isErr {

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -27,7 +27,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -276,13 +275,6 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 
 	// Generate certificate for AWS console application.
 	s.awsConsoleCertificate = s.generateCertificate(t, s.user, "aws.example.com", "readonly")
-
-	// Make sure the upload directory is created.
-	err = os.MkdirAll(filepath.Join(
-		s.dataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, defaults.Namespace,
-	), 0o755)
-	require.NoError(t, err)
 
 	lockWatcher, err := services.NewLockWatcher(s.closeContext, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -327,7 +327,7 @@ func (s *Server) newStreamer(ctx context.Context, chunkID string, recConfig type
 	s.log.Debugf("Using async streamer for session chunk %v.", chunkID)
 	uploadDir := filepath.Join(
 		s.c.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, apidefaults.Namespace,
+		events.StreamingSessionsDir, apidefaults.Namespace,
 	)
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {

--- a/lib/srv/db/streamer.go
+++ b/lib/srv/db/streamer.go
@@ -18,7 +18,6 @@ package db
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 
 	"github.com/gravitational/trace"
@@ -31,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/db/common"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 // newStreamWriter creates a streamer that will be used to stream the
@@ -78,18 +76,7 @@ func (s *Server) newStreamer(ctx context.Context, sessionID string, recConfig ty
 	s.log.Debugf("Using async streamer for session %v.", sessionID)
 	uploadDir := filepath.Join(
 		s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		libevents.StreamingLogsDir, apidefaults.Namespace)
-	// Make sure the upload dir exists, otherwise file streamer will fail.
-	_, err := utils.StatDir(uploadDir)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
-	if trace.IsNotFound(err) {
-		s.log.Debugf("Creating upload dir %v.", uploadDir)
-		if err := os.MkdirAll(uploadDir, 0755); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
+		libevents.StreamingSessionsDir, apidefaults.Namespace)
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -28,7 +28,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -433,19 +432,7 @@ func (s *WindowsService) newStreamer(ctx context.Context, recConfig types.Sessio
 	}
 	s.cfg.Log.Debugf("using async streamer (for mode %v)", recConfig.GetMode())
 	uploadDir := filepath.Join(s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		libevents.StreamingLogsDir, apidefaults.Namespace)
-
-	// ensure upload dir exists
-	_, err := utils.StatDir(uploadDir)
-	if trace.IsNotFound(err) {
-		s.cfg.Log.Debugf("Creating upload dir %v.", uploadDir)
-		if err := os.MkdirAll(uploadDir, 0755); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	} else if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+		libevents.StreamingSessionsDir, apidefaults.Namespace)
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -135,6 +135,7 @@ func newMockServer(t *testing.T) *mockServer {
 
 	return &mockServer{
 		auth:        authServer,
+		datadir:     t.TempDir(),
 		MockEmitter: &eventstest.MockEmitter{},
 		clock:       clock,
 	}
@@ -142,6 +143,7 @@ func newMockServer(t *testing.T) *mockServer {
 
 type mockServer struct {
 	*eventstest.MockEmitter
+	datadir   string
 	auth      *auth.Server
 	component string
 	clock     clockwork.FakeClock
@@ -191,7 +193,7 @@ func (m *mockServer) GetSessionServer() rsession.Service {
 
 // GetDataDir returns data directory of the server
 func (m *mockServer) GetDataDir() string {
-	return "testDataDir"
+	return m.datadir
 }
 
 // GetPAM returns PAM configuration for this server.

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -264,7 +264,6 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 		nodeClient,
 		serverOptions...)
 	require.NoError(t, err)
-	require.NoError(t, auth.CreateUploaderDir(nodeDir))
 	require.NoError(t, sshSrv.Start())
 	t.Cleanup(func() {
 		require.NoError(t, sshSrv.Close())
@@ -1785,7 +1784,6 @@ func TestLimiter(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, srv.Start())
 
-	require.NoError(t, auth.CreateUploaderDir(nodeStateDir))
 	defer srv.Close()
 
 	config := &ssh.ClientConfig{

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1276,7 +1276,7 @@ func (s *session) newStreamer(ctx *ServerContext) (events.Streamer, error) {
 func sessionsStreamingUploadDir(ctx *ServerContext) string {
 	return filepath.Join(
 		ctx.srv.GetDataDir(), teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, ctx.srv.GetNamespace(),
+		events.StreamingSessionsDir, ctx.srv.GetNamespace(),
 	)
 }
 

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -97,11 +97,6 @@ func TestSession_newRecorder(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	nodeRecording, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
-		Mode: types.RecordAtNode,
-	})
-	require.NoError(t, err)
-
 	nodeRecordingSync, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
 		Mode: types.RecordAtNodeSync,
 	})
@@ -163,28 +158,6 @@ func TestSession_newRecorder(t *testing.T) {
 				_, ok := i.(*events.DiscardStream)
 				require.True(t, ok)
 			},
-		},
-		{
-			desc: "err-new-streamer-fails",
-			sess: &session{
-				id:  "test",
-				log: logger,
-				registry: &SessionRegistry{
-					SessionRegistryConfig: SessionRegistryConfig{
-						Srv: &mockServer{
-							component: teleport.ComponentNode,
-						},
-					},
-				},
-			},
-			sctx: &ServerContext{
-				SessionRecordingConfig: nodeRecording,
-				srv: &mockServer{
-					component: teleport.ComponentNode,
-				},
-			},
-			errAssertion: require.Error,
-			recAssertion: require.Nil,
 		},
 		{
 			desc: "strict-err-new-audit-writer-fails",

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -277,7 +277,6 @@ func newWebSuite(t *testing.T) *WebSuite {
 	s.node = node
 	s.srvID = node.ID()
 	require.NoError(t, s.node.Start())
-	require.NoError(t, auth.CreateUploaderDir(nodeDataDir))
 
 	// create reverse tunnel service:
 	proxyID := "proxy"
@@ -5110,7 +5109,6 @@ func newWebPack(t *testing.T, numProxies int) *webPack {
 
 	require.NoError(t, node.Start())
 	t.Cleanup(func() { require.NoError(t, node.Close()) })
-	require.NoError(t, auth.CreateUploaderDir(nodeDataDir))
 
 	var proxies []*testProxy
 	for p := 0; p < numProxies; p++ {


### PR DESCRIPTION
Backports the following PRs, which consolidate on a single uploader service per-process and ensure that corrupted uploads are moved out of the scan directory.

- #14521
- #19011