### PR TITLE
[v9] uploader: move corrupted uploads to separate directory 

### DIFF
--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -299,7 +299,6 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 	)
 	require.NoError(t, err)
 	s.srv = srv
-	require.NoError(t, auth.CreateUploaderDirs(nodeDir))
 	require.NoError(t, s.srv.Start())
 	return s
 }

--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -299,7 +299,7 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 	)
 	require.NoError(t, err)
 	s.srv = srv
-	require.NoError(t, auth.CreateUploaderDir(nodeDir))
+	require.NoError(t, auth.CreateUploaderDirs(nodeDir))
 	require.NoError(t, s.srv.Start())
 	return s
 }

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -92,23 +92,16 @@ func (cfg *TestAuthServerConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-// CreateUploaderDir creates directory for file uploader service
-func CreateUploaderDir(dir string) error {
-	// DELETE IN(5.1.0)
-	// this folder is no longer used past 5.0 upgrade
-	err := os.MkdirAll(filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload,
-		events.SessionLogsDir, apidefaults.Namespace), teleport.SharedDirMode)
-	if err != nil {
-		return trace.ConvertSystemError(err)
+// CreateUploaderDirs creates the directory structure for the file uploader service.
+func CreateUploaderDirs(dir string) error {
+	var errs []error
+
+	for _, dirname := range []string{events.StreamingSessionsDir, events.CorruptedSessionsDir} {
+		path := filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload, dirname, apidefaults.Namespace)
+		errs = append(errs, trace.ConvertSystemError(os.MkdirAll(path, teleport.SharedDirMode)))
 	}
 
-	err = os.MkdirAll(filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, apidefaults.Namespace), teleport.SharedDirMode)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-
-	return nil
+	return trace.NewAggregate(errs...)
 }
 
 // TestServer defines the set of server components for a test

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -21,8 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"net"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -34,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
@@ -90,18 +87,6 @@ func (cfg *TestAuthServerConfig) CheckAndSetDefaults() error {
 		cfg.CipherSuites = utils.DefaultCipherSuites()
 	}
 	return nil
-}
-
-// CreateUploaderDirs creates the directory structure for the file uploader service.
-func CreateUploaderDirs(dir string) error {
-	var errs []error
-
-	for _, dirname := range []string{events.StreamingSessionsDir, events.CorruptedSessionsDir} {
-		path := filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload, dirname, apidefaults.Namespace)
-		errs = append(errs, trace.ConvertSystemError(os.MkdirAll(path, teleport.SharedDirMode)))
-	}
-
-	return trace.NewAggregate(errs...)
 }
 
 // TestServer defines the set of server components for a test

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -52,9 +52,17 @@ const (
 	// in /var/lib/teleport/log/sessions
 	SessionLogsDir = "sessions"
 
-	// StreamingLogsDir is a subdirectory of sessions /var/lib/teleport/log/streaming
-	// is used in new versions of the uploader
-	StreamingLogsDir = "streaming"
+	// StreamingSessionsDir is a subdirectory of sessions (/var/lib/teleport/log/upload/streaming)
+	// that is used in new versions of the uploader. This directory is used in asynchronous
+	// recording modes where recordings are buffered to disk before being uploaded
+	// to the auth server.
+	StreamingSessionsDir = "streaming"
+
+	// CorruptedSessionsDir is a subdirectory of sessions (/var/lib/teleport/log/upload/corrupted)
+	// where corrupted session recordings are placed. This ensures that the uploader doesn't
+	// continue to try to upload corrupted sessions, but preserves the recording in case it contains
+	// valuable info.
+	CorruptedSessionsDir = "corrupted"
 
 	// RecordsDir is a subdirectory with default records /var/lib/teleport/log/records
 	// is used in new versions of the uploader

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -97,6 +97,13 @@ func NewUploader(cfg UploaderConfig) (*Uploader, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	if err := os.MkdirAll(cfg.ScanDir, teleport.SharedDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	if err := os.MkdirAll(cfg.CorruptedDir, teleport.SharedDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
 	uploader := &Uploader{
 		cfg: cfg,
 		log: log.WithFields(log.Fields{

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -38,9 +38,7 @@ import (
 
 // NewStreamer creates a streamer sending uploads to disk
 func NewStreamer(dir string) (*events.ProtoStreamer, error) {
-	handler, err := NewHandler(Config{
-		Directory: dir,
-	})
+	handler, err := NewHandler(Config{Directory: dir})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -62,6 +62,10 @@ func (s *Config) CheckAndSetDefaults() error {
 
 // NewHandler returns new file sessions handler
 func NewHandler(cfg Config) (*Handler, error) {
+	if err := os.MkdirAll(cfg.Directory, teleport.SharedDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -750,10 +750,10 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 // async streamer buffers the events to disk and uploads the events later
 func (f *Forwarder) newStreamer(ctx *authContext) (events.Streamer, error) {
 	if services.IsRecordSync(ctx.recordingConfig.GetMode()) {
-		f.log.Debugf("Using sync streamer for session.")
+		f.log.Debug("Using sync streamer for session.")
 		return f.cfg.AuthClient, nil
 	}
-	f.log.Debugf("Using async streamer for session.")
+	f.log.Debug("Using async streamer for session.")
 	dir := filepath.Join(
 		f.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
 		events.StreamingSessionsDir, apidefaults.Namespace,

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -756,7 +756,7 @@ func (f *Forwarder) newStreamer(ctx *authContext) (events.Streamer, error) {
 	f.log.Debugf("Using async streamer for session.")
 	dir := filepath.Join(
 		f.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, apidefaults.Namespace,
+		events.StreamingSessionsDir, apidefaults.Namespace,
 	)
 	fileStreamer, err := filesessions.NewStreamer(dir)
 	if err != nil {

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -251,8 +251,13 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	// Make sure the upload directory is created.
 	err = os.MkdirAll(filepath.Join(
 		s.dataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, defaults.Namespace,
-	), 0755)
+		events.StreamingSessionsDir, defaults.Namespace,
+	), 0o755)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(
+		s.dataDir, teleport.LogsDir, teleport.ComponentUpload,
+		events.CorruptedSessionsDir, defaults.Namespace,
+	), 0o755)
 	require.NoError(t, err)
 
 	lockWatcher, err := services.NewLockWatcher(s.closeContext, services.LockWatcherConfig{

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -27,7 +27,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -247,18 +246,6 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 
 	// Generate certificate for AWS console application.
 	s.awsConsoleCertificate = s.generateCertificate(t, s.user, "aws.example.com", "readonly")
-
-	// Make sure the upload directory is created.
-	err = os.MkdirAll(filepath.Join(
-		s.dataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingSessionsDir, defaults.Namespace,
-	), 0o755)
-	require.NoError(t, err)
-	err = os.MkdirAll(filepath.Join(
-		s.dataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.CorruptedSessionsDir, defaults.Namespace,
-	), 0o755)
-	require.NoError(t, err)
 
 	lockWatcher, err := services.NewLockWatcher(s.closeContext, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -307,7 +307,7 @@ func (s *Server) newStreamer(ctx context.Context, chunkID string, recConfig type
 	s.log.Debugf("Using async streamer for session chunk %v.", chunkID)
 	uploadDir := filepath.Join(
 		s.c.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, apidefaults.Namespace,
+		events.StreamingSessionsDir, apidefaults.Namespace,
 	)
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {

--- a/lib/srv/db/streamer.go
+++ b/lib/srv/db/streamer.go
@@ -18,7 +18,6 @@ package db
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 
 	"github.com/gravitational/teleport"
@@ -29,7 +28,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/db/common"
-	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
 )
@@ -79,24 +77,6 @@ func (s *Server) newStreamer(ctx context.Context, sessionID string, recConfig ty
 	uploadDir := filepath.Join(
 		s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
 		libevents.StreamingSessionsDir, apidefaults.Namespace)
-	corruptedDir := filepath.Join(
-		s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		libevents.CorruptedSessionsDir, apidefaults.Namespace)
-
-	for _, dir := range []string{uploadDir, corruptedDir} {
-		// Make sure the upload dir exists, otherwise file streamer will fail.
-		_, err := utils.StatDir(dir)
-		if err != nil && !trace.IsNotFound(err) {
-			return nil, trace.Wrap(err)
-		}
-		if trace.IsNotFound(err) {
-			s.log.Debugf("Creating upload dir %v.", uploadDir)
-			if err := os.MkdirAll(uploadDir, 0755); err != nil {
-				return nil, trace.Wrap(err)
-			}
-		}
-	}
-
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/db/streamer.go
+++ b/lib/srv/db/streamer.go
@@ -78,18 +78,25 @@ func (s *Server) newStreamer(ctx context.Context, sessionID string, recConfig ty
 	s.log.Debugf("Using async streamer for session %v.", sessionID)
 	uploadDir := filepath.Join(
 		s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		libevents.StreamingLogsDir, apidefaults.Namespace)
-	// Make sure the upload dir exists, otherwise file streamer will fail.
-	_, err := utils.StatDir(uploadDir)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
-	if trace.IsNotFound(err) {
-		s.log.Debugf("Creating upload dir %v.", uploadDir)
-		if err := os.MkdirAll(uploadDir, 0755); err != nil {
+		libevents.StreamingSessionsDir, apidefaults.Namespace)
+	corruptedDir := filepath.Join(
+		s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
+		libevents.CorruptedSessionsDir, apidefaults.Namespace)
+
+	for _, dir := range []string{uploadDir, corruptedDir} {
+		// Make sure the upload dir exists, otherwise file streamer will fail.
+		_, err := utils.StatDir(dir)
+		if err != nil && !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
+		if trace.IsNotFound(err) {
+			s.log.Debugf("Creating upload dir %v.", uploadDir)
+			if err := os.MkdirAll(uploadDir, 0755); err != nil {
+				return nil, trace.Wrap(err)
+			}
+		}
 	}
+
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -28,7 +28,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -426,22 +425,6 @@ func (s *WindowsService) newStreamer(ctx context.Context, recConfig types.Sessio
 	s.cfg.Log.Debugf("using async streamer (for mode %v)", recConfig.GetMode())
 	uploadDir := filepath.Join(s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
 		libevents.StreamingSessionsDir, apidefaults.Namespace)
-	corruptedDir := filepath.Join(s.cfg.DataDir, teleport.LogsDir, teleport.ComponentUpload,
-		libevents.CorruptedSessionsDir, apidefaults.Namespace)
-
-	// ensure uploader directories exist
-	for _, dir := range []string{uploadDir, corruptedDir} {
-		_, err := utils.StatDir(dir)
-		if trace.IsNotFound(err) {
-			s.cfg.Log.Debugf("Creating upload dir %v.", dir)
-			if err := os.MkdirAll(dir, 0755); err != nil {
-				return nil, trace.Wrap(err)
-			}
-		} else if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
 	fileStreamer, err := filesessions.NewStreamer(uploadDir)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -127,6 +127,7 @@ func newMockServer(t *testing.T) *mockServer {
 
 	return &mockServer{
 		auth:        authServer,
+		datadir:     t.TempDir(),
 		MockEmitter: &events.MockEmitter{},
 		clock:       clock,
 	}
@@ -134,6 +135,7 @@ func newMockServer(t *testing.T) *mockServer {
 
 type mockServer struct {
 	*events.MockEmitter
+	datadir   string
 	auth      *auth.Server
 	component string
 	clock     clockwork.FakeClock
@@ -183,7 +185,7 @@ func (m *mockServer) GetSessionServer() rsession.Service {
 
 // GetDataDir returns data directory of the server
 func (m *mockServer) GetDataDir() string {
-	return "test"
+	return m.datadir
 }
 
 // GetPAM returns PAM configuration for this server.

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -263,7 +263,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 		nodeClient,
 		serverOptions...)
 	require.NoError(t, err)
-	require.NoError(t, auth.CreateUploaderDir(nodeDir))
+	require.NoError(t, auth.CreateUploaderDirs(nodeDir))
 	require.NoError(t, sshSrv.Start())
 	t.Cleanup(func() {
 		require.NoError(t, sshSrv.Close())
@@ -1791,7 +1791,7 @@ func TestLimiter(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, srv.Start())
 
-	require.NoError(t, auth.CreateUploaderDir(nodeStateDir))
+	require.NoError(t, auth.CreateUploaderDirs(nodeStateDir))
 	defer srv.Close()
 
 	config := &ssh.ClientConfig{

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -263,7 +263,6 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 		nodeClient,
 		serverOptions...)
 	require.NoError(t, err)
-	require.NoError(t, auth.CreateUploaderDirs(nodeDir))
 	require.NoError(t, sshSrv.Start())
 	t.Cleanup(func() {
 		require.NoError(t, sshSrv.Close())
@@ -1791,7 +1790,6 @@ func TestLimiter(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, srv.Start())
 
-	require.NoError(t, auth.CreateUploaderDirs(nodeStateDir))
 	defer srv.Close()
 
 	config := &ssh.ClientConfig{

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1170,7 +1170,7 @@ func (s *session) newStreamer(ctx *ServerContext) (events.Streamer, error) {
 func sessionsStreamingUploadDir(ctx *ServerContext) string {
 	return filepath.Join(
 		ctx.srv.GetDataDir(), teleport.LogsDir, teleport.ComponentUpload,
-		events.StreamingLogsDir, ctx.srv.GetNamespace(),
+		events.StreamingSessionsDir, ctx.srv.GetNamespace(),
 	)
 }
 

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -95,11 +95,6 @@ func TestSession_newRecorder(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	nodeRecording, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
-		Mode: types.RecordAtNode,
-	})
-	require.NoError(t, err)
-
 	nodeRecordingSync, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
 		Mode: types.RecordAtNodeSync,
 	})
@@ -161,28 +156,6 @@ func TestSession_newRecorder(t *testing.T) {
 				_, ok := i.(*events.DiscardStream)
 				require.True(t, ok)
 			},
-		},
-		{
-			desc: "err-new-streamer-fails",
-			sess: &session{
-				id:  "test",
-				log: logger,
-				registry: &SessionRegistry{
-					SessionRegistryConfig: SessionRegistryConfig{
-						Srv: &mockServer{
-							component: teleport.ComponentNode,
-						},
-					},
-				},
-			},
-			sctx: &ServerContext{
-				SessionRecordingConfig: nodeRecording,
-				srv: &mockServer{
-					component: teleport.ComponentNode,
-				},
-			},
-			errAssertion: require.Error,
-			recAssertion: require.Nil,
 		},
 		{
 			desc: "err-new-audit-writer-fails",

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -261,7 +261,6 @@ func newWebSuite(t *testing.T) *WebSuite {
 	s.node = node
 	s.srvID = node.ID()
 	require.NoError(t, s.node.Start())
-	require.NoError(t, auth.CreateUploaderDirs(nodeDataDir))
 
 	// create reverse tunnel service:
 	proxyID := "proxy"
@@ -4143,7 +4142,6 @@ func newWebPack(t *testing.T, numProxies int) *webPack {
 
 	require.NoError(t, node.Start())
 	t.Cleanup(func() { require.NoError(t, node.Close()) })
-	require.NoError(t, auth.CreateUploaderDirs(nodeDataDir))
 
 	var proxies []*testProxy
 	for p := 0; p < numProxies; p++ {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -261,7 +261,7 @@ func newWebSuite(t *testing.T) *WebSuite {
 	s.node = node
 	s.srvID = node.ID()
 	require.NoError(t, s.node.Start())
-	require.NoError(t, auth.CreateUploaderDir(nodeDataDir))
+	require.NoError(t, auth.CreateUploaderDirs(nodeDataDir))
 
 	// create reverse tunnel service:
 	proxyID := "proxy"
@@ -4143,7 +4143,7 @@ func newWebPack(t *testing.T, numProxies int) *webPack {
 
 	require.NoError(t, node.Start())
 	t.Cleanup(func() { require.NoError(t, node.Close()) })
-	require.NoError(t, auth.CreateUploaderDir(nodeDataDir))
+	require.NoError(t, auth.CreateUploaderDirs(nodeDataDir))
 
 	var proxies []*testProxy
 	for p := 0; p < numProxies; p++ {


### PR DESCRIPTION
Backports #19011 

Note: unlike the v10 backport (#19259) we're not backporting #14521 here, because it depends on some of the instance role work added in v10.