### PR TITLE
Correct teleport start for db getting started

### DIFF
--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -116,14 +116,13 @@ endpoint and region appropriately. The `--auth-server` flag must point to the
 address of your Teleport Proxy Service.
 
 ```code
-$ teleport start \
-  --roles=db \
+$ teleport db start \
   --token=/tmp/token \
-  --db-name=aurora \
+  --name=aurora \
   --auth-server=teleport.example.com:3080 \
-  --db-protocol=postgres \
-  --db-uri=postgres-aurora-instance-1.abcdefghijklm.us-west-1.rds.amazonaws.com:5432 \
-  --db-aws-region=us-west-1
+  --protocol=postgres \
+  --uri=postgres-aurora-instance-1.abcdefghijklm.us-west-1.rds.amazonaws.com:5432 \
+  --aws-region=us-west-1
 ```
 
 </ScopedBlock>
@@ -135,14 +134,13 @@ endpoint and region appropriately. The `--auth-server` flag must point to the
 address of your Teleport Cloud tenant.
 
 ```code
-$ teleport start \
-  --roles=db \
+$ teleport db start \
   --token=/tmp/token \
-  --db-name=aurora \
+  --name=aurora \
   --auth-server=mytenant.teleport.sh:443 \
-  --db-protocol=postgres \
-  --db-uri=postgres-aurora-instance-1.abcdefghijklm.us-west-1.rds.amazonaws.com:5432 \
-  --db-aws-region=us-west-1
+  --protocol=postgres \
+  --uri=postgres-aurora-instance-1.abcdefghijklm.us-west-1.rds.amazonaws.com:5432 \
+  --aws-region=us-west-1
 ```
 
 </ScopedBlock>

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -116,7 +116,8 @@ endpoint and region appropriately. The `--auth-server` flag must point to the
 address of your Teleport Proxy Service.
 
 ```code
-$ teleport db start \
+$ teleport start \
+  --roles=db \
   --token=/tmp/token \
   --db-name=aurora \
   --auth-server=teleport.example.com:3080 \
@@ -134,7 +135,8 @@ endpoint and region appropriately. The `--auth-server` flag must point to the
 address of your Teleport Cloud tenant.
 
 ```code
-$ teleport db start \
+$ teleport start \
+  --roles=db \
   --token=/tmp/token \
   --db-name=aurora \
   --auth-server=mytenant.teleport.sh:443 \


### PR DESCRIPTION
Corrected parameters to work with `teleport db start`