### PR TITLE
helm: add PodMonitor support

### DIFF
--- a/examples/chart/teleport-cluster/templates/podmonitor.yaml
+++ b/examples/chart/teleport-cluster/templates/podmonitor.yaml
@@ -1,0 +1,32 @@
+{{- if.Values.podMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "teleport-cluster.labels" . | nindent 4 }}
+  {{- with .Values.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels: {{- include "teleport-cluster.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+  endpoints:
+    - port: diag
+      path: /metrics
+      {{- with .Values.podMonitor.interval }}
+      interval: {{ . | quote }}
+      {{- end }}
+      podTargetLabels:
+        - "app.kubernetes.io/name"
+        - "app.kubernetes.io/instance"
+        - "app.kubernetes.io/component"
+        - "app.kubernetes.io/version"
+        - "teleport.dev/majorVersion"
+{{- end }}

--- a/examples/chart/teleport-cluster/tests/podmonitor_test.yaml
+++ b/examples/chart/teleport-cluster/tests/podmonitor_test.yaml
@@ -1,0 +1,39 @@
+suite: PodMonitor
+templates:
+  - podmonitor.yaml
+tests:
+  - it: does not create a PodMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates a PodMonitor when enabled
+    set:
+      podMonitor:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodMonitor
+
+  - it: configures scrape interval if provided
+    set:
+      podMonitor:
+        enabled: true
+        interval: 2m
+    asserts:
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 2m
+
+  - it: wears additional labels if provided
+    set:
+      podMonitor:
+        enabled: true
+        additionalLabels:
+          prometheus: teleport-only
+    asserts:
+      - equal:
+          path: metadata.labels.prometheus
+          value: teleport-only

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -10,6 +10,7 @@
         "labels",
         "chartMode",
         "highAvailability",
+        "podMonitor",
         "tls",
         "image",
         "enterpriseImage",
@@ -42,6 +43,29 @@
             "$id": "#/properties/createProxyToken",
             "type": "boolean",
             "default": true
+        },
+        "podMonitor": {
+            "$id": "#/properties/podMonitor",
+            "type": "object",
+            "required": ["enabled"],
+            "properties": {
+                "enabled": {
+                    "$id": "#/properties/podMonitor/enabled",
+                    "type": "boolean",
+                    "default": false
+                },
+                "additionalLabels": {
+                    "$id": "#/properties/podMonitor/additionalLabels",
+                    "type": "object",
+                    "default": {"prometheus": "default"},
+                    "additionalProperties": {"type": "string"}
+                },
+                "interval": {
+                    "$id": "#/properties/podMonitor/interval",
+                    "type": "string",
+                    "default": "30s"
+                }
+            }
         },
         "authentication": {
             "$id": "#/properties/authentication",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -185,6 +185,23 @@ chartMode: standalone
 # Helm chart user is responsible for configuring working join_params on the proxy.
 createProxyToken: true
 
+# podMonitor controls the PodMonitor CR (from monitoring.coreos.com/v1)
+# This CRD is managed by the prometheus-operator and allows workload to
+# get monitored. To use this value, you need to run a `prometheus-operator`
+# in the cluster for this value to take effect.
+# See https://prometheus-operator.dev/docs/prologue/introduction/
+podMonitor:
+  # Whether the chart should deploy a PodMonitor.
+  # Disabled by default as it requires the PodMonitor CRD to be installed.
+  enabled: false
+  # additionalLabels to put on the PodMonitor.
+  # This is used to be selected by a specific prometheus instance.
+  # Defaults to {prometheus: default} which seems to be the common default prometheus selector
+  additionalLabels:
+    prometheus: default
+  # interval is the interval between two metrics scrapes. Defaults to 30s
+  interval: 30s
+
 ######################################################################
 # Persistence settings (only used in "standalone" and "custom" modes)
 # NOTE: Changes in Kubernetes 1.23+ mean that persistent volumes will not automatically be provisioned in AWS EKS clusters


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/pull/18274

Fixes https://github.com/gravitational/teleport/issues/13260

Adds prometheus-operator support for the chart. With this change, users can leverage their existing Prometheus deployments to collect Teleport metrics without manually configuring it.

I suggest using a `PodMonitor` instead of a `ServiceMonitor` because the chart v12 will deploy multiple pods, multiple services sometimes overlapping. A PodMonitor seemed easier and more adequate.

Note: merge only once the [auth/proxy split PR](https://github.com/gravitational/teleport/pull/18857) has been merged