### PR TITLE
remove onboard prefix from recovery events

### DIFF
--- a/lib/web/userevent.go
+++ b/lib/web/userevent.go
@@ -34,9 +34,9 @@ const (
 	getStartedClickEvent            = "tp.ui.onboard.getStarted.click"
 	setCredentialSubmitEvent        = "tp.ui.onboard.setCredential.submit"
 	registerChallengeSubmitEvent    = "tp.ui.onboard.registerChallenge.submit"
-	recoveryCodesContinueClickEvent = "tp.ui.onboard.recoveryCodesContinue.click"
 	addFirstResourceClickEvent      = "tp.ui.onboard.addFirstResource.click"
 	addFirstResourceLaterClickEvent = "tp.ui.onboard.addFirstResourceLater.click"
+	recoveryCodesContinueClickEvent = "tp.ui.recoveryCodesContinue.click"
 )
 
 // createPreUserEventRequest contains the event and properties associated with a user event


### PR DESCRIPTION
Update missed mapping from previous naming refactor, which is currently causing us to drop the event