### PR TITLE
[v11] Handle empty slice in `tdpMFACodec.decode()`

### DIFF
--- a/lib/web/fuzz_test.go
+++ b/lib/web/fuzz_test.go
@@ -23,10 +23,12 @@ import (
 )
 
 func FuzzTdpMFACodecDecode(f *testing.F) {
+	f.Add([]byte(""))
+
 	f.Fuzz(func(t *testing.T, buf []byte) {
 		require.NotPanics(t, func() {
 			codec := tdpMFACodec{}
-			codec.decode(buf, "")
+			_, _ = codec.decode(buf, "")
 		})
 	})
 }

--- a/lib/web/mfa_codec.go
+++ b/lib/web/mfa_codec.go
@@ -90,7 +90,10 @@ func (tdpMFACodec) encode(chal *client.MFAAuthenticateChallenge, envelopeType st
 }
 
 func (tdpMFACodec) decode(buf []byte, envelopeType string) (*authproto.MFAAuthenticateResponse, error) {
-	if len(buf) == 0 || tdp.MessageType(buf[0]) != tdp.TypeMFA {
+	if len(buf) == 0 {
+		return nil, trace.BadParameter("empty MFA message received")
+	}
+	if tdp.MessageType(buf[0]) != tdp.TypeMFA {
 		return nil, trace.BadParameter("expected MFA message type %v, got %v", tdp.TypeMFA, buf[0])
 	}
 	msg, err := tdp.DecodeMFA(bytes.NewReader(buf[1:]))


### PR DESCRIPTION
Backport #19270 to branch/v11