### PR TITLE
Provides a way to disable providing access to the in-cluster kubernet…

### DIFF
--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -100,7 +100,7 @@ data:
       proxy_listener_mode: multiplex
   {{- end }}
     kubernetes_service:
-      enabled: true
+      enabled: {{ .Values.kubernetesServiceEnabled }}
   {{- if eq .Values.proxyListenerMode "multiplex" }}
       listen_addr: 0.0.0.0:443
   {{- else if not .Values.proxyListenerMode }}

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -325,6 +325,9 @@ log:
 # NOTE: If affinity is set here, highAvailability.requireAntiAffinity cannot also be used - you can only set one or the other.
 affinity: {}
 
+# Whether to enable/disable access to the in-cluster kubernetes cluster
+kubernetesServiceEnabled: true
+
 # Kubernetes annotations to apply
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 annotations:


### PR DESCRIPTION
There are cases where we want to deploy a teleport cluster onto a kubernetes cluster without exposing that kubernetes cluster via teleport. This just adds an option to override the kubernetes_service.enabled value. The default is true.
