### PR TITLE
TBot CA rotation - less flaky, more performant, more integration

### DIFF
--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -216,7 +216,7 @@ func (s *Server) deleteBot(ctx context.Context, botName string) error {
 	// Note: this does not remove any locks for the bot's user / role. That
 	// might be convenient in case of accidental bot locking but there doesn't
 	// seem to be any automatic deletion of locks in teleport today (other
-	// than expiration). Consistency around security controls seems important
+	// than expiration). Consistency around security controls seems important,
 	// but we can revisit this if desired.
 	resourceName := BotResourceName(botName)
 
@@ -365,10 +365,10 @@ func (s *Server) validateGenerationLabel(ctx context.Context, user types.User, c
 
 		// Fetch a fresh copy of the user we can mutate safely. We can't
 		// implement a protobuf clone on User due to protobuf's proto.Clone()
-		// panicing when the user object has traits set, and a JSON
+		// panicking when the user object has traits set, and a JSON
 		// marshal/unmarshal creates an import cycle so... here we are.
 		// There's a tiny chance the underlying user is mutated between calls
-		// to GetUser() but we're comparing with an older value so it'll fail
+		// to GetUser() but we're comparing with an older value, so it'll fail
 		// safely.
 		newUser, err := s.Services.GetUser(user.GetName(), false)
 		if err != nil {

--- a/lib/auth/clt_test.go
+++ b/lib/auth/clt_test.go
@@ -52,8 +52,8 @@ func TestClient_DialTimeout(t *testing.T) {
 	}
 
 	for _, tt := range cases {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			tt := tt
 			t.Parallel()
 
 			// create a client that will attempt to connect to a blackholed address. The address is reserved

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -51,6 +52,17 @@ type Bot struct {
 	_proxyPong *webclient.PingResponse
 	_cas       map[types.CertAuthType][]types.CertAuthority
 	started    bool
+}
+
+// TestBot is a wrapper around Bot struct with some internal exposed.
+type TestBot struct {
+	*Bot
+}
+
+// Ident exposes private Bot.ident() method. testing.T parameter allows this
+// method only to be used in tests.
+func (b *TestBot) Ident(_ *testing.T) *identity.Identity {
+	return b.ident()
 }
 
 func New(cfg *config.BotConfig, log logrus.FieldLogger, reloadChan chan struct{}) *Bot {

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -279,7 +279,7 @@ func (b *Bot) initialize(ctx context.Context) (func() error, error) {
 		)
 	}
 
-	// Now attempt to lock the destination so we have sole use of it
+	// Now attempt to lock the destination, so we have sole use of it.
 	unlock, err := dest.TryLock()
 	if err != nil {
 		if errors.Is(err, utils.ErrUnsuccessfulLockTry) {
@@ -411,7 +411,7 @@ func checkDestinations(cfg *config.BotConfig) error {
 		return trace.Wrap(err)
 	}
 
-	// TODO: consider warning if ownership of all destintions is not expected.
+	// TODO: consider warning if ownership of all destinations is not expected.
 
 	// Note: no subdirs to init for bot's internal storage.
 	if err := storage.Init([]string{}); err != nil {

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
@@ -42,11 +43,11 @@ func TestMain(m *testing.M) {
 }
 
 func rotate(
-	ctx context.Context, t *testing.T, log logrus.FieldLogger, svc *service.TeleportProcess, phase string,
+	ctx context.Context, t *testing.T, log logrus.FieldLogger, svc func() *service.TeleportProcess, phase string, reload chan struct{},
 ) {
 	t.Helper()
 	log.Infof("Triggering rotation: %s", phase)
-	err := svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+	err := svc().GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
 		// only rotate Host CA as to avoid race condition serverside when
 		// multiple CAs are rotated at once and the database closes off.
 		Type:        types.HostCA,
@@ -58,9 +59,85 @@ func rotate(
 	}
 	require.NoError(t, err)
 	log.Infof("Triggered rotation: %s", phase)
+
+	if phase == types.RotationPhaseInit {
+		err = waitForProcessEvent(svc(), service.TeleportPhaseChangeEvent, 30*time.Second)
+		require.NoError(t, err)
+	} else {
+		err = waitForProcessEvent(svc(), service.TeleportReloadEvent, 30*time.Second)
+		require.NoError(t, err)
+
+		select {
+		case <-reload:
+			t.Logf("service reloaded")
+		case <-time.After(10 * time.Second):
+			require.FailNow(t, "failed waiting of the service restart")
+		}
+
+		err = waitForProcessEvent(svc(), service.TeleportReadyEvent, 30*time.Second)
+		require.NoError(t, err)
+	}
+
+	cid := types.CertAuthID{Type: types.HostCA, DomainName: "ubuntu-22-04"}
+
+	require.Eventually(t, func() bool {
+		cert, err := svc().GetAuthServer().GetCertAuthority(ctx, cid, false)
+		require.NoError(t, err)
+		if err != nil {
+			return false
+		}
+		return cert.GetRotation().Phase == phase
+	}, 30*time.Second, 200*time.Millisecond)
 }
 
-func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *testing.T, wg *sync.WaitGroup) (auth.ClientI, func() *service.TeleportProcess, *config.FileConfig) {
+// waitForProcessEvent waits for process event to occur or timeout
+func waitForProcessEvent(svc *service.TeleportProcess, event string, timeout time.Duration) error {
+	if _, err := svc.WaitForEventTimeout(timeout, event); err != nil {
+		return trace.BadParameter("timeout waiting for service to broadcast event %v", event)
+	}
+	return nil
+}
+
+//// waitForReload waits for multiple events to happen:
+////
+//// 1. new service to be created and started
+//// 2. old service, if present to shut down
+////
+//// this helper function allows to serialize tests for reloads.
+//func waitForReload(serviceC chan *service.TeleportProcess, old *service.TeleportProcess) (*service.TeleportProcess, error) {
+//	var svc *service.TeleportProcess
+//	select {
+//	case svc = <-serviceC:
+//	case <-time.After(1 * time.Minute):
+//		//dumpGoroutineProfile()
+//		return nil, trace.BadParameter("timeout waiting for service to start")
+//	}
+//
+//	if _, err := svc.WaitForEventTimeout(20*time.Second, service.TeleportReadyEvent); err != nil {
+//		//dumpGoroutineProfile()
+//		return nil, trace.BadParameter("timeout waiting for service to broadcast ready status")
+//	}
+//
+//	// if old service is present, wait for it to complete shut down procedure
+//	if old != nil {
+//		ctx, cancel := context.WithCancel(context.TODO())
+//		go func() {
+//			defer cancel()
+//			old.Supervisor.Wait()
+//		}()
+//		select {
+//		case <-ctx.Done():
+//		case <-time.After(1 * time.Minute):
+//			//dumpGoroutineProfile()
+//			return nil, trace.BadParameter("timeout waiting for old service to stop")
+//		}
+//	}
+//	return svc, nil
+//}
+
+func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *testing.T,
+	errC chan error) (auth.ClientI, func() *service.TeleportProcess, *config.FileConfig, chan struct{},
+) {
 	fc, fds := testhelpers.DefaultConfig(t)
 
 	cfg := service.MakeDefaultConfig()
@@ -69,11 +146,11 @@ func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *test
 	cfg.Log = log
 	cfg.CachePolicy.Enabled = false
 	cfg.Proxy.DisableWebInterface = true
+	cfg.RotationConnectionInterval = 500 * time.Millisecond
+	cfg.PollingPeriod = time.Second
 
 	svcC := make(chan *service.TeleportProcess)
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		err := service.Run(ctx, *cfg, func(cfg *service.Config) (service.Process, error) {
 			svc, err := service.NewTeleport(cfg)
 			if err == nil {
@@ -81,7 +158,8 @@ func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *test
 			}
 			return svc, err
 		})
-		require.NoError(t, err)
+		//require.NoError(t, err)
+		errC <- err
 	}()
 
 	var svc *service.TeleportProcess
@@ -99,18 +177,22 @@ func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *test
 	// timeout here because this isn't the kind of problem that this test is meant to catch.
 	require.NoError(t, err, "auth server didn't start after 30s")
 
+	reloadChan := make(chan struct{})
 	// Tracks the latest instance of the Teleport service through reloads
 	activeSvc := svc
 	activeSvcMu := sync.Mutex{}
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer func() {
+			errC <- nil
+		}()
+
 		for {
 			select {
 			case svc := <-svcC:
 				activeSvcMu.Lock()
 				activeSvc = svc
 				activeSvcMu.Unlock()
+				reloadChan <- struct{}{}
 			case <-ctx.Done():
 				return
 			}
@@ -121,75 +203,96 @@ func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *test
 		activeSvcMu.Lock()
 		defer activeSvcMu.Unlock()
 		return activeSvc
-	}, fc
+	}, fc, reloadChan
 }
 
 // TestCARotation is a heavy integration test that through a rotation, the bot
 // receives credentials for a new CA.
 func TestBot_Run_CARotation(t *testing.T) {
 	t.Parallel()
-	if testing.Short() {
-		t.Skip("test skipped when -short provided")
-	}
 
-	// wg and context manage the cancellation of long running processes e.g
+	// wg and context manage the cancellation of long-running processes e.g.
 	// teleport and tbot in the test.
 	log := utils.NewLoggerForTests()
-	wg := &sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())
+
+	errC := make(chan error)
 	t.Cleanup(func() {
 		log.Infof("Shutting down long running test processes..")
 		cancel()
-		wg.Wait()
+
+		for i := 0; i < 3; i++ {
+			require.NoError(t, <-errC)
+		}
 	})
 
-	client, teleportProcess, fc := setupServerForCARotationTest(ctx, log, t, wg)
+	client, teleportProcess, fc, reloadChan := setupServerForCARotationTest(ctx, log, t, errC)
 
 	// Make and join a new bot instance.
 	botParams := testhelpers.MakeBot(t, client, "test", "access")
 	botConfig := testhelpers.MakeMemoryBotConfig(t, fc, botParams)
+	botConfig.RenewalInterval = 5 * time.Second
 	b := New(botConfig, log, make(chan struct{}))
 
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		err := b.Run(ctx)
-		require.NoError(t, err)
+		errC <- err
 	}()
+
 	// Allow time for bot to start running and watching for CA rotations
 	// TODO: We should modify the bot to emit events that may be useful...
-	time.Sleep(10 * time.Second)
+	//time.Sleep(10 * time.Second)
+
+	require.Eventually(t, func() bool {
+		return b.ident() != nil
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// fetch initial host cert
 	require.Len(t, b.ident().TLSCACertsBytes, 2)
 	initialCAs := [][]byte{}
 	copy(initialCAs, b.ident().TLSCACertsBytes)
 
-	// Begin rotating through all of the phases, testing the client after
+	// Begin rotating through all the phases, testing the client after
 	// each rotation phase has completed.
-	rotate(ctx, t, log, teleportProcess(), types.RotationPhaseInit)
+	rotate(ctx, t, log, teleportProcess, types.RotationPhaseInit, reloadChan)
 	// TODO: These sleeps allow the client time to rotate. They could be
 	// replaced if tbot emitted a CA rotation/renewal event.
-	time.Sleep(time.Second * 30)
+	//time.Sleep(time.Second * 30)
 	_, err := b.Client().Ping(ctx)
 	require.NoError(t, err)
 
-	rotate(ctx, t, log, teleportProcess(), types.RotationPhaseUpdateClients)
-	time.Sleep(time.Second * 30)
+	rotate(ctx, t, log, teleportProcess, types.RotationPhaseUpdateClients, reloadChan)
+	//time.Sleep(time.Second * 30)
 	// Ensure both sets of CA certificates are now available locally
-	require.Len(t, b.ident().TLSCACertsBytes, 3)
-	_, err = b.Client().Ping(ctx)
-	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return len(b.ident().TLSCACertsBytes) == 3
+	}, 30*time.Second, 200*time.Millisecond)
 
-	rotate(ctx, t, log, teleportProcess(), types.RotationPhaseUpdateServers)
-	time.Sleep(time.Second * 30)
-	_, err = b.Client().Ping(ctx)
+	//require.Len(t, b.ident().TLSCACertsBytes, 3)
+	resp, err := b.Client().Ping(ctx)
 	require.NoError(t, err)
+	require.NotEqual(t, "", resp.ServerVersion)
 
-	rotate(ctx, t, log, teleportProcess(), types.RotationStateStandby)
-	time.Sleep(time.Second * 30)
+	rotate(ctx, t, log, teleportProcess, types.RotationPhaseUpdateServers, reloadChan)
+	//time.Sleep(time.Second * 30)
+	//_, err = b.Client().GetCertAuthority(ctx, types.CertAuthID{
+	//	Type:       types.HostCA,
+	//	DomainName: "ubuntu-22-04",
+	//}, false)
+	//require.NoError(t, err)
+	//require.NotEqual(t, "", resp.ServerVersion)
+	//b.Client().
+
+	rotate(ctx, t, log, teleportProcess, types.RotationStateStandby, reloadChan)
+	//b.Client().DeleteAllLocks()
+	//time.Sleep(time.Second * 30)
 	_, err = b.Client().Ping(ctx)
 	require.NoError(t, err)
+	require.NotEqual(t, "", resp.ServerVersion)
+
+	require.Eventually(t, func() bool {
+		return len(b.ident().TLSCACertsBytes) == 2
+	}, 30*time.Second, 200*time.Millisecond)
 
 	require.Len(t, b.ident().TLSCACertsBytes, 2)
 	finalCAs := b.ident().TLSCACertsBytes


### PR DESCRIPTION
This PR reduces the flakiness of `TestBot_Run_CARotation` and reduces the runtime from 120s to ~15s. I also moved the test to integrations, as 15s is still too long/much work for a unit test.