### PR TITLE
Adds `sid` to the `ldap` section of the `w_d_s`

### DIFF
--- a/docs/pages/desktop-access/manual-setup.mdx
+++ b/docs/pages/desktop-access/manual-setup.mdx
@@ -100,6 +100,14 @@ dsacls "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuratio
 
 ```
 
+To save yourself time later, you can use the same prompt to get the security identifier of your new service account by running this command:
+
+```powershell
+Get-AdUser -Identity $SamAccountName | Select SID
+```
+
+Note this value (beginning with "S-") down, as it will be used as the `sid` field in the `ldap` section of your configuration file in a later step.
+
 ## Step 2/7. Prevent the service account from performing interactive logins
 
 <Admonition type="note" title="gpupdate.exe">
@@ -500,7 +508,8 @@ windows_desktop_service:
     # e.g. example.com:636
     addr: "$LDAP_SERVER_ADDRESS"
     domain: "$LDAP_DOMAIN_NAME"
-    username: '$LDAP_USERNAME'
+    username: "$LDAP_USERNAME"
+    sid: "$LDAP_USER_SID"
     # This should be the path to the certificate exported in Step 4.
     der_ca_file: /path/to/cert
   discovery:
@@ -540,7 +549,8 @@ windows_desktop_service:
     # e.g. example.com:636
     addr: "$LDAP_SERVER_ADDRESS"
     domain: "$LDAP_DOMAIN_NAME"
-    username: '$LDAP_USERNAME'
+    username: "$LDAP_USERNAME"
+    sid: "$LDAP_USER_SID"
     # This should be the path to the certificate exported in Step 5.
     der_ca_file: /path/to/cert
   discovery:

--- a/docs/pages/includes/desktop-access/desktop-config.yaml
+++ b/docs/pages/includes/desktop-access/desktop-config.yaml
@@ -24,6 +24,19 @@ windows_desktop_service:
     # likely "EXAMPLE". When connecting as the "svc-teleport" user, you should
     # use the format: "EXAMPLE\svc-teleport".
     username: '$LDAP_USERNAME'
+    # The security identifier of the service account specified by the username
+    # field above. This looks like a string starting with "S-".
+    #
+    # An administrator with access to the domain controller can obtain this value
+    # by opening a PowerShell and running
+    # ```
+    # Get-AdUser -Identity $LDAP_USERNAME | Select SID
+    # ```
+    #
+    # The value can be obtained over LDAP by constructing a query with the
+    # filter = (&(objectCategory=person)(objectClass=user)(name=$LDAP_USERNAME))
+    # and requesting the attribute = objectSid
+    sid: '$LDAP_USER_SID'
     # You can skip LDAPS certificate verification by setting
     # this to true. It is recommended that this be set to false
     # and the certificate added your system's trusted repository,

--- a/lib/auth/windows/ldap.go
+++ b/lib/auth/windows/ldap.go
@@ -36,6 +36,8 @@ type LDAPConfig struct {
 	// Username is an LDAP username, like "EXAMPLE\Administrator", where
 	// "EXAMPLE" is the NetBIOS version of Domain.
 	Username string
+	// SID is the SID for the user specified by Username.
+	SID string
 	// InsecureSkipVerify decides whether we skip verifying with the LDAP server's CA when making the LDAPS connection.
 	InsecureSkipVerify bool
 	// ServerName is the name of the LDAP server for TLS.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1591,6 +1591,7 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *service.Config) error {
 	cfg.WindowsDesktop.LDAP = service.LDAPConfig{
 		Addr:               fc.WindowsDesktop.LDAP.Addr,
 		Username:           fc.WindowsDesktop.LDAP.Username,
+		SID:                fc.WindowsDesktop.LDAP.SID,
 		Domain:             fc.WindowsDesktop.LDAP.Domain,
 		InsecureSkipVerify: fc.WindowsDesktop.LDAP.InsecureSkipVerify,
 		ServerName:         fc.WindowsDesktop.LDAP.ServerName,

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1930,7 +1930,7 @@ type LDAPConfig struct {
 	Domain string `yaml:"domain"`
 	// Username for LDAP authentication.
 	Username string `yaml:"username"`
-	// SID is the SID for the user specified by Username.
+	// SID is the Security Identifier for the service account specified by Username.
 	SID string `yaml:"sid"`
 	// InsecureSkipVerify decides whether whether we skip verifying with the LDAP server's CA when making the LDAPS connection.
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1930,6 +1930,8 @@ type LDAPConfig struct {
 	Domain string `yaml:"domain"`
 	// Username for LDAP authentication.
 	Username string `yaml:"username"`
+	// SID is the SID for the user specified by Username.
+	SID string `yaml:"sid"`
 	// InsecureSkipVerify decides whether whether we skip verifying with the LDAP server's CA when making the LDAPS connection.
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
 	// ServerName is the name of the LDAP server for TLS.

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -1358,6 +1358,8 @@ type LDAPConfig struct {
 	Domain string
 	// Username for LDAP authentication.
 	Username string
+	// SID is the SID for the user specified by Username.
+	SID string
 	// InsecureSkipVerify decides whether whether we skip verifying with the LDAP server's CA when making the LDAPS connection.
 	InsecureSkipVerify bool
 	// ServerName is the name of the LDAP server for TLS.

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -420,8 +420,14 @@ func (s *WindowsService) tlsConfigForLDAP() (*tls.Config, error) {
 	if i := strings.LastIndex(s.cfg.Username, `\`); i != -1 {
 		user = user[i+1:]
 	}
-
-	certDER, keyDER, err := s.generateCredentials(s.closeCtx, user, s.cfg.Domain, windowsDesktopServiceCertTTL, nil)
+	var activeDirectorySID *string = &s.cfg.SID
+	if s.cfg.SID == "" {
+		s.cfg.Log.Warnf(`Your ldap config is missing the SID of the user you're
+		using to sign in. This is set to become a strict requirement by May 2023,
+		please update your configuration file before then.`)
+		activeDirectorySID = nil
+	}
+	certDER, keyDER, err := s.generateCredentials(s.closeCtx, user, s.cfg.Domain, windowsDesktopServiceCertTTL, activeDirectorySID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -422,7 +422,7 @@ func (s *WindowsService) tlsConfigForLDAP() (*tls.Config, error) {
 	}
 	var activeDirectorySID *string = &s.cfg.SID
 	if s.cfg.SID == "" {
-		s.cfg.Log.Warnf(`Your ldap config is missing the SID of the user you're
+		s.cfg.Log.Warnf(`Your LDAP config is missing the SID of the user you're
 		using to sign in. This is set to become a strict requirement by May 2023,
 		please update your configuration file before then.`)
 		activeDirectorySID = nil

--- a/lib/web/scripts/desktop/configure-ad.ps1
+++ b/lib/web/scripts/desktop/configure-ad.ps1
@@ -136,16 +136,17 @@ $CA_CERT_YAML = $CA_CERT_PEM | ForEach-Object { "        " + $_  } | Out-String
 
 $NET_BIOS_NAME = (Get-ADDomain).NetBIOSName
 $LDAP_USERNAME = "$NET_BIOS_NAME\$SAM_ACCOUNT_NAME"
+$LDAP_USER_SID=(Get-ADUser -Identity $SAM_ACCOUNT_NAME).SID.Value
 
 $COMPUTER_NAME = (Resolve-DnsName -Type A $Env:COMPUTERNAME).Name
 $COMPUTER_IP = (Resolve-DnsName -Type A $Env:COMPUTERNAME).Address
 $LDAP_ADDR="$COMPUTER_IP" + ":636"
 
-$DESKTOP_ACCESS_CONFIG_YAML=@'
+$DESKTOP_ACCESS_CONFIG_YAML=@"
 version: v3
 teleport:
-  auth_token: {0}
-  proxy_server: {1}
+  auth_token: $TELEPORT_PROVISION_TOKEN
+  proxy_server: $TELEPORT_PROXY_PUBLIC_ADDR
 
 auth_service:
   enabled: no
@@ -157,18 +158,19 @@ proxy_service:
 windows_desktop_service:
   enabled: yes
   ldap:
-    addr:     '{2}'
-    domain:   '{3}'
-    username: '{4}'
-    server_name: '{5}'
+    addr:     '$LDAP_ADDR'
+    domain:   '$DOMAIN_NAME'
+    username: '$LDAP_USERNAME'
+    sid: '$LDAP_USER_SID'
+    server_name: '$COMPUTER_NAME'
     insecure_skip_verify: false
     ldap_ca_cert: |
-{6}
+$CA_CERT_YAML
   discovery:
     base_dn: '*'
   labels:
-    teleport.internal/resource-id: {7}
-'@ -f $TELEPORT_PROVISION_TOKEN, $TELEPORT_PROXY_PUBLIC_ADDR, $LDAP_ADDR, $DOMAIN_NAME, $LDAP_USERNAME, $COMPUTER_NAME, $CA_CERT_YAML, $TELEPORT_INTERNAL_RESOURCE_ID
+    teleport.internal/resource-id: $TELEPORT_INTERNAL_RESOURCE_ID
+"@
 
 $OUTPUT=@'
 


### PR DESCRIPTION
Adds an `sid` field to the ldap config of the w_d_s to address https://github.com/gravitational/teleport/pull/19340 for the service account. Docs updates instructing users how to find this value and updates to the automated setup script will come in separate PR's.

**Currently we just warn the user if they are missing this new field**. We should probably create some plan for rolling it out as mandatory, in order to ensure our users have it set by the time Microsoft makes it mandatory (May 2023).

Depends on https://github.com/gravitational/teleport/pull/19340

```diff
windows_desktop_service:
  enabled: yes
  listen_addr: "0.0.0.0:3028"
  ldap:
    addr: "ec2-34-229-163-27.compute-1.amazonaws.com:636"
    domain: "teleport.dev"
    username: 'TELEPORT\svc-teleport'
+  sid: S-1-5-21-1329593140-2634913955-1900852804-1111
    insecure_skip_verify: true
```

depends on https://github.com/gravitational/teleport/pull/19340