### PR TITLE
Add support for device extensions in TLS and SSH certificates

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -472,6 +472,13 @@ const (
 	// CertExtensionPrivateKeyPolicy is used to mark certificates with their supported
 	// private key policy.
 	CertExtensionPrivateKeyPolicy = "private-key-policy"
+	// CertExtensionDeviceID is the trusted device identifier.
+	CertExtensionDeviceID = "teleport-device-id"
+	// CertExtensionDeviceAssetTag is the device inventory identifier.
+	CertExtensionDeviceAssetTag = "teleport-device-asset-tag"
+	// CertExtensionDeviceCredentialID is the identifier for the credential used
+	// by the device to authenticate itself.
+	CertExtensionDeviceCredentialID = "teleport-device-credential-id"
 )
 
 // Note: when adding new providers to this list, consider updating the help message for --provider flag

--- a/lib/auth/keygen/keygen.go
+++ b/lib/auth/keygen/keygen.go
@@ -219,6 +219,15 @@ func (k *Keygen) GenerateUserCertWithoutValidation(c services.UserCertParams) ([
 	if c.PrivateKeyPolicy != "" {
 		cert.Permissions.Extensions[teleport.CertExtensionPrivateKeyPolicy] = string(c.PrivateKeyPolicy)
 	}
+	if devID := c.DeviceID; devID != "" {
+		cert.Permissions.Extensions[teleport.CertExtensionDeviceID] = devID
+	}
+	if assetTag := c.DeviceAssetTag; assetTag != "" {
+		cert.Permissions.Extensions[teleport.CertExtensionDeviceAssetTag] = assetTag
+	}
+	if credID := c.DeviceCredentialID; credID != "" {
+		cert.Permissions.Extensions[teleport.CertExtensionDeviceCredentialID] = credID
+	}
 
 	if c.SourceIP != "" {
 		if modules.GetModules().BuildType() != modules.BuildEnterprise {

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -296,6 +296,13 @@ type UserCertParams struct {
 	ConnectionDiagnosticID string
 	// PrivateKeyPolicy is the private key policy supported by this certificate.
 	PrivateKeyPolicy keys.PrivateKeyPolicy
+	// DeviceID is the trusted device identifier.
+	DeviceID string
+	// DeviceAssetTag is the device inventory identifier.
+	DeviceAssetTag string
+	// DeviceCredentialID is the identifier for the credential used by the device
+	// to authenticate itself.
+	DeviceCredentialID string
 }
 
 // CheckAndSetDefaults checks the user certificate parameters

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -21,12 +21,15 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -238,4 +241,66 @@ func TestAzureExtensions(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(out, &identity))
 	require.Equal(t, "43de4ffa8509aff3e3990e941400a403a12a6024d59897167b780ec0d03a1f15", out.RouteToApp.SessionID)
+}
+
+func TestIdentity_ToFromSubject(t *testing.T) {
+	assertStringOID := func(t *testing.T, want string, oid asn1.ObjectIdentifier, subj *pkix.Name, msgAndArgs ...any) {
+		for _, en := range subj.ExtraNames {
+			if !oid.Equal(en.Type) {
+				continue
+			}
+
+			got, ok := en.Value.(string)
+			require.True(t, ok, "Value for OID %v is not a string: %T", oid, en.Value)
+			assert.Equal(t, want, got, msgAndArgs)
+			return
+		}
+		t.Fatalf("OID %v not found", oid)
+	}
+
+	tests := []struct {
+		name          string
+		identity      *Identity
+		assertSubject func(t *testing.T, identity *Identity, subj *pkix.Name)
+	}{
+		{
+			name: "device extensions",
+			identity: &Identity{
+				Username: "llama",                      // Required.
+				Groups:   []string{"editor", "viewer"}, // Required.
+				DeviceExtensions: DeviceExtensions{
+					DeviceID:     "deviceid1",
+					AssetTag:     "assettag2",
+					CredentialID: "credentialid3",
+				},
+			},
+			assertSubject: func(t *testing.T, identity *Identity, subj *pkix.Name) {
+				want := identity.DeviceExtensions
+				assertStringOID(t, want.DeviceID, DeviceIDExtensionOID, subj, "DeviceID mismatch")
+				assertStringOID(t, want.AssetTag, DeviceAssetTagExtensionOID, subj, "AssetTag mismatch")
+				assertStringOID(t, want.CredentialID, DeviceCredentialIDExtensionOID, subj, "CredentialID mismatch")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			identity := test.identity
+
+			// Marshal identity into subject.
+			subj, err := identity.Subject()
+			require.NoError(t, err, "Subject failed")
+			test.assertSubject(t, identity, &subj)
+
+			// ExtraNames are appended to Names when the cert is created.
+			subj.Names = append(subj.Names, subj.ExtraNames...)
+			subj.ExtraNames = nil
+
+			// Extract identity from subject and verify that no data got lost.
+			got, err := FromSubject(subj, identity.Expires)
+			require.NoError(t, err, "FromSubject failed")
+			if diff := cmp.Diff(identity, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("FromSubject mismatch (-want +got)\n%s", diff)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Add support for device extensions for TLS and SSH issued certificates.

This is a first step in issuing certificates augmented with device extensions.

https://github.com/gravitational/teleport.e/issues/514