### PR TITLE
Allow issuance of device-aware certificates

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1446,12 +1446,14 @@ func (a *Server) AugmentContextUserCertificates(
 	// Augment SSH certificate.
 	var newAuthorizedKey []byte
 	if sshCert != nil {
+		// Add some leeway to validAfter to avoid time skew errors.
+		validAfter := a.clock.Now().UTC().Add(-1 * time.Minute)
 		newSSHCert := &ssh.Certificate{
 			Key:             sshCert.Key,
 			CertType:        ssh.UserCert,
 			KeyId:           sshCert.KeyId,
 			ValidPrincipals: sshCert.ValidPrincipals,
-			ValidAfter:      sshCert.ValidAfter,
+			ValidAfter:      uint64(validAfter.Unix()),
 			// Use the same expiration as the x509 cert.
 			ValidBefore: uint64(x509Cert.NotAfter.Unix()),
 			Permissions: sshCert.Permissions,

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -61,6 +61,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/retryutils"
+	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/native"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
@@ -1249,6 +1250,227 @@ func (a *Server) GenerateDatabaseTestCert(req DatabaseTestCertRequest) ([]byte, 
 	return certs.TLS, nil
 }
 
+// DeviceExtensions hold device-aware user certificate extensions.
+// Device extensions are a part of Device Trust, a feature exclusive to Teleport
+// Enterprise.
+type DeviceExtensions tlsca.DeviceExtensions
+
+// AugmentUserCertificateOpts aggregates options for extending user
+// certificates.
+// See [AugmentContextUserCertificates].
+type AugmentUserCertificateOpts struct {
+	// SSHAuthorizedKey is an SSH certificate, in the authorized key format, to
+	// augment with opts.
+	// The SSH certificate must be issued for the current authenticated user and
+	// must match their TLS certificate.
+	SSHAuthorizedKey []byte
+	// DeviceExtensions are the device-aware extensions to add to the certificates
+	// being augmented.
+	DeviceExtensions *DeviceExtensions
+}
+
+// AugmentContextUserCertificates augments the context user certificates with
+// the given extensions. It requires the user's TLS certificate to be present
+// in the [ctx], in addition to the [authCtx] itself.
+//
+// Any additional certificates to augment, such as the SSH certificate, must be
+// valid and fully match the certificate used to authenticate (likely the user's
+// mTLS cert).
+//
+// Used by Device Trust to add device extensions to the user certificate.
+func (a *Server) AugmentContextUserCertificates(
+	ctx context.Context,
+	authCtx *Context, opts *AugmentUserCertificateOpts) (*proto.Certs, error) {
+	switch {
+	case authCtx == nil:
+		return nil, trace.BadParameter("authCtx required")
+	case opts == nil:
+		return nil, trace.BadParameter("opts required")
+	}
+
+	// Is at least one extension present?
+	// Are the extensions valid?
+	identity := authCtx.Identity.GetIdentity()
+	dev := opts.DeviceExtensions
+	switch {
+	case dev == nil: // Only extension that currently exists.
+		return nil, trace.BadParameter("at least one opts extension must be present")
+	case dev.DeviceID == "":
+		return nil, trace.BadParameter("opts.DeviceExtensions.DeviceID required")
+	case dev.AssetTag == "":
+		return nil, trace.BadParameter("opts.DeviceExtensions.AssetTag required")
+	case dev.CredentialID == "":
+		return nil, trace.BadParameter("opts.DeviceExtensions.CredentialID required")
+	// Do not reissue if device extensions are already present.
+	case identity.DeviceExtensions.DeviceID != "",
+		identity.DeviceExtensions.AssetTag != "",
+		identity.DeviceExtensions.CredentialID != "":
+		return nil, trace.BadParameter("device extensions already present")
+	}
+
+	// Fetch user TLS certificate.
+	x509Cert, ok := ctx.Value(contextUserCertificate).(*x509.Certificate)
+	if !ok {
+		return nil, trace.BadParameter("user certificate missing from context")
+	}
+
+	// Sanity check: x509Cert matches identity.
+	// Both the TLS certificate and the identity come from the same source, so
+	// they are unlikely to mismatch unless Teleport itself mixes it up.
+	if x509Cert.Subject.CommonName != identity.Username {
+		return nil, trace.BadParameter("identity and x509 user mismatch")
+	}
+
+	// Parse and verify SSH certificate.
+	sshAuthorizedKey := opts.SSHAuthorizedKey
+	var sshCert *ssh.Certificate
+	if len(sshAuthorizedKey) > 0 {
+		var err error
+		sshCert, err = apisshutils.ParseCertificate(sshAuthorizedKey)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		xPubKey, err := ssh.NewPublicKey(x509Cert.PublicKey)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		// Verify SSH certificate against identity.
+		// The SSH certificate isn't used to establish the connection that
+		// eventually reaches this method, so we check it more thoroughly.
+		// In the end it still has to be signed by the Teleport CA and share the
+		// TLS public key, but we verify most fields to be safe.
+		switch {
+		case sshCert.CertType != ssh.UserCert:
+			return nil, trace.BadParameter("ssh cert type mismatch")
+		case sshCert.KeyId != identity.Username:
+			return nil, trace.BadParameter("identity and SSH user mismatch")
+		case !slices.Equal(sshCert.ValidPrincipals, identity.Principals):
+			return nil, trace.BadParameter("identity and SSH principals mismatch")
+		case !apisshutils.KeysEqual(sshCert.Key, xPubKey):
+			return nil, trace.BadParameter("x509 and SSH public key mismatch")
+		// Do not reissue if device extensions are already present.
+		case sshCert.Extensions[teleport.CertExtensionDeviceID] != "",
+			sshCert.Extensions[teleport.CertExtensionDeviceAssetTag] != "",
+			sshCert.Extensions[teleport.CertExtensionDeviceCredentialID] != "":
+			return nil, trace.BadParameter("device extensions already present")
+		}
+	}
+
+	// Fetch TLS CA and SSH signer.
+	domainName, err := a.GetDomainName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsCA, sshSigner, _, err := a.getUserSigningCAs(ctx, domainName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Verify TLS certificate against CA.
+	now := a.clock.Now()
+	roots := x509.NewCertPool()
+	roots.AddCert(tlsCA.Cert)
+	if _, err := x509Cert.Verify(x509.VerifyOptions{
+		Roots:       roots,
+		CurrentTime: now,
+		KeyUsages: []x509.ExtKeyUsage{
+			// Extensions added by tlsca.
+			// See https://github.com/gravitational/teleport/blob/master/lib/tlsca/ca.go#L963.
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Verify SSH certificate against CA.
+	if sshCert != nil {
+		// ValidPrincipals are checked against identity above.
+		// Pick the first one from the cert here.
+		var principal string
+		if len(sshCert.ValidPrincipals) > 0 {
+			principal = sshCert.ValidPrincipals[0]
+		}
+
+		certChecker := &ssh.CertChecker{
+			Clock: a.clock.Now,
+		}
+		if err := certChecker.CheckCert(principal, sshCert); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		// CheckCert verifies the signature but not the CA.
+		// Do that here.
+		if !apisshutils.KeysEqual(sshCert.SignatureKey, sshSigner.PublicKey()) {
+			return nil, trace.BadParameter("ssh certificate signed by unknown authority")
+		}
+	}
+
+	// Verify locks right before we re-issue any certificates.
+	authPref, err := a.GetAuthPreference(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := a.verifyLocksForUserCerts(verifyLocksForUserCertsReq{
+		checker:              authCtx.Checker,
+		defaultMode:          authPref.GetLockingMode(),
+		username:             identity.Username,
+		mfaVerified:          identity.MFAVerified,
+		activeAccessRequests: identity.ActiveRequests,
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Augment TLS certificate.
+	newIdentity := identity
+	newIdentity.DeviceExtensions.DeviceID = dev.DeviceID
+	newIdentity.DeviceExtensions.AssetTag = dev.AssetTag
+	newIdentity.DeviceExtensions.CredentialID = dev.CredentialID
+	subj, err := newIdentity.Subject()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	newTLSCert, err := tlsCA.GenerateCertificate(tlsca.CertificateRequest{
+		Clock:     a.clock,
+		PublicKey: x509Cert.PublicKey,
+		Subject:   subj,
+		// Use the same expiration as the original cert.
+		NotAfter: x509Cert.NotAfter,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Augment SSH certificate.
+	var newAuthorizedKey []byte
+	if sshCert != nil {
+		newSSHCert := &ssh.Certificate{
+			Key:             sshCert.Key,
+			CertType:        ssh.UserCert,
+			KeyId:           sshCert.KeyId,
+			ValidPrincipals: sshCert.ValidPrincipals,
+			ValidAfter:      sshCert.ValidAfter,
+			// Use the same expiration as the x509 cert.
+			ValidBefore: uint64(x509Cert.NotAfter.Unix()),
+			Permissions: sshCert.Permissions,
+		}
+		newSSHCert.Extensions[teleport.CertExtensionDeviceID] = dev.DeviceID
+		newSSHCert.Extensions[teleport.CertExtensionDeviceAssetTag] = dev.AssetTag
+		newSSHCert.Extensions[teleport.CertExtensionDeviceCredentialID] = dev.CredentialID
+		if err := newSSHCert.SignCert(rand.Reader, sshSigner); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		newAuthorizedKey = ssh.MarshalAuthorizedKey(newSSHCert)
+	}
+
+	return &proto.Certs{
+		SSH: newAuthorizedKey,
+		TLS: newTLSCert,
+	}, nil
+}
+
 // generateUserCert generates user certificates
 func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 	ctx := context.TODO()
@@ -1266,18 +1488,13 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	lockingMode := req.checker.LockingMode(authPref.GetLockingMode())
-	lockTargets := []types.LockTarget{
-		{User: req.user.GetName()},
-		{MFADevice: req.mfaVerified},
-	}
-	lockTargets = append(lockTargets,
-		services.RolesToLockTargets(req.checker.RoleNames())...,
-	)
-	lockTargets = append(lockTargets,
-		services.AccessRequestsToLockTargets(req.activeRequests.AccessRequests)...,
-	)
-	if err := a.checkLockInForce(lockingMode, lockTargets); err != nil {
+	if err := a.verifyLocksForUserCerts(verifyLocksForUserCertsReq{
+		checker:              req.checker,
+		defaultMode:          authPref.GetLockingMode(),
+		username:             req.user.GetName(),
+		mfaVerified:          req.mfaVerified,
+		activeAccessRequests: req.activeRequests.AccessRequests,
+	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -1358,14 +1575,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 		}
 	}
 
-	userCA, err := a.GetCertAuthority(ctx, types.CertAuthID{
-		Type:       types.UserCA,
-		DomainName: clusterName,
-	}, true)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	caSigner, err := a.keyStore.GetSSHSigner(ctx, userCA)
+	tlsCA, sshSigner, userCA, err := a.getUserSigningCAs(ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1380,7 +1590,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 	}
 
 	params := services.UserCertParams{
-		CASigner:                caSigner,
+		CASigner:                sshSigner,
 		PublicUserKey:           req.publicKey,
 		Username:                req.user.GetName(),
 		Impersonator:            req.impersonator,
@@ -1406,7 +1616,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 		ConnectionDiagnosticID:  req.connectionDiagnosticID,
 		PrivateKeyPolicy:        attestedKeyPolicy,
 	}
-	sshCert, err := a.Authority.GenerateUserCert(params)
+	sshCert, err := a.GenerateUserCert(params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1449,14 +1659,6 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 	}
 
 	// generate TLS certificate
-	cert, signer, err := a.keyStore.GetTLSCertAndSigner(ctx, userCA)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	tlsAuthority, err := tlsca.FromCertAndSigner(cert, signer)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	identity := tlsca.Identity{
 		Username:          req.user.GetName(),
 		Impersonator:      req.impersonator,
@@ -1508,7 +1710,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 		Subject:   subject,
 		NotAfter:  a.clock.Now().UTC().Add(sessionTTL),
 	}
-	tlsCert, err := tlsAuthority.GenerateCertificate(certRequest)
+	tlsCert, err := tlsCA.GenerateCertificate(certRequest)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1553,6 +1755,73 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 	}
 
 	return certs, nil
+}
+
+type verifyLocksForUserCertsReq struct {
+	checker services.AccessChecker
+
+	// defaultMode is the default locking mode, as recorded in the cluster
+	// Auth Preferences.
+	defaultMode constants.LockingMode
+	// username is the Teleport username.
+	// Eg: tlsca.Identity.Username.
+	username string
+	// mfaVerified is the UUID of the MFA device used to authenticate the user.
+	// Eg: tlsca.Identity.MFAVerified.
+	mfaVerified string
+	// activeAccessRequests are the UUIDs of active access requests for the user.
+	// Eg: tlsca.Identity.ActiveRequests.
+	activeAccessRequests []string
+}
+
+// verifyLocksForUserCerts verifies if any locks are in place before issuing new
+// user certificates.
+func (a *Server) verifyLocksForUserCerts(req verifyLocksForUserCertsReq) error {
+	checker := req.checker
+	lockingMode := checker.LockingMode(req.defaultMode)
+
+	lockTargets := []types.LockTarget{
+		{User: req.username},
+		{MFADevice: req.mfaVerified},
+		// TODO(codingllama): Verify device locks.
+	}
+	lockTargets = append(lockTargets,
+		services.RolesToLockTargets(checker.RoleNames())...,
+	)
+	lockTargets = append(lockTargets,
+		services.AccessRequestsToLockTargets(req.activeAccessRequests)...,
+	)
+
+	return trace.Wrap(a.checkLockInForce(lockingMode, lockTargets))
+}
+
+// getUserSigningCAs returns the necessary resources to issue/sign new user
+// certificates.
+func (a *Server) getUserSigningCAs(ctx context.Context, domainName string) (*tlsca.CertAuthority, ssh.Signer, types.CertAuthority, error) {
+	const loadKeys = true
+	userCA, err := a.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.UserCA,
+		DomainName: domainName,
+	}, loadKeys)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+
+	tlsCert, tlsSigner, err := a.keyStore.GetTLSCertAndSigner(ctx, userCA)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+	tlsCA, err := tlsca.FromCertAndSigner(tlsCert, tlsSigner)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+
+	sshSigner, err := a.keyStore.GetSSHSigner(ctx, userCA)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+
+	return tlsCA, sshSigner, userCA, nil
 }
 
 // WithUserLock executes function authenticateFn that performs user authentication

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -18,9 +18,13 @@ package auth
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	mathrand "math/rand"
@@ -34,6 +38,7 @@ import (
 	reporting "github.com/gravitational/reporting/types"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
@@ -1084,6 +1089,544 @@ func TestEmitSSOLoginFailureEvent(t *testing.T) {
 			UserMessage: "some error",
 		},
 	})
+}
+
+func TestServer_AugmentContextUserCertificates(t *testing.T) {
+	testServer := newTestTLSServer(t)
+	authServer := testServer.Auth()
+	ctx := context.Background()
+
+	const username = "llama"
+	const pass = "secret!!1!"
+
+	// Prepare the user to test with.
+	_, _, err := CreateUserAndRole(authServer, username, []string{username})
+	require.NoError(t, err, "CreateUserAndRole failed")
+	require.NoError(t,
+		authServer.UpsertPassword(username, []byte(pass)),
+		"UpsertPassword failed")
+
+	// Authenticate and create certificates.
+	_, pub, err := testauthority.New().GetNewKeyPairFromPool()
+	require.NoError(t, err, "GetNewKeyPairFromPool failed")
+	authResp, err := authServer.AuthenticateSSHUser(ctx, AuthenticateSSHRequest{
+		AuthenticateUserRequest: AuthenticateUserRequest{
+			Username: username,
+			Pass: &PassCreds{
+				Password: []byte(pass),
+			},
+		},
+		PublicKey: pub,
+		TTL:       1 * time.Hour,
+	})
+	require.NoError(t, err, "AuthenticateSSHUser failed")
+
+	const devID = "deviceid1"
+	const devTag = "devicetag1"
+	const devCred = "devicecred1"
+
+	tests := []struct {
+		name           string
+		x509PEM        []byte
+		opts           *AugmentUserCertificateOpts
+		wantSSHCert    bool
+		assertX509Cert func(t *testing.T, c *x509.Certificate)
+		assertSSHCert  func(t *testing.T, c *ssh.Certificate)
+	}{
+		{
+			name:    "device extensions",
+			x509PEM: authResp.TLSCert,
+			opts: &AugmentUserCertificateOpts{
+				SSHAuthorizedKey: authResp.Cert,
+				DeviceExtensions: &DeviceExtensions{
+					DeviceID:     devID,
+					AssetTag:     devTag,
+					CredentialID: devCred,
+				},
+			},
+			wantSSHCert: true,
+			assertX509Cert: func(t *testing.T, c *x509.Certificate) {
+				id, err := tlsca.FromSubject(c.Subject, c.NotAfter)
+				require.NoError(t, err, "FromSubject failed")
+				assert.Equal(t, devID, id.DeviceExtensions.DeviceID, "DeviceID mismatch")
+				assert.Equal(t, devTag, id.DeviceExtensions.AssetTag, "AssetTag mismatch")
+				assert.Equal(t, devCred, id.DeviceExtensions.CredentialID, "CredentialID mismatch")
+			},
+			assertSSHCert: func(t *testing.T, c *ssh.Certificate) {
+				assert.Equal(t, devID, c.Extensions[teleport.CertExtensionDeviceID], "DeviceID mismatch")
+				assert.Equal(t, devTag, c.Extensions[teleport.CertExtensionDeviceAssetTag], "AssetTag mismatch")
+				assert.Equal(t, devCred, c.Extensions[teleport.CertExtensionDeviceCredentialID], "CredentialID mismatch")
+			},
+		},
+		{
+			name:    "augment without SSH",
+			x509PEM: authResp.TLSCert,
+			opts: &AugmentUserCertificateOpts{
+				DeviceExtensions: &DeviceExtensions{
+					DeviceID:     devID,
+					AssetTag:     devTag,
+					CredentialID: devCred,
+				},
+			},
+			// Nothing to assert, we are just looking for the absence of errors here.
+			assertX509Cert: func(t *testing.T, c *x509.Certificate) {},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			xCert, identity := parseX509PEMAndIdentity(t, test.x509PEM)
+
+			// Prepare ctx and auth.Context.
+			ctx = context.WithValue(ctx, contextUserCertificate, xCert)
+			ctx = context.WithValue(ctx, ContextUser, LocalUser{
+				Username: username,
+				Identity: *identity,
+			})
+			authCtx, err := testServer.APIConfig.Authorizer.Authorize(ctx)
+			require.NoError(t, err, "Authorize failed")
+
+			// Test!
+			certs, err := authServer.AugmentContextUserCertificates(ctx, authCtx, test.opts)
+			require.NoError(t, err, "AugmentContextUserCertificates failed")
+			require.NotNil(t, certs, "AugmentContextUserCertificates returned nil certs")
+
+			// Assert X.509 certificate.
+			newXCert, _ := parseX509PEMAndIdentity(t, certs.TLS)
+			test.assertX509Cert(t, newXCert)
+			assert.Equal(t, xCert.NotAfter, newXCert.NotAfter, "newXCert.NotAfter mismatch")
+
+			// Assert SSH certificate.
+			if test.wantSSHCert && len(certs.SSH) == 0 {
+				t.Errorf("AugmentContextUserCertificates returned no SSH certificate")
+			} else if !test.wantSSHCert {
+				return
+			}
+			newSSHCert, err := sshutils.ParseCertificate(certs.SSH)
+			require.NoError(t, err, "ParseCertificate failed")
+			test.assertSSHCert(t, newSSHCert)
+			assert.Equal(t, uint64(xCert.NotAfter.Unix()), newSSHCert.ValidBefore, "newSSHCert.ValidBefore mismatch")
+		})
+	}
+}
+
+func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
+	testServer := newTestTLSServer(t)
+	authServer := testServer.Auth()
+	ctx := context.Background()
+
+	const pass1 = "secret!!1!"
+	const pass2 = "secret!!2!"
+	const pass3 = "secret!!3!"
+
+	// Prepare a few distinct users.
+	user1, _, err := CreateUserAndRole(authServer, "llama", []string{"llama"})
+	require.NoError(t, err, "CreateUserAndRole failed")
+	require.NoError(t,
+		authServer.UpsertPassword(user1.GetName(), []byte(pass1)),
+		"UpsertPassword failed")
+
+	user2, _, err := CreateUserAndRole(authServer, "alpaca", []string{"alpaca"})
+	require.NoError(t, err, "CreateUserAndRole failed")
+	require.NoError(t,
+		authServer.UpsertPassword(user2.GetName(), []byte(pass2)),
+		"UpsertPassword failed")
+
+	user3, _, err := CreateUserAndRole(authServer, "camel", []string{"camel"})
+	require.NoError(t, err, "CreateUserAndRole failed")
+	require.NoError(t,
+		authServer.UpsertPassword(user3.GetName(), []byte(pass3)),
+		"UpsertPassword failed")
+
+	// authenticate authenticates the specified user, creating a new key pair, a
+	// new pair of certificates, and parsing all relevant responses.
+	authenticate := func(t *testing.T, user, pass string) (tlsRaw, sshRaw []byte, xCert *x509.Certificate, sshCert *ssh.Certificate, identity *tlsca.Identity) {
+		// Avoid using recycled keys here, otherwise the test may flake.
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err, "GenerateKey failed")
+		sPubKey, err := ssh.NewPublicKey(privKey.Public())
+		require.NoError(t, err, "NewPublicKey failed")
+
+		authResp, err := authServer.AuthenticateSSHUser(ctx, AuthenticateSSHRequest{
+			AuthenticateUserRequest: AuthenticateUserRequest{
+				Username: user,
+				Pass: &PassCreds{
+					Password: []byte(pass),
+				},
+			},
+			PublicKey: ssh.MarshalAuthorizedKey(sPubKey),
+			TTL:       1 * time.Hour,
+		})
+		require.NoError(t, err, "AuthenticateSSHUser(%q) failed", user)
+
+		xCert, identity = parseX509PEMAndIdentity(t, authResp.TLSCert)
+		// parseX509PEMAndIdentity reports errors via t.
+
+		sshCert, err = sshutils.ParseCertificate(authResp.Cert)
+		require.NoError(t, err, "ParseCertificate failed")
+
+		return authResp.TLSCert, authResp.Cert, xCert, sshCert, identity
+	}
+
+	// Authenticate.
+	// user1 covers most of the tests.
+	// user2 is mainly used to test mismatched certificates against user1.
+	// user3 is used to test locking.
+	_, sshRaw1, xCert1, sshCert1, identity1 := authenticate(t, user1.GetName(), pass1)
+	_, sshRaw2, xCert2, _, _ := authenticate(t, user2.GetName(), pass2)
+	_, _, xCert3, _, identity3 := authenticate(t, user3.GetName(), pass3)
+
+	// sshRaw11 is identical to sshRaw1, except it is backed by a different
+	// key pair.
+	_, sshRaw11, _, _, _ := authenticate(t, user1.GetName(), pass1)
+
+	// wrongKey is used to represent an invalid/unknown CA.
+	wrongKey, err := rsa.GenerateKey(rand.Reader, 2048 /* bits */)
+	require.NoError(t, err, "GenerateKey failed")
+
+	// Build an invalid version of xCert1 (signed using wrongKey).
+	userCA, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.UserCA,
+		DomainName: testServer.ClusterName(),
+	}, true /* loadKeys */)
+	require.NoError(t, err, "GetCertAuthority failed")
+	caXPEM := userCA.GetActiveKeys().TLS[0].Cert
+
+	caXCert, _ := parseX509PEMAndIdentity(t, caXPEM)
+	caXCert.PublicKey = wrongKey.Public()
+	wrongXCert1DER, err := x509.CreateCertificate(rand.Reader, xCert1, caXCert, xCert1.PublicKey, wrongKey)
+	require.NoError(t, err, "CreateCertificate failed")
+	wrongXCert1, err := x509.ParseCertificate(wrongXCert1DER)
+	require.NoError(t, err, "ParseCertificate failed")
+
+	// Build an invalid version of sshCert1 (signed using wrongKey).
+	sshSigner, err := ssh.NewSignerFromKey(wrongKey)
+	require.NoError(t, err, "NewSignerFromKey failed")
+	wrongSSHCert1, err := sshutils.ParseCertificate(sshRaw1)
+	require.NoError(t, err, "ParseCertificate failed")
+	require.NoError(t, wrongSSHCert1.SignCert(rand.Reader, sshSigner), "SignCert failed")
+	wrongSSHRaw1 := ssh.MarshalAuthorizedKey(wrongSSHCert1)
+
+	// Issue augmented certs for user1.
+	// Used to test that re-issue of augmented certs is not allowed.
+	ctxFromAuthorize := testServer.APIConfig.Authorizer.Authorize
+	aCtx := context.WithValue(context.Background(), contextUserCertificate, xCert1)
+	aCtx = context.WithValue(aCtx, ContextUser, LocalUser{
+		Username: identity1.Username,
+		Identity: *identity1,
+	})
+	aaCtx, err := ctxFromAuthorize(aCtx)
+	require.NoError(t, err, "ctxFromAuthorize failed")
+	augResp, err := authServer.AugmentContextUserCertificates(aCtx, aaCtx, &AugmentUserCertificateOpts{
+		SSHAuthorizedKey: sshRaw1,
+		DeviceExtensions: &DeviceExtensions{
+			DeviceID:     "device1",
+			AssetTag:     "tag1",
+			CredentialID: "credential1",
+		},
+	})
+	require.NoError(t, err, "AugmentContextUserCertificates failed")
+	augCert1, augIdentity1 := parseX509PEMAndIdentity(t, augResp.TLS)
+	augSSHRaw1 := augResp.SSH
+
+	// signAndMarshalSSH is used to create variations of SSH certificates signed
+	// by the Teleport CA.
+	signAndMarshalSSH := func(t *testing.T, c *ssh.Certificate) (sshRaw []byte) {
+		signer, err := authServer.GetKeyStore().GetSSHSigner(ctx, userCA)
+		require.NoError(t, err, "GetSSHSigner failed")
+
+		err = c.SignCert(rand.Reader, signer)
+		require.NoError(t, err, "SignCert failed")
+
+		return ssh.MarshalAuthorizedKey(c)
+	}
+
+	baseOpts := &AugmentUserCertificateOpts{
+		DeviceExtensions: &DeviceExtensions{
+			DeviceID:     "deviceid1",
+			AssetTag:     "devicetag1",
+			CredentialID: "credentialid1",
+		},
+	}
+	optsFromBase := func(_ *testing.T) *AugmentUserCertificateOpts { return baseOpts }
+
+	tests := []struct {
+		name     string
+		x509Cert *x509.Certificate
+		identity *tlsca.Identity
+		// createAuthCtx defaults to ctxFromAuthorize.
+		createAuthCtx func(ctx context.Context) (*Context, error)
+		// createOpts defaults to optsFromBase.
+		createOpts func(t *testing.T) *AugmentUserCertificateOpts
+		wantErr    string
+	}{
+		// Simple input validation errors.
+		{
+			name:          "authCtx nil",
+			x509Cert:      xCert1,
+			identity:      identity1,
+			createAuthCtx: func(ctx context.Context) (*Context, error) { return nil, nil },
+			wantErr:       "authCtx",
+		},
+		{
+			name:       "opts nil",
+			x509Cert:   xCert1,
+			identity:   identity1,
+			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts { return nil },
+			wantErr:    "opts",
+		},
+		{
+			name:     "opts missing extensions",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+				cp := *baseOpts
+				cp.DeviceExtensions = nil
+				return &cp
+			},
+			wantErr: "at least one opts extension",
+		},
+
+		// DeviceExtensions.
+		{
+			name:     "opts.DeviceExtensions.DeviceID empty",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+				cp := *baseOpts
+				cp.DeviceExtensions = &DeviceExtensions{
+					DeviceID:     "",
+					AssetTag:     "asset1",
+					CredentialID: "credential1",
+				}
+				return &cp
+			},
+			wantErr: "DeviceID",
+		},
+		{
+			name:     "opts.DeviceExtensions.AssetTag empty",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+				cp := *baseOpts
+				cp.DeviceExtensions = &DeviceExtensions{
+					DeviceID:     "id1",
+					AssetTag:     "",
+					CredentialID: "credential1",
+				}
+				return &cp
+			},
+			wantErr: "AssetTag",
+		},
+		{
+			name:     "opts.DeviceExtensions.CredentialID empty",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+				cp := *baseOpts
+				cp.DeviceExtensions = &DeviceExtensions{
+					DeviceID:     "id1",
+					AssetTag:     "asset1",
+					CredentialID: "",
+				}
+				return &cp
+			},
+			wantErr: "CredentialID",
+		},
+
+		// Identity and certificate mismatch scenarios.
+		{
+			name:     "x509/identity mismatch",
+			x509Cert: xCert2, // should be xCert1
+			identity: identity1,
+			wantErr:  "x509 user mismatch",
+		},
+		{
+			name:     "x509/SSH public key mismatch",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+				cp := *baseOpts
+				cp.SSHAuthorizedKey = sshRaw11 // should be sshRaw1
+				return &cp
+			},
+			wantErr: "public key mismatch",
+		},
+		{
+			name:     "SSH/identity mismatch",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+				cp := *baseOpts
+				cp.SSHAuthorizedKey = sshRaw2 // should be sshRaw1
+				return &cp
+			},
+			wantErr: "SSH user mismatch",
+		},
+		{
+			name:     "SSH/identity principals mismatch",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(t *testing.T) *AugmentUserCertificateOpts {
+				changedPrincipals := *sshCert1
+				changedPrincipals.ValidPrincipals = append(changedPrincipals.ValidPrincipals, "camel")
+				sshRaw := signAndMarshalSSH(t, &changedPrincipals)
+
+				cp := *baseOpts
+				cp.SSHAuthorizedKey = sshRaw
+				return &cp
+			},
+			wantErr: "principals mismatch",
+		},
+		{
+			name:     "SSH cert type mismatch",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(t *testing.T) *AugmentUserCertificateOpts {
+				changedType := *sshCert1
+				changedType.CertType = ssh.HostCert // shouldn't happen!
+				sshRaw := signAndMarshalSSH(t, &changedType)
+
+				cp := *baseOpts
+				cp.SSHAuthorizedKey = sshRaw
+				return &cp
+			},
+			wantErr: "cert type mismatch",
+		},
+
+		// Invalid certificates.
+		{
+			name:     "x509 cert unknown authority",
+			x509Cert: wrongXCert1, // signed by a different CA
+			identity: identity1,
+			wantErr:  "unknown authority",
+		},
+		{
+			name:     "SSH cert unknown authority",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+				cp := *baseOpts
+				cp.SSHAuthorizedKey = wrongSSHRaw1 // signed by a different CA
+				return &cp
+			},
+			wantErr: "unknown authority",
+		},
+		{
+			name:     "SSH cert expired",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(t *testing.T) *AugmentUserCertificateOpts {
+				// Fake a 1h TTL, expired cert.
+				now := testServer.Clock().Now()
+				after := now.Add(-1 * time.Hour)
+				before := now.Add(-1 * time.Minute)
+
+				expiredCert := *sshCert1
+				expiredCert.ValidAfter = uint64(after.Unix())
+				expiredCert.ValidBefore = uint64(before.Unix())
+				sshRaw := signAndMarshalSSH(t, &expiredCert)
+
+				cp := *baseOpts
+				cp.SSHAuthorizedKey = sshRaw
+				return &cp
+			},
+			wantErr: "cert has expired",
+		},
+
+		// Certificates with existing extensions are not reissued.
+		{
+			name:     "x509 cert with device extensions not reissued",
+			x509Cert: augCert1,     // already has extensions
+			identity: augIdentity1, // already has extensions
+			wantErr:  "extensions already present",
+		},
+		{
+			name:     "SSH cert with device extensions not reissued",
+			x509Cert: xCert1,
+			identity: identity1,
+			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+				cp := *baseOpts
+				cp.SSHAuthorizedKey = augSSHRaw1 // already has extensions.
+				return &cp
+			},
+			wantErr: "extensions already present",
+		},
+
+		// Locks.
+		{
+			name:     "locked user",
+			x509Cert: xCert3,
+			identity: identity3, // user3 is locked!
+			createAuthCtx: func(ctx context.Context) (*Context, error) {
+				// Authorize user3...
+				authCtx, err := ctxFromAuthorize(ctx)
+				if err != nil {
+					return nil, err
+				}
+
+				lockTarget := types.LockTarget{
+					User: user3.GetName(),
+				}
+				watcher, err := authServer.lockWatcher.Subscribe(ctx, lockTarget)
+				if err != nil {
+					return nil, err
+				}
+				defer watcher.Close()
+
+				// ...and lock them right after.
+				user3Lock, err := types.NewLock("user3-lock", types.LockSpecV2{
+					Target:  lockTarget,
+					Message: "locked for testing",
+				})
+				if err != nil {
+					return nil, err
+				}
+				if err := authServer.UpsertLock(ctx, user3Lock); err != nil {
+					return nil, err
+				}
+
+				<-watcher.Events() // Wait for the lock to go through.
+				return authCtx, nil
+			},
+			wantErr: "locked for testing",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.createAuthCtx == nil {
+				test.createAuthCtx = ctxFromAuthorize
+			}
+			if test.createOpts == nil {
+				test.createOpts = optsFromBase
+			}
+
+			// Prepare ctx and auth.Context.
+			ctx = context.WithValue(ctx, contextUserCertificate, test.x509Cert)
+			ctx = context.WithValue(ctx, ContextUser, LocalUser{
+				Username: test.identity.Username,
+				Identity: *test.identity,
+			})
+			authCtx, err := test.createAuthCtx(ctx)
+			require.NoError(t, err, "createAuthCtx failed")
+
+			// Test!
+			_, err = authServer.AugmentContextUserCertificates(ctx, authCtx, test.createOpts(t))
+			assert.ErrorContains(t, err, test.wantErr, "AugmentContextUserCertificates error mismatch")
+		})
+	}
+}
+
+func parseX509PEMAndIdentity(t *testing.T, rawPEM []byte) (*x509.Certificate, *tlsca.Identity) {
+	b, _ := pem.Decode(rawPEM)
+	require.NotNil(t, b, "Decode failed")
+
+	cert, err := x509.ParseCertificate(b.Bytes)
+	require.NoError(t, err, "ParseCertificate failed: %v", err)
+
+	identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+	require.NoError(t, err, "FromSubject failed: %v", err)
+
+	return cert, identity
 }
 
 func TestGenerateUserCertWithCertExtension(t *testing.T) {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1092,6 +1092,8 @@ func TestEmitSSOLoginFailureEvent(t *testing.T) {
 }
 
 func TestServer_AugmentContextUserCertificates(t *testing.T) {
+	t.Parallel()
+
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	ctx := context.Background()
@@ -1228,6 +1230,8 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 }
 
 func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
+	t.Parallel()
+
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	ctx := context.Background()

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -387,8 +387,18 @@ func (a *Middleware) withAuthenticatedUser(ctx context.Context) (context.Context
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(&tlsInfo.State))
 	ctx = context.WithValue(ctx, ContextClientAddr, peerInfo.Addr)
-	return context.WithValue(ctx, ContextUser, user), nil
+	ctx = context.WithValue(ctx, ContextUser, user)
+	return ctx, nil
+}
+
+func certFromConnState(state *tls.ConnectionState) *x509.Certificate {
+	if state == nil || len(state.PeerCertificates) != 1 {
+		return nil
+	}
+	return state.PeerCertificates[0]
 }
 
 // withAuthenticatedUserUnaryInterceptor is a gRPC unary server interceptor
@@ -598,9 +608,9 @@ func extractAdditionalSystemRoles(roles []string) types.SystemRoles {
 
 // ServeHTTP serves HTTP requests
 func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	baseContext := r.Context()
-	if baseContext == nil {
-		baseContext = context.TODO()
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	if r.TLS == nil {
 		trace.WriteError(w, trace.AccessDenied("missing authentication"))
@@ -613,8 +623,9 @@ func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// determine authenticated user based on the request parameters
-	requestWithContext := r.WithContext(context.WithValue(baseContext, ContextUser, user))
-	a.Handler.ServeHTTP(w, requestWithContext)
+	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(r.TLS))
+	ctx = context.WithValue(ctx, ContextUser, user)
+	a.Handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // WrapContextWithUser enriches the provided context with the identity information
@@ -627,12 +638,15 @@ func (a *Middleware) WrapContextWithUser(ctx context.Context, conn utils.TLSConn
 			return nil, trace.ConvertSystemError(err)
 		}
 	}
-	user, err := a.GetUser(conn.ConnectionState())
+	tlsState := conn.ConnectionState()
+	user, err := a.GetUser(tlsState)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	requestWithContext := context.WithValue(ctx, ContextUser, user)
-	return requestWithContext, nil
+
+	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(&tlsState))
+	ctx = context.WithValue(ctx, ContextUser, user)
+	return ctx, nil
 }
 
 // ClientCertPool returns trusted x509 certificate authority pool with CAs provided as caTypes.

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -608,10 +608,6 @@ func extractAdditionalSystemRoles(roles []string) types.SystemRoles {
 
 // ServeHTTP serves HTTP requests
 func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	if r.TLS == nil {
 		trace.WriteError(w, trace.AccessDenied("missing authentication"))
 		return
@@ -623,6 +619,7 @@ func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// determine authenticated user based on the request parameters
+	ctx := r.Context()
 	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(r.TLS))
 	ctx = context.WithValue(ctx, ContextUser, user)
 	a.Handler.ServeHTTP(w, r.WithContext(ctx))

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -803,6 +803,11 @@ func contextForLocalUser(u LocalUser, accessPoint AuthorizerAccessPoint, cluster
 type contextKey string
 
 const (
+	// contextUserCertificate is the X.509 certificate used by the ContextUser to
+	// establish the mTLS connection.
+	// Holds a *x509.Certificate.
+	contextUserCertificate contextKey = "teleport-user-cert"
+
 	// ContextUser is a user set in the context of the request
 	ContextUser contextKey = "teleport-user"
 	// ContextClientAddr is a client address set in the context of the request


### PR DESCRIPTION
Allow issuance of augmented, device-aware user certificates via auth.Server.

Device-aware certificate issuance takes as input existing user certificates and augments them with the appropriate device extensions. The certificates to augment must be valid, issued by the Teleport CA, match each other and the current user, and share the same public key, among other criteria.

Device authentication is performed by Teleport Enterprise. The present PR adds only the means to issue the certificates, but doesn't wire that functionality to any endpoints.

https://github.com/gravitational/teleport.e/issues/514