### PR TITLE
Reduce CPU usage in enhanced session

### DIFF
--- a/bpf/enhancedrecording/disk.bpf.c
+++ b/bpf/enhancedrecording/disk.bpf.c
@@ -14,6 +14,9 @@
 // the userspace can adjust this value based on config.
 #define EVENTS_BUF_SIZE (4096*128)
 
+// Maximum monitored sessions.
+#define MAX_MONITORED_SESSIONS 1024
+
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 struct val_t {
@@ -32,6 +35,9 @@ struct data_t {
 };
 
 BPF_HASH(infotmp, u64, struct val_t, INFLIGHT_MAX);
+
+// hashmap keeps all cgroups id that should be monitored by Teleport.
+BPF_HASH(monitored_cgroups, u64, int64_t, MAX_MONITORED_SESSIONS);
 
 // open_events ring buffer
 BPF_RING_BUF(open_events, EVENTS_BUF_SIZE);
@@ -52,11 +58,21 @@ static int enter_open(const char *filename, int flags) {
 
 static int exit_open(int ret) {
     u64 id = bpf_get_current_pid_tgid();
+    u64 cgroup = bpf_get_current_cgroup_id();
+
     struct val_t *valp;
     struct data_t data = {};
+    u64 *is_monitored;
 
     valp = bpf_map_lookup_elem(&infotmp, &id);
-    if (valp == 0) {
+    if (valp == NULL) {
+        // Missed entry.
+        return 0;
+    }
+
+    // Check if the cgroup should be monitored.
+    is_monitored = bpf_map_lookup_elem(&monitored_cgroups, &cgroup);
+    if (is_monitored == NULL) {
         // Missed entry.
         return 0;
     }
@@ -70,7 +86,7 @@ static int exit_open(int ret) {
     data.pid = valp->pid;
     data.flags = valp->flags;
     data.ret = ret;
-    data.cgroup = bpf_get_current_cgroup_id();
+    data.cgroup = cgroup;
 
     if (bpf_ringbuf_output(&open_events, &data, sizeof(data), 0) != 0)
         INCR_COUNTER(lost);

--- a/lib/bpf/disk.go
+++ b/lib/bpf/disk.go
@@ -21,6 +21,7 @@ package bpf
 
 import (
 	_ "embed"
+	"unsafe"
 
 	"github.com/aquasecurity/libbpfgo"
 	"github.com/gravitational/trace"
@@ -41,6 +42,7 @@ var (
 
 const (
 	diskEventsBuffer = "open_events"
+	monitoredCGroups = "monitored_cgroups"
 )
 
 // rawOpenEvent is sent by the eBPF program that Teleport pulls off the perf
@@ -63,6 +65,11 @@ type rawOpenEvent struct {
 
 	// Flags are the flags passed to open.
 	Flags int32
+}
+
+type cgroupRegister interface {
+	startSession(cgroupID uint64) error
+	endSession(cgroupID uint64) error
 }
 
 type open struct {
@@ -135,4 +142,35 @@ func (o *open) close() {
 // events contains raw events off the perf buffer.
 func (o *open) events() <-chan []byte {
 	return o.eventBuf.EventCh
+}
+
+// startSession registers the given cgroup in the BPF module. Only registered
+// cgroups will return events to the userspace.
+func (o *open) startSession(cgroupID uint64) error {
+	cgroupMap, err := o.module.GetMap(monitoredCGroups)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	dummyVal := 0
+	err = cgroupMap.Update(unsafe.Pointer(&cgroupID), unsafe.Pointer(&dummyVal))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// endSession removes the previously registered cgroup from the BPF module.
+func (o *open) endSession(cgroupID uint64) error {
+	cgroupMap, err := o.module.GetMap(monitoredCGroups)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := cgroupMap.DeleteKey(unsafe.Pointer(&cgroupID)); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
 }

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -143,7 +143,7 @@ func (s *Service) Remove(sessionID string) error {
 	return nil
 }
 
-// Place  place a process in the cgroup for that session.
+// Place places a process in the cgroup for that session.
 func (s *Service) Place(sessionID string, pid int) error {
 	// Open cgroup.procs file for the cgroup.
 	filepath := filepath.Join(s.teleportRoot, sessionID, cgroupProcs)
@@ -159,7 +159,7 @@ func (s *Service) Place(sessionID string, pid int) error {
 		return trace.Wrap(err)
 	}
 
-	return nil
+	return trace.Wrap(f.Sync())
 }
 
 // readPids returns a slice of PIDs from a file. Used to get list of all PIDs
@@ -200,7 +200,7 @@ func writePids(path string, pids []string) error {
 		}
 	}
 
-	return nil
+	return trace.Wrap(f.Sync())
 }
 
 // cleanupHierarchy removes any cgroups for any exisiting sessions.


### PR DESCRIPTION
Currently, our BPF modules send all events from the kernel to the userspace, where we filter them and log only the ones related to our process. Sending the events between the user and kernel space is expensive, and most of the events are discarded after.
This PR moves the filtering from the userspace to the kernel, where we can filter them earlier and not pay for sending all events to our userspace process. Because the filtering happens in the kernel, the BPF test had to be rewritten to execute events in a sub-cgroup instead of the global one.