### PR TITLE
Add reference links to all required Helm guides

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
@@ -273,3 +273,9 @@ important to review Teleport's audit log.
 ## Feedback
 
 If you have any issues with this plugin please create an [issue here](https://github.com/gravitational/teleport-plugins/issues/new).
+
+## Next steps
+
+To see all of the options available to you when using the Helm chart for the
+Teleport Jira plugin, consult our [reference
+guide](../../reference/helm-reference/teleport-plugin-jira.mdx).

--- a/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
@@ -270,5 +270,9 @@ $ helm --namespace teleport uninstall teleport
 
 ## Next steps
 
+To see all of the options you can set in the values file for the
+`teleport-cluster` Helm chart, consult our [reference
+guide](../../reference/helm-reference/teleport-cluster.mdx).
+
 You can follow our [Getting Started with Teleport guide](../../management/guides/docker.mdx#step-34-creating-a-teleport-user) to finish setting up your
 Teleport cluster.

--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -202,6 +202,13 @@ Teleport keeps an audit log of access to a Kubernetes cluster. In the screenshot
 
 ## Next steps
 
+To see all of the options you can set in the values file for the
+`teleport-cluster` Helm chart, consult our [reference
+guide](../../reference/helm-reference/teleport-cluster.mdx).
+
+Read our guides to additional ways you can protect a Kubernetes cluster with
+Teleport:
+
 - [Connect Multiple Kubernetes Clusters](../../kubernetes-access/guides/multiple-clusters.mdx)
 - [Set up CI/CD Access with Teleport](../../kubernetes-access/guides/cicd.mdx)
 - [Federated Access using Trusted Clusters](../../kubernetes-access/guides/federation.mdx)

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -358,6 +358,13 @@ the default one in case there is a problem.
 
 ## Next steps
 
+To see all of the options you can set in the values file for the
+`teleport-cluster` Helm chart, consult our [reference
+guide](../../reference/helm-reference/teleport-cluster.mdx).
+
+Read our guides to additional ways you can protect Kubernetes clusters with
+Teleport:
+
 - [Connect Multiple Kubernetes Clusters](../../kubernetes-access/guides/multiple-clusters.mdx)
 - [Set up CI/CD Access with Teleport](../../kubernetes-access/guides/cicd.mdx)
 - [Federated Access using Trusted Clusters](../../kubernetes-access/guides/federation.mdx)

--- a/docs/pages/deploy-a-cluster/helm-deployments/migration.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/migration.mdx
@@ -253,3 +253,10 @@ To uninstall the `teleport-cluster` chart, use `helm uninstall <release-name>`. 
 ```code
 $ helm --namespace teleport-cluster uninstall teleport
 ```
+
+## Next steps
+
+To see all of the options you can set in the values file for the
+`teleport-cluster` Helm chart, consult our [reference
+guide](../../reference/helm-reference/teleport-cluster.mdx).
+

--- a/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
+++ b/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
@@ -144,3 +144,10 @@ $ kubectl get pods
 (!docs/pages/includes/kubernetes-access/rbac.mdx!)
 
 </Details>
+
+## Next steps
+
+To see all of the options you can set in the values file for the
+`teleport-kube-agent` Helm chart, consult our [reference
+guide](../../reference/helm-reference/teleport-kube-agent.mdx).
+

--- a/docs/pages/management/guides/fluentd.mdx
+++ b/docs/pages/management/guides/fluentd.mdx
@@ -448,4 +448,9 @@ INFO[0046] Event sent id=0b5f2a3e-faa5-4d77-ab6e-362bca0994fc ts="2021-06-08 11:
 
 ## Next Steps
 
-- Read more about [impersonation](https://goteleport.com/docs/access-controls/guides/impersonation/) here.
+- Read more about
+  [impersonation](../../access-controls/guides/impersonation.mdx)
+- To see all of the options you can set in the values file for the
+  `teleport-plugin-event-handler` Helm chart, consult our [reference
+  guide](../../reference/helm-reference/teleport-plugin-event-handler.mdx).
+

--- a/docs/pages/try-out-teleport/local-kubernetes.mdx
+++ b/docs/pages/try-out-teleport/local-kubernetes.mdx
@@ -372,6 +372,10 @@ Terminate the `minikube tunnel` process you started earlier and run
 
 ## Next steps
 
+To see all of the options you can set in the values file for the
+`teleport-cluster` and `teleport-kube-agent` Helm charts, consult our [reference
+guide](../reference/helm-reference.mdx).
+
 Now that you have used Teleport to securely access resources in your local
 Kubernetes cluster, read our guides to setting up Teleport for Kubernetes in
 production.
@@ -384,5 +388,4 @@ production.
   [Single Sign-On and Kubernetes RBAC](../kubernetes-access/controls.mdx)
 - Have a Kubernetes cluster but don't want to run Teleport there?
   [Kubernetes Access from Standalone Teleport](../kubernetes-access/guides/standalone-teleport.mdx)
-
 


### PR DESCRIPTION
Closes #19189

Ensure that all Helm guides include a link to the relevant Helm chart at the end of the guide.