### PR TITLE
Add `GetEmitter()` to allow proper emitter wrapping for PreHog

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -869,7 +869,8 @@ func (a *Server) GetEmitter() apievents.Emitter {
 	return a.emitter
 }
 
-// SetEmitter sets the current audit log emitter.
+// SetEmitter sets the current audit log emitter. Note that this is only safe to
+// use before main server start.
 func (a *Server) SetEmitter(emitter apievents.Emitter) {
 	a.emitter = emitter
 }
@@ -879,7 +880,8 @@ func (a *Server) SetEnforcer(enforcer services.Enforcer) {
 	a.Services.Enforcer = enforcer
 }
 
-// SetUsageReporter sets the server's usage reporter
+// SetUsageReporter sets the server's usage reporter. Note that this is only
+// safe to use before server start.
 func (a *Server) SetUsageReporter(reporter services.UsageReporter) {
 	a.Services.UsageReporter = reporter
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -864,12 +864,14 @@ func (a *Server) SetAuditLog(auditLog events.IAuditLog) {
 	a.Services.IAuditLog = auditLog
 }
 
-func (a *Server) SetEmitter(emitter apievents.Emitter) {
-	a.emitter = emitter
-}
-
+// GetEmitter fetches the current audit log emitter implementation.
 func (a *Server) GetEmitter() apievents.Emitter {
 	return a.emitter
+}
+
+// SetEmitter sets the current audit log emitter.
+func (a *Server) SetEmitter(emitter apievents.Emitter) {
+	a.emitter = emitter
 }
 
 // SetEnforcer sets the server's enforce service

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -868,6 +868,10 @@ func (a *Server) SetEmitter(emitter apievents.Emitter) {
 	a.emitter = emitter
 }
 
+func (a *Server) GetEmitter() apievents.Emitter {
+	return a.emitter
+}
+
 // SetEnforcer sets the server's enforce service
 func (a *Server) SetEnforcer(enforcer services.Enforcer) {
 	a.Services.Enforcer = enforcer

--- a/lib/events/usageevents/usageevents.go
+++ b/lib/events/usageevents/usageevents.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
-	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -107,7 +106,7 @@ func (u *UsageLogger) EmitAuditEvent(ctx context.Context, event apievents.AuditE
 // New creates a new usage event IAuditLog impl, which wraps another IAuditLog
 // impl and forwards a subset of audit log events to the cluster UsageReporter
 // service.
-func New(reporter services.UsageReporter, log logrus.FieldLogger, inner events.IAuditLog) (*UsageLogger, error) {
+func New(reporter services.UsageReporter, log logrus.FieldLogger, inner apievents.Emitter) (*UsageLogger, error) {
 	if log == nil {
 		log = logrus.StandardLogger()
 	}

--- a/lib/services/local/usagereporter.go
+++ b/lib/services/local/usagereporter.go
@@ -418,6 +418,7 @@ func NewPrehogSubmitter(ctx context.Context, prehogEndpoint string, clientCert *
 			// isn't ideal.
 			req := connect.NewRequest(event.Event)
 			if _, err := client.SubmitEvent(ctx, req); err != nil {
+				failed = append(failed, event)
 				errors = append(errors, err)
 			}
 		}


### PR DESCRIPTION
This is part of a fix for the PreHog usage reporter to resolve a bug where an improper emitter implementation was wrapped, potentially replacing a valid set of emitters. A new `GetEmitter` function is added to `Server` to allow fetching of the correct implementation so it can be wrapped overwritten sensibly.

Additionally, this changes the signature of `UsageLogger.New()` to require just an `events.Emitter` interface rather than an `IAuditLog` specifically.

Finally, this fixes a small bug in the PreHog submitter where failed events were accidentally dropped too early.

Co-authored-by: Roman Tkachenko <roman@goteleport.com>