### PR TITLE
Fix an issue tsh throws assertion error on REDIS_REPLY_STATUS for Redis 7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -387,7 +387,7 @@ replace (
 	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-20221005103706-b9e66c056e90
 	github.com/denisenkom/go-mssqldb => github.com/gravitational/go-mssqldb v0.11.1-0.20221006130402-25bef12c7ee1
 	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.5.0-teleport.1
-	github.com/go-redis/redis/v9 => github.com/gravitational/redis/v9 v9.0.0-teleport.2
+	github.com/go-redis/redis/v9 => github.com/gravitational/redis/v9 v9.0.0-teleport.3
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 	github.com/gravitational/teleport/api => ./api
 	github.com/julienschmidt/httprouter => github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5

--- a/go.sum
+++ b/go.sum
@@ -759,8 +759,8 @@ github.com/gravitational/predicate v1.3.0 h1:n1lmH6YU1oX/Y546qHQNJb50FJy6Ou/+MvW
 github.com/gravitational/predicate v1.3.0/go.mod h1:wPNu01gNYh2LRVtIGmFBvRpfBzl4nI2EaxbYDG8Mm4w=
 github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf h1:MQ4e8XcxvZTeuOmRl7yE519vcWc2h/lyvYzsvt41cdY=
 github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/gravitational/redis/v9 v9.0.0-teleport.2 h1:cX6NjKFy8zcqS0RF+EsOuHBqv+XWAgNUTVxS1y6hg88=
-github.com/gravitational/redis/v9 v9.0.0-teleport.2/go.mod h1:8et+z03j0l8N+DvsVnclzjf3Dl/pFHgRk+2Ct1qw66A=
+github.com/gravitational/redis/v9 v9.0.0-teleport.3 h1:Eg/j3jiNUZ558KDXOqzF682EFmf97vxAFFnMgZ0YHns=
+github.com/gravitational/redis/v9 v9.0.0-teleport.3/go.mod h1:8et+z03j0l8N+DvsVnclzjf3Dl/pFHgRk+2Ct1qw66A=
 github.com/gravitational/reporting v0.0.0-20210923183620-237377721140 h1:UACNXsuOXxe2dpjn3SA2g4YUgOoZTxQ6yf+QYAYcQMc=
 github.com/gravitational/reporting v0.0.0-20210923183620-237377721140/go.mod h1:rBJeI3JYVzbL7Yw2hYrp4QdKIkncb1pUHo95DyoEGns=
 github.com/gravitational/roundtrip v1.0.2 h1:eOCY0NEKKaB0ksJmvhO6lPMFz1pIIef+vyPBTBROQ5c=

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/siddontang/go/log"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
@@ -266,7 +265,7 @@ func (l *LocalProxy) StartHTTPAccessProxy(ctx context.Context) error {
 				// TODO: find a cleaner way of formatting the error.
 				errHeader = strings.Replace(errHeader, " \t", "\n\t", -1)
 				errHeader = strings.Replace(errHeader, " User Message:", "\n\n\tUser Message:", -1)
-				log.Warn(errHeader)
+				logrus.Warn(errHeader)
 			}
 			return nil
 		},

--- a/lib/srv/db/redis/protocol/resp2_test.go
+++ b/lib/srv/db/redis/protocol/resp2_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-redis/redis/v9"
@@ -109,6 +110,26 @@ func TestWriteCmd(t *testing.T) {
 			require.Equal(t, tt.expected, buf.Bytes())
 		})
 	}
+}
+
+func TestReadWriteStatus(t *testing.T) {
+	inputStatusBytes := []byte("+status\r\n")
+
+	// Read the status into a redis.Cmd.
+	cmd := &redis.Cmd{}
+	err := cmd.ReadReply(redis.NewReader(bytes.NewReader(inputStatusBytes)))
+	require.NoError(t, err)
+
+	// Verify result.
+	value, err := cmd.Result()
+	require.NoError(t, err)
+	require.Equal(t, "status", fmt.Sprintf("%v", value))
+
+	// Verify WriteCmd.
+	outputStatusBytes := &bytes.Buffer{}
+	err = WriteCmd(redis.NewWriter(outputStatusBytes), value)
+	require.NoError(t, err)
+	require.Equal(t, string(inputStatusBytes), outputStatusBytes.String())
 }
 
 func TestMakeUnknownCommandErrorForCmd(t *testing.T) {


### PR DESCRIPTION
Fixes #19240 
- #19240

Error from `tsh db connect <redis-7>`
```
$ tsh db connect --db-user=test marek-redis07
Assertion failed: (flags->element[j]->type == REDIS_REPLY_STATUS), function cliAddArgument, file redis-cli.c, line 585.
ERROR: signal: abort trap
```

Root cause:
`redis-cli` sends `COMMAND DOCS` to construct docs for commands and expect status type (`+<status>`) as part of the response. The go-redis driver however reads status into golang strings and writes them as string types (`$<len><string>`). 

Changes:
- Driver side change: https://github.com/gravitational/redis/pull/22
- Adding a UT for regression test

Notes:

- `COMMAND DOCS` is new to Redis 7, so using `redis-cli` 6.2 would not see this issue
- There was a test escpae from my side when first testing out Redis 7 as I was testing with a user without `COMMAND XXX` permissions so `redis-cli` will always get `NO PERM` thus not seeing this error.