### PR TITLE
Implement client-side device authentication

### DIFF
--- a/lib/devicetrust/authn/authn.go
+++ b/lib/devicetrust/authn/authn.go
@@ -82,7 +82,7 @@ func RunCeremony(ctx context.Context, devicesClient devicepb.DeviceTrustServiceC
 	// 2. Challenge.
 	chalResp := resp.GetChallenge()
 	if chalResp == nil {
-		return nil, trace.BadParameter("unexpected challenge payload from server: %T", resp.Payload)
+		return nil, trace.BadParameter("unexpected payload from server, expected AuthenticateDeviceChallenge: %T", resp.Payload)
 	}
 	sig, err := signChallenge(chalResp.Challenge)
 	if err != nil {
@@ -105,7 +105,7 @@ func RunCeremony(ctx context.Context, devicesClient devicepb.DeviceTrustServiceC
 	// 3. User certificates.
 	newCerts := resp.GetUserCertificates()
 	if newCerts == nil {
-		return nil, trace.BadParameter("unexpected challenge payload from server: %T", resp.Payload)
+		return nil, trace.BadParameter("unexpected payload from server, expected UserCertificates: %T", resp.Payload)
 	}
 	return newCerts, nil
 }

--- a/lib/devicetrust/authn/authn.go
+++ b/lib/devicetrust/authn/authn.go
@@ -1,0 +1,111 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authn
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	"github.com/gravitational/teleport/lib/devicetrust/native"
+)
+
+// vars below are used to swap native methods for fakes in tests.
+var (
+	getDeviceCredential = native.GetDeviceCredential
+	collectDeviceData   = native.CollectDeviceData
+	signChallenge       = native.SignChallenge
+)
+
+// RunCeremony performs the client-side device authentication ceremony.
+//
+// Device authentication requires a previously registered and enrolled device
+// (see the lib/devicetrust/enroll package).
+//
+// The outcome of the authentication ceremony is a pair of user certificates
+// augmented with device extensions.
+func RunCeremony(ctx context.Context, devicesClient devicepb.DeviceTrustServiceClient, certs *devicepb.UserCertificates) (*devicepb.UserCertificates, error) {
+	switch {
+	case devicesClient == nil:
+		return nil, trace.BadParameter("devicesClient required")
+	case certs == nil:
+		return nil, trace.BadParameter("certs required")
+	}
+
+	stream, err := devicesClient.AuthenticateDevice(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// 1. Init.
+	cred, err := getDeviceCredential()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cd, err := collectDeviceData()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := stream.Send(&devicepb.AuthenticateDeviceRequest{
+		Payload: &devicepb.AuthenticateDeviceRequest_Init{
+			Init: &devicepb.AuthenticateDeviceInit{
+				UserCertificates: &devicepb.UserCertificates{
+					// Forward only the SSH certificate, the TLS identity is part of the
+					// connection.
+					SshAuthorizedKey: certs.SshAuthorizedKey,
+				},
+				CredentialId: cred.Id,
+				DeviceData:   cd,
+			},
+		},
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// 2. Challenge.
+	chalResp := resp.GetChallenge()
+	if chalResp == nil {
+		return nil, trace.BadParameter("unexpected challenge payload from server: %T", resp.Payload)
+	}
+	sig, err := signChallenge(chalResp.Challenge)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := stream.Send(&devicepb.AuthenticateDeviceRequest{
+		Payload: &devicepb.AuthenticateDeviceRequest_ChallengeResponse{
+			ChallengeResponse: &devicepb.AuthenticateDeviceChallengeResponse{
+				Signature: sig,
+			},
+		},
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	resp, err = stream.Recv()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// 3. User certificates.
+	newCerts := resp.GetUserCertificates()
+	if newCerts == nil {
+		return nil, trace.BadParameter("unexpected challenge payload from server: %T", resp.Payload)
+	}
+	return newCerts, nil
+}

--- a/lib/devicetrust/authn/authn_test.go
+++ b/lib/devicetrust/authn/authn_test.go
@@ -1,0 +1,138 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authn_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	"github.com/gravitational/teleport/lib/devicetrust/authn"
+	"github.com/gravitational/teleport/lib/devicetrust/testenv"
+)
+
+func TestRunCeremony(t *testing.T) {
+	env := testenv.MustNew()
+	defer env.Close()
+	t.Cleanup(resetNative())
+
+	devices := env.DevicesClient
+	ctx := context.Background()
+
+	// Create a fake device and enroll it, so the fake server has the necessary
+	// data to verify challenge signatures.
+	macOSDev1, err := testenv.NewFakeMacOSDevice()
+	require.NoError(t, err, "NewFakeMacOSDevice failed")
+	require.NoError(t, enrollDevice(ctx, devices, macOSDev1), "enrollDevice failed")
+
+	tests := []struct {
+		name  string
+		dev   *testenv.FakeMacOSDevice
+		certs *devicepb.UserCertificates
+	}{
+		{
+			name: "ok",
+			dev:  macOSDev1,
+			certs: &devicepb.UserCertificates{
+				// SshAuthorizedKey is not parsed by the fake server.
+				SshAuthorizedKey: []byte("<a proper SSH certificate goes here>"),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			*authn.GetDeviceCredential = func() (*devicepb.DeviceCredential, error) {
+				return test.dev.DeviceCredential(), nil
+			}
+			*authn.CollectDeviceData = test.dev.CollectDeviceData
+			*authn.SignChallenge = test.dev.SignChallenge
+
+			_, err := authn.RunCeremony(ctx, devices, test.certs)
+			// A nil error is good enough for this test.
+			assert.NoError(t, err, "RunCeremony failed")
+		})
+	}
+}
+
+func resetNative() func() {
+	gdc := authn.GetDeviceCredential
+	cdd := authn.CollectDeviceData
+	sc := authn.SignChallenge
+	return func() {
+		authn.GetDeviceCredential = gdc
+		authn.CollectDeviceData = cdd
+		authn.SignChallenge = sc
+	}
+}
+
+func enrollDevice(ctx context.Context, devices devicepb.DeviceTrustServiceClient, dev *testenv.FakeMacOSDevice) error {
+	stream, err := devices.EnrollDevice(ctx)
+	if err != nil {
+		return err
+	}
+
+	// 1. Init.
+	cd, err := dev.CollectDeviceData()
+	if err != nil {
+		return err
+	}
+	if err := stream.Send(&devicepb.EnrollDeviceRequest{
+		Payload: &devicepb.EnrollDeviceRequest_Init{
+			Init: &devicepb.EnrollDeviceInit{
+				Token:        "fake enroll token",
+				CredentialId: dev.ID,
+				DeviceData:   cd,
+				Macos: &devicepb.MacOSEnrollPayload{
+					PublicKeyDer: dev.PubKeyDER,
+				},
+			},
+		},
+	}); err != nil {
+		return err
+	}
+
+	// 2. Challenge.
+	resp, err := stream.Recv()
+	if err != nil {
+		return fmt.Errorf("challenge Recv: %w", err)
+	}
+	sig, err := dev.SignChallenge(resp.GetMacosChallenge().Challenge)
+	if err != nil {
+		return err
+	}
+	if err := stream.Send(&devicepb.EnrollDeviceRequest{
+		Payload: &devicepb.EnrollDeviceRequest_MacosChallengeResponse{
+			MacosChallengeResponse: &devicepb.MacOSEnrollChallengeResponse{
+				Signature: sig,
+			},
+		},
+	}); err != nil {
+		return err
+	}
+
+	// 3. Success.
+	resp, err = stream.Recv()
+	switch {
+	case err != nil:
+		return fmt.Errorf("challenge response Recv: %w", err)
+	case resp.GetSuccess() == nil:
+		return fmt.Errorf("success response is nil, got %T instead", resp.Payload)
+	}
+	return nil
+}

--- a/lib/devicetrust/authn/export_test.go
+++ b/lib/devicetrust/authn/export_test.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authn
+
+var (
+	GetDeviceCredential = &getDeviceCredential
+	CollectDeviceData   = &collectDeviceData
+	SignChallenge       = &signChallenge
+)

--- a/lib/devicetrust/testenv/fake_device_service.go
+++ b/lib/devicetrust/testenv/fake_device_service.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -27,17 +28,29 @@ import (
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 )
 
+type storedDevice struct {
+	pb  *devicepb.Device
+	pub *ecdsa.PublicKey
+}
+
 type fakeDeviceService struct {
 	devicepb.UnimplementedDeviceTrustServiceServer
+
+	mu      sync.Mutex
+	devices []storedDevice
 }
 
 func newFakeDeviceService() *fakeDeviceService {
 	return &fakeDeviceService{}
 }
 
+// EnrollDevice implements a fake, server-side device enrollment ceremony.
+//
+// As long as all required fields are non-nil and the challenge signature
+// matches, the fake server lets any device be enrolled. Unlike a proper
+// DeviceTrustService implementation, it's not necessary to call CreateDevice or
+// acquire an enrollment token from the server.
 func (s *fakeDeviceService) EnrollDevice(stream devicepb.DeviceTrustService_EnrollDeviceServer) error {
-	// As long as all required fields are non-nil and the challenge signature
-	// matches, the fake server lets any device be enrolled.
 	req, err := stream.Recv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -50,19 +63,16 @@ func (s *fakeDeviceService) EnrollDevice(stream devicepb.DeviceTrustService_Enro
 		return trace.BadParameter("token required")
 	case initReq.CredentialId == "":
 		return trace.BadParameter("credential ID required")
-	case initReq.DeviceData == nil:
-		return trace.BadParameter("device data required")
-	case initReq.DeviceData.OsType == devicepb.OSType_OS_TYPE_UNSPECIFIED:
-		return trace.BadParameter("device OsType required")
-	case initReq.DeviceData.SerialNumber == "":
-		return trace.BadParameter("device SerialNumber required")
+	}
+	if err := validateCollectedData(initReq.DeviceData); err != nil {
+		return trace.Wrap(err)
 	}
 
 	// OS-specific enrollment.
 	if initReq.DeviceData.OsType != devicepb.OSType_OS_TYPE_MACOS {
 		return trace.BadParameter("os not supported")
 	}
-	cred, err := enrollMacOS(stream, initReq)
+	cred, pub, err := enrollMacOS(stream, initReq)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -80,6 +90,12 @@ func (s *fakeDeviceService) EnrollDevice(stream devicepb.DeviceTrustService_Enro
 		EnrollStatus: devicepb.DeviceEnrollStatus_DEVICE_ENROLL_STATUS_ENROLLED,
 		Credential:   cred,
 	}
+	s.mu.Lock()
+	s.devices = append(s.devices, storedDevice{
+		pb:  dev,
+		pub: pub,
+	})
+	s.mu.Unlock()
 
 	// Success.
 	err = stream.Send(&devicepb.EnrollDeviceResponse{
@@ -92,26 +108,26 @@ func (s *fakeDeviceService) EnrollDevice(stream devicepb.DeviceTrustService_Enro
 	return trace.Wrap(err)
 }
 
-func enrollMacOS(stream devicepb.DeviceTrustService_EnrollDeviceServer, initReq *devicepb.EnrollDeviceInit) (*devicepb.DeviceCredential, error) {
+func enrollMacOS(stream devicepb.DeviceTrustService_EnrollDeviceServer, initReq *devicepb.EnrollDeviceInit) (*devicepb.DeviceCredential, *ecdsa.PublicKey, error) {
 	switch {
 	case initReq.Macos == nil:
-		return nil, trace.BadParameter("device Macos data required")
+		return nil, nil, trace.BadParameter("device Macos data required")
 	case len(initReq.Macos.PublicKeyDer) == 0:
-		return nil, trace.BadParameter("device Macos.PublicKeyDer required")
+		return nil, nil, trace.BadParameter("device Macos.PublicKeyDer required")
 	}
 	pubKey, err := x509.ParsePKIXPublicKey(initReq.Macos.PublicKeyDer)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 	ecPubKey, ok := pubKey.(*ecdsa.PublicKey)
 	if !ok {
-		return nil, trace.BadParameter("unexpected public key type: %T", pubKey)
+		return nil, nil, trace.BadParameter("unexpected public key type: %T", pubKey)
 	}
 
 	// 2. Challenge.
-	chal := make([]byte, 32)
-	if _, err := rand.Reader.Read(chal); err != nil {
-		return nil, trace.Wrap(err)
+	chal, err := newChallenge()
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
 	}
 	if err := stream.Send(&devicepb.EnrollDeviceResponse{
 		Payload: &devicepb.EnrollDeviceResponse_MacosChallenge{
@@ -120,28 +136,143 @@ func enrollMacOS(stream devicepb.DeviceTrustService_EnrollDeviceServer, initReq 
 			},
 		},
 	}); err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
 	// 3. Challenge response.
 	resp, err := stream.Recv()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 	chalResp := resp.GetMacosChallengeResponse()
 	switch {
 	case chalResp == nil:
-		return nil, trace.BadParameter("challenge response required")
+		return nil, nil, trace.BadParameter("challenge response required")
 	case len(chalResp.Signature) == 0:
-		return nil, trace.BadParameter("signature required")
+		return nil, nil, trace.BadParameter("signature required")
 	}
-	h := sha256.Sum256(chal)
-	if !ecdsa.VerifyASN1(ecPubKey, h[:], chalResp.Signature) {
-		return nil, trace.BadParameter("signature verification failed")
+	if err := verifyChallenge(chal, chalResp.Signature, ecPubKey); err != nil {
+		return nil, nil, trace.BadParameter("signature verification failed")
 	}
 
 	return &devicepb.DeviceCredential{
 		Id:           initReq.CredentialId,
 		PublicKeyDer: initReq.Macos.PublicKeyDer,
-	}, nil
+	}, ecPubKey, nil
+}
+
+// AuthenticateDevice implements a fake, server-side device authentication
+// ceremony.
+//
+// AuthenticateDevice requires an enrolled device, so the challenge signature
+// can be verified. It largely ignores received certificates and doesn't reply
+// with proper certificates in the response. Certificates are acquired outside
+// of devicetrust packages, so it's not essential to check them here.
+func (s *fakeDeviceService) AuthenticateDevice(stream devicepb.DeviceTrustService_AuthenticateDeviceServer) error {
+	// 1. Init.
+	req, err := stream.Recv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	initReq := req.GetInit()
+	switch {
+	case initReq == nil:
+		return trace.BadParameter("init required")
+	case initReq.CredentialId == "":
+		return trace.BadParameter("credential ID required")
+	}
+	if err := validateCollectedData(initReq.DeviceData); err != nil {
+		return trace.Wrap(err)
+	}
+	dev, err := s.findMatchingDevice(initReq.DeviceData, initReq.CredentialId)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// 2. Challenge.
+	chal, err := newChallenge()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := stream.Send(&devicepb.AuthenticateDeviceResponse{
+		Payload: &devicepb.AuthenticateDeviceResponse_Challenge{
+			Challenge: &devicepb.AuthenticateDeviceChallenge{
+				Challenge: chal,
+			},
+		},
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	req, err = stream.Recv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// 3. Challenge response.
+	chalResp := req.GetChallengeResponse()
+	switch {
+	case chalResp == nil:
+		return trace.BadParameter("challenge response required")
+	case len(chalResp.Signature) == 0:
+		return trace.BadParameter("signature required")
+	}
+	if err := verifyChallenge(chal, chalResp.Signature, dev.pub); err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = stream.Send(&devicepb.AuthenticateDeviceResponse{
+		Payload: &devicepb.AuthenticateDeviceResponse_UserCertificates{
+			UserCertificates: &devicepb.UserCertificates{
+				X509Der:          []byte("<insert augmented X.509 cert here"),
+				SshAuthorizedKey: []byte("<insert augmented SSH cert here"),
+			},
+		},
+	})
+	return trace.Wrap(err)
+}
+
+func (s *fakeDeviceService) findMatchingDevice(cd *devicepb.DeviceCollectedData, credentialID string) (*storedDevice, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, stored := range s.devices {
+		if cd.OsType != stored.pb.OsType || cd.SerialNumber != stored.pb.AssetTag {
+			continue
+		}
+		if stored.pb.Credential.Id != credentialID {
+			return nil, trace.BadParameter("unknown credential for device")
+		}
+		return &stored, nil
+	}
+	return nil, trace.NotFound("device %v/%q not enrolled", cd.OsType, cd.SerialNumber)
+}
+
+func validateCollectedData(cd *devicepb.DeviceCollectedData) error {
+	switch {
+	case cd == nil:
+		return trace.BadParameter("device data required")
+	case cd.OsType == devicepb.OSType_OS_TYPE_UNSPECIFIED:
+		return trace.BadParameter("device OsType invalid")
+	case cd.SerialNumber == "":
+		return trace.BadParameter("device SerialNumber required")
+	}
+	if err := cd.CollectTime.CheckValid(); err != nil {
+		return trace.BadParameter("device CollectTime invalid: %v", err)
+	}
+	return nil
+}
+
+func newChallenge() ([]byte, error) {
+	chal := make([]byte, 32)
+	if _, err := rand.Reader.Read(chal); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return chal, nil
+}
+
+func verifyChallenge(chal, sig []byte, pub *ecdsa.PublicKey) error {
+	h := sha256.Sum256(chal)
+	if !ecdsa.VerifyASN1(pub, h[:], sig) {
+		return trace.BadParameter("signature verification failed")
+	}
+	return nil
 }


### PR DESCRIPTION
Implement the client-side device authentication ceremony.

Device authentication requires a previously registered and enrolled device. In exchange for solving a challenge, the ceremony allows the user to augment their certificates with device extensions, which are necessary to clear device-aware authentication.

Wiring to `tsh` to be done in a follow-up PR.

https://github.com/gravitational/teleport.e/issues/514