### PR TITLE
Bump shellcheck to v0.9.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -197,7 +197,7 @@ RUN (curl -L https://github.com/bats-core/bats-core/archive/v1.2.1.tar.gz | tar 
      rm -r bats-core-1.2.1)
 
 # Install shellcheck.
-RUN scversion='v0.8.0' && \
+RUN scversion='v0.9.0' && \
     curl -sSL "https://github.com/koalaman/shellcheck/releases/download/$scversion/shellcheck-$scversion.linux.$(if [ "$BUILDARCH" = "amd64" ]; then echo "x86_64"; else echo "aarch64"; fi).tar.xz" | \
         tar -xJv && \
     cp "shellcheck-$scversion/shellcheck" /usr/local/bin/ && \


### PR DESCRIPTION
Keep up with new shellcheck releases.