### PR TITLE
Bump cloud version to 11.1.3

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1207,7 +1207,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "11.1.2",
+      "version": "11.1.3",
       "major_version": "11",
       "sla": {
         "monthly_percentage": "99.5%",


### PR DESCRIPTION
Teleport Cloud tenants will be upgraded to Teleport v11.1.3 on Thursday 12/15. See: https://github.com/gravitational/cloud/issues/2793