### PR TITLE
Clone TLS configuration for WebSocket dialer

### DIFF
--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -116,8 +116,8 @@ type suiteConfig struct {
 	ServerStreamer events.Streamer
 	// ValidateRequest is a function that will validate the request received by the application.
 	ValidateRequest func(*Suite, *http.Request)
-	// UseWebsockets will make the application server use a websocket for connection.
-	UseWebsockets bool
+	// EnableHTTP2 defines if the test server will support HTTP2.
+	EnableHTTP2 bool
 	// CloudImporter will use the given cloud importer for the app server.
 	CloudImporter labels.Importer
 	// AppLabels are the labels assigned to the application.
@@ -202,7 +202,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	s.message = uuid.New().String()
 
 	s.testhttp = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if config.UseWebsockets {
+		if strings.ToLower(r.Header.Get("upgrade")) == "websocket" {
 			upgrader := websocket.Upgrader{
 				ReadBufferSize:  1024,
 				WriteBufferSize: 1024,
@@ -220,11 +220,16 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 			config.ValidateRequest(s, r)
 		}
 	}))
+	// Add NextProtos to support both protocols: h2, http/1.1
 	s.testhttp.Config.TLSConfig = &tls.Config{Time: s.clock.Now}
-	if config.UseWebsockets {
+	if config.EnableHTTP2 {
 		s.testhttp.EnableHTTP2 = true
+		// Add NextProtos to support both protocols: h2, http/1.1
+		s.testhttp.Config.TLSConfig.NextProtos = []string{"h2", "http/1.1"}
+		s.testhttp.StartTLS()
+	} else {
+		s.testhttp.Start()
 	}
-	s.testhttp.Start()
 
 	// Extract the hostport that the in-memory HTTP server is running on.
 	u, err := url.Parse(s.testhttp.URL)
@@ -243,9 +248,10 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		Name:   "foo",
 		Labels: appLabels,
 	}, types.AppSpecV3{
-		URI:           s.testhttp.URL,
-		PublicAddr:    "foo.example.com",
-		DynamicLabels: types.LabelsToV2(dynamicLabels),
+		URI:                s.testhttp.URL,
+		PublicAddr:         "foo.example.com",
+		InsecureSkipVerify: true,
+		DynamicLabels:      types.LabelsToV2(dynamicLabels),
 	})
 	require.NoError(t, err)
 	appAWS, err := types.NewAppV3(types.Metadata{
@@ -371,8 +377,9 @@ func TestStart(t *testing.T) {
 		Name:   "foo",
 		Labels: staticLabels,
 	}, types.AppSpecV3{
-		URI:        s.testhttp.URL,
-		PublicAddr: "foo.example.com",
+		URI:                s.testhttp.URL,
+		PublicAddr:         "foo.example.com",
+		InsecureSkipVerify: true,
 		DynamicLabels: map[string]types.CommandLabelV2{
 			dynamicLabelName: {
 				Period:  dynamicLabelPeriod,
@@ -600,9 +607,44 @@ func TestHandleConnectionWS(t *testing.T) {
 			// websocket transport header rewriter delegate.
 			require.Equal(t, s.serverPort, r.Header.Get(forward.XForwardedPort))
 		},
-		UseWebsockets: true,
 	})
 
+	s.checkWSResponse(t, s.clientCertificate, func(messageType int, message string) {
+		require.Equal(t, websocket.TextMessage, messageType)
+		require.Equal(t, s.message, message)
+	})
+}
+
+// TestHandleConnectionHTTP2WS given a server that supports HTTP2, make a
+// request and then connect to WebSocket, ensuring that both succeed.
+//
+// This test guarantees the server is capable of handing requests and websockets
+// in different HTTP versions.
+func TestHandleConnectionHTTP2WS(t *testing.T) {
+	s := SetUpSuiteWithConfig(t, suiteConfig{
+		EnableHTTP2: true,
+		ValidateRequest: func(s *Suite, r *http.Request) {
+			// Differentiate WebSocket requests.
+			if strings.ToLower(r.Header.Get("upgrade")) == "websocket" {
+				// Expect WS requests to be using http 1.
+				require.Equal(t, 1, r.ProtoMajor)
+				return
+			}
+
+			// Expect http requests to be using h2.
+			require.Equal(t, 2, r.ProtoMajor)
+		},
+	})
+
+	// First, make the request. This will be using HTTP2.
+	s.checkHTTPResponse(t, s.clientCertificate, func(resp *http.Response) {
+		require.Equal(t, resp.StatusCode, http.StatusOK)
+		buf, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, strings.TrimSpace(string(buf)), s.message)
+	})
+
+	// Second, make the WebSocket connection. This will be using HTTP/1.1
 	s.checkWSResponse(t, s.clientCertificate, func(messageType int, message string) {
 		require.Equal(t, websocket.TextMessage, messageType)
 		require.Equal(t, s.message, message)
@@ -904,8 +946,9 @@ func (s *Suite) checkHTTPResponse(t *testing.T, clientCert tls.Certificate, chec
 	checkResp(resp)
 	require.NoError(t, resp.Body.Close())
 
-	// Close should not trigger an error.
-	require.NoError(t, s.appServer.Close())
+	// Close should not trigger an error. Closing the connection is enough to
+	// get out of the HandleConnection routine.
+	require.NoError(t, pw.Close())
 
 	// Wait for the application server to actually stop serving before
 	// closing the test. This will make sure the server removes the listeners
@@ -960,8 +1003,9 @@ func (s *Suite) checkWSResponse(t *testing.T, clientCert tls.Certificate, checkM
 	// This should not trigger an error.
 	require.NoError(t, ws.Close())
 
-	// Close should not trigger an error.
-	require.NoError(t, s.appServer.Close())
+	// Close should not trigger an error. Closing the connection is enough to
+	// get out of the HandleConnection routine.
+	require.NoError(t, pw.Close())
 
 	// Wait for the application server to actually stop serving before
 	// closing the test. This will make sure the server removes the listeners

--- a/lib/srv/app/transport.go
+++ b/lib/srv/app/transport.go
@@ -113,7 +113,7 @@ func newTransport(ctx context.Context, c *transportConfig) (*transport, error) {
 		c:            c,
 		uri:          uri,
 		tr:           tr,
-		ws:           newWebsocketTransport(uri, tr.TLSClientConfig, c),
+		ws:           newWebsocketTransport(uri, tr.TLSClientConfig.Clone(), c),
 	}, nil
 }
 


### PR DESCRIPTION
Closes #19022 and added a test to cover the scenario described (`TestHandleConnectionHTTP2WS`).

### Problem
Teleport couldn't connect to WebSockets after issuing an HTTP2 request to the same server. This was caused because both dialers (for requests and WebSockets) were using the same TLS Configuration. When the user issued a request, and the server handled it as HTTP2, the configuration would be changed, and the following connections using the configuration would resolve to the same protocol. When a WebSocket request arrived, it would use HTTP2, which [is not supported](https://github.com/golang/go/issues/49918), causing the server to fail to upgrade the connection.

<details>
  <summary>Logs from the server</summary>

  ```
  2022-12-15T11:03:34-03:00 ERRO             Unable to read websocket upgrade response: malformed HTTP response "\x00\x00\x18\x04\x00\x00\x00\x00\x00\x00\x05\x00\x10\x00\x00\x00\x03\x00\x00\x00\xfa\x00\x06\x00\x10\x01@\x00\x04\x00\x10\x00\x00" forward/fwd.go:309
```
</details>

<details>
  <summary>Error from `TestHandleConnectionHTTP2WS` test before the fix</summary>

  ```
  2022/12/15 11:01:31 http2: server: error reading preface from client 127.0.0.1:51752: bogus greeting "GET / 
  HTTP/1.1\r\nHost: 12"
  --- FAIL: TestHandleConnectionHTTP2WS (0.17s)
      server_test.go:990:
                  Error Trace:    /teleport/teleport/lib/srv/app/server_test.go:990
                                                        /teleport/teleport/lib/srv/app/server_test.go:648
                  Error:          Received unexpected error:
                                  unexpected EOF
                  Test:           TestHandleConnectionHTTP2WS
  FAIL
  FAIL    github.com/gravitational/teleport/lib/srv/app   6.328s
  FAIL
  ```
</details>

### Solution
Clone the TLS configuration instead of using the same for both dialers. This enables requests and WebSockets from the same `sessionChunk` to use different protocols.