### PR TITLE
Fix `ALPNConnUpgradeDialer` when not in insecure mode

### DIFF
--- a/lib/srv/alpnproxy/dialer.go
+++ b/lib/srv/alpnproxy/dialer.go
@@ -68,7 +68,7 @@ func (d ALPNDialer) DialContext(ctx context.Context, network, addr string) (net.
 
 	dialer := apiclient.NewDialer(ctx, d.cfg.DialTimeout, d.cfg.DialTimeout)
 	if d.cfg.ALPNConnUpgradeRequired {
-		dialer = newALPNConnUpgradeDialer(dialer, d.cfg.TLSConfig.InsecureSkipVerify)
+		dialer = newALPNConnUpgradeDialer(dialer, d.cfg.TLSConfig)
 	}
 
 	conn, err := dialer.DialContext(ctx, network, addr)


### PR DESCRIPTION
After #18993 the ALPN connection upgrade stopped working when not running with `--insecure`, because the TLS handshake would immediately fail with `tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config`. That's because when moving from `tls.DialWithDialer` to our custom dialer plus `tls.Client`, we didn't bother setting the `ServerName` in the config (something that `tls.DialWithDialer` does on its own).

This PR makes it so that we pass a `*tls.Config` from the outside into the `ALPNConnUpgradeDialer` at construction time, which is used for the outer connection, and replicates the behavior of `tls.DialWithDialer` with regards to `ServerName`.