### PR TITLE
Skip TestBot_Run_CARotation

### DIFF
--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -127,6 +127,9 @@ func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *test
 // TestCARotation is a heavy integration test that through a rotation, the bot
 // receives credentials for a new CA.
 func TestBot_Run_CARotation(t *testing.T) {
+	// TODO(jakule): Re-enable this test https://github.com/gravitational/teleport/issues/19403
+	t.Skip("Temporary disable until it's fixed - flaky")
+
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("test skipped when -short provided")

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func rotate(
+func rotate( //nolint:unused // used in skipped test
 	ctx context.Context, t *testing.T, log logrus.FieldLogger, svc *service.TeleportProcess, phase string,
 ) {
 	t.Helper()
@@ -60,7 +60,8 @@ func rotate(
 	log.Infof("Triggered rotation: %s", phase)
 }
 
-func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *testing.T, wg *sync.WaitGroup) (auth.ClientI, func() *service.TeleportProcess, *config.FileConfig) {
+func setupServerForCARotationTest(ctx context.Context, log utils.Logger, t *testing.T, wg *sync.WaitGroup, //nolint:unused // used in skipped test
+) (auth.ClientI, func() *service.TeleportProcess, *config.FileConfig) {
 	fc, fds := testhelpers.DefaultConfig(t)
 
 	cfg := service.MakeDefaultConfig()


### PR DESCRIPTION
Skip the tbot rotation for now, as this test is currently the flakiest in our whole test suite. 

Updates https://github.com/gravitational/teleport/issues/14471