### PR TITLE
Enable nolintlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,6 @@ linters-settings:
     custom-order: true # Required for "sections" to take effect.
   nolintlint:
     allow-unused: false
-    allow-no-explanation: [ ]
     require-explanation: true
     require-specific: true
 output:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,7 @@ linters-settings:
     skip-generated: true # Skip generated files.
     custom-order: true # Required for "sections" to take effect.
   nolintlint:
-    allow-unused: true
+    allow-unused: true # Enabled because of conditional builds / build tags.
     require-explanation: true
     require-specific: true
 output:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,7 @@ linters-settings:
     skip-generated: true # Skip generated files.
     custom-order: true # Required for "sections" to take effect.
   nolintlint:
-    allow-unused: false
+    allow-unused: true
     require-explanation: true
     require-specific: true
 output:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - nolintlint
     - revive
     - staticcheck
     - unconvert
@@ -54,10 +55,15 @@ linters-settings:
       - prefix(github.com/gravitational/teleport) # Custom section: groups all imports with the specified Prefix.
     skip-generated: true # Skip generated files.
     custom-order: true # Required for "sections" to take effect.
+  nolintlint:
+    allow-unused: false
+    allow-no-explanation: [ ]
+    require-explanation: true
+    require-specific: true
 output:
   uniq-by-line: false
 
 run:
   skip-dirs-use-default: false
   timeout: 5m
-  go: '1.18'
+  go: '1.19'

--- a/api/breaker/round_tripper.go
+++ b/api/breaker/round_tripper.go
@@ -34,13 +34,11 @@ func NewRoundTripper(cb *CircuitBreaker, tripper http.RoundTripper) *RoundTrippe
 
 // RoundTrip forwards the request on to the provided http.RoundTripper if
 // the CircuitBreaker allows it
-//
-// nolint:bodyclose
-// The interface{} conversion to *http.Response trips the linter even though this
-// is merely a pass through function. Closing the body here would prevent the actual
-// consumer to not be able to read it. Copying here to satisfy the linter seems wasteful.
 func (t *RoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	v, err := t.cb.Execute(func() (interface{}, error) {
+		//nolint:bodyclose // The interface{} conversion to *http.Response trips the linter even though this
+		// is merely a pass through function. Closing the body here would prevent the actual
+		// consumer to not be able to read it. Copying here to satisfy the linter seems wasteful.
 		return t.tripper.RoundTrip(request)
 	})
 

--- a/api/client/proxy.go
+++ b/api/client/proxy.go
@@ -104,7 +104,7 @@ func dialProxyWithHTTPDialer(
 	// and then hand off the underlying connection to the caller.
 	// resp.Body.Close() would drain conn and close it, we don't need to do it
 	// here. Disabling bodyclose linter for this edge case.
-	//nolint:bodyclose
+	//nolint:bodyclose // avoid draining the connection
 	resp, err := http.ReadResponse(br, connectReq)
 	if err != nil {
 		conn.Close()

--- a/api/client/proxy/proxy_test.go
+++ b/api/client/proxy/proxy_test.go
@@ -191,7 +191,7 @@ func TestProxyAwareRoundTripper(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "https://localhost:9999", nil)
 	require.NoError(t, err)
 	// Don't care about response, only if the scheme changed.
-	//nolint:bodyclose
+	//nolint:bodyclose // resp should be nil, so there will be no body to close.
 	_, err = rt.RoundTrip(req)
 	require.Error(t, err)
 	require.Equal(t, "http", req.URL.Scheme)

--- a/api/client/webclient/webclient_test.go
+++ b/api/client/webclient/webclient_test.go
@@ -327,8 +327,7 @@ func TestNewWebClientRespectHTTPProxy(t *testing.T) {
 		ProxyAddr: "localhost:3080",
 	})
 	require.NoError(t, err)
-	// resp should be nil, so there will be no body to close.
-	//nolint:bodyclose
+	//nolint:bodyclose // resp should be nil, so there will be no body to close.
 	resp, err := client.Get("https://fakedomain.example.com")
 	// Client should try to proxy through nonexistent server at localhost.
 	require.Error(t, err, "GET unexpectedly succeeded: %+v", resp)
@@ -345,7 +344,7 @@ func TestNewWebClientNoProxy(t *testing.T) {
 		ProxyAddr: "localhost:3080",
 	})
 	require.NoError(t, err)
-	//nolint:bodyclose
+	//nolint:bodyclose // resp should be nil, so there will be no body to close.
 	resp, err := client.Get("https://fakedomain.example.com")
 	require.Error(t, err, "GET unexpectedly succeeded: %+v", resp)
 	require.NotContains(t, err.Error(), "proxyconnect")

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -55,7 +55,6 @@ func newKubePipeline(name string) pipeline {
 	}
 }
 
-//nolint:deadcode,unused
 func newExecPipeline(name string) pipeline {
 	return pipeline{
 		comment: generatedComment(),

--- a/lib/auth/webauthnwin/ctypes.go
+++ b/lib/auth/webauthnwin/ctypes.go
@@ -128,7 +128,6 @@ type webauthnAuthenticatorMakeCredentialOptions struct {
 	_ uint32
 }
 
-//nolint:unused // This struct is kept just to keep size of struct valid.
 type webauthnCredentials struct {
 	_ uint32
 	_ *webauthnCredential

--- a/lib/client/https_client_test.go
+++ b/lib/client/https_client_test.go
@@ -25,8 +25,7 @@ import (
 func TestNewInsecureWebClientHTTPProxy(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "fakeproxy.example.com:9999")
 	client := NewInsecureWebClient()
-	// resp should be nil, so there will be no body to close.
-	//nolint:bodyclose
+	//nolint:bodyclose // resp should be nil, so there will be no body to close.
 	resp, err := client.Get("https://fakedomain.example.com")
 	// Client should try to proxy through nonexistent server at localhost.
 	require.Error(t, err, "GET unexpectedly succeeded: %+v", resp)
@@ -39,7 +38,7 @@ func TestNewInsecureWebClientNoProxy(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "fakeproxy.example.com:9999")
 	t.Setenv("NO_PROXY", "fakedomain.example.com")
 	client := NewInsecureWebClient()
-	//nolint:bodyclose
+	//nolint:bodyclose // resp should be nil, so there will be no body to close.
 	resp, err := client.Get("https://fakedomain.example.com")
 	require.Error(t, err, "GET unexpectedly succeeded: %+v", resp)
 	require.NotContains(t, err.Error(), "proxyconnect")
@@ -50,8 +49,7 @@ func TestNewInsecureWebClientNoProxy(t *testing.T) {
 func TestNewClientWithPoolHTTPProxy(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "fakeproxy.example.com:9999")
 	client := newClientWithPool(nil)
-	// resp should be nil, so there will be no body to close.
-	//nolint:bodyclose
+	//nolint:bodyclose // resp should be nil, so there will be no body to close.
 	resp, err := client.Get("https://fakedomain.example.com")
 	// Client should try to proxy through nonexistent server at localhost.
 	require.Error(t, err, "GET unexpectedly succeeded: %+v", resp)
@@ -64,7 +62,7 @@ func TestNewClientWithPoolNoProxy(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "fakeproxy.example.com:9999")
 	t.Setenv("NO_PROXY", "fakedomain.example.com")
 	client := newClientWithPool(nil)
-	//nolint:bodyclose
+	//nolint:bodyclose // resp should be nil, so there will be no body to close.
 	resp, err := client.Get("https://fakedomain.example.com")
 	require.Error(t, err, "GET unexpectedly succeeded: %+v", resp)
 	require.NotContains(t, err.Error(), "proxyconnect")

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -14,7 +14,7 @@
 
 package proxy
 
-//nolint:goimports
+//nolint:goimports // goimports disagree with gci on blank imports
 import (
 	"context"
 	"fmt"

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4892,8 +4892,8 @@ func getPublicAddr(authClient auth.ReadAppsAccessPoint, a App) (string, error) {
 // It uses external configuration to make the decision
 func newHTTPFileSystem() (http.FileSystem, error) {
 	if !isDebugMode() {
-		fs, err := teleport.NewWebAssetsFilesystem() //nolint:staticcheck
-		if err != nil {                              //nolint:staticcheck
+		fs, err := teleport.NewWebAssetsFilesystem() //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
+		if err != nil {                              //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
 			return nil, trace.Wrap(err)
 		}
 		return fs, nil

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -1294,7 +1294,7 @@ func IsRedshiftClusterAvailable(cluster *redshift.Cluster) bool {
 	// if the status is resulted by modifying the cluster, and the cluster is
 	// assumed to be unavailable if the cluster cannot be created or restored.
 	switch aws.StringValue(cluster.ClusterStatus) {
-	// nolint:misspell
+	//nolint:misspell // cancelling is marked as non-existing word
 	case "available", "available, prep-for-resize", "available, resize-cleanup",
 		"cancelling-resize", "final-snapshot", "modifying", "rebooting",
 		"renaming", "resizing", "rotating-keys", "storage-full", "updating-hsm",

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package db
 
-//nolint:goimports
+//nolint:goimports // goimports disagree with gci on blank imports
 import (
 	"context"
 	"crypto/tls"

--- a/lib/srv/db/snowflake/test.go
+++ b/lib/srv/db/snowflake/test.go
@@ -18,7 +18,6 @@
 
 package snowflake
 
-//nolint:goimports
 import (
 	"context"
 	"crypto/tls"

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -61,7 +61,7 @@ type Config struct {
 // GenerateUserCertFn generates user certificates for RDP authentication.
 type GenerateUserCertFn func(ctx context.Context, username string, ttl time.Duration) (certDER, keyDER []byte, err error)
 
-//nolint:unused // useful for debugging?
+//nolint:unused // used in client.go that is behind desktop_access_rdp build flag
 func (c *Config) checkAndSetDefaults() error {
 	if c.Addr == "" {
 		return trace.BadParameter("missing Addr in rdpclient.Config")

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -61,7 +61,7 @@ type Config struct {
 // GenerateUserCertFn generates user certificates for RDP authentication.
 type GenerateUserCertFn func(ctx context.Context, username string, ttl time.Duration) (certDER, keyDER []byte, err error)
 
-//nolint:unused
+//nolint:unused // useful for debugging?
 func (c *Config) checkAndSetDefaults() error {
 	if c.Addr == "" {
 		return trace.BadParameter("missing Addr in rdpclient.Config")

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -40,8 +40,8 @@ import (
 func NewHostUsers(ctx context.Context, storage *local.PresenceService, uuid string) HostUsers {
 	// newHostUsersBackend statically returns a valid backend or an error,
 	// resulting in a staticcheck linter error on darwin
-	backend, err := newHostUsersBackend(uuid) //nolint:staticcheck
-	if err != nil {                           //nolint:staticcheck
+	backend, err := newHostUsersBackend(uuid) //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
+	if err != nil {                           //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
 		log.Warnf("Error making new HostUsersBackend: %s", err)
 		return nil
 	}

--- a/lib/sshutils/scp/stat_darwin.go
+++ b/lib/sshutils/scp/stat_darwin.go
@@ -28,5 +28,5 @@ func GetAtime(fi os.FileInfo) time.Time {
 }
 
 func timespecToTime(ts syscall.Timespec) time.Time {
-	return time.Unix(int64(ts.Sec), int64(ts.Nsec)) //nolint:unconvert
+	return time.Unix(ts.Sec, ts.Nsec)
 }

--- a/lib/sshutils/scp/stat_linux.go
+++ b/lib/sshutils/scp/stat_linux.go
@@ -28,5 +28,5 @@ func GetAtime(fi os.FileInfo) time.Time {
 }
 
 func timespecToTime(ts syscall.Timespec) time.Time {
-	return time.Unix(int64(ts.Sec), int64(ts.Nsec)) //nolint:unconvert
+	return time.Unix(ts.Sec, ts.Nsec)
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-//nolint:goimports
+//nolint:goimports // goimports disagree with gci on blank imports
 import (
 	"flag"
 	"os"

--- a/tool/tbot/init.go
+++ b/tool/tbot/init.go
@@ -252,7 +252,7 @@ func ensurePermissions(params *ensurePermissionsParams, key string, isDir bool) 
 
 		//nolint:staticcheck // staticcheck doesn't like nop implementations in fs_other.go
 		err = botfs.VerifyACL(path, params.aclOptions)
-		//nolint:staticcheck
+		//nolint:staticcheck // staticcheck doesn't like nop implementations in fs_other.go
 		if err != nil && (currentUser.Uid == RootUID || currentUser.Uid == params.ownerUser.Uid) {
 			if verboseLogging {
 				log.Warnf("ACL for %q is not correct and will be corrected: %v", path, err)

--- a/webassets_noembed.go
+++ b/webassets_noembed.go
@@ -27,6 +27,6 @@ import (
 const webAssetsMissingError = "the teleport binary was built without web assets, try building with `make release`"
 
 // NewWebAssetsFilesystem is a no-op in this build mode.
-func NewWebAssetsFilesystem() (http.FileSystem, error) { //nolint:staticcheck
+func NewWebAssetsFilesystem() (http.FileSystem, error) { //nolint:staticcheck // suppress 'never returns nil' as this is value is platform dependent
 	return nil, trace.NotFound(webAssetsMissingError)
 }


### PR DESCRIPTION
`nolintlint` shows unused `nolint` directives and forces adding a comment about why the linter is disabled.