### PR TITLE
Use a blank-ish `tls.Config` to hit the web listener

### DIFF
--- a/lib/srv/alpnproxy/dialer.go
+++ b/lib/srv/alpnproxy/dialer.go
@@ -68,7 +68,9 @@ func (d ALPNDialer) DialContext(ctx context.Context, network, addr string) (net.
 
 	dialer := apiclient.NewDialer(ctx, d.cfg.DialTimeout, d.cfg.DialTimeout)
 	if d.cfg.ALPNConnUpgradeRequired {
-		dialer = newALPNConnUpgradeDialer(dialer, d.cfg.TLSConfig)
+		dialer = newALPNConnUpgradeDialer(dialer, &tls.Config{
+			InsecureSkipVerify: d.cfg.TLSConfig.InsecureSkipVerify,
+		})
 	}
 
 	conn, err := dialer.DialContext(ctx, network, addr)


### PR DESCRIPTION
Tweak the fix in #19398 to use a blank-ish, webpki-trusting `tls.Config` for the "outer" connection in `ALPNConnUpgradeDialer`.