### PR TITLE
Update predicate evaluation engine + constraint refactor of partial solver

### DIFF
--- a/lib/auth/predicate/access_test.go
+++ b/lib/auth/predicate/access_test.go
@@ -100,35 +100,35 @@ func TestFnSanity(t *testing.T) {
 func TestCheckAccessToNode(t *testing.T) {
 	withNameAsLogin := types.NewAccessPolicy("allow", types.AccessPolicySpecV1{
 		Allow: map[string]string{
-			"node": "(node.login == user.name) || (add(user.name, \"-admin\") == node.login)",
+			"access_node": "(access_node.login == user.name) || (add(user.name, \"-admin\") == access_node.login)",
 		},
 	})
 
 	denyMike := types.NewAccessPolicy("allow", types.AccessPolicySpecV1{
 		Deny: map[string]string{
-			"node": "node.login == \"mike\"",
+			"access_node": "access_node.login == \"mike\"",
 		},
 	})
 
 	checker := NewPredicateAccessChecker([]types.AccessPolicy{withNameAsLogin})
-	access, err := checker.CheckAccessToNode(&Node{Login: "mike"}, &User{Name: "mike"})
+	access, err := checker.CheckLoginAccessToNode(&Node{}, &AccessNode{Login: "mike"}, &User{Name: "mike"})
 	require.NoError(t, err)
-	require.True(t, access)
+	require.Equal(t, access, AccessAllowed)
 
-	access, err = checker.CheckAccessToNode(&Node{Login: "alice"}, &User{Name: "bob"})
+	access, err = checker.CheckLoginAccessToNode(&Node{}, &AccessNode{Login: "alice"}, &User{Name: "bob"})
 	require.NoError(t, err)
-	require.False(t, access)
+	require.Equal(t, access, AccessUndecided)
 
-	access, err = checker.CheckAccessToNode(&Node{Login: "bob-admin"}, &User{Name: "bob"})
+	access, err = checker.CheckLoginAccessToNode(&Node{}, &AccessNode{Login: "bob-admin"}, &User{Name: "bob"})
 	require.NoError(t, err)
-	require.True(t, access)
+	require.Equal(t, access, AccessAllowed)
 
 	checkerWithDeny := NewPredicateAccessChecker([]types.AccessPolicy{withNameAsLogin, denyMike})
-	access, err = checkerWithDeny.CheckAccessToNode(&Node{Login: "mike"}, &User{Name: "mike"})
+	access, err = checkerWithDeny.CheckLoginAccessToNode(&Node{}, &AccessNode{Login: "mike"}, &User{Name: "mike"})
 	require.NoError(t, err)
-	require.False(t, access)
+	require.Equal(t, access, AccessDenied)
 
-	access, err = checkerWithDeny.CheckAccessToNode(&Node{Login: "bob"}, &User{Name: "bob"})
+	access, err = checkerWithDeny.CheckLoginAccessToNode(&Node{}, &AccessNode{Login: "bob"}, &User{Name: "bob"})
 	require.NoError(t, err)
-	require.True(t, access)
+	require.Equal(t, access, AccessAllowed)
 }

--- a/lib/auth/predicate/access_test.go
+++ b/lib/auth/predicate/access_test.go
@@ -104,7 +104,7 @@ func TestCheckAccessToNode(t *testing.T) {
 		},
 	})
 
-	denyMike := types.NewAccessPolicy("allow", types.AccessPolicySpecV1{
+	denyMike := types.NewAccessPolicy("deny", types.AccessPolicySpecV1{
 		Deny: map[string]string{
 			"access_node": "access_node.login == \"mike\"",
 		},

--- a/lib/auth/predicate/partial/builtin.go
+++ b/lib/auth/predicate/partial/builtin.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package partial
+
+import "github.com/aclements/go-z3/z3"
+
+func builtinUpper(ctx *z3.Context) (z3.FuncDecl, error) {
+	fnUpper := ctx.FuncDeclRec("string_upper", []z3.Sort{ctx.StringSort()}, ctx.StringSort())
+	element := ctx.StringConst("string_upper_input")
+	zero := ctx.FromInt(0, ctx.IntSort()).(z3.Int)
+	one := ctx.FromInt(1, ctx.IntSort()).(z3.Int)
+
+	charUpper := func(char z3.String) z3.String {
+		zc := ctx.FromString("z").ToCode()
+		ac := ctx.FromString("a").ToCode()
+		Ac := ctx.FromString("A").ToCode()
+
+		code := char.ToCode()
+		isLower := code.GE(ac).And(code.LE(zc))
+		upper := ctx.StringFromCode(code.Add(Ac.Sub(ac)))
+		return ctx.If(isLower, upper.AsAST(), char.AsAST()).AsValue().(z3.String)
+	}
+
+	rem := fnUpper.Apply(element.Substring(one, element.Length().Sub(one))).(z3.String)
+
+	fnUpper.DefineRec(
+		[]z3.Value{element},
+		ctx.If(
+			element.Length().Eq(zero),
+			element.AsAST(),
+			charUpper(element.Substring(zero, one)).Concat(rem).AsAST(),
+		))
+
+	return fnUpper, nil
+}
+
+func builtinLower(ctx *z3.Context) (z3.FuncDecl, error) {
+	fnLower := ctx.FuncDeclRec("string_lower", []z3.Sort{ctx.StringSort()}, ctx.StringSort())
+	element := ctx.StringConst("string_lower_input")
+	zero := ctx.FromInt(0, ctx.IntSort()).(z3.Int)
+	one := ctx.FromInt(1, ctx.IntSort()).(z3.Int)
+
+	charUpper := func(char z3.String) z3.String {
+		Zc := ctx.FromString("Z").ToCode()
+		Ac := ctx.FromString("A").ToCode()
+		ac := ctx.FromString("a").ToCode()
+
+		code := char.ToCode()
+		isUpper := code.GE(Ac).And(code.LE(Zc))
+		upper := ctx.StringFromCode(code.Sub(Ac.Sub(ac)))
+		return ctx.If(isUpper, upper.AsAST(), char.AsAST()).AsValue().(z3.String)
+	}
+
+	rem := fnLower.Apply(element.Substring(one, element.Length().Sub(one))).(z3.String)
+
+	fnLower.DefineRec(
+		[]z3.Value{element},
+		ctx.If(
+			element.Length().Eq(zero),
+			element.AsAST(),
+			charUpper(element.Substring(zero, one)).Concat(rem).AsAST(),
+		))
+
+	return fnLower, nil
+}

--- a/lib/auth/predicate/partial/lower.go
+++ b/lib/auth/predicate/partial/lower.go
@@ -1,0 +1,323 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package partial
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+	"strings"
+
+	"github.com/aclements/go-z3/z3"
+	"github.com/gravitational/trace"
+)
+
+// Resolver resolves an identifier to a value. Returns nil if the identifier is not found and is unknown.
+type Resolver func([]string) any
+
+// Type represents a type of a value within a predicate expression.
+type Type int
+
+const (
+	// TypeInt is an Go int type.
+	TypeInt Type = iota
+
+	// TypeBool is a Go bool type.
+	TypeBool
+
+	// TypeString is a Go string type.
+	TypeString
+)
+
+type ctx struct {
+	// def is the Z3 context instance
+	def *z3.Context
+	// solver is the Z3 solver instance
+	solver *z3.Solver
+	// idents is a map of identifiers to their Z3 values
+	idents map[string]z3.Value
+	// the type of the unknown identifier, needed for type checking during lowering
+	unkTy z3.Sort
+	// resolveIdentifier is a function which resolves an identifier to a value
+	resolveIdentifier Resolver
+}
+
+// resolve an identifier to a value, if the identifier is not found, the resolver is called to resolve it
+func (ctx *ctx) resolve(fields []string) (z3.Value, error) {
+	full := strings.Join(fields, ".")
+	if v, ok := ctx.idents[full]; ok {
+		return v, nil
+	}
+
+	if val := ctx.resolveIdentifier(fields); val != nil {
+		var ident z3.Value
+		switch val := val.(type) {
+		case bool:
+			ident = ctx.def.FromBool(val)
+		case int:
+			ident = ctx.def.FromInt(int64(val), ctx.def.IntSort())
+		case string:
+			ident = ctx.def.FromString(val)
+		default:
+			return nil, trace.BadParameter("unsupported type %T", val)
+		}
+
+		ctx.idents[full] = ident
+		return ident, nil
+	}
+
+	val := ctx.def.Const(full, ctx.unkTy)
+	ctx.idents[full] = val
+	return val, nil
+}
+
+// lower lowers a Go AST into a Z3 AST.
+// Lowering is a term commonly used within compiler development/interpreters etc to describe
+// the process of transforming a high level construct into a lower level construct, usually with more primitive operators
+// and more data/constraints. In this case, lowering is the process of converting a Go AST into a set
+// of Z3 variables and constraints. Variables are used to describe the input and output of each primitive
+// operation such as arithmetic or comparisons and constraints are used to define a relationship between them.
+// For the uninitiated, such a constraint set is the usual form that a SMT solver sees problems in.
+//
+// To keep it simple, lower operates by recursively traversing the Go AST depth-first
+// and at each AST node, defining one or more variables and possibly one or more constraints between those variables.
+// To organize this, each lowering operation returns the variable that represents the result of the relation between
+// the input and output variables. Note that this function doesn't actually do any problem computation;
+// it merely converts it into a simpler form that Z3 can grasp.
+func lower(ctx *ctx, node ast.Expr) (z3.Value, error) {
+	switch n := node.(type) {
+	case *ast.ParenExpr:
+		return lower(ctx, n.X)
+	case *ast.BinaryExpr:
+		return lowerBinary(ctx, n)
+	case *ast.UnaryExpr:
+		return lowerUnary(ctx, n)
+	case *ast.BasicLit:
+		return lowerBasicLit(ctx, n)
+	case *ast.IndexExpr:
+		return lowerIndexExpr(ctx, n)
+	case *ast.SelectorExpr:
+		return lowerSelectorExpr(ctx, n)
+	case *ast.Ident:
+		return lowerIdent(ctx, n)
+	case *ast.CallExpr:
+		return lowerCallExpr(ctx, n)
+	default:
+		return nil, trace.NotImplemented("node type %T unsupported", n)
+	}
+}
+
+func pickType(ctx *ctx, x, y z3.Value) (z3.Kind, error) {
+	xk := x.Sort().Kind()
+	yk := y.Sort().Kind()
+	if xk != yk {
+		return 0, trace.BadParameter("type mismatch %v != %v", xk, yk)
+	}
+
+	return xk, nil
+}
+
+func lowerBinary(ctx *ctx, node *ast.BinaryExpr) (z3.Value, error) {
+	x, err := lower(ctx, node.X)
+	if err != nil {
+		return nil, err
+	}
+
+	y, err := lower(ctx, node.Y)
+	if err != nil {
+		return nil, err
+	}
+
+	switch node.Op {
+	case token.EQL:
+		ty, err := pickType(ctx, x, y)
+		if err != nil {
+			return nil, err
+		}
+
+		switch ty {
+		case z3.KindInt:
+			return x.(z3.Int).Eq(y.(z3.Int)), nil
+		case z3.KindBool:
+			return x.(z3.Bool).Eq(y.(z3.Bool)), nil
+		case z3.KindString:
+			return x.(z3.String).Eq(y.(z3.String)), nil
+		default:
+			return nil, trace.BadParameter("type %v does not support equals", ty)
+		}
+	case token.LSS:
+		xi, ok1 := x.(z3.Int)
+		yi, ok2 := y.(z3.Int)
+		if !ok1 || !ok2 {
+			return nil, trace.BadParameter("type invalid, must be int %v, %v", x.Sort().Kind(), y.Sort().Kind())
+		}
+
+		return xi.LT(yi), nil
+	case token.LEQ:
+		xi, ok1 := x.(z3.Int)
+		yi, ok2 := y.(z3.Int)
+		if !ok1 || !ok2 {
+			return nil, trace.BadParameter("type invalid, must be int %v, %v", x.Sort().Kind(), y.Sort().Kind())
+		}
+
+		return xi.LE(yi), nil
+	case token.GTR:
+		xi, ok1 := x.(z3.Int)
+		yi, ok2 := y.(z3.Int)
+		if !ok1 || !ok2 {
+			return nil, trace.BadParameter("type invalid, must be int %v, %v", x.Sort().Kind(), y.Sort().Kind())
+		}
+
+		return xi.GT(yi), nil
+	case token.GEQ:
+		xi, ok1 := x.(z3.Int)
+		yi, ok2 := y.(z3.Int)
+		if !ok1 || !ok2 {
+			return nil, trace.BadParameter("type invalid, must be int %v, %v", x.Sort().Kind(), y.Sort().Kind())
+		}
+
+		return xi.GE(yi), nil
+	case token.LAND:
+		xb, ok1 := x.(z3.Bool)
+		yb, ok2 := y.(z3.Bool)
+		if !ok1 || !ok2 {
+			return nil, trace.BadParameter("type invalid, must be bool %v, %v", x.Sort().Kind(), y.Sort().Kind())
+		}
+
+		return xb.And(yb), nil
+	case token.LOR:
+		xb, ok1 := x.(z3.Bool)
+		yb, ok2 := y.(z3.Bool)
+		if !ok1 || !ok2 {
+			return nil, trace.BadParameter("type invalid, must be bool %v, %v", x.Sort().Kind(), y.Sort().Kind())
+		}
+
+		return xb.Or(yb), nil
+	default:
+		return nil, trace.NotImplemented("unary op %v unsupported", node.Op)
+	}
+}
+
+func lowerUnary(ctx *ctx, node *ast.UnaryExpr) (z3.Value, error) {
+	switch node.Op {
+	case token.NOT:
+		x, err := lower(ctx, node.X)
+		if err != nil {
+			return nil, err
+		}
+
+		xb, ok := x.(z3.Bool)
+		if !ok {
+			return nil, trace.BadParameter("expected bool, got %T", x)
+		}
+
+		return xb.Not(), nil
+	default:
+		return nil, trace.NotImplemented("unary op %v unsupported", node.Op)
+	}
+}
+
+func lowerBasicLit(ctx *ctx, node *ast.BasicLit) (z3.Value, error) {
+	switch {
+	case node.Kind == token.INT:
+		value, err := strconv.Atoi(node.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		return ctx.def.FromInt(int64(value), ctx.def.IntSort()), nil
+	case node.Kind == token.STRING:
+		return ctx.def.FromString(node.Value[1 : len(node.Value)-1]), nil
+	default:
+		return nil, trace.NotImplemented("basic lit kind %v unsupported", node.Kind)
+	}
+}
+
+func lowerIndexExpr(ctx *ctx, node *ast.IndexExpr) (z3.Value, error) {
+	// TODO(joel): impl maps
+	return nil, trace.BadParameter("maps are not supported")
+}
+
+func lowerSelectorExpr(ctx *ctx, node *ast.SelectorExpr) (z3.Value, error) {
+	fields, err := evaluateSelector(node, []string{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ctx.resolve(fields)
+}
+
+func evaluateSelector(sel *ast.SelectorExpr, fields []string) ([]string, error) {
+	fields = append([]string{sel.Sel.Name}, fields...)
+	switch l := sel.X.(type) {
+	case *ast.SelectorExpr:
+		return evaluateSelector(l, fields)
+	case *ast.Ident:
+		fields = append([]string{l.Name}, fields...)
+		return fields, nil
+	default:
+		return nil, trace.BadParameter("unsupported selector type: %T", l)
+	}
+}
+
+func lowerIdent(ctx *ctx, node *ast.Ident) (z3.Value, error) {
+	switch node.Name {
+	case "true":
+		return ctx.def.FromBool(true), nil
+	case "false":
+		return ctx.def.FromBool(true), nil
+	default:
+		return ctx.resolve([]string{node.Name})
+	}
+}
+
+func lowerCallExpr(ctx *ctx, node *ast.CallExpr) (z3.Value, error) {
+	args := make([]z3.Value, len(node.Args))
+	for i, arg := range node.Args {
+		v, err := lower(ctx, arg)
+		if err != nil {
+			return nil, err
+		}
+
+		args[i] = v
+	}
+
+	fn, ok := node.Fun.(*ast.Ident)
+	if !ok {
+		return nil, trace.BadParameter("expected basic lit function name, got %T", node.Fun)
+	}
+
+	// TODO(joel): impl additional functions
+	switch fn.Name {
+	case "upper":
+		upper, err := builtinUpper(ctx.def)
+		if err != nil {
+			return nil, err
+		}
+
+		return upper.Apply(args...), nil
+	case "lower":
+		lower, err := builtinLower(ctx.def)
+		if err != nil {
+			return nil, err
+		}
+
+		return lower.Apply(args...), nil
+	default:
+		return nil, trace.BadParameter("unknown function %v", fn.Name)
+	}
+}

--- a/lib/auth/predicate/partial/solver.go
+++ b/lib/auth/predicate/partial/solver.go
@@ -14,36 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package predicate
+package partial
 
 import (
-	"go/ast"
+	"context"
 	"go/parser"
-	"go/token"
-	"strconv"
-	"strings"
-	"time"
+	"sync"
 
 	"github.com/aclements/go-z3/z3"
 	"github.com/gravitational/trace"
 )
 
-// Resolver resolves an identifier to a value. Returns nil if the identifier is not found and is unknown.
-type Resolver func([]string) any
+var cachedSolvers = &sync.Pool{New: func() any { return NewSolver() }}
 
-// Type represents a type of a value within a predicate expression.
-type Type int
+// GetCachedSolver returns a solver from a global cache or creates a new one if the cache is empty.
+// One must call PutCachedSolver to return the solver to the cache once it is no longer needed.
+func GetCachedSolver() *Solver {
+	return cachedSolvers.Get().(*Solver)
+}
 
-const (
-	// TypeInt is an Go int type.
-	TypeInt Type = iota
-
-	// TypeBool is a Go bool type.
-	TypeBool
-
-	// TypeString is a Go string type.
-	TypeString
-)
+// PutCachedSolver returns a solver instance to the global cache.
+func PutCachedSolver(solver *Solver) {
+	cachedSolvers.Put(solver)
+}
 
 // Solver is a solver instance which can be used to solve partial predicate expressions.
 // This is rather expensive to create so it should preferably be reused when possible.
@@ -60,10 +53,19 @@ func NewSolver() *Solver {
 	return &Solver{def, solver}
 }
 
-// PartialSolveForAll solves a given partial predicate expression for all possible values of the given identifier.
-// The expression must have a boolean output type and the type of the unknown identifier must be specified.
+// Constraint represents a predicate expression which must be satisfied to either true or false
+type Constraint struct {
+	// Allow is true if the expression must be satisfies to true, false otherwise.
+	Allow bool
+
+	// Expr is a predicate expression.
+	Expr string
+}
+
+// PartialSolveForAll solves a given set of partial predicate expression for all possible values of the given identifier.
+// The expressions must have a boolean output type and the type of the unknown identifier must be specified and be shared across all expressions.
 // On timeout, no solutions are returned.
-func (s *Solver) PartialSolveForAll(predicate string, resolveIdentifier Resolver, querying string, to Type, maxSolutions int, timeout time.Duration) ([]z3.Value, error) {
+func (s *Solver) PartialSolveForAll(ctx context.Context, constraints []Constraint, resolveIdentifier Resolver, querying string, to Type, maxSolutions int) ([]z3.Value, error) {
 	outCh := make(chan []z3.Value, 1)
 	errCh := make(chan error, 1)
 
@@ -72,7 +74,7 @@ func (s *Solver) PartialSolveForAll(predicate string, resolveIdentifier Resolver
 		defer close(outCh)
 		defer close(errCh)
 
-		out, err := s.partialSolveForAllImpl(predicate, resolveIdentifier, querying, to, maxSolutions)
+		out, err := s.partialSolveForAllImpl(constraints, resolveIdentifier, querying, to, maxSolutions)
 		if err != nil {
 			errCh <- err
 			return
@@ -86,7 +88,7 @@ func (s *Solver) PartialSolveForAll(predicate string, resolveIdentifier Resolver
 		return out, nil
 	case err := <-errCh:
 		return nil, err
-	case <-time.After(timeout):
+	case <-ctx.Done():
 		s.def.Interrupt()
 		// wait for the other goroutine to cleanup
 		<-outCh
@@ -95,13 +97,7 @@ func (s *Solver) PartialSolveForAll(predicate string, resolveIdentifier Resolver
 }
 
 // partialSolveForAllImpl is the implementation of PartialSolveForAll that runs logic directly.
-func (s *Solver) partialSolveForAllImpl(predicate string, resolveIdentifier Resolver, querying string, to Type, maxSolutions int) (out []z3.Value, err error) {
-	// parse the predicate expression into a Go AST
-	ast, err := parser.ParseExpr(predicate)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *Solver) partialSolveForAllImpl(constraints []Constraint, resolveIdentifier Resolver, querying string, to Type, maxSolutions int) (out []z3.Value, err error) {
 	// create a context struct which is used to share various information obtained during lowering
 	ctx := &ctx{s.def, s.solver, make(map[string]z3.Value), z3.Sort{}, resolveIdentifier}
 
@@ -120,20 +116,33 @@ func (s *Solver) partialSolveForAllImpl(predicate string, resolveIdentifier Reso
 		return nil, trace.BadParameter("unsupported output type %v", to)
 	}
 
-	// lower the Go AST into a Z3 AST, see the lower godoc for more details
-	cond, err := lower(ctx, ast)
-	if err != nil {
-		return nil, err
-	}
+	for _, constraint := range constraints {
+		// parse the predicate expression into a Go AST
+		ast, err := parser.ParseExpr(constraint.Expr)
+		if err != nil {
+			return nil, err
+		}
 
-	// assert the expression must evaluate to a boolean
-	boolCond, ok := cond.(z3.Bool)
-	if !ok {
-		return nil, trace.BadParameter("predicate must evaluate to a boolean value")
-	}
+		// lower the Go AST into a Z3 AST, see the lower godoc for more details
+		cond, err := lower(ctx, ast)
+		if err != nil {
+			return nil, err
+		}
 
-	// assert the boolean must be equal to true
-	ctx.solver.Assert(boolCond)
+		// assert the expression must evaluate to a boolean
+		boolCond, ok := cond.(z3.Bool)
+		if !ok {
+			return nil, trace.BadParameter("predicate must evaluate to a boolean value")
+		}
+
+		// if the constraint is of form deny, invert the condition
+		if !constraint.Allow {
+			boolCond = boolCond.Not()
+		}
+
+		// assert the boolean must be equal to true
+		ctx.solver.Assert(boolCond)
+	}
 
 	// defer a recover here to catch any panics from Z3, this can happen when we call call Interrupt()
 	// on a timeout. The bindings have this unfortunate behaviour but this seems like a reasonable fix.
@@ -179,251 +188,4 @@ func (s *Solver) partialSolveForAllImpl(predicate string, resolveIdentifier Reso
 			return out, nil
 		}
 	}
-}
-
-type ctx struct {
-	// def is the Z3 context instance
-	def *z3.Context
-	// solver is the Z3 solver instance
-	solver *z3.Solver
-	// idents is a map of identifiers to their Z3 values
-	idents map[string]z3.Value
-	// the type of the unknown identifier, needed for type checking during lowering
-	unkTy z3.Sort
-	// resolveIdentifier is a function which resolves an identifier to a value
-	resolveIdentifier Resolver
-}
-
-// resolve an identifier to a value, if the identifier is not found, the resolver is called to resolve it
-func (ctx *ctx) resolve(fields []string) (z3.Value, error) {
-	full := strings.Join(fields, ".")
-	if v, ok := ctx.idents[full]; ok {
-		return v, nil
-	}
-
-	if val := ctx.resolveIdentifier(fields); val != nil {
-		var ident z3.Value
-		switch val := val.(type) {
-		case bool:
-			ident = ctx.def.FromBool(val)
-		case int:
-			ident = ctx.def.FromInt(int64(val), ctx.def.IntSort())
-		case string:
-			ident = ctx.def.FromString(val)
-		default:
-			return nil, trace.BadParameter("unsupported type %T", val)
-		}
-
-		ctx.idents[full] = ident
-		return ident, nil
-	}
-
-	val := ctx.def.Const(full, ctx.unkTy)
-	ctx.idents[full] = val
-	return val, nil
-}
-
-// lower lowers a Go AST into a Z3 AST.
-// Lowering is a term commonly used within compiler development/interpreters etc to describe
-// the process of transforming a high level construct into a lower level construct, usually with more primitive operators
-// and more data/constraints. In this case, lowering is the process of converting a Go AST into a set
-// of Z3 variables and constraints. Variables are used to describe the input and output of each primitive
-// operation such as arithmetic or comparisons and constraints are used to define a relationship between them.
-// For the uninitiated, such a constraint set is the usual form that a SMT solver sees problems in.
-//
-// To keep it simple, lower operates by recursively traversing the Go AST depth-first
-// and at each AST node, defining one or more variables and possibly one or more constraints between those variables.
-// To organize this, each lowering operation returns the variable that represents the result of the relation between
-// the input and output variables. Note that this function doesn't actually do any problem computation;
-// it merely converts it into a simpler form that Z3 can grasp.
-func lower(ctx *ctx, node ast.Expr) (z3.Value, error) {
-	switch n := node.(type) {
-	case *ast.ParenExpr:
-		return lower(ctx, n.X)
-	case *ast.BinaryExpr:
-		return lowerBinary(ctx, n)
-	case *ast.UnaryExpr:
-		return lowerUnary(ctx, n)
-	case *ast.BasicLit:
-		return lowerBasicLit(ctx, n)
-	case *ast.IndexExpr:
-		return lowerIndexExpr(ctx, n)
-	case *ast.SelectorExpr:
-		return lowerSelectorExpr(ctx, n)
-	case *ast.Ident:
-		return lowerIdent(ctx, n)
-	case *ast.CallExpr:
-		return lowerCallExpr(ctx, n)
-	default:
-		return nil, trace.NotImplemented("node type %T unsupported", n)
-	}
-}
-
-func pickType(ctx *ctx, x, y z3.Value) (z3.Kind, error) {
-	xk := x.Sort().Kind()
-	yk := y.Sort().Kind()
-	if xk != yk {
-		return 0, trace.BadParameter("type mismatch %v != %v", xk, yk)
-	}
-
-	return xk, nil
-}
-
-func lowerBinary(ctx *ctx, node *ast.BinaryExpr) (z3.Value, error) {
-	x, err := lower(ctx, node.X)
-	if err != nil {
-		return nil, err
-	}
-
-	y, err := lower(ctx, node.Y)
-	if err != nil {
-		return nil, err
-	}
-
-	switch node.Op {
-	case token.EQL:
-		ty, err := pickType(ctx, x, y)
-		if err != nil {
-			return nil, err
-		}
-
-		switch ty {
-		case z3.KindInt:
-			return x.(z3.Int).Eq(y.(z3.Int)), nil
-		case z3.KindBool:
-			return x.(z3.Bool).Eq(y.(z3.Bool)), nil
-		case z3.KindString:
-			return x.(z3.String).Eq(y.(z3.String)), nil
-		default:
-			return nil, trace.BadParameter("type %v does not support equals", ty)
-		}
-	case token.LSS:
-		xi, ok1 := x.(z3.Int)
-		yi, ok2 := y.(z3.Int)
-		if !ok1 || !ok2 {
-			return nil, trace.BadParameter("type invalid, must be int %v, %v", x.Sort().Kind(), y.Sort().Kind())
-		}
-
-		return xi.LT(yi), nil
-	case token.LEQ:
-		xi, ok1 := x.(z3.Int)
-		yi, ok2 := y.(z3.Int)
-		if !ok1 || !ok2 {
-			return nil, trace.BadParameter("type invalid, must be int %v, %v", x.Sort().Kind(), y.Sort().Kind())
-		}
-
-		return xi.LE(yi), nil
-	case token.GTR:
-		xi, ok1 := x.(z3.Int)
-		yi, ok2 := y.(z3.Int)
-		if !ok1 || !ok2 {
-			return nil, trace.BadParameter("type invalid, must be int %v, %v", x.Sort().Kind(), y.Sort().Kind())
-		}
-
-		return xi.GT(yi), nil
-	case token.GEQ:
-		xi, ok1 := x.(z3.Int)
-		yi, ok2 := y.(z3.Int)
-		if !ok1 || !ok2 {
-			return nil, trace.BadParameter("type invalid, must be int %v, %v", x.Sort().Kind(), y.Sort().Kind())
-		}
-
-		return xi.GE(yi), nil
-	case token.LAND:
-		xb, ok1 := x.(z3.Bool)
-		yb, ok2 := y.(z3.Bool)
-		if !ok1 || !ok2 {
-			return nil, trace.BadParameter("type invalid, must be bool %v, %v", x.Sort().Kind(), y.Sort().Kind())
-		}
-
-		return xb.And(yb), nil
-	case token.LOR:
-		xb, ok1 := x.(z3.Bool)
-		yb, ok2 := y.(z3.Bool)
-		if !ok1 || !ok2 {
-			return nil, trace.BadParameter("type invalid, must be bool %v, %v", x.Sort().Kind(), y.Sort().Kind())
-		}
-
-		return xb.Or(yb), nil
-	default:
-		return nil, trace.NotImplemented("unary op %v unsupported", node.Op)
-	}
-}
-
-func lowerUnary(ctx *ctx, node *ast.UnaryExpr) (z3.Value, error) {
-	switch node.Op {
-	case token.NOT:
-		x, err := lower(ctx, node.X)
-		if err != nil {
-			return nil, err
-		}
-
-		xb, ok := x.(z3.Bool)
-		if !ok {
-			return nil, trace.BadParameter("expected bool, got %T", x)
-		}
-
-		return xb.Not(), nil
-	default:
-		return nil, trace.NotImplemented("unary op %v unsupported", node.Op)
-	}
-}
-
-func lowerBasicLit(ctx *ctx, node *ast.BasicLit) (z3.Value, error) {
-	switch {
-	case node.Kind == token.INT:
-		value, err := strconv.Atoi(node.Value)
-		if err != nil {
-			return nil, err
-		}
-
-		return ctx.def.FromInt(int64(value), ctx.def.IntSort()), nil
-	case node.Kind == token.STRING:
-		return ctx.def.FromString(node.Value[1 : len(node.Value)-1]), nil
-	default:
-		return nil, trace.NotImplemented("basic lit kind %v unsupported", node.Kind)
-	}
-}
-
-func lowerIndexExpr(ctx *ctx, node *ast.IndexExpr) (z3.Value, error) {
-	// todo: impl maps
-	return nil, trace.BadParameter("maps are not supported")
-}
-
-func lowerSelectorExpr(ctx *ctx, node *ast.SelectorExpr) (z3.Value, error) {
-	fields, err := evaluateSelector(node, []string{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return ctx.resolve(fields)
-}
-
-func evaluateSelector(sel *ast.SelectorExpr, fields []string) ([]string, error) {
-	fields = append([]string{sel.Sel.Name}, fields...)
-	switch l := sel.X.(type) {
-	case *ast.SelectorExpr:
-		return evaluateSelector(l, fields)
-	case *ast.Ident:
-		fields = append([]string{l.Name}, fields...)
-		return fields, nil
-	default:
-		return nil, trace.BadParameter("unsupported selector type: %T", l)
-	}
-}
-
-func lowerIdent(ctx *ctx, node *ast.Ident) (z3.Value, error) {
-	switch node.Name {
-	case "true":
-		return ctx.def.FromBool(true), nil
-	case "false":
-		return ctx.def.FromBool(true), nil
-	default:
-		return ctx.resolve([]string{node.Name})
-	}
-}
-
-func lowerCallExpr(ctx *ctx, node *ast.CallExpr) (z3.Value, error) {
-	// todo: impl fn calls
-	return nil, trace.BadParameter("fn calls are not supported")
 }

--- a/lib/auth/predicate/partial/solver_test.go
+++ b/lib/auth/predicate/partial/solver_test.go
@@ -45,13 +45,14 @@ func TestSolverIntEq(t *testing.T) {
 // TestSolverFn tests custom functions
 func TestSolverFn(t *testing.T) {
 	state := NewSolver()
-	x, err := state.PartialSolveForAll(context.Background(), constraint("lower(\"BANANA\") == x"), func(s []string) any {
+	x, err := state.PartialSolveForAll(context.Background(), constraint("upper(x) == \"BANANA\""), func(s []string) any {
 		return nil
-	}, "x", TypeString, 1)
+	}, "x", TypeString, 2)
 
 	require.NoError(t, err)
-	require.Len(t, x, 1)
-	require.Equal(t, "\"banana\"", x[0].String())
+	require.Len(t, x, 2)
+	require.Equal(t, "\"BananA\"", x[0].String())
+	require.Equal(t, "\"BAnanA\"", x[1].String())
 }
 
 // TestSolverStringExpMultiSolution tests solving against a string equality expression with two solutions.

--- a/lib/auth/predicate/partial/solver_test.go
+++ b/lib/auth/predicate/partial/solver_test.go
@@ -50,9 +50,12 @@ func TestSolverFn(t *testing.T) {
 	}, "x", TypeString, 2)
 
 	require.NoError(t, err)
-	require.Len(t, x, 2)
-	require.Equal(t, "\"BananA\"", x[0].String())
-	require.Equal(t, "\"BAnanA\"", x[1].String())
+
+	s := make([]string, len(x))
+	for i, v := range x {
+		s[i] = v.String()
+	}
+	require.ElementsMatch(t, []string{"\"BananA\"", "\"BAnanA\""}, s)
 }
 
 // TestSolverStringExpMultiSolution tests solving against a string equality expression with two solutions.

--- a/lib/auth/predicate/partial/solver_test.go
+++ b/lib/auth/predicate/partial/solver_test.go
@@ -14,25 +14,44 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package predicate
+package partial
 
 import (
+	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
+func constraint(expr string) []Constraint {
+	return []Constraint{{
+		Allow: true,
+		Expr:  expr,
+	}}
+}
+
 // TestSolverIntEq tests solving for a single integer equality.
 func TestSolverIntEq(t *testing.T) {
 	state := NewSolver()
-	x, err := state.PartialSolveForAll("x == 7", func(s []string) any {
+	x, err := state.PartialSolveForAll(context.Background(), constraint("x == 7"), func(s []string) any {
 		return nil
-	}, "x", TypeInt, 1, 10*time.Second)
+	}, "x", TypeInt, 1)
 
 	require.NoError(t, err)
 	require.Len(t, x, 1)
 	require.Equal(t, "7", x[0].String())
+}
+
+// TestSolverFn tests custom functions
+func TestSolverFn(t *testing.T) {
+	state := NewSolver()
+	x, err := state.PartialSolveForAll(context.Background(), constraint("lower(\"BANANA\") == x"), func(s []string) any {
+		return nil
+	}, "x", TypeString, 1)
+
+	require.NoError(t, err)
+	require.Len(t, x, 1)
+	require.Equal(t, "\"banana\"", x[0].String())
 }
 
 // TestSolverStringExpMultiSolution tests solving against a string equality expression with two solutions.
@@ -45,7 +64,7 @@ func TestSolverStringExpMultiSolution(t *testing.T) {
 	}
 
 	state := NewSolver()
-	x, err := state.PartialSolveForAll("x == \"blah\" || x == \"root\" || x == jimsName", resolver, "x", TypeString, 3, 10*time.Second)
+	x, err := state.PartialSolveForAll(context.Background(), constraint("x == \"blah\" || x == \"root\" || x == jimsName"), resolver, "x", TypeString, 3)
 	require.NoError(t, err)
 
 	s := make([]string, len(x))
@@ -69,7 +88,7 @@ func BenchmarkSolverStringExpMultiSolutionCached(b *testing.B) {
 	state := NewSolver()
 
 	for i := 0; i < b.N; i++ {
-		x, err := state.PartialSolveForAll("x == \"blah\" || x == \"root\" || x == jimsName", resolver, "x", TypeString, 3, 10*time.Second)
+		x, err := state.PartialSolveForAll(context.Background(), constraint("x == \"blah\" || x == \"root\" || x == jimsName"), resolver, "x", TypeString, 3)
 
 		if err != nil {
 			b.Fatal(err)
@@ -96,7 +115,7 @@ func BenchmarkSolverStringExpMultiSolution(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		state := NewSolver()
-		x, err := state.PartialSolveForAll("x == \"blah\" || x == \"root\" || x == jimsName", resolver, "x", TypeString, 3, 10*time.Second)
+		x, err := state.PartialSolveForAll(context.Background(), constraint("x == \"blah\" || x == \"root\" || x == jimsName"), resolver, "x", TypeString, 3)
 
 		if err != nil {
 			b.Fatal(err)

--- a/lib/auth/predicate/predicate.go
+++ b/lib/auth/predicate/predicate.go
@@ -22,7 +22,7 @@ import (
 	"github.com/vulcand/predicate"
 )
 
-// AccesDecision represents the result of an access engine working through a set of rules.
+// AccessDecision represents the result of an access engine working through a set of rules.
 type AccessDecision int
 
 const (

--- a/lib/auth/predicate/predicate.go
+++ b/lib/auth/predicate/predicate.go
@@ -22,6 +22,20 @@ import (
 	"github.com/vulcand/predicate"
 )
 
+// AccesDecision represents the result of an access engine working through a set of rules.
+type AccessDecision int
+
+const (
+	// AccessUndecided means access was not granted or denied by a rule.
+	AccessUndecided AccessDecision = iota
+
+	// AccessAllowed means access was granted by a rule.
+	AccessAllowed
+
+	// AccessDenied means access was denied by a rule.
+	AccessDenied
+)
+
 // NamedParameter is an object with a name that can be added to the environment in which a predicate expression runs.
 type NamedParameter interface {
 	// GetName returns the name of the object.
@@ -89,18 +103,30 @@ func NewPredicateAccessChecker(policies []types.AccessPolicy) *PredicateAccessCh
 	return &PredicateAccessChecker{policies}
 }
 
-// CheckAccessToNode checks if a given user has access to a Server Access node.
-func (c *PredicateAccessChecker) CheckAccessToNode(node *Node, user *User) (bool, error) {
-	env := buildEnv(node, user)
-	return c.checkPolicyExprs("node", env)
+// CheckAccessToNode checks if a given user has login access to a Server Access node.
+func (c *PredicateAccessChecker) CheckLoginAccessToNode(node *Node, access *AccessNode, user *User) (AccessDecision, error) {
+	env := buildEnv(node, access, user)
+	return c.checkPolicyExprs("access_node", env)
+}
+
+// CheckAccessToResource checks if a given user has access to view a resource.
+func (c *PredicateAccessChecker) CheckAccessToResource(resource *Resource, user *User) (AccessDecision, error) {
+	env := buildEnv(resource, user)
+	return c.checkPolicyExprs("resource", env)
+}
+
+// CheckSessionJoinAccess checks if a given user can join a session.
+func (c *PredicateAccessChecker) CheckSessionJoinAccess(session *Session, join *JoinSession, user *User) (AccessDecision, error) {
+	env := buildEnv(session, join, user)
+	return c.checkPolicyExprs("join_session", env)
 }
 
 // checkPolicyExprs is the internal routine that evaluates expressions in a given scope from all policies
 // with a provided execution environment containing input values.
-func (c *PredicateAccessChecker) checkPolicyExprs(scope string, env map[string]any) (bool, error) {
+func (c *PredicateAccessChecker) checkPolicyExprs(scope string, env map[string]any) (AccessDecision, error) {
 	parser, err := newParser(env)
 	if err != nil {
-		return false, trace.Wrap(err)
+		return AccessUndecided, trace.Wrap(err)
 	}
 
 	evaluate := func(expr string) (bool, error) {
@@ -121,11 +147,11 @@ func (c *PredicateAccessChecker) checkPolicyExprs(scope string, env map[string]a
 		if expr, ok := policy.GetDeny()[scope]; ok {
 			denied, err := evaluate(expr)
 			if err != nil {
-				return false, trace.Wrap(err)
+				return AccessUndecided, trace.Wrap(err)
 			}
 
 			if denied {
-				return false, nil
+				return AccessDenied, nil
 			}
 		}
 	}
@@ -134,24 +160,53 @@ func (c *PredicateAccessChecker) checkPolicyExprs(scope string, env map[string]a
 		if expr, ok := policy.GetAllow()[scope]; ok {
 			allowed, err := evaluate(expr)
 			if err != nil {
-				return false, trace.Wrap(err)
+				return AccessUndecided, trace.Wrap(err)
 			}
 
 			if allowed {
-				return true, nil
+				return AccessAllowed, nil
 			}
 		}
 	}
 
-	return false, nil
+	return AccessUndecided, nil
+}
+
+// Resource describes an arbitrary resource that can be viewed and listed.
+type Resource struct {
+	// The resource kind.
+	Kind string `json:"kind"`
+
+	// The resource subkind.
+	SubKind string `json:"subkind"`
+
+	// The version of the resource.
+	Version string `json:"version"`
+
+	// The name of the resource.
+	Name string `json:"name"`
+
+	// The unique ID of the resource.
+	Id string `json:"id"`
+
+	// The verb of the operation, e.g. "list", "read" or "write".
+	Verb string `json:"verb"`
+}
+
+// GetName returns the name of the object.
+func (n *Resource) GetName() string {
+	return "resource"
 }
 
 // Node describes a Server Access node.
 type Node struct {
-	// The UNIX login of the login request.
-	Login string `json:"login"`
+	// Hostname is the hostname of the node.
+	Hostname string `json:"hostname"`
 
-	// The labels on the target node.
+	// Address is the address reported by the node.
+	Address string `json:"address"`
+
+	// The complete (static+dynamic) set of labels for the node.
 	Labels map[string]string `json:"labels"`
 }
 
@@ -160,10 +215,30 @@ func (n *Node) GetName() string {
 	return "node"
 }
 
+// The name of the AccessNode predicate rule.
+const AccessNodeField = "access_node"
+
+// The name of the AccessNode.Login predicate field.
+const AccessNodeLoginField = AccessNodeField + ".login"
+
+// AccessNode represents the action of opening a connection to a node.
+type AccessNode struct {
+	// Login is the requested UNIX login.
+	Login string `json:"login"`
+}
+
+// GetName returns the name of the object.
+func (n *AccessNode) GetName() string {
+	return AccessNodeField
+}
+
 // User describes a Teleport user.
 type User struct {
 	// The name of the Teleport user.
 	Name string `json:"name"`
+
+	// All access policies assigned to the user.
+	Policies []string `json:"policies"`
 
 	// The traits associated with the user.
 	Traits map[string][]string `json:"traits"`
@@ -172,4 +247,29 @@ type User struct {
 // GetName returns the name of the object.
 func (u *User) GetName() string {
 	return "user"
+}
+
+// Session describes an active Teleport session.
+type Session struct {
+	// Owner is the user who created the session.
+	Owner *User `json:"owner"`
+
+	// Participants is the list of current session participants.
+	Participants []string `json:"participants"`
+}
+
+// GetName returns the name of the object.
+func (u *Session) GetName() string {
+	return "session"
+}
+
+// JoinSession describes a request to join a session.
+type JoinSession struct {
+	// Mode is the participant mode, e.g. "observer" or "peer".
+	Mode string `json:"mode"`
+}
+
+// GetName returns the name of the object.
+func (u *JoinSession) GetName() string {
+	return "join_session"
 }

--- a/lib/auth/predicate/specialty.go
+++ b/lib/auth/predicate/specialty.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/teleport/lib/auth/predicate/partial"
+	"github.com/gravitational/trace"
+)
+
+const attemptTimeout = time.Second
+
+// ComputeValidNodeLogins computes a list of valid logins for a given node.
+func (c *PredicateAccessChecker) ComputeValidNodeLogins(ctx context.Context, node *Node, limit int) ([]string, error) {
+	var constraints []partial.Constraint
+
+	for _, policy := range c.policies {
+		if expr, ok := policy.GetAllow()["node"]; ok {
+			constraints = append(constraints, partial.Constraint{
+				Allow: true,
+				Expr:  expr,
+			})
+		}
+
+		if expr, ok := policy.GetDeny()["node"]; ok {
+			constraints = append(constraints, partial.Constraint{
+				Allow: false,
+				Expr:  expr,
+			})
+		}
+	}
+
+	solver := partial.GetCachedSolver()
+	defer partial.PutCachedSolver(solver)
+	runCtx, cancelRunCtx := context.WithTimeout(ctx, attemptTimeout)
+	defer cancelRunCtx()
+
+	z3v, err := solver.PartialSolveForAll(runCtx, constraints, nil, AccessNodeLoginField, partial.TypeString, limit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	valid := make([]string, len(z3v))
+	for i, v := range z3v {
+		s := v.String()
+		valid[i] = s[1 : len(s)-1]
+	}
+
+	return valid, nil
+}


### PR DESCRIPTION
This PR refactors the predicate package to accomplish a couple goals related to the evaluator and partial solver:
- Update the non-partial evaluator to deal with semantic changes and new primitives in the predicate Python DSL
- Update the non-partial evaluator to return yes/no/undecided from access decisions to allow blending with the standard RBAC engine later on
- Refactor the partial solver to split it semantically across multiple files for better code navigation
- Update the core loop of the partial solver to solve over a set of constraint expressions instead of over a single one. This is needed to evaluate possible logins across multiple policies at once.
- Introduce two z3 test functions `upper` and `lower` that can be used in partial constraints for login solving. More to be added later.

This PR is marked do-not-merge, while it is ready for review, it is part of a sequence of staggered PR's based upon eachother that will be merged top-down into dev-predicate when they are all green, which means I'll merge them in a special order.