### PR TITLE
Wire device authentication into `tsh`

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3590,7 +3590,7 @@ func (tc *TeleportClient) Login(ctx context.Context) (*Key, error) {
 }
 
 // AttemptDeviceLogin attempts device authentication for the current device.
-// It expects to receive the latest activated [key], as acquired via
+// It expects to receive the latest activated key, as acquired via
 // [TeleportClient.Login], and augments the certificates within the key with
 // device extensions.
 //

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -65,7 +65,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/touchid"
-	"github.com/gravitational/teleport/lib/auth/webauthncli"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	"github.com/gravitational/teleport/lib/client/terminal"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -4777,14 +4776,14 @@ func (tc *TeleportClient) SearchSessionEvents(ctx context.Context, fromUTC, toUT
 	return sessions, nil
 }
 
-func parseMFAMode(in string) (webauthncli.AuthenticatorAttachment, error) {
+func parseMFAMode(in string) (wancli.AuthenticatorAttachment, error) {
 	switch in {
 	case "auto", "":
-		return webauthncli.AttachmentAuto, nil
+		return wancli.AttachmentAuto, nil
 	case "platform":
-		return webauthncli.AttachmentPlatform, nil
+		return wancli.AttachmentPlatform, nil
 	case "cross-platform":
-		return webauthncli.AttachmentCrossPlatform, nil
+		return wancli.AttachmentCrossPlatform, nil
 	default:
 		return 0, trace.BadParameter("unsupported mfa mode %q", in)
 	}

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base32"
+	"encoding/pem"
 	"errors"
 	"io"
 	"os"
@@ -36,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
@@ -369,6 +371,108 @@ func TestTeleportClient_PromptMFAChallenge(t *testing.T) {
 	}
 }
 
+func TestTeleportClient_DeviceLogin(t *testing.T) {
+	silenceLogger(t)
+
+	clock := clockwork.NewFakeClockAt(time.Now())
+	sa := newStandaloneTeleport(t, clock)
+	username := sa.Username
+	password := sa.Password
+
+	// Disable MFA. It makes testing easier.
+	ctx := context.Background()
+	authServer := sa.Auth.GetAuthServer()
+	authPref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
+		Type:         constants.Local,
+		SecondFactor: constants.SecondFactorOff,
+	})
+	require.NoError(t, err, "NewAuthPreference failed")
+	require.NoError(t,
+		authServer.SetAuthPreference(ctx, authPref),
+		"SetAuthPreference failed")
+
+	// Prepare client config, it won't change throughout the test.
+	cfg := client.MakeDefaultConfig()
+	cfg.Stdout = io.Discard
+	cfg.Stderr = io.Discard
+	cfg.Stdin = &bytes.Buffer{}
+	cfg.Username = username
+	cfg.HostLogin = username
+	cfg.AddKeysToAgent = client.AddKeysToAgentNo
+	cfg.WebProxyAddr = sa.ProxyWebAddr
+	cfg.KeysDir = t.TempDir()
+	cfg.InsecureSkipVerify = true
+
+	teleportClient, err := client.NewClient(cfg)
+	require.NoError(t, err, "NewClient failed")
+
+	// Prepare prompt with the user password, for login, and reset it after tests.
+	oldStdin := prompt.Stdin()
+	t.Cleanup(func() { prompt.SetStdin(oldStdin) })
+	prompt.SetStdin(prompt.NewFakeReader().AddString(password))
+
+	// Login the current user and fetch a valid pair of certificates.
+	key, err := teleportClient.Login(ctx)
+	require.NoError(t, err, "Login failed")
+	require.NoError(t,
+		teleportClient.ActivateKey(ctx, key),
+		"ActivateKey failed")
+
+	// Prepare "device aware" certificates from key.
+	// In a real scenario these would be augmented certs.
+	block, _ := pem.Decode(key.TLSCert)
+	require.NotNil(t, block, "Decode failed")
+	validCerts := &devicepb.UserCertificates{
+		X509Der:          block.Bytes,
+		SshAuthorizedKey: key.Cert,
+	}
+
+	// Reset dtAuthnRunCeremony after tests.
+	oldRunCeremony := *client.DTAuthnRunCeremony
+	t.Cleanup(func() { *client.DTAuthnRunCeremony = oldRunCeremony })
+
+	// validatingRunCeremony checks the parameters passed to dtAuthnRunCeremony
+	// and returns validCerts on success.
+	validatingRunCeremony := func(_ context.Context, devicesClient devicepb.DeviceTrustServiceClient, certs *devicepb.UserCertificates) (*devicepb.UserCertificates, error) {
+		switch {
+		case devicesClient == nil:
+			return nil, errors.New("want non-nil devicesClient")
+		case certs == nil:
+			return nil, errors.New("want non-nil certs")
+		case len(certs.SshAuthorizedKey) == 0:
+			return nil, errors.New("want non-empty certs.SshAuthorizedKey")
+		}
+		return validCerts, nil
+	}
+	*client.DTAuthnRunCeremony = validatingRunCeremony
+
+	// Sanity check that we can do authenticated actions before
+	// AttemptDeviceLogin.
+	authenticatedAction := func() error {
+		// Any authenticated action would do.
+		_, err := teleportClient.ListAllNodes(ctx)
+		return err
+	}
+	require.NoError(t, authenticatedAction(), "Authenticated action failed *before* AttemptDeviceLogin")
+
+	// Test! Exercise DeviceLogin.
+	got, err := teleportClient.DeviceLogin(ctx, &devicepb.UserCertificates{
+		SshAuthorizedKey: key.Cert,
+	})
+	require.NoError(t, err, "DeviceLogin failed")
+	require.Equal(t, validCerts, got, "DeviceLogin mismatch")
+
+	// Test! Exercise AttemptDeviceLogin.
+	// Absence of errors is good enough here, since we know that DeviceLogin
+	// works based on the assertions above.
+	require.NoError(t,
+		teleportClient.AttemptDeviceLogin(ctx, key),
+		"AttemptDeviceLogin failed")
+
+	// Verify that the "new" key was applied correctly.
+	require.NoError(t, authenticatedAction(), "Authenticated action failed after AttemptDeviceLogin")
+}
+
 type standaloneBundle struct {
 	AuthAddr, ProxyWebAddr string
 	Username, Password     string
@@ -379,8 +483,7 @@ type standaloneBundle struct {
 }
 
 // TODO(codingllama): Consider refactoring newStandaloneTeleport into a public
-//
-//	function and reusing in other places.
+// function and reusing in other places.
 func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundle {
 	randomAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 
@@ -392,14 +495,18 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 
 	staticToken := uuid.New().String()
 
-	user, err := types.NewUser("llama")
-	require.NoError(t, err)
-	role, err := types.NewRoleV3(user.GetName(), types.RoleSpecV5{
+	// Prepare role and user.
+	// Both resources are bootstrapped by the Auth Server below.
+	const username = "llama"
+	role, err := types.NewRoleV3(username, types.RoleSpecV5{
 		Allow: types.RoleConditions{
-			Logins: []string{user.GetName()},
+			Logins: []string{username},
 		},
 	})
 	require.NoError(t, err)
+	user, err := types.NewUser("llama")
+	require.NoError(t, err)
+	user.AddRole(role.GetName())
 
 	// AuthServer setup.
 	cfg := service.MakeDefaultConfig()
@@ -417,7 +524,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 		},
 	})
 	require.NoError(t, err)
-	cfg.Auth.BootstrapResources = []types.Resource{user, role}
+	cfg.Auth.BootstrapResources = []types.Resource{role, user}
 	cfg.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
 		StaticTokens: []types.ProvisionTokenV1{
 			{
@@ -445,7 +552,6 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 
 	// Initialize user's password and MFA.
 	ctx := context.Background()
-	username := user.GetName()
 	const password = "supersecretpassword"
 	token, err := authServer.CreateResetPasswordToken(ctx, auth.CreateUserTokenRequest{
 		Name: username,

--- a/lib/client/export_test.go
+++ b/lib/client/export_test.go
@@ -14,4 +14,5 @@
 
 package client
 
+var DTAuthnRunCeremony = &dtAuthnRunCeremony
 var HasTouchIDCredentials = &hasTouchIDCredentials

--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -186,6 +186,11 @@ func (c *Cluster) login(ctx context.Context, sshLoginFunc client.SSHLoginFunc) e
 		return trace.Wrap(err)
 	}
 
+	// Attempt device login. This activates a fresh key if successful.
+	if err := c.clusterClient.AttemptDeviceLogin(ctx, key); err != nil {
+		return trace.Wrap(err)
+	}
+
 	if err := c.clusterClient.SaveProfile(c.dir, true); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1570,6 +1570,13 @@ func onLogin(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
+	// Attempt device login. This activates a fresh key if successful.
+	// We do not save the resulting in the identity file above on purpose, as this
+	// certificate is bound to the present device.
+	if err := tc.AttemptDeviceLogin(cf.Context, key); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// If the proxy is advertising that it supports Kubernetes, update kubeconfig.
 	if tc.KubeProxyAddr != "" {
 		if err := updateKubeConfig(cf, tc, ""); err != nil {


### PR DESCRIPTION
Wire device authentication into `tsh`, so it attempts to acquire device certificates after user login. This affects direct logins (`tsh login`), indirect logins (RetryWithRelogin) and Connect.

If authentication fails (non-Enterprise cluster, device not enrolled, etc) `tsh` proceeds as usual, but the final user certificate won't contain device extensions.

https://github.com/gravitational/teleport.e/issues/514