### PR TITLE
Add tctl get handlers.

### DIFF
--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -108,7 +108,7 @@ func (c *AppsCommand) ListApps(ctx context.Context, clt auth.ClientI) error {
 
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout))
+		return trace.Wrap(coll.WriteText(os.Stdout))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -309,7 +309,7 @@ func (a *AuthCommand) ListAuthServers(ctx context.Context, clusterAPI auth.Clien
 
 	switch a.format {
 	case teleport.Text:
-		return sc.writeText(os.Stdout)
+		return sc.WriteText(os.Stdout)
 	case teleport.YAML:
 		return writeYAML(sc, os.Stdout)
 	case teleport.JSON:

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -36,8 +36,8 @@ import (
 )
 
 type ResourceCollection interface {
-	writeText(w io.Writer) error
-	resources() []types.Resource
+	WriteText(w io.Writer) error
+	Resources() []types.Resource
 }
 
 type roleCollection struct {
@@ -45,14 +45,14 @@ type roleCollection struct {
 	verbose bool
 }
 
-func (r *roleCollection) resources() (res []types.Resource) {
+func (r *roleCollection) Resources() (res []types.Resource) {
 	for _, resource := range r.roles {
 		res = append(res, resource)
 	}
 	return res
 }
 
-func (r *roleCollection) writeText(w io.Writer) error {
+func (r *roleCollection) WriteText(w io.Writer) error {
 	var rows [][]string
 	for _, r := range r.roles {
 		if r.GetName() == constants.DefaultImplicitRole {
@@ -81,14 +81,14 @@ type namespaceCollection struct {
 	namespaces []types.Namespace
 }
 
-func (n *namespaceCollection) resources() (r []types.Resource) {
+func (n *namespaceCollection) Resources() (r []types.Resource) {
 	for _, resource := range n.namespaces {
 		r = append(r, &resource)
 	}
 	return r
 }
 
-func (n *namespaceCollection) writeText(w io.Writer) error {
+func (n *namespaceCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, n := range n.namespaces {
 		t.AddRow([]string{n.Metadata.Name})
@@ -129,14 +129,14 @@ type serverCollection struct {
 	verbose bool
 }
 
-func (s *serverCollection) resources() (r []types.Resource) {
+func (s *serverCollection) Resources() (r []types.Resource) {
 	for _, resource := range s.servers {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (s *serverCollection) writeText(w io.Writer) error {
+func (s *serverCollection) WriteText(w io.Writer) error {
 	var rows [][]string
 	for _, se := range s.servers {
 		labels := stripInternalTeleportLabels(s.verbose, se.GetAllLabels())
@@ -168,14 +168,14 @@ type userCollection struct {
 	users []types.User
 }
 
-func (u *userCollection) resources() (r []types.Resource) {
+func (u *userCollection) Resources() (r []types.Resource) {
 	for _, resource := range u.users {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (u *userCollection) writeText(w io.Writer) error {
+func (u *userCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"User"})
 	for _, user := range u.users {
 		t.AddRow([]string{user.GetName()})
@@ -188,14 +188,14 @@ type authorityCollection struct {
 	cas []types.CertAuthority
 }
 
-func (a *authorityCollection) resources() (r []types.Resource) {
+func (a *authorityCollection) Resources() (r []types.Resource) {
 	for _, resource := range a.cas {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (a *authorityCollection) writeText(w io.Writer) error {
+func (a *authorityCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Cluster Name", "CA Type", "Fingerprint", "Role Map"})
 	for _, a := range a.cas {
 		for _, key := range a.GetTrustedSSHKeyPairs() {
@@ -225,14 +225,14 @@ type reverseTunnelCollection struct {
 	tunnels []types.ReverseTunnel
 }
 
-func (r *reverseTunnelCollection) resources() (res []types.Resource) {
+func (r *reverseTunnelCollection) Resources() (res []types.Resource) {
 	for _, resource := range r.tunnels {
 		res = append(res, resource)
 	}
 	return res
 }
 
-func (r *reverseTunnelCollection) writeText(w io.Writer) error {
+func (r *reverseTunnelCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Cluster Name", "Dial Addresses"})
 	for _, tunnel := range r.tunnels {
 		t.AddRow([]string{
@@ -247,14 +247,14 @@ type oidcCollection struct {
 	connectors []types.OIDCConnector
 }
 
-func (c *oidcCollection) resources() (r []types.Resource) {
+func (c *oidcCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.connectors {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *oidcCollection) writeText(w io.Writer) error {
+func (c *oidcCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Name", "Issuer URL", "Additional Scope"})
 	for _, conn := range c.connectors {
 		t.AddRow([]string{
@@ -269,14 +269,14 @@ type samlCollection struct {
 	connectors []types.SAMLConnector
 }
 
-func (c *samlCollection) resources() (r []types.Resource) {
+func (c *samlCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.connectors {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *samlCollection) writeText(w io.Writer) error {
+func (c *samlCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Name", "SSO URL"})
 	for _, conn := range c.connectors {
 		t.AddRow([]string{conn.GetName(), conn.GetSSO()})
@@ -291,7 +291,7 @@ type connectorsCollection struct {
 	github []types.GithubConnector
 }
 
-func (c *connectorsCollection) resources() (r []types.Resource) {
+func (c *connectorsCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.oidc {
 		r = append(r, resource)
 	}
@@ -304,14 +304,14 @@ func (c *connectorsCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *connectorsCollection) writeText(w io.Writer) error {
+func (c *connectorsCollection) WriteText(w io.Writer) error {
 	if len(c.oidc) > 0 {
 		_, err := io.WriteString(w, "\nOIDC:\n")
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		oc := &oidcCollection{connectors: c.oidc}
-		err = oc.writeText(w)
+		err = oc.WriteText(w)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -323,7 +323,7 @@ func (c *connectorsCollection) writeText(w io.Writer) error {
 			return trace.Wrap(err)
 		}
 		sc := &samlCollection{connectors: c.saml}
-		err = sc.writeText(w)
+		err = sc.WriteText(w)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -335,7 +335,7 @@ func (c *connectorsCollection) writeText(w io.Writer) error {
 			return trace.Wrap(err)
 		}
 		gc := &githubCollection{connectors: c.github}
-		err = gc.writeText(w)
+		err = gc.WriteText(w)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -348,14 +348,14 @@ type trustedClusterCollection struct {
 	trustedClusters []types.TrustedCluster
 }
 
-func (c *trustedClusterCollection) resources() (r []types.Resource) {
+func (c *trustedClusterCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.trustedClusters {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *trustedClusterCollection) writeText(w io.Writer) error {
+func (c *trustedClusterCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{
 		"Name", "Enabled", "Token", "Proxy Address", "Reverse Tunnel Address", "Role Map"})
 	for _, tc := range c.trustedClusters {
@@ -376,14 +376,14 @@ type githubCollection struct {
 	connectors []types.GithubConnector
 }
 
-func (c *githubCollection) resources() (r []types.Resource) {
+func (c *githubCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.connectors {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *githubCollection) writeText(w io.Writer) error {
+func (c *githubCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Name", "Teams To Logins"})
 	for _, conn := range c.connectors {
 		t.AddRow([]string{conn.GetName(), formatTeamsToLogins(
@@ -406,14 +406,14 @@ type remoteClusterCollection struct {
 	remoteClusters []types.RemoteCluster
 }
 
-func (c *remoteClusterCollection) resources() (r []types.Resource) {
+func (c *remoteClusterCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.remoteClusters {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *remoteClusterCollection) writeText(w io.Writer) error {
+func (c *remoteClusterCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Name", "Status", "Last Heartbeat"})
 	for _, cluster := range c.remoteClusters {
 		lastHeartbeat := cluster.GetLastHeartbeat()
@@ -431,25 +431,25 @@ func formatLastHeartbeat(t time.Time) string {
 }
 
 func writeJSON(c ResourceCollection, w io.Writer) error {
-	return utils.WriteJSON(w, c.resources())
+	return utils.WriteJSON(w, c.Resources())
 }
 
 func writeYAML(c ResourceCollection, w io.Writer) error {
-	return utils.WriteYAML(w, c.resources())
+	return utils.WriteYAML(w, c.Resources())
 }
 
 type semaphoreCollection struct {
 	sems []types.Semaphore
 }
 
-func (c *semaphoreCollection) resources() (r []types.Resource) {
+func (c *semaphoreCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.sems {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *semaphoreCollection) writeText(w io.Writer) error {
+func (c *semaphoreCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Kind", "Name", "LeaseID", "Holder", "Expires"})
 	for _, sem := range c.sems {
 		for _, ref := range sem.LeaseRefs() {
@@ -467,14 +467,14 @@ type appServerCollection struct {
 	verbose bool
 }
 
-func (a *appServerCollection) resources() (r []types.Resource) {
+func (a *appServerCollection) Resources() (r []types.Resource) {
 	for _, resource := range a.servers {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (a *appServerCollection) writeText(w io.Writer) error {
+func (a *appServerCollection) WriteText(w io.Writer) error {
 	var rows [][]string
 	for _, server := range a.servers {
 		app := server.GetApp()
@@ -507,14 +507,14 @@ type appCollection struct {
 	verbose bool
 }
 
-func (c *appCollection) resources() (r []types.Resource) {
+func (c *appCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.apps {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *appCollection) writeText(w io.Writer) error {
+func (c *appCollection) WriteText(w io.Writer) error {
 	var rows [][]string
 	for _, app := range c.apps {
 		labels := stripInternalTeleportLabels(c.verbose, app.GetAllLabels())
@@ -536,11 +536,11 @@ type authPrefCollection struct {
 	authPref types.AuthPreference
 }
 
-func (c *authPrefCollection) resources() (r []types.Resource) {
+func (c *authPrefCollection) Resources() (r []types.Resource) {
 	return []types.Resource{c.authPref}
 }
 
-func (c *authPrefCollection) writeText(w io.Writer) error {
+func (c *authPrefCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Type", "Second Factor"})
 	t.AddRow([]string{c.authPref.GetType(), string(c.authPref.GetSecondFactor())})
 	_, err := t.AsBuffer().WriteTo(w)
@@ -551,11 +551,11 @@ type netConfigCollection struct {
 	netConfig types.ClusterNetworkingConfig
 }
 
-func (c *netConfigCollection) resources() (r []types.Resource) {
+func (c *netConfigCollection) Resources() (r []types.Resource) {
 	return []types.Resource{c.netConfig}
 }
 
-func (c *netConfigCollection) writeText(w io.Writer) error {
+func (c *netConfigCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Client Idle Timeout", "Keep Alive Interval", "Keep Alive Count Max", "Session Control Timeout"})
 	t.AddRow([]string{
 		c.netConfig.GetClientIdleTimeout().String(),
@@ -571,11 +571,11 @@ type recConfigCollection struct {
 	recConfig types.SessionRecordingConfig
 }
 
-func (c *recConfigCollection) resources() (r []types.Resource) {
+func (c *recConfigCollection) Resources() (r []types.Resource) {
 	return []types.Resource{c.recConfig}
 }
 
-func (c *recConfigCollection) writeText(w io.Writer) error {
+func (c *recConfigCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Mode", "Proxy Checks Host Keys"})
 	t.AddRow([]string{c.recConfig.GetMode(), strconv.FormatBool(c.recConfig.GetProxyChecksHostKeys())})
 	_, err := t.AsBuffer().WriteTo(w)
@@ -597,7 +597,7 @@ func (w *writer) write(s string) {
 	}
 }
 
-func (c *netRestrictionsCollection) resources() (r []types.Resource) {
+func (c *netRestrictionsCollection) Resources() (r []types.Resource) {
 	r = append(r, c.netRestricts)
 	return
 }
@@ -609,7 +609,7 @@ func (c *netRestrictionsCollection) writeList(as []types.AddressCondition, w *wr
 	}
 }
 
-func (c *netRestrictionsCollection) writeText(w io.Writer) error {
+func (c *netRestrictionsCollection) WriteText(w io.Writer) error {
 	out := &writer{w: w}
 	out.write("ALLOW\n")
 	c.writeList(c.netRestricts.GetAllow(), out)
@@ -624,14 +624,14 @@ type databaseServerCollection struct {
 	verbose bool
 }
 
-func (c *databaseServerCollection) resources() (r []types.Resource) {
+func (c *databaseServerCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.servers {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *databaseServerCollection) writeText(w io.Writer) error {
+func (c *databaseServerCollection) WriteText(w io.Writer) error {
 	var rows [][]string
 	for _, server := range c.servers {
 		labels := stripInternalTeleportLabels(c.verbose, server.GetDatabase().GetAllLabels())
@@ -668,14 +668,14 @@ type databaseCollection struct {
 	verbose   bool
 }
 
-func (c *databaseCollection) resources() (r []types.Resource) {
+func (c *databaseCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.databases {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *databaseCollection) writeText(w io.Writer) error {
+func (c *databaseCollection) WriteText(w io.Writer) error {
 	var rows [][]string
 	for _, database := range c.databases {
 		labels := stripInternalTeleportLabels(c.verbose, database.GetAllLabels())
@@ -698,14 +698,14 @@ type lockCollection struct {
 	locks []types.Lock
 }
 
-func (c *lockCollection) resources() (r []types.Resource) {
+func (c *lockCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.locks {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *lockCollection) writeText(w io.Writer) error {
+func (c *lockCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"ID", "Target", "Message", "Expires"})
 	for _, lock := range c.locks {
 		target := lock.Target()
@@ -723,14 +723,14 @@ type windowsDesktopServiceCollection struct {
 	services []types.WindowsDesktopService
 }
 
-func (c *windowsDesktopServiceCollection) resources() (r []types.Resource) {
+func (c *windowsDesktopServiceCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.services {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *windowsDesktopServiceCollection) writeText(w io.Writer) error {
+func (c *windowsDesktopServiceCollection) WriteText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Name", "Address", "Version"})
 	for _, service := range c.services {
 		addr := service.GetAddr()
@@ -748,14 +748,14 @@ type windowsDesktopCollection struct {
 	verbose  bool
 }
 
-func (c *windowsDesktopCollection) resources() (r []types.Resource) {
+func (c *windowsDesktopCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.desktops {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *windowsDesktopCollection) writeText(w io.Writer) error {
+func (c *windowsDesktopCollection) WriteText(w io.Writer) error {
 	var rows [][]string
 	for _, d := range c.desktops {
 		labels := stripInternalTeleportLabels(c.verbose, d.GetAllLabels())
@@ -796,14 +796,14 @@ type tokenCollection struct {
 	tokens []types.ProvisionToken
 }
 
-func (c *tokenCollection) resources() (r []types.Resource) {
+func (c *tokenCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.tokens {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *tokenCollection) writeText(w io.Writer) error {
+func (c *tokenCollection) WriteText(w io.Writer) error {
 	for _, token := range c.tokens {
 		_, err := w.Write([]byte(token.String()))
 		if err != nil {
@@ -818,14 +818,14 @@ type kubeServerCollection struct {
 	verbose bool
 }
 
-func (c *kubeServerCollection) resources() (r []types.Resource) {
+func (c *kubeServerCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.servers {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *kubeServerCollection) writeText(w io.Writer) error {
+func (c *kubeServerCollection) WriteText(w io.Writer) error {
 	var rows [][]string
 	for _, server := range c.servers {
 		kube := server.GetCluster()
@@ -866,7 +866,7 @@ type kubeClusterCollection struct {
 	verbose  bool
 }
 
-func (c *kubeClusterCollection) resources() (r []types.Resource) {
+func (c *kubeClusterCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.clusters {
 		r = append(r, resource)
 	}
@@ -881,7 +881,7 @@ func (c *kubeClusterCollection) resources() (r []types.Resource) {
 // cluster3      region=northcentralus,resource-group=cluster3,subscription-id=subID
 // cluster4      owner=cluster4,region=southcentralus,resource-group=cluster4,subscription-id=subID
 // If verbose is disabled, labels column can be truncated to fit into the console.
-func (c *kubeClusterCollection) writeText(w io.Writer) error {
+func (c *kubeClusterCollection) WriteText(w io.Writer) error {
 	sort.Sort(types.KubeClusters(c.clusters))
 	var rows [][]string
 	for _, cluster := range c.clusters {
@@ -905,7 +905,7 @@ type installerCollection struct {
 	installers []types.Installer
 }
 
-func (c *installerCollection) resources() []types.Resource {
+func (c *installerCollection) Resources() []types.Resource {
 	var r []types.Resource
 	for _, inst := range c.installers {
 		r = append(r, inst)
@@ -913,7 +913,7 @@ func (c *installerCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *installerCollection) writeText(w io.Writer) error {
+func (c *installerCollection) WriteText(w io.Writer) error {
 	for _, inst := range c.installers {
 		if _, err := fmt.Fprintf(w, "Script: %s\n----------\n", inst.GetName()); err != nil {
 			return trace.Wrap(err)

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -88,7 +88,7 @@ func Test_kubeClusterCollection_writeText(t *testing.T) {
 				verbose:  tt.fields.verbose,
 			}
 			w := &bytes.Buffer{}
-			err := c.writeText(w)
+			err := c.WriteText(w)
 			require.NoError(t, err)
 			require.Contains(t, w.String(), tt.wantTable())
 		})

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -107,7 +107,7 @@ func (c *DBCommand) ListDatabases(ctx context.Context, clt auth.ClientI) error {
 	coll := &databaseServerCollection{servers: servers, verbose: c.verbose}
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout))
+		return trace.Wrap(coll.WriteText(os.Stdout))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/desktop_command.go
+++ b/tool/tctl/common/desktop_command.go
@@ -77,7 +77,7 @@ func (c *DesktopCommand) ListDesktop(ctx context.Context, client auth.ClientI) e
 	}
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout))
+		return trace.Wrap(coll.WriteText(os.Stdout))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -74,7 +74,7 @@ func (c *KubeCommand) ListKube(ctx context.Context, client auth.ClientI) error {
 	coll := &kubeServerCollection{servers: kubes, verbose: c.verbose}
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout))
+		return trace.Wrap(coll.WriteText(os.Stdout))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -240,7 +240,7 @@ func (c *NodeCommand) ListActive(ctx context.Context, clt auth.ClientI) error {
 	coll := &serverCollection{servers: nodes, verbose: c.verbose}
 	switch c.lsFormat {
 	case teleport.Text:
-		if err := coll.writeText(os.Stdout); err != nil {
+		if err := coll.WriteText(os.Stdout); err != nil {
 			return trace.Wrap(err)
 		}
 	case teleport.YAML:

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -55,7 +55,7 @@ func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI auth.ClientI)
 
 	switch p.format {
 	case teleport.Text:
-		return sc.writeText(os.Stdout)
+		return sc.WriteText(os.Stdout)
 	case teleport.YAML:
 		return writeYAML(sc, os.Stdout)
 	case teleport.JSON:


### PR DESCRIPTION
As we expand functionality into enterprise Teleport, there will be enterprise only clients that OSS tctl will be unable to access. To support `tctl get` for objects associated with enterprise only features, GetHandlers have been added. These are similar to CreateHandlers in that the enterprise `tctl` will be able to add to these handlers on initialization, allowing us to expand the objects and types that `tctl` is able to retrieve.

Note: I haven't changed any of the existing get logic, I've simply moved them into independent functions.