### PR TITLE
[v10] Added selective prerelease check to container images promotion pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9266,6 +9266,22 @@ steps:
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
+- name: Record if tag ($DRONE_TAG) is prerelease
+  image: golang:1.18-alpine
+  commands:
+  - apk add git
+  - mkdir -pv "/tmp/repo"
+  - cd "/tmp/repo"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_TAG}"
+  - mkdir -pv $(dirname "/go/vars/release-is-prerelease")
+  - cd "/tmp/repo/build.assets/tooling"
+  - go run ./cmd/check -tag $DRONE_TAG -check prerelease &> /dev/null || echo 'Version
+    is a prerelease' > "/go/vars/release-is-prerelease"
+  - printf 'Version is '; [ ! -f "/go/vars/release-is-prerelease" ] && printf 'not
+    '; echo 'a prerelease'
 - name: Wait for docker
   image: docker
   commands:
@@ -9275,6 +9291,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
 - name: Wait for docker registry
   image: alpine
   commands:
@@ -9283,6 +9300,7 @@ steps:
     != "200" ]; do sleep 1; done'
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
 - name: Check out code
   image: alpine/git:latest
   commands:
@@ -9294,6 +9312,7 @@ steps:
   - git checkout -qf "$DRONE_TAG"
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
 - name: Build major, minor, and full semvers
   image: alpine
   commands:
@@ -9308,6 +9327,7 @@ steps:
   - echo $(cat "/go/var/full-version")
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
   commands:
@@ -9334,6 +9354,7 @@ steps:
     path: /root/.aws
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
   commands:
@@ -9361,6 +9382,7 @@ steps:
   depends_on:
   - Assume ECR - staging AWS Role
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
 - name: Pull teleport:v10-amd64 and push it to Local Registry
   image: docker
   commands:
@@ -9382,6 +9404,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
   - Wait for docker
   - Wait for docker registry
   - Check out code
@@ -9409,6 +9432,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
   - Wait for docker
   - Wait for docker registry
   - Check out code
@@ -9436,6 +9460,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
   - Wait for docker
   - Wait for docker registry
   - Check out code
@@ -9529,6 +9554,10 @@ steps:
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
@@ -9553,6 +9582,10 @@ steps:
 - name: Create manifest and push "teleport:minor" to Quay
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
@@ -9683,6 +9716,10 @@ steps:
 - name: Create manifest and push "teleport:major" to ECR - production
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
@@ -9706,6 +9743,10 @@ steps:
 - name: Create manifest and push "teleport:minor" to ECR - production
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
@@ -9772,6 +9813,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
   - Wait for docker
   - Wait for docker registry
   - Check out code
@@ -9799,6 +9841,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
   - Wait for docker
   - Wait for docker registry
   - Check out code
@@ -9826,6 +9869,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
   - Wait for docker
   - Wait for docker registry
   - Check out code
@@ -9919,6 +9963,10 @@ steps:
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
@@ -9943,6 +9991,10 @@ steps:
 - name: Create manifest and push "teleport-ent:minor" to Quay
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
@@ -10076,6 +10128,10 @@ steps:
 - name: Create manifest and push "teleport-ent:major" to ECR - production
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
@@ -10099,6 +10155,10 @@ steps:
 - name: Create manifest and push "teleport-ent:minor" to ECR - production
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
@@ -10166,6 +10226,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
   - Wait for docker
   - Wait for docker registry
   - Check out code
@@ -10203,6 +10264,10 @@ steps:
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
@@ -10223,6 +10288,10 @@ steps:
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
@@ -10293,6 +10362,10 @@ steps:
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
@@ -10312,6 +10385,10 @@ steps:
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
@@ -10371,6 +10448,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
   - Wait for docker
   - Wait for docker registry
   - Check out code
@@ -10399,6 +10477,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
   - Wait for docker
   - Wait for docker registry
   - Check out code
@@ -10427,6 +10506,7 @@ steps:
     path: /var/run
   depends_on:
   - Verify build is tagged
+  - Record if tag ($DRONE_TAG) is prerelease
   - Wait for docker
   - Wait for docker registry
   - Check out code
@@ -10520,6 +10600,10 @@ steps:
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
@@ -10544,6 +10628,10 @@ steps:
 - name: Create manifest and push "teleport-operator:minor" to Quay
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
@@ -10678,6 +10766,10 @@ steps:
 - name: Create manifest and push "teleport-operator:major" to ECR - production
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
@@ -10701,6 +10793,10 @@ steps:
 - name: Create manifest and push "teleport-operator:minor" to ECR - production
   image: docker
   commands:
+  - printf "Prerelease "; ! [ -f /go/vars/release-is-prerelease ] && printf "not ";
+    printf "detected for version $DRONE_TAG, "; [ -f /go/vars/release-is-prerelease
+    ] && echo "skipping" || echo "continuing"
+  - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
@@ -18264,6 +18360,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 4465f8038b3e6d86e2f5050f5cd2407ab02c26ed91dae95a952186ba3e8d3f5b
+hmac: 198f8324a2a274ccd01d1c73e142aad844ebb3df49079bf1daa5f6c56eab041b
 
 ...

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -305,6 +305,7 @@ func (p *Product) getBaseImage(arch string, version *ReleaseVersion, containerRe
 			ShellBaseValue:   version.GetFullSemver().GetSemverValue(),
 			DisplayBaseValue: version.MajorVersion,
 			Arch:             arch,
+			IsForFullSemver:  true,
 		},
 	)
 }

--- a/dronegen/container_images.go
+++ b/dronegen/container_images.go
@@ -70,15 +70,8 @@ type ImageTag struct {
 	DisplayBaseValue string // Should be set to a human-readable version of ShellTag
 	Arch             string
 	IsImmutable      bool
+	IsForFullSemver  bool // True if the image tag contains a full semver
 }
-
-// Commented out for linter but left incase needed in the future
-// func NewLatestTag() *ImageTag {
-// 	return &ImageTag{
-// 		ShellBaseValue:   "latest",
-// 		DisplayBaseValue: "latest",
-// 	}
-// }
 
 func (it *ImageTag) AppendString(s string) {
 	it.ShellBaseValue += fmt.Sprintf("-%s", s)

--- a/dronegen/container_images_release_version.go
+++ b/dronegen/container_images_release_version.go
@@ -32,6 +32,7 @@ const (
 type ReleaseVersion struct {
 	MajorVersion        string // This is the major version of a given build. `SearchVersion` should match this when evaluated.
 	ShellVersion        string // This value will be evaluated by the shell in the context of a Drone step
+	ShellIsPrerelease   string // This value will be evaluated in a shell context to determine if a release version is a prerelease. Must be POSIX compliant and not rely on other external utilities.
 	RelativeVersionName string // The set of values for this should not change between major releases
 	SetupSteps          []step // Version-specific steps that must be ran before executing build and push steps
 }
@@ -272,6 +273,7 @@ func (rv *ReleaseVersion) getTagsForVersion(onlyBuildFullSemver bool) []*ImageTa
 			ShellBaseValue:   semver.GetSemverValue(),
 			DisplayBaseValue: semver.Name,
 			IsImmutable:      semver.IsImmutable,
+			IsForFullSemver:  semver.IsFull,
 		})
 	}
 


### PR DESCRIPTION
Original branch/v10 PR is borked so I reopened the PR on a new branch based on `branch/v10`.

Source PR: https://github.com/gravitational/teleport/pull/18833

Fixes a regression added by bug fix https://github.com/gravitational/teleport/pull/18392 which resulted in promoted dev tags to overwrite major and minor semver image tags in production repos. This patch causes only full dev tags to be published to production repos.

For example, when `v1.2.3-fred.1` is published, the following tags are currently updated:
* ECR production/Quay `v1`
* ECR production/Quay `v1.2`
* ECR production/Quay `v1.2.3-fred.1`
With this patch, only ECR production/Quay `v1.2.3-fred.1` will be updated upon dev tag promotion.

Tests:
* Promotion of prerelease tag `v1.2.3-fred.12`: https://drone.platform.teleport.sh/gravitational/teleport/18006/ (full version is promoted but major/minor are untouched)
* Promotion of non-prerelease tag `v11.0.3`: https://drone.platform.teleport.sh/gravitational/teleport/18013/ (all versions are promoted)