### PR TITLE
Allow for shortcut registration for Enterprise resource types.

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -55,6 +55,16 @@ func (m *MarshalConfig) GetVersion() string {
 // MarshalOption sets marshaling option
 type MarshalOption func(c *MarshalConfig) error
 
+var shortcuts = map[string]string{}
+
+// RegisterShortcut registers a resource type and any associated shortcut names to the resource.
+func RegisterShortcut(resourceName string, resourceShortcuts ...string) {
+	shortcuts[resourceName] = resourceName
+	for _, resourceShortcut := range resourceShortcuts {
+		shortcuts[resourceShortcut] = resourceName
+	}
+}
+
 // CollectOptions collects all options from functional arg and returns config
 func CollectOptions(opts []MarshalOption) (*MarshalConfig, error) {
 	var cfg MarshalConfig
@@ -116,69 +126,13 @@ func ParseShortcut(in string) (string, error) {
 	if in == "" {
 		return "", trace.BadParameter("missing resource name")
 	}
-	switch strings.ToLower(in) {
-	case types.KindRole, "roles":
-		return types.KindRole, nil
-	case types.KindNamespace, "namespaces", "ns":
-		return types.KindNamespace, nil
-	case types.KindAuthServer, "auth_servers", "auth":
-		return types.KindAuthServer, nil
-	case types.KindProxy, "proxies":
-		return types.KindProxy, nil
-	case types.KindNode, "nodes":
-		return types.KindNode, nil
-	case types.KindOIDCConnector:
-		return types.KindOIDCConnector, nil
-	case types.KindSAMLConnector:
-		return types.KindSAMLConnector, nil
-	case types.KindGithubConnector:
-		return types.KindGithubConnector, nil
-	case types.KindConnectors, "connector":
-		return types.KindConnectors, nil
-	case types.KindUser, "users":
-		return types.KindUser, nil
-	case types.KindCertAuthority, "cert_authorities", "cas":
-		return types.KindCertAuthority, nil
-	case types.KindReverseTunnel, "reverse_tunnels", "rts":
-		return types.KindReverseTunnel, nil
-	case types.KindTrustedCluster, "tc", "cluster", "clusters":
-		return types.KindTrustedCluster, nil
-	case types.KindClusterAuthPreference, "cluster_authentication_preferences", "cap":
-		return types.KindClusterAuthPreference, nil
-	case types.KindClusterNetworkingConfig, "networking_config", "networking", "net_config", "netconfig":
-		return types.KindClusterNetworkingConfig, nil
-	case types.KindSessionRecordingConfig, "recording_config", "session_recording", "rec_config", "recconfig":
-		return types.KindSessionRecordingConfig, nil
-	case types.KindRemoteCluster, "remote_clusters", "rc", "rcs":
-		return types.KindRemoteCluster, nil
-	case types.KindSemaphore, "semaphores", "sem", "sems":
-		return types.KindSemaphore, nil
-	case types.KindKubernetesCluster, "kube_clusters":
-		return types.KindKubernetesCluster, nil
-	case types.KindKubeService, "kube_services":
-		return types.KindKubeService, nil
-	case types.KindKubeServer, "kube_servers":
-		return types.KindKubeServer, nil
-	case types.KindLock, "locks":
-		return types.KindLock, nil
-	case types.KindDatabaseServer:
-		return types.KindDatabaseServer, nil
-	case types.KindNetworkRestrictions:
-		return types.KindNetworkRestrictions, nil
-	case types.KindDatabase:
-		return types.KindDatabase, nil
-	case types.KindApp, "apps":
-		return types.KindApp, nil
-	case types.KindWindowsDesktopService, "windows_service", "win_desktop_service", "win_service":
-		return types.KindWindowsDesktopService, nil
-	case types.KindWindowsDesktop, "win_desktop":
-		return types.KindWindowsDesktop, nil
-	case types.KindToken, "tokens":
-		return types.KindToken, nil
-	case types.KindInstaller:
-		return types.KindInstaller, nil
+
+	resourceName := shortcuts[in]
+
+	if resourceName == "" {
+		return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 	}
-	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
+	return resourceName, nil
 }
 
 // ParseRef parses resource reference eg daemonsets/ds1
@@ -530,6 +484,38 @@ func init() {
 		}
 		return token, nil
 	})
+
+	// Setup shortcuts
+	RegisterShortcut(types.KindRole, "roles")
+	RegisterShortcut(types.KindNamespace, "namespaces", "ns")
+	RegisterShortcut(types.KindAuthServer, "auth_servers", "auth")
+	RegisterShortcut(types.KindProxy, "proxies")
+	RegisterShortcut(types.KindNode, "nodes")
+	RegisterShortcut(types.KindOIDCConnector)
+	RegisterShortcut(types.KindSAMLConnector)
+	RegisterShortcut(types.KindGithubConnector)
+	RegisterShortcut(types.KindConnectors, "connector")
+	RegisterShortcut(types.KindUser, "users")
+	RegisterShortcut(types.KindCertAuthority, "cert_authorities", "cas")
+	RegisterShortcut(types.KindReverseTunnel, "reverse_tunnels", "rts")
+	RegisterShortcut(types.KindTrustedCluster, "tc", "cluster", "clusters")
+	RegisterShortcut(types.KindClusterAuthPreference, "cluster_authentication_preferences", "cap")
+	RegisterShortcut(types.KindClusterNetworkingConfig, "networking_config", "networking", "net_config", "netconfig")
+	RegisterShortcut(types.KindSessionRecordingConfig, "recording_config", "session_recording", "rec_config", "recconfig")
+	RegisterShortcut(types.KindRemoteCluster, "remote_clusters", "rc", "rcs")
+	RegisterShortcut(types.KindSemaphore, "semaphores", "sem", "sems")
+	RegisterShortcut(types.KindKubernetesCluster, "kube_clusters")
+	RegisterShortcut(types.KindKubeService, "kube_services")
+	RegisterShortcut(types.KindKubeServer, "kube_servers")
+	RegisterShortcut(types.KindLock, "locks")
+	RegisterShortcut(types.KindDatabaseServer)
+	RegisterShortcut(types.KindNetworkRestrictions)
+	RegisterShortcut(types.KindDatabase)
+	RegisterShortcut(types.KindApp, "apps")
+	RegisterShortcut(types.KindWindowsDesktopService, "windows_service", "win_desktop_service", "win_service")
+	RegisterShortcut(types.KindWindowsDesktop, "win_desktop")
+	RegisterShortcut(types.KindToken, "tokens")
+	RegisterShortcut(types.KindInstaller)
 }
 
 // MarshalResource attempts to marshal a resource dynamically, returning NotImplementedError

--- a/lib/services/resource_test.go
+++ b/lib/services/resource_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestParseShortcut(t *testing.T) {
+	checks := map[string]bool{}
+	tests := []struct {
+		name   string
+		inputs []string
+		output string
+		err    bool
+	}{
+		{
+			name:   "role",
+			inputs: []string{types.KindRole, "roles"},
+			output: types.KindRole,
+		},
+		{
+			name:   "namespace",
+			inputs: []string{types.KindNamespace, "namespaces", "ns"},
+			output: types.KindNamespace,
+		},
+		{
+			name:   "auth server",
+			inputs: []string{types.KindAuthServer, "auth_servers", "auth"},
+			output: types.KindAuthServer,
+		},
+		{
+			name:   "proxy",
+			inputs: []string{types.KindProxy, "proxies"},
+			output: types.KindProxy,
+		},
+		{
+			name:   "node",
+			inputs: []string{types.KindNode, "nodes"},
+			output: types.KindNode,
+		},
+		{
+			name:   "oidc connecto",
+			inputs: []string{types.KindOIDCConnector},
+			output: types.KindOIDCConnector,
+		},
+		{
+			name:   "saml connector",
+			inputs: []string{types.KindSAMLConnector},
+			output: types.KindSAMLConnector,
+		},
+		{
+			name:   "github connector",
+			inputs: []string{types.KindGithubConnector},
+			output: types.KindGithubConnector,
+		},
+		{
+			name:   "connectors",
+			inputs: []string{types.KindConnectors, "connector"},
+			output: types.KindConnectors,
+		},
+		{
+			name:   "user",
+			inputs: []string{types.KindUser, "users"},
+			output: types.KindUser,
+		},
+		{
+			name:   "cert authority",
+			inputs: []string{types.KindCertAuthority, "cert_authorities", "cas"},
+			output: types.KindCertAuthority,
+		},
+		{
+			name:   "reverse tunnel",
+			inputs: []string{types.KindReverseTunnel, "reverse_tunnels", "rts"},
+			output: types.KindReverseTunnel,
+		},
+		{
+			name:   "trusted cluster",
+			inputs: []string{types.KindTrustedCluster, "tc", "cluster", "clusters"},
+			output: types.KindTrustedCluster,
+		},
+		{
+			name:   "cluster authentication preference",
+			inputs: []string{types.KindClusterAuthPreference, "cluster_authentication_preferences", "cap"},
+			output: types.KindClusterAuthPreference,
+		},
+		{
+			name:   "cluster networking config",
+			inputs: []string{types.KindClusterNetworkingConfig, "networking_config", "networking", "net_config", "netconfig"},
+			output: types.KindClusterNetworkingConfig,
+		},
+		{
+			name:   "session recording config",
+			inputs: []string{types.KindSessionRecordingConfig, "recording_config", "session_recording", "rec_config", "recconfig"},
+			output: types.KindSessionRecordingConfig,
+		},
+		{
+			name:   "remote cluster",
+			inputs: []string{types.KindRemoteCluster, "remote_clusters", "rc", "rcs"},
+			output: types.KindRemoteCluster,
+		},
+		{
+			name:   "semaphore",
+			inputs: []string{types.KindSemaphore, "semaphores", "sem", "sems"},
+			output: types.KindSemaphore,
+		},
+		{
+			name:   "kube cluster",
+			inputs: []string{types.KindKubernetesCluster, "kube_clusters"},
+			output: types.KindKubernetesCluster,
+		},
+		{
+			name:   "kube service",
+			inputs: []string{types.KindKubeService, "kube_services"},
+			output: types.KindKubeService,
+		},
+		{
+			name:   "kube server",
+			inputs: []string{types.KindKubeServer, "kube_servers"},
+			output: types.KindKubeServer,
+		},
+		{
+			name:   "lock",
+			inputs: []string{types.KindLock, "locks"},
+			output: types.KindLock,
+		},
+		{
+			name:   "database server",
+			inputs: []string{types.KindDatabaseServer},
+			output: types.KindDatabaseServer,
+		},
+		{
+			name:   "network restrictions",
+			inputs: []string{types.KindNetworkRestrictions},
+			output: types.KindNetworkRestrictions,
+		},
+		{
+			name:   "database",
+			inputs: []string{types.KindDatabase},
+			output: types.KindDatabase,
+		},
+		{
+			name:   "app",
+			inputs: []string{types.KindApp, "apps"},
+			output: types.KindApp,
+		},
+		{
+			name:   "windows desktop service",
+			inputs: []string{types.KindWindowsDesktopService, "windows_service", "win_desktop_service", "win_service"},
+			output: types.KindWindowsDesktopService,
+		},
+		{
+			name:   "windows desktop",
+			inputs: []string{types.KindWindowsDesktop, "win_desktop"},
+			output: types.KindWindowsDesktop,
+		},
+		{
+			name:   "token",
+			inputs: []string{types.KindToken, "tokens"},
+			output: types.KindToken,
+		},
+		{
+			name:   "installer",
+			inputs: []string{types.KindInstaller},
+			output: types.KindInstaller,
+		},
+		{
+			name:   "error",
+			inputs: []string{"non-existent shortcut"},
+			output: "",
+			err:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, input := range test.inputs {
+				output, err := ParseShortcut(input)
+				require.Equal(t, test.output, output)
+				if test.err {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					checks[input] = true
+				}
+			}
+		})
+	}
+
+	require.Len(t, checks, len(shortcuts), "not all shortcuts were tested")
+}


### PR DESCRIPTION
In order to allow enterprise objects to remain in the enterprise repository, shortcuts for enterprise specific objects should be added during enterprise startup without needing to expose these shortcuts and object types within OSS Teleport.

A type cannot be used by `tctl` (and possibly other places in our codebase) if these shortcuts are not present.

Note:

Using a test type without its type shortcut being registered:
```
➜  teleport git:(mike.wilson/allow-shortcut-registration) ✗ build/tctl get my_test_type
...
ERROR: unsupported resource: "my_test_type" - resources should be expressed as 'type/name', for example 'connector/github'
```

Using a test type with its type shortcut being registered, which shows it failing within the `ResourceCommand` itself:

```
➜  teleport git:(mike.wilson/allow-shortcut-registration) ✗ build/tctl get my_test_type
ERROR: getting "my_test_type" is not supported
```

This will allow us to migrate enterprise type names out of the OSS code base.