### PR TITLE
Allow `tctl` to create extended auth clients.

### DIFF
--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/tool/tctl/common"
 )
 
@@ -24,5 +25,5 @@ func main() {
 	commands := common.Commands()
 	commands = append(commands, common.OSSCommands()...)
 
-	common.Run(commands)
+	common.Run(commands, authclient.Connect)
 }


### PR DESCRIPTION
`tctl` is now able to create extended auth clients. This will allow the enterprise version of `tctl` to explicitly create versions of the auth client without having to expose enterprise API calls in the OSS library (e.g. the SAML connectors).

See https://github.com/gravitational/teleport.e/pull/666 for an example.