### PR TITLE
Fix known cases where audit log events can be bypassed by exceeding limit

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -48,7 +48,10 @@ func (m *DatabaseSessionQuery) TrimToMaxSize(maxSize int) AuditEvent {
 	out.DatabaseQuery = ""
 	out.DatabaseQueryParameters = nil
 
-	// Use 12% max size ballast + message size without custom fields.
+	// Use 12% max size ballast + message size without custom fields. This was
+	// changed from 10% to 12% to handle the additional overhead of logging
+	// large MongoDB queries that require larger amounts of escaping. See issue:
+	// https://github.com/gravitational/teleport/issues/15645
 	sizeBallast := maxSize/8 + out.Size()
 	maxSize -= sizeBallast
 

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -36,7 +36,7 @@ func maxSizePerField(maxLength, customFields int) int {
 }
 
 // TrimToMaxSize trims the DatabaseSessionQuery message content. The maxSize is used to calculate
-// per-filed max size where only user input message fields DatabaseQuery and DatabaseQueryParameters are taken into
+// per-field max size where only user input message fields DatabaseQuery and DatabaseQueryParameters are taken into
 // account.
 func (m *DatabaseSessionQuery) TrimToMaxSize(maxSize int) AuditEvent {
 	size := m.Size()

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -48,8 +48,8 @@ func (m *DatabaseSessionQuery) TrimToMaxSize(maxSize int) AuditEvent {
 	out.DatabaseQuery = ""
 	out.DatabaseQueryParameters = nil
 
-	// Use 10% max size ballast + message size without custom fields.
-	sizeBallast := maxSize/10 + out.Size()
+	// Use 12% max size ballast + message size without custom fields.
+	sizeBallast := maxSize/8 + out.Size()
 	maxSize -= sizeBallast
 
 	// Check how many custom fields are set.

--- a/api/types/events/events_test.go
+++ b/api/types/events/events_test.go
@@ -42,7 +42,7 @@ func TestTrimToMaxSize(t *testing.T) {
 				DatabaseQuery: strings.Repeat("A", 7000),
 			},
 			want: &DatabaseSessionQuery{
-				DatabaseQuery: strings.Repeat("A", 5227),
+				DatabaseQuery: strings.Repeat("A", 5375),
 			},
 		},
 		{
@@ -56,7 +56,7 @@ func TestTrimToMaxSize(t *testing.T) {
 				},
 			},
 			want: &DatabaseSessionQuery{
-				DatabaseQuery: strings.Repeat("A", 575),
+				DatabaseQuery: strings.Repeat("A", 590),
 				DatabaseQueryParameters: []string{
 					strings.Repeat("A", 89),
 					strings.Repeat("A", 89),
@@ -82,11 +82,21 @@ func TestTrimToMaxSize(t *testing.T) {
 					ClusterName: strings.Repeat("A", 2000),
 					Index:       1,
 				},
-				DatabaseQuery: strings.Repeat("A", 198),
+				DatabaseQuery: strings.Repeat("A", 221),
 				DatabaseQueryParameters: []string{
 					strings.Repeat("A", 89),
 					strings.Repeat("A", 89),
 				},
+			},
+		},
+		{
+			name:    "Query requires heavy escaping",
+			maxSize: 50,
+			in: &DatabaseSessionQuery{
+				DatabaseQuery: `{` + strings.Repeat(`"a": "b",`, 100) + "}",
+			},
+			want: &DatabaseSessionQuery{
+				DatabaseQuery: `{"a": "b","a":`,
 			},
 		},
 	}
@@ -101,5 +111,23 @@ func TestTrimToMaxSize(t *testing.T) {
 			require.Empty(t, cmp.Diff(got, tc.want))
 			require.Less(t, got.Size(), tc.maxSize)
 		})
+	}
+}
+
+func TestTrimN(t *testing.T) {
+	tests := []struct {
+		have string
+		want string
+	}{
+		{strings.Repeat("A", 17) + `\n`, strings.Repeat("A", 17) + `\`},
+		{strings.Repeat(`A\n`, 200), `A\nA\nA\nA\nA\`},
+		{strings.Repeat(`A\a`, 200), `A\aA\aA\aA\aA\`},
+		{strings.Repeat(`A\t`, 200), `A\tA\tA\tA\tA\`},
+		{`{` + strings.Repeat(`"a": "b",`, 100) + "}", `{"a": "b","a"`},
+	}
+
+	const maxLen = 20
+	for _, test := range tests {
+		require.Equal(t, trimN(test.have, maxLen), test.want)
 	}
 }

--- a/api/types/events/events_test.go
+++ b/api/types/events/events_test.go
@@ -42,7 +42,7 @@ func TestTrimToMaxSize(t *testing.T) {
 				DatabaseQuery: strings.Repeat("A", 7000),
 			},
 			want: &DatabaseSessionQuery{
-				DatabaseQuery: strings.Repeat("A", 5377),
+				DatabaseQuery: strings.Repeat("A", 5227),
 			},
 		},
 		{
@@ -56,7 +56,7 @@ func TestTrimToMaxSize(t *testing.T) {
 				},
 			},
 			want: &DatabaseSessionQuery{
-				DatabaseQuery: strings.Repeat("A", 592),
+				DatabaseQuery: strings.Repeat("A", 575),
 				DatabaseQueryParameters: []string{
 					strings.Repeat("A", 89),
 					strings.Repeat("A", 89),
@@ -82,7 +82,7 @@ func TestTrimToMaxSize(t *testing.T) {
 					ClusterName: strings.Repeat("A", 2000),
 					Index:       1,
 				},
-				DatabaseQuery: strings.Repeat("A", 223),
+				DatabaseQuery: strings.Repeat("A", 198),
 				DatabaseQueryParameters: []string{
 					strings.Repeat("A", 89),
 					strings.Repeat("A", 89),

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -100,6 +100,9 @@ const (
 const (
 	// githubCacheTimeout is how long Github org entries are cached.
 	githubCacheTimeout = time.Hour
+
+	// mfaDeviceNameMaxLen is the maximum length of a device name.
+	mfaDeviceNameMaxLen = 30
 )
 
 var ErrRequiresEnterprise = services.ErrRequiresEnterprise
@@ -2329,8 +2332,8 @@ type newMFADeviceFields struct {
 
 // verifyMFARespAndAddDevice validates MFA register response and on success adds the new MFA device.
 func (a *Server) verifyMFARespAndAddDevice(ctx context.Context, req *newMFADeviceFields) (*types.MFADevice, error) {
-	if len(req.newDeviceName) > 31 {
-		return nil, trace.BadParameter("Device Name must be 30 characters or less")
+	if len(req.newDeviceName) > mfaDeviceNameMaxLen {
+		return nil, trace.BadParameter("device name must be %v characters or less", mfaDeviceNameMaxLen)
 	}
 
 	cap, err := a.GetAuthPreference(ctx)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2329,6 +2329,10 @@ type newMFADeviceFields struct {
 
 // verifyMFARespAndAddDevice validates MFA register response and on success adds the new MFA device.
 func (a *Server) verifyMFARespAndAddDevice(ctx context.Context, req *newMFADeviceFields) (*types.MFADevice, error) {
+	if len(req.newDeviceName) > 31 {
+		return nil, trace.BadParameter("Device Name must be 30 characters or less")
+	}
+
 	cap, err := a.GetAuthPreference(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -30,6 +30,7 @@ import (
 	mathrand "math/rand"
 	"os"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -2342,6 +2343,24 @@ func TestAddMFADeviceSync(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:       "invalid device name length",
+			deviceName: strings.Repeat("A", mfaDeviceNameMaxLen+1),
+			wantErr:    true,
+			getReq: func(deviceName string) *proto.AddMFADeviceSyncRequest {
+				privExToken, err := srv.Auth().createPrivilegeToken(ctx, u.username, UserTokenTypePrivilegeException)
+				require.NoError(t, err)
+
+				_, webauthnRes, err := getMockedWebauthnAndRegisterRes(srv.Auth(), privExToken.GetName(), proto.DeviceUsage_DEVICE_USAGE_MFA)
+				require.NoError(t, err)
+
+				return &proto.AddMFADeviceSyncRequest{
+					TokenID:        privExToken.GetName(),
+					NewDeviceName:  deviceName,
+					NewMFAResponse: webauthnRes,
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -2349,7 +2368,8 @@ func TestAddMFADeviceSync(t *testing.T) {
 			res, err := clt.AddMFADeviceSync(ctx, tc.getReq(tc.deviceName))
 			switch {
 			case tc.wantErr:
-				require.True(t, trace.IsAccessDenied(err))
+				expectedErr := trace.IsAccessDenied(err) || trace.IsBadParameter(err)
+				require.True(t, expectedErr)
 			default:
 				require.NoError(t, err)
 				require.Equal(t, tc.deviceName, res.GetDevice().GetName())

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -35,6 +35,11 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+const (
+	// maxUserAgentLen is the maximum length of a user agent that will be logged.
+	maxUserAgentLen = 2048
+)
+
 // AuthenticateUserRequest is a request to authenticate interactive user
 type AuthenticateUserRequest struct {
 	// Username is a username
@@ -121,7 +126,6 @@ func (s *Server) AuthenticateUser(req AuthenticateUserRequest) (string, error) {
 	}
 	if req.ClientMetadata != nil {
 		event.RemoteAddr = req.ClientMetadata.RemoteAddr
-		const maxUserAgentLen = 2048
 		if len(req.ClientMetadata.UserAgent) > maxUserAgentLen {
 			event.UserAgent = req.ClientMetadata.UserAgent[:maxUserAgentLen-3] + "..."
 		} else {

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -37,6 +37,12 @@ import (
 
 const (
 	// maxUserAgentLen is the maximum length of a user agent that will be logged.
+	// There is no current consensus on what the maximum length of a User-Agent
+	// should be and there were reports of extremely large UAs especially from
+	// older versions of IE. 2048 was picked because it still allowed for very
+	// large UAs but keeps from causing logging issues. For reference Nginx
+	// defaults to 4k or 8k header size limits for ALL headers so 2k seems more
+	// than sufficient.
 	maxUserAgentLen = 2048
 )
 

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -121,7 +121,12 @@ func (s *Server) AuthenticateUser(req AuthenticateUserRequest) (string, error) {
 	}
 	if req.ClientMetadata != nil {
 		event.RemoteAddr = req.ClientMetadata.RemoteAddr
-		event.UserAgent = req.ClientMetadata.UserAgent
+		const maxUserAgentLen = 2048
+		if len(req.ClientMetadata.UserAgent) > maxUserAgentLen {
+			event.UserAgent = req.ClientMetadata.UserAgent[:maxUserAgentLen-3] + "..."
+		} else {
+			event.UserAgent = req.ClientMetadata.UserAgent
+		}
 	}
 	if err != nil {
 		event.Code = events.UserLocalLoginFailureCode

--- a/lib/auth/methods_test.go
+++ b/lib/auth/methods_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/stretchr/testify/require"
+)
+
+type emitter struct {
+	count int
+}
+
+func (e *emitter) EmitAuditEvent(_ context.Context, event apievents.AuditEvent) error {
+	loginEvent, ok := event.(*apievents.UserLogin)
+	if ok && len(loginEvent.UserAgent) <= maxUserAgentLen {
+		e.count++
+	}
+	return nil
+}
+
+func TestServerAuthenticateUserUserAgentTrim(t *testing.T) {
+	emitter := &emitter{}
+
+	r := AuthenticateUserRequest{
+		ClientMetadata: &ForwardedClientMetadata{
+			UserAgent: strings.Repeat("A", maxUserAgentLen+1),
+		},
+	}
+	// Ignoring the error here because we really just care that the event was logged.
+	(&Server{emitter: emitter}).AuthenticateUser(r)
+
+	require.Equal(t, 1, emitter.count)
+}

--- a/lib/auth/methods_test.go
+++ b/lib/auth/methods_test.go
@@ -20,9 +20,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
-	"github.com/stretchr/testify/require"
 )
 
 func TestServerAuthenticateUserUserAgentTrim(t *testing.T) {

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -194,7 +194,7 @@ func (l *FileLog) trimSizeAndMarshal(event apievents.AuditEvent) ([]byte, error)
 		return nil, trace.Wrap(err)
 	}
 	if len(line) > l.MaxScanTokenSize {
-		return nil, trace.BadParameter("event %T reached max FileLog entry size limit", event.Size())
+		return nil, trace.BadParameter("event %T reached max FileLog entry size limit, current size %v", event, len(line))
 	}
 	return line, nil
 }

--- a/lib/events/filelog_test.go
+++ b/lib/events/filelog_test.go
@@ -183,7 +183,7 @@ func TestLargeEvent(t *testing.T) {
 				makeQueryEvent("1", "select 1"),
 				makeQueryEvent("2", strings.Repeat("A", bufio.MaxScanTokenSize)),
 				makeQueryEvent("3", "select 3"),
-				makeQueryEvent("4", makeMongoQuery()),
+				makeQueryEvent("4", makeLargeMongoQuery()),
 			},
 			checks: []check{
 				hasEventsLength(4),
@@ -232,10 +232,10 @@ func TestLargeEvent(t *testing.T) {
 	}
 }
 
-// makeMongoQuery returns an example MongoDB query to test TrimToMaxSize when a
+// makeLargeMongoQuery returns an example MongoDB query to test TrimToMaxSize when a
 // query contains a lot of characters that need to be escaped. The additional
 // escaping might push the message size over the limit even after being trimmed.
-func makeMongoQuery() string {
+func makeLargeMongoQuery() string {
 	return `OpMsg(Body={"insert": "books","ordered": true,"lsid": {"id": {"$binary":{"base64":"NX7MXcLdRi6pIT86e52k5A==","subType":"04"}}},"$db": "teleport"}, Documents=[` +
 		strings.Repeat(`{"_id": {"$oid":"63a0dd6da68baaeb828581fe"},"title": "sQtjZtXfYlm7hFwe","author": "55ME1NendNsDZqtI","year_published": 2010}, `, 550) +
 		`], Flags=)`

--- a/lib/events/filelog_test.go
+++ b/lib/events/filelog_test.go
@@ -183,10 +183,11 @@ func TestLargeEvent(t *testing.T) {
 				makeQueryEvent("1", "select 1"),
 				makeQueryEvent("2", strings.Repeat("A", bufio.MaxScanTokenSize)),
 				makeQueryEvent("3", "select 3"),
+				makeQueryEvent("4", makeMongoQuery()),
 			},
 			checks: []check{
-				hasEventsLength(3),
-				hasEventsIDs("1", "2", "3"),
+				hasEventsLength(4),
+				hasEventsIDs("1", "2", "3", "4"),
 			},
 		},
 		{
@@ -229,6 +230,15 @@ func TestLargeEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+// makeMongoQuery returns an example MongoDB query to test TrimToMaxSize when a
+// query contains a lot of characters that need to be escaped. The additional
+// escaping might push the message size over the limit even after being trimmed.
+func makeMongoQuery() string {
+	return `OpMsg(Body={"insert": "books","ordered": true,"lsid": {"id": {"$binary":{"base64":"NX7MXcLdRi6pIT86e52k5A==","subType":"04"}}},"$db": "teleport"}, Documents=[` +
+		strings.Repeat(`{"_id": {"$oid":"63a0dd6da68baaeb828581fe"},"title": "sQtjZtXfYlm7hFwe","author": "55ME1NendNsDZqtI","year_published": 2010}, `, 550) +
+		`], Flags=)`
 }
 
 func makeQueryEvent(id string, query string) *events.DatabaseSessionQuery {

--- a/lib/events/filelog_test.go
+++ b/lib/events/filelog_test.go
@@ -19,6 +19,8 @@ package events
 import (
 	"bufio"
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -153,7 +155,7 @@ func TestSearchSessionEvents(t *testing.T) {
 }
 
 // TestLargeEvent test fileLog behavior in case of large events.
-// If an event is serializable the FileLog handler should trie to trim the event size.
+// If an event is serializable the FileLog handler should try to trim the event size.
 func TestLargeEvent(t *testing.T) {
 	type check func(t *testing.T, event []events.AuditEvent)
 
@@ -172,6 +174,9 @@ func TestLargeEvent(t *testing.T) {
 		}
 	}
 
+	largeMongoQuery, err := makeLargeMongoQuery()
+	require.NoError(t, err)
+
 	tests := []struct {
 		name   string
 		in     []events.AuditEvent
@@ -183,7 +188,7 @@ func TestLargeEvent(t *testing.T) {
 				makeQueryEvent("1", "select 1"),
 				makeQueryEvent("2", strings.Repeat("A", bufio.MaxScanTokenSize)),
 				makeQueryEvent("3", "select 3"),
-				makeQueryEvent("4", makeLargeMongoQuery()),
+				makeQueryEvent("4", largeMongoQuery),
 			},
 			checks: []check{
 				hasEventsLength(4),
@@ -235,10 +240,23 @@ func TestLargeEvent(t *testing.T) {
 // makeLargeMongoQuery returns an example MongoDB query to test TrimToMaxSize when a
 // query contains a lot of characters that need to be escaped. The additional
 // escaping might push the message size over the limit even after being trimmed.
-func makeLargeMongoQuery() string {
+// The goal of to make this about as pathological a query as is possible so there
+// are many very small string fields that will require quoting.
+func makeLargeMongoQuery() (string, error) {
+	record := map[string]string{"_id": `{"$oid":"63a0dd6da68baaeb828581fe"}`}
+	for i := 0; i < 100; i++ {
+		t := fmt.Sprintf("%v", i)
+		record[t] = t
+	}
+
+	out, err := json.Marshal(record)
+	if err != nil {
+		return "", err
+	}
+
 	return `OpMsg(Body={"insert": "books","ordered": true,"lsid": {"id": {"$binary":{"base64":"NX7MXcLdRi6pIT86e52k5A==","subType":"04"}}},"$db": "teleport"}, Documents=[` +
-		strings.Repeat(`{"_id": {"$oid":"63a0dd6da68baaeb828581fe"},"title": "sQtjZtXfYlm7hFwe","author": "55ME1NendNsDZqtI","year_published": 2010}, `, 550) +
-		`], Flags=)`
+		strings.Repeat(string(out), 500) +
+		`], Flags=)`, nil
 }
 
 func makeQueryEvent(id string, query string) *events.DatabaseSessionQuery {

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -386,14 +386,19 @@ func (s *ProtoStream) Done() <-chan struct{} {
 
 // EmitAuditEvent emits a single audit event to the stream
 func (s *ProtoStream) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+	messageSize := event.Size()
+	if messageSize > MaxProtoMessageSizeBytes {
+		switch v := event.(type) {
+		case messageSizeTrimmer:
+			event = v.TrimToMaxSize(MaxProtoMessageSizeBytes)
+		default:
+			return trace.BadParameter("record size %v exceeds max message size of %v bytes", messageSize, MaxProtoMessageSizeBytes)
+		}
+	}
+
 	oneof, err := apievents.ToOneOf(event)
 	if err != nil {
 		return trace.Wrap(err)
-	}
-
-	messageSize := oneof.Size()
-	if messageSize > MaxProtoMessageSizeBytes {
-		return trace.BadParameter("record size %v exceeds max message size of %v bytes", messageSize, MaxProtoMessageSizeBytes)
 	}
 
 	start := time.Now()

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -17,12 +17,14 @@ package events
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/session"
 )
 
@@ -149,6 +151,50 @@ func TestNewStreamErrors(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestProtoStreamLargeEvent tests ProtoStream behavior in the case of receiving
+// a large event. If an event is trimmable (implements messageSizeTrimmer) than
+// it should be trimmed otherwise an error should be thrown.
+func TestProtoStreamLargeEvent(t *testing.T) {
+	tests := []struct {
+		name      string
+		event     events.AuditEvent
+		expectErr bool
+	}{
+		{
+			name:      "large trimmable event is trimmed",
+			event:     makeQueryEvent("1", strings.Repeat("A", MaxProtoMessageSizeBytes)),
+			expectErr: false,
+		},
+		{
+			name:      "large untrimmable event returns error",
+			event:     makeAccessRequestEvent("1", strings.Repeat("A", MaxProtoMessageSizeBytes)),
+			expectErr: true,
+		},
+	}
+
+	ctx := context.Background()
+
+	streamer, err := NewProtoStreamer(ProtoStreamerConfig{
+		Uploader: NewMemoryUploader(nil),
+	})
+	require.NoError(t, err)
+
+	stream, err := streamer.CreateAuditStream(ctx, session.ID("1"))
+	require.NoError(t, err)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err = stream.EmitAuditEvent(ctx, test.event)
+			if test.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+	require.NoError(t, stream.Complete(ctx))
 }
 
 type mockUploader struct {

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -158,18 +158,18 @@ func TestNewStreamErrors(t *testing.T) {
 // it should be trimmed otherwise an error should be thrown.
 func TestProtoStreamLargeEvent(t *testing.T) {
 	tests := []struct {
-		name      string
-		event     events.AuditEvent
+		name         string
+		event        events.AuditEvent
 		errAssertion require.ErrorAssertionFunc
 	}{
 		{
-			name:      "large trimmable event is trimmed",
-			event:     makeQueryEvent("1", strings.Repeat("A", MaxProtoMessageSizeBytes)),
+			name:         "large trimmable event is trimmed",
+			event:        makeQueryEvent("1", strings.Repeat("A", MaxProtoMessageSizeBytes)),
 			errAssertion: require.NoError,
 		},
 		{
-			name:      "large untrimmable event returns error",
-			event:     makeAccessRequestEvent("1", strings.Repeat("A", MaxProtoMessageSizeBytes)),
+			name:         "large untrimmable event returns error",
+			event:        makeAccessRequestEvent("1", strings.Repeat("A", MaxProtoMessageSizeBytes)),
 			errAssertion: require.Error,
 		},
 	}
@@ -186,12 +186,7 @@ func TestProtoStreamLargeEvent(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err = stream.EmitAuditEvent(ctx, test.event)
-			if test.expectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			test.errAssertion(t, stream.EmitAuditEvent(ctx, test.event))
 		})
 	}
 	require.NoError(t, stream.Complete(ctx))

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -160,17 +160,17 @@ func TestProtoStreamLargeEvent(t *testing.T) {
 	tests := []struct {
 		name      string
 		event     events.AuditEvent
-		expectErr bool
+		errAssertion require.ErrorAssertionFunc
 	}{
 		{
 			name:      "large trimmable event is trimmed",
 			event:     makeQueryEvent("1", strings.Repeat("A", MaxProtoMessageSizeBytes)),
-			expectErr: false,
+			errAssertion: require.NoError,
 		},
 		{
 			name:      "large untrimmable event returns error",
 			event:     makeAccessRequestEvent("1", strings.Repeat("A", MaxProtoMessageSizeBytes)),
-			expectErr: true,
+			errAssertion: require.Error,
 		},
 	}
 


### PR DESCRIPTION
### Purpose

Fixes known cases where audit log events can be bypassed by exceeding the entry size limit. Also fixes gravitational/teleport#15645 where memory can balloon when doing large inserts in MongoDB and audit records are lost. 

### Implementation

1. Increase the ballast size when trimming to max size. This helps account for additional quoting required in MongoDB queries.
2. When adding an additional factor limit the Device Name to 30 characters or less.
3. When logging the UserAgent on login limit it to the first 2048 characters. When researching this I found some browsers like IE can send very long UAs but I think this is more than enough.
4. Implement TrimToMaxSize in ProtoStream.