### PR TITLE
Remove Server Access Ansible guide redirect

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1505,11 +1505,6 @@
       "permanent": true
     },
     {
-      "source": "/server-access/guides/ansible/",
-      "destination": "/machine-id/guides/ansible/",
-      "permanent": true
-    },
-    {
       "source": "/server-access/guides/tsh/",
       "destination": "/connect-your-client/tsh/",
       "permanent": true


### PR DESCRIPTION
At one point, we had moved the Ansible Server Access guide to the Machine ID section and added a redirect. Since we restored the Ansible Server Access guide, the redirect is no longer correct.