### PR TITLE
Add Enterprise installation instructions

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -47,7 +47,12 @@ While the Kubernetes cluster is being provisioned, follow the "Getting Started" 
 
 (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 
-Install Teleport in your Kubernetes cluster using the `teleport-cluster` Helm chart.
+Install Teleport in your Kubernetes cluster using the `teleport-cluster` Helm
+chart:
+
+<Tabs>
+<TabItem scope="oss" label="Teleport Community Edition">
+
 ```code
 $ CLUSTERNAME=tele.example.com # replace with your preferred domain name
 $ EMAIL_ADDR=dodemo@goteleport.com # replace with your email
@@ -66,7 +71,48 @@ REVISION: 1
 TEST SUITE: None
 ```
 
+</TabItem>
+<TabItem scope="enterprise" label="Teleport Enterprise">
+
+Create a namespace for your Teleport cluster resources:
+
+```code
+$ kubectl create namespace teleport-cluster
+```
+
+Obtain your Teleport Enterprise license file from the [Teleport Customer
+Portal](https://dashboard.gravitational.com/web/login). Create a secret called
+"license" in the namespace you created:
+
+```code
+$ kubectl -n teleport-cluster create secret generic license --from-file=license.pem
+```
+
+Install Teleport:
+
+```code
+$ CLUSTERNAME=tele.example.com # replace with your preferred domain name
+$ EMAIL_ADDR=dodemo@goteleport.com # replace with your email
+$ helm install teleport-cluster teleport/teleport-cluster \
+  --namespace=teleport-cluster \
+  --set clusterName=$CLUSTERNAME \
+  --set acme=true \
+  --set acmeEmail=$EMAIL_ADDR \
+  --set enterprise=true \
+  --version (=teleport.version=)
+NAME: teleport-cluster
+LAST DEPLOYED: Tue Oct 26 17:01:21 2021
+NAMESPACE: teleport-cluster
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+```
+
+</TabItem>
+</Tabs>
+
 ### Update DNS for `clusterName`
+
 First, get the external IP (from the `EXTERNAL-IP` field) for the Kubernetes cluster. 
 ```code
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/migration.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/migration.mdx
@@ -90,7 +90,8 @@ cat teleport.yaml
 # ...
 ```
 
-Once you have the config, you should upload this to a separate Kubernetes namespace (where you intend to run the `teleport-cluster` chart).
+Once you have the config, you should upload this to a separate Kubernetes
+namespace (where you intend to run the `teleport-cluster` chart).
 
 ```code
 $ kubectl create namespace teleport-cluster
@@ -132,11 +133,13 @@ $ kubectl --namespace teleport-cluster create secret generic bootstrap --from-fi
 
 ## Step 5/6. Start the new cluster with your old config file and backup
 
-We will start the new cluster and bootstrap it using the backup of your cluster's data. Once this step is complete and the cluster is working,
-we'll modify the deployment to remove references to the backup data, and remove it from Kubernetes for security.
+We will start the new cluster and bootstrap it using the backup of your
+cluster's data. Once this step is complete and the cluster is working, we'll
+modify the deployment to remove references to the backup data, and remove it
+from Kubernetes for security.
 
 <Tabs>
-  <TabItem label="Using values.yaml">
+  <TabItem scope="oss" label="Teleport Community Edition">
   Write a `teleport-cluster-values.yaml` file containing the following values:
 
   ```yaml
@@ -154,23 +157,41 @@ we'll modify the deployment to remove references to the backup data, and remove 
   ```code
   $ helm install teleport teleport/teleport-cluster \
     --namespace teleport-cluster \
-    --create-namespace \
     -f teleport-cluster-values.yaml
   ```
 
   </TabItem>
-  <TabItem label="Using --set via CLI">
-    ```code
-    $ helm install teleport teleport/teleport-cluster \
-    --create-namespace \
+  <TabItem scope="enterprise" label="Teleport Enterprise">
+
+  Obtain your Teleport Enterprise license file from the [Teleport Customer
+  Portal](https://dashboard.gravitational.com/web/login). Create a secret called
+  "license" in the namespace you created:
+
+  ```code
+  $ kubectl -n teleport-cluster create secret generic license --from-file=license.pem
+  ```
+
+  Write a `teleport-cluster-values.yaml` file containing the following values:
+
+  ```yaml
+  enterprise: true
+  chartMode: custom
+  extraArgs: ['--bootstrap', '/etc/teleport-bootstrap/backup.yaml']
+  extraVolumes:
+  - name: bootstrap
+    secret:
+      name: bootstrap
+  extraVolumeMounts:
+  - name: bootstrap
+    path: /etc/teleport-bootstrap
+  ```
+
+  ```code
+  $ helm install teleport teleport/teleport-cluster \
     --namespace teleport-cluster \
-    --set chartMode=custom \
-    --set extraArgs="{'--bootstrap', '/etc/teleport-bootstrap/backup.yaml'}" \
-    --set extraVolumes[0].name="bootstrap" \
-    --set extraVolumes[0].secret.name="bootstrap" \
-    --set extraVolumeMounts[0].name="bootstrap" \
-    --set extraVolumeMounts[0].path="/etc/teleport-bootstrap"
-    ```
+    -f teleport-cluster-values.yaml
+  ```
+
   </TabItem>
 </Tabs>
 

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -55,9 +55,11 @@ binaries, including `teleport`, `tctl`, `tsh`, and `tbot`:
 - `tsh` is the client tool you will use to log in to the Teleport Cluster (steps 2/4 and 4/4)
 - `tbot` is the Machine ID tool you will use to associate a bot user with a machine (step 3/4)
 
-Machine ID is available starting from the Teleport `9.0.0` release. Download
-the appropriate Teleport package for your platform from our
-[downloads page](https://goteleport.com/teleport/download).
+Machine ID is available starting from the Teleport `9.0.0` release. 
+
+Download the appropriate Teleport package for your platform: 
+
+(!docs/pages/includes/install-linux.mdx!)
 
 ## Step 2/4. Create a bot user
 

--- a/docs/pages/management/guides/teleport-operator.mdx
+++ b/docs/pages/management/guides/teleport-operator.mdx
@@ -52,7 +52,10 @@ $ kubectl cluster-info
 
 (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 
-Install the Helm chart for the Teleport Cluster with `operator.enabled=true`.
+Install the Helm chart for the Teleport Cluster with `operator.enabled=true`:
+
+<Tabs>
+<TabItem scope="oss" label="Teleport Community Edition">
 
 ```code
 $ helm install teleport-cluster teleport/teleport-cluster \
@@ -61,6 +64,36 @@ $ helm install teleport-cluster teleport/teleport-cluster \
         --set operator.enabled=true \
         --version (=teleport.version=)
 ```
+</TabItem>
+<TabItem scope="enterprise" label="Teleport Enterprise">
+
+Create a namespace for your Teleport cluster resources:
+
+```code
+$ kubectl create namespace teleport-cluster
+```
+
+Obtain your Teleport Enterprise license file from the [Teleport Customer
+Portal](https://dashboard.gravitational.com/web/login). Create a secret called
+"license" in the namespace you created:
+
+```code
+$ kubectl -n teleport-cluster create secret generic license --from-file=license.pem
+```
+
+Deploy your Teleport cluster and the Teleport Kubernetes Operator:
+
+```code
+$ helm install teleport-cluster teleport/teleport-cluster \
+        --namespace teleport-cluster \
+        --set enterprise=true \
+        --set clusterName=teleport-cluster.teleport-cluster.svc.cluster.local \
+        --set operator.enabled=true \
+        --version (=teleport.version=)
+```
+</TabItem>
+
+</Tabs>
 
 This command installs the required Kubernetes CRDs and deploys the Teleport Kubernetes Operator next to the Teleport
 cluster. All resources (except CRDs, which are cluster-scoped) are created in the `teleport-cluster` namespace.


### PR DESCRIPTION
This addresses some observations from @stevenGravy about a couple places in the docs where Enterprise-specific installation steps are missing.

- Edit the Machine ID Getting Started guide: Use the `install-linux.mdx` partial for download instructions, since these include instructiosn for Enterprise users.

- Add Enterprise instructions to Helm guides that only include OSS installation instructions.