### PR TITLE
[v11] chore: Bump Buf to v1.11.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -203,7 +203,7 @@ RUN (git clone https://github.com/gogo/protobuf.git --branch ${GOGO_PROTO_TAG} -
 
 # Install buf
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.10.0" && \
+    VERSION="1.11.0" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \

--- a/lib/teleterm/api/protogen/golang/v1/service.pb.go
+++ b/lib/teleterm/api/protogen/golang/v1/service.pb.go
@@ -339,7 +339,7 @@ type GetAccessRequestRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	ClusterUri string `protobuf:"bytes,1,opt,name=cluster_uri,json=clusterUri,proto3" json:"cluster_uri,omitempty"`
-	// specificies a specific request id
+	// specifcies a specific request id
 	AccessRequestId string `protobuf:"bytes,2,opt,name=access_request_id,json=accessRequestId,proto3" json:"access_request_id,omitempty"`
 }
 


### PR DESCRIPTION
Update Buf to the latest release. No formatting, linter, or codegen changes.

https://github.com/bufbuild/buf/releases/tag/v1.11.0

Backport #19515 to branch/v11