### PR TITLE
[v10] chore: Bump Buf to v1.11.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -182,7 +182,7 @@ RUN (git clone https://github.com/gogo/protobuf.git ${GOPATH}/src/github.com/gog
 
 # Install buf
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.10.0" && \
+    VERSION="1.11.0" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Update Buf to the latest release. No formatting, linter, or codegen changes.

https://github.com/bufbuild/buf/releases/tag/v1.11.0

Backport #19515 to branch/v10