### PR TITLE
Enforce device extensions for SSH access

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2399,6 +2399,7 @@ func userSingleUseCertsGenerate(ctx context.Context, actx *grpcContext, req prot
 		certRequestMFAVerified(mfaDev.Id),
 		certRequestPreviousIdentityExpires(actx.Identity.GetIdentity().Expires),
 		certRequestClientIP(clientIP),
+		certRequestDeviceExtensions(actx.Identity.GetIdentity().DeviceExtensions),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -443,16 +443,18 @@ func generateCertificate(authServer *Server, identity TestIdentity) ([]byte, []b
 		if identity.TTL == 0 {
 			identity.TTL = time.Hour
 		}
+
 		certs, err := authServer.generateUserCert(certRequest{
-			publicKey:      pub,
-			user:           user,
-			ttl:            identity.TTL,
-			usage:          identity.AcceptedUsage,
-			routeToCluster: identity.RouteToCluster,
-			checker:        checker,
-			traits:         user.GetTraits(),
-			renewable:      identity.Renewable,
-			generation:     identity.Generation,
+			publicKey:        pub,
+			user:             user,
+			ttl:              identity.TTL,
+			usage:            identity.AcceptedUsage,
+			routeToCluster:   identity.RouteToCluster,
+			checker:          checker,
+			traits:           user.GetTraits(),
+			renewable:        identity.Renewable,
+			generation:       identity.Generation,
+			deviceExtensions: DeviceExtensions(id.Identity.DeviceExtensions),
 		})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)

--- a/lib/devicetrust/authz/authz.go
+++ b/lib/devicetrust/authz/authz.go
@@ -1,0 +1,83 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	"sync"
+
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/devicetrust/config"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+// VerifyTLSUser verifies if the TLS identity has the required extensions to
+// fulfill the device trust configuration.
+func VerifyTLSUser(dt *types.DeviceTrust, identity tlsca.Identity) error {
+	return verifyDeviceExtensions(dt, identity.Username, identity.DeviceExtensions)
+}
+
+// VerifySSHUser verifies if the SSH certificate has the required extensions to
+// fulfill the device trust configuration.
+func VerifySSHUser(dt *types.DeviceTrust, cert *ssh.Certificate) error {
+	if cert == nil {
+		return trace.BadParameter("cert required")
+	}
+
+	username := cert.KeyId
+	return verifyDeviceExtensions(dt, username, tlsca.DeviceExtensions{
+		DeviceID:     cert.Extensions[teleport.CertExtensionDeviceID],
+		AssetTag:     cert.Extensions[teleport.CertExtensionDeviceAssetTag],
+		CredentialID: cert.Extensions[teleport.CertExtensionDeviceCredentialID],
+	})
+}
+
+func verifyDeviceExtensions(dt *types.DeviceTrust, username string, ext tlsca.DeviceExtensions) error {
+	mode := config.GetEffectiveMode(dt)
+	maybeLogModeMismatch(mode, dt)
+
+	if mode != constants.DeviceTrustModeRequired {
+		return nil // OK, extensions not enforced.
+	}
+
+	// Teleport-issued device certificates always contain all three fields, so we
+	// either all or none to be present.
+	// There's little value in trying to distinguish other situations.
+	if ext.DeviceID == "" || ext.AssetTag == "" || ext.CredentialID == "" {
+		log.
+			WithField("User", username).
+			Debug("Device Trust: denied access for unidentified device")
+		return trace.AccessDenied("unauthorized device")
+	}
+
+	return nil
+}
+
+var logModeOnce sync.Once
+
+func maybeLogModeMismatch(effective string, dt *types.DeviceTrust) {
+	if dt == nil || dt.Mode == "" || effective == dt.Mode {
+		return
+	}
+
+	logModeOnce.Do(func() {
+		log.Warnf("Device Trust: mode %q requires Teleport Enterprise. Using effective mode %q.", dt.Mode, effective)
+	})
+}

--- a/lib/devicetrust/authz/authz.go
+++ b/lib/devicetrust/authz/authz.go
@@ -58,7 +58,7 @@ func verifyDeviceExtensions(dt *types.DeviceTrust, username string, ext tlsca.De
 	}
 
 	// Teleport-issued device certificates always contain all three fields, so we
-	// either all or none to be present.
+	// expect either all or none to be present.
 	// There's little value in trying to distinguish other situations.
 	if ext.DeviceID == "" || ext.AssetTag == "" || ext.CredentialID == "" {
 		log.

--- a/lib/devicetrust/authz/authz_test.go
+++ b/lib/devicetrust/authz/authz_test.go
@@ -1,0 +1,159 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz_test
+
+import (
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/devicetrust/authz"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestVerifyTLSUser(t *testing.T) {
+	runVerifyUserTest(t, "VerifyTLSUser", func(dt *types.DeviceTrust, ext *tlsca.DeviceExtensions) error {
+		return authz.VerifyTLSUser(dt, tlsca.Identity{
+			Username:         "llama",
+			DeviceExtensions: *ext,
+		})
+	})
+}
+
+func TestVerifySSHUser(t *testing.T) {
+	runVerifyUserTest(t, "VerifySSHUser", func(dt *types.DeviceTrust, ext *tlsca.DeviceExtensions) error {
+		return authz.VerifySSHUser(dt, &ssh.Certificate{
+			KeyId: "llama",
+			Permissions: ssh.Permissions{
+				Extensions: map[string]string{
+					teleport.CertExtensionDeviceID:           ext.DeviceID,
+					teleport.CertExtensionDeviceAssetTag:     ext.AssetTag,
+					teleport.CertExtensionDeviceCredentialID: ext.CredentialID,
+				},
+			},
+		})
+	})
+}
+
+func runVerifyUserTest(t *testing.T, method string, verify func(dt *types.DeviceTrust, ext *tlsca.DeviceExtensions) error) {
+	assertNoErr := func(t *testing.T, err error) {
+		assert.NoError(t, err, "%v mismatch", method)
+	}
+	assertDeniedErr := func(t *testing.T, err error) {
+		assert.ErrorContains(t, err, "unauthorized device", "%v mismatch", method)
+		assert.True(t, trace.IsAccessDenied(err), "%v returned an error other than trace.AccessDeniedError: %T", method, err)
+	}
+
+	userWithoutExtensions := &tlsca.DeviceExtensions{}
+	userWithExtensions := &tlsca.DeviceExtensions{
+		DeviceID:     "deviceid1",
+		AssetTag:     "assettag1",
+		CredentialID: "credentialid1",
+	}
+
+	tests := []struct {
+		name      string
+		buildType string
+		dt        *types.DeviceTrust
+		ext       *tlsca.DeviceExtensions
+		assertErr func(t *testing.T, err error)
+	}{
+		{
+			name:      "OSS dt=nil",
+			buildType: modules.BuildOSS,
+			dt:        nil, // OK, config absent.
+			ext:       userWithoutExtensions,
+			assertErr: assertNoErr,
+		},
+		{
+			name:      "OSS mode=off",
+			buildType: modules.BuildOSS,
+			dt: &types.DeviceTrust{
+				Mode: constants.DeviceTrustModeOff, // Valid for OSS.
+			},
+			ext:       userWithoutExtensions,
+			assertErr: assertNoErr,
+		},
+		{
+			name:      "OSS mode never enforced",
+			buildType: modules.BuildOSS,
+			dt: &types.DeviceTrust{
+				Mode: constants.DeviceTrustModeRequired, // Invalid for OSS, treated as "off".
+			},
+			ext:       userWithoutExtensions,
+			assertErr: assertNoErr,
+		},
+		{
+			name:      "Enterprise mode=off",
+			buildType: modules.BuildEnterprise,
+			dt: &types.DeviceTrust{
+				Mode: constants.DeviceTrustModeOff,
+			},
+			ext:       userWithoutExtensions,
+			assertErr: assertNoErr,
+		},
+		{
+			name:      "Enterprise mode=optional without extensions",
+			buildType: modules.BuildEnterprise,
+			dt: &types.DeviceTrust{
+				Mode: constants.DeviceTrustModeOptional,
+			},
+			ext:       userWithoutExtensions,
+			assertErr: assertNoErr,
+		},
+		{
+			name:      "Enterprise mode=optional with extensions",
+			buildType: modules.BuildEnterprise,
+			dt: &types.DeviceTrust{
+				Mode: constants.DeviceTrustModeOptional,
+			},
+			ext:       userWithExtensions, // Happens if the device is enrolled.
+			assertErr: assertNoErr,
+		},
+		{
+			name:      "nok: Enterprise mode=required without extensions",
+			buildType: modules.BuildEnterprise,
+			dt: &types.DeviceTrust{
+				Mode: constants.DeviceTrustModeRequired,
+			},
+			ext:       userWithoutExtensions,
+			assertErr: assertDeniedErr,
+		},
+		{
+			name:      "Enterprise mode=required with extensions",
+			buildType: modules.BuildEnterprise,
+			dt: &types.DeviceTrust{
+				Mode: constants.DeviceTrustModeRequired,
+			},
+			ext:       userWithExtensions,
+			assertErr: assertNoErr,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modules.SetTestModules(t, &modules.TestModules{
+				TestBuildType: test.buildType,
+			})
+
+			test.assertErr(t, verify(test.dt, test.ext))
+		})
+	}
+}


### PR DESCRIPTION
Add device-aware authorization for SSH access, including both long-lived and single-use certificates.

If the device trust mode is set to "required", then the presence of the corresponding extensions is enforced. (Requires Teleport Enterprise.)

Adds logic related to TLS validation and single-use certificates as well, where appropriate. TLS device-aware validation is not wired into Teleport yet, but will be in follow up PRs.

https://github.com/gravitational/teleport.e/issues/514