### PR TITLE
[v11] Fix TestExecLongCommand - cleanup unlink

### DIFF
--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -755,7 +755,7 @@ func TestMaxSessions(t *testing.T) {
 // command and send the command to then launch through a pipe.
 func TestExecLongCommand(t *testing.T) {
 	t.Parallel()
-	f := newFixture(t)
+	f := newFixtureWithoutDiskBasedLogging(t)
 	ctx := context.Background()
 
 	// Get the path to where the "echo" command is on disk.


### PR DESCRIPTION
Backport #19540 to branch/v11