### PR TITLE
Fix TestExportingTraces race

### DIFF
--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -3616,11 +3616,6 @@ func spanAssertion(containsTSH, empty bool) func(t *testing.T, spans []*otlp.Sco
 func TestForwardingTraces(t *testing.T) {
 	t.Parallel()
 
-	connector := mockConnector(t)
-	alice, err := types.NewUser("alice@example.com")
-	require.NoError(t, err)
-	alice.SetRoles([]string{"access"})
-
 	cases := []struct {
 		name          string
 		cfg           func(c *tracing.Collector) service.TracingConfig
@@ -3664,6 +3659,12 @@ func TestForwardingTraces(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tmpHomePath := t.TempDir()
+
+			connector := mockConnector(t)
+			alice, err := types.NewUser("alice@example.com")
+			require.NoError(t, err)
+			alice.SetRoles([]string{"access"})
+
 			collector, err := tracing.NewCollector(tracing.CollectorConfig{})
 			require.NoError(t, err)
 
@@ -3734,11 +3735,6 @@ func TestForwardingTraces(t *testing.T) {
 func TestExportingTraces(t *testing.T) {
 	t.Parallel()
 
-	connector := mockConnector(t)
-	alice, err := types.NewUser("alice@example.com")
-	require.NoError(t, err)
-	alice.SetRoles([]string{"access"})
-
 	cases := []struct {
 		name                  string
 		cfg                   func(c *tracing.Collector) service.TracingConfig
@@ -3783,6 +3779,12 @@ func TestExportingTraces(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			connector := mockConnector(t)
+			alice, err := types.NewUser("alice@example.com")
+			require.NoError(t, err)
+			alice.SetRoles([]string{"access"})
+
 			tmpHomePath := t.TempDir()
 
 			teleportCollector, err := tracing.NewCollector(tracing.CollectorConfig{})


### PR DESCRIPTION
Move the creation of the connector and user within the subtests so that each Auth doesn't `setStaticFields` on the resources at the same time.

Updates #19589