### PR TITLE
GHA: Fix skipped but required checks

### DIFF
--- a/.github/workflows/build-macos-bypass.yaml
+++ b/.github/workflows/build-macos-bypass.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build:
-    name: Skipped
+    name: Build on Mac OS
     runs-on: macos-12
 
     permissions:

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: Build all tools on Mac OS
+    name: Build on Mac OS
     runs-on: macos-12 # TODO(r0mant): Update with large runner when it's available
 
     permissions:

--- a/.github/workflows/build-windows-bypass.yaml
+++ b/.github/workflows/build-windows-bypass.yaml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    name: Skipped
+    name: Build on Windows
     runs-on: windows-latest
 
     permissions:

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    name: Build tsh tool on Windows
+    name: Build on Windows
     runs-on: windows-2022-16core
 
     permissions:

--- a/.github/workflows/integration-tests-non-root-bypass.yaml
+++ b/.github/workflows/integration-tests-non-root-bypass.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test:
-    name: Skipped
+    name: Integration Tests (Non-root)
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/integration-tests-root-bypass.yaml
+++ b/.github/workflows/integration-tests-root-bypass.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test:
-    name: Skipped
+    name: Integration Tests (Root)
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  build:
-    name: Build Artifacts
+  test:
+    name: OS Compatibility Test
     runs-on: ubuntu-22.04-16core
 
     permissions:
@@ -28,36 +28,9 @@ jobs:
 
       - name: Run make
         run: |
-          make build/tctl build/tsh build/tbot build/teleport
-
-      - name: Upload binaries
-        uses: actions/upload-artifact@v3
-        with:
-          name: build
-          path: ${{ github.workspace }}/build/
-
-  test-compat:
-    needs: build
-    name: Run Compatibility Test
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download binaries
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: ${{ github.workspace }}/build
-
-      - name: chmod +x
-        run: chmod +x ${GITHUB_WORKSPACE}/build/*
+          make binaries
 
       - name: Run compat matrix
         timeout-minutes: 10
         run: |
-          cd ${GITHUB_WORKSPACE} && ./build.assets/build-test-compat.sh
+          ./build.assets/build-test-compat.sh

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: OS Compatibility Test
+  build:
+    name: OS Compatibility Build
     runs-on: ubuntu-22.04-16core
 
     permissions:
@@ -30,7 +30,34 @@ jobs:
         run: |
           make binaries
 
+      - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: ${{ github.workspace }}/build/
+
+  test-compat:
+    needs: build
+    name: OS Compatibility Test
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: ${{ github.workspace }}/build
+
+      - name: chmod +x
+        run: chmod +x ${GITHUB_WORKSPACE}/build/*
+
       - name: Run compat matrix
         timeout-minutes: 10
         run: |
-          ./build.assets/build-test-compat.sh
+          cd ${GITHUB_WORKSPACE} && ./build.assets/build-test-compat.sh

--- a/.github/workflows/unit-tests-code-bypass.yaml
+++ b/.github/workflows/unit-tests-code-bypass.yaml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   test:
-    name: Skipped
+    name: Unit Tests (Go)
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/unit-tests-helm-bypass.yaml
+++ b/.github/workflows/unit-tests-helm-bypass.yaml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   test:
-    name: Skipped
+    name: Unit Tests (Helm)
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/unit-tests-operator-bypass.yaml
+++ b/.github/workflows/unit-tests-operator-bypass.yaml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   test:
-    name: Skipped
+    name: Unit Tests (Operator)
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/unit-tests-rust-bypass.yaml
+++ b/.github/workflows/unit-tests-rust-bypass.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test:
-    name: Skipped
+    name: Unit Tests (Rust)
     runs-on: ubuntu-latest
 
     permissions:

--- a/api/client/proxy.go
+++ b/api/client/proxy.go
@@ -33,7 +33,8 @@ func DialProxy(ctx context.Context, proxyURL *url.URL, addr string) (net.Conn, e
 	return DialProxyWithDialer(ctx, proxyURL, addr, &net.Dialer{})
 }
 
-// DialProxyWithDialer creates a connection to a server via an HTTP or SOCKS5 Proxy using a specified dialer.
+// DialProxyWithDialer creates a connection to a server via an HTTP or SOCKS5
+// Proxy using a specified dialer.
 func DialProxyWithDialer(
 	ctx context.Context,
 	proxyURL *url.URL,

--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -27,8 +27,8 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 )
 
-// CertAuthority is a host or user certificate authority that
-// can check and if it has private key stored as well, sign it too
+// CertAuthority is a host or user certificate authority that can check and if
+// it has private key stored as well, sign it too.
 type CertAuthority interface {
 	// ResourceWithSecrets sets common resource properties
 	ResourceWithSecrets

--- a/lib/srv/desktop/rdp/rdpclient/src/piv.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/piv.rs
@@ -45,8 +45,8 @@ pub struct Card<const S: usize> {
     piv_auth_cert: Vec<u8>,
     piv_auth_key: RsaPrivateKey,
     pin: String,
-    // Pending command and response to receive/send over multiple messages when they don't fit into
-    // one.
+    // Pending command and response to receive/send over multiple messages when
+    // they don't fit into one.
     pending_command: Option<Command<S>>,
     pending_response: Option<Cursor<Vec<u8>>>,
 }


### PR DESCRIPTION
Turns out Github considers both workflow name and job name as a full check name so in order for [skipped but required](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks) checks to work properly, the job names in "no-op" workflows have to be the same as in the real workflows.
