### PR TITLE
Update Rust to 1.66.0

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -27,7 +27,7 @@ GOLANG_VERSION ?= go1.19.4
 
 NODE_VERSION ?= 16.18.1
 
-RUST_VERSION ?= 1.64.0 # don't bump this without checking GLIBC compatibility
+RUST_VERSION ?= 1.66.0
 LIBBPF_VERSION ?= 0.7.0-teleport
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 


### PR DESCRIPTION
The new Rust version has been [released](https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html) a few days ago so I thought it would be great to keep our project in sync with it.

I've checked the GLIBC in both versions and max GLIBC requirement for both version is GLIBC_2.17 so it didn't change after the rust version update.

[objdump_teleport_rust_1_64.txt](https://github.com/gravitational/teleport/files/10287839/objdump_teleport_rust_1_64.txt)
[objdump_teleport_rust_1_66.txt](https://github.com/gravitational/teleport/files/10287840/objdump_teleport_rust_1_66.txt)
