### PR TITLE
Run GHA tests when build.assets/Makefile changes

### DIFF
--- a/.github/workflows/build-macos-bypass.yaml
+++ b/.github/workflows/build-macos-bypass.yaml
@@ -20,6 +20,7 @@ on:
       - '**.rs'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'build.assets/Makefile'
 
 jobs:
   build:

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -13,6 +13,7 @@ on:
       - '**.rs'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'build.assets/Makefile'
 
 jobs:
   build:

--- a/.github/workflows/build-windows-bypass.yaml
+++ b/.github/workflows/build-windows-bypass.yaml
@@ -19,6 +19,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - 'build.assets/Makefile'
 
 jobs:
   build:

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -12,6 +12,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - 'build.assets/Makefile'
 
 jobs:
   build:

--- a/.github/workflows/integration-tests-non-root-bypass.yaml
+++ b/.github/workflows/integration-tests-non-root-bypass.yaml
@@ -17,6 +17,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - 'build.assets/Makefile'
 
 jobs:
   test:

--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -10,6 +10,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - 'build.assets/Makefile'
 
 jobs:
   test:

--- a/.github/workflows/integration-tests-root-bypass.yaml
+++ b/.github/workflows/integration-tests-root-bypass.yaml
@@ -17,6 +17,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - 'build.assets/Makefile'
 
 jobs:
   test:

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -10,6 +10,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - 'build.assets/Makefile'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-code-bypass.yaml
+++ b/.github/workflows/unit-tests-code-bypass.yaml
@@ -15,6 +15,9 @@ on:
   pull_request:
     paths-ignore:
       - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'build.assets/Makefile'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -10,6 +10,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - 'build.assets/Makefile'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-operator-bypass.yaml
+++ b/.github/workflows/unit-tests-operator-bypass.yaml
@@ -14,11 +14,12 @@ run-name: Skip Unit Tests (Operator) - ${{ github.run_id }} - @${{ github.actor 
 on:
   pull_request:
     paths-ignore:
-      - /go.mod
-      - /go.sum
-      - operator/**
-      - api/types/**
-      - lib/tbot/**
+      - '/go.mod'
+      - '/go.sum'
+      - 'operator/**'
+      - 'api/types/**'
+      - 'lib/tbot/**'
+      - 'build.assets/Makefile'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-operator.yaml
+++ b/.github/workflows/unit-tests-operator.yaml
@@ -7,11 +7,12 @@ on:
       - master
   pull_request:
     paths:
-      - /go.mod
-      - /go.sum
-      - operator/**
-      - api/types/**
-      - lib/tbot/**
+      - '/go.mod'
+      - '/go.sum'
+      - 'operator/**'
+      - 'api/types/**'
+      - 'lib/tbot/**
+      - 'build.assets/Makefile'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-rust-bypass.yaml
+++ b/.github/workflows/unit-tests-rust-bypass.yaml
@@ -17,6 +17,7 @@ on:
       - '**.rs'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'build.assets/Makefile'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -10,6 +10,7 @@ on:
       - '**.rs'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'build.assets/Makefile'
 
 jobs:
   test:

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -42,7 +42,7 @@ RUNTIME_ARCH_aarch64 := arm64
 RUNTIME_ARCH := $(RUNTIME_ARCH_$(HOST_ARCH))
 
 PROTOC_VER ?= 3.20.3
-# Keep in sync with api/proto/buf.yaml (and buf.lock).
+# Keep in sync with api/proto/buf.yaml (and buf.lock)
 GOGO_PROTO_TAG ?= v1.3.2
 
 # BUILDBOX_VERSION, BUILDBOX and BUILDBOX_variant variables are included


### PR DESCRIPTION
I've noticed we don't run any tests on PR that don't change any source code but, for example, update Rust or Go version in build.assets/Makefile. This PR includes this Makefile in path filters for the test workflows.