### PR TITLE
[v10] Use our own fake IdP instead of external one.

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -427,6 +427,8 @@ func TestOIDCAuthRequest(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
+	idp := newFakeIDP(t, false /* tls */)
+
 	emptyRole, err := CreateRole(ctx, srv.Auth(), "test-empty", types.RoleSpecV5{})
 	require.NoError(t, err)
 
@@ -479,7 +481,7 @@ func TestOIDCAuthRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	conn, err := types.NewOIDCConnector("example", types.OIDCConnectorSpecV3{
-		IssuerURL:    "https://gitlab.com",
+		IssuerURL:    idp.s.URL,
 		ClientID:     "example-client-id",
 		ClientSecret: "example-client-secret",
 		RedirectURLs: []string{"https://localhost:3080/v1/webapi/oidc/callback"},
@@ -504,7 +506,7 @@ func TestOIDCAuthRequest(t *testing.T) {
 		Type:        constants.OIDC,
 		SSOTestFlow: true,
 		ConnectorSpec: &types.OIDCConnectorSpecV3{
-			IssuerURL:    "https://gitlab.com",
+			IssuerURL:    idp.s.URL,
 			ClientID:     "example-client-id",
 			ClientSecret: "example-client-secret",
 			RedirectURLs: []string{"https://localhost:3080/v1/webapi/oidc/callback"},


### PR DESCRIPTION
Fix on master: https://github.com/gravitational/teleport.e/pull/674