### PR TITLE
Run GHA tests on Dockerfile updates

### DIFF
--- a/.github/workflows/build-macos-bypass.yaml
+++ b/.github/workflows/build-macos-bypass.yaml
@@ -21,6 +21,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   build:

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -14,6 +14,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   build:

--- a/.github/workflows/build-windows-bypass.yaml
+++ b/.github/workflows/build-windows-bypass.yaml
@@ -20,6 +20,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   build:

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -13,6 +13,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   build:

--- a/.github/workflows/integration-tests-non-root-bypass.yaml
+++ b/.github/workflows/integration-tests-non-root-bypass.yaml
@@ -18,6 +18,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   test:

--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -11,6 +11,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   test:

--- a/.github/workflows/integration-tests-root-bypass.yaml
+++ b/.github/workflows/integration-tests-root-bypass.yaml
@@ -18,6 +18,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   test:

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -11,6 +11,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-code-bypass.yaml
+++ b/.github/workflows/unit-tests-code-bypass.yaml
@@ -18,6 +18,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -11,6 +11,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-operator-bypass.yaml
+++ b/.github/workflows/unit-tests-operator-bypass.yaml
@@ -20,6 +20,7 @@ on:
       - 'api/types/**'
       - 'lib/tbot/**'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-operator.yaml
+++ b/.github/workflows/unit-tests-operator.yaml
@@ -13,6 +13,7 @@ on:
       - 'api/types/**'
       - 'lib/tbot/**
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-rust-bypass.yaml
+++ b/.github/workflows/unit-tests-rust-bypass.yaml
@@ -18,6 +18,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -11,6 +11,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
 
 jobs:
   test:

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -18,7 +18,7 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum clean all
 
 # Install libudev-zero.
-# libudev-zero replaces systemd's libudev
+# libudev-zero replaces systemd's libudev.
 RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 && \
     cd libudev-zero && \
     [ "$(git rev-parse HEAD)" = "4154cf252c17297f98a8ca33693ead003b4509da" ] && \


### PR DESCRIPTION
Follow up to https://github.com/gravitational/teleport/pull/19616 to also run tests on Dockerfile updates.