### PR TITLE
Improve error message when trying to rename resource

### DIFF
--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -231,7 +231,7 @@ type Presence interface {
 	// DeleteAllWindowsDesktopServices removes all Windows desktop services.
 	DeleteAllWindowsDesktopServices(context.Context) error
 
-	// ListResoures returns a paginated list of resources.
+	// ListResources returns a paginated list of resources.
 	ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
 
 	// UpsertDatabaseService updates an existing DatabaseService resource.

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -393,6 +393,6 @@ type resourcesAPIGetter interface {
 	GetTrustedClusters(ctx context.Context) ([]types.TrustedCluster, error)
 	// DeleteTrustedCluster removes a TrustedCluster from the backend by name.
 	DeleteTrustedCluster(ctx context.Context, name string) error
-	// ListResoures returns a paginated list of resources.
+	// ListResources returns a paginated list of resources.
 	ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
 }

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -306,7 +306,7 @@ func CheckResourceUpsertableByError(err error, httpMethod, resourceName string) 
 	}
 
 	if !exists && httpMethod == http.MethodPut {
-		return trace.NotFound("cannot find resource with name %q", resourceName)
+		return trace.NotFound("resource renaming is not supported, please create a different resource and then delete this one")
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #18771.

This commit improves the error message when a user tries to rename a resource (role, auth connector and trusted cluster) using the web UI.

#### Testing

- role:

<img width="1512" alt="Screenshot 2022-12-22 at 19 44 19" src="https://user-images.githubusercontent.com/4520516/209214713-ff83ca84-ebba-4a40-b4ae-d35b02ac13f7.png">

- auth connector:
<img width="1512" alt="Screenshot 2022-12-22 at 19 45 20" src="https://user-images.githubusercontent.com/4520516/209214723-e179d46d-69d7-4870-ada7-f1fed7adf29b.png">

- auth connector (smaller window):
<img width="350" alt="Screenshot 2022-12-22 at 19 44 45" src="https://user-images.githubusercontent.com/4520516/209214732-09f7d06c-738b-4e36-a95a-df66395d3c6d.png">