### PR TITLE
Fix Rust warnings

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -27,6 +27,7 @@ GOLANG_VERSION ?= go1.19.4
 
 NODE_VERSION ?= 16.18.1
 
+# run lint-rust check locally before merging code after you bump this
 RUST_VERSION ?= 1.66.0
 LIBBPF_VERSION ?= 0.7.0-teleport
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport

--- a/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
@@ -1113,7 +1113,7 @@ mod tests {
         let _pdu_header = vchan::ChannelPDUHeader::decode(&mut payload).unwrap();
         let header = ClipboardPDUHeader::decode(&mut payload).unwrap();
         let format_list =
-            FormatListPDU::<LongFormatName>::decode(&mut payload, header.data_len as u32).unwrap();
+            FormatListPDU::<LongFormatName>::decode(&mut payload, header.data_len).unwrap();
         assert_eq!(ClipboardPDUType::CB_FORMAT_LIST, header.msg_type);
         assert_eq!(1, format_list.format_names.len());
         assert_eq!(

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -1154,7 +1154,7 @@ fn read_rdp_output_inner(client: &Client) -> ReadRdpOutputReturns {
     //
     // Wait for some data to be available on the TCP socket FD before consuming it. This prevents
     // us from locking the mutex in Client permanently while no data is available.
-    while wait_for_fd(tcp_fd as usize) {
+    while wait_for_fd(tcp_fd) {
         let mut err = CGOErrCode::ErrCodeSuccess;
         let res = client.rdp_client.lock().unwrap().read(|rdp_event| {
             // This callback can be called multiple times per rdp_client.read()

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -2962,7 +2962,7 @@ impl FileRenameInformation {
         w.write_u8(Boolean::to_u8(&self.replace_if_exists).unwrap())?;
         // RootDirectory. For network operations, this value MUST be zero.
         w.write_u8(0)?;
-        w.write_u32::<LittleEndian>(self.file_name.len() as u32)?;
+        w.write_u32::<LittleEndian>(self.file_name.len())?;
         w.extend_from_slice(&util::to_unicode(&self.file_name.path, false));
         Ok(w)
     }
@@ -2984,7 +2984,7 @@ impl FileRenameInformation {
     }
 
     fn size(&self) -> u32 {
-        Self::BASE_SIZE + self.file_name.len() as u32
+        Self::BASE_SIZE + self.file_name.len()
     }
 }
 
@@ -3732,7 +3732,7 @@ impl ClientDriveSetInformationResponse {
     fn new(req: &ServerDriveSetInformationRequest, io_status: NTSTATUS) -> Self {
         Self {
             device_io_reply: DeviceIoResponse::new(&req.device_io_request, io_status),
-            length: req.set_buffer.size() as u32,
+            length: req.set_buffer.size(),
         }
     }
 

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/consts.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/consts.rs
@@ -109,6 +109,7 @@ pub enum MinorFunction {
 #[derive(ToPrimitive, FromPrimitive, Debug, PartialEq, Eq, Copy, Clone)]
 #[repr(u32)]
 #[allow(non_camel_case_types)]
+#[allow(clippy::upper_case_acronyms)]
 #[allow(dead_code)]
 pub enum NTSTATUS {
     STATUS_SUCCESS = 0x00000000,

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -841,7 +841,7 @@ impl Encode for ListReaders_Call {
         let mut index = 0;
         self.context.encode_ptr(&mut index, &mut w)?;
         encode_ptr(Some(self.groups_ptr_length), &mut index, &mut w)?; // takes care of encoding groups_ptr
-        let readers_is_null = if self.readers_is_null { 1 } else { 0 };
+        let readers_is_null = u32::from(self.readers_is_null);
         w.write_u32::<LittleEndian>(readers_is_null)?;
         w.write_u32::<LittleEndian>(self.readers_size)?;
 
@@ -1521,7 +1521,7 @@ impl Encode for Status_Call {
 
         let mut index = 0;
         self.handle.encode_ptr(&mut index, &mut w)?;
-        let reader_names_is_null = if self.reader_names_is_null { 1 } else { 0 };
+        let reader_names_is_null = u32::from(self.reader_names_is_null);
         w.write_u32::<LittleEndian>(reader_names_is_null)?;
         w.write_u32::<LittleEndian>(self.reader_length)?;
         w.write_u32::<LittleEndian>(self.atr_length)?;
@@ -1676,7 +1676,7 @@ impl Encode for Transmit_Call {
         } else {
             w.write_u32::<LittleEndian>(0)?;
         }
-        let recv_buffer_is_null = if self.recv_buffer_is_null { 1 } else { 0 };
+        let recv_buffer_is_null = u32::from(self.recv_buffer_is_null);
         w.write_u32::<LittleEndian>(recv_buffer_is_null)?;
         w.write_u32::<LittleEndian>(self.recv_length)?;
 
@@ -1929,7 +1929,7 @@ impl ReadCache_Common {
         encode_ptr(None, index, w)?; // _card_uuid_ptr
 
         w.write_u32::<LittleEndian>(self.freshness_counter)?;
-        let data_is_null = if self.data_is_null { 1 } else { 0 };
+        let data_is_null = u32::from(self.data_is_null);
         w.write_u32::<LittleEndian>(data_is_null)?;
         w.write_u32::<LittleEndian>(self.data_len)?;
 


### PR DESCRIPTION
New Rust version https://github.com/gravitational/teleport/pull/19605 introduced a few warnings that are causing `lint-rust` to fail. 
This PR fixes all of them.