### PR TITLE
Add support for Moderated Sessions in the Web UI 

### DIFF
--- a/lib/auth/session_access.go
+++ b/lib/auth/session_access.go
@@ -204,6 +204,7 @@ func (e *SessionAccessEvaluator) CanJoin(user SessionAccessContext) []types.Sess
 
 	// Session owners can always join their own sessions.
 	if user.Username == e.owner {
+		fmt.Printf("MADE IT HERE")
 		return []types.SessionParticipantMode{types.SessionPeerMode, types.SessionModeratorMode, types.SessionObserverMode}
 	}
 

--- a/lib/auth/session_access.go
+++ b/lib/auth/session_access.go
@@ -204,7 +204,6 @@ func (e *SessionAccessEvaluator) CanJoin(user SessionAccessContext) []types.Sess
 
 	// Session owners can always join their own sessions.
 	if user.Username == e.owner {
-		fmt.Printf("MADE IT HERE")
 		return []types.SessionParticipantMode{types.SessionPeerMode, types.SessionModeratorMode, types.SessionObserverMode}
 	}
 

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -104,6 +104,8 @@ type Session struct {
 	DatabaseName string `json:"database_name"`
 	// AppName is the name of the app being accessed.
 	AppName string `json:"app_name"`
+	// Owner is the name of the session owner, ie the one who created the session.
+	Owner string `json:"owner"`
 }
 
 // Participants returns the usernames of the current session participants.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2330,7 +2330,8 @@ func (h *Handler) siteNodeConnect(
 
 	if req.SessionID.IsZero() {
 		// An existing session ID was not provided so we need to create a new one.
-		sessionData, err = h.generateSession(ctx, clt, req, clusterName)
+		sessionData, err = h.generateSession(ctx, clt, req, clusterName, sessionCtx.cfg.User)
+		fmt.Printf("\n THE USER CREATING THE SESSION IS %v \n", sessionCtx.cfg.User)
 		if err != nil {
 			h.log.WithError(err).Debug("Unable to generate new ssh session.")
 			return nil, trace.Wrap(err)
@@ -2341,6 +2342,18 @@ func (h *Handler) siteNodeConnect(
 			return nil, trace.Wrap(err)
 		}
 	}
+
+	// If the participantMode is not specified, and the user is the one who created the session,
+	// they should be in Peer mode. If not, default to Observer mode.
+	if req.ParticipantMode == "" {
+		if sessionData.Owner == sessionCtx.cfg.User {
+			req.ParticipantMode = types.SessionPeerMode
+		} else {
+			req.ParticipantMode = types.SessionObserverMode
+		}
+	}
+
+	fmt.Printf("%v IS JOINING AS A %v \n", sessionCtx.cfg.User, req.ParticipantMode)
 
 	h.log.Debugf("New terminal request for server=%s, login=%s, sid=%s, websid=%s.",
 		req.Server, req.Login, sessionData.ID, sessionCtx.GetSessionID())
@@ -2368,6 +2381,7 @@ func (h *Handler) siteNodeConnect(
 		InteractiveCommand: req.InteractiveCommand,
 		Router:             h.cfg.Router,
 		TracerProvider:     h.cfg.TracerProvider,
+		ParticipantMode:    req.ParticipantMode,
 	}
 
 	term, err := NewTerminal(ctx, terminalConfig)
@@ -2383,7 +2397,7 @@ func (h *Handler) siteNodeConnect(
 	return nil, nil
 }
 
-func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *TerminalRequest, clusterName string) (session.Session, error) {
+func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *TerminalRequest, clusterName string, owner string) (session.Session, error) {
 	var (
 		id   string
 		host string
@@ -2481,6 +2495,7 @@ func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *Te
 		Created:        time.Now().UTC(),
 		LastActive:     time.Now().UTC(),
 		Namespace:      apidefaults.Namespace,
+		Owner:          owner,
 	}, nil
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1267,7 +1267,7 @@ func TestResizeTerminal(t *testing.T) {
 
 	// Create a new user "bar", open a terminal to the session created above
 	pack2 := s.authPack(t, "bar")
-	ws2, sess2, err := s.makeTerminal(t, pack2, withSessionID(sess.ID))
+	ws2, sess2, err := s.makeTerminal(t, pack2, withSessionID(sess.ID), withParticipantMode(types.SessionPeerMode))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, ws2.Close()) })
 
@@ -1286,6 +1286,7 @@ func TestResizeTerminal(t *testing.T) {
 	// size, and one for the manual resize request)
 	done := time.After(10 * time.Second)
 	t1ResizeEvents, t1RawEvents := 0, 0
+	fmt.Printf("RAW EVENTS: %v", t1RawEvents)
 t1ready:
 	for {
 		select {
@@ -6133,6 +6134,10 @@ func withServer(target string) terminalOpt {
 
 func withKeepaliveInterval(d time.Duration) terminalOpt {
 	return func(t *TerminalRequest) { t.KeepAliveInterval = d }
+}
+
+func withParticipantMode(m types.SessionParticipantMode) terminalOpt {
+	return func(t *TerminalRequest) { t.ParticipantMode = m }
 }
 
 func (s *WebSuite) makeTerminal(t *testing.T, pack *authPack, opts ...terminalOpt) (*websocket.Conn, *session.Session, error) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1286,7 +1286,6 @@ func TestResizeTerminal(t *testing.T) {
 	// size, and one for the manual resize request)
 	done := time.After(10 * time.Second)
 	t1ResizeEvents, t1RawEvents := 0, 0
-	fmt.Printf("RAW EVENTS: %v", t1RawEvents)
 t1ready:
 	for {
 		select {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1897,6 +1897,7 @@ func TestActiveSessions(t *testing.T) {
 		require.Equal(t, s.node.GetInfo().GetHostname(), session.ServerHostname)
 		require.Equal(t, s.srvID, session.ServerAddr)
 		require.Equal(t, s.server.ClusterName(), session.ClusterName)
+		require.ElementsMatch(t, []types.SessionParticipantMode{"peer"}, session.ParticipantModes)
 	}
 }
 

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -81,6 +81,9 @@ type TerminalRequest struct {
 	// This value is pulled from the cluster network config and
 	// guaranteed to be set to a nonzero value as it's enforced by the configuration.
 	KeepAliveInterval time.Duration
+
+	// ParticipantMode is the mode that determines what you can do when you join an active session.
+	ParticipantMode types.SessionParticipantMode `json:"mode"`
 }
 
 // AuthProvider is a subset of the full Auth API.
@@ -121,6 +124,7 @@ func NewTerminal(ctx context.Context, cfg TerminalHandlerConfig) (*TerminalHandl
 		term:               cfg.Term,
 		router:             cfg.Router,
 		tracer:             cfg.tracer,
+		participantMode:    cfg.ParticipantMode,
 	}, nil
 }
 
@@ -151,6 +155,8 @@ type TerminalHandlerConfig struct {
 	TracerProvider oteltrace.TracerProvider
 	// tracer is used to create spans
 	tracer oteltrace.Tracer
+	// ParticipantMode is the mode that determines what you can do when you join an active session.
+	ParticipantMode types.SessionParticipantMode
 }
 
 func (t *TerminalHandlerConfig) CheckAndSetDefaults() error {
@@ -254,6 +260,9 @@ type TerminalHandler struct {
 
 	// tracer creates spans
 	tracer oteltrace.Tracer
+
+	// participantMode is the mode that determines what you can do when you join an active session.
+	participantMode types.SessionParticipantMode
 }
 
 // ServeHTTP builds a connection to the remote node and then pumps back two types of
@@ -721,7 +730,7 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 
 	// Establish SSH connection to the server. This function will block until
 	// either an error occurs or it completes successfully.
-	if err = nc.RunInteractiveShell(ctx, types.SessionPeerMode, nil); err != nil {
+	if err = nc.RunInteractiveShell(ctx, t.participantMode, nil); err != nil {
 		t.log.WithError(err).Warn("Unable to stream terminal - failure running interactive shell")
 		t.writeError(err, ws)
 		return

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -798,7 +798,7 @@ func (t *TerminalHandler) streamEvents(ws *websocket.Conn, tc *client.TeleportCl
 			t.wsLock.Unlock()
 			if err != nil {
 				if errors.Is(err, websocket.ErrCloseSent) {
-					logger.Info("Websocket was closed, no longer streaming events (%v)", err)
+					logger.WithError(err).Debug("Websocket was closed, no longer streaming events")
 					return
 				}
 				logger.WithError(err).Error("Unable to send audit event to web client")


### PR DESCRIPTION
## Purpose

Part of https://github.com/gravitational/teleport/issues/13936
`webapps` counterpart: https://github.com/gravitational/webapps/pull/1460

Adds support for the Web UI to specify which `participantMode` to join an active session with. Also returns a user's available `participantModes` when listing active sessions.

## TODO

- [x] Fix bug not listing `participantModes` for a user's own sessions 