### PR TITLE
Turn on allowing no db CLI for tsh proxy db

### DIFF
--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -442,6 +442,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 			dbcmd.WithNoTLS(),
 			dbcmd.WithLogger(log),
 			dbcmd.WithPrintFormat(),
+			dbcmd.WithTolerateMissingCLIClient(),
 		}
 		if opts, err = maybeAddDBUserPassword(db, opts); err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION

The tunnel mode was requiring the `mysql` or `mariadb` executable in the client path.  This causes issues when user don't have these executables and they are not required.