### PR TITLE
[v9] Update Rust to 1.66.0 (#19605) (#19643)

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -18,7 +18,8 @@ OS ?= linux
 ARCH ?= amd64
 BUILDBOX_VERSION=teleport9
 GOLANG_VERSION ?= go1.17.11
-RUST_VERSION ?= 1.63.0 # don't bump this without checking GLIBC compatibility
+# run lint-rust check locally before merging code after you bump this
+RUST_VERSION ?= 1.66.0
 BORINGCRYPTO_RUNTIME=$(GOLANG_VERSION)b7
 LIBBPF_VERSION ?= 0.7.0-teleport
 

--- a/lib/datalog/roletester/src/role_tester.rs
+++ b/lib/datalog/roletester/src/role_tester.rs
@@ -116,27 +116,27 @@ pub unsafe extern "C" fn process_access(input: *const c_uchar, input_len: size_t
 
     for pred in &r.predicates {
         if pred.name == types::facts::PredicateType::HasRole as i32 {
-            runtime.extend(&[HasRole(pred.atoms[0], pred.atoms[1])]);
+            runtime.extend([HasRole(pred.atoms[0], pred.atoms[1])]);
         } else if pred.name == types::facts::PredicateType::HasTrait as i32 {
-            runtime.extend(&[HasTrait(pred.atoms[0], pred.atoms[1], pred.atoms[2])]);
+            runtime.extend([HasTrait(pred.atoms[0], pred.atoms[1], pred.atoms[2])]);
         } else if pred.name == types::facts::PredicateType::RoleAllowsLogin as i32 {
-            runtime.extend(&[RoleAllowsLogin(pred.atoms[0], pred.atoms[1])]);
+            runtime.extend([RoleAllowsLogin(pred.atoms[0], pred.atoms[1])]);
         } else if pred.name == types::facts::PredicateType::RoleDeniesLogin as i32 {
-            runtime.extend(&[RoleDeniesLogin(pred.atoms[0], pred.atoms[1])]);
+            runtime.extend([RoleDeniesLogin(pred.atoms[0], pred.atoms[1])]);
         } else if pred.name == types::facts::PredicateType::RoleAllowsNodeLabel as i32 {
-            runtime.extend(&[RoleAllowsNodeLabel(
+            runtime.extend([RoleAllowsNodeLabel(
                 pred.atoms[0],
                 pred.atoms[1],
                 pred.atoms[2],
             )]);
         } else if pred.name == types::facts::PredicateType::RoleDeniesNodeLabel as i32 {
-            runtime.extend(&[RoleDeniesNodeLabel(
+            runtime.extend([RoleDeniesNodeLabel(
                 pred.atoms[0],
                 pred.atoms[1],
                 pred.atoms[2],
             )]);
         } else if pred.name == types::facts::PredicateType::NodeHasLabel as i32 {
-            runtime.extend(&[NodeHasLabel(pred.atoms[0], pred.atoms[1], pred.atoms[2])]);
+            runtime.extend([NodeHasLabel(pred.atoms[0], pred.atoms[1], pred.atoms[2])]);
         }
     }
 
@@ -231,8 +231,8 @@ pub unsafe extern "C" fn drop_output_struct(output: *mut Output) {
     if db.length > 0 {
         let s = std::slice::from_raw_parts_mut(db.access, db.length);
         let s = s.as_mut_ptr();
-        Box::from_raw(s);
+        drop(Box::from_raw(s));
     }
     // Drop struct
-    Box::from_raw(output);
+    drop(Box::from_raw(output));
 }

--- a/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
@@ -1115,7 +1115,7 @@ mod tests {
         let _pdu_header = vchan::ChannelPDUHeader::decode(&mut payload).unwrap();
         let header = ClipboardPDUHeader::decode(&mut payload).unwrap();
         let format_list =
-            FormatListPDU::<LongFormatName>::decode(&mut payload, header.data_len as u32).unwrap();
+            FormatListPDU::<LongFormatName>::decode(&mut payload, header.data_len).unwrap();
         assert_eq!(ClipboardPDUType::CB_FORMAT_LIST, header.msg_type);
         assert_eq!(1, format_list.format_names.len());
         assert_eq!(

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -1138,7 +1138,7 @@ fn read_rdp_output_inner(client: &Client) -> ReadRdpOutputReturns {
     //
     // Wait for some data to be available on the TCP socket FD before consuming it. This prevents
     // us from locking the mutex in Client permanently while no data is available.
-    while wait_for_fd(tcp_fd as usize) {
+    while wait_for_fd(tcp_fd) {
         let mut err = CGOErrCode::ErrCodeSuccess;
         let res = client.rdp_client.lock().unwrap().read(|rdp_event| {
             // This callback can be called multiple times per rdp_client.read()

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -2985,7 +2985,7 @@ impl FileRenameInformation {
         w.write_u8(Boolean::to_u8(&self.replace_if_exists).unwrap())?;
         // RootDirectory. For network operations, this value MUST be zero.
         w.write_u8(0)?;
-        w.write_u32::<LittleEndian>(self.file_name.len() as u32)?;
+        w.write_u32::<LittleEndian>(self.file_name.len())?;
         w.extend_from_slice(&util::to_unicode(&self.file_name.path, false));
         Ok(w)
     }
@@ -3007,7 +3007,7 @@ impl FileRenameInformation {
     }
 
     fn size(&self) -> u32 {
-        Self::BASE_SIZE + self.file_name.len() as u32
+        Self::BASE_SIZE + self.file_name.len()
     }
 }
 
@@ -3755,7 +3755,7 @@ impl ClientDriveSetInformationResponse {
     fn new(req: &ServerDriveSetInformationRequest, io_status: NTSTATUS) -> Self {
         Self {
             device_io_reply: DeviceIoResponse::new(&req.device_io_request, io_status),
-            length: req.set_buffer.size() as u32,
+            length: req.set_buffer.size(),
         }
     }
 

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/consts.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/consts.rs
@@ -109,6 +109,7 @@ pub enum MinorFunction {
 #[derive(ToPrimitive, FromPrimitive, Debug, PartialEq, Eq, Copy, Clone)]
 #[repr(u32)]
 #[allow(non_camel_case_types)]
+#[allow(clippy::upper_case_acronyms)]
 #[allow(dead_code)]
 pub enum NTSTATUS {
     STATUS_SUCCESS = 0x00000000,

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -841,7 +841,7 @@ impl Encode for ListReaders_Call {
         let mut index = 0;
         self.context.encode_ptr(&mut index, &mut w)?;
         encode_ptr(Some(self.groups_ptr_length), &mut index, &mut w)?; // takes care of encoding groups_ptr
-        let readers_is_null = if self.readers_is_null { 1 } else { 0 };
+        let readers_is_null = u32::from(self.readers_is_null);
         w.write_u32::<LittleEndian>(readers_is_null)?;
         w.write_u32::<LittleEndian>(self.readers_size)?;
 
@@ -1521,7 +1521,7 @@ impl Encode for Status_Call {
 
         let mut index = 0;
         self.handle.encode_ptr(&mut index, &mut w)?;
-        let reader_names_is_null = if self.reader_names_is_null { 1 } else { 0 };
+        let reader_names_is_null = u32::from(self.reader_names_is_null);
         w.write_u32::<LittleEndian>(reader_names_is_null)?;
         w.write_u32::<LittleEndian>(self.reader_length)?;
         w.write_u32::<LittleEndian>(self.atr_length)?;
@@ -1676,7 +1676,7 @@ impl Encode for Transmit_Call {
         } else {
             w.write_u32::<LittleEndian>(0)?;
         }
-        let recv_buffer_is_null = if self.recv_buffer_is_null { 1 } else { 0 };
+        let recv_buffer_is_null = u32::from(self.recv_buffer_is_null);
         w.write_u32::<LittleEndian>(recv_buffer_is_null)?;
         w.write_u32::<LittleEndian>(self.recv_length)?;
 
@@ -1929,7 +1929,7 @@ impl ReadCache_Common {
         encode_ptr(None, index, w)?; // _card_uuid_ptr
 
         w.write_u32::<LittleEndian>(self.freshness_counter)?;
-        let data_is_null = if self.data_is_null { 1 } else { 0 };
+        let data_is_null = u32::from(self.data_is_null);
         w.write_u32::<LittleEndian>(data_is_null)?;
         w.write_u32::<LittleEndian>(self.data_len)?;
 


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/19605 and https://github.com/gravitational/teleport/pull/19643 to branch/v9