### PR TITLE
chore: Bump libcbor from v0.9.0 to v0.10.1

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -22,16 +22,15 @@ RUN apt-get update && \
 # libudev-zero replaces systemd's libudev
 RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 && \
     cd libudev-zero && \
-    [ "$(git rev-parse HEAD)" = "4154cf252c17297f98a8ca33693ead003b4509da" ] && \
+    [ "$(git rev-parse HEAD)" = '4154cf252c17297f98a8ca33693ead003b4509da' ] && \
     make install-static && \
     make clean
 
 # Install libcbor.
-RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
+RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.1 && \
     cd libcbor && \
-    [ "$(git rev-parse HEAD)" = "58b3319b8c3ec15171cb00f01a3a1e9d400899e1" ] && \
+    [ "$(git rev-parse HEAD)" = '5c1bb892c94b6ae2ef99e3c6673d5e0857242f38' ] && \
     cmake \
-        -DCBOR_CUSTOM_ALLOC=ON \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DWITH_EXAMPLES=OFF . && \
@@ -43,7 +42,7 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 # Depends on libcbor, libssl-dev, zlib1g-dev and libudev.
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
-    [ "$(git rev-parse HEAD)" = "659a02679f99fd34a44e06e35dce90794f6ecc86" ] && \
+    [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
     CFLAGS=-pthread cmake \
         -DBUILD_EXAMPLES=OFF \
         -DBUILD_MANPAGES=OFF \

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -21,7 +21,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 # libudev-zero replaces systemd's libudev.
 RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 && \
     cd libudev-zero && \
-    [ "$(git rev-parse HEAD)" = "4154cf252c17297f98a8ca33693ead003b4509da" ] && \
+    [ "$(git rev-parse HEAD)" = '4154cf252c17297f98a8ca33693ead003b4509da' ] && \
     make install-static LIBDIR='$(PREFIX)/lib64'
 
 # Instal openssl.
@@ -29,17 +29,16 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 # install_sw install only binaries, skips docs.
 RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1s && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = "129058165d195e43a0ad10111b0c2e29bdf65980" ] && \
+    [ "$(git rev-parse HEAD)" = '129058165d195e43a0ad10111b0c2e29bdf65980' ] && \
     ./config --release && \
     make && \
     make install_sw
 
 # Install libcbor.
-RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
+RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.1 && \
     cd libcbor && \
-    [ "$(git rev-parse HEAD)" = "58b3319b8c3ec15171cb00f01a3a1e9d400899e1" ] && \
+    [ "$(git rev-parse HEAD)" = '5c1bb892c94b6ae2ef99e3c6673d5e0857242f38' ] && \
     cmake3 \
-        -DCBOR_CUSTOM_ALLOC=ON \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DWITH_EXAMPLES=OFF . && \
@@ -51,7 +50,7 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 # Linked so `make build/tsh` finds the library where it expects it.
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
-    [ "$(git rev-parse HEAD)" = "659a02679f99fd34a44e06e35dce90794f6ecc86" ] && \
+    [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
     scl enable devtoolset-11 "\
       cmake3 \
           -DBUILD_EXAMPLES=OFF \

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -14,8 +14,8 @@ set -eu
 readonly MACOS_VERSION_MIN=10.13
 
 # Note: versions are the same as the corresponding git tags for each repo.
-readonly CBOR_VERSION=v0.9.0
-readonly CBOR_COMMIT=58b3319b8c3ec15171cb00f01a3a1e9d400899e1
+readonly CBOR_VERSION=v0.10.1
+readonly CBOR_COMMIT=5c1bb892c94b6ae2ef99e3c6673d5e0857242f38
 readonly CRYPTO_VERSION=OpenSSL_1_1_1s
 readonly CRYPTO_COMMIT=129058165d195e43a0ad10111b0c2e29bdf65980
 readonly FIDO2_VERSION=1.12.0
@@ -82,7 +82,6 @@ cbor_build() {
   cd "$src"
 
   cmake \
-    -DCBOR_CUSTOM_ALLOC=ON \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="$dest" \
     -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_VERSION_MIN" \


### PR DESCRIPTION
Keep up with latest releases.

Dropped `-DCBOR_CUSTOM_ALLOC=ON`, since it's now obsolete (custom alloc is always on).

Release notes:
* https://github.com/PJK/libcbor/releases/tag/v0.10.0
* https://github.com/PJK/libcbor/releases/tag/v0.10.1