### PR TITLE
[v10] chore: Bump libcbor, libfido2 and OpenSSL

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -33,8 +33,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 
 # Install libfido2.
 # Depends on libcbor, libssl-dev, zlib1g-dev and libudev.
-RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.11.0 && \
+RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
+    [ "$(git rev-parse HEAD)" = "659a02679f99fd34a44e06e35dce90794f6ecc86" ] && \
     CFLAGS=-pthread cmake \
         -DBUILD_EXAMPLES=OFF \
         -DBUILD_MANPAGES=OFF \
@@ -229,11 +230,11 @@ COPY --from=libfido2 /usr/local/lib/pkgconfig/ /usr/local/lib/pkgconfig/
 COPY --from=libfido2 \
     /usr/local/lib/libcbor.a \
     /usr/local/lib/libfido2.a \
-    /usr/local/lib/libfido2.so.1.11.0 \
+    /usr/local/lib/libfido2.so.1.12.0 \
     /usr/local/lib/libudev.a \
     /usr/local/lib/
 RUN cd /usr/local/lib && \
-    ln -s libfido2.so.1.11.0 libfido2.so.1 && \
+    ln -s libfido2.so.1.12.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
     ldconfig
 COPY pkgconfig/buildbox/ /

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -18,13 +18,15 @@ RUN apt-get update && \
 # libudev-zero replaces systemd's libudev
 RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 && \
     cd libudev-zero && \
-    make install-static
+    [ "$(git rev-parse HEAD)" = '4154cf252c17297f98a8ca33693ead003b4509da' ] && \
+    make install-static && \
+    make clean
 
 # Install libcbor.
-RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
+RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.1 && \
     cd libcbor && \
+    [ "$(git rev-parse HEAD)" = '5c1bb892c94b6ae2ef99e3c6673d5e0857242f38' ] && \
     cmake \
-        -DCBOR_CUSTOM_ALLOC=ON \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DWITH_EXAMPLES=OFF . && \
@@ -35,7 +37,7 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 # Depends on libcbor, libssl-dev, zlib1g-dev and libudev.
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
-    [ "$(git rev-parse HEAD)" = "659a02679f99fd34a44e06e35dce90794f6ecc86" ] && \
+    [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
     CFLAGS=-pthread cmake \
         -DBUILD_EXAMPLES=OFF \
         -DBUILD_MANPAGES=OFF \

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -31,7 +31,8 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.1 && \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DWITH_EXAMPLES=OFF . && \
     make && \
-    make install
+    make install && \
+    make clean
 
 # Install libfido2.
 # Depends on libcbor, libssl-dev, zlib1g-dev and libudev.
@@ -44,7 +45,8 @@ RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
         -DBUILD_TOOLS=OFF \
         -DCMAKE_BUILD_TYPE=Release . && \
     make && \
-    make install
+    make install  && \
+    make clean
 
 FROM ubuntu:18.04 AS buildbox
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -22,9 +22,9 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 # Instal openssl.
 # Pulled from source because repository versions are too old.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1r && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1s && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = "fbda8a9e3b6266da377a6f57d597d657257d9cff" ] && \
+    [ "$(git rev-parse HEAD)" = "129058165d195e43a0ad10111b0c2e29bdf65980" ] && \
     ./config --release && \
     make && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -17,6 +17,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 # libudev-zero replaces systemd's libudev
 RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 && \
     cd libudev-zero && \
+    [ "$(git rev-parse HEAD)" = '4154cf252c17297f98a8ca33693ead003b4509da' ] && \
     make install-static LIBDIR='$(PREFIX)/lib64'
 
 # Instal openssl.
@@ -24,16 +25,16 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 # install_sw install only binaries, skips docs.
 RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1s && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = "129058165d195e43a0ad10111b0c2e29bdf65980" ] && \
+    [ "$(git rev-parse HEAD)" = '129058165d195e43a0ad10111b0c2e29bdf65980' ] && \
     ./config --release && \
     make && \
     make install_sw
 
 # Install libcbor.
-RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
+RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.1 && \
     cd libcbor && \
+    [ "$(git rev-parse HEAD)" = '5c1bb892c94b6ae2ef99e3c6673d5e0857242f38' ] && \
     cmake3 \
-        -DCBOR_CUSTOM_ALLOC=ON \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DWITH_EXAMPLES=OFF . && \
@@ -45,7 +46,7 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 # Linked so `make build/tsh` finds the library where it expects it.
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
-    [ "$(git rev-parse HEAD)" = "659a02679f99fd34a44e06e35dce90794f6ecc86" ] && \
+    [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
     scl enable devtoolset-11 "\
       cmake3 \
           -DBUILD_EXAMPLES=OFF \

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -22,9 +22,9 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 # Instal openssl.
 # Pulled from source because repository versions are too old.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1q && \
+RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1r && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = "29708a562a1887a91de0fa6ca668c71871accde9" ] && \
+    [ "$(git rev-parse HEAD)" = "fbda8a9e3b6266da377a6f57d597d657257d9cff" ] && \
     ./config --release && \
     make && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -20,8 +20,9 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 # Instal openssl.
 # Pulled from source because repository versions are too old.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1o && \
+RUN git clone --depth=1 git://git.openssl.org/openssl.git -b OpenSSL_1_1_1q && \
     cd openssl && \
+    [ "$(git rev-parse HEAD)" = "29708a562a1887a91de0fa6ca668c71871accde9" ] && \
     ./config --release && \
     make && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -3,9 +3,11 @@ FROM centos:7 AS libfido2
 
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
+    yum install -y centos-release-scl-rh && \
     yum update -y && \
     yum install -y \
         cmake3 \
+        devtoolset-11-gcc* \
         git \
         libudev-devel \
         zlib-devel && \
@@ -41,18 +43,18 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.9.0 && \
 # Install libfido2.
 # Depends on libcbor, openssl, zlib-devel and libudev.
 # Linked so `make build/tsh` finds the library where it expects it.
-RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.11.0 && \
+RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
-    cmake3 \
-        -DBUILD_EXAMPLES=OFF \
-        -DBUILD_MANPAGES=OFF \
-        -DBUILD_TOOLS=OFF \
-        -DCMAKE_BUILD_TYPE=Release . && \
-    make && \
+    [ "$(git rev-parse HEAD)" = "659a02679f99fd34a44e06e35dce90794f6ecc86" ] && \
+    scl enable devtoolset-11 "\
+      cmake3 \
+          -DBUILD_EXAMPLES=OFF \
+          -DBUILD_MANPAGES=OFF \
+          -DBUILD_TOOLS=OFF \
+          -DCMAKE_BUILD_TYPE=Release . && \
+      make" && \
     make install && \
-# Update ld.
-    echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
-    ldconfig
+    make clean
 
 FROM centos:7 AS libbpf
 
@@ -172,20 +174,21 @@ COPY --from=libfido2 \
     /usr/local/lib64/libcrypto.a \
     /usr/local/lib64/libcrypto.so.1.1 \
     /usr/local/lib64/libfido2.a \
-    /usr/local/lib64/libfido2.so.1.11.0 \
+    /usr/local/lib64/libfido2.so.1.12.0 \
     /usr/local/lib64/libssl.a \
     /usr/local/lib64/libssl.so.1.1 \
     /usr/local/lib64/libudev.a \
     /usr/local/lib64/
-RUN cd /usr/local/lib64 && \
 # Re-create usual lib64 links.
+RUN cd /usr/local/lib64 && \
     ln -s libcrypto.so.1.1 libcrypto.so && \
-    ln -s libfido2.so.1.11.0 libfido2.so.1 && \
+    ln -s libfido2.so.1.12.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
     ln -s libssl.so.1.1 libssl.so && \
 # Update ld.
     echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
     ldconfig
+# Configure pkg-config.
 COPY pkgconfig/centos7/ /
 ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
 

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -14,8 +14,8 @@ set -eu
 readonly MACOS_VERSION_MIN=10.13
 
 # Note: versions are the same as the corresponding git tags for each repo.
-readonly CBOR_VERSION=v0.9.0
-readonly CBOR_COMMIT=58b3319b8c3ec15171cb00f01a3a1e9d400899e1
+readonly CBOR_VERSION=v0.10.1
+readonly CBOR_COMMIT=5c1bb892c94b6ae2ef99e3c6673d5e0857242f38
 readonly CRYPTO_VERSION=OpenSSL_1_1_1s
 readonly CRYPTO_COMMIT=129058165d195e43a0ad10111b0c2e29bdf65980
 readonly FIDO2_VERSION=1.12.0
@@ -82,7 +82,6 @@ cbor_build() {
   cd "$src"
 
   cmake \
-    -DCBOR_CUSTOM_ALLOC=ON \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="$dest" \
     -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_VERSION_MIN" \

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -16,8 +16,8 @@ readonly MACOS_VERSION_MIN=10.13
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.9.0
 readonly CBOR_COMMIT=58b3319b8c3ec15171cb00f01a3a1e9d400899e1
-readonly CRYPTO_VERSION=OpenSSL_1_1_1r
-readonly CRYPTO_COMMIT=fbda8a9e3b6266da377a6f57d597d657257d9cff
+readonly CRYPTO_VERSION=OpenSSL_1_1_1s
+readonly CRYPTO_COMMIT=129058165d195e43a0ad10111b0c2e29bdf65980
 readonly FIDO2_VERSION=1.12.0
 readonly FIDO2_COMMIT=659a02679f99fd34a44e06e35dce90794f6ecc86
 
@@ -226,7 +226,11 @@ EOF
 }
 
 cleanup() {
-  for path in "${CLEANUPS[@]}"; do
+  # The strange looking expansion below (`${arr[@]+"${arr[@]}"}`) avoids unbound
+  # errors when the array is empty. (The actual expansion is quoted.)
+  # See https://stackoverflow.com/a/7577209.
+  #shellcheck disable=SC2068
+  for path in ${CLEANUPS[@]+"${CLEANUPS[@]}"}; do
     echo "Removing: $path" >&2
     rm -fr "$path"
   done

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -15,7 +15,7 @@ readonly MACOS_VERSION_MIN=10.13
 
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.9.0
-readonly CRYPTO_VERSION=OpenSSL_1_1_1o
+readonly CRYPTO_VERSION=OpenSSL_1_1_1q
 readonly FIDO2_VERSION=1.11.0
 
 readonly LIB_CACHE="/tmp/teleport-fido2-cache"

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -15,8 +15,11 @@ readonly MACOS_VERSION_MIN=10.13
 
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.9.0
-readonly CRYPTO_VERSION=OpenSSL_1_1_1q
+readonly CBOR_COMMIT=58b3319b8c3ec15171cb00f01a3a1e9d400899e1
+readonly CRYPTO_VERSION=OpenSSL_1_1_1r
+readonly CRYPTO_COMMIT=fbda8a9e3b6266da377a6f57d597d657257d9cff
 readonly FIDO2_VERSION=1.12.0
+readonly FIDO2_COMMIT=659a02679f99fd34a44e06e35dce90794f6ecc86
 
 readonly LIB_CACHE="/tmp/teleport-fido2-cache"
 readonly PKGFILE_DIR="$LIB_CACHE/fido2-${FIDO2_VERSION}_cbor-${CBOR_VERSION}_crypto-${CRYPTO_VERSION}"
@@ -26,19 +29,22 @@ readonly CBOR_PATH="$LIB_CACHE/cbor-$CBOR_VERSION"
 readonly CRYPTO_PATH="$LIB_CACHE/crypto-$CRYPTO_VERSION"
 readonly FIDO2_PATH="$LIB_CACHE/fido2-$FIDO2_VERSION"
 
+# List of folders/files to remove on exit.
+# See cleanup and main.
+CLEANUPS=()
+
 fetch_and_build() {
   local name="$1"      # eg, cbor
   local version="$2"   # eg, v0.9.0
-  local url="$3"       # eg, https://github.com/...
-  local buildcmd="$4"  # eg, cbor_build, a bash function name
+  local commit="$3"    # eg, 58b3319b8c3ec15171cb00f01a3a1e9d400899e1
+  local url="$4"       # eg, https://github.com/...
+  local buildcmd="$5"  # eg, cbor_build, a bash function name
   echo "$name: fetch and build" >&2
 
   mkdir -p "$LIB_CACHE"
   local tmp=''
   tmp="$(mktemp -d "$LIB_CACHE/build.XXXXXX")"
-  # Early expansion on purpose.
-  #shellcheck disable=SC2064
-  trap "rm -fr '$tmp'" EXIT
+  CLEANUPS+=("$tmp")
 
   local fullname="$name-$version"
   local install_path="$tmp/$fullname"
@@ -46,6 +52,13 @@ fetch_and_build() {
   cd "$tmp"
   git clone --depth=1 -b "$version" "$url"
   cd "$(ls)"  # a single folder exists at this point
+  local head
+  head="$(git rev-parse HEAD)"
+  if [[ "$head" != "$commit" ]]; then
+    echo "Found unexpected HEAD commit for $name, aborting: $head" >&2
+    exit 1
+  fi
+
   mkdir -p "$install_path"
   eval "$buildcmd '$PWD' '$install_path'"
 
@@ -83,7 +96,8 @@ cbor_build() {
 
 cbor_fetch_and_build() {
   fetch_and_build \
-    cbor "$CBOR_VERSION" 'https://github.com/pjk/libcbor.git' cbor_build
+    cbor "$CBOR_VERSION" "$CBOR_COMMIT" 'https://github.com/pjk/libcbor.git' \
+    cbor_build
 }
 
 crypto_build() {
@@ -109,7 +123,8 @@ crypto_build() {
 
 crypto_fetch_and_build() {
   fetch_and_build \
-    crypto "$CRYPTO_VERSION" 'https://github.com/openssl/openssl.git' \
+    crypto "$CRYPTO_VERSION" "$CRYPTO_COMMIT" \
+    'https://github.com/openssl/openssl.git' \
     crypto_build
 }
 
@@ -135,15 +150,15 @@ fido2_build() {
 
 fido2_fetch_and_build() {
   fetch_and_build \
-    fido2 "$FIDO2_VERSION" 'https://github.com/Yubico/libfido2.git' fido2_build
+    fido2 "$FIDO2_VERSION" "$FIDO2_COMMIT" \
+    'https://github.com/Yubico/libfido2.git' \
+    fido2_build
 }
 
 fido2_compile_toy() {
   local toydir=''
   toydir="$(mktemp -d)"
-  # Early expansion on purpose.
-  #shellcheck disable=SC2064
-  trap "rm -fr '$toydir'" EXIT
+  CLEANUPS+=("$toydir")
 
   cat >"$toydir/toy.c" <<EOF
 #include <fido.h>
@@ -184,9 +199,7 @@ build() {
   if [[ ! -f "$pkgfile" ]]; then
     local tmp=''
     tmp="$(mktemp)"  # file, not dir!
-    # Early expansion on purpose.
-    #shellcheck disable=SC2064
-    trap "rm -f '$tmp'" EXIT
+    CLEANUPS+=("$tmp")
 
     # Write libfido2-static.pc to tmp.
     cat >"$tmp" <<EOF
@@ -212,11 +225,19 @@ EOF
   fi
 }
 
+cleanup() {
+  for path in "${CLEANUPS[@]}"; do
+    echo "Removing: $path" >&2
+    rm -fr "$path"
+  done
+}
+
 main() {
   if [[ $# -ne 1 ]]; then
     usage
     exit 1
   fi
+  trap cleanup EXIT
 
   case "$1" in
     build)

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -16,7 +16,7 @@ readonly MACOS_VERSION_MIN=10.13
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.9.0
 readonly CRYPTO_VERSION=OpenSSL_1_1_1q
-readonly FIDO2_VERSION=1.11.0
+readonly FIDO2_VERSION=1.12.0
 
 readonly LIB_CACHE="/tmp/teleport-fido2-cache"
 readonly PKGFILE_DIR="$LIB_CACHE/fido2-${FIDO2_VERSION}_cbor-${CBOR_VERSION}_crypto-${CRYPTO_VERSION}"

--- a/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libfido2-static.pc
+++ b/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libfido2-static.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: libfido2
 Description: A FIDO2 library
 URL: https://github.com/yubico/libfido2
-Version: 1.11.0
+Version: 1.12.0
 Requires: libcrypto-static
 # libfido2, libcbor and libudev combined here for simplicity.
 Libs: ${libdir}/libfido2.a ${libdir}/libcbor.a ${libdir}/libudev.a -pthread

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -6,6 +6,6 @@ enginesdir=${libdir}/engines-1.1
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 1.1.1o
+Version: 1.1.1q
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libfido2-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libfido2-static.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: libfido2
 Description: A FIDO2 library
 URL: https://github.com/yubico/libfido2
-Version: 1.11.0
+Version: 1.12.0
 Requires: libcrypto-static
 # libfido2, libcbor and libudev combined here for simplicity.
 Libs: ${libdir}/libfido2.a ${libdir}/libcbor.a ${libdir}/libudev.a -pthread


### PR DESCRIPTION
Bumps libcbor and OpenSSL to their latest versions.

Backports the following PRs:

* https://github.com/gravitational/teleport/pull/19797
* https://github.com/gravitational/teleport/pull/18009
* https://github.com/gravitational/teleport/pull/17927
* https://github.com/gravitational/teleport/pull/16732
* https://github.com/gravitational/teleport/pull/16573