### PR TITLE
[v11] Remove watcher for DatabaseService for RemoteProxy

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -176,7 +176,6 @@ func ForRemoteProxy(cfg Config) Config {
 		{Kind: types.KindRemoteCluster},
 		{Kind: types.KindKubeService},
 		{Kind: types.KindDatabaseServer},
-		{Kind: types.KindDatabaseService},
 		{Kind: types.KindKubeServer},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize


### PR DESCRIPTION
This was causing an issue where if we connected a root cluster with v>=11.1.4 and a leaf cluster v<11.1.4, the leaf cluster wouldn't know about the DatabaseService resource and fail to set up the cache.

This commit removes the watcher for DatabaseService for RemoteProxies.

It shouldn't be required for Remote Proxies to watch this resource kind. Its scope is very limited: Discover Day 1.

An issue can occur if:
- user is going through the Discover Flow
- selects database and enters its endpoint
- there's no Database Service proxying the database
- the user installs the Database Service in a leaf cluster The UI wouldn't detect this new Database Service and show an error to the user saying that the Agent was not detected.
To fix this particular situation, the user could re-create the Database, but this time it would work because there's at least one proxy for the Database (it would work on 3rd step)

Fixes https://github.com/gravitational/teleport/issues/19907