### PR TITLE
Add remote mfa support with local agent forwarding

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -984,6 +984,7 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 		localAgentCfg.KeyringOpts = []ExtendedKeyringOpt{
 			WithKeyExtension(localAgentCfg.ClientStore),
 			WithSignExtension(),
+			WithPromptMFAChallengeExtension(),
 		}
 	}
 

--- a/lib/client/extended_keyring.go
+++ b/lib/client/extended_keyring.go
@@ -520,7 +520,7 @@ func promptMFAChallengeExtensionHandler(r *extendedKeyring) extensionHandler {
 			return nil, trace.Wrap(err)
 		}
 
-		mfaResp, err := PromptMFAChallenge(context.Background(), &challengeReq, req.ProxyAddr, &challengeOpts)
+		mfaResp, err := promptMFAStandalone(context.Background(), &challengeReq, req.ProxyAddr, &challengeOpts)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/client/extended_keyring.go
+++ b/lib/client/extended_keyring.go
@@ -491,13 +491,19 @@ func callKeyExtension(agent agent.ExtendedAgent) (*profile.Profile, *ForwardedKe
 	return &profile, &forwardedKey, nil
 }
 
+// KeyExtensionResponse is a request object for the prompt-mfa-challenge@goteleport.com extension.
 type promptMFAChallengeRequest struct {
-	ProxyAddr         string
-	MFAChallengeBlob  []byte
-	ChallengeOptsBlob []byte
+	// ProxyAddr is the teleport proxy address that this challenge originated from.
+	ProxyAddr string
+	// MFAChallengeBlob is a json encoded *proto.MFAAuthenticateChallenge.
+	MFAChallengeBlob []byte
+	// MFAChallengeOptsBlob is a json encoded *proto.PromptMFAChallengeOpts.
+	MFAChallengeOptsBlob []byte
 }
 
+// KeyExtensionResponse is a response object for the prompt-mfa-challenge@goteleport.com extension.
 type promptMFAChallengeResponse struct {
+	// MFAChallengeResponseBlob is a json encoded *proto.MFAAuthenticateRespons.
 	MFAChallengeResponseBlob []byte
 }
 
@@ -516,7 +522,7 @@ func promptMFAChallengeExtensionHandler(r *extendedKeyring) extensionHandler {
 		}
 
 		var challengeOpts PromptMFAChallengeOpts
-		if err := json.Unmarshal(req.ChallengeOptsBlob, &challengeOpts); err != nil {
+		if err := json.Unmarshal(req.MFAChallengeOptsBlob, &challengeOpts); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -554,9 +560,9 @@ func callPromptMFAChallengeExtension(agent agent.ExtendedAgent, proxyAddr string
 	}
 
 	req := promptMFAChallengeRequest{
-		ProxyAddr:         proxyAddr,
-		MFAChallengeBlob:  challengeBlob,
-		ChallengeOptsBlob: challengeOptsBlob,
+		ProxyAddr:            proxyAddr,
+		MFAChallengeBlob:     challengeBlob,
+		MFAChallengeOptsBlob: challengeOptsBlob,
 	}
 
 	respBlob, err := agent.Extension(promptMFAChallengeAgentExtension, ssh.Marshal(req))

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -29,7 +29,6 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/gravitational/teleport"
-
 	"github.com/gravitational/teleport/api/client/proto"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -252,7 +252,8 @@ func (ns *NodeSession) createServerSession(ctx context.Context) (*tracessh.Sessi
 		log.Debugf("Forwarding system key agent.")
 		targetAgent = ns.nodeClient.TC.localAgent.sshAgent
 	case ForwardAgentLocal:
-		log.Warnf("Forwarding local agent. This operation is insecure as it can put your current Teleport credentials at risk. It should only be used on trusted hosts.")
+		log.Debugf("Forwarding local agent.")
+		fmt.Fprintln(ns.nodeClient.TC.Stdout, "WARNING: Local agent forwarding is insecure and can put your current Teleport credentials at risk. It should only be used on trusted hosts.")
 		targetAgent = ns.nodeClient.TC.localAgent.ExtendedAgent
 	default:
 		log.Debugf("No Key Agent selected.")


### PR DESCRIPTION
This PR implements the `prompt-mfa-challenge@goteleport.com` extension described in https://github.com/gravitational/teleport/pull/18032.

When a remote agent connection is discovered with support for this extension, it will be used instead of local mfa prompt. This only affects functionality for `tsh ssh -o "ForwardAgent local"`.

Note: this feature is not currently used for remote mfa login, but this can be done as well.

based off of https://github.com/gravitational/teleport/pull/19421

Updates https://github.com/gravitational/teleport/issues/1648