### PR TITLE
Enable device authorization for k8s access

### DIFF
--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -178,8 +178,6 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 		ClusterName: teleportClusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
-		// TODO(codingllama): Enable after testing.
-		DisableDeviceAuthorization: true,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3758,8 +3758,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
-			// TODO(codingllama): Enable after testing.
-			DisableDeviceAuthorization: true,
 		})
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
Follow up on #19659 by enabling device authorization for k8s access.

All relevant changes and tests are already part of the aforementioned PR, I was simply holding this out until I could do more thorough manual testing.

Without session MFA:

```shell
$ tsh logout; tsh login
$ kubectl get ns
> ERROR: unauthorized device
> 
> Unable to connect to the server: getting credentials: exec: executable tsh failed with exit code 1

$ ./tsh logout; ./tsh login # tsh signed for device authn
$ kubectl get ns
> NAME                 STATUS   AGE
> default              Active   27h
> kube-node-lease      Active   27h
> kube-public          Active   27h
> kube-system          Active   27h
> local-path-storage   Active   27h
> teleport             Active   126m
```

With session MFA:

```shell
$ tsh logout; tsh login
$ kubectl get ns
> ERROR: rpc error: code = PermissionDenied desc = unauthorized device
>
> Unable to connect to the server: getting credentials: exec: executable tsh failed with exit code 1

$ ./tsh logout; ./tsh login # tsh signed for device authn
$ kubectl get ns
> Tap any security key
*taps*
> NAME                 STATUS   AGE
> default              Active   27h
> kube-node-lease      Active   27h
> kube-public          Active   27h
> kube-system          Active   27h
> local-path-storage   Active   27h
> teleport             Active   122m
```

https://github.com/gravitational/teleport.e/issues/514