### PR TITLE
Fix panic when printing ascii table while running in debugger

### DIFF
--- a/lib/asciitable/table.go
+++ b/lib/asciitable/table.go
@@ -72,7 +72,7 @@ func MakeTable(headers []string, rows ...[]string) Table {
 // width.
 func MakeTableWithTruncatedColumn(columnOrder []string, rows [][]string, truncatedColumn string) Table {
 	width, _, err := term.GetSize(int(os.Stdin.Fd()))
-	if err != nil {
+	if err != nil || width == 0 {
 		width = 80
 	}
 	truncatedColMinSize := 16


### PR DESCRIPTION
When running in debugger `width` was returning as 0, even though there was no error (thanks @tigrato for investigation). This resulted in panic further down the code, because column maxCellLength ended up to be negative.