### PR TITLE
[Discover] Fix yaml formatting with yaml lists for db join token request

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5824,6 +5824,8 @@ func TestCreateDatabase(t *testing.T) {
 	username := "someuser"
 	roleCreateDatabase, err := types.NewRole(services.RoleNameForUser(username), types.RoleSpecV6{
 		Allow: types.RoleConditions{
+			DatabaseNames: []string{"name1"},
+			DatabaseUsers: []string{"user1"},
 			Rules: []types.Rule{
 				types.NewRule(types.KindDatabase,
 					[]string{types.VerbCreate}),
@@ -5853,6 +5855,7 @@ func TestCreateDatabase(t *testing.T) {
 				Name:     "mydatabase",
 				Protocol: "mysql",
 				URI:      "someuri:3306",
+				Labels:   []ui.Label{},
 			},
 			expectedStatus: http.StatusOK,
 			errAssert:      require.NoError,
@@ -5945,6 +5948,21 @@ func TestCreateDatabase(t *testing.T) {
 		for _, label := range tt.req.Labels {
 			require.Contains(t, databaseLabels, label.Name, "label not found")
 			require.Equal(t, label.Value, databaseLabels[label.Name], "label exists but has unexpected value")
+		}
+
+		// Check response value:
+		if tt.expectedStatus == http.StatusOK {
+			result := ui.Database{}
+			require.NoError(t, json.Unmarshal(resp.Bytes(), &result))
+			require.Equal(t, result, ui.Database{
+				Name:          tt.req.Name,
+				Protocol:      tt.req.Protocol,
+				Type:          types.DatabaseTypeSelfHosted,
+				Labels:        tt.req.Labels,
+				Hostname:      "someuri",
+				DatabaseUsers: []string{"user1"},
+				DatabaseNames: []string{"name1"},
+			})
 		}
 	}
 }

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -123,7 +123,16 @@ func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p
 		return nil, trace.Wrap(err)
 	}
 
-	return ui.MakeDatabase(database, nil /* dbUsers */, nil /* dbNames */), nil
+	accessChecker, err := sctx.GetUserAccessChecker()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	dbNames, dbUsers, err := getDatabaseUsersAndNames(accessChecker)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.MakeDatabase(database, dbUsers, dbNames), nil
 }
 
 // updateDatabaseRequest contains some updatable fields of a database resource.

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -347,7 +347,7 @@ func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter
 	var dbServiceResourceLabels []string
 	if settings.databaseInstallMode {
 		suggestedAgentMatcherLabels := token.GetSuggestedAgentMatcherLabels()
-		dbServiceResourceLabels, err = scripts.MarshalLabelsYAML(suggestedAgentMatcherLabels)
+		dbServiceResourceLabels, err = scripts.MarshalLabelsYAML(suggestedAgentMatcherLabels, 6)
 		if err != nil {
 			return "", trace.Wrap(err)
 		}

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -608,6 +608,7 @@ func TestGetDatabaseJoinScript(t *testing.T) {
 					SuggestedAgentMatcherLabels: types.Labels{
 						"env":     utils.Strings{"prod"},
 						"product": utils.Strings{"*"},
+						"os":      utils.Strings{"mac", "linux"},
 					},
 				},
 			}
@@ -656,6 +657,9 @@ db_service:
   resources:
     - labels:
         env: prod
+        os:
+          - mac
+          - linux
         product: '*'
 `)
 			},

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -18,6 +18,7 @@ package scripts
 
 import (
 	_ "embed"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -51,9 +52,15 @@ var installNodeBashScript string
 
 var InstallNodeBashScript = template.Must(template.New("nodejoin").Parse(installNodeBashScript))
 
-// MarshalLabelsYAML returns a list of strings, each one containing a label key/value pair.
+// MarshalLabelsYAML returns a list of strings, each one containing a
+// label key and list of value's pair.
 // This is used to create yaml sections within the join scripts.
-func MarshalLabelsYAML(resourceMatcherLabels types.Labels) ([]string, error) {
+//
+// The arg `extraListIndent` allows adding `extra` indent space on
+// top of the default space already used, for the default yaml listing
+// format (the listing values with the dashes). If `extraListIndent`
+// is zero, it's equivalent to using default space only (which is 4 spaces).
+func MarshalLabelsYAML(resourceMatcherLabels types.Labels, extraListIndent int) ([]string, error) {
 	if len(resourceMatcherLabels) == 0 {
 		return []string{"{}"}, nil
 	}
@@ -69,13 +76,24 @@ func MarshalLabelsYAML(resourceMatcherLabels types.Labels) ([]string, error) {
 	sort.Strings(labelKeys)
 
 	for _, labelName := range labelKeys {
-		labelValue := resourceMatcherLabels[labelName]
-		bs, err := yaml.Marshal(map[string]utils.Strings{labelName: labelValue})
+		labelValues := resourceMatcherLabels[labelName]
+		bs, err := yaml.Marshal(map[string]utils.Strings{labelName: labelValues})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		ret = append(ret, strings.TrimSpace(string(bs)))
+		labelStr := strings.TrimSpace(string(bs))
+		if len(labelValues) > 1 && extraListIndent > 0 {
+			words := strings.Split(labelStr, "\n")
+			// Skip the first word, since that is the label key.
+			// Add extra spaces defined by `yamlListIndent` arg.
+			for i := 1; i < len(words); i++ {
+				words[i] = fmt.Sprintf("%s%s", strings.Repeat(" ", extraListIndent), words[i])
+			}
+			labelStr = strings.Join(words, "\n")
+		}
+
+		ret = append(ret, labelStr)
 	}
 
 	return ret, nil

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -84,17 +84,22 @@ func MarshalLabelsYAML(resourceMatcherLabels types.Labels, extraListIndent int) 
 
 		labelStr := strings.TrimSpace(string(bs))
 		if len(labelValues) > 1 && extraListIndent > 0 {
-			words := strings.Split(labelStr, "\n")
-			// Skip the first word, since that is the label key.
-			// Add extra spaces defined by `yamlListIndent` arg.
-			for i := 1; i < len(words); i++ {
-				words[i] = fmt.Sprintf("%s%s", strings.Repeat(" ", extraListIndent), words[i])
-			}
-			labelStr = strings.Join(words, "\n")
+			labelStr = addExtraListIndentToYAMLLabelStr(labelStr, extraListIndent)
 		}
 
 		ret = append(ret, labelStr)
 	}
 
 	return ret, nil
+}
+
+func addExtraListIndentToYAMLLabelStr(labelStr string, indent int) string {
+	words := strings.Split(labelStr, "\n")
+	// Skip the first word, since that is the label key.
+	// Add extra spaces defined by `yamlListIndent` arg.
+	for i := 1; i < len(words); i++ {
+		words[i] = fmt.Sprintf("%s%s", strings.Repeat(" ", indent), words[i])
+	}
+
+	return strings.Join(words, "\n")
 }

--- a/lib/web/scripts/install_node_test.go
+++ b/lib/web/scripts/install_node_test.go
@@ -26,9 +26,10 @@ import (
 
 func TestMarshalLabelsYAML(t *testing.T) {
 	for _, tt := range []struct {
-		name     string
-		labels   types.Labels
-		expected []string
+		name           string
+		labels         types.Labels
+		numExtraIndent int
+		expected       []string
 	}{
 		{
 			name:     "empty",
@@ -50,8 +51,18 @@ func TestMarshalLabelsYAML(t *testing.T) {
 			},
 			expected: []string{`dev: '*'`, `product: scripts`},
 		},
+		{
+			name: "multiple label values",
+			labels: types.Labels{
+				"dev":     utils.Strings{types.Wildcard},
+				"env":     utils.Strings{"dev1", "dev2"},
+				"product": utils.Strings{"scripts"},
+			},
+			expected:       []string{"dev: '*'", "env:\n      - dev1\n      - dev2", "product: scripts"},
+			numExtraIndent: 2,
+		},
 	} {
-		got, err := MarshalLabelsYAML(tt.labels)
+		got, err := MarshalLabelsYAML(tt.labels, tt.numExtraIndent)
 		require.NoError(t, err)
 
 		require.Equal(t, tt.expected, got)

--- a/lib/web/scripts/install_node_test.go
+++ b/lib/web/scripts/install_node_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package scripts
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -65,6 +66,6 @@ func TestMarshalLabelsYAML(t *testing.T) {
 		got, err := MarshalLabelsYAML(tt.labels, tt.numExtraIndent)
 		require.NoError(t, err)
 
-		require.Equal(t, tt.expected, got)
+		require.YAMLEq(t, strings.Join(tt.expected, "\n"), strings.Join(got, "\n"))
 	}
 }


### PR DESCRIPTION
#### Description
Ran into issue that prevented the database agent from starting where given a list of key values for a label, the default yaml list format was not spaced correctly. This was present in the join token script where we create `teleport.yaml`:

Example misformat
```
db_service:
  enabled: "yes"
  resources:
    - labels:
        env: test
        fruit:
    - apple
    - banana
    - carrot
        os: mac
```

Should be:
```
db_service:
  enabled: "yes"
  resources:
    - labels:
        env: test
        fruit:
          - apple
          - banana
          - carrot
        os: mac
```

Also snuck in returning db users and names (result from access checker) when creating database