### PR TITLE
[v11] Add rate limiter to saml/oidc routes

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -598,13 +598,13 @@ func (h *Handler) bindDefaultEndpoints() {
 	// OIDC related callback handlers
 	h.GET("/webapi/oidc/login/web", h.WithRedirect(h.oidcLoginWeb))
 	h.GET("/webapi/oidc/callback", h.WithMetaRedirect(h.oidcCallback))
-	h.POST("/webapi/oidc/login/console", httplib.MakeHandler(h.oidcLoginConsole))
+	h.POST("/webapi/oidc/login/console", h.WithLimiter(h.oidcLoginConsole))
 
 	// SAML 2.0 handlers
 	h.POST("/webapi/saml/acs", h.WithMetaRedirect(h.samlACS))
 	h.POST("/webapi/saml/acs/:connector", h.WithMetaRedirect(h.samlACS))
 	h.GET("/webapi/saml/sso", h.WithMetaRedirect(h.samlSSO))
-	h.POST("/webapi/saml/login/console", httplib.MakeHandler(h.samlSSOConsole))
+	h.POST("/webapi/saml/login/console", h.WithLimiter(h.samlSSOConsole))
 
 	// Github connector handlers
 	h.GET("/webapi/github/login/web", h.WithRedirect(h.githubLoginWeb))


### PR DESCRIPTION
This is a backport of adding the rate limiter to routes that are currently in the `e` submodule but in v11 were in the main repo. It is an extension of #19869. 