### PR TITLE
Skip device authentication based on Ping

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -391,6 +391,9 @@ type AuthenticationSettings struct {
 	Github *GithubSettings `json:"github,omitempty"`
 	// PrivateKeyPolicy contains the cluster-wide private key policy.
 	PrivateKeyPolicy keys.PrivateKeyPolicy `json:"private_key_policy"`
+	// DeviceTrustDisabled provides a clue to Teleport clients on whether to avoid
+	// device authentication.
+	DeviceTrustDisabled bool `json:"device_trust_disabled,omitempty"`
 
 	// HasMessageOfTheDay is a flag indicating that the cluster has MOTD
 	// banner text that must be retrieved, displayed and acknowledged by

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -428,17 +428,9 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 		SshAuthorizedKey: key.Cert,
 	}
 
-	// Reset dtAuthnRunCeremony after tests.
-	oldIgnorePing := *client.DTAttemptLoginIgnorePing
-	oldRunCeremony := *client.DTAuthnRunCeremony
-	t.Cleanup(func() {
-		*client.DTAttemptLoginIgnorePing = oldIgnorePing
-		*client.DTAuthnRunCeremony = oldRunCeremony
-	})
-
 	t.Run("device login", func(t *testing.T) {
 		// We need this because the running standalone process is not Enterprise.
-		*client.DTAttemptLoginIgnorePing = true
+		teleportClient.SetDTAttemptLoginIgnorePing(true)
 
 		// validatingRunCeremony checks the parameters passed to dtAuthnRunCeremony
 		// and returns validCerts on success.
@@ -455,7 +447,7 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 			}
 			return validCerts, nil
 		}
-		*client.DTAuthnRunCeremony = validatingRunCeremony
+		teleportClient.SetDTAuthnRunCeremony(validatingRunCeremony)
 
 		// Sanity check that we can do authenticated actions before
 		// AttemptDeviceLogin.
@@ -486,11 +478,11 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 
 	t.Run("attempt login respects ping", func(t *testing.T) {
 		runCeremonyCalled := false
-		*client.DTAttemptLoginIgnorePing = false
-		*client.DTAuthnRunCeremony = func(_ context.Context, _ devicepb.DeviceTrustServiceClient, _ *devicepb.UserCertificates) (*devicepb.UserCertificates, error) {
+		teleportClient.SetDTAttemptLoginIgnorePing(false)
+		teleportClient.SetDTAuthnRunCeremony(func(_ context.Context, _ devicepb.DeviceTrustServiceClient, _ *devicepb.UserCertificates) (*devicepb.UserCertificates, error) {
 			runCeremonyCalled = true
 			return nil, errors.New("dtAuthnRunCeremony called unexpectedly")
-		}
+		})
 
 		// Sanity check the Ping response.
 		resp, err := teleportClient.Ping(ctx)

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -429,49 +429,81 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 	}
 
 	// Reset dtAuthnRunCeremony after tests.
+	oldIgnorePing := *client.DTAttemptLoginIgnorePing
 	oldRunCeremony := *client.DTAuthnRunCeremony
-	t.Cleanup(func() { *client.DTAuthnRunCeremony = oldRunCeremony })
-
-	// validatingRunCeremony checks the parameters passed to dtAuthnRunCeremony
-	// and returns validCerts on success.
-	validatingRunCeremony := func(_ context.Context, devicesClient devicepb.DeviceTrustServiceClient, certs *devicepb.UserCertificates) (*devicepb.UserCertificates, error) {
-		switch {
-		case devicesClient == nil:
-			return nil, errors.New("want non-nil devicesClient")
-		case certs == nil:
-			return nil, errors.New("want non-nil certs")
-		case len(certs.SshAuthorizedKey) == 0:
-			return nil, errors.New("want non-empty certs.SshAuthorizedKey")
-		}
-		return validCerts, nil
-	}
-	*client.DTAuthnRunCeremony = validatingRunCeremony
-
-	// Sanity check that we can do authenticated actions before
-	// AttemptDeviceLogin.
-	authenticatedAction := func() error {
-		// Any authenticated action would do.
-		_, err := teleportClient.ListAllNodes(ctx)
-		return err
-	}
-	require.NoError(t, authenticatedAction(), "Authenticated action failed *before* AttemptDeviceLogin")
-
-	// Test! Exercise DeviceLogin.
-	got, err := teleportClient.DeviceLogin(ctx, &devicepb.UserCertificates{
-		SshAuthorizedKey: key.Cert,
+	t.Cleanup(func() {
+		*client.DTAttemptLoginIgnorePing = oldIgnorePing
+		*client.DTAuthnRunCeremony = oldRunCeremony
 	})
-	require.NoError(t, err, "DeviceLogin failed")
-	require.Equal(t, validCerts, got, "DeviceLogin mismatch")
 
-	// Test! Exercise AttemptDeviceLogin.
-	// Absence of errors is good enough here, since we know that DeviceLogin
-	// works based on the assertions above.
-	require.NoError(t,
-		teleportClient.AttemptDeviceLogin(ctx, key),
-		"AttemptDeviceLogin failed")
+	t.Run("device login", func(t *testing.T) {
+		// We need this because the running standalone process is not Enterprise.
+		*client.DTAttemptLoginIgnorePing = true
 
-	// Verify that the "new" key was applied correctly.
-	require.NoError(t, authenticatedAction(), "Authenticated action failed after AttemptDeviceLogin")
+		// validatingRunCeremony checks the parameters passed to dtAuthnRunCeremony
+		// and returns validCerts on success.
+		var runCeremonyCalls int
+		validatingRunCeremony := func(_ context.Context, devicesClient devicepb.DeviceTrustServiceClient, certs *devicepb.UserCertificates) (*devicepb.UserCertificates, error) {
+			runCeremonyCalls++
+			switch {
+			case devicesClient == nil:
+				return nil, errors.New("want non-nil devicesClient")
+			case certs == nil:
+				return nil, errors.New("want non-nil certs")
+			case len(certs.SshAuthorizedKey) == 0:
+				return nil, errors.New("want non-empty certs.SshAuthorizedKey")
+			}
+			return validCerts, nil
+		}
+		*client.DTAuthnRunCeremony = validatingRunCeremony
+
+		// Sanity check that we can do authenticated actions before
+		// AttemptDeviceLogin.
+		authenticatedAction := func() error {
+			// Any authenticated action would do.
+			_, err := teleportClient.ListAllNodes(ctx)
+			return err
+		}
+		require.NoError(t, authenticatedAction(), "Authenticated action failed *before* AttemptDeviceLogin")
+
+		// Test! Exercise DeviceLogin.
+		got, err := teleportClient.DeviceLogin(ctx, &devicepb.UserCertificates{
+			SshAuthorizedKey: key.Cert,
+		})
+		require.NoError(t, err, "DeviceLogin failed")
+		require.Equal(t, validCerts, got, "DeviceLogin mismatch")
+		assert.Equal(t, 1, runCeremonyCalls, `DeviceLogin didn't call dtAuthnRunCeremony()`)
+
+		// Test! Exercise AttemptDeviceLogin.
+		require.NoError(t,
+			teleportClient.AttemptDeviceLogin(ctx, key),
+			"AttemptDeviceLogin failed")
+		assert.Equal(t, 2, runCeremonyCalls, `AttemptDeviceLogin didn't call dtAuthnRunCeremony()`)
+
+		// Verify that the "new" key was applied correctly.
+		require.NoError(t, authenticatedAction(), "Authenticated action failed *after* AttemptDeviceLogin")
+	})
+
+	t.Run("attempt login respects ping", func(t *testing.T) {
+		runCeremonyCalled := false
+		*client.DTAttemptLoginIgnorePing = false
+		*client.DTAuthnRunCeremony = func(_ context.Context, _ devicepb.DeviceTrustServiceClient, _ *devicepb.UserCertificates) (*devicepb.UserCertificates, error) {
+			runCeremonyCalled = true
+			return nil, errors.New("dtAuthnRunCeremony called unexpectedly")
+		}
+
+		// Sanity check the Ping response.
+		resp, err := teleportClient.Ping(ctx)
+		require.NoError(t, err, "Ping failed")
+		require.True(t, resp.Auth.DeviceTrustDisabled, "Expected device trust to be disabled for Teleport OSS")
+
+		// Test!
+		// AttemptDeviceLogin should obey Ping and not attempt the ceremony.
+		require.NoError(t,
+			teleportClient.AttemptDeviceLogin(ctx, key),
+			"AttemptDeviceLogin failed")
+		assert.False(t, runCeremonyCalled, "AttemptDeviceLogin called DeviceLogin/dtAuthnRunCeremony, despite the Ping response")
+	})
 }
 
 type standaloneBundle struct {

--- a/lib/client/export_test.go
+++ b/lib/client/export_test.go
@@ -14,5 +14,6 @@
 
 package client
 
+var DTAttemptLoginIgnorePing = &dtAttemptLoginIgnorePing
 var DTAuthnRunCeremony = &dtAuthnRunCeremony
 var HasTouchIDCredentials = &hasTouchIDCredentials

--- a/lib/client/export_test.go
+++ b/lib/client/export_test.go
@@ -14,6 +14,12 @@
 
 package client
 
-var DTAttemptLoginIgnorePing = &dtAttemptLoginIgnorePing
-var DTAuthnRunCeremony = &dtAuthnRunCeremony
 var HasTouchIDCredentials = &hasTouchIDCredentials
+
+func (tc *TeleportClient) SetDTAttemptLoginIgnorePing(val bool) {
+	tc.dtAttemptLoginIgnorePing = val
+}
+
+func (tc *TeleportClient) SetDTAuthnRunCeremony(fn dtAuthnRunCeremonyFunc) {
+	tc.dtAuthnRunCeremony = fn
+}


### PR DESCRIPTION
AttemptDeviceLogin, which is the main entry point for device authentication, now checks the Ping response and skips the attempt entirely if device trust is disabled.

The main objective is to avoid a needless roundtrip if the feature is disabled, as one should only pay for what is in use.

There's actual little consequence in attempting the roundtrip, apart from the added latency on logins, so I've gone with a negative flag ("Disabled" instead of "Enabled"). The negative is less harmful if, for some reason, it's wrongly absent (say, because of some future Ping code branch).

https://github.com/gravitational/teleport.e/issues/514