### PR TITLE
[v11] Add redirects to the new Audit Events section (#19553)

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2126,6 +2126,16 @@
       "source": "/getting-started/",
       "destination": "/try-out-teleport/introduction/",
       "permanent": true
+    },
+    {
+      "source": "/management/guides/fluentd/",
+      "destination": "/management/export-audit-events/fluentd/",
+      "permanent": true
+    },
+    {
+      "source": "/management/guides/elastic-stack/",
+      "destination": "/management/export-audit-events/elastic-stack/",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
The changes in #17405 added a section to the docs for guides to exporting audit events, and moved guides from
`docs/pages/management/guides`, but failed to add redirects. This change adds the missing redirects.