### PR TITLE
[v10] Use one Buf workspace instead of three

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -922,18 +922,15 @@ protos/all: protos/build protos/lint protos/format
 .PHONY: protos/build
 protos/build: buf/installed
 	$(BUF) build
-	cd lib/teleterm && $(BUF) build
 
 .PHONY: protos/format
 protos/format: buf/installed
 	$(BUF) format -w
-	cd lib/teleterm && $(BUF) format -w
 
 .PHONY: protos/lint
 protos/lint: buf/installed
 	$(BUF) lint
-	cd api/proto && $(BUF) lint --config=buf-legacy.yaml
-	cd lib/teleterm && $(BUF) lint
+	$(BUF) lint --config=api/proto/buf-legacy.yaml api/proto
 
 .PHONY: lint-protos
 lint-protos: protos/lint
@@ -977,7 +974,7 @@ grpc-teleterm:
 # Unlike grpc-teleterm, this target runs locally.
 .PHONY: grpc-teleterm/host
 grpc-teleterm/host: protos/all
-	cd lib/teleterm && $(BUF) generate
+	$(BUF) generate --template=lib/teleterm/buf.gen.yaml lib/teleterm/api/proto
 
 .PHONY: goinstall
 goinstall:

--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,4 +1,5 @@
 version: v1
 directories:
   - api/proto
+  - lib/teleterm/api/proto
   - proto

--- a/build.assets/genproto.sh
+++ b/build.assets/genproto.sh
@@ -12,7 +12,8 @@ main() {
   # the correct relative path.
   trap 'rm -fr github.com' EXIT   # don't leave github.com/ behind
   rm -fr api/gen/proto gen/proto  # cleanup gen/proto folders
-  buf generate
+  buf generate api/proto
+  buf generate proto
   cp -r github.com/gravitational/teleport/* .
 }
 

--- a/lib/teleterm/buf.gen.yaml
+++ b/lib/teleterm/buf.gen.yaml
@@ -6,21 +6,21 @@ plugins:
   # protoc itself may be the latest one.
   # $ go install github.com/golang/protobuf/protoc-gen-go@v1.4.3
   - name: go
-    out: api/protogen/golang
+    out: lib/teleterm/api/protogen/golang
     opt:
       - plugins=grpc
       - paths=source_relative
 
   - name: js
-    out: api/protogen/js
+    out: lib/teleterm/api/protogen/js
     opt:
       - import_style=commonjs,binary
 
   - name: grpc
-    out: api/protogen/js
+    out: lib/teleterm/api/protogen/js
     opt: grpc_js
     path: grpc_tools_node_protoc_plugin
 
   - name: ts
-    out: api/protogen/js
+    out: lib/teleterm/api/protogen/js
     opt: "service=grpc-node"

--- a/lib/teleterm/buf.work.yaml
+++ b/lib/teleterm/buf.work.yaml
@@ -1,3 +1,0 @@
-version: v1
-directories:
-  - api/proto


### PR DESCRIPTION
Backport #19774.

It's a similar situation to the backport to v11 (#19990) with the exception that we don't have lib/prehog to worry about.