### PR TITLE
Fix Machine ID Certificate TTL on IAM join

### DIFF
--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -588,6 +588,7 @@ func registerUsingIAMMethod(joinServiceClient joinServiceClient, token string, p
 					DNSNames:             params.DNSNames,
 					PublicTLSKey:         params.PublicTLSKey,
 					PublicSSHKey:         params.PublicSSHKey,
+					Expires:              params.Expires,
 				},
 				StsIdentityRequest: signedRequest,
 			}, nil


### PR DESCRIPTION
Closes #16691 

The Expires field is set on all other join methods, but was not set for IAM, which uses a different RPC. This PR rectifies it not being set for the IAM RPC.