### PR TITLE
Trim error messages on UserLogin events

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -131,7 +131,7 @@ func (e *Exec) TrimToMaxSize(maxSize int) AuditEvent {
 // craft a request that creates error messages too large to be handled by the
 // underlying storage and thus cause the events to be omitted entirely. See
 // teleport-private#172.
-func (e *UserLogin) TrimToMaxSize(maxSize int) AuditEvent {
+func (e *UserLogin) TrimToMaxSize(maxSize int) *UserLogin {
 	size := e.Size()
 	if size <= maxSize {
 		return e

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -125,3 +125,30 @@ func (e *Exec) TrimToMaxSize(maxSize int) AuditEvent {
 
 	return out
 }
+
+// TrimToMaxSize trims the UserLogin event to the given maximum size.
+// The initial implementation is to cover concerns that a malicious user could
+// craft a request that creates error messages too large to be handled by the
+// underlying storage and thus cause the events to be ommitted entirely. See
+// teleport-private#172.
+func (e *UserLogin) TrimToMaxSize(maxSize int) AuditEvent {
+	size := e.Size()
+	if size <= maxSize {
+		return e
+	}
+
+	out := proto.Clone(e).(*UserLogin)
+	out.Status.Error = ""
+	out.Status.UserMessage = ""
+
+	// Use 10% max size ballast + message size without Error and UserMessage
+	sizeBallast := maxSize/10 + out.Size()
+	maxSize -= sizeBallast
+
+	maxFieldSize := maxSizePerField(maxSize, 2)
+
+	out.Status.Error = trimN(e.Status.Error, maxFieldSize)
+	out.Status.UserMessage = trimN(e.Status.UserMessage, maxFieldSize)
+
+	return out
+}

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -131,7 +131,7 @@ func (e *Exec) TrimToMaxSize(maxSize int) AuditEvent {
 // craft a request that creates error messages too large to be handled by the
 // underlying storage and thus cause the events to be omitted entirely. See
 // teleport-private#172.
-func (e *UserLogin) TrimToMaxSize(maxSize int) *UserLogin {
+func (e *UserLogin) TrimToMaxSize(maxSize int) AuditEvent {
 	size := e.Size()
 	if size <= maxSize {
 		return e

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -129,7 +129,7 @@ func (e *Exec) TrimToMaxSize(maxSize int) AuditEvent {
 // TrimToMaxSize trims the UserLogin event to the given maximum size.
 // The initial implementation is to cover concerns that a malicious user could
 // craft a request that creates error messages too large to be handled by the
-// underlying storage and thus cause the events to be ommitted entirely. See
+// underlying storage and thus cause the events to be omitted entirely. See
 // teleport-private#172.
 func (e *UserLogin) TrimToMaxSize(maxSize int) AuditEvent {
 	size := e.Size()


### PR DESCRIPTION
### Purpose

Truncate error messages in failed UserLogin events so that the event isn't omitted because it is too large for the underlying storage. See gravitational/teleport-private#172.

### Implementation

Certain user supplied variables can end up in error messages causing the audit message to be too large for the underlying storage which causes them to be omitted. This PR truncates the error messages by implementing the messageSizeTrimmer.