### PR TITLE
[v11] Remove RW on `license` and `download` from preset editor role (#19997)

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -73,8 +73,6 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindDatabase, RW()),
 					types.NewRule(types.KindDatabaseCertificate, RW()),
 					types.NewRule(types.KindInstaller, RW()),
-					types.NewRule(types.KindLicense, RO()),
-					types.NewRule(types.KindDownload, RO()),
 					types.NewRule(types.KindInstance, RO()),
 					// Please see defaultAllowRules when adding a new rule.
 				},


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/19997 to v11