### PR TITLE
Update watched resources for RemoteOldProxy cache

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -221,6 +221,7 @@ func ForOldRemoteProxy(cfg Config) Config {
 		{Kind: types.KindRemoteCluster},
 		{Kind: types.KindKubeService},
 		{Kind: types.KindDatabaseServer},
+		{Kind: types.KindKubeServer},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize
 	return cfg

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1193,15 +1193,15 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 }
 
 // createRemoteAccessPoint creates a new access point for the remote cluster.
-// Checks if the cluster that is connecting is a pre-v11 cluster. If it is,
-// we disable the watcher for types.KindKubeServer and types.KindKubeCluster resources
-// since both resources are not supported in a v10 leaf cluster.
+// Checks if the cluster that is connecting is a pre-v12 cluster. If it is,
+// we disable the watcher for resources not supported in a v11 leaf cluster:
+// - types.KindDatabaseService
 //
 // **WARNING**: Ensure that the version below matches the version in which backward incompatible
 // changes were introduced so that the cache is created successfully. Otherwise, the remote cache may
 // never become healthy due to unknown resources.
 func createRemoteAccessPoint(srv *server, clt auth.ClientI, version, domainName string) (auth.RemoteProxyAccessPoint, error) {
-	ok, err := utils.MinVerWithoutPreRelease(version, utils.VersionBeforeAlpha("11.0.0"))
+	ok, err := utils.MinVerWithoutPreRelease(version, utils.VersionBeforeAlpha("12.0.0"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -170,9 +170,15 @@ func TestCreateRemoteAccessPoint(t *testing.T) {
 			assertion: require.Error,
 		},
 		{
-			name:      "remote running 11.0.0",
+			name:      "remote running 12.0.0",
 			assertion: require.NoError,
-			version:   "11.0.0",
+			version:   "12.0.0",
+		},
+		{
+			name:           "remote running 11.0.0",
+			assertion:      require.NoError,
+			version:        "11.0.0",
+			oldRemoteProxy: true,
 		},
 		{
 			name:           "remote running 10.0.0",


### PR DESCRIPTION
Update the version we should check against: v12 (the current in master)

Update the list of resources to watch for RemoteOldProxy. The list should be equal to the RemoteProxy as seen in `branch/v11`

As soon as we cut v12, we should update this again in master because we'll be preparing v13.