### PR TITLE
Fix CertificateInvalidError in formatCertError

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -243,7 +243,7 @@ func formatCertError(err error) string {
 	}
 
 	var certInvalidErr x509.CertificateInvalidError
-	if errors.As(err, &x509.CertificateInvalidError{}) {
+	if errors.As(err, &certInvalidErr) {
 		return fmt.Sprintf(`WARNING:
 
   The certificate presented by the proxy is invalid: %v.


### PR DESCRIPTION
Fix the formatting of `x509.CertificateInvalidError` in `lib/utils.formatCertError`; currently, this always displays `The certificate presented by the proxy is invalid: x509: unknown error.`.