### PR TITLE
Remove default type from cert rotation

### DIFF
--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -45,7 +45,7 @@ const (
 )
 
 // CertAuthTypes lists all certificate authority types.
-var CertAuthTypes = []CertAuthType{HostCA, UserCA, DatabaseCA, JWTSigner, AllCAsType}
+var CertAuthTypes = []CertAuthType{HostCA, UserCA, DatabaseCA, JWTSigner}
 
 // Check checks if certificate authority type value is correct
 func (c CertAuthType) Check() error {

--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -38,10 +38,14 @@ const (
 	// certificates but rather is an authority that signs tokens, however it behaves
 	// much like a CA in terms of rotation and storage.
 	JWTSigner CertAuthType = "jwt"
+	// AllCAsType is a special type that represents all CertAuthTypes.
+	// DEPRECATED, DELETE IN 14.0.0. For more information see:
+	// https://github.com/gravitational/teleport/issues/17493
+	AllCAsType CertAuthType = "all"
 )
 
 // CertAuthTypes lists all certificate authority types.
-var CertAuthTypes = []CertAuthType{HostCA, UserCA, DatabaseCA, JWTSigner}
+var CertAuthTypes = []CertAuthType{HostCA, UserCA, DatabaseCA, JWTSigner, AllCAsType}
 
 // Check checks if certificate authority type value is correct
 func (c CertAuthType) Check() error {

--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -38,7 +38,7 @@ const (
 	// certificates but rather is an authority that signs tokens, however it behaves
 	// much like a CA in terms of rotation and storage.
 	JWTSigner CertAuthType = "jwt"
-	// AllCAsType is a special type that represents all CertAuthTypes.
+	// CertAuthTypeAll is a special type that represents all CertAuthTypes.
 	// DEPRECATED, DELETE IN 14.0.0. For more information see:
 	// https://github.com/gravitational/teleport/issues/17493
 	CertAuthTypeAll CertAuthType = "all"

--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -41,7 +41,7 @@ const (
 	// AllCAsType is a special type that represents all CertAuthTypes.
 	// DEPRECATED, DELETE IN 14.0.0. For more information see:
 	// https://github.com/gravitational/teleport/issues/17493
-	AllCAsType CertAuthType = "all"
+	CertAuthTypeAll CertAuthType = "all"
 )
 
 // CertAuthTypes lists all certificate authority types.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4252,6 +4252,8 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	clusterMain := "rotate-main"
 	clusterAux := "rotate-aux"
 
+	allTypes := types.CertAuthType("all")
+
 	tconf := suite.rotationConfig(false)
 	main := suite.newNamedTeleportInstance(t, clusterMain)
 	aux := suite.newNamedTeleportInstance(t, clusterAux)
@@ -4348,7 +4350,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.CertAuthType("all"),
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -4383,6 +4385,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// update clients
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -4428,6 +4431,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// complete rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseStandby,
 		Mode:        types.RotationModeManual,
 	})

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3996,6 +3996,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -4011,6 +4012,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// update clients
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -4038,6 +4040,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// move to the next phase
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
@@ -4067,6 +4070,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// complete rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseStandby,
 		Mode:        types.RotationModeManual,
 	})
@@ -4160,6 +4164,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -4172,6 +4177,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -4199,6 +4205,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// move to the next phase
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
@@ -4212,6 +4219,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// complete rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseRollback,
 		Mode:        types.RotationModeManual,
 	})

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3946,7 +3946,6 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 		teleport.AddUser(login, []string{login})
 	}
 
-	allTypes := types.CertAuthType("all")
 	tconf := suite.rotationConfig(true)
 	config, err := teleport.GenerateConfig(t, nil, tconf)
 	require.NoError(t, err)
@@ -3997,7 +3996,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -4013,7 +4012,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// update clients
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -4041,7 +4040,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// move to the next phase
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
@@ -4071,7 +4070,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// complete rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseStandby,
 		Mode:        types.RotationModeManual,
 	})
@@ -4113,7 +4112,6 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	allTypes := types.CertAuthType("all")
 	tconf := s.rotationConfig(true)
 	teleport := s.NewTeleportInstance(t)
 	defer teleport.StopAll()
@@ -4166,7 +4164,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -4179,7 +4177,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -4207,7 +4205,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// move to the next phase
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
@@ -4221,7 +4219,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// complete rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseRollback,
 		Mode:        types.RotationModeManual,
 	})
@@ -4261,8 +4259,6 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	clusterMain := "rotate-main"
 	clusterAux := "rotate-aux"
-
-	allTypes := types.CertAuthType("all")
 
 	tconf := suite.rotationConfig(false)
 	main := suite.newNamedTeleportInstance(t, clusterMain)
@@ -4360,7 +4356,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -4395,7 +4391,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// update clients
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -4415,7 +4411,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// move to the next phase
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
@@ -4442,7 +4438,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// complete rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        allTypes,
+		Type:        types.AllCAsType,
 		TargetPhase: types.RotationPhaseStandby,
 		Mode:        types.RotationModeManual,
 	})

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3946,6 +3946,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 		teleport.AddUser(login, []string{login})
 	}
 
+	allTypes := types.CertAuthType("all")
 	tconf := suite.rotationConfig(true)
 	config, err := teleport.GenerateConfig(t, nil, tconf)
 	require.NoError(t, err)
@@ -4112,6 +4113,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	allTypes := types.CertAuthType("all")
 	tconf := s.rotationConfig(true)
 	teleport := s.NewTeleportInstance(t)
 	defer teleport.StopAll()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3996,7 +3996,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -4012,7 +4012,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// update clients
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -4040,7 +4040,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// move to the next phase
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
@@ -4070,7 +4070,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 
 	// complete rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseStandby,
 		Mode:        types.RotationModeManual,
 	})
@@ -4164,7 +4164,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -4177,7 +4177,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -4205,7 +4205,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// move to the next phase
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
@@ -4219,7 +4219,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 
 	// complete rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseRollback,
 		Mode:        types.RotationModeManual,
 	})
@@ -4356,7 +4356,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
@@ -4391,7 +4391,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// update clients
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseUpdateClients,
 		Mode:        types.RotationModeManual,
 	})
@@ -4411,7 +4411,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// move to the next phase
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})
@@ -4438,7 +4438,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// complete rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
-		Type:        types.AllCAsType,
+		Type:        types.CertAuthTypeAll,
 		TargetPhase: types.RotationPhaseStandby,
 		Mode:        types.RotationModeManual,
 	})

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4405,6 +4405,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// move to the next phase
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        allTypes,
 		TargetPhase: types.RotationPhaseUpdateServers,
 		Mode:        types.RotationModeManual,
 	})

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4348,6 +4348,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 
 	// start rotation
 	err = svc.GetAuthServer().RotateCertAuthority(ctx, auth.RotateRequest{
+		Type:        types.CertAuthType("all"),
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -304,11 +304,7 @@ func (c *Client) CreateCertAuthority(ca types.CertAuthority) error {
 
 // RotateCertAuthority starts or restarts certificate authority rotation process.
 func (c *Client) RotateCertAuthority(ctx context.Context, req RotateRequest) error {
-	caType := "all"
-	if req.Type != "" {
-		caType = string(req.Type)
-	}
-	_, err := c.PostJSON(ctx, c.Endpoint("authorities", caType, "rotate"), req)
+	_, err := c.PostJSON(ctx, c.Endpoint("authorities", string(req.Type), "rotate"), req)
 	return trace.Wrap(err)
 }
 

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -88,7 +88,7 @@ func (r *RotateRequest) CheckAndSetDefaults(clock clockwork.Clock) error {
 	if r.Mode == "" {
 		r.Mode = types.RotationModeManual
 	}
-	// Type all is valid too but will be deprecated in a future release.
+	// types.CertAuthTypeAll is valid too but will be deprecated in a future release.
 	// See: https://github.com/gravitational/teleport/issues/17493
 	if err := r.Type.Check(); err != nil && r.Type != types.CertAuthTypeAll {
 		return trace.Wrap(err)

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -88,7 +88,8 @@ func (r *RotateRequest) CheckAndSetDefaults(clock clockwork.Clock) error {
 	if r.Mode == "" {
 		r.Mode = types.RotationModeManual
 	}
-	// Type all is valid too.
+	// Type all is valid too but will be deprecated in a future release.
+	// See: https://github.com/gravitational/teleport/issues/17493
 	if err := r.Type.Check(); err != nil && r.Type != "all" {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -90,7 +90,7 @@ func (r *RotateRequest) CheckAndSetDefaults(clock clockwork.Clock) error {
 	}
 	// Type all is valid too but will be deprecated in a future release.
 	// See: https://github.com/gravitational/teleport/issues/17493
-	if err := r.Type.Check(); err != nil && r.Type != "all" {
+	if err := r.Type.Check(); err != nil && r.Type != types.AllCAsType {
 		return trace.Wrap(err)
 	}
 	if r.GracePeriod == nil {

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -63,7 +63,7 @@ type RotateRequest struct {
 // Types returns cert authority types requested to be rotated.
 func (r *RotateRequest) Types() []types.CertAuthType {
 	switch r.Type {
-	case "all":
+	case types.AllCAsType:
 		return types.CertAuthTypes[:]
 	case types.HostCA:
 		return []types.CertAuthType{types.HostCA}

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -63,7 +63,7 @@ type RotateRequest struct {
 // Types returns cert authority types requested to be rotated.
 func (r *RotateRequest) Types() []types.CertAuthType {
 	switch r.Type {
-	case "":
+	case "all":
 		return types.CertAuthTypes[:]
 	case types.HostCA:
 		return []types.CertAuthType{types.HostCA}
@@ -88,8 +88,8 @@ func (r *RotateRequest) CheckAndSetDefaults(clock clockwork.Clock) error {
 	if r.Mode == "" {
 		r.Mode = types.RotationModeManual
 	}
-	// Empty r.Type is valid too.
-	if err := r.Type.Check(); err != nil && r.Type != "" {
+	// Type all is valid too.
+	if err := r.Type.Check(); err != nil && r.Type != "all" {
 		return trace.Wrap(err)
 	}
 	if r.GracePeriod == nil {

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -63,7 +63,7 @@ type RotateRequest struct {
 // Types returns cert authority types requested to be rotated.
 func (r *RotateRequest) Types() []types.CertAuthType {
 	switch r.Type {
-	case types.AllCAsType:
+	case types.CertAuthTypeAll:
 		return types.CertAuthTypes[:]
 	case types.HostCA:
 		return []types.CertAuthType{types.HostCA}
@@ -90,7 +90,7 @@ func (r *RotateRequest) CheckAndSetDefaults(clock clockwork.Clock) error {
 	}
 	// Type all is valid too but will be deprecated in a future release.
 	// See: https://github.com/gravitational/teleport/issues/17493
-	if err := r.Type.Check(); err != nil && r.Type != types.AllCAsType {
+	if err := r.Type.Check(); err != nil && r.Type != types.CertAuthTypeAll {
 		return trace.Wrap(err)
 	}
 	if r.GracePeriod == nil {

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -279,7 +279,7 @@ func (a *AuthCommand) RotateCertAuthority(ctx context.Context, client auth.Clien
 	if a.rotateType == "" {
 		return trace.BadParameter("required flag --type not provided; previous versions defaulted to --type=all which is deprecated and will be removed in a future version")
 	}
-	if a.rotateType == "all" {
+	if a.rotateType == types.AllCAsType {
 		fmt.Println("\033[0;31mNOTICE:\033[0m --type=all will be deprecated in a future version")
 	}
 
@@ -853,9 +853,10 @@ func getDatabaseServer(ctx context.Context, clientAPI auth.ClientI, dbName strin
 }
 
 func getCertAuthTypes() []string {
-	t := []string{string(types.AllCAsType)}
+	t := make([]string, 0, len(types.CertAuthTypes)+1)
 	for _, at := range types.CertAuthTypes {
 		t = append(t, string(at))
 	}
+	t = append(t, string(types.AllCAsType))
 	return t
 }

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -280,8 +280,9 @@ func (a *AuthCommand) RotateCertAuthority(ctx context.Context, client auth.Clien
 		return trace.BadParameter("required flag --type not provided; previous versions defaulted to --type=all which is deprecated and will be removed in a future version")
 	}
 	if a.rotateType == "all" {
-		log.Warningln("--type=all will be deprecated in a future version")
+		fmt.Println("\033[0;31mNOTICE:\033[0m --type=all will be deprecated in a future version")
 	}
+
 	req := auth.RotateRequest{
 		Type:        types.CertAuthType(a.rotateType),
 		GracePeriod: &a.rotateGracePeriod,

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -132,7 +132,7 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, config *service.Confi
 		Default(fmt.Sprintf("%v", defaults.RotationGracePeriod)).
 		DurationVar(&a.rotateGracePeriod)
 	a.authRotate.Flag("manual", "Activate manual rotation , set rotation phases manually").BoolVar(&a.rotateManualMode)
-	a.authRotate.Flag("type", fmt.Sprintf("Certificate authority to rotate, must be one of: %s", strings.Join(getCertAuthTypes(), ", "))).StringVar(&a.rotateType)
+	a.authRotate.Flag("type", fmt.Sprintf("Certificate authority to rotate, one of: %s", strings.Join(getCertAuthTypes(), ", "))).EnumVar(&a.rotateType, getCertAuthTypes()...)
 	a.authRotate.Flag("phase", fmt.Sprintf("Target rotation phase to set, used in manual rotation, one of: %v", strings.Join(types.RotatePhases, ", "))).StringVar(&a.rotateTargetPhase)
 
 	a.authLS = auth.Command("ls", "List connected auth servers")

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -853,7 +853,7 @@ func getDatabaseServer(ctx context.Context, clientAPI auth.ClientI, dbName strin
 }
 
 func getCertAuthTypes() []string {
-	t := []string{"all"}
+	var t []string
 	for _, at := range types.CertAuthTypes {
 		t = append(t, string(at))
 	}

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -279,7 +279,7 @@ func (a *AuthCommand) RotateCertAuthority(ctx context.Context, client auth.Clien
 	if a.rotateType == "" {
 		return trace.BadParameter("required flag --type not provided; previous versions defaulted to --type=all which is deprecated and will be removed in a future version")
 	}
-	if a.rotateType == types.AllCAsType {
+	if a.rotateType == string(types.CertAuthTypeAll) {
 		fmt.Println("\033[0;31mNOTICE:\033[0m --type=all will be deprecated in a future version")
 	}
 
@@ -857,6 +857,6 @@ func getCertAuthTypes() []string {
 	for _, at := range types.CertAuthTypes {
 		t = append(t, string(at))
 	}
-	t = append(t, string(types.AllCAsType))
+	t = append(t, string(types.CertAuthTypeAll))
 	return t
 }

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -132,7 +132,7 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, config *service.Confi
 		Default(fmt.Sprintf("%v", defaults.RotationGracePeriod)).
 		DurationVar(&a.rotateGracePeriod)
 	a.authRotate.Flag("manual", "Activate manual rotation , set rotation phases manually").BoolVar(&a.rotateManualMode)
-	a.authRotate.Flag("type", "Certificate authority to rotate, rotates host, user and database CA by default").StringVar(&a.rotateType)
+	a.authRotate.Flag("type", fmt.Sprintf("Certificate authority to rotate, must be one of: %s", strings.Join(getCertAuthTypes(), ", "))).Required().StringVar(&a.rotateType)
 	a.authRotate.Flag("phase", fmt.Sprintf("Target rotation phase to set, used in manual rotation, one of: %v", strings.Join(types.RotatePhases, ", "))).StringVar(&a.rotateTargetPhase)
 
 	a.authLS = auth.Command("ls", "List connected auth servers")
@@ -843,4 +843,12 @@ func getDatabaseServer(ctx context.Context, clientAPI auth.ClientI, dbName strin
 	}
 
 	return nil, trace.NotFound("database %q not found", dbName)
+}
+
+func getCertAuthTypes() []string {
+	t := []string{"all"}
+	for _, at := range types.CertAuthTypes {
+		t = append(t, string(at))
+	}
+	return t
 }

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -853,7 +853,7 @@ func getDatabaseServer(ctx context.Context, clientAPI auth.ClientI, dbName strin
 }
 
 func getCertAuthTypes() []string {
-	var t []string
+	t := []string{string(types.AllCAsType)}
 	for _, at := range types.CertAuthTypes {
 		t = append(t, string(at))
 	}


### PR DESCRIPTION
### Purpose

Remove the default cert rotation (implicit --type=all) that currently rotates all certs at once when a user does `tctl auth rotate`. This is the start to addressing gravitational/teleport#17493.

### Implementation

Remove the command line default of rotating all certs and force the user to explicitly use `--type=all` to rotate all certs. Docs changes to discourage this will be forthcoming.

#### UI changes

When passing in an invalid type the user will see:

```
$ tctl auth rotate --type=jello
usage: tctl auth rotate [<flags>]

Rotate certificate authorities in the cluster

Flags:
<... Snipped for brevity ...>
      --type          Certificate authority to rotate, must be one of: all, host, user, db, jwt
<... Snipped for brevity ...>

Aliases:

ERROR: enum value must be one of all,host,user,db,jwt, got 'jello'
```

When omitting `--type` the user will see:

```
$ tctl auth rotate          
ERROR: required flag --type not provided; previous versions defaulted to --type=all which is deprecated and will be removed in a future version
```

When using `--type=all` the user will see:

```
tctl auth rotate --type=all 
NOTICE: --type=all will be deprecated in a future version
```

The above is similar to the error messages from Kingpin.