### PR TITLE
GCP CLI support: add support for `gsutil`.

### DIFF
--- a/tool/tsh/gcp.go
+++ b/tool/tsh/gcp.go
@@ -17,6 +17,7 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
+	"hash/fnv"
 	"net"
 	"os"
 	"os/exec"
@@ -38,6 +39,7 @@ import (
 
 const (
 	gcloudCLIBinaryName = "gcloud"
+	gsutilCLIBinaryName = "gsutil"
 )
 
 func onGcloud(cf *CLIConf) error {
@@ -63,12 +65,38 @@ func onGcloud(cf *CLIConf) error {
 	return app.RunCommand(cmd)
 }
 
+func onGsutil(cf *CLIConf) error {
+	app, err := pickActiveGCPApp(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = app.StartLocalProxies()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	defer func() {
+		if err := app.Close(); err != nil {
+			log.WithError(err).Error("Failed to close GCP app.")
+		}
+	}()
+
+	args := cf.GCPCommandArgs
+
+	cmd := exec.Command(gsutilCLIBinaryName, args...)
+	return app.RunCommand(cmd)
+}
+
 // gcpApp is an GCP app that can start local proxies to serve GCP APIs.
 type gcpApp struct {
 	cf      *CLIConf
 	profile *client.ProfileStatus
 	app     tlsca.RouteToApp
 	secret  string
+	// prefix is a prefix added to the name of configuration files, allowing two instances of gcpApp
+	// to run concurrently without overwriting each other files.
+	prefix string
 
 	localALPNProxy    *alpnproxy.LocalProxy
 	localForwardProxy *alpnproxy.ForwardProxy
@@ -80,11 +108,17 @@ func newGCPApp(cf *CLIConf, profile *client.ProfileStatus, app tlsca.RouteToApp)
 	if err != nil {
 		return nil, err
 	}
+
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(secret))
+	prefix := fmt.Sprintf("%x", h.Sum32())
+
 	return &gcpApp{
 		cf:      cf,
 		profile: profile,
 		app:     app,
 		secret:  secret,
+		prefix:  prefix,
 	}, nil
 }
 
@@ -106,6 +140,11 @@ func getGCPSecret() (string, error) {
 // The request flow to remote server (i.e. GCP APIs) looks like this:
 // clients -> local forward proxy -> local ALPN proxy -> remote server
 func (a *gcpApp) StartLocalProxies() error {
+	// configuration files
+	if err := a.writeBotoConfig(); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// HTTPS proxy mode
 	if err := a.startLocalALPNProxy(""); err != nil {
 		return trace.Wrap(err)
@@ -119,12 +158,15 @@ func (a *gcpApp) StartLocalProxies() error {
 // Close makes all necessary close calls.
 func (a *gcpApp) Close() error {
 	var errs []error
+	// close proxies
 	if a.localALPNProxy != nil {
 		errs = append(errs, a.localALPNProxy.Close())
 	}
 	if a.localForwardProxy != nil {
 		errs = append(errs, a.localForwardProxy.Close())
 	}
+	// remove boto config
+	errs = append(errs, a.removeBotoConfig()...)
 	return trace.NewAggregate(errs...)
 }
 
@@ -161,6 +203,56 @@ func projectIDFromServiceAccountName(serviceAccount string) (string, error) {
 	return projectID, nil
 }
 
+// removeBotoConfig removes config files written by WriteBotoConfig.
+func (a *gcpApp) removeBotoConfig() []error {
+	// try to remove both files
+	return []error{os.Remove(a.getExternalAccountFilePath()), os.Remove(a.getBotoConfigPath())}
+}
+
+func (a *gcpApp) getBotoConfigDir() string {
+	return path.Join(profile.FullProfilePath(a.cf.HomePath), "gcp", a.app.ClusterName, a.app.Name)
+}
+
+func (a *gcpApp) getBotoConfigPath() string {
+	return path.Join(a.getBotoConfigDir(), a.prefix+"_boto.cfg")
+}
+
+func (a *gcpApp) getExternalAccountFilePath() string {
+	return path.Join(a.getBotoConfigDir(), a.prefix+"_external.json")
+}
+
+// getBotoConfig returns minimal boto configuration, referencing an external account file.
+func (a *gcpApp) getBotoConfig() string {
+	return fmt.Sprintf(`[Credentials]
+gs_external_account_authorized_user_file = %v
+`, a.getExternalAccountFilePath())
+}
+
+// getExternalAccountFile returns the contents of external account file, which depend on a current secret.
+func (a *gcpApp) getExternalAccountFile() string {
+	return fmt.Sprintf(`{ "type": "external_account_authorized_user","token": %q }`, a.secret)
+}
+
+// writeBotoConfig writes app-specific boto configuration file as well as external account file, referenced in boto config.
+func (a *gcpApp) writeBotoConfig() error {
+	err := os.MkdirAll(a.getBotoConfigDir(), 0700)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = os.WriteFile(a.getBotoConfigPath(), []byte(a.getBotoConfig()), 0644)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = os.WriteFile(a.getExternalAccountFilePath(), []byte(a.getExternalAccountFile()), 0644)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
 // GetEnvVars returns required environment variables to configure the
 // clients.
 func (a *gcpApp) GetEnvVars() (map[string]string, error) {
@@ -185,6 +277,10 @@ func (a *gcpApp) GetEnvVars() (map[string]string, error) {
 		// Use isolated gcloud config path.
 		// https://cloud.google.com/sdk/docs/configurations#:~:text=The%20config%20directory%20can%20be%20changed%20by%20setting%20the%20environment%20variable%20CLOUDSDK_CONFIG
 		"CLOUDSDK_CONFIG": a.getGcloudConfigPath(),
+
+		// Set custom path to boto config. Used to provide fixed access token for `gsutil`.
+		// More info: https://cloud.google.com/storage/docs/boto-gsutil
+		"BOTO_CONFIG": a.getBotoConfigPath(),
 	}
 
 	// Set proxy settings.

--- a/tool/tsh/gcp_test.go
+++ b/tool/tsh/gcp_test.go
@@ -15,10 +15,14 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -278,6 +282,30 @@ func Test_gcpApp_Config(t *testing.T) {
 	require.Equal(t, "my_secret", app.secret)
 	require.Equal(t, cf.HomePath+"/gcp/test.teleport.io/myapp/gcloud", app.getGcloudConfigPath())
 
+	require.Equal(t, "c45b4408", app.prefix)
+
+	require.NoError(t, app.writeBotoConfig())
+
+	require.Equal(t, cf.HomePath+"/gcp/test.teleport.io/myapp", app.getBotoConfigDir())
+
+	require.Equal(t, cf.HomePath+"/gcp/test.teleport.io/myapp/c45b4408_boto.cfg", app.getBotoConfigPath())
+	expectedBotoConfig := fmt.Sprintf(`[Credentials]
+gs_external_account_authorized_user_file = %v/gcp/test.teleport.io/myapp/c45b4408_external.json
+`, cf.HomePath)
+	require.Equal(t, expectedBotoConfig, app.getBotoConfig())
+	out, err := os.ReadFile(app.getBotoConfigPath())
+	require.NoError(t, err)
+	require.Equal(t, expectedBotoConfig, string(out))
+
+	expectedExternalAccountFile := `{ "type": "external_account_authorized_user","token": "my_secret" }`
+	require.Equal(t, cf.HomePath+"/gcp/test.teleport.io/myapp/c45b4408_external.json", app.getExternalAccountFilePath())
+	require.Equal(t, expectedExternalAccountFile, app.getExternalAccountFile())
+	out, err = os.ReadFile(app.getExternalAccountFilePath())
+	require.NoError(t, err)
+	require.Equal(t, expectedExternalAccountFile, string(out))
+
+	require.NoError(t, trace.NewAggregate(app.removeBotoConfig()...))
+
 	env, err := app.GetEnvVars()
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{
@@ -285,6 +313,7 @@ func Test_gcpApp_Config(t *testing.T) {
 		"CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE": "keys/-app/myapp-localca.pem",
 		"CLOUDSDK_CORE_PROJECT":              "myproject-123456",
 		"CLOUDSDK_CONFIG":                    app.getGcloudConfigPath(),
+		"BOTO_CONFIG":                        app.getBotoConfigPath(),
 	}, env)
 }
 

--- a/tool/tsh/gcp_test.go
+++ b/tool/tsh/gcp_test.go
@@ -20,9 +20,8 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/tlsca"

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -643,10 +643,14 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	azure.Arg("command", "`az` command and subcommands arguments that are going to be forwarded to Azure CLI.").StringsVar(&cf.AzureCommandArgs)
 	azure.Flag("app", "Optional name of the Azure application to use if logged into multiple.").StringVar(&cf.AppName)
 
-	gcloud := app.Command("gcloud", "Access GCP API.").Interspersed(false)
-	gcloud.Arg("command", "`gcloud` command and subcommands arguments that are going to be forwarded to GCP CLI.").StringsVar(&cf.GCPCommandArgs)
+	gcloud := app.Command("gcloud", "Access GCP API with the gcloud command.").Interspersed(false)
+	gcloud.Arg("command", "`gcloud` command and subcommands arguments.").StringsVar(&cf.GCPCommandArgs)
 	gcloud.Flag("app", "Optional name of the GCP application to use if logged into multiple.").StringVar(&cf.AppName)
 	gcloud.Alias("gcp")
+
+	gsutil := app.Command("gsutil", "Access Google Cloud Storage with the gsutil command.").Interspersed(false)
+	gsutil.Arg("command", "`gsutil` command and subcommands arguments.").StringsVar(&cf.GCPCommandArgs)
+	gsutil.Flag("app", "Optional name of the GCP application to use if logged into multiple.").StringVar(&cf.AppName)
 
 	// Applications.
 	apps := app.Command("apps", "View and control proxied applications.").Alias("app")
@@ -1150,6 +1154,8 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 		err = onAzure(&cf)
 	case gcloud.FullCommand():
 		err = onGcloud(&cf)
+	case gsutil.FullCommand():
+		err = onGsutil(&cf)
 	case daemonStart.FullCommand():
 		err = onDaemonStart(&cf)
 	case f2Diag.FullCommand():


### PR DESCRIPTION
This PR adds changes necessary to support `gsutil` v2 in GCP App Access. `gsutil` v2 does not support `CLOUDSDK_AUTH_ACCESS_TOKEN`; instead, we have to write the token to file and set env variables so that `gsutil` reads the configuration file, which points at the file with token.

`gsutil` v3 is based on GCP Cloud SDK and, therefore, already supported.

More info: https://github.com/GoogleCloudPlatform/gsutil/issues/357#issuecomment-1058353166

This change is a follow-up to https://github.com/gravitational/teleport/issues/17257.

Setup: see https://github.com/gravitational/teleport/pull/19790. 

Usage options:
1. Directly call `gsutil` using `tsh` as wrapper:
```
> tsh gsutil ls
gs://example-gcp-bucket-001/
gs://example-gcp-bucket-002/
```
2. Start proxy in one console. Use `gsutil` in another console after setting env variables:
```
> tsh proxy gcp --port 3500

Started GCP proxy on http://127.0.0.1:3500.

Use the following credentials and HTTPS proxy setting to connect to the proxy:

  export BOTO_CONFIG=/Users/username/.tsh/gcp/teleport.example.com/gcp/5b46ada1_boto.cfg
  export CLOUDSDK_AUTH_ACCESS_TOKEN=8db77684aea05ef3c49ca0a313d5d9fd
  export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE=/Users/username/.tsh/keys/teleport.example.com/username-app/teleport.example.com/gcp-localca.pem
  export HTTPS_PROXY=http://127.0.0.1:3500
```

```
> export BOTO_CONFIG=/Users/username/.tsh/gcp/teleport.example.com/gcp/5b46ada1_boto.cfg
> export CLOUDSDK_AUTH_ACCESS_TOKEN=8db77684aea05ef3c49ca0a313d5d9fd
> export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE=/Users/username/.tsh/keys/teleport.example.com/username-app/teleport.example.com/gcp-localca.pem
> export HTTPS_PROXY=http://127.0.0.1:3500
> gsutil ls
gs://example-gcp-bucket-001/
gs://example-gcp-bucket-002/
```