### PR TITLE
Improve UserMetadata audit logging

### DIFF
--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -173,7 +173,7 @@ func (s *Server) verifyRecoveryCode(ctx context.Context, user string, givenCode 
 			continue
 		}
 		codeMatch = true
-		// Mark matched token as used in backend so it can't be used again.
+		// Mark matched token as used in backend, so it can't be used again.
 		recovery.GetCodes()[i].IsUsed = true
 		if err := s.UpsertRecoveryCodes(ctx, user, recovery); err != nil {
 			log.Error(trace.DebugReport(err))
@@ -187,9 +187,7 @@ func (s *Server) verifyRecoveryCode(ctx context.Context, user string, givenCode 
 			Type: events.RecoveryCodeUsedEvent,
 			Code: events.RecoveryCodeUseSuccessCode,
 		},
-		UserMetadata: apievents.UserMetadata{
-			User: user,
-		},
+		UserMetadata: ClientUserMetadataWithUser(ctx, user),
 		Status: apievents.Status{
 			Success: true,
 		},
@@ -554,9 +552,7 @@ func (s *Server) generateAndUpsertRecoveryCodes(ctx context.Context, username st
 			Type: events.RecoveryCodeGeneratedEvent,
 			Code: events.RecoveryCodesGenerateCode,
 		},
-		UserMetadata: apievents.UserMetadata{
-			User: username,
-		},
+		UserMetadata: ClientUserMetadataWithUser(ctx, username),
 	}); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{"user": username}).Warn("Failed to emit recovery tokens generate event.")
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2299,9 +2299,7 @@ func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName str
 			Code:        events.MFADeviceDeleteEventCode,
 			ClusterName: clusterName.GetClusterName(),
 		},
-		UserMetadata: apievents.UserMetadata{
-			User: user,
-		},
+		UserMetadata:      ClientUserMetadataWithUser(ctx, user),
 		MFADeviceMetadata: mfaDeviceEventMetadata(deviceToDelete),
 	}); err != nil {
 		return nil, trace.Wrap(err)
@@ -2402,9 +2400,7 @@ func (a *Server) verifyMFARespAndAddDevice(ctx context.Context, req *newMFADevic
 			Code:        events.MFADeviceAddEventCode,
 			ClusterName: clusterName.GetClusterName(),
 		},
-		UserMetadata: apievents.UserMetadata{
-			User: req.username,
-		},
+		UserMetadata:      ClientUserMetadataWithUser(ctx, req.username),
 		MFADeviceMetadata: mfaDeviceEventMetadata(dev),
 	}); err != nil {
 		log.WithError(err).Warn("Failed to emit add mfa device event.")

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -148,9 +148,7 @@ func (s *Server) ChangePassword(ctx context.Context, req *proto.ChangePasswordRe
 			Type: events.UserPasswordChangeEvent,
 			Code: events.UserPasswordChangeCode,
 		},
-		UserMetadata: apievents.UserMetadata{
-			User: user,
-		},
+		UserMetadata: ClientUserMetadataWithUser(ctx, user),
 	}); err != nil {
 		log.WithError(err).Warn("Failed to emit password change event.")
 	}

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -891,14 +891,13 @@ func ClientImpersonator(ctx context.Context) string {
 // did not come from an HTTP request, metadata for teleport.UserSystem is
 // returned.
 func ClientUserMetadata(ctx context.Context) apievents.UserMetadata {
-	userI := ctx.Value(ContextUser)
-	userWithIdentity, ok := userI.(IdentityGetter)
+	identityGetter, ok := ctx.Value(ContextUser).(IdentityGetter)
 	if !ok {
 		return apievents.UserMetadata{
 			User: teleport.UserSystem,
 		}
 	}
-	meta := userWithIdentity.GetIdentity().GetUserMetadata()
+	meta := identityGetter.GetIdentity().GetUserMetadata()
 	if meta.User == "" {
 		meta.User = teleport.UserSystem
 	}
@@ -909,14 +908,7 @@ func ClientUserMetadata(ctx context.Context) apievents.UserMetadata {
 // by a remote client making a call, with the specified username overriding the one
 // from the remote client.
 func ClientUserMetadataWithUser(ctx context.Context, user string) apievents.UserMetadata {
-	userI := ctx.Value(ContextUser)
-	userWithIdentity, ok := userI.(IdentityGetter)
-	if !ok {
-		return apievents.UserMetadata{
-			User: user,
-		}
-	}
-	meta := userWithIdentity.GetIdentity().GetUserMetadata()
+	meta := ClientUserMetadata(ctx)
 	meta.User = user
 	return meta
 }

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -163,10 +163,7 @@ func (s *Server) CompareAndSwapUser(ctx context.Context, new, existing types.Use
 			Type: events.UserUpdatedEvent,
 			Code: events.UserUpdateCode,
 		},
-		UserMetadata: apievents.UserMetadata{
-			User:         ClientUsername(ctx),
-			Impersonator: ClientImpersonator(ctx),
-		},
+		UserMetadata: ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    new.GetName(),
 			Expires: new.Expiry(),

--- a/lib/auth/usertoken.go
+++ b/lib/auth/usertoken.go
@@ -433,9 +433,7 @@ func (s *Server) createRecoveryToken(ctx context.Context, username, tokenType st
 			Type: events.RecoveryTokenCreateEvent,
 			Code: events.RecoveryTokenCreateCode,
 		},
-		UserMetadata: apievents.UserMetadata{
-			User: username,
-		},
+		UserMetadata: ClientUserMetadataWithUser(ctx, username),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    req.Name,
 			TTL:     req.TTL.String(),
@@ -530,9 +528,7 @@ func (s *Server) createPrivilegeToken(ctx context.Context, username, tokenKind s
 			Type: events.PrivilegeTokenCreateEvent,
 			Code: events.PrivilegeTokenCreateCode,
 		},
-		UserMetadata: apievents.UserMetadata{
-			User: username,
-		},
+		UserMetadata: ClientUserMetadataWithUser(ctx, username),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    req.Name,
 			TTL:     req.TTL.String(),

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -363,6 +363,12 @@ func (c *authContext) eventUserMeta() apievents.UserMetadata {
 	return meta
 }
 
+func (c *authContext) eventUserMetaWithLogin(login string) apievents.UserMetadata {
+	meta := c.eventUserMeta()
+	meta.Login = login
+	return meta
+}
+
 type dialFunc func(ctx context.Context, network string, endpoint kubeClusterEndpoint) (net.Conn, error)
 
 // teleportClusterClient is a client for either a k8s endpoint in local cluster or a

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -545,11 +545,7 @@ func (s *session) launch() error {
 			SessionID: s.id.String(),
 			WithMFA:   s.ctx.Identity.GetIdentity().MFAVerified,
 		},
-		UserMetadata: apievents.UserMetadata{
-			User:         s.ctx.User.GetName(),
-			Login:        s.ctx.User.GetName(),
-			Impersonator: s.ctx.Identity.GetIdentity().Impersonator,
-		},
+		UserMetadata: s.ctx.eventUserMeta(),
 		ConnectionMetadata: apievents.ConnectionMetadata{
 			RemoteAddr: s.req.RemoteAddr,
 			LocalAddr:  s.sess.kubeAddress,
@@ -653,11 +649,7 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 					SessionID: s.id.String(),
 					WithMFA:   s.ctx.Identity.GetIdentity().MFAVerified,
 				},
-				UserMetadata: apievents.UserMetadata{
-					User:         s.ctx.User.GetName(),
-					Login:        s.ctx.User.GetName(),
-					Impersonator: s.ctx.Identity.GetIdentity().Impersonator,
-				},
+				UserMetadata:              s.ctx.eventUserMeta(),
 				TerminalSize:              params.Serialize(),
 				KubernetesClusterMetadata: s.ctx.eventClusterMeta(),
 				KubernetesPodMetadata:     eventPodMeta,
@@ -883,11 +875,7 @@ func (s *session) join(p *party) error {
 		SessionMetadata: apievents.SessionMetadata{
 			SessionID: s.id.String(),
 		},
-		UserMetadata: apievents.UserMetadata{
-			User:         p.Ctx.User.GetName(),
-			Login:        "root",
-			Impersonator: p.Ctx.Identity.GetIdentity().Impersonator,
-		},
+		UserMetadata: p.Ctx.eventUserMetaWithLogin("root"),
 		ConnectionMetadata: apievents.ConnectionMetadata{
 			RemoteAddr: s.params.ByName("podName"),
 		},
@@ -1011,11 +999,7 @@ func (s *session) unlockedLeave(id uuid.UUID) (bool, error) {
 		SessionMetadata: apievents.SessionMetadata{
 			SessionID: s.id.String(),
 		},
-		UserMetadata: apievents.UserMetadata{
-			User:         party.Ctx.User.GetName(),
-			Login:        "root",
-			Impersonator: party.Ctx.Identity.GetIdentity().Impersonator,
-		},
+		UserMetadata: party.Ctx.eventUserMetaWithLogin("root"),
 		ConnectionMetadata: apievents.ConnectionMetadata{
 			RemoteAddr: s.params.ByName("podName"),
 		},

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -163,15 +163,15 @@ func (h *Handler) HandleConnection(ctx context.Context, clientConn net.Conn) err
 	}
 	if ws.GetUser() != identity.Username {
 		err := trace.AccessDenied("session owner %q does not match caller %q", ws.GetUser(), identity.Username)
+
+		userMeta := identity.GetUserMetadata()
+		userMeta.Login = ws.GetUser()
 		h.c.AuthClient.EmitAuditEvent(h.closeContext, &apievents.AuthAttempt{
 			Metadata: apievents.Metadata{
 				Type: events.AuthAttemptEvent,
 				Code: events.AuthAttemptFailureCode,
 			},
-			UserMetadata: apievents.UserMetadata{
-				Login: ws.GetUser(),
-				User:  identity.Username,
-			},
+			UserMetadata: userMeta,
 			ConnectionMetadata: apievents.ConnectionMetadata{
 				LocalAddr:  clientConn.LocalAddr().String(),
 				RemoteAddr: clientConn.RemoteAddr().String(),
@@ -316,15 +316,15 @@ func (h *Handler) getAppSessionFromCert(r *http.Request) (types.WebSession, erro
 	if ws.GetUser() != identity.Username {
 		err := trace.AccessDenied("session owner %q does not match caller %q",
 			ws.GetUser(), identity.Username)
+
+		userMeta := identity.GetUserMetadata()
+		userMeta.Login = ws.GetUser()
 		h.c.AuthClient.EmitAuditEvent(h.closeContext, &apievents.AuthAttempt{
 			Metadata: apievents.Metadata{
 				Type: events.AuthAttemptEvent,
 				Code: events.AuthAttemptFailureCode,
 			},
-			UserMetadata: apievents.UserMetadata{
-				Login: ws.GetUser(),
-				User:  identity.Username,
-			},
+			UserMetadata: userMeta,
 			ConnectionMetadata: apievents.ConnectionMetadata{
 				LocalAddr:  r.Host,
 				RemoteAddr: r.RemoteAddr,


### PR DESCRIPTION
Improve UserMetadata audit logging by using `tlsca.Identity.GetUserMetadata()` more consistently in audit logs.

There are still a handful of logs that don't include the data above for lack of context (in the general sense and in the Go context sense), but many more entries now call back to identity in some way.

Related to https://github.com/gravitational/teleport.e/issues/514.