### PR TITLE
Log trusted device in UserMetadata audit events

### DIFF
--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -333,8 +333,9 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 				Code: events.AuthAttemptFailureCode,
 			},
 			UserMetadata: apievents.UserMetadata{
-				Login: conn.User(),
-				User:  teleportUser,
+				Login:         conn.User(),
+				User:          teleportUser,
+				TrustedDevice: eventDeviceMetadataFromCert(cert),
 			},
 			ConnectionMetadata: apievents.ConnectionMetadata{
 				LocalAddr:  conn.LocalAddr().String(),

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -1054,12 +1054,32 @@ func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 	}, nil
 }
 
+func eventDeviceMetadataFromCert(cert *ssh.Certificate) *apievents.DeviceMetadata {
+	if cert == nil {
+		return nil
+	}
+
+	devID := cert.Extensions[teleport.CertExtensionDeviceID]
+	assetTag := cert.Extensions[teleport.CertExtensionDeviceAssetTag]
+	credID := cert.Extensions[teleport.CertExtensionDeviceCredentialID]
+	if devID == "" && assetTag == "" && credID == "" {
+		return nil
+	}
+
+	return &apievents.DeviceMetadata{
+		DeviceId:     devID,
+		AssetTag:     assetTag,
+		CredentialId: credID,
+	}
+}
+
 func (id *IdentityContext) GetUserMetadata() apievents.UserMetadata {
 	return apievents.UserMetadata{
 		Login:          id.Login,
 		User:           id.TeleportUser,
 		Impersonator:   id.Impersonator,
 		AccessRequests: id.ActiveRequests,
+		TrustedDevice:  eventDeviceMetadataFromCert(id.Certificate),
 	}
 }
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1686,11 +1686,7 @@ func (s *Server) handleX11Forward(ch ssh.Channel, req *ssh.Request, ctx *srv.Ser
 			Type: events.X11ForwardEvent,
 			Code: events.X11ForwardCode,
 		},
-		UserMetadata: apievents.UserMetadata{
-			Login:        ctx.Identity.Login,
-			User:         ctx.Identity.TeleportUser,
-			Impersonator: ctx.Identity.Impersonator,
-		},
+		UserMetadata: ctx.Identity.GetUserMetadata(),
 		ConnectionMetadata: apievents.ConnectionMetadata{
 			LocalAddr:  ctx.ServerConn.LocalAddr().String(),
 			RemoteAddr: ctx.ServerConn.RemoteAddr().String(),

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1001,6 +1001,15 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 }
 
 func (id Identity) GetUserMetadata() events.UserMetadata {
+	var device *events.DeviceMetadata
+	if id.DeviceExtensions != (DeviceExtensions{}) {
+		device = &events.DeviceMetadata{
+			DeviceId:     id.DeviceExtensions.DeviceID,
+			AssetTag:     id.DeviceExtensions.AssetTag,
+			CredentialId: id.DeviceExtensions.CredentialID,
+		}
+	}
+
 	return events.UserMetadata{
 		User:              id.Username,
 		Impersonator:      id.Impersonator,
@@ -1008,6 +1017,7 @@ func (id Identity) GetUserMetadata() events.UserMetadata {
 		AzureIdentity:     id.RouteToApp.AzureIdentity,
 		GCPServiceAccount: id.RouteToApp.GCPServiceAccount,
 		AccessRequests:    id.ActiveRequests,
+		TrustedDevice:     device,
 	}
 }
 


### PR DESCRIPTION
Log the trusted device along with UserMetadata audit events.

Complements #20081.

https://github.com/gravitational/teleport.e/issues/514