### PR TITLE
[v10] chore: Bump Go to 1.19.5

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ name: push-build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
   UID: "1000"
 trigger:
   event:
@@ -152,7 +152,7 @@ name: push-build-linux-386
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
   UID: "1000"
 trigger:
   event:
@@ -257,7 +257,7 @@ name: push-build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
   UID: "1000"
 trigger:
   event:
@@ -366,7 +366,7 @@ name: push-build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
   UID: "1000"
 trigger:
   event:
@@ -533,7 +533,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.19.4
+    RUNTIME: go1.19.5
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -1114,7 +1114,7 @@ name: push-build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
   UID: "1000"
 trigger:
   event:
@@ -1219,7 +1219,7 @@ name: push-build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
   UID: "1000"
 trigger:
   event:
@@ -1636,7 +1636,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
 trigger:
   event:
     include:
@@ -1825,7 +1825,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
 trigger:
   event:
     include:
@@ -2013,7 +2013,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
 trigger:
   event:
     include:
@@ -2214,7 +2214,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
 trigger:
   event:
     include:
@@ -3428,7 +3428,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
 trigger:
   event:
     include:
@@ -4188,7 +4188,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.19.4
+    RUNTIME: go1.19.5
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -4759,7 +4759,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
 trigger:
   event:
     include:
@@ -4946,7 +4946,7 @@ name: build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
   UID: "1000"
 trigger:
   event:
@@ -6034,7 +6034,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.4
+  RUNTIME: go1.19.5
 trigger:
   event:
     include:
@@ -18211,6 +18211,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: ff29a9539d300da7f3b70c1943ad3e64c71d510979a151446c057748f4256bb7
+hmac: e42c5cd9e67f3be920bdcb49de3717b50120419811d9f53d84869301ea381963
 
 ...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - goimports
     - gosimple
@@ -23,10 +22,8 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
     - unused
     - unconvert
-    - varcheck
 
 linters-settings:
   depguard:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,4 +43,4 @@ output:
 run:
   skip-dirs-use-default: false
   timeout: 5m
-  go: '1.18'
+  go: '1.19'

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -21,7 +21,7 @@ TEST_KUBE ?=
 
 OS ?= linux
 ARCH ?= amd64
-GOLANG_VERSION ?= go1.19.4
+GOLANG_VERSION ?= go1.19.5
 # run lint-rust check locally before merging code after you bump this
 RUST_VERSION ?= 1.66.0
 NODE_VERSION ?= 16.13.2
@@ -423,17 +423,17 @@ release-arm64: buildbox-arm
 # #############################################################################
 
 #
-# The `release-oss` and `release-enterprise` make targets are for building OSS 
+# The `release-oss` and `release-enterprise` make targets are for building OSS
 # and Enterprise releases from GitHub actions. These make targets execute in a
 # container based on a caller-supplied `BUILDBOX` image.
 #
 # Unlike the other release targets, these release targets do not attempt to
-# automatically construct the buildbox image at build time - the build box 
-# image *must* be pre-built and the tag supplied via `BUILDBOX=...` on the 
+# automatically construct the buildbox image at build time - the build box
+# image *must* be pre-built and the tag supplied via `BUILDBOX=...` on the
 # make command line
 #
-# Separating the construction of build environment from the actual build itself 
-# allows us to use the appropriate GHA actions to pre-build the buildbox 
+# Separating the construction of build environment from the actual build itself
+# allows us to use the appropriate GHA actions to pre-build the buildbox
 # image, so that the image construction works nicely with GHA.
 #
 


### PR DESCRIPTION
Update Go to the latest patch.

Bumps golangci-lint Go version and remove deprecated linters as well.

Backports #20060.