### PR TITLE
[v11] revert docs plugin version

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1274,7 +1274,7 @@
       "version": "11.2.0",
       "golang": "1.19",
       "plugin": {
-        "version": "11.2.0"
+        "version": "11.1.4"
       },
       "helm_repo_url": "https://charts.releases.teleport.dev",
       "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport:11.2.0",


### PR DESCRIPTION
reverting to `11.1.4` till `11.2.0` is available