### PR TITLE
[v11] Fix `certificate signed by unknown authority` after reconciling a dynamic RDS resource

### DIFF
--- a/api/types/cmp.go
+++ b/api/types/cmp.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,38 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package services
+package types
 
 import (
 	"strings"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-
-	"github.com/gravitational/teleport/api/types"
 )
 
-// CompareResources compares two resources by all significant fields.
-func CompareResources(resA, resB types.Resource) int {
-	equal := cmp.Equal(resA, resB,
-		ignoreProtoXXXFields(),
-		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
-		cmpopts.IgnoreFields(types.DatabaseV3{}, "Status"),
-		cmpopts.EquateEmpty(),
-	)
-	if equal {
-		return Equal
-	}
-	return Different
-}
-
-// ignoreProtoXXXFields is a cmp.Option that ignores XXX_* fields from proto
-// messages.
-func ignoreProtoXXXFields() cmp.Option {
-	return cmp.FilterPath(func(path cmp.Path) bool {
+// protoEqual returns true if provided proto messages are equal, ignoring the
+// XXX_* fields.
+func protoEqual(a, b proto.Message) bool {
+	return cmp.Equal(a, b, cmp.FilterPath(func(path cmp.Path) bool {
 		if field, ok := path.Last().(cmp.StructField); ok {
 			return strings.HasPrefix(field.Name(), "XXX_")
 		}
 		return false
-	}, cmp.Ignore())
+	}, cmp.Ignore()))
 }

--- a/api/types/cmp_test.go
+++ b/api/types/cmp_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtoEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inputA proto.Message
+		inputB proto.Message
+		assert require.BoolAssertionFunc
+	}{
+		{
+			name: "true",
+			inputA: &AWS{
+				Region: "us-west-1",
+				Redshift: Redshift{
+					ClusterID: "id",
+				},
+			},
+			inputB: &AWS{
+				Region: "us-west-1",
+				Redshift: Redshift{
+					ClusterID: "id",
+				},
+			},
+			assert: require.True,
+		},
+		{
+			name: "true ignoring XXX_unrecognized",
+			inputA: &AWS{
+				Region:           "us-west-1",
+				XXX_unrecognized: []byte{66, 0},
+			},
+			inputB: &AWS{
+				Region: "us-west-1",
+			},
+			assert: require.True,
+		},
+		{
+			name: "true ignoring nested XXX_unrecognized",
+			inputA: &AWS{
+				Region: "us-west-1",
+				MemoryDB: MemoryDB{
+					XXX_unrecognized: []byte{99, 0},
+				},
+			},
+			inputB: &AWS{
+				Region: "us-west-1",
+			},
+			assert: require.True,
+		},
+		{
+			name: "false differrent values",
+			inputA: &AWS{
+				Region: "us-west-1",
+				Redshift: Redshift{
+					ClusterID: "id",
+				},
+			},
+			inputB: &AWS{
+				Region: "us-west-1",
+				Redshift: Redshift{
+					ClusterID: "differrent-id",
+				},
+			},
+			assert: require.False,
+		},
+		{
+			name: "false different types",
+			inputA: &AWS{
+				Region: "us-west-1",
+			},
+			inputB: &KubeAWS{
+				Region: "us-west-1",
+			},
+			assert: require.False,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.assert(t, protoEqual(test.inputA, test.inputB))
+		})
+	}
+}

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
@@ -299,7 +298,7 @@ func (d *DatabaseV3) SetMySQLServerVersion(version string) {
 
 // IsEmpty returns true if AWS metadata is empty.
 func (a AWS) IsEmpty() bool {
-	return cmp.Equal(a, AWS{})
+	return protoEqual(&a, &AWS{})
 }
 
 // GetAWS returns the database AWS metadata.
@@ -322,7 +321,7 @@ func (d *DatabaseV3) GetGCP() GCPCloudSQL {
 
 // IsEmpty returns true if Azure metadata is empty.
 func (a Azure) IsEmpty() bool {
-	return cmp.Equal(a, Azure{})
+	return protoEqual(&a, &Azure{})
 }
 
 // GetAzure returns Azure database server metadata.

--- a/api/types/database_test.go
+++ b/api/types/database_test.go
@@ -494,3 +494,48 @@ func TestDatabaseSelfHosted(t *testing.T) {
 		})
 	}
 }
+
+func TestAWSIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  AWS
+		assert require.BoolAssertionFunc
+	}{
+		{
+			name:   "true",
+			input:  AWS{},
+			assert: require.True,
+		},
+		{
+			name: "true with unrecognized bytes",
+			input: AWS{
+				XXX_unrecognized: []byte{66, 0},
+			},
+			assert: require.True,
+		},
+		{
+			name: "true with nested unrecognized bytes",
+			input: AWS{
+				MemoryDB: MemoryDB{
+					XXX_unrecognized: []byte{99, 0},
+				},
+			},
+			assert: require.True,
+		},
+		{
+			name: "false",
+			input: AWS{
+				Region: "us-west-1",
+			},
+			assert: require.False,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.assert(t, test.input.IsEmpty())
+		})
+	}
+}

--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -274,23 +274,17 @@ func (k *KubernetesClusterV3) SetGCPConfig(cfg KubeGCP) {
 
 // IsAzure indentifies if the KubeCluster contains Azure details.
 func (k *KubernetesClusterV3) IsAzure() bool {
-	// on protobuf default values are not encoded.
-	// the empty structure returns no storage.
-	return k.Spec.Azure.Size() != 0
+	return !protoEqual(&k.Spec.Azure, &KubeAzure{})
 }
 
 // IsAWS indentifies if the KubeCluster contains AWS details.
 func (k *KubernetesClusterV3) IsAWS() bool {
-	// on protobuf default values are not encoded.
-	// the empty structure returns no storage.
-	return k.Spec.AWS.Size() != 0
+	return !protoEqual(&k.Spec.AWS, &KubeAWS{})
 }
 
 // IsGCP indentifies if the KubeCluster contains GCP details.
 func (k *KubernetesClusterV3) IsGCP() bool {
-	// on protobuf default values are not encoded.
-	// the empty structure returns no storage.
-	return k.Spec.GCP.Size() != 0
+	return !protoEqual(&k.Spec.GCP, &KubeGCP{})
 }
 
 // IsKubeconfig identifies if the KubeCluster contains kubeconfig data.

--- a/api/types/lock.go
+++ b/api/types/lock.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/utils"
@@ -179,7 +178,7 @@ func (c *LockV2) CheckAndSetDefaults() error {
 
 // IsEmpty returns true if none of the target's fields is set.
 func (t LockTarget) IsEmpty() bool {
-	return cmp.Equal(t, LockTarget{})
+	return protoEqual(&t, &LockTarget{})
 }
 
 // IntoMap returns the target attributes in the form of a map.

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
@@ -48,6 +49,14 @@ func CertAuthoritiesEquivalent(lhs, rhs types.CertAuthority) bool {
 	return cmp.Equal(lhs, rhs,
 		ignoreProtoXXXFields(),
 		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+		// Optimize types.CAKeySet comparison.
+		cmp.Comparer(func(a, b types.CAKeySet) bool {
+			// Note that Clone drops XXX_ fields. And it's benchmarked that cloning
+			// plus using proto.Equal is more efficient than cmp.Equal.
+			aClone := a.Clone()
+			bClone := b.Clone()
+			return proto.Equal(&aClone, &bClone)
+		}),
 	)
 }
 

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -45,7 +45,10 @@ import (
 // CertAuthoritiesEquivalent checks if a pair of certificate authority resources are equivalent.
 // This differs from normal equality only in that resource IDs are ignored.
 func CertAuthoritiesEquivalent(lhs, rhs types.CertAuthority) bool {
-	return cmp.Equal(lhs, rhs, cmpopts.IgnoreFields(types.Metadata{}, "ID"))
+	return cmp.Equal(lhs, rhs,
+		ignoreProtoXXXFields(),
+		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+	)
 }
 
 // ValidateCertAuthority validates the CertAuthority

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -55,6 +55,7 @@ func ValidateUserRoles(ctx context.Context, u types.User, roleGetter RoleGetter)
 // UsersEquals checks if the users are equal
 func UsersEquals(u types.User, other types.User) bool {
 	return cmp.Equal(u, other,
+		ignoreProtoXXXFields(),
 		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
 		cmpopts.SortSlices(func(a, b *types.MFADevice) bool {
 			return a.Metadata.Name < b.Metadata.Name

--- a/lib/srv/discovery/fetchers/aks_test.go
+++ b/lib/srv/discovery/fetchers/aks_test.go
@@ -210,6 +210,7 @@ func aksClustersToResources(t *testing.T, clusters ...*azure.AKSCluster) types.R
 	for _, cluster := range clusters {
 		kubeCluster, err := services.NewKubeClusterFromAzureAKS(cluster)
 		require.NoError(t, err)
+		require.True(t, kubeCluster.IsAzure())
 		kubeClusters = append(kubeClusters, kubeCluster)
 	}
 	return kubeClusters.AsResources()

--- a/lib/srv/discovery/fetchers/eks_test.go
+++ b/lib/srv/discovery/fetchers/eks_test.go
@@ -196,6 +196,7 @@ func eksClustersToResources(t *testing.T, clusters ...*eks.Cluster) types.Resour
 	for _, cluster := range clusters {
 		kubeCluster, err := services.NewKubeClusterFromAWSEKS(cluster)
 		require.NoError(t, err)
+		require.True(t, kubeCluster.IsAWS())
 		kubeClusters = append(kubeClusters, kubeCluster)
 	}
 	return kubeClusters.AsResources()

--- a/lib/srv/discovery/fetchers/gke_test.go
+++ b/lib/srv/discovery/fetchers/gke_test.go
@@ -177,6 +177,7 @@ func gkeClustersToResources(t *testing.T, clusters ...gcp.GKECluster) types.Reso
 	for _, cluster := range clusters {
 		kubeCluster, err := services.NewKubeClusterFromGCPGKE(cluster)
 		require.NoError(t, err)
+		require.True(t, kubeCluster.IsGCP())
 		kubeClusters = append(kubeClusters, kubeCluster)
 	}
 	return kubeClusters.AsResources()


### PR DESCRIPTION
backport of #19413 #20008

one minor merge conflict on the UT as `RedshiftServerless` is only in master. Changed the test to test on `Redshift`.