### PR TITLE
[v10] Fix `certificate signed by unknown authority` after reconciling a dynamic RDS resource

### DIFF
--- a/api/types/cmp.go
+++ b/api/types/cmp.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,38 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package services
+package types
 
 import (
 	"strings"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-
-	"github.com/gravitational/teleport/api/types"
 )
 
-// CompareResources compares two resources by all significant fields.
-func CompareResources(resA, resB types.Resource) int {
-	equal := cmp.Equal(resA, resB,
-		ignoreProtoXXXFields(),
-		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
-		cmpopts.IgnoreFields(types.DatabaseV3{}, "Status"),
-		cmpopts.EquateEmpty(),
-	)
-	if equal {
-		return Equal
-	}
-	return Different
-}
-
-// ignoreProtoXXXFields is a cmp.Option that ignores XXX_* fields from proto
-// messages.
-func ignoreProtoXXXFields() cmp.Option {
-	return cmp.FilterPath(func(path cmp.Path) bool {
+// protoEqual returns true if provided proto messages are equal, ignoring the
+// XXX_* fields.
+func protoEqual(a, b proto.Message) bool {
+	return cmp.Equal(a, b, cmp.FilterPath(func(path cmp.Path) bool {
 		if field, ok := path.Last().(cmp.StructField); ok {
 			return strings.HasPrefix(field.Name(), "XXX_")
 		}
 		return false
-	}, cmp.Ignore())
+	}, cmp.Ignore()))
 }

--- a/api/types/cmp_test.go
+++ b/api/types/cmp_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtoEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inputA proto.Message
+		inputB proto.Message
+		assert require.BoolAssertionFunc
+	}{
+		{
+			name: "true",
+			inputA: &AWS{
+				Region: "us-west-1",
+				Redshift: Redshift{
+					ClusterID: "id",
+				},
+			},
+			inputB: &AWS{
+				Region: "us-west-1",
+				Redshift: Redshift{
+					ClusterID: "id",
+				},
+			},
+			assert: require.True,
+		},
+		{
+			name: "true ignoring XXX_unrecognized",
+			inputA: &AWS{
+				Region:           "us-west-1",
+				XXX_unrecognized: []byte{66, 0},
+			},
+			inputB: &AWS{
+				Region: "us-west-1",
+			},
+			assert: require.True,
+		},
+		{
+			name: "true ignoring nested XXX_unrecognized",
+			inputA: &AWS{
+				Region: "us-west-1",
+				MemoryDB: MemoryDB{
+					XXX_unrecognized: []byte{99, 0},
+				},
+			},
+			inputB: &AWS{
+				Region: "us-west-1",
+			},
+			assert: require.True,
+		},
+		{
+			name: "false differrent values",
+			inputA: &AWS{
+				Region: "us-west-1",
+				Redshift: Redshift{
+					ClusterID: "id",
+				},
+			},
+			inputB: &AWS{
+				Region: "us-west-1",
+				Redshift: Redshift{
+					ClusterID: "differrent-id",
+				},
+			},
+			assert: require.False,
+		},
+		{
+			name:   "false different types",
+			inputA: &AWS{},
+			inputB: &Azure{},
+			assert: require.False,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.assert(t, protoEqual(test.inputA, test.inputB))
+		})
+	}
+}

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
@@ -297,7 +296,7 @@ func (d *DatabaseV3) SetMySQLServerVersion(version string) {
 
 // IsEmpty returns true if AWS metadata is empty.
 func (a AWS) IsEmpty() bool {
-	return cmp.Equal(a, AWS{})
+	return protoEqual(&a, &AWS{})
 }
 
 // GetAWS returns the database AWS metadata.
@@ -320,7 +319,7 @@ func (d *DatabaseV3) GetGCP() GCPCloudSQL {
 
 // IsEmpty returns true if Azure metadata is empty.
 func (a Azure) IsEmpty() bool {
-	return cmp.Equal(a, Azure{})
+	return protoEqual(&a, &Azure{})
 }
 
 // GetAzure returns Azure database server metadata.

--- a/api/types/database_test.go
+++ b/api/types/database_test.go
@@ -223,3 +223,48 @@ func TestMySQLServerVersion(t *testing.T) {
 	database.SetMySQLServerVersion("8.0.1")
 	require.Equal(t, "8.0.1", database.GetMySQLServerVersion())
 }
+
+func TestAWSIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  AWS
+		assert require.BoolAssertionFunc
+	}{
+		{
+			name:   "true",
+			input:  AWS{},
+			assert: require.True,
+		},
+		{
+			name: "true with unrecognized bytes",
+			input: AWS{
+				XXX_unrecognized: []byte{66, 0},
+			},
+			assert: require.True,
+		},
+		{
+			name: "true with nested unrecognized bytes",
+			input: AWS{
+				MemoryDB: MemoryDB{
+					XXX_unrecognized: []byte{99, 0},
+				},
+			},
+			assert: require.True,
+		},
+		{
+			name: "false",
+			input: AWS{
+				Region: "us-west-1",
+			},
+			assert: require.False,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.assert(t, test.input.IsEmpty())
+		})
+	}
+}

--- a/api/types/lock.go
+++ b/api/types/lock.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/utils"
@@ -179,7 +178,7 @@ func (c *LockV2) CheckAndSetDefaults() error {
 
 // IsEmpty returns true if none of the target's fields is set.
 func (t LockTarget) IsEmpty() bool {
-	return cmp.Equal(t, LockTarget{})
+	return protoEqual(&t, &LockTarget{})
 }
 
 // IntoMap returns the target attributes in the form of a map.

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -44,7 +44,10 @@ import (
 // CertAuthoritiesEquivalent checks if a pair of certificate authority resources are equivalent.
 // This differs from normal equality only in that resource IDs are ignored.
 func CertAuthoritiesEquivalent(lhs, rhs types.CertAuthority) bool {
-	return cmp.Equal(lhs, rhs, cmpopts.IgnoreFields(types.Metadata{}, "ID"))
+	return cmp.Equal(lhs, rhs,
+		ignoreProtoXXXFields(),
+		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+	)
 }
 
 // ValidateCertAuthority validates the CertAuthority

--- a/lib/services/authority_test.go
+++ b/lib/services/authority_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package services_test
 
 import (
+	"bytes"
 	"crypto/x509/pkix"
 	"testing"
 	"time"
@@ -207,4 +208,46 @@ func TestCertAuthorityUTCUnmarshal(t *testing.T) {
 	require.NotPanics(t, func() { caUTC.Clone() })
 
 	require.True(t, CertAuthoritiesEquivalent(caLocal, caUTC))
+}
+
+func BenchmarkCertAuthoritiesEquivalent(b *testing.B) {
+	ca1, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.HostCA,
+		ClusterName: "cluster1",
+		ActiveKeys: types.CAKeySet{
+			TLS: []*types.TLSKeyPair{{
+				Cert: bytes.Repeat([]byte{49}, 1600),
+				Key:  bytes.Repeat([]byte{49}, 1200),
+			}},
+		},
+	})
+	require.NoError(b, err)
+
+	// ca2 is a clone of ca1.
+	ca2 := ca1.Clone()
+
+	// ca3 has different cert bytes from ca1.
+	ca3, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.HostCA,
+		ClusterName: "cluster1",
+		ActiveKeys: types.CAKeySet{
+			TLS: []*types.TLSKeyPair{{
+				Cert: bytes.Repeat([]byte{49}, 1666),
+				Key:  bytes.Repeat([]byte{49}, 1222),
+			}},
+		},
+	})
+	require.NoError(b, err)
+
+	b.Run("true", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			require.True(b, CertAuthoritiesEquivalent(ca1, ca2))
+		}
+	})
+
+	b.Run("false", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			require.False(b, CertAuthoritiesEquivalent(ca1, ca3))
+		}
+	})
 }

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -55,6 +55,7 @@ func ValidateUserRoles(ctx context.Context, u types.User, roleGetter RoleGetter)
 // UsersEquals checks if the users are equal
 func UsersEquals(u types.User, other types.User) bool {
 	return cmp.Equal(u, other,
+		ignoreProtoXXXFields(),
 		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
 		cmpopts.SortSlices(func(a, b *types.MFADevice) bool {
 			return a.Metadata.Name < b.Metadata.Name


### PR DESCRIPTION
backport of #19413 #20008

Minus kube discovery as they are not in v10.