### PR TITLE
helm: have proxy reload certificates daily

### DIFF
--- a/examples/chart/teleport-cluster/templates/proxy/_config.common.tpl
+++ b/examples/chart/teleport-cluster/templates/proxy/_config.common.tpl
@@ -25,13 +25,13 @@ proxy_service:
 {{- end }}
 {{- if eq .Values.proxyListenerMode "separate" }}
   listen_addr: 0.0.0.0:3023
-{{- if .Values.sshPublicAddr }}
+  {{- if .Values.sshPublicAddr }}
   ssh_public_addr: {{- toYaml .Values.sshPublicAddr | nindent 8 }}
-{{- end }}
+  {{- end }}
   tunnel_listen_addr: 0.0.0.0:3024
-{{- if .Values.tunnelPublicAddr }}
+  {{- if .Values.tunnelPublicAddr }}
   tunnel_public_addr: {{- toYaml .Values.tunnelPublicAddr | nindent 8 }}
-{{- end }}
+  {{- end }}
   kube_listen_addr: 0.0.0.0:3026
   {{- if .Values.kubePublicAddr }}
   kube_public_addr: {{- toYaml .Values.kubePublicAddr | nindent 8 }}
@@ -61,6 +61,7 @@ proxy_service:
   https_keypairs:
   - key_file: /etc/teleport-tls/tls.key
     cert_file: /etc/teleport-tls/tls.crt
+  https_keypairs_reload_interval: 12h
 {{- else if .Values.acme }}
   acme:
     enabled: {{ .Values.acme }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -1,0 +1,360 @@
+matches snapshot for acme-on.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        acme:
+          email: test@email.com
+          enabled: true
+        enabled: true
+        kube_listen_addr: 0.0.0.0:3026
+        listen_addr: 0.0.0.0:3023
+        mysql_listen_addr: 0.0.0.0:3036
+        public_addr: test-acme-cluster:443
+        tunnel_listen_addr: 0.0.0.0:3024
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for acme-uri-staging.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        acme:
+          email: test@email.com
+          enabled: true
+          uri: https://acme-staging-v02.api.letsencrypt.org/directory
+        enabled: true
+        kube_listen_addr: 0.0.0.0:3026
+        listen_addr: 0.0.0.0:3023
+        mysql_listen_addr: 0.0.0.0:3036
+        public_addr: test-acme-cluster:443
+        tunnel_listen_addr: 0.0.0.0:3024
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for aws-ha-acme.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        enabled: true
+        https_keypairs:
+        - cert_file: /etc/teleport-tls/tls.crt
+          key_file: /etc/teleport-tls/tls.key
+        https_keypairs_reload_interval: 12h
+        kube_listen_addr: 0.0.0.0:3026
+        listen_addr: 0.0.0.0:3023
+        mysql_listen_addr: 0.0.0.0:3036
+        public_addr: test-aws-cluster:443
+        tunnel_listen_addr: 0.0.0.0:3024
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for existing-tls-secret.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        enabled: true
+        https_keypairs:
+        - cert_file: /etc/teleport-tls/tls.crt
+          key_file: /etc/teleport-tls/tls.key
+        https_keypairs_reload_interval: 12h
+        kube_listen_addr: 0.0.0.0:3026
+        listen_addr: 0.0.0.0:3023
+        mysql_listen_addr: 0.0.0.0:3036
+        public_addr: test-cluster-name:443
+        tunnel_listen_addr: 0.0.0.0:3024
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for log-basic.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        enabled: true
+        kube_listen_addr: 0.0.0.0:3026
+        listen_addr: 0.0.0.0:3023
+        mysql_listen_addr: 0.0.0.0:3036
+        public_addr: test-log-cluster:443
+        tunnel_listen_addr: 0.0.0.0:3024
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: json
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for log-extra.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        enabled: true
+        kube_listen_addr: 0.0.0.0:3026
+        listen_addr: 0.0.0.0:3023
+        mysql_listen_addr: 0.0.0.0:3036
+        public_addr: test-log-cluster:443
+        tunnel_listen_addr: 0.0.0.0:3024
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - level
+            - timestamp
+            - component
+            - caller
+            output: json
+          output: /var/lib/teleport/test.log
+          severity: DEBUG
+      version: v3
+matches snapshot for proxy-listener-mode-multiplex.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        enabled: true
+        public_addr: test-proxy-listener-mode:443
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for proxy-listener-mode-separate.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        enabled: true
+        kube_listen_addr: 0.0.0.0:3026
+        listen_addr: 0.0.0.0:3023
+        mysql_listen_addr: 0.0.0.0:3036
+        public_addr: test-proxy-listener-mode:443
+        tunnel_listen_addr: 0.0.0.0:3024
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for public-addresses.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        enabled: true
+        kube_listen_addr: 0.0.0.0:3026
+        kube_public_addr:
+        - loadbalancer.example.com:3026
+        listen_addr: 0.0.0.0:3023
+        mongo_listen_addr: 0.0.0.0:27017
+        mongo_public_addr:
+        - loadbalancer.example.com:27017
+        mysql_listen_addr: 0.0.0.0:3036
+        mysql_public_addr:
+        - loadbalancer.example.com:3036
+        postgres_listen_addr: 0.0.0.0:5432
+        postgres_public_addr:
+        - loadbalancer.example.com:5432
+        public_addr:
+        - loadbalancer.example.com:443
+        ssh_public_addr:
+        - loadbalancer.example.com:3023
+        tunnel_listen_addr: 0.0.0.0:3024
+        tunnel_public_addr:
+        - loadbalancer.example.com:3024
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for separate-mongo-listener.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        enabled: true
+        kube_listen_addr: 0.0.0.0:3026
+        listen_addr: 0.0.0.0:3023
+        mongo_listen_addr: 0.0.0.0:27017
+        mongo_public_addr: helm-lint:27017
+        mysql_listen_addr: 0.0.0.0:3036
+        public_addr: helm-lint:443
+        tunnel_listen_addr: 0.0.0.0:3024
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for separate-postgres-listener.yaml:
+  1: |
+    |-
+      auth_service:
+        enabled: false
+      proxy_service:
+        enabled: true
+        kube_listen_addr: 0.0.0.0:3026
+        listen_addr: 0.0.0.0:3023
+        mysql_listen_addr: 0.0.0.0:3036
+        postgres_listen_addr: 0.0.0.0:5432
+        postgres_public_addr: helm-lint:5432
+        public_addr: helm-lint:443
+        tunnel_listen_addr: 0.0.0.0:3024
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3025
+        join_params:
+          method: kubernetes
+          token_name: RELEASE-NAME-proxy
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3

--- a/examples/chart/teleport-cluster/tests/proxy_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_config_test.yaml
@@ -1,0 +1,139 @@
+suite: ConfigMap
+templates:
+  - proxy/config.yaml
+tests:
+  - it: matches snapshot for log-basic.yaml
+    values:
+      - ../.lint/log-basic.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for log-extra.yaml
+    values:
+      - ../.lint/log-extra.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for public-addresses.yaml
+    values:
+      - ../.lint/public-addresses.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: wears annotations (annotations.yaml)
+    values:
+      - ../.lint/annotations.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.annotations.kubernetes\.io/config
+          value: test-annotation
+      - equal:
+          path: metadata.annotations.kubernetes\.io/config-different
+          value: 2
+
+  - it: matches snapshot for proxy-listener-mode-multiplex.yaml
+    values:
+      - ../.lint/proxy-listener-mode-multiplex.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for proxy-listener-mode-separate.yaml
+    values:
+      - ../.lint/proxy-listener-mode-separate.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for separate-mongo-listener.yaml
+    values:
+      - ../.lint/separate-mongo-listener.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for separate-postgres-listener.yaml
+    values:
+      - ../.lint/separate-postgres-listener.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for aws-ha-acme.yaml
+    values:
+      - ../.lint/aws-ha-acme.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for existing-tls-secret.yaml
+    values:
+      - ../.lint/existing-tls-secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for acme-on.yaml
+    values:
+      - ../.lint/acme-on.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for acme-uri-staging.yaml
+    values:
+      - ../.lint/acme-uri-staging.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml


### PR DESCRIPTION
Fixes #11622

This PR contains two commits:
- one to use the new certificate-reloading capabilities, so the proxies always serve non-expired certs (cert-manager/LE issued certs are refreshed 30 days before expiry, this gives us 59 reloading attempts before the certs expire). This commit also contains a cosmetic indentation fix.
- one to add proxy config tests. I made the change and expected the tests to fail. As they did not, I realized the test file got lost during the chart split 🙃 . I added relevant proxy snapshot tests back.