### PR TITLE
Add missing assignment of `GCPServiceAccounts`, lost in merge.

### DIFF
--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -358,6 +358,7 @@ func profileStatusFromKey(key *Key, opts profileOptions) (*ProfileStatus, error)
 		Apps:               apps,
 		AWSRolesARNs:       tlsID.AWSRoleARNs,
 		AzureIdentities:    tlsID.AzureIdentities,
+		GCPServiceAccounts: tlsID.GCPServiceAccounts,
 		IsVirtual:          opts.IsVirtual,
 		AllowedResourceIDs: allowedResourceIDs,
 	}, nil


### PR DESCRIPTION
This change should have been part of commit https://github.com/gravitational/teleport/commit/e053cba973ef4339bd4c76933debfcb32a625a36