### PR TITLE
GCP: set project id, use isolated config

### DIFF
--- a/tool/tsh/gcp.go
+++ b/tool/tsh/gcp.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -132,8 +131,6 @@ func (a *gcpApp) Close() error {
 func (a *gcpApp) getGcloudConfigPath() string {
 	return path.Join(profile.FullProfilePath(a.cf.HomePath), "gcp", a.app.ClusterName, a.app.Name, "gcloud")
 }
-
-var projectIDRegexp = regexp.MustCompile(`.*@(?P<projectID>.*)\.iam\.gserviceaccount\.com`)
 
 func projectIDFromServiceAccountName(serviceAccount string) (string, error) {
 	if serviceAccount == "" {

--- a/tool/tsh/gcp_test.go
+++ b/tool/tsh/gcp_test.go
@@ -258,3 +258,43 @@ func TestSortedGCPServiceAccounts(t *testing.T) {
 		})
 	}
 }
+
+func Test_projectIDFromServiceAccountName(t *testing.T) {
+	tests := []struct {
+		name           string
+		serviceAccount string
+		want           string
+		wantErr        require.ErrorAssertionFunc
+	}{
+		{
+			name:           "empty string",
+			serviceAccount: "",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "cannot extract project ID from service account")
+			},
+		},
+		{
+			name:           "good service account",
+			serviceAccount: "test@myproject-123456.iam.gserviceaccount.com",
+			want:           "myproject-123456",
+			wantErr:        require.NoError,
+		},
+		{
+			name:           "missing domain",
+			serviceAccount: "test@myproject-123456",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "cannot extract project ID from service account")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := projectIDFromServiceAccountName(tt.serviceAccount)
+			require.Equal(t, tt.want, got)
+			tt.wantErr(t, err)
+		})
+	}
+}

--- a/tool/tsh/gcp_test.go
+++ b/tool/tsh/gcp_test.go
@@ -296,25 +296,65 @@ func Test_projectIDFromServiceAccountName(t *testing.T) {
 		wantErr        require.ErrorAssertionFunc
 	}{
 		{
+			name:           "valid service account",
+			serviceAccount: "test@myproject-123456.iam.gserviceaccount.com",
+			want:           "myproject-123456",
+			wantErr:        require.NoError,
+		},
+		{
 			name:           "empty string",
 			serviceAccount: "",
 			want:           "",
 			wantErr: func(t require.TestingT, err error, i ...interface{}) {
-				require.ErrorContains(t, err, "cannot extract project ID from service account")
+				require.ErrorContains(t, err, "invalid service account format: empty string received")
 			},
 		},
 		{
-			name:           "good service account",
-			serviceAccount: "test@myproject-123456.iam.gserviceaccount.com",
-			want:           "myproject-123456",
-			wantErr:        require.NoError,
+			name:           "missing @",
+			serviceAccount: "test",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: missing @")
+			},
+		},
+		{
+			name:           "missing domain after @",
+			serviceAccount: "test@",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: missing <project-id>.iam.gserviceaccount.com after @")
+			},
+		},
+		{
+			name:           "missing user before @",
+			serviceAccount: "@project",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: empty user")
+			},
 		},
 		{
 			name:           "missing domain",
 			serviceAccount: "test@myproject-123456",
 			want:           "",
 			wantErr: func(t require.TestingT, err error, i ...interface{}) {
-				require.ErrorContains(t, err, "cannot extract project ID from service account")
+				require.ErrorContains(t, err, "invalid service account format: missing <project-id>.iam.gserviceaccount.com after @")
+			},
+		},
+		{
+			name:           "wrong domain suffix",
+			serviceAccount: "test@myproject-123456.iam.gserviceaccount",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: expected suffix \"iam.gserviceaccount.com\", got \"iam.gserviceaccount\"")
+			},
+		},
+		{
+			name:           "missing project id",
+			serviceAccount: "test@.iam.gserviceaccount.com",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: missing project ID")
 			},
 		},
 	}


### PR DESCRIPTION
This PR fixes two issues with GCP integration:
- If a user has an existing `gcloud` installation, the configuration (in particular authorized accounts) can conflict with the configuration we set. Following the example set by Azure integration, we will use an isolated config under `~/.tsh/gcp`. This is done with `CLOUDSDK_CONFIG` env var.
- Without preexisting configuration, `tsh gcloud` will be missing the project id. There are multiple ways we can set that, but here we use the `CLOUDSDK_CORE_PROJECT` env variable. 