### PR TITLE
Add Azure SQL Server to test plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1142,6 +1142,7 @@ tsh bench sessions --max=5000 --web user ls
   - [ ] Elasticsearch.
   - [ ] Cassandra/ScyllaDB.
   - [ ] Dynamodb.
+  - [ ] Azure SQL Server.
 - [ ] Connect to a database within a remote cluster via a trusted cluster.
   - [ ] Self-hosted Postgres.
   - [ ] Self-hosted MySQL.
@@ -1163,6 +1164,7 @@ tsh bench sessions --max=5000 --web user ls
   - [ ] Elasticsearch.
   - [ ] Cassandra/ScyllaDB.
   - [ ] Dynamodb.
+  - [ ] Azure SQL Server.
 - [ ] Verify audit events.
   - [ ] `db.session.start` is emitted when you connect.
   - [ ] `db.session.end` is emitted when you disconnect.
@@ -1190,6 +1192,7 @@ tsh bench sessions --max=5000 --web user ls
     - [ ] Azure
       - [ ] Can detect and register MySQL and Postgres instances.
       - [ ] Can detect and register Azure Cache for Redis servers.
+      - [ ] Can detect and register Azure SQL Servers and Azure SQL Managed Instances.
 - [ ] Verify Teleport managed users (password rotation, auto 'auth' on connection, etc.).
   - [ ] Can detect and manage ElastiCache users
   - [ ] Can detect and manage MemoryDB users 


### PR DESCRIPTION
Test plan tasks related to Azure SQL Server, implemented at #17745 and #17142