### PR TITLE
Add a connection limiting listener

### DIFF
--- a/lib/limiter/connlimiter.go
+++ b/lib/limiter/connlimiter.go
@@ -29,7 +29,7 @@ import (
 // ConnectionsLimiter is a network connection limiter and tracker
 type ConnectionsLimiter struct {
 	*connlimit.ConnLimiter
-	*sync.Mutex
+	sync.Mutex
 	connections    map[string]int64
 	maxConnections int64
 }
@@ -38,7 +38,6 @@ type ConnectionsLimiter struct {
 // limits are not set, they won't be tracked
 func NewConnectionsLimiter(config Config) (*ConnectionsLimiter, error) {
 	limiter := ConnectionsLimiter{
-		Mutex:          &sync.Mutex{},
 		maxConnections: config.MaxConnections,
 		connections:    make(map[string]int64),
 	}
@@ -48,8 +47,7 @@ func NewConnectionsLimiter(config Config) (*ConnectionsLimiter, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	limiter.ConnLimiter, err = connlimit.New(
-		nil, ipExtractor, config.MaxConnections)
+	limiter.ConnLimiter, err = connlimit.New(nil, ipExtractor, config.MaxConnections)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -64,55 +62,62 @@ func (l *ConnectionsLimiter) WrapHandle(h http.Handler) {
 
 // AcquireConnection acquires connection and bumps counter
 func (l *ConnectionsLimiter) AcquireConnection(token string) error {
-	l.Lock()
-	defer l.Unlock()
-
 	if l.maxConnections == 0 {
 		return nil
 	}
+
+	l.Lock()
+	defer l.Unlock()
 
 	numberOfConnections, exists := l.connections[token]
 	if !exists {
 		l.connections[token] = 1
 		return nil
 	}
+
 	if numberOfConnections >= l.maxConnections {
-		return trace.LimitExceeded(
-			"too many connections from %v: %v, max is %v",
-			token, numberOfConnections, l.maxConnections)
+		return trace.LimitExceeded("too many connections from %v: %v, max is %v", token, numberOfConnections, l.maxConnections)
 	}
-	l.connections[token] = numberOfConnections + 1
+
+	l.connections[token]++
 	return nil
 }
 
 // ReleaseConnection decrements the counter
 func (l *ConnectionsLimiter) ReleaseConnection(token string) {
-	l.Lock()
-	defer l.Unlock()
-
 	if l.maxConnections == 0 {
 		return
 	}
 
+	l.Lock()
+	defer l.Unlock()
+
 	numberOfConnections, exists := l.connections[token]
 	if !exists {
 		log.Errorf("Trying to set negative number of connections")
+		return
+	}
+
+	if numberOfConnections <= 1 {
+		delete(l.connections, token)
 	} else {
-		if numberOfConnections <= 1 {
-			delete(l.connections, token)
-		} else {
-			l.connections[token] = numberOfConnections - 1
-		}
+		l.connections[token]--
 	}
 }
 
-// GetNumConnections returns the current number of connections for a token
+// GetNumConnection returns the current number of connections for a token
 func (l *ConnectionsLimiter) GetNumConnection(token string) (int64, error) {
+	if l.maxConnections == 0 {
+		return 0, nil
+	}
+
 	l.Lock()
 	defer l.Unlock()
+
 	numberOfConnections, exists := l.connections[token]
 	if !exists {
-		return -1, trace.Errorf("Trying to get connections of a nonexistent token: %s", token)
+		return -1, trace.BadParameter("unable to get connections of a nonexistent token: %q", token)
 	}
+
 	return numberOfConnections, nil
 }

--- a/lib/limiter/connlimiter.go
+++ b/lib/limiter/connlimiter.go
@@ -29,9 +29,10 @@ import (
 // ConnectionsLimiter is a network connection limiter and tracker
 type ConnectionsLimiter struct {
 	*connlimit.ConnLimiter
-	sync.Mutex
-	connections    map[string]int64
 	maxConnections int64
+
+	sync.Mutex
+	connections map[string]int64
 }
 
 // NewConnectionsLimiter returns new connection limiter, in case if connection
@@ -79,7 +80,7 @@ func (l *ConnectionsLimiter) AcquireConnection(token string) error {
 		return trace.LimitExceeded("too many connections from %v: %v, max is %v", token, numberOfConnections, l.maxConnections)
 	}
 
-	l.connections[token]++
+	l.connections[token] = numberOfConnections + 1
 	return nil
 }
 
@@ -101,7 +102,7 @@ func (l *ConnectionsLimiter) ReleaseConnection(token string) {
 	if numberOfConnections <= 1 {
 		delete(l.connections, token)
 	} else {
-		l.connections[token]--
+		l.connections[token] = numberOfConnections - 1
 	}
 }
 

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -60,20 +60,24 @@ func (l *Config) SetEnv(v string) error {
 
 // NewLimiter returns new rate and connection limiter
 func NewLimiter(config Config) (*Limiter, error) {
-	var err error
-	limiter := Limiter{}
+	if config.MaxConnections < 0 {
+		config.MaxConnections = 0
+	}
 
-	limiter.ConnectionsLimiter, err = NewConnectionsLimiter(config)
+	connectionsLimiter, err := NewConnectionsLimiter(config)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	limiter.rateLimiter, err = NewRateLimiter(config)
+	rateLimiter, err := NewRateLimiter(config)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return &limiter, nil
+	return &Limiter{
+		ConnectionsLimiter: connectionsLimiter,
+		rateLimiter:        rateLimiter,
+	}, nil
 }
 
 func (l *Limiter) RegisterRequest(token string) error {
@@ -150,7 +154,7 @@ func (l *Limiter) UnaryServerInterceptorWithCustomRate(customRate CustomRateFunc
 	}
 }
 
-// StreamServerInterceptor is a GPRC stream interceptor that rate limits
+// StreamServerInterceptor is a gPRC stream interceptor that rate limits
 // incoming requests by client IP.
 func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	peerInfo, ok := peer.FromContext(serverStream.Context())
@@ -170,4 +174,10 @@ func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.Ser
 	}
 	defer l.ConnLimiter.Release(clientIP, 1)
 	return handler(srv, serverStream)
+}
+
+// WrapListener returns a [Listener] that wraps the provided listener
+// with one that limits connections
+func (l *Limiter) WrapListener(ln net.Listener) *Listener {
+	return NewListener(ln, l.ConnectionsLimiter)
 }

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -154,7 +154,7 @@ func (l *Limiter) UnaryServerInterceptorWithCustomRate(customRate CustomRateFunc
 	}
 }
 
-// StreamServerInterceptor is a gPRC stream interceptor that rate limits
+// StreamServerInterceptor is a gRPC stream interceptor that rate limits
 // incoming requests by client IP.
 func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	peerInfo, ok := peer.FromContext(serverStream.Context())

--- a/lib/limiter/listener.go
+++ b/lib/limiter/listener.go
@@ -1,0 +1,87 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limiter
+
+import (
+	"net"
+	"sync"
+
+	"github.com/gravitational/trace"
+)
+
+// Listener wraps a [net.Listener] and applies connection limiting
+// per client to all connections that are accepted.
+type Listener struct {
+	net.Listener
+	limiter *ConnectionsLimiter
+}
+
+// NewListener creates a [Listener] that enforces the limits of
+// the provided [ConnectionsLimiter] on the all connections accepted
+// by the provided [net.Listener].
+func NewListener(ln net.Listener, limiter *ConnectionsLimiter) *Listener {
+	return &Listener{
+		Listener: ln,
+		limiter:  limiter,
+	}
+}
+
+// Accept waits for and returns the next connection to the listener
+// if the limiter is able to acquire a connection. If not, and the max number
+// of connections has been exceeded then a [trace.LimitExceeded] error
+// is returned.
+func (l *Listener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	remoteAddr, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+	if err != nil {
+		return nil, trace.NewAggregate(err, conn.Close())
+	}
+
+	if err := l.limiter.AcquireConnection(remoteAddr); err != nil {
+		// Aggregating the error here makes trace.IsLimitExceeded
+		// return false, which poses problems for consumers relying
+		// on that to determine if the connection was prevented.
+		_ = conn.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	return &wrappedConn{
+		Conn: conn,
+		release: func() {
+			l.limiter.ReleaseConnection(remoteAddr)
+		},
+	}, nil
+
+}
+
+// wrappedConn allows connections accepted via the [Listener] to decrement
+// the connection count.
+type wrappedConn struct {
+	net.Conn
+
+	once    sync.Once
+	release func()
+}
+
+// Close releases the connection from the limiter and closes the
+// underlying [net.Conn].
+func (w *wrappedConn) Close() error {
+	w.once.Do(w.release)
+	return trace.Wrap(w.Conn.Close())
+}


### PR DESCRIPTION
Introduces `limiter.Listener` to provide a consistent and resuable mechanism for limiting incoming connections per client. The new listener is used by `sshutils/server.go` instead of manually applying limits in `HandleConnection`.

This is particuarly important now that the Proxy SSH port multiplexes both SSH and gRPC. Each listener is now wrapped in a `limiter.Listener` that uses the same `limiter.ConnectionsListener` to ensure that the connection limits for the Proxy are enforced for all traffic on the port.