### PR TITLE
update testplan for azure databases

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -749,6 +749,8 @@ tsh bench sessions --max=5000 --web user ls
   - [ ] GCP Cloud SQL MySQL.
   - [ ] Snowflake.
   - [ ] Azure Cache for Redis.
+  - [ ] Azure single-server MySQL and Postgres
+  - [ ] Azure flexible-server MySQL and Postgres
   - [ ] Elasticsearch.
   - [ ] Cassandra/ScyllaDB.
   - [ ] Dynamodb.
@@ -772,6 +774,8 @@ tsh bench sessions --max=5000 --web user ls
   - [ ] GCP Cloud SQL MySQL.
   - [ ] Snowflake.
   - [ ] Azure Cache for Redis.
+  - [ ] Azure single-server MySQL and Postgres
+  - [ ] Azure flexible-server MySQL and Postgres
   - [ ] Elasticsearch.
   - [ ] Cassandra/ScyllaDB.
   - [ ] Dynamodb.
@@ -802,7 +806,8 @@ tsh bench sessions --max=5000 --web user ls
       - [ ] Can detect and register ElastiCache Redis clusters.
       - [ ] Can detect and register MemoryDB clusters.
     - [ ] Azure
-      - [ ] Can detect and register MySQL and Postgres instances.
+      - [ ] Can detect and register MySQL and Postgres single-server instances.
+      - [ ] Can detect and register MySQL and Postgres flexible-server instances.
       - [ ] Can detect and register Azure Cache for Redis servers.
 - [ ] Verify Teleport managed users (password rotation, auto 'auth' on connection, etc.).
   - [ ] Can detect and manage ElastiCache users


### PR DESCRIPTION
This PR adds a distinction for Azure flex vs single-server to the testplan document.

I also added Azure connect tests to remote/local clusters, since the Azure flex integration required a change to the way we modify Azure `--db-user` before the agent engine connects, so we want to ensure that connections for both flex/single-server still work.

edit: I already updated the v12 issue to include these changes, this is just to get it in the template going forward.