### PR TITLE
(buddy) helm: Add nodeSelector field

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1362,6 +1362,33 @@ See the [Teleport config file reference](../../reference/config.mdx) for more de
   </TabItem>
 </Tabs>
 
+## `nodeSelector`
+
+| Type | Default value |
+| - | - |
+| `object` | `{}` |
+
+`nodeSelector` can be used to add a map of key-value pairs to constrain the
+nodes that Teleport pods will run on.
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  nodeSelector:
+    role: bastion
+    environment: security
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  --set nodeSelector.role=bastion \
+  --set nodeSelector.environment=security
+  ```
+  </TabItem>
+</Tabs>
+
 ## `affinity`
 
 | Type | Default value | Can be used in `custom` mode? |

--- a/examples/chart/teleport-cluster/.lint/node-selector.yaml
+++ b/examples/chart/teleport-cluster/.lint/node-selector.yaml
@@ -1,0 +1,4 @@
+clusterName: test-cluster-name
+nodeSelector:
+  role: bastion
+  environment: security

--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -43,6 +43,9 @@ spec:
         {{- include "teleport-cluster.auth.labels" . | nindent 8 }}
         app: {{ .Release.Name }}
     spec:
+{{- if $auth.nodeSelector }}
+      nodeSelector: {{- toYaml $auth.nodeSelector | nindent 8 }}
+{{- end }}
       affinity:
 {{- if $auth.affinity }}
   {{- if $auth.highAvailability.requireAntiAffinity }}

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -50,6 +50,9 @@ spec:
 {{- end }}
       labels: {{- include "teleport-cluster.proxy.labels" . | nindent 8 }}
     spec:
+{{- if $proxy.nodeSelector }}
+      nodeSelector: {{- toYaml $proxy.nodeSelector | nindent 8 }}
+{{- end }}
       affinity:
 {{- if $proxy.affinity }}
   {{- if $proxy.highAvailability.requireAntiAffinity }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -112,6 +112,54 @@ should set affinity when set in values:
             operator: In
             values:
             - teleport
+should set nodeSelector when set in values:
+  1: |
+    affinity:
+      podAntiAffinity: null
+    containers:
+    - args:
+      - --diag-addr=0.0.0.0:3000
+      - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
+      image: public.ecr.aws/gravitational/teleport:12.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      name: teleport
+      ports:
+      - containerPort: 3000
+        name: diag
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 12
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      volumeMounts:
+      - mountPath: /etc/teleport
+        name: config
+        readOnly: true
+      - mountPath: /var/lib/teleport
+        name: data
+    nodeSelector:
+      environment: security
+      role: bastion
+    serviceAccountName: RELEASE-NAME
+    volumes:
+    - configMap:
+        name: RELEASE-NAME-auth
+      name: config
+    - name: data
+      persistentVolumeClaim:
+        claimName: RELEASE-NAME
 should set required affinity when highAvailability.requireAntiAffinity is set:
   1: |
     podAntiAffinity:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -44,6 +44,52 @@ should set affinity when set in values:
             operator: In
             values:
             - teleport
+should set nodeSelector when set in values:
+  1: |
+    affinity:
+      podAntiAffinity: null
+    containers:
+    - args:
+      - --diag-addr=0.0.0.0:3000
+      image: public.ecr.aws/gravitational/teleport:12.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      name: teleport
+      ports:
+      - containerPort: 3000
+        name: diag
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 12
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      volumeMounts:
+      - mountPath: /etc/teleport
+        name: config
+        readOnly: true
+      - mountPath: /var/lib/teleport
+        name: data
+    nodeSelector:
+      environment: security
+      role: bastion
+    serviceAccountName: RELEASE-NAME-proxy
+    volumes:
+    - configMap:
+        name: RELEASE-NAME-proxy
+      name: config
+    - emptyDir: {}
+      name: data
 should set required affinity when highAvailability.requireAntiAffinity is set:
   1: |
     podAntiAffinity:

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -68,6 +68,20 @@ tests:
       - matchSnapshot:
           path: spec.template.spec.affinity
 
+  - it: should set nodeSelector when set in values
+    template: auth/deployment.yaml
+    set:
+      chartMode: scratch
+      clusterName: helm-lint.example.com
+      nodeSelector:
+        role: bastion
+        environment: security
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.nodeSelector
+      - matchSnapshot:
+          path: spec.template.spec
+
   - it: should set required affinity when highAvailability.requireAntiAffinity is set
     template: auth/deployment.yaml
     values:

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -561,3 +561,17 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: null
+
+  - it: should set nodeSelector when set in values
+    template: proxy/deployment.yaml
+    set:
+      chartMode: scratch
+      clusterName: helm-lint.example.com
+      nodeSelector:
+        role: bastion
+        environment: security
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.nodeSelector
+      - matchSnapshot:
+          path: spec.template.spec

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -17,6 +17,7 @@
         "enterpriseImage",
         "log",
         "affinity",
+        "nodeSelector",
         "annotations",
         "extraVolumes",
         "extraVolumeMounts",
@@ -659,6 +660,11 @@
         },
         "affinity": {
             "$id": "#/properties/affinity",
+            "type": "object",
+            "default": {}
+        },
+        "nodeSelector": {
+            "$id": "#/properties/nodeSelector",
             "type": "object",
             "default": {}
         },

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -369,6 +369,10 @@ log:
 # Extra Kubernetes configuration #
 ##################################
 
+# nodeSelector to apply for pod assignment
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+nodeSelector: {}
+
 # Affinity for pod assignment
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 # NOTE: If affinity is set here, highAvailability.requireAntiAffinity cannot also be used - you can only set one or the other.


### PR DESCRIPTION
This is the buddy PR for @yanntoque's external contribution: https://github.com/gravitational/teleport/pull/15590

Note for reviewers: the `nodeSelector` field was already supported by the `teleport-kube-agent` chart.