### PR TITLE
Update the cert rotation deprecation comment

### DIFF
--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -39,7 +39,7 @@ const (
 	// much like a CA in terms of rotation and storage.
 	JWTSigner CertAuthType = "jwt"
 	// CertAuthTypeAll is a special type that represents all CertAuthTypes.
-	// DEPRECATED, DELETE IN 14.0.0. For more information see:
+	// DEPRECATED, DELETE IN 13.0.0. For more information see:
 	// https://github.com/gravitational/teleport/issues/17493
 	CertAuthTypeAll CertAuthType = "all"
 )


### PR DESCRIPTION
After discussions with @zmb3 and @rosstimothy we decided to remove the deprecated ca rotation code in v13. Just updating the comment to reflect that properly for v12.