### PR TITLE
Validate GCP service accounts in `tctl users add/update` and `tsh app login`.

### DIFF
--- a/lib/utils/gcp/gcp.go
+++ b/lib/utils/gcp/gcp.go
@@ -1,0 +1,89 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// SortedGCPServiceAccounts sorts service accounts by project and service account name.
+type SortedGCPServiceAccounts []string
+
+// Len returns the length of a list.
+func (s SortedGCPServiceAccounts) Len() int {
+	return len(s)
+}
+
+// Less compares items. Given two accounts, it first compares the project (i.e. what goes after @)
+// and if they are equal proceeds to compare the service account name (what goes before @).
+// Example of sorted list:
+// - test-0@example-100200.iam.gserviceaccount.com
+// - test-1@example-123456.iam.gserviceaccount.com
+// - test-2@example-123456.iam.gserviceaccount.com
+// - test-3@example-123456.iam.gserviceaccount.com
+// - test-0@other-999999.iam.gserviceaccount.com
+func (s SortedGCPServiceAccounts) Less(i, j int) bool {
+	beforeI, afterI, _ := strings.Cut(s[i], "@")
+	beforeJ, afterJ, _ := strings.Cut(s[j], "@")
+
+	if afterI != afterJ {
+		return afterI < afterJ
+	}
+
+	return beforeI < beforeJ
+}
+
+// Swap swaps two items in a list.
+func (s SortedGCPServiceAccounts) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+const expectedParentDomain = "iam.gserviceaccount.com"
+
+func ProjectIDFromServiceAccountName(serviceAccount string) (string, error) {
+	if serviceAccount == "" {
+		return "", trace.BadParameter("invalid service account format: empty string received")
+	}
+
+	user, domain, found := strings.Cut(serviceAccount, "@")
+	if !found {
+		return "", trace.BadParameter("invalid service account format: missing @")
+	}
+	if user == "" {
+		return "", trace.BadParameter("invalid service account format: empty user")
+	}
+
+	projectID, iamDomain, found := strings.Cut(domain, ".")
+	if !found {
+		return "", trace.BadParameter("invalid service account format: missing <project-id>.iam.gserviceaccount.com after @")
+	}
+
+	if projectID == "" {
+		return "", trace.BadParameter("invalid service account format: missing project ID")
+	}
+
+	if iamDomain != expectedParentDomain {
+		return "", trace.BadParameter("invalid service account format: expected suffix %q, got %q", expectedParentDomain, iamDomain)
+	}
+
+	return projectID, nil
+}
+
+func ValidateGCPServiceAccountName(serviceAccount string) error {
+	_, err := ProjectIDFromServiceAccountName(serviceAccount)
+	return err
+}

--- a/lib/utils/gcp/gcp_test.go
+++ b/lib/utils/gcp/gcp_test.go
@@ -1,0 +1,190 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortedGCPServiceAccounts(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "empty",
+			args: nil,
+			want: nil,
+		},
+		{
+			name: "unsorted accounts",
+			args: []string{
+				"test-3@example-123456.iam.gserviceaccount.com",
+				"test-2@example-123456.iam.gserviceaccount.com",
+				"test-1@example-123456.iam.gserviceaccount.com",
+				"test-0@example-100200.iam.gserviceaccount.com",
+				"test-0@other-999999.iam.gserviceaccount.com",
+			},
+			want: []string{
+				"test-0@example-100200.iam.gserviceaccount.com",
+				"test-1@example-123456.iam.gserviceaccount.com",
+				"test-2@example-123456.iam.gserviceaccount.com",
+				"test-3@example-123456.iam.gserviceaccount.com",
+				"test-0@other-999999.iam.gserviceaccount.com",
+			},
+		},
+		{
+			name: "invalid accounts",
+			args: []string{
+				"",
+				"@",
+				"@@@",
+				"test-3_example-123456.iam.gserviceaccount.com",
+				"test-2_example-123456.iam.gserviceaccount.com",
+				"test-1_example-123456.iam.gserviceaccount.com",
+				"test-0_example-100200.iam.gserviceaccount.com",
+				"test-0_other-999999.iam.gserviceaccount.com",
+			},
+			want: []string{
+				"",
+				"@",
+				"test-0_example-100200.iam.gserviceaccount.com",
+				"test-0_other-999999.iam.gserviceaccount.com",
+				"test-1_example-123456.iam.gserviceaccount.com",
+				"test-2_example-123456.iam.gserviceaccount.com",
+				"test-3_example-123456.iam.gserviceaccount.com",
+				"@@@",
+			},
+		},
+		{
+			name: "mixed invalid and valid accounts",
+			args: []string{
+				"",
+				"@",
+				"@@@",
+				"test-3_example-123456.iam.gserviceaccount.com",
+				"test-2_example-123456.iam.gserviceaccount.com",
+				"test-3@example-123456.iam.gserviceaccount.com",
+				"test-2@example-123456.iam.gserviceaccount.com",
+				"test-1_example-123456.iam.gserviceaccount.com",
+				"test-0@example-100200.iam.gserviceaccount.com",
+				"test-0_other-999999.iam.gserviceaccount.com",
+			},
+			want: []string{
+				"",
+				"@",
+				"test-0_other-999999.iam.gserviceaccount.com",
+				"test-1_example-123456.iam.gserviceaccount.com",
+				"test-2_example-123456.iam.gserviceaccount.com",
+				"test-3_example-123456.iam.gserviceaccount.com",
+				"@@@",
+				"test-0@example-100200.iam.gserviceaccount.com",
+				"test-2@example-123456.iam.gserviceaccount.com",
+				"test-3@example-123456.iam.gserviceaccount.com",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acc := SortedGCPServiceAccounts(tt.args)
+			sort.Sort(acc)
+			require.Equal(t, tt.want, []string(acc))
+		})
+	}
+}
+
+func TestProjectIDFromServiceAccountName(t *testing.T) {
+	tests := []struct {
+		name           string
+		serviceAccount string
+		want           string
+		wantErr        require.ErrorAssertionFunc
+	}{
+		{
+			name:           "valid service account",
+			serviceAccount: "test@myproject-123456.iam.gserviceaccount.com",
+			want:           "myproject-123456",
+			wantErr:        require.NoError,
+		},
+		{
+			name:           "empty string",
+			serviceAccount: "",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: empty string received")
+			},
+		},
+		{
+			name:           "missing @",
+			serviceAccount: "test",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: missing @")
+			},
+		},
+		{
+			name:           "missing domain after @",
+			serviceAccount: "test@",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: missing <project-id>.iam.gserviceaccount.com after @")
+			},
+		},
+		{
+			name:           "missing user before @",
+			serviceAccount: "@project",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: empty user")
+			},
+		},
+		{
+			name:           "missing domain",
+			serviceAccount: "test@myproject-123456",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: missing <project-id>.iam.gserviceaccount.com after @")
+			},
+		},
+		{
+			name:           "wrong domain suffix",
+			serviceAccount: "test@myproject-123456.iam.gserviceaccount",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: expected suffix \"iam.gserviceaccount.com\", got \"iam.gserviceaccount\"")
+			},
+		},
+		{
+			name:           "missing project id",
+			serviceAccount: "test@.iam.gserviceaccount.com",
+			want:           "",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "invalid service account format: missing project ID")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ProjectIDFromServiceAccountName(tt.serviceAccount)
+			require.Equal(t, tt.want, got)
+			tt.wantErr(t, err)
+		})
+	}
+}

--- a/tool/tctl/common/user_command_test.go
+++ b/tool/tctl/common/user_command_test.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -63,6 +64,157 @@ func TestTrimDurationSuffix(t *testing.T) {
 	}
 }
 
+func TestUserAdd(t *testing.T) {
+	fileConfig := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: mustGetFreeLocalListenerAddr(t),
+			},
+		},
+	}
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig))
+	ctx := context.Background()
+	client := getAuthClient(ctx, t, fileConfig)
+
+	tests := []struct {
+		name string
+		args []string
+		// if dontAddDefaultRoles is false (default), `--roles auditor` is added to the command line.
+		// this makes it easier to see the essence of particular test case.
+		dontAddDefaultRoles bool
+		wantRoles           []string
+		wantTraits          map[string][]string
+		errorChecker        require.ErrorAssertionFunc
+	}{
+		{
+			name:                "set roles",
+			dontAddDefaultRoles: true,
+			args:                []string{"--roles", "editor,access"},
+			wantRoles:           []string{"editor", "access"},
+		},
+		{
+			name:                "nonexistent roles",
+			dontAddDefaultRoles: true,
+			args:                []string{"--roles", "editor,access,fake"},
+			errorChecker: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsNotFound(err), err)
+			},
+		},
+		{
+			name: "logins",
+			args: []string{"--logins", "l1,l2,l3"},
+			wantTraits: map[string][]string{
+				constants.TraitLogins: {"l1", "l2", "l3"},
+			},
+		},
+		{
+			name: "windows logins",
+			args: []string{"--windows-logins", "w1,w2,w3"},
+			wantTraits: map[string][]string{
+				constants.TraitWindowsLogins: {"w1", "w2", "w3"},
+			},
+		},
+		{
+			name: "kube users",
+			args: []string{"--kubernetes-users", "k1,k2,k3"},
+			wantTraits: map[string][]string{
+				constants.TraitKubeUsers: {"k1", "k2", "k3"},
+			},
+		},
+		{
+			name: "kube groups",
+			args: []string{"--kubernetes-groups", "k4,k5,k6"},
+			wantTraits: map[string][]string{
+				constants.TraitKubeGroups: {"k4", "k5", "k6"},
+			},
+		},
+		{
+			name: "db users",
+			args: []string{"--db-users", "d1,d2,d3"},
+			wantTraits: map[string][]string{
+				constants.TraitDBUsers: {"d1", "d2", "d3"},
+			},
+		},
+		{
+			name: "db names",
+			args: []string{"--db-names", "d4,d5,d6"},
+			wantTraits: map[string][]string{
+				constants.TraitDBNames: {"d4", "d5", "d6"},
+			},
+		},
+		{
+			name: "AWS role ARNs",
+			args: []string{"--aws-role-arns", "a1,a2,a3"},
+			wantTraits: map[string][]string{
+				constants.TraitAWSRoleARNs: {"a1", "a2", "a3"},
+			},
+		},
+		{
+			name: "Azure identities",
+			args: []string{"--azure-identities", "/subscriptions/1020304050607-cafe-8090-a0b0c0d0e0f0/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/teleport-azure-1,/subscriptions/1020304050607-cafe-8090-a0b0c0d0e0f0/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/teleport-azure-2,/subscriptions/1020304050607-cafe-8090-a0b0c0d0e0f0/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/teleport-azure-3"},
+			wantTraits: map[string][]string{
+				constants.TraitAzureIdentities: {
+					"/subscriptions/1020304050607-cafe-8090-a0b0c0d0e0f0/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/teleport-azure-1",
+					"/subscriptions/1020304050607-cafe-8090-a0b0c0d0e0f0/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/teleport-azure-2",
+					"/subscriptions/1020304050607-cafe-8090-a0b0c0d0e0f0/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/teleport-azure-3",
+				},
+			},
+		},
+		{
+			name: "GCP service accounts",
+			args: []string{"--gcp-service-accounts", "a1@example-123456.iam.gserviceaccount.com,a2@example-456789.iam.gserviceaccount.com,a3@example-111222.iam.gserviceaccount.com"},
+			wantTraits: map[string][]string{
+				constants.TraitGCPServiceAccounts: {
+					"a1@example-123456.iam.gserviceaccount.com",
+					"a2@example-456789.iam.gserviceaccount.com",
+					"a3@example-111222.iam.gserviceaccount.com",
+				},
+			},
+		},
+		{
+			name: "invalid GCP service account are rejected",
+			args: []string{"--gcp-service-accounts", "foobar"},
+			errorChecker: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "GCP service account \"foobar\" is invalid")
+			},
+		},
+	}
+
+	for ix, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			username := fmt.Sprintf("test-user-%v", ix)
+
+			args := []string{"add"}
+			if !tc.dontAddDefaultRoles {
+				args = append(args, "--roles", "auditor")
+			}
+			args = append(args, tc.args...)
+			args = append(args, username)
+			err := runUserCommand(t, fileConfig, args)
+			if tc.errorChecker != nil {
+				tc.errorChecker(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			createdUser, err := client.GetUser(username, false)
+			require.NoError(t, err)
+
+			if len(tc.wantRoles) > 0 {
+				require.Equal(t, tc.wantRoles, createdUser.GetRoles())
+			}
+
+			for trait, values := range tc.wantTraits {
+				require.Equal(t, values, createdUser.GetTraits()[trait])
+			}
+		})
+	}
+}
+
 func TestUserUpdate(t *testing.T) {
 	fileConfig := &config.FileConfig{
 		Global: config.Global{
@@ -87,11 +239,13 @@ func TestUserUpdate(t *testing.T) {
 		args         []string
 		wantRoles    []string
 		wantTraits   map[string][]string
-		errorChecker func(error) bool
+		errorChecker require.ErrorAssertionFunc
 	}{
 		{
-			name:         "no args",
-			errorChecker: trace.IsBadParameter,
+			name: "no args",
+			errorChecker: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsBadParameter(err), err)
+			},
 		},
 		{
 			name:      "new roles",
@@ -99,9 +253,11 @@ func TestUserUpdate(t *testing.T) {
 			wantRoles: []string{"editor", "access"},
 		},
 		{
-			name:         "nonexistant roles",
-			args:         []string{"--set-roles", "editor,access,fake"},
-			errorChecker: trace.IsNotFound,
+			name: "nonexistent roles",
+			args: []string{"--set-roles", "editor,access,fake"},
+			errorChecker: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsNotFound(err), err)
+			},
 		},
 		{
 			name: "new logins",
@@ -165,9 +321,20 @@ func TestUserUpdate(t *testing.T) {
 		},
 		{
 			name: "new GCP service accounts",
-			args: []string{"--set-gcp-service-accounts", "a1,a2,a3"},
+			args: []string{"--set-gcp-service-accounts", "a1@example-123456.iam.gserviceaccount.com,a2@example-456789.iam.gserviceaccount.com,a3@example-111222.iam.gserviceaccount.com"},
 			wantTraits: map[string][]string{
-				constants.TraitGCPServiceAccounts: {"a1", "a2", "a3"},
+				constants.TraitGCPServiceAccounts: {
+					"a1@example-123456.iam.gserviceaccount.com",
+					"a2@example-456789.iam.gserviceaccount.com",
+					"a3@example-111222.iam.gserviceaccount.com",
+				},
+			},
+		},
+		{
+			name: "invalid GCP service account are rejected",
+			args: []string{"--set-gcp-service-accounts", "foobar"},
+			errorChecker: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "GCP service account \"foobar\" is invalid")
 			},
 		},
 	}
@@ -179,7 +346,7 @@ func TestUserUpdate(t *testing.T) {
 			args = append(args, "test-user")
 			err := runUserCommand(t, fileConfig, args)
 			if tc.errorChecker != nil {
-				require.True(t, tc.errorChecker(err), err)
+				tc.errorChecker(t, err)
 				return
 			}
 

--- a/tool/tsh/gcp.go
+++ b/tool/tsh/gcp.go
@@ -36,6 +36,7 @@ import (
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/gcp"
 )
 
 const (
@@ -175,35 +176,6 @@ func (a *gcpApp) getGcloudConfigPath() string {
 	return path.Join(profile.FullProfilePath(a.cf.HomePath), "gcp", a.app.ClusterName, a.app.Name, "gcloud")
 }
 
-func projectIDFromServiceAccountName(serviceAccount string) (string, error) {
-	if serviceAccount == "" {
-		return "", trace.BadParameter("invalid service account format: empty string received")
-	}
-
-	user, domain, found := strings.Cut(serviceAccount, "@")
-	if !found {
-		return "", trace.BadParameter("invalid service account format: missing @")
-	}
-	if user == "" {
-		return "", trace.BadParameter("invalid service account format: empty user")
-	}
-
-	projectID, iamDomain, found := strings.Cut(domain, ".")
-	if !found {
-		return "", trace.BadParameter("invalid service account format: missing <project-id>.iam.gserviceaccount.com after @")
-	}
-
-	if projectID == "" {
-		return "", trace.BadParameter("invalid service account format: missing project ID")
-	}
-
-	if iamDomain != "iam.gserviceaccount.com" {
-		return "", trace.BadParameter("invalid service account format: expected suffix %q, got %q", "iam.gserviceaccount.com", iamDomain)
-	}
-
-	return projectID, nil
-}
-
 // removeBotoConfig removes config files written by WriteBotoConfig.
 func (a *gcpApp) removeBotoConfig() []error {
 	// try to remove both files
@@ -263,7 +235,7 @@ func (a *gcpApp) writeBotoConfig() error {
 // GetEnvVars returns required environment variables to configure the
 // clients.
 func (a *gcpApp) GetEnvVars() (map[string]string, error) {
-	projectID, err := projectIDFromServiceAccountName(a.app.GCPServiceAccount)
+	projectID, err := gcp.ProjectIDFromServiceAccountName(a.app.GCPServiceAccount)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -437,38 +409,6 @@ func printGCPServiceAccounts(accounts []string) {
 	fmt.Println(formatGCPServiceAccounts(accounts))
 }
 
-// SortedGCPServiceAccounts sorts service accounts by project and service account name.
-type SortedGCPServiceAccounts []string
-
-// Len returns the length of a list.
-func (s SortedGCPServiceAccounts) Len() int {
-	return len(s)
-}
-
-// Less compares items. Given two accounts, it first compares the project (i.e. what goes after @)
-// and if they are equal proceeds to compare the service account name (what goes before @).
-// Example of sorted list:
-// - test-0@example-100200.iam.gserviceaccount.com
-// - test-1@example-123456.iam.gserviceaccount.com
-// - test-2@example-123456.iam.gserviceaccount.com
-// - test-3@example-123456.iam.gserviceaccount.com
-// - test-0@other-999999.iam.gserviceaccount.com
-func (s SortedGCPServiceAccounts) Less(i, j int) bool {
-	beforeI, afterI, _ := strings.Cut(s[i], "@")
-	beforeJ, afterJ, _ := strings.Cut(s[j], "@")
-
-	if afterI != afterJ {
-		return afterI < afterJ
-	}
-
-	return beforeI < beforeJ
-}
-
-// Swap swaps two items in a list.
-func (s SortedGCPServiceAccounts) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
 func formatGCPServiceAccounts(accounts []string) string {
 	if len(accounts) == 0 {
 		return ""
@@ -476,7 +416,7 @@ func formatGCPServiceAccounts(accounts []string) string {
 
 	t := asciitable.MakeTable([]string{"Available GCP service accounts"})
 
-	acc := SortedGCPServiceAccounts(accounts)
+	acc := gcp.SortedGCPServiceAccounts(accounts)
 	sort.Sort(acc)
 
 	for _, account := range acc {
@@ -487,6 +427,15 @@ func formatGCPServiceAccounts(accounts []string) string {
 }
 
 func getGCPServiceAccountFromFlags(cf *CLIConf, profile *client.ProfileStatus) (string, error) {
+	// helper function to validate correctness of matched service account
+	validate := func(account string) (string, error) {
+		err := gcp.ValidateGCPServiceAccountName(account)
+		if err != nil {
+			return "", trace.Wrap(err, "chosen GCP service account %q is invalid", account)
+		}
+		return account, nil
+	}
+
 	accounts := profile.GCPServiceAccounts
 	if len(accounts) == 0 {
 		return "", trace.BadParameter("no GCP service accounts available, check your permissions")
@@ -498,7 +447,7 @@ func getGCPServiceAccountFromFlags(cf *CLIConf, profile *client.ProfileStatus) (
 	if reqAccount == "" {
 		if len(accounts) == 1 {
 			log.Infof("GCP service account %v is selected by default as it is the only one available for this GCP app.", accounts[0])
-			return accounts[0], nil
+			return validate(accounts[0])
 		}
 
 		// we will never have zero identities here: this is a pre-condition checked above.
@@ -507,9 +456,9 @@ func getGCPServiceAccountFromFlags(cf *CLIConf, profile *client.ProfileStatus) (
 	}
 
 	// exact match?
-	for _, identity := range accounts {
-		if identity == reqAccount {
-			return identity, nil
+	for _, account := range accounts {
+		if account == reqAccount {
+			return validate(account)
 		}
 	}
 
@@ -524,7 +473,7 @@ func getGCPServiceAccountFromFlags(cf *CLIConf, profile *client.ProfileStatus) (
 
 	switch len(matches) {
 	case 1:
-		return matches[0], nil
+		return validate(matches[0])
 	case 0:
 		printGCPServiceAccounts(accounts)
 		return "", trace.NotFound("failed to find the service account matching %q", cf.GCPServiceAccount)


### PR DESCRIPTION
This change adds validation of GCP service accounts to the commands:
1. `tctl users add`
2. `tctl users update`
3. `tsh app login`

The first two should prevent the majority of issues for local users. For SSO users, there is no validation step for traits, and `tsh app login` appears to be a good place to add those.