### PR TITLE
Add Pod resource search web API

### DIFF
--- a/lib/kube/grpc/grpc_test.go
+++ b/lib/kube/grpc/grpc_test.go
@@ -101,6 +101,8 @@ func TestListKubernetesResources(t *testing.T) {
 		searchAsRoles  bool
 		namespace      string
 		searchKeywords []string
+		sortBy         *types.SortBy
+		startKey       string
 	}
 	tests := []struct {
 		name      string
@@ -269,6 +271,70 @@ func TestListKubernetesResources(t *testing.T) {
 			},
 			assertErr: require.NoError,
 		},
+		{
+			name: "user with no access listing dev namespace using search as roles and sort",
+			args: args{
+				user:          userNoAccess,
+				searchAsRoles: true,
+				namespace:     "dev",
+				sortBy: &types.SortBy{
+					Field:  "name",
+					IsDesc: true,
+				},
+			},
+			want: &proto.ListKubernetesResourcesResponse{
+				TotalCount: 2,
+				Resources: []*types.KubernetesResourceV1{
+					{
+						Kind: "pod",
+						Metadata: types.Metadata{
+							Name: "nginx-2",
+						},
+						Spec: types.KubernetesResourceSpecV1{
+							Namespace: "dev",
+						},
+					},
+					{
+						Kind: "pod",
+						Metadata: types.Metadata{
+							Name: "nginx-1",
+						},
+						Spec: types.KubernetesResourceSpecV1{
+							Namespace: "dev",
+						},
+					},
+				},
+			},
+			assertErr: require.NoError,
+		},
+		{
+			name: "user with no access listing dev namespace using search as roles and sort with start key",
+			args: args{
+				user:          userNoAccess,
+				searchAsRoles: true,
+				namespace:     "dev",
+				sortBy: &types.SortBy{
+					Field:  "name",
+					IsDesc: true,
+				},
+				startKey: "nginx-1",
+			},
+			want: &proto.ListKubernetesResourcesResponse{
+				TotalCount: 2,
+				Resources: []*types.KubernetesResourceV1{
+					{
+						Kind: "pod",
+						Metadata: types.Metadata{
+							Name: "nginx-1",
+						},
+						Spec: types.KubernetesResourceSpecV1{
+							Namespace: "dev",
+						},
+					},
+				},
+			},
+			assertErr: require.NoError,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -290,6 +356,8 @@ func TestListKubernetesResources(t *testing.T) {
 					KubernetesNamespace: tt.args.namespace,
 					UseSearchAsRoles:    tt.args.searchAsRoles,
 					SearchKeywords:      tt.args.searchKeywords,
+					SortBy:              tt.args.sortBy,
+					StartKey:            tt.args.startKey,
 				},
 			)
 			tt.assertErr(t, err)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -620,6 +620,7 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	// Kube access handlers.
 	h.GET("/webapi/sites/:site/kubernetes", h.WithClusterAuth(h.clusterKubesGet))
+	h.GET("/webapi/sites/:site/pods", h.WithClusterAuth(h.clusterKubePodsGet))
 
 	// Github connector handlers
 	h.GET("/webapi/github/login/web", h.WithRedirect(h.githubLoginWeb))

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -57,6 +57,7 @@ import (
 	lemma_secret "github.com/mailgun/lemma/secret"
 	"github.com/mailgun/timetools"
 	"github.com/pquerna/otp/totp"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
@@ -64,6 +65,8 @@ import (
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/exp/slices"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
@@ -80,6 +83,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -1600,7 +1604,6 @@ func TestTerminalNameResolution(t *testing.T) {
 			require.Equal(t, tt.port, resp.ServerHostPort)
 		})
 	}
-
 }
 
 func TestTerminalRequireSessionMfa(t *testing.T) {
@@ -3362,7 +3365,6 @@ func TestClusterDatabasesGet(t *testing.T) {
 		DatabaseUsers: []string{"user1"},
 		DatabaseNames: []string{"name1"},
 	}})
-
 }
 
 func TestClusterDatabaseGet(t *testing.T) {
@@ -3660,6 +3662,94 @@ func TestClusterKubesGet(t *testing.T) {
 		require.Len(t, resp.Items, 2)
 		require.Equal(t, 2, resp.TotalCount)
 		require.ElementsMatch(t, tc.expectedResponse, resp.Items)
+	}
+}
+
+func TestClusterKubePodsGet(t *testing.T) {
+	t.Parallel()
+	kubeClusterName := "kube_cluster"
+
+	roleWithFullAccess := func(username string) []types.Role {
+		ret, err := types.NewRole(services.RoleNameForUser(username), types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				Namespaces:       []string{apidefaults.Namespace},
+				KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+				Rules: []types.Rule{
+					types.NewRule(types.KindConnectionDiagnostic, services.RW()),
+				},
+				KubeGroups: []string{"groups"},
+				KubernetesResources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: types.Wildcard,
+						Name:      types.Wildcard,
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		return []types.Role{ret}
+	}
+	require.NotNil(t, roleWithFullAccess)
+
+	env := newWebPack(t, 1)
+
+	type testResponse struct {
+		Items      []ui.KubeResource `json:"items"`
+		TotalCount int               `json:"totalCount"`
+	}
+
+	tt := []struct {
+		name             string
+		user             string
+		expectedResponse []ui.KubeResource
+	}{
+		{
+			name: "get pods from gRPC server",
+			user: "test-user@example.com",
+			expectedResponse: []ui.KubeResource{
+				{
+					Kind:        types.KindKubePod,
+					Name:        "test-pod",
+					Namespace:   "default",
+					Labels:      []ui.Label{{Name: "app", Value: "test"}},
+					KubeCluster: kubeClusterName,
+				},
+				{
+					Kind:        types.KindKubePod,
+					Name:        "test-pod2",
+					Namespace:   "default",
+					Labels:      []ui.Label{{Name: "app", Value: "test2"}},
+					KubeCluster: kubeClusterName,
+				},
+			},
+		},
+	}
+	proxy := env.proxies[0]
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	// Init fake grpc Kube service.
+	initGRPCServer(t, env, listener)
+	addr := utils.MustParseAddr(listener.Addr().String())
+	proxy.handler.handler.cfg.ProxyWebAddr = *addr
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			pack := proxy.authPack(t, tc.user, roleWithFullAccess(tc.user))
+
+			endpoint := pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "pods")
+			params := url.Values{}
+			params.Add("kubeCluster", kubeClusterName)
+			re, err := pack.clt.Get(context.Background(), endpoint, params)
+			require.NoError(t, err)
+
+			resp := testResponse{}
+			require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
+			require.Len(t, resp.Items, 2)
+			require.Equal(t, 2, resp.TotalCount)
+			require.ElementsMatch(t, tc.expectedResponse, resp.Items)
+		})
 	}
 }
 
@@ -7741,4 +7831,104 @@ func TestLogout(t *testing.T) {
 	_, err = clt2.Get(ctx, clt2.Endpoint("webapi", "sites"), url.Values{})
 	require.True(t, trace.IsAccessDenied(err))
 	require.ErrorIs(t, err, trace.AccessDenied("need auth"))
+}
+
+// initGRPCServer creates a grpc server serving on the provided listener.
+func initGRPCServer(t *testing.T, env *webPack, listener net.Listener) {
+	clusterName := env.server.ClusterName()
+	// Auth client, lock watcher and authorizer for Kube proxy.
+	proxyAuthClient, err := env.server.TLS.NewClient(auth.TestBuiltin(types.RoleProxy))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, proxyAuthClient.Close()) })
+
+	serverIdentity, err := auth.NewServerIdentity(env.server.Auth(), uuid.NewString(), types.RoleProxy)
+	require.NoError(t, err)
+	tlsConfig, err := serverIdentity.TLSConfig(nil)
+	require.NoError(t, err)
+	limiter, err := limiter.NewLimiter(limiter.Config{MaxConnections: 100})
+	require.NoError(t, err)
+	// authMiddleware authenticates request assuming TLS client authentication
+	// adds authentication information to the context
+	// and passes it to the API server
+	authMiddleware := &auth.Middleware{
+		AccessPoint:   proxyAuthClient,
+		Limiter:       limiter,
+		AcceptedUsage: []string{teleport.UsageKubeOnly},
+	}
+
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(
+			authMiddleware.UnaryInterceptor(),
+		),
+		grpc.ChainStreamInterceptor(
+			authMiddleware.StreamInterceptor(),
+		),
+		grpc.Creds(credentials.NewTLS(
+			copyAndConfigureTLS(tlsConfig, logrus.New(), proxyAuthClient, clusterName),
+		)),
+	)
+
+	kubeproto.RegisterKubeServiceServer(grpcServer, &fakeKubeService{})
+	errC := make(chan error, 1)
+	t.Cleanup(func() {
+		grpcServer.GracefulStop()
+		require.NoError(t, <-errC)
+	})
+	go func() {
+		err := grpcServer.Serve(listener)
+		errC <- trace.Wrap(err)
+	}()
+}
+
+// copyAndConfigureTLS can be used to copy and modify an existing *tls.Config
+// for Teleport application proxy servers.
+func copyAndConfigureTLS(config *tls.Config, log logrus.FieldLogger, accessPoint auth.AccessCache, clusterName string) *tls.Config {
+	tlsConfig := config.Clone()
+
+	// Require clients to present a certificate
+	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+
+	// Configure function that will be used to fetch the CA that signed the
+	// client's certificate to verify the chain presented. If the client does not
+	// pass in the cluster name, this functions pulls back all CA to try and
+	// match the certificate presented against any CA.
+	tlsConfig.GetConfigForClient = auth.WithClusterCAs(tlsConfig.Clone(), accessPoint, clusterName, log)
+
+	return tlsConfig
+}
+
+type fakeKubeService struct {
+	kubeproto.UnimplementedKubeServiceServer
+}
+
+func (s *fakeKubeService) ListKubernetesResources(ctx context.Context, req *kubeproto.ListKubernetesResourcesRequest) (*kubeproto.ListKubernetesResourcesResponse, error) {
+	return &kubeproto.ListKubernetesResourcesResponse{
+		Resources: []*types.KubernetesResourceV1{
+			{
+				Kind: types.KindKubePod,
+				Metadata: types.Metadata{
+					Name: "test-pod",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: types.KubernetesResourceSpecV1{
+					Namespace: "default",
+				},
+			},
+			{
+				Kind: types.KindKubePod,
+				Metadata: types.Metadata{
+					Name: "test-pod2",
+					Labels: map[string]string{
+						"app": "test2",
+					},
+				},
+				Spec: types.KubernetesResourceSpecV1{
+					Namespace: "default",
+				},
+			},
+		},
+		TotalCount: 2,
+	}, nil
 }

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -19,6 +19,7 @@ package web
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/web/ui"
@@ -748,4 +750,81 @@ func (m *mockedResourceAPIGetter) ListResources(ctx context.Context, req proto.L
 	}
 
 	return nil, trace.NotImplemented("mockListResources not implemented")
+}
+
+func Test_newKubeListRequest(t *testing.T) {
+	type args struct {
+		query        string
+		site         string
+		resourceKind string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *kubeproto.ListKubernetesResourcesRequest
+	}{
+		{
+			name: "list resources",
+			args: args{
+				query:        "kind=kind1",
+				site:         "site1",
+				resourceKind: "kind1",
+			},
+			want: &kubeproto.ListKubernetesResourcesRequest{
+				TeleportCluster: "site1",
+				ResourceType:    "kind1",
+				SortBy:          &types.SortBy{},
+				Limit:           defaults.MaxIterationLimit,
+			},
+		},
+		{
+			name: "list resources with sort and query",
+			args: args{
+				query:        "kind=kind1&query=foo&sort=bar:desc&limit=10",
+				site:         "site1",
+				resourceKind: "kind1",
+			},
+			want: &kubeproto.ListKubernetesResourcesRequest{
+				TeleportCluster:     "site1",
+				ResourceType:        "kind1",
+				PredicateExpression: "foo",
+				SortBy: &types.SortBy{
+					Field:  "bar",
+					IsDesc: true,
+				},
+				Limit: 10,
+			},
+		},
+		{
+			name: "list resources with search as roles",
+			args: args{
+				query:        "startKey=startK1&query=bar&sort=foo:asc&searchAsRoles=yes&limit=10&kubeCluster=cluster&kubeNamespace=namespace",
+				site:         "site1",
+				resourceKind: "kind1",
+			},
+			want: &kubeproto.ListKubernetesResourcesRequest{
+				StartKey:            "startK1",
+				KubernetesCluster:   "cluster",
+				KubernetesNamespace: "namespace",
+				TeleportCluster:     "site1",
+				ResourceType:        "kind1",
+				PredicateExpression: "bar",
+				SortBy: &types.SortBy{
+					Field:  "foo",
+					IsDesc: false,
+				},
+				UseSearchAsRoles: true,
+				Limit:            10,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, err := url.ParseQuery(tt.args.query)
+			require.NoError(t, err)
+			got, err := newKubeListRequest(values, tt.args.site, tt.args.resourceKind)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -124,6 +124,41 @@ func MakeKubeClusters(clusters []types.KubeCluster, userRoles services.RoleSet) 
 	return uiKubeClusters
 }
 
+// KubeResource describes a Kubernetes resource.
+type KubeResource struct {
+	// Kind is the kind of the Kubernetes resource.
+	// Curently supported kinds are: pod.
+	Kind string `json:"kind"`
+	// Name is the name of the Kubernetes resource.
+	Name string `json:"name"`
+	// Labels is a map of static associated with a Kubernetes resource.
+	Labels []Label `json:"labels"`
+	// Namespace is the Kubernetes namespace where the resource is located.
+	Namespace string `json:"namespace"`
+	// KubeCluster is the Kubernetes cluster the resource blongs to.
+	KubeCluster string `json:"cluster"`
+}
+
+// MakeKubeResources creates ui kube resource objects and returns a list.
+func MakeKubeResources(resources []*types.KubernetesResourceV1, cluster string) []KubeResource {
+	uiKubeResources := make([]KubeResource, 0, len(resources))
+	for _, resource := range resources {
+		staticLabels := resource.GetStaticLabels()
+		uiLabels := makeLabels(staticLabels)
+
+		uiKubeResources = append(uiKubeResources,
+			KubeResource{
+				Kind:        resource.Kind,
+				Name:        resource.GetName(),
+				Labels:      uiLabels,
+				Namespace:   resource.Spec.Namespace,
+				KubeCluster: cluster,
+			},
+		)
+	}
+	return uiKubeResources
+}
+
 // getAllowedKubeUsersAndGroupsForCluster works on a given set of roles to return
 // a list of allowed `kubernetes_users` and `kubernetes_groups` that can be used
 // to access a given kubernetes cluster.


### PR DESCRIPTION
This PR introduces a web API for users to search, from the UI, for Kubernetes pods whose access is only granted by their `search_as_roles`.
The new API can be used to create access requests for those resources.


The new API is located
```bash
curl 'https://<proxy_endpoint>:3080/v1/webapi/sites/<teleport_cluster>/pods?kubeCluster=<kube_cluster>&kubeNamespace=<kube_namespace|empty>&searchAsRoles=yes&limit=10&startKey=&query=&search=&sort=name:asc' \
   | jq .
```
The JSON response:

```json
{
  "items": [
    {
      "kind": "pod",
      "name": "coredns-6d4b75cb6d-k84h9",
      "labels": [
        {
          "name": "k8s-app",
          "value": "kube-dns"
        },
        {
          "name": "pod-template-hash",
          "value": "6d4b75cb6d"
        }
      ],
      "namespace": "kube-system",
      "cluster": "minikube"
    },
    {
      "kind": "pod",
      "name": "etcd-minikube",
      "labels": [
        {
          "name": "component",
          "value": "etcd"
        },
        {
          "name": "tier",
          "value": "control-plane"
        }
      ],
      "namespace": "kube-system",
      "cluster": "minikube"
    },
    {
      "kind": "pod",
      "name": "kube-apiserver-minikube",
      "labels": [
        {
          "name": "component",
          "value": "kube-apiserver"
        },
        {
          "name": "tier",
          "value": "control-plane"
        }
      ],
      "namespace": "kube-system",
      "cluster": "minikube"
    },
    {
      "kind": "pod",
      "name": "kube-controller-manager-minikube",
      "labels": [
        {
          "name": "component",
          "value": "kube-controller-manager"
        },
        {
          "name": "tier",
          "value": "control-plane"
        }
      ],
      "namespace": "kube-system",
      "cluster": "minikube"
    },
    {
      "kind": "pod",
      "name": "kube-proxy-g7j5r",
      "labels": [
        {
          "name": "controller-revision-hash",
          "value": "94985b49"
        },
        {
          "name": "k8s-app",
          "value": "kube-proxy"
        },
        {
          "name": "pod-template-generation",
          "value": "1"
        }
      ],
      "namespace": "kube-system",
      "cluster": "minikube"
    },
    {
      "kind": "pod",
      "name": "kube-scheduler-minikube",
      "labels": [
        {
          "name": "component",
          "value": "kube-scheduler"
        },
        {
          "name": "tier",
          "value": "control-plane"
        }
      ],
      "namespace": "kube-system",
      "cluster": "minikube"
    },
    {
      "kind": "pod",
      "name": "nginx-deployment-6595874d85-6j2zm",
      "labels": [
        {
          "name": "app",
          "value": "nginx"
        },
        {
          "name": "pod-template-hash",
          "value": "6595874d85"
        }
      ],
      "namespace": "default",
      "cluster": "minikube"
    },
    {
      "kind": "pod",
      "name": "nginx-deployment-6595874d85-7xgmb",
      "labels": [
        {
          "name": "app",
          "value": "nginx"
        },
        {
          "name": "pod-template-hash",
          "value": "6595874d85"
        }
      ],
      "namespace": "default",
      "cluster": "minikube"
    },
    {
      "kind": "pod",
      "name": "nginx-deployment-6595874d85-c4kz8",
      "labels": [
        {
          "name": "app",
          "value": "nginx"
        },
        {
          "name": "pod-template-hash",
          "value": "6595874d85"
        }
      ],
      "namespace": "default",
      "cluster": "minikube"
    },
    {
      "kind": "pod",
      "name": "storage-provisioner",
      "labels": [
        {
          "name": "addonmanager.kubernetes.io/mode",
          "value": "Reconcile"
        },
        {
          "name": "integration-test",
          "value": "storage-provisioner"
        }
      ],
      "namespace": "kube-system",
      "cluster": "minikube"
    }
  ],
  "startKey": "teleport-agent-0",
  "totalCount": 11
}
```

Part of #20324 and #19573
Updates #19573