### PR TITLE
Update Rust to 1.66.1

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -28,7 +28,7 @@ GOLANG_VERSION ?= go1.19.5
 NODE_VERSION ?= 16.18.1
 
 # run lint-rust check locally before merging code after you bump this
-RUST_VERSION ?= 1.66.0
+RUST_VERSION ?= 1.66.1
 LIBBPF_VERSION ?= 0.7.0-teleport
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 


### PR DESCRIPTION
Bump up the Rust version to mitigate CVE-2022-46176, context: https://blog.rust-lang.org/2023/01/10/cve-2022-46176.html