### PR TITLE
[v9] Allow k8s agents to manage semaphore resources

### DIFF
--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -648,6 +648,8 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindRole, services.RO()),
 						types.NewRule(types.KindNamespace, services.RO()),
 						types.NewRule(types.KindLock, services.RO()),
+						types.NewRule(types.KindKubernetesCluster, services.RW()),
+						types.NewRule(types.KindSemaphore, services.RW()),
 					},
 				},
 			})

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -648,7 +648,6 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindRole, services.RO()),
 						types.NewRule(types.KindNamespace, services.RO()),
 						types.NewRule(types.KindLock, services.RO()),
-						types.NewRule(types.KindKubernetesCluster, services.RW()),
 						types.NewRule(types.KindSemaphore, services.RW()),
 					},
 				},


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/20172 to branch/v9