### PR TITLE
Fixed build issue where enterprise repo builds will fail if Apple username/password is not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,9 +469,12 @@ release-darwin-unsigned: clean full build-archive
 .PHONY: release-darwin
 release-darwin: ABSOLUTE_BINARY_PATHS:=$(addprefix $(CURDIR)/,$(BINARIES))
 release-darwin: release-darwin-unsigned
-	cd ./build.assets/tooling/ && \
-	go run ./cmd/notarize-apple-binaries/*.go \
-		--log-level=debug $(ABSOLUTE_BINARY_PATHS)
+	# Only run if Apple username/pass for notarization are provided
+	if [ -n "$$APPLE_USERNAME" -a -n "$$APPLE_PASSWORD" ]; then \
+		cd ./build.assets/tooling/ && \
+		go run ./cmd/notarize-apple-binaries/*.go \
+			--log-level=debug $(ABSOLUTE_BINARY_PATHS); \
+	fi
 	$(MAKE) build-archive
 	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
 


### PR DESCRIPTION
PR https://github.com/gravitational/teleport/pull/18719 introduced an issue where `make release` fails when ran from the `teleport.e` repo due to reliance on `APPLE_USERNAME` and `APPLE_PASSWORD` environment variables. This fixes the issue by only running the new notarization tool if the variables are both set.