### PR TITLE
fix: Always dial to root cluster for single-use certificates

### DIFF
--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -472,8 +472,10 @@ func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.T
 	ctx, span := t.tracer.Start(ctx, "terminal/issueSessionMFACerts")
 	defer span.End()
 
+	// Always acquire single-use certificates from the root cluster, that's where
+	// both the user and their devices are registered.
 	log.Debug("Attempting to issue a single-use user certificate with an MFA check.")
-	stream, err := t.authProvider.GenerateUserSingleUseCerts(ctx)
+	stream, err := t.ctx.cfg.RootClient.GenerateUserSingleUseCerts(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
The Web UI terminal wrongly dials to the leaf cluster, in trusted cluster scenarios, to issue single-use certificates (the kind one needs when `require_session_mfa` is enabled).

This fixes that by always dialing to the root cluster, [a behavior that matches `tsh`][1]

[1]: https://github.com/gravitational/teleport/blob/c23532cc009a67c9e11b505b5686d825fd4f68f8/lib/client/client.go#L455-L480

#20208