### PR TITLE
Track active ssh sessions established via the web

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1495,6 +1495,7 @@ func (w *WebClient) SSH(termReq web.TerminalRequest) (*web.TerminalStream, error
 		return nil, trace.Wrap(err)
 	}
 
+	defer resp.Body.Close()
 	ty, raw, err := ws.ReadMessage()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1516,11 +1517,6 @@ func (w *WebClient) SSH(termReq web.TerminalRequest) (*web.TerminalStream, error
 
 	var sessResp siteSessionGenerateResponse
 	err = json.Unmarshal([]byte(env.Payload), &sessResp)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	err = resp.Body.Close()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -36,6 +36,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime/pprof"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -83,6 +84,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/web"
 )
 
 type integrationTestSuite struct {
@@ -1329,88 +1331,129 @@ func testShutdown(t *testing.T, suite *integrationTestSuite) {
 	tr := utils.NewTracer(utils.ThisFunction()).Start()
 	defer tr.Stop()
 
-	teleport := suite.newTeleport(t, nil, true)
-
-	// get a reference to site obj:
-	site := teleport.GetSiteAPI(helpers.Site)
-	require.NotNil(t, site)
-
-	person := NewTerminal(250)
-
-	cl, err := teleport.NewClient(helpers.ClientConfig{
-		Login:   suite.Me.Username,
-		Cluster: helpers.Site,
-		Host:    Host,
-		Port:    helpers.Port(t, teleport.SSH),
-	})
-	require.NoError(t, err)
-	cl.Stdout = person
-	cl.Stdin = person
-
-	sshCtx, sshCancel := context.WithCancel(context.Background())
-	t.Cleanup(sshCancel)
 	sshErr := make(chan error)
-	go func() {
-		sshErr <- cl.SSH(sshCtx, nil, false)
-		sshCancel()
-	}()
 
-	retry := func(command, pattern string) {
-		person.Type(command)
-		// wait for both sites to see each other via their reverse tunnels (for up to 10 seconds)
-		abortTime := time.Now().Add(10 * time.Second)
-		var matched bool
-		var output string
-		for {
-			output = replaceNewlines(person.Output(1000))
-			matched, _ = regexp.MatchString(pattern, output)
-			if matched {
-				break
-			}
-			time.Sleep(time.Millisecond * 200)
-			if time.Now().After(abortTime) {
-				require.FailNowf(t, "failed to capture output: %v", pattern)
-			}
-		}
-		if !matched {
-			require.FailNowf(t, "output %q does not match pattern %q", output, pattern)
-		}
+	tests := []struct {
+		name          string
+		createSession func(t *testing.T, i *helpers.TeleInstance, term *Terminal, cfg helpers.ClientConfig)
+	}{
+		{
+			name: "cli sessions",
+			createSession: func(t *testing.T, i *helpers.TeleInstance, term *Terminal, cfg helpers.ClientConfig) {
+				tc, err := i.NewClient(cfg)
+				require.NoError(t, err)
+
+				tc.Stdin = term
+				tc.Stdout = term
+
+				sshCtx, sshCancel := context.WithCancel(context.Background())
+				t.Cleanup(sshCancel)
+				go func() {
+					sshErr <- tc.SSH(sshCtx, nil, false)
+					sshCancel()
+				}()
+			},
+		},
+		{
+			name: "web sessions",
+			createSession: func(t *testing.T, i *helpers.TeleInstance, term *Terminal, cfg helpers.ClientConfig) {
+				wc, err := i.NewWebClient(cfg)
+				require.NoError(t, err)
+
+				stream, err := wc.SSH(web.TerminalRequest{
+					Server: net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port)),
+					Login:  cfg.Login,
+					Term: session.TerminalParams{
+						W: 100,
+						H: 100,
+					},
+				})
+				require.NoError(t, err)
+
+				go func() {
+					err := utils.ProxyConn(context.Background(), term, stream)
+					sshErr <- err
+				}()
+			},
+		},
 	}
 
-	retry("echo start \r\n", ".*start.*")
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	// initiate shutdown
-	ctx := context.TODO()
-	shutdownContext := teleport.Process.StartShutdown(ctx)
+			// Enable web service.
+			cfg := suite.defaultServiceConfig()
+			cfg.Auth.Enabled = true
+			cfg.Auth.Preference.SetSecondFactor("off")
+			cfg.Proxy.DisableWebService = false
+			cfg.Proxy.DisableWebInterface = true
+			cfg.Proxy.Enabled = true
+			cfg.SSH.Enabled = true
 
-	require.Eventually(t, func() bool {
-		// TODO: check that we either get a connection that fully works or a connection refused error
-		c, err := net.DialTimeout("tcp", teleport.ReverseTunnel, 250*time.Millisecond)
-		if err != nil {
-			require.True(t, utils.IsConnectionRefused(trace.Unwrap(err)))
-			return true
-		}
-		require.NoError(t, c.Close())
-		return false
-	}, time.Second*5, time.Millisecond*500, "proxy should not accept new connections while shutting down")
+			teleport := suite.NewTeleportWithConfig(t, []string{"test"}, nil, cfg)
 
-	// make sure that terminal still works
-	retry("echo howdy \r\n", ".*howdy.*")
+			password := uuid.NewString()
+			teleport.CreateWebUser(t, suite.Me.Username, password)
 
-	// now type exit and wait for shutdown to complete
-	person.Type("exit\n\r")
+			// get a reference to site obj:
+			site := teleport.GetSiteAPI(helpers.Site)
+			require.NotNil(t, site)
 
-	select {
-	case err := <-sshErr:
-		require.NoError(t, err)
-	case <-time.After(5 * time.Second):
-		require.FailNow(t, "failed to shutdown ssh session")
-	}
+			person := NewTerminal(250)
 
-	select {
-	case <-shutdownContext.Done():
-	case <-time.After(5 * time.Second):
-		require.FailNow(t, "Failed to shut down the server.")
+			test.createSession(t, teleport, person, helpers.ClientConfig{
+				Login:    suite.Me.Username,
+				Password: password,
+				Cluster:  helpers.Site,
+				Host:     Loopback,
+				Port:     helpers.Port(t, teleport.SSH),
+			})
+
+			person.Type("echo start \r\n")
+			require.Eventually(t, func() bool {
+				output := replaceNewlines(person.Output(1000))
+				matched, _ := regexp.MatchString(".*start.*", output)
+				return matched
+			}, 10*time.Second, 200*time.Millisecond)
+
+			// initiate shutdown
+			shutdownContext := teleport.Process.StartShutdown(context.Background())
+
+			require.Eventually(t, func() bool {
+				// TODO: check that we either get a connection that fully works or a connection refused error
+				c, err := net.DialTimeout("tcp", teleport.ReverseTunnel, 250*time.Millisecond)
+				if err != nil {
+					return utils.IsConnectionRefused(trace.Unwrap(err))
+				}
+				return c.Close() == nil
+			}, time.Second*5, time.Millisecond*500, "proxy should not accept new connections while shutting down")
+
+			// make sure that terminal still works
+			person.Type("echo howdy \r\n")
+			require.Eventually(t, func() bool {
+				output := replaceNewlines(person.Output(1000))
+				matched, _ := regexp.MatchString(".*howdy.*", output)
+				return matched
+			}, 10*time.Second, 200*time.Millisecond)
+
+			// now type exit and wait for shutdown to complete
+			person.Type("exit\n\r")
+
+			select {
+			case err := <-sshErr:
+				require.NoError(t, err)
+			case <-time.After(5 * time.Second):
+				require.FailNow(t, "failed to shutdown ssh session")
+			}
+
+			select {
+			case <-shutdownContext.Done():
+			case <-time.After(5 * time.Second):
+				require.FailNow(t, "Failed to shut down the server.")
+			}
+		})
 	}
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3529,10 +3529,8 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	// Register web proxy server
 	alpnHandlerForWeb := &alpnproxy.ConnectionHandlerWrapper{}
-	var webServer *http.Server
-	var webHandler *web.APIHandler
-	var minimalWebServer *http.Server
-	var minimalWebHandler *web.APIHandler
+	var webServer *web.Server
+	var minimalWebServer *web.Server
 
 	if !process.Config.Proxy.DisableWebService {
 		var fs http.FileSystem
@@ -3595,7 +3593,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Router:           proxyRouter,
 			SessionControl:   sessionController,
 		}
-		webHandler, err = web.NewHandler(webConfig)
+		webHandler, err := web.NewHandler(webConfig)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -3620,18 +3618,26 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			})
 		}
 
-		webServer = &http.Server{
-			Handler:           httplib.MakeTracingHandler(proxyLimiter, teleport.ComponentProxy),
-			ReadHeaderTimeout: apidefaults.DefaultDialTimeout,
-			ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentProxy),
+		webServer, err = web.NewServer(web.ServerConfig{
+			Server: &http.Server{
+				Handler:           httplib.MakeTracingHandler(proxyLimiter, teleport.ComponentProxy),
+				ReadHeaderTimeout: apidefaults.DefaultDialTimeout,
+				ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentProxy),
+			},
+			Handler: webHandler,
+			Log:     log,
+		})
+		if err != nil {
+			return trace.Wrap(err)
 		}
+
 		process.RegisterCriticalFunc("proxy.web", func() error {
 			utils.Consolef(cfg.Console, log, teleport.ComponentProxy, "Web proxy service %s:%s is starting on %v.",
 				teleport.Version, teleport.Gitref, cfg.Proxy.WebAddr.Addr)
 			log.Infof("Web proxy service %s:%s is starting on %v.", teleport.Version, teleport.Gitref, cfg.Proxy.WebAddr.Addr)
 			defer webHandler.Close()
 			process.BroadcastEvent(Event{Name: ProxyWebServerReady, Payload: webHandler})
-			if err := webServer.Serve(listeners.web); err != nil && err != http.ErrServerClosed {
+			if err := webServer.Serve(listeners.web); err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) {
 				log.Warningf("Error while serving web requests: %v", err)
 			}
 			log.Info("Exited.")
@@ -3639,7 +3645,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		})
 
 		if listeners.reverseTunnelMux != nil {
-			if minimalWebServer, minimalWebHandler, err = process.initMinimalReverseTunnel(listeners, tlsConfigWeb, cfg, webConfig, log); err != nil {
+			if minimalWebServer, err = process.initMinimalReverseTunnel(listeners, tlsConfigWeb, cfg, webConfig, log); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -3652,7 +3658,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	if alpnRouter != nil {
 		alpnRouter.Add(alpnproxy.HandlerDecs{
 			MatchFunc: alpnproxy.MatchByProtocol(alpncommon.ProtocolTCP),
-			Handler:   webHandler.HandleConnection,
+			Handler:   webServer.HandleConnection,
 		})
 	}
 
@@ -4058,20 +4064,14 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			if proxyServer != nil {
 				warnOnErr(proxyServer.Close(), log)
 			}
-			if peerClient != nil {
-				warnOnErr(peerClient.Stop(), log)
-			}
 			if webServer != nil {
 				warnOnErr(webServer.Close(), log)
-			}
-			if webHandler != nil {
-				warnOnErr(webHandler.Close(), log)
 			}
 			if minimalWebServer != nil {
 				warnOnErr(minimalWebServer.Close(), log)
 			}
-			if minimalWebHandler != nil {
-				warnOnErr(minimalWebHandler.Close(), log)
+			if peerClient != nil {
+				warnOnErr(peerClient.Stop(), log)
 			}
 			warnOnErr(sshProxy.Close(), log)
 			sshGRPCServer.Stop()
@@ -4092,6 +4092,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			}
 			warnOnErr(sshProxy.Shutdown(ctx), log)
 			sshGRPCServer.GracefulStop()
+			if webServer != nil {
+				warnOnErr(webServer.Shutdown(ctx), log)
+			}
+			if minimalWebServer != nil {
+				warnOnErr(minimalWebServer.Shutdown(ctx), log)
+			}
 			if tsrv != nil {
 				warnOnErr(tsrv.Shutdown(ctx), log)
 			}
@@ -4101,20 +4107,8 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			if peerClient != nil {
 				peerClient.Shutdown()
 			}
-			if webServer != nil {
-				warnOnErr(webServer.Shutdown(ctx), log)
-			}
-			if minimalWebServer != nil {
-				warnOnErr(minimalWebServer.Shutdown(ctx), log)
-			}
 			if kubeServer != nil {
 				warnOnErr(kubeServer.Shutdown(ctx), log)
-			}
-			if webHandler != nil {
-				warnOnErr(webHandler.Close(), log)
-			}
-			if minimalWebHandler != nil {
-				warnOnErr(minimalWebHandler.Close(), log)
 			}
 			if grpcServer != nil {
 				grpcServer.GracefulStop()
@@ -4145,10 +4139,7 @@ func (process *TeleportProcess) getJWTSigner(ident *auth.Identity) (*jwt.Key, er
 	return jwtSigner, nil
 }
 
-func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListeners, tlsConfigWeb *tls.Config, cfg *Config, webConfig web.Config, log *logrus.Entry) (*http.Server, *web.APIHandler, error) {
-	var minimalWebServer *http.Server
-	var minimalWebHandler *web.APIHandler
-
+func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListeners, tlsConfigWeb *tls.Config, cfg *Config, webConfig web.Config, log *logrus.Entry) (*web.Server, error) {
 	internalListener := listeners.reverseTunnelMux.TLS()
 	if !cfg.Proxy.DisableTLS {
 		internalListener = tls.NewListener(internalListener, tlsConfigWeb)
@@ -4158,18 +4149,18 @@ func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListene
 		Listener: internalListener,
 	})
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	listeners.minimalTLS = minimalListener
 
 	minimalProxyLimiter, err := limiter.NewLimiter(cfg.Proxy.Limiter)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	webConfig.MinimalReverseTunnelRoutesOnly = true
-	minimalWebHandler, err = web.NewHandler(webConfig)
+	minimalWebHandler, err := web.NewHandler(webConfig)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	minimalProxyLimiter.WrapHandle(minimalWebHandler)
 
@@ -4182,11 +4173,19 @@ func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListene
 		return nil
 	})
 
-	minimalWebServer = &http.Server{
-		Handler:           httplib.MakeTracingHandler(minimalProxyLimiter, teleport.ComponentProxy),
-		ReadHeaderTimeout: apidefaults.DefaultDialTimeout,
-		ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentReverseTunnelServer),
+	minimalWebServer, err := web.NewServer(web.ServerConfig{
+		Server: &http.Server{
+			Handler:           httplib.MakeTracingHandler(minimalProxyLimiter, teleport.ComponentProxy),
+			ReadHeaderTimeout: apidefaults.DefaultDialTimeout,
+			ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentReverseTunnelServer),
+		},
+		Handler: minimalWebHandler,
+		Log:     log,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
+
 	process.RegisterCriticalFunc("proxy.reversetunnel.web", func() error {
 		utils.Consolef(
 			cfg.Console, log, teleport.ComponentProxy,
@@ -4200,7 +4199,8 @@ func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListene
 		log.Info("Exited.")
 		return nil
 	})
-	return minimalWebServer, minimalWebHandler, nil
+
+	return minimalWebServer, nil
 }
 
 // kubeDialAddr returns Proxy Kube service address used for dialing local kube service

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -33,6 +33,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -117,6 +118,9 @@ type Handler struct {
 	// sshPort specifies the SSH proxy port extracted
 	// from configuration
 	sshPort string
+
+	// userConns tracks amount of current active connections with user certificates.
+	userConns atomic.Int32
 
 	// ClusterFeatures contain flags for supported and unsupported features.
 	ClusterFeatures proto.Features
@@ -2386,6 +2390,9 @@ func (h *Handler) siteNodeConnect(
 		h.log.WithError(err).Error("Unable to create terminal.")
 		return nil, trace.Wrap(err)
 	}
+
+	h.userConns.Add(1)
+	defer h.userConns.Add(-1)
 
 	// start the websocket session with a web-based terminal:
 	h.log.Infof("Getting terminal to %#v.", req)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -43,7 +43,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -58,7 +57,6 @@ import (
 	lemma_secret "github.com/mailgun/lemma/secret"
 	"github.com/mailgun/timetools"
 	"github.com/pquerna/otp/totp"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
@@ -66,7 +64,6 @@ import (
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/exp/slices"
-	"golang.org/x/text/encoding/unicode"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
@@ -1221,9 +1218,6 @@ func TestNewTerminalHandler(t *testing.T) {
 	require.Equal(t, validCfg.Term, term.term)
 	require.Equal(t, validCfg.DisplayLogin, term.displayLogin)
 	// newly added
-	require.NotNil(t, term.encoder)
-	require.NotNil(t, term.decoder)
-	require.NotNil(t, term.wsLock)
 	require.NotNil(t, term.log)
 }
 
@@ -1446,14 +1440,7 @@ func TestTerminal(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, ws.Close()) })
 
-			termHandler := newTerminalHandler()
-			stream := termHandler.asTerminalStream(ws)
-
-			// here we intentionally run a command where the output we're looking
-			// for is not present in the command itself
-			_, err = io.WriteString(stream, "echo txlxport | sed 's/x/e/g'\r\n")
-			require.NoError(t, err)
-			require.NoError(t, waitForOutput(stream, "teleport"))
+			validateTerminalStream(t, ws)
 		})
 	}
 }
@@ -1535,8 +1522,8 @@ func TestTerminalRouting(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() { tt.wsCloseAssertion(t, ws.Close()) })
 
-			termHandler := newTerminalHandler()
-			stream := termHandler.asTerminalStream(ws)
+			stream, err := NewTerminalStream(ws)
+			require.NoError(t, err)
 
 			// here we intentionally run a command where the output we're looking
 			// for is not present in the command itself
@@ -1618,12 +1605,12 @@ func TestTerminalRequireSessionMfa(t *testing.T) {
 			require.Nil(t, json.Unmarshal([]byte(env.Payload), &chals))
 
 			// Send response over ws.
-			termHandler := newTerminalHandler()
-			_, err = termHandler.write(tc.getChallengeResponseBytes(chals, dev), ws)
+			stream, err := NewTerminalStream(ws)
+			require.NoError(t, err)
+			_, err = stream.Write(tc.getChallengeResponseBytes(chals, dev))
 			require.Nil(t, err)
 
 			// Test we can write.
-			stream := termHandler.asTerminalStream(ws)
 			_, err = io.WriteString(stream, "echo alpacas\r\n")
 			require.Nil(t, err)
 			require.Nil(t, waitForOutput(stream, "alpacas"))
@@ -1810,8 +1797,8 @@ func TestWebAgentForward(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, ws.Close()) })
 
-	termHandler := newTerminalHandler()
-	stream := termHandler.asTerminalStream(ws)
+	stream, err := NewTerminalStream(ws)
+	require.NoError(t, err)
 
 	_, err = io.WriteString(stream, "echo $SSH_AUTH_SOCK\r\n")
 	require.NoError(t, err)
@@ -1910,8 +1897,8 @@ func TestCloseConnectionsOnLogout(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, ws.Close()) })
 
-	termHandler := newTerminalHandler()
-	stream := termHandler.asTerminalStream(ws)
+	stream, err := NewTerminalStream(ws)
+	require.NoError(t, err)
 
 	// to make sure we have a session
 	_, err = io.WriteString(stream, "expr 137 + 39\r\n")
@@ -6210,7 +6197,7 @@ func (s *WebSuite) makeTerminal(t *testing.T, pack *authPack, opts ...terminalOp
 	return ws, &sessResp.Session, nil
 }
 
-func waitForOutput(stream *terminalStream, substr string) error {
+func waitForOutput(stream *TerminalStream, substr string) error {
 	timeoutCh := time.After(10 * time.Second)
 
 	for {
@@ -6299,15 +6286,6 @@ func removeSpace(in string) string {
 		in = strings.Replace(in, c, " ", -1)
 	}
 	return strings.TrimSpace(in)
-}
-
-func newTerminalHandler() TerminalHandler {
-	return TerminalHandler{
-		log:     logrus.WithFields(logrus.Fields{}),
-		encoder: unicode.UTF8.NewEncoder(),
-		decoder: unicode.UTF8.NewDecoder(),
-		wsLock:  &sync.Mutex{},
-	}
 }
 
 func decodeSessionCookie(t *testing.T, value string) (sessionID string) {
@@ -6907,14 +6885,14 @@ func login(t *testing.T, clt *TestWebClient, cookieToken, reqToken string, reqDa
 	return resp
 }
 
-func validateTerminalStream(t *testing.T, conn *websocket.Conn) {
+func validateTerminalStream(t *testing.T, ws *websocket.Conn) {
 	t.Helper()
-	termHandler := newTerminalHandler()
-	stream := termHandler.asTerminalStream(conn)
+	stream, err := NewTerminalStream(ws)
+	require.NoError(t, err)
 
 	// here we intentionally run a command where the output we're looking
 	// for is not present in the command itself
-	_, err := io.WriteString(stream, "echo txlxport | sed 's/x/e/g'\r\n")
+	_, err = io.WriteString(stream, "echo txlxport | sed 's/x/e/g'\r\n")
 	require.NoError(t, err)
 	require.NoError(t, waitForOutput(stream, "teleport"))
 }

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -242,7 +242,10 @@ func desktopTLSConfig(ctx context.Context, ws *websocket.Conn, pc *client.ProxyC
 		return nil, trace.Wrap(err)
 	}
 
-	var wsLock sync.Mutex
+	stream, err := NewTerminalStream(ws)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	key, err := pc.IssueUserCertsWithMFA(ctx, client.ReissueParams{
 		RouteToWindowsDesktop: proto.RouteToWindowsDesktop{
 			WindowsDesktop: desktopName,
@@ -255,7 +258,7 @@ func desktopTLSConfig(ctx context.Context, ws *websocket.Conn, pc *client.ProxyC
 			TLSCert:             sessCtx.cfg.Session.GetTLSCert(),
 			WindowsDesktopCerts: make(map[string][]byte),
 		},
-	}, promptMFAChallenge(ws, &wsLock, tdpMFACodec{}))
+	}, promptMFAChallenge(stream, tdpMFACodec{}))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/server.go
+++ b/lib/web/server.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// ServerConfig provides dependencies required to create a [Server]
+// ServerConfig provides dependencies required to create a [Server].
 type ServerConfig struct {
 	// Server serves the web api
 	Server *http.Server
@@ -62,7 +62,7 @@ func (c *ServerConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-// Server serves the web api
+// Server serves the web api.
 type Server struct {
 	cfg ServerConfig
 
@@ -70,7 +70,7 @@ type Server struct {
 	ln net.Listener
 }
 
-// NewServer constructs a [Server] from the provided [ServerConfig]
+// NewServer constructs a [Server] from the provided [ServerConfig].
 func NewServer(cfg ServerConfig) (*Server, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -81,7 +81,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	}, nil
 }
 
-// Serve launches the configured [http.Server]
+// Serve launches the configured [http.Server].
 func (s *Server) Serve(l net.Listener) error {
 	s.mu.Lock()
 	s.ln = l
@@ -89,7 +89,7 @@ func (s *Server) Serve(l net.Listener) error {
 	return trace.Wrap(s.cfg.Server.Serve(l))
 }
 
-// Close immediately closes the [http.Server]
+// Close immediately closes the [http.Server].
 func (s *Server) Close() error {
 	return trace.NewAggregate(s.cfg.Handler.Close(), s.cfg.Server.Close())
 }

--- a/lib/web/server.go
+++ b/lib/web/server.go
@@ -1,0 +1,140 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// ServerConfig provides dependencies required to create a [Server]
+type ServerConfig struct {
+	// Server serves the web api
+	Server *http.Server
+	// Handler web handler
+	Handler *APIHandler
+	// Log to write log messages
+	Log logrus.FieldLogger
+	// ShutdownPollPeriod sets polling period for shutdown
+	ShutdownPollPeriod time.Duration
+}
+
+// CheckAndSetDefaults validates fields and populates empty fields with default values.
+func (c *ServerConfig) CheckAndSetDefaults() error {
+	if c.Server == nil {
+		return trace.BadParameter("missing required parameter Server")
+	}
+
+	if c.Handler == nil {
+		return trace.BadParameter("missing required parameter Handler")
+	}
+
+	if c.ShutdownPollPeriod <= 0 {
+		c.ShutdownPollPeriod = defaults.ShutdownPollPeriod
+	}
+
+	if c.Log == nil {
+		c.Log = utils.NewLogger().WithField(trace.Component, teleport.ComponentProxy)
+	}
+
+	return nil
+}
+
+// Server serves the web api
+type Server struct {
+	cfg ServerConfig
+
+	mu sync.Mutex
+	ln net.Listener
+}
+
+// NewServer constructs a [Server] from the provided [ServerConfig]
+func NewServer(cfg ServerConfig) (*Server, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &Server{
+		cfg: cfg,
+	}, nil
+}
+
+// Serve launches the configured [http.Server]
+func (s *Server) Serve(l net.Listener) error {
+	s.mu.Lock()
+	s.ln = l
+	s.mu.Unlock()
+	return trace.Wrap(s.cfg.Server.Serve(l))
+}
+
+// Close immediately closes the [http.Server]
+func (s *Server) Close() error {
+	return trace.NewAggregate(s.cfg.Handler.Close(), s.cfg.Server.Close())
+}
+
+// HandleConnection handles connections from plain TCP applications.
+func (s *Server) HandleConnection(ctx context.Context, conn net.Conn) error {
+	return s.cfg.Handler.appHandler.HandleConnection(ctx, conn)
+}
+
+// Shutdown initiates graceful shutdown. The underlying [http.Server]
+// is not shutdown until all active connections are terminated or
+// the context times out. This is required because the [http.Server]
+// does not attempt to close nor wait for hijacked connections such as
+// WebSockets during Shutdown; which means that any open sessions in the
+// web UI will not prevent the [http.Server] from shutting down.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.mu.Lock()
+	err := s.ln.Close()
+	s.mu.Unlock()
+
+	activeConnections := s.cfg.Handler.handler.userConns.Load()
+	if activeConnections == 0 {
+		err := s.cfg.Server.Shutdown(ctx)
+		return trace.NewAggregate(err, s.cfg.Handler.Close())
+	}
+
+	s.cfg.Log.Infof("Shutdown: waiting for %v connections to finish.", activeConnections)
+	lastReport := time.Time{}
+	ticker := time.NewTicker(s.cfg.ShutdownPollPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			activeConnections = s.cfg.Handler.handler.userConns.Load()
+			if activeConnections == 0 {
+				err := s.cfg.Server.Shutdown(ctx)
+				return trace.NewAggregate(err, s.cfg.Handler.Close())
+			}
+			if time.Since(lastReport) > 10*s.cfg.ShutdownPollPeriod {
+				s.cfg.Log.Infof("Shutdown: waiting for %v connections to finish.", activeConnections)
+				lastReport = time.Now()
+			}
+		case <-ctx.Done():
+			s.cfg.Log.Infof("Context canceled wait, returning.")
+			return trace.ConnectionProblem(trace.NewAggregate(err, s.cfg.Handler.Close()), "context canceled")
+		}
+	}
+}

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -113,9 +113,6 @@ func NewTerminal(ctx context.Context, cfg TerminalHandlerConfig) (*TerminalHandl
 		}),
 		ctx:                cfg.SessionCtx,
 		authProvider:       cfg.AuthProvider,
-		encoder:            unicode.UTF8.NewEncoder(),
-		decoder:            unicode.UTF8.NewDecoder(),
-		wsLock:             &sync.Mutex{},
 		displayLogin:       cfg.DisplayLogin,
 		sessionData:        cfg.SessionData,
 		keepAliveInterval:  cfg.KeepAliveInterval,
@@ -224,19 +221,7 @@ type TerminalHandler struct {
 	// authProvider is used to fetch nodes and sessions from the backend.
 	authProvider AuthProvider
 
-	// encoder is used to encode strings into UTF-8.
-	encoder *encoding.Encoder
-
-	// decoder is used to decode UTF-8 strings.
-	decoder *encoding.Decoder
-
-	// buffer is a buffer used to store the remaining payload data if it did not
-	// fit into the buffer provided by the callee to Read method
-	buffer []byte
-
 	closeOnce sync.Once
-
-	wsLock *sync.Mutex
 
 	// keepAliveInterval is the interval for sending ping frames to web client.
 	// This value is pulled from the cluster network config and
@@ -263,6 +248,10 @@ type TerminalHandler struct {
 
 	// participantMode is the mode that determines what you can do when you join an active session.
 	participantMode types.SessionParticipantMode
+
+	// stream manages sending and receiving [Envelope] to the UI
+	// for the duration of the session
+	stream *TerminalStream
 }
 
 // ServeHTTP builds a connection to the remote node and then pumps back two types of
@@ -387,6 +376,17 @@ func (t *TerminalHandler) startPingLoop(ws *websocket.Conn) {
 func (t *TerminalHandler) handler(ws *websocket.Conn, r *http.Request) {
 	defer ws.Close()
 
+	// Create a terminal stream that wraps/unwraps the envelope used to
+	// communicate over the websocket.
+	resizeC := make(chan *session.TerminalParams, 1)
+	stream, err := NewTerminalStream(ws, WithTerminalStreamResizeHandler(resizeC))
+	if err != nil {
+		t.log.WithError(err).Info("Failed creating a terminal stream for session")
+		t.writeError(err)
+		return
+	}
+	t.stream = stream
+
 	// Create a context for signaling when the terminal session is over and
 	// link it first with the trace context from the request context
 	tctx := oteltrace.ContextWithRemoteSpanContext(context.Background(), oteltrace.SpanContextFromContext(r.Context()))
@@ -394,10 +394,10 @@ func (t *TerminalHandler) handler(ws *websocket.Conn, r *http.Request) {
 
 	// Create a Teleport client, if not able to, show the reason to the user in
 	// the terminal.
-	tc, err := t.makeClient(ws, r)
+	tc, err := t.makeClient(r.Context(), ws)
 	if err != nil {
 		t.log.WithError(err).Info("Failed creating a client for session")
-		t.writeError(err, ws)
+		t.writeError(err)
 		return
 	}
 
@@ -414,7 +414,10 @@ func (t *TerminalHandler) handler(ws *websocket.Conn, r *http.Request) {
 
 	// Pump raw terminal in/out and audit events into the websocket.
 	go t.streamTerminal(ws, tc)
-	go t.streamEvents(ws, tc)
+	go t.streamEvents(tc)
+
+	// process window resizing
+	go t.handleWindowResize(resizeC)
 
 	// Block until the terminal session is complete.
 	<-t.terminalContext.Done()
@@ -422,8 +425,8 @@ func (t *TerminalHandler) handler(ws *websocket.Conn, r *http.Request) {
 }
 
 // makeClient builds a *client.TeleportClient for the connection.
-func (t *TerminalHandler) makeClient(ws *websocket.Conn, r *http.Request) (*client.TeleportClient, error) {
-	ctx, span := tracing.DefaultProvider().Tracer("terminal").Start(r.Context(), "terminal/makeClient")
+func (t *TerminalHandler) makeClient(ctx context.Context, ws *websocket.Conn) (*client.TeleportClient, error) {
+	ctx, span := tracing.DefaultProvider().Tracer("terminal").Start(ctx, "terminal/makeClient")
 	defer span.End()
 
 	clientConfig, err := makeTeleportClientConfig(ctx, t.ctx)
@@ -431,16 +434,12 @@ func (t *TerminalHandler) makeClient(ws *websocket.Conn, r *http.Request) (*clie
 		return nil, trace.Wrap(err)
 	}
 
-	// Create a terminal stream that wraps/unwraps the envelope used to
-	// communicate over the websocket.
-	stream := t.asTerminalStream(ws)
-
 	clientConfig.HostLogin = t.sessionData.Login
 	clientConfig.ForwardAgent = client.ForwardAgentLocal
 	clientConfig.Namespace = apidefaults.Namespace
-	clientConfig.Stdout = stream
-	clientConfig.Stderr = stream
-	clientConfig.Stdin = stream
+	clientConfig.Stdout = t.stream
+	clientConfig.Stderr = t.stream
+	clientConfig.Stdin = t.stream
 	clientConfig.SiteName = t.sessionData.ClusterName
 	if err := clientConfig.ParseProxyHost(t.proxyHostPort); err != nil {
 		return nil, trace.BadParameter("failed to parse proxy address: %v", err)
@@ -448,7 +447,7 @@ func (t *TerminalHandler) makeClient(ws *websocket.Conn, r *http.Request) (*clie
 	clientConfig.Host = t.sessionData.ServerHostname
 	clientConfig.HostPort = t.sessionData.ServerHostPort
 	clientConfig.SessionID = t.sessionData.ID.String()
-	clientConfig.ClientAddr = r.RemoteAddr
+	clientConfig.ClientAddr = ws.RemoteAddr().String()
 	clientConfig.Tracer = t.tracer
 
 	if len(t.interactiveCommand) > 0 {
@@ -465,7 +464,7 @@ func (t *TerminalHandler) makeClient(ws *websocket.Conn, r *http.Request) (*clie
 	// to allow future window changes.
 	tc.OnShellCreated = func(s *tracessh.Session, c *tracessh.Client, _ io.ReadWriteCloser) (bool, error) {
 		t.sshSession = s
-		t.windowChange(r.Context(), &t.term)
+		t.windowChange(ctx, &t.term)
 
 		return false, nil
 	}
@@ -477,7 +476,7 @@ func (t *TerminalHandler) makeClient(ws *websocket.Conn, r *http.Request) (*clie
 // used to access nodes which require per-session mfa. The ceremony is performed directly
 // to make use of the authProvider already established for the session instead of leveraging
 // the TeleportClient which would require dialing the auth server a second time.
-func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.TeleportClient, ws *websocket.Conn) error {
+func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.TeleportClient) error {
 	ctx, span := t.tracer.Start(ctx, "terminal/issueSessionMFACerts")
 	defer span.End()
 
@@ -537,7 +536,7 @@ func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.T
 	}
 
 	span.AddEvent("prompting user with mfa challenge")
-	assertion, err := promptMFAChallenge(ws, t.wsLock, protobufMFACodec{})(ctx, tc.WebProxyAddr, challenge)
+	assertion, err := promptMFAChallenge(t.stream, protobufMFACodec{})(ctx, tc.WebProxyAddr, challenge)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -578,49 +577,28 @@ func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.T
 }
 
 func promptMFAChallenge(
-	ws *websocket.Conn,
-	wsLock *sync.Mutex,
+	stream *TerminalStream,
 	codec mfaCodec,
 ) client.PromptMFAChallengeHandler {
 	return func(ctx context.Context, proxyAddr string, c *authproto.MFAAuthenticateChallenge) (*authproto.MFAAuthenticateResponse, error) {
-		var chal *client.MFAAuthenticateChallenge
-		var envelopeType string
+		var challenge *client.MFAAuthenticateChallenge
 
 		// Convert from proto to JSON types.
 		switch {
 		case c.GetWebauthnChallenge() != nil:
-			envelopeType = defaults.WebsocketWebauthnChallenge
-			chal = &client.MFAAuthenticateChallenge{
+			challenge = &client.MFAAuthenticateChallenge{
 				WebauthnChallenge: wanlib.CredentialAssertionFromProto(c.WebauthnChallenge),
 			}
 		default:
 			return nil, trace.AccessDenied("only hardware keys are supported on the web terminal, please register a hardware device to connect to this server")
 		}
 
-		// Send the challenge over the socket.
-		msg, err := codec.encode(chal, envelopeType)
-		if err != nil {
+		if err := stream.writeChallenge(challenge, codec); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		wsLock.Lock()
-		err = ws.WriteMessage(websocket.BinaryMessage, msg)
-		wsLock.Unlock()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		// Read the challenge response.
-		var bytes []byte
-		ty, bytes, err := ws.ReadMessage()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		if ty != websocket.BinaryMessage {
-			return nil, trace.BadParameter("expected websocket.BinaryMessage, got %v", ty)
-		}
-
-		return codec.decode(bytes, envelopeType)
+		resp, err := stream.readChallenge(codec)
+		return resp, trace.Wrap(err)
 	}
 }
 
@@ -635,7 +613,7 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 	accessChecker, err := t.ctx.GetUserAccessChecker()
 	if err != nil {
 		t.log.WithError(err).Warn("Unable to stream terminal - failed to get access checker")
-		t.writeError(err, ws)
+		t.writeError(err)
 		return
 	}
 
@@ -649,11 +627,11 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 
 		if errors.Is(err, trace.NotFound(teleport.NodeIsAmbiguous)) {
 			const message = "error: ambiguous host could match multiple nodes\n\nHint: try addressing the node by unique id (ex: user@node-id)\n"
-			t.writeError(trace.NotFound(message), ws)
+			t.writeError(trace.NotFound(message))
 			return
 		}
 
-		t.writeError(err, ws)
+		t.writeError(err)
 		return
 	}
 
@@ -677,7 +655,7 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 	switch {
 	case connectErr != nil && !trace.IsAccessDenied(connectErr): // catastrophic error, return it
 		t.log.WithError(connectErr).Warn("Unable to stream terminal - failed to create node client")
-		t.writeError(connectErr, ws)
+		t.writeError(connectErr)
 		return
 	case connectErr != nil && trace.IsAccessDenied(connectErr): // see if per session mfa would allow access
 		mfaRequiredResp, err := t.authProvider.IsMFARequired(ctx, &authproto.IsMFARequiredRequest{
@@ -691,21 +669,21 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 		if err != nil {
 			t.log.WithError(err).Warn("Unable to stream terminal - failed to determine if per session mfa is required")
 			// write the original connect error
-			t.writeError(connectErr, ws)
+			t.writeError(connectErr)
 			return
 		}
 
 		if !mfaRequiredResp.Required {
 			t.log.WithError(connectErr).Warn("Unable to stream terminal - user does not have access to host")
 			// write the original connect error
-			t.writeError(connectErr, ws)
+			t.writeError(connectErr)
 			return
 		}
 
 		// perform mfa ceremony and retrieve new certs
-		if err := t.issueSessionMFACerts(ctx, tc, ws); err != nil {
+		if err := t.issueSessionMFACerts(ctx, tc); err != nil {
 			t.log.WithError(err).Warn("Unable to stream terminal - failed to perform mfa ceremony")
-			t.writeError(err, ws)
+			t.writeError(err)
 			return
 		}
 
@@ -716,14 +694,14 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 		conn, err = t.router.DialHost(ctx, ws.RemoteAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker, agentGetter)
 		if err != nil {
 			t.log.WithError(err).Warn("Unable to stream terminal - failed to dial host")
-			t.writeError(err, ws)
+			t.writeError(err)
 			return
 		}
 
 		nc, err = client.NewNodeClient(ctx, sshConfig, conn, net.JoinHostPort(t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort)), tc, modules.GetModules().IsBoringBinary())
 		if err != nil {
 			t.log.WithError(err).Warn("Unable to stream terminal - failed to create node client")
-			t.writeError(err, ws)
+			t.writeError(err)
 			return
 		}
 	}
@@ -732,26 +710,11 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 	// either an error occurs or it completes successfully.
 	if err = nc.RunInteractiveShell(ctx, t.participantMode, nil); err != nil {
 		t.log.WithError(err).Warn("Unable to stream terminal - failure running interactive shell")
-		t.writeError(err, ws)
+		t.writeError(err)
 		return
 	}
 
-	// Send close envelope to web terminal upon exit without an error.
-	envelope := &Envelope{
-		Version: defaults.WebsocketVersion,
-		Type:    defaults.WebsocketClose,
-		Payload: "",
-	}
-	envelopeBytes, err := proto.Marshal(envelope)
-	if err != nil {
-		t.log.WithError(err).Error("Unable to marshal close event for web client.")
-		return
-	}
-
-	t.wsLock.Lock()
-	err = ws.WriteMessage(websocket.BinaryMessage, envelopeBytes)
-	t.wsLock.Unlock()
-	if err != nil {
+	if err := t.stream.Close(); err != nil {
 		t.log.WithError(err).Error("Unable to send close event to web client.")
 		return
 	}
@@ -761,49 +724,32 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 
 // streamEvents receives events over the SSH connection and forwards them to
 // the web client.
-func (t *TerminalHandler) streamEvents(ws *websocket.Conn, tc *client.TeleportClient) {
+func (t *TerminalHandler) streamEvents(tc *client.TeleportClient) {
 	for {
 		select {
 		// Send push events that come over the events channel to the web client.
 		case event := <-tc.EventsChannel():
-			data, err := json.Marshal(event)
 			logger := t.log.WithField("event", event.GetType())
+
+			data, err := json.Marshal(event)
 			if err != nil {
-				logger.WithError(err).Errorf("Unable to marshal audit event")
+				logger.WithError(err).Error("Unable to marshal audit event")
 				continue
 			}
 
 			logger.Debug("Sending audit event to web client.")
 
-			// UTF-8 encode the error message and then wrap it in a raw envelope.
-			encodedPayload, err := t.encoder.String(string(data))
-			if err != nil {
-				logger.WithError(err).Debug("Unable to send audit event to web client")
-				continue
-			}
-			envelope := &Envelope{
-				Version: defaults.WebsocketVersion,
-				Type:    defaults.WebsocketAudit,
-				Payload: encodedPayload,
-			}
-			envelopeBytes, err := proto.Marshal(envelope)
-			if err != nil {
-				logger.WithError(err).Debug("Unable to send audit event to web client")
-				continue
+			if err := t.stream.writeAuditEvent(data); err != nil {
+				if err != nil {
+					if errors.Is(err, websocket.ErrCloseSent) {
+						logger.WithError(err).Debug("Websocket was closed, no longer streaming events")
+						return
+					}
+					logger.WithError(err).Error("Unable to send audit event to web client")
+					continue
+				}
 			}
 
-			// Send bytes over the websocket to the web client.
-			t.wsLock.Lock()
-			err = ws.WriteMessage(websocket.BinaryMessage, envelopeBytes)
-			t.wsLock.Unlock()
-			if err != nil {
-				if errors.Is(err, websocket.ErrCloseSent) {
-					logger.WithError(err).Debug("Websocket was closed, no longer streaming events")
-					return
-				}
-				logger.WithError(err).Error("Unable to send audit event to web client")
-				continue
-			}
 		// Once the terminal stream is over (and the close envelope has been sent),
 		// close stop streaming envelopes.
 		case <-t.terminalContext.Done():
@@ -812,8 +758,25 @@ func (t *TerminalHandler) streamEvents(ws *websocket.Conn, tc *client.TeleportCl
 	}
 }
 
-// windowChange is called when the browser window is resized. It sends a
-// "window-change" channel request to the server.
+// handleWindowResize receives window resize events and forwards
+// them to the SSH session.
+func (t *TerminalHandler) handleWindowResize(resizeC <-chan *session.TerminalParams) {
+	for {
+		select {
+		case <-t.terminalContext.Done():
+			return
+		case params := <-resizeC:
+			// nil params indicates the channel was closed
+			if params == nil {
+				return
+			}
+			// process window change
+			t.windowChange(t.terminalContext, params)
+		}
+	}
+}
+
+// writeError displays an error in the terminal window.
 func (t *TerminalHandler) windowChange(ctx context.Context, params *session.TerminalParams) {
 	if t.sshSession == nil {
 		return
@@ -825,12 +788,8 @@ func (t *TerminalHandler) windowChange(ctx context.Context, params *session.Term
 }
 
 // writeError displays an error in the terminal window.
-func (t *TerminalHandler) writeError(err error, ws *websocket.Conn) {
-	// Replace \n with \r\n so the message correctly aligned.
-	r := strings.NewReplacer("\r\n", "\r\n", "\n", "\r\n")
-	errMessage := r.Replace(err.Error())
-
-	if _, writeErr := t.write([]byte(errMessage), ws); writeErr != nil {
+func (t *TerminalHandler) writeError(err error) {
+	if writeErr := t.stream.writeError(err); writeErr != nil {
 		t.log.WithError(writeErr).Warnf("Unable to send error to terminal: %v", err)
 	}
 }
@@ -877,7 +836,141 @@ func serverHostPort(servername string) (string, int, error) {
 	return host, port, nil
 }
 
-func (t *TerminalHandler) write(data []byte, ws *websocket.Conn) (n int, err error) {
+// WithTerminalStreamEncoder overrides the default stream encoder
+func WithTerminalStreamEncoder(enc *encoding.Encoder) func(stream *TerminalStream) {
+	return func(stream *TerminalStream) {
+		stream.encoder = enc
+	}
+}
+
+// WithTerminalStreamDecoder overrides the default stream decoder
+func WithTerminalStreamDecoder(dec *encoding.Decoder) func(stream *TerminalStream) {
+	return func(stream *TerminalStream) {
+		stream.decoder = dec
+	}
+}
+
+// WithTerminalStreamResizeHandler provides a channel to subscribe to
+// terminal resize events
+func WithTerminalStreamResizeHandler(resizeC chan<- *session.TerminalParams) func(stream *TerminalStream) {
+	return func(stream *TerminalStream) {
+		stream.resizeC = resizeC
+	}
+}
+
+// NewTerminalStream creates a stream that manages reading and writing
+// data over the provided [websocket.Conn]
+func NewTerminalStream(ws *websocket.Conn, opts ...func(*TerminalStream)) (*TerminalStream, error) {
+	switch {
+	case ws == nil:
+		return nil, trace.BadParameter("required parameter ws not provided")
+	}
+
+	t := &TerminalStream{
+		ws:      ws,
+		encoder: unicode.UTF8.NewEncoder(),
+		decoder: unicode.UTF8.NewDecoder(),
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	return t, nil
+}
+
+// TerminalStream manages the [websocket.Conn] to the web UI
+// for a terminal session.
+type TerminalStream struct {
+	// encoder is used to encode UTF-8 strings.
+	encoder *encoding.Encoder
+	// decoder is used to decode UTF-8 strings.
+	decoder *encoding.Decoder
+
+	// buffer is a buffer used to store the remaining payload data if it did not
+	// fit into the buffer provided by the callee to Read method
+	buffer []byte
+
+	// once ensures that resizeC is closed at most one time
+	once sync.Once
+	// resizeC a channel to forward resize events so that
+	// they happen out of band and don't block reads
+	resizeC chan<- *session.TerminalParams
+
+	// mu protects writes to ws
+	mu sync.Mutex
+	// ws the connection to the UI
+	ws *websocket.Conn
+}
+
+// writeError displays an error in the terminal window.
+func (t *TerminalStream) writeError(err error) error {
+	// Replace \n with \r\n so the message correctly aligned.
+	r := strings.NewReplacer("\n", "\r\n")
+
+	_, writeErr := t.Write([]byte(r.Replace(err.Error())))
+	return trace.Wrap(writeErr)
+}
+
+// writeChallenge encodes and writes the challenge to the
+// websocket in the correct format.
+func (t *TerminalStream) writeChallenge(challenge *client.MFAAuthenticateChallenge, codec mfaCodec) error {
+	// Send the challenge over the socket.
+	msg, err := codec.encode(challenge, defaults.WebsocketWebauthnChallenge)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return trace.Wrap(t.ws.WriteMessage(websocket.BinaryMessage, msg))
+}
+
+// readChallenge reads and decodes the challenge response from the
+// websocket in the correct format.
+func (t *TerminalStream) readChallenge(codec mfaCodec) (*authproto.MFAAuthenticateResponse, error) {
+	// Read the challenge response.
+	ty, bytes, err := t.ws.ReadMessage()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if ty != websocket.BinaryMessage {
+		return nil, trace.BadParameter("expected websocket.BinaryMessage, got %v", ty)
+	}
+
+	resp, err := codec.decode(bytes, defaults.WebsocketWebauthnChallenge)
+	return resp, trace.Wrap(err)
+}
+
+// writeAuditEvent encodes and writes the audit event to the
+// websocket in the correct format.
+func (t *TerminalStream) writeAuditEvent(event []byte) error {
+	// UTF-8 encode the error message and then wrap it in a raw envelope.
+	encodedPayload, err := t.encoder.String(string(event))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	envelope := &Envelope{
+		Version: defaults.WebsocketVersion,
+		Type:    defaults.WebsocketAudit,
+		Payload: encodedPayload,
+	}
+
+	envelopeBytes, err := proto.Marshal(envelope)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Send bytes over the websocket to the web client.
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return trace.Wrap(t.ws.WriteMessage(websocket.BinaryMessage, envelopeBytes))
+}
+
+// Write wraps the data bytes in a raw envelope and sends.
+func (t *TerminalStream) Write(data []byte) (n int, err error) {
 	// UTF-8 encode data and wrap it in a raw envelope.
 	encodedPayload, err := t.encoder.String(string(data))
 	if err != nil {
@@ -894,9 +987,9 @@ func (t *TerminalHandler) write(data []byte, ws *websocket.Conn) (n int, err err
 	}
 
 	// Send bytes over the websocket to the web client.
-	t.wsLock.Lock()
-	err = ws.WriteMessage(websocket.BinaryMessage, envelopeBytes)
-	t.wsLock.Unlock()
+	t.mu.Lock()
+	err = t.ws.WriteMessage(websocket.BinaryMessage, envelopeBytes)
+	t.mu.Unlock()
 	if err != nil {
 		return 0, trace.Wrap(err)
 	}
@@ -906,7 +999,7 @@ func (t *TerminalHandler) write(data []byte, ws *websocket.Conn) (n int, err err
 
 // Read unwraps the envelope and either fills out the passed in bytes or
 // performs an action on the connection (sending window-change request).
-func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error) {
+func (t *TerminalStream) Read(out []byte) (n int, err error) {
 	if len(t.buffer) > 0 {
 		n := copy(out, t.buffer)
 		if n == len(t.buffer) {
@@ -917,7 +1010,7 @@ func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error
 		return n, nil
 	}
 
-	ty, bytes, err := ws.ReadMessage()
+	ty, bytes, err := t.ws.ReadMessage()
 	if err != nil {
 		if err == io.EOF || websocket.IsCloseError(err, websocket.CloseAbnormalClosure, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
 			return 0, io.EOF
@@ -943,6 +1036,9 @@ func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error
 	}
 
 	switch envelope.GetType() {
+	// the session was closed
+	case defaults.WebsocketClose:
+		return 0, io.EOF
 	case defaults.WebsocketRaw:
 		n := copy(out, data)
 		// if payload size is greater than [out], store the remaining
@@ -952,6 +1048,10 @@ func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error
 		}
 		return n, nil
 	case defaults.WebsocketResize:
+		if t.resizeC == nil {
+			return n, nil
+		}
+
 		var e events.EventFields
 		err := json.Unmarshal(data, &e)
 		if err != nil {
@@ -965,7 +1065,10 @@ func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error
 
 		// Send the window change request in a goroutine so reads are not blocked
 		// by network connectivity issues.
-		go t.windowChange(t.terminalContext, params)
+		select {
+		case t.resizeC <- params:
+		default:
+		}
 
 		return 0, nil
 	default:
@@ -973,32 +1076,28 @@ func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error
 	}
 }
 
-func (t *TerminalHandler) asTerminalStream(ws *websocket.Conn) *terminalStream {
-	return &terminalStream{
-		ws:       ws,
-		terminal: t,
+// Close send a close message on the web socket
+// prior to closing the web socket altogether.
+func (t *TerminalStream) Close() error {
+	if t.resizeC != nil {
+		t.once.Do(func() {
+			close(t.resizeC)
+		})
 	}
-}
 
-type terminalStream struct {
-	ws       *websocket.Conn
-	terminal *TerminalHandler
-}
+	// Send close envelope to web terminal upon exit without an error.
+	envelope := &Envelope{
+		Version: defaults.WebsocketVersion,
+		Type:    defaults.WebsocketClose,
+	}
+	envelopeBytes, err := proto.Marshal(envelope)
+	if err != nil {
+		return trace.NewAggregate(err, t.ws.Close())
+	}
 
-// Write wraps the data bytes in a raw envelope and sends.
-func (w *terminalStream) Write(data []byte) (n int, err error) {
-	return w.terminal.write(data, w.ws)
-}
-
-// Read unwraps the envelope and either fills out the passed in bytes or
-// performs an action on the connection (sending window-change request).
-func (w *terminalStream) Read(out []byte) (n int, err error) {
-	return w.terminal.read(out, w.ws)
-}
-
-// Close the websocket.
-func (w *terminalStream) Close() error {
-	return w.ws.Close()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return trace.NewAggregate(t.ws.WriteMessage(websocket.BinaryMessage, envelopeBytes), t.ws.Close())
 }
 
 // deadlineForInterval returns a suitable network read deadline for a given ping interval.

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -903,12 +903,12 @@ type TerminalStream struct {
 	ws *websocket.Conn
 }
 
+// Replace \n with \r\n so the message is correctly aligned.
+var replacer = strings.NewReplacer("\r\n", "\r\n", "\n", "\r\n")
+
 // writeError displays an error in the terminal window.
 func (t *TerminalStream) writeError(err error) error {
-	// Replace \n with \r\n so the message correctly aligned.
-	r := strings.NewReplacer("\n", "\r\n")
-
-	_, writeErr := t.Write([]byte(r.Replace(err.Error())))
+	_, writeErr := replacer.WriteString(t, err.Error())
 	return trace.Wrap(writeErr)
 }
 


### PR DESCRIPTION
Adds open session tracking in `web.Handler` and introduces a new
 `web.Server` to prevent closing the web `http.Server` during
a graceful shutdown if there are still open sessions. From the `http.Server/Shutdown` docs:

> Shutdown does not attempt to close nor wait for hijacked
> connections such as WebSockets. The caller of Shutdown should
> separately notify such long-lived connections of shutdown and wait
> for them to close, if desired.

Because the web sessions use WebSockets, `Shutdown` will not wait for them to be idle before terminating. This used to work due to the fact that web sessions dialed the Proxy SSH Port  to establish the SSH session. Which meant that all accounting of active user connections by `sshutils/server.go` was accurate. But now that sessions are established directly via the `proxy.Router` the web sessions were unaccounted for.

The `web.Server` now mimics the behavior of `Shutdown` in `sshutils/server.go`. Only once all the active web sessions have been terminated will the underlying `http.Server` be shutdown.

Fixes #20227