### PR TITLE
Fix `tsh proxy ssh` relogin

### DIFF
--- a/api/utils/keys/policy.go
+++ b/api/utils/keys/policy.go
@@ -72,6 +72,10 @@ func NewPrivateKeyPolicyError(p PrivateKeyPolicy) error {
 // ParsePrivateKeyPolicyError checks if the given error is a private key policy
 // error and returns the contained unmet PrivateKeyPolicy.
 func ParsePrivateKeyPolicyError(err error) (PrivateKeyPolicy, error) {
+	if err == nil {
+		return "", trace.BadParameter("provided error is not a key policy error")
+	}
+
 	// subMatches should have two groups - the full string and the policy "(\w+)"
 	subMatches := privateKeyPolicyErrRegex.FindStringSubmatch(err.Error())
 	if subMatches == nil || len(subMatches) != 2 {

--- a/api/utils/keys/policy.go
+++ b/api/utils/keys/policy.go
@@ -73,13 +73,13 @@ func NewPrivateKeyPolicyError(p PrivateKeyPolicy) error {
 // error and returns the contained unmet PrivateKeyPolicy.
 func ParsePrivateKeyPolicyError(err error) (PrivateKeyPolicy, error) {
 	if err == nil {
-		return "", trace.BadParameter("provided error is not a key policy error")
+		return "", trace.BadParameter("provided error is not a key policy error: %v", err)
 	}
 
 	// subMatches should have two groups - the full string and the policy "(\w+)"
 	subMatches := privateKeyPolicyErrRegex.FindStringSubmatch(err.Error())
 	if subMatches == nil || len(subMatches) != 2 {
-		return "", trace.BadParameter("provided error is not a key policy error")
+		return "", trace.BadParameter("provided error is not a key policy error: %v", err)
 	}
 
 	policy := PrivateKeyPolicy(subMatches[1])

--- a/api/utils/keys/policy.go
+++ b/api/utils/keys/policy.go
@@ -72,10 +72,6 @@ func NewPrivateKeyPolicyError(p PrivateKeyPolicy) error {
 // ParsePrivateKeyPolicyError checks if the given error is a private key policy
 // error and returns the contained unmet PrivateKeyPolicy.
 func ParsePrivateKeyPolicyError(err error) (PrivateKeyPolicy, error) {
-	if err == nil {
-		return "", trace.BadParameter("provided error is not a key policy error: %v", err)
-	}
-
 	// subMatches should have two groups - the full string and the policy "(\w+)"
 	subMatches := privateKeyPolicyErrRegex.FindStringSubmatch(err.Error())
 	if subMatches == nil || len(subMatches) != 2 {

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1311,6 +1311,8 @@ func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.Te
 		Stderr:                cfg.Stderr,
 		Stdin:                 cfg.Stdin,
 		Stdout:                cfg.Stdout,
+		SkipLocalAuth:         true,
+		UseKeyPrincipals:      true,
 	}
 
 	// JumpHost turns on jump host mode

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -498,6 +498,11 @@ func VirtualPathEnvNames(kind VirtualPathKind, params VirtualPathParams) []strin
 // RetryWithRelogin is a helper error handling method, attempts to relogin and
 // retry the function once.
 func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) error {
+	// Don't try to re-login when using an identity file / external identity.
+	if tc.SkipLocalAuth {
+		return trace.Wrap(fn())
+	}
+
 	retryWithRelogin := func() error {
 		key, err := tc.Login(ctx)
 		if err != nil {


### PR DESCRIPTION
`tsh proxy ssh` will fail if a user does not have an active profile with proxy info. This PR updates `RetryWithRelogin` to check this simple case before running the function.

Closes https://github.com/gravitational/teleport/issues/19094