### PR TITLE
Fix db agent fails to get tags for Redshift Serverless VPC endpoints

### DIFF
--- a/lib/srv/discovery/fetchers/db/aws_redshift_serverless_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift_serverless_test.go
@@ -40,8 +40,6 @@ func TestRedshiftServerlessFetcher(t *testing.T) {
 	tagsByARN := map[string][]*redshiftserverless.Tag{
 		aws.StringValue(workgroupProd.WorkgroupArn): libcloudaws.LabelsToTags[redshiftserverless.Tag](envProdLabels),
 		aws.StringValue(workgroupDev.WorkgroupArn):  libcloudaws.LabelsToTags[redshiftserverless.Tag](envDevLabels),
-		aws.StringValue(endpointProd.EndpointArn):   libcloudaws.LabelsToTags[redshiftserverless.Tag](envProdLabels),
-		aws.StringValue(endpointDev.EndpointArn):    libcloudaws.LabelsToTags[redshiftserverless.Tag](envDevLabels),
 	}
 
 	workgroupNotAvailable := mocks.RedshiftServerlessWorkgroup("wg-creating", "us-east-1")


### PR DESCRIPTION
Fix for

> [WATCH:RSS] Failed to get tags for "arn:aws:redshift-serverless:eu-west-2:<account>:managedvpcendpoint/<endpoint-id>". error:[ValidationException: The input resource ARN has invalid uuid managedvpcendpoint/<endpoint-id>.] labels:map[Owner:[STeve]] region:eu-west-2 db/aws_redshift_serverless.go:174

Turned out the endpoints cannot have resource tags at all. This change makes the endpoints use the tags from their parent workgroups. 

This bug is missed from the original development as wildcard was used in dev testing and didn't examine the logs carefully.