### PR TITLE
`tsh`, `tctl` support for creating Pod access requests

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -359,6 +359,8 @@ type authContext struct {
 	// kubeResource.Namespace is the resource namespace and kubeResource.Name
 	// is the resource name.
 	kubeResource *types.KubernetesResource
+	// httpMethod is the request HTTP Method.
+	httpMethod string
 }
 
 func (c authContext) String() string {
@@ -469,10 +471,22 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	authContext, err := f.setupContext(*userContext, req, isRemoteUser, clientIdentity)
+	// kubeResource is the Kubernetes Resource the request is targeted at.
+	// Currently only supports Pods and it includes the pod name and namespace.
+	kubeResource := getPodResourceFromRequest(req.RequestURI)
+	authContext, err := f.setupContext(*userContext, req, isRemoteUser, clientIdentity, kubeResource)
 	if err != nil {
 		f.log.WithError(err).Warn("Unable to setup context.")
 		if trace.IsAccessDenied(err) {
+			if kubeResource != nil {
+				return nil, trace.AccessDenied(
+					kubeResourceDeniedAccessMsg(
+						clientIdentity.Username,
+						req.Method,
+						kubeResource,
+					),
+				)
+			}
 			return nil, trace.AccessDenied(accessDeniedMsg)
 		}
 		return nil, trace.Wrap(err)
@@ -556,6 +570,7 @@ func (f *Forwarder) formatResponseError(rw http.ResponseWriter, respErr error) {
 		// low-level to be useful.
 		Message: respErr.Error(),
 		Code:    int32(trace.ErrorToCode(respErr)),
+		Reason:  errorToKubeStatusReason(respErr),
 	}
 	data, err := runtime.Encode(kubeCodecs.LegacyCodec(), status)
 	if err != nil {
@@ -564,16 +579,17 @@ func (f *Forwarder) formatResponseError(rw http.ResponseWriter, respErr error) {
 		return
 	}
 	rw.Header().Set(responsewriters.ContentTypeHeader, "application/json")
-	// Always write InternalServerError, that's the only code that kubectl will
-	// parse the Status object for. The Status object has the real status code
-	// embedded.
-	rw.WriteHeader(http.StatusInternalServerError)
+	// Always write the correct error code in the response so kubectl can parse
+	// it correctly. If response code and status.Code drift, kubectl prints
+	// `Error from server (InternalError): an error on the server ("unknown")
+	// has prevented the request from succeeding`` instead of the correct reason.
+	rw.WriteHeader(trace.ErrorToCode(respErr))
 	if _, err := rw.Write(data); err != nil {
 		f.log.Warningf("Failed writing kube error response body: %v", err)
 	}
 }
 
-func (f *Forwarder) setupContext(authCtx auth.Context, req *http.Request, isRemoteUser bool, clientIdentity *tlsca.Identity) (*authContext, error) {
+func (f *Forwarder) setupContext(authCtx auth.Context, req *http.Request, isRemoteUser bool, clientIdentity *tlsca.Identity, kubeResource *types.KubernetesResource) (*authContext, error) {
 	roles := authCtx.Checker
 
 	// adjust session ttl to the smaller of two values: the session
@@ -610,9 +626,6 @@ func (f *Forwarder) setupContext(authCtx auth.Context, req *http.Request, isRemo
 	var (
 		kubeUsers, kubeGroups []string
 		kubeLabels            map[string]string
-		// kubeResource is the KubernetesResource the request is targeted at.
-		// Currently only supports Pods and it includes the pod name and namespace.
-		kubeResource = getPodResourceFromRequest(req.RequestURI)
 	)
 	// Only check k8s principals for local clusters.
 	//
@@ -720,6 +733,7 @@ func (f *Forwarder) setupContext(authCtx auth.Context, req *http.Request, isRemo
 			isRemote:       isRemoteCluster,
 			isRemoteClosed: isRemoteClosed,
 		},
+		httpMethod: req.Method,
 	}, nil
 }
 
@@ -905,7 +919,11 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 	notFoundMessage := fmt.Sprintf("kubernetes cluster %q not found", actx.kubeClusterName)
 	var roleMatchers services.RoleMatchers
 	if actx.kubeResource != nil {
-		notFoundMessage = fmt.Sprintf("%s %q from Kubernetes cluster %q not found", actx.kubeResource.Kind, actx.kubeResource.ClusterResource(), actx.kubeClusterName)
+		notFoundMessage = kubeResourceDeniedAccessMsg(
+			actx.User.GetName(),
+			actx.httpMethod,
+			actx.kubeResource,
+		)
 		roleMatchers = services.RoleMatchers{
 			// Append a matcher that validates if the Kubernetes resource is allowed
 			// by the roles that satisfy the Kubernetes Cluster.
@@ -2621,4 +2639,75 @@ func parseDeleteCollectionBody(r io.Reader, decoder runtime.Decoder) (metav1.Del
 	}
 	_, _, err = decoder.Decode(data, nil, &into)
 	return into, trace.Wrap(err)
+}
+
+// kubeResourceDeniedAccessMsg creates a Kubernetes API like forbidden response.
+// Logic from:
+// https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go#L51
+func kubeResourceDeniedAccessMsg(user, method string, kubeResource *types.KubernetesResource) string {
+	resource := pluralize(kubeResource.Kind)
+	// pod api group is ""
+	// Check this code when we introduce new resources.
+	apiGroup := ""
+	// <resource> "<pod_name>" is forbidden: User "<user>" cannot create resource "<resource>" in API group "" in the namespace "<namespace>"
+	return fmt.Sprintf(
+		"%s %q is forbidden: User %q cannot %s resource %q in API group %q in the namespace %q",
+		resource,
+		kubeResource.Name,
+		user,
+		getRequestVerb(method),
+		resource,
+		apiGroup,
+		kubeResource.Namespace,
+	)
+}
+
+// pluralize adds an s at the end of the input string.
+func pluralize(s string) string {
+	return s + "s"
+}
+
+// getRequestVerb converts the request method into a Kubernetes Verb.
+func getRequestVerb(method string) string {
+	apiVerb := ""
+	switch method {
+	case http.MethodPost:
+		apiVerb = "create"
+	case http.MethodGet:
+		apiVerb = "get"
+	case http.MethodPut:
+		apiVerb = "update"
+	case http.MethodPatch:
+		apiVerb = "patch"
+	case http.MethodDelete:
+		apiVerb = "delete"
+	}
+	return apiVerb
+}
+
+// errorToKubeStatusReason returns an appropriate StatusReason based on the
+// provided error type.
+func errorToKubeStatusReason(err error) metav1.StatusReason {
+	switch {
+	case trace.IsAggregate(err):
+		return metav1.StatusReasonTimeout
+	case trace.IsNotFound(err):
+		return metav1.StatusReasonNotFound
+	case trace.IsBadParameter(err) || trace.IsOAuth2(err):
+		return metav1.StatusReasonBadRequest
+	case trace.IsNotImplemented(err):
+		return metav1.StatusReasonMethodNotAllowed
+	case trace.IsCompareFailed(err):
+		return metav1.StatusReasonConflict
+	case trace.IsAccessDenied(err):
+		return metav1.StatusReasonForbidden
+	case trace.IsAlreadyExists(err):
+		return metav1.StatusReasonConflict
+	case trace.IsLimitExceeded(err):
+		return metav1.StatusReasonTooManyRequests
+	case trace.IsConnectionProblem(err):
+		return metav1.StatusReasonTimeout
+	default:
+		return metav1.StatusReasonUnknown
+	}
 }

--- a/lib/kube/proxy/pod_rbac_test.go
+++ b/lib/kube/proxy/pod_rbac_test.go
@@ -225,8 +225,9 @@ func TestListPodRBAC(t *testing.T) {
 				getTestPodResult: &kubeerrors.StatusError{
 					ErrStatus: metav1.Status{
 						Status:  "Failure",
-						Message: "[00] access denied",
+						Message: "pods \"test\" is forbidden: User \"limited_user\" cannot get resource \"pods\" in API group \"\" in the namespace \"default\"",
 						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
 					},
 				},
 			},

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -37,7 +37,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	spdystream "k8s.io/apimachinery/pkg/util/httpstream/spdy"
 	"k8s.io/apiserver/pkg/util/wsstream"
@@ -88,12 +87,6 @@ const (
 	// into the connection before terminating the portforward connection.
 	PortForwardPayload = "Portforward handler message"
 )
-
-// statusScheme is private scheme for the decoding here until someone fixes the TODO in NewConnection
-var statusScheme = runtime.NewScheme()
-
-// ParameterCodec knows about query parameters used with the meta v1 API spec.
-var statusCodecs = serializer.NewCodecFactory(statusScheme)
 
 type KubeMockServer struct {
 	router      *httprouter.Router
@@ -164,7 +157,7 @@ func (s *KubeMockServer) formatResponseError(rw http.ResponseWriter, respErr err
 		Message: respErr.Error(),
 		Code:    int32(trace.ErrorToCode(respErr)),
 	}
-	data, err := runtime.Encode(statusCodecs.LegacyCodec(), status)
+	data, err := runtime.Encode(kubeCodecs.LegacyCodec(), status)
 	if err != nil {
 		s.log.Warningf("Failed encoding error into kube Status object: %v", err)
 		trace.WriteError(rw, respErr)

--- a/lib/kube/proxy/testing/kube_server/scheme.go
+++ b/lib/kube/proxy/testing/kube_server/scheme.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeserver
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var (
+	// kubeScheme is the runtime Scheme that holds information about supported
+	// message types.
+	kubeScheme = runtime.NewScheme()
+	// kubeCodecs creates a serializer/deserizalier for the different codecs
+	// supported by the Kubernetes API.
+	kubeCodecs = serializer.NewCodecFactory(kubeScheme)
+)
+
+// Register all groups in the schema's registry.
+// It manually registers support for `metav1.Table` because go-client does not
+// support it but `kubectl` calls require support for it.
+func init() {
+	// Register external types for Scheme
+	metav1.AddToGroupVersion(kubeScheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(metav1.AddMetaToScheme(kubeScheme))
+	utilruntime.Must(metav1beta1.AddMetaToScheme(kubeScheme))
+	utilruntime.Must(scheme.AddToScheme(kubeScheme))
+	utilruntime.Must(kubeScheme.SetVersionPriority(corev1.SchemeGroupVersion))
+}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1492,16 +1492,26 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 		return nil, trace.Wrap(err)
 	}
 
-	resources, err := GetResourcesByResourceIDs(ctx, m.getter, resourceIDs)
+	resources, err := m.getUnderlyingResourcesByResourceIDs(ctx, resourceIDs)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	necessaryRoles := make(map[string]struct{})
 	for _, resource := range resources {
-		var rolesForResource []types.Role
+		var (
+			rolesForResource []types.Role
+			resourceMatcher  *KubeResourcesMatcher
+		)
+		kubernetesResources, err := getKubeResourcesFromResourceIDs(resourceIDs, resource.GetName())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if len(kubernetesResources) > 0 {
+			resourceMatcher = NewKubeResourcesMatcher(kubernetesResources)
+		}
 		for _, role := range allRoles {
-			roleAllowsAccess, err := roleAllowsResource(ctx, role, resource, loginHint)
+			roleAllowsAccess, err := roleAllowsResource(ctx, role, resource, loginHint, resourceMatcherToMatcherSlice(resourceMatcher)...)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1511,6 +1521,20 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 				continue
 			}
 			rolesForResource = append(rolesForResource, role)
+		}
+		// If any of the requested resources didn't match with the provided roles,
+		// we deny the request because the user is trying to request more access
+		// than what is allowed by its search_as_roles.
+		if resourceMatcher != nil && len(resourceMatcher.Unmatched()) > 0 {
+			resourcesStr, err := types.ResourceIDsToString(resourceIDs)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return nil, trace.BadParameter(
+				`no roles configured in the "search_as_roles" for this user allow `+
+					`access to at least one requested resources. `+
+					`resources: %s roles: %v unmatched resources: %v`,
+				resourcesStr, roles, resourceMatcher.Unmatched())
 		}
 		if len(loginHint) > 0 {
 			// If we have a login hint, request the single role with the fewest
@@ -1572,12 +1596,14 @@ func roleAllowsResource(
 	role types.Role,
 	resource types.ResourceWithLabels,
 	loginHint string,
+	extraMatchers ...RoleMatcher,
 ) (bool, error) {
 	roleSet := RoleSet{role}
 	var matchers []RoleMatcher
 	if len(loginHint) > 0 {
 		matchers = append(matchers, NewLoginMatcher(loginHint))
 	}
+	matchers = append(matchers, extraMatchers...)
 	err := roleSet.checkAccess(resource, AccessMFAParams{Verified: true}, matchers...)
 	if trace.IsAccessDenied(err) {
 		// Access denied, this role does not allow access to this resource, no
@@ -1732,4 +1758,54 @@ func MapListResourcesResultToLeafResource(resource types.ResourceWithLabels, hin
 	default:
 	}
 	return types.ResourcesWithLabels{resource}, nil
+}
+
+// resourceMatcherToMatcherSlice returns the resourceMatcher in a RoleMatcher slice
+// if the resourceMatcher is not nil, otherwise returns a nil slice.
+func resourceMatcherToMatcherSlice(resourceMatcher *KubeResourcesMatcher) []RoleMatcher {
+	if resourceMatcher == nil {
+		return nil
+	}
+	return []RoleMatcher{resourceMatcher}
+}
+
+// getUnderlyingResourcesByResourceIDs gets the underlying resources the user
+// requested access. Except for resource Kinds present in types.KubernetesResourcesKinds,
+// the underlying resources are the same as requested. If the resource requested
+// is a Kubernetes resource, we return the underlying Kubernetes cluster.
+func (m *RequestValidator) getUnderlyingResourcesByResourceIDs(ctx context.Context, resourceIDs []types.ResourceID) ([]types.ResourceWithLabels, error) {
+	// When searching for Kube Resources, we change the resource Kind to the Kubernetes
+	// Cluster in order to load the roles that grant access to it and to verify
+	// if the access to it is allowed. We later verify if every Kubernetes Resource
+	// requested is fulfilled by at least one role.
+	searchableResourcesIDs := slices.Clone(resourceIDs)
+	for i := range searchableResourcesIDs {
+		if slices.Contains(types.KubernetesResourcesKinds, searchableResourcesIDs[i].Kind) {
+			searchableResourcesIDs[i].Kind = types.KindKubernetesCluster
+		}
+	}
+	// load the underlying resources.
+	resources, err := GetResourcesByResourceIDs(ctx, m.getter, searchableResourcesIDs)
+	return resources, trace.Wrap(err)
+}
+
+// getKubeResourcesFromResourceIDs returns the Kubernetes Resources requested for
+// the configured cluster.
+func getKubeResourcesFromResourceIDs(resourceIDs []types.ResourceID, clusterName string) ([]types.KubernetesResource, error) {
+	kubernetesResources := make([]types.KubernetesResource, 0, len(resourceIDs))
+
+	for _, resourceID := range resourceIDs {
+		if slices.Contains(types.KubernetesResourcesKinds, resourceID.Kind) && resourceID.Name == clusterName {
+			splits := strings.SplitN(resourceID.SubResourceName, "/", 3)
+			if len(splits) != 2 {
+				return nil, trace.BadParameter("subresource name %q does not follow <namespace>/<name> format", resourceID.SubResourceName)
+			}
+			kubernetesResources = append(kubernetesResources, types.KubernetesResource{
+				Kind:      resourceID.Kind,
+				Namespace: splits[0],
+				Name:      splits[1],
+			})
+		}
+	}
+	return kubernetesResources, nil
 }

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1796,7 +1796,7 @@ func getKubeResourcesFromResourceIDs(resourceIDs []types.ResourceID, clusterName
 
 	for _, resourceID := range resourceIDs {
 		if slices.Contains(types.KubernetesResourcesKinds, resourceID.Kind) && resourceID.Name == clusterName {
-			splits := strings.SplitN(resourceID.SubResourceName, "/", 3)
+			splits := strings.Split(resourceID.SubResourceName, "/")
 			if len(splits) != 2 {
 				return nil, trace.BadParameter("subresource name %q does not follow <namespace>/<name> format", resourceID.SubResourceName)
 			}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2101,6 +2101,63 @@ type kubernetesClusterLabelMatcher struct {
 	clusterLabels map[string]string
 }
 
+// NewKubeResourcesMatcher creates a new KubeResourcesMatcher matcher that
+// matches a role against any Kubernetes Resource specified.
+// It also keeps track of the resources that did not match any of user's roles and
+// that shouldn't be included in the resource ids because the user is not allowed
+// to request them.
+func NewKubeResourcesMatcher(resources []types.KubernetesResource) *KubeResourcesMatcher {
+	matcher := &KubeResourcesMatcher{
+		resources:     resources,
+		unmatchedReqs: map[string]struct{}{},
+	}
+	for _, name := range resources {
+		matcher.unmatchedReqs[name.ClusterResource()] = struct{}{}
+	}
+	return matcher
+}
+
+// KubeResourcesMatcher matches a role against any Kubernetes Resource specified.
+// It also keeps track of the resources that did not match any of user's roles and
+// that shouldn't be included in the resource ids because the user is not allowed
+// to request them.
+type KubeResourcesMatcher struct {
+	resources     []types.KubernetesResource
+	unmatchedReqs map[string]struct{}
+}
+
+// Match matches a Kubernetes resource against provided role and condition.
+func (m *KubeResourcesMatcher) Match(role types.Role, condition types.RoleConditionType) (bool, error) {
+	var finalResult bool
+	for _, pod := range m.resources {
+		result, err := utils.KubeResourceMatchesRegex(pod, role.GetKubeResources(condition))
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+
+		if result {
+			delete(m.unmatchedReqs, pod.ClusterResource())
+			finalResult = true
+		}
+	}
+	return finalResult, nil
+}
+
+// String returns the matcher's string representation.
+func (m *KubeResourcesMatcher) String() string {
+	return fmt.Sprintf("KubeResourcesMatcher(Resources=%v)", m.resources)
+}
+
+// Unmatched returns the Kubernetes Resource request access that that didn't
+// match with any `search_as_roles` kubernetes resources.
+func (m *KubeResourcesMatcher) Unmatched() []string {
+	unmatched := make([]string, 0, len(m.unmatchedReqs))
+	for k := range m.unmatchedReqs {
+		unmatched = append(unmatched, k)
+	}
+	return unmatched
+}
+
 // KubernetesResourceMatcher matches a role against a Kubernetes Resource.
 // Kind is must be stricly equal but namespace and name allow wildcards.
 type KubernetesResourceMatcher struct {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -6278,3 +6278,217 @@ func TestMatchGCPServiceAccount(t *testing.T) {
 		})
 	}
 }
+
+func TestKubeResourcesMatcher(t *testing.T) {
+	defaultRole, err := types.NewRole("kube",
+		types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				KubernetesResources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "dev",
+						Name:      types.Wildcard,
+					},
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "default",
+						Name:      "nginx-*",
+					},
+				},
+			},
+			Deny: types.RoleConditions{
+				KubernetesResources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "default",
+						Name:      "restricted",
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	prodRole, err := types.NewRole("kube2",
+		types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				KubernetesResources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "prod",
+						Name:      "pod",
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	invalidRole, err := types.NewRole("kube3",
+		types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				KubernetesResources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: `^[($`,
+						Name:      `^[($`,
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	type args struct {
+		resources []types.KubernetesResource
+		roles     []types.Role
+		cond      types.RoleConditionType
+	}
+	tests := []struct {
+		name               string
+		args               args
+		wantMatch          []bool
+		assertErr          require.ErrorAssertionFunc
+		unmatchedResources []string
+	}{
+		{
+			name: "user requests a valid subset of pods for defaultRole",
+			args: args{
+				roles: []types.Role{defaultRole},
+				cond:  types.Allow,
+				resources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "dev",
+						Name:      "pod",
+					},
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "default",
+						Name:      "nginx-*",
+					},
+				},
+			},
+			wantMatch:          boolsToSlice(true),
+			assertErr:          require.NoError,
+			unmatchedResources: []string{},
+		},
+		{
+			name: "user requests a valid and invalid pod for role defaultRole",
+			args: args{
+				roles: []types.Role{defaultRole},
+				cond:  types.Allow,
+				resources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "dev",
+						Name:      "pod",
+					},
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "default",
+						Name:      "nginx*",
+					},
+				},
+			},
+			// returns true because the first resource matched but the request will fail
+			// because unmatchedResources is not empty.
+			wantMatch:          boolsToSlice(true),
+			assertErr:          require.NoError,
+			unmatchedResources: []string{"default/nginx*"},
+		},
+		{
+			name: "user requests a valid subset of pods but distributed across two roles",
+			args: args{
+				roles: []types.Role{defaultRole, prodRole},
+				cond:  types.Allow,
+				resources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "dev",
+						Name:      "pod",
+					},
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "prod",
+						Name:      "pod",
+					},
+				},
+			},
+			wantMatch:          boolsToSlice(true, true),
+			assertErr:          require.NoError,
+			unmatchedResources: []string{},
+		},
+		{
+			name: "user requests a pod that does not match any role",
+			args: args{
+				roles: []types.Role{defaultRole, prodRole},
+				cond:  types.Allow,
+				resources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "default",
+						Name:      "pod",
+					},
+				},
+			},
+			wantMatch:          boolsToSlice(false, false),
+			assertErr:          require.NoError,
+			unmatchedResources: []string{"default/pod"},
+		},
+		{
+			name: "user requests a denied pod",
+			args: args{
+				roles: []types.Role{defaultRole},
+				cond:  types.Deny,
+				resources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "default",
+						Name:      "restricted",
+					},
+				},
+			},
+			wantMatch:          boolsToSlice(true),
+			assertErr:          require.NoError,
+			unmatchedResources: []string{},
+		},
+		{
+			name: "user requests a role with wrong regex",
+			args: args{
+				roles: []types.Role{invalidRole},
+				cond:  types.Allow,
+				resources: []types.KubernetesResource{
+					{
+						Kind:      types.KindKubePod,
+						Namespace: "default",
+						Name:      "restricted",
+					},
+				},
+			},
+			wantMatch:          boolsToSlice(false),
+			assertErr:          require.Error,
+			unmatchedResources: []string{"default/restricted"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := NewKubeResourcesMatcher(tt.args.resources)
+			// Verify each role independently. If a resource matches the role, matched
+			// is true. Later, after analyzing all roles we verify the resources that
+			// missed the match.
+			for i, role := range tt.args.roles {
+				matched, err := matcher.Match(role, tt.args.cond)
+				require.Equal(t, tt.wantMatch[i], matched)
+				tt.assertErr(t, err)
+			}
+			unmatched := matcher.Unmatched()
+			sort.Strings(unmatched)
+			require.Equal(t, tt.unmatchedResources, unmatched)
+		})
+	}
+}
+
+func boolsToSlice(v ...bool) []bool {
+	return v
+}


### PR DESCRIPTION
This PR introduces support for creating resource access requests to `pod` resources to `tsh` and their approval from `tsh` and `tctl`. 

Adds support `tsh request create --resource /<cluster>/pod/<kube_cluster>/<namespace>/<podname>`.

Part of #18434
Updates #19573