### PR TITLE
Validate AWS regions when configuring the AWSMatcher

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -503,7 +503,7 @@ func checkAndSetDefaultsForAWSMatchers(matcherInput []AWSMatcher) error {
 
 		for _, region := range matcher.Regions {
 			if !slices.Contains(regions, region) {
-				return trace.BadParameter("discovery service type does not support region %q; supported regions are: %v",
+				return trace.BadParameter("discovery service does not support region %q; supported regions are: %v",
 					region, regions)
 			}
 		}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -30,10 +30,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v2"
 
@@ -470,9 +472,21 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
+// awsRegions returns the list of all regions available on every aws partition.
+// It is used to validate the AWSMatcher.Regions values.
+func awsRegions() []string {
+	var regions []string
+	partitions := endpoints.DefaultPartitions()
+	for _, partition := range partitions {
+		regions = append(regions, maps.Keys(partition.Regions())...)
+	}
+	return regions
+}
+
 // checkAndSetDefaultsForAWSMatchers sets the default values for discovery AWS matchers
 // and validates the provided types.
 func checkAndSetDefaultsForAWSMatchers(matcherInput []AWSMatcher) error {
+	regions := awsRegions()
 	for i := range matcherInput {
 		matcher := &matcherInput[i]
 		for _, matcherType := range matcher.Types {
@@ -481,6 +495,19 @@ func checkAndSetDefaultsForAWSMatchers(matcherInput []AWSMatcher) error {
 					matcherType, services.SupportedAWSMatchers)
 			}
 		}
+
+		if len(matcher.Regions) == 0 {
+			return trace.BadParameter("discovery service requires at least one region; supported regions are: %v",
+				regions)
+		}
+
+		for _, region := range matcher.Regions {
+			if !slices.Contains(regions, region) {
+				return trace.BadParameter("discovery service type does not support region %q; supported regions are: %v",
+					region, regions)
+			}
+		}
+
 		if matcher.Tags == nil || len(matcher.Tags) == 0 {
 			matcher.Tags = map[string]apiutils.Strings{types.Wildcard: {types.Wildcard}}
 		}

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -379,7 +379,8 @@ func TestAuthenticationConfig_HandleSecondFactorOffOnWithoutQuotes(t *testing.T)
 		expectError        require.ErrorAssertionFunc
 		expectSecondFactor require.ValueAssertionFunc
 	}{
-		{desc: "handle off with quotes", input: `
+		{
+			desc: "handle off with quotes", input: `
 auth_service:
   enabled: yes
   authentication:
@@ -390,8 +391,10 @@ teleport:
 ssh_service:
   enabled: yes`,
 			expectError:        require.NoError,
-			expectSecondFactor: requireEqual(constants.SecondFactorOff)},
-		{desc: "handle off without quotes", input: `
+			expectSecondFactor: requireEqual(constants.SecondFactorOff),
+		},
+		{
+			desc: "handle off without quotes", input: `
 auth_service:
   enabled: yes
   authentication:
@@ -402,8 +405,10 @@ teleport:
 ssh_service:
   enabled: yes`,
 			expectError:        require.NoError,
-			expectSecondFactor: requireEqual(constants.SecondFactorOff)},
-		{desc: "handle on without quotes", input: `
+			expectSecondFactor: requireEqual(constants.SecondFactorOff),
+		},
+		{
+			desc: "handle on without quotes", input: `
 auth_service:
   enabled: yes
   authentication:
@@ -414,8 +419,10 @@ teleport:
 ssh_service:
   enabled: yes`,
 			expectError:        require.NoError,
-			expectSecondFactor: requireEqual(constants.SecondFactorOn)},
-		{desc: "unsupported numeric type as second_factor", input: `
+			expectSecondFactor: requireEqual(constants.SecondFactorOn),
+		},
+		{
+			desc: "unsupported numeric type as second_factor", input: `
 auth_service:
   enabled: yes
   authentication:
@@ -684,7 +691,6 @@ func TestSSHSection(t *testing.T) {
 			if testCase.expectFileCopying != nil {
 				testCase.expectFileCopying(t, cfg.SSH.SSHFileCopy())
 			}
-
 		})
 	}
 }
@@ -798,7 +804,8 @@ func TestDiscoveryConfig(t *testing.T) {
 						Subscriptions:  []string{"*"},
 						ResourceGroups: []string{"*"},
 					},
-				}},
+				},
+			},
 		},
 		{
 			desc:          "Azure section is filled with values",
@@ -829,7 +836,8 @@ func TestDiscoveryConfig(t *testing.T) {
 						Subscriptions:  []string{"sub1", "sub2"},
 						ResourceGroups: []string{"group1", "group2"},
 					},
-				}},
+				},
+			},
 		},
 		{
 			desc:          "AWS section is filled with defaults",
@@ -864,8 +872,10 @@ func TestDiscoveryConfig(t *testing.T) {
 						},
 						SSM: AWSSSM{DocumentName: defaults.AWSInstallerDocument},
 					},
-				}},
-		}, {
+				},
+			},
+		},
+		{
 			desc:          "AWS section is filled with custom configs",
 			expectError:   require.NoError,
 			expectEnabled: require.True,
@@ -910,7 +920,26 @@ func TestDiscoveryConfig(t *testing.T) {
 					},
 				},
 			},
-		}, {
+		},
+		{
+			desc:          "AWS section is filled with invalid region",
+			expectError:   require.Error,
+			expectEnabled: require.True,
+			mutate: func(cfg cfgMap) {
+				cfg["discovery_service"].(cfgMap)["enabled"] = "yes"
+				cfg["discovery_service"].(cfgMap)["aws"] = []cfgMap{
+					{
+						"types":   []string{"ec2"},
+						"regions": []string{"*"},
+						"tags": cfgMap{
+							"discover_teleport": "yes",
+						},
+					},
+				}
+			},
+			expectedDiscoverySection: Discovery{},
+		},
+		{
 			desc:          "AWS section is filled with invalid join method",
 			expectError:   require.Error,
 			expectEnabled: require.True,
@@ -928,7 +957,8 @@ func TestDiscoveryConfig(t *testing.T) {
 				}
 			},
 			expectedDiscoverySection: Discovery{},
-		}, {
+		},
+		{
 			desc:          "AWS section is filled with no token",
 			expectError:   require.NoError,
 			expectEnabled: require.True,
@@ -936,6 +966,7 @@ func TestDiscoveryConfig(t *testing.T) {
 				cfg["discovery_service"].(cfgMap)["enabled"] = "yes"
 				cfg["discovery_service"].(cfgMap)["aws"] = []cfgMap{
 					{
+						"regions": []string{"eu-west-1"},
 						"install": cfgMap{
 							"join_params": cfgMap{
 								"method": "iam",
@@ -950,7 +981,8 @@ func TestDiscoveryConfig(t *testing.T) {
 						SSM: AWSSSM{
 							DocumentName: defaults.AWSInstallerDocument,
 						},
-						Tags: map[string]apiutils.Strings{"*": {"*"}},
+						Regions: []string{"eu-west-1"},
+						Tags:    map[string]apiutils.Strings{"*": {"*"}},
 						InstallParams: &InstallParams{
 							JoinParams: JoinParams{
 								TokenName: defaults.IAMInviteTokenName,
@@ -969,7 +1001,8 @@ func TestDiscoveryConfig(t *testing.T) {
 			mutate: func(cfg cfgMap) {
 				cfg["discovery_service"].(cfgMap)["enabled"] = "yes"
 				cfg["discovery_service"].(cfgMap)["azure"] = []cfgMap{
-					{"types": []string{"vm"},
+					{
+						"types":           []string{"vm"},
 						"regions":         []string{"westcentralus"},
 						"resource_groups": []string{"rg1"},
 						"subscriptions":   []string{"88888888-8888-8888-8888-888888888888"},


### PR DESCRIPTION
This PR validates if the provided list of regions belongs to any AWS partition. If the region list is invalid or empty, Teleport prints a helpful message and exits.

Fixes #20276