### PR TITLE
Remove direct dependency of `gobuffalo/flect`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/go-piv/piv-go v1.10.0
 	github.com/go-redis/redis/v9 v9.0.0-rc.1 // replaced
 	github.com/go-webauthn/webauthn v0.5.0
-	github.com/gobuffalo/flect v1.0.0
+	github.com/gobuffalo/flect v1.0.0 // indirect
 	github.com/gocql/gocql v1.3.1
 	github.com/gofrs/flock v0.8.1
 	github.com/gogo/protobuf v1.3.2 // replaced

--- a/operator/crdgen/schemagen.go
+++ b/operator/crdgen/schemagen.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/gobuffalo/flect"
+	"github.com/dustin/go-humanize/english"
 	"github.com/gravitational/trace"
 	"golang.org/x/exp/slices"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -123,7 +123,7 @@ func (generator *SchemaGenerator) addResource(file *File, name string, overrideV
 			groupName:  generator.groupName,
 			kind:       resourceKind,
 			name:       strings.ToLower(resourceKind),
-			pluralName: strings.ToLower(flect.Pluralize(resourceKind)),
+			pluralName: strings.ToLower(english.PluralWord(2, resourceKind, "")),
 		}
 		generator.roots[resourceKind] = root
 	}


### PR DESCRIPTION
This lib was used to convert a noum to its plural.

This feature is also provided by `go-humanize` lib.

Given that `go-humanize` is much more used across the repo, we replaced the `gobuffalo/flect` with its equivalent in the `go-humanize`.
We still depend on this lib for the repo, but only as an indirect dependency.

```bash
~/s/teleport (marco/remove_flect)> go mod why github.com/gobuffalo/flect
# github.com/gobuffalo/flect
github.com/gravitational/teleport/operator/crdgen
sigs.k8s.io/controller-tools/pkg/crd
github.com/gobuffalo/flect
```