### PR TITLE
Point at source version in docs rather then generic master.

### DIFF
--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -115,7 +115,7 @@ proxy_service:
 
 ### Systemd Unit File
 
-Next, download the systemd service unit file from the [examples directory](https://github.com/gravitational/teleport/tree/master/examples/systemd/fips)
+Next, download the systemd service unit file from the [examples directory](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/systemd/fips)
 on GitHub and save it as `/etc/systemd/system/teleport.service` on both servers.
 
 ```code

--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -115,7 +115,7 @@ proxy_service:
 
 ### Systemd Unit File
 
-Next, download the systemd service unit file from the [examples directory](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/systemd/fips)
+Next, download the systemd service unit file from the [examples directory](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/systemd/fips)
 on GitHub and save it as `/etc/systemd/system/teleport.service` on both servers.
 
 ```code

--- a/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
@@ -4,7 +4,7 @@ description: How to configure Teleport in High Availability mode for AWS deploym
 h1: Running Teleport Enterprise in High Availability mode on AWS
 ---
 
-This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
+This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to manage the resulting Teleport deployment.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)

--- a/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
@@ -4,7 +4,7 @@ description: How to configure Teleport in High Availability mode for AWS deploym
 h1: Running Teleport Enterprise in High Availability mode on AWS
 ---
 
-This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
+This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to manage the resulting Teleport deployment.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -9,7 +9,7 @@ Service, or a custom configuration to deploy resource services such as the
 Teleport Kubernetes Service or Database Service.
 
 You can
-[browse the source on GitHub](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/chart/teleport-cluster).
+[browse the source on GitHub](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/chart/teleport-cluster).
 
 The `teleport-cluster` chart runs two Teleport services:
 

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -9,7 +9,7 @@ Service, or a custom configuration to deploy resource services such as the
 Teleport Kubernetes Service or Database Service.
 
 You can
-[browse the source on GitHub](https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-cluster).
+[browse the source on GitHub](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/chart/teleport-cluster).
 
 The `teleport-cluster` chart runs two Teleport services:
 

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -8,7 +8,7 @@ runs in a remote Kubernetes cluster to provide access to resources in your
 infrastructure. 
 
 You can [browse the source on
-GitHub](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/chart/teleport-kube-agent).
+GitHub](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/chart/teleport-kube-agent).
 
 This reference details available values for the `teleport-kube-agent` chart.
 

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -8,7 +8,7 @@ runs in a remote Kubernetes cluster to provide access to resources in your
 infrastructure. 
 
 You can [browse the source on
-GitHub](https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-kube-agent).
+GitHub](https://github.com/gravitational/teleport/tree/v(=teleport.version=)/examples/chart/teleport-kube-agent).
 
 This reference details available values for the `teleport-kube-agent` chart.
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
@@ -5,7 +5,7 @@ description: Values that can be set using the teleport-plugin-event-handler Helm
 
 The `teleport-plugin-event-handler` Helm chart is used to configure the Event Handler Teleport plugin which allows users to send events and session logs to a Fluentd instance for further processing or storage.
 
-You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/master/charts/event-handler).
+You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/event-handler).
 
 This reference details available values for the `teleport-plugin-event-handler` chart.
 
@@ -53,7 +53,7 @@ data:
   auth_id: ...
 ```
 
-Check out the [Event Handler Helm Chart documentation](https://github.com/gravitational/teleport-plugins/tree/master/charts/event-handler/#prerequisites) for more information about how to acquire these credentials.
+Check out the [Event Handler Helm Chart documentation](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/event-handler/#prerequisites) for more information about how to acquire these credentials.
 
 <Tabs>
   <TabItem label="values.yaml">

--- a/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
@@ -7,7 +7,7 @@ The `teleport-plugin-jira` Helm chart runs the Jira Teleport plugin, which
 allows users to receive and manage Access Requests as tasks in a Jira project.
 
 You can [browse the source on
-GitHub](https://github.com/gravitational/teleport-plugins/tree/master/charts/access/jira).
+GitHub](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/access/jira).
 
 This reference details available values for the `teleport-plugin-jira` chart.
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
@@ -7,7 +7,7 @@ The `teleport-plugin-mattermost` Helm chart is used to configure the
 Mattermost Teleport plugin, which allows users to receive Access
 Requests via channels or as direct messages in Mattermost.
 
-You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/master/charts/access/mattermost).
+You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/access/mattermost).
 
 This reference details available values for the `teleport-plugin-mattermost` chart.
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
@@ -5,7 +5,7 @@ description: Values that can be set using the teleport-plugin-pagerduty Helm cha
 
 The `teleport-plugin-pagerduty` Helm chart is used to configure the PagerDuty Teleport plugin, which allows users to receive access requests as pages via PagerDuty.
 
-You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/master/charts/access/pagerduty).
+You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/access/pagerduty).
 
 This reference details available values for the `teleport-plugin-pagerduty` chart.
 
@@ -53,7 +53,7 @@ data:
   auth_id: ...
 ```
 
-Read the [PagerDuty Helm Chart documentation](https://github.com/gravitational/teleport-plugins/tree/master/charts/access/pagerduty#prerequisites) for more information about how to acquire these credentials.
+Read the [PagerDuty Helm Chart documentation](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/access/pagerduty#prerequisites) for more information about how to acquire these credentials.
 
 <Tabs>
   <TabItem label="values.yaml">

--- a/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
@@ -5,7 +5,7 @@ description: Values that can be set using the teleport-plugin-slack Helm chart
 
 The `teleport-plugin-slack` Helm chart is used to configure the Slack Teleport plugin, which allows users to receive Access Requests via channels or direct messages in Slack.
 
-You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/master/charts/access/slack).
+You can [browse the source on GitHub](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/access/slack).
 
 This reference details available values for the `teleport-plugin-slack` chart.
 


### PR DESCRIPTION
Pointing at branch version rather then `master`.  Teleport Plugins are pointing at the specific version in that repo until they're moved over to the `teleport` repo.

  Pointing at `master` can result in incompatible versions used vs the supported document version.