### PR TITLE
Refactor AccessMFAParams and MFAParams to allow additional data

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3861,12 +3861,12 @@ func (a *Server) SubmitUsageEvent(ctx context.Context, req *proto.SubmitUsageEve
 }
 
 func (a *Server) isMFARequired(ctx context.Context, checker services.AccessChecker, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
-	pref, err := a.GetAuthPreference(ctx)
+	authPref, err := a.GetAuthPreference(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	switch params := checker.MFAParams(pref.GetRequireMFAType()); params.MFARequired {
+	switch state := checker.GetAccessState(authPref); state.MFARequired {
 	case services.MFARequiredAlways:
 		return &proto.IsMFARequiredResponse{Required: true}, nil
 	case services.MFARequiredNever:

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3866,7 +3866,7 @@ func (a *Server) isMFARequired(ctx context.Context, checker services.AccessCheck
 		return nil, trace.Wrap(err)
 	}
 
-	switch params := checker.MFAParams(pref.GetRequireMFAType()); params.Required {
+	switch params := checker.MFAParams(pref.GetRequireMFAType()); params.MFARequired {
 	case services.MFARequiredAlways:
 		return &proto.IsMFARequiredResponse{Required: true}, nil
 	case services.MFARequiredNever:
@@ -3916,7 +3916,7 @@ func (a *Server) isMFARequired(ctx context.Context, checker services.AccessCheck
 		for _, n := range matches {
 			err := checker.CheckAccess(
 				n,
-				services.AccessMFAParams{},
+				services.AccessState{},
 				services.NewLoginMatcher(t.Node.Login),
 			)
 
@@ -3949,7 +3949,7 @@ func (a *Server) isMFARequired(ctx context.Context, checker services.AccessCheck
 			return nil, trace.Wrap(notFoundErr)
 		}
 
-		noMFAAccessErr = checker.CheckAccess(cluster, services.AccessMFAParams{})
+		noMFAAccessErr = checker.CheckAccess(cluster, services.AccessState{})
 
 	case *proto.IsMFARequiredRequest_Database:
 		notFoundErr = trace.NotFound("database service %q not found", t.Database.ServiceName)
@@ -3978,7 +3978,7 @@ func (a *Server) isMFARequired(ctx context.Context, checker services.AccessCheck
 		)
 		noMFAAccessErr = checker.CheckAccess(
 			db,
-			services.AccessMFAParams{},
+			services.AccessState{},
 			dbRoleMatchers...,
 		)
 	case *proto.IsMFARequiredRequest_WindowsDesktop:
@@ -3991,7 +3991,7 @@ func (a *Server) isMFARequired(ctx context.Context, checker services.AccessCheck
 		}
 
 		noMFAAccessErr = checker.CheckAccess(desktops[0],
-			services.AccessMFAParams{},
+			services.AccessState{},
 			services.NewWindowsLoginMatcher(t.WindowsDesktop.GetLogin()))
 
 	default:

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4311,18 +4311,18 @@ func (a *ServerWithRoles) UpsertKubeService(ctx context.Context, s types.Server)
 		return trace.Wrap(err)
 	}
 
-	ap, err := a.authServer.GetAuthPreference(ctx)
+	authPref, err := a.authServer.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	mfaParams := a.context.MFAParams(ap.GetRequireMFAType())
+	state := a.context.GetAccessState(authPref)
 	for _, kube := range s.GetKubernetesClusters() {
 		k8sV3, err := types.NewKubernetesClusterV3FromLegacyCluster(s.GetNamespace(), kube)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := a.context.Checker.CheckAccess(k8sV3, mfaParams); err != nil {
+		if err := a.context.Checker.CheckAccess(k8sV3, state); err != nil {
 			return utils.OpaqueAccessDenied(err)
 		}
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1357,24 +1357,24 @@ type resourceChecker struct {
 func (r resourceChecker) CanAccess(resource types.Resource) error {
 	// MFA is not required for operations on app resources but
 	// will be enforced at the connection time.
-	mfaParams := services.AccessMFAParams{Verified: true}
+	state := services.AccessState{MFAVerified: true}
 	switch rr := resource.(type) {
 	case types.AppServer:
-		return r.CheckAccess(rr.GetApp(), mfaParams)
+		return r.CheckAccess(rr.GetApp(), state)
 	case types.KubeServer:
-		return r.CheckAccess(rr.GetCluster(), mfaParams)
+		return r.CheckAccess(rr.GetCluster(), state)
 	case types.DatabaseServer:
-		return r.CheckAccess(rr.GetDatabase(), mfaParams)
+		return r.CheckAccess(rr.GetDatabase(), state)
 	case types.DatabaseService:
-		return r.CheckAccess(rr, mfaParams)
+		return r.CheckAccess(rr, state)
 	case types.Database:
-		return r.CheckAccess(rr, mfaParams)
+		return r.CheckAccess(rr, state)
 	case types.Server:
-		return r.CheckAccess(rr, mfaParams)
+		return r.CheckAccess(rr, state)
 	case types.WindowsDesktop:
-		return r.CheckAccess(rr, mfaParams)
+		return r.CheckAccess(rr, state)
 	case types.WindowsDesktopService:
-		return r.CheckAccess(rr, mfaParams)
+		return r.CheckAccess(rr, state)
 	default:
 		return trace.BadParameter("could not check access to resource type %T", r)
 	}
@@ -1439,7 +1439,7 @@ func (k *kubeChecker) canAccessKubernetesLegacy(server types.Server) error {
 			return trace.Wrap(err)
 		}
 
-		if err := k.checker.CheckAccess(k8sV3, services.AccessMFAParams{Verified: true}); err != nil {
+		if err := k.checker.CheckAccess(k8sV3, services.AccessState{MFAVerified: true}); err != nil {
 			if trace.IsAccessDenied(err) {
 				continue
 			}
@@ -1456,7 +1456,7 @@ func (k *kubeChecker) canAccessKubernetesLegacy(server types.Server) error {
 
 func (k *kubeChecker) canAccessKubernetes(server types.KubeServer) error {
 	kube := server.GetCluster()
-	err := k.checker.CheckAccess(kube, services.AccessMFAParams{Verified: true})
+	err := k.checker.CheckAccess(kube, services.AccessState{MFAVerified: true})
 	return trace.Wrap(err)
 }
 
@@ -4050,7 +4050,7 @@ func (a *ServerWithRoles) checkAccessToApp(app types.Application) error {
 		app,
 		// MFA is not required for operations on app resources but
 		// will be enforced at the connection time.
-		services.AccessMFAParams{Verified: true})
+		services.AccessState{MFAVerified: true})
 }
 
 // GetApplicationServers returns all registered application servers.
@@ -4343,7 +4343,7 @@ func (a *ServerWithRoles) checkAccessToKubeCluster(cluster types.KubeCluster) er
 		cluster,
 		// MFA is not required for operations on kube clusters resources but
 		// will be enforced at the connection time.
-		services.AccessMFAParams{Verified: true})
+		services.AccessState{MFAVerified: true})
 }
 
 // GetKubernetesServers returns all registered kubernetes servers.
@@ -4849,14 +4849,14 @@ func (a *ServerWithRoles) checkAccessToNode(node types.Server) error {
 	return a.context.Checker.CheckAccess(node,
 		// MFA is not required for operations on node resources but
 		// will be enforced at the connection time.
-		services.AccessMFAParams{Verified: true})
+		services.AccessState{MFAVerified: true})
 }
 
 func (a *ServerWithRoles) checkAccessToDatabase(database types.Database) error {
 	return a.context.Checker.CheckAccess(database,
 		// MFA is not required for operations on database resources but
 		// will be enforced at the connection time.
-		services.AccessMFAParams{Verified: true})
+		services.AccessState{MFAVerified: true})
 }
 
 // CreateDatabase creates a new database resource.
@@ -5150,7 +5150,7 @@ func (a *ServerWithRoles) filterWindowsDesktops(desktops []types.WindowsDesktop)
 func (a *ServerWithRoles) checkAccessToWindowsDesktop(w types.WindowsDesktop) error {
 	return a.context.Checker.CheckAccess(w,
 		// MFA is not required for operations on desktop resources
-		services.AccessMFAParams{Verified: true},
+		services.AccessState{MFAVerified: true},
 		// Note: we don't use the Windows login matcher here, as we won't know what OS user
 		// the user is trying to log in as until they initiate the connection.
 	)

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -179,15 +179,16 @@ func (c *Context) UseExtraRoles(access services.RoleGetter, clusterName string, 
 	return nil
 }
 
-// MFAParams returns MFA params for the given auth context and auth preference MFA requirement.
-func (c *Context) MFAParams(authPrefMFARequirement types.RequireMFAType) services.AccessState {
-	params := c.Checker.MFAParams(authPrefMFARequirement)
+// GetAccessState returns the AccessState based on the underlying
+// [services.AccessChecker] and [tlsca.Identity].
+func (c *Context) GetAccessState(authPref types.AuthPreference) services.AccessState {
+	state := c.Checker.GetAccessState(authPref)
 
 	// Builtin services (like proxy_service and kube_service) are not gated
 	// on MFA and only need to pass normal RBAC action checks.
 	_, isService := c.Identity.(BuiltinRole)
-	params.MFAVerified = isService || c.Identity.GetIdentity().MFAVerified != ""
-	return params
+	state.MFAVerified = isService || c.Identity.GetIdentity().MFAVerified != ""
+	return state
 }
 
 // Authorize authorizes user based on identity supplied via context

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -180,13 +180,13 @@ func (c *Context) UseExtraRoles(access services.RoleGetter, clusterName string, 
 }
 
 // MFAParams returns MFA params for the given auth context and auth preference MFA requirement.
-func (c *Context) MFAParams(authPrefMFARequirement types.RequireMFAType) services.AccessMFAParams {
+func (c *Context) MFAParams(authPrefMFARequirement types.RequireMFAType) services.AccessState {
 	params := c.Checker.MFAParams(authPrefMFARequirement)
 
 	// Builtin services (like proxy_service and kube_service) are not gated
 	// on MFA and only need to pass normal RBAC action checks.
 	_, isService := c.Identity.(BuiltinRole)
-	params.Verified = isService || c.Identity.GetIdentity().MFAVerified != ""
+	params.MFAVerified = isService || c.Identity.GetIdentity().MFAVerified != ""
 	return params
 }
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -909,12 +909,12 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ap, err := f.cfg.CachingAuthClient.GetAuthPreference(ctx)
+	authPref, err := f.cfg.CachingAuthClient.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	mfaParams := actx.MFAParams(ap.GetRequireMFAType())
+	state := actx.GetAccessState(authPref)
 
 	notFoundMessage := fmt.Sprintf("kubernetes cluster %q not found", actx.kubeClusterName)
 	var roleMatchers services.RoleMatchers
@@ -941,7 +941,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			continue
 		}
 
-		if err := actx.Checker.CheckAccess(ks, mfaParams, roleMatchers...); err != nil {
+		if err := actx.Checker.CheckAccess(ks, state, roleMatchers...); err != nil {
 			return trace.AccessDenied(notFoundMessage)
 		}
 		// If the user has active Access requests we need to validate that they allow

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -188,9 +188,10 @@ type AccessChecker interface {
 	// PinSourceIP forces the same client IP for certificate generation and SSH usage
 	PinSourceIP() bool
 
-	// MFAParams returns MFA params for the given use given their roles, the cluster
-	// auth preference, and whether mfa has been verified.
-	MFAParams(authPrefMFARequirement types.RequireMFAType) AccessState
+	// GetAccessState returns the AccessState for the user given their roles, the
+	// cluster auth preference, and whether MFA and the user's device were
+	// verified.
+	GetAccessState(authPref types.AuthPreference) AccessState
 	// PrivateKeyPolicy returns the enforced private key policy for this role set,
 	// or the provided defaultPolicy - whichever is stricter.
 	PrivateKeyPolicy(defaultPolicy keys.PrivateKeyPolicy) keys.PrivateKeyPolicy

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -44,7 +44,7 @@ type AccessChecker interface {
 	Roles() []types.Role
 
 	// CheckAccess checks access to the specified resource.
-	CheckAccess(r AccessCheckable, mfa AccessMFAParams, matchers ...RoleMatcher) error
+	CheckAccess(r AccessCheckable, state AccessState, matchers ...RoleMatcher) error
 
 	// CheckAccessToRemoteCluster checks access to remote cluster
 	CheckAccessToRemoteCluster(cluster types.RemoteCluster) error
@@ -190,7 +190,7 @@ type AccessChecker interface {
 
 	// MFAParams returns MFA params for the given use given their roles, the cluster
 	// auth preference, and whether mfa has been verified.
-	MFAParams(authPrefMFARequirement types.RequireMFAType) AccessMFAParams
+	MFAParams(authPrefMFARequirement types.RequireMFAType) AccessState
 	// PrivateKeyPolicy returns the enforced private key policy for this role set,
 	// or the provided defaultPolicy - whichever is stricter.
 	PrivateKeyPolicy(defaultPolicy keys.PrivateKeyPolicy) keys.PrivateKeyPolicy
@@ -303,11 +303,11 @@ func (a *accessChecker) checkAllowedResources(r AccessCheckable) error {
 
 // CheckAccess checks if the identity for this AccessChecker has access to the
 // given resource.
-func (a *accessChecker) CheckAccess(r AccessCheckable, mfa AccessMFAParams, matchers ...RoleMatcher) error {
+func (a *accessChecker) CheckAccess(r AccessCheckable, state AccessState, matchers ...RoleMatcher) error {
 	if err := a.checkAllowedResources(r); err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(a.RoleSet.checkAccess(r, mfa, matchers...))
+	return trace.Wrap(a.RoleSet.checkAccess(r, state, matchers...))
 }
 
 // GetKubeResources returns the allowed and denied Kubernetes Resources configured

--- a/lib/services/access_checker_test.go
+++ b/lib/services/access_checker_test.go
@@ -246,7 +246,7 @@ func TestAccessCheckerKubeResources(t *testing.T) {
 
 			err := accessChecker.CheckAccess(
 				tt.kubeCluster,
-				AccessMFAParams{Required: MFARequiredNever},
+				AccessState{MFARequired: MFARequiredNever},
 				// Append a matcher that validates if the Kubernetes resource is allowed
 				// by the roles that satisfy the Kubernetes Cluster.
 				NewKubernetesResourceMatcher(tt.fields.resource),

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1604,7 +1604,7 @@ func roleAllowsResource(
 		matchers = append(matchers, NewLoginMatcher(loginHint))
 	}
 	matchers = append(matchers, extraMatchers...)
-	err := roleSet.checkAccess(resource, AccessMFAParams{Verified: true}, matchers...)
+	err := roleSet.checkAccess(resource, AccessState{MFAVerified: true}, matchers...)
 	if trace.IsAccessDenied(err) {
 		// Access denied, this role does not allow access to this resource, no
 		// unexpected error to report.

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -971,7 +971,7 @@ func (set RoleSet) EnumerateDatabaseUsers(database types.Database, extraUsers ..
 
 		result.wildcardDenied = result.wildcardDenied || wildcardDenied
 
-		if err := NewRoleSet(role).checkAccess(database, AccessMFAParams{Verified: true}); err == nil {
+		if err := NewRoleSet(role).checkAccess(database, AccessState{MFAVerified: true}); err == nil {
 			result.wildcardAllowed = result.wildcardAllowed || wildcardAllowed
 		}
 
@@ -981,7 +981,7 @@ func (set RoleSet) EnumerateDatabaseUsers(database types.Database, extraUsers ..
 
 	// check each individual user against the database.
 	for _, user := range users {
-		err := set.checkAccess(database, AccessMFAParams{Verified: true}, &DatabaseUserMatcher{User: user})
+		err := set.checkAccess(database, AccessState{MFAVerified: true}, &DatabaseUserMatcher{User: user})
 		result.allowedDeniedMap[user] = err == nil
 	}
 
@@ -1005,7 +1005,7 @@ func (set RoleSet) EnumerateServerLogins(server types.Server) EnumerationResult 
 
 	// check each individual user against the server.
 	for _, user := range logins {
-		err := set.checkAccess(server, AccessMFAParams{Verified: true}, NewLoginMatcher(user))
+		err := set.checkAccess(server, AccessState{MFAVerified: true}, NewLoginMatcher(user))
 		result.allowedDeniedMap[user] = err == nil
 	}
 
@@ -1167,21 +1167,21 @@ func (set RoleSet) PinSourceIP() bool {
 
 // MFAParams returns MFA params for the given user given their roles, the cluster
 // auth preference, and whether mfa has been verified.
-func (set RoleSet) MFAParams(authPrefRequirement types.RequireMFAType) (params AccessMFAParams) {
+func (set RoleSet) MFAParams(authPrefRequirement types.RequireMFAType) (params AccessState) {
 	// per-session MFA is overridden by hardware key PIV touch requirement.
 	// check if the auth pref or any roles have this option.
 	if authPrefRequirement == types.RequireMFAType_HARDWARE_KEY_TOUCH {
-		return AccessMFAParams{Required: MFARequiredNever}
+		return AccessState{MFARequired: MFARequiredNever}
 	}
 	for _, role := range set {
 		if role.GetOptions().RequireMFAType == types.RequireMFAType_HARDWARE_KEY_TOUCH {
-			return AccessMFAParams{Required: MFARequiredNever}
+			return AccessState{MFARequired: MFARequiredNever}
 		}
 	}
 
 	// MFA is always required according to the cluster auth pref.
 	if authPrefRequirement.IsSessionMFARequired() {
-		return AccessMFAParams{Required: MFARequiredAlways}
+		return AccessState{MFARequired: MFARequiredAlways}
 	}
 
 	// If MFA requirement is the same across all roles, we can skip the per-role check.
@@ -1191,17 +1191,17 @@ func (set RoleSet) MFAParams(authPrefRequirement types.RequireMFAType) (params A
 		for _, role := range set[1:] {
 			if role.GetOptions().RequireMFAType.IsSessionMFARequired() != rolesMFARequired {
 				// This role differs from the MFA requirement of the other roles, return per-role.
-				return AccessMFAParams{Required: MFARequiredPerRole}
+				return AccessState{MFARequired: MFARequiredPerRole}
 			}
 		}
 
 		if rolesMFARequired {
-			return AccessMFAParams{Required: MFARequiredAlways}
+			return AccessState{MFARequired: MFARequiredAlways}
 		}
 	}
 
 	// No roles to check or no roles require MFA.
-	return AccessMFAParams{Required: MFARequiredNever}
+	return AccessState{MFARequired: MFARequiredNever}
 }
 
 // PrivateKeyPolicy returns the enforced private key policy for this role set.
@@ -2241,13 +2241,13 @@ func rbacDebugLogger() (debugEnabled bool, debugf func(format string, args ...in
 
 // checkAccess checks if this role set has access to a particular resource,
 // optionally matching the resource's labels.
-func (set RoleSet) checkAccess(r AccessCheckable, mfa AccessMFAParams, matchers ...RoleMatcher) error {
+func (set RoleSet) checkAccess(r AccessCheckable, state AccessState, matchers ...RoleMatcher) error {
 	// Note: logging in this function only happens in debug mode. This is because
 	// adding logging to this function (which is called on every resource returned
 	// by the backend) can slow down this function by 50x for large clusters!
 	isDebugEnabled, debugf := rbacDebugLogger()
 
-	if mfa.Required == MFARequiredAlways && !mfa.Verified {
+	if state.MFARequired == MFARequiredAlways && !state.MFAVerified {
 		debugf("Access to %v %q denied, cluster requires per-session MFA", r.GetKind(), r.GetName())
 		return ErrSessionMFARequired
 	}
@@ -2362,7 +2362,7 @@ func (set RoleSet) checkAccess(r AccessCheckable, mfa AccessMFAParams, matchers 
 
 		// if we've reached this point, namespace, labels, and matchers all match.
 		// if MFA is verified or never required, we're done.
-		if mfa.Verified || mfa.Required == MFARequiredNever {
+		if state.MFAVerified || state.MFARequired == MFARequiredNever {
 			return nil
 		}
 		// if MFA is not verified and we require session MFA, deny access
@@ -2899,13 +2899,15 @@ func (set RoleSet) GetAllowedPreviewAsRoles() []string {
 	return apiutils.Deduplicate(allowed)
 }
 
-// AccessMFAParams contains MFA-related parameters for methods that check access.
-type AccessMFAParams struct {
-	// Required determines whether a user's MFA requirement dynamically changes based on
-	// their active role (per-role), or is static across all roles (always/never).
-	Required MFARequired
-	// Verified is set when MFA has been verified by the caller.
-	Verified bool
+// AccessState holds state for the present access attempt, including both
+// cluster settings and user state (MFA, device trust, etc).
+type AccessState struct {
+	// MFARequired determines whether a user's MFA requirement dynamically changes
+	// based on their active role (per-role), or is static across all roles
+	// (always/never).
+	MFARequired MFARequired
+	// MFAVerified is set when MFA has been verified by the caller.
+	MFAVerified bool
 }
 
 // MFARequired determines when MFA is required for a user to access a resource.

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1165,12 +1165,12 @@ func (set RoleSet) PinSourceIP() bool {
 	return false
 }
 
-// MFAParams returns MFA params for the given user given their roles, the cluster
-// auth preference, and whether mfa has been verified.
-func (set RoleSet) MFAParams(authPrefRequirement types.RequireMFAType) (params AccessState) {
+// GetAccessState returns the AccessState for the user given their roles, the
+// cluster auth preference, and whether MFA and the user's device were verified.
+func (set RoleSet) GetAccessState(authPref types.AuthPreference) AccessState {
 	// per-session MFA is overridden by hardware key PIV touch requirement.
 	// check if the auth pref or any roles have this option.
-	if authPrefRequirement == types.RequireMFAType_HARDWARE_KEY_TOUCH {
+	if authPref.GetRequireMFAType() == types.RequireMFAType_HARDWARE_KEY_TOUCH {
 		return AccessState{MFARequired: MFARequiredNever}
 	}
 	for _, role := range set {
@@ -1180,7 +1180,7 @@ func (set RoleSet) MFAParams(authPrefRequirement types.RequireMFAType) (params A
 	}
 
 	// MFA is always required according to the cluster auth pref.
-	if authPrefRequirement.IsSessionMFARequired() {
+	if authPref.GetRequireMFAType().IsSessionMFARequired() {
 		return AccessState{MFARequired: MFARequiredAlways}
 	}
 

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1029,7 +1029,7 @@ func TestCheckAccessToServer(t *testing.T) {
 			for j, check := range tc.checks {
 				comment := fmt.Sprintf("check %v: user: %v, server: %v, should access: %v", j, check.login, check.server.GetName(), check.hasAccess)
 				mfaParams := set.MFAParams(tc.authPrefMFARequireType)
-				mfaParams.Verified = tc.mfaVerified
+				mfaParams.MFAVerified = tc.mfaVerified
 				err := set.checkAccess(
 					check.server,
 					mfaParams,
@@ -2792,8 +2792,8 @@ func TestCheckAccessToDatabase(t *testing.T) {
 	testCases := []struct {
 		name      string
 		roles     RoleSet
-		access    []access
-		mfaParams AccessMFAParams
+		access []access
+		state  AccessState
 	}{
 		{
 			name:  "developer allowed any username/database in stage database except one database",
@@ -2824,33 +2824,33 @@ func TestCheckAccessToDatabase(t *testing.T) {
 			},
 		},
 		{
-			name:      "prod database requires MFA, no MFA provided",
-			roles:     RoleSet{roleDevStage, roleDevProdWithMFA, roleDevProd},
-			mfaParams: AccessMFAParams{Verified: false},
+			name:  "prod database requires MFA, no MFA provided",
+			roles: RoleSet{roleDevStage, roleDevProdWithMFA, roleDevProd},
+			state: AccessState{MFAVerified: false},
 			access: []access{
 				{server: dbStage, dbName: "test", dbUser: "dev", access: true},
 				{server: dbProd, dbName: "test", dbUser: "dev", access: false},
 			},
 		},
 		{
-			name:      "prod database requires MFA, MFA provided",
-			roles:     RoleSet{roleDevStage, roleDevProdWithMFA, roleDevProd},
-			mfaParams: AccessMFAParams{Verified: true},
+			name:  "prod database requires MFA, MFA provided",
+			roles: RoleSet{roleDevStage, roleDevProdWithMFA, roleDevProd},
+			state: AccessState{MFAVerified: true},
 			access: []access{
 				{server: dbStage, dbName: "test", dbUser: "dev", access: true},
 				{server: dbProd, dbName: "test", dbUser: "dev", access: true},
 			},
 		},
 		{
-			name:      "cluster requires MFA, no MFA provided",
-			roles:     RoleSet{roleDevStage, roleDevProdWithMFA, roleDevProd},
-			mfaParams: AccessMFAParams{Verified: false, Required: MFARequiredAlways},
-			access:    []access{},
+			name:   "cluster requires MFA, no MFA provided",
+			roles:  RoleSet{roleDevStage, roleDevProdWithMFA, roleDevProd},
+			state:  AccessState{MFAVerified: false, MFARequired: MFARequiredAlways},
+			access: []access{},
 		},
 		{
-			name:      "cluster requires MFA, MFA provided",
-			roles:     RoleSet{roleDevStage, roleDevProdWithMFA, roleDevProd},
-			mfaParams: AccessMFAParams{Verified: true, Required: MFARequiredAlways},
+			name:  "cluster requires MFA, MFA provided",
+			roles: RoleSet{roleDevStage, roleDevProdWithMFA, roleDevProd},
+			state: AccessState{MFAVerified: true, MFARequired: MFARequiredAlways},
 			access: []access{
 				{server: dbStage, dbName: "test", dbUser: "dev", access: true},
 				{server: dbProd, dbName: "test", dbUser: "dev", access: true},
@@ -2860,7 +2860,7 @@ func TestCheckAccessToDatabase(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, access := range tc.access {
-				err := tc.roles.checkAccess(access.server, tc.mfaParams,
+				err := tc.roles.checkAccess(access.server, tc.state,
 					&DatabaseUserMatcher{User: access.dbUser},
 					&DatabaseNameMatcher{Name: access.dbName})
 				if access.access {
@@ -2946,7 +2946,7 @@ func TestCheckAccessToDatabaseUser(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, access := range tc.access {
-				err := tc.roles.checkAccess(access.server, AccessMFAParams{}, &DatabaseUserMatcher{User: access.dbUser})
+				err := tc.roles.checkAccess(access.server, AccessState{}, &DatabaseUserMatcher{User: access.dbUser})
 				if access.access {
 					require.NoError(t, err)
 				} else {
@@ -3559,7 +3559,7 @@ func TestCheckAccessToDatabaseService(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, access := range tc.access {
-				err := tc.roles.checkAccess(access.server, AccessMFAParams{})
+				err := tc.roles.checkAccess(access.server, AccessState{})
 				if access.access {
 					require.NoError(t, err)
 				} else {
@@ -3667,7 +3667,7 @@ func TestCheckAccessToAWSConsole(t *testing.T) {
 			for _, access := range test.access {
 				err := test.roles.checkAccess(
 					app,
-					AccessMFAParams{},
+					AccessState{},
 					&AWSRoleARNMatcher{RoleARN: access.roleARN})
 				if access.hasAccess {
 					require.NoError(t, err)
@@ -3766,7 +3766,7 @@ func TestCheckAccessToAzureCloud(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for identity, hasAccess := range test.access {
-				err := test.roles.checkAccess(app, AccessMFAParams{}, &AzureIdentityMatcher{Identity: identity})
+				err := test.roles.checkAccess(app, AccessState{}, &AzureIdentityMatcher{Identity: identity})
 				if hasAccess {
 					require.NoError(t, err)
 				} else {
@@ -3864,7 +3864,7 @@ func TestCheckAccessToGCP(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for account, hasAccess := range test.access {
-				err := test.roles.checkAccess(app, AccessMFAParams{}, &GCPServiceAccountMatcher{ServiceAccount: account})
+				err := test.roles.checkAccess(app, AccessState{}, &GCPServiceAccountMatcher{ServiceAccount: account})
 				if hasAccess {
 					require.NoError(t, err)
 				} else {
@@ -4341,7 +4341,7 @@ func TestCheckAccessToKubernetes(t *testing.T) {
 		name      string
 		roles     []*types.RoleV6
 		cluster   *types.KubernetesCluster
-		mfaParams AccessMFAParams
+		state     AccessState
 		hasAccess bool
 	}{
 		{
@@ -4396,28 +4396,28 @@ func TestCheckAccessToKubernetes(t *testing.T) {
 			name:      "role requires MFA but MFA not verified",
 			roles:     []*types.RoleV6{matchingLabelsRole, matchingLabelsRoleWithMFA},
 			cluster:   clusterWithLabels,
-			mfaParams: AccessMFAParams{Verified: false},
+			state:     AccessState{MFAVerified: false},
 			hasAccess: false,
 		},
 		{
 			name:      "role requires MFA and MFA verified",
 			roles:     []*types.RoleV6{matchingLabelsRole, matchingLabelsRoleWithMFA},
 			cluster:   clusterWithLabels,
-			mfaParams: AccessMFAParams{Verified: true},
+			state:     AccessState{MFAVerified: true},
 			hasAccess: true,
 		},
 		{
 			name:      "cluster requires MFA but MFA not verified",
 			roles:     []*types.RoleV6{matchingLabelsRole},
 			cluster:   clusterWithLabels,
-			mfaParams: AccessMFAParams{Verified: false, Required: MFARequiredAlways},
+			state:     AccessState{MFAVerified: false, MFARequired: MFARequiredAlways},
 			hasAccess: false,
 		},
 		{
 			name:      "role requires MFA and MFA verified",
 			roles:     []*types.RoleV6{matchingLabelsRole},
 			cluster:   clusterWithLabels,
-			mfaParams: AccessMFAParams{Verified: true, Required: MFARequiredAlways},
+			state:     AccessState{MFAVerified: true, MFARequired: MFARequiredAlways},
 			hasAccess: true,
 		},
 	}
@@ -4430,7 +4430,7 @@ func TestCheckAccessToKubernetes(t *testing.T) {
 			k8sV3, err := types.NewKubernetesClusterV3FromLegacyCluster(apidefaults.Namespace, tc.cluster)
 			require.NoError(t, err)
 
-			err = set.checkAccess(k8sV3, tc.mfaParams)
+			err = set.checkAccess(k8sV3, tc.state)
 			if tc.hasAccess {
 				require.NoError(t, err)
 			} else {
@@ -4599,9 +4599,9 @@ func TestCheckAccessToWindowsDesktop(t *testing.T) {
 
 	for _, test := range []struct {
 		name      string
-		roleSet   RoleSet
-		mfaParams AccessMFAParams
-		checks    []check
+		roleSet RoleSet
+		state   AccessState
+		checks  []check
 	}{
 		{
 			name:    "no roles, no access",
@@ -4688,7 +4688,7 @@ func TestCheckAccessToWindowsDesktop(t *testing.T) {
 			for i, check := range test.checks {
 				msg := fmt.Sprintf("check=%d, user=%v, server=%v, should_have_access=%v",
 					i, check.login, check.desktop.GetName(), check.hasAccess)
-				err := test.roleSet.checkAccess(check.desktop, test.mfaParams, NewWindowsLoginMatcher(check.login))
+				err := test.roleSet.checkAccess(check.desktop, test.state, NewWindowsLoginMatcher(check.login))
 				if check.hasAccess {
 					require.NoError(t, err, msg)
 				} else {
@@ -4779,7 +4779,7 @@ func BenchmarkCheckAccessToServer(b *testing.B) {
 				// is testing the performance of failed RBAC checks
 				_ = set.checkAccess(
 					servers[i],
-					AccessMFAParams{},
+					AccessState{},
 					NewLoginMatcher(login),
 				)
 			}
@@ -5827,12 +5827,12 @@ func TestMFAParams(t *testing.T) {
 		name                   string
 		roleMFARequireTypes    []types.RequireMFAType
 		authPrefMFARequireType types.RequireMFAType
-		expectMFAParams        AccessMFAParams
+		expectState            AccessState
 	}{
 		{
 			name: "empty role set and auth pref requirement",
-			expectMFAParams: AccessMFAParams{
-				Required: MFARequiredNever,
+			expectState: AccessState{
+				MFARequired: MFARequiredNever,
 			},
 		},
 		{
@@ -5842,8 +5842,8 @@ func TestMFAParams(t *testing.T) {
 				types.RequireMFAType_OFF,
 			},
 			authPrefMFARequireType: types.RequireMFAType_OFF,
-			expectMFAParams: AccessMFAParams{
-				Required: MFARequiredNever,
+			expectState: AccessState{
+				MFARequired: MFARequiredNever,
 			},
 		},
 		{
@@ -5853,8 +5853,8 @@ func TestMFAParams(t *testing.T) {
 				types.RequireMFAType_OFF,
 			},
 			authPrefMFARequireType: types.RequireMFAType_SESSION,
-			expectMFAParams: AccessMFAParams{
-				Required: MFARequiredAlways,
+			expectState: AccessState{
+				MFARequired: MFARequiredAlways,
 			},
 		},
 		{
@@ -5864,8 +5864,8 @@ func TestMFAParams(t *testing.T) {
 				types.RequireMFAType_SESSION,
 			},
 			authPrefMFARequireType: types.RequireMFAType_OFF,
-			expectMFAParams: AccessMFAParams{
-				Required: MFARequiredPerRole,
+			expectState: AccessState{
+				MFARequired: MFARequiredPerRole,
 			},
 		},
 		{
@@ -5875,8 +5875,8 @@ func TestMFAParams(t *testing.T) {
 				types.RequireMFAType_SESSION,
 			},
 			authPrefMFARequireType: types.RequireMFAType_SESSION,
-			expectMFAParams: AccessMFAParams{
-				Required: MFARequiredAlways,
+			expectState: AccessState{
+				MFARequired: MFARequiredAlways,
 			},
 		},
 		{
@@ -5886,8 +5886,8 @@ func TestMFAParams(t *testing.T) {
 				types.RequireMFAType_SESSION,
 			},
 			authPrefMFARequireType: types.RequireMFAType_SESSION,
-			expectMFAParams: AccessMFAParams{
-				Required: MFARequiredAlways,
+			expectState: AccessState{
+				MFARequired: MFARequiredAlways,
 			},
 		},
 		{
@@ -5897,8 +5897,8 @@ func TestMFAParams(t *testing.T) {
 				types.RequireMFAType_SESSION,
 			},
 			authPrefMFARequireType: types.RequireMFAType_OFF,
-			expectMFAParams: AccessMFAParams{
-				Required: MFARequiredAlways,
+			expectState: AccessState{
+				MFARequired: MFARequiredAlways,
 			},
 		},
 		{
@@ -5908,8 +5908,8 @@ func TestMFAParams(t *testing.T) {
 				types.RequireMFAType_SESSION,
 			},
 			authPrefMFARequireType: types.RequireMFAType_HARDWARE_KEY_TOUCH,
-			expectMFAParams: AccessMFAParams{
-				Required: MFARequiredNever,
+			expectState: AccessState{
+				MFARequired: MFARequiredNever,
 			},
 		},
 		{
@@ -5919,8 +5919,8 @@ func TestMFAParams(t *testing.T) {
 				types.RequireMFAType_HARDWARE_KEY_TOUCH,
 			},
 			authPrefMFARequireType: types.RequireMFAType_SESSION,
-			expectMFAParams: AccessMFAParams{
-				Required: MFARequiredNever,
+			expectState: AccessState{
+				MFARequired: MFARequiredNever,
 			},
 		},
 	}
@@ -5934,7 +5934,7 @@ func TestMFAParams(t *testing.T) {
 					r.Spec.Options.RequireMFAType = roleRequirement
 				}))
 			}
-			require.Equal(t, tc.expectMFAParams, set.MFAParams(tc.authPrefMFARequireType))
+			require.Equal(t, tc.expectState, set.MFAParams(tc.authPrefMFARequireType))
 		})
 	}
 }

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -919,7 +919,7 @@ func (s *Server) authorizeContext(ctx context.Context) (*auth.Context, types.App
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	ap, err := s.c.AccessPoint.GetAuthPreference(ctx)
+	authPref, err := s.c.AccessPoint.GetAuthPreference(ctx)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -949,10 +949,10 @@ func (s *Server) authorizeContext(ctx context.Context) (*auth.Context, types.App
 		})
 	}
 
-	mfaParams := authContext.MFAParams(ap.GetRequireMFAType())
+	state := authContext.GetAccessState(authPref)
 	err = authContext.Checker.CheckAccess(
 		app,
-		mfaParams,
+		state,
 		matchers...)
 	if err != nil {
 		return nil, nil, utils.OpaqueAccessDenied(err)

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -570,7 +570,7 @@ func (h *AuthHandlers) canLoginWithRBAC(cert *ssh.Certificate, clusterName strin
 		return trace.Wrap(err)
 	}
 	mfaParams := accessChecker.MFAParams(ap.GetRequireMFAType())
-	_, mfaParams.Verified = cert.Extensions[teleport.CertExtensionMFAVerified]
+	_, mfaParams.MFAVerified = cert.Extensions[teleport.CertExtensionMFAVerified]
 
 	// check if roles allow access to server
 	if err := accessChecker.CheckAccess(

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -565,17 +565,17 @@ func (h *AuthHandlers) canLoginWithRBAC(cert *ssh.Certificate, clusterName strin
 		return nil
 	}
 
-	ap, err := h.c.AccessPoint.GetAuthPreference(ctx)
+	authPref, err := h.c.AccessPoint.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	mfaParams := accessChecker.MFAParams(ap.GetRequireMFAType())
-	_, mfaParams.MFAVerified = cert.Extensions[teleport.CertExtensionMFAVerified]
+	state := accessChecker.GetAccessState(authPref)
+	_, state.MFAVerified = cert.Extensions[teleport.CertExtensionMFAVerified]
 
 	// check if roles allow access to server
 	if err := accessChecker.CheckAccess(
 		h.c.Server.GetInfo(),
-		mfaParams,
+		state,
 		services.NewLoginMatcher(osUser),
 	); err != nil {
 		return trace.AccessDenied("user %s@%s is not authorized to login as %v@%s: %v",

--- a/lib/srv/db/cassandra/engine.go
+++ b/lib/srv/db/cassandra/engine.go
@@ -249,11 +249,11 @@ func (e *Engine) processPacket(packet *protocol.Packet) error {
 // authorizeConnection does authorization check for Cassandra connection about
 // to be established.
 func (e *Engine) authorizeConnection(ctx context.Context) error {
-	ap, err := e.Auth.GetAuthPreference(ctx)
+	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	mfaParams := e.sessionCtx.MFAParams(ap.GetRequireMFAType())
+	state := e.sessionCtx.GetAccessState(authPref)
 
 	dbRoleMatchers := role.DatabaseRoleMatchers(
 		e.sessionCtx.Database.GetProtocol(),
@@ -262,7 +262,7 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	)
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
-		mfaParams,
+		state,
 		dbRoleMatchers...,
 	)
 	if err != nil {

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -58,9 +58,10 @@ func (c *Session) String() string {
 		c.Database.GetName(), c.Identity.Username, c.DatabaseUser, c.DatabaseName)
 }
 
-// MFAParams returns MFA params for the given auth context and auth preference MFA requirement.
-func (c *Session) MFAParams(authPrefMFARequirement types.RequireMFAType) services.AccessState {
-	params := c.Checker.MFAParams(authPrefMFARequirement)
-	params.MFAVerified = c.Identity.MFAVerified != ""
-	return params
+// GetAccessState returns the AccessState based on the underlying
+// [services.AccessChecker] and [tlsca.Identity].
+func (c *Session) GetAccessState(authPref types.AuthPreference) services.AccessState {
+	state := c.Checker.GetAccessState(authPref)
+	state.MFAVerified = c.Identity.MFAVerified != ""
+	return state
 }

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -59,8 +59,8 @@ func (c *Session) String() string {
 }
 
 // MFAParams returns MFA params for the given auth context and auth preference MFA requirement.
-func (c *Session) MFAParams(authPrefMFARequirement types.RequireMFAType) services.AccessMFAParams {
+func (c *Session) MFAParams(authPrefMFARequirement types.RequireMFAType) services.AccessState {
 	params := c.Checker.MFAParams(authPrefMFARequirement)
-	params.Verified = c.Identity.MFAVerified != ""
+	params.MFAVerified = c.Identity.MFAVerified != ""
 	return params
 }

--- a/lib/srv/db/dynamodb/engine.go
+++ b/lib/srv/db/dynamodb/engine.go
@@ -276,12 +276,12 @@ func (e *Engine) emitAuditEvent(req *http.Request, uri string, statusCode uint32
 // checkAccess does authorization check for DynamoDB connection about
 // to be established.
 func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) error {
-	ap, err := e.Auth.GetAuthPreference(ctx)
+	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	mfaParams := sessionCtx.MFAParams(ap.GetRequireMFAType())
+	state := sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
 		sessionCtx.Database.GetProtocol(),
 		sessionCtx.DatabaseUser,
@@ -289,7 +289,7 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 	)
 	err = sessionCtx.Checker.CheckAccess(
 		sessionCtx.Database,
-		mfaParams,
+		state,
 		dbRoleMatchers...,
 	)
 	return trace.Wrap(err)

--- a/lib/srv/db/elasticsearch/engine.go
+++ b/lib/srv/db/elasticsearch/engine.go
@@ -374,12 +374,12 @@ func (e *Engine) sendResponse(resp *http.Response) error {
 // authorizeConnection does authorization check for elasticsearch connection about
 // to be established.
 func (e *Engine) authorizeConnection(ctx context.Context) error {
-	ap, err := e.Auth.GetAuthPreference(ctx)
+	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	mfaParams := e.sessionCtx.MFAParams(ap.GetRequireMFAType())
+	state := e.sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
 		e.sessionCtx.Database.GetProtocol(),
 		e.sessionCtx.DatabaseUser,
@@ -387,7 +387,7 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	)
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
-		mfaParams,
+		state,
 		dbRoleMatchers...,
 	)
 	if err != nil {

--- a/lib/srv/db/mongodb/engine.go
+++ b/lib/srv/db/mongodb/engine.go
@@ -195,7 +195,7 @@ func (e *Engine) checkClientMessage(sessionCtx *common.Session, message protocol
 	// Legacy OP_KILL_CURSORS command doesn't contain database information.
 	if _, ok := message.(*protocol.MessageOpKillCursors); ok {
 		return sessionCtx.Checker.CheckAccess(sessionCtx.Database,
-			services.AccessMFAParams{Verified: true},
+			services.AccessState{MFAVerified: true},
 			&services.DatabaseUserMatcher{User: sessionCtx.DatabaseUser})
 	}
 	// Do not allow certain commands that deal with authentication.
@@ -209,7 +209,7 @@ func (e *Engine) checkClientMessage(sessionCtx *common.Session, message protocol
 	}
 	// Otherwise authorize the command against allowed databases.
 	return sessionCtx.Checker.CheckAccess(sessionCtx.Database,
-		services.AccessMFAParams{Verified: true},
+		services.AccessState{MFAVerified: true},
 		role.DatabaseRoleMatchers(
 			defaults.ProtocolMongoDB,
 			sessionCtx.DatabaseUser,

--- a/lib/srv/db/mongodb/engine.go
+++ b/lib/srv/db/mongodb/engine.go
@@ -151,18 +151,18 @@ func (e *Engine) handleClientMessage(ctx context.Context, sessionCtx *common.Ses
 // authorizeConnection does authorization check for MongoDB connection about
 // to be established.
 func (e *Engine) authorizeConnection(ctx context.Context, sessionCtx *common.Session) error {
-	ap, err := e.Auth.GetAuthPreference(ctx)
+	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	mfaParams := sessionCtx.MFAParams(ap.GetRequireMFAType())
+	state := sessionCtx.GetAccessState(authPref)
 	// Only the username is checked upon initial connection. MongoDB sends
 	// database name with each protocol message (for query, update, etc.)
 	// so it is checked when we receive a message from client.
 	err = sessionCtx.Checker.CheckAccess(
 		sessionCtx.Database,
-		mfaParams,
+		state,
 		&services.DatabaseUserMatcher{User: sessionCtx.DatabaseUser},
 	)
 	if err != nil {

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -147,12 +147,12 @@ func (e *Engine) updateServerVersion(sessionCtx *common.Session, serverConn *cli
 
 // checkAccess does authorization check for MySQL connection about to be established.
 func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) error {
-	ap, err := e.Auth.GetAuthPreference(ctx)
+	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	mfaParams := sessionCtx.MFAParams(ap.GetRequireMFAType())
+	state := sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
 		defaults.ProtocolMySQL,
 		sessionCtx.DatabaseUser,
@@ -160,7 +160,7 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 	)
 	err = sessionCtx.Checker.CheckAccess(
 		sessionCtx.Database,
-		mfaParams,
+		state,
 		dbRoleMatchers...,
 	)
 	if err != nil {

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -180,12 +180,12 @@ func (e *Engine) handleStartup(client *pgproto3.Backend, sessionCtx *common.Sess
 }
 
 func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) error {
-	ap, err := e.Auth.GetAuthPreference(ctx)
+	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	mfaParams := sessionCtx.MFAParams(ap.GetRequireMFAType())
+	state := sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
 		sessionCtx.Database.GetProtocol(),
 		sessionCtx.DatabaseUser,
@@ -193,7 +193,7 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 	)
 	err = sessionCtx.Checker.CheckAccess(
 		sessionCtx.Database,
-		mfaParams,
+		state,
 		dbRoleMatchers...,
 	)
 	if err != nil {

--- a/lib/srv/db/redis/client.go
+++ b/lib/srv/db/redis/client.go
@@ -155,7 +155,7 @@ func fetchUserPasswordOnConnect(sessionCtx *common.Session, users common.Users, 
 	var auditOnce sync.Once
 	return func(ctx context.Context, conn *redis.Conn) error {
 		err := sessionCtx.Checker.CheckAccess(sessionCtx.Database,
-			services.AccessMFAParams{Verified: true},
+			services.AccessState{MFAVerified: true},
 			role.DatabaseRoleMatchers(
 				defaults.ProtocolRedis,
 				sessionCtx.DatabaseUser,

--- a/lib/srv/db/redis/cmds.go
+++ b/lib/srv/db/redis/cmds.go
@@ -174,7 +174,7 @@ func (e *Engine) processAuth(ctx context.Context, cmd *redis.Cmd) error {
 		}
 
 		err := e.sessionCtx.Checker.CheckAccess(e.sessionCtx.Database,
-			services.AccessMFAParams{Verified: true},
+			services.AccessState{MFAVerified: true},
 			role.DatabaseRoleMatchers(
 				defaults.ProtocolRedis,
 				e.sessionCtx.DatabaseUser,
@@ -221,7 +221,7 @@ func (e *Engine) processAuth(ctx context.Context, cmd *redis.Cmd) error {
 		}
 
 		err := e.sessionCtx.Checker.CheckAccess(e.sessionCtx.Database,
-			services.AccessMFAParams{Verified: true},
+			services.AccessState{MFAVerified: true},
 			role.DatabaseRoleMatchers(
 				defaults.ProtocolRedis,
 				e.sessionCtx.DatabaseUser,

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -81,12 +81,12 @@ func (e *Engine) InitializeConnection(clientConn net.Conn, sessionCtx *common.Se
 // authorizeConnection does authorization check for Redis connection about
 // to be established.
 func (e *Engine) authorizeConnection(ctx context.Context) error {
-	ap, err := e.Auth.GetAuthPreference(ctx)
+	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	mfaParams := e.sessionCtx.MFAParams(ap.GetRequireMFAType())
+	state := e.sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
 		e.sessionCtx.Database.GetProtocol(),
 		e.sessionCtx.DatabaseUser,
@@ -94,7 +94,7 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	)
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
-		mfaParams,
+		state,
 		dbRoleMatchers...,
 	)
 	if err != nil {

--- a/lib/srv/db/snowflake/engine.go
+++ b/lib/srv/db/snowflake/engine.go
@@ -341,11 +341,11 @@ func (e *Engine) processResponse(resp *http.Response, modifyReqFn func(body []by
 // authorizeConnection does authorization check for Snowflake connection about
 // to be established.
 func (e *Engine) authorizeConnection(ctx context.Context) error {
-	ap, err := e.Auth.GetAuthPreference(ctx)
+	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	mfaParams := e.sessionCtx.MFAParams(ap.GetRequireMFAType())
+	state := e.sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
 		e.sessionCtx.Database.GetProtocol(),
 		e.sessionCtx.DatabaseUser,
@@ -353,7 +353,7 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	)
 	err = e.sessionCtx.Checker.CheckAccess(
 		e.sessionCtx.Database,
-		mfaParams,
+		state,
 		dbRoleMatchers...,
 	)
 	if err != nil {

--- a/lib/srv/db/sqlserver/engine.go
+++ b/lib/srv/db/sqlserver/engine.go
@@ -191,13 +191,13 @@ func (e *Engine) handleLogin7(sessionCtx *common.Session) (*protocol.Login7Packe
 }
 
 func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) error {
-	ap, err := e.Auth.GetAuthPreference(ctx)
+	authPref, err := e.Auth.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	mfaParams := sessionCtx.MFAParams(ap.GetRequireMFAType())
-	err = sessionCtx.Checker.CheckAccess(sessionCtx.Database, mfaParams,
+	state := sessionCtx.GetAccessState(authPref)
+	err = sessionCtx.Checker.CheckAccess(sessionCtx.Database, state,
 		&services.DatabaseUserMatcher{
 			User: sessionCtx.DatabaseUser,
 		})

--- a/lib/srv/db/sqlserver/engine_test.go
+++ b/lib/srv/db/sqlserver/engine_test.go
@@ -238,18 +238,18 @@ type mockChecker struct {
 	services.AccessChecker
 }
 
-func (m *mockChecker) CheckAccess(r services.AccessCheckable, mfa services.AccessMFAParams, matchers ...services.RoleMatcher) error {
+func (m *mockChecker) CheckAccess(r services.AccessCheckable, state services.AccessState, matchers ...services.RoleMatcher) error {
 	return nil
 }
 
-func (m *mockChecker) MFAParams(authPrefMFARequirement types.RequireMFAType) services.AccessMFAParams {
+func (m *mockChecker) MFAParams(authPrefMFARequirement types.RequireMFAType) services.AccessState {
 	if authPrefMFARequirement.IsSessionMFARequired() {
-		return services.AccessMFAParams{
-			Required: services.MFARequiredAlways,
+		return services.AccessState{
+			MFARequired: services.MFARequiredAlways,
 		}
 	}
-	return services.AccessMFAParams{
-		Required: services.MFARequiredNever,
+	return services.AccessState{
+		MFARequired: services.MFARequiredNever,
 	}
 }
 

--- a/lib/srv/db/sqlserver/engine_test.go
+++ b/lib/srv/db/sqlserver/engine_test.go
@@ -242,8 +242,8 @@ func (m *mockChecker) CheckAccess(r services.AccessCheckable, state services.Acc
 	return nil
 }
 
-func (m *mockChecker) MFAParams(authPrefMFARequirement types.RequireMFAType) services.AccessState {
-	if authPrefMFARequirement.IsSessionMFARequired() {
+func (m *mockChecker) GetAccessState(authPref types.AuthPreference) services.AccessState {
+	if authPref.GetRequireMFAType().IsSessionMFARequired() {
 		return services.AccessState{
 			MFARequired: services.MFARequiredAlways,
 		}

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -799,10 +799,10 @@ func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger,
 	var windowsUser string
 	authorize := func(login string) error {
 		windowsUser = login // capture attempted login user
-		mfaParams := authCtx.MFAParams(authPref.GetRequireMFAType())
+		state := authCtx.GetAccessState(authPref)
 		return authCtx.Checker.CheckAccess(
 			desktop,
-			mfaParams,
+			state,
 			services.NewWindowsLoginMatcher(login))
 	}
 


### PR DESCRIPTION
Refactor `services.AccessMFAParams` and the accompanying `MFAParams` methods so they may be extended to carry additional data (eg, information required to perform device trust checks).

This PR refactors existing code without adding any new functionality, so it may be backported to older branches to alleviate eventual conflicts. Follow up changes will take advantage of it to add support for device trust.

Related to https://github.com/gravitational/teleport.e/issues/514.