### PR TITLE
[v9] Point at source version in docs rather then generic master.

### DIFF
--- a/docs/pages/enterprise/fedramp.mdx
+++ b/docs/pages/enterprise/fedramp.mdx
@@ -109,7 +109,7 @@ proxy_service:
 
 ### Systemd Unit File
 
-Next, download the systemd service unit file from the [examples directory](https://github.com/gravitational/teleport/tree/master/examples/systemd/fips)
+Next, download the systemd service unit file from the [examples directory](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/systemd/fips)
 on GitHub and save it as `/etc/systemd/system/teleport.service` on both servers.
 
 ```code

--- a/docs/pages/production.mdx
+++ b/docs/pages/production.mdx
@@ -74,7 +74,7 @@ of them is configurable.
 
 ### Systemd unit file
 
-In production, we recommend starting teleport daemon via an init system like `systemd`. If `systemd` and unit files are new to you, check out [this helpful guide](https://www.digitalocean.com/community/tutorials/understanding-systemd-units-and-unit-files). Here's an example systemd unit file for the Teleport [Proxy, Node, and Auth Service](https://github.com/gravitational/teleport/tree/master/examples/systemd/production).
+In production, we recommend starting teleport daemon via an init system like `systemd`. If `systemd` and unit files are new to you, check out [this helpful guide](https://www.digitalocean.com/community/tutorials/understanding-systemd-units-and-unit-files). Here's an example systemd unit file for the Teleport [Proxy, Node, and Auth Service](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/systemd/production).
 
 There are a couple of important things to notice about this file:
 

--- a/docs/pages/setup/deployments/aws-terraform.mdx
+++ b/docs/pages/setup/deployments/aws-terraform.mdx
@@ -4,7 +4,7 @@ description: How to configure Teleport in High Availability mode for AWS deploym
 h1: Running Teleport Enterprise in High Availability mode on AWS
 ---
 
-This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
+This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to manage the resulting Teleport deployment.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)

--- a/docs/pages/setup/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/setup/helm-reference/teleport-cluster.mdx
@@ -9,7 +9,7 @@ Service, or a custom configuration to deploy resource services such as the
 Teleport Kubernetes Service or Database Service.
 
 You can
-[browse the source on GitHub](https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-cluster).
+[browse the source on GitHub](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/chart/teleport-cluster).
 
 The `teleport-cluster` chart runs two Teleport services:
 
@@ -335,7 +335,7 @@ You can also use any other ACME-compatible server.
 | - | - | - |
 | `bool` | `true` | ✅ |
 
-By default, Teleport charts also install a [`podSecurityPolicy`](https://github.com/gravitational/teleport/blob/master/examples/chart/teleport-cluster/templates/psp.yaml).
+By default, Teleport charts also install a [`podSecurityPolicy`](https://github.com/gravitational/teleport/blob/branch/v(=teleport.version=)/examples/chart/teleport-cluster/templates/psp.yaml).
 
 To disable this, you can set `enabled` to `false`.
 

--- a/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/setup/helm-reference/teleport-kube-agent.mdx
@@ -7,7 +7,7 @@ The `teleport-kube-agent` Helm chart is used to configure a Teleport instance
 that runs in a remote Kubernetes cluster and joins back to a Teleport cluster to
 provide access to services running there.
 
-You can [browse the source on GitHub](https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-kube-agent).
+You can [browse the source on GitHub](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/chart/teleport-kube-agent).
 
 The `teleport-kube-agent` chart can run any or all of three Teleport services:
 


### PR DESCRIPTION
backport #20299 