### PR TITLE
tctl edit: fetch resource with secrets

### DIFF
--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -76,11 +76,12 @@ func (e *EditCommand) TryRun(ctx context.Context, cmd string, client auth.Client
 	}()
 
 	rc := &ResourceCommand{
-		refs:     services.Refs{e.ref},
-		format:   teleport.YAML,
-		stdout:   f,
-		filename: f.Name(),
-		force:    true,
+		refs:        services.Refs{e.ref},
+		format:      teleport.YAML,
+		stdout:      f,
+		filename:    f.Name(),
+		force:       true,
+		withSecrets: true,
 	}
 	rc.Initialize(e.app, e.config)
 


### PR DESCRIPTION
Ensure that tctl edit does the equivalent of
    tctl get --with-secrets

Without this, the resource we fetch may be missing important details that get overwritten when the edit completes.

Fixes #20326