### PR TITLE
WebAPI/CreateDB: improve error message when DB already exists

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5856,6 +5856,14 @@ func TestCreateDatabase(t *testing.T) {
 
 	createDatabaseEndpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "databases")
 
+	// Create an initial database to table test a duplicate creation
+	_, err = pack.clt.PostJSON(ctx, createDatabaseEndpoint, createDatabaseRequest{
+		Name:     "duplicatedb",
+		Protocol: "mysql",
+		URI:      "someuri:3306",
+	})
+	require.NoError(t, err)
+
 	for _, tt := range []struct {
 		name           string
 		req            createDatabaseRequest
@@ -5944,6 +5952,19 @@ func TestCreateDatabase(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 			errAssert: func(tt require.TestingT, err error, i ...interface{}) {
 				require.ErrorContains(tt, err, "missing port in address")
+			},
+		},
+		{
+			name: "duplicatedb",
+			req: createDatabaseRequest{
+				Name:     "duplicatedb",
+				Protocol: "mysql",
+				URI:      "someuri:3306",
+			},
+			expectedStatus: http.StatusConflict,
+			errAssert: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAlreadyExists(err), "expected already exists error, got %v", err)
+				require.Contains(t, err.Error(), `failed to create database ("duplicatedb" already exists), please use another name`)
 			},
 		},
 	} {

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -121,6 +121,9 @@ func (h *Handler) handleDatabaseCreate(w http.ResponseWriter, r *http.Request, p
 	}
 
 	if err := clt.CreateDatabase(r.Context(), database); err != nil {
+		if trace.IsAlreadyExists(err) {
+			return nil, trace.AlreadyExists("failed to create database (%q already exists), please use another name", req.Name)
+		}
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
When creating a database with the same name of an already existing one, we were getting a raw error (depends on the backend implementation: memory, lite, dynamo, ...).
This message is shown to the user which sees it as a cryptic error.

To improve this we should present the error in a better way and provide an immediate action.

Fixes #20204