### PR TITLE
Add incomplete session upload metric to the teleport namespace

### DIFF
--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -82,8 +82,9 @@ func (cfg *UploadCompleterConfig) CheckAndSetDefaults() error {
 var (
 	incompleteSessionUploads = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: teleport.MetricIncompleteSessionUploads,
-			Help: "Number of sessions not yet uploaded to auth",
+			Namespace: "teleport",
+			Name:      teleport.MetricIncompleteSessionUploads,
+			Help:      "Number of sessions not yet uploaded to auth",
 		},
 	)
 )

--- a/metrics.go
+++ b/metrics.go
@@ -89,7 +89,7 @@ const (
 	TagMigration = "migration"
 
 	// MetricIncompleteSessionUploads returns the number of incomplete session uploads
-	MetricIncompleteSessionUploads = "incomplete_session_uploads"
+	MetricIncompleteSessionUploads = "incomplete_session_uploads_total"
 
 	// TagCluster is a metric tag for a cluster
 	TagCluster = "cluster"


### PR DESCRIPTION
Changes incomplte session upload metric added in https://github.com/gravitational/teleport/pull/19724 to match prometheus naming conventions. Also adds metric to teleport namespace.