### PR TITLE
Bump buildbox version build by Drone to 13

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,7 +37,7 @@ kind: pipeline
 type: kubernetes
 name: push-build-linux-amd64
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   GID: "1000"
   RUNTIME: go1.19.5
   UID: "1000"
@@ -142,7 +142,7 @@ kind: pipeline
 type: kubernetes
 name: push-build-linux-386
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   GID: "1000"
   RUNTIME: go1.19.5
   UID: "1000"
@@ -245,7 +245,7 @@ kind: pipeline
 type: kubernetes
 name: push-build-linux-amd64-fips
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   GID: "1000"
   RUNTIME: go1.19.5
   UID: "1000"
@@ -352,7 +352,7 @@ kind: pipeline
 type: kubernetes
 name: push-build-windows-amd64
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   GID: "1000"
   RUNTIME: go1.19.5
   UID: "1000"
@@ -657,7 +657,7 @@ platform:
   os: windows
   arch: amd64
 node:
-  buildbox_version: teleport12
+  buildbox_version: teleport13
 clone:
   disable: true
 steps:
@@ -930,7 +930,7 @@ platform:
   os: windows
   arch: amd64
 node:
-  buildbox_version: teleport12
+  buildbox_version: teleport13
 clone:
   disable: true
 depends_on:
@@ -1120,7 +1120,7 @@ kind: pipeline
 type: kubernetes
 name: push-build-linux-arm
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   GID: "1000"
   RUNTIME: go1.19.5
   UID: "1000"
@@ -1223,7 +1223,7 @@ kind: pipeline
 type: kubernetes
 name: push-build-linux-arm64
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   GID: "1000"
   RUNTIME: go1.19.5
   UID: "1000"
@@ -1640,7 +1640,7 @@ kind: pipeline
 type: kubernetes
 name: build-linux-amd64-centos7
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   RUNTIME: go1.19.5
 trigger:
   event:
@@ -1828,7 +1828,7 @@ kind: pipeline
 type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   RUNTIME: go1.19.5
 trigger:
   event:
@@ -2015,7 +2015,7 @@ kind: pipeline
 type: kubernetes
 name: build-linux-amd64
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   RUNTIME: go1.19.5
 trigger:
   event:
@@ -2209,7 +2209,7 @@ kind: pipeline
 type: kubernetes
 name: build-linux-amd64-fips
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   RUNTIME: go1.19.5
 trigger:
   event:
@@ -3412,7 +3412,7 @@ kind: pipeline
 type: kubernetes
 name: build-linux-386
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   RUNTIME: go1.19.5
 trigger:
   event:
@@ -4759,7 +4759,7 @@ kind: pipeline
 type: kubernetes
 name: build-linux-arm
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   RUNTIME: go1.19.5
 trigger:
   event:
@@ -4944,7 +4944,7 @@ kind: pipeline
 type: kubernetes
 name: build-linux-arm64
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   GID: "1000"
   RUNTIME: go1.19.5
   UID: "1000"
@@ -6027,7 +6027,7 @@ kind: pipeline
 type: kubernetes
 name: build-windows-amd64
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   RUNTIME: go1.19.5
 trigger:
   event:
@@ -6564,7 +6564,7 @@ kind: pipeline
 type: kubernetes
 name: build-buildboxes
 environment:
-  BUILDBOX_VERSION: teleport12
+  BUILDBOX_VERSION: teleport13
   GID: "1000"
   UID: "1000"
 trigger:
@@ -8862,7 +8862,7 @@ steps:
   - docker buildx build --push --builder "teleport-operator-v11-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:teleport12 --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:teleport13 --build-arg
     COMPILER_NAME=x86_64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
   - docker buildx rm "teleport-operator-v11-amd64-builder"
@@ -8899,7 +8899,7 @@ steps:
   - docker buildx build --push --builder "teleport-operator-v11-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport12 --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
     COMPILER_NAME=arm-linux-gnueabihf-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
   - docker buildx rm "teleport-operator-v11-arm-builder"
@@ -8936,7 +8936,7 @@ steps:
   - docker buildx build --push --builder "teleport-operator-v11-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport12 --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
     COMPILER_NAME=aarch64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
   - docker buildx rm "teleport-operator-v11-arm64-builder"
@@ -12741,7 +12741,7 @@ steps:
   - docker buildx build --push --builder "teleport-operator-v11-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:teleport12 --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:teleport13 --build-arg
     COMPILER_NAME=x86_64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
   - docker buildx rm "teleport-operator-v11-amd64-builder"
@@ -12780,7 +12780,7 @@ steps:
   - docker buildx build --push --builder "teleport-operator-v11-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport12 --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
     COMPILER_NAME=arm-linux-gnueabihf-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
   - docker buildx rm "teleport-operator-v11-arm-builder"
@@ -12819,7 +12819,7 @@ steps:
   - docker buildx build --push --builder "teleport-operator-v11-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport12 --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
     COMPILER_NAME=aarch64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
   - docker buildx rm "teleport-operator-v11-arm64-builder"
@@ -15407,7 +15407,7 @@ steps:
   - docker buildx build --push --builder "teleport-operator-v10-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:teleport12 --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:teleport13 --build-arg
     COMPILER_NAME=x86_64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
   - docker buildx rm "teleport-operator-v10-amd64-builder"
@@ -15446,7 +15446,7 @@ steps:
   - docker buildx build --push --builder "teleport-operator-v10-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport12 --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
     COMPILER_NAME=arm-linux-gnueabihf-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
   - docker buildx rm "teleport-operator-v10-arm-builder"
@@ -15485,7 +15485,7 @@ steps:
   - docker buildx build --push --builder "teleport-operator-v10-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport12 --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
     COMPILER_NAME=aarch64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
   - docker buildx rm "teleport-operator-v10-arm64-builder"
@@ -18196,6 +18196,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 24649d5f6f03fa5443228ad9b739a90c4eeb34b9c83b4d47c5d6a4c36e74b997
+hmac: 6b5da87020674e14fd257475a809160f81cda8d554a347516950c9c9d04d22fe
 
 ...

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -122,7 +122,7 @@ func NewTeleportOperatorProduct(cloneDirectory string) *Product {
 				compilerName = "arm-linux-gnueabihf-gcc"
 			}
 
-			buildboxName += ":teleport12"
+			buildboxName += ":teleport13"
 
 			return []string{
 				fmt.Sprintf("BUILDBOX=%s", buildboxName),


### PR DESCRIPTION
Follow up to https://github.com/gravitational/teleport/pull/20372 to also bump buildbox version built by Drone.