### PR TITLE
Bump cloud version to 11.2.2

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1249,7 +1249,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "11.2.1",
+      "version": "11.2.2",
       "major_version": "11",
       "sla": {
         "monthly_percentage": "99.5%",


### PR DESCRIPTION
Teleport Cloud tenants will be upgraded to 11.2.2 on Thursday 1/19.