### PR TITLE
feat(helm): allow to use templates in some kube-agent values

### DIFF
--- a/examples/chart/teleport-kube-agent/.lint/extra-env-tpl.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/extra-env-tpl.yaml
@@ -1,0 +1,7 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube
+kubeClusterName: test-kube-cluster
+extraEnv:
+- name: TEST_CLUSTER_NAME
+  value: "{{ .Values.kubeClusterName }}"

--- a/examples/chart/teleport-kube-agent/templates/_helpers.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_helpers.tpl
@@ -16,3 +16,15 @@ if serviceAccount is not defined or serviceAccount.name is empty, use .Release.N
 {{- define "teleport.serviceAccountName" -}}
 {{- coalesce .Values.serviceAccount.name .Values.serviceAccountName .Release.Name -}}
 {{- end -}}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "teleport.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "teleport.tplvalues.render" -}}
+  {{- if typeIs "string" .value }}
+      {{- tpl .value .context }}
+  {{- else }}
+    {{- tpl (.value | toYaml) .context }}
+  {{- end }}
+{{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -12,11 +12,11 @@ metadata:
   labels:
     app: {{ .Release.Name }}
   {{- if .Values.extraLabels.deployment }}
-    {{- toYaml .Values.extraLabels.deployment | nindent 4 }}
+    {{- include "teleport.tplvalues.render" (dict "value" .Values.extraLabels.deployment "context" $) | nindent 4 }}
   {{- end }}
   {{- if .Values.annotations.deployment }}
   annotations:
-    {{- toYaml .Values.annotations.deployment | nindent 4 }}
+    {{- include "teleport.tplvalues.render" (dict "value" .Values.annotations.deployment "context" $) | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ $replicaCount }}
@@ -29,12 +29,12 @@ spec:
         # ConfigMap checksum, to recreate the pod on config changes.
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
 {{- if .Values.annotations.pod }}
-  {{- toYaml .Values.annotations.pod | nindent 8 }}
+  {{- include "teleport.tplvalues.render" (dict "value" .Values.annotations.pod "context" $) | nindent 8 }}
 {{- end }}
       labels:
         app: {{ .Release.Name }}
 {{- if .Values.extraLabels.pod }}
-  {{- toYaml .Values.extraLabels.pod | nindent 8 }}
+  {{- include "teleport.tplvalues.render" (dict "value" .Values.extraLabels.pod "context" $) | nindent 8 }}
 {{- end }}
     spec:
       {{- if .Values.dnsConfig }}
@@ -49,7 +49,7 @@ spec:
           {{- if .Values.highAvailability.requireAntiAffinity }}
             {{- fail "Cannot use highAvailability.requireAntiAffinity when affinity is also set in chart values - unset one or the other" }}
           {{- end }}
-          {{- toYaml .Values.affinity | nindent 8 }}
+          {{- include "teleport.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
         {{- else }}
         podAntiAffinity:
         {{- if .Values.highAvailability.requireAntiAffinity }}
@@ -127,8 +127,8 @@ spec:
         {{- end }}
         {{- if or .Values.extraEnv .Values.tls.existingCASecretName }}
         env:
-        {{- if (gt (len .Values.extraEnv) 0) }}
-          {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- if .Values.extraEnv }}
+          {{- include "teleport.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.tls.existingCASecretName }}
         - name: SSL_CERT_FILE
@@ -141,7 +141,7 @@ spec:
         - "--insecure"
         {{- end }}
         {{- if .Values.extraArgs }}
-          {{- toYaml .Values.extraArgs | nindent 8 }}
+          {{- include "teleport.tplvalues.render" (dict "value" .Values.extraArgs "context" $) | nindent 8 }}
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -190,7 +190,7 @@ spec:
           readOnly: true
           {{- end }}
 {{- if .Values.extraVolumeMounts }}
-  {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
+  {{- include "teleport.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 8 }}
 {{- end }}
       volumes:
       - name: "config"
@@ -209,7 +209,7 @@ spec:
           secretName: {{ .Values.tls.existingCASecretName }}
       {{- end }}
 {{- if .Values.extraVolumes }}
-  {{- toYaml .Values.extraVolumes | nindent 6 }}
+  {{- include "teleport.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 6 }}
 {{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -1148,6 +1148,8 @@ should set environment when extraEnv set in values if action is Upgrade:
       env:
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
+      - name: KUBE_CLUSTER
+        value: helm-lint.example.com
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:

--- a/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
@@ -336,12 +336,19 @@ tests:
       extraEnv:
         - name: HTTPS_PROXY
           value: "http://username:password@my.proxy.host:3128"
+        - name: KUBE_CLUSTER
+          value: "{{ .Values.kubeClusterName }}"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: HTTPS_PROXY
             value: "http://username:password@my.proxy.host:3128"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBE_CLUSTER
+            value: helm-lint.example.com
       - matchSnapshot:
           path: spec.template.spec
 


### PR DESCRIPTION
This PR allows users to use Helm templates in some values for the teleport-kubernetes-agent chart.
It doesn't change the interface, and it permit users to customize more in depth the render result.

This is particulary useful for users who wrap this chart in another chart, because it allows to dynamically configure the teleport sub-chart.

For example, if you need to inject a secret, you can template the secret name to use the release name.
This is currently not possible because the `volumes` part of the deployment is static.
With this feature you can use a volume like this in the values:

``` yaml
extraVolumes:
  - name: my-secret-volume
    secret:
      name: "{{ .Release.Namespace }}-xxx-data"
```

I did this first PR to validate the design. If accepted, it would be nice to use it in more variables.

This design is heavilly used in [bitnami charts](https://github.com/bitnami/charts) for example.