### PR TITLE
Return NotFound error when trait does not exist

### DIFF
--- a/lib/utils/parse/parse.go
+++ b/lib/utils/parse/parse.go
@@ -105,7 +105,7 @@ func (e *Expression) Interpolate(varValidation func(namespace, name string) erro
 
 			values, ok := traits[v.name]
 			if !ok {
-				return nil, trace.BadParameter("variable not found: %s", v)
+				return nil, trace.NotFound("variable not found: %s", v)
 			}
 			return values, nil
 		},

--- a/lib/utils/parse/parse_test.go
+++ b/lib/utils/parse/parse_test.go
@@ -211,9 +211,16 @@ func TestVariable(t *testing.T) {
 // TestInterpolate tests variable interpolation
 func TestInterpolate(t *testing.T) {
 	t.Parallel()
+
+	errCheckIsNotFound := func(tt require.TestingT, err error, i ...interface{}) {
+		require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+	}
+	errCheckIsBadParameter := func(tt require.TestingT, err error, i ...interface{}) {
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter error, got %v", err)
+	}
 	type result struct {
-		values []string
-		err    error
+		values   []string
+		errCheck require.ErrorAssertionFunc
 	}
 	var tests = []struct {
 		title  string
@@ -237,7 +244,7 @@ func TestInterpolate(t *testing.T) {
 			title:  "missed traits",
 			in:     "{{external.baz}}",
 			traits: map[string][]string{"foo": {"a", "b"}, "bar": {"c"}},
-			res:    result{err: trace.NotFound("not found"), values: []string{}},
+			res:    result{errCheck: errCheckIsNotFound, values: []string{}},
 		},
 		{
 			title:  "traits with prefix and suffix",
@@ -249,7 +256,7 @@ func TestInterpolate(t *testing.T) {
 			title:  "error in mapping traits",
 			in:     "{{email.local(external.foo)}}",
 			traits: map[string][]string{"foo": {"Alice <alice"}},
-			res:    result{err: trace.BadParameter("")},
+			res:    result{errCheck: errCheckIsBadParameter},
 		},
 		{
 			title:  "literal expression",
@@ -291,8 +298,8 @@ func TestInterpolate(t *testing.T) {
 				return nil
 			}
 			values, err := expr.Interpolate(noVarValidation, tt.traits)
-			if tt.res.err != nil {
-				require.IsType(t, tt.res.err, err)
+			if tt.res.errCheck != nil {
+				tt.res.errCheck(t, err)
 				require.Empty(t, values)
 				return
 			}


### PR DESCRIPTION
We were returning a trace.BadParameter, however we should return trace.IsNotFound.
The godoc suggests that error.
The tests suggests that error, but they were only matching for type which is the same for all the trace.XYZ errors.

Tests are now using the `trace.Is<Error>` helper method to correctly validate the error message.

The side effect of this change is that we were receiving a lot of logs when interpolating traits in a role.
That log is supressed when the error is NotFound.
That was not the case before this commit: the error was a BadParameter one, so the log is written (as debug, but still a lot of noise).


For the record, here's the log message
```log
2023-01-19T14:33:18Z DEBU             Skipping database user "{{internal.db_users}}". error:[
ERROR REPORT:
Original Error: *trace.BadParameterError variable not found: {internal db_users}
Stack Trace:
        github.com/gravitational/teleport/lib/utils/parse/parse.go:108 github.com/gravitational/teleport/lib/utils/parse.(*Expression).Interpolate.func1
        github.com/gravitational/teleport/lib/utils/parse/ast.go:149 github.com/gravitational/teleport/lib/utils/parse.(*VarExpr).Evaluate
        github.com/gravitational/teleport/lib/utils/parse/parse.go:114 github.com/gravitational/teleport/lib/utils/parse.(*Expression).Interpolate
        github.com/gravitational/teleport/lib/services/role.go:521 github.com/gravitational/teleport/lib/services.ApplyValueTraits
        github.com/gravitational/teleport/lib/services/role.go:434 github.com/gravitational/teleport/lib/services.applyValueTraitsSlice
.....
        google.golang.org/grpc@v1.51.0/server.go:1713 google.golang.org/grpc.(*Server).handleStream
        google.golang.org/grpc@v1.51.0/server.go:965 google.golang.org/grpc.(*Server).serveStreams.func1.2
User Message: variable not found: {internal db_users}] services/role.go:437
```