### PR TITLE
Run webassets build in Docker as current OS user

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -248,9 +248,10 @@ teleterm: buildbox-teleterm
 	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_TELETERM) \
 		bash -c "cd $(SRCDIR) && export CONNECT_TSH_BIN_PATH=\$$PWD/../teleport/build/tsh && yarn install --frozen-lockfile && yarn build-term && yarn package-term -c.extraMetadata.version=$(CONNECT_VERSION)"
 
+# Builds webassets inside Docker.
 .PHONY:ui
 ui: buildbox
-	docker run -v "$$(pwd)/../":/teleport $(BUILDBOX) \
+	docker run -u $(UID):$(GID) -v "$$(pwd)/../":/teleport $(BUILDBOX) \
 		bash -c "cd ../teleport && yarn install --frozen-lockfile && yarn build-ui"
 
 # grpc generates GRPC stubs from inside the buildbox


### PR DESCRIPTION
Set the current user when running webassets builds. In this way, the build artifacts will have correct permissions.