### PR TITLE
Add credential picker to passwordless testplan

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -465,6 +465,11 @@ FIDO2 items.
   - [ ] `tsh login --auth=passwordless --mfa-mode=auto` prefers platform authenticator
     - [ ] Touch ID
     - [ ] Windows Hello
+  - [ ] Exercise credential picker (register credentials for multiple users in
+        the same device)
+    - [ ] FIDO2 macOS/Linux
+    - [ ] Touch ID
+    - [ ] Windows
   - [ ] Passwordless disable switch works
         (`auth_service.authentication.passwordless = false`)
   - [ ] Cluster in passwordless mode defaults to passwordless


### PR DESCRIPTION
Add an item to cover credential pickers in the testplan.