### PR TITLE
Desktop session recording improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0 // replaced
 	github.com/keys-pub/go-libfido2 v1.5.3-0.20220306005615-8ab03fb1ec27 // replaced
+	github.com/klauspost/compress v1.15.15
 	github.com/mailgun/lemma v0.0.0-20170619173223-4214099fb348
 	github.com/mailgun/timetools v0.0.0-20170619190023-f3a7b8ffff47
 	github.com/mailgun/ttlmap v0.0.0-20170619185759-c1c17f74874f
@@ -275,7 +276,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v1.0.0 // indirect
 	github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d // indirect
-	github.com/klauspost/compress v1.15.13 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -798,8 +798,8 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.15.13 h1:NFn1Wr8cfnenSJSA46lLq4wHCcBzKTSjnBIexDMMOV0=
-github.com/klauspost/compress v1.15.13/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
+github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -19,7 +19,6 @@ package events
 import (
 	"bufio"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -33,6 +32,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/klauspost/compress/gzip"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 

--- a/lib/events/auditwriter.go
+++ b/lib/events/auditwriter.go
@@ -49,7 +49,7 @@ func NewAuditWriter(cfg AuditWriterConfig) (*AuditWriter, error) {
 	writer := &AuditWriter{
 		mtx:    sync.Mutex{},
 		cfg:    cfg,
-		stream: NewCheckingStream(stream, cfg.Clock, cfg.ClusterName),
+		stream: stream,
 		log: logrus.WithFields(logrus.Fields{
 			trace.Component: cfg.Component,
 		}),

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -97,7 +97,7 @@ func (*DiscardStream) EmitAuditEvent(ctx context.Context, event apievents.AuditE
 		"event_type":  event.GetType(),
 		"event_time":  event.GetTime(),
 		"event_index": event.GetIndex(),
-	}).Debugf("Discarding stream event")
+	}).Traceln("Discarding stream event")
 	return nil
 }
 

--- a/lib/events/filesessions/filestream_test.go
+++ b/lib/events/filesessions/filestream_test.go
@@ -196,6 +196,7 @@ func BenchmarkAuditWriter(b *testing.B) {
 
 	b.StopTimer()
 	stats := writer.Stats()
-	b.Logf("encountered %d/%d slow writes", stats.SlowWrites, stats.AcceptedEvents)
+	b.Logf("encountered %d/%d slow writes, dropped %v",
+		stats.SlowWrites, stats.AcceptedEvents, stats.LostEvents)
 	writer.Close(ctx)
 }

--- a/lib/events/playback.go
+++ b/lib/events/playback.go
@@ -19,7 +19,6 @@ package events
 import (
 	"archive/tar"
 	"bufio"
-	"compress/gzip"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -28,6 +27,7 @@ import (
 	"path/filepath"
 
 	"github.com/gravitational/trace"
+	"github.com/klauspost/compress/gzip"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"

--- a/lib/events/sessionlog.go
+++ b/lib/events/sessionlog.go
@@ -17,13 +17,13 @@ limitations under the License.
 package events
 
 import (
-	"compress/gzip"
 	"fmt"
 	"io"
 	"path/filepath"
 	"sync"
 
 	"github.com/gravitational/trace"
+	"github.com/klauspost/compress/gzip"
 
 	"github.com/gravitational/teleport/lib/session"
 )

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -207,7 +207,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 		Log:          log,
 		Clock:        process.Clock,
 		Authorizer:   authorizer,
-		Emitter:      conn.Client,
+		Emitter:      conn.Client, // TODO(zmb3): consider using an async emitter here
 		TLS:          tlsConfig,
 		AccessPoint:  accessPoint,
 		ConnLimiter:  connLimiter,

--- a/lib/srv/desktop/audit.go
+++ b/lib/srv/desktop/audit.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
-func (s *WindowsService) onSessionStart(ctx context.Context, emitter events.Emitter, id *tlsca.Identity, startTime time.Time, windowsUser, sessionID string, desktop types.WindowsDesktop, err error) {
+func (s *WindowsService) onSessionStart(ctx context.Context, id *tlsca.Identity, startTime time.Time, windowsUser, sessionID string, desktop types.WindowsDesktop, err error) {
 	userMetadata := id.GetUserMetadata()
 	userMetadata.Login = windowsUser
 
@@ -65,10 +65,10 @@ func (s *WindowsService) onSessionStart(ctx context.Context, emitter events.Emit
 		event.Error = trace.Unwrap(err).Error()
 		event.UserMessage = err.Error()
 	}
-	s.emit(ctx, emitter, event)
+	s.emit(ctx, s.cfg.Emitter, event)
 }
 
-func (s *WindowsService) onSessionEnd(ctx context.Context, emitter events.Emitter, id *tlsca.Identity, startedAt time.Time, recorded bool, windowsUser, sid string, desktop types.WindowsDesktop) {
+func (s *WindowsService) onSessionEnd(ctx context.Context, id *tlsca.Identity, startedAt time.Time, recorded bool, windowsUser, sid string, desktop types.WindowsDesktop) {
 	// Ensure audit cache gets cleaned up
 	s.auditCache.Delete(sessionID(sid))
 
@@ -99,7 +99,7 @@ func (s *WindowsService) onSessionEnd(ctx context.Context, emitter events.Emitte
 		// There can only be 1 participant, desktop sessions are not join-able.
 		Participants: []string{userMetadata.User},
 	}
-	s.emit(ctx, emitter, event)
+	s.emit(ctx, s.cfg.Emitter, event)
 }
 
 func (s *WindowsService) onClipboardSend(ctx context.Context, emitter events.Emitter, id *tlsca.Identity, sessionID string, desktopAddr string, length int32) {


### PR DESCRIPTION
This commit introduces 2 changes:

1. Previously, we leveraged a `TeeStreamer` which would ensure that the audit events we emitted would go to both the session recording (so long as the event type passed a simple check) and Teleport's audit log. This has been removed, and we now leverage the stream writer for session recordings, and the service's configured emitter for events that are destined for the audit log. This is a bit more efficient, because TeeStreamer would perform two EmitAuditEvent calls sequentially, and for desktop access we usually only need one.
2. Leverage a discard stream when session recording is disabled. Prior to this, disabling session recordings would prevent them from being uploaded, but wouldn't prevent them from being written to disk, so users would incur a performance penalty (and fill up their disk) even when session recording is disabled.

Updates #16773