### PR TITLE
Respect --auth and --mfa-mode before defaulting to passwordless

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3154,21 +3154,25 @@ var hasTouchIDCredentials = touchid.HasCredentials
 // canDefaultToPasswordless checks without user interaction
 // if there is any registered passwordless login.
 func (tc *TeleportClient) canDefaultToPasswordless(pr *webclient.PingResponse) bool {
-	if !pr.Auth.AllowPasswordless {
+	// Verify if client flags are compatible with passwordless.
+	allowedConnector := tc.AuthConnector == ""
+	allowedAttachment := tc.AuthenticatorAttachment == wancli.AttachmentAuto || tc.AuthenticatorAttachment == wancli.AttachmentPlatform
+	if !allowedConnector || !allowedAttachment || tc.PreferOTP {
 		return false
 	}
-	if tc.Config.AuthenticatorAttachment == wancli.AttachmentCrossPlatform {
+
+	// Verify if server is compatible with passwordless.
+	if !pr.Auth.AllowPasswordless || pr.Auth.Webauthn == nil {
 		return false
 	}
-	if pr.Auth.Webauthn == nil {
-		return false
-	}
+
 	// Only pass on the user if explicitly set, otherwise let the credential
 	// picker kick in.
 	user := ""
 	if tc.ExplicitUsername {
 		user = tc.Username
 	}
+
 	return hasTouchIDCredentials(pr.Auth.Webauthn.RPID, user)
 }
 

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -212,7 +212,6 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			secondFactor:          constants.SecondFactorOptional,
 			inputReader:           prompt.NewFakeReader(), // no inputs
 			solveWebauthn:         solvePwdless,
-			authConnector:         constants.LocalConnector,
 			hasTouchIDCredentials: true,
 		},
 		{
@@ -224,9 +223,32 @@ func TestTeleportClient_Login_local(t *testing.T) {
 					panic("this should not be called")
 				}),
 			solveWebauthn:           solveWebauthn,
-			authConnector:           constants.LocalConnector,
 			hasTouchIDCredentials:   true,
 			authenticatorAttachment: wancli.AttachmentCrossPlatform,
+		},
+		{
+			name:         "local connector doesn't default to passwordless",
+			secondFactor: constants.SecondFactorOptional,
+			inputReader: prompt.NewFakeReader().
+				AddString(password).
+				AddReply(func(ctx context.Context) (string, error) {
+					panic("this should not be called")
+				}),
+			solveWebauthn:         solveWebauthn,
+			authConnector:         constants.LocalConnector,
+			hasTouchIDCredentials: true,
+		},
+		{
+			name:         "OTP preferred doesn't default to passwordless",
+			secondFactor: constants.SecondFactorOptional,
+			inputReader: prompt.NewFakeReader().
+				AddString(password).
+				AddReply(solveOTP),
+			solveWebauthn: func(ctx context.Context, origin string, assertion *wanlib.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
+				panic("this should not be called")
+			},
+			preferOTP:             true,
+			hasTouchIDCredentials: true,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Since #16964, `tsh login` defaults to passwordless if it finds suitable platform credentials - it is safer and more convenient than other authentication methods. Unfortunately, it is a bit too eager in doing that.

This change adds the following prerequisites for the switch, in addition to existing conditions:

1. `--auth` must not be specified
2. `--mfa-mode` must be either `auto` or `platform`

(1) avoids defaulting when `--auth=local` is present, as well as for other custom/future values. (If `--auth=passwordless` is passed, we'll do passwordless anyway.)

(2) includes both an explicit platform attachment test (which is a bit more conservative in face of changes), as well as checking for `--mfa-mode=otp`.

#20429 and #20322.