### PR TITLE
Add nodejs to the fips dockerfile.

### DIFF
--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -131,6 +131,18 @@ ENV GOEXPERIMENT=boringcrypto \
     GOROOT="/opt/go" \
     PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
+# Install Nodejs
+ARG NODE_VERSION
+ENV NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${BUILDARCH}.tar.xz"
+ENV NODE_PATH="/usr/local/lib/nodejs-linux"
+ENV PATH="$PATH:${NODE_PATH}/bin"
+RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo "arm64"; fi) && \
+     export NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
+     mkdir -p ${NODE_PATH} && \
+     curl -o /tmp/nodejs.tar.xz -L ${NODE_URL} && \
+     tar -xJf /tmp/nodejs.tar.xz -C /usr/local/lib/nodejs-linux --strip-components=1
+RUN corepack enable yarn
+
 # Install libbpf
 ARG LIBBPF_VERSION
 RUN mkdir -p /opt && cd /opt && curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -148,6 +148,7 @@ buildbox-fips:
 		docker build \
 			--build-arg UID=$(UID) \
 			--build-arg GID=$(GID) \
+			--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 			--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 			--build-arg NODE_VERSION=$(NODE_VERSION) \
 			--build-arg RUST_VERSION=$(RUST_VERSION) \


### PR DESCRIPTION
To enable the UI to be built in the fips dockerfile we need Node in the image.