### PR TITLE
helm: fix potential deadlock during proxy install

### DIFF
--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
@@ -72,6 +72,8 @@ spec:
       - name: teleport-tls
         secret:
           secretName: teleport-tls
+          # this avoids deadlock during initial setup
+          optional: true
 {{- else if $proxy.tls.existingSecretName }}
       - name: teleport-tls
         secret:


### PR DESCRIPTION
Fixes a deadlock happening on fresh clusters where cert-manager has not yet issued a certificate.

What happens:
- Helm runs hooks creating config validation job
- the proxy config job wants to mount TLS certs
- TLS certs have not been issued yet because the `Certificate` object is created after the hooks
- deadlock

This was undetected for so long because the secret name is not named after the release and is kept after uninstall. Broken releases were picking up certs from previous releases. I don't think I can change the secret name now without breaking the chart, but it will hurt people releasing in the same namespace.