### PR TITLE
[Docs] TLS partial minor upgrade.

### DIFF
--- a/docs/pages/includes/tls-certificate-setup.mdx
+++ b/docs/pages/includes/tls-certificate-setup.mdx
@@ -17,9 +17,7 @@ deployments, use your own private key and certificate.
     used for notifications (you can use any domain):
 
     ```code
-    $ DOMAIN=tele.example.com
-    $ EMAIL=user@example.com
-    $ teleport configure --acme --acme-email=${EMAIL?} --cluster-name=${DOMAIN?} | \
+    $ teleport configure --acme --acme-email=<Var name="user@example.com" description="Your email address to register with Let's Encrypt for TLS certificates" /> --cluster-name=<Var name="tele.example.com" description="The domain name of your Teleport cluster" /> | \
     sudo tee /etc/teleport.yaml > /dev/null
     ```
 

--- a/docs/pages/includes/tls-certificate-setup.mdx
+++ b/docs/pages/includes/tls-certificate-setup.mdx
@@ -21,10 +21,6 @@ deployments, use your own private key and certificate.
     sudo tee /etc/teleport.yaml > /dev/null
     ```
 
-    <Admonition type="tip">
-    Depending on your installation method you may need to run this command as `root` or with `sudo`.
-    </Admonition>
-
     The `--acme`, `--acme-email`, and `--cluster-name` flags will add the following
     settings to your Teleport configuration file:
 

--- a/docs/pages/includes/tls-certificate-setup.mdx
+++ b/docs/pages/includes/tls-certificate-setup.mdx
@@ -21,6 +21,10 @@ deployments, use your own private key and certificate.
     sudo tee /etc/teleport.yaml > /dev/null
     ```
 
+    <Admonition type="tip">
+    Depending on your installation method you may need to run this command as `root` or with `sudo`.
+    </Admonition>
+
     The `--acme`, `--acme-email`, and `--cluster-name` flags will add the following
     settings to your Teleport configuration file:
 


### PR DESCRIPTION
- Uses the Vars component to streamline the `teleport configure` example.
- ~Notes the need for root privileges when running said command~.

Note that I didn't include the VarList component because this is a partial file, and we don't know what other Vars may exist on the pages it's included in.