### PR TITLE
[v11] Add incomplete session upload metric to the teleport namespace (#20351)

### DIFF
--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
@@ -77,6 +78,16 @@ func (cfg *UploadCompleterConfig) CheckAndSetDefaults() error {
 	}
 	return nil
 }
+
+var (
+	incompleteSessionUploads = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "teleport",
+			Name:      teleport.MetricIncompleteSessionUploads,
+			Help:      "Number of sessions not yet uploaded to auth",
+		},
+	)
+)
 
 // NewUploadCompleter returns a new UploadCompleter.
 func NewUploadCompleter(cfg UploadCompleterConfig) (*UploadCompleter, error) {

--- a/metrics.go
+++ b/metrics.go
@@ -88,6 +88,9 @@ const (
 	// TagMigration is a metric tag for a migration
 	TagMigration = "migration"
 
+	// MetricIncompleteSessionUploads returns the number of incomplete session uploads
+	MetricIncompleteSessionUploads = "incomplete_session_uploads_total"
+
 	// TagCluster is a metric tag for a cluster
 	TagCluster = "cluster"
 )


### PR DESCRIPTION
Also change name to match prometheus naming practices

backport of #20351 