### PR TITLE
[v12] Add device-specific verbs to RoleAdmin

### DIFF
--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -670,6 +670,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					WindowsDesktopLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
 					Rules: []types.Rule{
 						types.NewRule(types.Wildcard, services.RW()),
+						types.NewRule(types.KindDevice, append(services.RW(), types.VerbCreateEnrollToken, types.VerbEnroll)),
 					},
 				},
 			})

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -707,7 +707,7 @@ func RoleSetFromSpec(name string, spec types.RoleSpecV6) (RoleSet, error) {
 	return NewRoleSet(role), nil
 }
 
-// RW is a shortcut that returns all verbs.
+// RW is a shortcut that returns all CRUD verbs.
 func RW() []string {
 	return []string{types.VerbList, types.VerbCreate, types.VerbRead, types.VerbUpdate, types.VerbDelete}
 }


### PR DESCRIPTION
Add device-specific verbs to RoleAdmin, which are not included in the default
`RW()` set. Fixes issues while using `tctl devices add --enroll` and
`tctl devices enroll`.

#514

Backport #20505 to branch/v12