### PR TITLE
Fix kube access proxy peering compatibility

### DIFF
--- a/api/types/kubernetes_server.go
+++ b/api/types/kubernetes_server.go
@@ -113,6 +113,7 @@ func NewKubeServersV3FromServer(server Server) (result []KubeServer, err error) 
 			HostID:   server.GetName(),
 			Rotation: server.GetRotation(),
 			Cluster:  kubeCluster,
+			ProxyIDs: server.GetProxyIDs(),
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
The change from kube_service to kube_server in v11 lead to breaking backwards compatibility for v10 agents connecting to a v11 teleport cluster when proxy peering is enabled.

The issue was in converting from a kube_service to kube_server the proxy ids the kube agent is connected to was never copied.

This leads to kube agents being reachable through the proxy they are connected to but not through peer proxies.