### PR TITLE
dependabot-batcher - Specify environment

### DIFF
--- a/.github/workflows/dependabot-batcher.yaml
+++ b/.github/workflows/dependabot-batcher.yaml
@@ -15,6 +15,7 @@ jobs:
   dependabot-batcher:
     name: 'Combine Dependabot PRs'
     runs-on: ubuntu-latest
+    environment: dependabot-batcher
     steps:
       - name: Generate GitHub Token
         id: generate_token


### PR DESCRIPTION
The environment on this workflow needs to be specified to have access to the GitHub App auth.