### PR TITLE
[v11] fix `tctl auth sign --format kubernetes` when using remote auth server

### DIFF
--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -524,6 +524,26 @@ type KeyPairPath struct {
 	Certificate string
 }
 
+// WebPublicAddr returns the address for the web endpoint on this proxy that
+// can be reached by clients.
+func (c ProxyConfig) WebPublicAddr() (string, error) {
+	return c.getDefaultAddr(c.WebAddr.Port(defaults.HTTPListenPort)), nil
+}
+
+func (c ProxyConfig) getDefaultAddr(port int) string {
+	host := "<proxyhost>"
+	// Try to guess the hostname from the HTTP public_addr.
+	if len(c.PublicAddrs) > 0 {
+		host = c.PublicAddrs[0].Host()
+	}
+
+	u := url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+	}
+	return u.String()
+}
+
 // KubeAddr returns the address for the Kubernetes endpoint on this proxy that
 // can be reached by clients.
 func (c ProxyConfig) KubeAddr() (string, error) {
@@ -533,16 +553,8 @@ func (c ProxyConfig) KubeAddr() (string, error) {
 	if len(c.Kube.PublicAddrs) > 0 {
 		return fmt.Sprintf("https://%s", c.Kube.PublicAddrs[0].Addr), nil
 	}
-	host := "<proxyhost>"
-	// Try to guess the hostname from the HTTP public_addr.
-	if len(c.PublicAddrs) > 0 {
-		host = c.PublicAddrs[0].Host()
-	}
-	u := url.URL{
-		Scheme: "https",
-		Host:   net.JoinHostPort(host, strconv.Itoa(c.Kube.ListenAddr.Port(defaults.KubeListenPort))),
-	}
-	return u.String(), nil
+
+	return c.getDefaultAddr(c.Kube.ListenAddr.Port(defaults.KubeListenPort)), nil
 }
 
 // publicPeerAddr attempts to returns the public address the proxy advertises

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -671,7 +671,7 @@ client_encryption_options:
 
 func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI auth.ClientI) error {
 	// Validate --proxy flag.
-	if err := a.checkProxyAddr(clusterAPI); err != nil {
+	if err := a.checkProxyAddr(ctx, clusterAPI); err != nil {
 		return trace.Wrap(err)
 	}
 	// parse compatibility parameter
@@ -790,7 +790,13 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI auth.Clie
 	kubeTLSServerName := ""
 	if proxyListenerMode == types.ProxyListenerMode_Multiplex {
 		log.Debug("Using Proxy SNI for kube TLS server name")
-		kubeTLSServerName = client.GetKubeTLSServerName(a.config.Proxy.WebAddr.Host())
+		u, err := parseURL(a.proxyAddr)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		// extract host part if present
+		split := strings.Split(u.Host, ":")
+		kubeTLSServerName = client.GetKubeTLSServerName(split[0])
 	}
 
 	expires, err := key.TeleportTLSCertValidBefore()
@@ -874,7 +880,7 @@ func (a *AuthCommand) checkKubeCluster(ctx context.Context, clusterAPI auth.Clie
 	return nil
 }
 
-func (a *AuthCommand) checkProxyAddr(clusterAPI auth.ClientI) error {
+func (a *AuthCommand) checkProxyAddr(ctx context.Context, clusterAPI auth.ClientI) error {
 	if a.outputFormat != identityfile.FormatKubernetes && a.proxyAddr != "" {
 		// User set --proxy but it's not actually used for the chosen --format.
 		// Print a warning but continue.
@@ -886,7 +892,7 @@ func (a *AuthCommand) checkProxyAddr(clusterAPI auth.ClientI) error {
 	}
 	if a.proxyAddr != "" {
 		// User set --proxy. Validate it and set its scheme to https in case it was omitted.
-		u, err := url.Parse(a.proxyAddr)
+		u, err := parseURL(a.proxyAddr)
 		if err != nil {
 			return trace.WrapWithMessage(err, "specified --proxy URL is invalid")
 		}
@@ -907,8 +913,17 @@ func (a *AuthCommand) checkProxyAddr(clusterAPI auth.ClientI) error {
 	// Is the auth server also a proxy?
 	if a.config.Proxy.Kube.Enabled {
 		var err error
+		if a.config.Auth.NetworkingConfig != nil &&
+			a.config.Auth.NetworkingConfig.GetProxyListenerMode() == types.ProxyListenerMode_Multiplex {
+			a.proxyAddr, err = a.config.Proxy.WebPublicAddr()
+			return trace.Wrap(err)
+		}
 		a.proxyAddr, err = a.config.Proxy.KubeAddr()
 		return trace.Wrap(err)
+	}
+	netConfig, err := clusterAPI.GetClusterNetworkingConfig(ctx)
+	if err != nil {
+		return trace.WrapWithMessage(err, "couldn't load cluster network configuration, try setting --proxy manually")
 	}
 	// Fetch proxies known to auth server and try to find a public address.
 	proxies, err := clusterAPI.GetProxies()
@@ -920,6 +935,16 @@ func (a *AuthCommand) checkProxyAddr(clusterAPI auth.ClientI) error {
 		if addr == "" {
 			continue
 		}
+
+		if netConfig.GetProxyListenerMode() == types.ProxyListenerMode_Multiplex {
+			u := url.URL{
+				Scheme: "https",
+				Host:   addr,
+			}
+			a.proxyAddr = u.String()
+			return nil
+		}
+
 		uaddr, err := utils.ParseAddr(addr)
 		if err != nil {
 			log.Warningf("Invalid public address on the proxy %q: %q: %v.", p.GetName(), addr, err)
@@ -964,6 +989,22 @@ func hostCAFormat(ca types.CertAuthority, keyBytes []byte, client auth.ClientI) 
 	}
 	allowedLogins, _ := roles.GetLoginsForTTL(apidefaults.MinCertDuration + time.Second)
 	return sshutils.MarshalAuthorizedHostsFormat(ca.GetClusterName(), keyBytes, allowedLogins)
+}
+
+func parseURL(rawurl string) (*url.URL, error) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// If no scheme is provided url.Parse fails the parsing and considers the host
+	// as scheme, leaving the host empty.
+	if u.Host == "" {
+		return &url.URL{
+			Host: rawurl,
+		}, nil
+	}
+
+	return u, nil
 }
 
 func getApplicationServer(ctx context.Context, clusterAPI auth.ClientI, appName string) (types.AppServer, error) {

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -69,7 +69,7 @@ func TestAuthSignKubeconfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	client := &mockClient{
+	separatedCluster := &mockClient{
 		clusterName:    clusterName,
 		remoteClusters: []types.RemoteCluster{remoteCluster},
 		userCerts: &proto.Certs{
@@ -93,15 +93,21 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			},
 		},
 	}
+	multiplexCluster := *separatedCluster
+	multiplexCluster.networkConfig = &types.ClusterNetworkingConfigV2{}
+	multiplexCluster.networkConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+
 	tests := []struct {
 		desc        string
 		ac          AuthCommand
+		client      *mockClient
 		wantAddr    string
 		wantCluster string
 		assertErr   require.ErrorAssertionFunc
 	}{
 		{
-			desc: "valid --proxy URL with valid URL scheme",
+			desc:   "valid --proxy URL with valid URL scheme",
+			client: separatedCluster,
 			ac: AuthCommand{
 				output:        filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat:  identityfile.FormatKubernetes,
@@ -112,7 +118,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			desc: "valid --proxy URL with invalid URL scheme",
+			desc:   "valid --proxy URL with invalid URL scheme",
+			client: separatedCluster,
 			ac: AuthCommand{
 				output:        filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat:  identityfile.FormatKubernetes,
@@ -125,7 +132,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			},
 		},
 		{
-			desc: "valid --proxy URL without URL scheme",
+			desc:   "valid --proxy URL without URL scheme",
+			client: separatedCluster,
 			ac: AuthCommand{
 				output:        filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat:  identityfile.FormatKubernetes,
@@ -136,7 +144,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			desc: "invalid --proxy URL",
+			desc:   "invalid --proxy URL",
+			client: separatedCluster,
 			ac: AuthCommand{
 				output:        filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat:  identityfile.FormatKubernetes,
@@ -149,7 +158,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			},
 		},
 		{
-			desc: "k8s proxy running locally with public_addr",
+			desc:   "k8s proxy running locally with public_addr",
+			client: separatedCluster,
 			ac: AuthCommand{
 				output:        filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat:  identityfile.FormatKubernetes,
@@ -163,7 +173,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			desc: "k8s proxy running locally without public_addr",
+			desc:   "k8s proxy running locally without public_addr",
+			client: separatedCluster,
 			ac: AuthCommand{
 				output:        filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat:  identityfile.FormatKubernetes,
@@ -179,7 +190,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			desc: "k8s proxy from cluster info",
+			desc:   "k8s proxy from cluster info",
+			client: separatedCluster,
 			ac: AuthCommand{
 				output:        filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat:  identityfile.FormatKubernetes,
@@ -194,7 +206,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			desc: "--kube-cluster specified with valid cluster",
+			desc:   "--kube-cluster specified with valid cluster",
+			client: separatedCluster,
 			ac: AuthCommand{
 				output:        filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat:  identityfile.FormatKubernetes,
@@ -210,7 +223,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			assertErr:   require.NoError,
 		},
 		{
-			desc: "--kube-cluster specified with invalid cluster",
+			desc:   "--kube-cluster specified with invalid cluster",
+			client: separatedCluster,
 			ac: AuthCommand{
 				output:        filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat:  identityfile.FormatKubernetes,
@@ -227,11 +241,50 @@ func TestAuthSignKubeconfig(t *testing.T) {
 				require.Equal(t, err.Error(), "couldn't find leaf cluster named \"doesnotexist.example.com\"")
 			},
 		},
+		{
+			desc:   "k8s proxy running locally in multiplex mode without public_addr",
+			client: &multiplexCluster,
+			ac: AuthCommand{
+				output:        filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat:  identityfile.FormatKubernetes,
+				signOverwrite: true,
+				config: &service.Config{
+					Auth: service.AuthConfig{
+						NetworkingConfig: &types.ClusterNetworkingConfigV2{
+							Spec: types.ClusterNetworkingConfigSpecV2{
+								ProxyListenerMode: types.ProxyListenerMode_Multiplex,
+							},
+						},
+					},
+					Proxy: service.ProxyConfig{Kube: service.KubeProxyConfig{
+						Enabled: true,
+					}, PublicAddrs: []utils.NetAddr{{Addr: "proxy-from-config.example.com:3080"}}},
+				},
+			},
+			wantAddr:  "https://proxy-from-config.example.com:3080",
+			assertErr: require.NoError,
+		},
+		{
+			desc:   "k8s proxy from cluster info",
+			client: &multiplexCluster,
+			ac: AuthCommand{
+				output:        filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat:  identityfile.FormatKubernetes,
+				signOverwrite: true,
+				config: &service.Config{Proxy: service.ProxyConfig{
+					Kube: service.KubeProxyConfig{
+						Enabled: false,
+					},
+				}},
+			},
+			wantAddr:  "https://proxy-from-api.example.com:3080",
+			assertErr: require.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			// Generate kubeconfig.
-			err := tt.ac.generateUserKeys(context.Background(), client)
+			err := tt.ac.generateUserKeys(context.Background(), tt.client)
 			tt.assertErr(t, err)
 
 			// Validate kubeconfig contents.
@@ -244,8 +297,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 				t.Fatalf("currentContext %q not present in kubeconfig", kc.CurrentContext)
 			}
 			gotCert := kc.AuthInfos[currentCtx.AuthInfo].ClientCertificateData
-			if !bytes.Equal(gotCert, client.userCerts.TLS) {
-				t.Errorf("got client cert: %q, want %q", gotCert, client.userCerts.TLS)
+			if !bytes.Equal(gotCert, tt.client.userCerts.TLS) {
+				t.Errorf("got client cert: %q, want %q", gotCert, tt.client.userCerts.TLS)
 			}
 			gotCA := kc.Clusters[currentCtx.Cluster].CertificateAuthorityData
 			wantCA := ca.GetActiveKeys().TLS[0].Cert


### PR DESCRIPTION
Backport #20497 to branch/v11