### PR TITLE
Fixed incorrect container image branch version numbers

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8084,7 +8084,7 @@ steps:
   - Build full semver
   - Assume ECR - staging AWS Role
   - Assume ECR - authenticated-pull AWS Role
-- name: Download "teleport_v11-tag_amd64.deb" artifacts from S3
+- name: Download "teleport_v13-tag_amd64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
   - END_TIME=$(( $(date +%s) + 3600 ))
@@ -8114,26 +8114,26 @@ steps:
   depends_on:
   - Assume S3 Download AWS Role for teleport
   - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v11-amd64"
+- name: Build teleport image "teleport:v13-amd64"
   image: docker
   commands:
   - docker run --privileged --rm tonistiigi/binfmt --install all
   - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v11-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v11-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v11-amd64-builder/buildkitd.toml"
+  - mkdir -pv "/tmp/teleport-v13-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v13-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v13-amd64-builder/buildkitd.toml"
   - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v11-amd64-builder" --config "/tmp/teleport-v11-amd64-builder/buildkitd.toml"
+    "teleport-v13-amd64-builder" --config "/tmp/teleport-v13-amd64-builder/buildkitd.toml"
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
-  - docker buildx build --push --builder "teleport-v11-amd64-builder" --target "teleport"
+  - docker buildx build --push --builder "teleport-v13-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
     /go/build
   - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v11-amd64-builder"
-  - rm -rf "/tmp/teleport-v11-amd64-builder"
+  - docker buildx rm "teleport-v13-amd64-builder"
+  - rm -rf "/tmp/teleport-v13-amd64-builder"
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
@@ -8144,8 +8144,8 @@ steps:
     path: /var/run
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v11-tag_amd64.deb" artifacts from S3
-- name: Download "teleport_v11-tag_arm.deb" artifacts from S3
+  - Download "teleport_v13-tag_amd64.deb" artifacts from S3
+- name: Download "teleport_v13-tag_arm.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
   - END_TIME=$(( $(date +%s) + 3600 ))
@@ -8175,26 +8175,26 @@ steps:
   depends_on:
   - Assume S3 Download AWS Role for teleport
   - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v11-arm"
+- name: Build teleport image "teleport:v13-arm"
   image: docker
   commands:
   - docker run --privileged --rm tonistiigi/binfmt --install all
   - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v11-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v11-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v11-arm-builder/buildkitd.toml"
+  - mkdir -pv "/tmp/teleport-v13-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v13-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v13-arm-builder/buildkitd.toml"
   - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v11-arm-builder" --config "/tmp/teleport-v11-arm-builder/buildkitd.toml"
+    "teleport-v13-arm-builder" --config "/tmp/teleport-v13-arm-builder/buildkitd.toml"
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
-  - docker buildx build --push --builder "teleport-v11-arm-builder" --target "teleport"
+  - docker buildx build --push --builder "teleport-v13-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
     /go/build
   - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v11-arm-builder"
-  - rm -rf "/tmp/teleport-v11-arm-builder"
+  - docker buildx rm "teleport-v13-arm-builder"
+  - rm -rf "/tmp/teleport-v13-arm-builder"
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
@@ -8205,8 +8205,8 @@ steps:
     path: /var/run
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v11-tag_arm.deb" artifacts from S3
-- name: Download "teleport_v11-tag_arm64.deb" artifacts from S3
+  - Download "teleport_v13-tag_arm.deb" artifacts from S3
+- name: Download "teleport_v13-tag_arm64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
   - END_TIME=$(( $(date +%s) + 3600 ))
@@ -8236,26 +8236,26 @@ steps:
   depends_on:
   - Assume S3 Download AWS Role for teleport
   - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v11-arm64"
+- name: Build teleport image "teleport:v13-arm64"
   image: docker
   commands:
   - docker run --privileged --rm tonistiigi/binfmt --install all
   - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v11-arm64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v11-arm64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v11-arm64-builder/buildkitd.toml"
+  - mkdir -pv "/tmp/teleport-v13-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v13-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v13-arm64-builder/buildkitd.toml"
   - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v11-arm64-builder" --config "/tmp/teleport-v11-arm64-builder/buildkitd.toml"
+    "teleport-v13-arm64-builder" --config "/tmp/teleport-v13-arm64-builder/buildkitd.toml"
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
-  - docker buildx build --push --builder "teleport-v11-arm64-builder" --target "teleport"
+  - docker buildx build --push --builder "teleport-v13-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
     /go/build
   - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v11-arm64-builder"
-  - rm -rf "/tmp/teleport-v11-arm64-builder"
+  - docker buildx rm "teleport-v13-arm64-builder"
+  - rm -rf "/tmp/teleport-v13-arm64-builder"
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
@@ -8266,8 +8266,8 @@ steps:
     path: /var/run
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v11-tag_arm64.deb" artifacts from S3
-- name: Tag and push image "teleport:v11-amd64" to ECR - staging
+  - Download "teleport_v13-tag_arm64.deb" artifacts from S3
+- name: Tag and push image "teleport:v13-amd64" to ECR - staging
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
@@ -8289,8 +8289,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Build teleport image "teleport:v11-amd64"
-- name: Tag and push image "teleport:v11-arm" to ECR - staging
+  - Build teleport image "teleport:v13-amd64"
+- name: Tag and push image "teleport:v13-arm" to ECR - staging
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
@@ -8312,8 +8312,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Build teleport image "teleport:v11-arm"
-- name: Tag and push image "teleport:v11-arm64" to ECR - staging
+  - Build teleport image "teleport:v13-arm"
+- name: Tag and push image "teleport:v13-arm64" to ECR - staging
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
@@ -8335,7 +8335,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Build teleport image "teleport:v11-arm64"
+  - Build teleport image "teleport:v13-arm64"
 - name: Create manifest and push "teleport:full" to ECR - staging
   image: docker
   commands:
@@ -8359,9 +8359,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport:v11-amd64" to ECR - staging
-  - Tag and push image "teleport:v11-arm" to ECR - staging
-  - Tag and push image "teleport:v11-arm64" to ECR - staging
+  - Tag and push image "teleport:v13-amd64" to ECR - staging
+  - Tag and push image "teleport:v13-arm" to ECR - staging
+  - Tag and push image "teleport:v13-arm64" to ECR - staging
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
   commands:
@@ -8411,7 +8411,7 @@ steps:
   - Build full semver
   - Assume ECR - staging AWS Role
   - Assume ECR - authenticated-pull AWS Role
-- name: Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
+- name: Download "teleport-ent_v13-tag_amd64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
   - END_TIME=$(( $(date +%s) + 3600 ))
@@ -8441,26 +8441,26 @@ steps:
   depends_on:
   - Assume S3 Download AWS Role for teleport-ent
   - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v11-amd64"
+- name: Build teleport-ent image "teleport-ent:v13-amd64"
   image: docker
   commands:
   - docker run --privileged --rm tonistiigi/binfmt --install all
   - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v11-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v11-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v11-amd64-builder/buildkitd.toml"
+  - mkdir -pv "/tmp/teleport-ent-v13-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v13-amd64-builder/buildkitd.toml"
   - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v11-amd64-builder" --config "/tmp/teleport-ent-v11-amd64-builder/buildkitd.toml"
+    "teleport-ent-v13-amd64-builder" --config "/tmp/teleport-ent-v13-amd64-builder/buildkitd.toml"
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v11-amd64-builder" --target
+  - docker buildx build --push --builder "teleport-ent-v13-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
     DEB_PATH=teleport-ent_$(cat "/go/var/full-version")_amd64.deb /go/build
   - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v11-amd64-builder"
-  - rm -rf "/tmp/teleport-ent-v11-amd64-builder"
+  - docker buildx rm "teleport-ent-v13-amd64-builder"
+  - rm -rf "/tmp/teleport-ent-v13-amd64-builder"
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
@@ -8471,8 +8471,8 @@ steps:
     path: /var/run
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
-- name: Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
+  - Download "teleport-ent_v13-tag_amd64.deb" artifacts from S3
+- name: Download "teleport-ent_v13-tag_arm.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
   - END_TIME=$(( $(date +%s) + 3600 ))
@@ -8502,26 +8502,26 @@ steps:
   depends_on:
   - Assume S3 Download AWS Role for teleport-ent
   - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v11-arm"
+- name: Build teleport-ent image "teleport-ent:v13-arm"
   image: docker
   commands:
   - docker run --privileged --rm tonistiigi/binfmt --install all
   - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v11-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v11-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v11-arm-builder/buildkitd.toml"
+  - mkdir -pv "/tmp/teleport-ent-v13-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
   - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v11-arm-builder" --config "/tmp/teleport-ent-v11-arm-builder/buildkitd.toml"
+    "teleport-ent-v13-arm-builder" --config "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v11-arm-builder" --target "teleport"
+  - docker buildx build --push --builder "teleport-ent-v13-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
     "/go/var/full-version")_arm.deb /go/build
   - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v11-arm-builder"
-  - rm -rf "/tmp/teleport-ent-v11-arm-builder"
+  - docker buildx rm "teleport-ent-v13-arm-builder"
+  - rm -rf "/tmp/teleport-ent-v13-arm-builder"
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
@@ -8532,8 +8532,8 @@ steps:
     path: /var/run
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
-- name: Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
+  - Download "teleport-ent_v13-tag_arm.deb" artifacts from S3
+- name: Download "teleport-ent_v13-tag_arm64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
   - END_TIME=$(( $(date +%s) + 3600 ))
@@ -8563,26 +8563,26 @@ steps:
   depends_on:
   - Assume S3 Download AWS Role for teleport-ent
   - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v11-arm64"
+- name: Build teleport-ent image "teleport-ent:v13-arm64"
   image: docker
   commands:
   - docker run --privileged --rm tonistiigi/binfmt --install all
   - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v11-arm64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v11-arm64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v11-arm64-builder/buildkitd.toml"
+  - mkdir -pv "/tmp/teleport-ent-v13-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v13-arm64-builder/buildkitd.toml"
   - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v11-arm64-builder" --config "/tmp/teleport-ent-v11-arm64-builder/buildkitd.toml"
+    "teleport-ent-v13-arm64-builder" --config "/tmp/teleport-ent-v13-arm64-builder/buildkitd.toml"
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v11-arm64-builder" --target
+  - docker buildx build --push --builder "teleport-ent-v13-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
     DEB_PATH=teleport-ent_$(cat "/go/var/full-version")_arm64.deb /go/build
   - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v11-arm64-builder"
-  - rm -rf "/tmp/teleport-ent-v11-arm64-builder"
+  - docker buildx rm "teleport-ent-v13-arm64-builder"
+  - rm -rf "/tmp/teleport-ent-v13-arm64-builder"
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
@@ -8593,8 +8593,8 @@ steps:
     path: /var/run
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
-- name: Tag and push image "teleport-ent:v11-amd64" to ECR - staging
+  - Download "teleport-ent_v13-tag_arm64.deb" artifacts from S3
+- name: Tag and push image "teleport-ent:v13-amd64" to ECR - staging
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -8616,8 +8616,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Build teleport-ent image "teleport-ent:v11-amd64"
-- name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
+  - Build teleport-ent image "teleport-ent:v13-amd64"
+- name: Tag and push image "teleport-ent:v13-arm" to ECR - staging
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -8639,8 +8639,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Build teleport-ent image "teleport-ent:v11-arm"
-- name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
+  - Build teleport-ent image "teleport-ent:v13-arm"
+- name: Tag and push image "teleport-ent:v13-arm64" to ECR - staging
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -8662,7 +8662,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Build teleport-ent image "teleport-ent:v11-arm64"
+  - Build teleport-ent image "teleport-ent:v13-arm64"
 - name: Create manifest and push "teleport-ent:full" to ECR - staging
   image: docker
   commands:
@@ -8686,9 +8686,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v11-arm" to ECR - staging
-  - Tag and push image "teleport-ent:v11-arm64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm64" to ECR - staging
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
   commands:
@@ -8739,7 +8739,7 @@ steps:
   - Build full semver
   - Assume ECR - staging AWS Role
   - Assume ECR - authenticated-pull AWS Role
-- name: Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
+- name: Download "teleport-ent_v13-tag-fips_amd64.deb" artifacts from S3
   image: amazon/aws-cli
   commands:
   - END_TIME=$(( $(date +%s) + 3600 ))
@@ -8769,27 +8769,27 @@ steps:
   depends_on:
   - Assume S3 Download AWS Role for teleport-ent-fips
   - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for teleport-ent-fips
-- name: Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
+- name: Build teleport-ent-fips image "teleport-ent:v13-fips-amd64"
   image: docker
   commands:
   - docker run --privileged --rm tonistiigi/binfmt --install all
   - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v11-fips-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v11-fips-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v11-fips-amd64-builder/buildkitd.toml"
+  - mkdir -pv "/tmp/teleport-ent-v13-fips-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-fips-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v13-fips-amd64-builder/buildkitd.toml"
   - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v11-fips-amd64-builder" --config "/tmp/teleport-ent-v11-fips-amd64-builder/buildkitd.toml"
+    "teleport-ent-v13-fips-amd64-builder" --config "/tmp/teleport-ent-v13-fips-amd64-builder/buildkitd.toml"
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v11-fips-amd64-builder" --target
+  - docker buildx build --push --builder "teleport-ent-v13-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
     --build-arg DEB_PATH=teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
     /go/build
   - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v11-fips-amd64-builder"
-  - rm -rf "/tmp/teleport-ent-v11-fips-amd64-builder"
+  - docker buildx rm "teleport-ent-v13-fips-amd64-builder"
+  - rm -rf "/tmp/teleport-ent-v13-fips-amd64-builder"
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
@@ -8800,8 +8800,8 @@ steps:
     path: /var/run
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
-- name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
+  - Download "teleport-ent_v13-tag-fips_amd64.deb" artifacts from S3
+- name: Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -8823,7 +8823,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
+  - Build teleport-ent-fips image "teleport-ent:v13-fips-amd64"
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - staging
   image: docker
   commands:
@@ -8845,28 +8845,28 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
-- name: Build teleport-operator image "teleport-operator:v11-amd64"
+  - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
+- name: Build teleport-operator image "teleport-operator:v13-amd64"
   image: docker
   commands:
   - docker run --privileged --rm tonistiigi/binfmt --install all
   - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
-  - mkdir -pv "/tmp/teleport-operator-v11-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v11-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-operator-v11-amd64-builder/buildkitd.toml"
+  - mkdir -pv "/tmp/teleport-operator-v13-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v13-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-operator-v13-amd64-builder/buildkitd.toml"
   - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-operator-v11-amd64-builder" --config "/tmp/teleport-operator-v11-amd64-builder/buildkitd.toml"
+    "teleport-operator-v13-amd64-builder" --config "/tmp/teleport-operator-v13-amd64-builder/buildkitd.toml"
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
-  - docker buildx build --push --builder "teleport-operator-v11-amd64-builder" --platform
+  - docker buildx build --push --builder "teleport-operator-v13-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
     BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:teleport13 --build-arg
     COMPILER_NAME=x86_64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-operator-v11-amd64-builder"
-  - rm -rf "/tmp/teleport-operator-v11-amd64-builder"
+  - docker buildx rm "teleport-operator-v13-amd64-builder"
+  - rm -rf "/tmp/teleport-operator-v13-amd64-builder"
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
@@ -8883,27 +8883,27 @@ steps:
   - Build full semver
   - Assume ECR - staging AWS Role
   - Assume ECR - authenticated-pull AWS Role
-- name: Build teleport-operator image "teleport-operator:v11-arm"
+- name: Build teleport-operator image "teleport-operator:v13-arm"
   image: docker
   commands:
   - docker run --privileged --rm tonistiigi/binfmt --install all
   - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
-  - mkdir -pv "/tmp/teleport-operator-v11-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v11-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-operator-v11-arm-builder/buildkitd.toml"
+  - mkdir -pv "/tmp/teleport-operator-v13-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v13-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-operator-v13-arm-builder/buildkitd.toml"
   - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-operator-v11-arm-builder" --config "/tmp/teleport-operator-v11-arm-builder/buildkitd.toml"
+    "teleport-operator-v13-arm-builder" --config "/tmp/teleport-operator-v13-arm-builder/buildkitd.toml"
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
-  - docker buildx build --push --builder "teleport-operator-v11-arm-builder" --platform
+  - docker buildx build --push --builder "teleport-operator-v13-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
     BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
     COMPILER_NAME=arm-linux-gnueabihf-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-operator-v11-arm-builder"
-  - rm -rf "/tmp/teleport-operator-v11-arm-builder"
+  - docker buildx rm "teleport-operator-v13-arm-builder"
+  - rm -rf "/tmp/teleport-operator-v13-arm-builder"
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
@@ -8920,27 +8920,27 @@ steps:
   - Build full semver
   - Assume ECR - staging AWS Role
   - Assume ECR - authenticated-pull AWS Role
-- name: Build teleport-operator image "teleport-operator:v11-arm64"
+- name: Build teleport-operator image "teleport-operator:v13-arm64"
   image: docker
   commands:
   - docker run --privileged --rm tonistiigi/binfmt --install all
   - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
-  - mkdir -pv "/tmp/teleport-operator-v11-arm64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v11-arm64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-operator-v11-arm64-builder/buildkitd.toml"
+  - mkdir -pv "/tmp/teleport-operator-v13-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v13-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-operator-v13-arm64-builder/buildkitd.toml"
   - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-operator-v11-arm64-builder" --config "/tmp/teleport-operator-v11-arm64-builder/buildkitd.toml"
+    "teleport-operator-v13-arm64-builder" --config "/tmp/teleport-operator-v13-arm64-builder/buildkitd.toml"
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
-  - docker buildx build --push --builder "teleport-operator-v11-arm64-builder" --platform
+  - docker buildx build --push --builder "teleport-operator-v13-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
     BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
     COMPILER_NAME=aarch64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
   - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-operator-v11-arm64-builder"
-  - rm -rf "/tmp/teleport-operator-v11-arm64-builder"
+  - docker buildx rm "teleport-operator-v13-arm64-builder"
+  - rm -rf "/tmp/teleport-operator-v13-arm64-builder"
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
@@ -8957,7 +8957,7 @@ steps:
   - Build full semver
   - Assume ECR - staging AWS Role
   - Assume ECR - authenticated-pull AWS Role
-- name: Tag and push image "teleport-operator:v11-amd64" to ECR - staging
+- name: Tag and push image "teleport-operator:v13-amd64" to ECR - staging
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -8979,8 +8979,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Build teleport-operator image "teleport-operator:v11-amd64"
-- name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
+  - Build teleport-operator image "teleport-operator:v13-amd64"
+- name: Tag and push image "teleport-operator:v13-arm" to ECR - staging
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -9002,8 +9002,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Build teleport-operator image "teleport-operator:v11-arm"
-- name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
+  - Build teleport-operator image "teleport-operator:v13-arm"
+- name: Tag and push image "teleport-operator:v13-arm64" to ECR - staging
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -9025,7 +9025,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Build teleport-operator image "teleport-operator:v11-arm64"
+  - Build teleport-operator image "teleport-operator:v13-arm64"
 - name: Create manifest and push "teleport-operator:full" to ECR - staging
   image: docker
   commands:
@@ -9049,9 +9049,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
-  - Tag and push image "teleport-operator:v11-arm" to ECR - staging
-  - Tag and push image "teleport-operator:v11-arm64" to ECR - staging
+  - Tag and push image "teleport-operator:v13-amd64" to ECR - staging
+  - Tag and push image "teleport-operator:v13-arm" to ECR - staging
+  - Tag and push image "teleport-operator:v13-arm64" to ECR - staging
 services:
 - name: Start Docker
   image: docker:dind
@@ -9219,7 +9219,7 @@ steps:
   - Assume ECR - staging AWS Role
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
-- name: Pull teleport:v11-amd64 and push it to Local Registry
+- name: Pull teleport:v13-amd64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -9247,7 +9247,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport:v11-arm and push it to Local Registry
+- name: Pull teleport:v13-arm and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -9275,7 +9275,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport:v11-arm64 and push it to Local Registry
+- name: Pull teleport:v13-arm64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -9303,7 +9303,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Tag and push image "teleport:v11-amd64" to Quay
+- name: Tag and push image "teleport:v13-amd64" to Quay
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
@@ -9330,8 +9330,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport:v11-amd64 and push it to Local Registry
-- name: Tag and push image "teleport:v11-arm" to Quay
+  - Pull teleport:v13-amd64 and push it to Local Registry
+- name: Tag and push image "teleport:v13-arm" to Quay
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
@@ -9358,8 +9358,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport:v11-arm and push it to Local Registry
-- name: Tag and push image "teleport:v11-arm64" to Quay
+  - Pull teleport:v13-arm and push it to Local Registry
+- name: Tag and push image "teleport:v13-arm64" to Quay
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
@@ -9386,7 +9386,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport:v11-arm64 and push it to Local Registry
+  - Pull teleport:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
@@ -9412,9 +9412,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport:v11-amd64" to Quay
-  - Tag and push image "teleport:v11-arm" to Quay
-  - Tag and push image "teleport:v11-arm64" to Quay
+  - Tag and push image "teleport:v13-amd64" to Quay
+  - Tag and push image "teleport:v13-arm" to Quay
+  - Tag and push image "teleport:v13-arm64" to Quay
 - name: Create manifest and push "teleport:minor" to Quay
   image: docker
   commands:
@@ -9440,9 +9440,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport:v11-amd64" to Quay
-  - Tag and push image "teleport:v11-arm" to Quay
-  - Tag and push image "teleport:v11-arm64" to Quay
+  - Tag and push image "teleport:v13-amd64" to Quay
+  - Tag and push image "teleport:v13-arm" to Quay
+  - Tag and push image "teleport:v13-arm64" to Quay
 - name: Create manifest and push "teleport:full" to Quay
   image: docker
   commands:
@@ -9465,10 +9465,10 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport:v11-amd64" to Quay
-  - Tag and push image "teleport:v11-arm" to Quay
-  - Tag and push image "teleport:v11-arm64" to Quay
-- name: Tag and push image "teleport:v11-amd64" to ECR - production
+  - Tag and push image "teleport:v13-amd64" to Quay
+  - Tag and push image "teleport:v13-arm" to Quay
+  - Tag and push image "teleport:v13-arm64" to Quay
+- name: Tag and push image "teleport:v13-amd64" to ECR - production
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
@@ -9494,8 +9494,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport:v11-amd64 and push it to Local Registry
-- name: Tag and push image "teleport:v11-arm" to ECR - production
+  - Pull teleport:v13-amd64 and push it to Local Registry
+- name: Tag and push image "teleport:v13-arm" to ECR - production
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
@@ -9521,8 +9521,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport:v11-arm and push it to Local Registry
-- name: Tag and push image "teleport:v11-arm64" to ECR - production
+  - Pull teleport:v13-arm and push it to Local Registry
+- name: Tag and push image "teleport:v13-arm64" to ECR - production
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
@@ -9548,7 +9548,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport:v11-arm64 and push it to Local Registry
+  - Pull teleport:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to ECR - production
   image: docker
   commands:
@@ -9573,9 +9573,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport:v11-amd64" to ECR - production
-  - Tag and push image "teleport:v11-arm" to ECR - production
-  - Tag and push image "teleport:v11-arm64" to ECR - production
+  - Tag and push image "teleport:v13-amd64" to ECR - production
+  - Tag and push image "teleport:v13-arm" to ECR - production
+  - Tag and push image "teleport:v13-arm64" to ECR - production
 - name: Create manifest and push "teleport:minor" to ECR - production
   image: docker
   commands:
@@ -9600,9 +9600,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport:v11-amd64" to ECR - production
-  - Tag and push image "teleport:v11-arm" to ECR - production
-  - Tag and push image "teleport:v11-arm64" to ECR - production
+  - Tag and push image "teleport:v13-amd64" to ECR - production
+  - Tag and push image "teleport:v13-arm" to ECR - production
+  - Tag and push image "teleport:v13-arm64" to ECR - production
 - name: Create manifest and push "teleport:full" to ECR - production
   image: docker
   commands:
@@ -9625,10 +9625,10 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport:v11-amd64" to ECR - production
-  - Tag and push image "teleport:v11-arm" to ECR - production
-  - Tag and push image "teleport:v11-arm64" to ECR - production
-- name: Pull teleport-ent:v11-amd64 and push it to Local Registry
+  - Tag and push image "teleport:v13-amd64" to ECR - production
+  - Tag and push image "teleport:v13-arm" to ECR - production
+  - Tag and push image "teleport:v13-arm64" to ECR - production
+- name: Pull teleport-ent:v13-amd64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -9656,7 +9656,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport-ent:v11-arm and push it to Local Registry
+- name: Pull teleport-ent:v13-arm and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -9684,7 +9684,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport-ent:v11-arm64 and push it to Local Registry
+- name: Pull teleport-ent:v13-arm64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -9712,7 +9712,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Tag and push image "teleport-ent:v11-amd64" to Quay
+- name: Tag and push image "teleport-ent:v13-amd64" to Quay
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -9739,8 +9739,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-ent:v11-amd64 and push it to Local Registry
-- name: Tag and push image "teleport-ent:v11-arm" to Quay
+  - Pull teleport-ent:v13-amd64 and push it to Local Registry
+- name: Tag and push image "teleport-ent:v13-arm" to Quay
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -9767,8 +9767,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-ent:v11-arm and push it to Local Registry
-- name: Tag and push image "teleport-ent:v11-arm64" to Quay
+  - Pull teleport-ent:v13-arm and push it to Local Registry
+- name: Tag and push image "teleport-ent:v13-arm64" to Quay
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -9795,7 +9795,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-ent:v11-arm64 and push it to Local Registry
+  - Pull teleport-ent:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
@@ -9821,9 +9821,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-amd64" to Quay
-  - Tag and push image "teleport-ent:v11-arm" to Quay
-  - Tag and push image "teleport-ent:v11-arm64" to Quay
+  - Tag and push image "teleport-ent:v13-amd64" to Quay
+  - Tag and push image "teleport-ent:v13-arm" to Quay
+  - Tag and push image "teleport-ent:v13-arm64" to Quay
 - name: Create manifest and push "teleport-ent:minor" to Quay
   image: docker
   commands:
@@ -9849,9 +9849,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-amd64" to Quay
-  - Tag and push image "teleport-ent:v11-arm" to Quay
-  - Tag and push image "teleport-ent:v11-arm64" to Quay
+  - Tag and push image "teleport-ent:v13-amd64" to Quay
+  - Tag and push image "teleport-ent:v13-arm" to Quay
+  - Tag and push image "teleport-ent:v13-arm64" to Quay
 - name: Create manifest and push "teleport-ent:full" to Quay
   image: docker
   commands:
@@ -9875,10 +9875,10 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-amd64" to Quay
-  - Tag and push image "teleport-ent:v11-arm" to Quay
-  - Tag and push image "teleport-ent:v11-arm64" to Quay
-- name: Tag and push image "teleport-ent:v11-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-amd64" to Quay
+  - Tag and push image "teleport-ent:v13-arm" to Quay
+  - Tag and push image "teleport-ent:v13-arm64" to Quay
+- name: Tag and push image "teleport-ent:v13-amd64" to ECR - production
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -9905,8 +9905,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-ent:v11-amd64 and push it to Local Registry
-- name: Tag and push image "teleport-ent:v11-arm" to ECR - production
+  - Pull teleport-ent:v13-amd64 and push it to Local Registry
+- name: Tag and push image "teleport-ent:v13-arm" to ECR - production
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -9932,8 +9932,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-ent:v11-arm and push it to Local Registry
-- name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
+  - Pull teleport-ent:v13-arm and push it to Local Registry
+- name: Tag and push image "teleport-ent:v13-arm64" to ECR - production
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -9960,7 +9960,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-ent:v11-arm64 and push it to Local Registry
+  - Pull teleport-ent:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to ECR - production
   image: docker
   commands:
@@ -9985,9 +9985,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v11-arm" to ECR - production
-  - Tag and push image "teleport-ent:v11-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v13-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor" to ECR - production
   image: docker
   commands:
@@ -10012,9 +10012,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v11-arm" to ECR - production
-  - Tag and push image "teleport-ent:v11-arm64" to ECR - production
+  - Tag and push image "teleport-ent:v13-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm64" to ECR - production
 - name: Create manifest and push "teleport-ent:full" to ECR - production
   image: docker
   commands:
@@ -10037,10 +10037,10 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v11-arm" to ECR - production
-  - Tag and push image "teleport-ent:v11-arm64" to ECR - production
-- name: Pull teleport-ent:v11-fips-amd64 and push it to Local Registry
+  - Tag and push image "teleport-ent:v13-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm64" to ECR - production
+- name: Pull teleport-ent:v13-fips-amd64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -10069,7 +10069,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Tag and push image "teleport-ent:v11-fips-amd64" to Quay
+- name: Tag and push image "teleport-ent:v13-fips-amd64" to Quay
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -10096,7 +10096,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-ent:v11-fips-amd64 and push it to Local Registry
+  - Pull teleport-ent:v13-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
@@ -10120,7 +10120,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
+  - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
@@ -10144,7 +10144,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
+  - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
@@ -10166,8 +10166,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
-- name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
+- name: Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -10194,7 +10194,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-ent:v11-fips-amd64 and push it to Local Registry
+  - Pull teleport-ent:v13-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
   image: docker
   commands:
@@ -10217,7 +10217,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
   image: docker
   commands:
@@ -10240,7 +10240,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
   image: docker
   commands:
@@ -10261,8 +10261,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
-- name: Pull teleport-operator:v11-amd64 and push it to Local Registry
+  - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
+- name: Pull teleport-operator:v13-amd64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -10291,7 +10291,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport-operator:v11-arm and push it to Local Registry
+- name: Pull teleport-operator:v13-arm and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -10320,7 +10320,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Pull teleport-operator:v11-arm64 and push it to Local Registry
+- name: Pull teleport-operator:v13-arm64 and push it to Local Registry
   image: docker
   commands:
   - apk add --no-cache aws-cli
@@ -10349,7 +10349,7 @@ steps:
   - Build major, minor, and full semvers
   - Assume ECR - staging AWS Role
   - Assume ECR - production AWS Role
-- name: Tag and push image "teleport-operator:v11-amd64" to Quay
+- name: Tag and push image "teleport-operator:v13-amd64" to Quay
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -10376,8 +10376,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-operator:v11-amd64 and push it to Local Registry
-- name: Tag and push image "teleport-operator:v11-arm" to Quay
+  - Pull teleport-operator:v13-amd64 and push it to Local Registry
+- name: Tag and push image "teleport-operator:v13-arm" to Quay
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -10404,8 +10404,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-operator:v11-arm and push it to Local Registry
-- name: Tag and push image "teleport-operator:v11-arm64" to Quay
+  - Pull teleport-operator:v13-arm and push it to Local Registry
+- name: Tag and push image "teleport-operator:v13-arm64" to Quay
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -10432,7 +10432,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-operator:v11-arm64 and push it to Local Registry
+  - Pull teleport-operator:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
@@ -10458,9 +10458,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-operator:v11-amd64" to Quay
-  - Tag and push image "teleport-operator:v11-arm" to Quay
-  - Tag and push image "teleport-operator:v11-arm64" to Quay
+  - Tag and push image "teleport-operator:v13-amd64" to Quay
+  - Tag and push image "teleport-operator:v13-arm" to Quay
+  - Tag and push image "teleport-operator:v13-arm64" to Quay
 - name: Create manifest and push "teleport-operator:minor" to Quay
   image: docker
   commands:
@@ -10486,9 +10486,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-operator:v11-amd64" to Quay
-  - Tag and push image "teleport-operator:v11-arm" to Quay
-  - Tag and push image "teleport-operator:v11-arm64" to Quay
+  - Tag and push image "teleport-operator:v13-amd64" to Quay
+  - Tag and push image "teleport-operator:v13-arm" to Quay
+  - Tag and push image "teleport-operator:v13-arm64" to Quay
 - name: Create manifest and push "teleport-operator:full" to Quay
   image: docker
   commands:
@@ -10512,10 +10512,10 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-operator:v11-amd64" to Quay
-  - Tag and push image "teleport-operator:v11-arm" to Quay
-  - Tag and push image "teleport-operator:v11-arm64" to Quay
-- name: Tag and push image "teleport-operator:v11-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v13-amd64" to Quay
+  - Tag and push image "teleport-operator:v13-arm" to Quay
+  - Tag and push image "teleport-operator:v13-arm64" to Quay
+- name: Tag and push image "teleport-operator:v13-amd64" to ECR - production
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -10542,8 +10542,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-operator:v11-amd64 and push it to Local Registry
-- name: Tag and push image "teleport-operator:v11-arm" to ECR - production
+  - Pull teleport-operator:v13-amd64 and push it to Local Registry
+- name: Tag and push image "teleport-operator:v13-arm" to ECR - production
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -10570,8 +10570,8 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-operator:v11-arm and push it to Local Registry
-- name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
+  - Pull teleport-operator:v13-arm and push it to Local Registry
+- name: Tag and push image "teleport-operator:v13-arm64" to ECR - production
   image: docker
   commands:
   - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -10598,7 +10598,7 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Pull teleport-operator:v11-arm64 and push it to Local Registry
+  - Pull teleport-operator:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to ECR - production
   image: docker
   commands:
@@ -10623,9 +10623,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-operator:v11-amd64" to ECR - production
-  - Tag and push image "teleport-operator:v11-arm" to ECR - production
-  - Tag and push image "teleport-operator:v11-arm64" to ECR - production
+  - Tag and push image "teleport-operator:v13-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm64" to ECR - production
 - name: Create manifest and push "teleport-operator:minor" to ECR - production
   image: docker
   commands:
@@ -10650,9 +10650,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-operator:v11-amd64" to ECR - production
-  - Tag and push image "teleport-operator:v11-arm" to ECR - production
-  - Tag and push image "teleport-operator:v11-arm64" to ECR - production
+  - Tag and push image "teleport-operator:v13-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm64" to ECR - production
 - name: Create manifest and push "teleport-operator:full" to ECR - production
   image: docker
   commands:
@@ -10675,9 +10675,9 @@ steps:
   - name: dockersock
     path: /var/run
   depends_on:
-  - Tag and push image "teleport-operator:v11-amd64" to ECR - production
-  - Tag and push image "teleport-operator:v11-arm" to ECR - production
-  - Tag and push image "teleport-operator:v11-arm64" to ECR - production
+  - Tag and push image "teleport-operator:v13-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm64" to ECR - production
 services:
 - name: Start Docker
   image: docker:dind
@@ -10705,6 +10705,5338 @@ volumes:
 kind: pipeline
 type: kubernetes
 name: teleport-container-images-current-version-cron
+environment:
+  DEBIAN_FRONTEND: noninteractive
+trigger:
+  cron:
+    include:
+    - teleport-container-images-cron
+  repo:
+    include:
+    - gravitational/teleport
+workspace:
+  path: /go
+clone:
+  disable: true
+steps:
+- name: Find the latest available semver for v13
+  image: golang:1.18
+  commands:
+  - mkdir -pv "/tmp/teleport"
+  - cd "/tmp/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "branch/v13"
+  - mkdir -pv $(dirname "/go/vars/full-version-v13")
+  - cd "/tmp/teleport/build.assets/tooling/cmd/query-latest"
+  - go run . "v13" | sed 's/v//' > "/go/vars/full-version-v13"
+  - echo Found full semver "$(cat "/go/vars/full-version-v13")" for major version
+    "v13"
+- name: Wait for docker
+  image: docker
+  commands:
+  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  volumes:
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Find the latest available semver for v13
+- name: Wait for docker registry
+  image: alpine
+  commands:
+  - apk add curl
+  - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
+    != "200" ]; do sleep 1; done'
+  depends_on:
+  - Find the latest available semver for v13
+- name: Check out code
+  image: alpine/git:latest
+  commands:
+  - mkdir -pv "/go/src/github.com/gravitational/teleport"
+  - cd "/go/src/github.com/gravitational/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "v$(cat '/go/vars/full-version-v13')"
+  depends_on:
+  - Find the latest available semver for v13
+- name: Build major, minor, and full semvers
+  image: alpine
+  commands:
+  - mkdir -pv $(dirname "/go/var/major-version")
+  - echo v$(cat '/go/vars/full-version-v13') | sed 's/v//' | cut -d'.' -f "1" > "/go/var/major-version"
+  - echo $(cat "/go/var/major-version")
+  - mkdir -pv $(dirname "/go/var/minor-version")
+  - echo v$(cat '/go/vars/full-version-v13') | sed 's/v//' | cut -d'.' -f "1,2" >
+    "/go/var/minor-version"
+  - echo $(cat "/go/var/minor-version")
+  - mkdir -pv $(dirname "/go/var/full-version")
+  - echo v$(cat '/go/vars/full-version-v13') | sed 's/v//' > "/go/var/full-version"
+  - echo $(cat "/go/var/full-version")
+  depends_on:
+  - Find the latest available semver for v13
+- name: Assume ECR - staging AWS Role
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[ecr-staging]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile ecr-staging
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: STAGING_TELEPORT_DRONE_USER_ECR_KEY
+    AWS_ROLE:
+      from_secret: STAGING_TELEPORT_DRONE_ECR_AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: STAGING_TELEPORT_DRONE_USER_ECR_SECRET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Find the latest available semver for v13
+- name: Assume ECR - authenticated-pull AWS Role
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[ecr-authenticated-pull]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile ecr-authenticated-pull
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
+    AWS_ROLE:
+      from_secret: PRODUCTION_TELEPORT_DRONE_ECR_AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_SECRET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume ECR - staging AWS Role
+  - Find the latest available semver for v13
+- name: Assume ECR - production AWS Role
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[ecr-production]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile ecr-production
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
+    AWS_ROLE:
+      from_secret: PRODUCTION_TELEPORT_DRONE_ECR_AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_SECRET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Find the latest available semver for v13
+- name: Assume S3 Download AWS Role for teleport
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[s3-download-teleport]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile s3-download-teleport
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_ROLE:
+      from_secret: AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Find the latest available semver for v13
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+  image: alpine/git:latest
+  commands:
+  - mkdir -pv "/tmp/repo"
+  - cd "/tmp/repo"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "v$(cat '/go/vars/full-version-v13')"
+  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport")
+  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport"
+  depends_on:
+  - Find the latest available semver for v13
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download "teleport_v13-tag_amd64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_amd64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
+    "/go/var/full-version")_amd64.deb /go/build/teleport_$(cat "/go/var/full-version")_amd64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+- name: Build teleport image "teleport:v13-amd64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-v13-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v13-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v13-amd64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-v13-amd64-builder" --config "/tmp/teleport-v13-amd64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-v13-amd64-builder" --target "teleport"
+    --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-v13-amd64-builder"
+  - rm -rf "/tmp/teleport-v13-amd64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport_v13-tag_amd64.deb" artifacts from S3
+- name: Download "teleport_v13-tag_arm.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
+    "/go/var/full-version")_arm.deb /go/build/teleport_$(cat "/go/var/full-version")_arm.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+- name: Build teleport image "teleport:v13-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-v13-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v13-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v13-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-v13-arm-builder" --config "/tmp/teleport-v13-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-v13-arm-builder" --target "teleport"
+    --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-v13-arm-builder"
+  - rm -rf "/tmp/teleport-v13-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport_v13-tag_arm.deb" artifacts from S3
+- name: Download "teleport_v13-tag_arm64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
+    "/go/var/full-version")_arm64.deb /go/build/teleport_$(cat "/go/var/full-version")_arm64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+- name: Build teleport image "teleport:v13-arm64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-v13-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v13-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v13-arm64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-v13-arm64-builder" --config "/tmp/teleport-v13-arm64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-v13-arm64-builder" --target "teleport"
+    --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-v13-arm64-builder"
+  - rm -rf "/tmp/teleport-v13-arm64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport_v13-tag_arm64.deb" artifacts from S3
+- name: Tag and push image "teleport:v13-amd64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-amd64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-amd64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-amd64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-amd64"
+- name: Tag and push image "teleport:v13-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-arm"
+- name: Tag and push image "teleport:v13-arm64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-arm64"
+- name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v13-amd64" to ECR - staging
+  - Tag and push image "teleport:v13-arm" to ECR - staging
+  - Tag and push image "teleport:v13-arm64" to ECR - staging
+- name: Create manifest and push "teleport:minor-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v13-amd64" to ECR - staging
+  - Tag and push image "teleport:v13-arm" to ECR - staging
+  - Tag and push image "teleport:v13-arm64" to ECR - staging
+- name: Create manifest and push "teleport:full-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v13-amd64" to ECR - staging
+  - Tag and push image "teleport:v13-arm" to ECR - staging
+  - Tag and push image "teleport:v13-arm64" to ECR - staging
+- name: Tag and push image "teleport:v13-amd64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
+    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-amd64"
+- name: Tag and push image "teleport:v13-arm" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-arm"
+- name: Tag and push image "teleport:v13-arm64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
+    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-arm64"
+- name: Create manifest and push "teleport:major" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
+    --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
+    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
+    "/go/var/major-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v13-amd64" to Quay
+  - Tag and push image "teleport:v13-arm" to Quay
+  - Tag and push image "teleport:v13-arm64" to Quay
+- name: Create manifest and push "teleport:minor" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
+    --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
+    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
+    "/go/var/minor-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v13-amd64" to Quay
+  - Tag and push image "teleport:v13-arm" to Quay
+  - Tag and push image "teleport:v13-arm64" to Quay
+- name: Create manifest and push "teleport:full" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
+    "/go/var/full-version")-amd64 --amend quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    --amend quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64 &&
+    docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v13-amd64" to Quay
+  - Tag and push image "teleport:v13-arm" to Quay
+  - Tag and push image "teleport:v13-arm64" to Quay
+- name: Tag and push image "teleport:v13-amd64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
+    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-amd64"
+- name: Tag and push image "teleport:v13-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-arm"
+- name: Tag and push image "teleport:v13-arm64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
+    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v13-arm64"
+- name: Create manifest and push "teleport:major" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v13-amd64" to ECR - production
+  - Tag and push image "teleport:v13-arm" to ECR - production
+  - Tag and push image "teleport:v13-arm64" to ECR - production
+- name: Create manifest and push "teleport:minor" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v13-amd64" to ECR - production
+  - Tag and push image "teleport:v13-arm" to ECR - production
+  - Tag and push image "teleport:v13-arm64" to ECR - production
+- name: Create manifest and push "teleport:full" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64 --amend
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm --amend
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 && docker
+    manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version"))
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v13-amd64" to ECR - production
+  - Tag and push image "teleport:v13-arm" to ECR - production
+  - Tag and push image "teleport:v13-arm64" to ECR - production
+- name: Assume S3 Download AWS Role for teleport-ent
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[s3-download-teleport-ent]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile s3-download-teleport-ent
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_ROLE:
+      from_secret: AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Find the latest available semver for v13
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+  image: alpine/git:latest
+  commands:
+  - mkdir -pv "/tmp/repo"
+  - cd "/tmp/repo"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "v$(cat '/go/vars/full-version-v13')"
+  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport-ent")
+  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport-ent"
+  depends_on:
+  - Find the latest available semver for v13
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download "teleport-ent_v13-tag_amd64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_amd64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")_amd64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_amd64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+- name: Build teleport-ent image "teleport-ent:v13-amd64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v13-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v13-amd64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v13-amd64-builder" --config "/tmp/teleport-ent-v13-amd64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-ent-v13-amd64-builder" --target
+    "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
+    DEB_PATH=teleport-ent_$(cat "/go/var/full-version")_amd64.deb /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v13-amd64-builder"
+  - rm -rf "/tmp/teleport-ent-v13-amd64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v13-tag_amd64.deb" artifacts from S3
+- name: Download "teleport-ent_v13-tag_arm.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")_arm.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+- name: Build teleport-ent image "teleport-ent:v13-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v13-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v13-arm-builder" --config "/tmp/teleport-ent-v13-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-ent-v13-arm-builder" --target "teleport"
+    --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
+    "/go/var/full-version")_arm.deb /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v13-arm-builder"
+  - rm -rf "/tmp/teleport-ent-v13-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v13-tag_arm.deb" artifacts from S3
+- name: Download "teleport-ent_v13-tag_arm64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")_arm64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+- name: Build teleport-ent image "teleport-ent:v13-arm64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v13-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v13-arm64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v13-arm64-builder" --config "/tmp/teleport-ent-v13-arm64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-ent-v13-arm64-builder" --target
+    "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
+    DEB_PATH=teleport-ent_$(cat "/go/var/full-version")_arm64.deb /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v13-arm64-builder"
+  - rm -rf "/tmp/teleport-ent-v13-arm64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v13-tag_arm64.deb" artifacts from S3
+- name: Tag and push image "teleport-ent:v13-amd64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-amd64"
+- name: Tag and push image "teleport-ent:v13-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-arm"
+- name: Tag and push image "teleport-ent:v13-arm64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-arm64"
+- name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm64" to ECR - staging
+- name: Create manifest and push "teleport-ent:minor-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm64" to ECR - staging
+- name: Create manifest and push "teleport-ent:full-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm" to ECR - staging
+  - Tag and push image "teleport-ent:v13-arm64" to ECR - staging
+- name: Tag and push image "teleport-ent:v13-amd64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
+    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-amd64"
+- name: Tag and push image "teleport-ent:v13-arm" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-arm"
+- name: Tag and push image "teleport-ent:v13-arm64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-arm64"
+- name: Create manifest and push "teleport-ent:major" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-amd64" to Quay
+  - Tag and push image "teleport-ent:v13-arm" to Quay
+  - Tag and push image "teleport-ent:v13-arm64" to Quay
+- name: Create manifest and push "teleport-ent:minor" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-amd64" to Quay
+  - Tag and push image "teleport-ent:v13-arm" to Quay
+  - Tag and push image "teleport-ent:v13-arm64" to Quay
+- name: Create manifest and push "teleport-ent:full" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64 --amend
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm --amend quay.io/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 && docker manifest push quay.io/gravitational/teleport-ent:$(cat
+    "/go/var/full-version"))
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-amd64" to Quay
+  - Tag and push image "teleport-ent:v13-arm" to Quay
+  - Tag and push image "teleport-ent:v13-arm64" to Quay
+- name: Tag and push image "teleport-ent:v13-amd64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-amd64"
+- name: Tag and push image "teleport-ent:v13-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-arm"
+- name: Tag and push image "teleport-ent:v13-arm64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v13-arm64"
+- name: Create manifest and push "teleport-ent:major" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm64" to ECR - production
+- name: Create manifest and push "teleport-ent:minor" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm64" to ECR - production
+- name: Create manifest and push "teleport-ent:full" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version"))
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm" to ECR - production
+  - Tag and push image "teleport-ent:v13-arm64" to ECR - production
+- name: Assume S3 Download AWS Role for teleport-ent-fips
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[s3-download-teleport-ent-fips]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile s3-download-teleport-ent-fips
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_ROLE:
+      from_secret: AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Find the latest available semver for v13
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for
+    teleport-ent-fips
+  image: alpine/git:latest
+  commands:
+  - mkdir -pv "/tmp/repo"
+  - cd "/tmp/repo"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "v$(cat '/go/vars/full-version-v13')"
+  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport-ent-fips")
+  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport-ent-fips"
+  depends_on:
+  - Find the latest available semver for v13
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download "teleport-ent_v13-tag-fips_amd64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")-fips_amd64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent-fips
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent-fips
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for teleport-ent-fips
+- name: Build teleport-ent-fips image "teleport-ent:v13-fips-amd64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v13-fips-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v13-fips-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v13-fips-amd64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v13-fips-amd64-builder" --config "/tmp/teleport-ent-v13-fips-amd64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-ent-v13-fips-amd64-builder" --target
+    "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
+    --build-arg DEB_PATH=teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v13-fips-amd64-builder"
+  - rm -rf "/tmp/teleport-ent-v13-fips-amd64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v13-tag-fips_amd64.deb" artifacts from S3
+- name: Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v13-fips-amd64"
+- name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
+- name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
+- name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
+- name: Tag and push image "teleport-ent:v13-fips-amd64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v13-fips-amd64"
+- name: Create manifest and push "teleport-ent:major-fips" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
+- name: Create manifest and push "teleport-ent:minor-fips" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
+- name: Create manifest and push "teleport-ent:full-fips" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64 &&
+    docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
+- name: Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v13-fips-amd64"
+- name: Create manifest and push "teleport-ent:major-fips" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
+- name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
+- name: Create manifest and push "teleport-ent:full-fips" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
+- name: Build teleport-operator image "teleport-operator:v13-amd64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
+  - mkdir -pv "/tmp/teleport-operator-v13-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v13-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-operator-v13-amd64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-operator-v13-amd64-builder" --config "/tmp/teleport-operator-v13-amd64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-operator-v13-amd64-builder" --platform
+    "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+    --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:teleport13 --build-arg
+    COMPILER_NAME=x86_64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-operator-v13-amd64-builder"
+  - rm -rf "/tmp/teleport-operator-v13-amd64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Find the latest available semver for v13
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Build teleport-operator image "teleport-operator:v13-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
+  - mkdir -pv "/tmp/teleport-operator-v13-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v13-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-operator-v13-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-operator-v13-arm-builder" --config "/tmp/teleport-operator-v13-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-operator-v13-arm-builder" --platform
+    "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+    --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
+    COMPILER_NAME=arm-linux-gnueabihf-gcc /go/src/github.com/gravitational/teleport
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-operator-v13-arm-builder"
+  - rm -rf "/tmp/teleport-operator-v13-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Find the latest available semver for v13
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Build teleport-operator image "teleport-operator:v13-arm64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
+  - mkdir -pv "/tmp/teleport-operator-v13-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v13-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-operator-v13-arm64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-operator-v13-arm64-builder" --config "/tmp/teleport-operator-v13-arm64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-operator-v13-arm64-builder" --platform
+    "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+    --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
+    COMPILER_NAME=aarch64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-operator-v13-arm64-builder"
+  - rm -rf "/tmp/teleport-operator-v13-arm64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Find the latest available semver for v13
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Tag and push image "teleport-operator:v13-amd64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v13-amd64"
+- name: Tag and push image "teleport-operator:v13-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v13-arm"
+- name: Tag and push image "teleport-operator:v13-arm64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v13-arm64"
+- name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v13-amd64" to ECR - staging
+  - Tag and push image "teleport-operator:v13-arm" to ECR - staging
+  - Tag and push image "teleport-operator:v13-arm64" to ECR - staging
+- name: Create manifest and push "teleport-operator:minor-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v13-amd64" to ECR - staging
+  - Tag and push image "teleport-operator:v13-arm" to ECR - staging
+  - Tag and push image "teleport-operator:v13-arm64" to ECR - staging
+- name: Create manifest and push "teleport-operator:full-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v13-amd64" to ECR - staging
+  - Tag and push image "teleport-operator:v13-arm" to ECR - staging
+  - Tag and push image "teleport-operator:v13-arm64" to ECR - staging
+- name: Tag and push image "teleport-operator:v13-amd64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
+    && docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v13-amd64"
+- name: Tag and push image "teleport-operator:v13-arm" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
+    && docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v13-arm"
+- name: Tag and push image "teleport-operator:v13-arm64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
+    && docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v13-arm64"
+- name: Create manifest and push "teleport-operator:major" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v13-amd64" to Quay
+  - Tag and push image "teleport-operator:v13-arm" to Quay
+  - Tag and push image "teleport-operator:v13-arm64" to Quay
+- name: Create manifest and push "teleport-operator:minor" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v13-amd64" to Quay
+  - Tag and push image "teleport-operator:v13-arm" to Quay
+  - Tag and push image "teleport-operator:v13-arm64" to Quay
+- name: Create manifest and push "teleport-operator:full" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64 --amend
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm --amend
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64 &&
+    docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v13-amd64" to Quay
+  - Tag and push image "teleport-operator:v13-arm" to Quay
+  - Tag and push image "teleport-operator:v13-arm64" to Quay
+- name: Tag and push image "teleport-operator:v13-amd64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 && docker push public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v13-amd64"
+- name: Tag and push image "teleport-operator:v13-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-arm && docker push public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v13-arm"
+- name: Tag and push image "teleport-operator:v13-arm64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 && docker push public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v13-arm64"
+- name: Create manifest and push "teleport-operator:major" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v13-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm64" to ECR - production
+- name: Create manifest and push "teleport-operator:minor" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v13-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm64" to ECR - production
+- name: Create manifest and push "teleport-operator:full" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
+    && docker manifest push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version"))
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v13-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm" to ECR - production
+  - Tag and push image "teleport-operator:v13-arm64" to ECR - production
+services:
+- name: Start Docker
+  image: docker:dind
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+- name: drone-docker-registry
+  image: registry:2
+  privileged: false
+  volumes: []
+volumes:
+- name: awsconfig
+  temp: {}
+- name: dockersock
+  temp: {}
+
+---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/container_images_release_version.go (main.(*ReleaseVersion).buildVersionPipeline)
+################################################
+
+kind: pipeline
+type: kubernetes
+name: teleport-container-images-previous-version-1-cron
+environment:
+  DEBIAN_FRONTEND: noninteractive
+trigger:
+  cron:
+    include:
+    - teleport-container-images-cron
+  repo:
+    include:
+    - gravitational/teleport
+workspace:
+  path: /go
+clone:
+  disable: true
+steps:
+- name: Find the latest available semver for v12
+  image: golang:1.18
+  commands:
+  - mkdir -pv "/tmp/teleport"
+  - cd "/tmp/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "branch/v12"
+  - mkdir -pv $(dirname "/go/vars/full-version-v12")
+  - cd "/tmp/teleport/build.assets/tooling/cmd/query-latest"
+  - go run . "v12" | sed 's/v//' > "/go/vars/full-version-v12"
+  - echo Found full semver "$(cat "/go/vars/full-version-v12")" for major version
+    "v12"
+- name: Wait for docker
+  image: docker
+  commands:
+  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  volumes:
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Find the latest available semver for v12
+- name: Wait for docker registry
+  image: alpine
+  commands:
+  - apk add curl
+  - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
+    != "200" ]; do sleep 1; done'
+  depends_on:
+  - Find the latest available semver for v12
+- name: Check out code
+  image: alpine/git:latest
+  commands:
+  - mkdir -pv "/go/src/github.com/gravitational/teleport"
+  - cd "/go/src/github.com/gravitational/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "v$(cat '/go/vars/full-version-v12')"
+  depends_on:
+  - Find the latest available semver for v12
+- name: Build major, minor, and full semvers
+  image: alpine
+  commands:
+  - mkdir -pv $(dirname "/go/var/major-version")
+  - echo v$(cat '/go/vars/full-version-v12') | sed 's/v//' | cut -d'.' -f "1" > "/go/var/major-version"
+  - echo $(cat "/go/var/major-version")
+  - mkdir -pv $(dirname "/go/var/minor-version")
+  - echo v$(cat '/go/vars/full-version-v12') | sed 's/v//' | cut -d'.' -f "1,2" >
+    "/go/var/minor-version"
+  - echo $(cat "/go/var/minor-version")
+  - mkdir -pv $(dirname "/go/var/full-version")
+  - echo v$(cat '/go/vars/full-version-v12') | sed 's/v//' > "/go/var/full-version"
+  - echo $(cat "/go/var/full-version")
+  depends_on:
+  - Find the latest available semver for v12
+- name: Assume ECR - staging AWS Role
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[ecr-staging]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile ecr-staging
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: STAGING_TELEPORT_DRONE_USER_ECR_KEY
+    AWS_ROLE:
+      from_secret: STAGING_TELEPORT_DRONE_ECR_AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: STAGING_TELEPORT_DRONE_USER_ECR_SECRET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Find the latest available semver for v12
+- name: Assume ECR - authenticated-pull AWS Role
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[ecr-authenticated-pull]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile ecr-authenticated-pull
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
+    AWS_ROLE:
+      from_secret: PRODUCTION_TELEPORT_DRONE_ECR_AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_SECRET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume ECR - staging AWS Role
+  - Find the latest available semver for v12
+- name: Assume ECR - production AWS Role
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[ecr-production]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile ecr-production
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
+    AWS_ROLE:
+      from_secret: PRODUCTION_TELEPORT_DRONE_ECR_AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_SECRET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Find the latest available semver for v12
+- name: Assume S3 Download AWS Role for teleport
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[s3-download-teleport]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile s3-download-teleport
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_ROLE:
+      from_secret: AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Find the latest available semver for v12
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+  image: alpine/git:latest
+  commands:
+  - mkdir -pv "/tmp/repo"
+  - cd "/tmp/repo"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "v$(cat '/go/vars/full-version-v12')"
+  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport")
+  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport"
+  depends_on:
+  - Find the latest available semver for v12
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download "teleport_v12-tag_amd64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_amd64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
+    "/go/var/full-version")_amd64.deb /go/build/teleport_$(cat "/go/var/full-version")_amd64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+- name: Build teleport image "teleport:v12-amd64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-v12-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v12-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v12-amd64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-v12-amd64-builder" --config "/tmp/teleport-v12-amd64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-v12-amd64-builder" --target "teleport"
+    --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-v12-amd64-builder"
+  - rm -rf "/tmp/teleport-v12-amd64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport_v12-tag_amd64.deb" artifacts from S3
+- name: Download "teleport_v12-tag_arm.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
+    "/go/var/full-version")_arm.deb /go/build/teleport_$(cat "/go/var/full-version")_arm.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+- name: Build teleport image "teleport:v12-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-v12-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v12-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v12-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-v12-arm-builder" --config "/tmp/teleport-v12-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-v12-arm-builder" --target "teleport"
+    --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-v12-arm-builder"
+  - rm -rf "/tmp/teleport-v12-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport_v12-tag_arm.deb" artifacts from S3
+- name: Download "teleport_v12-tag_arm64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
+    "/go/var/full-version")_arm64.deb /go/build/teleport_$(cat "/go/var/full-version")_arm64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
+- name: Build teleport image "teleport:v12-arm64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-v12-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v12-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-v12-arm64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-v12-arm64-builder" --config "/tmp/teleport-v12-arm64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-v12-arm64-builder" --target "teleport"
+    --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-v12-arm64-builder"
+  - rm -rf "/tmp/teleport-v12-arm64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport_v12-tag_arm64.deb" artifacts from S3
+- name: Tag and push image "teleport:v12-amd64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-amd64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-amd64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-amd64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-amd64"
+- name: Tag and push image "teleport:v12-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-arm"
+- name: Tag and push image "teleport:v12-arm64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm64
+    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-arm64"
+- name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/major-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v12-amd64" to ECR - staging
+  - Tag and push image "teleport:v12-arm" to ECR - staging
+  - Tag and push image "teleport:v12-arm64" to ECR - staging
+- name: Create manifest and push "teleport:minor-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/minor-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v12-amd64" to ECR - staging
+  - Tag and push image "teleport:v12-arm" to ECR - staging
+  - Tag and push image "teleport:v12-arm64" to ECR - staging
+- name: Create manifest and push "teleport:full-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
+    "/go/var/full-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v12-amd64" to ECR - staging
+  - Tag and push image "teleport:v12-arm" to ECR - staging
+  - Tag and push image "teleport:v12-arm64" to ECR - staging
+- name: Tag and push image "teleport:v12-amd64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
+    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-amd64"
+- name: Tag and push image "teleport:v12-arm" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-arm"
+- name: Tag and push image "teleport:v12-arm64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
+    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-arm64"
+- name: Create manifest and push "teleport:major" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
+    --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
+    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
+    "/go/var/major-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v12-amd64" to Quay
+  - Tag and push image "teleport:v12-arm" to Quay
+  - Tag and push image "teleport:v12-arm64" to Quay
+- name: Create manifest and push "teleport:minor" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
+    --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
+    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
+    "/go/var/minor-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v12-amd64" to Quay
+  - Tag and push image "teleport:v12-arm" to Quay
+  - Tag and push image "teleport:v12-arm64" to Quay
+- name: Create manifest and push "teleport:full" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
+    "/go/var/full-version")-amd64 --amend quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    --amend quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64 &&
+    docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v12-amd64" to Quay
+  - Tag and push image "teleport:v12-arm" to Quay
+  - Tag and push image "teleport:v12-arm64" to Quay
+- name: Tag and push image "teleport:v12-amd64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
+    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-amd64"
+- name: Tag and push image "teleport:v12-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-arm"
+- name: Tag and push image "teleport:v12-arm64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
+    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
+    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport image "teleport:v12-arm64"
+- name: Create manifest and push "teleport:major" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v12-amd64" to ECR - production
+  - Tag and push image "teleport:v12-arm" to ECR - production
+  - Tag and push image "teleport:v12-arm64" to ECR - production
+- name: Create manifest and push "teleport:minor" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
+    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v12-amd64" to ECR - production
+  - Tag and push image "teleport:v12-arm" to ECR - production
+  - Tag and push image "teleport:v12-arm64" to ECR - production
+- name: Create manifest and push "teleport:full" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64 --amend
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm --amend
+    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 && docker
+    manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version"))
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport:v12-amd64" to ECR - production
+  - Tag and push image "teleport:v12-arm" to ECR - production
+  - Tag and push image "teleport:v12-arm64" to ECR - production
+- name: Assume S3 Download AWS Role for teleport-ent
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[s3-download-teleport-ent]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile s3-download-teleport-ent
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_ROLE:
+      from_secret: AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Find the latest available semver for v12
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+  image: alpine/git:latest
+  commands:
+  - mkdir -pv "/tmp/repo"
+  - cd "/tmp/repo"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "v$(cat '/go/vars/full-version-v12')"
+  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport-ent")
+  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport-ent"
+  depends_on:
+  - Find the latest available semver for v12
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download "teleport-ent_v12-tag_amd64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_amd64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")_amd64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_amd64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+- name: Build teleport-ent image "teleport-ent:v12-amd64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v12-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v12-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v12-amd64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v12-amd64-builder" --config "/tmp/teleport-ent-v12-amd64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-ent-v12-amd64-builder" --target
+    "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
+    DEB_PATH=teleport-ent_$(cat "/go/var/full-version")_amd64.deb /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v12-amd64-builder"
+  - rm -rf "/tmp/teleport-ent-v12-amd64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v12-tag_amd64.deb" artifacts from S3
+- name: Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")_arm.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+- name: Build teleport-ent image "teleport-ent:v12-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v12-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v12-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v12-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v12-arm-builder" --config "/tmp/teleport-ent-v12-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-ent-v12-arm-builder" --target "teleport"
+    --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
+    "/go/var/full-version")_arm.deb /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v12-arm-builder"
+  - rm -rf "/tmp/teleport-ent-v12-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
+- name: Download "teleport-ent_v12-tag_arm64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")_arm64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
+- name: Build teleport-ent image "teleport-ent:v12-arm64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v12-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v12-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v12-arm64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v12-arm64-builder" --config "/tmp/teleport-ent-v12-arm64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-ent-v12-arm64-builder" --target
+    "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
+    DEB_PATH=teleport-ent_$(cat "/go/var/full-version")_arm64.deb /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v12-arm64-builder"
+  - rm -rf "/tmp/teleport-ent-v12-arm64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v12-tag_arm64.deb" artifacts from S3
+- name: Tag and push image "teleport-ent:v12-amd64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-amd64"
+- name: Tag and push image "teleport-ent:v12-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-arm"
+- name: Tag and push image "teleport-ent:v12-arm64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-arm64"
+- name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v12-arm" to ECR - staging
+  - Tag and push image "teleport-ent:v12-arm64" to ECR - staging
+- name: Create manifest and push "teleport-ent:minor-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v12-arm" to ECR - staging
+  - Tag and push image "teleport-ent:v12-arm64" to ECR - staging
+- name: Create manifest and push "teleport-ent:full-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
+  - Tag and push image "teleport-ent:v12-arm" to ECR - staging
+  - Tag and push image "teleport-ent:v12-arm64" to ECR - staging
+- name: Tag and push image "teleport-ent:v12-amd64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
+    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-amd64"
+- name: Tag and push image "teleport-ent:v12-arm" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-arm"
+- name: Tag and push image "teleport-ent:v12-arm64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-arm64"
+- name: Create manifest and push "teleport-ent:major" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-amd64" to Quay
+  - Tag and push image "teleport-ent:v12-arm" to Quay
+  - Tag and push image "teleport-ent:v12-arm64" to Quay
+- name: Create manifest and push "teleport-ent:minor" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-amd64" to Quay
+  - Tag and push image "teleport-ent:v12-arm" to Quay
+  - Tag and push image "teleport-ent:v12-arm64" to Quay
+- name: Create manifest and push "teleport-ent:full" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64 --amend
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm --amend quay.io/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 && docker manifest push quay.io/gravitational/teleport-ent:$(cat
+    "/go/var/full-version"))
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-amd64" to Quay
+  - Tag and push image "teleport-ent:v12-arm" to Quay
+  - Tag and push image "teleport-ent:v12-arm64" to Quay
+- name: Tag and push image "teleport-ent:v12-amd64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-amd64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-amd64"
+- name: Tag and push image "teleport-ent:v12-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-arm"
+- name: Tag and push image "teleport-ent:v12-arm64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-arm64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent image "teleport-ent:v12-arm64"
+- name: Create manifest and push "teleport-ent:major" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v12-arm" to ECR - production
+  - Tag and push image "teleport-ent:v12-arm64" to ECR - production
+- name: Create manifest and push "teleport-ent:minor" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v12-arm" to ECR - production
+  - Tag and push image "teleport-ent:v12-arm64" to ECR - production
+- name: Create manifest and push "teleport-ent:full" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
+    && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version"))
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-amd64" to ECR - production
+  - Tag and push image "teleport-ent:v12-arm" to ECR - production
+  - Tag and push image "teleport-ent:v12-arm64" to ECR - production
+- name: Assume S3 Download AWS Role for teleport-ent-fips
+  image: amazon/aws-cli
+  commands:
+  - aws sts get-caller-identity
+  - |-
+    printf "[s3-download-teleport-ent-fips]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+      $(aws sts assume-role \
+        --role-arn "$AWS_ROLE" \
+        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+        --output text) \
+      >> /root/.aws/credentials
+  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  - aws sts get-caller-identity --profile s3-download-teleport-ent-fips
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_ROLE:
+      from_secret: AWS_ROLE
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Find the latest available semver for v12
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for
+    teleport-ent-fips
+  image: alpine/git:latest
+  commands:
+  - mkdir -pv "/tmp/repo"
+  - cd "/tmp/repo"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "v$(cat '/go/vars/full-version-v12')"
+  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport-ent-fips")
+  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport-ent-fips"
+  depends_on:
+  - Find the latest available semver for v12
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Download "teleport-ent_v12-tag-fips_amd64.deb" artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - END_TIME=$(( $(date +%s) + 3600 ))
+  - TIMED_OUT=true
+  - while [ $(date +%s) -lt $${END_TIME?} ]; do
+  - SUCCESS=true
+  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
+    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
+    || SUCCESS=false
+  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
+  - echo 'Condition not met yet, waiting another 60 seconds...'
+  - sleep 60
+  - done
+  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
+    "$SUCCESS" = "true" ]'' && exit 1'
+  - mkdir -pv "/go/build"
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
+    "/go/var/full-version")-fips_amd64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
+  environment:
+    AWS_PROFILE: s3-download-teleport-ent-fips
+    AWS_REGION: us-west-2
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  depends_on:
+  - Assume S3 Download AWS Role for teleport-ent-fips
+  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for teleport-ent-fips
+- name: Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/build" && cd "/go/build"
+  - mkdir -pv "/tmp/teleport-ent-v12-fips-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v12-fips-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-ent-v12-fips-amd64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-ent-v12-fips-amd64-builder" --config "/tmp/teleport-ent-v12-fips-amd64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-ent-v12-fips-amd64-builder" --target
+    "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
+    --build-arg DEB_PATH=teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
+    /go/build
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-ent-v12-fips-amd64-builder"
+  - rm -rf "/tmp/teleport-ent-v12-fips-amd64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Download "teleport-ent_v12-tag-fips_amd64.deb" artifacts from S3
+- name: Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
+    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
+- name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/major-version")-$TIMESTAMP-fips)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
+- name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-fips)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
+- name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-$TIMESTAMP-fips)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
+- name: Tag and push image "teleport-ent:v12-fips-amd64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
+- name: Create manifest and push "teleport-ent:major-fips" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
+- name: Create manifest and push "teleport-ent:minor-fips" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
+    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
+- name: Create manifest and push "teleport-ent:full-fips" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
+    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64 &&
+    docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
+- name: Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
+    "/go/var/full-version")-fips-amd64)
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
+- name: Create manifest and push "teleport-ent:major-fips" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
+  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
+- name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
+  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
+- name: Create manifest and push "teleport-ent:full-fips" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
+    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
+    && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
+- name: Build teleport-operator image "teleport-operator:v12-amd64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
+  - mkdir -pv "/tmp/teleport-operator-v12-amd64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v12-amd64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-operator-v12-amd64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-operator-v12-amd64-builder" --config "/tmp/teleport-operator-v12-amd64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-operator-v12-amd64-builder" --platform
+    "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+    --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:teleport13 --build-arg
+    COMPILER_NAME=x86_64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-operator-v12-amd64-builder"
+  - rm -rf "/tmp/teleport-operator-v12-amd64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Find the latest available semver for v12
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Build teleport-operator image "teleport-operator:v12-arm"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
+  - mkdir -pv "/tmp/teleport-operator-v12-arm-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v12-arm-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-operator-v12-arm-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-operator-v12-arm-builder" --config "/tmp/teleport-operator-v12-arm-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-operator-v12-arm-builder" --platform
+    "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+    --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
+    COMPILER_NAME=arm-linux-gnueabihf-gcc /go/src/github.com/gravitational/teleport
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-operator-v12-arm-builder"
+  - rm -rf "/tmp/teleport-operator-v12-arm-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Find the latest available semver for v12
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Build teleport-operator image "teleport-operator:v12-arm64"
+  image: docker
+  commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
+  - mkdir -pv "/tmp/teleport-operator-v12-arm64-builder"
+  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v12-arm64-builder/buildkitd.toml"
+  - echo '  http = true' >> "/tmp/teleport-operator-v12-arm64-builder/buildkitd.toml"
+  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
+    "teleport-operator-v12-arm64-builder" --config "/tmp/teleport-operator-v12-arm64-builder/buildkitd.toml"
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker buildx build --push --builder "teleport-operator-v12-arm64-builder" --platform
+    "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+    --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
+    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
+    COMPILER_NAME=aarch64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
+  - docker logout "public.ecr.aws"
+  - docker buildx rm "teleport-operator-v12-arm64-builder"
+  - rm -rf "/tmp/teleport-operator-v12-arm64-builder"
+  environment:
+    AWS_PROFILE: ecr-authenticated-pull
+    DOCKER_BUILDKIT: "1"
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Assume ECR - authenticated-pull AWS Role
+  - Find the latest available semver for v12
+  - Wait for docker
+  - Wait for docker registry
+  - Check out code
+  - Build major, minor, and full semvers
+  - Assume ECR - staging AWS Role
+  - Assume ECR - authenticated-pull AWS Role
+  - Assume ECR - production AWS Role
+- name: Tag and push image "teleport-operator:v12-amd64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v12-amd64"
+- name: Tag and push image "teleport-operator:v12-arm" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v12-arm"
+- name: Tag and push image "teleport-operator:v12-arm64" to ECR - staging
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64)
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
+    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v12-arm64"
+- name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/major-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
+  - Tag and push image "teleport-operator:v12-arm" to ECR - staging
+  - Tag and push image "teleport-operator:v12-arm64" to ECR - staging
+- name: Create manifest and push "teleport-operator:minor-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/minor-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
+  - Tag and push image "teleport-operator:v12-arm" to ECR - staging
+  - Tag and push image "teleport-operator:v12-arm64" to ECR - staging
+- name: Create manifest and push "teleport-operator:full-$TIMESTAMP" to ECR - staging
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
+    146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
+  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
+    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-$TIMESTAMP)
+  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
+  environment:
+    AWS_PROFILE: ecr-staging
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
+  - Tag and push image "teleport-operator:v12-arm" to ECR - staging
+  - Tag and push image "teleport-operator:v12-arm64" to ECR - staging
+- name: Tag and push image "teleport-operator:v12-amd64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
+    && docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v12-amd64"
+- name: Tag and push image "teleport-operator:v12-arm" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
+    && docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v12-arm"
+- name: Tag and push image "teleport-operator:v12-arm64" to Quay
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
+    && docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v12-arm64"
+- name: Create manifest and push "teleport-operator:major" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v12-amd64" to Quay
+  - Tag and push image "teleport-operator:v12-arm" to Quay
+  - Tag and push image "teleport-operator:v12-arm64" to Quay
+- name: Create manifest and push "teleport-operator:minor" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v12-amd64" to Quay
+  - Tag and push image "teleport-operator:v12-arm" to Quay
+  - Tag and push image "teleport-operator:v12-arm64" to Quay
+- name: Create manifest and push "teleport-operator:full" to Quay
+  image: docker
+  commands:
+  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64 --amend
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm --amend
+    quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64 &&
+    docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
+  - docker logout "quay.io"
+  environment:
+    QUAY_PASSWORD:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    QUAY_USERNAME:
+      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v12-amd64" to Quay
+  - Tag and push image "teleport-operator:v12-arm" to Quay
+  - Tag and push image "teleport-operator:v12-arm64" to Quay
+- name: Tag and push image "teleport-operator:v12-amd64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-amd64 && docker push public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-amd64)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v12-amd64"
+- name: Tag and push image "teleport-operator:v12-arm" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-arm && docker push public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-arm)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v12-arm"
+- name: Tag and push image "teleport-operator:v12-arm64" to ECR - production
+  image: docker
+  commands:
+  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-arm64 && docker push public.ecr.aws/gravitational/teleport-operator:$(cat
+    "/go/var/full-version")-arm64)
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
+    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Build teleport-operator image "teleport-operator:v12-arm64"
+- name: Create manifest and push "teleport-operator:major" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v12-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v12-arm" to ECR - production
+  - Tag and push image "teleport-operator:v12-arm64" to ECR - production
+- name: Create manifest and push "teleport-operator:minor" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
+  - docker manifest push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v12-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v12-arm" to ECR - production
+  - Tag and push image "teleport-operator:v12-arm64" to ECR - production
+- name: Create manifest and push "teleport-operator:full" to ECR - production
+  image: docker
+  commands:
+  - apk add --no-cache aws-cli
+  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
+    public.ecr.aws
+  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
+    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
+    create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
+    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
+    && docker manifest push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version"))
+  - docker logout "public.ecr.aws"
+  environment:
+    AWS_PROFILE: ecr-production
+  volumes:
+  - name: awsconfig
+    path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  depends_on:
+  - Tag and push image "teleport-operator:v12-amd64" to ECR - production
+  - Tag and push image "teleport-operator:v12-arm" to ECR - production
+  - Tag and push image "teleport-operator:v12-arm64" to ECR - production
+services:
+- name: Start Docker
+  image: docker:dind
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+- name: drone-docker-registry
+  image: registry:2
+  privileged: false
+  volumes: []
+volumes:
+- name: awsconfig
+  temp: {}
+- name: dockersock
+  temp: {}
+
+---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/container_images_release_version.go (main.(*ReleaseVersion).buildVersionPipeline)
+################################################
+
+kind: pipeline
+type: kubernetes
+name: teleport-container-images-previous-version-2-cron
 environment:
   DEBIAN_FRONTEND: noninteractive
 trigger:
@@ -13365,4717 +18697,6 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/container_images_release_version.go (main.(*ReleaseVersion).buildVersionPipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
-name: teleport-container-images-previous-version-1-cron
-environment:
-  DEBIAN_FRONTEND: noninteractive
-trigger:
-  cron:
-    include:
-    - teleport-container-images-cron
-  repo:
-    include:
-    - gravitational/teleport
-workspace:
-  path: /go
-clone:
-  disable: true
-steps:
-- name: Find the latest available semver for v10
-  image: golang:1.18
-  commands:
-  - mkdir -pv "/tmp/teleport"
-  - cd "/tmp/teleport"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "branch/v10"
-  - mkdir -pv $(dirname "/go/vars/full-version-v10")
-  - cd "/tmp/teleport/build.assets/tooling/cmd/query-latest"
-  - go run . "v10" | sed 's/v//' > "/go/vars/full-version-v10"
-  - echo Found full semver "$(cat "/go/vars/full-version-v10")" for major version
-    "v10"
-- name: Wait for docker
-  image: docker
-  commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  volumes:
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Find the latest available semver for v10
-- name: Wait for docker registry
-  image: alpine
-  commands:
-  - apk add curl
-  - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
-    != "200" ]; do sleep 1; done'
-  depends_on:
-  - Find the latest available semver for v10
-- name: Check out code
-  image: alpine/git:latest
-  commands:
-  - mkdir -pv "/go/src/github.com/gravitational/teleport"
-  - cd "/go/src/github.com/gravitational/teleport"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "v$(cat '/go/vars/full-version-v10')"
-  depends_on:
-  - Find the latest available semver for v10
-- name: Build major, minor, and full semvers
-  image: alpine
-  commands:
-  - mkdir -pv $(dirname "/go/var/major-version")
-  - echo v$(cat '/go/vars/full-version-v10') | sed 's/v//' | cut -d'.' -f "1" > "/go/var/major-version"
-  - echo $(cat "/go/var/major-version")
-  - mkdir -pv $(dirname "/go/var/minor-version")
-  - echo v$(cat '/go/vars/full-version-v10') | sed 's/v//' | cut -d'.' -f "1,2" >
-    "/go/var/minor-version"
-  - echo $(cat "/go/var/minor-version")
-  - mkdir -pv $(dirname "/go/var/full-version")
-  - echo v$(cat '/go/vars/full-version-v10') | sed 's/v//' > "/go/var/full-version"
-  - echo $(cat "/go/var/full-version")
-  depends_on:
-  - Find the latest available semver for v10
-- name: Assume ECR - staging AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[ecr-staging]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile ecr-staging
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: STAGING_TELEPORT_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: STAGING_TELEPORT_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: STAGING_TELEPORT_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Find the latest available semver for v10
-- name: Assume ECR - authenticated-pull AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[ecr-authenticated-pull]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile ecr-authenticated-pull
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: PRODUCTION_TELEPORT_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume ECR - staging AWS Role
-  - Find the latest available semver for v10
-- name: Assume ECR - production AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[ecr-production]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile ecr-production
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: PRODUCTION_TELEPORT_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Find the latest available semver for v10
-- name: Assume S3 Download AWS Role for teleport
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[s3-download-teleport]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile s3-download-teleport
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Find the latest available semver for v10
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-  image: alpine/git:latest
-  commands:
-  - mkdir -pv "/tmp/repo"
-  - cd "/tmp/repo"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "v$(cat '/go/vars/full-version-v10')"
-  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport")
-  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport"
-  depends_on:
-  - Find the latest available semver for v10
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download "teleport_v10-tag_amd64.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_amd64.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
-    "/go/var/full-version")_amd64.deb /go/build/teleport_$(cat "/go/var/full-version")_amd64.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v10-amd64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v10-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v10-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v10-amd64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v10-amd64-builder" --config "/tmp/teleport-v10-amd64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-v10-amd64-builder" --target "teleport"
-    --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v10-amd64-builder"
-  - rm -rf "/tmp/teleport-v10-amd64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v10-tag_amd64.deb" artifacts from S3
-- name: Download "teleport_v10-tag_arm.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
-    "/go/var/full-version")_arm.deb /go/build/teleport_$(cat "/go/var/full-version")_arm.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v10-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v10-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v10-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v10-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v10-arm-builder" --config "/tmp/teleport-v10-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-v10-arm-builder" --target "teleport"
-    --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v10-arm-builder"
-  - rm -rf "/tmp/teleport-v10-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v10-tag_arm.deb" artifacts from S3
-- name: Download "teleport_v10-tag_arm64.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm64.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
-    "/go/var/full-version")_arm64.deb /go/build/teleport_$(cat "/go/var/full-version")_arm64.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v10-arm64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v10-arm64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v10-arm64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v10-arm64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v10-arm64-builder" --config "/tmp/teleport-v10-arm64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-v10-arm64-builder" --target "teleport"
-    --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v10-arm64-builder"
-  - rm -rf "/tmp/teleport-v10-arm64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v10-tag_arm64.deb" artifacts from S3
-- name: Tag and push image "teleport:v10-amd64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-amd64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-amd64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-amd64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v10-amd64"
-- name: Tag and push image "teleport:v10-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v10-arm"
-- name: Tag and push image "teleport:v10-arm64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v10-arm64"
-- name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v10-amd64" to ECR - staging
-  - Tag and push image "teleport:v10-arm" to ECR - staging
-  - Tag and push image "teleport:v10-arm64" to ECR - staging
-- name: Create manifest and push "teleport:minor-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v10-amd64" to ECR - staging
-  - Tag and push image "teleport:v10-arm" to ECR - staging
-  - Tag and push image "teleport:v10-arm64" to ECR - staging
-- name: Create manifest and push "teleport:full-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v10-amd64" to ECR - staging
-  - Tag and push image "teleport:v10-arm" to ECR - staging
-  - Tag and push image "teleport:v10-arm64" to ECR - staging
-- name: Tag and push image "teleport:v10-amd64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
-    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v10-amd64"
-- name: Tag and push image "teleport:v10-arm" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v10-arm"
-- name: Tag and push image "teleport:v10-arm64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
-    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm64
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm64
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v10-arm64"
-- name: Create manifest and push "teleport:major" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
-    --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
-    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
-    "/go/var/major-version")-arm64
-  - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v10-amd64" to Quay
-  - Tag and push image "teleport:v10-arm" to Quay
-  - Tag and push image "teleport:v10-arm64" to Quay
-- name: Create manifest and push "teleport:minor" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
-    --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
-    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
-    "/go/var/minor-version")-arm64
-  - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v10-amd64" to Quay
-  - Tag and push image "teleport:v10-arm" to Quay
-  - Tag and push image "teleport:v10-arm64" to Quay
-- name: Create manifest and push "teleport:full" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
-    "/go/var/full-version")-amd64 --amend quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    --amend quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64 &&
-    docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v10-amd64" to Quay
-  - Tag and push image "teleport:v10-arm" to Quay
-  - Tag and push image "teleport:v10-arm64" to Quay
-- name: Tag and push image "teleport:v10-amd64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
-    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v10-amd64"
-- name: Tag and push image "teleport:v10-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v10-arm"
-- name: Tag and push image "teleport:v10-arm64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
-    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v10-arm64"
-- name: Create manifest and push "teleport:major" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
-  - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v10-amd64" to ECR - production
-  - Tag and push image "teleport:v10-arm" to ECR - production
-  - Tag and push image "teleport:v10-arm64" to ECR - production
-- name: Create manifest and push "teleport:minor" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
-  - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v10-amd64" to ECR - production
-  - Tag and push image "teleport:v10-arm" to ECR - production
-  - Tag and push image "teleport:v10-arm64" to ECR - production
-- name: Create manifest and push "teleport:full" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64 --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 && docker
-    manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version"))
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v10-amd64" to ECR - production
-  - Tag and push image "teleport:v10-arm" to ECR - production
-  - Tag and push image "teleport:v10-arm64" to ECR - production
-- name: Assume S3 Download AWS Role for teleport-ent
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[s3-download-teleport-ent]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile s3-download-teleport-ent
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Find the latest available semver for v10
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-  image: alpine/git:latest
-  commands:
-  - mkdir -pv "/tmp/repo"
-  - cd "/tmp/repo"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "v$(cat '/go/vars/full-version-v10')"
-  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport-ent")
-  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport-ent"
-  depends_on:
-  - Find the latest available semver for v10
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_amd64.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")_amd64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_amd64.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v10-amd64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v10-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v10-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v10-amd64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v10-amd64-builder" --config "/tmp/teleport-ent-v10-amd64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v10-amd64-builder" --target
-    "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
-    DEB_PATH=teleport-ent_$(cat "/go/var/full-version")_amd64.deb /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v10-amd64-builder"
-  - rm -rf "/tmp/teleport-ent-v10-amd64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
-- name: Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")_arm.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v10-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v10-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v10-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v10-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v10-arm-builder" --config "/tmp/teleport-ent-v10-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v10-arm-builder" --target "teleport"
-    --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
-    "/go/var/full-version")_arm.deb /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v10-arm-builder"
-  - rm -rf "/tmp/teleport-ent-v10-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
-- name: Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm64.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")_arm64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm64.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v10-arm64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v10-arm64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v10-arm64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v10-arm64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v10-arm64-builder" --config "/tmp/teleport-ent-v10-arm64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v10-arm64-builder" --target
-    "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
-    DEB_PATH=teleport-ent_$(cat "/go/var/full-version")_arm64.deb /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v10-arm64-builder"
-  - rm -rf "/tmp/teleport-ent-v10-arm64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
-- name: Tag and push image "teleport-ent:v10-amd64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v10-amd64"
-- name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v10-arm"
-- name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v10-arm64"
-- name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v10-arm" to ECR - staging
-  - Tag and push image "teleport-ent:v10-arm64" to ECR - staging
-- name: Create manifest and push "teleport-ent:minor-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v10-arm" to ECR - staging
-  - Tag and push image "teleport-ent:v10-arm64" to ECR - staging
-- name: Create manifest and push "teleport-ent:full-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v10-arm" to ECR - staging
-  - Tag and push image "teleport-ent:v10-arm64" to ECR - staging
-- name: Tag and push image "teleport-ent:v10-amd64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v10-amd64"
-- name: Tag and push image "teleport-ent:v10-arm" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v10-arm"
-- name: Tag and push image "teleport-ent:v10-arm64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
-    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v10-arm64"
-- name: Create manifest and push "teleport-ent:major" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-amd64" to Quay
-  - Tag and push image "teleport-ent:v10-arm" to Quay
-  - Tag and push image "teleport-ent:v10-arm64" to Quay
-- name: Create manifest and push "teleport-ent:minor" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-amd64" to Quay
-  - Tag and push image "teleport-ent:v10-arm" to Quay
-  - Tag and push image "teleport-ent:v10-arm64" to Quay
-- name: Create manifest and push "teleport-ent:full" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64 --amend
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm --amend quay.io/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 && docker manifest push quay.io/gravitational/teleport-ent:$(cat
-    "/go/var/full-version"))
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-amd64" to Quay
-  - Tag and push image "teleport-ent:v10-arm" to Quay
-  - Tag and push image "teleport-ent:v10-arm64" to Quay
-- name: Tag and push image "teleport-ent:v10-amd64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-amd64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v10-amd64"
-- name: Tag and push image "teleport-ent:v10-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v10-arm"
-- name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-arm64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v10-arm64"
-- name: Create manifest and push "teleport-ent:major" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v10-arm" to ECR - production
-  - Tag and push image "teleport-ent:v10-arm64" to ECR - production
-- name: Create manifest and push "teleport-ent:minor" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v10-arm" to ECR - production
-  - Tag and push image "teleport-ent:v10-arm64" to ECR - production
-- name: Create manifest and push "teleport-ent:full" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
-    && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version"))
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v10-arm" to ECR - production
-  - Tag and push image "teleport-ent:v10-arm64" to ECR - production
-- name: Assume S3 Download AWS Role for teleport-ent-fips
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[s3-download-teleport-ent-fips]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile s3-download-teleport-ent-fips
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Find the latest available semver for v10
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for
-    teleport-ent-fips
-  image: alpine/git:latest
-  commands:
-  - mkdir -pv "/tmp/repo"
-  - cd "/tmp/repo"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "v$(cat '/go/vars/full-version-v10')"
-  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport-ent-fips")
-  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport-ent-fips"
-  depends_on:
-  - Find the latest available semver for v10
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")-fips_amd64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent-fips
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent-fips
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for teleport-ent-fips
-- name: Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v10-fips-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v10-fips-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v10-fips-amd64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v10-fips-amd64-builder" --config "/tmp/teleport-ent-v10-fips-amd64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v10-fips-amd64-builder" --target
-    "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
-    --build-arg DEB_PATH=teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v10-fips-amd64-builder"
-  - rm -rf "/tmp/teleport-ent-v10-fips-amd64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
-- name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
-    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
-    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
-    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
-- name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
-- name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
-- name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
-- name: Tag and push image "teleport-ent:v10-fips-amd64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
-- name: Create manifest and push "teleport-ent:major-fips" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
-- name: Create manifest and push "teleport-ent:minor-fips" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
-- name: Create manifest and push "teleport-ent:full-fips" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64 &&
-    docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
-- name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
-- name: Create manifest and push "teleport-ent:major-fips" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
-- name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
-- name: Create manifest and push "teleport-ent:full-fips" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
-- name: Build teleport-operator image "teleport-operator:v10-amd64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
-  - mkdir -pv "/tmp/teleport-operator-v10-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v10-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-operator-v10-amd64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-operator-v10-amd64-builder" --config "/tmp/teleport-operator-v10-amd64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-operator-v10-amd64-builder" --platform
-    "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
-    --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox:teleport13 --build-arg
-    COMPILER_NAME=x86_64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-operator-v10-amd64-builder"
-  - rm -rf "/tmp/teleport-operator-v10-amd64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Find the latest available semver for v10
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Build teleport-operator image "teleport-operator:v10-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
-  - mkdir -pv "/tmp/teleport-operator-v10-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v10-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-operator-v10-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-operator-v10-arm-builder" --config "/tmp/teleport-operator-v10-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-operator-v10-arm-builder" --platform
-    "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
-    --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
-    COMPILER_NAME=arm-linux-gnueabihf-gcc /go/src/github.com/gravitational/teleport
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-operator-v10-arm-builder"
-  - rm -rf "/tmp/teleport-operator-v10-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Find the latest available semver for v10
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Build teleport-operator image "teleport-operator:v10-arm64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/src/github.com/gravitational/teleport" && cd "/go/src/github.com/gravitational/teleport"
-  - mkdir -pv "/tmp/teleport-operator-v10-arm64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-operator-v10-arm64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-operator-v10-arm64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-operator-v10-arm64-builder" --config "/tmp/teleport-operator-v10-arm64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-operator-v10-arm64-builder" --platform
-    "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
-    --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
-    BUILDBOX=public.ecr.aws/gravitational/teleport-buildbox-arm:teleport13 --build-arg
-    COMPILER_NAME=aarch64-linux-gnu-gcc /go/src/github.com/gravitational/teleport
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-operator-v10-arm64-builder"
-  - rm -rf "/tmp/teleport-operator-v10-arm64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Find the latest available semver for v10
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Tag and push image "teleport-operator:v10-amd64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-operator image "teleport-operator:v10-amd64"
-- name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-operator image "teleport-operator:v10-arm"
-- name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-operator image "teleport-operator:v10-arm64"
-- name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/major-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
-  - Tag and push image "teleport-operator:v10-arm" to ECR - staging
-  - Tag and push image "teleport-operator:v10-arm64" to ECR - staging
-- name: Create manifest and push "teleport-operator:minor-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/minor-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
-  - Tag and push image "teleport-operator:v10-arm" to ECR - staging
-  - Tag and push image "teleport-operator:v10-arm64" to ECR - staging
-- name: Create manifest and push "teleport-operator:full-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
-  - Tag and push image "teleport-operator:v10-arm" to ECR - staging
-  - Tag and push image "teleport-operator:v10-arm64" to ECR - staging
-- name: Tag and push image "teleport-operator:v10-amd64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
-    && docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64)
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
-    quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
-  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
-    quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
-  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-operator image "teleport-operator:v10-amd64"
-- name: Tag and push image "teleport-operator:v10-arm" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
-    && docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
-    quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
-  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
-    quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
-  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-operator image "teleport-operator:v10-arm"
-- name: Tag and push image "teleport-operator:v10-arm64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
-    && docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64)
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
-    quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
-  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
-    quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
-  - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-operator image "teleport-operator:v10-arm64"
-- name: Create manifest and push "teleport-operator:major" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
-    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
-    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
-    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
-  - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-operator:v10-amd64" to Quay
-  - Tag and push image "teleport-operator:v10-arm" to Quay
-  - Tag and push image "teleport-operator:v10-arm64" to Quay
-- name: Create manifest and push "teleport-operator:minor" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
-    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
-    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
-    --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
-  - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-operator:v10-amd64" to Quay
-  - Tag and push image "teleport-operator:v10-arm" to Quay
-  - Tag and push image "teleport-operator:v10-arm64" to Quay
-- name: Create manifest and push "teleport-operator:full" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
-    quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64 --amend
-    quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm --amend
-    quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64 &&
-    docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-operator:v10-amd64" to Quay
-  - Tag and push image "teleport-operator:v10-arm" to Quay
-  - Tag and push image "teleport-operator:v10-arm64" to Quay
-- name: Tag and push image "teleport-operator:v10-amd64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-amd64 && docker push public.ecr.aws/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-amd64)
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
-    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
-  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
-    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
-  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-operator image "teleport-operator:v10-amd64"
-- name: Tag and push image "teleport-operator:v10-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-arm && docker push public.ecr.aws/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-operator image "teleport-operator:v10-arm"
-- name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
-    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-arm64 && docker push public.ecr.aws/gravitational/teleport-operator:$(cat
-    "/go/var/full-version")-arm64)
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
-    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
-  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
-  - docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
-    public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
-  - docker push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-operator image "teleport-operator:v10-arm64"
-- name: Create manifest and push "teleport-operator:major" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
-    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
-    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm64
-  - docker manifest push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-operator:v10-amd64" to ECR - production
-  - Tag and push image "teleport-operator:v10-arm" to ECR - production
-  - Tag and push image "teleport-operator:v10-arm64" to ECR - production
-- name: Create manifest and push "teleport-operator:minor" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
-    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
-    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
-  - docker manifest push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-operator:v10-amd64" to ECR - production
-  - Tag and push image "teleport-operator:v10-arm" to ECR - production
-  - Tag and push image "teleport-operator:v10-arm64" to ECR - production
-- name: Create manifest and push "teleport-operator:full" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
-    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
-    --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
-    && docker manifest push public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version"))
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-operator:v10-amd64" to ECR - production
-  - Tag and push image "teleport-operator:v10-arm" to ECR - production
-  - Tag and push image "teleport-operator:v10-arm64" to ECR - production
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-- name: drone-docker-registry
-  image: registry:2
-  privileged: false
-  volumes: []
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/container_images_release_version.go (main.(*ReleaseVersion).buildVersionPipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
-name: teleport-container-images-previous-version-2-cron
-environment:
-  DEBIAN_FRONTEND: noninteractive
-trigger:
-  cron:
-    include:
-    - teleport-container-images-cron
-  repo:
-    include:
-    - gravitational/teleport
-workspace:
-  path: /go
-clone:
-  disable: true
-steps:
-- name: Find the latest available semver for v9
-  image: golang:1.18
-  commands:
-  - mkdir -pv "/tmp/teleport"
-  - cd "/tmp/teleport"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "branch/v9"
-  - mkdir -pv $(dirname "/go/vars/full-version-v9")
-  - cd "/tmp/teleport/build.assets/tooling/cmd/query-latest"
-  - go run . "v9" | sed 's/v//' > "/go/vars/full-version-v9"
-  - echo Found full semver "$(cat "/go/vars/full-version-v9")" for major version "v9"
-- name: Wait for docker
-  image: docker
-  commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  volumes:
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Find the latest available semver for v9
-- name: Wait for docker registry
-  image: alpine
-  commands:
-  - apk add curl
-  - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
-    != "200" ]; do sleep 1; done'
-  depends_on:
-  - Find the latest available semver for v9
-- name: Check out code
-  image: alpine/git:latest
-  commands:
-  - mkdir -pv "/go/src/github.com/gravitational/teleport"
-  - cd "/go/src/github.com/gravitational/teleport"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "v$(cat '/go/vars/full-version-v9')"
-  depends_on:
-  - Find the latest available semver for v9
-- name: Build major, minor, and full semvers
-  image: alpine
-  commands:
-  - mkdir -pv $(dirname "/go/var/major-version")
-  - echo v$(cat '/go/vars/full-version-v9') | sed 's/v//' | cut -d'.' -f "1" > "/go/var/major-version"
-  - echo $(cat "/go/var/major-version")
-  - mkdir -pv $(dirname "/go/var/minor-version")
-  - echo v$(cat '/go/vars/full-version-v9') | sed 's/v//' | cut -d'.' -f "1,2" > "/go/var/minor-version"
-  - echo $(cat "/go/var/minor-version")
-  - mkdir -pv $(dirname "/go/var/full-version")
-  - echo v$(cat '/go/vars/full-version-v9') | sed 's/v//' > "/go/var/full-version"
-  - echo $(cat "/go/var/full-version")
-  depends_on:
-  - Find the latest available semver for v9
-- name: Assume ECR - staging AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[ecr-staging]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile ecr-staging
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: STAGING_TELEPORT_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: STAGING_TELEPORT_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: STAGING_TELEPORT_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Find the latest available semver for v9
-- name: Assume ECR - authenticated-pull AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[ecr-authenticated-pull]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile ecr-authenticated-pull
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: PRODUCTION_TELEPORT_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume ECR - staging AWS Role
-  - Find the latest available semver for v9
-- name: Assume ECR - production AWS Role
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[ecr-production]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile ecr-production
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_KEY
-    AWS_ROLE:
-      from_secret: PRODUCTION_TELEPORT_DRONE_ECR_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: PRODUCTION_TELEPORT_DRONE_USER_ECR_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Find the latest available semver for v9
-- name: Assume S3 Download AWS Role for teleport
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[s3-download-teleport]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile s3-download-teleport
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Find the latest available semver for v9
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-  image: alpine/git:latest
-  commands:
-  - mkdir -pv "/tmp/repo"
-  - cd "/tmp/repo"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "v$(cat '/go/vars/full-version-v9')"
-  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport")
-  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport"
-  depends_on:
-  - Find the latest available semver for v9
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download "teleport_v9-tag_amd64.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_amd64.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
-    "/go/var/full-version")_amd64.deb /go/build/teleport_$(cat "/go/var/full-version")_amd64.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v9-amd64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v9-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v9-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v9-amd64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v9-amd64-builder" --config "/tmp/teleport-v9-amd64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-v9-amd64-builder" --target "teleport"
-    --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v9-amd64-builder"
-  - rm -rf "/tmp/teleport-v9-amd64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v9-tag_amd64.deb" artifacts from S3
-- name: Download "teleport_v9-tag_arm.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
-    "/go/var/full-version")_arm.deb /go/build/teleport_$(cat "/go/var/full-version")_arm.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v9-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v9-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v9-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v9-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v9-arm-builder" --config "/tmp/teleport-v9-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-v9-arm-builder" --target "teleport"
-    --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v9-arm-builder"
-  - rm -rf "/tmp/teleport-v9-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v9-tag_arm.deb" artifacts from S3
-- name: Download "teleport_v9-tag_arm64.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport_$(cat "/go/var/full-version")_arm64.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport_$(cat
-    "/go/var/full-version")_arm64.deb /go/build/teleport_$(cat "/go/var/full-version")_arm64.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport" for teleport
-- name: Build teleport image "teleport:v9-arm64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-v9-arm64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-v9-arm64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-v9-arm64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-v9-arm64-builder" --config "/tmp/teleport-v9-arm64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-v9-arm64-builder" --target "teleport"
-    --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-v9-arm64-builder"
-  - rm -rf "/tmp/teleport-v9-arm64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport_v9-tag_arm64.deb" artifacts from S3
-- name: Tag and push image "teleport:v9-amd64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-amd64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-amd64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-amd64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v9-amd64"
-- name: Tag and push image "teleport:v9-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v9-arm"
-- name: Tag and push image "teleport:v9-arm64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/full-version")-$TIMESTAMP-arm64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/major-version")-$TIMESTAMP-arm64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat "/go/var/minor-version")-$TIMESTAMP-arm64
-    && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v9-arm64"
-- name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/major-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v9-amd64" to ECR - staging
-  - Tag and push image "teleport:v9-arm" to ECR - staging
-  - Tag and push image "teleport:v9-arm64" to ECR - staging
-- name: Create manifest and push "teleport:minor-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/minor-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v9-amd64" to ECR - staging
-  - Tag and push image "teleport:v9-arm" to ECR - staging
-  - Tag and push image "teleport:v9-arm64" to ECR - staging
-- name: Create manifest and push "teleport:full-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
-    "/go/var/full-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v9-amd64" to ECR - staging
-  - Tag and push image "teleport:v9-arm" to ECR - staging
-  - Tag and push image "teleport:v9-arm64" to ECR - staging
-- name: Tag and push image "teleport:v9-amd64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
-    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v9-amd64"
-- name: Tag and push image "teleport:v9-arm" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v9-arm"
-- name: Tag and push image "teleport:v9-arm64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
-    && docker push quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm64
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm64
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
-  - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v9-arm64"
-- name: Create manifest and push "teleport:major" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
-    --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
-    quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
-    "/go/var/major-version")-arm64
-  - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v9-amd64" to Quay
-  - Tag and push image "teleport:v9-arm" to Quay
-  - Tag and push image "teleport:v9-arm64" to Quay
-- name: Create manifest and push "teleport:minor" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
-    --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
-    quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
-    "/go/var/minor-version")-arm64
-  - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v9-amd64" to Quay
-  - Tag and push image "teleport:v9-arm" to Quay
-  - Tag and push image "teleport:v9-arm64" to Quay
-- name: Create manifest and push "teleport:full" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
-    "/go/var/full-version")-amd64 --amend quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    --amend quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64 &&
-    docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v9-amd64" to Quay
-  - Tag and push image "teleport:v9-arm" to Quay
-  - Tag and push image "teleport:v9-arm64" to Quay
-- name: Tag and push image "teleport:v9-amd64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
-    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v9-amd64"
-- name: Tag and push image "teleport:v9-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v9-arm"
-- name: Tag and push image "teleport:v9-arm64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
-    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
-    && docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64)
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
-  - docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
-  - docker push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport image "teleport:v9-arm64"
-- name: Create manifest and push "teleport:major" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm64
-  - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v9-amd64" to ECR - production
-  - Tag and push image "teleport:v9-arm" to ECR - production
-  - Tag and push image "teleport:v9-arm64" to ECR - production
-- name: Create manifest and push "teleport:minor" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
-    --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
-  - docker manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v9-amd64" to ECR - production
-  - Tag and push image "teleport:v9-arm" to ECR - production
-  - Tag and push image "teleport:v9-arm64" to ECR - production
-- name: Create manifest and push "teleport:full" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64 --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm --amend
-    public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64 && docker
-    manifest push public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version"))
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport:v9-amd64" to ECR - production
-  - Tag and push image "teleport:v9-arm" to ECR - production
-  - Tag and push image "teleport:v9-arm64" to ECR - production
-- name: Assume S3 Download AWS Role for teleport-ent
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[s3-download-teleport-ent]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile s3-download-teleport-ent
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Find the latest available semver for v9
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-  image: alpine/git:latest
-  commands:
-  - mkdir -pv "/tmp/repo"
-  - cd "/tmp/repo"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "v$(cat '/go/vars/full-version-v9')"
-  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport-ent")
-  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport-ent"
-  depends_on:
-  - Find the latest available semver for v9
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download "teleport-ent_v9-tag_amd64.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_amd64.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")_amd64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_amd64.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v9-amd64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v9-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v9-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v9-amd64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v9-amd64-builder" --config "/tmp/teleport-ent-v9-amd64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v9-amd64-builder" --target
-    "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
-    DEB_PATH=teleport-ent_$(cat "/go/var/full-version")_amd64.deb /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v9-amd64-builder"
-  - rm -rf "/tmp/teleport-ent-v9-amd64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v9-tag_amd64.deb" artifacts from S3
-- name: Download "teleport-ent_v9-tag_arm.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")_arm.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v9-arm"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v9-arm-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v9-arm-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v9-arm-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v9-arm-builder" --config "/tmp/teleport-ent-v9-arm-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v9-arm-builder" --target "teleport"
-    --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
-    "/go/var/full-version")_arm.deb /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v9-arm-builder"
-  - rm -rf "/tmp/teleport-ent-v9-arm-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v9-tag_arm.deb" artifacts from S3
-- name: Download "teleport-ent_v9-tag_arm64.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")_arm64.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")_arm64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")_arm64.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent" for teleport-ent
-- name: Build teleport-ent image "teleport-ent:v9-arm64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v9-arm64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v9-arm64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v9-arm64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v9-arm64-builder" --config "/tmp/teleport-ent-v9-arm64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v9-arm64-builder" --target
-    "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
-    DEB_PATH=teleport-ent_$(cat "/go/var/full-version")_arm64.deb /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v9-arm64-builder"
-  - rm -rf "/tmp/teleport-ent-v9-arm64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v9-tag_arm64.deb" artifacts from S3
-- name: Tag and push image "teleport-ent:v9-amd64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v9-amd64"
-- name: Tag and push image "teleport-ent:v9-arm" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v9-arm"
-- name: Tag and push image "teleport-ent:v9-arm64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v9-arm64"
-- name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v9-arm" to ECR - staging
-  - Tag and push image "teleport-ent:v9-arm64" to ECR - staging
-- name: Create manifest and push "teleport-ent:minor-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v9-arm" to ECR - staging
-  - Tag and push image "teleport-ent:v9-arm64" to ECR - staging
-- name: Create manifest and push "teleport-ent:full-$TIMESTAMP" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
-    skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-amd64 --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-arm64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
-  - Tag and push image "teleport-ent:v9-arm" to ECR - staging
-  - Tag and push image "teleport-ent:v9-arm64" to ECR - staging
-- name: Tag and push image "teleport-ent:v9-amd64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v9-amd64"
-- name: Tag and push image "teleport-ent:v9-arm" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v9-arm"
-- name: Tag and push image "teleport-ent:v9-arm64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
-    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v9-arm64"
-- name: Create manifest and push "teleport-ent:major" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-amd64" to Quay
-  - Tag and push image "teleport-ent:v9-arm" to Quay
-  - Tag and push image "teleport-ent:v9-arm64" to Quay
-- name: Create manifest and push "teleport-ent:minor" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-amd64" to Quay
-  - Tag and push image "teleport-ent:v9-arm" to Quay
-  - Tag and push image "teleport-ent:v9-arm64" to Quay
-- name: Create manifest and push "teleport-ent:full" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64 --amend
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm --amend quay.io/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 && docker manifest push quay.io/gravitational/teleport-ent:$(cat
-    "/go/var/full-version"))
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-amd64" to Quay
-  - Tag and push image "teleport-ent:v9-arm" to Quay
-  - Tag and push image "teleport-ent:v9-arm64" to Quay
-- name: Tag and push image "teleport-ent:v9-amd64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-amd64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-amd64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v9-amd64"
-- name: Tag and push image "teleport-ent:v9-arm" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    && docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v9-arm"
-- name: Tag and push image "teleport-ent:v9-arm64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-arm64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-arm64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent image "teleport-ent:v9-arm64"
-- name: Create manifest and push "teleport-ent:major" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm64
-  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v9-arm" to ECR - production
-  - Tag and push image "teleport-ent:v9-arm64" to ECR - production
-- name: Create manifest and push "teleport-ent:minor" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
-  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v9-arm" to ECR - production
-  - Tag and push image "teleport-ent:v9-arm64" to ECR - production
-- name: Create manifest and push "teleport-ent:full" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
-    && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version"))
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-amd64" to ECR - production
-  - Tag and push image "teleport-ent:v9-arm" to ECR - production
-  - Tag and push image "teleport-ent:v9-arm64" to ECR - production
-- name: Assume S3 Download AWS Role for teleport-ent-fips
-  image: amazon/aws-cli
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[s3-download-teleport-ent-fips]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      >> /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile s3-download-teleport-ent-fips
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Find the latest available semver for v9
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for
-    teleport-ent-fips
-  image: alpine/git:latest
-  commands:
-  - mkdir -pv "/tmp/repo"
-  - cd "/tmp/repo"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "v$(cat '/go/vars/full-version-v9')"
-  - mkdir -pv $(dirname "/go/build/Dockerfile-teleport-ent-fips")
-  - cp "/tmp/repo/build.assets/charts/Dockerfile" "/go/build/Dockerfile-teleport-ent-fips"
-  depends_on:
-  - Find the latest available semver for v9
-  - Wait for docker
-  - Wait for docker registry
-  - Check out code
-  - Build major, minor, and full semvers
-  - Assume ECR - staging AWS Role
-  - Assume ECR - authenticated-pull AWS Role
-  - Assume ECR - production AWS Role
-- name: Download "teleport-ent_v9-tag-fips_amd64.deb" artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - END_TIME=$(( $(date +%s) + 3600 ))
-  - TIMED_OUT=true
-  - while [ $(date +%s) -lt $${END_TIME?} ]; do
-  - SUCCESS=true
-  - aws s3 ls s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/ | tr
-    -s ' ' | cut -d' ' -f 4 | grep -x teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
-    || SUCCESS=false
-  - '[ "$SUCCESS" = "true" ] && TIMED_OUT=false && break;'
-  - echo 'Condition not met yet, waiting another 60 seconds...'
-  - sleep 60
-  - done
-  - '[ $${TIMED_OUT?} = true ] && echo ''Timed out while waiting for condition: [
-    "$SUCCESS" = "true" ]'' && exit 1'
-  - mkdir -pv "/go/build"
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/tag/$(cat "/go/var/full-version")/teleport-ent_$(cat
-    "/go/var/full-version")-fips_amd64.deb /go/build/teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
-  environment:
-    AWS_PROFILE: s3-download-teleport-ent-fips
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  depends_on:
-  - Assume S3 Download AWS Role for teleport-ent-fips
-  - Download Teleport Dockerfile to "/go/build/Dockerfile-teleport-ent-fips" for teleport-ent-fips
-- name: Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
-  image: docker
-  commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - mkdir -pv "/go/build" && cd "/go/build"
-  - mkdir -pv "/tmp/teleport-ent-v9-fips-amd64-builder"
-  - echo '[registry."drone-docker-registry:5000"]' > "/tmp/teleport-ent-v9-fips-amd64-builder/buildkitd.toml"
-  - echo '  http = true' >> "/tmp/teleport-ent-v9-fips-amd64-builder/buildkitd.toml"
-  - docker buildx create --driver "docker-container" --driver-opt "network=host" --name
-    "teleport-ent-v9-fips-amd64-builder" --config "/tmp/teleport-ent-v9-fips-amd64-builder/buildkitd.toml"
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker buildx build --push --builder "teleport-ent-v9-fips-amd64-builder" --target
-    "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
-    --build-arg DEB_PATH=teleport-ent_$(cat "/go/var/full-version")-fips_amd64.deb
-    /go/build
-  - docker logout "public.ecr.aws"
-  - docker buildx rm "teleport-ent-v9-fips-amd64-builder"
-  - rm -rf "/tmp/teleport-ent-v9-fips-amd64-builder"
-  environment:
-    AWS_PROFILE: ecr-authenticated-pull
-    DOCKER_BUILDKIT: "1"
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Assume ECR - authenticated-pull AWS Role
-  - Download "teleport-ent_v9-tag-fips_amd64.deb" artifacts from S3
-- name: Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
-    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
-    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64)
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
-    existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
-- name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/major-version")-$TIMESTAMP-fips)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
-- name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/minor-version")-$TIMESTAMP-fips)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
-- name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
-    146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
-  - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
-    image, skipping' || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips --amend 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips-amd64 && docker manifest push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-$TIMESTAMP-fips)
-  - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
-  environment:
-    AWS_PROFILE: ecr-staging
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
-- name: Tag and push image "teleport-ent:v9-fips-amd64" to Quay
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    && docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
-- name: Create manifest and push "teleport-ent:major-fips" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
-- name: Create manifest and push "teleport-ent:minor-fips" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
-    --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
-- name: Create manifest and push "teleport-ent:full-fips" to Quay
-  image: docker
-  commands:
-  - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
-  - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
-    quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64 &&
-    docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
-  - docker logout "quay.io"
-  environment:
-    QUAY_PASSWORD:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    QUAY_USERNAME:
-      from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
-- name: Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
-  image: docker
-  commands:
-  - docker pull drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64 && docker push public.ecr.aws/gravitational/teleport-ent:$(cat
-    "/go/var/full-version")-fips-amd64)
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
-- name: Create manifest and push "teleport-ent:major-fips" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
-  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
-- name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
-  - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
-- name: Create manifest and push "teleport-ent:full-fips" to ECR - production
-  image: docker
-  commands:
-  - apk add --no-cache aws-cli
-  - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
-    > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
-    create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
-    --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
-    && docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
-  - docker logout "public.ecr.aws"
-  environment:
-    AWS_PROFILE: ecr-production
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  depends_on:
-  - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-- name: drone-docker-registry
-  image: registry:2
-  privileged: false
-  volumes: []
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
 # Generated at dronegen/relcli.go (main.relcliPipeline)
 ################################################
 
@@ -18196,6 +18817,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 6b5da87020674e14fd257475a809160f81cda8d554a347516950c9c9d04d22fe
+hmac: 07e009074925c70d220c660c6fef5ee1b113824e5fb4b8649972bdc2a8ac1e8e
 
 ...

--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -12,7 +12,7 @@ This checklist is to be run after cutting a release.
 ### Major releases only
 
 - [ ] Update support matrix in docs FAQ page
-- [ ] Update `CURRENT_VERSION_ROOT` and other previous versions in Drone `teleport-docker-cron` job
+- [ ] Update `branchMajorVersion` const in Dronegen `/dronegen/container_images.go`, then run `make dronegen`
   - Example: https://github.com/gravitational/teleport/pull/4602
 - [ ] Create PR to update default Teleport image referenced in docker/teleport-quickstart.yml and docker/teleport-ent-quickstart.yml
   - Example: https://github.com/gravitational/teleport/pull/4655

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -122,7 +122,7 @@ func NewTeleportOperatorProduct(cloneDirectory string) *Product {
 				compilerName = "arm-linux-gnueabihf-gcc"
 			}
 
-			buildboxName += ":teleport13"
+			buildboxName = fmt.Sprintf("%s:teleport%d", buildboxName, branchMajorVersion)
 
 			return []string{
 				fmt.Sprintf("BUILDBOX=%s", buildboxName),

--- a/dronegen/container_images.go
+++ b/dronegen/container_images.go
@@ -19,22 +19,35 @@ import (
 	"strings"
 )
 
+// *************************************************************
+// ****** These need to be updated on each major release. ******
+// ****** After updating, "make dronegen" must be reran.  ******
+// *************************************************************
+const branchMajorVersion int = 13
+
+func buildPipelineVersions() (string, []string) {
+	branchMajorSemver := fmt.Sprintf("v%d", branchMajorVersion)
+	// Note that this only matters in the context of the master branch
+	updateVersionCount := 3
+	imageUpdateSemvers := make([]string, updateVersionCount)
+	for i := 0; i < updateVersionCount; i++ {
+		imageUpdateSemvers[i] = fmt.Sprintf("v%d", branchMajorVersion-i)
+	}
+
+	return branchMajorSemver, imageUpdateSemvers
+}
+
 func buildContainerImagePipelines() []pipeline {
-	// *************************************************************
-	// ****** These need to be updated on each major release. ******
-	// ****** After updating, "make dronegen" must be reran.  ******
-	// *************************************************************
-	latestMajorVersions := []string{"v11", "v10", "v9"}
-	branchMajorVersion := "v11"
+	branchMajorSemver, imageUpdateSemvers := buildPipelineVersions()
 
 	triggers := []*TriggerInfo{
-		NewTagTrigger(branchMajorVersion),
-		NewPromoteTrigger(branchMajorVersion),
-		NewCronTrigger(latestMajorVersions),
+		NewTagTrigger(branchMajorSemver),
+		NewPromoteTrigger(branchMajorSemver),
+		NewCronTrigger(imageUpdateSemvers),
 	}
 
 	if configureForPRTestingOnly {
-		triggers = append(triggers, NewTestTrigger(prBranch, branchMajorVersion))
+		triggers = append(triggers, NewTestTrigger(prBranch, branchMajorSemver))
 	}
 
 	pipelines := make([]pipeline, 0, len(triggers))


### PR DESCRIPTION
This PR fixes an issue introduced by https://github.com/gravitational/teleport/pull/17597 where the branch major version number ended up not getting update for the last couple major versions. This PR updates to docs to reflect the required post-release changes, and simplifies the changes to only one number.

Note that there is a large number of line changes, but almost all the changes are a single number ("11" to "13" and similar)