### PR TITLE
Add label selector to `tctl get`.

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
-	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/asciitable"
@@ -984,13 +983,13 @@ func (c *databaseServiceCollection) writeText(w io.Writer) error {
 }
 
 type loginRuleCollection struct {
-	rules []*loginrulepb.LoginRule
+	rules []*loginrule.Resource
 }
 
 func (l *loginRuleCollection) writeText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Name", "Priority"})
 	for _, rule := range l.rules {
-		t.AddRow([]string{rule.Metadata.Name, strconv.FormatInt(int64(rule.Priority), 10)})
+		t.AddRow([]string{rule.Metadata.Name, strconv.FormatInt(int64(rule.Spec.Priority), 10)})
 	}
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
@@ -999,7 +998,7 @@ func (l *loginRuleCollection) writeText(w io.Writer) error {
 func (l *loginRuleCollection) resources() []types.Resource {
 	resources := make([]types.Resource, len(l.rules))
 	for i, rule := range l.rules {
-		resources[i] = loginrule.ProtoToResource(rule)
+		resources[i] = rule
 	}
 	return resources
 }


### PR DESCRIPTION
`tctl get` can now use the label selector from k8s apimachinery to filter results by labels. This will be handy when doing things like filtering results by origin.