### PR TITLE
[v12] Convert rhel `VERSION_ID`s to only include the major version

### DIFF
--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -28,6 +28,9 @@
     sudo apt-get update
     sudo apt-get install -y teleport jq
   elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ]; then
+	if [ "$ID" = "rhel" ]; then
+      VERSION_ID=$(echo "$VERSION_ID" | sed 's/\..*//') # convert version numbers like '7.2' to only include the major version
+    fi
     sudo yum-config-manager --add-repo \
       "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/{{ .MajorVersion }}/teleport.repo")"
     sudo yum install -y teleport jq

--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -11,24 +11,24 @@
   # adding the key apt shows a key signing error when installing teleport.
   LEGACY_UBUNTU=false
   if [ "$VERSION_CODENAME" = "xenial" ] || [ "$VERSION_CODENAME" = "trusty" ]; then
-	  LEGACY_UBUNTU=true
+    LEGACY_UBUNTU=true
   fi
 
   if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
-	if [ "$LEGACY_UBUNTU" = true ]; then
-		curl -o /tmp/teleport-pubkey.asc https://deb.releases.teleport.dev/teleport-pubkey.asc
-		cat /tmp/teleport-pubkey.asc | sudo apt-key add -
-		echo "deb https://apt.releases.teleport.dev/ubuntu ${VERSION_CODENAME?} stable/{{ .MajorVersion }}" | sudo tee /etc/apt/sources.list.d/teleport.list
-		rm /tmp/teleport-pubkey.asc
-	else
-		sudo curl https://deb.releases.teleport.dev/teleport-pubkey.asc \
-			 -o /usr/share/keyrings/teleport-archive-keyring.asc
-		echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/{{ .MajorVersion }}" |  sudo tee /etc/apt/sources.list.d/teleport.list >/dev/null
-	fi
+    if [ "$LEGACY_UBUNTU" = true ]; then
+      curl -o /tmp/teleport-pubkey.asc https://deb.releases.teleport.dev/teleport-pubkey.asc
+      cat /tmp/teleport-pubkey.asc | sudo apt-key add -
+      echo "deb https://apt.releases.teleport.dev/ubuntu ${VERSION_CODENAME?} stable/{{ .MajorVersion }}" | sudo tee /etc/apt/sources.list.d/teleport.list
+      rm /tmp/teleport-pubkey.asc
+    else
+      sudo curl https://deb.releases.teleport.dev/teleport-pubkey.asc \
+        -o /usr/share/keyrings/teleport-archive-keyring.asc
+      echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/{{ .MajorVersion }}" | sudo tee /etc/apt/sources.list.d/teleport.list >/dev/null
+    fi
     sudo apt-get update
     sudo apt-get install -y teleport jq
   elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ]; then
-	if [ "$ID" = "rhel" ]; then
+    if [ "$ID" = "rhel" ]; then
       VERSION_ID=$(echo "$VERSION_ID" | sed 's/\..*//') # convert version numbers like '7.2' to only include the major version
     fi
     sudo yum-config-manager --add-repo \


### PR DESCRIPTION
Backport #20403 to branch/v12