### PR TITLE
AWS IAM role matching for database users

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -111,6 +111,9 @@ type Database interface {
 	IsAWSHosted() bool
 	// IsCloudHosted returns true if database is hosted in the cloud (AWS, Azure or Cloud SQL).
 	IsCloudHosted() bool
+	// RequireAWSIAMRolesAsUsers returns true for database types that require
+	// AWS IAM roles as database users.
+	RequireAWSIAMRolesAsUsers() bool
 	// Copy returns a copy of this database resource.
 	Copy() *DatabaseV3
 }
@@ -306,6 +309,11 @@ func (d *DatabaseV3) SetMySQLServerVersion(version string) {
 // IsEmpty returns true if AWS metadata is empty.
 func (a AWS) IsEmpty() bool {
 	return protoEqual(&a, &AWS{})
+}
+
+// Partition returns the AWS partition based on the region.
+func (a AWS) Partition() string {
+	return awsutils.GetPartitionFromRegion(a.Region)
 }
 
 // GetAWS returns the database AWS metadata.
@@ -718,6 +726,24 @@ func (d *DatabaseV3) GetManagedUsers() []string {
 // SetManagedUsers sets a list of database users that are managed by Teleport.
 func (d *DatabaseV3) SetManagedUsers(users []string) {
 	d.Status.ManagedUsers = users
+}
+
+// RequireAWSIAMRolesAsUsers returns true for database types that require AWS
+// IAM roles as database users.
+func (d *DatabaseV3) RequireAWSIAMRolesAsUsers() bool {
+	awsType, ok := d.getAWSType()
+	if !ok {
+		return false
+	}
+
+	switch awsType {
+	case DatabaseTypeAWSKeyspaces,
+		DatabaseTypeDynamoDB,
+		DatabaseTypeRedshiftServerless:
+		return true
+	default:
+		return false
+	}
 }
 
 const (

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3972,7 +3972,7 @@ func (a *Server) isMFARequired(ctx context.Context, checker services.AccessCheck
 		}
 
 		dbRoleMatchers := role.DatabaseRoleMatchers(
-			db.GetProtocol(),
+			db,
 			t.Database.Username,
 			t.Database.GetDatabase(),
 		)

--- a/lib/client/conntest/database.go
+++ b/lib/client/conntest/database.go
@@ -234,17 +234,8 @@ func (s *DatabaseConnectionTester) getDatabaseServers(ctx context.Context, datab
 }
 
 func checkDatabaseLogin(protocol, databaseUser, databaseName string) error {
-	matchers := role.DatabaseRoleMatchers(protocol, databaseUser, databaseName)
-	needUser := false
-	needDatabase := false
-
-	for _, matcher := range matchers {
-		_, userMatcher := matcher.(*services.DatabaseUserMatcher)
-		needUser = needUser || userMatcher
-
-		_, nameMatcher := matcher.(*services.DatabaseNameMatcher)
-		needDatabase = needDatabase || nameMatcher
-	}
+	needUser := role.RequireDatabaseUserMatcher(protocol)
+	needDatabase := role.RequireDatabaseNameMatcher(protocol)
 
 	if needUser && databaseUser == "" {
 		return trace.BadParameter("missing required parameter Database User")

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/google/uuid"
 	"github.com/gravitational/configure/cstrings"
 	"github.com/gravitational/trace"
@@ -42,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
@@ -981,7 +983,7 @@ func (set RoleSet) EnumerateDatabaseUsers(database types.Database, extraUsers ..
 
 	// check each individual user against the database.
 	for _, user := range users {
-		err := set.checkAccess(database, AccessState{MFAVerified: true}, &DatabaseUserMatcher{User: user})
+		err := set.checkAccess(database, AccessState{MFAVerified: true}, NewDatabaseUserMatcher(database, user))
 		result.allowedDeniedMap[user] = err == nil
 	}
 
@@ -1071,9 +1073,12 @@ func MatchDatabaseName(selectors []string, name string) (bool, string) {
 }
 
 // MatchDatabaseUser returns true if provided database user matches selectors.
-func MatchDatabaseUser(selectors []string, user string) (bool, string) {
+func MatchDatabaseUser(selectors []string, user string, matchWildcard bool) (bool, string) {
 	for _, u := range selectors {
-		if u == user || u == types.Wildcard {
+		if u == user {
+			return true, "matched"
+		}
+		if matchWildcard && u == types.Wildcard {
 			return true, "matched"
 		}
 	}
@@ -2032,20 +2037,66 @@ func (m RoleMatchers) MatchAny(role types.Role, condition types.RoleConditionTyp
 	return false, nil, nil
 }
 
-// DatabaseUserMatcher matches a role against database account name.
-type DatabaseUserMatcher struct {
-	User string
+// databaseUserMatcher matches a role against database account name.
+type databaseUserMatcher struct {
+	// user is the name of the database user.
+	user string
+	// alternativeNames is a list of alternative names for the database user.
+	alternativeNames []string
+}
+
+// NewDatabaseUserMatcher creates a RoleMatcher that checks whether the role's
+// database users match the specified condition.
+func NewDatabaseUserMatcher(db types.Database, user string) RoleMatcher {
+	if db.RequireAWSIAMRolesAsUsers() {
+		return &databaseUserMatcher{
+			user:             user,
+			alternativeNames: makeAlternativeNamesForAWSRole(db, user),
+		}
+	}
+
+	return &databaseUserMatcher{user: user}
 }
 
 // Match matches database account name against provided role and condition.
-func (m *DatabaseUserMatcher) Match(role types.Role, condition types.RoleConditionType) (bool, error) {
-	match, _ := MatchDatabaseUser(role.GetDatabaseUsers(condition), m.User)
-	return match, nil
+func (m *databaseUserMatcher) Match(role types.Role, condition types.RoleConditionType) (bool, error) {
+	selectors := role.GetDatabaseUsers(condition)
+	if match, _ := MatchDatabaseUser(selectors, m.user, true); match {
+		return true, nil
+	}
+
+	for _, altName := range m.alternativeNames {
+		if match, _ := MatchDatabaseUser(selectors, altName, false); match {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // String returns the matcher's string representation.
-func (m *DatabaseUserMatcher) String() string {
-	return fmt.Sprintf("DatabaseUserMatcher(User=%v)", m.User)
+func (m *databaseUserMatcher) String() string {
+	return fmt.Sprintf("databaseUserMatcher(user=%v, alternativeNames=%v)", m.user, m.alternativeNames)
+}
+
+func makeAlternativeNamesForAWSRole(db types.Database, user string) []string {
+	metadata := db.GetAWS()
+	if metadata.Region == "" || metadata.AccountID == "" {
+		return nil
+	}
+
+	// If input database user is a role ARN, try the short role name.
+	// The input role ARN must have matching partition and account ID in
+	// order to try the short role name.
+	if arn.IsARN(user) {
+		roleName, err := awsutils.ValidateRoleARNAndExtractRoleName(user, metadata.Partition(), metadata.AccountID)
+		if err != nil {
+			return nil
+		}
+		return []string{roleName}
+	}
+
+	// If input database user is the short role name, try the full ARN.
+	return []string{awsutils.BuildRoleARN(user, metadata.Region, metadata.AccountID)}
 }
 
 // DatabaseNameMatcher matches a role against database name.

--- a/lib/srv/db/cassandra/engine.go
+++ b/lib/srv/db/cassandra/engine.go
@@ -256,7 +256,7 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	state := e.sessionCtx.GetAccessState(authPref)
 
 	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database.GetProtocol(),
+		e.sessionCtx.Database,
 		e.sessionCtx.DatabaseUser,
 		e.sessionCtx.DatabaseName,
 	)

--- a/lib/srv/db/common/role/role.go
+++ b/lib/srv/db/common/role/role.go
@@ -17,14 +17,39 @@ limitations under the License.
 package role
 
 import (
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 )
 
-// DatabaseRoleMatchers returns role matchers based on the database protocol.
-func DatabaseRoleMatchers(dbProtocol string, user, database string) services.RoleMatchers {
+// DatabaseRoleMatchers returns role matchers based on the database.
+func DatabaseRoleMatchers(db types.Database, user, database string) services.RoleMatchers {
+	roleMatchers := services.RoleMatchers{
+		services.NewDatabaseUserMatcher(db, user),
+	}
+
+	if matcher, ok := databaseNameMatcher(db.GetProtocol(), database); ok {
+		roleMatchers = append(roleMatchers, matcher)
+	}
+	return roleMatchers
+}
+
+// RequireDatabaseUserMatcher returns true if databases with provided protocol
+// require database users.
+func RequireDatabaseUserMatcher(protocol string) bool {
+	return true // Always required.
+}
+
+// RequireDatabaseNameMatcher returns true if databases with provided protocol
+// require database names.
+func RequireDatabaseNameMatcher(protocol string) bool {
+	_, ok := databaseNameMatcher(protocol, "")
+	return ok
+}
+
+func databaseNameMatcher(dbProtocol, database string) (*services.DatabaseNameMatcher, bool) {
 	switch dbProtocol {
-	case defaults.ProtocolMySQL:
+	case
 		// In MySQL, unlike Postgres, "database" and "schema" are the same thing
 		// and there's no good way to prevent users from performing cross-database
 		// queries once they're connected, apart from granting proper privileges
@@ -35,40 +60,21 @@ func DatabaseRoleMatchers(dbProtocol string, user, database string) services.Rol
 		// on queries, we might be able to restrict db_names as well e.g. by
 		// detecting full-qualified table names like db.table, until then the
 		// proper way is to use MySQL grants system.
-		return services.RoleMatchers{
-			&services.DatabaseUserMatcher{User: user},
-		}
-	case defaults.ProtocolCockroachDB:
+		defaults.ProtocolMySQL,
 		// Cockroach uses the same wire protocol as Postgres but handling of
 		// databases is different and there's no way to prevent cross-database
 		// queries so only apply RBAC to db_users.
-		return services.RoleMatchers{
-			&services.DatabaseUserMatcher{User: user},
-		}
-	case defaults.ProtocolRedis:
+		defaults.ProtocolCockroachDB,
 		// Redis integration doesn't support schema access control.
-		return services.RoleMatchers{
-			&services.DatabaseUserMatcher{User: user},
-		}
-	case defaults.ProtocolCassandra:
+		defaults.ProtocolRedis,
 		// Cassandra integration doesn't support schema access control.
-		return services.RoleMatchers{
-			&services.DatabaseUserMatcher{User: user},
-		}
-	case defaults.ProtocolElasticsearch:
+		defaults.ProtocolCassandra,
 		// Elasticsearch integration doesn't support schema access control.
-		return services.RoleMatchers{
-			&services.DatabaseUserMatcher{User: user},
-		}
-	case defaults.ProtocolDynamoDB:
+		defaults.ProtocolElasticsearch,
 		// DynamoDB integration doesn't support schema access control.
-		return services.RoleMatchers{
-			&services.DatabaseUserMatcher{User: user},
-		}
+		defaults.ProtocolDynamoDB:
+		return nil, false
 	default:
-		return services.RoleMatchers{
-			&services.DatabaseUserMatcher{User: user},
-			&services.DatabaseNameMatcher{Name: database},
-		}
+		return &services.DatabaseNameMatcher{Name: database}, true
 	}
 }

--- a/lib/srv/db/common/role/role.go
+++ b/lib/srv/db/common/role/role.go
@@ -28,7 +28,7 @@ func DatabaseRoleMatchers(db types.Database, user, database string) services.Rol
 		services.NewDatabaseUserMatcher(db, user),
 	}
 
-	if matcher, ok := databaseNameMatcher(db.GetProtocol(), database); ok {
+	if matcher := databaseNameMatcher(db.GetProtocol(), database); matcher != nil {
 		roleMatchers = append(roleMatchers, matcher)
 	}
 	return roleMatchers
@@ -43,11 +43,10 @@ func RequireDatabaseUserMatcher(protocol string) bool {
 // RequireDatabaseNameMatcher returns true if databases with provided protocol
 // require database names.
 func RequireDatabaseNameMatcher(protocol string) bool {
-	_, ok := databaseNameMatcher(protocol, "")
-	return ok
+	return databaseNameMatcher(protocol, "") != nil
 }
 
-func databaseNameMatcher(dbProtocol, database string) (*services.DatabaseNameMatcher, bool) {
+func databaseNameMatcher(dbProtocol, database string) *services.DatabaseNameMatcher {
 	switch dbProtocol {
 	case
 		// In MySQL, unlike Postgres, "database" and "schema" are the same thing
@@ -73,8 +72,8 @@ func databaseNameMatcher(dbProtocol, database string) (*services.DatabaseNameMat
 		defaults.ProtocolElasticsearch,
 		// DynamoDB integration doesn't support schema access control.
 		defaults.ProtocolDynamoDB:
-		return nil, false
+		return nil
 	default:
-		return &services.DatabaseNameMatcher{Name: database}, true
+		return &services.DatabaseNameMatcher{Name: database}
 	}
 }

--- a/lib/srv/db/dynamodb/engine.go
+++ b/lib/srv/db/dynamodb/engine.go
@@ -283,7 +283,7 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 
 	state := sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
-		sessionCtx.Database.GetProtocol(),
+		sessionCtx.Database,
 		sessionCtx.DatabaseUser,
 		sessionCtx.DatabaseName,
 	)

--- a/lib/srv/db/elasticsearch/engine.go
+++ b/lib/srv/db/elasticsearch/engine.go
@@ -381,7 +381,7 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 
 	state := e.sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database.GetProtocol(),
+		e.sessionCtx.Database,
 		e.sessionCtx.DatabaseUser,
 		e.sessionCtx.DatabaseName,
 	)

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -154,7 +154,7 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 
 	state := sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
-		defaults.ProtocolMySQL,
+		sessionCtx.Database,
 		sessionCtx.DatabaseUser,
 		sessionCtx.DatabaseName,
 	)

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -187,7 +187,7 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 
 	state := sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
-		sessionCtx.Database.GetProtocol(),
+		sessionCtx.Database,
 		sessionCtx.DatabaseUser,
 		sessionCtx.DatabaseName,
 	)

--- a/lib/srv/db/redis/client.go
+++ b/lib/srv/db/redis/client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/go-redis/redis/v9"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/role"
@@ -157,7 +156,7 @@ func fetchUserPasswordOnConnect(sessionCtx *common.Session, users common.Users, 
 		err := sessionCtx.Checker.CheckAccess(sessionCtx.Database,
 			services.AccessState{MFAVerified: true},
 			role.DatabaseRoleMatchers(
-				defaults.ProtocolRedis,
+				sessionCtx.Database,
 				sessionCtx.DatabaseUser,
 				sessionCtx.DatabaseName,
 			)...)

--- a/lib/srv/db/redis/cmds.go
+++ b/lib/srv/db/redis/cmds.go
@@ -176,7 +176,7 @@ func (e *Engine) processAuth(ctx context.Context, cmd *redis.Cmd) error {
 		err := e.sessionCtx.Checker.CheckAccess(e.sessionCtx.Database,
 			services.AccessState{MFAVerified: true},
 			role.DatabaseRoleMatchers(
-				defaults.ProtocolRedis,
+				e.sessionCtx.Database,
 				e.sessionCtx.DatabaseUser,
 				e.sessionCtx.DatabaseName,
 			)...)
@@ -223,7 +223,7 @@ func (e *Engine) processAuth(ctx context.Context, cmd *redis.Cmd) error {
 		err := e.sessionCtx.Checker.CheckAccess(e.sessionCtx.Database,
 			services.AccessState{MFAVerified: true},
 			role.DatabaseRoleMatchers(
-				defaults.ProtocolRedis,
+				e.sessionCtx.Database,
 				e.sessionCtx.DatabaseUser,
 				e.sessionCtx.DatabaseName,
 			)...)

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -88,7 +88,7 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 
 	state := e.sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database.GetProtocol(),
+		e.sessionCtx.Database,
 		e.sessionCtx.DatabaseUser,
 		e.sessionCtx.DatabaseName,
 	)

--- a/lib/srv/db/snowflake/engine.go
+++ b/lib/srv/db/snowflake/engine.go
@@ -347,7 +347,7 @@ func (e *Engine) authorizeConnection(ctx context.Context) error {
 	}
 	state := e.sessionCtx.GetAccessState(authPref)
 	dbRoleMatchers := role.DatabaseRoleMatchers(
-		e.sessionCtx.Database.GetProtocol(),
+		e.sessionCtx.Database,
 		e.sessionCtx.DatabaseUser,
 		e.sessionCtx.DatabaseName,
 	)

--- a/lib/srv/db/sqlserver/engine.go
+++ b/lib/srv/db/sqlserver/engine.go
@@ -198,9 +198,8 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 
 	state := sessionCtx.GetAccessState(authPref)
 	err = sessionCtx.Checker.CheckAccess(sessionCtx.Database, state,
-		&services.DatabaseUserMatcher{
-			User: sessionCtx.DatabaseUser,
-		})
+		services.NewDatabaseUserMatcher(sessionCtx.Database, sessionCtx.DatabaseUser),
+	)
 	if err != nil {
 		e.Audit.OnSessionStart(e.Context, sessionCtx, err)
 		return trace.Wrap(err)

--- a/lib/utils/aws/aws.go
+++ b/lib/utils/aws/aws.go
@@ -397,10 +397,10 @@ func ValidateRoleARNAndExtractRoleName(roleARN, wantPartition, wantAccountID str
 		return "", trace.Wrap(err)
 	}
 	if !strings.HasPrefix(role.Resource, "role/") || role.Service != iam.ServiceName {
-		return "", trace.BadParameter("%q is not a IAM role", roleARN)
+		return "", trace.BadParameter("%q is not an IAM role", roleARN)
 	}
 	if role.Partition != wantPartition {
-		return "", trace.BadParameter("expecting AWS account partition %q but got %q", wantPartition, role.Partition)
+		return "", trace.BadParameter("expecting AWS partition %q but got %q", wantPartition, role.Partition)
 	}
 	if role.AccountID != wantAccountID {
 		return "", trace.BadParameter("expecting AWS account ID %q but got %q", wantAccountID, role.AccountID)

--- a/lib/utils/aws/aws_test.go
+++ b/lib/utils/aws/aws_test.go
@@ -207,7 +207,7 @@ func TestValidateRoleARNAndExtractRoleName(t *testing.T) {
 		wantError      bool
 	}{
 		{
-			name:           "sucess",
+			name:           "success",
 			inputARN:       "arn:aws:iam::123456789012:role/role-name",
 			inputPartition: "aws",
 			inputAccountID: "123456789012",

--- a/lib/utils/aws/aws_test.go
+++ b/lib/utils/aws/aws_test.go
@@ -196,3 +196,62 @@ func TestRoles(t *testing.T) {
 		})
 	})
 }
+
+func TestValidateRoleARNAndExtractRoleName(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputARN       string
+		inputPartition string
+		inputAccountID string
+		wantRoleName   string
+		wantError      bool
+	}{
+		{
+			name:           "sucess",
+			inputARN:       "arn:aws:iam::123456789012:role/role-name",
+			inputPartition: "aws",
+			inputAccountID: "123456789012",
+			wantRoleName:   "role-name",
+		},
+		{
+			name:           "invalid arn",
+			inputARN:       "arn::::aws:iam::123456789012:role/role-name",
+			inputPartition: "aws",
+			inputAccountID: "123456789012",
+			wantError:      true,
+		},
+		{
+			name:           "invalid partition",
+			inputARN:       "arn:aws:iam::123456789012:role/role-name",
+			inputPartition: "aws-cn",
+			inputAccountID: "123456789012",
+			wantError:      true,
+		},
+		{
+			name:           "invalid account ID",
+			inputARN:       "arn:aws:iam::123456789012:role/role-name",
+			inputPartition: "aws",
+			inputAccountID: "123456789000",
+			wantError:      true,
+		},
+		{
+			name:           "not role arn",
+			inputARN:       "arn:aws:iam::123456789012:user/username",
+			inputPartition: "aws",
+			inputAccountID: "123456789012",
+			wantError:      true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualRoleName, err := ValidateRoleARNAndExtractRoleName(test.inputARN, test.inputPartition, test.inputAccountID)
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.wantRoleName, actualRoleName)
+			}
+		})
+	}
+}

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -1017,17 +1017,8 @@ func formatDatabaseConnectCommand(clusterFlag string, active tlsca.RouteToDataba
 // formatDatabaseConnectArgs generates the arguments for "tsh db connect" command.
 func formatDatabaseConnectArgs(clusterFlag string, active tlsca.RouteToDatabase) (flags []string) {
 	// figure out if we need --db-user and --db-name
-	matchers := role.DatabaseRoleMatchers(active.Protocol, active.Username, active.Database)
-	needUser := false
-	needDatabase := false
-
-	for _, matcher := range matchers {
-		_, userMatcher := matcher.(*services.DatabaseUserMatcher)
-		needUser = needUser || userMatcher
-
-		_, nameMatcher := matcher.(*services.DatabaseNameMatcher)
-		needDatabase = needDatabase || nameMatcher
-	}
+	needUser := role.RequireDatabaseUserMatcher(active.Protocol)
+	needDatabase := role.RequireDatabaseNameMatcher(active.Database)
 
 	if clusterFlag != "" {
 		flags = append(flags, fmt.Sprintf("--cluster=%s", clusterFlag))

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -1018,7 +1018,7 @@ func formatDatabaseConnectCommand(clusterFlag string, active tlsca.RouteToDataba
 func formatDatabaseConnectArgs(clusterFlag string, active tlsca.RouteToDatabase) (flags []string) {
 	// figure out if we need --db-user and --db-name
 	needUser := role.RequireDatabaseUserMatcher(active.Protocol)
-	needDatabase := role.RequireDatabaseNameMatcher(active.Database)
+	needDatabase := role.RequireDatabaseNameMatcher(active.Protocol)
 
 	if clusterFlag != "" {
 		flags = append(flags, fmt.Sprintf("--cluster=%s", clusterFlag))


### PR DESCRIPTION
Fixes #20359 

For databases that require AWS IAM roles as database users (AWS Keyspaces, DynamoDB, Redshift Serverless), today `tsh` accepts either the short-IAM-role-name or the full-IAM-role-ARN as `--db-user`.

This change allows either format to be specified in the teleport role, and will mix-match either format when IAM role is specified through `--db-user`.

Matching example from UT:
role
```
types.RoleSpecV6{             
     Allow: types.RoleConditions{       
         Namespaces:     []string{apidefaults.Namespace},       
         DatabaseLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},           
         DatabaseUsers: []string{                 
             "allow-role-with-short-name",           
             "arn:aws:iam::123456789012:role/allow-role-with-full-arn",           
         },                                                          
     },                                               
 },   
```
access
```
access: []access{            
    {server: dbRequireAWSRoles, dbUser: "allow-role-with-short-name", access: true},            
    {server: dbRequireAWSRoles, dbUser: "allow-role-with-full-arn", access: true},              
    {server: dbRequireAWSRoles, dbUser: "arn:aws:iam::123456789012:role/allow-role-with-full-arn", access: true},            
    {server: dbRequireAWSRoles, dbUser: "arn:aws:iam::123456789012:role/allow-role-with-short-name", access: true},            
    {server: dbRequireAWSRoles, dbUser: "unknown-role-name", access: false},                                                   
    {server: dbRequireAWSRoles, dbUser: "arn:aws:iam::123456789012:role/unknown-role-name", access: false},            
    {server: dbRequireAWSRoles, dbUser: "arn:aws:iam::123456789012:user/username", access: false},                     
    {server: dbRequireAWSRoles, dbUser: "arn:aws-cn:iam::123456789012:role/allow-role-with-short-name", access: false},            
},  
```