### PR TITLE
Allow role-based device verification in AccessChecker

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -79,6 +79,10 @@ var DefaultCertAuthorityRules = []types.Rule{
 	types.NewRule(types.KindCertAuthority, ReadNoSecrets()),
 }
 
+// ErrTrustedDeviceRequired is returned by AccessChecker when access to a
+// resource requires a trusted device.
+var ErrTrustedDeviceRequired = trace.AccessDenied("access to resource requires a trusted device")
+
 // ErrSessionMFARequired is returned by AccessChecker when access to a resource
 // requires an MFA check.
 var ErrSessionMFARequired = trace.AccessDenied("access to resource requires MFA")
@@ -2908,6 +2912,17 @@ type AccessState struct {
 	MFARequired MFARequired
 	// MFAVerified is set when MFA has been verified by the caller.
 	MFAVerified bool
+	// EnableDeviceVerification enables device verification in access checks.
+	// It's recommended to set this in tandem with DeviceVerified, so device
+	// checks are easier to reason about and have a proper chance of succeeding.
+	// Defaults to false for backwards compatibility.
+	EnableDeviceVerification bool
+	// DeviceVerified is true if the user certificate contains all required
+	// device extensions.
+	// A value of true enables the caller to clear device trust checks.
+	// It's recommended to set this in tandem with EnableDeviceVerification.
+	// See [dtauthz.IsTLSDeviceVerified] and [dtauthz.IsSSHDeviceVerified].
+	DeviceVerified bool
 }
 
 // MFARequired determines when MFA is required for a user to access a resource.

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2331,11 +2331,11 @@ func (set RoleSet) checkAccess(r AccessCheckable, state AccessState, matchers ..
 		}
 	}
 
-	mfaVerified := state.MFAVerified || state.MFARequired == MFARequiredNever
+	mfaAllowed := state.MFAVerified || state.MFARequired == MFARequiredNever
 
 	// TODO(codingllama): Consider making EnableDeviceVerification opt-out instead
 	//  of opt-in.
-	deviceVerified := !state.EnableDeviceVerification || state.DeviceVerified
+	deviceAllowed := !state.EnableDeviceVerification || state.DeviceVerified
 
 	var errs []error
 	allowed := false
@@ -2388,21 +2388,21 @@ func (set RoleSet) checkAccess(r AccessCheckable, state AccessState, matchers ..
 		// (and gets an early exit) or we need to check every applicable role to
 		// ensure the access is permitted.
 
-		if mfaVerified && deviceVerified {
+		if mfaAllowed && deviceAllowed {
 			debugf("Access to %v %q granted, allow rule in role %q matched.",
 				r.GetKind(), r.GetName(), role.GetName())
 			return nil
 		}
 
 		// MFA verification.
-		if !mfaVerified && role.GetOptions().RequireMFAType.IsSessionMFARequired() {
+		if !mfaAllowed && role.GetOptions().RequireMFAType.IsSessionMFARequired() {
 			debugf("Access to %v %q denied, role %q requires per-session MFA",
 				r.GetKind(), r.GetName(), role.GetName())
 			return ErrSessionMFARequired
 		}
 
 		// Device verification.
-		if !deviceVerified && role.GetOptions().DeviceTrustMode == constants.DeviceTrustModeRequired {
+		if !deviceAllowed && role.GetOptions().DeviceTrustMode == constants.DeviceTrustModeRequired {
 			debugf("Access to %v %q denied, role %q requires a trusted device",
 				r.GetKind(), r.GetName(), role.GetName())
 			return ErrTrustedDeviceRequired

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1174,8 +1174,8 @@ func (set RoleSet) PinSourceIP() bool {
 func (set RoleSet) GetAccessState(authPref types.AuthPreference) AccessState {
 	return AccessState{
 		MFARequired: set.getMFARequired(authPref.GetRequireMFAType()),
-		// We don't set ClusterDeviceMode here, as both ClusterDeviceMode and
-		// DeviceVerified should be set in tandem.
+		// We don't set EnableDeviceVerification here, as both it and DeviceVerified
+		// should be set in tandem.
 	}
 }
 

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -4877,7 +4877,6 @@ func TestCheckAccessToWindowsDesktop(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		roleSet RoleSet
-		state   AccessState
 		checks  []check
 	}{
 		{
@@ -4965,7 +4964,7 @@ func TestCheckAccessToWindowsDesktop(t *testing.T) {
 			for i, check := range test.checks {
 				msg := fmt.Sprintf("check=%d, user=%v, server=%v, should_have_access=%v",
 					i, check.login, check.desktop.GetName(), check.hasAccess)
-				err := test.roleSet.checkAccess(check.desktop, test.state, NewWindowsLoginMatcher(check.login))
+				err := test.roleSet.checkAccess(check.desktop, AccessState{}, NewWindowsLoginMatcher(check.login))
 				if check.hasAccess {
 					require.NoError(t, err, msg)
 				} else {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1025,6 +1025,58 @@ func TestCheckAccessToServer(t *testing.T) {
 				{server: serverDB, login: "root", hasAccess: true},
 			},
 		},
+		{
+			name: "cluster requires session+hardware key, MFA not verified",
+			roles: []*types.RoleV6{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.Logins = []string{"root"}
+				}),
+			},
+			authSpec: types.AuthPreferenceSpecV2{
+				// Functionally equivalent to "session".
+				RequireMFAType: types.RequireMFAType_SESSION_AND_HARDWARE_KEY,
+			},
+			checks: []check{
+				{server: serverNoLabels, login: "root", hasAccess: false},
+				{server: serverWorker, login: "root", hasAccess: false},
+				{server: serverDB, login: "root", hasAccess: false},
+			},
+		},
+		{
+			name: "cluster requires session+hardware key, MFA verified",
+			roles: []*types.RoleV6{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.Logins = []string{"root"}
+				}),
+			},
+			authSpec: types.AuthPreferenceSpecV2{
+				// Functionally equivalent to "session".
+				RequireMFAType: types.RequireMFAType_SESSION_AND_HARDWARE_KEY,
+			},
+			mfaVerified: true,
+			checks: []check{
+				{server: serverNoLabels, login: "root", hasAccess: true},
+				{server: serverWorker, login: "root", hasAccess: true},
+				{server: serverDB, login: "root", hasAccess: true},
+			},
+		},
+		{
+			name: "cluster requires hardware key touch, MFA not verified",
+			roles: []*types.RoleV6{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.Logins = []string{"root"}
+				}),
+			},
+			authSpec: types.AuthPreferenceSpecV2{
+				// Functionally equivalent to "off".
+				RequireMFAType: types.RequireMFAType_HARDWARE_KEY_TOUCH,
+			},
+			checks: []check{
+				{server: serverNoLabels, login: "root", hasAccess: true},
+				{server: serverWorker, login: "root", hasAccess: true},
+				{server: serverDB, login: "root", hasAccess: true},
+			},
+		},
 		// Device Trust.
 		{
 			name: "role requires trusted device, device not verified",


### PR DESCRIPTION
Add the capability to verify devices via AccessState / AccessChecker.

Device verification is disabled by default in order to not disrupt/break existing functionality. Follow up work will selectively enable it for various services.

Global mode verification, as in `authorization.device_trust.mode`, is still performed by the auth.Authorizer implementation.

https://github.com/gravitational/teleport.e/issues/514