### PR TITLE
Enable role-based device authz for DB, k8s and SSH

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1350,7 +1350,7 @@ func serverWithAllowRules(t *testing.T, srv *TestAuthServer, allowRules []types.
 	require.NoError(t, err)
 
 	localUser := LocalUser{Username: username, Identity: tlsca.Identity{Username: username}}
-	authContext, err := contextForLocalUser(localUser, srv.AuthServer, srv.ClusterName)
+	authContext, err := contextForLocalUser(localUser, srv.AuthServer, srv.ClusterName, true /* disableDeviceAuthz */)
 	require.NoError(t, err)
 
 	return &ServerWithRoles{

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -135,6 +135,10 @@ type Context struct {
 	// user, UnmappedIdentity holds the data before role mapping. Otherwise,
 	// it's identical to Identity.
 	UnmappedIdentity IdentityGetter
+
+	// disableDeviceAuthorization disables device verification.
+	// Inherited from the authorizer that creates the context.
+	disableDeviceAuthorization bool
 }
 
 // LockTargets returns a list of LockTargets inferred from the context's
@@ -183,11 +187,16 @@ func (c *Context) UseExtraRoles(access services.RoleGetter, clusterName string, 
 // [services.AccessChecker] and [tlsca.Identity].
 func (c *Context) GetAccessState(authPref types.AuthPreference) services.AccessState {
 	state := c.Checker.GetAccessState(authPref)
+	identity := c.Identity.GetIdentity()
 
 	// Builtin services (like proxy_service and kube_service) are not gated
 	// on MFA and only need to pass normal RBAC action checks.
 	_, isService := c.Identity.(BuiltinRole)
-	state.MFAVerified = isService || c.Identity.GetIdentity().MFAVerified != ""
+	state.MFAVerified = isService || identity.MFAVerified != ""
+
+	state.EnableDeviceVerification = !c.disableDeviceAuthorization
+	state.DeviceVerified = isService || dtauthz.IsTLSDeviceVerified(&identity.DeviceExtensions)
+
 	return state
 }
 
@@ -262,7 +271,7 @@ func (a *authorizer) fromUser(ctx context.Context, userI interface{}) (*Context,
 
 // authorizeLocalUser returns authz context based on the username
 func (a *authorizer) authorizeLocalUser(u LocalUser) (*Context, error) {
-	return contextForLocalUser(u, a.accessPoint, a.clusterName)
+	return contextForLocalUser(u, a.accessPoint, a.clusterName, a.disableDeviceAuthorization)
 }
 
 // authorizeRemoteUser returns checker based on cert authority roles
@@ -342,10 +351,11 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 	}
 
 	return &Context{
-		User:             user,
-		Checker:          checker,
-		Identity:         WrapIdentity(identity),
-		UnmappedIdentity: u,
+		User:                       user,
+		Checker:                    checker,
+		Identity:                   WrapIdentity(identity),
+		UnmappedIdentity:           u,
+		disableDeviceAuthorization: a.disableDeviceAuthorization,
 	}, nil
 }
 
@@ -419,10 +429,11 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, 
 		AllowedResourceIDs: nil,
 	}, a.clusterName, roleSet)
 	return &Context{
-		User:             user,
-		Checker:          checker,
-		Identity:         r,
-		UnmappedIdentity: r,
+		User:                       user,
+		Checker:                    checker,
+		Identity:                   r,
+		UnmappedIdentity:           r,
+		disableDeviceAuthorization: a.disableDeviceAuthorization,
 	}, nil
 }
 
@@ -791,14 +802,15 @@ func contextForBuiltinRole(r BuiltinRole, recConfig types.SessionRecordingConfig
 		AllowedResourceIDs: nil,
 	}, r.ClusterName, roleSet)
 	return &Context{
-		User:             user,
-		Checker:          checker,
-		Identity:         r,
-		UnmappedIdentity: r,
+		User:                       user,
+		Checker:                    checker,
+		Identity:                   r,
+		UnmappedIdentity:           r,
+		disableDeviceAuthorization: true, // Builtin roles skip device trust.
 	}, nil
 }
 
-func contextForLocalUser(u LocalUser, accessPoint AuthorizerAccessPoint, clusterName string) (*Context, error) {
+func contextForLocalUser(u LocalUser, accessPoint AuthorizerAccessPoint, clusterName string, disableDeviceAuthz bool) (*Context, error) {
 	// User has to be fetched to check if it's a blocked username
 	user, err := accessPoint.GetUser(u.Username, false)
 	if err != nil {
@@ -823,10 +835,11 @@ func contextForLocalUser(u LocalUser, accessPoint AuthorizerAccessPoint, cluster
 	user.SetTraits(accessInfo.Traits)
 
 	return &Context{
-		User:             user,
-		Checker:          accessChecker,
-		Identity:         u,
-		UnmappedIdentity: u,
+		User:                       user,
+		Checker:                    accessChecker,
+		Identity:                   u,
+		UnmappedIdentity:           u,
+		disableDeviceAuthorization: disableDeviceAuthz,
 	}, nil
 }
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1624,6 +1624,9 @@ func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Co
 	if err != nil {
 		if utils.IsHandshakeFailedError(err) {
 			conn.Close()
+			// TODO(codingllama): Improve error message below for device trust.
+			//  An alternative we have here is querying the cluster to check if device
+			//  trust is required, a check similar to `IsMFARequired`.
 			log.Infof("Access denied to %v connecting to %v: %v", sshConfig.User, nodeAddress, err)
 			return nil, trace.AccessDenied(`access denied to %v connecting to %v`, sshConfig.User, nodeAddress)
 		}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -941,9 +941,13 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			continue
 		}
 
-		if err := actx.Checker.CheckAccess(ks, state, roleMatchers...); err != nil {
+		switch err := actx.Checker.CheckAccess(ks, state, roleMatchers...); {
+		case errors.Is(err, services.ErrTrustedDeviceRequired):
+			return trace.Wrap(err)
+		case err != nil:
 			return trace.AccessDenied(notFoundMessage)
 		}
+
 		// If the user has active Access requests we need to validate that they allow
 		// the kubeResource.
 		// This is required because CheckAccess does not validate the subresource type.

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -37,6 +37,7 @@ import (
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auditd"
 	"github.com/gravitational/teleport/lib/auth"
+	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
@@ -571,6 +572,8 @@ func (h *AuthHandlers) canLoginWithRBAC(cert *ssh.Certificate, clusterName strin
 	}
 	state := accessChecker.GetAccessState(authPref)
 	_, state.MFAVerified = cert.Extensions[teleport.CertExtensionMFAVerified]
+	state.EnableDeviceVerification = true
+	state.DeviceVerified = dtauthz.IsSSHDeviceVerified(cert)
 
 	// check if roles allow access to server
 	if err := accessChecker.CheckAccess(

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
+	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -63,5 +64,7 @@ func (c *Session) String() string {
 func (c *Session) GetAccessState(authPref types.AuthPreference) services.AccessState {
 	state := c.Checker.GetAccessState(authPref)
 	state.MFAVerified = c.Identity.MFAVerified != ""
+	state.EnableDeviceVerification = true
+	state.DeviceVerified = dtauthz.IsTLSDeviceVerified(&c.Identity.DeviceExtensions)
 	return state
 }

--- a/lib/srv/db/common/session_test.go
+++ b/lib/srv/db/common/session_test.go
@@ -1,0 +1,94 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSession_GetAccessState(t *testing.T) {
+	checker := &fakeAccessChecker{}
+	authPref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{})
+	require.NoError(t, err, "NewAuthPreference failed")
+
+	tests := []struct {
+		name    string
+		session common.Session
+		want    services.AccessState
+	}{
+		{
+			name: "default",
+			session: common.Session{
+				Checker: checker,
+			},
+			want: services.AccessState{
+				EnableDeviceVerification: true, // always set
+			},
+		},
+		{
+			name: "mfa verified",
+			session: common.Session{
+				Identity: tlsca.Identity{
+					MFAVerified: "device-id",
+				},
+				Checker: checker,
+			},
+			want: services.AccessState{
+				MFAVerified:              true,
+				EnableDeviceVerification: true,
+			},
+		},
+		{
+			name: "device verified",
+			session: common.Session{
+				Identity: tlsca.Identity{
+					DeviceExtensions: tlsca.DeviceExtensions{
+						DeviceID:     "deviceid1",
+						AssetTag:     "assettag1",
+						CredentialID: "credentialid1",
+					},
+				},
+				Checker: checker,
+			},
+			want: services.AccessState{
+				DeviceVerified:           true,
+				EnableDeviceVerification: true,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.session.GetAccessState(authPref)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("GetAccessState mismatch (-want +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+type fakeAccessChecker struct {
+	services.AccessChecker
+}
+
+func (c *fakeAccessChecker) GetAccessState(authPref types.AuthPreference) services.AccessState {
+	return services.AccessState{}
+}

--- a/lib/srv/db/common/session_test.go
+++ b/lib/srv/db/common/session_test.go
@@ -18,11 +18,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSession_GetAccessState(t *testing.T) {


### PR DESCRIPTION
Enable role-based device authorization by setting the necessary fields in
auth.Context (k8s), db.common.Session (DB) and lib.srv.AuthHandlers (SSH).

For auth.Context, sessions are enabled according to the underlying Authorizer,
following the work done on #19659. DB and SSH enable the checks unconditionally
- this matches what we want for non-Auth services.

gravitational/teleport.e#514