### PR TITLE
[v11] Enforce using github.com/google/uuid 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,8 @@ linters-settings:
     packages-with-error-message:
     - io/ioutil: 'use "io" or "os" packages instead'
     - github.com/golang/protobuf: 'use "google.golang.org/protobuf"'
+    - github.com/hashicorp/go-uuid: 'use "github.com/google/uuid" instead'
+    - github.com/pborman/uuid: 'use "github.com/google/uuid" instead'
     - github.com/siddontang/go-log/log: 'use "github.com/sirupsen/logrus" instead'
     - go.uber.org/atomic: 'use "sync/atomic" instead'
   misspell:


### PR DESCRIPTION
Backport #20633 to branch/v11

Note: https://github.com/gravitational/teleport/pull/19648 was not backported to v11 so this only contains the depguard rules 