### PR TITLE
Change prettier to ignore markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "lint": "yarn prettier-check && yarn eslint",
     "eslint": "eslint --quiet --ext .js,.jsx,.ts,.tsx web/ e/",
     "type-check": "tsc --noEmit",
-    "prettier-check": "yarn prettier --check '+(e|web)/**/*.{ts,tsx,js,jsx,md}'",
-    "prettier-write": "yarn prettier --write '+(e|web)/**/*.{ts,tsx,js,jsx,md}'"
+    "prettier-check": "yarn prettier --check '+(e|web)/**/*.{ts,tsx,js,jsx}'",
+    "prettier-write": "yarn prettier --write '+(e|web)/**/*.{ts,tsx,js,jsx}'"
   },
   "private": true,
   "resolutions": {


### PR DESCRIPTION
Our docs linter may prefer `*` instead of `-` for lists and markdown changes that and a few other things, so let's leave out prettier from styling markdown