### PR TITLE
ci: Use large macOS runner for `build-macos` workflow

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: Build on Mac OS
     if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
-    runs-on: macos-12 # TODO(r0mant): Update with large runner when it's available
+    runs-on: macos-12-xl
 
     permissions:
       contents: read

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1074,7 +1074,7 @@ func (c *Client) deleteAllKubernetesServersFallback(ctx context.Context) error {
 }
 
 // UpsertKubernetesServer is used by kubernetes services to report their presence
-// to other auth servers in form of hearbeat expiring after ttl period.
+// to other auth servers in form of heartbeat expiring after ttl period.
 func (c *Client) UpsertKubernetesServer(ctx context.Context, s types.KubeServer) (*types.KeepAlive, error) {
 	server, ok := s.(*types.KubernetesServerV3)
 	if !ok {
@@ -1088,7 +1088,7 @@ func (c *Client) UpsertKubernetesServer(ctx context.Context, s types.KubeServer)
 }
 
 // UpsertKubeService is used by kubernetes services to report their presence
-// to other auth servers in form of hearbeat expiring after ttl period.
+// to other auth servers in form of heartbeat expiring after ttl period.
 // DELETE IN 13.0.0
 func (c *Client) UpsertKubeService(ctx context.Context, s types.Server) error {
 	server, ok := s.(*types.ServerV2)
@@ -1102,7 +1102,7 @@ func (c *Client) UpsertKubeService(ctx context.Context, s types.Server) error {
 }
 
 // UpsertKubeServiceV2 is used by kubernetes services to report their presence
-// to other auth servers in form of hearbeat expiring after ttl period.
+// to other auth servers in form of heartbeat expiring after ttl period.
 // DELETE IN 13.0.0
 func (c *Client) UpsertKubeServiceV2(ctx context.Context, s types.Server) (*types.KeepAlive, error) {
 	server, ok := s.(*types.ServerV2)
@@ -3021,7 +3021,7 @@ func (c *Client) CreateAlertAck(ctx context.Context, ack types.AlertAcknowledgem
 	return trail.FromGRPC(err)
 }
 
-// GetAlertAcks gets active alert ackowledgements.
+// GetAlertAcks gets active alert acknowledgements.
 func (c *Client) GetAlertAcks(ctx context.Context) ([]types.AlertAcknowledgement, error) {
 	rsp, err := c.grpc.GetAlertAcks(ctx, &proto.GetAlertAcksRequest{}, c.callOpts...)
 	if err != nil {


### PR DESCRIPTION
Use larger macOS runner with GitHub Actions to speed up builds.