### PR TITLE
[v11] ci: Use large macOS runner for build-macos workflow

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: Build on Mac OS
     if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
-    runs-on: macos-12 # TODO(r0mant): Update with large runner when it's available
+    runs-on: macos-12-xl
 
     permissions:
       contents: read


### PR DESCRIPTION
Use larger macOS runner with GitHub Actions to speed up builds.