### PR TITLE
Use concurrent streams for SFTP connections

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1917,7 +1917,7 @@ func (tc *TeleportClient) SFTP(ctx context.Context, args []string, port int, opt
 	}
 
 	if !quiet {
-		config.cfg.ProgressWriter = func(fileInfo os.FileInfo) io.ReadWriteCloser {
+		config.cfg.ProgressStream = func(fileInfo os.FileInfo) io.ReadWriter {
 			return sftp.NewProgressBar(fileInfo.Size(), fileInfo.Name(), tc.Stdout)
 		}
 	}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1917,7 +1917,7 @@ func (tc *TeleportClient) SFTP(ctx context.Context, args []string, port int, opt
 	}
 
 	if !quiet {
-		config.cfg.ProgressWriter = func(fileInfo os.FileInfo) io.Writer {
+		config.cfg.ProgressWriter = func(fileInfo os.FileInfo) io.ReadWriteCloser {
 			return sftp.NewProgressBar(fileInfo.Size(), fileInfo.Name(), tc.Stdout)
 		}
 	}

--- a/lib/sshutils/scp/http.go
+++ b/lib/sshutils/scp/http.go
@@ -49,7 +49,7 @@ type HTTPTransferRequest struct {
 	HTTPRequest *http.Request
 	// HTTPRequest is HTTP request
 	HTTPResponse http.ResponseWriter
-	// ProgressWriter is a writer for printing the progress
+	// ProgressStream is a writer for printing the progress
 	Progress io.Writer
 	// User is a user name
 	User string

--- a/lib/sshutils/scp/http.go
+++ b/lib/sshutils/scp/http.go
@@ -49,9 +49,9 @@ type HTTPTransferRequest struct {
 	HTTPRequest *http.Request
 	// HTTPRequest is HTTP request
 	HTTPResponse http.ResponseWriter
-	// ProgressStream is a writer for printing the progress
+	// Progress is a writer for printing the progress
 	Progress io.Writer
-	// User is a user name
+	// User is a username
 	User string
 	// AuditLog is AuditLog log
 	AuditLog events.IAuditLog

--- a/lib/sshutils/sftp/remote.go
+++ b/lib/sshutils/sftp/remote.go
@@ -62,7 +62,7 @@ func (r *remoteFS) ReadDir(ctx context.Context, path string) ([]os.FileInfo, err
 	return fileInfos, nil
 }
 
-func (r *remoteFS) Open(ctx context.Context, path string) (io.ReadCloser, error) {
+func (r *remoteFS) Open(ctx context.Context, path string) (WriterToCloser, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/lib/sshutils/sftp/remote.go
+++ b/lib/sshutils/sftp/remote.go
@@ -19,6 +19,7 @@ package sftp
 import (
 	"context"
 	"io"
+	"io/fs"
 	"os"
 	"time"
 
@@ -62,7 +63,7 @@ func (r *remoteFS) ReadDir(ctx context.Context, path string) ([]os.FileInfo, err
 	return fileInfos, nil
 }
 
-func (r *remoteFS) Open(ctx context.Context, path string) (WriterToCloser, error) {
+func (r *remoteFS) Open(ctx context.Context, path string) (fs.File, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/lib/sshutils/sftp/sftp_test.go
+++ b/lib/sshutils/sftp/sftp_test.go
@@ -194,7 +194,7 @@ func TestUpload(t *testing.T) {
 			require.NoError(t, err)
 			// use all local filesystems to avoid SSH overhead
 			cfg.dstFS = &localFS{}
-			cfg.initFS(ctx, nil, nil)
+			cfg.initFS(nil, nil)
 
 			err = cfg.transfer(ctx)
 			if tt.expectedErr == "" {
@@ -278,7 +278,7 @@ func TestDownload(t *testing.T) {
 			require.NoError(t, err)
 			// use all local filesystems to avoid SSH overhead
 			cfg.srcFS = &localFS{}
-			cfg.initFS(ctx, nil, nil)
+			cfg.initFS(nil, nil)
 
 			err = cfg.transfer(ctx)
 			if tt.expectedErr == "" {

--- a/lib/sshutils/sftp/sftp_test.go
+++ b/lib/sshutils/sftp/sftp_test.go
@@ -194,7 +194,8 @@ func TestUpload(t *testing.T) {
 			require.NoError(t, err)
 			// use all local filesystems to avoid SSH overhead
 			cfg.dstFS = &localFS{}
-			cfg.initFS(nil, nil)
+			err = cfg.initFS(nil, nil)
+			require.NoError(t, err)
 
 			err = cfg.transfer(ctx)
 			if tt.expectedErr == "" {
@@ -278,7 +279,8 @@ func TestDownload(t *testing.T) {
 			require.NoError(t, err)
 			// use all local filesystems to avoid SSH overhead
 			cfg.srcFS = &localFS{}
-			cfg.initFS(nil, nil)
+			err = cfg.initFS(nil, nil)
+			require.NoError(t, err)
 
 			err = cfg.transfer(ctx)
 			if tt.expectedErr == "" {

--- a/lib/sshutils/sftp/utils.go
+++ b/lib/sshutils/sftp/utils.go
@@ -1,0 +1,97 @@
+/*
+ *
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package sftp
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"os"
+)
+
+// fileWrapper provides minimal required file interface for SFTP package
+// including WriteTo() method required for concurrent data transfer.
+type fileWrapper struct {
+	file *os.File
+}
+
+func (wt *fileWrapper) Read(p []byte) (n int, err error) {
+	return wt.file.Read(p)
+}
+
+func (wt *fileWrapper) Close() error {
+	return wt.file.Close()
+}
+
+func (wt *fileWrapper) WriteTo(w io.Writer) (n int64, err error) {
+	return io.Copy(w, wt.file)
+}
+
+func (wt *fileWrapper) Stat() (os.FileInfo, error) {
+	return wt.file.Stat()
+}
+
+// fileStreamReader is a thin wrapper around fs.File with additional streams.
+type fileStreamReader struct {
+	streams []io.Reader
+	file    fs.File
+}
+
+// Stat returns file stats.
+func (a *fileStreamReader) Stat() (os.FileInfo, error) {
+	return a.file.Stat()
+}
+
+// Read reads the data from a file and passes the read data to all readers.
+// All errors from stream are returned except io.EOF.
+func (a *fileStreamReader) Read(b []byte) (int, error) {
+	n, err := a.file.Read(b)
+	// Create a copy as not whole buffer can be filled.
+	readBuff := b[:n]
+
+	for _, stream := range a.streams {
+		if _, innerError := stream.Read(readBuff); innerError != nil {
+			// Ignore EOF
+			if err != io.EOF {
+				return 0, innerError
+			}
+		}
+	}
+
+	return n, err
+}
+
+// cancelReaderWriter implements io.ReadWriter interface with context cancellation.
+type cancelReaderWriter struct {
+	ctx context.Context
+}
+
+func (c *cancelReaderWriter) Read(_ []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return 0, nil
+}
+
+func (c *cancelReaderWriter) Write(b []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}

--- a/lib/sshutils/sftp/utils.go
+++ b/lib/sshutils/sftp/utils.go
@@ -92,5 +92,5 @@ func (c *cancelWriter) Write(b []byte) (int, error) {
 	if err := c.ctx.Err(); err != nil {
 		return 0, err
 	}
-	return c.Write(b)
+	return c.stream.Write(b)
 }

--- a/lib/teleterm/clusters/cluster_file_transfer.go
+++ b/lib/teleterm/clusters/cluster_file_transfer.go
@@ -35,7 +35,7 @@ func (c *Cluster) TransferFile(ctx context.Context, request *api.FileTransferReq
 		return trace.Wrap(err)
 	}
 
-	config.ProgressWriter = func(fileInfo os.FileInfo) io.ReadWriteCloser {
+	config.ProgressStream = func(fileInfo os.FileInfo) io.ReadWriter {
 		return newFileTransferProgress(fileInfo.Size(), sendProgress)
 	}
 
@@ -57,7 +57,7 @@ func getSftpConfig(request *api.FileTransferRequest) (*sftp.Config, error) {
 	}
 }
 
-func newFileTransferProgress(fileSize int64, sendProgress FileTransferProgressSender) io.ReadWriteCloser {
+func newFileTransferProgress(fileSize int64, sendProgress FileTransferProgressSender) io.ReadWriter {
 	return &fileTransferProgress{
 		sendProgress: sendProgress,
 		sentSize:     0,
@@ -72,10 +72,6 @@ type fileTransferProgress struct {
 	lastSentPercentage uint32
 	lastSentAt         time.Time
 	lock               sync.Mutex
-}
-
-func (p *fileTransferProgress) Close() error {
-	return nil
 }
 
 func (p *fileTransferProgress) Read(bytes []byte) (int, error) {

--- a/lib/teleterm/clusters/cluster_file_transfer.go
+++ b/lib/teleterm/clusters/cluster_file_transfer.go
@@ -74,17 +74,19 @@ type fileTransferProgress struct {
 	lock               sync.Mutex
 }
 
-func (p2 *fileTransferProgress) Read(p []byte) (n int, err error) {
-	//TODO implement me
-	panic("implement me")
+func (p *fileTransferProgress) Close() error {
+	return nil
 }
 
-func (p2 *fileTransferProgress) Close() error {
-	//TODO implement me
-	panic("implement me")
+func (p *fileTransferProgress) Read(bytes []byte) (int, error) {
+	return p.maybeUpdateProgress(bytes)
 }
 
 func (p *fileTransferProgress) Write(bytes []byte) (int, error) {
+	return p.maybeUpdateProgress(bytes)
+}
+
+func (p *fileTransferProgress) maybeUpdateProgress(bytes []byte) (int, error) {
 	bytesLength := len(bytes)
 
 	p.lock.Lock()

--- a/lib/teleterm/clusters/cluster_file_transfer.go
+++ b/lib/teleterm/clusters/cluster_file_transfer.go
@@ -35,7 +35,7 @@ func (c *Cluster) TransferFile(ctx context.Context, request *api.FileTransferReq
 		return trace.Wrap(err)
 	}
 
-	config.ProgressWriter = func(fileInfo os.FileInfo) io.Writer {
+	config.ProgressWriter = func(fileInfo os.FileInfo) io.ReadWriteCloser {
 		return newFileTransferProgress(fileInfo.Size(), sendProgress)
 	}
 
@@ -57,7 +57,7 @@ func getSftpConfig(request *api.FileTransferRequest) (*sftp.Config, error) {
 	}
 }
 
-func newFileTransferProgress(fileSize int64, sendProgress FileTransferProgressSender) io.Writer {
+func newFileTransferProgress(fileSize int64, sendProgress FileTransferProgressSender) io.ReadWriteCloser {
 	return &fileTransferProgress{
 		sendProgress: sendProgress,
 		sentSize:     0,
@@ -72,6 +72,16 @@ type fileTransferProgress struct {
 	lastSentPercentage uint32
 	lastSentAt         time.Time
 	lock               sync.Mutex
+}
+
+func (p2 *fileTransferProgress) Read(p []byte) (n int, err error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p2 *fileTransferProgress) Close() error {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (p *fileTransferProgress) Write(bytes []byte) (int, error) {


### PR DESCRIPTION
Our current SFTP implementation uses a single channel to transfer data. Connections with a high latency cause very slow transfer. `github.com/pkg/sftp` allows transferring data using concurrent streams, which seems to solve the problem. In order to utilize the feature, the remote file must implement the `WriteTo()` or `ReadFrom()` and `Stat()` methods. I've moved the progress bar to relay the data from a local file, as we can still call `Read()` or `Write()` on it to update the progress.

This PR doesn't address the high CPU usage by `github.com/pkg/sftp` on low latency links.

Closes https://github.com/gravitational/teleport/issues/20579