### PR TITLE
Update Cache for Proxies using pre-v13 versions

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -221,6 +221,7 @@ func ForOldRemoteProxy(cfg Config) Config {
 		{Kind: types.KindRemoteCluster},
 		{Kind: types.KindKubeService},
 		{Kind: types.KindDatabaseServer},
+		{Kind: types.KindDatabaseService},
 		{Kind: types.KindKubeServer},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1192,15 +1192,15 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 }
 
 // createRemoteAccessPoint creates a new access point for the remote cluster.
-// Checks if the cluster that is connecting is a pre-v12 cluster. If it is,
-// we disable the watcher for resources not supported in a v11 leaf cluster:
-// - types.KindDatabaseService
+// Checks if the cluster that is connecting is a pre-v13 cluster. If it is,
+// we disable the watcher for resources not supported in a v12 leaf cluster:
+// - (to fill when we add new resources)
 //
 // **WARNING**: Ensure that the version below matches the version in which backward incompatible
 // changes were introduced so that the cache is created successfully. Otherwise, the remote cache may
 // never become healthy due to unknown resources.
 func createRemoteAccessPoint(srv *server, clt auth.ClientI, version, domainName string) (auth.RemoteProxyAccessPoint, error) {
-	ok, err := utils.MinVerWithoutPreRelease(version, utils.VersionBeforeAlpha("12.0.0"))
+	ok, err := utils.MinVerWithoutPreRelease(version, utils.VersionBeforeAlpha("13.0.0"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -170,9 +170,15 @@ func TestCreateRemoteAccessPoint(t *testing.T) {
 			assertion: require.Error,
 		},
 		{
-			name:      "remote running 12.0.0",
+			name:      "remote running 13.0.0",
 			assertion: require.NoError,
-			version:   "12.0.0",
+			version:   "13.0.0",
+		},
+		{
+			name:           "remote running 12.0.0",
+			assertion:      require.NoError,
+			version:        "12.0.0",
+			oldRemoteProxy: true,
 		},
 		{
 			name:           "remote running 11.0.0",


### PR DESCRIPTION
When a v13 Root Cluster is paired with v12 Leaf Cluster, we must cache only the known resources by a v12 Proxy.

This PR updates the watching list to now include the DatabaseService which was added in V12.
It also updates the version we check to decide whether to use the new (v13) or the old (v12) set of known resources depending on the reported version by the remote proxy.
