### PR TITLE
Reuse auth token when upgrading an Helm chart without token

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/secret.yaml
+++ b/examples/chart/teleport-kube-agent/templates/secret.yaml
@@ -1,8 +1,3 @@
-{{- $oldToken := "" }}
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.secretName) -}}
-{{- if and $secret $secret.data }}
-{{- $oldToken = index ($secret).data "auth-token"}}
-{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,4 +10,4 @@ metadata:
 type: Opaque
 stringData:
   auth-token: |
-    {{ coalesce .Values.joinParams.tokenName .Values.authToken $oldToken }}
+    {{ coalesce .Values.joinParams.tokenName .Values.authToken }}

--- a/examples/chart/teleport-kube-agent/templates/secret.yaml
+++ b/examples/chart/teleport-kube-agent/templates/secret.yaml
@@ -1,4 +1,8 @@
-{{- if or .Values.authToken .Values.joinParams.tokenName }}
+{{- $oldToken := "" }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.secretName) -}}
+{{- if and $secret $secret.data }}
+{{- $oldToken = index ($secret).data "auth-token"}}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,5 +15,4 @@ metadata:
 type: Opaque
 stringData:
   auth-token: |
-    {{ coalesce .Values.joinParams.tokenName .Values.authToken }}
-{{- end }}
+    {{ coalesce .Values.joinParams.tokenName .Values.authToken $oldToken }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/secret_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/secret_test.yaml.snap
@@ -1,3 +1,13 @@
+generate a secret when neither authToken nor joinParams.tokenName are provided:
+  1: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: teleport-kube-agent-join-token
+      namespace: NAMESPACE
+    stringData:
+      auth-token: ""
+    type: Opaque
 generates a secret when authToken is provided:
   1: |
     apiVersion: v1

--- a/examples/chart/teleport-kube-agent/tests/secret_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/secret_test.yaml
@@ -2,11 +2,13 @@ suite: Secret
 templates:
   - secret.yaml
 tests:
-  - it: does not generate a secret when join method is token and neither authToken nor joinParams.tokenName are provided
+  - it: generate a secret when neither authToken nor joinParams.tokenName are provided
     asserts:
       - hasDocuments:
-          count: 0
-
+          count: 1
+      - isKind:
+          of: Secret
+      - matchSnapshot: {}
   - it: generates a secret when authToken is provided
     set:
       authToken: sample-auth-token-dont-use-this


### PR DESCRIPTION
When upgrading an Helm chat and not providing the auth token because it was previously set, Helm deleted the secret and Statefulset pods become stuck because the secret does not exist.

This PR forces the creation the secret even if no token is provided.

Fixes #20761