### PR TITLE
Connect: Update xterm to 5.1.0 and xterm-addon-fit to 0.7.0

### DIFF
--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -54,8 +54,8 @@
     "split2": "4.1.0",
     "ts-loader": "^9.3.1",
     "winston": "^3.3.3",
-    "xterm": "^4.15.0",
-    "xterm-addon-fit": "^0.5.0",
+    "xterm": "^5.0.0",
+    "xterm-addon-fit": "^0.7.0",
     "zod": "^3.20.0"
   },
   "productName": "Teleport Connect"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15733,20 +15733,10 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-xterm-addon-fit@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz#2d51b983b786a97dcd6cde805e700c7f913bc596"
-  integrity sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==
-
 xterm-addon-fit@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz#b8ade6d96e63b47443862088f6670b49fb752c6a"
   integrity sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==
-
-xterm@^4.15.0:
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.15.0.tgz#e52038507eba7e0d36d47f81e29fe548c82b9561"
-  integrity sha512-Ik1GoSq1yqKZQ2LF37RPS01kX9t4TP8gpamUYblD09yvWX5mEYuMK4CcqH6+plgiNEZduhTz/UrcaWs97gOlOw==
 
 xterm@^5.0.0:
   version "5.1.0"


### PR DESCRIPTION
This makes teleterm match the versions used by teleport.

* https://github.com/gravitational/webapps/pull/1400
* https://github.com/gravitational/teleport/pull/20696

I ran the test plan items related to the shell and everything seems to work fine. I went through the list of breaking changes in 5.0.0 and 5.1.0 and it doesn't look like they affect us.