### PR TITLE
[v9] Pass parent context to `prompt.Confirmation()` in `identityfile`.

### DIFF
--- a/integration/proxy_helpers_test.go
+++ b/integration/proxy_helpers_test.go
@@ -531,7 +531,7 @@ func mustCreateUserIdentityFile(t *testing.T, tc *TeleInstance, username string,
 	key.TrustedCA = auth.AuthoritiesToTrustedCerts(hostCAs)
 
 	idPath := filepath.Join(t.TempDir(), "user_identity")
-	_, err = identityfile.Write(identityfile.WriteConfig{
+	_, err = identityfile.Write(context.Background(), identityfile.WriteConfig{
 		OutputPath: idPath,
 		Key:        key,
 		Format:     identityfile.FormatFile,

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -16,6 +16,7 @@ package identityfile
 
 import (
 	"bytes"
+	"context"
 	"crypto/rsa"
 	"crypto/x509/pkix"
 	"io/ioutil"
@@ -124,7 +125,7 @@ func TestWrite(t *testing.T) {
 	// test OpenSSH-compatible identity file creation:
 	cfg.OutputPath = filepath.Join(outputDir, "openssh")
 	cfg.Format = FormatOpenSSH
-	_, err := Write(cfg)
+	_, err := Write(context.Background(), cfg)
 	require.NoError(t, err)
 
 	// key is OK:
@@ -140,7 +141,7 @@ func TestWrite(t *testing.T) {
 	// test standard Teleport identity file creation:
 	cfg.OutputPath = filepath.Join(outputDir, "file")
 	cfg.Format = FormatFile
-	_, err = Write(cfg)
+	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
 
 	// key+cert are OK:
@@ -162,7 +163,7 @@ func TestWrite(t *testing.T) {
 	cfg.Format = FormatKubernetes
 	cfg.KubeProxyAddr = "far.away.cluster"
 	cfg.KubeTLSServerName = "kube.far.away.cluster"
-	_, err = Write(cfg)
+	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
 	assertKubeconfigContents(t, cfg.OutputPath, key.ClusterName, "far.away.cluster", cfg.KubeTLSServerName)
 }
@@ -177,13 +178,13 @@ func TestKubeconfigOverwrite(t *testing.T) {
 		Key:                  key,
 		OverwriteDestination: true,
 	}
-	_, err := Write(cfg)
+	_, err := Write(context.Background(), cfg)
 	require.NoError(t, err)
 
 	// Write a kubeconfig to the same file path. It should be overwritten.
 	cfg.Format = FormatKubernetes
 	cfg.KubeProxyAddr = "far.away.cluster"
-	_, err = Write(cfg)
+	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
 	assertKubeconfigContents(t, cfg.OutputPath, key.ClusterName, "far.away.cluster", "")
 
@@ -191,7 +192,7 @@ func TestKubeconfigOverwrite(t *testing.T) {
 	// should be overwritten.
 	cfg.KubeProxyAddr = "other.cluster"
 	cfg.KubeTLSServerName = "kube.other.cluster"
-	_, err = Write(cfg)
+	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
 	assertKubeconfigContents(t, cfg.OutputPath, key.ClusterName, "other.cluster", cfg.KubeTLSServerName)
 }

--- a/lib/tbot/config/configtemplate_cockroach.go
+++ b/lib/tbot/config/configtemplate_cockroach.go
@@ -81,7 +81,7 @@ func (t *TemplateCockroach) Render(ctx context.Context, authClient auth.ClientI,
 		OverwriteDestination: true,
 	}
 
-	files, err := identityfile.Write(cfg)
+	files, err := identityfile.Write(ctx, cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/config/configtemplate_identity.go
+++ b/lib/tbot/config/configtemplate_identity.go
@@ -78,7 +78,7 @@ func (t *TemplateIdentity) Render(ctx context.Context, authClient auth.ClientI, 
 		OverwriteDestination: true,
 	}
 
-	files, err := identityfile.Write(cfg)
+	files, err := identityfile.Write(ctx, cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/config/configtemplate_mongo.go
+++ b/lib/tbot/config/configtemplate_mongo.go
@@ -82,7 +82,7 @@ func (t *TemplateMongo) Render(ctx context.Context, authClient auth.ClientI, cur
 		OverwriteDestination: true,
 	}
 
-	files, err := identityfile.Write(cfg)
+	files, err := identityfile.Write(ctx, cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/config/configtemplate_tls.go
+++ b/lib/tbot/config/configtemplate_tls.go
@@ -132,7 +132,7 @@ func (t *TemplateTLS) Render(ctx context.Context, authClient auth.ClientI, curre
 		OverwriteDestination: true,
 	}
 
-	files, err := identityfile.Write(cfg)
+	files, err := identityfile.Write(ctx, cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -402,7 +402,7 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI auth.Clie
 		filePath = principals[0]
 	}
 
-	filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+	filesWritten, err := identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           filePath,
 		Key:                  key,
 		Format:               a.outputFormat,
@@ -478,7 +478,7 @@ func (a *AuthCommand) generateDatabaseKeysForKey(ctx context.Context, clusterAPI
 	}
 	key.TLSCert = resp.Cert
 	key.TrustedCA = []auth.TrustedCerts{{TLSCertificates: resp.CACerts}}
-	filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+	filesWritten, err := identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           a.output,
 		Key:                  key,
 		Format:               a.outputFormat,
@@ -708,7 +708,7 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI auth.Clie
 	}
 
 	// write the cert+private key to the output:
-	filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+	filesWritten, err := identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           a.output,
 		Key:                  key,
 		Format:               a.outputFormat,
@@ -863,7 +863,7 @@ func (a *AuthCommand) checkProxyAddr(ctx context.Context, clusterAPI auth.Client
 // base64-encoded key, comment.
 // For example:
 //
-//    cert-authority AAA... type=user&clustername=cluster-a
+//	cert-authority AAA... type=user&clustername=cluster-a
 //
 // URL encoding is used to pass the CA type and cluster name into the comment field.
 func userCAFormat(ca types.CertAuthority, keyBytes []byte) (string, error) {
@@ -875,7 +875,7 @@ func userCAFormat(ca types.CertAuthority, keyBytes []byte) (string, error) {
 // authorized_hosts format, a space-separated list of: marker, hosts, key, and comment.
 // For example:
 //
-//    @cert-authority *.cluster-a ssh-rsa AAA... type=host
+//	@cert-authority *.cluster-a ssh-rsa AAA... type=host
 //
 // URL encoding is used to pass the CA type and allowed logins into the comment field.
 func hostCAFormat(ca types.CertAuthority, keyBytes []byte, client auth.ClientI) (string, error) {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1276,7 +1276,7 @@ func onLogin(cf *CLIConf) error {
 			kubeHost, _ := tc.KubeProxyHostPort()
 			kubeTLSServerName = client.GetKubeTLSServerName(kubeHost)
 		}
-		filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+		filesWritten, err := identityfile.Write(cf.Context, identityfile.WriteConfig{
 			OutputPath:           cf.IdentityFileOut,
 			Key:                  key,
 			Format:               cf.IdentityFormat,


### PR DESCRIPTION
Backport #20685 to branch/v9