### PR TITLE
[v10] Pass parent context to `prompt.Confirmation()` in `identityfile`.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -1898,7 +1898,7 @@ func MustCreateUserIdentityFile(t *testing.T, tc *TeleInstance, username string,
 	key.TrustedCA = auth.AuthoritiesToTrustedCerts(hostCAs)
 
 	idPath := filepath.Join(t.TempDir(), "user_identity")
-	_, err = identityfile.Write(identityfile.WriteConfig{
+	_, err = identityfile.Write(context.Background(), identityfile.WriteConfig{
 		OutputPath: idPath,
 		Key:        key,
 		Format:     identityfile.FormatFile,

--- a/lib/client/db/database_certificates.go
+++ b/lib/client/db/database_certificates.go
@@ -112,7 +112,7 @@ func GenerateDatabaseCertificates(ctx context.Context, req GenerateDatabaseCerti
 
 	req.Key.TLSCert = resp.Cert
 	req.Key.TrustedCA = []auth.TrustedCerts{{TLSCertificates: resp.CACerts}}
-	filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+	filesWritten, err := identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           req.OutputLocation,
 		Key:                  req.Key,
 		Format:               req.OutputFormat,

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -168,7 +168,7 @@ type WriteConfig struct {
 
 // Write writes user credentials to disk in a specified format.
 // It returns the names of the files successfully written.
-func Write(cfg WriteConfig) (filesWritten []string, err error) {
+func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err error) {
 	// If no writer was set, use the standard implementation.
 	writer := cfg.Writer
 	if writer == nil {
@@ -183,7 +183,7 @@ func Write(cfg WriteConfig) (filesWritten []string, err error) {
 	// dump user identity into a single file:
 	case FormatFile:
 		filesWritten = append(filesWritten, cfg.OutputPath)
-		if err := checkOverwrite(writer, cfg.OverwriteDestination, filesWritten...); err != nil {
+		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -222,7 +222,7 @@ func Write(cfg WriteConfig) (filesWritten []string, err error) {
 		keyPath := cfg.OutputPath
 		certPath := keypaths.IdentitySSHCertPath(keyPath)
 		filesWritten = append(filesWritten, keyPath, certPath)
-		if err := checkOverwrite(writer, cfg.OverwriteDestination, filesWritten...); err != nil {
+		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -249,7 +249,7 @@ func Write(cfg WriteConfig) (filesWritten []string, err error) {
 		}
 
 		filesWritten = append(filesWritten, keyPath, certPath, casPath)
-		if err := checkOverwrite(writer, cfg.OverwriteDestination, filesWritten...); err != nil {
+		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -279,7 +279,7 @@ func Write(cfg WriteConfig) (filesWritten []string, err error) {
 		certPath := cfg.OutputPath + ".crt"
 		casPath := cfg.OutputPath + ".cas"
 		filesWritten = append(filesWritten, certPath, casPath)
-		if err := checkOverwrite(writer, cfg.OverwriteDestination, filesWritten...); err != nil {
+		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		err = writer.WriteFile(certPath, append(cfg.Key.TLSCert, cfg.Key.PrivateKeyPEM()...), identityfile.FilePermissions)
@@ -300,7 +300,7 @@ func Write(cfg WriteConfig) (filesWritten []string, err error) {
 		pubPath := cfg.OutputPath + ".pub"
 		filesWritten = append(filesWritten, pubPath)
 
-		if err := checkOverwrite(writer, cfg.OverwriteDestination, pubPath); err != nil {
+		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, pubPath); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -332,7 +332,7 @@ func Write(cfg WriteConfig) (filesWritten []string, err error) {
 		filesWritten = append(filesWritten, cfg.OutputPath)
 		// If the user does not want to override,  it will merge the previous kubeconfig
 		// with the new entry.
-		if err := checkOverwrite(writer, cfg.OverwriteDestination, filesWritten...); err != nil && !trace.IsAlreadyExists(err) {
+		if err := checkOverwrite(ctx, writer, cfg.OverwriteDestination, filesWritten...); err != nil && !trace.IsAlreadyExists(err) {
 			return nil, trace.Wrap(err)
 		} else if err == nil {
 			// Clean up the existing file, if it exists.
@@ -365,7 +365,7 @@ func Write(cfg WriteConfig) (filesWritten []string, err error) {
 	return filesWritten, nil
 }
 
-func checkOverwrite(writer ConfigWriter, force bool, paths ...string) error {
+func checkOverwrite(ctx context.Context, writer ConfigWriter, force bool, paths ...string) error {
 	var existingFiles []string
 	// Check if the destination file exists.
 	for _, path := range paths {
@@ -386,7 +386,7 @@ func checkOverwrite(writer ConfigWriter, force bool, paths ...string) error {
 	}
 
 	// Some files exist, prompt user whether to overwrite.
-	overwrite, err := prompt.Confirmation(context.Background(), os.Stderr, prompt.Stdin(), fmt.Sprintf("Destination file(s) %s exist. Overwrite?", strings.Join(existingFiles, ", ")))
+	overwrite, err := prompt.Confirmation(ctx, os.Stderr, prompt.Stdin(), fmt.Sprintf("Destination file(s) %s exist. Overwrite?", strings.Join(existingFiles, ", ")))
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -16,6 +16,7 @@ package identityfile
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/x509/pkix"
 	"os"
@@ -115,7 +116,7 @@ func TestWrite(t *testing.T) {
 	// test OpenSSH-compatible identity file creation:
 	cfg.OutputPath = filepath.Join(outputDir, "openssh")
 	cfg.Format = FormatOpenSSH
-	_, err := Write(cfg)
+	_, err := Write(context.Background(), cfg)
 	require.NoError(t, err)
 
 	// key is OK:
@@ -131,7 +132,7 @@ func TestWrite(t *testing.T) {
 	// test standard Teleport identity file creation:
 	cfg.OutputPath = filepath.Join(outputDir, "file")
 	cfg.Format = FormatFile
-	_, err = Write(cfg)
+	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
 
 	// key+cert are OK:
@@ -153,7 +154,7 @@ func TestWrite(t *testing.T) {
 	cfg.Format = FormatKubernetes
 	cfg.KubeProxyAddr = "far.away.cluster"
 	cfg.KubeTLSServerName = "kube.far.away.cluster"
-	_, err = Write(cfg)
+	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
 	assertKubeconfigContents(t, cfg.OutputPath, key.ClusterName, "far.away.cluster", cfg.KubeTLSServerName)
 }
@@ -180,7 +181,7 @@ func TestWriteAllFormats(t *testing.T) {
 				cfg.OutputPath = t.TempDir()
 			}
 
-			files, err := Write(cfg)
+			files, err := Write(context.Background(), cfg)
 			require.NoError(t, err)
 			for _, file := range files {
 				require.True(t, strings.HasPrefix(file, cfg.OutputPath))
@@ -200,13 +201,13 @@ func TestKubeconfigOverwrite(t *testing.T) {
 		Key:                  key,
 		OverwriteDestination: true,
 	}
-	_, err := Write(cfg)
+	_, err := Write(context.Background(), cfg)
 	require.NoError(t, err)
 
 	// Write a kubeconfig to the same file path. It should be overwritten.
 	cfg.Format = FormatKubernetes
 	cfg.KubeProxyAddr = "far.away.cluster"
-	_, err = Write(cfg)
+	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
 	assertKubeconfigContents(t, cfg.OutputPath, key.ClusterName, "far.away.cluster", "")
 
@@ -214,7 +215,7 @@ func TestKubeconfigOverwrite(t *testing.T) {
 	// should be overwritten.
 	cfg.KubeProxyAddr = "other.cluster"
 	cfg.KubeTLSServerName = "kube.other.cluster"
-	_, err = Write(cfg)
+	_, err = Write(context.Background(), cfg)
 	require.NoError(t, err)
 	assertKubeconfigContents(t, cfg.OutputPath, key.ClusterName, "other.cluster", cfg.KubeTLSServerName)
 }

--- a/lib/tbot/config/configtemplate_cockroach.go
+++ b/lib/tbot/config/configtemplate_cockroach.go
@@ -86,7 +86,7 @@ func (t *TemplateCockroach) Render(ctx context.Context, bot Bot, currentIdentity
 		OverwriteDestination: true,
 	}
 
-	files, err := identityfile.Write(cfg)
+	files, err := identityfile.Write(ctx, cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/config/configtemplate_identity.go
+++ b/lib/tbot/config/configtemplate_identity.go
@@ -83,7 +83,7 @@ func (t *TemplateIdentity) Render(ctx context.Context, bot Bot, currentIdentity 
 		OverwriteDestination: true,
 	}
 
-	files, err := identityfile.Write(cfg)
+	files, err := identityfile.Write(ctx, cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/config/configtemplate_mongo.go
+++ b/lib/tbot/config/configtemplate_mongo.go
@@ -87,7 +87,7 @@ func (t *TemplateMongo) Render(ctx context.Context, bot Bot, currentIdentity *id
 		OverwriteDestination: true,
 	}
 
-	files, err := identityfile.Write(cfg)
+	files, err := identityfile.Write(ctx, cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/config/configtemplate_ssh_host_cert.go
+++ b/lib/tbot/config/configtemplate_ssh_host_cert.go
@@ -165,7 +165,7 @@ func (c *TemplateSSHHostCert) Render(ctx context.Context, bot Bot, currentIdenti
 		OverwriteDestination: true,
 	}
 
-	files, err := identityfile.Write(cfg)
+	files, err := identityfile.Write(ctx, cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/config/configtemplate_tls.go
+++ b/lib/tbot/config/configtemplate_tls.go
@@ -137,7 +137,7 @@ func (t *TemplateTLS) Render(ctx context.Context, bot Bot, currentIdentity *iden
 		OverwriteDestination: true,
 	}
 
-	files, err := identityfile.Write(cfg)
+	files, err := identityfile.Write(ctx, cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -366,7 +366,7 @@ func (a *AuthCommand) generateSnowflakeKey(ctx context.Context, clusterAPI auth.
 
 	key.TrustedCA = []auth.TrustedCerts{{TLSCertificates: services.GetTLSCerts(databaseCA)}}
 
-	filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+	filesWritten, err := identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           a.output,
 		Key:                  key,
 		Format:               a.outputFormat,
@@ -444,7 +444,7 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI auth.Clie
 		filePath = principals[0]
 	}
 
-	filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+	filesWritten, err := identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           filePath,
 		Key:                  key,
 		Format:               a.outputFormat,
@@ -739,7 +739,7 @@ func (a *AuthCommand) generateUserKeys(ctx context.Context, clusterAPI auth.Clie
 	}
 
 	// write the cert+private key to the output:
-	filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+	filesWritten, err := identityfile.Write(ctx, identityfile.WriteConfig{
 		OutputPath:           a.output,
 		Key:                  key,
 		Format:               a.outputFormat,

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1526,7 +1526,7 @@ func onLogin(cf *CLIConf) error {
 			kubeHost, _ := tc.KubeProxyHostPort()
 			kubeTLSServerName = client.GetKubeTLSServerName(kubeHost)
 		}
-		filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+		filesWritten, err := identityfile.Write(cf.Context, identityfile.WriteConfig{
 			OutputPath:           cf.IdentityFileOut,
 			Key:                  key,
 			Format:               cf.IdentityFormat,


### PR DESCRIPTION
Backport #20685 to branch/v10