### PR TITLE
Renew Kubernetes cluster credentials until the cluster is removed from inventory

### DIFF
--- a/lib/kube/proxy/kube_creds.go
+++ b/lib/kube/proxy/kube_creds.go
@@ -130,12 +130,14 @@ func newDynamicKubeCreds(ctx context.Context, kubeCluster types.KubeCluster, log
 	}
 
 	go func() {
-		select {
-		case <-dyn.closeC:
-			return
-		case <-dyn.renewTicker.C:
-			if err := dyn.renewClientset(kubeCluster); err != nil {
-				log.WithError(err).Warnf("Unable to renew cluster %q credentials.", kubeCluster.GetName())
+		for {
+			select {
+			case <-dyn.closeC:
+				return
+			case <-dyn.renewTicker.C:
+				if err := dyn.renewClientset(kubeCluster); err != nil {
+					log.WithError(err).Warnf("Unable to renew cluster %q credentials.", kubeCluster.GetName())
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
This PR renews the dynamic credentials until the cluster is removed instead of renewing it once.

