### PR TITLE
Fix the navigation not allowing switching back to resources

### DIFF
--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -129,8 +129,6 @@ export function Navigation() {
       history.push(
         previousRoute || getFirstRouteForCategory(features, category)
       );
-
-      setView(category);
     },
     [view, location.pathname, previousRoute]
   );


### PR DESCRIPTION
Due to the way we were tracking the previous location (only when the user actually swaps between resources & management), we weren't updating the previous location when the navigation is switched on the user's behalf (i.e. clicking "Add Server").

To fix this, the tracking of the previous route has been changed to react on any history changes through the proper `subscribe` method. If there's a navigation change that happens where the category is different, it'll track the previous location regardless of how the change in category occurred.