### PR TITLE
[v11] InstallNode Script: use correct version (oss vs ent)

### DIFF
--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -42,10 +42,16 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web/scripts"
 	"github.com/gravitational/teleport/lib/web/ui"
+)
+
+const (
+	teleportOSSPackageName = "teleport"
+	teleportEntPackageName = "teleport-ent"
 )
 
 // nodeJoinToken contains node token fields for the UI.
@@ -364,6 +370,12 @@ func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter
 			return "", trace.BadParameter("appURI %q contains invalid characters", settings.appURI)
 		}
 	}
+
+	packageName := teleportOSSPackageName
+	if modules.GetModules().BuildType() == modules.BuildEnterprise {
+		packageName = teleportEntPackageName
+	}
+
 	// This section relies on Go's default zero values to make sure that the settings
 	// are correct when not installing an app.
 	err = scripts.InstallNodeBashScript.Execute(&buf, map[string]interface{}{
@@ -377,6 +389,7 @@ func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter
 		// file has been completely converted over.
 		"caPinsOld":                  strings.Join(caPins, " "),
 		"caPins":                     strings.Join(caPins, ","),
+		"packageName":                packageName,
 		"version":                    version,
 		"appInstallMode":             strconv.FormatBool(settings.appInstallMode),
 		"appName":                    settings.appName,

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -777,9 +777,9 @@ fi
 if [[ ${TELEPORT_FORMAT} == "tarball" ]]; then
     # handle centos6 URL override
     if [[ ${DISTRO_TYPE} == "centos6" ]]; then
-        URL="https://get.gravitational.com/teleport-v${TELEPORT_VERSION}-${TELEPORT_BINARY_TYPE}-${TELEPORT_ARCH}-centos6-bin.tar.gz"
+        URL="https://get.gravitational.com/{{.packageName}}-v${TELEPORT_VERSION}-${TELEPORT_BINARY_TYPE}-${TELEPORT_ARCH}-centos6-bin.tar.gz"
     else
-        URL="https://get.gravitational.com/teleport-v${TELEPORT_VERSION}-${TELEPORT_BINARY_TYPE}-${TELEPORT_ARCH}-bin.tar.gz"
+        URL="https://get.gravitational.com/{{.packageName}}-v${TELEPORT_VERSION}-${TELEPORT_BINARY_TYPE}-${TELEPORT_ARCH}-bin.tar.gz"
     fi
     # check that needed tools are installed
     check_exists_fatal curl tar
@@ -804,7 +804,7 @@ elif [[ ${TELEPORT_FORMAT} == "deb" ]]; then
     elif [[ ${TELEPORT_ARCH} == "arm64" ]]; then
         DEB_ARCH="arm64"
     fi
-    URL="https://get.gravitational.com/teleport_${TELEPORT_VERSION}_${DEB_ARCH}.deb"
+    URL="https://get.gravitational.com/{{.packageName}}_${TELEPORT_VERSION}_${DEB_ARCH}.deb"
     check_deb_not_already_installed
     # check that needed tools are installed
     check_exists_fatal curl dpkg
@@ -826,7 +826,7 @@ elif [[ ${TELEPORT_FORMAT} == "rpm" ]]; then
     elif [[ ${TELEPORT_ARCH} == "arm64" ]]; then
         RPM_ARCH="arm64"
     fi
-    URL="https://get.gravitational.com/teleport-${TELEPORT_VERSION}-1.${RPM_ARCH}.rpm"
+    URL="https://get.gravitational.com/{{.packageName}}-${TELEPORT_VERSION}-1.${RPM_ARCH}.rpm"
     check_rpm_not_already_installed
     # check for package managers
     if check_exists dnf; then


### PR DESCRIPTION
Backport #20275 to branch/v11