### PR TITLE
Stop the support link pretending it's a dropdown

### DIFF
--- a/web/packages/teleport/src/Navigation/NavigationItem.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationItem.tsx
@@ -40,9 +40,11 @@ interface NavigationItemProps {
 }
 
 const ExternalLink = styled.a`
-  padding: 16px 30px;
-
   ${commonNavigationItemStyles};
+
+  &:focus {
+    background: rgba(255, 255, 255, 0.05);
+  }
 `;
 
 const Link = styled(NavLink)`
@@ -144,7 +146,7 @@ export function NavigationItem(props: NavigationItemProps) {
     []
   );
 
-  if (navigationItem && route) {
+  if (navigationItem) {
     const linkProps = {
       style: {
         transitionDelay: `${props.transitionDelay}ms,0s`,
@@ -164,30 +166,34 @@ export function NavigationItem(props: NavigationItemProps) {
           target="_blank"
           rel="noopener noreferrer"
         >
-          {getIcon(props.feature, props.size)}
-          {navigationItem.title}
+          <LinkContent size={props.size}>
+            {getIcon(props.feature, props.size)}
+            {navigationItem.title}
 
-          <ExternalLinkIndicator>
-            <ExternalLinkIcon size={14} />
-          </ExternalLinkIndicator>
+            <ExternalLinkIndicator>
+              <ExternalLinkIcon size={14} />
+            </ExternalLinkIndicator>
+          </LinkContent>
         </ExternalLink>
       );
     }
 
-    return (
-      <Link
-        {...linkProps}
-        onKeyDown={handleKeyDown}
-        tabIndex={props.visible ? 0 : -1}
-        to={navigationItem.getLink(clusterId)}
-        exact={navigationItem.exact}
-      >
-        <LinkContent size={props.size}>
-          {getIcon(props.feature, props.size)}
-          {navigationItem.title}
-        </LinkContent>
-      </Link>
-    );
+    if (route) {
+      return (
+        <Link
+          {...linkProps}
+          onKeyDown={handleKeyDown}
+          tabIndex={props.visible ? 0 : -1}
+          to={navigationItem.getLink(clusterId)}
+          exact={navigationItem.exact}
+        >
+          <LinkContent size={props.size}>
+            {getIcon(props.feature, props.size)}
+            {navigationItem.title}
+          </LinkContent>
+        </Link>
+      );
+    }
   }
 
   return (


### PR DESCRIPTION
Previously, the navigation would only display a link in the navigation if it had a corresponding `route` attribute on the feature class.

For the support link that goes into the navigation, it doesn't have a `route` as it links to an external page.

This fixes the logic to show the support link as an external link instead of a dropdown.

Before:
<img width="272" alt="image" src="https://user-images.githubusercontent.com/7922109/215123650-7dcbf510-969d-4f9c-b88c-d0e3ca9de3e6.png">

Now:
<img width="292" alt="image" src="https://user-images.githubusercontent.com/7922109/215123446-b4ccbd37-d139-4b40-a1ce-b6c51961607b.png">
