### PR TITLE
PresetRoles: remove unecessary upsert when role doesn't change

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -575,28 +575,44 @@ func migrateLegacyResources(ctx context.Context, asrv *Server) error {
 	return nil
 }
 
+// PresetRoleManager contains the required Role Management methods to create a Preset Role.
+type PresetRoleManager interface {
+	// GetRole returns role by name.
+	GetRole(ctx context.Context, name string) (types.Role, error)
+	// CreateRole creates a role.
+	CreateRole(ctx context.Context, role types.Role) error
+	// UpsertRole creates or updates a role and emits a related audit event.
+	UpsertRole(ctx context.Context, role types.Role) error
+}
+
 // createPresets creates preset resources (eg, roles).
-func createPresets(ctx context.Context, asrv *Server) error {
+func createPresets(ctx context.Context, rm PresetRoleManager) error {
 	roles := []types.Role{
 		services.NewPresetEditorRole(),
 		services.NewPresetAccessRole(),
 		services.NewPresetAuditorRole(),
 	}
 	for _, role := range roles {
-		err := asrv.CreateRole(ctx, role)
+		err := rm.CreateRole(ctx, role)
 		if err != nil {
 			if !trace.IsAlreadyExists(err) {
 				return trace.WrapWithMessage(err, "failed to create preset role %v", role.GetName())
 			}
 
-			currentRole, err := asrv.GetRole(ctx, role.GetName())
+			currentRole, err := rm.GetRole(ctx, role.GetName())
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			role = services.AddDefaultAllowRules(currentRole)
+			role, err := services.AddDefaultAllowRules(currentRole)
+			if trace.IsAlreadyExists(err) {
+				continue
+			}
+			if err != nil {
+				return trace.Wrap(err)
+			}
 
-			err = asrv.UpsertRole(ctx, role)
+			err = rm.UpsertRole(ctx, role)
 			if err != nil {
 				return trace.WrapWithMessage(err, "failed to update preset role %v", role.GetName())
 			}

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -580,6 +580,99 @@ func TestPresets(t *testing.T) {
 			return true
 		}, "missing default rule")
 	})
+
+	t.Run("Does not upsert roles if nothing changes", func(t *testing.T) {
+		presetRoleCount := 3
+
+		roleManager := &mockRoleManager{
+			roles: make(map[string]types.Role, presetRoleCount),
+		}
+
+		err := createPresets(ctx, roleManager)
+		require.NoError(t, err)
+
+		require.Equal(t, 0, roleManager.upsertRoleCallsCount, "unexpectd call to UpsertRole")
+		require.Equal(t, 0, roleManager.getRoleCallsCount, "unexpectd call to GetRole")
+		require.Equal(t, presetRoleCount, roleManager.createRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.createRoleCallsCount)
+
+		// Running a second time should return Already Exists, so it fetches the role.
+		// The role was not changed, so it can't call the UpsertRole method.
+		roleManager.ResetCallCounters()
+
+		err = createPresets(ctx, roleManager)
+		require.NoError(t, err)
+
+		require.Equal(t, 0, roleManager.upsertRoleCallsCount, "unexpectd call to UpsertRole")
+		require.Equal(t, presetRoleCount, roleManager.getRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.getRoleCallsCount)
+		require.Equal(t, presetRoleCount, roleManager.createRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.createRoleCallsCount)
+
+		// Removing a specific resource which is part of the Default Allow Rules should trigger an UpsertRole call
+		editorRole := roleManager.roles[teleport.PresetEditorRoleName]
+		allowRulesWithoutConnectionDiag := []types.Rule{}
+
+		for _, r := range editorRole.GetRules(types.Allow) {
+			if slices.Contains(r.Resources, types.KindConnectionDiagnostic) {
+				continue
+			}
+			allowRulesWithoutConnectionDiag = append(allowRulesWithoutConnectionDiag, r)
+		}
+		editorRole.SetRules(types.Allow, allowRulesWithoutConnectionDiag)
+		roleManager.UpsertRole(ctx, editorRole)
+
+		roleManager.ResetCallCounters()
+		err = createPresets(ctx, roleManager)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, roleManager.upsertRoleCallsCount, "unexpectd call to UpsertRole")
+		require.Equal(t, presetRoleCount, roleManager.getRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.getRoleCallsCount)
+		require.Equal(t, presetRoleCount, roleManager.createRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.createRoleCallsCount)
+	})
+}
+
+type mockRoleManager struct {
+	roles                map[string]types.Role
+	getRoleCallsCount    int
+	createRoleCallsCount int
+	upsertRoleCallsCount int
+}
+
+// ResetCallCounters resets the method call counters.
+func (m *mockRoleManager) ResetCallCounters() {
+	m.getRoleCallsCount = 0
+	m.createRoleCallsCount = 0
+	m.upsertRoleCallsCount = 0
+}
+
+// GetRole returns role by name.
+func (m *mockRoleManager) GetRole(ctx context.Context, name string) (types.Role, error) {
+	m.getRoleCallsCount = m.getRoleCallsCount + 1
+
+	role, ok := m.roles[name]
+	if !ok {
+		return nil, trace.NotFound("role not found")
+	}
+	return role, nil
+}
+
+// CreateRole creates a role.
+func (m *mockRoleManager) CreateRole(ctx context.Context, role types.Role) error {
+	m.createRoleCallsCount = m.createRoleCallsCount + 1
+
+	_, ok := m.roles[role.GetName()]
+	if ok {
+		return trace.AlreadyExists("role not found")
+	}
+
+	m.roles[role.GetName()] = role
+	return nil
+}
+
+// UpsertRole creates or updates a role and emits a related audit event.
+func (m *mockRoleManager) UpsertRole(ctx context.Context, role types.Role) error {
+	m.upsertRoleCallsCount = m.upsertRoleCallsCount + 1
+	m.roles[role.GetName()] = role
+
+	return nil
 }
 
 func setupConfig(t *testing.T) InitConfig {

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 
@@ -197,16 +198,17 @@ func defaultAllowRules() map[string][]types.Rule {
 
 // AddDefaultAllowRules adds default rules to a preset role.
 // Only rules whose resources are not already defined (either allowing or denying) are added.
-func AddDefaultAllowRules(role types.Role) types.Role {
+func AddDefaultAllowRules(role types.Role) (types.Role, error) {
 	defaultRules, ok := defaultAllowRules()[role.GetName()]
 	if !ok || len(defaultRules) == 0 {
-		return role
+		return nil, trace.AlreadyExists("no change")
 	}
 
-	combined := append(role.GetRules(types.Allow), role.GetRules(types.Deny)...)
+	existingRules := append(role.GetRules(types.Allow), role.GetRules(types.Deny)...)
 
+	changed := false
 	for _, defaultRule := range defaultRules {
-		if resourceBelongsToRules(combined, defaultRule.Resources) {
+		if resourceBelongsToRules(existingRules, defaultRule.Resources) {
 			continue
 		}
 
@@ -214,9 +216,14 @@ func AddDefaultAllowRules(role types.Role) types.Role {
 		rules := role.GetRules(types.Allow)
 		rules = append(rules, defaultRule)
 		role.SetRules(types.Allow, rules)
+		changed = true
 	}
 
-	return role
+	if !changed {
+		return nil, trace.AlreadyExists("no change")
+	}
+
+	return role, nil
 }
 
 func resourceBelongsToRules(rules []types.Rule, resources []string) bool {


### PR DESCRIPTION
We were upserting the preset roles everytime the auth server started.
This created a lot of spam in the audit log.

This PR changes this behavior to only upsert if the role was actually changed from applying DefaultAllowRules.

Demo
Before
![image](https://user-images.githubusercontent.com/689271/215142177-cf4ec205-2800-445c-8151-7c8bc786bdf5.png)

After
![image](https://user-images.githubusercontent.com/689271/215142017-c6b156f2-d2e6-480a-9d1b-9276ca207573.png)
