### PR TITLE
Set certain ssh env variables without waiting for a reply

### DIFF
--- a/api/observability/tracing/ssh/channel.go
+++ b/api/observability/tracing/ssh/channel.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -54,6 +55,7 @@ func (c *Channel) SendRequest(ctx context.Context, name string, wantReply bool, 
 		fmt.Sprintf("ssh.ChannelRequest/%s", name),
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 		oteltrace.WithAttributes(
+			attribute.Bool("want_reply", wantReply),
 			semconv.RPCServiceKey.String("ssh.Channel"),
 			semconv.RPCMethodKey.String("SendRequest"),
 			semconv.RPCSystemKey.String("ssh"),

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1505,7 +1505,7 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress NodeDet
 	// pass the true client IP (if specified) to the proxy so it could pass it into the
 	// SSH session for proper audit
 	if len(proxy.clientAddr) > 0 {
-		if err = proxySession.Setenv(ctx, sshutils.TrueClientAddrVar, proxy.clientAddr); err != nil {
+		if err := proxySession.SetenvNoReply(ctx, sshutils.TrueClientAddrVar, proxy.clientAddr); err != nil {
 			log.Error(err)
 		}
 	}

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -229,16 +229,14 @@ func (ns *NodeSession) createServerSession(ctx context.Context) (*tracessh.Sessi
 	evarsToPass := []string{"LANG", "LANGUAGE"}
 	for _, evar := range evarsToPass {
 		if value := os.Getenv(evar); value != "" {
-			err = sess.Setenv(ctx, evar, value)
-			if err != nil {
+			if err := sess.SetenvNoReply(ctx, evar, value); err != nil {
 				log.Warn(err)
 			}
 		}
 	}
 	// pass environment variables set by client
 	for key, val := range ns.env {
-		err = sess.Setenv(ctx, key, val)
-		if err != nil {
+		if err := sess.SetenvNoReply(ctx, key, val); err != nil {
 			log.Warn(err)
 		}
 	}

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -641,7 +641,7 @@ func (t *remoteTerminal) prepareRemoteSession(ctx context.Context, session *trac
 	}
 
 	for k, v := range envs {
-		if err := session.Setenv(ctx, k, v); err != nil {
+		if err := session.SetenvNoReply(ctx, k, v); err != nil {
 			t.log.Debugf("Unable to set environment variable: %v: %v", k, v)
 		}
 	}


### PR DESCRIPTION
Setting an env on an ssh session requires waiting for the server to process and reply to the request. This makes setting N env vars in a row a rather slow task as they aren't done in parallel. Since we only log the returned error and continue on if setting an env fails in some cases we can get a slight reduction in latency if we don't request a reply from the server.