### PR TITLE
[v11] chore: Bump Buf to 1.13.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -206,7 +206,7 @@ RUN (git clone https://github.com/gogo/protobuf.git --branch ${GOGO_PROTO_TAG} -
 
 # Install buf
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.12.0" && \
+    VERSION="1.13.0" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Keep up with the latest updates.

No format, lint or codegen changes.

https://github.com/bufbuild/buf/releases/tag/v1.13.0

Backport #20814 to branch/v11