### PR TITLE
Adds Origin and Label functions to ResourceHeader.

### DIFF
--- a/api/types/connection_diagnostic.go
+++ b/api/types/connection_diagnostic.go
@@ -86,16 +86,6 @@ func (c *ConnectionDiagnosticV1) CheckAndSetDefaults() error {
 	return nil
 }
 
-// GetAllLabels returns combined static and dynamic labels.
-func (c *ConnectionDiagnosticV1) GetAllLabels() map[string]string {
-	return CombineLabels(c.Metadata.Labels, nil)
-}
-
-// GetStaticLabels returns the connection diagnostic static labels.
-func (c *ConnectionDiagnosticV1) GetStaticLabels() map[string]string {
-	return c.Metadata.Labels
-}
-
 // IsSuccess returns whether the connection was successful
 func (c *ConnectionDiagnosticV1) IsSuccess() bool {
 	return c.Spec.Success
@@ -131,16 +121,6 @@ func (c *ConnectionDiagnosticV1) AppendTrace(trace *ConnectionDiagnosticTrace) {
 func (c *ConnectionDiagnosticV1) MatchSearch(values []string) bool {
 	fieldVals := append(utils.MapToStrings(c.GetAllLabels()), c.GetName())
 	return MatchSearch(fieldVals, values, nil)
-}
-
-// Origin returns the origin value of the resource.
-func (c *ConnectionDiagnosticV1) Origin() string {
-	return c.Metadata.Labels[OriginLabel]
-}
-
-// SetOrigin sets the origin value of the resource.
-func (c *ConnectionDiagnosticV1) SetOrigin(o string) {
-	c.Metadata.Labels[OriginLabel] = o
 }
 
 // SetStaticLabels sets the connection diagnostic static labels.

--- a/api/types/databaseservice.go
+++ b/api/types/databaseservice.go
@@ -71,34 +71,9 @@ func (s *DatabaseServiceV1) GetNamespace() string {
 	return s.Metadata.Namespace
 }
 
-// GetAllLabels returns combined static and dynamic labels.
-func (s *DatabaseServiceV1) GetAllLabels() map[string]string {
-	return s.Metadata.Labels
-}
-
-// GetStaticLabels returns the static labels.
-func (s *DatabaseServiceV1) GetStaticLabels() map[string]string {
-	return s.Metadata.Labels
-}
-
-// SetStaticLabels sets the static labels.
-func (s *DatabaseServiceV1) SetStaticLabels(sl map[string]string) {
-	s.Metadata.Labels = sl
-}
-
 // MatchSearch goes through select field values and tries to
 // match against the list of search values.
 func (s *DatabaseServiceV1) MatchSearch(values []string) bool {
 	fieldVals := append(utils.MapToStrings(s.GetAllLabels()), s.GetName())
 	return MatchSearch(fieldVals, values, nil)
-}
-
-// Origin returns the origin value of the resource.
-func (s *DatabaseServiceV1) Origin() string {
-	return s.Metadata.Origin()
-}
-
-// SetOrigin sets the origin value of the resource.
-func (s *DatabaseServiceV1) SetOrigin(origin string) {
-	s.Metadata.SetOrigin(origin)
 }

--- a/api/types/desktop.go
+++ b/api/types/desktop.go
@@ -96,16 +96,6 @@ func (s *WindowsDesktopServiceV3) GetTeleportVersion() string {
 	return s.Spec.TeleportVersion
 }
 
-// Origin returns the origin value of the resource.
-func (s *WindowsDesktopServiceV3) Origin() string {
-	return s.Metadata.Origin()
-}
-
-// SetOrigin sets the origin value of the resource.
-func (s *WindowsDesktopServiceV3) SetOrigin(origin string) {
-	s.Metadata.SetOrigin(origin)
-}
-
 // GetProxyID returns a list of proxy ids this server is connected to.
 func (s *WindowsDesktopServiceV3) GetProxyIDs() []string {
 	return s.Spec.ProxyIDs
@@ -114,21 +104,6 @@ func (s *WindowsDesktopServiceV3) GetProxyIDs() []string {
 // SetProxyID sets the proxy ids this server is connected to.
 func (s *WindowsDesktopServiceV3) SetProxyIDs(proxyIDs []string) {
 	s.Spec.ProxyIDs = proxyIDs
-}
-
-// GetAllLabels returns the resources labels.
-func (s *WindowsDesktopServiceV3) GetAllLabels() map[string]string {
-	return s.Metadata.Labels
-}
-
-// GetStaticLabels returns the windows desktop static labels.
-func (s *WindowsDesktopServiceV3) GetStaticLabels() map[string]string {
-	return s.Metadata.Labels
-}
-
-// SetStaticLabels sets the windows desktop static labels.
-func (s *WindowsDesktopServiceV3) SetStaticLabels(sl map[string]string) {
-	s.Metadata.Labels = sl
 }
 
 // GetHostname returns the windows hostname of this service.
@@ -212,22 +187,6 @@ func (d *WindowsDesktopV3) GetHostID() string {
 	return d.Spec.HostID
 }
 
-// GetAllLabels returns combined static and dynamic labels.
-func (d *WindowsDesktopV3) GetAllLabels() map[string]string {
-	// TODO(zmb3): add dynamic labels when running in agent mode
-	return CombineLabels(d.Metadata.Labels, nil)
-}
-
-// GetStaticLabels returns the windows desktop static labels.
-func (d *WindowsDesktopV3) GetStaticLabels() map[string]string {
-	return d.Metadata.Labels
-}
-
-// SetStaticLabels sets the windows desktop static labels.
-func (d *WindowsDesktopV3) SetStaticLabels(sl map[string]string) {
-	d.Metadata.Labels = sl
-}
-
 // LabelsString returns all desktop labels as a string.
 func (d *WindowsDesktopV3) LabelsString() string {
 	return LabelsAsString(d.Metadata.Labels, nil)
@@ -236,16 +195,6 @@ func (d *WindowsDesktopV3) LabelsString() string {
 // GetDomain returns the Active Directory domain of this host.
 func (d *WindowsDesktopV3) GetDomain() string {
 	return d.Spec.Domain
-}
-
-// Origin returns the origin value of the resource.
-func (d *WindowsDesktopV3) Origin() string {
-	return d.Metadata.Labels[OriginLabel]
-}
-
-// SetOrigin sets the origin value of the resource.
-func (d *WindowsDesktopV3) SetOrigin(o string) {
-	d.Metadata.Labels[OriginLabel] = o
 }
 
 // MatchSearch goes through select field values and tries to

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -298,6 +298,31 @@ func (h *ResourceHeader) SetSubKind(s string) {
 	h.SubKind = s
 }
 
+// Origin returns the origin value of the resource.
+func (h *ResourceHeader) Origin() string {
+	return h.Metadata.Origin()
+}
+
+// SetOrigin sets the origin value of the resource.
+func (h *ResourceHeader) SetOrigin(origin string) {
+	h.Metadata.SetOrigin(origin)
+}
+
+// GetStaticLabels returns the static labels for the resource.
+func (h *ResourceHeader) GetStaticLabels() map[string]string {
+	return h.Metadata.Labels
+}
+
+// SetStaticLabels sets the static labels for the resource.
+func (h *ResourceHeader) SetStaticLabels(sl map[string]string) {
+	h.Metadata.Labels = sl
+}
+
+// GetAllLabels returns all labels from the resource..
+func (h *ResourceHeader) GetAllLabels() map[string]string {
+	return h.Metadata.Labels
+}
+
 func (h *ResourceHeader) CheckAndSetDefaults() error {
 	if h.Kind == "" {
 		return trace.BadParameter("resource has an empty Kind field")

--- a/api/types/session_tracker.go
+++ b/api/types/session_tracker.go
@@ -137,61 +137,6 @@ func NewSessionTracker(spec SessionTrackerSpecV1) (SessionTracker, error) {
 	return session, nil
 }
 
-// GetVersion returns resource version.
-func (s *SessionTrackerV1) GetVersion() string {
-	return s.Version
-}
-
-// GetName returns the name of the resource.
-func (s *SessionTrackerV1) GetName() string {
-	return s.Metadata.Name
-}
-
-// SetName sets the name of the resource.
-func (s *SessionTrackerV1) SetName(e string) {
-	s.Metadata.Name = e
-}
-
-// SetExpiry sets expiry time for the object.
-func (s *SessionTrackerV1) SetExpiry(expires time.Time) {
-	s.Metadata.SetExpiry(expires)
-}
-
-// Expiry returns object expiry setting.
-func (s *SessionTrackerV1) Expiry() time.Time {
-	return s.Metadata.Expiry()
-}
-
-// GetMetadata returns object metadata.
-func (s *SessionTrackerV1) GetMetadata() Metadata {
-	return s.Metadata
-}
-
-// GetResourceID returns resource ID.
-func (s *SessionTrackerV1) GetResourceID() int64 {
-	return s.Metadata.ID
-}
-
-// SetResourceID sets resource ID.
-func (s *SessionTrackerV1) SetResourceID(id int64) {
-	s.Metadata.ID = id
-}
-
-// GetKind returns resource kind.
-func (s *SessionTrackerV1) GetKind() string {
-	return s.Kind
-}
-
-// GetSubKind returns resource subkind.
-func (s *SessionTrackerV1) GetSubKind() string {
-	return s.SubKind
-}
-
-// SetSubKind sets resource subkind.
-func (s *SessionTrackerV1) SetSubKind(sk string) {
-	s.SubKind = sk
-}
-
 // setStaticFields sets static resource header and metadata fields.
 func (s *SessionTrackerV1) setStaticFields() {
 	s.Kind = KindSessionTracker


### PR DESCRIPTION
ResourceHeader now has Origin and Set/GetLabel functions that enable structs with ResourceHeader embedded to avoid needing to implement these themselves. Duplicative implementations of these functions have been removed from structs which are composed from ResourceHeader.

Most resources do not have any notion of dynamic labels, so GetAllLabels just returns the static labels. Any struct that needs further customization can have its own variant of GetAllLabels.