### PR TITLE
Hardware Key UX fixes

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -96,6 +96,9 @@ type Profile struct {
 	// MFAMode ("auto", "platform", "cross-platform").
 	// Equivalent to the --mfa-mode tsh flag.
 	MFAMode string `yaml:"mfa_mode,omitempty"`
+
+	// PrivateKeyPolicy is a key policy enforced for this profile.
+	PrivateKeyPolicy keys.PrivateKeyPolicy `yaml:"private_key_policy"`
 }
 
 // Copy returns a shallow copy of p, or nil if p is nil.

--- a/api/utils/keys/yubikey.go
+++ b/api/utils/keys/yubikey.go
@@ -288,7 +288,7 @@ func (y *yubiKey) generatePrivateKey(slot piv.Slot, touchPolicy piv.TouchPolicy)
 	}
 
 	// Create a self signed certificate and store it in the PIV slot so that other
-	// Teleport Clients know to reuse the stored key instead of genearting a new one.
+	// Teleport Clients know to reuse the stored key instead of generating a new one.
 	priv, err := yk.PrivateKey(slot, pub, piv.KeyAuth{})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -590,6 +590,7 @@ func (c *Config) LoadProfile(ps ProfileStore, proxyAddr string) error {
 	c.KeysDir = profile.Dir
 	c.AuthConnector = profile.AuthConnector
 	c.LoadAllCAs = profile.LoadAllCAs
+	c.PrivateKeyPolicy = profile.PrivateKeyPolicy
 	c.AuthenticatorAttachment, err = parseMFAMode(profile.MFAMode)
 	if err != nil {
 		return trace.BadParameter("unable to parse mfa mode in user profile: %v.", err)
@@ -629,6 +630,7 @@ func (c *Config) SaveProfile(makeCurrent bool) error {
 		AuthConnector:     c.AuthConnector,
 		MFAMode:           c.AuthenticatorAttachment.String(),
 		LoadAllCAs:        c.LoadAllCAs,
+		PrivateKeyPolicy:  c.PrivateKeyPolicy,
 	}
 
 	if err := c.ClientStore.SaveProfile(p, makeCurrent); err != nil {
@@ -3182,7 +3184,7 @@ type SSHLoginFunc func(context.Context, *keys.PrivateKey) (*auth.SSHLoginRespons
 // SSHLogin uses the given login function to login the client. This function handles
 // private key logic and parsing the resulting auth response.
 func (tc *TeleportClient) SSHLogin(ctx context.Context, sshLoginFunc SSHLoginFunc) (*Key, error) {
-	priv, err := tc.GetNewLoginKey(ctx, tc.PrivateKeyPolicy)
+	priv, err := tc.GetNewLoginKey(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3195,7 +3197,8 @@ func (tc *TeleportClient) SSHLogin(ctx context.Context, sshLoginFunc SSHLoginFun
 			fmt.Fprintf(tc.Stderr, "Unmet private key policy %q.\n", privateKeyPolicy)
 
 			// Set the private key policy to the expected value and re-login.
-			priv, err = tc.GetNewLoginKey(ctx, privateKeyPolicy)
+			tc.PrivateKeyPolicy = privateKeyPolicy
+			priv, err = tc.GetNewLoginKey(ctx)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3241,25 +3244,13 @@ func (tc *TeleportClient) SSHLogin(ctx context.Context, sshLoginFunc SSHLoginFun
 }
 
 // GetNewLoginKey gets a new private key for login.
-func (tc *TeleportClient) GetNewLoginKey(ctx context.Context, keyPolicy keys.PrivateKeyPolicy) (*keys.PrivateKey, error) {
-	key, err := tc.LocalAgent().GetCoreKey()
-	if err == nil {
-		// If we find an existing key with a non-zero key polic and it meets
-		// the given keyPolicy requirement, then we should use the existing key.
-		if coreKeyPolicy := keys.GetPrivateKeyPolicy(key.PrivateKey); coreKeyPolicy != keys.PrivateKeyPolicyNone {
-			if err := keyPolicy.VerifyPolicy(coreKeyPolicy); err == nil {
-				return key.PrivateKey, nil
-			}
-		}
-	} else if !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
-
-	switch keyPolicy {
+func (tc *TeleportClient) GetNewLoginKey(ctx context.Context) (*keys.PrivateKey, error) {
+	switch tc.PrivateKeyPolicy {
 	case keys.PrivateKeyPolicyHardwareKey, keys.PrivateKeyPolicyHardwareKeyTouch:
 		log.Debugf("Attempting to login with YubiKey private key.")
 
-		priv, err := keys.GetOrGenerateYubiKeyPrivateKey(keyPolicy == keys.PrivateKeyPolicyHardwareKeyTouch)
+		touchRequired := tc.PrivateKeyPolicy == keys.PrivateKeyPolicyHardwareKeyTouch
+		priv, err := keys.GetOrGenerateYubiKeyPrivateKey(touchRequired)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -148,9 +148,10 @@ func (s *Store) ReadProfileStatus(profileName string) (*ProfileStatus, error) {
 	}
 	key, err := s.GetKey(idx, WithAllCerts...)
 	if err != nil {
-		if trace.IsNotFound(err) {
-			// If we can't find a key to match the profile, return a partial status. This
-			// is used for some superficial functions `tsh logout` and `tsh status`.
+		if trace.IsNotFound(err) || trace.IsConnectionProblem(err) {
+			// If we can't find a key to match the profile, or can't connect to
+			// the key (hardware key), return a partial status. This is used for
+			// some superficial functions `tsh logout` and `tsh status`.
 			return &ProfileStatus{
 				Name: profileName,
 				Dir:  profile.Dir,

--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -161,8 +161,6 @@ func (c *Cluster) updateClientFromPingResponse(ctx context.Context) (*webclient.
 		return nil, trace.Wrap(err)
 	}
 
-	c.clusterClient.PrivateKeyPolicy = pingResp.Auth.PrivateKeyPolicy
-
 	return pingResp, nil
 }
 

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -109,9 +109,7 @@ type ClusterAlertGetter interface {
 // ShowClusterAlerts shows cluster alerts with the given labels and severity.
 func ShowClusterAlerts(ctx context.Context, client ClusterAlertGetter, w io.Writer, labels map[string]string, minSeverity, maxSeverity types.AlertSeverity) error {
 	// get any "on login" alerts
-	alertCtx, cancelAlertCtx := context.WithTimeout(ctx, constants.TimeoutGetClusterAlerts)
-	defer cancelAlertCtx()
-	alerts, err := client.GetClusterAlerts(alertCtx, types.GetClusterAlertsRequest{
+	alerts, err := client.GetClusterAlerts(ctx, types.GetClusterAlertsRequest{
 		Labels:   labels,
 		Severity: minSeverity,
 	})

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -109,7 +109,10 @@ type ClusterAlertGetter interface {
 // ShowClusterAlerts shows cluster alerts with the given labels and severity.
 func ShowClusterAlerts(ctx context.Context, client ClusterAlertGetter, w io.Writer, labels map[string]string, minSeverity, maxSeverity types.AlertSeverity) error {
 	// get any "on login" alerts
-	alerts, err := client.GetClusterAlerts(ctx, types.GetClusterAlertsRequest{
+	alertCtx, cancelAlertCtx := context.WithTimeout(ctx, constants.TimeoutGetClusterAlerts)
+	defer cancelAlertCtx()
+
+	alerts, err := client.GetClusterAlerts(alertCtx, types.GetClusterAlertsRequest{
 		Labels:   labels,
 		Severity: minSeverity,
 	})

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -214,7 +215,10 @@ func TryRun(commands []CLICommand, args []string) error {
 		}
 	}
 
-	if err := common.ShowClusterAlerts(ctx, client, os.Stderr, nil,
+	alertCtx, cancelAlertCtx := context.WithTimeout(ctx, constants.TimeoutGetClusterAlerts)
+	defer cancelAlertCtx()
+
+	if err := common.ShowClusterAlerts(alertCtx, client, os.Stderr, nil,
 		types.AlertSeverity_HIGH, types.AlertSeverity_HIGH); err != nil {
 		log.WithError(err).Warn("Failed to display cluster alerts.")
 	}

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
-	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -215,10 +214,7 @@ func TryRun(commands []CLICommand, args []string) error {
 		}
 	}
 
-	alertCtx, cancelAlertCtx := context.WithTimeout(ctx, constants.TimeoutGetClusterAlerts)
-	defer cancelAlertCtx()
-
-	if err := common.ShowClusterAlerts(alertCtx, client, os.Stderr, nil,
+	if err := common.ShowClusterAlerts(ctx, client, os.Stderr, nil,
 		types.AlertSeverity_HIGH, types.AlertSeverity_HIGH); err != nil {
 		log.WithError(err).Warn("Failed to display cluster alerts.")
 	}


### PR DESCRIPTION
Changes:
 - Cache private key policy in profile
   - This way, `tsh` can detect the private key policy without loading up the key, ex: https://github.com/gravitational/teleport/pull/20806
 - Fix `tsh status` and `tsh logout` when the user unplugs their Yubikey. `tsh status` now shows profile expired, matching the output when you delete the private key from disk.

```
$ tsh status
> Profile URL:        https://proxy.example.com:3080
  Logged in as:       dev
  Cluster:            root-cluster
  Roles:              
  Logins:             
  Kubernetes:         enabled
  Valid until:        2023-01-27 11:22:33.602155139 -0800 PST m=+0.068568995 [EXPIRED]
  Extensions:         

ERROR: Active profile expired.
```

 - Add extra prompt and longer timeout for `tsh status` cluster alert check when used with private key policy `hardare_key_touch`.

```
$ tsh status
> Profile URL:        https://proxy.example.com:3080
  Logged in as:       dev
  ...

Checking server for cluster alerts.
Tap your YubiKey
```

