### PR TITLE
Use a GitHub app for the check and backport workflows

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -17,9 +17,16 @@ permissions:
 jobs:
   backport-pull-request:
     name: Backport Pull Request
+    environment: reviewers
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub Token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -37,4 +44,4 @@ jobs:
           go-version-file: .github/shared-workflows/bot/go.mod
         # Run "check" subcommand on bot.
       - name: Backport PR
-        run: ( cd .github/shared-workflows/bot && go build ) && .github/shared-workflows/bot/bot -workflow=backport -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: ( cd .github/shared-workflows/bot && go build ) && .github/shared-workflows/bot/bot -workflow=backport -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -32,9 +32,16 @@ permissions:
 jobs:
   check-reviews:
     name: Checking reviewers
+    environment: reviewers
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub Token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
       # Checkout main branch of shared-workflow repository.
       - name: Checkout shared-workflow
         uses: actions/checkout@v3
@@ -48,4 +55,4 @@ jobs:
           go-version-file: .github/shared-workflows/bot/go.mod
         # Run "check" subcommand on bot.
       - name: Checking reviewers
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=check -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=check -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"


### PR DESCRIPTION
These workflows need to be able to check org membership for the PR author in order to determine whether or not the author is an internal employee. This information is only available when authenticated.