### PR TITLE
Add fake "check reviewers" workflow for merge queue

### DIFF
--- a/.github/workflows/check-merge-queue.yaml
+++ b/.github/workflows/check-merge-queue.yaml
@@ -1,0 +1,25 @@
+# This check runs only on PRs that are in the merge queue.
+#
+# PRs in the merge queue have already been approved but the reviewers check
+# is still required so this workflow allows the required check to succeed,
+# otherwise PRs in the merge queue would be blocked indefinitely.
+#
+# See "Handling skipped but required checks" for more info:
+#
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Note both workflows must have the same name.
+name: Check
+on:
+  merge_group:
+
+jobs:
+  test:
+    name: Checking reviewers
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: none
+
+    steps:
+      - run: 'echo "Skipping reviewers check in merge queue"'


### PR DESCRIPTION
This PR adds a "check reviewers" workflow that runs on PRs in the merge queue and always succeeds. It is similar to other "bypass" workflows we have - otherwise PRs in the merge queue will be blocked from merging waiting for the "Check" check to succeed.

I've tested this on these 2 test PRs:

https://github.com/gravitational/teleport/pull/20843
https://github.com/gravitational/teleport/pull/20844