### PR TITLE
CI Required Steps Bypass

### DIFF
--- a/.github/workflows/codeql-bypass.yaml
+++ b/.github/workflows/codeql-bypass.yaml
@@ -1,0 +1,29 @@
+# This workflow is required to ensure that required Github check passes even if
+# the actual "CodeQL" workflow skipped due to path filtering. Otherwise
+# it will stay forever pending.
+#
+# See "Handling skipped but required checks" for more info:
+#
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Note both workflows must have the same name.
+
+name: Code scanning results
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'rfd/**'
+      - '**.md'
+
+jobs:
+  analyze:
+    name: CodeQL
+    runs-on: ubuntu-20.04
+
+    permissions:
+      contents: none
+
+    steps:
+      - run: 'echo "No changes to verify"'

--- a/.github/workflows/dependency-review-bypass.yaml
+++ b/.github/workflows/dependency-review-bypass.yaml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    paths:
+    paths-ignore:
       - '**go.mod'
       - '**go.sum'
       - '**package.json'
@@ -11,7 +11,11 @@ on:
 
 jobs:
   dependency-review:
-    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
-    uses: gravitational/shared-workflows/.github/workflows/dependency-review.yaml@main
+    name: dependency-review / Dependency Review
+    runs-on: ubuntu-20.04
+
     permissions:
-      contents: read
+      contents: none
+
+    steps:
+      - run: 'echo "No changes to verify"'


### PR DESCRIPTION
This configures dependency review so it will only execute on go and javascript dependency changes.  That is due to friction we are having in the Rust ecosystem with dependency-review. As a general optimization dependency review will otherwise not run with a `bypass` job to complete the PR requirements.

CodeQL already had similar filtering for efficency, but it was missing a similar bypass job, so this change introduces that also.