### PR TITLE
Use ghcr image for doc tests

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
 
     container:
-      image: public.ecr.aws/gravitational/docs:latest
+      image: ghcr.io/gravitational/docs:latest
       volumes:
         - ${{ github.workspace }}:/src/content
 


### PR DESCRIPTION
Use ghcr docs image to avoid ECR throttling. The workflow that builds and pushes docs image is here: https://github.com/gravitational/docs/pull/226.