### PR TITLE
Add port number to cloud address examples for proxy server

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -241,7 +241,7 @@ $ tsh status
 ```code
 $ tsh status
 
-# > Profile URL:  https://mytenant.teleport.sh:3080
+# > Profile URL:  https://mytenant.teleport.sh:443
 #   Logged in as: johndoe
 #  Cluster:      mytenant.teleport.sh
 #   Roles:        admin*

--- a/docs/pages/database-access/guides/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/azure-sql-server-ad.mdx
@@ -129,7 +129,7 @@ $ teleport db configure create \
 $ teleport db configure create \
    -o file \
    --token=/tmp/token \
-   --proxy=mytenant.teleport.sh \
+   --proxy=mytenant.teleport.sh:443 \
    --azure-sqlserver-discovery=eastus
 ```
 </ScopedBlock>

--- a/docs/pages/database-access/guides/elastic.mdx
+++ b/docs/pages/database-access/guides/elastic.mdx
@@ -93,7 +93,7 @@ Configure `teleport.yaml` using the example below:
 version: v3
 teleport:
   auth_token: <insert token here>
-  proxy_server: mytenant.teleport.sh
+  proxy_server: mytenant.teleport.sh:443
 
 # disable services that are on by default
 ssh_service: { enabled: no }

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -130,7 +130,7 @@ On the node where you will run the Teleport Database Service, run
 version: v3
 teleport:
   auth_token: "/tmp/token"
-  proxy_server: mytenant.teleport.sh
+  proxy_server: mytenant.teleport.sh:443
 db_service:
   enabled: "yes"
   databases:

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -181,7 +181,7 @@ teleport:
   data_dir: /var/lib/teleport-db
   nodename: test
   # Proxy address to connect to. Use your Teleport Cloud tenant address.
-  proxy_server: mytenant.teleport.sh
+  proxy_server: mytenant.teleport.sh:443
 db_service:
   enabled: "yes"
   # This section contains definitions of all databases proxied by this

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -252,7 +252,7 @@ teleport:
   data_dir: /var/lib/teleport-db
   nodename: test
   # Proxy address to connect to. Use your Teleport Cloud tenant address here.
-  proxy_server: mytenant.teleport.sh
+  proxy_server: mytenant.teleport.sh:443
 db_service:
   enabled: "yes"
   # This section contains definitions of all databases proxied by this

--- a/docs/pages/database-access/guides/redis-aws.mdx
+++ b/docs/pages/database-access/guides/redis-aws.mdx
@@ -74,7 +74,7 @@ Create the Database Service configuration:
   ```code
   $ teleport db configure create \
      -o file \
-     --proxy=mytenant.teleport.sh \
+     --proxy=mytenant.teleport.sh:443 \
      --token=/tmp/token \
      --elasticache-discovery=us-west-1
   ```
@@ -83,7 +83,7 @@ Create the Database Service configuration:
   ```
   $ teleport db configure create \
      -o file \
-     --proxy=mytenant.teleport.sh \
+     --proxy=mytenant.teleport.sh:443 \
      --token=/tmp/token \
      --memorydb-discovery=us-west-1
   ```

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -258,7 +258,7 @@ endpoint.
   $ sudo teleport db configure create \
     -o file \
     --token=/tmp/token \
-    --proxy=mytenant.teleport.sh:443:443 \
+    --proxy=mytenant.teleport.sh:443 \
     --name=sqlserver \
     --protocol=sqlserver \
     --uri=sqlserver.example.com:1433 \

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -90,7 +90,7 @@ $ teleport db configure create \
 $ teleport db configure create --rds-discovery=us-west-1 --rds-discovery=us-west-2
 $ teleport db configure create \
   --token=/tmp/token \
-  --proxy=mytenant.teleport.sh:3080 \
+  --proxy=mytenant.teleport.sh:443 \
   --name=example \
   --protocol=postgres \
   --uri=postgres://postgres.mytenant.teleport.sh:5432 \

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -138,7 +138,7 @@ Service, and then use the following configuration:
 version: v3
 teleport:
   auth_token: /path/to/token
-  proxy_server: teleport.example.com # replace with your proxy address
+  proxy_server: teleport.example.com:443 # replace with your proxy address
 windows_desktop_service:
   enabled: yes
   ldap:
@@ -175,7 +175,7 @@ Service, and then use the following configuration:
 version: v3
 teleport:
   auth_token: /path/to/token
-  proxy_server: mytenant.teleport.sh # replace with your cloud tenant
+  proxy_server: mytenant.teleport.sh:443 # replace with your cloud tenant
 windows_desktop_service:
   enabled: yes
   ldap:


### PR DESCRIPTION
The port number is required or it will default to `3080` that doesn't exist for cloud tenants.