### PR TITLE
Disable desktop recording with a discard stream

### DIFF
--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -97,7 +97,7 @@ func (*DiscardStream) EmitAuditEvent(ctx context.Context, event apievents.AuditE
 		"event_type":  event.GetType(),
 		"event_time":  event.GetTime(),
 		"event_index": event.GetIndex(),
-	}).Debugf("Discarding stream event")
+	}).Traceln("Discarding stream event")
 	return nil
 }
 

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -399,6 +399,13 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 }
 
 func (s *WindowsService) newStreamWriter(record bool, sessionID string) (libevents.StreamWriter, error) {
+	// AuditWriter doesn't always respect the RecordOuptut field,
+	// so ensure the session isn't recorded by using a discard stream.
+	// See https://github.com/gravitational/teleport/issues/16773
+	if !record {
+		return &libevents.DiscardStream{}, nil
+	}
+
 	return libevents.NewAuditWriter(libevents.AuditWriterConfig{
 		Component:    teleport.ComponentWindowsDesktop,
 		Namespace:    apidefaults.Namespace,
@@ -408,7 +415,7 @@ func (s *WindowsService) newStreamWriter(record bool, sessionID string) (libeven
 		SessionID:    session.ID(sessionID),
 		Streamer:     s.streamer,
 		ServerID:     s.cfg.Heartbeat.HostUUID,
-		RecordOutput: record,
+		RecordOutput: true,
 	})
 }
 


### PR DESCRIPTION
Prior to this, disabling desktop recordings would prevent them from being uploaded, but AuditWriter would still write them to disk. As a result, users who weren't recording sesions would still incur both a performance penalty and unnecessary use of disk space.

Updates #16773