### PR TITLE
Add workflow for building the API module

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -1,0 +1,35 @@
+name: Build API Module
+run-name: Build API Module
+
+on:
+  pull_request:
+    paths:
+      - 'api/**.go'
+      - 'api/go.mod'
+      - 'api/go.sum'
+  merge_group:
+    paths:
+      - 'api/**.go'
+      - 'api/go.mod'
+      - 'api/go.sum'
+
+jobs:
+  build:
+    name: Build API
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          # use the version declared in API's go.mod
+          go-version-file: api/go.mod
+
+      - name: Build
+        run: go build ./api/...


### PR DESCRIPTION
In the past, we've mistakenly introduced dependencies on a newer Go version than what the API module declares as its minimum required version.

To prevent this from happening in the future, this job will build the API with the version of Go declared by the API.