### PR TITLE
[v12] chore: Bump Buf to v1.13.1

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -316,7 +316,7 @@ RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.12.0" && \
+    VERSION="1.13.0" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -316,7 +316,7 @@ RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.13.0" && \
+    VERSION="1.13.1" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Keep up with the latest updates.

No format, lint or codegen changes.

* https://github.com/bufbuild/buf/releases/tag/v1.13.1
* https://github.com/bufbuild/buf/releases/tag/v1.13.0

Backports #20814 and #20856 to branch/v12.