### PR TITLE
[v10] chore: Bump Buf to v1.13.1

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -242,7 +242,7 @@ RUN curl -L https://github.com/golangci/golangci-lint/releases/download/v1.46.0/
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.13.0" && \
+    VERSION="1.13.1" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -242,7 +242,7 @@ RUN curl -L https://github.com/golangci/golangci-lint/releases/download/v1.46.0/
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.12.0" && \
+    VERSION="1.13.0" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Keep up with the latest updates.

No format, lint or codegen changes.

* https://github.com/bufbuild/buf/releases/tag/v1.13.1
* https://github.com/bufbuild/buf/releases/tag/v1.13.0

Backports #20814 and #20856 to branch/v10.