### PR TITLE
Add public docs for device trust

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -252,6 +252,11 @@
               "title": "Hardware Key Support (Preview)",
               "slug": "/access-controls/guides/hardware-key-support/",
               "forScopes": ["enterprise", "cloud"]
+            },
+            {
+              "title": "Device Trust (Preview)",
+              "slug": "/access-controls/guides/device-trust/",
+              "forScopes": ["enterprise", "cloud"]
             }
           ]
         },

--- a/docs/config.json
+++ b/docs/config.json
@@ -1261,6 +1261,10 @@
         "monthly_downtime": "3 hours 40 minutes"
       }
     },
+    "devicetrust": {
+      "asset_tag": "C00AA0AAAA0A",
+      "enroll_token": "AAAAAAAAAAAAAAAAAAAAAAAA-this-is-an-example"
+    },
     "docker": {
       "version": "20.10.7",
       "compose": {

--- a/docs/pages/access-controls/guides.mdx
+++ b/docs/pages/access-controls/guides.mdx
@@ -17,4 +17,4 @@ security policies for your organization.
 - [Per-Session MFA](./guides/per-session-mfa.mdx): Per-session multi-mactor authentication.
 - [Locking](./guides/locking.mdx): Lock access to active user sessions or hosts.
 - [Moderated Sessions](./guides/moderated-sessions.mdx): Require session auditors and allow fine-grained live session access.
-
+- [Device Trust (Preview)](./guides/device-trust.mdx): Register and enforce trusted devices.

--- a/docs/pages/access-controls/guides/device-trust.mdx
+++ b/docs/pages/access-controls/guides/device-trust.mdx
@@ -3,13 +3,11 @@ title: "Device Trust (Preview)"
 description: Learn how to use and enforce trusted devices with Teleport
 ---
 
-<Admonition type="warning" title="Preview">
+<Admonition type="warning">
 Device Trust is currently in Preview mode.
-</Admonition>
 
-<ScopedBlock scope="oss">
 Device Trust requires Teleport Enterprise.
-</ScopedBlock>
+</Admonition>
 
 Device Trust allows Teleport admins to enforce the use of trusted devices.
 Resources protected by the device mode "required" will enforce the use of a

--- a/docs/pages/access-controls/guides/device-trust.mdx
+++ b/docs/pages/access-controls/guides/device-trust.mdx
@@ -4,11 +4,11 @@ description: Learn how to use and enforce trusted devices with Teleport
 ---
 
 <Admonition type="warning" title="Preview">
-  Device Trust is currently in Preview mode.
+Device Trust is currently in Preview mode.
 </Admonition>
 
 <ScopedBlock scope="oss">
-  Device Trust requires a commercial edition of Teleport.
+Device Trust requires Teleport Enterprise.
 </ScopedBlock>
 
 Device Trust allows Teleport admins to enforce the use of trusted devices.
@@ -30,17 +30,17 @@ Teleport versions.
 ## Concepts
 
 Device Trust uses the Secure Enclave in macOS devices to store a device private
-key. That key is used to solve device challenges, issued by the Teleport Auth
-Server, thus proving the identity of the trusted device.
+key. That key is used to solve device challenges issued by the Teleport Auth
+Server, proving the identity of the trusted device.
 
 Device management is divided into two separate phases: inventory management and
 device enrollment.
 
-__Inventory management__ is performed by a device admin. In this step, devices
+**Inventory management** is performed by a device admin. In this step, devices
 are registered or removed from Teleport. For example, this happens when the IT
 department of your company acquires new devices, or retires devices from use.
 
-__Device enrollment__ is performed either by a device admin or by the end-user,
+**Device enrollment** is performed either by a device admin or by the end-user,
 at your discretion. This is the step that creates the Secure Enclave private key
 in the device and register its public key counterpart with the Teleport Auth
 Server. Enrollment has to run in the actual device that you want to enroll. For
@@ -49,9 +49,9 @@ IT prepares a new device for a user. Enrollment only needs to happen once per
 user/device combination.
 
 <Admonition type="tip" title="Enrollment">
-  Device enrollment is key in correctly identifying a device throughout its
-  lifetime. The more trusted the enrollment operator, the better are the ongoing
-  guarantees that the device itself is trustworthy.
+Device enrollment is key in correctly identifying a device throughout its
+lifetime. The more trusted the enrollment operator, the better the ongoing
+guarantees that the device itself is trustworthy.
 </Admonition>
 
 The tie between the device inventory and enrollment is a device enrollment
@@ -99,16 +99,16 @@ spec:
 
 ```code
 $ tctl create -f device-admin.yaml
-# role 'device-admin' has been created
+role 'device-admin' has been created
 ```
 
 <Admonition type="tip" title="Editor Role">
-  For clusters created using Teleport v12 or newer, the builtin role `editor`
-  has the necessary permissions to manage devices.
-  For production setups a separate role is still recommended.
+For clusters created using Teleport v12 or newer, the builtin role `editor` has
+the necessary permissions to manage devices. For production setups a separate
+role is still recommended.
 </Admonition>
 
-Note that, in addition to the usual CRUD verbs (create, read, list, update and
+Note that in addition to the usual CRUD verbs (create, read, list, update and
 delete), we have also included `create_enroll_token` and `enroll`. The
 `create_enroll_token` verb is necessary to execute the `tctl devices enroll`
 command; `enroll` is necessary to execute `tsh device enroll`. Both are
@@ -130,7 +130,8 @@ version: v2
 
 ```code
 $ tctl edit users/codingllama
-# user "codingllama" has been updated
+user "codingllama" has been updated
+
 $ tsh logout; tsh login --proxy=example.com --user=codingllama ## fetch new certificates
 ```
 
@@ -141,25 +142,24 @@ the `$serial` below with your macOS device serial number (visible under Apple ->
 ```code
 $ serial="$(ioreg -c IOPlatformExpertDevice -d 2 | grep -i IOPlatformSerialNumber | awk -F'"' '{print $4}')"
 $ tctl devices add --os=macos --asset-tag="$serial"
-# Device C00AA3BBBB6C/macOS added to the inventory
+Device C00AA3BBBB6C/macOS added to the inventory
 ```
 
 View registered devices:
 
 ```code
 $ tctl devices ls
-# Asset Tag    OS    Enroll Status Device ID
-# ------------ ----- ------------- ------------------------------------
-# C00AA3BBBB6C macOS not enrolled  d40f2ee4-856d-4aef-b784-c4371e39c036
+Asset Tag    OS    Enroll Status Device ID
+------------ ----- ------------- ------------------------------------
+C00AA3BBBB6C macOS not enrolled  d40f2ee4-856d-4aef-b784-c4371e39c036
 ```
 
 A registered device is a device that Teleport knows about. Once a registered
 device is enrolled, it becomes a trusted device.
 
 <Admonition type="tip" title="Removing Devices">
-  A device that is no longer in use may be removed using
-  `tctl devices rm --device-id=<ID>` or
-  `tctl devices rm --asset-tag=<SERIAL_NUMBER>`.
+A device that is no longer in use may be removed using `tctl devices rm
+--device-id=<ID>` or `tctl devices rm --asset-tag=<SERIAL_NUMBER>`.
 </Admonition>
 
 ## Step 2/2. Enroll a trusted device
@@ -173,24 +173,23 @@ the serial number of the device we want to enroll.
 
 ```code
 $ tctl devices enroll --asset-tag="C00AA3BBBB6C"
-# Run the command below on device "C00AA3BBBB6C" to enroll it:
-# tsh device enroll --token=MQi9gkOfyvdyNyN2moJZz9cqx/GyILR5uNu4NE9dxO8
+Run the command below on device "C00AA3BBBB6C" to enroll it:
+tsh device enroll --token=MQi9gkOfyvdyNyN2moJZz9cqx/GyILR5uNu4NE9dxO8
 ```
 
-To perform the enrollment ceremony, using device specified above, type the
+To perform the enrollment ceremony, using the device specified above, type the
 command printed by `tctl devices enroll`:
 
 ```code
 $ tsh device enroll --token=MQi9gkOfyvdyNyN2moJZz9cqx/GyILR5uNu4NE9dxO8
-# Device "C00AA3BBBB6C"/macOS enrolled
+Device "C00AA3BBBB6C"/macOS enrolled
 
 $ tsh logout; tsh login --proxy=example.com --user=codingllama # fetch new certificates
 ```
 
 <Admonition type="warning" title="macOS">
-  macOS enrollments are tied to the current user in the device.
-  If the same device is handed to a new user, they will need to perform
-  enrollment again.
+macOS enrollments are tied to the current user in the device. If the same device
+is handed to a new user, they will need to perform enrollment again.
 </Admonition>
 
 The device above is now a trusted device.
@@ -213,9 +212,9 @@ Enterprise clusters run in `optional` mode by default. Changing the mode to
 accesses.
 
 <Admonition type="warning" title="Web UI">
-  The Web UI is not capable of trusted device access during the device trust
-  preview. Only `tsh` and Teleport Connect are able to fulfill device mode
-  `required`.
+The Web UI is not capable of trusted device access during the device trust
+preview. Only `tsh` and Teleport Connect are able to fulfill device mode
+`required`.
 </Admonition>
 
 To enable device mode `required` update your configuration as follows:
@@ -258,7 +257,7 @@ To enable device mode `required` update your configuration as follows:
 
     ```code
     $ tctl create -f cap.yaml
-    # cluster auth preference has been updated
+    cluster auth preference has been updated
     ```
   </TabItem>
 </Tabs>
@@ -286,24 +285,24 @@ Update the configuration:
 
 ```code
 $ tctl create -f cap.yaml
-# cluster auth preference has been updated
+cluster auth preference has been updated
 ```
 </ScopedBlock>
 
 SSH, Database and Kubernetes access without a trusted device is now forbidden.
 For example, SSH access without a trusted device fails with the following error:
 
-```
+```code
 $ tsh ssh zarquon
-# ERROR: ssh: rejected: administratively prohibited (unauthorized device)
+ERROR: ssh: rejected: administratively prohibited (unauthorized device)
 ```
 
 <Admonition type="tip" title="Trusted Clusters">
-  It is possible to use [trusted
-  clusters](../../management/admin/trustedclusters.mdx) to limit the impact of
-  device mode `required`. A leaf cluster in mode `required` will enforce access
-  to all of its resources, without imposing the same restrictions to the root
-  cluster.
+It is possible to use [trusted
+clusters](../../management/admin/trustedclusters.mdx) to limit the impact of
+device mode `required`. A leaf cluster in mode `required` will enforce access to
+all of its resources, without imposing the same restrictions to the root
+cluster.
 </Admonition>
 
 ## Troubleshooting

--- a/docs/pages/access-controls/guides/device-trust.mdx
+++ b/docs/pages/access-controls/guides/device-trust.mdx
@@ -117,13 +117,13 @@ demonstrated in the following section.
 Make sure your user has the `device-admin` role:
 
 ```code
-$ tctl edit users/codingllama
+$ tctl edit users/alice
 ```
 
 ```diff
 kind: user
 metadata:
-  name: codingllama
+  name: alice
   # unrelated fields omitted.
 spec:
   roles:
@@ -135,7 +135,7 @@ version: v2
 Relogin to fetch updated certificates:
 
 ```code
-$ tsh logout; tsh login --proxy=example.com --user=codingllama
+$ tsh logout; tsh login --proxy=example.com --user=alice
 ```
 
 Having the necessary permissions, let's add a device to the inventory. Replace
@@ -187,7 +187,7 @@ command printed by `tctl devices enroll`:
 $ tsh device enroll --token=MQi9gkOfyvdyNyN2moJZz9cqx/GyILR5uNu4NE9dxO8
 Device "C00AA3BBBB6C"/macOS enrolled
 
-$ tsh logout; tsh login --proxy=example.com --user=codingllama # fetch new certificates
+$ tsh logout; tsh login --proxy=example.com --user=alice # fetch new certificates
 ```
 
 <Admonition type="warning" title="macOS">
@@ -296,7 +296,7 @@ SSH, Database and Kubernetes access without a trusted device is now forbidden.
 For example, SSH access without a trusted device fails with the following error:
 
 ```code
-$ tsh ssh zarquon
+$ tsh ssh server1
 ERROR: ssh: rejected: administratively prohibited (unauthorized device)
 ```
 

--- a/docs/pages/access-controls/guides/device-trust.mdx
+++ b/docs/pages/access-controls/guides/device-trust.mdx
@@ -273,7 +273,8 @@ It is possible to use [trusted
 clusters](../../management/admin/trustedclusters.mdx) to limit the impact of
 device mode `required`. A leaf cluster in mode `required` will enforce access to
 all of its resources, without imposing the same restrictions to the root
-cluster.
+cluster. Likewise, a root cluster will not enforce device trust on resources in
+leaf clusters.
 </Admonition>
 
 ## Troubleshooting

--- a/docs/pages/access-controls/guides/device-trust.mdx
+++ b/docs/pages/access-controls/guides/device-trust.mdx
@@ -17,12 +17,12 @@ trusted device, in addition to establishing the user's identity and enforcing
 the necessary roles. Furthermore, users using a trusted device leave audit
 trails that include the device's information.
 
-The device trust preview supports the following Teleport features:
+The device trust preview works only with macOS devices and supports the
+following Teleport features:
 
 - SSH access enforcement
 - Database access enforcement
 - Kubernetes access enforcement
-- macOS trusted devices
 
 Support for other operating systems and access features is planned for upcoming
 Teleport versions.

--- a/docs/pages/access-controls/guides/device-trust.mdx
+++ b/docs/pages/access-controls/guides/device-trust.mdx
@@ -1,0 +1,326 @@
+---
+title: "Device Trust (Preview)"
+description: Learn how to use and enforce trusted devices with Teleport
+---
+
+<Admonition type="warning" title="Preview">
+  Device Trust is currently in Preview mode.
+</Admonition>
+
+<ScopedBlock scope="oss">
+  Device Trust requires a commercial edition of Teleport.
+</ScopedBlock>
+
+Device Trust allows Teleport admins to enforce the use of trusted devices.
+Resources protected by the device mode "required" will enforce the use of a
+trusted device, in addition to establishing the user's identity and enforcing
+the necessary roles. Furthermore, users using a trusted device leave audit
+trails that include the device's information.
+
+The device trust preview supports the following Teleport features:
+
+- SSH access enforcement
+- Database access enforcement
+- Kubernetes access enforcement
+- macOS trusted devices
+
+Support for other operating systems and access features is planned for upcoming
+Teleport versions.
+
+## Concepts
+
+Device Trust uses the Secure Enclave in macOS devices to store a device private
+key. That key is used to solve device challenges, issued by the Teleport Auth
+Server, thus proving the identity of the trusted device.
+
+Device management is divided into two separate phases: inventory management and
+device enrollment.
+
+__Inventory management__ is performed by a device admin. In this step, devices
+are registered or removed from Teleport. For example, this happens when the IT
+department of your company acquires new devices, or retires devices from use.
+
+__Device enrollment__ is performed either by a device admin or by the end-user,
+at your discretion. This is the step that creates the Secure Enclave private key
+in the device and register its public key counterpart with the Teleport Auth
+Server. Enrollment has to run in the actual device that you want to enroll. For
+example, this happens when a user gets a new device for the first time, or when
+IT prepares a new device for a user. Enrollment only needs to happen once per
+user/device combination.
+
+<Admonition type="tip" title="Enrollment">
+  Device enrollment is key in correctly identifying a device throughout its
+  lifetime. The more trusted the enrollment operator, the better are the ongoing
+  guarantees that the device itself is trustworthy.
+</Admonition>
+
+The tie between the device inventory and enrollment is a device enrollment
+token. A device enrollment token needs to be created by a device admin and sent
+to the person performing the enrollment ceremony. The token ties the actual
+device being enrolled to the expected device in the inventory, adding an extra
+layer of protection.
+
+## Prerequisites
+
+(!docs/pages/includes/commercial-prereqs-tabs.mdx!)
+
+- A signed and notarized `tsh` binary for enrollment.
+  [Download the macOS tsh installer](../../installation.mdx#macos).
+- A macOS device to register and enroll.
+
+## Step 1/2. Register a trusted device
+
+The `tctl` tool is used to manage the device inventory. A device admin is
+responsible for managing devices, adding new devices to the inventory and
+removing devices that are no longer in use.
+
+A role that grants permissions for the `device` resource is necessary to manage
+the inventory. Save the yaml below as `device-admin.yaml` and create it in your
+cluster:
+
+```yaml
+version: v6
+kind: role
+metadata:
+  name: device-admin
+spec:
+  allow:
+    rules:
+    - resources: ["device"]
+      verbs:
+      - create
+      - read
+      - list
+      - update
+      - delete
+      - create_enroll_token
+      - enroll
+```
+
+```code
+$ tctl create -f device-admin.yaml
+# role 'device-admin' has been created
+```
+
+<Admonition type="tip" title="Editor Role">
+  For clusters created using Teleport v12 or newer, the builtin role `editor`
+  has the necessary permissions to manage devices.
+  For production setups a separate role is still recommended.
+</Admonition>
+
+Note that, in addition to the usual CRUD verbs (create, read, list, update and
+delete), we have also included `create_enroll_token` and `enroll`. The
+`create_enroll_token` verb is necessary to execute the `tctl devices enroll`
+command; `enroll` is necessary to execute `tsh device enroll`. Both are
+demonstrated in the following section.
+
+Make sure your user has the `device-admin` role:
+
+```yaml
+kind: user
+metadata:
+  name: codingllama
+  # unrelated fields omitted.
+spec:
+  roles:
+  - access
+  - device-admin # add this line
+version: v2
+```
+
+```code
+$ tctl edit users/codingllama
+# user "codingllama" has been updated
+$ tsh logout; tsh login --proxy=example.com --user=codingllama ## fetch new certificates
+```
+
+Having the necessary permissions, let's add a device to the inventory. Replace
+the `$serial` below with your macOS device serial number (visible under Apple ->
+"About This Mac" -> "Serial number").
+
+```code
+$ serial="$(ioreg -c IOPlatformExpertDevice -d 2 | grep -i IOPlatformSerialNumber | awk -F'"' '{print $4}')"
+$ tctl devices add --os=macos --asset-tag="$serial"
+# Device C00AA3BBBB6C/macOS added to the inventory
+```
+
+View registered devices:
+
+```code
+$ tctl devices ls
+# Asset Tag    OS    Enroll Status Device ID
+# ------------ ----- ------------- ------------------------------------
+# C00AA3BBBB6C macOS not enrolled  d40f2ee4-856d-4aef-b784-c4371e39c036
+```
+
+A registered device is a device that Teleport knows about. Once a registered
+device is enrolled, it becomes a trusted device.
+
+<Admonition type="tip" title="Removing Devices">
+  A device that is no longer in use may be removed using
+  `tctl devices rm --device-id=<ID>` or
+  `tctl devices rm --asset-tag=<SERIAL_NUMBER>`.
+</Admonition>
+
+## Step 2/2. Enroll a trusted device
+
+A registered device becomes a trusted device after it goes through the
+enrollment ceremony. Enrollment exchanges an enrollment token, created by a
+device admin, for the opportunity to enroll the corresponding device.
+
+To create an enrollment token run the following command, where `--asset-tag` is
+the serial number of the device we want to enroll.
+
+```code
+$ tctl devices enroll --asset-tag="C00AA3BBBB6C"
+# Run the command below on device "C00AA3BBBB6C" to enroll it:
+# tsh device enroll --token=MQi9gkOfyvdyNyN2moJZz9cqx/GyILR5uNu4NE9dxO8
+```
+
+To perform the enrollment ceremony, using device specified above, type the
+command printed by `tctl devices enroll`:
+
+```code
+$ tsh device enroll --token=MQi9gkOfyvdyNyN2moJZz9cqx/GyILR5uNu4NE9dxO8
+# Device "C00AA3BBBB6C"/macOS enrolled
+
+$ tsh logout; tsh login --proxy=example.com --user=codingllama # fetch new certificates
+```
+
+<Admonition type="warning" title="macOS">
+  macOS enrollments are tied to the current user in the device.
+  If the same device is handed to a new user, they will need to perform
+  enrollment again.
+</Admonition>
+
+The device above is now a trusted device.
+
+## Optional: Enforce trusted devices
+
+Device trust has the following modes of operation, represented by the
+`device_trust.mode` authentication setting:
+
+- `off` - disables device trust. Device authentication is not performed and
+  device-aware audit logs are absent.
+- `optional` - enables device authentication and device-aware audit, but doesn't
+  require a trusted device to access resources.
+- `required` - enables device authentication and device-aware audit.
+  Additionally, it requires a trusted device for all SSH, Database and
+  Kubernetes connections.
+
+Enterprise clusters run in `optional` mode by default. Changing the mode to
+`required` will enforce a trusted device for all SSH, Database and Kubernetes
+accesses.
+
+<Admonition type="warning" title="Web UI">
+  The Web UI is not capable of trusted device access during the device trust
+  preview. Only `tsh` and Teleport Connect are able to fulfill device mode
+  `required`.
+</Admonition>
+
+To enable device mode `required` update your configuration as follows:
+
+<ScopedBlock scope={["enterprise"]}>
+<Tabs>
+  <TabItem label="Static Config">
+    Auth Server `teleport.yaml` file:
+
+    ```yaml
+    auth_service:
+      authentication:
+        type: local
+        second_factor: "on"
+        webauthn:
+          rp_id: example.com
+        device_trust:
+          mode: "required" # add this line
+    ```
+  </TabItem>
+  <TabItem label="Dynamic resources">
+    Create a `cap.yaml` file or get the existing configuration using
+    `tctl get cluster_auth_preference`:
+
+    ```yaml
+    kind: cluster_auth_preference
+    version: v2
+    metadata:
+      name: cluster-auth-preference
+    spec:
+      type: local
+      second_factor: "on"
+      webauthn:
+        rp_id: example.com
+      device_trust:
+        mode: "required" # add this line
+    ```
+
+    Update the configuration:
+
+    ```code
+    $ tctl create -f cap.yaml
+    # cluster auth preference has been updated
+    ```
+  </TabItem>
+</Tabs>
+</ScopedBlock>
+
+<ScopedBlock scope={["cloud"]}>
+Create a `cap.yaml` file or get the existing configuration using
+`tctl get cluster_auth_preference`:
+
+```yaml
+kind: cluster_auth_preference
+version: v2
+metadata:
+  name: cluster-auth-preference
+spec:
+  type: local
+  second_factor: "on"
+  webauthn:
+    rp_id: example.com
+  device_trust:
+    mode: "required"
+```
+
+Update the configuration:
+
+```code
+$ tctl create -f cap.yaml
+# cluster auth preference has been updated
+```
+</ScopedBlock>
+
+SSH, Database and Kubernetes access without a trusted device is now forbidden.
+For example, SSH access without a trusted device fails with the following error:
+
+```
+$ tsh ssh zarquon
+# ERROR: ssh: rejected: administratively prohibited (unauthorized device)
+```
+
+<Admonition type="tip" title="Trusted Clusters">
+  It is possible to use [trusted
+  clusters](../../management/admin/trustedclusters.mdx) to limit the impact of
+  device mode `required`. A leaf cluster in mode `required` will enforce access
+  to all of its resources, without imposing the same restrictions to the root
+  cluster.
+</Admonition>
+
+## Troubleshooting
+
+### "binary missing signature or entitlements" on `tsh device enroll`
+
+A signed and notarized `tsh` binary is necessary to enroll and use a a trusted
+device. [Download the macOS tsh installer](../../installation.mdx#macos) to fix
+the problem.
+
+### "unauthorized device" errors using a trusted device
+
+A signed and notarized `tsh` binary is necessary to use a trusted device. Make
+sure to download and use the
+[macOS tsh installer](../../installation.mdx#macos).
+
+A trusted device needs to be registered and enrolled before it is recognized by
+Teleport as such. Follow the [registration](#step-12-register-a-trusted-device)
+and [enrollment steps](#step-22-enroll-a-trusted-device) and make sure to `tsh
+logout` and `tsh login` after enrollment is done.

--- a/docs/pages/access-controls/guides/device-trust.mdx
+++ b/docs/pages/access-controls/guides/device-trust.mdx
@@ -227,7 +227,7 @@ To enable device mode `required` update your configuration as follows:
   <TabItem label="Static Config">
     Auth Server `teleport.yaml` file:
 
-    ```yaml
+    ```diff
     auth_service:
       authentication:
         type: local
@@ -235,14 +235,14 @@ To enable device mode `required` update your configuration as follows:
         webauthn:
           rp_id: example.com
         device_trust:
-          mode: "required" # add this line
+    +     mode: "required" # add this line
     ```
   </TabItem>
   <TabItem label="Dynamic resources">
     Create a `cap.yaml` file or get the existing configuration using
     `tctl get cluster_auth_preference`:
 
-    ```yaml
+    ```diff
     kind: cluster_auth_preference
     version: v2
     metadata:
@@ -253,7 +253,7 @@ To enable device mode `required` update your configuration as follows:
       webauthn:
         rp_id: example.com
       device_trust:
-        mode: "required" # add this line
+    +   mode: "required" # add this line
     ```
 
     Update the configuration:

--- a/docs/pages/access-controls/guides/device-trust.mdx
+++ b/docs/pages/access-controls/guides/device-trust.mdx
@@ -145,7 +145,7 @@ the `$SERIAL` below with your macOS device serial number (visible under Apple ->
 ```code
 $ SERIAL="$(ioreg -c IOPlatformExpertDevice -d 2 | grep -i IOPlatformSerialNumber | awk -F'"' '{print $4}')"
 $ tctl devices add --os=macos --asset-tag="$SERIAL"
-Device C00AA3BBBB6C/macOS added to the inventory
+Device (=devicetrust.asset_tag=)/macOS added to the inventory
 ```
 
 View registered devices:
@@ -154,7 +154,7 @@ View registered devices:
 $ tctl devices ls
 Asset Tag    OS    Enroll Status Device ID
 ------------ ----- ------------- ------------------------------------
-C00AA3BBBB6C macOS not enrolled  d40f2ee4-856d-4aef-b784-c4371e39c036
+(=devicetrust.asset_tag=) macOS not enrolled  d40f2ee4-856d-4aef-b784-c4371e39c036
 ```
 
 A registered device is a device that Teleport knows about. Once a registered
@@ -178,17 +178,17 @@ To create an enrollment token run the following command, where `--asset-tag` is
 the serial number of the device we want to enroll.
 
 ```code
-$ tctl devices enroll --asset-tag="C00AA3BBBB6C"
-Run the command below on device "C00AA3BBBB6C" to enroll it:
-tsh device enroll --token=MQi9gkOfyvdyNyN2moJZz9cqx/GyILR5uNu4NE9dxO8
+$ tctl devices enroll --asset-tag="(=devicetrust.asset_tag=)"
+Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
+tsh device enroll --token=(=devicetrust.enroll_token=)
 ```
 
 To perform the enrollment ceremony, using the device specified above, type the
 command printed by `tctl devices enroll`:
 
 ```code
-$ tsh device enroll --token=MQi9gkOfyvdyNyN2moJZz9cqx/GyILR5uNu4NE9dxO8
-Device "C00AA3BBBB6C"/macOS enrolled
+$ tsh device enroll --token=(=devicetrust.enroll_token=)
+Device "(=devicetrust.asset_tag=)"/macOS enrolled
 
 $ tsh logout; tsh login --proxy=example.com --user=alice # fetch new certificates
 ```

--- a/docs/pages/access-controls/guides/device-trust.mdx
+++ b/docs/pages/access-controls/guides/device-trust.mdx
@@ -116,7 +116,11 @@ demonstrated in the following section.
 
 Make sure your user has the `device-admin` role:
 
-```yaml
+```code
+$ tctl edit users/codingllama
+```
+
+```diff
 kind: user
 metadata:
   name: codingllama
@@ -124,15 +128,14 @@ metadata:
 spec:
   roles:
   - access
-  - device-admin # add this line
++ - device-admin # add this line
 version: v2
 ```
 
-```code
-$ tctl edit users/codingllama
-user "codingllama" has been updated
+Relogin to fetch updated certificates:
 
-$ tsh logout; tsh login --proxy=example.com --user=codingllama ## fetch new certificates
+```code
+$ tsh logout; tsh login --proxy=example.com --user=codingllama
 ```
 
 Having the necessary permissions, let's add a device to the inventory. Replace

--- a/docs/pages/access-controls/guides/device-trust.mdx
+++ b/docs/pages/access-controls/guides/device-trust.mdx
@@ -139,12 +139,12 @@ $ tsh logout; tsh login --proxy=example.com --user=alice
 ```
 
 Having the necessary permissions, let's add a device to the inventory. Replace
-the `$serial` below with your macOS device serial number (visible under Apple ->
-"About This Mac" -> "Serial number").
+the `$SERIAL` below with your macOS device serial number (visible under Apple ->
+"About This Mac" -> "Serial number", or use the command below).
 
 ```code
-$ serial="$(ioreg -c IOPlatformExpertDevice -d 2 | grep -i IOPlatformSerialNumber | awk -F'"' '{print $4}')"
-$ tctl devices add --os=macos --asset-tag="$serial"
+$ SERIAL="$(ioreg -c IOPlatformExpertDevice -d 2 | grep -i IOPlatformSerialNumber | awk -F'"' '{print $4}')"
+$ tctl devices add --os=macos --asset-tag="$SERIAL"
 Device C00AA3BBBB6C/macOS added to the inventory
 ```
 
@@ -162,7 +162,7 @@ device is enrolled, it becomes a trusted device.
 
 <Admonition type="tip" title="Removing Devices">
 A device that is no longer in use may be removed using `tctl devices rm
---device-id=<ID>` or `tctl devices rm --asset-tag=<SERIAL_NUMBER>`.
+--device-id=<ID>` or `tctl devices rm --asset-tag=<SERIAL>`.
 </Admonition>
 
 ## Step 2/2. Enroll a trusted device
@@ -170,6 +170,9 @@ A device that is no longer in use may be removed using `tctl devices rm
 A registered device becomes a trusted device after it goes through the
 enrollment ceremony. Enrollment exchanges an enrollment token, created by a
 device admin, for the opportunity to enroll the corresponding device.
+
+macOS enrollments are tied to the current user in the device. If the same device
+is handed to a new user, they will need to perform enrollment again.
 
 To create an enrollment token run the following command, where `--asset-tag` is
 the serial number of the device we want to enroll.
@@ -189,11 +192,6 @@ Device "C00AA3BBBB6C"/macOS enrolled
 
 $ tsh logout; tsh login --proxy=example.com --user=alice # fetch new certificates
 ```
-
-<Admonition type="warning" title="macOS">
-macOS enrollments are tied to the current user in the device. If the same device
-is handed to a new user, they will need to perform enrollment again.
-</Admonition>
 
 The device above is now a trusted device.
 
@@ -222,55 +220,26 @@ preview. Only `tsh` and Teleport Connect are able to fulfill device mode
 
 To enable device mode `required` update your configuration as follows:
 
-<ScopedBlock scope={["enterprise"]}>
 <Tabs>
-  <TabItem label="Static Config">
-    Auth Server `teleport.yaml` file:
+<TabItem label="Static Config">
+Edit the Auth Server's `teleport.yaml` file:
 
-    ```diff
-    auth_service:
-      authentication:
-        type: local
-        second_factor: "on"
-        webauthn:
-          rp_id: example.com
-        device_trust:
-    +     mode: "required" # add this line
-    ```
-  </TabItem>
-  <TabItem label="Dynamic resources">
-    Create a `cap.yaml` file or get the existing configuration using
-    `tctl get cluster_auth_preference`:
-
-    ```diff
-    kind: cluster_auth_preference
-    version: v2
-    metadata:
-      name: cluster-auth-preference
-    spec:
-      type: local
-      second_factor: "on"
-      webauthn:
-        rp_id: example.com
-      device_trust:
-    +   mode: "required" # add this line
-    ```
-
-    Update the configuration:
-
-    ```code
-    $ tctl create -f cap.yaml
-    cluster auth preference has been updated
-    ```
-  </TabItem>
-</Tabs>
-</ScopedBlock>
-
-<ScopedBlock scope={["cloud"]}>
+```diff
+auth_service:
+  authentication:
+    type: local
+    second_factor: "on"
+    webauthn:
+      rp_id: example.com
+    device_trust:
++     mode: "required" # add this line
+```
+</TabItem>
+<TabItem label="Dynamic resources">
 Create a `cap.yaml` file or get the existing configuration using
 `tctl get cluster_auth_preference`:
 
-```yaml
+```diff
 kind: cluster_auth_preference
 version: v2
 metadata:
@@ -281,7 +250,7 @@ spec:
   webauthn:
     rp_id: example.com
   device_trust:
-    mode: "required"
++   mode: "required" # add this line
 ```
 
 Update the configuration:
@@ -290,7 +259,8 @@ Update the configuration:
 $ tctl create -f cap.yaml
 cluster auth preference has been updated
 ```
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 SSH, Database and Kubernetes access without a trusted device is now forbidden.
 For example, SSH access without a trusted device fails with the following error:

--- a/docs/pages/access-controls/introduction.mdx
+++ b/docs/pages/access-controls/introduction.mdx
@@ -31,6 +31,7 @@ guide.
 - [Second Factor - WebAuthn](./guides/webauthn.mdx): Add Two-Factor Authentication through WebAuthn.
 - [Per-session MFA](./guides/per-session-mfa.mdx): Per-session Multi-Factor Authentication.
 - [Locking](./guides/locking.mdx): Locking sessions and identities.
+- [Device Trust (Preview)](./guides/device-trust.mdx): Register and enforce trusted devices.
 
 ## How does it work?
 

--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -34,7 +34,7 @@
   # Teleport v(=cloud.version=) go(=teleport.golang=)
   
   $ tsh version
-  # Teleport v(=cloud.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
   ```
 
 </TabItem>

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -2396,6 +2396,113 @@ $ tctl alerts create \
     "The system is under maintenance, functionality may be limited."
 ```
 
+### tctl devices add
+
+Register a device.
+
+
+```code
+$ tctl devices add --os=OS --asset-tag=SERIAL_NUMBER
+```
+
+#### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--os` | none | `linux`, `macos`, `windows` | Device operating system |
+| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
+| `--enroll` | false | boolean | If set, creates a device enrollment token |
+
+#### Examples
+
+```code
+$ tctl devices add --os=macos --asset-tag=C00AA3BBBB6C
+# Device C00AA3BBBB6C/macOS added to the inventory
+
+$ tctl devices add --os=macos --asset-tag=C00AA3BBBB6C --enroll
+# Device C00AA3BBBB6C/macOS added to the inventory
+# Run the command below on device "C00AA3BBBB6C" to enroll it:
+# tsh device enroll --token=KKO1nmJ+VsGk+w1MqtAM8v428LoENHw/1ZcrSqitjzs
+```
+
+### tctl devices ls
+
+List registered devices.
+
+
+```code
+$ tctl devices ls
+```
+
+#### Examples
+
+```code
+$ tctl devices ls
+#
+# Asset Tag    OS    Enroll Status Device ID
+# ------------ ----- ------------- ------------------------------------
+# C00AA3BBBB6C macOS enrolled      d40f2ee4-856d-4aef-b784-c4371e39c036
+```
+
+### tctl devices rm
+
+Removes a registered device.
+
+A removed device is not considered a trusted device for future device
+authentication attempts.
+
+```code
+$ tctl devices rm [--device-id=ID] [--asset-tag=ASSET_TAG]
+```
+
+#### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--device-id` | none | string | Teleport device identifier |
+| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
+
+One of `--device-id` or `--asset-tag` must be present.
+
+#### Examples
+
+```code
+$ tctl devices rm --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
+# Device "ac3590ec-87d4-4519-8e9e-2f35af0a9f85" removed
+
+$ tctl devices rm --asset-tag=C00AA3BBBB6C
+# Device "C00AA3BBBB6C" removed
+```
+
+### tctl devices enroll
+
+Create an enrollment token for a device.
+
+```code
+$ tctl devices enroll [--device-id=ID] [--asset-tag=ASSET_TAG]
+```
+
+#### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--device-id` | none | string | Teleport device identifier |
+| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
+
+One of `--device-id` or `--asset-tag` must be present.
+
+#### Examples
+
+```code
+$ tctl devices enroll --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
+# Run the command below on device "d40f2ee4-856d-4aef-b784-c4371e39c036" to enroll it:
+# tsh device enroll --token=gN/p5TJwZcyROT6zWYarmK0U5EXqkyZeTsgroaRWDu0
+
+$ tctl devices enroll --asset-tag=C00AA3BBBB6C
+# Run the command below on device "C00AA3BBBB6C" to enroll it:
+# tsh device enroll --token=9XJdnX67xNASU9uwR1DPJTXbxZpv8gnDobhSUAoZ4QI
+```
+
 ### tctl top
 
 Reports diagnostic information.

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1116,7 +1116,7 @@ $ tsh device enroll --token=TOKEN
 
 ```code
 $ tsh device enroll --token=(=devicetrust.enroll_token=)
-# Device "(=devicetrust.asset_tag=)"/macOS enrolled
+Device "(=devicetrust.asset_tag=)"/macOS enrolled
 ```
 
 ### tsh environment variables
@@ -2417,12 +2417,12 @@ $ tctl devices add --os=OS --asset-tag=SERIAL_NUMBER
 
 ```code
 $ tctl devices add --os=macos --asset-tag=(=devicetrust.asset_tag=)
-# Device (=devicetrust.asset_tag=)/macOS added to the inventory
+Device (=devicetrust.asset_tag=)/macOS added to the inventory
 
 $ tctl devices add --os=macos --asset-tag=(=devicetrust.asset_tag=) --enroll
-# Device (=devicetrust.asset_tag=)/macOS added to the inventory
-# Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
-# tsh device enroll --token=(=devicetrust.enroll_token=)
+Device (=devicetrust.asset_tag=)/macOS added to the inventory
+Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
+tsh device enroll --token=(=devicetrust.enroll_token=)
 ```
 
 ### tctl devices enroll
@@ -2446,12 +2446,12 @@ One of `--device-id` or `--asset-tag` must be present.
 
 ```code
 $ tctl devices enroll --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
-# Run the command below on device "d40f2ee4-856d-4aef-b784-c4371e39c036" to enroll it:
-# tsh device enroll --token=(=devicetrust.enroll_token=)
+Run the command below on device "d40f2ee4-856d-4aef-b784-c4371e39c036" to enroll it:
+tsh device enroll --token=(=devicetrust.enroll_token=)
 
 $ tctl devices enroll --asset-tag=(=devicetrust.asset_tag=)
-# Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
-# tsh device enroll --token=(=devicetrust.enroll_token=)
+Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
+tsh device enroll --token=(=devicetrust.enroll_token=)
 ```
 
 ### tctl devices ls
@@ -2467,10 +2467,10 @@ $ tctl devices ls
 
 ```code
 $ tctl devices ls
-#
-# Asset Tag    OS    Enroll Status Device ID
-# ------------ ----- ------------- ------------------------------------
-# (=devicetrust.asset_tag=) macOS enrolled      d40f2ee4-856d-4aef-b784-c4371e39c036
+
+Asset Tag    OS    Enroll Status Device ID
+------------ ----- ------------- ------------------------------------
+(=devicetrust.asset_tag=) macOS enrolled      d40f2ee4-856d-4aef-b784-c4371e39c036
 ```
 
 ### tctl devices rm
@@ -2497,10 +2497,10 @@ One of `--device-id` or `--asset-tag` must be present.
 
 ```code
 $ tctl devices rm --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
-# Device "ac3590ec-87d4-4519-8e9e-2f35af0a9f85" removed
+Device "ac3590ec-87d4-4519-8e9e-2f35af0a9f85" removed
 
 $ tctl devices rm --asset-tag=(=devicetrust.asset_tag=)
-# Device "(=devicetrust.asset_tag=)" removed
+Device "(=devicetrust.asset_tag=)" removed
 ```
 
 ### tctl top

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -2425,6 +2425,35 @@ $ tctl devices add --os=macos --asset-tag=C00AA3BBBB6C --enroll
 # tsh device enroll --token=KKO1nmJ+VsGk+w1MqtAM8v428LoENHw/1ZcrSqitjzs
 ```
 
+### tctl devices enroll
+
+Create an enrollment token for a device.
+
+```code
+$ tctl devices enroll [--device-id=ID] [--asset-tag=ASSET_TAG]
+```
+
+#### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--device-id` | none | string | Teleport device identifier |
+| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
+
+One of `--device-id` or `--asset-tag` must be present.
+
+#### Examples
+
+```code
+$ tctl devices enroll --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
+# Run the command below on device "d40f2ee4-856d-4aef-b784-c4371e39c036" to enroll it:
+# tsh device enroll --token=gN/p5TJwZcyROT6zWYarmK0U5EXqkyZeTsgroaRWDu0
+
+$ tctl devices enroll --asset-tag=C00AA3BBBB6C
+# Run the command below on device "C00AA3BBBB6C" to enroll it:
+# tsh device enroll --token=9XJdnX67xNASU9uwR1DPJTXbxZpv8gnDobhSUAoZ4QI
+```
+
 ### tctl devices ls
 
 List registered devices.
@@ -2472,35 +2501,6 @@ $ tctl devices rm --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
 
 $ tctl devices rm --asset-tag=C00AA3BBBB6C
 # Device "C00AA3BBBB6C" removed
-```
-
-### tctl devices enroll
-
-Create an enrollment token for a device.
-
-```code
-$ tctl devices enroll [--device-id=ID] [--asset-tag=ASSET_TAG]
-```
-
-#### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--device-id` | none | string | Teleport device identifier |
-| `--asset-tag` | none | string | Device inventory identifier (e.g., Mac serial number) |
-
-One of `--device-id` or `--asset-tag` must be present.
-
-#### Examples
-
-```code
-$ tctl devices enroll --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
-# Run the command below on device "d40f2ee4-856d-4aef-b784-c4371e39c036" to enroll it:
-# tsh device enroll --token=gN/p5TJwZcyROT6zWYarmK0U5EXqkyZeTsgroaRWDu0
-
-$ tctl devices enroll --asset-tag=C00AA3BBBB6C
-# Run the command below on device "C00AA3BBBB6C" to enroll it:
-# tsh device enroll --token=9XJdnX67xNASU9uwR1DPJTXbxZpv8gnDobhSUAoZ4QI
 ```
 
 ### tctl top

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1115,8 +1115,8 @@ $ tsh device enroll --token=TOKEN
 #### Examples
 
 ```code
-$ tsh device enroll --token=f3oJYqWfO6XG1ZCIF+faz8HIpDye54LsRFObftGKVVU
-# Device "C00AA3BBBB6C"/macOS enrolled
+$ tsh device enroll --token=(=devicetrust.enroll_token=)
+# Device "(=devicetrust.asset_tag=)"/macOS enrolled
 ```
 
 ### tsh environment variables
@@ -2416,13 +2416,13 @@ $ tctl devices add --os=OS --asset-tag=SERIAL_NUMBER
 #### Examples
 
 ```code
-$ tctl devices add --os=macos --asset-tag=C00AA3BBBB6C
-# Device C00AA3BBBB6C/macOS added to the inventory
+$ tctl devices add --os=macos --asset-tag=(=devicetrust.asset_tag=)
+# Device (=devicetrust.asset_tag=)/macOS added to the inventory
 
-$ tctl devices add --os=macos --asset-tag=C00AA3BBBB6C --enroll
-# Device C00AA3BBBB6C/macOS added to the inventory
-# Run the command below on device "C00AA3BBBB6C" to enroll it:
-# tsh device enroll --token=KKO1nmJ+VsGk+w1MqtAM8v428LoENHw/1ZcrSqitjzs
+$ tctl devices add --os=macos --asset-tag=(=devicetrust.asset_tag=) --enroll
+# Device (=devicetrust.asset_tag=)/macOS added to the inventory
+# Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
+# tsh device enroll --token=(=devicetrust.enroll_token=)
 ```
 
 ### tctl devices enroll
@@ -2447,11 +2447,11 @@ One of `--device-id` or `--asset-tag` must be present.
 ```code
 $ tctl devices enroll --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
 # Run the command below on device "d40f2ee4-856d-4aef-b784-c4371e39c036" to enroll it:
-# tsh device enroll --token=gN/p5TJwZcyROT6zWYarmK0U5EXqkyZeTsgroaRWDu0
+# tsh device enroll --token=(=devicetrust.enroll_token=)
 
-$ tctl devices enroll --asset-tag=C00AA3BBBB6C
-# Run the command below on device "C00AA3BBBB6C" to enroll it:
-# tsh device enroll --token=9XJdnX67xNASU9uwR1DPJTXbxZpv8gnDobhSUAoZ4QI
+$ tctl devices enroll --asset-tag=(=devicetrust.asset_tag=)
+# Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
+# tsh device enroll --token=(=devicetrust.enroll_token=)
 ```
 
 ### tctl devices ls
@@ -2470,7 +2470,7 @@ $ tctl devices ls
 #
 # Asset Tag    OS    Enroll Status Device ID
 # ------------ ----- ------------- ------------------------------------
-# C00AA3BBBB6C macOS enrolled      d40f2ee4-856d-4aef-b784-c4371e39c036
+# (=devicetrust.asset_tag=) macOS enrolled      d40f2ee4-856d-4aef-b784-c4371e39c036
 ```
 
 ### tctl devices rm
@@ -2499,8 +2499,8 @@ One of `--device-id` or `--asset-tag` must be present.
 $ tctl devices rm --device-id=d40f2ee4-856d-4aef-b784-c4371e39c036
 # Device "ac3590ec-87d4-4519-8e9e-2f35af0a9f85" removed
 
-$ tctl devices rm --asset-tag=C00AA3BBBB6C
-# Device "C00AA3BBBB6C" removed
+$ tctl devices rm --asset-tag=(=devicetrust.asset_tag=)
+# Device "(=devicetrust.asset_tag=)" removed
 ```
 
 ### tctl top

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -316,7 +316,7 @@ $ tsh play c0a02222-70dc-4be8-9308-7b7901d2d60
 # List recorded sessions that occurred between Nov 1, 2022 to Nov 3, 2022
 $ tsh recordings ls --from-utc=2022-11-01 --to-utc=2022-11-3
 
-# Retrieve recorded sessions in the last 6 hours 
+# Retrieve recorded sessions in the last 6 hours
 $ tsh recordings ls --last=6h0m0s
 ```
 
@@ -444,7 +444,7 @@ Use the following command to connect to the database:
 ### tsh proxy ssh
 
 Start a local TLS proxy for `ssh` connections when using Teleport in TLS Routing mode.
-This is typically used as part of the SSH client configuration to use `ssh` as a client 
+This is typically used as part of the SSH client configuration to use `ssh` as a client
 through Teleport.  See the [OpenSSH Guide](../server-access/guides/openssh.mdx) guide
 on configuring OpenSSH servers and clients.  The `tsh config` output will include `tsh proxy ssh`
 within a `ProxyCommand` directive.
@@ -475,7 +475,7 @@ Run the following command to generate an OpenSSH client configuration:
 $ tsh config
 ```
 
-This command produces the following configuration: 
+This command produces the following configuration:
 
 ```
 # Common flags for all example.com hosts
@@ -590,7 +590,7 @@ This command does not accept any arguments.
 #### Flags
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--app` | none | string | Name of the Teleport application representing Azure (i.e., based on `tsh apps ls`). Use this flag if your Teleport user has access to multiple Azure applications. | 
+| `--app` | none | string | Name of the Teleport application representing Azure (i.e., based on `tsh apps ls`). Use this flag if your Teleport user has access to multiple Azure applications. |
 | `--port` | none | port number | The port on `localhost` where the local proxy will listen for connections. |
 | `--format` | `powershell` if on Windows, `unix` otherwise | `text`, `unix`, `command-prompt`, or `powershell` | The format to use for listing environment variables for Azure client applications connecting to the local proxy. |
 
@@ -605,7 +605,7 @@ Start a local proxy for AWS access. The user must already be logged in to at
 least one AWS application via Teleport before the proxy can start.
 
 ```code
-$ tsh proxy aws [<flags>] 
+$ tsh proxy aws [<flags>]
 ```
 
 #### Flags
@@ -887,9 +887,9 @@ $ kubectl config get-contexts
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--all` | false | Boolean | Whether to generate a kubeconfig for every Kubernetes cluster the current Teleport user has access to. If this is false, `tsh` will only generate a kubeconfig for the cluster specified in the `tsh kube login` command.|  
+| `--all` | false | Boolean | Whether to generate a kubeconfig for every Kubernetes cluster the current Teleport user has access to. If this is false, `tsh` will only generate a kubeconfig for the cluster specified in the `tsh kube login` command.|
 | `--as` | none | string | The Kubernetes user that the current Teleport user will log in as when they authenticate to the specified Kubernetes cluster. <br/><br/>This uses [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation), so the Teleport user's Kubernetes user must have permissions to impersonate the target user. |
-| `--as-groups` | none | string | A Kubernetes group that the current Teleport user will log in as when they authenticate to the specified Kubernetes cluster. <br/><br/>This uses [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation), so the Teleport user's Kubernetes user must have permissions to impersonate the target group. <br /><br/>You can include this flag multiple times to enable impersonation of multiple Kubernetes groups. | 
+| `--as-groups` | none | string | A Kubernetes group that the current Teleport user will log in as when they authenticate to the specified Kubernetes cluster. <br/><br/>This uses [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation), so the Teleport user's Kubernetes user must have permissions to impersonate the target group. <br /><br/>You can include this flag multiple times to enable impersonation of multiple Kubernetes groups. |
 | `--cluster` | none | string | Name of the Teleport cluster to log into in order to connect to the given Kubernetes cluster. |
 | `-n`, `--kube-namespace` | none | string | The name of the Kubernetes namespace to configure as the default within the cluster the user is logging into. |
 
@@ -1095,6 +1095,29 @@ $ tsh request drop [<request-id>...]
 - `<request-id>` - IDs of requests to "drop" from the current identity so that
   your certificate will lose elevated roles and/or resource restrictions.
   If no request ID is given, the default is to drop all Access Requests.
+
+### tsh device enroll
+
+Enroll the current device as a trusted device.
+
+Requires a device enrollment token created via `tctl devices enroll`.
+
+```code
+$ tsh device enroll --token=TOKEN
+```
+
+#### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--token` | none | String | Device enrollment token |
+
+#### Examples
+
+```code
+$ tsh device enroll --token=f3oJYqWfO6XG1ZCIF+faz8HIpDye54LsRFObftGKVVU
+# Device "C00AA3BBBB6C"/macOS enrolled
+```
 
 ### tsh environment variables
 
@@ -2066,7 +2089,7 @@ $ tctl sso configure oidc ... | tctl sso test
 
 Configure the SAML auth connector, optionally using a preset.
 
-The flag `--attributes-to-roles/-r` can be provided multiple times. 
+The flag `--attributes-to-roles/-r` can be provided multiple times.
 
 To avoid errors when pasting XML to a YAML file, we encourage the usage of the flag `--entity-descriptor`/`-e`.
 
@@ -2314,7 +2337,7 @@ $ tctl edit role/sre
 $ TELEPORT_EDITOR=nano tctl edit user/alice
 ```
 
-  
+
 ### tctl status
 
 Report cluster status:

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -5,7 +5,7 @@ description: The detailed guide and reference documentation for configuring Tele
 
 Teleport uses the YAML file format for configuration. A full configuration
 reference file is shown below. This provides comments and all available options
-for `teleport.yaml`. 
+for `teleport.yaml`.
 
 By default, Teleport reads its configuration from `/etc/teleport.yaml`.
 
@@ -33,16 +33,16 @@ configure` in the [Teleport CLI Reference](cli.mdx#teleport).
 <Notice type="warning">
 
 You should back up your configuration file before making changes. This will
-enable you to roll back to the previous configuration if you need to.  
+enable you to roll back to the previous configuration if you need to.
 
 </Notice>
 
 ## Enabling Teleport services
 
-The `teleport` process can run multiple services. 
+The `teleport` process can run multiple services.
 
 For some services, you must enable the service within your Teleport
-configuration in order to start it. Other services are enabled by default. 
+configuration in order to start it. Other services are enabled by default.
 
 To enable or disable a service, include the following in your Teleport
 configuration, replacing `service_name` with the name of your service (service
@@ -416,6 +416,22 @@ auth_service:
         # (https://goteleport.com/docs/access-controls/guides/locking/#locking-mode).
         locking_mode: best_effort
 
+        # Device Trust configures Teleport's behavior in regards to trusted
+        # devices.
+        # Device Trust is a Teleport Enterprise feature.
+        # (https://goteleport.com/docs/access-controls/guides/device-trust/)
+        device_trust:
+          # 'mode' is the cluster-wide device trust mode.
+          # The following values are supported:
+          # - 'off' - disables device trust. Device authentication is not
+          #   performed and device-aware audit logs are absent.
+          # - 'optional' - enables device authentication and device-aware audit,
+          #   but doesn't require a trusted device to access resources.
+          # - 'required' - enables device authentication and device-aware audit.
+          #   Additionally, it requires a trusted device for all SSH, Database
+          #   and Kubernetes connections.
+          mode: optional # always "off" for OSS
+
     # IP and the port to bind to. Other Teleport Nodes will be connecting to
     # this port (AKA "Auth API" or "Cluster API") to validate client
     # certificates
@@ -437,13 +453,13 @@ auth_service:
         - "auth:yyyy"
 
     # Optional setting for configuring session recording. Possible values are:
-    #    "node"      : (default) sessions will be recorded on the node 
-    #                  and periodically cleaned up after they are uploaded 
+    #    "node"      : (default) sessions will be recorded on the node
+    #                  and periodically cleaned up after they are uploaded
     #                  to the storage service.
     #    "node-sync" : session recordings will be streamed from
     #                  node -> auth -> storage service without being stored on
     #                  disk at all.
-    #    "proxy"     : sessions will be recorded on the proxy and periodically 
+    #    "proxy"     : sessions will be recorded on the proxy and periodically
     #                  cleaned up after they are uploaded to the storage service.
     #    "proxy-sync : session recordings will be streamed from
     #                  proxy -> auth -> storage service without being stored on


### PR DESCRIPTION
Add the following public documentation:

* Device Trust guide under access control
* Device Trust configuration reference
* `tctl devices` command reference
* `tsh device enroll` command reference

https://github.com/gravitational/teleport.e/issues/514