### PR TITLE
Add more info re: AWS credentials to the docs

### DIFF
--- a/docs/pages/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/application-access/cloud-apis/aws-console.mdx
@@ -162,7 +162,10 @@ Templates](../../access-controls/guides/role-templates.mdx) for details.
 
 ## Step 5/9. Register AWS console application in Teleport
 
-Add AWS management console to your application service configuration:
+### Configure the Application Service
+
+Add the AWS management console to your Application Service configuration by
+editing `/etc/teleport.yaml` on the host that runs the Application Service:
 
 ```yaml
 version: v3
@@ -189,18 +192,10 @@ ssh_service:
   enabled: "no"
 proxy_service:
   enabled: "no"
-
-```
-
-Start the application service
-
-
-```code
-sudo teleport start --config=/path/to/teleport.yaml
 ```
 
 Note that the URI must start with one of the following values in order to be
-recognized as an AWS console.
+recognized as an AWS console:
 
 | Regions                   | AWS Console URL |
 | ------------------------- | --------------- |
@@ -208,14 +203,7 @@ recognized as an AWS console.
 | AWS GovCloud (US) regions | `https://console.amazonaws-us-gov.com` |
 | AWS China regions         | `https://console.amazonaws.cn` |
 
-<Admonition type="warning" title="non-standard AWS regions">
-For non-standard AWS regions such as AWS GovCloud (US) regions and AWS China
-regions, please set the corresponding region in the `AWS_REGION` environment
-variable or in the AWS credentials file so that the Application Service can use
-the correct STS endpoint.
-</Admonition>
-
-### Multiple AWS accounts
+<Details title="Multiple AWS accounts">
 
 If you have multiple AWS accounts and would like to logically separate them
 in the UI, register an application entry for each and set `aws_account_id`
@@ -249,6 +237,21 @@ belong to the specific account.
 For AWS accounts that require external IDs for accessing their resources, set
 the `external_id` field, which the Application Service uses when assuming the
 AWS roles in these accounts.
+
+</Details>
+
+### Start the Teleport Application Service
+
+(!docs/pages/includes/aws-credentials.mdx service="the Application Service"!)
+
+(!docs/pages/includes/start-teleport.mdx service="the Application Service"!)
+
+<Admonition type="warning" title="non-standard AWS regions">
+For non-standard AWS regions such as AWS GovCloud (US) regions and AWS China
+regions, please set the corresponding region in the `AWS_REGION` environment
+variable or in the AWS credentials file so that the Application Service can use
+the correct STS endpoint.
+</Admonition>
 
 ## Step 6/9. Connect to AWS console with assumed IAM role
 

--- a/docs/pages/application-access/guides/dynamodb.mdx
+++ b/docs/pages/application-access/guides/dynamodb.mdx
@@ -125,8 +125,8 @@ $ tctl tokens add \
     --app-uri=https://console.aws.amazon.com/dynamodbv2/home
 ```
 
-The output should contain a `teleport app start` command that can be used to
-start the Teleport Application Service in the next step.
+On the host where you will run the Teleport Application Service, copy the token
+to a file called `/tmp/token`.
 
 <Admonition type="tip" title="non-standard AWS regions">
 Replace `https://console.aws.amazon.com` with
@@ -135,23 +135,40 @@ Replace `https://console.aws.amazon.com` with
 </Admonition>
 
 ### Install and start Teleport
+
 Install Teleport on the host where you will run the Teleport Application
 Service. See our [Installation](../../installation.mdx) page for options
 besides Linux servers.
 
 (!docs/pages/includes/install-linux.mdx!)
 
-Now start the Teleport Application Service using the output from the previous
-step:
+Edit the Teleport configuration file (`/etc/teleport.yaml`) to include the
+following information, adjusting the value of `proxy_server` to specify the host
+and port of your Teleport Proxy Service:
 
-```code
-$ teleport app start \
-   --token=(=presets.tokens.first=) \
-   --ca-pin=(=presets.ca_pin=) \
-   --auth-server=https://teleport.example.com:443 \
-   --name=aws-dynamodb \
-   --uri=https://console.aws.amazon.com/dynamodbv2/home
+```yaml
+version: v3
+teleport:
+  join_params:
+    token_name: "/tmp/token"
+    method: token
+  proxy_server: "teleport.example.com:443"
+auth_service:
+  enabled: off
+proxy_service:
+  enabled: off
+ssh_service:
+  enabled: off
+app_service:
+  enabled: true
+  apps:
+  - name: aws-dynamodb
+    uri: https://console.aws.amazon.com/dynamodbv2/home
 ```
+
+(!docs/pages/includes/aws-credentials.mdx service="the Teleport Application Service"!)
+
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Application Service"!)
 
 <Admonition type="warning" title="non-standard AWS regions">
 For non-standard AWS regions such as AWS GovCloud (US) regions and AWS China

--- a/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
@@ -47,38 +47,30 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 <ScopedBlock scope={["oss", "enterprise"]}>
 
-Start the Teleport Database Service, pointing the `--auth-server` flag to the
-address of your Teleport Proxy Service:
+Create a configuration for the Teleport Database Service, pointing the
+`--proxy` flag to the address of your Teleport Proxy Service:
 
 ```code
-$ teleport db start \
+$ teleport db configure create \
   --token=/tmp/token \
-  --auth-server=teleport.example.com:443 \
+  --proxy=teleport.example.com:443 \
   --name=keyspaces \
   --protocol=cassandra \
   --aws-account-id=12345678912 \
   --aws-region=us-east-1 \
   --labels=env=dev
 ```
-
-<Admonition type="note">
-
-The `--auth-server` flag must point to the Teleport cluster's Proxy Service
-endpoint because the Database Service always connects back to the cluster over a
-reverse tunnel.
-
-</Admonition>
 
 </ScopedBlock>
 <ScopedBlock scope={["cloud"]}>
 
-Start the Teleport Database Service, pointing the `--auth-server` flag to the
-address of your Teleport Cloud tenant:
+Create a configuration for the Teleport Database Service, pointing the
+`--proxy` flag to the address of your Teleport Proxy Service:
 
 ```code
-$ teleport db start \
+$ teleport db configure create \
   --token=/tmp/token \
-  --auth-server=mytenant.teleport.sh:443 \
+  --proxy=mytenant.teleport.sh:443 \
   --name=keyspaces \
   --protocol=cassandra \
   --aws-account-id=12345678912 \
@@ -88,15 +80,13 @@ $ teleport db start \
 
 </ScopedBlock>
 
-<Admonition type="tip">
-  You can start the Database Service using a configuration file instead of CLI flags.
-  See the [YAML reference](../reference/configuration.mdx) for details.
-</Admonition>
+(!docs/pages/includes/aws-credentials.mdx service="the Teleport Database Service"!)
+
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 ## Step 2/5. Create a Teleport user
 
 (!docs/pages/includes/database-access/create-user.mdx!)
-
 
 ## Step 3/5. Create an AWS Keyspaces role
 

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -77,29 +77,21 @@ Teleport needs AWS IAM permissions to be able to:
 - Discover and register Redshift databases.
 - Manage IAM user or IAM role policies.
 
+Before you can generate IAM permissions, you must provide the Teleport Database
+Service access to AWS credentials.
+
+(!docs/pages/includes/aws-credentials.mdx service="the Database Service"!)
+
 (!docs/pages/includes/database-access/aws-bootstrap.mdx!)
 
 ## Step 4/5. Start the Database Service
 
-Run the following command on the Database Service node:
-
-```code
-$ teleport start --config=/etc/teleport.yaml
-```
+(!docs/pages/includes/start-teleport.mdx service="the Database Service"!)
 
 The Database Service will discover all Redshift databases according to the configuration
 and register them in the cluster. The Database Service will also attempt to configure IAM
 access policies for the discovered databases. Keep in mind that AWS IAM changes
 may not propagate immediately and can take a few minutes to come into effect.
-
-<Admonition type="note" title="AWS credentials">
-
-  The Teleport Database Service uses the default credential provider chain to
-  find AWS credentials. See
-  [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials)
-  for more information.
-
-</Admonition>
 
 ## Step 5/5. Connect
 

--- a/docs/pages/database-access/guides/rds-proxy.mdx
+++ b/docs/pages/database-access/guides/rds-proxy.mdx
@@ -36,6 +36,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
+(!docs/pages/includes/aws-credentials.mdx service="the Teleport Database Service"!)
+
 Create the Database Service configuration. Replace <Var name="teleport.example.com" /> with
 your Teleport Proxy address or Teleport Cloud tenant (e.g. `mytenant.teleport.sh`),
 and replace <Var name="us-west-1" /> with your preferred region:
@@ -61,11 +63,7 @@ Proxy instances.
 
 ## Step 3/5. Start the Database Service
 
-Start the Database Service:
-
-```code
-$ teleport start --config=/etc/teleport.yaml
-```
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 The Database Service will discover all RDS Proxy instances according to the
 configuration and register them in the cluster. In addition to the primary

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -86,15 +86,16 @@ Teleport needs AWS IAM permissions to be able to:
 - Discover and register RDS instances and Aurora clusters.
 - Configure IAM authentication for them.
 
+Before you can generate IAM permissions, you must provide the Teleport Database
+Service access to AWS credentials.
+
+(!docs/pages/includes/aws-credentials.mdx service="the Database Service"!)
+
 (!docs/pages/includes/database-access/aws-bootstrap.mdx!)
 
 ## Step 4/6. Start the Database Service
 
-Start the Database Service:
-
-```code
-$ teleport start --config=/etc/teleport.yaml
-```
+(!docs/pages/includes/start-teleport.mdx service="the Database Service"!)
 
 The Database Service will discover all RDS instances and Aurora clusters according to the
 configuration and register them in the cluster. In addition to the primary
@@ -104,11 +105,6 @@ will also be registered.
 The Database Service will also attempt to enable IAM auth and configure IAM access
 policies for the discovered databases. Keep in mind that AWS IAM changes may
 not propagate immediately and can take a few minutes to come into effect.
-
-<Admonition type="note" title="AWS credentials">
-  The Teleport Database Service uses the default
-  credential provider chain to find AWS credentials. See [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials) for more information.
-</Admonition>
 
 ## Step 5/6. Create a database IAM user
 

--- a/docs/pages/database-access/guides/redis-aws.mdx
+++ b/docs/pages/database-access/guides/redis-aws.mdx
@@ -104,15 +104,16 @@ Teleport needs AWS IAM permissions to be able to:
 - Modify ElastiCache and MemoryDB user passwords for Teleport-managed users.
 - Save user passwords in AWS Secrets Manager for Teleport-managed users.
 
+Before you can generate IAM permissions, you must provide the Teleport Database
+Service access to AWS credentials.
+
+(!docs/pages/includes/aws-credentials.mdx service="the Database Service"!)
+
 (!docs/pages/includes/database-access/aws-bootstrap.mdx!)
 
 ## Step 4/6. Start the Database Service
 
-Start the Database Service:
-
-```code
-$ teleport start --config=/etc/teleport.yaml
-```
+(!docs/pages/includes/start-teleport.mdx service="the Database Service"!)
 
 The Database Service will discover and register all ElastiCache and MemoryDB
 for Redis clusters according to the configuration.

--- a/docs/pages/includes/aws-credentials.mdx
+++ b/docs/pages/includes/aws-credentials.mdx
@@ -33,7 +33,7 @@ AWS_DEFAULT_REGION=<YOUR_REGION>
 </TabItem>
 </Tabs>
 
-<Details title="Have multiple credentials sources?">
+<Details title="Have multiple sources of AWS credentials?">
 
 Teleport's AWS client loads credentials from different sources in the following
 order:

--- a/docs/pages/includes/aws-credentials.mdx
+++ b/docs/pages/includes/aws-credentials.mdx
@@ -1,0 +1,57 @@
+{{ service="your Teleport instance" }}
+
+Grant {{ service }} access to credentials that it can use to authenticate to
+AWS. If you are running {{ service }} on an EC2 instance, you should use the EC2
+Instance Metadata Service method. Otherwise, you must use environment variables:
+
+<Tabs>
+<TabItem label="Instance Metadata Service">
+
+Teleport will detect when it is running on an EC2 instance and use the Instance
+Metadata Service to fetch credentials. 
+
+</TabItem>
+<TabItem label="Environment Variables">
+
+Teleport's built-in AWS client reads credentials from the following environment
+variables:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_DEFAULT_REGION`
+
+When you start {{ service }}, the service reads environment variables from a
+file at the path `/etc/default/teleport`. Obtain these credentials from your
+organization. Ensure that `/etc/default/teleport` has the following content,
+replacing the values of each variable:
+
+```text
+AWS_ACCESS_KEY_ID=00000000000000000000
+AWS_SECRET_ACCESS_KEY=0000000000000000000000000000000000000000
+AWS_DEFAULT_REGION=<YOUR_REGION>
+```
+</TabItem>
+</Tabs>
+
+<Details title="Have multiple credentials sources?">
+
+Teleport's AWS client loads credentials from different sources in the following
+order:
+
+- Environment Variables
+- Shared credentials file
+- Shared configuration file (Teleport always enables shared configuration)
+- EC2 Instance Metadata (credentials only)
+
+While you can provide AWS credentials via a shared credentials file or shared
+configuration file, you will need to run {{ service }} with the `AWS_PROFILE`
+environment variable assigned to the name of your profile of choice. 
+
+If you have a specific use case that the instructions above do not account for,
+consult the documentation for the [AWS SDK for
+Go](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/) for a detailed
+description of credential loading behavior.
+
+</Details>
+
+

--- a/docs/pages/includes/database-access/aws-bootstrap.mdx
+++ b/docs/pages/includes/database-access/aws-bootstrap.mdx
@@ -1,17 +1,12 @@
 Teleport can bootstrap IAM permissions for the Database Service based on its
 configuration using the `teleport db configure bootstrap` command. You can use
 this command in automatic or manual mode:
+
 - In automatic mode, Teleport will attempt to create appropriate IAM policies
   and attach them to the specified IAM identity (user or role). This requires
   IAM permissions to create and attach IAM policies.
 - In manual mode, Teleport will print required IAM policies. You can then create
   and attach them manually using the AWS management console.
-
-<Admonition type="note" title="AWS credentials">
-  AWS Credentials are only required if you’re running the command in "automatic"
-  mode. The command uses the default credential provider chain to find AWS
-  credentials. See [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials) for more information.
-</Admonition>
 
 Run one of the following commands on your Database Service node:
 

--- a/docs/pages/includes/start-teleport.mdx
+++ b/docs/pages/includes/start-teleport.mdx
@@ -14,7 +14,7 @@ $ sudo systemctl start teleport
 ```
 
 </TabItem>
-<TabItem  label="TAR Archive">
+<TabItem label="TAR Archive">
 
 On the host where you will run {{ service }}, create a systemd service
 configuration for Teleport, enable the Teleport service, and start Teleport:

--- a/docs/pages/includes/start-teleport.mdx
+++ b/docs/pages/includes/start-teleport.mdx
@@ -1,0 +1,29 @@
+{{ service="your Teleport instance" }}
+
+Configure {{ service }} to start automatically when the host boots up by
+creating a systemd service for it. The instructions depend on how you installed
+{{ service }}.
+
+<Tabs>
+<TabItem label="Package Manager">
+
+On the host where you will run {{ service }}, start Teleport:
+
+```code
+$ sudo systemctl start teleport
+```
+
+</TabItem>
+<TabItem  label="TAR Archive">
+
+On the host where you will run {{ service }}, create a systemd service
+configuration for Teleport, enable the Teleport service, and start Teleport:
+
+```code
+$ sudo teleport install systemd -o /etc/systemd/system/teleport.service
+$ sudo systemctl enable teleport
+$ sudo systemctl start teleport
+```
+
+</TabItem>
+</Tabs>

--- a/docs/pages/kubernetes-access/discovery/aws.mdx
+++ b/docs/pages/kubernetes-access/discovery/aws.mdx
@@ -233,6 +233,8 @@ and create the `ClusterRole` and `ClusterRoleBinding` resources during cluster p
 
 ## Step 3/3. Configure Teleport to discover EKS clusters
 
+### Get a join token
+
 Teleport EKS Auto-Discovery requires a valid Teleport auth token for the Discovery and 
 Kubernetes services to join the cluster. Generate one by running the following 
 command against your Teleport Auth Service and save it in `/tmp/token` on the 
@@ -241,6 +243,8 @@ machine that will run Kubernetes Auto-Discovery:
 ```code
 $ tctl tokens add --type=discovery,kube
 ```
+
+### Configure the Teleport Kubernetes and Discovery Services
 
 Enabling EKS Auto-Discovery requires that the `discovery_service.aws` section 
 include at least one entry and that `discovery_service.aws.types` include `eks`. 
@@ -277,9 +281,15 @@ kubernetes_service:
       "env": "prod" # Match Kubernetes Cluster labels specified earlier
 ```
 
-Once you have added this configuration, start Teleport. EKS clusters matching the tags and regions
-specified in the AWS section will be added to the Teleport cluster automatically.
+### Start the Kubernetes and Discovery Services
 
+(!docs/pages/includes/aws-credentials.mdx service="the Kubernetes and Discovery Services"!)
+
+(!docs/pages/includes/start-teleport.mdx service="the Kubernetes and Discovery Services"!)
+
+Once the Kubernetes and Discovery Services start, EKS clusters matching the tags
+and regions specified in the AWS section will be added to the Teleport cluster
+automatically.
 
 ## Troubleshooting
 

--- a/docs/pages/management/guides/joining-nodes-aws-iam.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-iam.mdx
@@ -161,5 +161,9 @@ proxy_service:
 
 ## Step 4/4. Launch your Teleport Node
 
-Start Teleport on the Node and confirm that it is able to connect to and join
-your cluster. You're all set!
+(!docs/pages/includes/aws-credentials.mdx!)
+
+(!docs/pages/includes/start-teleport.mdx!)
+
+Once you have started Teleport, confirm that your Node is able to connect to and
+join your cluster. 

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -185,21 +185,21 @@ teleport:
   in Teleport Architecture documentation.
 </Admonition>
 
-<Admonition
-  type="tip"
-  title="AWS Authentication"
->
-  The configuration examples below contain AWS
-  access keys and secret keys. They are optional, they exist for your convenience but we DO NOT RECOMMEND using them in production. If Teleport is running on an AWS instance it will automatically use the instance IAM role.
-  Teleport also will pick up AWS credentials from the `~/.aws` folder, just like the AWS CLI tool.
-</Admonition>
-
 S3 buckets can only be used as storage for the recorded sessions. S3 cannot
 store the audit log or the cluster state.
 
 S3 buckets must have versioning enabled, which ensures that a session log cannot
 be permanently altered or deleted. Teleport will always look at the oldest
 version of a recording.
+
+### Authenticating to AWS
+
+The Teleport Auth Service must be able to read AWS credentials in order to
+authenticate to S3. 
+
+(!docs/pages/includes/aws-credentials.mdx service="the Teleport Auth Service"!)
+
+### Configuring the S3 backend
 
 Below is an example of how to configure the Teleport Auth Service to store the
 recorded sessions in an S3 bucket.
@@ -217,9 +217,6 @@ teleport:
       # Teleport assumes credentials. Using provider chains, assuming IAM role or
       # standard .aws/credentials in the home folder.
 ```
-
-The AWS authentication settings above can be omitted if the machine itself is
-running on an EC2 instance with an IAM role.
 
 You can add optional query parameters to the S3 URL. The Teleport Auth
 Service reads these parameters to configure its interactions with S3:
@@ -409,10 +406,47 @@ High Availability. DynamoDB backend supports two types of Teleport data:
 - Audit log events
 
 DynamoDB cannot store the recorded sessions. You are advised to use AWS S3 for
-that as shown above. To configure Teleport to use DynamoDB:
+that as shown above. 
 
-- Make sure you have AWS access key and a secret key that give you access to
-  DynamoDB account. If you're using (as recommended) an IAM role for this, the policy with the necessary permissions is listed below.
+### Authenticating to AWS
+
+The Teleport Auth Service must be able to read AWS credentials in order to
+authenticate to DynamoDB. 
+
+(!docs/pages/includes/aws-credentials.mdx service="the Teleport Auth Service"!)
+
+The IAM role that the Teleport Auth Service authenticates as must have the
+policies specified in the next section.
+
+### IAM policies
+
+Make sure that the IAM role assigned to the Teleport Auth Service is configured
+with sufficient access to DynamoDB. Below is the example of the IAM policy you
+can use: 
+
+```js
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+            "Sid": "AllAPIActionsOnTeleportAuth",
+            "Effect": "Allow",
+            "Action": "dynamodb:*",
+            "Resource": "arn:aws:dynamodb:eu-west-1:123456789012:table/prod.teleport.auth"
+        },
+        {
+            "Sid": "AllAPIActionsOnTeleportStreams",
+            "Effect": "Allow",
+            "Action": "dynamodb:*",
+            "Resource": "arn:aws:dynamodb:eu-west-1:123456789012:table/prod.teleport.auth/stream/*"
+        }
+    ]
+}
+```
+
+### Configuring the DynamoDB backend
+
+To configure Teleport to use DynamoDB:
+
 - Configure all Teleport Auth servers to use DynamoDB back-end in the "storage"
   section of `teleport.yaml` as shown below.
 - Deploy several auth servers connected to DynamoDB storage back-end.
@@ -450,7 +484,6 @@ teleport:
   with your own settings.  Teleport will create the table automatically.
 - `Example_TELEPORT_DYNAMO_TABLE_NAME` and `events_table_name` **must** be different
   DynamoDB tables. The schema is different for each. Using the same table name for both will result in errors.
-- The AWS authentication setting above can be omitted if the machine itself is running on an EC2 instance with an IAM role.
 - Audit log settings above are optional. If specified, Teleport will store the
   audit log in DynamoDB and the session recordings **must** be stored in an S3
   bucket, i.e. both `audit_xxx` settings must be present. If they are not set,
@@ -464,34 +497,6 @@ The optional `GET` parameters shown below control how Teleport interacts with a 
 - `region=us-east-1` - set the Amazon region to use.
 - `endpoint=dynamo.example.com` - connect to a custom S3 endpoint.
 - `use_fips_endpoint=true` -  [Configure DynamoDB FIPS endpoints](#configuring-aws-fips-endpoints).
-
-<Admonition
-  type="warning"
-  title="Access to DynamoDB"
->
-  Make sure that the IAM role assigned to
-  Teleport is configured with sufficient access to DynamoDB. Below is the
-  example of the IAM policy you can use:
-</Admonition>
-
-```js
-{
-    "Version": "2012-10-17",
-    "Statement": [{
-            "Sid": "AllAPIActionsOnTeleportAuth",
-            "Effect": "Allow",
-            "Action": "dynamodb:*",
-            "Resource": "arn:aws:dynamodb:eu-west-1:123456789012:table/prod.teleport.auth"
-        },
-        {
-            "Sid": "AllAPIActionsOnTeleportStreams",
-            "Effect": "Allow",
-            "Action": "dynamodb:*",
-            "Resource": "arn:aws:dynamodb:eu-west-1:123456789012:table/prod.teleport.auth/stream/*"
-        }
-    ]
-}
-```
 
 ### DynamoDB autoscaling
 

--- a/docs/pages/server-access/guides/ec2-discovery.mdx
+++ b/docs/pages/server-access/guides/ec2-discovery.mdx
@@ -24,7 +24,7 @@ install Teleport manually.)
 
 (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/6. Create an EC2 invite token
+## Step 1/7. Create an EC2 invite token
 
 When discovering EC2 instances, Teleport makes use of IAM invite tokens for
 authenticating joining Nodes.
@@ -58,7 +58,7 @@ Add the token to the Teleport cluster with:
 $ tctl create -f token.yaml
 ```
 
-## Step 2/6. Define an IAM policy
+## Step 2/7. Define an IAM policy
 
 The `teleport discovery bootstrap` command will automate the process of
 defining and implementing IAM policies required to make auto-discovery work. It
@@ -90,7 +90,7 @@ the command:
 
 Create this policy and apply it to the Node (EC2 instance) that will run the Discovery Service.
 
-## Step 3/6. Install Teleport on the Discovery Node
+## Step 3/7. Install Teleport on the Discovery Node
 
 <Admonition type="tip">
 
@@ -103,7 +103,7 @@ Install Teleport on the EC2 instance that will run the Discovery Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 4/6. Configure Teleport to discover EC2 instances
+## Step 4/7. Configure Teleport to discover EC2 instances
 
 If you are running the Discovery Service on its own host, the service requires a
 valid invite token to connect to the cluster. Generate one by running the
@@ -148,7 +148,7 @@ discovery_service:
   specifically the regions and tags you want to associate with the Discovery
   Service.
 
-## Step 5/6. Bootstrap the Discovery Service
+## Step 5/7. Bootstrap the Discovery Service AWS configuration
 
 On the same Node as above, run `teleport discovery bootstrap`. This command
 will generate and display the additional IAM policies and AWS Systems Manager (SSM) documents
@@ -294,12 +294,7 @@ This policy includes the following permissions:
 }
 ```
 
-Once Teleport is configured for discovery, it can be started and EC2 instances
-matching the tags specified in the AWS section will begin to be added to the
-Teleport cluster automatically. You can start Teleport now, or follow the next
-section to customize the Teleport installation script first.
-
-## Step 6/6. [Optional] Customize the default installer script
+## Step 6/7. [Optional] Customize the default installer script
 
 To customize the default installer script, execute the following command on
 your workstation:
@@ -373,6 +368,15 @@ The default installer will take the following actions:
 - Install Teleport via `apt` or `yum`.
 - Generate the Teleport config file and write it to `/etc/teleport.yaml`.
 - Enable and start the Teleport service.
+
+## Step 7/7. Start Teleport
+
+(!docs/pages/includes/aws-credentials.mdx service="the Discovery Service"!)
+
+(!docs/pages/includes/start-teleport.mdx service="the Discovery Service"!)
+
+Once you have started the Discovery Service, EC2 instances matching the tags you
+specified earlier will begin to be added to the Teleport cluster automatically.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Closes #2781

- Add a partial for how to provide credentials to Teleport's AWS client. Since this includes adding environment variables to the file used by our systemd service, I also created a partial re: how to configure Teleport's systemd service and added these two partials to the relevant guides.

- Removed `Admonition`s that link to the docs re: AWS credentials in favor of the partial above. (The partial links to the Go SDK for AWS docs for situations where users have a specific use case.)

- Remove mentions of the AWS credential-related config settings from the Backends reference. The example config snippets don't actually include the `access_key` and `secret_key` settings, so these are left over from an earlier version of the guide. While you can still add these settings to a config file, I thought it would make sense to leave them undocumented since using an EC2 instance, environment variables, etc. is the recommended approach.

- Split the S3/DynamoDB sections of the Backends reference into subsections so the extra authentication info fits a bit better.