### PR TITLE
Require flag for dynamic resources matching "tsh db configure create"

### DIFF
--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -103,21 +103,26 @@ $ teleport db configure create \
 | - | - |
 | `--proxy` | Teleport Proxy Service address to connect to. Default: `0.0.0.0:3080`. |
 | `--token` | Invitation token to register with the Auth Service. Default: none. |
-| `--rds-discovery` | List of AWS regions in which the Database Service will discover RDS/Aurora instances. |
-| `--redshift-discovery` | List of AWS regions in which the Database Service will discover Redshift instances. |
-| `--elasticache-discovery` | List of AWS regions in which the Database Service will discover ElastiCache Redis clusters. |
-| `--memorydb-discovery` | List of AWS regions in which the Database Service will discover MemoryDB clusters. |
+| `--rds-discovery` | List of AWS regions in which the agent will discover RDS/Aurora instances. |
+| `--rdsproxy-discovery` | List of AWS regions in which the agent will discover RDS Proxies. |
+| `--redshift-discovery` | List of AWS regions in which the agent will discover Redshift instances. |
+| `--redshift-serverless-discovery` | List of AWS regions in which the agent will discover Redshift Serverless instances. |
+| `--elasticache-discovery` | List of AWS regions in which the agent will discover ElastiCache Redis clusters. |
+| `--aws-tags` | (Only for AWS discoveries) Comma-separated list of AWS resource tags to match, for example env=dev,dept=it |
+| `--memorydb-discovery` | List of AWS regions in which the agent will discover MemoryDB clusters. |
 | `--azure-mysql-discovery` | List of Azure regions in which the agent will discover MySQL servers. |
 | `--azure-postgres-discovery` | List of Azure regions in which the agent will discover Postgres servers. |
 | `--azure-redis-discovery` | List of Azure regions in which the agent will discover Azure Cache For Redis servers. |
 | `--azure-subscription` | List of Azure subscription IDs for Azure discoveries. Default is "*". |
 | `--azure-resource-group` | List of Azure resource groups for Azure discoveries. Default is "*". |
+| `--azure-tags` | (Only for Azure discoveries) Comma-separated list of Azure resource tags to match, for example env=dev,dept=it |
 | `--ca-pin` | CA pin to validate the Auth Service (can be repeated for multiple pins). |
 | `--name` | Name of the proxied database. |
 | `--protocol` | Proxied database protocol. Supported are: `[postgres mysql mongodb cockroachdb redis sqlserver snowflake]`. |
 | `--uri` | Address the proxied database is reachable at. |
 | `--labels` | Comma-separated list of labels for the database, for example env=dev,dept=it |
 | `-o/--output` | Write to stdout with `-o=stdout`, the default config file with `-o=file`, or a custom path with `-o=file:///path` |
+| `--resources-labels` | Comma-separated list(s) of labels to match dynamic resources, for example env=dev,dept=it. Required to enable dynamic resources matching. |
 
 ## teleport db configure bootstrap
 

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -122,7 +122,7 @@ $ teleport db configure create \
 | `--uri` | Address the proxied database is reachable at. |
 | `--labels` | Comma-separated list of labels for the database, for example env=dev,dept=it |
 | `-o/--output` | Write to stdout with `-o=stdout`, the default config file with `-o=file`, or a custom path with `-o=file:///path` |
-| `--resources-labels` | Comma-separated list(s) of labels to match dynamic resources, for example env=dev,dept=it. Required to enable dynamic resources matching. |
+| `--dynamic-resources-labels` | Comma-separated list(s) of labels to match dynamic resources, for example env=dev,dept=it. Required to enable dynamic resources matching. |
 
 ## teleport db configure bootstrap
 

--- a/docs/pages/includes/database-access/database-config.yaml
+++ b/docs/pages/includes/database-access/database-config.yaml
@@ -2,10 +2,16 @@ db_service:
   # Enables the Database Service.
   enabled: "yes"
 
-  # Matchers for database resources created with "tctl create" command.
+  # Matchers for database resources created with "tctl create" command or by the
+  # discovery service.
+  #
+  # All database resources have a predefined "teleport.dev/origin" label with
+  # one of the following values:
+  # "dynamic": database resources created with "tctl create" command
+  # "cloud": database resources created by the discovery service
   resources:
   - labels:
-      "*": "*"
+      "": "*"
 
   # Matchers for registering AWS-hosted databases.
   aws:

--- a/docs/pages/includes/database-access/database-config.yaml
+++ b/docs/pages/includes/database-access/database-config.yaml
@@ -11,7 +11,7 @@ db_service:
   # "cloud": database resources created by the discovery service
   resources:
   - labels:
-      "": "*"
+      "*": "*"
 
   # Matchers for registering AWS-hosted databases.
   aws:

--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -55,11 +55,16 @@ teleport:
   {{- end }}
 db_service:
   enabled: "yes"
-  # Matchers for database resources created with "tctl create" command.
-  # For more information: https://goteleport.com/docs/database-access/guides/dynamic-registration/
+  # Matchers for database resources created with "tctl create" command or by the discovery service.
+  # For more information about dynamic registration: https://goteleport.com/docs/database-access/guides/dynamic-registration/
   resources:
+  {{- range $index, $resourceLabel := .ResourcesLabels }}
   - labels:
-      "*": "*"
+	{{- range $name, $value := $resourceLabel }}
+      "{{ $name }}": "{{ $value }}"
+    {{- end }}
+  {{- end }}
+
   {{- if or .RDSDiscoveryRegions .RDSProxyDiscoveryRegions .RedshiftDiscoveryRegions .RedshiftServerlessDiscoveryRegions .ElastiCacheDiscoveryRegions .MemoryDBDiscoveryRegions}}
   # Matchers for registering AWS-hosted databases.
   aws:
@@ -416,6 +421,10 @@ proxy_service:
 
 // DatabaseSampleFlags specifies configuration parameters for a database agent.
 type DatabaseSampleFlags struct {
+	// ResourcesRawLabels is the "raw" list of labels for dynamic "resources".
+	ResourcesRawLabels []string
+	// ResourcesLabels is the list of labels for dynamic "resources".
+	ResourcesLabels []map[string]string
 	// StaticDatabaseName static database name provided by the user.
 	StaticDatabaseName string
 	// StaticDatabaseProtocol static databse protocol provided by the user.
@@ -549,6 +558,15 @@ func (f *DatabaseSampleFlags) CheckAndSetDefaults() error {
 				return trace.Wrap(err)
 			}
 		}
+	}
+
+	// Labels for "resources" section.
+	for i := range f.ResourcesRawLabels {
+		labels, err := client.ParseLabelSpec(f.ResourcesRawLabels[i])
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		f.ResourcesLabels = append(f.ResourcesLabels, labels)
 	}
 
 	return nil

--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -58,7 +58,7 @@ db_service:
   # Matchers for database resources created with "tctl create" command or by the discovery service.
   # For more information about dynamic registration: https://goteleport.com/docs/database-access/guides/dynamic-registration/
   resources:
-  {{- range $index, $resourceLabel := .ResourcesLabels }}
+  {{- range $index, $resourceLabel := .DynamicResourcesLabels }}
   - labels:
 	{{- range $name, $value := $resourceLabel }}
       "{{ $name }}": "{{ $value }}"
@@ -421,10 +421,10 @@ proxy_service:
 
 // DatabaseSampleFlags specifies configuration parameters for a database agent.
 type DatabaseSampleFlags struct {
-	// ResourcesRawLabels is the "raw" list of labels for dynamic "resources".
-	ResourcesRawLabels []string
-	// ResourcesLabels is the list of labels for dynamic "resources".
-	ResourcesLabels []map[string]string
+	// DynamicResourcesRawLabels is the "raw" list of labels for dynamic "resources".
+	DynamicResourcesRawLabels []string
+	// DynamicResourcesLabels is the list of labels for dynamic "resources".
+	DynamicResourcesLabels []map[string]string
 	// StaticDatabaseName static database name provided by the user.
 	StaticDatabaseName string
 	// StaticDatabaseProtocol static databse protocol provided by the user.
@@ -561,12 +561,12 @@ func (f *DatabaseSampleFlags) CheckAndSetDefaults() error {
 	}
 
 	// Labels for "resources" section.
-	for i := range f.ResourcesRawLabels {
-		labels, err := client.ParseLabelSpec(f.ResourcesRawLabels[i])
+	for i := range f.DynamicResourcesRawLabels {
+		labels, err := client.ParseLabelSpec(f.DynamicResourcesRawLabels[i])
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		f.ResourcesLabels = append(f.ResourcesLabels, labels)
+		f.DynamicResourcesLabels = append(f.DynamicResourcesLabels, labels)
 	}
 
 	return nil

--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 )
 
@@ -239,6 +240,37 @@ func TestMakeDatabaseConfig(t *testing.T) {
 				})
 			}
 
+		})
+	})
+
+	t.Run("resource matchers", func(t *testing.T) {
+		t.Run("empty", func(t *testing.T) {
+			flags := DatabaseSampleFlags{}
+			databases := generateAndParseConfig(t, flags)
+			require.Len(t, databases.ResourceMatchers, 0)
+		})
+
+		t.Run("multiple labels", func(t *testing.T) {
+			flags := DatabaseSampleFlags{
+				ResourcesRawLabels: []string{
+					"env=dev",
+					"env=prod,name=my-name",
+				},
+			}
+			databases := generateAndParseConfig(t, flags)
+			require.Equal(t, []ResourceMatcher{
+				{
+					Labels: types.Labels{
+						"env": apiutils.Strings{"dev"},
+					},
+				},
+				{
+					Labels: types.Labels{
+						"name": apiutils.Strings{"my-name"},
+						"env":  apiutils.Strings{"prod"},
+					},
+				},
+			}, databases.ResourceMatchers)
 		})
 	})
 }

--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -252,7 +252,7 @@ func TestMakeDatabaseConfig(t *testing.T) {
 
 		t.Run("multiple labels", func(t *testing.T) {
 			flags := DatabaseSampleFlags{
-				ResourcesRawLabels: []string{
+				DynamicResourcesRawLabels: []string{
 					"env=dev",
 					"env=prod,name=my-name",
 				},

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -289,7 +289,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dbConfigureCreate.Flag("output",
 		"Write to stdout with -o=stdout, default config file with -o=file or custom path with -o=file:///path").Short('o').Default(
 		teleport.SchemeStdout).StringVar(&dbConfigCreateFlags.output)
-	dbConfigureCreate.Flag("resources-labels", "Comma-separated list(s) of labels to match dynamic resources, for example env=dev,dept=it. Required to enable dynamic resources matching.").StringsVar(&dbConfigCreateFlags.ResourcesRawLabels)
+	dbConfigureCreate.Flag("dynamic-resources-labels", "Comma-separated list(s) of labels to match dynamic resources, for example env=dev,dept=it. Required to enable dynamic resources matching.").StringsVar(&dbConfigCreateFlags.ResourcesRawLabels)
 	dbConfigureCreate.Alias(dbCreateConfigExamples) // We're using "alias" section to display usage examples.
 
 	dbConfigureBootstrap := dbConfigure.Command("bootstrap", "Bootstrap the necessary configuration for the database agent. It reads the provided agent configuration to determine what will be bootstrapped.")

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -289,7 +289,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dbConfigureCreate.Flag("output",
 		"Write to stdout with -o=stdout, default config file with -o=file or custom path with -o=file:///path").Short('o').Default(
 		teleport.SchemeStdout).StringVar(&dbConfigCreateFlags.output)
-	dbConfigureCreate.Flag("dynamic-resources-labels", "Comma-separated list(s) of labels to match dynamic resources, for example env=dev,dept=it. Required to enable dynamic resources matching.").StringsVar(&dbConfigCreateFlags.ResourcesRawLabels)
+	dbConfigureCreate.Flag("dynamic-resources-labels", "Comma-separated list(s) of labels to match dynamic resources, for example env=dev,dept=it. Required to enable dynamic resources matching.").StringsVar(&dbConfigCreateFlags.DynamicResourcesRawLabels)
 	dbConfigureCreate.Alias(dbCreateConfigExamples) // We're using "alias" section to display usage examples.
 
 	dbConfigureBootstrap := dbConfigure.Command("bootstrap", "Bootstrap the necessary configuration for the database agent. It reads the provided agent configuration to determine what will be bootstrapped.")

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -289,6 +289,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dbConfigureCreate.Flag("output",
 		"Write to stdout with -o=stdout, default config file with -o=file or custom path with -o=file:///path").Short('o').Default(
 		teleport.SchemeStdout).StringVar(&dbConfigCreateFlags.output)
+	dbConfigureCreate.Flag("resources-labels", "Comma-separated list(s) of labels to match dynamic resources, for example env=dev,dept=it. Required to enable dynamic resources matching.").StringsVar(&dbConfigCreateFlags.ResourcesRawLabels)
 	dbConfigureCreate.Alias(dbCreateConfigExamples) // We're using "alias" section to display usage examples.
 
 	dbConfigureBootstrap := dbConfigure.Command("bootstrap", "Bootstrap the necessary configuration for the database agent. It reads the provided agent configuration to determine what will be bootstrapped.")


### PR DESCRIPTION
Fixes #18580 

Other related PR #19739

```
$ teleport db configure create --rds-discovery us-east-1 --dynamic-resources-labels *=*
$ teleport db configure create --rds-discovery us-east-1 --dynamic-resources-labels env=dev --dynamic-resources-labels env=prod,teleport.dev/origin=dynamic
```