### PR TITLE
Use CDN links for install node scripts

### DIFF
--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -831,9 +831,8 @@ func TestJoinScriptEnterprise(t *testing.T) {
 			}, nil
 		},
 	}
-
-	isTeleportOSSLinkRegex := regexp.MustCompile(`https://get\.gravitational\.com/teleport[-_]v?\${TELEPORT_VERSION}`)
-	isTeleportEntLinkRegex := regexp.MustCompile(`https://get\.gravitational\.com/teleport-ent[-_]v?\${TELEPORT_VERSION}`)
+	isTeleportOSSLinkRegex := regexp.MustCompile(`https://cdn\.teleport\.dev/teleport[-_]v?\${TELEPORT_VERSION}`)
+	isTeleportEntLinkRegex := regexp.MustCompile(`https://cdn\.teleport\.dev/teleport-ent[-_]v?\${TELEPORT_VERSION}`)
 
 	// Using the OSS Version, all the links must contain only teleport as package name.
 	script, err := getJoinScript(context.Background(), scriptSettings{token: validToken}, m)
@@ -841,9 +840,9 @@ func TestJoinScriptEnterprise(t *testing.T) {
 
 	matches := isTeleportOSSLinkRegex.FindAllString(script, -1)
 	require.ElementsMatch(t, matches, []string{
-		"https://get.gravitational.com/teleport-v${TELEPORT_VERSION}",
-		"https://get.gravitational.com/teleport_${TELEPORT_VERSION}",
-		"https://get.gravitational.com/teleport-${TELEPORT_VERSION}",
+		"https://cdn.teleport.dev/teleport-v${TELEPORT_VERSION}",
+		"https://cdn.teleport.dev/teleport_${TELEPORT_VERSION}",
+		"https://cdn.teleport.dev/teleport-${TELEPORT_VERSION}",
 	})
 
 	// Using the Enterprise Version, all the links must contain teleport-ent as package name
@@ -853,9 +852,9 @@ func TestJoinScriptEnterprise(t *testing.T) {
 
 	matches = isTeleportEntLinkRegex.FindAllString(script, -1)
 	require.ElementsMatch(t, matches, []string{
-		"https://get.gravitational.com/teleport-ent-v${TELEPORT_VERSION}",
-		"https://get.gravitational.com/teleport-ent_${TELEPORT_VERSION}",
-		"https://get.gravitational.com/teleport-ent-${TELEPORT_VERSION}",
+		"https://cdn.teleport.dev/teleport-ent-v${TELEPORT_VERSION}",
+		"https://cdn.teleport.dev/teleport-ent_${TELEPORT_VERSION}",
+		"https://cdn.teleport.dev/teleport-ent-${TELEPORT_VERSION}",
 	})
 }
 

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -760,7 +760,7 @@ fi
 
 # select correct URL/installation method based on distro
 if [[ ${TELEPORT_FORMAT} == "tarball" ]]; then
-    URL="https://get.gravitational.com/{{.packageName}}-v${TELEPORT_VERSION}-${TELEPORT_BINARY_TYPE}-${TELEPORT_ARCH}-bin.tar.gz"
+    URL="https://cdn.teleport.dev/{{.packageName}}-v${TELEPORT_VERSION}-${TELEPORT_BINARY_TYPE}-${TELEPORT_ARCH}-bin.tar.gz"
 
     # check that needed tools are installed
     check_exists_fatal curl tar
@@ -785,7 +785,7 @@ elif [[ ${TELEPORT_FORMAT} == "deb" ]]; then
     elif [[ ${TELEPORT_ARCH} == "arm64" ]]; then
         DEB_ARCH="arm64"
     fi
-    URL="https://get.gravitational.com/{{.packageName}}_${TELEPORT_VERSION}_${DEB_ARCH}.deb"
+    URL="https://cdn.teleport.dev/{{.packageName}}_${TELEPORT_VERSION}_${DEB_ARCH}.deb"
     check_deb_not_already_installed
     # check that needed tools are installed
     check_exists_fatal curl dpkg
@@ -807,7 +807,7 @@ elif [[ ${TELEPORT_FORMAT} == "rpm" ]]; then
     elif [[ ${TELEPORT_ARCH} == "arm64" ]]; then
         RPM_ARCH="arm64"
     fi
-    URL="https://get.gravitational.com/{{.packageName}}-${TELEPORT_VERSION}-1.${RPM_ARCH}.rpm"
+    URL="https://cdn.teleport.dev/{{.packageName}}-${TELEPORT_VERSION}-1.${RPM_ARCH}.rpm"
     check_rpm_not_already_installed
     # check for package managers
     if check_exists dnf; then


### PR DESCRIPTION
According to https://goteleport.com/download/ we are now using the following CDN to download teleport binaries:
https://cdn.teleport.dev/