### PR TITLE
Attempt to reconnect a closed LDAP connection

### DIFF
--- a/lib/auth/windows/ldap.go
+++ b/lib/auth/windows/ldap.go
@@ -74,14 +74,15 @@ func (cfg LDAPConfig) DomainDN() string {
 	return sb.String()
 }
 
+// See: https://docs.microsoft.com/en-US/windows/security/identity-protection/access-control/security-identifiers
 const (
-	// See: https://docs.microsoft.com/en-US/windows/security/identity-protection/access-control/security-identifiers
-
 	// WritableDomainControllerGroupID is the windows security identifier for dcs with write permissions
 	WritableDomainControllerGroupID = "516"
 	// ReadOnlyDomainControllerGroupID is the windows security identifier for read only dcs
 	ReadOnlyDomainControllerGroupID = "521"
+)
 
+const (
 	// ClassComputer is the object class for computers in Active Directory
 	ClassComputer = "computer"
 	// ClassContainer is the object class for containers in Active Directory
@@ -118,16 +119,20 @@ const (
 	AttrObjectCategory = "objectCategory"
 	// AttrObjectClass is the object class of an LDAP object
 	AttrObjectClass = "objectClass"
-
-	// searchPageSize is desired page size for LDAP search. In Active Directory the default search size limit is 1000 entries,
-	// so in most cases the 1000 search page size will result in the optimal amount of requests made to
-	// LDAP server.
-	searchPageSize = 1000
 )
+
+// searchPageSize is desired page size for LDAP search. In Active Directory the default search size limit is 1000 entries,
+// so in most cases the 1000 search page size will result in the optimal amount of requests made to
+// LDAP server.
+const searchPageSize = 1000
 
 // Note: if you want to browse LDAP on the Windows machine, run ADSIEdit.msc.
 
-// LDAPClient is a windows LDAP client
+// LDAPClient is a windows LDAP client.
+//
+// It does not automatically detect when the underlying connection
+// is closed. Callers should check for trace.ConnectionProblem errors
+// and provide a new client with [SetClient].
 type LDAPClient struct {
 	// Cfg is the LDAPConfig
 	Cfg LDAPConfig
@@ -173,9 +178,9 @@ func (c *LDAPClient) ReadWithFilter(dn string, filter string, attrs []string) ([
 	defer c.mu.Unlock()
 	res, err := c.client.SearchWithPaging(req, searchPageSize)
 	if ldap.IsErrorWithCode(err, ldap.ErrorNetwork) {
-		return nil, trace.ConnectionProblem(err, "fetching LDAP object %q", dn)
+		return nil, trace.ConnectionProblem(err, "fetching LDAP object %q with filter %q: %v", dn, filter, err)
 	} else if err != nil {
-		return nil, trace.Wrap(err, "fetching LDAP object %q: %v", dn, err)
+		return nil, trace.Wrap(err, "fetching LDAP object %q with filter %q: %v", dn, filter, err)
 	}
 	return res.Entries, nil
 }

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -490,6 +490,8 @@ func (s *WindowsService) tlsConfigForLDAP() (*tls.Config, error) {
 // place before the certificate expires. If we are unable to obtain a certificate
 // and authenticate with the LDAP server, then the operation will be automatically
 // retried.
+//
+// This method is safe for concurrent calls.
 func (s *WindowsService) initializeLDAP() error {
 	tc, err := s.tlsConfigForLDAP()
 	if trace.IsAccessDenied(err) && modules.GetModules().BuildType() == modules.BuildEnterprise {
@@ -547,6 +549,7 @@ func (s *WindowsService) initializeLDAP() error {
 //
 // The lock on s.mu MUST be held.
 func (s *WindowsService) scheduleNextLDAPCertRenewalLocked(after time.Duration) {
+	s.cfg.Log.Infof("next LDAP cert renewal scheduled in %v", after)
 	if s.ldapCertRenew != nil {
 		s.ldapCertRenew.Reset(after)
 	} else {
@@ -612,7 +615,7 @@ func (s *WindowsService) startStaticHostHeartbeat(host utils.NetAddr, nonAD bool
 		GetServerInfo:   s.staticHostHeartbeatInfo(host, s.cfg.HostLabelsFn, nonAD),
 		KeepAlivePeriod: apidefaults.ServerKeepAliveTTL(),
 		AnnouncePeriod:  apidefaults.ServerAnnounceTTL/2 + utils.RandomDuration(apidefaults.ServerAnnounceTTL/10),
-		CheckPeriod:     defaults.HeartbeatCheckPeriod,
+		CheckPeriod:     5 * time.Minute,
 		ServerTTL:       apidefaults.ServerAnnounceTTL,
 		OnHeartbeat:     s.cfg.Heartbeat.OnHeartbeat,
 	})
@@ -1086,20 +1089,27 @@ func timer() func() int64 {
 	}
 }
 
-// generateUserCert queries LDAP for the passed username's SID and generates
-// a private key / public certificate pair for the given Windows username.
+// generateUserCert generates a keypair for the given Windows username,
+// optionally querying LDAP for the user's Security Identifier.
 func (s *WindowsService) generateUserCert(ctx context.Context, username string, ttl time.Duration, desktop types.WindowsDesktop) (certDER, keyDER []byte, err error) {
-	// Find the user's SID
-	s.cfg.Log.Debugf("querying LDAP for objectSid of Windows username: %v", username)
-	filters := []string{
-		fmt.Sprintf("(%s=%s)", windows.AttrObjectCategory, windows.CategoryPerson),
-		fmt.Sprintf("(%s=%s)", windows.AttrObjectClass, windows.ClassUser),
-		fmt.Sprintf("(%s=%s)", windows.AttrSAMAccountName, username),
-	}
-
 	var activeDirectorySID string
 	if !desktop.NonAD() {
+		// Find the user's SID
+		s.cfg.Log.Debugf("querying LDAP for objectSid of Windows username: %v", username)
+		filters := []string{
+			fmt.Sprintf("(%s=%s)", windows.AttrObjectCategory, windows.CategoryPerson),
+			fmt.Sprintf("(%s=%s)", windows.AttrObjectClass, windows.ClassUser),
+			fmt.Sprintf("(%s=%s)", windows.AttrSAMAccountName, username),
+		}
+
 		entries, err := s.lc.ReadWithFilter(s.cfg.LDAPConfig.DomainDN(), windows.CombineLDAPFilters(filters), []string{windows.AttrObjectSid})
+		// if LDAP-based desktop discovery is not enabled, there may not be enough
+		// traffic to keep the connection open. Attempt to open a new LDAP connection
+		// in this case.
+		if trace.IsConnectionProblem(err) {
+			s.initializeLDAP() // ignore error, this is a best effort attempt
+			entries, err = s.lc.ReadWithFilter(s.cfg.LDAPConfig.DomainDN(), windows.CombineLDAPFilters(filters), []string{windows.AttrObjectSid})
+		}
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -1113,8 +1123,6 @@ func (s *WindowsService) generateUserCert(ctx context.Context, username string, 
 			return nil, nil, trace.Wrap(err)
 		}
 		s.cfg.Log.Debugf("Found objectSid %v for Windows username %v", activeDirectorySID, username)
-		// Generate credentials with the user's SID
-
 	}
 	return s.generateCredentials(ctx, username, desktop.GetDomain(), ttl, activeDirectorySID)
 }


### PR DESCRIPTION
When desktop discovery via LDAP is enabled, there is enough traffic on the connection for it to remain open for long periods of time. If discovery is disabled and there are not frequent connections to desktops, the LDAP server may close the connection.

In this case, future connection attempts will fail when making an LDAP query for the user's SID. Now we detect closed connections in this code path and attempt to open a new LDAP connection.

The first connection attempt after the connection is closed will incur some extra latency, as we obtain a new cert when refreshing the LDAP connection.

Additionally, increase the heartbeat period for static hosts from 5s to 5m. These hosts are infrequently changing, so heartbeating every 5 seconds is an inefficient use of resources.

Fixes #20904