### PR TITLE
[doc] Update app access reserved headers X-Teleport-*

### DIFF
--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -266,8 +266,8 @@ rewritten:
 
 - `Teleport-Jwt-Assertion`
 - `Cf-Access-Token`
-- any `X-Teleport-*`
-- any `X-Forwarded-*`
+- Any header matching the pattern `X-Teleport-*`
+- Any header matching the pattern `X-Forwarded-*`
 
 Rewritten header values support the same templating variables as [role templates](../../access-controls/guides/role-templates.mdx).
 In the example above, `X-Internal-Trait` header will be populated with the value

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -262,7 +262,12 @@ requests forwarded to a web application.
 
 Headers injected this way override any headers with the same names that may
 be sent by an application. The following headers are reserved and can't be
-rewritten: `Teleport-Jwt-Assertion`, `Cf-Access-Token`, `X-Teleport-API-Error`, and any `X-Forwarded-*`.
+rewritten:
+
+- `Teleport-Jwt-Assertion`
+- `Cf-Access-Token`
+- any `X-Teleport-*`
+- any `X-Forwarded-*`
 
 Rewritten header values support the same templating variables as [role templates](../../access-controls/guides/role-templates.mdx).
 In the example above, `X-Internal-Trait` header will be populated with the value


### PR DESCRIPTION
Related PR
- #20568

Two more X-Teleport-XXX headers are used for AWS app access. Updating doc to state that any `X-Teleport-*` header should be reserved.

Will backport with #20568 to all its required branches.