### PR TITLE
Fix data race when closing listener

### DIFF
--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -269,7 +269,9 @@ func (t *TLSServer) Close() error {
 	if t.watcher != nil {
 		t.watcher.Close()
 	}
+	t.mu.Lock()
 	listClose := t.listener.Close()
+	t.mu.Unlock()
 	return trace.NewAggregate(append(errs, listClose)...)
 }
 


### PR DESCRIPTION
This PR fixes a data race when closing the listener.

Fixes #20998