### PR TITLE
[v12] Use 'path.Join' instead of 'filepath.Join' to build remote file paths

### DIFF
--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 // Package sftp handles file transfers client-side via SFTP
+// path.Join is intentionally used over filepath.Join because SFTP
+// requires Linux-style path separators
 package sftp
 
 import (
@@ -26,7 +28,6 @@ import (
 	"io/fs"
 	"os"
 	"path"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -202,7 +203,6 @@ func (c *Config) initFS(sshClient *ssh.Client, client *sftp.Client) error {
 	}
 
 	return trace.Wrap(c.expandPaths(srcOK, dstOK))
-
 }
 
 func (c *Config) expandPaths(srcIsRemote, dstIsRemote bool) (err error) {
@@ -221,9 +221,9 @@ func (c *Config) expandPaths(srcIsRemote, dstIsRemote bool) (err error) {
 	return trace.Wrap(err)
 }
 
-func expandPath(path string, getHomeDir homeDirRetriever) (string, error) {
-	if !needsExpansion(path) {
-		return path, nil
+func expandPath(pathStr string, getHomeDir homeDirRetriever) (string, error) {
+	if !needsExpansion(pathStr) {
+		return pathStr, nil
 	}
 
 	homeDir, err := getHomeDir()
@@ -233,7 +233,7 @@ func expandPath(path string, getHomeDir homeDirRetriever) (string, error) {
 
 	// this is safe because we verified that all paths are non-empty
 	// in CreateUploadConfig/CreateDownloadConfig
-	return filepath.Join(homeDir, path[1:]), nil
+	return path.Join(homeDir, pathStr[1:]), nil
 }
 
 // needsExpansion returns true if path is '~', '~/', or '~\' on Windows


### PR DESCRIPTION
Backport of #20961.