### PR TITLE
[v12] Pin helm-unittest plugin because of a broken release

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -271,7 +271,7 @@ RUN mkdir -p helm-tarball && \
     cp helm-tarball/$(go env GOOS)-$(go env GOARCH)/helm /bin/ && \
     rm -r helm-tarball*
 # TODO(hugoShaka): remove this backward compatible hack with teleportv13 buildbox
-RUN helm plugin install https://github.com/quintush/helm-unittest && \
+RUN helm plugin install https://github.com/quintush/helm-unittest --version 0.2.11 && \
     mkdir -p /home/ci/.local/share/helm && \
     cp -r /root/.local/share/helm/plugins /home/ci/.local/share/helm/plugins-new && \
     chown -R ci /home/ci/.local/share/helm && \


### PR DESCRIPTION
Backport #21013 to branch/v12