### PR TITLE
helm: Rename port from k8s -> kube for consistency between deployments

### DIFF
--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -169,7 +169,7 @@ spec:
         - name: sshtun
           containerPort: 3024
           protocol: TCP
-        - name: k8s
+        - name: kube
           containerPort: 3026
           protocol: TCP
         - name: mysql

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -88,7 +88,7 @@ should set nodeSelector when set in values:
         name: sshtun
         protocol: TCP
       - containerPort: 3026
-        name: k8s
+        name: kube
         protocol: TCP
       - containerPort: 3036
         name: mysql
@@ -181,7 +181,7 @@ should set resources when set in values:
         name: sshtun
         protocol: TCP
       - containerPort: 3026
-        name: k8s
+        name: kube
         protocol: TCP
       - containerPort: 3036
         name: mysql
@@ -263,7 +263,7 @@ should set securityContext when set in values:
         name: sshtun
         protocol: TCP
       - containerPort: 3026
-        name: k8s
+        name: kube
         protocol: TCP
       - containerPort: 3036
         name: mysql

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -490,7 +490,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].ports
           content:
-            name: k8s
+            name: kube
             containerPort: 3026
             protocol: TCP
 
@@ -503,7 +503,7 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].ports
           content:
-            name: k8s
+            name: kube
             containerPort: 3026
             protocol: TCP
 


### PR DESCRIPTION
Renames port 3026 from `k8s` to `kube` for consistency between auth and proxy deployments.

As requested by @espadolini in https://github.com/gravitational/teleport/pull/20485#discussion_r1090925343

Will be manually added to #20485 backport to `branch/v12`