### PR TITLE
helm: Fix proxy's ProvisionToken on etcd backend

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/config.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/config.yaml
@@ -16,7 +16,7 @@ data:
     version: v2
     metadata:
       name: {{ .Release.Name }}-proxy
-      expires: "3000-01-01T00:00:00Z"
+      expires: "2050-01-01T00:00:00Z"
     spec:
       roles: [Proxy]
       join_method: kubernetes

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1,3 +1,17 @@
+adds a proxy token by default:
+  1: |
+    |
+      kind: token
+      version: v2
+      metadata:
+        name: RELEASE-NAME-proxy
+        expires: "2050-01-01T00:00:00Z"
+      spec:
+        roles: [Proxy]
+        join_method: kubernetes
+        kubernetes:
+          allow:
+            - service_account: "NAMESPACE:RELEASE-NAME-proxy"
 matches snapshot for acme-off.yaml:
   1: |
     |-

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -467,3 +467,13 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data.teleport\.yaml
+
+  - it: adds a proxy token by default
+    set:
+      clusterName: teleport.example.com
+    asserts:
+      - notEqual:
+          path: data.apply-on-startup\.yaml
+          value: null
+      - matchSnapshot:
+          path: data.apply-on-startup\.yaml


### PR DESCRIPTION
Fixes #20960

etcd had a previously unknown TTL limitation (TTL is stored as nanoseconds in a signed int64, max TTL is ~= 29 years). Creating very long-lived resources with expiry higher than the max TTL is not supported and the process crashes on startup as it cannot apply the token.