### PR TITLE
Add enterprise license indicator in Windows Desktop certificate

### DIFF
--- a/lib/auth/desktop.go
+++ b/lib/auth/desktop.go
@@ -19,6 +19,7 @@ package auth
 import (
 	"context"
 	"crypto/x509"
+	"crypto/x509/pkix"
 
 	"github.com/gravitational/trace"
 
@@ -70,6 +71,10 @@ func (s *Server) GenerateWindowsDesktopCert(ctx context.Context, req *proto.Wind
 		// CRL is required for Windows smartcard certs.
 		CRLDistributionPoints: []string{req.CRLEndpoint},
 	}
+	certReq.ExtraExtensions = append(certReq.ExtraExtensions, pkix.Extension{
+		Id:    tlsca.LicenseOID,
+		Value: []byte(modules.GetModules().BuildType()),
+	})
 	cert, err := tlsCA.GenerateCertificate(certReq)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -470,6 +470,10 @@ var (
 	// When using the Test Connection feature, there's propagation of the ConnectionDiagnosticID.
 	// Each service (ex DB Agent) uses that to add checkpoints describing if it was a success or a failure.
 	ConnectionDiagnosticIDASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 13}
+
+	// LicenseOID is an extension OID signaling the license type of Teleport build.
+	// It should take values "oss" or "ent" (the values returned by modules.GetModules().BuildType())
+	LicenseOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 14}
 )
 
 // Device Trust OIDs.


### PR DESCRIPTION
This change adds enterprise license indicator in certificates generated for Windows Desktop access.
As there is no standard OID for license type, I selected one in unassigned region to avoid potential collisions. 