### PR TITLE
Update setup docs to include Yarn

### DIFF
--- a/BUILD_macos.md
+++ b/BUILD_macos.md
@@ -3,6 +3,7 @@
 The instructions below are provided as in a best-effort basis.
 PRs with corrections and updates are welcome!
 
+* Install [Homebrew](https://brew.sh/)
 * `Go` version from
   [go.mod](https://github.com/gravitational/teleport/blob/master/go.mod#L3)
   
@@ -70,6 +71,9 @@ PRs with corrections and updates are welcome!
   brew install libfido2
   ```
 
+* To install `yarn` for building the UI
+  * `brew install node yarn`
+  * Currently, [`yarn`](https://classic.yarnpkg.com/en/docs/install) (< 2.0.0) is required
 ##### Local Tests Dependencies
  
 To run a full test suite locally, you will need

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Ensure you have installed correct versions of necessary dependencies:
   [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/Makefile#L21)
   (search for `RUST_VERSION`)
 * For `tsh` version > `10.x` with FIDO support, you will need `libfido` and `openssl 1.1` installed locally
+* To build the web UI, [`yarn`](https://classic.yarnpkg.com/en/docs/install)(< 2.0.0) is required.
+  * If you prefer not to install/use yarn, but have docker available, you can run `make docker-ui` instead.
 
 For an example of Dev Environment setup on a Mac, see [these instructions](BUILD_macos.md). 
 


### PR DESCRIPTION
Include references to install Yarn for building the UI.

When running a plain `make`, it requires `yarn` to build the UI.