### PR TITLE
fix: missing space in podmonitor YAML

### DIFF
--- a/examples/chart/teleport-cluster/templates/podmonitor.yaml
+++ b/examples/chart/teleport-cluster/templates/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if.Values.podMonitor.enabled -}}
+{{- if .Values.podMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:


### PR DESCRIPTION
There's a missing space in the podmonitor YAML. 