### PR TITLE
[Web:Discover] Bring back db service checker

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -6108,8 +6108,7 @@ func TestUpdateDatabase_CACert(t *testing.T) {
 		{
 			name: "valid",
 			req: updateDatabaseRequest{
-				CACert:       fakeValidTLSCert,
-				UpdateCACert: true,
+				CACert: &fakeValidTLSCert,
 			},
 			expectedStatus: http.StatusOK,
 			errAssert:      require.NoError,
@@ -6117,8 +6116,7 @@ func TestUpdateDatabase_CACert(t *testing.T) {
 		{
 			name: "empty ca_cert",
 			req: updateDatabaseRequest{
-				CACert:       "",
-				UpdateCACert: true,
+				CACert: strPtr(""),
 			},
 			expectedStatus: http.StatusBadRequest,
 			errAssert: func(tt require.TestingT, err error, i ...interface{}) {
@@ -6128,8 +6126,7 @@ func TestUpdateDatabase_CACert(t *testing.T) {
 		{
 			name: "invalid certificate",
 			req: updateDatabaseRequest{
-				CACert:       "Not a certificate",
-				UpdateCACert: true,
+				CACert: strPtr("Not a certificate"),
 			},
 			expectedStatus: http.StatusBadRequest,
 			errAssert: func(tt require.TestingT, err error, i ...interface{}) {

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -132,7 +132,6 @@ func (r *updateDatabaseRequest) checkAndSetDefaults() error {
 		if _, err := tlsutils.ParseCertificatePEM([]byte(*r.CACert)); err != nil {
 			return trace.BadParameter("could not parse provided CA as X.509 PEM certificate")
 		}
-		return nil
 	}
 
 	// These fields can't be empty if set.
@@ -143,10 +142,9 @@ func (r *updateDatabaseRequest) checkAndSetDefaults() error {
 		if r.AWSRDS.AccountID == "" {
 			return trace.BadParameter("missing aws rds field account id")
 		}
-		return nil
 	}
 
-	if r.Labels == nil && r.URI == "" {
+	if r.CACert == nil && r.AWSRDS == nil && r.Labels == nil && r.URI == "" {
 		return trace.BadParameter("missing fields to update the database")
 	}
 

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -170,16 +170,14 @@ func TestUpdateDatabaseRequestParameters(t *testing.T) {
 		{
 			desc: "valid",
 			req: updateDatabaseRequest{
-				CACert:       fakeValidTLSCert,
-				UpdateCACert: true,
+				CACert: &fakeValidTLSCert,
 			},
 			errAssert: require.NoError,
 		},
 		{
 			desc: "invalid missing ca_cert",
 			req: updateDatabaseRequest{
-				CACert:       "",
-				UpdateCACert: true,
+				CACert: strPtr(""),
 			},
 			errAssert: func(t require.TestingT, err error, i ...interface{}) {
 				require.Error(t, err)
@@ -189,8 +187,7 @@ func TestUpdateDatabaseRequestParameters(t *testing.T) {
 		{
 			desc: "invalid ca_cert format",
 			req: updateDatabaseRequest{
-				CACert:       "ca_cert",
-				UpdateCACert: true,
+				CACert: strPtr("ca_cert"),
 			},
 			errAssert: func(t require.TestingT, err error, i ...interface{}) {
 				require.Error(t, err)
@@ -365,4 +362,8 @@ func requireDatabaseIAMPolicyAWS(t *testing.T, respBody []byte, database types.D
 	require.NoError(t, err)
 	require.Equal(t, expectedPolicyDocument, actualPolicyDocument)
 	require.Equal(t, []string(expectedPlaceholders), resp.AWS.Placeholders)
+}
+
+func strPtr(str string) *string {
+	return &str
 }

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -170,14 +170,16 @@ func TestUpdateDatabaseRequestParameters(t *testing.T) {
 		{
 			desc: "valid",
 			req: updateDatabaseRequest{
-				CACert: fakeValidTLSCert,
+				CACert:       fakeValidTLSCert,
+				UpdateCACert: true,
 			},
 			errAssert: require.NoError,
 		},
 		{
 			desc: "invalid missing ca_cert",
 			req: updateDatabaseRequest{
-				CACert: "",
+				CACert:       "",
+				UpdateCACert: true,
 			},
 			errAssert: func(t require.TestingT, err error, i ...interface{}) {
 				require.Error(t, err)
@@ -187,7 +189,8 @@ func TestUpdateDatabaseRequestParameters(t *testing.T) {
 		{
 			desc: "invalid ca_cert format",
 			req: updateDatabaseRequest{
-				CACert: "ca_cert",
+				CACert:       "ca_cert",
+				UpdateCACert: true,
 			},
 			errAssert: func(t require.TestingT, err error, i ...interface{}) {
 				require.Error(t, err)

--- a/web/packages/shared/components/FieldInput/FieldInput.tsx
+++ b/web/packages/shared/components/FieldInput/FieldInput.tsx
@@ -40,6 +40,7 @@ const FieldInput = forwardRef<HTMLInputElement, Props>(
       readonly = false,
       toolTipContent = null,
       disabled = false,
+      markAsError = false,
       ...styles
     },
     ref
@@ -47,13 +48,12 @@ const FieldInput = forwardRef<HTMLInputElement, Props>(
     const { valid, message } = useRule(rule(value));
     const hasError = !valid;
     const labelText = hasError ? message : label;
-
     const $inputElement = (
       <Input
         mt={1}
         ref={ref}
         type={type}
-        hasError={hasError}
+        hasError={hasError || markAsError}
         placeholder={placeholder}
         autoFocus={autoFocus}
         value={value}
@@ -128,6 +128,10 @@ type Props = {
   max?: number;
   toolTipContent?: React.ReactNode;
   disabled?: boolean;
+  // markAsError is a flag to highlight an
+  // input box as error color before validator
+  // runs (which marks it as error)
+  markAsError?: boolean;
   // TS: temporary handles ...styles
   [key: string]: any;
 };

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
@@ -75,7 +75,8 @@ const props: State = {
   clearAttempt: () => null,
   registerDatabase: () => null,
   canCreateDatabase: true,
-  // pollTimeout: Date.now() + 30000,
+  pollTimeout: Date.now() + 30000,
   dbEngine: DatabaseEngine.PostgreSQL,
   dbLocation: DatabaseLocation.SelfHosted,
+  isDbCreateErr: false,
 };

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.tsx
@@ -14,26 +14,24 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Text,
   Box,
   Flex,
-
-  // AnimatedProgressBar,
-  // ButtonPrimary,
-  // ButtonSecondary,
+  AnimatedProgressBar,
+  ButtonPrimary,
+  ButtonSecondary,
 } from 'design';
-import { Danger } from 'design/Alert';
 
-// import Dialog, { DialogContent } from 'design/DialogConfirmation';
-// import * as Icons from 'design/Icon';
+import Dialog, { DialogContent } from 'design/DialogConfirmation';
+import * as Icons from 'design/Icon';
 import Validation, { Validator } from 'shared/components/Validation';
 import FieldInput from 'shared/components/FieldInput';
 import { requiredField } from 'shared/components/Validation/rules';
 import TextEditor from 'shared/components/TextEditor';
 
-// import { Timeout } from 'teleport/Discover/Shared/Timeout';
+import { Timeout } from 'teleport/Discover/Shared/Timeout';
 
 import {
   ActionButtons,
@@ -41,7 +39,7 @@ import {
   Header,
   LabelsCreater,
   Mark,
-  // TextIcon,
+  TextIcon,
 } from '../../Shared';
 import { dbCU } from '../../yamlTemplates';
 import {
@@ -54,7 +52,7 @@ import { useCreateDatabase, State } from './useCreateDatabase';
 
 import type { AgentStepProps } from '../../types';
 import type { AgentLabel } from 'teleport/services/agents';
-// import type { Attempt } from 'shared/hooks/useAttemptNext';
+import type { Attempt } from 'shared/hooks/useAttemptNext';
 import type { AwsRds } from 'teleport/services/databases';
 
 export function CreateDatabase(props: AgentStepProps) {
@@ -64,12 +62,13 @@ export function CreateDatabase(props: AgentStepProps) {
 
 export function CreateDatabaseView({
   attempt,
-  // clearAttempt,
+  clearAttempt,
   registerDatabase,
   canCreateDatabase,
-  // pollTimeout,
+  pollTimeout,
   dbEngine,
   dbLocation,
+  isDbCreateErr,
 }: State) {
   const [dbName, setDbName] = useState('');
   const [dbUri, setDbUri] = useState('');
@@ -80,8 +79,25 @@ export function CreateDatabaseView({
   const [awsAccountId, setAwsAccountId] = useState('');
   const [awsResourceId, setAwsResourceId] = useState('');
 
-  function handleOnProceed(validator: Validator) {
+  const [finishedFirstStep, setFinishedFirstStep] = useState(false);
+
+  useEffect(() => {
+    // If error resulted from creating a db, reset the view
+    // to the beginning as the error could be from duplicate
+    // db name.
+    if (isDbCreateErr) {
+      setFinishedFirstStep(false);
+    }
+  }, [isDbCreateErr]);
+
+  function handleOnProceed(validator: Validator, retry = false) {
     if (!validator.validate()) {
+      return;
+    }
+
+    if (!retry && !finishedFirstStep) {
+      setFinishedFirstStep(true);
+      validator.reset();
       return;
     }
 
@@ -102,6 +118,7 @@ export function CreateDatabaseView({
     });
   }
 
+  const isAws = dbLocation === DatabaseLocation.AWS;
   return (
     <Validation>
       {({ validator }) => (
@@ -110,9 +127,6 @@ export function CreateDatabaseView({
           <HeaderSubtitle>
             Create a new database resource for the database server.
           </HeaderSubtitle>
-          {attempt.status === 'failed' && (
-            <Danger children={attempt.statusText} />
-          )}
           {!canCreateDatabase && (
             <Box>
               <Text>
@@ -131,85 +145,112 @@ export function CreateDatabaseView({
           )}
           {canCreateDatabase && (
             <>
-              <Box width="500px">
-                <FieldInput
-                  label="Database Name"
-                  // We need this name to comply with AWS policy name
-                  // since it will be used as part of the policy name
-                  // for the AWS flow.
-                  rule={requiredField('database name is required')}
-                  autoFocus
-                  value={dbName}
-                  placeholder="Enter database name"
-                  onChange={e => setDbName(e.target.value)}
-                  toolTipContent="An identifier name for this new database for Teleport."
-                />
-              </Box>
-              <Flex width="500px">
-                <FieldInput
-                  label="Database Connection Endpoint"
-                  rule={requiredField('connection endpoint is required')}
-                  value={dbUri}
-                  placeholder="db.example.com"
-                  onChange={e => setDbUri(e.target.value)}
-                  toolTipContent="Database location and connection information."
-                  width="50%"
-                  mr={2}
-                />
-                <FieldInput
-                  label="Endpoint Port"
-                  rule={requirePort}
-                  value={dbPort}
-                  placeholder="5432"
-                  onChange={e => setDbPort(e.target.value)}
-                  width="50%"
-                />
-              </Flex>
-              {dbLocation === DatabaseLocation.AWS && (
+              {!finishedFirstStep && (
+                <Box width="500px">
+                  <FieldInput
+                    label="Database Name"
+                    rule={requiredField('database name is required')}
+                    autoFocus
+                    value={dbName}
+                    placeholder="Enter database name"
+                    onChange={e => setDbName(e.target.value)}
+                    toolTipContent="An identifier name for this new database for Teleport."
+                  />
+                </Box>
+              )}
+              {finishedFirstStep && (
                 <>
-                  <Box width="500px">
+                  <Flex width="500px">
                     <FieldInput
-                      label="AWS Account ID"
-                      rule={requiredAwsAccountId}
-                      value={awsAccountId}
-                      placeholder="123456789012"
-                      onChange={e => setAwsAccountId(e.target.value)}
-                      toolTipContent="A 12-digit number that uniquely identifies your AWS account."
-                    />
-                  </Box>
-                  <Box width="500px" mb={6}>
-                    <FieldInput
-                      label="Resource ID"
-                      value={awsResourceId}
-                      rule={requiredField('database resource ID is required')}
-                      placeholder="db-ABCDE1234567..."
-                      onChange={e => setAwsResourceId(e.target.value)}
-                      toolTipContent={
-                        <Text>
-                          The unique identifier for your resource. For AWS
-                          database, may have the prefix <Mark light>db-</Mark>{' '}
-                          then follow with alphanumerics.
-                        </Text>
+                      autoFocus
+                      label="Database Connection Endpoint"
+                      rule={
+                        isAws
+                          ? requireAwsEndpoint
+                          : requiredField('connection endpoint is required')
                       }
+                      value={dbUri}
+                      placeholder={
+                        isAws
+                          ? 'db.example.us-west-1.rds.amazonaws.com'
+                          : 'db.example.com'
+                      }
+                      onChange={e => setDbUri(e.target.value)}
+                      width="70%"
+                      mr={2}
+                      toolTipContent={
+                        isAws ? (
+                          <Text>
+                            Database location and connection information.
+                            Typically in the format:{' '}
+                            <Mark
+                              light
+                            >{`<your-db-identifier>.<random-id>.<your-region>.rds.amazonaws.com`}</Mark>
+                          </Text>
+                        ) : (
+                          'Database location and connection information.'
+                        )
+                      }
+                    />
+                    <FieldInput
+                      label="Endpoint Port"
+                      rule={requirePort}
+                      value={dbPort}
+                      placeholder="5432"
+                      onChange={e => setDbPort(e.target.value)}
+                      width="30%"
+                    />
+                  </Flex>
+                  {dbLocation === DatabaseLocation.AWS && (
+                    <>
+                      <Box width="500px">
+                        <FieldInput
+                          label="AWS Account ID"
+                          rule={requiredAwsAccountId}
+                          value={awsAccountId}
+                          placeholder="123456789012"
+                          onChange={e => setAwsAccountId(e.target.value)}
+                          toolTipContent="A 12-digit number that uniquely identifies your AWS account."
+                        />
+                      </Box>
+                      <Box width="500px" mb={6}>
+                        <FieldInput
+                          label="Resource ID"
+                          value={awsResourceId}
+                          rule={requiredField(
+                            'database resource ID is required'
+                          )}
+                          placeholder="db-ABCDE1234567..."
+                          onChange={e => setAwsResourceId(e.target.value)}
+                          toolTipContent={
+                            <Text>
+                              The unique identifier for your resource. May have
+                              the prefix <Mark light>db-</Mark> then follow with
+                              alphanumerics.
+                            </Text>
+                          }
+                        />
+                      </Box>
+                    </>
+                  )}
+                  <Box mt={3}>
+                    <Text bold>Labels (optional)</Text>
+                    <Text mb={2}>
+                      Labels make this new database discoverable by the database
+                      service. <br />
+                      Not defining labels is equivalent to asteriks (any
+                      database service can discover this database).
+                    </Text>
+                    <LabelsCreater
+                      labels={labels}
+                      setLabels={setLabels}
+                      isLabelOptional={true}
+                      disableBtns={attempt.status === 'processing'}
+                      noDuplicateKey={true}
                     />
                   </Box>
                 </>
               )}
-              <Box mt={3}>
-                <Text bold>Labels (optional)</Text>
-                <Text mb={2}>
-                  Labels make this new database discoverable by the database
-                  service. <br />
-                  Not defining labels is equivalent to asteriks (any database
-                  service can discover this database).
-                </Text>
-                <LabelsCreater
-                  labels={labels}
-                  setLabels={setLabels}
-                  isLabelOptional={true}
-                  disableBtns={attempt.status === 'processing'}
-                />
-              </Box>
             </>
           )}
           <ActionButtons
@@ -219,82 +260,82 @@ export function CreateDatabaseView({
               attempt.status === 'processing' || !canCreateDatabase
             }
           />
-          {/* {(attempt.status === 'processing' || attempt.status === 'failed') && (
+          {(attempt.status === 'processing' || attempt.status === 'failed') && (
             <CreateDatabaseDialog
               pollTimeout={pollTimeout}
               attempt={attempt}
-              retry={() => handleOnProceed(validator)}
+              retry={() => handleOnProceed(validator, true /* retry */)}
               close={clearAttempt}
             />
-          )} */}
+          )}
         </Box>
       )}
     </Validation>
   );
 }
 
-// const CreateDatabaseDialog = ({
-//   pollTimeout,
-//   attempt,
-//   retry,
-//   close,
-// }: {
-//   pollTimeout: number;
-//   attempt: Attempt;
-//   retry(): void;
-//   close(): void;
-// }) => {
-//   return (
-//     <Dialog disableEscapeKeyDown={false} open={true}>
-//       <DialogContent
-//         width="400px"
-//         alignItems="center"
-//         mb={0}
-//         textAlign="center"
-//       >
-//         {attempt.status !== 'failed' ? (
-//           <>
-//             {' '}
-//             <Text bold caps mb={4}>
-//               Registering Database
-//             </Text>
-//             <AnimatedProgressBar />
-//             <TextIcon
-//               css={`
-//                 white-space: pre;
-//               `}
-//             >
-//               <Icons.Restore fontSize={4} />
-//               <Timeout
-//                 timeout={pollTimeout}
-//                 message=""
-//                 tailMessage={' seconds left'}
-//               />
-//             </TextIcon>
-//           </>
-//         ) : (
-//           <Box width="100%">
-//             <Text bold caps mb={3}>
-//               Database Register Failed
-//             </Text>
-//             <Text mb={5}>
-//               <Icons.Warning ml={1} mr={2} color="danger" />
-//               Error: {attempt.statusText}
-//             </Text>
-//             <Flex>
-//               <ButtonPrimary mr={2} width="50%" onClick={retry}>
-//                 Retry
-//               </ButtonPrimary>
-//               <ButtonSecondary width="50%" onClick={close}>
-//                 Close
-//               </ButtonSecondary>
-//             </Flex>
-//           </Box>
-//         )}
-//       </DialogContent>
-//     </Dialog>
-//   );
-// };
+const CreateDatabaseDialog = ({
+  pollTimeout,
+  attempt,
+  retry,
+  close,
+}: {
+  pollTimeout: number;
+  attempt: Attempt;
+  retry(): void;
+  close(): void;
+}) => {
+  return (
+    <Dialog disableEscapeKeyDown={false} open={true}>
+      <DialogContent
+        width="400px"
+        alignItems="center"
+        mb={0}
+        textAlign="center"
+      >
+        {attempt.status !== 'failed' ? (
+          <>
+            {' '}
+            <Text bold caps mb={4}>
+              Registering Database
+            </Text>
+            <AnimatedProgressBar />
+            <TextIcon
+              css={`
+                white-space: pre;
+              `}
+            >
+              <Icons.Restore fontSize={4} />
+              <Timeout
+                timeout={pollTimeout}
+                message=""
+                tailMessage={' seconds left'}
+              />
+            </TextIcon>
+          </>
+        ) : (
+          <Box width="100%">
+            <Text bold caps mb={3}>
+              Database Register Failed
+            </Text>
+            <Text mb={5}>
+              <Icons.Warning ml={1} mr={2} color="danger" />
+              Error: {attempt.statusText}
+            </Text>
+            <Flex>
+              <ButtonPrimary mr={2} width="50%" onClick={retry}>
+                Retry
+              </ButtonPrimary>
+              <ButtonSecondary width="50%" onClick={close}>
+                Close
+              </ButtonSecondary>
+            </Flex>
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
 
 // PORT_REGEXP only allows digits with length 4.
 export const PORT_REGEX = /^\d{4}$/;
@@ -321,6 +362,25 @@ const requiredAwsAccountId = value => () => {
       message: 'aws account id must be 12 digits',
     };
   }
+  return {
+    valid: true,
+  };
+};
+
+const requireAwsEndpoint = value => () => {
+  const parts = value.split('.');
+  // Following possible format (bare mininum len has to be 6):
+  // (len 6) test.abcd.us-west-2.rds.amazonaws.com
+  // (len 7) test.abcd.suffix.us-west-2.rds.amazonaws.com
+  // (len 8) test.abcd.suffix.us-west-2.rds.amazonaws.com.cn
+  const hasCorrectLen = parts.length >= 6; // loosely match
+  if (!hasCorrectLen || !value.includes('.rds.amazonaws.com')) {
+    return {
+      valid: false,
+      message: 'invalid connection endpoint format',
+    };
+  }
+
   return {
     valid: true,
   };

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.test.tsx
@@ -257,7 +257,7 @@ describe('registering new databases, mainly error checking', () => {
     nextStep: jest.fn(x => x),
     resourceState: {},
     eventState: {
-      currEventName: DiscoverEvent.ConfigureRegisterDatabase,
+      currEventName: DiscoverEvent.DatabaseRegister,
       id: '1234',
       resource: DiscoverEventResource.DatabaseMysqlSelfHosted,
     },

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.test.tsx
@@ -14,19 +14,38 @@
  * limitations under the License.
  */
 
-// import React from 'react';
-// import { renderHook, act } from '@testing-library/react-hooks';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { renderHook, act } from '@testing-library/react-hooks';
 
-// import { createTeleportContext } from 'teleport/mocks/contexts';
-// import { ContextProvider } from 'teleport';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { ContextProvider } from 'teleport';
+import { DiscoverProvider } from 'teleport/Discover/useDiscover';
+import api from 'teleport/services/api';
+import { FeaturesContextProvider } from 'teleport/FeaturesContext';
+import {
+  DiscoverEvent,
+  DiscoverEventResource,
+  userEventService,
+} from 'teleport/services/userEvent';
+import cfg from 'teleport/config';
 
 import {
-  // useCreateDatabase,
+  useCreateDatabase,
   findActiveDatabaseSvc,
-  // WAITING_TIMEOUT,
+  WAITING_TIMEOUT,
 } from './useCreateDatabase';
 
-// import type { CreateDatabaseRequest } from 'teleport/services/databases';
+import type { CreateDatabaseRequest } from 'teleport/services/databases';
+
+const crypto = require('crypto');
+
+// eslint-disable-next-line jest/require-hook
+Object.defineProperty(globalThis, 'crypto', {
+  value: {
+    randomUUID: () => crypto.randomUUID(),
+  },
+});
 
 const dbLabels = [
   { name: 'env', value: 'prod' },
@@ -34,236 +53,412 @@ const dbLabels = [
   { name: 'tag', value: 'v11.0.0' },
 ];
 
+const emptyAwsIdentity = {
+  accountId: '',
+  arn: '',
+  resourceType: '',
+  resourceName: '',
+};
+
 const services = [
   {
     name: 'svc1',
-    matcherLabels: { os: ['windows', 'linux'], env: ['staging'] },
+    matcherLabels: { os: ['windows', 'mac'], env: ['staging'] },
+    awsIdentity: emptyAwsIdentity,
   },
-  { name: 'svc2', matcherLabels: { fruit: ['orange'] } },
-  { name: 'svc3', matcherLabels: { os: ['windows', 'mac'] } }, // match
+  {
+    name: 'svc2', // match
+    matcherLabels: {
+      os: ['windows', 'mac', 'linux'],
+      tag: ['v11.0.0'],
+      env: ['staging', 'prod'],
+    },
+    awsIdentity: emptyAwsIdentity,
+  },
+  {
+    name: 'svc3',
+    matcherLabels: { env: ['prod'], fruit: ['orange'] },
+    awsIdentity: emptyAwsIdentity,
+  },
 ];
 
-describe('findActiveDatabaseSvc', () => {
-  test.each`
-    desc                                       | dbLabels                     | services                                                   | expected
-    ${'match with multi elements'}             | ${dbLabels}                  | ${services}                                                | ${true}
-    ${'match by asteriks'}                     | ${[]}                        | ${[{ matcherLabels: { '*': ['*'] } }]}                     | ${true}
-    ${'match by asteriks with labels defined'} | ${dbLabels}                  | ${[{ matcherLabels: { id: ['123', '123'], '*': ['*'] } }]} | ${true}
-    ${'match by any key, matching val'}        | ${dbLabels}                  | ${[{ matcherLabels: { '*': ['windows', 'mac'] } }]}        | ${true}
-    ${'match by any key, no matching val'}     | ${dbLabels}                  | ${[{ matcherLabels: { '*': ['windows', 'linux'] } }]}      | ${false}
-    ${'match by any val, matching key'}        | ${dbLabels}                  | ${[{ matcherLabels: { test: ['*'], tag: ['*'] } }]}        | ${true}
-    ${'match by any val, no matching key'}     | ${dbLabels}                  | ${[{ matcherLabels: { test: ['*'], test2: ['*'] } }]}      | ${false}
-    ${'no match'}                              | ${dbLabels}                  | ${[{ matcherLabels: { os: ['linux', 'windows'] } }]}       | ${false}
-    ${'no match with empty lists'}             | ${[]}                        | ${[]}                                                      | ${false}
-    ${'no match with empty fields'}            | ${[{ name: '', value: '' }]} | ${[{ matcherLabels: {} }]}                                 | ${false}
-    ${'no match with any key'}                 | ${[]}                        | ${[{ matcherLabels: { '*': ['mac'] } }]}                   | ${false}
-    ${'no match with any val'}                 | ${[]}                        | ${[{ matcherLabels: { os: ['*'] } }]}                      | ${false}
-  `('$desc', ({ dbLabels, services, expected }) => {
-    expect(findActiveDatabaseSvc(dbLabels, services)).toEqual(expected);
-  });
+const testCases = [
+  {
+    name: 'match in multiple services',
+    newLabels: dbLabels,
+    services,
+    expectedMatch: 'svc2',
+  },
+  {
+    name: 'no match despite matching all labels when a svc has a non-matching label',
+    newLabels: dbLabels,
+    services: [
+      {
+        name: 'svc1',
+        matcherLabels: { os: ['windows', 'mac'], env: ['staging'] },
+        awsIdentity: emptyAwsIdentity,
+      },
+      {
+        name: 'svc2',
+        matcherLabels: {
+          os: ['windows', 'mac', 'linux'],
+          tag: ['v11.0.0'],
+          env: ['staging', 'prod'],
+          fruit: ['apple', '*'], // the non-matching label
+        },
+        awsIdentity: emptyAwsIdentity,
+      },
+      {
+        name: 'svc3',
+        matcherLabels: { env: ['prod'], fruit: ['orange'] },
+        awsIdentity: emptyAwsIdentity,
+      },
+    ],
+    expectedMatch: undefined,
+  },
+  {
+    name: 'match by all asteriks',
+    newLabels: [],
+    services: [
+      {
+        name: 'svc1',
+        matcherLabels: { '*': ['dev'], env: ['*'] },
+        awsIdentity: emptyAwsIdentity,
+      },
+      {
+        name: 'svc2',
+        matcherLabels: { '*': ['*'] },
+        awsIdentity: emptyAwsIdentity,
+      },
+    ],
+    expectedMatch: 'svc2',
+  },
+  {
+    name: 'match by asteriks, despite labels being defined',
+    newLabels: dbLabels,
+    services: [
+      {
+        name: 'svc1',
+        matcherLabels: { id: ['env', 'dev'], a: [], '*': ['*'] },
+        awsIdentity: emptyAwsIdentity,
+      },
+    ],
+    expectedMatch: 'svc1',
+  },
+  {
+    name: 'match by any key, matching its val',
+    newLabels: dbLabels,
+    services: [
+      {
+        name: 'svc1',
+        matcherLabels: { env: ['*'], '*': ['dev'] },
+        awsIdentity: emptyAwsIdentity,
+      },
+      {
+        name: 'svc2',
+        matcherLabels: {
+          os: ['linux', 'mac'],
+          '*': ['prod', 'apple', 'v11.0.0'],
+        },
+        awsIdentity: emptyAwsIdentity,
+      },
+    ],
+    expectedMatch: 'svc2',
+  },
+  {
+    name: 'no matching value for any key',
+    newLabels: dbLabels,
+    services: [
+      {
+        name: 'svc1',
+        matcherLabels: { '*': ['windows', 'mac'] },
+        awsIdentity: emptyAwsIdentity,
+      },
+    ],
+    expectedMatch: undefined,
+  },
+  {
+    name: 'match by any val, matching its key',
+    newLabels: dbLabels,
+    services: [
+      {
+        name: 'svc1',
+        matcherLabels: {
+          env: ['dev', '*'],
+          os: ['windows', 'mac'],
+          tag: ['*'],
+        },
+        awsIdentity: emptyAwsIdentity,
+      },
+    ],
+    expectedMatch: 'svc1',
+  },
+  {
+    name: 'no matching key for any value',
+    newLabels: dbLabels,
+    services: [
+      {
+        name: 'svc1',
+        matcherLabels: {
+          fruit: ['*'],
+          os: ['mac'],
+        },
+        awsIdentity: emptyAwsIdentity,
+      },
+    ],
+    expectedMatch: undefined,
+  },
+  {
+    name: 'no match',
+    newLabels: dbLabels,
+    services: [
+      {
+        name: 'svc1',
+        matcherLabels: {
+          fruit: ['*'],
+        },
+        awsIdentity: emptyAwsIdentity,
+      },
+    ],
+    expectedMatch: undefined,
+  },
+  {
+    name: 'no match with empty service list',
+    newLabels: dbLabels,
+    services: [],
+    expectedMatch: undefined,
+  },
+  {
+    name: 'no match with empty label fields',
+    newLabels: dbLabels,
+    services: [{ name: '', matcherLabels: {}, awsIdentity: emptyAwsIdentity }],
+    expectedMatch: undefined,
+  },
+];
+
+test.each(testCases)('$name', ({ newLabels, services, expectedMatch }) => {
+  const foundSvc = findActiveDatabaseSvc(newLabels, services);
+  expect(foundSvc?.name).toEqual(expectedMatch);
 });
 
-// const newDatabaseReq: CreateDatabaseRequest = {
-//   name: 'db-name',
-//   protocol: 'postgres',
-//   uri: 'https://localhost:5432',
-//   labels: dbLabels,
-// };
+const newDatabaseReq: CreateDatabaseRequest = {
+  name: 'db-name',
+  protocol: 'postgres',
+  uri: 'https://localhost:5432',
+  labels: dbLabels,
+};
 
-// jest.useFakeTimers();
+jest.useFakeTimers();
 
-// eslint-disable-next-line jest/no-commented-out-tests
-// describe('registering new databases, mainly error checking', () => {
-//   const props = {
-//     agentMeta: {} as any,
-//     updateAgentMeta: jest.fn(x => x),
-//     nextStep: jest.fn(x => x),
-//     resourceState: {},
-//   };
-//   const ctx = createTeleportContext();
+describe('registering new databases, mainly error checking', () => {
+  const props = {
+    agentMeta: {} as any,
+    updateAgentMeta: jest.fn(x => x),
+    nextStep: jest.fn(x => x),
+    resourceState: {},
+    eventState: {
+      currEventName: DiscoverEvent.ConfigureRegisterDatabase,
+      id: '1234',
+      resource: DiscoverEventResource.DatabaseMysqlSelfHosted,
+    },
+  };
+  const ctx = createTeleportContext();
 
-//   let wrapper;
+  let wrapper;
 
-//   beforeEach(() => {
-//     jest
-//       .spyOn(ctx.databaseService, 'fetchDatabases')
-//       .mockResolvedValue({ agents: [{ name: 'new-db' } as any] });
-//     jest.spyOn(ctx.databaseService, 'createDatabase').mockResolvedValue(null); // ret val not used
-//     jest
-//       .spyOn(ctx.databaseService, 'fetchDatabaseServices')
-//       .mockResolvedValue({ services });
+  beforeEach(() => {
+    jest.spyOn(api, 'get').mockResolvedValue([]); // required for fetchClusterAlerts
 
-//     wrapper = ({ children }) => (
-//       <ContextProvider ctx={ctx}>{children}</ContextProvider>
-//     );
-//   });
+    jest
+      .spyOn(userEventService, 'captureDiscoverEvent')
+      .mockResolvedValue(null as never); // return value does not matter but required by ts
+    jest
+      .spyOn(ctx.databaseService, 'fetchDatabases')
+      .mockResolvedValue({ agents: [{ name: 'new-db' } as any] });
+    jest.spyOn(ctx.databaseService, 'createDatabase').mockResolvedValue(null); // ret val not used
+    jest.spyOn(ctx.databaseService, 'updateDatabase').mockResolvedValue(null); // ret val not used
+    jest
+      .spyOn(ctx.databaseService, 'fetchDatabaseServices')
+      .mockResolvedValue({ services });
 
-//   afterEach(() => {
-//     jest.clearAllMocks();
-//   });
+    wrapper = ({ children }) => (
+      <MemoryRouter
+        initialEntries={[
+          { pathname: cfg.routes.discover, state: { entity: 'database' } },
+        ]}
+      >
+        <ContextProvider ctx={ctx}>
+          <FeaturesContextProvider value={[]}>
+            <DiscoverProvider>{children}</DiscoverProvider>
+          </FeaturesContextProvider>
+        </ContextProvider>
+      </MemoryRouter>
+    );
+  });
 
-// eslint-disable-next-line jest/no-commented-out-tests
-//   test('with matching service, activates polling', async () => {
-//     const { result } = renderHook(() => useCreateDatabase(props), {
-//       wrapper,
-//     });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-//     // Check polling hasn't started.
-//     expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
+  test('with matching service, activates polling', async () => {
+    const { result } = renderHook(() => useCreateDatabase(props), {
+      wrapper,
+    });
 
-//     await act(async () => {
-//       result.current.registerDatabase(newDatabaseReq);
-//     });
-//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+    // Check polling hasn't started.
+    expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
 
-//     await act(async () => jest.advanceTimersByTime(3000));
-//     expect(ctx.databaseService.fetchDatabases).toHaveBeenCalledTimes(1);
-//     expect(props.nextStep).toHaveBeenCalledWith(2);
-//     expect(props.updateAgentMeta).toHaveBeenCalledWith({
-//       resourceName: 'db-name',
-//       agentMatcherLabels: dbLabels,
-//       db: { name: 'new-db' },
-//     });
-//   });
+    await act(async () => {
+      result.current.registerDatabase(newDatabaseReq);
+    });
+    expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
 
-// eslint-disable-next-line jest/no-commented-out-tests
-//   test('when there are no services, skips polling', async () => {
-//     jest
-//       .spyOn(ctx.databaseService, 'fetchDatabaseServices')
-//       .mockResolvedValue({ services: [] } as any);
-//     const { result, waitFor } = renderHook(() => useCreateDatabase(props), {
-//       wrapper,
-//     });
+    await act(async () => jest.advanceTimersByTime(3000));
+    expect(ctx.databaseService.fetchDatabases).toHaveBeenCalledTimes(1);
+    expect(props.nextStep).toHaveBeenCalledWith(2);
+    expect(props.updateAgentMeta).toHaveBeenCalledWith({
+      resourceName: 'db-name',
+      agentMatcherLabels: dbLabels,
+      db: { name: 'new-db' },
+    });
+  });
 
-//     act(() => {
-//       result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
-//     });
+  test('when there are no services, skips polling', async () => {
+    jest
+      .spyOn(ctx.databaseService, 'fetchDatabaseServices')
+      .mockResolvedValue({ services: [] } as any);
+    const { result, waitFor } = renderHook(() => useCreateDatabase(props), {
+      wrapper,
+    });
 
-//     await waitFor(() => {
-//       expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-//     });
+    act(() => {
+      result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
+    });
 
-//     await waitFor(() => {
-//       expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(
-//         1
-//       );
-//     });
+    await waitFor(() => {
+      expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+    });
 
-//     expect(props.nextStep).toHaveBeenCalledWith();
-//     expect(props.updateAgentMeta).toHaveBeenCalledWith({
-//       resourceName: 'db-name',
-//       agentMatcherLabels: [],
-//     });
-//     expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
-//   });
+    await waitFor(() => {
+      expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(
+        1
+      );
+    });
 
-// eslint-disable-next-line jest/no-commented-out-tests
-//   test('when failed to create db, stops flow', async () => {
-//     jest.spyOn(ctx.databaseService, 'createDatabase').mockRejectedValue(null);
-//     const { result } = renderHook(() => useCreateDatabase(props), {
-//       wrapper,
-//     });
+    expect(props.nextStep).toHaveBeenCalledWith();
+    expect(props.updateAgentMeta).toHaveBeenCalledWith({
+      resourceName: 'db-name',
+      agentMatcherLabels: [],
+    });
+    expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
+  });
 
-//     await act(async () => {
-//       result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
-//     });
+  test('when failed to create db, stops flow', async () => {
+    jest.spyOn(ctx.databaseService, 'createDatabase').mockRejectedValue(null);
+    const { result } = renderHook(() => useCreateDatabase(props), {
+      wrapper,
+    });
 
-//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-//     expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
-//     expect(props.nextStep).not.toHaveBeenCalled();
-//     expect(result.current.attempt.status).toBe('failed');
-//   });
+    await act(async () => {
+      result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
+    });
 
-// eslint-disable-next-line jest/no-commented-out-tests
-//   test('when failed to fetch services, stops flow and retries properly', async () => {
-//     jest
-//       .spyOn(ctx.databaseService, 'fetchDatabaseServices')
-//       .mockRejectedValue(null);
-//     const { result } = renderHook(() => useCreateDatabase(props), {
-//       wrapper,
-//     });
+    expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+    expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
+    expect(props.nextStep).not.toHaveBeenCalled();
+    expect(result.current.attempt.status).toBe('failed');
+  });
 
-//     await act(async () => {
-//       result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
-//     });
+  test('when failed to fetch services, stops flow and retries properly', async () => {
+    jest
+      .spyOn(ctx.databaseService, 'fetchDatabaseServices')
+      .mockRejectedValue(null);
+    const { result } = renderHook(() => useCreateDatabase(props), {
+      wrapper,
+    });
 
-//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-//     expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
-//     expect(props.nextStep).not.toHaveBeenCalled();
-//     expect(result.current.attempt.status).toBe('failed');
+    await act(async () => {
+      result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
+    });
 
-//     // Test retrying with same request, skips creating database since it's been already created.
-//     jest.clearAllMocks();
-//     await act(async () => {
-//       result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
-//     });
-//     expect(ctx.databaseService.createDatabase).not.toHaveBeenCalled();
-//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-//     expect(result.current.attempt.status).toBe('failed');
+    expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+    expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
+    expect(props.nextStep).not.toHaveBeenCalled();
+    expect(result.current.attempt.status).toBe('failed');
 
-//     // Test retrying with a new db request (new name), triggers create database.
-//     jest.clearAllMocks();
-//     await act(async () => {
-//       result.current.registerDatabase({
-//         ...newDatabaseReq,
-//         labels: [],
-//         name: 'new-db-name',
-//       });
-//     });
-//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-//     expect(result.current.attempt.status).toBe('failed');
-//   });
+    // Test retrying with same request, skips creating database since it's been already created.
+    jest.clearAllMocks();
+    await act(async () => {
+      result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
+    });
+    expect(ctx.databaseService.createDatabase).not.toHaveBeenCalled();
+    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+    expect(result.current.attempt.status).toBe('failed');
 
-// eslint-disable-next-line jest/no-commented-out-tests
-//   test('when polling timeout, retries properly', async () => {
-//     jest
-//       .spyOn(ctx.databaseService, 'fetchDatabases')
-//       .mockResolvedValue({ agents: [] });
-//     const { result } = renderHook(() => useCreateDatabase(props), {
-//       wrapper,
-//     });
+    // Test retrying with updated field, triggers create database.
+    jest.clearAllMocks();
+    await act(async () => {
+      result.current.registerDatabase({
+        ...newDatabaseReq,
+        labels: [],
+        uri: 'diff-uri',
+      });
+    });
+    expect(ctx.databaseService.createDatabase).not.toHaveBeenCalled();
+    expect(ctx.databaseService.updateDatabase).toHaveBeenCalledTimes(1);
+    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+    expect(result.current.attempt.status).toBe('failed');
+  });
 
-//     await act(async () => {
-//       result.current.registerDatabase(newDatabaseReq);
-//     });
+  test('when polling timeout, retries properly', async () => {
+    jest
+      .spyOn(ctx.databaseService, 'fetchDatabases')
+      .mockResolvedValue({ agents: [] });
+    const { result } = renderHook(() => useCreateDatabase(props), {
+      wrapper,
+    });
 
-//     act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
+    await act(async () => {
+      result.current.registerDatabase(newDatabaseReq);
+    });
 
-//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-//     expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
-//     expect(props.nextStep).not.toHaveBeenCalled();
-//     expect(result.current.attempt.status).toBe('failed');
-//     expect(result.current.attempt.statusText).toContain('could not detect');
+    act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
 
-//     // Test retrying with same request, skips creating database.
-//     jest.clearAllMocks();
-//     await act(async () => {
-//       result.current.registerDatabase(newDatabaseReq);
-//     });
-//     act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
+    expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+    expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
+    expect(props.nextStep).not.toHaveBeenCalled();
+    expect(result.current.attempt.status).toBe('failed');
+    expect(result.current.attempt.statusText).toContain('could not detect');
 
-//     expect(ctx.databaseService.createDatabase).not.toHaveBeenCalled();
-//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-//     expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
-//     expect(result.current.attempt.status).toBe('failed');
+    // Test retrying with same request, skips creating database.
+    jest.clearAllMocks();
+    await act(async () => {
+      result.current.registerDatabase(newDatabaseReq);
+    });
+    act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
 
-//     // Test retrying with request with diff db name, creates and fetches new services.
-//     jest.clearAllMocks();
-//     await act(async () => {
-//       result.current.registerDatabase({
-//         ...newDatabaseReq,
-//         name: 'new-db-name',
-//       });
-//     });
-//     act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
+    expect(ctx.databaseService.createDatabase).not.toHaveBeenCalled();
+    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+    expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
+    expect(result.current.attempt.status).toBe('failed');
 
-//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-//     expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
-//     expect(result.current.attempt.status).toBe('failed');
-//   });
-// });
+    // Test retrying with request with updated fields, updates db and fetches new services.
+    jest.clearAllMocks();
+    await act(async () => {
+      result.current.registerDatabase({
+        ...newDatabaseReq,
+        uri: 'diff-uri',
+      });
+    });
+    act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
+
+    expect(ctx.databaseService.updateDatabase).toHaveBeenCalledTimes(1);
+    expect(ctx.databaseService.createDatabase).not.toHaveBeenCalled();
+    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+    expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
+    expect(result.current.attempt.status).toBe('failed');
+  });
+});

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts
@@ -13,19 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useEffect, useState } from 'react';
 
 import useAttempt from 'shared/hooks/useAttemptNext';
 
 import useTeleport from 'teleport/useTeleport';
 import { useDiscover } from 'teleport/Discover/useDiscover';
-// import { usePoll } from 'teleport/Discover/Shared/usePoll';
+import { usePoll } from 'teleport/Discover/Shared/usePoll';
+import { compareByString } from 'teleport/lib/util';
 
 import { Database } from '../resources';
 
 import type { AgentStepProps } from '../../types';
 import type {
   CreateDatabaseRequest,
-  // Database as DatabaseResource,
+  Database as DatabaseResource,
   DatabaseService,
 } from 'teleport/services/databases';
 import type { AgentLabel } from 'teleport/services/agents';
@@ -39,8 +41,12 @@ export function useCreateDatabase(props: AgentStepProps) {
   const { attempt, setAttempt } = useAttempt('');
   const { emitErrorEvent } = useDiscover();
 
-  // const [pollTimeout, setPollTimeout] = useState(0);
-  // const [pollActive, setPollActive] = useState(false);
+  // isDbCreateErr is a flag that indicates
+  // attempt failed from trying to create a database.
+  const [isDbCreateErr, setIsDbCreateErr] = useState(false);
+
+  const [pollTimeout, setPollTimeout] = useState(0);
+  const [pollActive, setPollActive] = useState(false);
 
   // Required persisted states to determine if we can skip a request
   // because there can be multiple failed points:
@@ -50,151 +56,164 @@ export function useCreateDatabase(props: AgentStepProps) {
   //    - timed out due to combined previous requests taking longer than WAITING_TIMEOUT
   //    - timed out due to failure to query (this would most likely be some kind of
   //      backend error or network failure)
-  // const [newDb, setNewDb] = useState<CreateDatabaseRequest>();
+  const [createdDb, setCreatedDb] = useState<CreateDatabaseRequest>();
 
-  // const { timedOut, result } = usePoll<DatabaseResource>(
-  //   signal => fetchDatabaseServer(signal),
-  //   pollTimeout,
-  //   pollActive,
-  //   3000 // interval: poll every 3 seconds
-  // );
+  const { timedOut, result } = usePoll<DatabaseResource>(
+    signal => fetchDatabaseServer(signal),
+    pollTimeout,
+    pollActive,
+    3000 // interval: poll every 3 seconds
+  );
 
-  // // Handles polling timeout.
-  // useEffect(() => {
-  //   if (pollActive && Date.now() > pollTimeout) {
-  //     setPollActive(false);
-  //     setAttempt({
-  //       status: 'failed',
-  //       statusText:
-  //         'Teleport could not detect your new database in time. Please try again.',
-  //     });
-  //   }
-  // }, [pollActive, pollTimeout, timedOut]);
+  // Handles polling timeout.
+  useEffect(() => {
+    if (pollActive && Date.now() > pollTimeout) {
+      setPollActive(false);
+      setAttempt({
+        status: 'failed',
+        statusText:
+          'Teleport could not detect your new database in time. Please try again.',
+      });
+      // emitErrorEvent(
+      //   `timeout polling for new database with an existing service`
+      // );
+    }
+  }, [pollActive, pollTimeout, timedOut]);
 
-  // // Handles when polling successfully gets
-  // // a response.
-  // useEffect(() => {
-  //   if (!result) return;
+  // Handles when polling successfully gets
+  // a response.
+  useEffect(() => {
+    if (!result) return;
 
-  //   setPollTimeout(null);
-  //   setPollActive(false);
+    setPollTimeout(null);
+    setPollActive(false);
 
-  //   const numStepsToSkip = 2;
-  //   props.updateAgentMeta({
-  //     ...(props.agentMeta as DbMeta),
-  //     resourceName: newDb.name,
-  //     agentMatcherLabels: newDb.labels,
-  //     db: result,
-  //   });
+    const numStepsToSkip = 2;
+    props.updateAgentMeta({
+      ...(props.agentMeta as DbMeta),
+      resourceName: createdDb.name,
+      agentMatcherLabels: createdDb.labels,
+      db: result,
+    });
 
-  //   props.nextStep(numStepsToSkip);
-  // }, [result]);
+    props.nextStep(numStepsToSkip);
+  }, [result]);
 
-  // function fetchDatabaseServer(signal: AbortSignal) {
-  //   const request = {
-  //     search: newDb.name,
-  //     limit: 1,
-  //   };
-  //   return ctx.databaseService
-  //     .fetchDatabases(clusterId, request, signal)
-  //     .then(res => {
-  //       if (res.agents.length) {
-  //         return res.agents[0];
-  //       }
-  //       return null;
-  //     });
-  // }
+  function fetchDatabaseServer(signal: AbortSignal) {
+    const request = {
+      search: createdDb.name,
+      limit: 1,
+    };
+    return ctx.databaseService
+      .fetchDatabases(clusterId, request, signal)
+      .then(res => {
+        if (res.agents.length) {
+          return res.agents[0];
+        }
+        return null;
+      });
+  }
 
   async function registerDatabase(db: CreateDatabaseRequest) {
-    // // Set the timeout now, because this entire registering process
-    // // should take less than WAITING_TIMEOUT.
-    // setPollTimeout(Date.now() + WAITING_TIMEOUT);
-    // setAttempt({ status: 'processing' });
+    // Set the timeout now, because this entire registering process
+    // should take less than WAITING_TIMEOUT.
+    setPollTimeout(Date.now() + WAITING_TIMEOUT);
+    setAttempt({ status: 'processing' });
+    setIsDbCreateErr(false);
 
     // Attempt creating a new Database resource.
     // Handles a case where if there was a later failure point
     // and user decides to change the database fields, a new database
     // is created (ONLY if the database name has changed since this
     // request operation is only a CREATE operation).
-    // if (!newDb || db.name != newDb.name) {
-    try {
-      const createdDb = await ctx.databaseService
-        .createDatabase(clusterId, db)
-        .catch((error: Error) => {
-          emitErrorEvent(error.message);
-          throw error;
+    if (!createdDb) {
+      try {
+        await ctx.databaseService.createDatabase(clusterId, db);
+        setCreatedDb(db);
+      } catch (err) {
+        handleRequestError(err, 'failed to create database: ');
+        setIsDbCreateErr(true);
+        return;
+      }
+    }
+
+    function requiresDbUpdate() {
+      if (!createdDb) {
+        return false;
+      }
+
+      if (createdDb.labels.length === db.labels.length) {
+        // Sort by label keys.
+        const a = createdDb.labels.sort((a, b) =>
+          compareByString(a.name, b.name)
+        );
+        const b = db.labels.sort((a, b) => compareByString(a.name, b.name));
+
+        for (let i = 0; i < a.length; i++) {
+          if (JSON.stringify(a[i]) !== JSON.stringify(b[i])) {
+            return true;
+          }
+        }
+      }
+
+      return (
+        createdDb.uri !== db.uri ||
+        createdDb.awsRds?.accountId !== db.awsRds?.accountId ||
+        createdDb.awsRds?.resourceId !== db.awsRds?.resourceId
+      );
+    }
+
+    // Check and see if database resource need to be updated.
+    if (requiresDbUpdate()) {
+      try {
+        await ctx.databaseService.updateDatabase(clusterId, {
+          ...db,
+          updateCaCert: false,
         });
-      // setNewDb(db);
-      props.updateAgentMeta({
-        ...(props.agentMeta as DbMeta),
-        resourceName: db.name,
-        agentMatcherLabels: db.labels,
-        db: createdDb,
-      });
-      props.nextStep();
-      return;
+        setCreatedDb(db);
+      } catch (err) {
+        handleRequestError(err, 'failed to update database: ');
+        return;
+      }
+    }
+
+    // See if this new database can be picked up by an existing
+    // database service. If there is no active database service,
+    // user is led to the next step.
+    try {
+      const { services } = await ctx.databaseService.fetchDatabaseServices(
+        clusterId
+      );
+
+      if (!findActiveDatabaseSvc(db.labels, services)) {
+        props.updateAgentMeta({
+          ...(props.agentMeta as DbMeta),
+          resourceName: db.name,
+          agentMatcherLabels: db.labels,
+        });
+        props.nextStep();
+        return;
+      }
     } catch (err) {
-      handleRequestError(err);
+      handleRequestError(err, 'failed to fetch database services: ');
       return;
     }
-    // }
 
-    // TODO(lisa): temporary see if we can query this database.
-    // try {
-    //   const { services } = await ctx.databaseService.fetchDatabaseServices(
-    //     clusterId
-    //   );
-
-    //   if (!findActiveDatabaseSvc(db.labels, services)) {
-    //     props.updateAgentMeta({
-    //       ...(props.agentMeta as DbMeta),
-    //       resourceName: db.name,
-    //       agentMatcherLabels: db.labels,
-    //     });
-    //     props.nextStep();
-    //     return;
-    //   }
-    // } catch (err) {
-    //   handleRequestError(err);
-    //   return;
-    // }
-
-    // // See if this new database can be picked up by an existing
-    // // database service. If there is no active database service,
-    // // user is led to the next step.
-    // try {
-    //   const { services } = await ctx.databaseService.fetchDatabaseServices(
-    //     clusterId
-    //   );
-
-    //   if (!findActiveDatabaseSvc(db.labels, services)) {
-    //     props.updateAgentMeta({
-    //       ...(props.agentMeta as DbMeta),
-    //       resourceName: db.name,
-    //       agentMatcherLabels: db.labels,
-    //     });
-    //     props.nextStep();
-    //     return;
-    //   }
-    // } catch (err) {
-    //   handleRequestError(err);
-    //   return;
-    // }
-
-    // // Start polling until new database is picked up by an
-    // // existing database service.
-    // setPollActive(true);
+    // Start polling until new database is picked up by an
+    // existing database service.
+    setPollActive(true);
   }
 
   function clearAttempt() {
     setAttempt({ status: '' });
   }
 
-  function handleRequestError(err) {
-    let message;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function handleRequestError(err: Error, preErrMsg = '') {
+    let message = 'something went wrong';
     if (err instanceof Error) message = err.message;
-    else message = String(err);
     setAttempt({ status: 'failed', statusText: message });
+    // emitErrorEvent(`${preErrMsg}${message}`);
   }
 
   const access = ctx.storeUser.getDatabaseAccess();
@@ -204,9 +223,10 @@ export function useCreateDatabase(props: AgentStepProps) {
     clearAttempt,
     registerDatabase,
     canCreateDatabase: access.create,
-    // pollTimeout,
+    pollTimeout,
     dbEngine: dbState.engine,
     dbLocation: dbState.location,
+    isDbCreateErr,
   };
 }
 
@@ -217,58 +237,95 @@ export function findActiveDatabaseSvc(
   dbServices: DatabaseService[]
 ) {
   if (!dbServices.length) {
-    return false;
+    return null;
   }
 
-  // Create a map for db labels for easy lookup.
-  let dbKeyMap = {};
-  let dbValMap = {};
+  // Create maps for the new labels for easy lookup and matching.
+  let newDbLabelKeyMap = {};
+  let newDbLabelValMap = {};
+  let matchedLabelMap = {};
 
   newDbLabels.forEach(label => {
-    dbKeyMap[label.name] = label.value;
-    dbValMap[label.value] = label.name;
+    newDbLabelKeyMap[label.name] = label.value;
+    matchedLabelMap[label.name] = false;
+    newDbLabelValMap[label.value] = label.name;
   });
 
-  // Check if any service contains an asterik for labels.
-  // This means the service with asterik
-  // can pick up any database despite labels.
+  const newDbHasLabels = newDbLabels.length > 0;
   for (let i = 0; i < dbServices.length; i++) {
-    for (const [key, vals] of Object.entries(dbServices[i].matcherLabels)) {
+    let noMatch = false;
+
+    // Loop through the current service label keys and its value set.
+    const currService = dbServices[i];
+    // Sorted to have asteriks be the first to test.
+    const entries = Object.entries(currService.matcherLabels).sort();
+    matchLabels: for (const [key, vals] of entries) {
+      // Check if the label contains asteriks, which means this service can
+      // pick up any database regardless of other labels.
       const foundAsterikAsValue = vals.includes('*');
-      // Check if this service contains any labels with asteriks,
-      // which means this service can pick up any database regardless
-      // of labels.
       if (key === '*' && foundAsterikAsValue) {
-        return true;
+        return currService;
       }
 
-      // If no newDbLabels labels were defined, no need to look for other matches
-      // continue to next key.
-      if (!newDbLabels.length) {
+      // If no labels were defined with the new database, then there is no
+      // further matching to do with this currService.
+      if (!newDbHasLabels) {
+        noMatch = true;
+        break matchLabels;
+      }
+
+      // Start matching by value.
+      // Both the service matcher labels and the new db labels must be equal to each other.
+      // For example, if the service matcher has other labels that are not defined
+      // in the new db labels, then the service cannot detect the new db.
+
+      // This means any key is fine, as long as value matches.
+      if (key === '*') {
+        let found = false;
+        vals.forEach(val => {
+          const key = newDbLabelValMap[val];
+          if (key) {
+            matchedLabelMap[key] = true;
+            found = true;
+          }
+        });
+        if (found) {
+          continue;
+        }
+      }
+
+      // This means any value is fine, as long as a key matches.
+      // Note that db labels can't have duplicate keys.
+      else if (foundAsterikAsValue && newDbLabelKeyMap[key]) {
+        matchedLabelMap[key] = true;
         continue;
       }
 
-      // Start matching every combination.
-
-      // This means any key is fine, as long as a
-      // value matches.
-      if (key === '*' && vals.find(val => dbValMap[val])) {
-        return true;
+      // Match against actual values of key and its value.
+      else {
+        const dbVal = newDbLabelKeyMap[key];
+        if (dbVal && vals.find(val => val === dbVal)) {
+          matchedLabelMap[key] = true;
+          continue;
+        }
       }
 
-      // This means any value is fine, as long as a
-      // key matches.
-      if (foundAsterikAsValue && dbKeyMap[key]) {
-        return true;
-      }
+      // At this point, the current label did not match.
+      // This service will not be able to pick up the new db
+      // despite any matches so far.
+      noMatch = true;
+      break matchLabels;
+    }
 
-      // Match against key and value.
-      const dbVal = dbKeyMap[key];
-      if (dbVal && vals.find(val => val === dbVal)) {
-        return true;
-      }
+    // See if the current service has all required matching labels.
+    if (
+      !noMatch &&
+      newDbHasLabels &&
+      Object.keys(matchedLabelMap).every(key => matchedLabelMap[key])
+    ) {
+      return currService;
     }
   }
 
-  return false;
+  return null;
 }

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts
@@ -168,7 +168,6 @@ export function useCreateDatabase(props: AgentStepProps) {
       try {
         await ctx.databaseService.updateDatabase(clusterId, {
           ...db,
-          updateCaCert: false,
         });
         setCreatedDb(db);
       } catch (err) {

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts
@@ -75,9 +75,9 @@ export function useCreateDatabase(props: AgentStepProps) {
         statusText:
           'Teleport could not detect your new database in time. Please try again.',
       });
-      // emitErrorEvent(
-      //   `timeout polling for new database with an existing service`
-      // );
+      emitErrorEvent(
+        `timeout polling for new database with an existing service`
+      );
     }
   }, [pollActive, pollTimeout, timedOut]);
 
@@ -208,12 +208,11 @@ export function useCreateDatabase(props: AgentStepProps) {
     setAttempt({ status: '' });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function handleRequestError(err: Error, preErrMsg = '') {
     let message = 'something went wrong';
     if (err instanceof Error) message = err.message;
     setAttempt({ status: 'failed', statusText: message });
-    // emitErrorEvent(`${preErrMsg}${message}`);
+    emitErrorEvent(`${preErrMsg}${message}`);
   }
 
   const access = ctx.storeUser.getDatabaseAccess();

--- a/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
@@ -76,6 +76,7 @@ export function useMutualTls({ ctx, props }: Props) {
         .updateDatabase(clusterId, {
           name: meta.db.name,
           caCert,
+          updateCaCert: true,
         })
         .then(() => props.nextStep())
         .catch((error: Error) => {

--- a/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
@@ -76,7 +76,6 @@ export function useMutualTls({ ctx, props }: Props) {
         .updateDatabase(clusterId, {
           name: meta.db.name,
           caCert,
-          updateCaCert: true,
         })
         .then(() => props.nextStep())
         .catch((error: Error) => {

--- a/web/packages/teleport/src/Discover/Database/util.ts
+++ b/web/packages/teleport/src/Discover/Database/util.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { AgentLabel } from 'teleport/services/agents';
+
+// makeLabelMaps makes a few lookup tables out of the label prop
+// for easy lookup:
+//  - lookup table with label.name as key, and label.value as value
+//  - lookup table with label.value as key, and label.key as value
+//  - lookup table of flags with label.name as key, and booleans as value
+//    which serves to record seen labels.
+export function makeLabelMaps(labels: AgentLabel[]) {
+  let labelKeysToMatchMap: Record<string, string> = {};
+  let labelValsToMatchMap: Record<string, string> = {};
+  let labelToMatchSeenMap: Record<string, boolean> = {};
+
+  labels.forEach(label => {
+    labelKeysToMatchMap[label.name] = label.value;
+    labelToMatchSeenMap[label.name] = false;
+    labelValsToMatchMap[label.value] = label.name;
+  });
+
+  return { labelKeysToMatchMap, labelValsToMatchMap, labelToMatchSeenMap };
+}
+
+// matchLabels will go through each `matcherlabels` and record matched labels.
+// If all labels are matched (or all asteriks exists in `matcherLabels`),
+// returns true.
+//
+// It will return false when:
+//   - there were no labels to match
+//   - `matcherLabel` contains a label that isn't seen in the `xxxToMatchMap`
+export function matchLabels({
+  hasLabelsToMatch,
+  matcherLabels,
+  labelKeysToMatchMap,
+  labelValsToMatchMap,
+  labelToMatchSeenMap,
+}: {
+  hasLabelsToMatch: boolean;
+  matcherLabels: Record<string, string[]>;
+  labelKeysToMatchMap: Record<string, string>;
+  labelValsToMatchMap: Record<string, string>;
+  labelToMatchSeenMap: Record<string, boolean>;
+}) {
+  const matchedLabelMap = { ...labelToMatchSeenMap };
+  // Sorted to have asteriks be the first label key to test.
+  const entries = Object.entries({ ...matcherLabels }).sort();
+  for (const [key, vals] of entries) {
+    // Check if the label contains asteriks, which means match all eg:
+    // a service with match all can pick up any database regardless of other labels
+    // or no labels.
+    const foundAsterikAsValue = vals.includes('*');
+    if (key === '*' && foundAsterikAsValue) {
+      return true;
+    }
+
+    if (!hasLabelsToMatch) {
+      return false;
+    }
+
+    // Start matching by value.
+
+    // This means any key is fine, as long as value matches.
+    if (key === '*') {
+      let found = false;
+      vals.forEach(val => {
+        const key = labelValsToMatchMap[val];
+        if (key) {
+          matchedLabelMap[key] = true;
+          found = true;
+        }
+      });
+      if (found) {
+        continue;
+      }
+    }
+
+    // This means any value is fine, as long as a key matches.
+    // Note that db resource labels can't have duplicate keys
+    // (but db service can).
+    else if (foundAsterikAsValue && labelKeysToMatchMap[key]) {
+      matchedLabelMap[key] = true;
+      continue;
+    }
+
+    // Match against actual values of key and its value.
+    else {
+      const dbVal = labelKeysToMatchMap[key];
+      if (dbVal && vals.find(val => val === dbVal)) {
+        matchedLabelMap[key] = true;
+        continue;
+      }
+    }
+
+    // At this point, the current label did not match any criteria,
+    // we can abort, since it takes only one mismatch to fail.
+    return false;
+  }
+
+  return (
+    hasLabelsToMatch &&
+    Object.keys(matchedLabelMap).every(key => matchedLabelMap[key])
+  );
+}

--- a/web/packages/teleport/src/lib/util.test.ts
+++ b/web/packages/teleport/src/lib/util.test.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { generateTshLoginCommand, arrayStrDiff, compareSemVers } from './util';
+import {
+  generateTshLoginCommand,
+  arrayStrDiff,
+  compareSemVers,
+  compareByString,
+} from './util';
 
 let windowSpy;
 
@@ -94,5 +99,39 @@ test('compareSemVers', () => {
     '5.10.10',
     '10.1.0',
     '11.1.0',
+  ]);
+});
+
+test('sortByString with simple string array', () => {
+  const arr = ['cats', 'cat', 'x', 'ape', 'apes'];
+  expect(arr.sort((a, b) => compareByString(a, b))).toStrictEqual([
+    'ape',
+    'apes',
+    'cat',
+    'cats',
+    'x',
+  ]);
+});
+
+test('sortByString with objects with string fields', () => {
+  const arr = [
+    { name: 'cats', value: 'persian' },
+    { name: 'ape', value: 'kingkong' },
+    { name: 'cat', value: 'siamese' },
+    { name: 'apes', value: 'donkeykong' },
+  ];
+
+  expect(arr.sort((a, b) => compareByString(a.name, b.name))).toStrictEqual([
+    { name: 'ape', value: 'kingkong' },
+    { name: 'apes', value: 'donkeykong' },
+    { name: 'cat', value: 'siamese' },
+    { name: 'cats', value: 'persian' },
+  ]);
+
+  expect(arr.sort((a, b) => compareByString(a.value, b.value))).toStrictEqual([
+    { name: 'apes', value: 'donkeykong' },
+    { name: 'ape', value: 'kingkong' },
+    { name: 'cats', value: 'persian' },
+    { name: 'cat', value: 'siamese' },
   ]);
 });

--- a/web/packages/teleport/src/lib/util.ts
+++ b/web/packages/teleport/src/lib/util.ts
@@ -114,3 +114,15 @@ export const compareSemVers = (a: string, b: string): -1 | 1 => {
 
   return 1;
 };
+
+// compareByString is a sort compare function that
+// compares by string.
+export function compareByString(a: string, b: string) {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+}

--- a/web/packages/teleport/src/services/databases/databases.ts
+++ b/web/packages/teleport/src/services/databases/databases.ts
@@ -75,7 +75,10 @@ class DatabaseService {
     req: UpdateDatabaseRequest
   ): Promise<Database> {
     return api
-      .put(cfg.getDatabaseUrl(clusterId, req.name), { ca_cert: req.caCert })
+      .put(cfg.getDatabaseUrl(clusterId, req.name), {
+        ...req,
+        ca_cert: req.caCert,
+      })
       .then(makeDatabase);
   }
 

--- a/web/packages/teleport/src/services/databases/databases.ts
+++ b/web/packages/teleport/src/services/databases/databases.ts
@@ -75,10 +75,7 @@ class DatabaseService {
     req: UpdateDatabaseRequest
   ): Promise<Database> {
     return api
-      .put(cfg.getDatabaseUrl(clusterId, req.name), {
-        ...req,
-        ca_cert: req.caCert,
-      })
+      .put(cfg.getDatabaseUrl(clusterId, req.name), req)
       .then(makeDatabase);
   }
 

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -35,9 +35,17 @@ export type DatabasesResponse = {
   totalCount?: number;
 };
 
-export type UpdateDatabaseRequest = {
-  name: string;
-  caCert: string;
+export type UpdateDatabaseRequest = Omit<
+  Partial<CreateDatabaseRequest>,
+  'protocol'
+> & {
+  caCert?: string;
+  // updateCaCert is a flag to indicate that this request
+  // to update database is to only update the CA and validates
+  // the provided CA.
+  // When set to false, updates all other fields and
+  // skips updating and validating CA.
+  updateCaCert: boolean;
 };
 
 export type CreateDatabaseRequest = {

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -39,10 +39,7 @@ export type UpdateDatabaseRequest = Omit<
   Partial<CreateDatabaseRequest>,
   'protocol'
 > & {
-  // caCert can use the values null or undefined
-  // as a flag to mean updating the other updatable
-  // fields of a db.
-  caCert?: string | undefined | null;
+  caCert?: string;
 };
 
 export type CreateDatabaseRequest = {

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -39,13 +39,10 @@ export type UpdateDatabaseRequest = Omit<
   Partial<CreateDatabaseRequest>,
   'protocol'
 > & {
-  caCert?: string;
-  // updateCaCert is a flag to indicate that this request
-  // to update database is to only update the CA and validates
-  // the provided CA.
-  // When set to false, updates all other fields and
-  // skips updating and validating CA.
-  updateCaCert: boolean;
+  // caCert can use the values null or undefined
+  // as a flag to mean updating the other updatable
+  // fields of a db.
+  caCert?: string | undefined | null;
 };
 
 export type CreateDatabaseRequest = {


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/16858

Note: some files are large so you have to click `load diff` to see the file

#### Description
- Allows updating by other select database fields
- Re-enables the db service checker
- ~~Adds event emitter for failure to fetch service and update database~~
- Fixed the db service label checker to do exact matching (new db labels should == db service matcher labels)
- Placed a loose check for proper AWS endpoint connection format, as this caused db service to silently not pick up the database, despite matching labels
- Allow user to update db fields (only after they successfully created a DB, but they encountered an error later on (eg network error or db service not picking up the db), and they go back to the editing screen and wish to change things
- Split register db to two substeps as screenshotted below, this was to prevent user from changing the db name as that is not allowed with update action

#### Screenshot
First step, define db name

![image](https://user-images.githubusercontent.com/43280172/216017443-6e52f224-80c4-4416-a933-68cf5ddcf17a.png)

Second step (last), define other db fields (all these are updatable)

![image](https://user-images.githubusercontent.com/43280172/216017566-26ca533e-6d80-4617-bf85-9fee07af092e.png)
