### PR TITLE
Connect: Check for existence of update-*-database in after-install

### DIFF
--- a/web/packages/teleterm/build_resources/linux/after-install.tpl
+++ b/web/packages/teleterm/build_resources/linux/after-install.tpl
@@ -9,8 +9,15 @@ set -eu
 # SUID chrome-sandbox for Electron 5+
 chmod 4755 "/opt/${sanitizedProductName}/chrome-sandbox" || true
 
-update-mime-database /usr/share/mime || true
-update-desktop-database /usr/share/applications || true
+# update-mime-database and update-desktop-database might be missing from minimal variants of some
+# Linux distributions.
+if hash update-mime-database 2>/dev/null; then
+  update-mime-database /usr/share/mime || true
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+  update-desktop-database /usr/share/applications || true
+fi
 
 ###
 # Custom after-install.tpl script.


### PR DESCRIPTION
This fixes [an issue one of our users had](https://gravitational.slack.com/archives/C03FZRWDBR7/p1674746033225639) where a minimal installation of Debian does not have the `update-desktop-database` command available. See also https://github.com/electron-userland/electron-builder/issues/4341.

From what I can tell, Connect would still install successfully because the calls to both commands are followed by `|| true`, so the errors coming from them would be written to stderr but the exit status was ignored. I realized that only after preparing this change so I guess we can keep it to make the install script a bit cleaner if someone doesn't have those commands available.

---

The easiest way to test it is to temporarily rename both commands in /usr/bin.