### PR TITLE
helm: allow to set security contexts in `teleport-kube-agent`

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -2047,7 +2047,7 @@ applied to `initContainers`.
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
 
-The `securityContext` applies to any pods created by the chart, including `initContainers`.
+The `securityContext` applies to the main Teleport containers.
 
 <Tabs>
   <TabItem label="values.yaml">

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -2209,6 +2209,44 @@ will also be applied to `initContainers`.
   </TabItem>
 </Tabs>
 
+## `initSecurityContext`
+
+[Container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+to set for the [initContainer](#initcontainers).
+Defaults to:
+
+```yaml
+initSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - all
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 9807
+```
+
+To unset the security context, set it to `null` or `~`.
+
+## `securityContext`
+
+[Container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+to set for the main Teleport container.
+Defaults to:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - all
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 9807
+```
+
+To unset the security context, set it to `null` or `~`.
+
 ## `tolerations`
 
 | Type   | Default value | Can be used in `custom` mode? |

--- a/examples/chart/teleport-kube-agent/.lint/security-context-empty.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/security-context-empty.yaml
@@ -1,0 +1,5 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube
+securityContext: null
+initSecurityContext: null

--- a/examples/chart/teleport-kube-agent/.lint/security-context-empty.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/security-context-empty.yaml
@@ -1,5 +1,6 @@
 authToken: auth-token
 proxyAddr: proxy.example.com:3080
 roles: kube
+kubeClusterName: helm-lint
 securityContext: null
 initSecurityContext: null

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
   {{- end }}
   {{- if .Values.initSecurityContext }}
         securityContext: {{- toYaml .Values.initSecurityContext | nindent 10 }}
-  {{- end}}
+  {{- end }}
         volumeMounts:
         - mountPath: /etc/teleport
           name: "config"
@@ -139,7 +139,7 @@ spec:
         {{- end }}
         {{- if .Values.securityContext }}
         securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
-        {{- end}}
+        {{- end }}
         ports:
         - name: diag
           containerPort: 3000

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -86,17 +86,11 @@ spec:
 {{- if .Values.initContainers }}
       initContainers: {{- toYaml .Values.initContainers | nindent 6 }}
   {{- if .Values.resources }}
-        resources:
-    {{- toYaml .Values.resources | nindent 10 }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
   {{- end }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - all
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 9807
+  {{- if .Values.initSecurityContext }}
+        securityContext: {{- toYaml .Values.initSecurityContext | nindent 10 }}
+  {{- end}}
         volumeMounts:
         - mountPath: /etc/teleport
           name: "config"
@@ -143,14 +137,9 @@ spec:
         {{- if .Values.extraArgs }}
           {{- toYaml .Values.extraArgs | nindent 8 }}
         {{- end }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - all
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 9807
+        {{- if .Values.securityContext }}
+        securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end}}
         ports:
         - name: diag
           containerPort: 3000

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -88,7 +88,7 @@ spec:
   {{- end }}
   {{- if .Values.initSecurityContext }}
         securityContext: {{- toYaml .Values.initSecurityContext | nindent 10 }}
-  {{- end}}
+  {{- end }}
         volumeMounts:
         - mountPath: /etc/teleport
           name: "config"
@@ -149,7 +149,7 @@ spec:
         {{- end }}
         {{- if .Values.securityContext }}
         securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
-        {{- end}}
+        {{- end }}
         ports:
         - name: diag
           containerPort: 3000

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -84,17 +84,11 @@ spec:
 {{- if .Values.initContainers }}
       initContainers: {{- toYaml .Values.initContainers | nindent 6 }}
   {{- if .Values.resources }}
-        resources:
-    {{- toYaml .Values.resources | nindent 10 }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
   {{- end }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - all
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 9807
+  {{- if .Values.initSecurityContext }}
+        securityContext: {{- toYaml .Values.initSecurityContext | nindent 10 }}
+  {{- end}}
         volumeMounts:
         - mountPath: /etc/teleport
           name: "config"
@@ -153,14 +147,9 @@ spec:
         {{- if .Values.extraArgs }}
           {{- toYaml .Values.extraArgs | nindent 8 }}
         {{- end }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - all
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 9807
+        {{- if .Values.securityContext }}
+        securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end}}
         ports:
         - name: diag
           containerPort: 3000

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -255,6 +255,23 @@ sets Pod labels when specified if action is Upgrade:
         secretName: teleport-kube-agent-join-token
     - emptyDir: {}
       name: data
+sets by default a container security context if action is Upgrade:
+  1: |
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - all
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 9807
+  2: |
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - all
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 9807
 should add emptyDir for data when existingDataVolume is not set if action is Upgrade:
   1: |
     containers:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -230,6 +230,23 @@ sets StatefulSet labels when specified:
             requests:
               storage: 128Mi
           storageClassName: aws-gp2
+sets by default a container security context:
+  1: |
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - all
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 9807
+  2: |
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - all
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 9807
 should add insecureSkipProxyTLSVerify to args when set in values:
   1: |
     containers:

--- a/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
@@ -654,3 +654,34 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: sets by default a container security context if action is Upgrade
+    template: deployment.yaml
+    set:
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
+      # https://github.com/helm/helm/issues/8137
+      unitTestUpgrade: true
+    values:
+      - ../.lint/initcontainers.yaml
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec.initContainers[0].securityContext
+      - matchSnapshot:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: sets no container security context when manually unset and if action is Upgrade
+    template: deployment.yaml
+    set:
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
+      # https://github.com/helm/helm/issues/8137
+      unitTestUpgrade: true
+    values:
+      - ../.lint/initcontainers.yaml
+      - ../.lint/security-context-empty.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext
+          value: null
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value: null

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -655,3 +655,26 @@ tests:
           path: spec.volumeClaimTemplates
       - matchSnapshot:
           path: spec.template.spec
+
+  - it: sets by default a container security context
+    template: statefulset.yaml
+    values:
+      - ../.lint/initcontainers.yaml
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec.initContainers[0].securityContext
+      - matchSnapshot:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: sets no container security context when manually unset
+    template: statefulset.yaml
+    values:
+      - ../.lint/initcontainers.yaml
+      - ../.lint/security-context-empty.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext
+          value: null
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value: null

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -342,6 +342,28 @@ resources: {}
 #    cpu: "1"
 #    memory: "2Gi"
 
+# Security context to add to the initContainer
+initSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - all
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 9807
+# runAsUser: 99
+
+# Security context to add to the container
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - all
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 9807
+# runAsUser: 99
+
 # Priority class name to add to the deployment
 priorityClassName: ""
 

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -351,7 +351,6 @@ initSecurityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 9807
-# runAsUser: 99
 
 # Security context to add to the container
 securityContext:
@@ -362,7 +361,6 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 9807
-# runAsUser: 99
 
 # Priority class name to add to the deployment
 priorityClassName: ""


### PR DESCRIPTION
Fixes #20310 