### PR TITLE
Add auto-joining for Azure VMs

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -427,6 +427,14 @@ const (
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
 	AWSInstanceIDLabel = TeleportNamespace + "/instance-id"
+	// SubscriptionIDLabel is used to identify virtual machines by Azure
+	// subscription ID found via automatic discovery, to avoid re-running
+	// installation commands on the node.
+	SubscriptionIDLabel = TeleportNamespace + "/subscription-id"
+	// VMIDLabel is used to identify virtual machines by ID found
+	// via automatic discovery, to avoid re-running installation commands
+	// on the node.
+	VMIDLabel = TeleportNamespace + "/vm-id"
 
 	// CloudLabel is used to identify the cloud where the resource was discovered.
 	CloudLabel = TeleportNamespace + "/cloud"

--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -1,4 +1,17 @@
 #!/bin/sh
+
+on_ec2() {
+  EC2_STATUS=$(curl -o /dev/null -w "%{http_code}" -m5 -sS "http://169.254.169.254/latest/meta-data")
+  # EC2 metadata sometimes requires token access, so a successful hit may
+  # return unauthorized/forbidden.
+  [ "$EC2_STATUS" = "200" ] || [ "$EC2_STATUS" = "401" ] || [ "$EC2_STATUS" = "403" ]
+}
+
+on_azure() {
+  AZURE_STATUS=$(curl -o /dev/null -w "%{http_code}" -m5 -sS -H "Metadata:true" --noproxy "*" "http://169.254.169.254/metadata/versions")
+  [ "$AZURE_STATUS" = "200" ]
+}
+
 (
   flock -n 9 || exit 1
   if test -f /usr/local/bin/teleport; then
@@ -38,22 +51,41 @@
     echo "Unsupported distro: $ID"
     exit 1
   fi
+  
+  if on_azure ; then
+    API_VERSION=$(curl -m5 -sS -H "Metadata:true" --noproxy "*" "http://169.254.169.254/metadata/versions" | jq -r ".apiVersions[-1]")
+    INSTANCE_INFO=$(curl -m5 -sS -H "Metadata:true" --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=$API_VERSION&format=json")
 
-  IMDS_TOKEN=$(curl -m5 -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
-  INSTANCE_INFO=$(curl -m5 -sS -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" http://169.254.169.254/latest/dynamic/instance-identity/document)
+    REGION="$(echo "$INSTANCE_INFO" | jq -r .compute.location)"
+    RESOURCE_GROUP="$(echo "$INSTANCE_INFO" | jq -r .compute.resourceGroupName)"
+    SUBSCRIPTION_ID="$(echo "$INSTANCE_INFO" | jq -r .compute.subscriptionId)"
+    VM_ID="$(echo "$INSTANCE_INFO" | jq -r .compute.vmId)"
 
-  ACCOUNT_ID="$(echo "$INSTANCE_INFO" | jq -r .accountId)"
-  INSTANCE_ID="$(echo "$INSTANCE_INFO" | jq -r .instanceId)"
+    JOIN_METHOD=azure
+    LABELS="teleport.internal/vm-id=${VM_ID},teleport.internal/subscription-id=${SUBSCRIPTION_ID},teleport.internal/region=${REGION},teleport.internal/resource-group=${RESOURCE_GROUP}"
+  elif on_ec2 ; then
+    IMDS_TOKEN=$(curl -m5 -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+    INSTANCE_INFO=$(curl -m5 -sS -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" http://169.254.169.254/latest/dynamic/instance-identity/document)
+
+    ACCOUNT_ID="$(echo "$INSTANCE_INFO" | jq -r .accountId)"
+    INSTANCE_ID="$(echo "$INSTANCE_INFO" | jq -r .instanceId)"
+
+    JOIN_METHOD=iam
+    LABELS="teleport.dev/instance-id=${INSTANCE_ID},teleport.dev/account-id=${ACCOUNT_ID}"
+  else
+    echo "Could not determine cloud provider"
+    exit 1
+  fi
 
   # generate teleport ssh config
   # token is read as a parameter from the AWS ssm script run and
   # passed as the first argument to the script
   sudo /usr/local/bin/teleport node configure \
     --proxy="{{ .PublicProxyAddr }}" \
-    --join-method=iam \
+    --join-method=${JOIN_METHOD} \
     --token="$1" \
     --output=file \
-    --labels="teleport.dev/instance-id=${INSTANCE_ID},teleport.dev/account-id=${ACCOUNT_ID}"
+    --labels="${LABELS}"
 
   # enable and start teleport service
   sudo systemctl enable --now teleport

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -4575,36 +4575,22 @@ func (g *GRPCServer) GetInstallers(ctx context.Context, _ *emptypb.Empty) (*type
 		return nil, trace.Wrap(err)
 	}
 	var installersV1 []*types.InstallerV1
-	needDefault := true
-	needDefaultAgentless := true
+	defaultInstallers := map[string]*types.InstallerV1{
+		installers.InstallerScriptName:          installers.DefaultInstaller,
+		installers.InstallerScriptNameAgentless: installers.DefaultAgentlessInstaller,
+	}
+
 	for _, inst := range res {
 		instV1, ok := inst.(*types.InstallerV1)
 		if !ok {
 			return nil, trace.BadParameter("unsupported installer type %T", inst)
 		}
-		switch inst.GetName() {
-		case installers.InstallerScriptName:
-			needDefault = false
-		case installers.InstallerScriptNameAgentless:
-			needDefaultAgentless = false
-		}
+		delete(defaultInstallers, inst.GetName())
 		installersV1 = append(installersV1, instV1)
 	}
 
-	if len(installersV1) == 0 {
-		return &types.InstallerV1List{
-			Installers: []*types.InstallerV1{
-				installers.DefaultInstaller,
-				installers.DefaultAgentlessInstaller,
-			},
-		}, nil
-	}
-
-	if needDefault {
-		installersV1 = append(installersV1, installers.DefaultInstaller)
-	}
-	if needDefaultAgentless {
-		installersV1 = append(installersV1, installers.DefaultAgentlessInstaller)
+	for _, inst := range defaultInstallers {
+		installersV1 = append(installersV1, inst)
 	}
 
 	return &types.InstallerV1List{

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -190,7 +190,8 @@ func (a *Server) generateCertsBot(
 	case types.JoinMethodIAM,
 		types.JoinMethodGitHub,
 		types.JoinMethodCircleCI,
-		types.JoinMethodKubernetes:
+		types.JoinMethodKubernetes,
+		types.JoinMethodAzure:
 		shouldDeleteToken = false
 		renewable = false
 	default:

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -154,6 +154,8 @@ type AzureClients interface {
 	// GetAzurePostgresFlexServersClient returns an Azure PostgreSQL Flexible Server client for the
 	// specified subscription.
 	GetAzurePostgresFlexServersClient(subscription string) (azure.PostgresFlexServersClient, error)
+	// GetAzureRunCommandClient returns an Azure Run Command client for the given subscription.
+	GetAzureRunCommandClient(subscription string) (azure.RunCommandClient, error)
 }
 
 // NewClients returns a new instance of cloud clients retriever.
@@ -171,6 +173,7 @@ func NewClients() Clients {
 			azureManagedSQLServerClients:    azure.NewClientMap(azure.NewManagedSQLClient),
 			azureMySQLFlexServersClients:    azure.NewClientMap(azure.NewMySQLFlexServersClient),
 			azurePostgresFlexServersClients: azure.NewClientMap(azure.NewPostgresFlexServersClient),
+			azureRunCommandClients:          azure.NewClientMap(azure.NewRunCommandClient),
 		},
 	}
 }
@@ -224,6 +227,8 @@ type azureClients struct {
 	// azurePostgresFlexServersClients is the cached Azure PostgreSQL Flexible Server
 	// client.
 	azurePostgresFlexServersClients azure.ClientMap[azure.PostgresFlexServersClient]
+	// azureRunCommandClients contains the cached Azure Run Command clients.
+	azureRunCommandClients azure.ClientMap[azure.RunCommandClient]
 }
 
 // GetAWSSession returns AWS session for the specified region.
@@ -505,6 +510,12 @@ func (c *cloudClients) GetAzurePostgresFlexServersClient(subscription string) (a
 	return c.azurePostgresFlexServersClients.Get(subscription, c.GetAzureCredential)
 }
 
+// GetAzureRunCommandClient returns an Azure Run Command client for the given
+// subscription.
+func (c *cloudClients) GetAzureRunCommandClient(subscription string) (azure.RunCommandClient, error) {
+	return c.azureRunCommandClients.Get(subscription, c.GetAzureCredential)
+}
+
 // Close closes all initialized clients.
 func (c *cloudClients) Close() (err error) {
 	c.mtx.Lock()
@@ -747,6 +758,7 @@ type TestCloudClients struct {
 	AzureManagedSQLServer   azure.ManagedSQLServerClient
 	AzureMySQLFlex          azure.MySQLFlexServersClient
 	AzurePostgresFlex       azure.PostgresFlexServersClient
+	AzureRunCommand         azure.RunCommandClient
 }
 
 // GetAWSSession returns AWS session for the specified region.
@@ -919,6 +931,11 @@ func (c *TestCloudClients) GetAzureMySQLFlexServersClient(subscription string) (
 // GetAzurePostgresFlexServersClient returns an Azure PostgreSQL Flexible server client for listing PostgreSQL Flexible servers.
 func (c *TestCloudClients) GetAzurePostgresFlexServersClient(subscription string) (azure.PostgresFlexServersClient, error) {
 	return c.AzurePostgresFlex, nil
+}
+
+// GetAzureRunCommand returns an Azure Run Command client for the given subscription.
+func (c *TestCloudClients) GetAzureRunCommandClient(subscription string) (azure.RunCommandClient, error) {
+	return c.AzureRunCommand, nil
 }
 
 // Close closes all initialized clients.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -587,6 +587,12 @@ func checkAndSetDefaultsForAzureMatchers(matcherInput []AzureMatcher) error {
 			}
 		}
 
+		if slices.Contains(matcher.Types, services.AzureMatcherVM) {
+			if err := checkAndSetDefaultsForAzureInstaller(matcher); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
 		if slices.Contains(matcher.Regions, types.Wildcard) || len(matcher.Regions) == 0 {
 			matcher.Regions = []string{types.Wildcard}
 		}
@@ -605,6 +611,35 @@ func checkAndSetDefaultsForAzureMatchers(matcherInput []AzureMatcher) error {
 			}
 		}
 
+	}
+	return nil
+}
+
+func checkAndSetDefaultsForAzureInstaller(matcher *AzureMatcher) error {
+	if matcher.InstallParams == nil {
+		matcher.InstallParams = &InstallParams{
+			JoinParams: JoinParams{
+				TokenName: defaults.AzureInviteTokenName,
+				Method:    types.JoinMethodAzure,
+			},
+			ScriptName: installers.InstallerScriptName,
+		}
+		return nil
+	}
+
+	switch matcher.InstallParams.JoinParams.Method {
+	case types.JoinMethodAzure, "":
+		matcher.InstallParams.JoinParams.Method = types.JoinMethodAzure
+	default:
+		return trace.BadParameter("only Azure joining is supported for Azure auto-discovery")
+	}
+
+	if token := matcher.InstallParams.JoinParams.TokenName; token == "" {
+		matcher.InstallParams.JoinParams.TokenName = defaults.AzureInviteTokenName
+	}
+
+	if installer := matcher.InstallParams.ScriptName; installer == "" {
+		matcher.InstallParams.ScriptName = installers.InstallerScriptName
 	}
 	return nil
 }
@@ -1540,15 +1575,18 @@ type AWSMatcher struct {
 // InstallParams sets join method to use on discovered nodes
 type InstallParams struct {
 	// JoinParams sets the token and method to use when generating
-	// config on EC2 instances
+	// config on cloud instances
 	JoinParams JoinParams `yaml:"join_params,omitempty"`
 	// ScriptName is the name of the teleport installer script
-	// resource for the EC2 instance to execute
+	// resource for the cloud instance to execute
 	ScriptName string `yaml:"script_name,omitempty"`
 	// InstallTeleport disables agentless discovery
 	InstallTeleport string `yaml:"install_teleport,omitempty"`
 	// SSHDConfig provides the path to write sshd configuration changes
 	SSHDConfig string `yaml:"sshd_config,omitempty"`
+	// PublicProxyAddr is the address of the proxy the discovered node should use
+	// to connect to the cluster. Used ony in Azure.
+	PublicProxyAddr string `yaml:"public_proxy_addr,omitempty"`
 }
 
 func (ip *InstallParams) Parse() (services.InstallerParams, error) {
@@ -1592,6 +1630,9 @@ type AzureMatcher struct {
 	Regions []string `yaml:"regions,omitempty"`
 	// ResourceTags are Azure tags on resources to match.
 	ResourceTags map[string]apiutils.Strings `yaml:"tags,omitempty"`
+	// InstallParams sets the join method when installing on
+	// discovered Azure nodes.
+	InstallParams *InstallParams `yaml:"install,omitempty"`
 }
 
 // Database represents a single database proxied by the service.

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -805,7 +805,7 @@ func TestDiscoveryConfig(t *testing.T) {
 			},
 		},
 		{
-			desc:          "Azure section is filled with defaults",
+			desc:          "Azure section is filled with defaults (aks)",
 			expectError:   require.NoError,
 			expectEnabled: require.True,
 			mutate: func(cfg cfgMap) {
@@ -1021,7 +1021,7 @@ func TestDiscoveryConfig(t *testing.T) {
 			},
 		},
 		{
-			desc:          "Azure section is filled with defaults",
+			desc:          "Azure section is filled with defaults (vm)",
 			expectError:   require.NoError,
 			expectEnabled: require.True,
 			mutate: func(cfg cfgMap) {
@@ -1048,9 +1048,88 @@ func TestDiscoveryConfig(t *testing.T) {
 						ResourceTags: map[string]apiutils.Strings{
 							"discover_teleport": []string{"yes"},
 						},
+						InstallParams: &InstallParams{
+							JoinParams: JoinParams{
+								TokenName: "azure-discovery-token",
+								Method:    "azure",
+							},
+							ScriptName: "default-installer",
+						},
 					},
 				},
 			},
+		},
+		{
+			desc:          "Azure section is filled with custom config",
+			expectError:   require.NoError,
+			expectEnabled: require.True,
+			mutate: func(cfg cfgMap) {
+				cfg["discovery_service"].(cfgMap)["enabled"] = "yes"
+				cfg["discovery_service"].(cfgMap)["azure"] = []cfgMap{
+					{"types": []string{"vm"},
+						"regions":         []string{"westcentralus"},
+						"resource_groups": []string{"rg1"},
+						"subscriptions":   []string{"88888888-8888-8888-8888-888888888888"},
+						"tags": cfgMap{
+							"discover_teleport": "yes",
+						},
+						"install": cfgMap{
+							"join_params": cfgMap{
+								"token_name": "custom-azure-token",
+								"method":     "azure",
+							},
+							"script_name":       "custom-installer",
+							"public_proxy_addr": "teleport.example.com",
+						},
+					},
+				}
+			},
+			expectedDiscoverySection: Discovery{
+				AzureMatchers: []AzureMatcher{
+					{
+						Types:          []string{"vm"},
+						Regions:        []string{"westcentralus"},
+						ResourceGroups: []string{"rg1"},
+						Subscriptions:  []string{"88888888-8888-8888-8888-888888888888"},
+						ResourceTags: map[string]apiutils.Strings{
+							"discover_teleport": []string{"yes"},
+						},
+						InstallParams: &InstallParams{
+							JoinParams: JoinParams{
+								TokenName: "custom-azure-token",
+								Method:    "azure",
+							},
+							ScriptName:      "custom-installer",
+							PublicProxyAddr: "teleport.example.com",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:          "Azure section is filled with invalid join method",
+			expectError:   require.Error,
+			expectEnabled: require.True,
+			mutate: func(cfg cfgMap) {
+				cfg["discovery_service"].(cfgMap)["enabled"] = "yes"
+				cfg["discovery_service"].(cfgMap)["azure"] = []cfgMap{
+					{"types": []string{"vm"},
+						"regions":         []string{"westcentralus"},
+						"resource_groups": []string{"rg1"},
+						"subscriptions":   []string{"88888888-8888-8888-8888-888888888888"},
+						"tags": cfgMap{
+							"discover_teleport": "yes",
+						},
+						"install": cfgMap{
+							"join_params": cfgMap{
+								"token_name": "custom-azure-token",
+								"method":     "token",
+							},
+						},
+					},
+				}
+			},
+			expectedDiscoverySection: Discovery{},
 		},
 	}
 	for _, testCase := range testCases {

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -858,3 +858,7 @@ const (
 	// when using the agentless installer
 	SSHDConfigPath = "/etc/ssh/sshd_config"
 )
+
+// AzureInviteTokenName is the name of the default token to use
+// when templating the script to be executed.
+const AzureInviteTokenName = "azure-discovery-token"

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -51,19 +51,22 @@ type AWSSSM struct {
 	DocumentName string
 }
 
-// InstallerParams are passed to the AWS SSM document
+// InstallerParams are passed to the AWS SSM document or installation script
 type InstallerParams struct {
 	// JoinMethod is the method to use when joining the cluster
 	JoinMethod types.JoinMethod
 	// JoinToken is the token to use when joining the cluster
 	JoinToken string
-	// ScriptName is the name of the teleport script for the EC2
+	// ScriptName is the name of the teleport script for the cloud
 	// instance to execute
 	ScriptName string
 	// InstallTeleport disables agentless discovery
 	InstallTeleport bool
 	// SSHDConfig provides the path to write sshd configuration changes
 	SSHDConfig string
+	// PublicProxyAddr is the address of the proxy the discovered node should use
+	// to connect to the cluster. Used only in Azure.
+	PublicProxyAddr string
 }
 
 // AWSMatcher matches AWS databases.
@@ -93,6 +96,8 @@ type AzureMatcher struct {
 	Regions []string
 	// ResourceTags are Azure tags to match.
 	ResourceTags types.Labels
+	// Params are passed to Azure when installing.
+	Params InstallerParams
 }
 
 // GCPMatcher matches GCP resources.
@@ -136,6 +141,7 @@ func SimplifyAzureMatchers(matchers []AzureMatcher) []AzureMatcher {
 			Regions:        regions,
 			Types:          ts,
 			ResourceTags:   m.ResourceTags,
+			Params:         m.Params,
 		})
 	}
 	return result

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -18,6 +18,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -39,6 +40,8 @@ import (
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers/db"
 	"github.com/gravitational/teleport/lib/srv/server"
 )
+
+var errNoInstances = errors.New("all fetched nodes already enrolled")
 
 // Config provides configuration for the discovery server.
 type Config struct {
@@ -99,6 +102,9 @@ type Server struct {
 	ec2Installer *server.SSMInstaller
 	// azureWatcher periodically retrieves Azure virtual machines.
 	azureWatcher *server.Watcher
+	// azureInstaller is used to start the installation process on discovered Azure
+	// virtual machines.
+	azureInstaller *server.AzureInstaller
 	// kubeFetchers holds all kubernetes fetchers for Azure and other clouds.
 	kubeFetchers []common.Fetcher
 	// databaseFetchers holds all database fetchers.
@@ -209,6 +215,10 @@ func (s *Server) initAzureWatchers(ctx context.Context, matchers []services.Azur
 		s.azureWatcher, err = server.NewAzureWatcher(s.ctx, vmMatchers, s.Clients)
 		if err != nil {
 			return trace.Wrap(err)
+		}
+		s.azureInstaller = &server.AzureInstaller{
+			Emitter:     s.Emitter,
+			AccessPoint: s.AccessPoint,
 		}
 	}
 
@@ -399,12 +409,65 @@ func (s *Server) handleEC2Discovery() {
 	}
 }
 
+func (s *Server) filterExistingAzureNodes(instances *server.AzureInstances) {
+	nodes := s.nodeWatcher.GetNodes(func(n services.Node) bool {
+		labels := n.GetAllLabels()
+		_, subscriptionOK := labels[types.SubscriptionIDLabel]
+		_, vmOK := labels[types.VMIDLabel]
+		return subscriptionOK && vmOK
+	})
+	var filtered []*armcompute.VirtualMachine
+outer:
+	for _, inst := range instances.Instances {
+		for _, node := range nodes {
+			var vmID string
+			if inst.Properties != nil {
+				vmID = aws.StringValue(inst.Properties.VMID)
+			}
+			match := types.MatchLabels(node, map[string]string{
+				types.SubscriptionIDLabel: instances.SubscriptionID,
+				types.VMIDLabel:           vmID,
+			})
+			if match {
+				continue outer
+			}
+		}
+		filtered = append(filtered, inst)
+	}
+	instances.Instances = filtered
+}
+
 func (s *Server) handleAzureInstances(instances *server.AzureInstances) error {
-	s.Log.Error("Automatic Azure node joining not implemented")
-	return nil
+	client, err := s.Clients.GetAzureRunCommandClient(instances.SubscriptionID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	s.filterExistingAzureNodes(instances)
+	if len(instances.Instances) == 0 {
+		return trace.Wrap(errNoInstances)
+	}
+
+	s.Log.Debugf("Running Teleport installation on these virtual machines: SubscriptionID: %s, VMs: %s",
+		instances.SubscriptionID, genAzureInstancesLogStr(instances.Instances),
+	)
+	req := server.AzureRunRequest{
+		Client:          client,
+		Instances:       instances.Instances,
+		Region:          instances.Region,
+		ResourceGroup:   instances.ResourceGroup,
+		Params:          instances.Parameters,
+		ScriptName:      instances.ScriptName,
+		PublicProxyAddr: instances.PublicProxyAddr,
+	}
+	return trace.Wrap(s.azureInstaller.Run(s.ctx, req))
 }
 
 func (s *Server) handleAzureDiscovery() {
+	if err := s.nodeWatcher.WaitInitialization(); err != nil {
+		s.Log.WithError(err).Error("Failed to initialize nodeWatcher.")
+		return
+	}
+
 	go s.azureWatcher.Run()
 	for {
 		select {
@@ -414,7 +477,7 @@ func (s *Server) handleAzureDiscovery() {
 				instances.SubscriptionID, genAzureInstancesLogStr(azureInstances.Instances),
 			)
 			if err := s.handleAzureInstances(azureInstances); err != nil {
-				if trace.IsNotFound(err) {
+				if errors.Is(err, errNoInstances) {
 					s.Log.Debug("All discovered Azure VMs are already part of the cluster.")
 				} else {
 					s.Log.WithError(err).Error("Failed to enroll discovered Azure VMs.")

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -28,7 +28,9 @@ import (
 	"time"
 
 	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v2"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -1131,4 +1133,236 @@ func mustNewDatabase(t *testing.T, meta types.Metadata, spec types.DatabaseSpecV
 	database, err := types.NewDatabaseV3(meta, spec)
 	require.NoError(t, err)
 	return database
+}
+
+type mockAzureRunCommandClient struct{}
+
+func (m *mockAzureRunCommandClient) Run(_ context.Context, _ azure.RunCommandRequest) error {
+	return nil
+}
+
+type mockAzureClient struct {
+	vms []*armcompute.VirtualMachine
+}
+
+func (m *mockAzureClient) Get(_ context.Context, _ string) (*azure.VirtualMachine, error) {
+	return nil, nil
+}
+
+func (m *mockAzureClient) GetByVMID(_ context.Context, _, _ string) (*azure.VirtualMachine, error) {
+	return nil, nil
+}
+
+func (m *mockAzureClient) ListVirtualMachines(_ context.Context, _ string) ([]*armcompute.VirtualMachine, error) {
+	return m.vms, nil
+}
+
+func TestAzureVMDiscovery(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		presentVMs    []types.Server
+		foundAzureVMs []*armcompute.VirtualMachine
+		logHandler    func(*testing.T, io.Reader, chan struct{})
+	}{
+		{
+			name:       "no nodes present, 1 found",
+			presentVMs: []types.Server{},
+			foundAzureVMs: []*armcompute.VirtualMachine{
+				{
+					ID: aws.String((&arm.ResourceID{
+						SubscriptionID:    "testsub",
+						ResourceGroupName: "rg",
+						Name:              "testvm",
+					}).String()),
+					Location: aws.String("westcentralus"),
+					Tags: map[string]*string{
+						"teleport": aws.String("yes"),
+					},
+					Properties: &armcompute.VirtualMachineProperties{
+						VMID: aws.String("test-vmid"),
+					},
+				},
+			},
+			logHandler: func(t *testing.T, logs io.Reader, done chan struct{}) {
+				scanner := bufio.NewScanner(logs)
+				for scanner.Scan() {
+					if strings.Contains(scanner.Text(),
+						"Running Teleport installation on these virtual machines") {
+						done <- struct{}{}
+						return
+					}
+				}
+			},
+		},
+		{
+			name: "nodes present, instance filtered",
+			presentVMs: []types.Server{
+				&types.ServerV2{
+					Kind: types.KindNode,
+					Metadata: types.Metadata{
+						Name: "name",
+						Labels: map[string]string{
+							types.SubscriptionIDLabel: "testsub",
+							types.VMIDLabel:           "test-vmid",
+						},
+						Namespace: defaults.Namespace,
+					},
+				},
+			},
+			foundAzureVMs: []*armcompute.VirtualMachine{
+				{
+					ID: aws.String((&arm.ResourceID{
+						SubscriptionID:    "testsub",
+						ResourceGroupName: "rg",
+						Name:              "testvm",
+					}).String()),
+					Location: aws.String("westcentralus"),
+					Tags: map[string]*string{
+						"teleport": aws.String("yes"),
+					},
+					Properties: &armcompute.VirtualMachineProperties{
+						VMID: aws.String("test-vmid"),
+					},
+				},
+			},
+			logHandler: func(t *testing.T, logs io.Reader, done chan struct{}) {
+				scanner := bufio.NewScanner(logs)
+				for scanner.Scan() {
+					if strings.Contains(scanner.Text(),
+						"All discovered Azure VMs are already part of the cluster") {
+						done <- struct{}{}
+						return
+					}
+				}
+			},
+		},
+		{
+			name: "nodes present, instance not filtered",
+			presentVMs: []types.Server{
+				&types.ServerV2{
+					Kind: types.KindNode,
+					Metadata: types.Metadata{
+						Name: "name",
+						Labels: map[string]string{
+							types.SubscriptionIDLabel: "testsub",
+							types.VMIDLabel:           "alternate-vmid",
+						},
+						Namespace: defaults.Namespace,
+					},
+				},
+			},
+			foundAzureVMs: []*armcompute.VirtualMachine{
+				{
+					ID: aws.String((&arm.ResourceID{
+						SubscriptionID:    "testsub",
+						ResourceGroupName: "rg",
+						Name:              "testvm",
+					}).String()),
+					Location: aws.String("westcentralus"),
+					Tags: map[string]*string{
+						"teleport": aws.String("yes"),
+					},
+					Properties: &armcompute.VirtualMachineProperties{
+						VMID: aws.String("test-vmid"),
+					},
+				},
+			},
+			logHandler: func(t *testing.T, logs io.Reader, done chan struct{}) {
+				scanner := bufio.NewScanner(logs)
+				for scanner.Scan() {
+					if strings.Contains(scanner.Text(),
+						"Running Teleport installation on these virtual machines") {
+						done <- struct{}{}
+						return
+					}
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			testClients := cloud.TestCloudClients{
+				AzureVirtualMachines: &mockAzureClient{
+					vms: tc.foundAzureVMs,
+				},
+				AzureRunCommand: &mockAzureRunCommandClient{},
+			}
+
+			ctx := context.Background()
+			testAuthServer, err := auth.NewTestAuthServer(auth.TestAuthServerConfig{
+				Dir: t.TempDir(),
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
+
+			tlsServer, err := testAuthServer.NewTestTLSServer()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+			// Auth client for discovery service.
+			authClient, err := tlsServer.NewClient(auth.TestServerID(types.RoleDiscovery, "hostID"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, authClient.Close()) })
+
+			for _, instance := range tc.presentVMs {
+				_, err := tlsServer.Auth().UpsertNode(ctx, instance)
+				require.NoError(t, err)
+			}
+
+			logger := logrus.New()
+			emitter := &mockEmitter{}
+			server, err := New(context.Background(), &Config{
+				Clients:     &testClients,
+				AccessPoint: tlsServer.Auth(),
+				AzureMatchers: []services.AzureMatcher{{
+					Types:          []string{"vm"},
+					Subscriptions:  []string{"testsub"},
+					ResourceGroups: []string{"testrg"},
+					Regions:        []string{"westcentralus"},
+					ResourceTags:   types.Labels{"teleport": {"yes"}},
+				}},
+				Emitter: emitter,
+				Log:     logger,
+			})
+
+			require.NoError(t, err)
+			emitter.server = server
+			emitter.t = t
+
+			r, w := io.Pipe()
+			t.Cleanup(func() {
+				require.NoError(t, r.Close())
+				require.NoError(t, w.Close())
+			})
+			if tc.logHandler != nil {
+				logger.SetOutput(w)
+				logger.SetLevel(logrus.DebugLevel)
+			}
+
+			go server.Start()
+
+			if tc.logHandler != nil {
+				done := make(chan struct{})
+				go tc.logHandler(t, r, done)
+				timeoutCtx, cancelfn := context.WithTimeout(ctx, time.Second*5)
+				defer cancelfn()
+				select {
+				case <-timeoutCtx.Done():
+					t.Fatal("Timeout waiting for log entries")
+					return
+				case <-done:
+					server.Stop()
+					return
+				}
+			}
+
+			server.Wait()
+		})
+
+	}
 }

--- a/lib/srv/server/azure_installer.go
+++ b/lib/srv/server/azure_installer.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/cloud/azure"
+)
+
+// AzureInstaller handles running commands that install Teleport on Azure
+// virtual machines.
+type AzureInstaller struct {
+	Emitter     apievents.Emitter
+	AccessPoint auth.DiscoveryAccessPoint
+}
+
+// AzureRunRequest combines parameters for running commands on a set of Azure
+// virtual machines.
+type AzureRunRequest struct {
+	Client          azure.RunCommandClient
+	Instances       []*armcompute.VirtualMachine
+	Params          []string
+	Region          string
+	ResourceGroup   string
+	ScriptName      string
+	PublicProxyAddr string
+}
+
+// Run runs a command on a set of virtual machines and then blocks until the
+// commands have completed.
+func (ai *AzureInstaller) Run(ctx context.Context, req AzureRunRequest) error {
+	g, ctx := errgroup.WithContext(ctx)
+	// Somewhat arbitrary limit to make sure Teleport doesn't have to install
+	// hundreds of nodes at once.
+	g.SetLimit(10)
+
+	for _, inst := range req.Instances {
+		inst := inst
+		g.Go(func() error {
+			runRequest := azure.RunCommandRequest{
+				Region:        req.Region,
+				ResourceGroup: req.ResourceGroup,
+				VMName:        aws.StringValue(inst.Name),
+				Parameters:    req.Params,
+				Script:        getInstallerScript(req.ScriptName, req.PublicProxyAddr),
+			}
+			return trace.Wrap(req.Client.Run(ctx, runRequest))
+		})
+	}
+	return trace.Wrap(g.Wait())
+}
+
+func getInstallerScript(installerName, publicProxyAddr string) string {
+	return fmt.Sprintf("curl -s -L https://%s/v1/webapi/scripts/installer/%v | bash -s $@", publicProxyAddr, installerName)
+}

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -38,6 +38,14 @@ type AzureInstances struct {
 	SubscriptionID string
 	// ResourceGroup is the resource group for the instances.
 	ResourceGroup string
+	// ScriptName is the name of the script to execute on the instances to
+	// install Teleport.
+	ScriptName string
+	// PublicProxyAddr is the address of the proxy the discovered node should use
+	// to connect to the cluster.
+	PublicProxyAddr string
+	// Parameters are the parameters passed to the installation script.
+	Parameters []string
 	// Instances is a list of discovered Azure virtual machines.
 	Instances []*armcompute.VirtualMachine
 }
@@ -85,6 +93,7 @@ type azureInstanceFetcher struct {
 	Subscription  string
 	ResourceGroup string
 	Labels        types.Labels
+	Parameters    map[string]string
 }
 
 func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
@@ -94,6 +103,11 @@ func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
 		Subscription:  cfg.Subscription,
 		ResourceGroup: cfg.ResourceGroup,
 		Labels:        cfg.Matcher.ResourceTags,
+		Parameters: map[string]string{
+			"token":           cfg.Matcher.Params.JoinToken,
+			"scriptName":      cfg.Matcher.Params.ScriptName,
+			"publicProxyAddr": cfg.Matcher.Params.PublicProxyAddr,
+		},
 	}
 }
 
@@ -128,10 +142,13 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context) ([]Instances, e
 	for region, vms := range instancesByRegion {
 		if len(vms) > 0 {
 			instances = append(instances, Instances{AzureInstances: &AzureInstances{
-				SubscriptionID: f.Subscription,
-				Region:         region,
-				ResourceGroup:  f.ResourceGroup,
-				Instances:      vms,
+				SubscriptionID:  f.Subscription,
+				Region:          region,
+				ResourceGroup:   f.ResourceGroup,
+				Instances:       vms,
+				ScriptName:      f.Parameters["scriptName"],
+				PublicProxyAddr: f.Parameters["publicProxyAddr"],
+				Parameters:      []string{f.Parameters["token"]},
 			}})
 		}
 	}


### PR DESCRIPTION
This PR adds the ability for Azure virtual machines to automatically join a Teleport cluster (automatic discovery without joining was added in #17850). Implements [RFD 104](https://github.com/gravitational/teleport/blob/master/rfd/0104-automatic-azure-server-discovery.md).