### PR TITLE
docs: remove references to old Teleport versions

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -127,17 +127,6 @@ Teleport provides several pre-defined roles out-of-the-box:
 | `auditor`| Allows reading cluster events, audit logs, and playing back session records. |
 | `access`| Allows access to cluster resources. |
 
-<Details title="Version Warning: Before 8.0" opened={false}>
-Teleport versions prior to 8.0 also included a default `admin` role. This role
-has been deprecated in favor of smaller, more fine-grained roles like the
-presets mentioned above.
-
-Users installing a brand new Teleport cluster on version 8.0 or later will not
-see this `admin` role. Users who upgrade to Teleport 8 from an earlier version
-*will* continue to see the admin role, but are encouraged to migrate to roles
-that are more appropriately scoped.
-</Details>
-
 ### Role versions
 
 There are currently three supported role versions: `v3`, `v4` and `v5`. `v4` and `v5` roles are

--- a/docs/pages/desktop-access/reference/sessions.mdx
+++ b/docs/pages/desktop-access/reference/sessions.mdx
@@ -65,12 +65,6 @@ SSH recordings.
 
 ![Desktop Session Recording](../../../img/desktop-access/session-recording@2x.png)
 
-<Admonition type="note" title="RBAC for sessions">
-Since Teleport 8.1, sessions can be protected via RBAC. In order for a user to
-see desktop sessions in this list, their roles must permit access to the
-sessions resource.
-</Admonition>
-
 Click the play button to open the player in a new tab. The desktop session
 player supports toggling between play and pause, but does not support seeking to
 a specific point in the stream, rewinding, or restarting playback when the end

--- a/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
@@ -15,9 +15,8 @@ can use the [IAM join method](./joining-nodes-aws-iam.mdx) or
 
 </ScopedBlock>
 
-The EC2 join method is available in self-hosted versions of Teleport 7.3+. It is
-available to any Teleport Node or Proxy running on an EC2 instance. Only one
-Teleport Node or Proxy per EC2 instance may use the EC2 join method.
+The EC2 join method available to any Teleport service running on an EC2 instance.
+Only one Teleport service per EC2 instance may use the EC2 join method.
 
 IAM credentials with `ec2:DescribeInstances` permissions are required on
 your Teleport Auth Service. No IAM credentials are required on the Nodes or
@@ -32,8 +31,8 @@ scopeOnly
 
 There are two other AWS join methods available depending on your use case.
 
-The **IAM join method** is available in self-hosted editions of Teleport 8.3+.
-It is available to any Teleport Node or Proxy running anywhere with access to
+The **IAM join method** is available in self-hosted editions of Teleport.
+It is available to any Teleport service running anywhere with access to
 IAM credentials, such as an EC2 instance with an attached IAM role. No specific
 permissions or IAM policy is required: an IAM role with no attached policies is
 sufficient. No IAM credentials are required on the Teleport Auth Service.

--- a/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
@@ -15,7 +15,7 @@ can use the [IAM join method](./joining-nodes-aws-iam.mdx) or
 
 </ScopedBlock>
 
-The EC2 join method available to any Teleport service running on an EC2 instance.
+The EC2 join method is available to any Teleport service running on an EC2 instance.
 Only one Teleport service per EC2 instance may use the EC2 join method.
 
 IAM credentials with `ec2:DescribeInstances` permissions are required on

--- a/docs/pages/management/guides/joining-nodes-aws-iam.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-iam.mdx
@@ -7,11 +7,10 @@ This guide will explain how to use the **IAM join method** to configure Teleport
 Nodes and Proxy Service instances to join your Teleport cluster without sharing
 any secrets when they are running in AWS.
 
-The IAM join method is available in Teleport 8.3+. It is available to any
-Teleport Node or Proxy running anywhere with access to IAM credentials, such as
-an EC2 instance with an attached IAM role. No specific permissions or IAM policy
-is required: an IAM role with no attached policies is sufficient. No IAM
-credentials are required on the Teleport Auth Service.
+The IAM join method is available to any Teleport service running anywhere with
+access to IAM credentials, such as an EC2 instance with an attached IAM role.
+No specific permissions or IAM policy is required: an IAM role with no attached
+policies is sufficient. No IAM credentials are required on the Teleport Auth Service.
 
 <Details
 scope={["oss", "enterprise"]}
@@ -23,10 +22,9 @@ title="Other AWS Node joining methods"
 There are two additional methods you can use to join your Nodes to a Teleport
 cluster.
 
-The **EC2 join method** is available in self-hosted versions of Teleport 8.3+.
-It is available to any Teleport Node or Proxy Service instance running on an EC2
-instance. Only one Teleport Node or Proxy Service instance per EC2 instance may
-use the EC2 join method.
+The **EC2 join method** is available in self-hosted versions of Teleport.
+It is available to any Teleport service instance running on an EC2 instance.
+Only one Teleport service instance per EC2 instance may use the EC2 join method.
 
 IAM credentials with `ec2:DescribeInstances` permissions are required on
 your Teleport Auth Service. No IAM credentials are required on the Nodes or

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -631,9 +631,9 @@ It is recommended to set resource requests/limits for each container based on th
 | `string` | `nil` | ✅ |
 
 Normally the version of Teleport being used will match the version of the chart being installed. If you install chart version
-7.0.0, you'll be using Teleport 7.0.0. Upgrading the Helm chart will use the latest version from the repo.
+10.0.0, you'll be using Teleport 10.0.0. Upgrading the Helm chart will use the latest version from the repo.
 
-You can optionally override this to use a different published Teleport Docker image tag like `6.0.2` or `7`.
+You can optionally override this to use a different published Teleport Docker image tag like `10.1.2` or `11`.
 
 See our [installation guide](../../installation.mdx#docker) for information on
 Docker image versions.
@@ -641,12 +641,12 @@ Docker image versions.
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  teleportVersionOverride: "7"
+  teleportVersionOverride: "11"
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set teleportVersionOverride="7"
+  $ --set teleportVersionOverride="11"
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -688,9 +688,9 @@ You can specify multiple selectors by adding elements to the list.
 | `string` | `nil`         |
 
 Normally the version of Teleport being used will match the version of the chart being installed. If you install chart version
-7.0.0, you'll be using Teleport 7.0.0.
+10.0.0, you'll be using Teleport 10.0.0.
 
-You can optionally override this to use a different published Teleport Docker image tag like `6.0.2` or `7`.
+You can optionally override this to use a different published Teleport Docker image tag like `10.2.2` or `11`.
 
 See [this link for information on Community Docker image versions](../../management/guides/docker.mdx#step-14-pick-your-image).
 
@@ -702,12 +702,12 @@ See [this link for information on Community Docker image versions](../../managem
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
-  teleportVersionOverride: "7"
+  teleportVersionOverride: "11"
   ```
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set teleportVersionOverride="7"
+  $ --set teleportVersionOverride="11"
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/server-access/guides/jetbrains-sftp.mdx
+++ b/docs/pages/server-access/guides/jetbrains-sftp.mdx
@@ -116,7 +116,7 @@ After closing the SSH configuration window, you should see `Remote Host` menu in
 
 ### Using OpenSSH clients
 
-This guide makes use of `tsh config`, added in Teleport 7.0; refer to the
+This guide makes use of `tsh config`; refer to the
 [dedicated guide](./openssh.mdx) for additional information.
 
 ## Further reading

--- a/docs/pages/server-access/guides/vscode.mdx
+++ b/docs/pages/server-access/guides/vscode.mdx
@@ -156,7 +156,7 @@ connect to the host in VS Code.
 
 ### Using OpenSSH clients
 
-This guide makes use of `tsh config`, added in Teleport 7.0; refer to the
+This guide makes use of `tsh config`; refer to the
 [dedicated guide](./openssh.mdx) for additional information.
 
 ## Further reading


### PR DESCRIPTION
With the release of Teleport 12, the oldest supported version of Teleport will be Teleport 10. This commit removes some references to Teleport 7 and Teleport 8. The docs for those versions are no longer available on goteleport.com, so it's safe to assume that readers are on a more recent version.