### PR TITLE
Improve 'tsh scp' error message when no remote path is specified

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1596,7 +1596,6 @@ func (tc *TeleportClient) runShellOrCommandOnMultipleNodes(ctx context.Context, 
 	}
 	defer nodeClient.Close()
 	return tc.runShell(ctx, nodeClient, types.SessionPeerMode, nil, nil)
-
 }
 
 func (tc *TeleportClient) startPortForwarding(ctx context.Context, nodeClient *NodeClient) error {
@@ -1893,14 +1892,14 @@ func (tc *TeleportClient) SFTP(ctx context.Context, args []string, port int, opt
 	defer span.End()
 
 	if len(args) < 2 {
-		return trace.Errorf("need at least two arguments for scp")
+		return trace.Errorf("local and remote destinations are required")
 	}
 	first := args[0]
 	last := args[len(args)-1]
 
 	// local copy?
 	if !isRemoteDest(first) && !isRemoteDest(last) {
-		return trace.BadParameter("making local copies is not supported")
+		return trace.BadParameter("no remote destination specified")
 	}
 
 	var config *sftpConfig

--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -15,8 +15,6 @@ limitations under the License.
 */
 
 // Package sftp handles file transfers client-side via SFTP
-// path.Join is intentionally used over filepath.Join because SFTP
-// requires Linux-style path separators
 package sftp
 
 import (
@@ -27,7 +25,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
+	"path" // SFTP requires Linux-style path separators
 	"runtime"
 	"strings"
 	"time"

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -776,7 +776,7 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	// scp
 	scp := app.Command("scp", "Transfer files to a remote Node")
 	scp.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
-	scp.Arg("from, to", "Source and destination to copy").Required().StringsVar(&cf.CopySpec)
+	scp.Arg("from, to", "Source and destination to copy, one must be a local path and one must be a remote path").Required().StringsVar(&cf.CopySpec)
 	scp.Flag("recursive", "Recursive copy of subdirectories").Short('r').BoolVar(&cf.RecursiveCopy)
 	scp.Flag("port", "Port to connect to on the remote host").Short('P').Int32Var(&cf.NodePort)
 	scp.Flag("preserve", "Preserves access and modification times from the original file").Short('p').BoolVar(&cf.PreserveAttrs)
@@ -4317,7 +4317,6 @@ func withWarnOnDeprecatedSNI(printed *bool) updateKubeConfigOnLoginOpt {
 	return func(opt *updateKubeConfigOpt) {
 		opt.warnOnDeprecatedSNI = true
 		opt.warnSNIPrinted = printed
-
 	}
 }
 


### PR DESCRIPTION
While here, move package comment in SFTP client code to the specific
import it mentions.

Fixes #21052