### PR TITLE
Add `tsh request search --kind=pod` support

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2820,10 +2820,15 @@ func GetResourcesWithFilters(ctx context.Context, clt ListResourcesClient, req p
 func GetKubernetesResourcesWithFilters(ctx context.Context, clt kubeproto.KubeServiceClient, req kubeproto.ListKubernetesResourcesRequest) ([]types.ResourceWithLabels, error) {
 	var (
 		resources []types.ResourceWithLabels
-		startKey  string
+		startKey  = req.StartKey
 		// Retrieve the complete list of resources in chunks.
-		chunkSize = int32(defaults.DefaultChunkSize)
+		chunkSize = req.Limit
 	)
+
+	// Set the chunk size to the default if it is not set.
+	if chunkSize == 0 {
+		chunkSize = int32(defaults.DefaultChunkSize)
+	}
 
 	for {
 		// Reset startKey to the previous page's nextKey.

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/observability/tracing"
@@ -2805,6 +2806,56 @@ func GetResourcesWithFilters(ctx context.Context, clt ListResourcesClient, req p
 
 		startKey = resp.NextKey
 		resources = append(resources, resp.Resources...)
+		if startKey == "" || len(resp.Resources) == 0 {
+			break
+		}
+
+	}
+
+	return resources, nil
+}
+
+// GetKubernetesResourcesWithFilters is a helper for getting a list of kubernetes resources with optional filtering. In addition to
+// iterating pages, it also correctly handles downsizing pages when LimitExceeded errors are encountered.
+func GetKubernetesResourcesWithFilters(ctx context.Context, clt kubeproto.KubeServiceClient, req kubeproto.ListKubernetesResourcesRequest) ([]types.ResourceWithLabels, error) {
+	// Retrieve the complete list of resources in chunks.
+	var (
+		resources []types.ResourceWithLabels
+		startKey  string
+		chunkSize = int32(defaults.DefaultChunkSize)
+	)
+
+	for {
+		resp, err := clt.ListKubernetesResources(ctx, &kubeproto.ListKubernetesResourcesRequest{
+			ResourceType:        req.ResourceType,
+			StartKey:            startKey,
+			Limit:               chunkSize,
+			Labels:              req.Labels,
+			SearchKeywords:      req.SearchKeywords,
+			PredicateExpression: req.PredicateExpression,
+			UseSearchAsRoles:    req.UseSearchAsRoles,
+			KubernetesCluster:   req.KubernetesCluster,
+			KubernetesNamespace: req.KubernetesNamespace,
+			TeleportCluster:     req.TeleportCluster,
+		})
+		if err != nil {
+			if trace.IsLimitExceeded(err) {
+				// Cut chunkSize in half if gRPC max message size is exceeded.
+				chunkSize = chunkSize / 2
+				// This is an extremely unlikely scenario, but better to cover it anyways.
+				if chunkSize == 0 {
+					return nil, trace.Wrap(trail.FromGRPC(err), "resource is too large to retrieve")
+				}
+
+				continue
+			}
+
+			return nil, trail.FromGRPC(err)
+		}
+
+		startKey = resp.NextKey
+
+		resources = append(resources, types.KubeResources(resp.Resources).AsResources()...)
 		if startKey == "" || len(resp.Resources) == 0 {
 			break
 		}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -4303,11 +4303,11 @@ func parseMFAMode(in string) (wancli.AuthenticatorAttachment, error) {
 	}
 }
 
-// NewKubeClient connects to the proxy server and returns an authenticated gRPC
-// client.
-func (tc *TeleportClient) NewKubeClient(ctx context.Context, clusterName string) (kubeproto.KubeServiceClient, error) {
+// NewKubernetesServiceClient connects to the proxy and returns an authenticated gRPC
+// client to the Kubernetes service.
+func (tc *TeleportClient) NewKubernetesServiceClient(ctx context.Context, clusterName string) (kubeproto.KubeServiceClient, error) {
 	if !tc.TLSRoutingEnabled {
-		return nil, trace.BadParameter("kube client is not supported if TLS routing is not enabled")
+		return nil, trace.BadParameter("kube service is not supported if TLS routing is not enabled")
 	}
 	// get tlsConfig to dial to proxy.
 	tlsConfig, err := tc.LoadTLSConfig()

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -41,14 +41,17 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/net/http2"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/profile"
@@ -4298,4 +4301,31 @@ func parseMFAMode(in string) (wancli.AuthenticatorAttachment, error) {
 	default:
 		return 0, trace.BadParameter("unsupported mfa mode %q", in)
 	}
+}
+
+// NewKubeClient connects to the proxy server and returns an authenticated gRPC
+// client.
+func (tc *TeleportClient) NewKubeClient(ctx context.Context, clusterName string) (kubeproto.KubeServiceClient, error) {
+	if !tc.TLSRoutingEnabled {
+		return nil, trace.BadParameter("kube client is not supported if TLS routing is not enabled")
+	}
+	// get tlsConfig to dial to proxy.
+	tlsConfig, err := tc.LoadTLSConfig()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Set the ALPN protocols to use when dialing the proxy gRPC mTLS endpoint.
+	tlsConfig.NextProtos = []string{string(alpncommon.ProtocolProxyGRPCSecure), http2.NextProtoTLS}
+
+	clt, err := client.New(ctx, client.Config{
+		Addrs:            []string{tc.Config.WebProxyAddr},
+		DialInBackground: false,
+		Credentials: []client.Credentials{
+			client.LoadTLS(tlsConfig),
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return kubeproto.NewKubeServiceClient(clt.GetConnection()), nil
 }

--- a/lib/srv/alpnproxy/listener.go
+++ b/lib/srv/alpnproxy/listener.go
@@ -41,6 +41,7 @@ type ListenerMuxWrapper struct {
 	connC        chan net.Conn
 	errC         chan error
 	close        chan struct{}
+	once         sync.Once
 }
 
 // NewMuxListenerWrapper creates a new instance of ListenerMuxWrapper
@@ -124,11 +125,9 @@ func (l *ListenerMuxWrapper) Close() error {
 		}
 	}
 	// Close channel only once.
-	select {
-	case <-l.close:
-	default:
+	l.once.Do(func() {
 		close(l.close)
-	}
+	})
 	return trace.NewAggregate(errs...)
 }
 

--- a/tool/tsh/access_request_test.go
+++ b/tool/tsh/access_request_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestAccessRequestSearch(t *testing.T) {
+	modules.SetTestModules(t, &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			Kubernetes: true,
+		},
+	},
+	)
+	lib.SetInsecureDevMode(true)
+	t.Cleanup(func() { lib.SetInsecureDevMode(false) })
+	ctx := context.Background()
+	const (
+		rootClusterName = "root-cluster"
+		rootKubeCluster = "first-cluster"
+		leafClusterName = "leaf-cluster"
+		leafKubeCluster = "second-cluster"
+	)
+	s := newTestSuite(t,
+		withRootConfigFunc(func(cfg *service.Config) {
+			cfg.Auth.ClusterName.SetClusterName(rootClusterName)
+			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+			cfg.Kube.Enabled = true
+			cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
+			cfg.Kube.KubeconfigPath = newKubeConfigFile(t, rootKubeCluster)
+		}),
+		withLeafCluster(),
+		withLeafConfigFunc(
+			func(cfg *service.Config) {
+				cfg.Auth.ClusterName.SetClusterName(leafClusterName)
+				cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+				cfg.Kube.Enabled = true
+				cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
+				cfg.Kube.KubeconfigPath = newKubeConfigFile(t, leafKubeCluster)
+			},
+		),
+		withValidationFunc(func(s *suite) bool {
+			rootClusters, err := s.root.GetAuthServer().GetKubernetesServers(ctx)
+			require.NoError(t, err)
+			leafClusters, err := s.leaf.GetAuthServer().GetKubernetesServers(ctx)
+			require.NoError(t, err)
+			return len(rootClusters) >= 1 && len(leafClusters) >= 1
+		}),
+	)
+
+	type args struct {
+		teleportCluster string
+		kind            string
+		extraArgs       []string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantTable func() string
+	}{
+		{
+			name: "list pods in root cluster for default namespace",
+			args: args{
+				teleportCluster: rootClusterName,
+				extraArgs:       []string{fmt.Sprintf("--kube-cluster=%v", rootKubeCluster)},
+				kind:            types.KindKubePod,
+			},
+			wantTable: func() string {
+				table := asciitable.MakeTableWithTruncatedColumn(
+					[]string{"Name", "Namespace", "Labels", "Resource ID"},
+					[][]string{
+						{"nginx-1", "default", "", fmt.Sprintf("/%s/pod/%s/default/nginx-1", rootClusterName, rootKubeCluster)},
+						{"nginx-2", "default", "", fmt.Sprintf("/%s/pod/%s/default/nginx-2", rootClusterName, rootKubeCluster)},
+						{"test", "default", "", fmt.Sprintf("/%s/pod/%s/default/test", rootClusterName, rootKubeCluster)},
+					},
+					"Labels")
+				return table.AsBuffer().String()
+			},
+		},
+		{
+			name: "list pods in root cluster for dev namespace with search",
+			args: args{
+				teleportCluster: rootClusterName,
+				extraArgs:       []string{fmt.Sprintf("--kube-cluster=%v", rootKubeCluster), "--kube-namespace=dev", "--search=nginx-1"},
+				kind:            types.KindKubePod,
+			},
+			wantTable: func() string {
+				table := asciitable.MakeTableWithTruncatedColumn(
+					[]string{"Name", "Namespace", "Labels", "Resource ID"},
+					[][]string{
+						{"nginx-1", "dev", "", fmt.Sprintf("/%s/pod/%s/dev/nginx-1", rootClusterName, rootKubeCluster)},
+					},
+					"Labels")
+				return table.AsBuffer().String()
+			},
+		},
+		{
+			name: "list pods in leaf cluster for default namespace",
+			args: args{
+				teleportCluster: leafClusterName,
+				extraArgs:       []string{fmt.Sprintf("--kube-cluster=%v", leafKubeCluster)},
+				kind:            types.KindKubePod,
+			},
+			wantTable: func() string {
+				table := asciitable.MakeTableWithTruncatedColumn(
+					[]string{"Name", "Namespace", "Labels", "Resource ID"},
+					[][]string{
+						{"nginx-1", "default", "", fmt.Sprintf("/%s/pod/%s/default/nginx-1", leafClusterName, leafKubeCluster)},
+						{"nginx-2", "default", "", fmt.Sprintf("/%s/pod/%s/default/nginx-2", leafClusterName, leafKubeCluster)},
+						{"test", "default", "", fmt.Sprintf("/%s/pod/%s/default/test", leafClusterName, leafKubeCluster)},
+					},
+					"Labels")
+				return table.AsBuffer().String()
+			},
+		},
+		{
+			name: "list pods in leaf cluster for all namespaces",
+			args: args{
+				teleportCluster: leafClusterName,
+				extraArgs:       []string{fmt.Sprintf("--kube-cluster=%v", leafKubeCluster), "--all-kube-namespaces", "--search=nginx-1"},
+				kind:            types.KindKubePod,
+			},
+			wantTable: func() string {
+				table := asciitable.MakeTableWithTruncatedColumn(
+					[]string{"Name", "Namespace", "Labels", "Resource ID"},
+					[][]string{
+						{"nginx-1", "default", "", fmt.Sprintf("/%s/pod/%s/default/nginx-1", leafClusterName, leafKubeCluster)},
+						{"nginx-1", "dev", "", fmt.Sprintf("/%s/pod/%s/dev/nginx-1", leafClusterName, leafKubeCluster)},
+					},
+					"Labels")
+				return table.AsBuffer().String()
+			},
+		},
+		{
+			name: "list kube clusters in leaf cluster",
+			args: args{
+				teleportCluster: leafClusterName,
+				kind:            types.KindKubernetesCluster,
+			},
+			wantTable: func() string {
+				table := asciitable.MakeTableWithTruncatedColumn(
+					[]string{"Name", "Hostname", "Labels", "Resource ID"},
+					[][]string{
+						{leafKubeCluster, "", "", fmt.Sprintf("/%s/kube_cluster/%s", leafClusterName, leafKubeCluster)},
+					},
+					"Labels")
+				return table.AsBuffer().String()
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mustLoginSetEnv(t, s, tc.args.teleportCluster)
+			captureStdout := new(bytes.Buffer)
+			err := Run(
+				context.Background(),
+				append([]string{
+					"--insecure",
+					"request",
+					"search",
+					fmt.Sprintf("--kind=%s", tc.args.kind),
+				},
+					tc.args.extraArgs...,
+				),
+				func(cf *CLIConf) error {
+					cf.overrideStdout = io.MultiWriter(os.Stdout, captureStdout)
+					return nil
+				},
+			)
+			require.NoError(t, err)
+			require.Contains(t, captureStdout.String(), tc.wantTable())
+		})
+	}
+}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -4343,7 +4343,7 @@ func updateKubeConfigOnLogin(cf *CLIConf, tc *client.TeleportClient, opts ...upd
 		if !settings.warnOnDeprecatedSNI {
 			return
 		}
-		if settings.warnSNIPrinted == nil || *settings.warnSNIPrinted == true {
+		if settings.warnSNIPrinted == nil || *settings.warnSNIPrinted {
 			return
 		}
 		warnOnDeprecatedKubeConfigServerName(cf, tc)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -47,6 +47,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
@@ -409,6 +410,9 @@ type CLIConf struct {
 	kubernetesImpersonationConfig impersonationConfig
 	// kubeNamespace allows to configure the default Kubernetes namespace.
 	kubeNamespace string
+
+	// kubeAllNamespaces allows users to search for pods in every namespace.
+	kubeAllNamespaces bool
 
 	// kubeConfigPath is the location of the Kubeconfig for the current test.
 	// Setting this value allows Teleport tests to run `tsh login` commands in
@@ -890,6 +894,9 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	reqSearch.Flag("search", searchHelp).StringVar(&cf.SearchKeywords)
 	reqSearch.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
 	reqSearch.Flag("labels", labelHelp).StringVar(&cf.UserHost)
+	reqSearch.Flag("kube-cluster", "Kubernetes Cluster to search for Pods").StringVar(&cf.KubernetesCluster)
+	reqSearch.Flag("kube-namespace", "Kubernetes Namespace to search for Pods").Default(corev1.NamespaceDefault).StringVar(&cf.kubeNamespace)
+	reqSearch.Flag("all-kube-namespaces", "Search Pods in every namespace").BoolVar(&cf.kubeAllNamespaces)
 
 	reqDrop := req.Command("drop", "Drop one more access requests from current identity")
 	reqDrop.Arg("request-id", "IDs of requests to drop (default drops all requests)").Default("*").StringsVar(&cf.RequestIDs)

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -2562,17 +2562,19 @@ func mockConnector(t *testing.T) types.OIDCConnector {
 func mockSSOLogin(t *testing.T, authServer *auth.Server, user types.User) client.SSOLoginFunc {
 	return func(ctx context.Context, connectorID string, priv *keys.PrivateKey, protocol string) (*auth.SSHLoginResponse, error) {
 		// generate certificates for our user
+		clusterName, err := authServer.GetClusterName()
+		require.NoError(t, err)
 		sshCert, tlsCert, err := authServer.GenerateUserTestCerts(
 			priv.MarshalSSHPublicKey(), user.GetName(), time.Hour,
 			constants.CertificateFormatStandard,
-			"localhost", "",
+			clusterName.GetClusterName(), "",
 		)
 		require.NoError(t, err)
 
 		// load CA cert
 		authority, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,
-			DomainName: "localhost",
+			DomainName: clusterName.GetClusterName(),
 		}, false)
 		require.NoError(t, err)
 


### PR DESCRIPTION
This PR adds support for searching resources with `kind=pod`.

Adds `tsh request search --kind pod [--kube-cluster=<kube_cluster>]
  [--kube-namespace=<namespace> | --all-kube-namespaces]`

```
Name                              Namespace Labels                                 Resource ID
--------------------------------- --------- -------------------------------------- --------------------------------------------
nginx-deployment-6595874d85-6j2zm default   app=nginx,pod-template-hash=6595874d85 /tele.teleport.local/pod/minikube/default...
nginx-deployment-6595874d85-7xgmb default   app=nginx,pod-template-hash=6595874d85 /tele.teleport.local/pod/minikube/default...
nginx-deployment-6595874d85-c4kz8 default   app=nginx,pod-template-hash=6595874d85 /tele.teleport.local/pod/minikube/default...
test                              default   run=test                               /tele.teleport.local/pod/minikube/default...

To request access to these resources, run
> tsh request create --resource /tele.teleport.local/pod/minikube/default/nginx-deployment-6595874d85-6j2zm --resource /tele.teleport.local/pod/minikube/default/nginx-deployment-6595874d85-7xgmb --resource /tele.teleport.local/pod/minikube/default/nginx-deployment-6595874d85-c4kz8 --resource /tele.teleport.local/pod/minikube/default/test \
    --reason <request reason>

```

Part of #18434
Part of #20324
Updates #19573