### PR TITLE
tsh/tctl: Improve error message when using --identity without a proxy or auth server

### DIFF
--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -614,10 +614,14 @@ func KeyFromIdentityFile(identityPath, proxyHost, clusterName string) (*client.K
 // is also added to its profile store with the limited profile data available
 // in the identity file.
 //
-// Since identity files do not save a proxy address, proxyAddr must be provided
-// to fill in this data gap. clusterName can also be provided to aim the key at
-// a leaf cluster rather than the default root cluster.
+// Use [proxyAddr] to specify the host:port-like address of the proxy.
+// This is necessary because identity files do not store the proxy address.
+// Additionally, the [clusterName] argument can ve used to target a leaf cluster
+// rather than the default root cluster.
 func NewClientStoreFromIdentityFile(identityFile, proxyAddr, clusterName string) (*client.Store, error) {
+	if proxyAddr == "" {
+		return nil, trace.BadParameter("missing a Proxy address when loading an Identity File.")
+	}
 	proxyHost, err := utils.Host(proxyAddr)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -169,6 +169,13 @@ func TryRun(commands []CLICommand, args []string) error {
 		return trace.Wrap(err)
 	}
 
+	// Identity files do not currently contain a proxy address. When loading an
+	// Identity file, an auth server address must be passed on the command line
+	// as well.
+	if ccf.IdentityFilePath != "" && len(ccf.AuthServerAddr) == 0 {
+		return trace.BadParameter("tctl --identity also requires --auth-server")
+	}
+
 	// "version" command?
 	if selectedCmd == ver.FullCommand() {
 		utils.PrintVersion()

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -962,6 +962,12 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 		}
 	}
 
+	// Identity files do not currently contain a proxy address. When loading an
+	// Identity file, a proxy must be passed on the command line as well.
+	if cf.IdentityFileIn != "" && cf.Proxy == "" {
+		return trace.BadParameter("tsh --identity also requires --proxy")
+	}
+
 	// prevent Kingpin from calling os.Exit(), we want to handle errors ourselves.
 	// shouldTerminate will be checked after app.Parse() call.
 	var shouldTerminate *int


### PR DESCRIPTION
Fixes #19293
The error message "missing parameter hostname" wasn't very clear what hostname was missing. Fail faster further up the stack and print a better error message explaining what is happening.

This applies some checks aroung argument parsing while also adding some
belt-and-suspenders validation into `NewClientStoreFromIdentityFile`

Before:
```
% ~/src/teleport/build/tsh --identity=key.pem --insecure ssh root@localhost
ERROR: missing parameter hostname
```

After:
```
% ~/src/teleport/build/tsh --identity=key.pem--insecure ssh root@localhost
ERROR: missing proxy address. Specify --proxy or login with `tsh login`
```