### PR TITLE
Run go mod tidy in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Run `go mod tidy` and check for changes in go.mod and go.sum
+        # We have to add the current directory as a safe directory or else git commands will not work as expected.
+        run: go mod tidy && git config --global --add safe.directory $( realpath . ) && git status --ignored && ! [ -n "$( git status --porcelain --ignored )" ]
+
       - name: Run linter
         run: make lint
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,8 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run `go mod tidy`
-        # We have to add the current directory as a safe directory or else git commands will not work as expected.
-        run: go mod tidy && (cd api && go mod tidy)
+        run: rm go.sum api/go.sum && go mod tidy && (cd api && go mod tidy)
 
       - name: Check for changes
         # We have to add the current directory as a safe directory or else git commands will not work as expected.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Check for changes
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
-        run: git config --global --add safe.directory $( realpath . ) && git diff -- go.mod go.sum api/go.mod api/go.sum && git diff --quiet -- go.mod go.sum api/go.mod api/go.sum
+        run: git config --global --add safe.directory $( realpath . ) && git diff --exit-code -- go.mod go.sum api/go.mod api/go.sum
 
       - name: Run linter
         run: make lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,9 +25,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Run `go mod tidy` and check for changes in go.mod and go.sum
+      - name: Run `go mod tidy`
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
-        run: go mod tidy && git config --global --add safe.directory $( realpath . ) && git status --ignored && ! [ -n "$( git status --porcelain --ignored )" ]
+        run: go mod tidy && (cd api && go mod tidy)
+
+      - name: Check for changes
+        # We have to add the current directory as a safe directory or else git commands will not work as expected.
+        run: git config --global --add safe.directory $( realpath . ) && git diff -- go.mod go.sum api/go.mod api/go.sum && git diff --quiet -- go.mod go.sum api/go.mod api/go.sum
 
       - name: Run linter
         run: make lint

--- a/e_imports.go
+++ b/e_imports.go
@@ -22,8 +22,11 @@ package teleport
 // Dependabot) doesn't wrongly remove the modules they belong to.
 
 // Import list generator; remember to check that e is up to date and that there
-// is not a go.work file.
-// TODO(espadolini): turn this into a lint (needs access to teleport.e in CI)
+// is not a go.work file. The list of tags that might be needed in e (currently
+// only "piv") can be extracted with a (cd e && git grep //go:build).
+
+// TODO(espadolini): turn this into a lint (needs access to teleport.e in CI and
+// ideally a resolution to https://github.com/golang/go/issues/42504 )
 
 /*
 comm -13 <(
@@ -32,7 +35,7 @@ comm -13 <(
 	sort | uniq | grep -v -E -e "^github.com/gravitational/teleport(/.*)?$" -e "^C$" |
 	xargs go list -f '{{if not .Standard}}{{println .ImportPath}}{{end}}'
 ) <(
-	go list -f '{{range .Imports}}{{println .}}{{end}}' ./e/... |
+	go list -f '{{range .Imports}}{{println .}}{{end}}' -tags piv ./e/... |
 	sort | uniq | grep -v -E -e "^github.com/gravitational/teleport(/.*)?$" -e "^C$" |
 	xargs go list -f '{{if not .Standard}}{{println .ImportPath}}{{end}}'
 ) | awk '{ print "\t_ \"" $1 "\"" }'
@@ -41,6 +44,7 @@ comm -13 <(
 import (
 	_ "github.com/beevik/etree"
 	_ "github.com/coreos/go-oidc/oidc"
+	_ "github.com/go-piv/piv-go/piv"
 	_ "github.com/gravitational/form"
 	_ "google.golang.org/api/admin/directory/v1"
 	_ "google.golang.org/api/cloudidentity/v1"

--- a/e_imports.go
+++ b/e_imports.go
@@ -21,9 +21,10 @@ package teleport
 // teleport module, so tidying that doesn't have access to teleport.e (like
 // Dependabot) doesn't wrongly remove the modules they belong to.
 
-// Import list generator; remember to check that e is up to date and that there
-// is not a go.work file. The list of tags that might be needed in e (currently
-// only "piv") can be extracted with a (cd e && git grep //go:build).
+// Remember to check that e is up to date and that there is not a go.work file
+// before running the following command to generate the import list. The list of
+// tags that might be needed in e (currently only "piv") can be extracted with a
+// (cd e && git grep //go:build).
 
 // TODO(espadolini): turn this into a lint (needs access to teleport.e in CI and
 // ideally a resolution to https://github.com/golang/go/issues/42504 )

--- a/e_imports.go
+++ b/e_imports.go
@@ -16,18 +16,34 @@
 
 package teleport
 
-// Hold a few imports done exclusively by e/, so tidying that doesn't have
-// access to it (like Dependabot) doesn't wrongly remove them.
-// Any import that is present only in this file, but not in e/, can be safely
-// removed.
+// This file should import all non-stdlib, non-teleport packages that are
+// imported by any package in ./e/ but not by packages in the rest of the main
+// teleport module, so tidying that doesn't have access to teleport.e (like
+// Dependabot) doesn't wrongly remove the modules they belong to.
+
+// Import list generator; remember to check that e is up to date and that there
+// is not a go.work file.
+// TODO(espadolini): turn this into a lint (needs access to teleport.e in CI)
+
+/*
+comm -13 <(
+	go list ./... | sort | uniq | grep -v -E -e "^github.com/gravitational/teleport/e(/.*)?$" |
+	xargs go list -f '{{range .Imports}}{{println .}}{{end}}' |
+	sort | uniq | grep -v -E -e "^github.com/gravitational/teleport(/.*)?$" -e "^C$" |
+	xargs go list -f '{{if not .Standard}}{{println .ImportPath}}{{end}}'
+) <(
+	go list -f '{{range .Imports}}{{println .}}{{end}}' ./e/... |
+	sort | uniq | grep -v -E -e "^github.com/gravitational/teleport(/.*)?$" -e "^C$" |
+	xargs go list -f '{{if not .Standard}}{{println .ImportPath}}{{end}}'
+) | awk '{ print "\t_ \"" $1 "\"" }'
+*/
 
 import (
-	_ "github.com/beevik/etree"          // hold for e/
-	_ "github.com/coreos/go-oidc/oidc"   // hold for e/
-	_ "github.com/crewjam/saml/samlidp"  // hold for e/
-	_ "github.com/crewjam/saml/samlsp"   // hold for e/
-	_ "github.com/go-piv/piv-go/piv"     // hold for e/
-	_ "github.com/gravitational/form"    // hold for e/
-	_ "github.com/gravitational/license" // hold for e/
-	_ "gopkg.in/check.v1"                // hold for e/
+	_ "github.com/beevik/etree"
+	_ "github.com/coreos/go-oidc/oidc"
+	_ "github.com/gravitational/form"
+	_ "google.golang.org/api/admin/directory/v1"
+	_ "google.golang.org/api/cloudidentity/v1"
+	_ "google.golang.org/genproto/googleapis/rpc/status"
+	_ "gopkg.in/check.v1"
 )

--- a/e_imports.go
+++ b/e_imports.go
@@ -31,13 +31,13 @@ package teleport
 
 /*
 comm -13 <(
-	go list ./... | sort | uniq | grep -v -E -e "^github.com/gravitational/teleport/e(/.*)?$" |
+	go list ./... | sort -u | grep -Ev -e "^github.com/gravitational/teleport/e(/.*)?$" |
 	xargs go list -f '{{range .Imports}}{{println .}}{{end}}' |
-	sort | uniq | grep -v -E -e "^github.com/gravitational/teleport(/.*)?$" -e "^C$" |
+	sort -u | grep -Ev -e "^github.com/gravitational/teleport(/.*)?$" -e "^C$" |
 	xargs go list -f '{{if not .Standard}}{{println .ImportPath}}{{end}}'
 ) <(
 	go list -f '{{range .Imports}}{{println .}}{{end}}' -tags piv ./e/... |
-	sort | uniq | grep -v -E -e "^github.com/gravitational/teleport(/.*)?$" -e "^C$" |
+	sort -u | grep -Ev -e "^github.com/gravitational/teleport(/.*)?$" -e "^C$" |
 	xargs go list -f '{{if not .Standard}}{{println .ImportPath}}{{end}}'
 ) | awk '{ print "\t_ \"" $1 "\"" }'
 */

--- a/e_imports.go
+++ b/e_imports.go
@@ -45,6 +45,8 @@ comm -13 <(
 import (
 	_ "github.com/beevik/etree"
 	_ "github.com/coreos/go-oidc/oidc"
+	_ "github.com/crewjam/saml/samlidp"
+	_ "github.com/crewjam/saml/samlsp"
 	_ "github.com/go-piv/piv-go/piv"
 	_ "github.com/gravitational/form"
 	_ "google.golang.org/api/admin/directory/v1"


### PR DESCRIPTION
This PR adds a step in the Go lint CI workflow that runs `go mod tidy` for the main module and the api module, and then fails if there's any change in `go.mod` or `go.sum` compared to what's committed.

In addition, this PR updates `e_imports.go` and adds some instructions on how to keep it up to date. Enforcing that it's up to date in CI is challenging at the moment, as it would require access to the source code in `e`.

Failure example: https://github.com/gravitational/teleport/actions/runs/4086801103/jobs/7046536094