### PR TITLE
[v12] Fix forwarding of impersonated headers for `kubectl exec/portforward`

### DIFF
--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -39,6 +39,8 @@ var (
 	kubeCluster              = "test_cluster"
 	username                 = "test_user"
 	roleName                 = "kube_role"
+	usernameMultiUsers       = "test_user_multi_users"
+	roleNameMultiUsers       = "kube_role_multi_users"
 	roleKubeGroups           = []string{"kube"}
 	roleKubeUsers            = []string{"kube"}
 	podName                  = "teleport"
@@ -64,8 +66,8 @@ func TestExecKubeService(t *testing.T) {
 
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
-	user, _ := testCtx.createUserAndRole(
+	// create a userWithSingleKubeUser with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+	userWithSingleKubeUser, _ := testCtx.createUserAndRole(
 		testCtx.ctx,
 		t,
 		username,
@@ -76,24 +78,47 @@ func TestExecKubeService(t *testing.T) {
 		})
 
 	// generate a kube client with user certs for auth
-	_, config := testCtx.genTestKubeClientTLSCert(
+	_, configWithSingleKubeUser := testCtx.genTestKubeClientTLSCert(
 		t,
-		user.GetName(),
+		userWithSingleKubeUser.GetName(),
+		kubeCluster,
+	)
+	require.NoError(t, err)
+
+	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+	userMultiKubeUsers, _ := testCtx.createUserAndRole(
+		testCtx.ctx,
+		t,
+		usernameMultiUsers,
+		roleSpec{
+			name:       roleNameMultiUsers,
+			kubeUsers:  append(roleKubeUsers, "admin"),
+			kubeGroups: roleKubeGroups,
+		})
+
+	// generate a kube client with user certs for auth
+	_, configMultiKubeUsers := testCtx.genTestKubeClientTLSCert(
+		t,
+		userMultiKubeUsers.GetName(),
 		kubeCluster,
 	)
 	require.NoError(t, err)
 
 	type args struct {
 		executorBuilder func(*rest.Config, string, *url.URL) (remotecommand.Executor, error)
+		impersonateUser string
+		config          *rest.Config
 	}
 	tests := []struct {
-		name string
-		args args
+		name    string
+		args    args
+		wantErr bool
 	}{
 		{
 			name: "SPDY protocol",
 			args: args{
 				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          configWithSingleKubeUser,
 			},
 		},
 		{
@@ -105,7 +130,37 @@ func TestExecKubeService(t *testing.T) {
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return newWebSocketClient(c, s, u)
 				},
+				config: configWithSingleKubeUser,
 			},
+		},
+		{
+			name: "SPDY protocol for user with multiple kubernetes users",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          configMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
+			name: "Websocket protocol for user with multiple kubernetes users",
+			args: args{
+				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
+				// is merged into k8s go-client.
+				// For now go-client does not support connections over websockets.
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return newWebSocketClient(c, s, u)
+				},
+				config:          configMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
+			name: "SPDY protocol for user with multiple kubernetes users without specifying impersonate user",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          configMultiKubeUsers,
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -135,13 +190,18 @@ func TestExecKubeService(t *testing.T) {
 				streamOpts,
 			)
 			require.NoError(t, err)
-
-			exec, err := tt.args.executorBuilder(config, http.MethodPost, req.URL())
+			// configure the client to impersonate the user.
+			// If empty, the client ignores it.
+			tt.args.config.Impersonate.UserName = tt.args.impersonateUser
+			exec, err := tt.args.executorBuilder(tt.args.config, http.MethodPost, req.URL())
 			require.NoError(t, err)
 
 			err = exec.StreamWithContext(testCtx.ctx, streamOpts)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
-
 			require.Equal(t, fmt.Sprintf("%s\n%s", podContainerName, string(stdinContent)), stdout.String())
 			require.Equal(t, fmt.Sprintf("%s\n%s", podContainerName, string(stdinContent)), stderr.String())
 		})


### PR DESCRIPTION
Backport of #21102 to branch/v12