### PR TITLE
[v11] Fix forwarding of impersonated headers for `kubectl exec/portforward`

### DIFF
--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -39,6 +39,8 @@ var (
 	kubeCluster              = "test_cluster"
 	username                 = "test_user"
 	roleName                 = "kube_role"
+	usernameMultiUsers       = "test_user_multi_users"
+	roleNameMultiUsers       = "kube_role_multi_users"
 	roleKubeGroups           = []string{"kube"}
 	roleKubeUsers            = []string{"kube"}
 	podName                  = "teleport"
@@ -64,8 +66,8 @@ func TestExecKubeService(t *testing.T) {
 
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
-	user, _ := testCtx.createUserAndRole(
+	// create a userWithSingleKubeUser with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+	userWithSingleKubeUser, _ := testCtx.createUserAndRole(
 		testCtx.ctx,
 		t,
 		username,
@@ -76,24 +78,47 @@ func TestExecKubeService(t *testing.T) {
 		})
 
 	// generate a kube client with user certs for auth
-	_, config := testCtx.genTestKubeClientTLSCert(
+	_, configWithSingleKubeUser := testCtx.genTestKubeClientTLSCert(
 		t,
-		user.GetName(),
+		userWithSingleKubeUser.GetName(),
+		kubeCluster,
+	)
+	require.NoError(t, err)
+
+	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+	userMultiKubeUsers, _ := testCtx.createUserAndRole(
+		testCtx.ctx,
+		t,
+		usernameMultiUsers,
+		roleSpec{
+			name:       roleNameMultiUsers,
+			kubeUsers:  append(roleKubeUsers, "admin"),
+			kubeGroups: roleKubeGroups,
+		})
+
+	// generate a kube client with user certs for auth
+	_, configMultiKubeUsers := testCtx.genTestKubeClientTLSCert(
+		t,
+		userMultiKubeUsers.GetName(),
 		kubeCluster,
 	)
 	require.NoError(t, err)
 
 	type args struct {
 		executorBuilder func(*rest.Config, string, *url.URL) (remotecommand.Executor, error)
+		impersonateUser string
+		config          *rest.Config
 	}
 	tests := []struct {
-		name string
-		args args
+		name    string
+		args    args
+		wantErr bool
 	}{
 		{
 			name: "SPDY protocol",
 			args: args{
 				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          configWithSingleKubeUser,
 			},
 		},
 		{
@@ -105,7 +130,37 @@ func TestExecKubeService(t *testing.T) {
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return newWebSocketClient(c, s, u)
 				},
+				config: configWithSingleKubeUser,
 			},
+		},
+		{
+			name: "SPDY protocol for user with multiple kubernetes users",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          configMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
+			name: "Websocket protocol for user with multiple kubernetes users",
+			args: args{
+				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
+				// is merged into k8s go-client.
+				// For now go-client does not support connections over websockets.
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return newWebSocketClient(c, s, u)
+				},
+				config:          configMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
+			name: "SPDY protocol for user with multiple kubernetes users without specifying impersonate user",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          configMultiKubeUsers,
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -135,13 +190,18 @@ func TestExecKubeService(t *testing.T) {
 				streamOpts,
 			)
 			require.NoError(t, err)
-
-			exec, err := tt.args.executorBuilder(config, http.MethodPost, req.URL())
+			// configure the client to impersonate the user.
+			// If empty, the client ignores it.
+			tt.args.config.Impersonate.UserName = tt.args.impersonateUser
+			exec, err := tt.args.executorBuilder(tt.args.config, http.MethodPost, req.URL())
 			require.NoError(t, err)
 
 			err = exec.StreamWithContext(testCtx.ctx, streamOpts)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
-
 			require.Equal(t, fmt.Sprintf("%s\n%s", podContainerName, string(stdinContent)), stdout.String())
 			require.Equal(t, fmt.Sprintf("%s\n%s", podContainerName, string(stdinContent)), stderr.String())
 		})

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1620,11 +1620,12 @@ func (f *Forwarder) catchAll(ctx *authContext, w http.ResponseWriter, req *http.
 
 func (f *Forwarder) getExecutor(ctx authContext, sess *clusterSession, req *http.Request) (remotecommand.Executor, error) {
 	upgradeRoundTripper := NewSpdyRoundTripperWithDialer(roundTripperConfig{
-		ctx:        req.Context(),
-		authCtx:    ctx,
-		dial:       sess.DialWithContext,
-		tlsConfig:  sess.tlsConfig,
-		pingPeriod: f.cfg.ConnPingPeriod,
+		ctx:             req.Context(),
+		authCtx:         ctx,
+		dial:            sess.DialWithContext,
+		tlsConfig:       sess.tlsConfig,
+		pingPeriod:      f.cfg.ConnPingPeriod,
+		originalHeaders: req.Header,
 	})
 	rt := http.RoundTripper(upgradeRoundTripper)
 	if sess.creds != nil {
@@ -1639,11 +1640,12 @@ func (f *Forwarder) getExecutor(ctx authContext, sess *clusterSession, req *http
 
 func (f *Forwarder) getDialer(ctx authContext, sess *clusterSession, req *http.Request) (httpstream.Dialer, error) {
 	upgradeRoundTripper := NewSpdyRoundTripperWithDialer(roundTripperConfig{
-		ctx:        req.Context(),
-		authCtx:    ctx,
-		dial:       sess.DialWithContext,
-		tlsConfig:  sess.tlsConfig,
-		pingPeriod: f.cfg.ConnPingPeriod,
+		ctx:             req.Context(),
+		authCtx:         ctx,
+		dial:            sess.DialWithContext,
+		tlsConfig:       sess.tlsConfig,
+		pingPeriod:      f.cfg.ConnPingPeriod,
+		originalHeaders: req.Header,
 	})
 	rt := http.RoundTripper(upgradeRoundTripper)
 	if sess.creds != nil {

--- a/lib/kube/proxy/roundtrip.go
+++ b/lib/kube/proxy/roundtrip.go
@@ -47,8 +47,8 @@ import (
 // multiplexed streams. After RoundTrip() is invoked, Conn will be set
 // and usable. SpdyRoundTripper implements the UpgradeRoundTripper interface.
 type SpdyRoundTripper struct {
-	//tlsConfig holds the TLS configuration settings to use when connecting
-	//to the remote server.
+	// tlsConfig holds the TLS configuration settings to use when connecting
+	// to the remote server.
 	tlsConfig *tls.Config
 
 	authCtx authContext
@@ -69,27 +69,32 @@ type SpdyRoundTripper struct {
 	ctx context.Context
 
 	pingPeriod time.Duration
+	// originalHeaders are the headers that were passed from the original request.
+	originalHeaders http.Header
 }
 
-var _ utilnet.TLSClientConfigHolder = &SpdyRoundTripper{}
-var _ httpstream.UpgradeRoundTripper = &SpdyRoundTripper{}
-var _ utilnet.Dialer = &SpdyRoundTripper{}
+var (
+	_ utilnet.TLSClientConfigHolder  = &SpdyRoundTripper{}
+	_ httpstream.UpgradeRoundTripper = &SpdyRoundTripper{}
+	_ utilnet.Dialer                 = &SpdyRoundTripper{}
+)
 
 // DialWithContext is the function used to dial to remote endpoints
 type DialWithContext func(context context.Context, network, address string) (net.Conn, error)
 
 type roundTripperConfig struct {
-	ctx        context.Context
-	authCtx    authContext
-	dial       DialWithContext
-	tlsConfig  *tls.Config
-	pingPeriod time.Duration
+	ctx             context.Context
+	authCtx         authContext
+	dial            DialWithContext
+	tlsConfig       *tls.Config
+	pingPeriod      time.Duration
+	originalHeaders http.Header
 }
 
 // NewSpdyRoundTripperWithDialer creates a new SpdyRoundTripper that will use
 // the specified tlsConfig. This function is mostly meant for unit tests.
 func NewSpdyRoundTripperWithDialer(cfg roundTripperConfig) *SpdyRoundTripper {
-	return &SpdyRoundTripper{tlsConfig: cfg.tlsConfig, dialWithContext: cfg.dial, ctx: cfg.ctx, authCtx: cfg.authCtx, pingPeriod: cfg.pingPeriod}
+	return &SpdyRoundTripper{tlsConfig: cfg.tlsConfig, dialWithContext: cfg.dial, ctx: cfg.ctx, authCtx: cfg.authCtx, pingPeriod: cfg.pingPeriod, originalHeaders: cfg.originalHeaders}
 }
 
 // TLSClientConfig implements pkg/util/net.TLSClientConfigHolder for proper TLS checking during
@@ -147,14 +152,32 @@ func (s *SpdyRoundTripper) dial(url *url.URL) (net.Conn, error) {
 	return conn, nil
 }
 
+// copyImpersonationHeaders copies the impersonation headers from the source
+// request to the destination request.
+func copyImpersonationHeaders(dst, src http.Header) {
+	dst[ImpersonateUserHeader] = nil
+	dst[ImpersonateGroupHeader] = nil
+
+	for _, v := range src.Values(ImpersonateUserHeader) {
+		dst.Add(ImpersonateUserHeader, v)
+	}
+
+	for _, v := range src.Values(ImpersonateGroupHeader) {
+		dst.Add(ImpersonateGroupHeader, v)
+	}
+}
+
 // RoundTrip executes the Request and upgrades it. After a successful upgrade,
 // clients may call SpdyRoundTripper.Connection() to retrieve the upgraded
 // connection.
 func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	header := utilnet.CloneHeader(req.Header)
-	header.Add(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
-	header.Add(httpstream.HeaderUpgrade, streamspdy.HeaderSpdy31)
-
+	// copyImpersonationHeaders copies the headers from the original request to the new
+	// request headers. This is necessary to forward the original user's impersonation
+	// when multiple kubernetes_users are available.
+	copyImpersonationHeaders(header, s.originalHeaders)
+	header.Set(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
+	header.Set(httpstream.HeaderUpgrade, streamspdy.HeaderSpdy31)
 	if err := setupImpersonationHeaders(log.StandardLogger(), s.authCtx, header); err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport of #21102 to branch/v11