### PR TITLE
Move Connect-specific MenuLogin story out of shared package

### DIFF
--- a/web/packages/shared/components/MenuLogin/MenuLogin.story.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.story.tsx
@@ -18,8 +18,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Flex } from 'design';
 
-import { MenuLoginTheme } from 'teleterm/ui/DocumentCluster/ClusterResources/MenuLoginTheme';
-
 import { MenuLogin } from './MenuLogin';
 import { MenuLoginHandle } from './types';
 
@@ -27,18 +25,7 @@ storiesOf('Shared/MenuLogin', module).add('MenuLogin', () => {
   return <MenuLoginExamples />;
 });
 
-storiesOf('Shared/MenuLogin', module).add(
-  'MenuLogin in Teleport Connect',
-  () => {
-    return (
-      <MenuLoginTheme>
-        <MenuLoginExamples />
-      </MenuLoginTheme>
-    );
-  }
-);
-
-function MenuLoginExamples() {
+export function MenuLoginExamples() {
   return (
     <Flex
       width="400px"

--- a/web/packages/teleterm/src/ui/components/MenuLogin.story.tsx
+++ b/web/packages/teleterm/src/ui/components/MenuLogin.story.tsx
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { MenuLoginExamples } from 'shared/components/MenuLogin/MenuLogin.story';
+
+import { MenuLoginTheme } from 'teleterm/ui/DocumentCluster/ClusterResources/MenuLoginTheme';
+
+storiesOf('Shared/MenuLogin', module).add(
+  'MenuLogin in Teleport Connect',
+  () => {
+    return (
+      <MenuLoginTheme>
+        <MenuLoginExamples />
+      </MenuLoginTheme>
+    );
+  }
+);

--- a/web/packages/teleterm/src/ui/components/MenuLogin.story.tsx
+++ b/web/packages/teleterm/src/ui/components/MenuLogin.story.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Gravitational, Inc.
+Copyright 2023 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Connect provides its own theme for MenuLogin. Back when we were adding it to Connect, we also added a story so that if someone was looking at MenuLogin stories they'd be aware that Connect has its own special theme for it.

However, this makes packages/shared import packages/teleterm which is a no-no. This PR moves the story to packages/teleterm while keeping it in the correct place in the final storybook.