### PR TITLE
[Docs] single-source access control guides list

### DIFF
--- a/docs/pages/access-controls/guides.mdx
+++ b/docs/pages/access-controls/guides.mdx
@@ -9,12 +9,4 @@ infrastructure as well as how they can access those resources. Once you have
 deployed a Teleport cluster, configure access controls to achieve the right
 security policies for your organization.
 
-- [Dual Authorization](./guides/dual-authz.mdx): Protect access to critical resources with dual authorization.
-- [Role Templates](./guides/role-templates.mdx): Set up dynamic access policies with role templates.
-- [Impersonating Teleport Users](./guides/impersonation.mdx): Create certificates for other users with impersonation.
-- [Passwordless](./guides/passwordless.mdx): Use passwordless authentication.
-- [WebAuthn](./guides/webauthn.mdx): Add two-factor authentication through WebAuthn.
-- [Per-Session MFA](./guides/per-session-mfa.mdx): Per-session multi-mactor authentication.
-- [Locking](./guides/locking.mdx): Lock access to active user sessions or hosts.
-- [Moderated Sessions](./guides/moderated-sessions.mdx): Require session auditors and allow fine-grained live session access.
-- [Device Trust (Preview)](./guides/device-trust.mdx): Register and enforce trusted devices.
+(!docs/pages/includes/access-control-guides.mdx!)

--- a/docs/pages/access-controls/introduction.mdx
+++ b/docs/pages/access-controls/introduction.mdx
@@ -24,14 +24,7 @@ guide.
 
 ## Guides
 
-- [Dual Authorization](./guides/dual-authz.mdx): Dual Authorization for SSH and Kubernetes.
-- [Teleport Role Templates](./guides/role-templates.mdx): Dynamic Access Policies with Role Templates.
-- [Impersonating Teleport Users](./guides/impersonation.mdx): Create certs for CI/CD using impersonation.
-- [Passwordless](./guides/passwordless.mdx): Use passwordless authentication.
-- [Second Factor - WebAuthn](./guides/webauthn.mdx): Add Two-Factor Authentication through WebAuthn.
-- [Per-session MFA](./guides/per-session-mfa.mdx): Per-session Multi-Factor Authentication.
-- [Locking](./guides/locking.mdx): Locking sessions and identities.
-- [Device Trust (Preview)](./guides/device-trust.mdx): Register and enforce trusted devices.
+(!docs/pages/includes/access-control-guides.mdx!)
 
 ## How does it work?
 

--- a/docs/pages/includes/access-control-guides.mdx
+++ b/docs/pages/includes/access-control-guides.mdx
@@ -1,0 +1,9 @@
+- [Dual Authorization](./guides/dual-authz.mdx): Protect access to critical resources with dual authorization.
+- [Role Templates](./guides/role-templates.mdx): Set up Dynamic Access Policies with Role Templates.
+- [Impersonating Teleport Users](./guides/impersonation.mdx): Create certificates for CI/CD with impersonation.
+- [Passwordless](./guides/passwordless.mdx): Use passwordless authentication.
+- [Second Factor: WebAuthn](./guides/webauthn.mdx): Add Two-Factor Authentication through WebAuthn.
+- [Per-Session MFA](./guides/per-session-mfa.mdx): Per-session multi-mactor authentication.
+- [Locking](./guides/locking.mdx): Lock access to active user sessions or hosts.
+- [Moderated Sessions](./guides/moderated-sessions.mdx): Require session auditors and allow fine-grained live session access.
+- [Device Trust (Preview)](./guides/device-trust.mdx): Register and enforce trusted devices.


### PR DESCRIPTION
The lists of Access Control guides between the "Introduction" and "Cluster Access and RBAC" pages had different item counts and descriptions. This standardizes the list, as we do with Database guides.