### PR TITLE
Fix tsh proxy ssh relogin

### DIFF
--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -750,9 +750,23 @@ func TestMakeClient(t *testing.T) {
 	// minimal configuration (with defaults)
 	conf.Proxy = "proxy:3080"
 	conf.UserHost = "localhost"
+	conf.HomePath = t.TempDir()
+
+	// Create a empty profile so we don't ping proxy.
+	clientStore, err := initClientStore(&conf, conf.Proxy)
+	require.NoError(t, err)
+	profile := &profile.Profile{
+		SSHProxyAddr: "proxy:3023",
+		WebProxyAddr: "proxy:3080",
+	}
+	err = clientStore.SaveProfile(profile, true)
+	require.NoError(t, err)
+
 	tc, err = makeClient(&conf, true)
 	require.NoError(t, err)
 	require.NotNil(t, tc)
+
+	// profile info should be loaded into client
 	require.Equal(t, "proxy:3023", tc.Config.SSHProxyAddr)
 	require.Equal(t, "proxy:3080", tc.Config.WebProxyAddr)
 
@@ -829,10 +843,22 @@ func TestMakeClient(t *testing.T) {
 	proxySSHAddr, err := proxy.ProxySSHAddr()
 	require.NoError(t, err)
 
+	// If profile is missing, makeClient should call Ping on the proxy to fetch SSHProxyAddr
+	conf = CLIConf{
+		Proxy:              proxyWebAddr.String(),
+		Context:            context.Background(),
+		InsecureSkipVerify: true,
+	}
+	tc, err = makeClient(&conf, true)
+	require.NoError(t, err)
+	require.NotNil(t, tc)
+	require.Equal(t, proxyWebAddr.String(), tc.Config.WebProxyAddr)
+	require.Equal(t, proxySSHAddr.Addr, tc.Config.SSHProxyAddr)
+	require.NotNil(t, tc.LocalAgent().ExtendedAgent)
+
 	// With provided identity file.
 	//
-	// makeClient should call Ping on the proxy to fetch SSHProxyAddr, which is
-	// different from the default.
+	// makeClient should call Ping on the proxy to fetch SSHProxyAddr
 	conf = CLIConf{
 		Proxy:              proxyWebAddr.String(),
 		IdentityFileIn:     "../../fixtures/certs/identities/tls.pem",


### PR DESCRIPTION
`tsh proxy ssh` will fail if a user does not have an active profile with proxy info. This is not captured by RetryWithRelogin normally, since the error is a connection error caused by using the wrong server address. 

This PR loads the proxy info from Ping response when client profile is missing, so we get a retry-with-relogin-able error from`tsh proxy ssh`.

```
tsh -d proxy ssh --user=dev --proxy=proxy.example.com:3080 bjoerger@server01.root-cluster:3022                     
INFO [CLIENT]    [KEY AGENT] Connected to the system agent: "/run/user/1000/keyring/ssh" client/api.go:3884
DEBU [TSH]       Pinging the proxy to fetch listening addresses for non-web ports. tsh/tsh.go:3271
DEBU [CLIENT]    attempting to use loopback pool for local proxy addr: proxy.example.com:3080 client/api.go:3842
DEBU [CLIENT]    reading self-signed certs from: /var/lib/teleport/webproxy_cert.pem client/api.go:3850
DEBU [CLIENT]    could not open any path in: /var/lib/teleport/webproxy_cert.pem client/api.go:3854
DEBU             Attempting GET proxy.example.com:3080/webapi/ping webclient/webclient.go:129
DEBU [CLIENT]    Activating relogin on open /home/bjoerger/.tsh/keys/proxy.example.com/dev-x509.pem: no such file or directory. client/api.go:519
DEBU [CLIENT]    Attempting to login with a new RSA private key. client/api.go:3264
```

Closes https://github.com/gravitational/teleport/issues/19094