### PR TITLE
docs: login rule docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -312,6 +312,23 @@
             }
           ]
         },
+		{
+          "title": "Login Rules",
+          "slug": "/access-controls/login-rules/",
+          "forScopes": ["enterprise", "oss", "cloud"],
+          "entries": [
+            {
+              "title": "Set Up Login Rules",
+              "slug": "/access-controls/login-rules/guide/",
+              "forScopes": ["enterprise", "cloud"]
+            },
+            {
+              "title": "Login Rules Reference",
+              "slug": "/access-controls/login-rules/reference/",
+              "forScopes": ["enterprise", "cloud"]
+            }
+		  ]
+		},
         {
           "title": "Access Requests",
           "slug": "/access-controls/access-requests/",

--- a/docs/pages/access-controls/login-rules.mdx
+++ b/docs/pages/access-controls/login-rules.mdx
@@ -1,0 +1,85 @@
+---
+title: Login Rules (Preview)
+description: Transform User Traits with Login Rules
+layout: tocless-doc
+---
+
+<Admonition type="warning" title="Preview">
+  Login Rules are currently in Preview mode.
+</Admonition>
+
+When users log in to your Teleport cluster with a configured SSO provider,
+**Login Rules** can transform the traits provided by your IdP to meet your needs
+for configuring access within Teleport.
+
+Some use cases for Login Rules are:
+
+- When you need to modify a user trait based on logical rules, like
+  "users in group `db-admins` should also be added to group `db-users`",
+  Login Rules provide a powerful expression language to make these changes
+  without needing to modify claims in your IdP.
+- When your IdP provides a large number of traits with many values, all of these
+  traits will be included in your user's SSH certificates and JWTs, which can
+  become too large for some third-party applications to handle.  Login Rules can
+  filter out uneccessary traits and keep just the ones you need.
+- When you have multiple [Role Templates](./guides/role-templates.mdx) repeating
+  the same logic to combine and transform external traits, consider using Login
+  Rules to consolidate the logic to one place and simplify your Roles.
+
+Login Rules can solve these problems without requiring changes to your
+organization's IdP.
+
+Login Rules use a predicate language to provide maximum flexibility when
+configuring your cluster.
+This allows you to write simple or complex expressions to define the traits your
+users should be granted.
+
+For example, you can convert the value of a `username` trait to lowercase and
+conditionally extend the value of a groups trait with the following
+snippet:
+```yaml
+traits_map:
+  username:
+    - 'strings.lower(external.username)'
+  groups:
+    - 'ifelse(external.groups.contains("db-admins"), external.groups.add("db-users"), external.groups)'
+```
+
+Check out the [Login Rules guide](./login-rules/guide.mdx) for a quick walkthrough
+that will show you how to write, test, and add the first Login Rule to your
+cluster.
+
+When you're ready to take full advantage of Login Rules in your cluster, see the
+[Login Rules Reference](./login-rules/reference.mdx) for details on the expression
+language that powers them.
+
+## FAQ
+
+### Which users do Login Rules apply to?
+
+Login Rules apply to all users logging in via OIDC, SAML, or GitHub.
+They do not apply to local Teleport users.
+
+### When are Login Rules evaluated?
+
+Login Rules are evaluated once during each user login, after receiving the
+claims or assertions from your IdP, before mapping claims/assertions to Teleport
+roles, and before generating user certificates.
+If Login Rules modify and traits used for role mapping, the role mapping may be
+affected.
+
+### Can I define custom helper functions for the predicate language?
+
+No, but if you have a use case which is not adequately met by the currently
+supported helper functions, please talk to support or submit a GitHub issue and
+we will consider adding helpers which are generally useful.
+
+### Can I have multiple Login Rules in a single cluster?
+
+Yes.
+All Login Rules installed in the cluster will first be sorted by priority and
+then evaluated in order.
+Each subsequent Login Rule will receive the full output of the previous rule as
+its input.
+It is strongly recommended to give each Login Rule a unique priority, but ties
+will be broken by sorting by the rule name.

--- a/docs/pages/access-controls/login-rules/guide.mdx
+++ b/docs/pages/access-controls/login-rules/guide.mdx
@@ -1,0 +1,271 @@
+---
+title: Set Up Login Rules (Preview)
+description: Set up Login Rules to transform user traits
+---
+
+<Admonition type="warning" title="Preview">
+  Login Rules are currently in Preview mode.
+</Admonition>
+
+This guide will walk you through the process of writing, testing, and adding the
+first Login Rule to your Teleport cluster.
+
+## Prerequisites
+
+(!docs/pages/includes/commercial-prereqs-tabs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
+
+Before you get started you’ll need a running Teleport Enterprise or Cloud
+cluster on version 11.3.0 or greater.
+
+Login Rules only operate on SSO logins, so make sure you have
+configured an OIDC, SAML, or GitHub connector before you begin.
+Check the [Single Sign-On](../sso/) docs to learn how to set this up.
+
+## Step 1/4. Draft your Login Rule resource
+
+The following example will give all users a new `logins` trait set to the value
+of their current `username` trait converted to lowercase.
+Copy this example rule to a file called `my_rule.yaml` to continue with the
+guide.
+
+```
+# my_rule.yaml
+kind: login_rule
+version: v1
+metadata:
+  # Each Login Rule must have a unique name within the cluster.
+  name: my_rule
+
+  # expires is optional and usually should not be set for deployed login
+  # rules, but it can be useful to set an expiry a short time in the future
+  # while testing new Login Rules to prevent potentially locking yourself out of
+  # your Teleport cluster.
+  # expires: "2023-01-31T00:00:00-00:00"
+spec:
+  # priority orders the evaluation of Login Rules if multiple are present in the
+  # cluster, lower priorities are evaluated first.
+  priority: 0
+
+  # traits_expression is a predicate expression which will be evaluated to
+  # determine the final traits for each SSO user during login.
+  #
+  # This example expression sets the "logins" trait to the incoming "username"
+  # trait converted to lowercase.
+  traits_expression: 'external.put("logins", strings.lower(external["username"]))'
+```
+
+Each Login Rule resource must have either a `traits_map` or `traits_expression`
+field.
+In this guide we will use an example `traits_expression`.
+
+The `traits_expression` is a form of script which will be evaluated by your
+Teleport cluster at runtime to determine the traits for each SSO user who logs
+in.
+The expression can access the incoming traits for the user via the `external`
+variable.
+The `external` variable is a dictionary which maps trait keys to sets of values
+for that trait.
+
+## Step 2/4. Test the Login Rule
+
+The `tctl login_rule test` command can be used to experiment with new Login
+Rules to check their syntax and see exactly how they will operate on example
+incoming traits.
+
+Fetch your user's current traits and store them in `input.json`, then test your
+new Login Rule with that input.
+
+```code
+$ tctl get --format json users/<Var name="username"/> | jq 'first.spec.traits' > input.json
+$ tctl login_rule test --resource-file my_rule.yaml input.json
+access:
+- staging
+groups:
+- dbs
+- devs
+logins:
+- alice
+```
+
+This script will catch any syntax errors in your expressions.
+Make sure that all expected traits are present in the output.
+
+## Step 3/4. Create the Login Rule
+
+In order to run `tctl` commands for Login Rule resources, your user must have
+the built-in `editor` role or the appropriate allow rules in one of your roles:
+
+```yaml
+spec:
+  allow:
+    rules:
+      - resources: [login_rule]
+        verbs: [list, create, read, update, delete]
+```
+
+Use the following command to create the Login Rule in your cluster:
+
+```code
+$ tctl create my_rule.yaml
+```
+
+## Step 4/4. Try it out
+
+As a final step, log out of your cluster, then log in again and make sure your user received the
+expected traits and roles.
+You can check the traits and roles with the following command:
+
+```code
+$ tctl get --format json users/<Var name="username"/> | jq '{traits: first.spec.traits, roles: first.spec.roles}'
+{
+  "traits": {
+	"access": [
+	  "staging"
+    ],
+    "groups": [
+      "dbs",
+      "devs"
+    ],
+    "logins": [
+      "alice"
+    ]
+  },
+  "roles": [
+    "access",
+    "editor",
+    "auditor"
+  ]
+}
+```
+
+## Troubleshooting
+
+The [`tctl sso test`](../../reference/cli.mdx#tctl-sso-test) command can be used to
+debug SSO logins and see exactly which traits are being sent by your SSO
+provider and how they are being mapped by your Login Rules.
+
+`tctl sso test` expects a connector spec.
+Run the following command to debug with a connector currently intalled in your
+cluster.
+
+```code
+$ tctl get connector/<Var name="SSO connector name"/> --with-secrets | tctl sso test
+```
+
+## Next steps
+
+To learn more about the Login Rule expression syntax, check out the
+[Login Rule Reference](./reference.mdx) page.
+
+Learn about the `tctl login_rule test` command by running the help command or
+checking the [reference page](../../reference/cli.mdx#tctl-login_rule-test).
+```code
+$ tctl help login_rule test
+```
+
+The following `tctl` resource commands are helpful for viewing and modifying the
+login rules currently installed in your cluster.
+
+Command | Description
+------- | -----------
+`tctl get login_rules` | Show all Login Rules installed in your cluster.
+`tctl get login_rule/<rule_name>` | Get a specific installed Login Rule.
+`tctl create login_rule.yaml` | Install a new Login Rule.
+`tctl create -f login_rule.yaml` | Overwrite an existing Login Rule.
+`tctl rm login_rule/<rule_name>` | Delete a Login Rule.
+
+## Example Login Rules
+
+### Set a trait to a static list of values defined per group
+
+```yaml
+kind: login_rule
+version: v1
+metadata:
+  name: example
+spec:
+  priority: 0
+  traits_expression: |
+    external.put("allow-env",
+      choose(
+        option(external.group.contains("dev"), set("dev", "staging")),
+        option(external.group.contains("qa"), set("qa", "staging")),
+        option(external.group.contains("admin"), set("dev", "qa", "staging", "prod")),
+        option(true, set()),
+      ))
+```
+
+### Use only specific traits provided by the OIDC/SAML provider
+
+To only keep the `groups` and `email` traits, with their original values:
+
+```yaml
+kind: login_rule
+version: v1
+metadata:
+  name: example
+spec:
+  priority: 0
+  traits_map:
+    groups:
+      - external.groups
+    email:
+      - external.email
+```
+
+### Remove a specific trait
+
+To remove a specific trait and keep the rest:
+
+```yaml
+kind: login_rule
+version: v1
+metadata:
+  name: example
+spec:
+  priority: 0
+  traits_expression: |
+    external.remove("big-trait")
+```
+
+### Extend a specific trait with extra values
+
+```yaml
+kind: login_rule
+version: v1
+metadata:
+  name: example
+spec:
+  priority: 0
+  traits_expression: |
+    external.add_values("logins", "ubuntu", "ec2-user")
+```
+
+### Use the output of one Login Rule in another rule
+
+```yaml
+kind: login_rule
+version: v1
+metadata:
+  name: set_groups
+spec:
+  priority: 0
+  traits_expression: |
+    external.put("groups",
+      ifelse(external.groups.contains("admins"),
+        external["groups"].add("superusers"),
+        external["groups"]))
+---
+kind: login_rule
+version: v1
+metadata:
+  name: set_logins
+spec:
+  priority: 1
+  traits_expression: |
+    ifelse(external.groups.contains("superusers"),
+      external.add_values("logins", "root"),
+      external)
+```

--- a/docs/pages/access-controls/login-rules/reference.mdx
+++ b/docs/pages/access-controls/login-rules/reference.mdx
@@ -1,0 +1,678 @@
+---
+title: Login Rules Reference (Preview)
+description: Reference documentation for Login Rules
+---
+
+<Admonition type="warning" title="Preview">
+  Login Rules are currently in Preview mode.
+</Admonition>
+
+This page provides details on the expression language that powers Login Rules.
+To learn how to add the first login rule to your cluster, checkout out the
+[Login Rules Guide](./guide.mdx).
+
+## YAML specification
+
+(!docs/pages/includes/login-rule-spec.mdx!)
+
+## `traits_map` vs `traits_expression`
+
+Every login rule spec must contain either the `traits_map` field or a
+`traits_expression` field.
+
+They both serve the same purpose of transforming user traits.
+The difference lies only in the syntax you prefer for your use case, since you can write
+every `traits_map` as an equivalent `traits_expression`.
+
+### `traits_map`
+
+Here is an example Login Rule using a `traits_map` which implements the
+following rules:
+1. Every user with the `groups: devs` trait should receive an extra trait
+   `access: [staging]`.
+2. Every user with the `groups: admins` trait should receive an extra trait
+   `access: [staging, prod]`.
+3. Every user should receive a `logins` trait with the value of their incoming
+   `username` trait converted to lowercase.
+4. All traits other than `groups`, `logins`, and `access` should be filtered
+   out.
+
+```yaml
+kind: login_rule
+version: v1
+metadata:
+  name: my_expression_rule
+spec:
+  priority: 0
+
+  traits_map:
+    # the groups trait will be copied unmodified. Do the same for all other
+    # traits which should not be changed, any traits omitted here will *not* be
+    # set for your users and will *not* be used for role mapping.
+    groups:
+      - external["groups"]
+
+    # the logins traits will be set to the username trait converted to
+    # lowercase.
+    logins:
+      - 'strings.lower(external.username)'
+   
+    # the access trait is determined conditionally based on the incoming groups trait.
+    access:
+      - 'ifelse(external.groups.contains("devs"), set("staging"), set())'
+      - 'ifelse(external.groups.contains("admins"), set("staging", "prod"), set())'
+```
+
+### `traits_expression`
+
+Here is an example login rule using the `traits_expression` field implementing
+the same rules as the above example:
+
+```yaml
+kind: login_rule
+version: v1
+metadata:
+  name: my_expression_rule
+spec:
+  priority: 0
+
+  traits_expression: |
+    dict(
+      pair("groups", external.groups),
+      pair("logins", strings.lower(external.username)),
+      pair("access",
+        choose(
+          option(external.groups.contains("devs"), set("staging")),
+          option(external.groups.contains("admins"), set("staging", "prod")),
+          option(true, set()),
+        ),
+      ),
+    )
+```
+
+Every traits expression must return a value of type [`dict`](#dict-type) which will
+be used as the complete set of output traits.
+It is possible to construct a `dict` from scratch as shown above, or you can
+make modifications to the incoming traits stored in the `external` dict like the
+following:
+
+```yaml
+kind: login_rule
+version: v1
+metadata:
+  name: uppercase_logins
+spec:
+  priority: 0
+
+  # This example expression will return all incoming traits unmodified except
+  # for the "logins" trait which will be converted to lowercase.
+  traits_expression: |
+    external.put("logins", strings.lower(external.logins))
+```
+
+## `dict` type
+
+### Description
+
+`dict` is a dictionary type mapping from `string` keys to [`set`](#set-type) values.
+When Login Rule expressions access input traits with the
+`external.<trait>` or `external[<trait>]` syntax, `external` is a value of type
+`dict`.
+Values of type `dict` can also be constructed and accessed within expressions.
+Expressions used for the `traits_expression` field **must** return a value of
+type `dict`.
+
+### Constructor
+
+#### Signature
+
+```go
+func dict(pairs ...pair) dict
+```
+
+#### Description
+
+The `dict` constructor returns a new `dict` populated with initial key-value pairs
+from the `pairs` argument.
+Each `pair` must hold a `string` and a `set`.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`pairs` | `...pair` | Zero or more key-value pairs to initialize the `dict`.
+
+#### Returns
+
+Type | Description
+---- | ----------
+`dict`  | A new `dict`.
+
+#### Examples
+
+Expression | Result
+---------- | ------
+`dict()` | `{}`
+`dict(pair("a", set("x", "y")))` | `{"a": ("x", "y")}`
+
+### Accessors
+
+Syntax | Example | Description
+------ | ------- | -----------
+`dict.key` | `external.username` | The "dot" accessor returns the `set` for the given key, or the empty `set` if there is not value for that key.
+`dict["key"]` | `external["user-name"]` | The square brace accessor has the same behavior as the "dot" accessor, but supports keys with special characters (including `-`, `.`, ` `, etc) which must be quoted for parsing.
+
+### `dict.add_values`
+
+#### Signature
+
+```go
+func (dict) add_values(key string, values ...string) dict
+```
+
+#### Description
+
+`dict.add_values` returns a copy of the `dict` with the given values added to
+the `set` at `dict[key]`.
+If there is no `set` already present at `dict[key]` a new one will be created.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`key` | `string` | Key where the new values should be added.
+`values` | `...string` | One or more string values to add at `dict[key]`.
+
+#### Returns
+
+Type | Description
+---- | ----------
+`dict`  | A copy of the given `dict` with `values` added at key `key`.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`dict().add_values("logins", "ubuntu", "ec2-user")` | `{"logins": ("ubuntu", "ec2-user")}`
+`dict(pair("a", set("x"))).add_values("a", "y", "z")` | `{"a": ("x", "y", "z")}`
+
+### `dict.remove`
+
+#### Signature
+
+```go
+func (dict) remove(keys ...string) dict
+```
+
+#### Description
+
+`dict.remove` returns a copy of the `dict` with the given keys removed.
+Any given keys not present in the `dict` have no effect.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`keys` | `...string` | One or more keys to remove from the `dict`.
+
+#### Returns
+
+Type | Description
+---- | ----------
+`dict`  | A copy of the given `dict` with given keys removed.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`dict(pair("a", set("x"))).remove("a", "b")` | `{}`
+`dict(pair("a", set("x")), pair("b", set("c"))).remove("b")` | `{"a": ("x")}`
+
+### `dict.put`
+
+#### Signature
+
+```go
+func (dict) put(key string, value set) dict
+```
+
+#### Description
+
+`dict.put` returns a copy of the `dict` with `dict[key]` set to `value`.
+If there is already a value present for the given key it is overwritten.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`key` | `string` | key at which to set the new value
+`value` | `set` | set of strings to set at the given key
+
+#### Returns
+
+Type | Description
+---- | ----------
+`dict`  | a copy of the given `dict` with `dict[key]` set to `value`.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`dict(pair("a", set("x"))).put("a", set("y"))` | `{"a": ("y")}`
+`dict().put("b", set("z"))` | `{"b": ("z")}`
+
+## `set` type
+
+### Description
+
+`set` holds a set of unique strings.
+
+### Constructor
+
+#### Signature
+
+```go
+func set(values ...string) set
+```
+
+#### Description
+
+The `set` constructor returns a new `set` initialized with the given `values`.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`values` | `...string` | Zero or more strings to initialize the set.
+
+#### Returns
+
+Type | Description
+---- | -----------
+`set` | A new set initialized with the given values.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`set()` | `()`
+`set("a", "b", "a")` | `("a", "b")`
+
+### `set.contains`
+
+#### Signature
+
+```go
+func (set) contains(value) bool
+```
+
+#### Description
+
+`set.contains` returns `true` if the set contains an exact match for `value`,
+else it returns `false`.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`value` | `string` | A string to check for in the set.
+
+#### Returns
+
+Type | Description
+---- | ----------
+`bool` | `true` if the set contains an exact match for `value`, else `false`.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`set("a", "b").contains("a")` | `true`
+`set("a", "b").contains("x")` | `false`
+
+### `set.add`
+
+#### Signature
+
+```go
+func (set) add(values ...string) set
+```
+
+#### Description
+
+`set.add` returns a new set that is a copy of the given set with the new
+`values` added.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`values` | `...string` | Values to add to the set.
+
+#### Returns
+
+Type | Description
+---- | ----------
+`set` | A new set that is a copy of the given set with `values` added.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`set("a", "b").add("b", "c")` | `("a", "b", "c")`
+
+### `set.remove`
+
+#### Signature
+
+```go
+func (set) remove(values ...string) set
+```
+
+#### Description
+
+`set.remove` returns a new set that is a copy of the given set with all
+`values` removed.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`values` | `...string` | Values to remove from the set.
+
+#### Returns
+
+Type | Description
+---- | ----------
+`set` | A new set that is a copy of the given set with `values` removed.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`set("a", "b").remove("b", "c")` | `("a")`
+
+## `pair` type
+
+### Description
+
+`pair` can hold two values of any type.
+Currently its only use is in the `dict` constructor where it must hold key-value
+pairs of type `string` and `set`.
+
+### Constructor
+
+#### Signature
+
+```go
+func pair(first, second any) pair
+```
+
+#### Description
+
+The `pair` constructor returns a new `pair` holding `first` and `second`.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`first` | `any` | A value of any type.
+`second` | `any` | A value of any type.
+
+#### Returns
+
+Type | Description
+---- | -----------
+`pair` | A new `pair` holding `first` and `second`.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`pair("logins", set("root", "user"))` | `{"logins", ("root", "user")}`
+
+## `option` type
+
+### Description
+
+`option` is meant to be used exclusively as an argument to [`choose`](#choose).
+It holds a Boolean condition that may cause the `option` to be selected and a
+value which should be returned by the `choose` expression if that `option` is in
+fact selected.
+
+### Constructor
+
+#### Signature
+
+```go
+func option(cond bool, value any) option
+```
+
+#### Description
+
+Returns a new `option` holding `cond` and `value`.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`cond` | `bool` | A Boolean condition which may cause this `option` to be selected. |
+`value` | `any` | A value which should be returned by `choose` if this `option` is selected. |
+
+#### Returns
+
+Type | Description
+---- | ----------
+`option` | An `option` type which should be passed as an argument to `choose`.
+
+#### Examples
+
+See the examples for [`choose`](#choose).
+
+## Helper functions
+
+### `strings.upper`
+
+#### Signature
+
+```go
+func strings.upper(input set) set
+```
+
+#### Description
+
+`strings.upper` returns a copy of the given set of strings converted to
+uppercase.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`input` | `set` | set of input strings to convert to uppercase |
+
+#### Returns
+
+Type | Description
+---- | ----------
+`set`  | a copy of `input` where each string has been convert to uppercase
+
+#### Examples
+
+Expression | Result
+------- | ------
+`strings.upper(set("Alice"))` | `("ALICE")`
+`strings.upper(set("AbCdE", "fGhIj))` | `("ABCDE", "FGHIJ")`
+
+### `strings.lower`
+
+#### Signature
+
+```go
+func strings.lower(input set) set
+```
+
+#### Description
+
+`strings.lower` returns a copy of the given set of strings converted to
+lowercase.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`input` | `set` | set of input strings to convert to lowercase |
+
+#### Returns
+
+Type | Description
+---- | ----------
+`set`  | a copy of `input` where each string has been convert to lowercase
+
+#### Examples
+
+Expression | Result
+------- | ------
+`strings.lower(set("Alice"))` | `("alice")`
+`strings.lower(set("AbCdE", "fGhIj))` | `("abcde", "fghij")`
+
+### `strings.replaceall`
+
+#### Signature
+
+```go
+func strings.replaceall(input set, match string, replacement string) set
+```
+
+#### Description
+
+`strings.replaceall` implements substring replacement on sets of strings.
+The return value is a copy of `input` where each substring match of `match`
+found in each element of `input` will be replaced with `replacement`.
+The matching is literal and does not support regular expressions.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`input` | `set` | set of input strings where replacements are needed |
+`match` | `string` | literal substring to be replaced |
+`replacement` | `string` | literal string to replace all instances of `match` |
+
+#### Returns
+
+Type | Description
+---- | ----------
+`set`  | a copy of `input` where each instance of `match` found in each element of `input` has been replaced with `replacement`.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`strings.replaceall(set("user-name"), "-", "_")` | `("user_name")`
+`strings.replaceall(set("user-alice", "user-bob"), "user-", "")` | `("alice", "bob")`
+
+### `ifelse`
+
+#### Signature
+
+```go
+func ifelse(cond bool, valueIfTrue any, valueIfFalse any) any
+```
+
+#### Description
+
+`ifelse` implements the classic if-else branch in a pure functional style.
+If the first argument evaluates to `true` the second argument is returned, else
+the third argument is returned.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`cond` | `bool` | A Boolean condition that determines which of the following two arguments is returned.
+`valueIfTrue` | `any` | The value to return if `cond` is true, of any type.
+`valueIfFalse` | `any` | The value to return if `cond` is false, of any type.
+
+#### Returns
+
+Type | Description
+---- | ----------
+`any`  | The second or third argument will be returned.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`ifelse(set("a", "b").contains("a"), set("x", "y"), set("z"))` | `("x", "y")`
+`ifelse(set("a", "b").contains("c"), set("x", "y"), set("z"))` | `("z")`
+
+### `choose`
+
+#### Signature
+
+```go
+func choose(options ...option) any
+```
+
+#### Description
+
+`choose` implements a functional style of switch statement, returning the first
+[`option`](#option-type) argument with a condition evaluating to `true`.
+
+If no option can be selected at runtime, this will return an error and the login
+will not succeed.
+It is recommended to add a final option with the condition hardcoded to `true`
+to implement a default option and avoid this scenario.
+For example `choose(..., option(true, set()))` would return the empty set if no
+other option can be selected.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`options` | `...option` | One or more `option`s.
+
+#### Returns
+
+Type | Description
+---- | ----------
+`any`  | The value of the first `option` argument with a condition evaluating to `true`, which may be of any type.
+
+#### Examples
+
+Expression | Result
+------- | ------
+`choose(option(false, set("x")), option(true, set("y")), option(true, set("z")))` | `("y")`
+`choose(option(set("a", "b").contains("a"), set("x")), option(true, set("y")))` | `("x")`
+
+### `union`
+
+#### Signature
+
+```go
+func union(sets ...set) set
+```
+
+#### Description
+
+`union` returns a new [`set`](#set-type) containing the union of all elements in the
+given sets.
+
+#### Arguments
+
+Argument | Type | Description
+-------- | ---- | -----------
+`sets` | `...set` | Zero or more sets to union.
+
+#### Returns
+
+Type | Description
+---- | ----------
+`set`  | A new `set` containing the union of all given `set`s.
+
+#### Examples
+
+Expression | Result
+---------- | ------
+`union(set("a"), set("b"))` | `("a", "b")`
+`union(set("a", "b"), set("b", "c"))` | `("a", "b", "c")`

--- a/docs/pages/includes/login-rule-spec.mdx
+++ b/docs/pages/includes/login-rule-spec.mdx
@@ -1,0 +1,51 @@
+```
+kind: login_rule
+version: v1
+metadata:
+  # name is a unique name for the Login Rule in the cluster.
+  name: example
+
+  # expires is optional and usually should not be set for deployed login
+  # rules, but it can be useful to set an expiry a short time in the future
+  # while testing new Login Rules to prevent potentially locking yourself out of
+  # your teleport cluster.
+  # expires: "2023-01-31T00:00:00-00:00"
+spec:
+  # priority can be used to order the evaluation of multiple Login Rules within
+  # a cluster.
+  #
+  # Login Rules with lower numbered priorities will be applied first, followed
+  # by rules with priorities in increasing order. In case of a tie, Login Rules
+  # with the same priority will be ordered by a lexicographical sort of their
+  # names.
+  #
+  # The default value is 0, the supported range is -2147483648 to 2147483647
+  # (inclusive).
+  priority: 0
+
+  # If set, traits_map will determine the traits of all users who log in to the
+  # cluster.
+  #
+  # This is a YAML map where the key must be a static string which will be the
+  # final trait key, and the value is a list of predicate expressions which each
+  # must evaluate to a set of strings. The final trait will be set to the union
+  # of the resulting string sets of all predicate expressions for that trait
+  # key.
+  #
+  # traits_map must contain the complete set of desired traits. Any external
+  # traits not found here will not be included in the user's certificates.
+  #
+  # Exactly one of traits_map or traits_expression must be set.
+  traits_map:
+    logins:
+      - external.groups
+    logins:
+      - strings.lower(external.username)
+
+  # traits_expression is a string holding a single predicate expression which
+  # must evaluate to a dict. This will set all user's traits during login.
+  #
+  # Exactly one of traits_map or traits_expression must be set.
+  traits_expression: |
+    external.put("logins", strings.lower(external.logins))
+```

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -2263,6 +2263,47 @@ $ tctl sso configure saml -p okta -r group,dev,access -e https://dev-123456.okta
 $ tctl sso configure saml -p okta -r group,developer,access -e entity-desc.xml | tctl sso test
 ```
 
+### tctl login_rule test
+
+Test a Login Rule resource without installing it in the cluster.
+
+#### Arguments
+
+- `<traits-file>` input traits file in JSON or YAML format. Empty for stdin.
+
+#### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--resource-file` | none | **string** filepath | Path to Login Rule resource path, can be repeated for multiple files |
+| `--load-from-cluster` | `false` | `true, false` | When true, all Login Rules currently installed in the cluster will be loaded for the test. Can be combined with `--resource-file` to test interactions. |
+| `--format` | `yaml` | `yaml, json` | Output format for traits |
+
+#### Global flags
+
+These flags are available for all commands `--debug, --config`. Run
+`tctl help <subcommand>` or see the [Global Flags section](#tctl-global-flags).
+
+#### Examples
+
+Test evaluation of the Login Rules from rule1.yaml and rule2.yaml with input traits from traits.json
+
+```code
+$tctl login_rule test --resource-file rule1.yaml --resource-file rule2.yaml traits.json
+```
+
+Test the Login Rule in rule.yaml along with all Login Rules already present in the cluster
+
+```code
+$ tctl login_rule test --resource-file rule.yaml --load-from-cluster traits.json
+```
+
+Read the input traits from stdin
+
+```code
+$ echo '{"groups": ["example"]}' | tctl login_rule test --resource-file rule.yaml
+```
+
 ### tctl create
 
 Create or update a Teleport resource from a YAML file.

--- a/docs/pages/reference/resources.mdx
+++ b/docs/pages/reference/resources.mdx
@@ -119,6 +119,7 @@ Here's the list of resources currently exposed via [`tctl`](./cli.mdx#tctl):
 | connector | Authentication connectors for [Single Sign-On](../access-controls/sso.mdx) (SSO) for SAML, OIDC and GitHub. |
 | node | A registered SSH node. The same record is displayed via `tctl nodes ls` |
 | cluster | A trusted cluster. See [here](../management/admin/trustedclusters.mdx) for more details on connecting clusters together. |
+| login_rule | A Login Rule, see the [Login Rules guide](../access-controls/login-rules.mdx) for more info. |
 
 **Examples:**
 
@@ -189,3 +190,9 @@ Interactive and non-interactive users (bots) assume one or many roles.
 Roles govern access to databases, SSH servers, Kubernetes clusters, web services and applications and Windows Desktops.
 
 (!docs/pages/includes/role-spec.mdx!)
+
+### Login Rules
+
+Login rules contain logic to transform SSO user traits during login.
+
+(!docs/pages/includes/login-rule-spec.mdx!)


### PR DESCRIPTION
This PR adds documentation for the Login Rules feature as designed in [RFD 78](https://github.com/gravitational/teleport/blob/master/rfd/0078-login-rules.md). The implementation has already been released in Teleport 11.3.0.