### PR TITLE
refactor tsh db local proxy logic and improve user messages

### DIFF
--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -232,31 +232,32 @@ func onDatabaseLogin(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	routeToDatabase := tlsca.RouteToDatabase{
+	route := tlsca.RouteToDatabase{
 		ServiceName: cf.DatabaseService,
 		Protocol:    database.GetProtocol(),
 		Username:    cf.DatabaseUser,
 		Database:    cf.DatabaseName,
 	}
 
-	if err := databaseLogin(cf, tc, routeToDatabase); err != nil {
+	if err := databaseLogin(cf, tc, route); err != nil {
 		return trace.Wrap(err)
 	}
 
 	// Print after-login message.
 	templateData := map[string]string{
-		"name": routeToDatabase.ServiceName,
+		"name": route.ServiceName,
 	}
 
 	// DynamoDB does not support a connect command, so don't try to print one.
 	if database.GetProtocol() != defaults.ProtocolDynamoDB {
-		templateData["connectCommand"] = utils.Color(utils.Yellow, formatDatabaseConnectCommand(cf.SiteName, routeToDatabase))
+		templateData["connectCommand"] = utils.Color(utils.Yellow, formatDatabaseConnectCommand(cf.SiteName, route))
 	}
 
-	if shouldUseLocalProxyForDatabase(tc, &routeToDatabase) {
-		templateData["proxyCommand"] = utils.Color(utils.Yellow, formatDatabaseProxyCommand(cf.SiteName, routeToDatabase))
+	requires := getDBLocalProxyRequirement(tc, &route)
+	if requires.localProxy {
+		templateData["proxyCommand"] = utils.Color(utils.Yellow, formatDatabaseProxyCommand(cf.SiteName, route))
 	} else {
-		templateData["configCommand"] = utils.Color(utils.Yellow, formatDatabaseConfigCommand(cf.SiteName, routeToDatabase))
+		templateData["configCommand"] = utils.Color(utils.Yellow, formatDatabaseConfigCommand(cf.SiteName, route))
 	}
 	return trace.Wrap(dbConnectTemplate.Execute(cf.Stdout(), templateData))
 }
@@ -288,9 +289,9 @@ func checkAndSetDBRouteDefaults(r *tlsca.RouteToDatabase) error {
 	return nil
 }
 
-func databaseLogin(cf *CLIConf, tc *client.TeleportClient, db tlsca.RouteToDatabase) error {
-	log.Debugf("Fetching database access certificate for %s on cluster %v.", db, tc.SiteName)
-	if err := checkAndSetDBRouteDefaults(&db); err != nil {
+func databaseLogin(cf *CLIConf, tc *client.TeleportClient, route tlsca.RouteToDatabase) error {
+	log.Debugf("Fetching database access certificate for %s on cluster %v.", route, tc.SiteName)
+	if err := checkAndSetDBRouteDefaults(&route); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -309,10 +310,10 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, db tlsca.RouteToDatab
 			key, err = tc.IssueUserCertsWithMFA(cf.Context, client.ReissueParams{
 				RouteToCluster: tc.SiteName,
 				RouteToDatabase: proto.RouteToDatabase{
-					ServiceName: db.ServiceName,
-					Protocol:    db.Protocol,
-					Username:    db.Username,
-					Database:    db.Database,
+					ServiceName: route.ServiceName,
+					Protocol:    route.Protocol,
+					Username:    route.Username,
+					Database:    route.Database,
 				},
 				AccessRequests: profile.ActiveRequests.AccessRequests,
 			}, nil /*applyOpts*/)
@@ -331,7 +332,7 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, db tlsca.RouteToDatab
 		return trace.Wrap(err)
 	}
 	// Update the database-specific connection profile file.
-	err = dbprofile.Add(cf.Context, tc, db, *profile)
+	err = dbprofile.Add(cf.Context, tc, route, *profile)
 	return trace.Wrap(err)
 }
 
@@ -415,9 +416,9 @@ func onDatabaseEnv(cf *CLIConf) error {
 	if !dbprofile.IsSupported(*database) {
 		return trace.BadParameter(formatDbCmdUnsupportedDBProtocol(cf, database))
 	}
-	// MySQL requires ALPN local proxy in single port mode.
-	if tc.TLSRoutingEnabled && database.Protocol == defaults.ProtocolMySQL {
-		return trace.BadParameter(formatDbCmdUnsupportedTLSRouting(cf, database))
+	requires := getDBLocalProxyRequirement(tc, database)
+	if requires.localProxy {
+		return trace.BadParameter(formatDbCmdUnsupported(cf, database, requires.localProxyReasons...))
 	}
 
 	env, err := dbprofile.Env(tc, *database)
@@ -470,15 +471,13 @@ func onDatabaseConfig(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
+	requires := getDBLocalProxyRequirement(tc, database)
 	// "tsh db config" prints out instructions for native clients to connect to
 	// the remote proxy directly. Return errors here when direct connection
 	// does NOT work (e.g. when ALPN local proxy is required).
-	if isLocalProxyAlwaysRequired(tc, database.Protocol) {
-		return trace.BadParameter(formatDbCmdUnsupportedDBProtocol(cf, database))
-	}
-	// MySQL requires ALPN local proxy in single port mode.
-	if tc.TLSRoutingEnabled && database.Protocol == defaults.ProtocolMySQL {
-		return trace.BadParameter(formatDbCmdUnsupportedTLSRouting(cf, database))
+	if requires.localProxy {
+		msg := formatDbCmdUnsupported(cf, database, requires.localProxyReasons...)
+		return trace.BadParameter(msg)
 	}
 
 	host, port := tc.DatabaseProxyHostPort(*database)
@@ -552,24 +551,18 @@ func serializeDatabaseConfig(configInfo *dbConfigInfo, format string) (string, e
 // maybeStartLocalProxy starts local TLS ALPN proxy if needed depending on the
 // connection scenario and returns a list of options to use in the connect
 // command.
-func maybeStartLocalProxy(ctx context.Context, cf *CLIConf, tc *client.TeleportClient, profile *client.ProfileStatus, db *tlsca.RouteToDatabase,
-	database types.Database, rootClusterName string,
+func maybeStartLocalProxy(ctx context.Context, cf *CLIConf,
+	tc *client.TeleportClient, profile *client.ProfileStatus,
+	route *tlsca.RouteToDatabase, db types.Database, rootClusterName string,
+	req *dbLocalProxyRequirement,
 ) ([]dbcmd.ConnectCommandFunc, error) {
-	if !shouldUseLocalProxyForDatabase(tc, db) {
-		return []dbcmd.ConnectCommandFunc{}, nil
+	if !req.localProxy {
+		return nil, nil
 	}
-
-	// Some protocols (Snowflake, DynamoDB) only works in the local tunnel mode.
-	// ElasticSearch can work without the --tunnel flag, but not via `tsh db connect`.
-	localProxyTunnel := cf.LocalProxyTunnel
-	if requiresLocalProxyTunnel(tc, db.Protocol) || db.Protocol == defaults.ProtocolElasticsearch {
-		localProxyTunnel = true
-	}
-
-	if localProxyTunnel {
-		log.Debug("Starting local proxy tunnel")
+	if req.tunnel {
+		log.Debugf("Starting local proxy tunnel because: %v", strings.Join(req.tunnelReasons, ", "))
 	} else {
-		log.Debug("Starting local proxy")
+		log.Debugf("Starting local proxy because: %v", strings.Join(req.localProxyReasons, ", "))
 	}
 
 	listener, err := net.Listen("tcp", "localhost:0")
@@ -581,10 +574,10 @@ func maybeStartLocalProxy(ctx context.Context, cf *CLIConf, tc *client.TeleportC
 		cliConf:          cf,
 		teleportClient:   tc,
 		profile:          profile,
-		routeToDatabase:  db,
-		database:         database,
+		routeToDatabase:  route,
+		database:         db,
 		listener:         listener,
-		localProxyTunnel: localProxyTunnel,
+		localProxyTunnel: req.tunnel,
 		rootClusterName:  rootClusterName,
 	})
 	if err != nil {
@@ -615,7 +608,7 @@ func maybeStartLocalProxy(ctx context.Context, cf *CLIConf, tc *client.TeleportC
 	cmdOpts := []dbcmd.ConnectCommandFunc{
 		dbcmd.WithLocalProxy(host, addr.Port(0), profile.CACertPathForCluster(rootClusterName)),
 	}
-	if localProxyTunnel {
+	if req.tunnel {
 		cmdOpts = append(cmdOpts, dbcmd.WithNoTLS())
 	}
 	return cmdOpts, nil
@@ -727,14 +720,16 @@ func onDatabaseConnect(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	routeToDatabase, database, err := getDatabaseInfo(cf, tc, cf.DatabaseService)
+	route, database, err := getDatabaseInfo(cf, tc, cf.DatabaseService)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if routeToDatabase.Protocol == defaults.ProtocolDynamoDB {
-		return trace.BadParameter(formatDbCmdUnsupportedDBProtocol(cf, routeToDatabase))
+	if route.Protocol == defaults.ProtocolDynamoDB {
+		return trace.BadParameter(formatDbCmdUnsupportedDBProtocol(cf, route))
 	}
-	if err := maybeDatabaseLogin(cf, tc, profile, routeToDatabase); err != nil {
+
+	requires := getDBLocalProxyRequirement(tc, route, withConnectRequirements(tc, route))
+	if err := maybeDatabaseLogin(cf, tc, profile, route, requires); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -747,7 +742,7 @@ func onDatabaseConnect(cf *CLIConf) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	opts, err := maybeStartLocalProxy(ctx, cf, tc, profile, routeToDatabase, database, rootClusterName)
+	opts, err := maybeStartLocalProxy(ctx, cf, tc, profile, route, database, rootClusterName, requires)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -757,7 +752,7 @@ func onDatabaseConnect(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	bb := dbcmd.NewCmdBuilder(tc, profile, routeToDatabase, rootClusterName, opts...)
+	bb := dbcmd.NewCmdBuilder(tc, profile, route, rootClusterName, opts...)
 	cmd, err := bb.GetConnectCommand()
 	if err != nil {
 		return trace.Wrap(err)
@@ -840,14 +835,7 @@ func getDatabase(cf *CLIConf, tc *client.TeleportClient, dbName string) (types.D
 	return databases[0], nil
 }
 
-func needDatabaseRelogin(cf *CLIConf, tc *client.TeleportClient, database *tlsca.RouteToDatabase, profile *client.ProfileStatus) (bool, error) {
-	if cf.LocalProxyTunnel {
-		// Don't login to database here if local proxy tunnel is enabled.
-		// When local proxy tunnel is enabled, the local proxy will check if DB login is needed when
-		// it starts and on each new connection.
-		return false, nil
-	}
-
+func needDatabaseRelogin(cf *CLIConf, tc *client.TeleportClient, route *tlsca.RouteToDatabase, profile *client.ProfileStatus) (bool, error) {
 	found := false
 	activeDatabases, err := profile.DatabasesForCluster(tc.SiteName)
 	if err != nil {
@@ -855,7 +843,7 @@ func needDatabaseRelogin(cf *CLIConf, tc *client.TeleportClient, database *tlsca
 	}
 
 	for _, v := range activeDatabases {
-		if v.ServiceName == database.ServiceName {
+		if v.ServiceName == route.ServiceName {
 			found = true
 		}
 	}
@@ -866,32 +854,33 @@ func needDatabaseRelogin(cf *CLIConf, tc *client.TeleportClient, database *tlsca
 
 	// For database protocols where database username is encoded in client certificate like Mongo
 	// check if the command line dbUser matches the encoded username in database certificate.
-	userChanged, err := dbInfoHasChanged(cf, profile.DatabaseCertPathForCluster(tc.SiteName, database.ServiceName))
+	dbInfoChanged, err := dbInfoHasChanged(cf, profile.DatabaseCertPathForCluster(tc.SiteName, route.ServiceName))
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	if userChanged {
+	if dbInfoChanged {
 		return true, nil
 	}
-
-	// Call API and check is a user needs to use MFA to connect to the database.
-	mfaRequired, err := isMFADatabaseAccessRequired(cf, tc, database)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	return mfaRequired, nil
+	// Call API and check if a user needs to use MFA to connect to the database.
+	mfaRequired, err := isMFADatabaseAccessRequired(cf.Context, tc, route)
+	return mfaRequired, trace.Wrap(err)
 }
 
-// maybeDatabaseLogin checks if cert is still valid or DB connection requires
-// MFA, and that client is not requesting an authenticated local proxy tunnel. If yes trigger db login logic.
-func maybeDatabaseLogin(cf *CLIConf, tc *client.TeleportClient, profile *client.ProfileStatus, db *tlsca.RouteToDatabase) error {
-	reloginNeeded, err := needDatabaseRelogin(cf, tc, db, profile)
+// maybeDatabaseLogin checks if cert is still valid. If not valid, trigger db login logic.
+// returns a true/false indicating whether database login was triggered.
+func maybeDatabaseLogin(cf *CLIConf, tc *client.TeleportClient, profile *client.ProfileStatus, route *tlsca.RouteToDatabase, req *dbLocalProxyRequirement) error {
+	if req.localProxy && req.tunnel {
+		// We only need to (possibly) login if not using a local proxy tunnel,
+		// because a local proxy tunnel will handle db login itself.
+		return nil
+	}
+	reloginNeeded, err := needDatabaseRelogin(cf, tc, route, profile)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	if reloginNeeded {
-		return trace.Wrap(databaseLogin(cf, tc, *db))
+		return trace.Wrap(databaseLogin(cf, tc, *route))
 	}
 	return nil
 }
@@ -928,12 +917,12 @@ func dbInfoHasChanged(cf *CLIConf, certPath string) (bool, error) {
 
 // isMFADatabaseAccessRequired calls the IsMFARequired endpoint in order to get from user roles if access to the database
 // requires MFA.
-func isMFADatabaseAccessRequired(cf *CLIConf, tc *client.TeleportClient, database *tlsca.RouteToDatabase) (bool, error) {
-	proxy, err := tc.ConnectToProxy(cf.Context)
+func isMFADatabaseAccessRequired(ctx context.Context, tc *client.TeleportClient, database *tlsca.RouteToDatabase) (bool, error) {
+	proxy, err := tc.ConnectToProxy(ctx)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	cluster, err := proxy.ConnectToCluster(cf.Context, tc.SiteName)
+	cluster, err := proxy.ConnectToCluster(ctx, tc.SiteName)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
@@ -945,7 +934,7 @@ func isMFADatabaseAccessRequired(cf *CLIConf, tc *client.TeleportClient, databas
 		Username:    database.Username,
 		Database:    database.Database,
 	}
-	mfaResp, err := cluster.IsMFARequired(cf.Context, &proto.IsMFARequiredRequest{
+	mfaResp, err := cluster.IsMFARequired(ctx, &proto.IsMFARequiredRequest{
 		Target: &proto.IsMFARequiredRequest_Database{
 			Database: &dbParam,
 		},
@@ -1058,39 +1047,111 @@ func formatDatabaseConfigCommand(clusterFlag string, db tlsca.RouteToDatabase) s
 	return fmt.Sprintf("tsh db config --cluster=%v --format=cmd %v", clusterFlag, db.ServiceName)
 }
 
-// shouldUseLocalProxyForDatabase returns true if the ALPN local proxy should
-// be used for connecting to the provided database.
-func shouldUseLocalProxyForDatabase(tc *client.TeleportClient, db *tlsca.RouteToDatabase) bool {
-	return tc.TLSRoutingEnabled || isLocalProxyAlwaysRequired(tc, db.Protocol)
+// dbLocalProxyRequirement describes local proxy requirements for connecting to a database.
+type dbLocalProxyRequirement struct {
+	// localProxy is whether a local proxy is required to connect.
+	localProxy bool
+	// localProxyReasons is a list of reasons for why local proxy is required.
+	localProxyReasons []string
+	// localProxy is whether a local proxy tunnel is required to connect.
+	tunnel bool
+	// tunnelReasons is a list of reasons for why a tunnel is required.
+	tunnelReasons []string
 }
 
-// isLocalProxyAlwaysRequired returns true for protocols that always requires
-// an ALPN local proxy.
-func isLocalProxyAlwaysRequired(tc *client.TeleportClient, protocol string) bool {
+// requireLocalProxy sets the local proxy requirement and appends reasons.
+func (r *dbLocalProxyRequirement) requireLocalProxy(reasons ...string) {
+	r.localProxy = true
+	r.localProxyReasons = append(r.localProxyReasons, reasons...)
+}
+
+// requireLocalProxyWithTunnel sets the local proxy and tunnel requirements,
+// and appends reasons for both.
+func (r *dbLocalProxyRequirement) requireLocalProxyWithTunnel(reasons ...string) {
+	r.requireLocalProxy(reasons...)
+	r.tunnel = true
+	r.tunnelReasons = append(r.tunnelReasons, reasons...)
+}
+
+// requireOpt is an optional requirement function used when getting requirements,
+// that allows the caller to add further requirements.
+type requireOpt func(r *dbLocalProxyRequirement)
+
+// getDBLocalProxyRequirement determines what local proxy settings are required
+// for a given database.
+func getDBLocalProxyRequirement(tc *client.TeleportClient, route *tlsca.RouteToDatabase, opts ...requireOpt) *dbLocalProxyRequirement {
+	var out dbLocalProxyRequirement
 	switch tc.PrivateKeyPolicy {
 	case keys.PrivateKeyPolicyHardwareKey, keys.PrivateKeyPolicyHardwareKeyTouch:
-		return true
+		out.requireLocalProxyWithTunnel(formatKeyPolicyReason(tc.PrivateKeyPolicy))
 	}
-	switch protocol {
-	case defaults.ProtocolSQLServer,
-		defaults.ProtocolSnowflake,
-		defaults.ProtocolCassandra,
-		defaults.ProtocolDynamoDB:
-		return true
-	default:
-		return false
+
+	// Some protocols (Snowflake, DynamoDB) only works in the local tunnel mode.
+	switch route.Protocol {
+	case defaults.ProtocolSnowflake, defaults.ProtocolDynamoDB:
+		out.requireLocalProxyWithTunnel(formatDBProtocolReason(route.Protocol))
+	case defaults.ProtocolSQLServer, defaults.ProtocolCassandra:
+		out.requireLocalProxy(formatDBProtocolReason(route.Protocol))
+	case defaults.ProtocolMySQL:
+		if tc.TLSRoutingEnabled {
+			out.requireLocalProxy(fmt.Sprintf("%v and %v",
+				formatDBProtocolReason(route.Protocol),
+				formatTLSRoutingReason(tc.SiteName)))
+		}
+	}
+
+	for _, opt := range opts {
+		opt(&out)
+	}
+	return &out
+}
+
+// withConnectRequirements is requirement option fn that adds requirements specific to "tsh db connect".
+func withConnectRequirements(tc *client.TeleportClient, route *tlsca.RouteToDatabase) requireOpt {
+	return func(r *dbLocalProxyRequirement) {
+		if !r.localProxy && tc.TLSRoutingEnabled {
+			r.requireLocalProxy(formatTLSRoutingReason(tc.SiteName))
+		}
+		switch route.Protocol {
+		case defaults.ProtocolElasticsearch:
+			// ElasticSearch access can work without a local proxy tunnel, but not
+			// via `tsh db connect`.
+			// (elasticsearch-sql-cli cannot be configured to use specific certs).
+			r.requireLocalProxyWithTunnel(formatDBProtocolReason(route.Protocol))
+		}
 	}
 }
 
-// formatDbCmdUnsupportedWithCondition is a helper func that formats a generic unsupported DB error message.
-// The condition argument is optional and can be "", but otherwise it should be a specific condition for which this DB subcommand
-// is not supported, e.g. "when TLS routing is enabled" or "without using the --tunnel flag".
-func formatDbCmdUnsupportedWithCondition(cf *CLIConf, database *tlsca.RouteToDatabase, condition string) string {
+// formatKeyPolicyReason is a helper func that formats a private key policy "reason".
+// The "reason" is used to explain why something happened.
+func formatKeyPolicyReason(policy keys.PrivateKeyPolicy) string {
+	return fmt.Sprintf("private key policy is %v", policy)
+}
+
+// formatDBProtocolReason is a helper func that formats a database protocol
+// "reason".
+// The "reason" is used to explain why something happened.
+func formatDBProtocolReason(protocol string) string {
+	return fmt.Sprintf("database protocol is %v",
+		defaults.ReadableDatabaseProtocol(protocol))
+}
+
+// formatTLSRoutingReason is a helper func that formats a cluster proxy
+// TLS routing enabled "reason".
+// The "reason" is used to explain why something happened.
+func formatTLSRoutingReason(siteName string) string {
+	return fmt.Sprintf("cluster %v proxy is using TLS routing",
+		siteName)
+}
+
+// formatDbCmdUnsupported is a helper func that formats a generic unsupported DB error message.
+// The "reasons" arguments, if given, should specify condition for which this DB subcommand
+// is not supported, e.g. "TLS routing is enabled" or "using a local proxy without the --tunnel flag".
+func formatDbCmdUnsupported(cf *CLIConf, route *tlsca.RouteToDatabase, reasons ...string) string {
 	templateData := map[string]any{
 		"command":      cf.CommandWithBinary(),
-		"protocol":     defaults.ReadableDatabaseProtocol(database.Protocol),
-		"alternatives": getDbCmdAlternatives(cf.SiteName, database),
-		"condition":    condition,
+		"alternatives": getDbCmdAlternatives(cf.SiteName, route),
+		"reasons":      reasons,
 	}
 
 	buf := bytes.NewBuffer(nil)
@@ -1098,28 +1159,24 @@ func formatDbCmdUnsupportedWithCondition(cf *CLIConf, database *tlsca.RouteToDat
 	return buf.String()
 }
 
-// formatDbCmdUnsupportedDBProtocol is a helper func that formats the unsupported DB protocol error message unconditionally.
-func formatDbCmdUnsupportedDBProtocol(cf *CLIConf, database *tlsca.RouteToDatabase) string {
-	return formatDbCmdUnsupportedWithCondition(cf, database, "")
-}
-
-// formatDbCmdUnsupportedTLSRouting is a helper func that formats an unsupported DB Protocol error with a TLS routing condition.
-func formatDbCmdUnsupportedTLSRouting(cf *CLIConf, database *tlsca.RouteToDatabase) string {
-	return formatDbCmdUnsupportedWithCondition(cf, database, "when TLS routing is enabled on the Teleport Proxy Service")
+// formatDbCmdUnsupportedDBProtocol is a helper func that formats an unsupported DB protocol error message.
+func formatDbCmdUnsupportedDBProtocol(cf *CLIConf, route *tlsca.RouteToDatabase) string {
+	reason := formatDBProtocolReason(route.Protocol)
+	return formatDbCmdUnsupported(cf, route, reason)
 }
 
 // getDbCmdAlternatives is a helper func that returns alternative tsh commands for connecting to a database.
-func getDbCmdAlternatives(clusterFlag string, database *tlsca.RouteToDatabase) []string {
+func getDbCmdAlternatives(clusterFlag string, route *tlsca.RouteToDatabase) []string {
 	var alts []string
-	switch database.Protocol {
+	switch route.Protocol {
 	case defaults.ProtocolDynamoDB:
 		// DynamoDB only works with a local proxy tunnel and there is no "shell-like" cli, so `tsh db connect` doesn't make sense.
 	default:
 		// prefer displaying the connect command as the first suggested command alternative.
-		alts = append(alts, formatDatabaseConnectCommand(clusterFlag, *database))
+		alts = append(alts, formatDatabaseConnectCommand(clusterFlag, *route))
 	}
 	// all db protocols support this command.
-	alts = append(alts, formatDatabaseProxyCommand(clusterFlag, *database))
+	alts = append(alts, formatDatabaseProxyCommand(clusterFlag, *route))
 	return alts
 }
 
@@ -1137,7 +1194,12 @@ const (
 var (
 	// dbCmdUnsupportedTemplate is the error message printed when some
 	// database subcommands are not supported.
-	dbCmdUnsupportedTemplate = template.Must(template.New("").Parse(`"{{.command}}" is not supported for {{.protocol}} databases{{if .condition}} {{.condition}}{{end}}.
+	dbCmdUnsupportedTemplate = template.Must(template.New("").Parse(`"{{.command}}" is not supported{{if .reasons}} when:
+{{- range $reason := .reasons }}
+  - {{ $reason }}.
+{{- end}}
+{{- else}}.
+{{- end}}
 {{if eq (len .alternatives) 1}}
 Please use the following command to connect to the database:
     {{index .alternatives 0 -}}{{else}}

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -57,11 +57,26 @@ func TestDatabaseLogin(t *testing.T) {
 	require.NoError(t, err)
 	alice.SetRoles([]string{"access"})
 
-	authProcess, proxyProcess := makeTestServers(t, withBootstrap(connector, alice))
+	authProcess, proxyProcess := makeTestServers(t, withBootstrap(connector, alice),
+		withAuthConfig(func(cfg *service.AuthConfig) {
+			cfg.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+		}))
 	makeTestDatabaseServer(t, authProcess, proxyProcess, service.Database{
 		Name:     "postgres",
 		Protocol: defaults.ProtocolPostgres,
 		URI:      "localhost:5432",
+	}, service.Database{
+		Name:     "mysql",
+		Protocol: defaults.ProtocolMySQL,
+		URI:      "localhost:3306",
+	}, service.Database{
+		Name:     "cassandra",
+		Protocol: defaults.ProtocolCassandra,
+		URI:      "localhost:9042",
+	}, service.Database{
+		Name:     "snowflake",
+		Protocol: defaults.ProtocolSnowflake,
+		URI:      "localhost.snowflakecomputing.com",
 	}, service.Database{
 		Name:     "mongo",
 		Protocol: defaults.ProtocolMongoDB,
@@ -118,6 +133,24 @@ func TestDatabaseLogin(t *testing.T) {
 			expectCertsLen:        1,
 			expectErrForConfigCmd: true, // "tsh db config" not supported for MSSQL.
 			expectErrForEnvCmd:    true, // "tsh db env" not supported for MSSQL.
+		},
+		{
+			databaseName:          "mysql",
+			expectCertsLen:        1,
+			expectErrForConfigCmd: true, // "tsh db config" not supported for MySQL with TLS routing.
+			expectErrForEnvCmd:    true, // "tsh db env" not supported for MySQL with TLS routing.
+		},
+		{
+			databaseName:          "cassandra",
+			expectCertsLen:        1,
+			expectErrForConfigCmd: true, // "tsh db config" not supported for Cassandra.
+			expectErrForEnvCmd:    true, // "tsh db env" not supported for Cassandra.
+		},
+		{
+			databaseName:          "snowflake",
+			expectCertsLen:        1,
+			expectErrForConfigCmd: true, // "tsh db config" not supported for Snowflake.
+			expectErrForEnvCmd:    true, // "tsh db env" not supported for Snowflake.
 		},
 		{
 			databaseName:          "dynamodb",

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -375,17 +375,24 @@ func onProxyCommandDB(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	routeToDatabase, db, err := getDatabaseInfo(cf, client, cf.DatabaseService)
+	route, db, err := getDatabaseInfo(cf, client, cf.DatabaseService)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	// Some protocols require the --tunnel flag, e.g. Snowflake, DynamoDB.
-	if !cf.LocalProxyTunnel && requiresLocalProxyTunnel(client, routeToDatabase.Protocol) {
-		return trace.BadParameter(formatDbCmdUnsupportedWithCondition(cf, routeToDatabase, "without the --tunnel flag"))
+	// When proxying without the `--tunnel` flag, we need to:
+	// 1. check if --tunnel is required.
+	// 2. check if db login is required.
+	// These steps are not needed with `--tunnel`, because the local proxy tunnel
+	// will manage database certificates itself and reissue them as needed.
+	requires := getDBLocalProxyRequirement(client, route)
+	if requires.tunnel && !cf.LocalProxyTunnel {
+		// Some scenarios require the --tunnel flag, e.g.:
+		// - Snowflake, DynamoDB protocol
+		// - Hardware-backed private key policy
+		return trace.BadParameter(formatDbCmdUnsupported(cf, route, requires.tunnelReasons...))
 	}
-
-	if err := maybeDatabaseLogin(cf, client, profile, routeToDatabase); err != nil {
+	if err := maybeDatabaseLogin(cf, client, profile, route, requires); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -414,7 +421,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 		cliConf:          cf,
 		teleportClient:   client,
 		profile:          profile,
-		routeToDatabase:  routeToDatabase,
+		routeToDatabase:  route,
 		listener:         listener,
 		localProxyTunnel: cf.LocalProxyTunnel,
 		rootClusterName:  rootCluster,
@@ -448,7 +455,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 
-		commands, err := dbcmd.NewCmdBuilder(client, profile, routeToDatabase, rootCluster,
+		commands, err := dbcmd.NewCmdBuilder(client, profile, route, rootCluster,
 			opts...,
 		).GetConnectCommandAlternatives()
 		if err != nil {
@@ -457,8 +464,8 @@ func onProxyCommandDB(cf *CLIConf) error {
 
 		// shared template arguments
 		templateArgs := map[string]any{
-			"database":   routeToDatabase.ServiceName,
-			"type":       defaults.ReadableDatabaseProtocol(routeToDatabase.Protocol),
+			"database":   route.ServiceName,
+			"type":       defaults.ReadableDatabaseProtocol(route.Protocol),
 			"cluster":    client.SiteName,
 			"address":    listener.Addr().String(),
 			"randomPort": randomPort,
@@ -472,10 +479,10 @@ func onProxyCommandDB(cf *CLIConf) error {
 
 	} else {
 		err = dbProxyTpl.Execute(os.Stdout, map[string]any{
-			"database":   routeToDatabase.ServiceName,
+			"database":   route.ServiceName,
 			"address":    listener.Addr().String(),
 			"ca":         profile.CACertPathForCluster(rootCluster),
-			"cert":       profile.DatabaseCertPathForCluster(cf.SiteName, routeToDatabase.ServiceName),
+			"cert":       profile.DatabaseCertPathForCluster(cf.SiteName, route.ServiceName),
 			"key":        profile.KeyPath(),
 			"randomPort": randomPort,
 		})
@@ -918,20 +925,6 @@ func envVarCommand(format, key, value string) (string, error) {
 
 	default:
 		return "", trace.BadParameter("unsupported format %q", format)
-	}
-}
-
-// requiresLocalProxyTunnel returns whether the given protocol requires a local proxy with the --tunnel flag.
-func requiresLocalProxyTunnel(tc *libclient.TeleportClient, protocol string) bool {
-	switch tc.PrivateKeyPolicy {
-	case keys.PrivateKeyPolicyHardwareKey, keys.PrivateKeyPolicyHardwareKeyTouch:
-		return true
-	}
-	switch protocol {
-	case defaults.ProtocolSnowflake, defaults.ProtocolDynamoDB:
-		return true
-	default:
-		return false
 	}
 }
 


### PR DESCRIPTION
I split this PR out from changes I'm making to support https://github.com/gravitational/teleport/issues/20323 so that I can backport this change separately.

Consider this step 1 of 3 PRs to come.

This PR:
1. refactors some tsh code to consolidate all the logic surrounding whether we require/should use a local proxy/tunnel. The logic before was a little scattered and that made it hard to keep consistent.
2. adds some extra info to the logs when `tsh db connect` decides to start a local proxy/tunnel (only visible with `--debug`), which explain *why* `tsh db connect` is starting a local proxy/tunnel.
3. further improves error messages for scenarios where a `tsh db` command is not supported by explaining all the reasons *why* the command is not supported.

## Example user messages

```
$ tsh db login --db-user=database-access-group --db-name="mysql" teleport-mysql-flex
Tap your YubiKey
Connection information for database "teleport-mysql-flex" has been saved.

You can now connect to it using the following command:

  tsh db connect teleport-mysql-flex

You can start a local proxy for database GUI clients:

  tsh proxy db --tunnel teleport-mysql-flex

$ tsh db config
ERROR: "tsh db config" is not supported when:
 - private key policy is hardware_key_touch.
 - database protocol is MySQL and cluster mars.local.gd proxy is using TLS routing.

Please use one of the following commands to connect to the database:
    tsh db connect teleport-mysql-flex
    tsh proxy db --tunnel teleport-mysql-flex

$ tsh db env
ERROR: "tsh db env" is not supported when:
  - private key policy is hardware_key_touch.
  - database protocol is MySQL and cluster mars.local.gd proxy is using TLS routing.

Please use one of the following commands to connect to the database:
    tsh db connect teleport-mysql-flex
    tsh proxy db --tunnel teleport-mysql-flex

$ tsh db logout
Logged out of database teleport-mysql-flex

$ tsh db login dynamodb

$ tsh db env
ERROR: "tsh db env" is not supported when:
  - database protocol is DynamoDB.

Please use the following command to connect to the database:
    tsh proxy db --tunnel --db-user=<user> dynamodb

$ tsh db config
ERROR: "tsh db config" is not supported when:
  - private key policy is hardware_key_touch.
  - database protocol is DynamoDB.

Please use the following command to connect to the database:
    tsh proxy db --tunnel --db-user=<user> dynamodb
```

## TODO
Step 2/3: [protobuf update for cert requests](https://github.com/gravitational/teleport/pull/21197)
Step 3/3:[ small change to make local proxy tunnel disable per-session-mfa cert TTL and make `tsh db connect` use local proxy tunnel when  per-session-mfa is in effect.](https://github.com/gravitational/teleport/pull/21200)