### PR TITLE
[v11] Removes Drone concurrency limit on native windows build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -660,8 +660,6 @@ node:
   buildbox_version: teleport11
 clone:
   disable: true
-concurrency:
-  limit: 1
 steps:
 - name: Check out Teleport
   commands:
@@ -18295,6 +18293,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: d3b6b3345ab707a7c6a20a5528398904a01b6c556761be0bcdcaf0ba0b75541b
+hmac: f1f5f7d038ec77f951929aa8d5a91a05fa41509de471ad1b83ade892d1b1e4a5
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -1166,10 +1166,12 @@ init-submodules-e:
 # dronegen generates .drone.yml config
 #
 #    Usage:
-#    - install github.com/gravitational/tdr
-#    - set $DRONE_TOKEN and $DRONE_SERVER (https://drone.platform.teleport.sh)
+#    - install drone cli
+#    - set $DRONE_TOKEN
 #    - tsh login --proxy=platform.teleport.sh
 #    - tsh app login drone
+#    - tsh proxy app drone
+#    - export DRONE_SERVER=https://localhost:$TSH_PROXY_PORT
 #    - make dronegen
 .PHONY: dronegen
 dronegen:

--- a/dronegen/drone_cli.go
+++ b/dronegen/drone_cli.go
@@ -20,9 +20,9 @@ import (
 	"os/exec"
 )
 
-func checkTDR() error {
-	if _, err := exec.LookPath("tdr"); err != nil {
-		return fmt.Errorf("can't find tdr in $PATH: %w; get it from https://github.com/gravitational/tdr/", err)
+func checkDrone() error {
+	if _, err := exec.LookPath("drone"); err != nil {
+		return fmt.Errorf("can't find drone in $PATH: %w; get it from https://docs.drone.io/cli/install/ or `brew install drone`", err)
 	}
 	if os.Getenv("DRONE_SERVER") == "" || os.Getenv("DRONE_TOKEN") == "" {
 		return fmt.Errorf("$DRONE_SERVER and/or $DRONE_TOKEN env vars not set; get them at https://drone.platform.teleport.sh/account")
@@ -31,7 +31,7 @@ func checkTDR() error {
 }
 
 func signDroneConfig() error {
-	out, err := exec.Command("tdr", "sign", "gravitational/teleport", "--save").CombinedOutput()
+	out, err := exec.Command("drone", "sign", "gravitational/teleport", "--save").CombinedOutput()
 	if err != nil {
 		if len(out) > 0 {
 			err = fmt.Errorf("drone signing failed: %v\noutput:\n%s", err, out)

--- a/dronegen/main.go
+++ b/dronegen/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 func main() {
-	if err := checkTDR(); err != nil {
+	if err := checkDrone(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/dronegen/windows.go
+++ b/dronegen/windows.go
@@ -100,7 +100,6 @@ func windowsTagPipeline() pipeline {
 
 func windowsPushPipeline() pipeline {
 	p := newWindowsPipeline("push-build-native-windows-amd64")
-	p.Concurrency.Limit = 1
 	p.Trigger = trigger{
 		Event:  triggerRef{Include: []string{"push"}, Exclude: []string{"pull_request"}},
 		Branch: triggerRef{Include: []string{"master", "branch/*"}},


### PR DESCRIPTION
Windows builds are currently limited to 1 concurrent build for all stages
with the same name. This is causing unnecessary delay on the push build
queue, given that the Windows native builds are all set up to be independent
of one another.

Also updates the dronegen process to use a stock drone cli instance
proxied via tsh, to better match modern usage.