### PR TITLE
Fix the navigation not listening to the back button

### DIFF
--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -105,9 +105,9 @@ export function Navigation() {
       NavigationCategory.Resources
   );
 
-  const [previousRoute, setPreviousRoute] = useState<{ [category: string]: string }>(
-    {}
-  );
+  const [previousRoute, setPreviousRoute] = useState<{
+    [category: string]: string;
+  }>({});
 
   const handleLocationChange = useCallback(
     (next: history.Location<unknown> | Location) => {

--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -33,7 +33,7 @@ import { NavigationCategoryContainer } from 'teleport/Navigation/NavigationCateg
 
 import logo from './logo.png';
 
-import type { Location } from 'history';
+import type * as history from 'history';
 
 import type { TeleportFeature } from 'teleport/types';
 
@@ -77,7 +77,7 @@ export function getFirstRouteForCategory(
 
 function getCategoryForRoute(
   features: TeleportFeature[],
-  route: Location<unknown>
+  route: history.Location<unknown> | Location
 ) {
   const feature = features
     .filter(feature => Boolean(feature.route))
@@ -110,7 +110,7 @@ export function Navigation() {
   );
 
   const handleLocationChange = useCallback(
-    (next: Location<unknown>) => {
+    (next: history.Location<unknown> | Location) => {
       const previousPathName = location.pathname;
 
       const category = getCategoryForRoute(features, next);
@@ -132,7 +132,7 @@ export function Navigation() {
 
   const handlePopState = useCallback(
     (event: PopStateEvent) => {
-      handleLocationChange((event.currentTarget as any).location);
+      handleLocationChange((event.currentTarget as Window).location);
     },
     [view]
   );

--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -105,7 +105,7 @@ export function Navigation() {
       NavigationCategory.Resources
   );
 
-  const [previousRoute, setPreviousRoute] = useState<{ [key: string]: string }>(
+  const [previousRoute, setPreviousRoute] = useState<{ [category: string]: string }>(
     {}
   );
 


### PR DESCRIPTION
Unfortunately React Router's `useHistory()` and `history.listen` does not get notified when the user uses the back button, causing our previous route tracking logic to not fire. This could cause the navigation to get stuck, as it's previous route would be in the same category that the user was in, preventing them from changing categories.

This updates the code to listen to back/forward button presses via `window.onpopstate`, and to track the previous route per category so there's no chance of being stuck in the same category you're already in.