### PR TITLE
[v10] Use the webassets directory at the root of the project for the web ui

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4965,8 +4965,8 @@ func getPublicAddr(authClient auth.ReadAppsAccessPoint, a App) (string, error) {
 // It uses external configuration to make the decision
 func newHTTPFileSystem() (http.FileSystem, error) {
 	if !isDebugMode() {
-		fs, err := web.NewStaticFileSystem() //nolint:staticcheck
-		if err != nil {                      //nolint:staticcheck
+		fs, err := teleport.NewWebAssetsFilesystem() //nolint:staticcheck
+		if err != nil {                              //nolint:staticcheck
 			return nil, trace.Wrap(err)
 		}
 		return fs, nil

--- a/lib/web/assets.go
+++ b/lib/web/assets.go
@@ -68,36 +68,6 @@ func executableFolder() (string, error) {
 	return filepath.Dir(filepath.Clean(p)), nil
 }
 
-const (
-	webAssetsMissingError = "the teleport binary was built without web assets, try building with `make release`"
-	webAssetsReadError    = "failure reading web assets from the binary"
-)
-
-func readZipArchive(r io.ReaderAt, size int64) (ResourceMap, error) {
-	zreader, err := zip.NewReader(r, size)
-	if err != nil {
-		// this often happens when teleport is launched without the web assets
-		// zip file attached to the binary. for launching it in such mode
-		// set DEBUG environment variable to 1
-		if err == zip.ErrFormat {
-			return nil, trace.NotFound(webAssetsMissingError)
-		}
-		return nil, trace.NotFound("%s %v", webAssetsReadError, err)
-	}
-	entries := make(ResourceMap)
-	for _, file := range zreader.File {
-		if file.FileInfo().IsDir() {
-			continue
-		}
-		entries[file.Name] = file
-	}
-	// no entries found?
-	if len(entries) == 0 {
-		return nil, trace.Wrap(os.ErrInvalid)
-	}
-	return entries, nil
-}
-
 // resource struct implements http.File interface on top of zip.File object
 type resource struct {
 	reader io.ReadCloser

--- a/lib/web/static_test.go
+++ b/lib/web/static_test.go
@@ -18,10 +18,8 @@ package web
 
 import (
 	"io"
-	"os"
 	"strings"
 
-	"github.com/gravitational/trace"
 	"gopkg.in/check.v1"
 )
 
@@ -44,63 +42,4 @@ func (s *StaticSuite) TestLocalFS(c *check.C) {
 	c.Assert(f.Close(), check.IsNil)
 	c.Assert(strings.Contains(html, `<script src="/web/config.js"></script>`), check.Equals, true)
 	c.Assert(strings.Contains(html, `content="{{ .XCSRF }}"`), check.Equals, true)
-}
-
-func (s *StaticSuite) TestZipFS(c *check.C) {
-	fs, err := readZipArchiveAt("../../fixtures/assets.zip")
-	c.Assert(err, check.IsNil)
-	c.Assert(fs, check.NotNil)
-
-	// test simple full read:
-	f, err := fs.Open("/index.html")
-	c.Assert(err, check.IsNil)
-	bytes, err := io.ReadAll(f)
-	c.Assert(err, check.IsNil)
-	c.Assert(len(bytes), check.Equals, 813)
-	c.Assert(f.Close(), check.IsNil)
-
-	// seek + read
-	f, err = fs.Open("/index.html")
-	c.Assert(err, check.IsNil)
-	defer f.Close()
-
-	n, err := f.Seek(10, io.SeekStart)
-	c.Assert(err, check.IsNil)
-	c.Assert(n, check.Equals, int64(10))
-
-	bytes, err = io.ReadAll(f)
-	c.Assert(err, check.IsNil)
-	c.Assert(len(bytes), check.Equals, 803)
-
-	n, err = f.Seek(-50, io.SeekEnd)
-	c.Assert(err, check.IsNil)
-	c.Assert(n, check.Equals, int64(763))
-	bytes, err = io.ReadAll(f)
-	c.Assert(err, check.IsNil)
-	c.Assert(len(bytes), check.Equals, 50)
-
-	_, err = f.Seek(-50, io.SeekEnd)
-	c.Assert(err, check.IsNil)
-	n, err = f.Seek(-50, io.SeekCurrent)
-	c.Assert(err, check.IsNil)
-	c.Assert(n, check.Equals, int64(713))
-	bytes, err = io.ReadAll(f)
-	c.Assert(err, check.IsNil)
-	c.Assert(len(bytes), check.Equals, 100)
-}
-
-func readZipArchiveAt(path string) (ResourceMap, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	// file needs to stay open for http.FileSystem reads to work
-	//
-	// feed the binary into the zip reader and enumerate all files
-	// found in the attached zip file:
-	info, err := file.Stat()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return readZipArchive(file, info.Size())
 }

--- a/webassets_embed.go
+++ b/webassets_embed.go
@@ -1,0 +1,40 @@
+//go:build webassets_embed && !webassets_ent
+
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package teleport
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+
+	"github.com/gravitational/trace"
+)
+
+//go:embed webassets/teleport
+var embedded embed.FS
+
+// NewWebAssetsFilesystem returns the initialized implementation of
+// http.FileSystem interface which can be used to serve Teleport Proxy Web UI
+func NewWebAssetsFilesystem() (http.FileSystem, error) {
+	wfs, err := fs.Sub(embedded, "webassets/teleport")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return http.FS(wfs), nil
+}

--- a/webassets_embed_ent.go
+++ b/webassets_embed_ent.go
@@ -1,15 +1,11 @@
-//go:build webassets_embed
-// +build webassets_embed
+//go:build webassets_embed && webassets_ent
 
 /*
 Copyright 2021 Gravitational, Inc.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package web
+package teleport
 
 import (
 	"embed"
@@ -27,13 +23,13 @@ import (
 	"github.com/gravitational/trace"
 )
 
-//go:embed build/webassets
-var webassetFS embed.FS
+//go:embed webassets/e/teleport
+var embedded embed.FS
 
-// NewStaticFileSystem returns the initialized implementation of http.FileSystem
-// interface which can be used to serve Teleport Proxy Web UI
-func NewStaticFileSystem() (http.FileSystem, error) {
-	wfs, err := fs.Sub(webassetFS, "build/webassets")
+// NewWebAssetsFilesystem returns the initialized implementation of
+// http.FileSystem interface which can be used to serve Teleport Proxy Web UI
+func NewWebAssetsFilesystem() (http.FileSystem, error) {
+	wfs, err := fs.Sub(embedded, "webassets/e/teleport")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/webassets_noembed.go
+++ b/webassets_noembed.go
@@ -1,5 +1,4 @@
 //go:build !webassets_embed
-// +build !webassets_embed
 
 /*
 Copyright 2021 Gravitational, Inc.
@@ -17,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package web
+package teleport
 
 import (
 	"net/http"
@@ -25,7 +24,9 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// NewStaticFileSystem is a no-op in this build mode.
-func NewStaticFileSystem() (http.FileSystem, error) { //nolint:staticcheck
+const webAssetsMissingError = "the teleport binary was built without web assets, try building with `make release`"
+
+// NewWebAssetsFilesystem is a no-op in this build mode.
+func NewWebAssetsFilesystem() (http.FileSystem, error) { //nolint:staticcheck
 	return nil, trace.NotFound(webAssetsMissingError)
 }


### PR DESCRIPTION
This is a lift & shift from https://github.com/gravitational/teleport/pull/17058 to sync the webassets functionality from newer versions and to make it build correctly in drone.