### PR TITLE
Change error response formatting for "/version" endpoint

### DIFF
--- a/lib/client/conntest/kube.go
+++ b/lib/client/conntest/kube.go
@@ -257,8 +257,10 @@ func (s KubeConnectionTester) handleErrFromKube(ctx context.Context, clusterName
 		// agents is still running an older version.
 		// For this reason, messages are not shared between this connection test and
 		// `kubernetes_service` to force detection of incompatible messages.
+		// TODO(tigrato): Remove this check once we no longer support Teleport versions bellow 12.
 		noAssignedGroups := strings.Contains(kubeErr.ErrStatus.Message, "has no assigned groups or users")
-		if noAssignedGroups {
+		noConfiguredGroups := strings.Contains(kubeErr.ErrStatus.Message, "Please ask cluster administrator to ensure your role has appropriate kubernetes_groups and kubernetes_users set.")
+		if noAssignedGroups || noConfiguredGroups {
 			message := `User-associated roles do not configure "kubernetes_groups" or "kubernetes_users". Make sure that at least one is configured for the user.`
 			traceType := types.ConnectionDiagnosticTrace_RBAC_PRINCIPAL
 

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -264,7 +264,7 @@ func (t *TLSServer) Close() error {
 	return trace.Wrap(t.close(t.closeContext))
 }
 
-// Close closes the server and cleans up all resources.
+// Shutdown closes the server and cleans up all resources.
 func (t *TLSServer) Shutdown(ctx context.Context) error {
 	// TODO(tigrato): handle connections gracefully and wait for them to finish.
 	// This might be problematic because exec and port forwarding connections

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5796,7 +5796,8 @@ func TestDiagnoseKubeConnection(t *testing.T) {
 					Type:    types.ConnectionDiagnosticTrace_RBAC_PRINCIPAL,
 					Status:  types.ConnectionDiagnosticTrace_FAILED,
 					Details: "User-associated roles do not configure \"kubernetes_groups\" or \"kubernetes_users\". Make sure that at least one is configured for the user.",
-					Error:   "this user cannot request kubernetes access, has no assigned groups or users",
+					Error: "Your user's Teleport role does not allow Kubernetes access." +
+						" Please ask cluster administrator to ensure your role has appropriate kubernetes_groups and kubernetes_users set.",
 				},
 			},
 		},


### PR DESCRIPTION
This PR changes the formatting for the "/version" endpoint since Kubernetes clients do not expect a JSON response on that endpoint. This PR returns the error message directly into the body without any formatting so that `kubectl` is able to present the desired error.

```
kubectl version --short
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
Client Version: v1.25.4
Kustomize Version: v4.5.7
Error from server (InternalError): an error on the server ("Your user's Teleport role does not allow Kubernetes access. Please ask cluster administrator to ensure your role has appropriate kubernetes_groups and kubernetes_users set")
```

Fixes #20900