### PR TITLE
[doc] add missing comment for db dynamic resources config

### DIFF
--- a/docs/pages/includes/database-access/database-config.yaml
+++ b/docs/pages/includes/database-access/database-config.yaml
@@ -9,6 +9,7 @@ db_service:
   # one of the following values:
   # "dynamic": database resources created with "tctl create" command
   # "cloud": database resources created by the discovery service
+  # "config": database resources defined in the "databases" array below
   resources:
   - labels:
       "*": "*"


### PR DESCRIPTION
This is a quick follow-up on this [comment](https://github.com/gravitational/teleport/pull/20966#discussion_r1095863623)