### PR TITLE
fix redirects pointing at removed guide

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1624,7 +1624,7 @@
     },
     {
       "source": "/kubernetes-access/helm/guides/migration/",
-      "destination": "/deploy-a-cluster/helm-deployments/migration/",
+      "destination": "/deploy-a-cluster/helm-deployments/migration-v12/",
       "permanent": true
     },
     {
@@ -1829,7 +1829,7 @@
     },
     {
       "source": "/setup/helm-deployments/migration/",
-      "destination": "/deploy-a-cluster/helm-deployments/migration/",
+      "destination": "/deploy-a-cluster/helm-deployments/migration-v12/",
       "permanent": true
     },
     {


### PR DESCRIPTION
#21258 Removed a guide that had redirects pointing to it. This moves those redirect's destinations to the migration guide for v12.