### PR TITLE
Correctly handle closed websocket connections

### DIFF
--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -1012,7 +1012,10 @@ func (t *TerminalStream) Read(out []byte) (n int, err error) {
 
 	ty, bytes, err := t.ws.ReadMessage()
 	if err != nil {
-		if err == io.EOF || websocket.IsCloseError(err, websocket.CloseAbnormalClosure, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+		// if the connection has closed, we must return io.EOF in order to abort
+		// the websocket copy loop
+		if err == io.EOF || errors.Is(err, net.ErrClosed) ||
+			websocket.IsCloseError(err, websocket.CloseAbnormalClosure, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
 			return 0, io.EOF
 		}
 


### PR DESCRIPTION
We were properly handling graceful websocket closure, but in some cases (when terminating a session with ctrl+d, for example), the failure manifest as a generic connection closed error instead of a websocket close error.

Fixes #21334