### PR TITLE
Skip device authz when issuing App or Windows certs

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -114,6 +114,8 @@ type AuthPreference interface {
 	// GetDeviceTrust returns the cluster device trust settings, or nil if no
 	// explicit configurations are present.
 	GetDeviceTrust() *DeviceTrust
+	// SetDeviceTrust sets the cluster device trust settings.
+	SetDeviceTrust(*DeviceTrust)
 
 	// String represents a human readable version of authentication settings.
 	String() string
@@ -398,6 +400,11 @@ func (c *AuthPreferenceV2) GetDeviceTrust() *DeviceTrust {
 		return nil
 	}
 	return c.Spec.DeviceTrust
+}
+
+// SetDeviceTrust sets the cluster device trust settings.
+func (c *AuthPreferenceV2) SetDeviceTrust(dt *DeviceTrust) {
+	c.Spec.DeviceTrust = dt
 }
 
 // setStaticFields sets static resource header and metadata fields.

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -357,6 +357,8 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		ClusterName: srv.ClusterName,
 		AccessPoint: srv.AuthServer,
 		LockWatcher: srv.LockWatcher,
+		// AuthServer does explicit device authorization checks.
+		DisableDeviceAuthorization: true,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -727,6 +729,20 @@ func TestUser(username string) TestIdentity {
 		I: LocalUser{
 			Username: username,
 			Identity: tlsca.Identity{Username: username},
+		},
+	}
+}
+
+// TestUserWithDeviceExtensions returns a TestIdentity for a local user,
+// including the supplied device extensions in the tlsca.Identity.
+func TestUserWithDeviceExtensions(username string, exts tlsca.DeviceExtensions) TestIdentity {
+	return TestIdentity{
+		I: LocalUser{
+			Username: username,
+			Identity: tlsca.Identity{
+				Username:         username,
+				DeviceExtensions: exts,
+			},
 		},
 	}
 }


### PR DESCRIPTION
Skip device authorization for App or WindowsDesktop certificates - those modes don't yet support device trust, so there is no point in requiring a trusted device.

This fixes an issue for clusters that set the global `device_trust.mode` to `required` and have App or WindowsDesktop servers.

https://github.com/gravitational/teleport.e/issues/514