### PR TITLE
[v12] [Docs] fix lint-breaking spacing

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -859,7 +859,7 @@ When `existingDataVolume` is set to the name of an existing volume, the `/var/li
 
 | Type   | Default value                        |
 |--------|--------------------------------------|
-| `bool` | `true` for <1.23 `false` for >= 1.23 |
+| `bool` | `true` for < 1.23 `false` for >= 1.23 |
 
 By default, Teleport charts used to install a [`podSecurityPolicy`](https://github.com/gravitational/teleport/blob/master/examples/chart/teleport-cluster/templates/psp.yaml).
 


### PR DESCRIPTION
Backports #21351 to `branch/v12`.