### PR TITLE
[v12] Show enterprise installs for Cloud scope MacOS Installs (#19669)

### DIFF
--- a/docs/pages/includes/enterprise/install-macos.mdx
+++ b/docs/pages/includes/enterprise/install-macos.mdx
@@ -1,0 +1,20 @@
+  You can download one of the following .pkg installers for macOS:
+
+  | Link                                                                                                      | Binaries                                   |
+  |-----------------------------------------------------------------------------------------------------------|--------------------------------------------|
+  | [`teleport-ent-(=teleport.version=).pkg`](https://cdn.teleport.dev/teleport-ent-(=teleport.version=).pkg) | `teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot` |
+  | [`tsh-(=teleport.version=).pkg`](https://cdn.teleport.dev/tsh-(=teleport.version=).pkg)                   | `tsh`                                      |
+
+  You can also fetch an installer from the command line:
+
+  ```code
+  $ curl -O https://cdn.teleport.dev/teleport-ent-(=teleport.version=).pkg
+  # Install on Macintosh HD
+  $ sudo installer -pkg teleport-ent-(=teleport.version=).pkg -target / 
+  Password:
+  installer: Package name is teleport-ent-(=teleport.version=)
+  installer: Upgrading at base path /
+  installer: The upgrade was successful.
+  $ which teleport
+  /usr/local/bin/teleport
+  ```

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -104,8 +104,9 @@ chart.
 
 ## macOS
 
-<ScopedBlock scope={["oss", "cloud"]}>
-<Tabs>
+<Tabs dropdownView dropdownCaption="Teleport Edition">
+<TabItem label="Open Source" scope="oss">
+  <Tabs>
   <TabItem label="Installer">
 
   You can download one of the following .pkg installers for macOS:
@@ -132,96 +133,47 @@ chart.
   </TabItem>
 
   <TabItem label="Homebrew">
+ <Notice type="danger">
 
-  <Notice type="danger">
+The Teleport package in Homebrew is not maintained by Teleport and we can't
+guarantee its reliability or security. We recommend the use of our [official
+Teleport packages](https://goteleport.com/download?os=mac).
 
-  The Teleport package in Homebrew is not maintained by Teleport and we can't
-  guarantee its reliability or security. We recommend the use of our [official
-  Teleport packages](https://goteleport.com/download?os=mac).
+<ScopedBlock scope={["enterprise", "cloud"]}>
 
-  </Notice>
+The Homebrew version of Teleport lacks the ability to maintain SAML/OIDC authentication
+connectors through the `tctl` binary. We recommend installing the official Teleport Enterprise edition of `tctl`.
 
-    Run the following command:
+</ScopedBlock>
 
-    ```code
-    $ brew install teleport
-    ```
+</Notice>
 
-    If you choose to use Homebrew, you must verify that the versions of `tsh`
-    and `tctl` you run on your local machine are compatible with the versions
-    you run on your infrastructure. Homebrew usually ships the latest release of
-    Teleport, which may be incompatible with older versions. See our
-    [compatibility policy](./management/operations/upgrading.mdx) for details.
+To install Teleport with Homebrew, run the following command:
 
-    Log in to your cluster:
+```code
+$ brew install teleport
+```
 
-    <ScopedBlock scope="cloud">
+If you choose to use Homebrew, you must verify that the versions of `tsh`
+and `tctl` you run on your local machine are compatible with the versions
+you run on your infrastructure. Homebrew usually ships the latest release of
+Teleport, which may be incompatible with older versions. See our
+[compatibility policy](../management/operations/upgrading.mdx) for details.
 
-    ```code
-    $ tsh login --proxy=mytenant.teleport.sh --user=myuser
-    ```
+To verify versions, log in to your cluster and compare the output of `tctl status`
+against `tsh version` and `tctl version`.
 
-    </ScopedBlock>
-    <ScopedBlock scope={["oss", "enterprise"]}>
+ </TabItem>
+ </Tabs>
+</TabItem>
 
-    ```code
-    $ tsh login --proxy=teleport.example.com --user=myuser
-    ```
-
-    </ScopedBlock>
-
-    Get the version of your Teleport cluster:
-
-    <ScopedBlock scope="cloud">
-
-    ```code
-    $ tctl status
-    tctl status
-    Cluster  mytenant.teleport.sh                                           
-    Version  (=teleport.version=)                                                                   
-    Host CA  never updated                                                           
-    User CA  never updated                                                           
-    Jwt CA   never updated                                                           
-    CA pin   (=presets.ca_pin=)
-    ```
-
-    </ScopedBlock>
-    <ScopedBlock scope={["oss", "enterprise"]}>
-
-    ```code
-    $ tctl status
-    tctl status
-    Cluster  teleport.example.com
-    Version  (=teleport.version=)                                                                   
-    Host CA  never updated                                                           
-    User CA  never updated                                                           
-    Jwt CA   never updated                                                           
-    CA pin   (=presets.ca_pin=)
-    ```
-
-    </ScopedBlock>
-
-    Get your local tsh version:
-
-    ```code
-    $ tsh version
-    Teleport v(=teleport.version=) git:v(=teleport.version=) go(=teleport.golang=)
-    ```
-    
-    Get your local tctl version:
-
-    ```code
-    $ tctl version
-    Teleport v(=teleport.version=) git:v(=teleport.version=) go(=teleport.golang=)
-    ```
-    
-  </TabItem>
-
+<TabItem label="Enterprise" scope="enterprise">
+  (!docs/pages/includes/enterprise/install-macos.mdx!)
+</TabItem>
+<TabItem label="Cloud" scope="cloud">
+  (!docs/pages/includes/enterprise/install-macos.mdx!)  
+</TabItem>
 </Tabs>
-</ScopedBlock>
-<ScopedBlock scope="enterprise">
-(!docs/pages/includes/enterprise/install-macos-ent.mdx!)
-</ScopedBlock>
 
 ## Windows (tsh client only)
 


### PR DESCRIPTION
Backports #19669 to `branch/v12`.