### PR TITLE
[v10] Enable BuildKit for buildbox

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -120,7 +120,7 @@ build-binaries-fips: buildbox-fips
 buildbox:
 	if [[ "$(BUILDBOX_NAME)" == "$(BUILDBOX)" ]]; then \
 		if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX) 2>&1 >/dev/null; then docker pull $(BUILDBOX) || true; fi; \
-		docker build --platform=linux/$(RUNTIME_ARCH) \
+		DOCKER_BUILDKIT=1 docker build --platform=linux/$(RUNTIME_ARCH) \
 			--build-arg UID=$(UID) \
 			--build-arg GID=$(GID) \
 			--build-arg BUILDARCH=$(RUNTIME_ARCH) \


### PR DESCRIPTION
#21306 introduced Dockerfile changes to v10 which require [BuildKit](https://docs.docker.com/build/buildkit/). [push pipelines run by drone](https://drone.platform.teleport.sh/gravitational/teleport/20145/) & ["Build Ubuntu Buildbox" GitHub action](https://github.com/gravitational/teleport/actions/runs/4114919800/jobs/7102927967) have failed because they attempted to execute Dockerfile statements which were supposed to be executed only on arm64. Those statements wouldn't be executed with BuildKit enabled.

BuildKit was enabled for buildboxes in #14036. That PR however was not backported to v10 so only v11+ has buildkit enabled.

As far as I can judge from #14036, no other special changes are necessary when enabling BuildKit.

---

Also, for some reason [the drone pipeline which builds buildboxes succeeded](https://drone.platform.teleport.sh/gravitational/teleport/20145/10/1), but push pipelines which started rebuilding the image have failed.