### PR TITLE
Moderated sessions request is not forwarded into the leaf cluster

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1053,9 +1053,8 @@ func (f *Forwarder) join(ctx *authContext, w http.ResponseWriter, req *http.Requ
 	if err := f.setupForwardingHeaders(sess, req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// TODO: tigrato: This is a temporary fix to prevent the session from not
-	// being redirected to the correct cluster.
-	if sess.noAuditEvents || sess.teleportCluster.isRemote {
+
+	if !f.isLocalKubeCluster(sess) {
 		return f.remoteJoin(ctx, w, req, p, sess)
 	}
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1053,8 +1053,9 @@ func (f *Forwarder) join(ctx *authContext, w http.ResponseWriter, req *http.Requ
 	if err := f.setupForwardingHeaders(sess, req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	if sess.noAuditEvents {
+	// TODO: tigrato: This is a temporary fix to prevent the session from not
+	// being redirected to the correct cluster.
+	if sess.noAuditEvents || sess.teleportCluster.isRemote {
 		return f.remoteJoin(ctx, w, req, p, sess)
 	}
 


### PR DESCRIPTION
This PR fixes an issue when a user tries to join an existent moderated session on a leaf cluster from a root cluster.
The Kubernetes Proxy wasn't correctly forwarding the request into the leaf cluster and assumed that the session was available locally, which was not the case.

Fixes #21167