### PR TITLE
[v11] Bump OpenSSL and libcbor

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -31,9 +31,9 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
     make clean
 
 # Install libcbor.
-RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.1 && \
+RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
     cd libcbor && \
-    [ "$(git rev-parse HEAD)" = '5c1bb892c94b6ae2ef99e3c6673d5e0857242f38' ] && \
+    [ "$(git rev-parse HEAD)" = 'efa6c0886bae46bdaef9b679f61f4b9d8bc296ae' ] && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -27,9 +27,9 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 # Instal openssl.
 # Pulled from source because repository versions are too old.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1s && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1t && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = '129058165d195e43a0ad10111b0c2e29bdf65980' ] && \
+    [ "$(git rev-parse HEAD)" = '830bf8e1e4749ad65c51b6a1d0d769ae689404ba' ] && \
     ./config --release && \
     make && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -35,9 +35,9 @@ RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1s
     make install_sw
 
 # Install libcbor.
-RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.1 && \
+RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
     cd libcbor && \
-    [ "$(git rev-parse HEAD)" = '5c1bb892c94b6ae2ef99e3c6673d5e0857242f38' ] && \
+    [ "$(git rev-parse HEAD)" = 'efa6c0886bae46bdaef9b679f61f4b9d8bc296ae' ] && \
     cmake3 \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -16,8 +16,8 @@ readonly MACOS_VERSION_MIN=10.13
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.10.2
 readonly CBOR_COMMIT=efa6c0886bae46bdaef9b679f61f4b9d8bc296ae
-readonly CRYPTO_VERSION=OpenSSL_1_1_1s
-readonly CRYPTO_COMMIT=129058165d195e43a0ad10111b0c2e29bdf65980
+readonly CRYPTO_VERSION=OpenSSL_1_1_1t
+readonly CRYPTO_COMMIT=830bf8e1e4749ad65c51b6a1d0d769ae689404ba
 readonly FIDO2_VERSION=1.12.0
 readonly FIDO2_COMMIT=659a02679f99fd34a44e06e35dce90794f6ecc86
 

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -14,8 +14,8 @@ set -eu
 readonly MACOS_VERSION_MIN=10.13
 
 # Note: versions are the same as the corresponding git tags for each repo.
-readonly CBOR_VERSION=v0.10.1
-readonly CBOR_COMMIT=5c1bb892c94b6ae2ef99e3c6673d5e0857242f38
+readonly CBOR_VERSION=v0.10.2
+readonly CBOR_COMMIT=efa6c0886bae46bdaef9b679f61f4b9d8bc296ae
 readonly CRYPTO_VERSION=OpenSSL_1_1_1s
 readonly CRYPTO_COMMIT=129058165d195e43a0ad10111b0c2e29bdf65980
 readonly FIDO2_VERSION=1.12.0

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -6,6 +6,6 @@ enginesdir=${libdir}/engines-1.1
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 1.1.1q
+Version: 1.1.1t
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}


### PR DESCRIPTION
Updates OpenSSL to the latest security patch, 1.1.1t.

Updates libcbor to v0.10.2 as well.

* https://github.com/openssl/openssl/blob/OpenSSL_1_1_1t/CHANGES
* https://github.com/PJK/libcbor/releases/tag/v0.10.2

Backport #21420 to branch/v11