### PR TITLE
chore: Bump golangci-lint to v1.51.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,14 @@ output:
   uniq-by-line: false
 
 run:
+  go: '1.19'
+  skip-dirs:
+    - (^|/)node_modules/
+    - ^api/gen/
+    - ^docs/
+    - ^gen/
+    - ^rfd/
+    - ^web/
   skip-dirs-use-default: false
   timeout: 5m
-  go: '1.19'
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,13 +42,13 @@ linters-settings:
     list-type: denylist
     include-go-root: true # check against stdlib
     packages-with-error-message:
-    - io/ioutil: 'use "io" or "os" packages instead'
-    - github.com/golang/protobuf: 'use "google.golang.org/protobuf"'
-    - github.com/hashicorp/go-uuid: 'use "github.com/google/uuid" instead'
-    - github.com/pborman/uuid: 'use "github.com/google/uuid" instead'
-    - github.com/siddontang/go-log/log: 'use "github.com/sirupsen/logrus" instead'
-    - github.com/siddontang/go/log: 'use "github.com/sirupsen/logrus" instead'
-    - go.uber.org/atomic: 'use "sync/atomic" instead'
+      - io/ioutil: 'use "io" or "os" packages instead'
+      - github.com/golang/protobuf: 'use "google.golang.org/protobuf"'
+      - github.com/hashicorp/go-uuid: 'use "github.com/google/uuid" instead'
+      - github.com/pborman/uuid: 'use "github.com/google/uuid" instead'
+      - github.com/siddontang/go-log/log: 'use "github.com/sirupsen/logrus" instead'
+      - github.com/siddontang/go/log: 'use "github.com/sirupsen/logrus" instead'
+      - go.uber.org/atomic: 'use "sync/atomic" instead'
   misspell:
     locale: US
   gci:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,12 +10,6 @@ issues:
     - linters:
       - unused
       path: 'operator/controllers/resources/(.+)_controller_test\.go'
-    # TODO(codingllama): Remove ignore after the new golangci-lint image lands.
-    # For some reason this particular files causes problems between different
-    # goimports versions.
-    - path: lib/services/role_test.go
-      linters:
-      - goimports
   exclude-use-default: true
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -314,7 +314,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.8.2
 
 # Install golangci-lint.
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \


### PR DESCRIPTION
Update golangci-lint to v1.51.0 and do a few configuration tweaks.