### PR TITLE
Update JS grpc-tools to 1.12.4

### DIFF
--- a/buf-js.gen.yaml
+++ b/buf-js.gen.yaml
@@ -6,7 +6,7 @@ plugins:
     opt:
       - import_style=commonjs,binary
 
-  # https://github.com/grpc/grpc-node/tree/grpc-tools%401.11.2/packages/grpc-tools/
+  # https://github.com/grpc/grpc-node/tree/grpc-tools%401.12.4/packages/grpc-tools/
   - name: grpc
     out: gen/proto/js
     opt: grpc_js

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -9,12 +9,6 @@
 # teleport built on any newer Ubuntu version will not run on Centos 7 because
 # of this.
 
-# GRPC_NODE_PLUGIN_BINARY_TYPE has to be defined above the first FROM as it's
-# used in another FROM instruction. See the comment for grpc_node_plugin image
-# for more details.
-# Valid values are "prebuilt" and "compiled".
-ARG GRPC_NODE_PLUGIN_BINARY_TYPE
-
 ## LIBFIDO2 ###################################################################
 
 # Build libfido2 separately for isolation, speed and flexibility.
@@ -73,33 +67,6 @@ RUN mkdir -p /opt && cd /opt && curl -L https://github.com/gravitational/libbpf/
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make && \
     make install
-
-## GRPC_NODE_PLUGIN ###########################################################
-
-# grpc_node_plugin is built only on arm64.
-#
-# To generate JS protofiles, we need the grpc-tools npm package. Unfortunately,
-# it doesn't ship with a prebuilt grpc_node_plugin binary for Linux arm64. [1]
-#
-# We have to build it from source. Cloning all submodules takes a lot of time
-# and bandwith so we build the binary in a separate image.
-#
-# [1] https://github.com/grpc/grpc-node/issues/1405#issuecomment-1282201879
-
-FROM buildpack-deps:18.04 AS grpc_node_plugin
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends cmake
-COPY teleterm_linux_arm64.toolchain.cmake ./linux_arm64.toolchain.cmake
-RUN git clone --depth=1 --branch=grpc-tools@1.11.2 https://github.com/grpc/grpc-node.git && \
-    mv linux_arm64.toolchain.cmake grpc-node/packages/grpc-tools/. && \
-    cd grpc-node && \
-    git submodule update --init --recursive && \
-    cd packages/grpc-tools && \
-    cmake -DCMAKE_TOOLCHAIN_FILE=linux_arm64.toolchain.cmake . && \
-    cmake --build . --target clean && cmake --build . --target grpc_node_plugin -- -j 12 && \
-    mv grpc_node_plugin ../../../. && \
-    cd ../../.. && \
-    rm -rf grpc-node
 
 ## BUILDBOX ###################################################################
 #
@@ -286,7 +253,7 @@ RUN helm plugin install https://github.com/vbehar/helm3-unittest && \
     HELM_PLUGINS=/home/ci/.local/share/helm/plugins helm plugin list
 
 # Install JS gRPC tools.
-RUN (npm install --global grpc_tools_node_protoc_ts@5.0.1)
+RUN (npm install --global grpc_tools_node_protoc_ts@5.0.1 grpc-tools@1.12.4)
 
 # Install protobuf and grpc build tools.
 ARG PROTOC_VER
@@ -344,20 +311,6 @@ RUN cd /usr/local/lib && \
     ln -s libfido2.so.1 libfido2.so && \
     ldconfig
 COPY pkgconfig/buildbox/ /
-
-FROM buildbox AS grpc_node_plugin_binary_prebuilt
-ONBUILD RUN (npm install --global grpc-tools@1.11.2)
-
-FROM buildbox AS grpc_node_plugin_binary_compiled
-COPY --from=grpc_node_plugin grpc_node_plugin ./grpc_node_plugin
-ONBUILD RUN npm install --global --ignore-scripts grpc-tools@1.11.2 && \
-    mv grpc_node_plugin $(npm root -g)/grpc-tools/bin/. && \
-    # grpc-tools needs protoc but we already install it a couple of steps above.
-    ln -s $(which protoc) $(npm root -g)/grpc-tools/bin/protoc
-
-# A "conditional" FROM like this breaks up the number of steps in the progress bar of the given
-# image, so let's use it at the end. This way the progress bar for buildbox stays mostly untouched.
-FROM grpc_node_plugin_binary_${GRPC_NODE_PLUGIN_BINARY_TYPE} as buildbox
 
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -73,13 +73,6 @@ endif
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(GOCACHE):/go/cache -e GOCACHE=/go/cache
 endif
 
-ifeq ("$(RUNTIME_ARCH)","arm64")
-	GRPC_NODE_PLUGIN_BINARY_TYPE := compiled
-else
-	GRPC_NODE_PLUGIN_BINARY_TYPE := prebuilt
-endif
-export
-
 
 #
 # Build 'teleport' release inside a docker container
@@ -132,7 +125,6 @@ buildbox:
 			--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 			--build-arg RUST_VERSION=$(RUST_VERSION) \
 			--build-arg NODE_VERSION=$(NODE_VERSION) \
-			--build-arg GRPC_NODE_PLUGIN_BINARY_TYPE=$(GRPC_NODE_PLUGIN_BINARY_TYPE) \
 			--build-arg PROTOC_VER=$(PROTOC_VER) \
 			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \

--- a/build.assets/teleterm_linux_arm64.toolchain.cmake
+++ b/build.assets/teleterm_linux_arm64.toolchain.cmake
@@ -1,4 +1,0 @@
-# CMake toolchain used to build grpc_node_plugin for arm64 which is needed by grpc-tools.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a" CACHE STRING "c++ flags")
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -march=armv8-a" CACHE STRING "c flags")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -march=armv8-a" CACHE STRING "ld flags")

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -18,7 +18,7 @@
     "build-renderer": "webpack build --config webpack.renderer.prod.config.js --progress",
     "build-native-deps": "electron-builder install-app-deps",
     "package": "electron-builder build --config electron-builder-config.js --publish never -c.extraMetadata.name=teleport-connect",
-    "generate-grpc-shared": "npx -y --target_arch=x64 --package=grpc_tools_node_protoc_ts@5.3.2 --package=grpc-tools@1.11.2 -- grpc_tools_node_protoc -I=src/sharedProcess/api/proto --ts_out=service=grpc-node,mode=grpc-js:src/sharedProcess/api/protogen --grpc_out=grpc_js:src/sharedProcess/api/protogen --js_out=import_style=commonjs,binary:src/sharedProcess/api/protogen src/sharedProcess/api/proto/*.proto"
+    "generate-grpc-shared": "npx -y --target_arch=x64 --package=grpc_tools_node_protoc_ts@5.3.2 --package=grpc-tools@1.12.4 -- grpc_tools_node_protoc -I=src/sharedProcess/api/proto --ts_out=service=grpc-node,mode=grpc-js:src/sharedProcess/api/protogen --grpc_out=grpc_js:src/sharedProcess/api/protogen --js_out=import_style=commonjs,binary:src/sharedProcess/api/protogen src/sharedProcess/api/proto/*.proto"
   },
   "repository": {
     "type": "git",

--- a/web/packages/teleterm/src/sharedProcess/api/proto/ptyHostService.proto
+++ b/web/packages/teleterm/src/sharedProcess/api/proto/ptyHostService.proto
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(ravicious): Before introducing any changes, move this file to the /proto dir and
+// remove the generate-grpc-shared script.
+
 syntax = "proto3";
 
 import "google/protobuf/struct.proto";


### PR DESCRIPTION
1.11.2 didn't have support for arm64 so we had to do all this extra stuff in the Dockerfile.

1.11.3 added support for Darwin arm64 and 1.12.4 finally adds support for Linux arm64. This means we can completely remove extra cruft and just install grpc-tools 1.12.4 on all architectures.