### PR TITLE
docs: update contribute instructions to use major version

### DIFF
--- a/docs/pages/contributing/documentation/how-to-contribute.mdx
+++ b/docs/pages/contributing/documentation/how-to-contribute.mdx
@@ -28,7 +28,7 @@ $ yarn git-update
 Next, navigate to the directory under `content` that corresponds to the latest version of Teleport.
 
 ```code
-$ cd content/(=version=)
+$ cd content/(=teleport.version=).x
 ```
 
 Switch to the master branch (or versioned branch for updates specific to previous versions):


### PR DESCRIPTION
Updates contribute instructions to match https://github.com/gravitational/docs/pull/209. Pulled from #20643 since it was superseded by #21418, but applying to `master` since it's version-agnostic.