### PR TITLE
Docs: Fix Access Control Partial Links

### DIFF
--- a/docs/pages/includes/access-control-guides.mdx
+++ b/docs/pages/includes/access-control-guides.mdx
@@ -1,9 +1,9 @@
-- [Dual Authorization](./guides/dual-authz.mdx): Protect access to critical resources with dual authorization.
-- [Role Templates](./guides/role-templates.mdx): Set up Dynamic Access Policies with Role Templates.
-- [Impersonating Teleport Users](./guides/impersonation.mdx): Create certificates for CI/CD with impersonation.
-- [Passwordless](./guides/passwordless.mdx): Use passwordless authentication.
-- [Second Factor: WebAuthn](./guides/webauthn.mdx): Add Two-Factor Authentication through WebAuthn.
-- [Per-Session MFA](./guides/per-session-mfa.mdx): Per-session multi-mactor authentication.
-- [Locking](./guides/locking.mdx): Lock access to active user sessions or hosts.
-- [Moderated Sessions](./guides/moderated-sessions.mdx): Require session auditors and allow fine-grained live session access.
-- [Device Trust (Preview)](./guides/device-trust.mdx): Register and enforce trusted devices.
+- [Dual Authorization](../access-control../access-controls/guides/dual-authz.mdx): Protect access to critical resources with dual authorization.
+- [Role Templates](../access-controls/guides/role-templates.mdx): Set up Dynamic Access Policies with Role Templates.
+- [Impersonating Teleport Users](../access-controls/guides/impersonation.mdx): Create certificates for CI/CD with impersonation.
+- [Passwordless](../access-controls/guides/passwordless.mdx): Use passwordless authentication.
+- [Second Factor: WebAuthn](../access-controls/guides/webauthn.mdx): Add Two-Factor Authentication through WebAuthn.
+- [Per-Session MFA](../access-controls/guides/per-session-mfa.mdx): Per-session multi-mactor authentication.
+- [Locking](../access-controls/guides/locking.mdx): Lock access to active user sessions or hosts.
+- [Moderated Sessions](../access-controls/guides/moderated-sessions.mdx): Require session auditors and allow fine-grained live session access.
+- [Device Trust (Preview)](../access-controls/guides/device-trust.mdx): Register and enforce trusted devices.


### PR DESCRIPTION
Fixes relative paths in partial file for Access Control guides.

Issue introduced in https://github.com/gravitational/teleport/pull/21161