### PR TITLE
Align the Okta and Auth Connector configuration examples in Okta SSO …

### DIFF
--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -42,8 +42,8 @@ statements (special signed metadata exposed via a SAML XML response).
 
 GENERAL
 
-- Single sign on URL `https://teleport-proxy.example.com:443/v1/webapi/saml/acs/connectorName`
-- Audience URI (SP Entity ID)`https://teleport-proxy.example.com:443/v1/webapi/saml/acs/connectorName`
+- Single sign on URL `https://<cluster-url>/v1/webapi/saml/acs/new_saml_connector`
+- Audience URI (SP Entity ID)`https://<cluster-url>/v1/webapi/saml/acs/new_saml_connector`
 - Name ID format `EmailAddress`
 - Application username `Okta username`
 


### PR DESCRIPTION
…guide

Port `:443` is explicitly stated in the Okta configuration but not in the Teleport auth connector example (only has `cluster-url`).  This has recently created multiple Okta issues for users with mismatched configurations on the auth connector and Okta application.

The proposal is to align the configuration reference for the Okta and Teleport auth connector examples so users are clear these MUST match for the connector to work.  I chose to align the Okta to the Teleport example but it could go the other way too if desired.  Though in my opinion, almost all customers use port 443 for the web and it doesn't need to be listed explicitly.

We may also want to consider changing the order of the Okta guide.  With IDP-initiated configuration flow it makes more sense to create and name the Teleport connector first before trying to configure Okta.  But this is outside the scope of this PR.