### PR TITLE
Update database config samples

### DIFF
--- a/docs/pages/includes/database-access/database-config.yaml
+++ b/docs/pages/includes/database-access/database-config.yaml
@@ -18,10 +18,12 @@ db_service:
   aws:
     # Database types. Valid options are:
     # 'rds' - discovers and registers AWS RDS and Aurora databases.
+    # 'rdsproxy' - discovers and registers AWS RDS Proxy databases.
     # 'redshift' - discovers and registers AWS Redshift databases.
+    # 'redshift-serverless' - discovers and registers AWS Redshift Serverless databases.
     # 'elasticache' - discovers and registers AWS ElastiCache Redis databases.
     # 'memorydb' - discovers and registers AWS MemoryDB Redis databases.
-  - types: ["rds", "redshift", "elasticache", "memorydb"]
+  - types: ["rds", "rdsproxy","redshift", "redshift-serverless", "elasticache", "memorydb"]
     # AWS regions to register databases from.
     regions: ["us-west-1", "us-east-2"]
     # AWS resource tags to match when registering databases.
@@ -31,10 +33,11 @@ db_service:
   # Matchers for registering Azure-hosted databases.
   azure:
     # Database types. Valid options are:
-    # 'mysql' - discovers and registers Azure MySQL single-server databases.
-    # 'postgres' - discovers and registers Azure PostgreSQL single-server databases.
+    # 'mysql' - discovers and registers Azure MySQL databases.
+    # 'postgres' - discovers and registers Azure PostgreSQL databases.
     # 'redis' - discovers and registers Azure Cache for Redis databases.
-  - types: ["mysql", "postgres", "redis"]
+    # 'sqlserver' - discovers and registers Azure SQL Server databases.
+  - types: ["mysql", "postgres", "redis", "sqlserver"]
     # Azure regions to register databases from. Valid options are:
     # '*' - discovers databases in all regions (default).
     # Any valid Azure region name. List all valid regions using the Azure "az" cli: `az account list-locations -o table`
@@ -57,7 +60,7 @@ db_service:
     # Free-form description of the database proxy instance.
     description: "Production database"
 
-    # Database protocol. Can be: "postgres", "mysql", "mongodb", "cockroachdb", "sqlserver", or "redis".
+    # Database protocol. Can be: "postgres", "mysql", "mongodb", "cockroachdb", "redis", "snowflake", "sqlserver", "cassandra", "elasticsearch", or "dynamodb"
     protocol: "postgres"
 
     # Database connection endpoint. Must be reachable from Database Service.

--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -53,10 +53,13 @@ teleport:
   - {{ . }}
   {{- end }}
   {{- end }}
+
 db_service:
   enabled: "yes"
+
   # Matchers for database resources created with "tctl create" command or by the discovery service.
   # For more information about dynamic registration: https://goteleport.com/docs/database-access/guides/dynamic-registration/
+  {{- if .DynamicResourcesLabels }}
   resources:
   {{- range $index, $resourceLabel := .DynamicResourcesLabels }}
   - labels:
@@ -64,10 +67,38 @@ db_service:
       "{{ $name }}": "{{ $value }}"
     {{- end }}
   {{- end }}
+  {{- else }}
+  #
+  # resources:
+  # - labels:
+  #     "env": "dev"
+  {{- end }}
 
-  {{- if or .RDSDiscoveryRegions .RDSProxyDiscoveryRegions .RedshiftDiscoveryRegions .RedshiftServerlessDiscoveryRegions .ElastiCacheDiscoveryRegions .MemoryDBDiscoveryRegions}}
   # Matchers for registering AWS-hosted databases.
+  {{- if or .RDSDiscoveryRegions .RDSProxyDiscoveryRegions .RedshiftDiscoveryRegions .RedshiftServerlessDiscoveryRegions .ElastiCacheDiscoveryRegions .MemoryDBDiscoveryRegions}}
   aws:
+  {{- else }}
+  # For more information about AWS auto-discovery:
+  # RDS/Aurora: https://goteleport.com/docs/database-access/guides/rds/
+  # RDS Proxy: https://goteleport.com/docs/database-access/guides/rdsproxy/
+  # Redshift: https://goteleport.com/docs/database-access/guides/postgres-redshift/
+  # Redshift Serverless: https://goteleport.com/docs/database-access/guides/postgres-redshift-serverless/
+  # ElastiCache/MemoryDB: https://goteleport.com/docs/database-access/guides/redis-aws/
+  #
+  # aws:
+  #   # Database types. Valid options are:
+  #   # 'rds' - discovers and registers AWS RDS and Aurora databases
+  #   # 'rdsproxy' - discovers and registers AWS RDS Proxy databases.
+  #   # 'redshift' - discovers and registers AWS Redshift databases.
+  #   # 'redshift-serverless' - discovers and registers AWS Redshift Serverless databases.
+  #   # 'elasticache' - discovers and registers AWS ElastiCache Redis databases.
+  #   # 'memorydb' - discovers and registers AWS MemoryDB Redis databases.
+  # - types: ["rds", "rdsproxy","redshift", "redshift-serverless", "elasticache", "memorydb"]
+  #   # AWS regions to register databases from.
+  #   regions: ["us-west-1", "us-east-2"]
+  #   # AWS resource tags to match when registering databases.
+  #   tags:
+  #     "*": "*"
   {{- end }}
   {{- if .RDSDiscoveryRegions }}
   # RDS/Aurora databases auto-discovery.
@@ -159,9 +190,36 @@ db_service:
       "{{ $name }}": "{{ $value }}"
     {{- end }}
   {{- end }}
-  {{- if or .AzureMySQLDiscoveryRegions .AzurePostgresDiscoveryRegions .AzureRedisDiscoveryRegions .AzureSQLServerDiscoveryRegions }}
+
   # Matchers for registering Azure-hosted databases.
+  {{- if or .AzureMySQLDiscoveryRegions .AzurePostgresDiscoveryRegions .AzureRedisDiscoveryRegions .AzureSQLServerDiscoveryRegions }}
   azure:
+  {{- else }}
+  # For more information about Azure auto-discovery:
+  # MySQL/PostgreSQL: https://goteleport.com/docs/database-access/guides/azure-postgres-mysql/
+  # Redis: https://goteleport.com/docs/database-access/guides/azure-redis/
+  # SQL Server: https://goteleport.com/docs/database-access/guides/azure-sql-server-ad/
+  #
+  # azure:
+  #   # Database types. Valid options are:
+  #   # 'mysql' - discovers and registers Azure MySQL databases.
+  #   # 'postgres' - discovers and registers Azure PostgreSQL databases.
+  #   # 'redis' - discovers and registers Azure Cache for Redis databases.
+  #   # 'sqlserver' - discovers and registers Azure SQL Server databases.
+  # - types: ["mysql", "postgres", "redis", "sqlserver"]
+  #   # Azure regions to register databases from. Valid options are:
+  #   # '*' - discovers databases in all regions (default).
+  #   regions: ["eastus", "westus"]
+  #   # Azure subscription IDs to register databases from. Valid options are:
+  #   # '*' - discovers databases in all subscriptions (default).
+  #   subscriptions: ["11111111-2222-3333-4444-555555555555"]
+  #   # Azure resource groups to register databases from. Valid options are:
+  #   # '*' - discovers databases in all resource groups within configured subscription(s) (default).
+  #   resource_groups: ["group1", "group2"]
+  #   # Azure resource tags to match when registering databases.
+  #   tags:
+  #     "*": "*"
+  {{- end }}
   {{- if or .AzureMySQLDiscoveryRegions }}
   # Azure MySQL databases auto-discovery.
   # For more information about Azure MySQL auto-discovery: https://goteleport.com/docs/database-access/guides/azure-postgres-mysql/
@@ -262,7 +320,7 @@ db_service:
       "{{ $name }}": "{{ $value }}"
     {{- end }}
   {{- end }}
-  {{- end }}
+
   # Lists statically registered databases proxied by this agent.
   {{- if .StaticDatabaseName }}
   databases:
@@ -327,6 +385,7 @@ db_service:
     {{- end }}
     {{- end }}
   {{- else }}
+  #
   # databases:
   # # RDS database static configuration.
   # # RDS/Aurora databases Auto-discovery reference: https://goteleport.com/docs/database-access/guides/rds/
@@ -412,6 +471,7 @@ db_service:
   #   # Database connection endpoint. Must be reachable from Database service.
   #   uri: database.example.com:5432
   {{- end }}
+
 auth_service:
   enabled: "no"
 ssh_service:


### PR DESCRIPTION
This is follow-up on https://github.com/gravitational/teleport/pull/20966#discussion_r1094446937

### example calls
<details>
   <summary>teleport db configure create</summary>

```
#
# Teleport database agent configuration file.
# Configuration reference: https://goteleport.com/docs/database-access/reference/configuration/
#
version: v3
teleport:
  nodename: STeves-MacBook-Pro.local
  data_dir: /var/lib/teleport
  proxy_server: 0.0.0.0:3080
  auth_token: /tmp/token

db_service:
  enabled: "yes"

  # Matchers for database resources created with "tctl create" command or by the discovery service.
  # For more information about dynamic registration: https://goteleport.com/docs/database-access/guides/dynamic-registration/
  #
  # resources:
  # - labels:
  #     "env": "dev"

  # Matchers for registering AWS-hosted databases.
  # For more information about AWS auto-discovery:
  # RDS/Aurora: https://goteleport.com/docs/database-access/guides/rds/
  # RDS Proxy: https://goteleport.com/docs/database-access/guides/rdsproxy/
  # Redshift: https://goteleport.com/docs/database-access/guides/postgres-redshift/
  # Redshift Serverless: https://goteleport.com/docs/database-access/guides/postgres-redshift-serverless/
  # ElastiCache/MemoryDB: https://goteleport.com/docs/database-access/guides/redis-aws/
  #
  # aws:
  #   # Database types. Valid options are:
  #   # 'rds' - discovers and registers AWS RDS and Aurora databases
  #   # 'rdsproxy' - discovers and registers AWS RDS Proxy databases.
  #   # 'redshift' - discovers and registers AWS Redshift databases.
  #   # 'redshift-serverless' - discovers and registers AWS Redshift Serverless databases.
  #   # 'elasticache' - discovers and registers AWS ElastiCache Redis databases.
  #   # 'memorydb' - discovers and registers AWS MemoryDB Redis databases.
  # - types: ["rds", "rdsproxy","redshift", "redshift-serverless", "elasticache", "memorydb"]
  #   # AWS regions to register databases from.
  #   regions: ["us-west-1", "us-east-2"]
  #   # AWS resource tags to match when registering databases.
  #   tags:
  #     "*": "*"

  # Matchers for registering Azure-hosted databases.
  # For more information about Azure auto-discovery:
  # MySQL/PostgreSQL: https://goteleport.com/docs/database-access/guides/azure-postgres-mysql/
  # Redis: https://goteleport.com/docs/database-access/guides/azure-redis/
  # SQL Server: https://goteleport.com/docs/database-access/guides/azure-sql-server-ad/
  #
  # azure:
  #   # Database types. Valid options are:
  #   # 'mysql' - discovers and registers Azure MySQL databases.
  #   # 'postgres' - discovers and registers Azure PostgreSQL databases.
  #   # 'redis' - discovers and registers Azure Cache for Redis databases.
  #   # 'sqlserver' - discovers and registers Azure SQL Server databases.
  # - types: ["mysql", "postgres", "redis", "sqlserver"]
  #   # Azure regions to register databases from. Valid options are:
  #   # '*' - discovers databases in all regions (default).
  #   regions: ["eastus", "westus"]
  #   # Azure subscription IDs to register databases from. Valid options are:
  #   # '*' - discovers databases in all subscriptions (default).
  #   subscriptions: ["11111111-2222-3333-4444-555555555555"]
  #   # Azure resource groups to register databases from. Valid options are:
  #   # '*' - discovers databases in all resource groups within configured subscription(s) (default).
  #   resource_groups: ["group1", "group2"]
  #   # Azure resource tags to match when registering databases.
  #   tags:
  #     "*": "*"

  # Lists statically registered databases proxied by this agent.
  #
  # databases:
  # # RDS database static configuration.
  # # RDS/Aurora databases Auto-discovery reference: https://goteleport.com/docs/database-access/guides/rds/
  # - name: rds
  #   description: AWS RDS/Aurora instance configuration example.
  #   # Supported protocols for RDS/Aurora: "postgres" or "mysql"
  #   protocol: postgres
  #   # Database connection endpoint. Must be reachable from Database Service.
  #   uri: rds-instance-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432
  #   # AWS specific configuration.
  #   aws:
  #     # Region the database is deployed in.
  #     region: us-west-1
  #     # RDS/Aurora specific configuration.
  #     rds:
  #       # RDS Instance ID. Only present on RDS databases.
  #       instance_id: rds-instance-1
  # # Aurora database static configuration.
  # # RDS/Aurora databases Auto-discovery reference: https://goteleport.com/docs/database-access/guides/rds/
  # - name: aurora
  #   description: AWS Aurora cluster configuration example.
  #   # Supported protocols for RDS/Aurora: "postgres" or "mysql"
  #   protocol: postgres
  #   # Database connection endpoint. Must be reachable from Database Service.
  #   uri: aurora-cluster-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432
  #   # AWS specific configuration.
  #   aws:
  #     # Region the database is deployed in.
  #     region: us-west-1
  #     # RDS/Aurora specific configuration.
  #     rds:
  #       # Aurora Cluster ID. Only present on Aurora databases.
  #       cluster_id: aurora-cluster-1
  # # Redshift database static configuration.
  # # For more information: https://goteleport.com/docs/database-access/guides/postgres-redshift/
  # - name: redshift
  #   description: AWS Redshift cluster configuration example.
  #   # Supported protocols for Redshift: "postgres".
  #   protocol: postgres
  #   # Database connection endpoint. Must be reachable from Database service.
  #   uri: redshift-cluster-example-1.abcdefghijklmnop.us-west-1.redshift.amazonaws.com:5439
  #   # AWS specific configuration.
  #   aws:
  #     # Region the database is deployed in.
  #     region: us-west-1
  #     # Redshift specific configuration.
  #     redshift:
  #       # Redshift Cluster ID.
  #       cluster_id: redshift-cluster-example-1
  # # ElastiCache database static configuration.
  # - name: elasticache
  #   description: AWS ElastiCache cluster configuration example.
  #   protocol: redis
  #   # Database connection endpoint. Must be reachable from Database service.
  #   uri: master.redis-cluster-example.abcdef.usw1.cache.amazonaws.com:6379
  #   # AWS specific configuration.
  #   aws:
  #     # Region the database is deployed in.
  #     region: us-west-1
  #     # ElastiCache specific configuration.
  #     elasticache:
  #       # ElastiCache replication group ID.
  #       replication_group_id: redis-cluster-example
  # # MemoryDB database static configuration.
  # - name: memorydb
  #   description: AWS MemoryDB cluster configuration example.
  #   protocol: redis
  #   # Database connection endpoint. Must be reachable from Database service.
  #   uri: clustercfg.my-memorydb.xxxxxx.memorydb.us-east-1.amazonaws.com:6379
  #   # AWS specific configuration.
  #   aws:
  #     # Region the database is deployed in.
  #     region: us-west-1
  #     # MemoryDB specific configuration.
  #     memorydb:
  #       # MemoryDB cluster name.
  #       cluster_name: my-memorydb
  # # Self-hosted static configuration.
  # - name: self-hosted
  #   description: Self-hosted database configuration.
  #   # Supported protocols for self-hosted: postgres, mysql, mongodb, cockroachdb, redis, snowflake, sqlserver, cassandra, elasticsearch, dynamodb.
  #   protocol: postgres
  #   # Database connection endpoint. Must be reachable from Database service.
  #   uri: database.example.com:5432

auth_service:
  enabled: "no"
ssh_service:
  enabled: "no"
proxy_service:
  enabled: "no"
```
</details>

<details>
  <summary>teleport db configure create --rds-discovery us-west-1 --dynamic-resources-labels a=b  --azure-redis-discovery eastus --name self-hosted --uri localhost:8888 --protocol mysql</summary>

```
#
# Teleport database agent configuration file.
# Configuration reference: https://goteleport.com/docs/database-access/reference/configuration/
#
version: v3
teleport:
  nodename: STeves-MacBook-Pro.local
  data_dir: /var/lib/teleport
  proxy_server: 0.0.0.0:3080
  auth_token: /tmp/token

db_service:
  enabled: "yes"

  # Matchers for database resources created with "tctl create" command or by the discovery service.
  # For more information about dynamic registration: https://goteleport.com/docs/database-access/guides/dynamic-registration/
  resources:
  - labels:
      "a": "b"

  # Matchers for registering AWS-hosted databases.
  aws:
  # RDS/Aurora databases auto-discovery.
  # For more information about RDS/Aurora auto-discovery: https://goteleport.com/docs/database-access/guides/rds/
  - types: ["rds"]
    # AWS regions to register databases from.
    regions:
    - us-west-1
    # AWS resource tags to match when registering databases.
    tags:
      "*": "*"

  # Matchers for registering Azure-hosted databases.
  azure:
  # Azure Cache For Redis databases auto-discovery.
  # For more information about Azure Cache for Redis auto-discovery: https://goteleport.com/docs/database-access/guides/azure-redis/
  - types: ["redis"]
    # Azure subscription IDs to match.
    subscriptions:
    - "*"
    # Azure resource groups to match.
    resource_groups:
    - "*"
    # Azure regions to register databases from.
    regions:
    - "eastus"
    # Azure resource tags to match when registering databases.
    tags:
      "*": "*"

  # Lists statically registered databases proxied by this agent.
  databases:
  - name: self-hosted
    protocol: mysql
    uri: localhost:8888

auth_service:
  enabled: "no"
ssh_service:
  enabled: "no"
proxy_service:
  enabled: "no"
```
</details>
