### PR TITLE
node hb and watcher scalability improvements

### DIFF
--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -204,7 +204,7 @@ func (p *Suite) addNodeToLeafCluster(t *testing.T, tunnelNodeHostname string) {
 
 func (p *Suite) mustConnectToClusterAndRunSSHCommand(t *testing.T, config helpers.ClientConfig) {
 	const (
-		deadline         = time.Second * 5
+		deadline         = time.Second * 20
 		nextIterWaitTime = time.Millisecond * 100
 	)
 

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -820,7 +820,7 @@ func New(config Config) (*Cache, error) {
 // Start the cache. Should only be called once.
 func (c *Cache) Start() error {
 	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
-		First:  utils.HalfJitter(c.MaxRetryPeriod / 10),
+		First:  utils.FullJitter(c.MaxRetryPeriod / 10),
 		Step:   c.MaxRetryPeriod / 5,
 		Max:    c.MaxRetryPeriod,
 		Jitter: retryutils.NewHalfJitter(),

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -307,7 +307,7 @@ const (
 
 	// MaxWatcherBackoff is the maximum retry time a watcher should use in
 	// the event of connection issues
-	MaxWatcherBackoff = time.Minute
+	MaxWatcherBackoff = 90 * time.Second
 )
 
 const (

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -98,7 +98,7 @@ func (cfg *ResourceWatcherConfig) CheckAndSetDefaults() error {
 // incl. cfg.CheckAndSetDefaults.
 func newResourceWatcher(ctx context.Context, collector resourceCollector, cfg ResourceWatcherConfig) (*resourceWatcher, error) {
 	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
-		First:  utils.HalfJitter(cfg.MaxRetryPeriod / 10),
+		First:  utils.FullJitter(cfg.MaxRetryPeriod / 10),
 		Step:   cfg.MaxRetryPeriod / 5,
 		Max:    cfg.MaxRetryPeriod,
 		Jitter: retryutils.NewHalfJitter(),

--- a/lib/srv/heartbeatv2.go
+++ b/lib/srv/heartbeatv2.go
@@ -41,14 +41,14 @@ type SSHServerHeartbeatConfig struct {
 	InventoryHandle inventory.DownstreamHandle
 	// GetServer gets the latest server spec.
 	GetServer func() *types.ServerV2
+
+	// -- below values are all optional
+
 	// Announcer is a fallback used to perform basic upsert-style heartbeats
 	// if the control stream is unavailable.
 	//
 	// DELETE IN: 11.0 (only exists for back-compat with v9 auth servers)
 	Announcer auth.Announcer
-
-	// -- below values are all optional
-
 	// OnHeartbeat is a per-attempt callback (optional).
 	OnHeartbeat func(error)
 	// AnnounceInterval is the interval at which heartbeats are attempted (optional).
@@ -63,9 +63,6 @@ func (c *SSHServerHeartbeatConfig) Check() error {
 	}
 	if c.GetServer == nil {
 		return trace.BadParameter("missing required parameter GetServer for ssh heartbeat")
-	}
-	if c.Announcer == nil {
-		return trace.BadParameter("missing required parameter Announcer for ssh heartbeat")
 	}
 	return nil
 }

--- a/lib/srv/heartbeatv2_test.go
+++ b/lib/srv/heartbeatv2_test.go
@@ -72,6 +72,10 @@ func (h *fakeHeartbeatDriver) FallbackAnnounce(ctx context.Context) (ok bool) {
 	return true
 }
 
+func (h *fakeHeartbeatDriver) SupportsFallback() bool {
+	return true
+}
+
 func (h *fakeHeartbeatDriver) Announce(ctx context.Context, sender inventory.DownstreamSender) (ok bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/lib/srv/heartbeatv2_test.go
+++ b/lib/srv/heartbeatv2_test.go
@@ -48,6 +48,8 @@ type fakeHeartbeatDriver struct {
 	pollChanged int
 	fallbackErr int
 	announceErr int
+
+	disableFallback bool
 }
 
 func (h *fakeHeartbeatDriver) Poll() (changed bool) {
@@ -64,6 +66,9 @@ func (h *fakeHeartbeatDriver) Poll() (changed bool) {
 func (h *fakeHeartbeatDriver) FallbackAnnounce(ctx context.Context) (ok bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if !h.SupportsFallback() {
+		panic("FallbackAnnounce called when SupportsFallback is false")
+	}
 	h.fallbackCount++
 	if h.fallbackErr > 0 {
 		h.fallbackErr--
@@ -73,7 +78,7 @@ func (h *fakeHeartbeatDriver) FallbackAnnounce(ctx context.Context) (ok bool) {
 }
 
 func (h *fakeHeartbeatDriver) SupportsFallback() bool {
-	return true
+	return !h.disableFallback
 }
 
 func (h *fakeHeartbeatDriver) Announce(ctx context.Context, sender inventory.DownstreamSender) (ok bool) {
@@ -180,8 +185,8 @@ func TestHeartbeatV2Basics(t *testing.T) {
 	// use the control-stream announce. First poll always reads
 	// as different, so expect that too.
 	awaitEvents(t, hb.testEvents,
-		expect(hbv2PollDiff, hbv2FallbackOk, hbv2Start),
-		deny(hbv2FallbackErr, hbv2FallbackBackoff, hbv2AnnounceOk, hbv2AnnounceErr),
+		expect(hbv2PollDiff, hbv2FallbackOk, hbv2Start, hbv2OnHeartbeatOk),
+		deny(hbv2FallbackErr, hbv2FallbackBackoff, hbv2AnnounceOk, hbv2AnnounceErr, hbv2OnHeartbeatErr),
 	)
 
 	// verify that we're now polling "same" and that time-based announces
@@ -200,7 +205,7 @@ func TestHeartbeatV2Basics(t *testing.T) {
 	// wait for fallback errors to happen, and confirm that we see fallback backoff
 	// come into effect. we still expect no proper announce events.
 	awaitEvents(t, hb.testEvents,
-		expect(hbv2FallbackErr, hbv2FallbackErr, hbv2FallbackBackoff, hbv2FallbackOk),
+		expect(hbv2FallbackErr, hbv2FallbackErr, hbv2FallbackBackoff, hbv2FallbackOk, hbv2OnHeartbeatErr, hbv2OnHeartbeatOk),
 		deny(hbv2AnnounceOk, hbv2AnnounceErr),
 	)
 
@@ -228,8 +233,8 @@ func TestHeartbeatV2Basics(t *testing.T) {
 	// in case we refactor anything later). Take this opportunity to re-check that our announces
 	// are internval and not poll based.
 	awaitEvents(t, hb.testEvents,
-		expect(hbv2AnnounceOk, hbv2AnnounceOk, hbv2PollSame, hbv2AnnounceInterval),
-		deny(hbv2AnnounceErr, hbv2FallbackOk, hbv2FallbackErr),
+		expect(hbv2AnnounceOk, hbv2AnnounceOk, hbv2PollSame, hbv2AnnounceInterval, hbv2OnHeartbeatOk),
+		deny(hbv2AnnounceErr, hbv2FallbackOk, hbv2FallbackErr, hbv2OnHeartbeatErr),
 	)
 
 	// set up a "changed" poll since we haven't traversed that path
@@ -280,6 +285,119 @@ func TestHeartbeatV2Basics(t *testing.T) {
 	awaitEvents(t, hb.testEvents,
 		expect(hbv2AnnounceOk),
 		deny(hbv2AnnounceErr, hbv2FallbackOk, hbv2FallbackErr),
+	)
+}
+
+func TestHeartbeatV2NoFallbackUnchecked(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// set up fake hb driver that lets us easily inject failures for
+	// the diff steps and assists w/ faking inventory control handles.
+	driver := newFakeHeartbeatDriver(t)
+
+	driver.mu.Lock()
+	driver.disableFallback = true
+	driver.mu.Unlock()
+
+	// set up hb with very long degraded check interval to confirm expected
+	// OnHeartbeat behavior outside of periodic checks.
+	hb := newHeartbeatV2(driver.handle, driver, heartbeatV2Config{
+		announceInterval:      time.Millisecond * 200,
+		pollInterval:          time.Millisecond * 50,
+		fallbackBackoff:       time.Millisecond * 400,
+		degradedCheckInterval: time.Hour,
+		testEvents:            make(chan hbv2TestEvent, 1028),
+	})
+	go hb.Run()
+	defer hb.Close()
+
+	// verify that we tick but don't ever emit a degraded state
+	awaitEvents(t, hb.testEvents,
+		expect(hbv2NoFallback, hbv2NoFallback),
+		deny(hbv2OnHeartbeatOk, hbv2OnHeartbeatErr),
+	)
+
+	// make a stream available to the heartbeat instance
+	// (note: we don't need to pull from our half of the stream since
+	// fakeHeartbeatDriverInner doesn't actually send any messages across it).
+	stream := driver.newStream(ctx, t)
+
+	// verify heartbeats
+	awaitEvents(t, hb.testEvents,
+		expect(hbv2OnHeartbeatOk),
+		deny(hbv2OnHeartbeatErr),
+	)
+
+	// verify that while heartbeating, we don't hit the "NoFallback" case
+	awaitEvents(t, hb.testEvents,
+		expect(hbv2OnHeartbeatOk, hbv2OnHeartbeatOk),
+		deny(hbv2OnHeartbeatErr, hbv2NoFallback),
+	)
+
+	stream.Close()
+
+	awaitEvents(t, hb.testEvents,
+		expect(hbv2NoFallback),
+		deny(hbv2OnHeartbeatErr),
+	)
+}
+
+func TestHeartbeatV2NoFallbackChecked(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// set up fake hb driver that lets us easily inject failures for
+	// the diff steps and assists w/ faking inventory control handles.
+	driver := newFakeHeartbeatDriver(t)
+
+	driver.mu.Lock()
+	driver.disableFallback = true
+	driver.mu.Unlock()
+
+	// set up hb with fast degraded check interval
+	hb := newHeartbeatV2(driver.handle, driver, heartbeatV2Config{
+		announceInterval:      time.Millisecond * 200,
+		pollInterval:          time.Millisecond * 50,
+		fallbackBackoff:       time.Millisecond * 400,
+		degradedCheckInterval: time.Millisecond * 100,
+		testEvents:            make(chan hbv2TestEvent, 1028),
+	})
+	go hb.Run()
+	defer hb.Close()
+
+	// verify that we tick and emit hb errs
+	awaitEvents(t, hb.testEvents,
+		expect(hbv2NoFallback, hbv2NoFallback, hbv2OnHeartbeatErr),
+		deny(hbv2OnHeartbeatOk),
+	)
+
+	// make a stream available to the heartbeat instance
+	// (note: we don't need to pull from our half of the stream since
+	// fakeHeartbeatDriverInner doesn't actually send any messages across it).
+	stream := driver.newStream(ctx, t)
+
+	// verify heartbeats start
+	awaitEvents(t, hb.testEvents,
+		expect(hbv2OnHeartbeatOk),
+	)
+
+	// verify that the hb errs have stopped
+	awaitEvents(t, hb.testEvents,
+		expect(hbv2OnHeartbeatOk, hbv2OnHeartbeatOk),
+		deny(hbv2OnHeartbeatErr),
+	)
+
+	stream.Close()
+
+	// verify that closed stream means errs resume
+	awaitEvents(t, hb.testEvents,
+		expect(hbv2NoFallback, hbv2OnHeartbeatErr),
+		deny(hbv2OnHeartbeatOk),
 	)
 }
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -845,7 +845,6 @@ func New(
 		heartbeat, err = srv.NewSSHServerHeartbeat(srv.SSHServerHeartbeatConfig{
 			InventoryHandle: s.inventoryHandle,
 			GetServer:       s.getServerInfo,
-			Announcer:       s.authService,
 			OnHeartbeat:     s.onHeartbeat,
 		})
 	} else {

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -40,18 +40,15 @@ var SeventhJitter = retryutils.NewSeventhJitter()
 // any usecases that might scale with cluster size or request count.
 var FullJitter = retryutils.NewFullJitter()
 
-// NewDefaultLinear creates a linear retry using a half jitter, 10s step, and maxing out
-// at 1 minute. These values were selected by reviewing commonly used parameters elsewhere
-// in the code base, which (at the time of writing) seem to converge on approximately this
-// configuration for "critical but potentially load-inducing" operations like cache watcher
-// registration and auth connector setup. It also includes an auto-reset value of 5m. Auto-reset
-// is less commonly used, and if used should probably be shorter, but 5m is a reasonable
-// safety net to reduce the impact of accidental misuse.
+// NewDefaultLinear creates a linear retry with reasonable default parameters for
+// attempting to restart "critical but potentially load-inducing" operations, such
+// as watcher or control stream resume. Exact parameters are subject to change,
+// but this retry will always be configured for automatic reset.
 func NewDefaultLinear() *retryutils.Linear {
 	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
-		First:     HalfJitter(time.Second * 5),
-		Step:      time.Second * 10,
-		Max:       time.Minute,
+		First:     FullJitter(time.Second * 10),
+		Step:      time.Second * 15,
+		Max:       time.Second * 90,
 		Jitter:    retryutils.NewHalfJitter(),
 		AutoReset: 5,
 	})


### PR DESCRIPTION
Improve retry parameters for watchers and for the inventory control stream.  Retries now use a larger but also more jittered initial step, and max out at 90s instead of 60s.  These changes should have no observable effect on the speed of resume when a health auth is available, but should reduce the "thundering heard" effect caused by full auth outage/upgrade, as retries will start out _significantly_ more spread out (10s range vs 2.4s range), and be about 50% more spread out after full backoff (I estimate maybe 20-30% reduction in peak req/s, but that's a wild guess based on mental math).

This PR also ports over some logic from https://github.com/gravitational/teleport/pull/19899 that improved heartbeatv2 behavior when no fallback announce method is present, and deprecates the fallback announce method for node heartbeats. This will ensure that node heartbeats do not circumvent the backoff of the inventory control stream.  Safe to for back port to v11 and later,  but *not* to v10 or earlier.

Fixes https://github.com/gravitational/teleport/issues/21382