### PR TITLE
[v10] Rename protoEqual and add a big warning

### DIFF
--- a/api/types/cmp.go
+++ b/api/types/cmp.go
@@ -23,9 +23,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-// protoEqual returns true if provided proto messages are equal, ignoring the
-// XXX_* fields.
-func protoEqual(a, b proto.Message) bool {
+// protoKnownFieldsEqual returns true if the provided proto messages are equal,
+// ignoring any unknown fields found during unmarshal (ie, this ignores XXX_*
+// fields).
+// This is not a substitute for [proto.Equal] and should not be used as a full
+// equility check.
+// Do not use this method lightly or without a strong reason to do so.
+func protoKnownFieldsEqual(a, b proto.Message) bool {
 	return cmp.Equal(a, b, cmp.FilterPath(func(path cmp.Path) bool {
 		if field, ok := path.Last().(cmp.StructField); ok {
 			return strings.HasPrefix(field.Name(), "XXX_")

--- a/api/types/cmp_test.go
+++ b/api/types/cmp_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProtoEqual(t *testing.T) {
+func TestProtoKnownFieldsEqual(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -98,7 +98,7 @@ func TestProtoEqual(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.assert(t, protoEqual(test.inputA, test.inputB))
+			test.assert(t, protoKnownFieldsEqual(test.inputA, test.inputB))
 		})
 	}
 }

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -296,7 +296,7 @@ func (d *DatabaseV3) SetMySQLServerVersion(version string) {
 
 // IsEmpty returns true if AWS metadata is empty.
 func (a AWS) IsEmpty() bool {
-	return protoEqual(&a, &AWS{})
+	return protoKnownFieldsEqual(&a, &AWS{})
 }
 
 // GetAWS returns the database AWS metadata.
@@ -319,7 +319,7 @@ func (d *DatabaseV3) GetGCP() GCPCloudSQL {
 
 // IsEmpty returns true if Azure metadata is empty.
 func (a Azure) IsEmpty() bool {
-	return protoEqual(&a, &Azure{})
+	return protoKnownFieldsEqual(&a, &Azure{})
 }
 
 // GetAzure returns Azure database server metadata.

--- a/api/types/lock.go
+++ b/api/types/lock.go
@@ -178,7 +178,7 @@ func (c *LockV2) CheckAndSetDefaults() error {
 
 // IsEmpty returns true if none of the target's fields is set.
 func (t LockTarget) IsEmpty() bool {
-	return protoEqual(&t, &LockTarget{})
+	return protoKnownFieldsEqual(&t, &LockTarget{})
 }
 
 // IntoMap returns the target attributes in the form of a map.


### PR DESCRIPTION
Rename `protoEqual` to `protoKnownFieldsEqual` and add a warning about its usage.

Manually ignoring `XXX_` fields in full comparisons runs the risk of ignoring
unknown fields, which in itself is a strong hint that we are running outdated
code. The recommended practice for scenarios where full equality is not
desirable is to code it as such, comparing the fields that matter.

`proto.Equal` should be preferred in most scenarios.

Backport #21491 to branch/v10