### PR TITLE
Change debug commands during discover flow

### DIFF
--- a/web/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
+++ b/web/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
@@ -171,7 +171,7 @@ export function DownloadScript(
         <Text mb={3}>
           - The Teleport Database Service could not join this Teleport cluster.
           Check the logs for errors by running{' '}
-          <Mark>journalctl status teleport</Mark>.
+          <Mark>journalctl -fu teleport</Mark>.
         </Text>
 
         <Text>

--- a/web/packages/teleport/src/Discover/Desktop/ConnectTeleport/StartTeleport.tsx
+++ b/web/packages/teleport/src/Discover/Desktop/ConnectTeleport/StartTeleport.tsx
@@ -97,7 +97,7 @@ export function StartTeleport(
           <Text mb={3}>
             - The Teleport Desktop Service could not join this Teleport cluster.
             Check the logs for errors by running{' '}
-            <Mark>journalctl status teleport</Mark>.
+            <Mark>journalctl -fu teleport</Mark>.
           </Text>
 
           <Text>

--- a/web/packages/teleport/src/Discover/Desktop/DiscoverDesktops/DiscoverDesktops.tsx
+++ b/web/packages/teleport/src/Discover/Desktop/DiscoverDesktops/DiscoverDesktops.tsx
@@ -234,7 +234,7 @@ export function DiscoverDesktops() {
           <Text mb={3}>
             - A Desktop could have had issues joining the Teleport Desktop
             Service. Check the logs for errors by running{' '}
-            <Mark>journalctl status teleport</Mark> on your Desktop Service.
+            <Mark>journalctl -fu teleport</Mark> on your Desktop Service.
           </Text>
 
           <Text>

--- a/web/packages/teleport/src/Discover/Discover.tsx
+++ b/web/packages/teleport/src/Discover/Discover.tsx
@@ -68,7 +68,7 @@ function DiscoverContent() {
           selectedResource={selectedResource}
           views={views}
         />
-          {content}
+        {content}
       </FeatureBox>
 
       <Prompt

--- a/web/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.tsx
+++ b/web/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.tsx
@@ -126,8 +126,7 @@ export function DownloadScript(props: AgentStepProps) {
 
         <Text mb={3}>
           - The Teleport SSH Service could not join this Teleport cluster. Check
-          the logs for errors by running <Mark>journalctl status teleport</Mark>
-          .
+          the logs for errors by running <Mark>journalctl -fu teleport</Mark>.
         </Text>
 
         <Text>


### PR DESCRIPTION
`journalctl status teleport` isn't a command. I've updated these to use `journalctl -fu teleport` like our docs mention.

Also fixes a prettier issue with `Discover.tsx` as I had to run prettier