### PR TITLE
Use test IP addresses for auth_proxy_test.

### DIFF
--- a/lib/srv/alpnproxy/auth/auth_proxy_test.go
+++ b/lib/srv/alpnproxy/auth/auth_proxy_test.go
@@ -18,6 +18,7 @@ package alpnproxyauth
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -33,13 +34,15 @@ func TestDialLocalAuthServerNoServers(t *testing.T) {
 }
 
 func TestDialLocalAuthServerNoAvailableServers(t *testing.T) {
-	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", []string{"0.0.0.0:3025"}, nil, nil)
-	_, err := s.dialLocalAuthServer(context.Background())
+	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", []string{"203.0.113.1:3025"}, nil, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_, err := s.dialLocalAuthServer(ctx)
 	require.Error(t, err, "dialLocalAuthServer expected to fail")
 	var netErr *net.OpError
 	require.ErrorAs(t, err, &netErr)
 	require.Equal(t, "dial", netErr.Op)
-	require.Equal(t, "0.0.0.0:3025", netErr.Addr.String())
+	require.Equal(t, "203.0.113.1:3025", netErr.Addr.String())
 }
 
 func TestDialLocalAuthServerAvailableServers(t *testing.T) {
@@ -51,11 +54,13 @@ func TestDialLocalAuthServerAvailableServers(t *testing.T) {
 	authServers[0] = socket.Addr().String()
 	// multiple invalid servers to minimize chance that we select good one first try
 	for i := 0; i < 10; i++ {
-		authServers = append(authServers, "0.0.0.0:3025")
+		authServers = append(authServers, fmt.Sprintf("203.0.113.%d:3025", i+1))
 	}
 	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", authServers, nil, nil)
 	require.Eventually(t, func() bool {
-		conn, err := s.dialLocalAuthServer(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		conn, err := s.dialLocalAuthServer(ctx)
 		if err != nil {
 			return false
 		}

--- a/lib/srv/alpnproxy/auth/auth_proxy_test.go
+++ b/lib/srv/alpnproxy/auth/auth_proxy_test.go
@@ -59,7 +59,7 @@ func TestDialLocalAuthServerAvailableServers(t *testing.T) {
 	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", authServers, nil, nil)
 	require.Eventually(t, func() bool {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-		defer cancel()
+		t.Cleanup(cancel)
 		conn, err := s.dialLocalAuthServer(ctx)
 		if err != nil {
 			return false

--- a/lib/srv/alpnproxy/auth/auth_proxy_test.go
+++ b/lib/srv/alpnproxy/auth/auth_proxy_test.go
@@ -58,7 +58,7 @@ func TestDialLocalAuthServerAvailableServers(t *testing.T) {
 	}
 	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", authServers, nil, nil)
 	require.Eventually(t, func() bool {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		t.Cleanup(cancel)
 		conn, err := s.dialLocalAuthServer(ctx)
 		if err != nil {

--- a/lib/srv/alpnproxy/auth/auth_proxy_test.go
+++ b/lib/srv/alpnproxy/auth/auth_proxy_test.go
@@ -34,6 +34,8 @@ func TestDialLocalAuthServerNoServers(t *testing.T) {
 }
 
 func TestDialLocalAuthServerNoAvailableServers(t *testing.T) {
+	// The 203.0.113.0/24 range is part of block TEST-NET-3 as defined in RFC-5735 (https://www.rfc-editor.org/rfc/rfc5735).
+	// IPs in this range do not appear on the public internet.
 	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", []string{"203.0.113.1:3025"}, nil, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	t.Cleanup(cancel)
@@ -54,6 +56,8 @@ func TestDialLocalAuthServerAvailableServers(t *testing.T) {
 	authServers[0] = socket.Addr().String()
 	// multiple invalid servers to minimize chance that we select good one first try
 	for i := 0; i < 10; i++ {
+		// The 203.0.113.0/24 range is part of block TEST-NET-3 as defined in RFC-5735 (https://www.rfc-editor.org/rfc/rfc5735).
+		// IPs in this range do not appear on the public internet.
 		authServers = append(authServers, fmt.Sprintf("203.0.113.%d:3025", i+1))
 	}
 	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", authServers, nil, nil)

--- a/lib/srv/alpnproxy/auth/auth_proxy_test.go
+++ b/lib/srv/alpnproxy/auth/auth_proxy_test.go
@@ -36,7 +36,7 @@ func TestDialLocalAuthServerNoServers(t *testing.T) {
 func TestDialLocalAuthServerNoAvailableServers(t *testing.T) {
 	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", []string{"203.0.113.1:3025"}, nil, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
+	t.Cleanup(cancel)
 	_, err := s.dialLocalAuthServer(ctx)
 	require.Error(t, err, "dialLocalAuthServer expected to fail")
 	var netErr *net.OpError


### PR DESCRIPTION
The auth_proxy_test file now uses IP addresses from the block `TEST-NET-3` as specified in https://www.rfc-editor.org/rfc/rfc5735#section-3. Previously, it was using `0.0.0.0` IP addresses. This has a chance of actually hitting locally running services depending on the test runner setup, making the tests non-deterministic. The hope here is that this change will avoid the spurious test failures seen in CI.

Fixes #21453