### PR TITLE
Docs: fix link in troubleshooting guide

### DIFF
--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -276,7 +276,7 @@ Teleport currently requires that NLA is disabled in order to perform its
 certificate-based passwordless login.
 
 To disable NLA, follow the instructions in our
-[Desktop Access Manual Setup](./active-directory-manual-setup.mdx#allow-remote-rdp-connections).
+[Desktop Access Manual Setup](./active-directory-manual.mdx#allow-remote-rdp-connections).
 If you are still encountering this error after disabling NLA in Active Directory,
 run the following command from the Windows Desktop command prompt as an administrator
 to force the policy update:


### PR DESCRIPTION
Resolves broken link in Desktop Access troubleshooting guide.