### PR TITLE
[v12] Skip device authz when issuing App or Windows certs

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -114,6 +114,8 @@ type AuthPreference interface {
 	// GetDeviceTrust returns the cluster device trust settings, or nil if no
 	// explicit configurations are present.
 	GetDeviceTrust() *DeviceTrust
+	// SetDeviceTrust sets the cluster device trust settings.
+	SetDeviceTrust(*DeviceTrust)
 
 	// String represents a human readable version of authentication settings.
 	String() string
@@ -398,6 +400,11 @@ func (c *AuthPreferenceV2) GetDeviceTrust() *DeviceTrust {
 		return nil
 	}
 	return c.Spec.DeviceTrust
+}
+
+// SetDeviceTrust sets the cluster device trust settings.
+func (c *AuthPreferenceV2) SetDeviceTrust(dt *DeviceTrust) {
+	c.Spec.DeviceTrust = dt
 }
 
 // setStaticFields sets static resource header and metadata fields.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2483,18 +2483,7 @@ func (a *ServerWithRoles) desiredAccessInfoForUser(ctx context.Context, req *pro
 
 // GenerateUserCerts generates users certificates
 func (a *ServerWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-	authPref, err := a.authServer.GetAuthPreference(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	identity := a.context.Identity.GetIdentity()
-
-	// Device trust: authorize device before issuing certificates, if applicable.
-	// This gives a better UX by failing earlier in the access attempt.
-	if err := dtauthz.VerifyTLSUser(authPref.GetDeviceTrust(), identity); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	return a.generateUserCerts(
 		ctx, req,
 		certRequestDeviceExtensions(identity.DeviceExtensions),
@@ -2502,7 +2491,14 @@ func (a *ServerWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserC
 }
 
 func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserCertsRequest, opts ...certRequestOption) (*proto.Certs, error) {
-	var err error
+	// Device trust: authorize device before issuing certificates.
+	authPref, err := a.authServer.GetAuthPreference(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := a.verifyUserDeviceForCertIssuance(req.Usage, authPref.GetDeviceTrust()); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	// this prevents clients who have no chance at getting a cert and impersonating anyone
 	// from enumerating local users and hitting database
@@ -2764,6 +2760,23 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	}
 
 	return certs, nil
+}
+
+// verifyUserDeviceForCertIssuance verifies if the user device is a trusted
+// device, in accordance to the certificate usage and the cluster's DeviceTrust
+// settings. It's meant to be called before issuing new user certificates.
+// Each Node (or access server) verifies the device independently, so this check
+// is not paramount to the access system itself, but it stops bad attempts from
+// progressing further and provides better feedback than other protocol-specific
+// failures.
+func (a *ServerWithRoles) verifyUserDeviceForCertIssuance(usage proto.UserCertsRequest_CertUsage, dt *types.DeviceTrust) error {
+	// Ignore App or WindowsDeskop requests, they do not support device trust.
+	if usage == proto.UserCertsRequest_App || usage == proto.UserCertsRequest_WindowsDesktop {
+		return nil
+	}
+
+	identity := a.context.Identity.GetIdentity()
+	return trace.Wrap(dtauthz.VerifyTLSUser(dt, identity))
 }
 
 // CreateBot creates a new certificate renewal bot and returns a join token.

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -357,6 +357,8 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		ClusterName: srv.ClusterName,
 		AccessPoint: srv.AuthServer,
 		LockWatcher: srv.LockWatcher,
+		// AuthServer does explicit device authorization checks.
+		DisableDeviceAuthorization: true,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -727,6 +729,20 @@ func TestUser(username string) TestIdentity {
 		I: LocalUser{
 			Username: username,
 			Identity: tlsca.Identity{Username: username},
+		},
+	}
+}
+
+// TestUserWithDeviceExtensions returns a TestIdentity for a local user,
+// including the supplied device extensions in the tlsca.Identity.
+func TestUserWithDeviceExtensions(username string, exts tlsca.DeviceExtensions) TestIdentity {
+	return TestIdentity{
+		I: LocalUser{
+			Username: username,
+			Identity: tlsca.Identity{
+				Username:         username,
+				DeviceExtensions: exts,
+			},
 		},
 	}
 }


### PR DESCRIPTION
Skip device authorization for App or WindowsDesktop certificates - those modes
don't yet support device trust, so there is no point in requiring a trusted
device.

This fixes an issue for clusters that set the global `device_trust.mode` to
`required` and have App or WindowsDesktop servers.

gravitational/teleport.e#514

Backport #21344 to branch/v12