### PR TITLE
[v12] Compare TLS and SSH principals independent of order

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1412,7 +1412,7 @@ func (a *Server) AugmentContextUserCertificates(
 
 		// filter and sort TLS and SSH principals for comparison.
 		// Order does not matter and "-teleport-*" principals are filtered out.
-		filterPrincipals := func(s []string) []string {
+		filterAndSortPrincipals := func(s []string) []string {
 			res := make([]string, 0, len(s))
 			for _, principal := range s {
 				// Ignore -teleport- internal principals.
@@ -1435,7 +1435,7 @@ func (a *Server) AugmentContextUserCertificates(
 			return nil, trace.BadParameter("ssh cert type mismatch")
 		case sshCert.KeyId != identity.Username:
 			return nil, trace.BadParameter("identity and SSH user mismatch")
-		case !slices.Equal(filterPrincipals(sshCert.ValidPrincipals), filterPrincipals(identity.Principals)):
+		case !slices.Equal(filterAndSortPrincipals(sshCert.ValidPrincipals), filterAndSortPrincipals(identity.Principals)):
 			return nil, trace.BadParameter("identity and SSH principals mismatch")
 		case !apisshutils.KeysEqual(sshCert.Key, xPubKey):
 			return nil, trace.BadParameter("x509 and SSH public key mismatch")

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1105,8 +1105,13 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	const username = "llama"
 	const pass = "secret!!1!"
 
+	// Use a >1 list of principals.
+	// This is enough to cause ordering issues between the TLS and SSH principal
+	// lists, which caused a bug in the device trust preview.
+	principals := []string{"login0", "-teleport-internal-join", username}
+
 	// Prepare the user to test with.
-	_, _, err := CreateUserAndRole(authServer, username, []string{username})
+	_, _, err := CreateUserAndRole(authServer, username, principals)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	require.NoError(t,
 		authServer.UpsertPassword(username, []byte(pass)),

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1108,7 +1108,7 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	// Use a >1 list of principals.
 	// This is enough to cause ordering issues between the TLS and SSH principal
 	// lists, which caused a bug in the device trust preview.
-	principals := []string{"login0", "-teleport-internal-join", username}
+	principals := []string{"login0", username, "-teleport-internal-join"}
 
 	// Prepare the user to test with.
 	_, _, err := CreateUserAndRole(authServer, username, principals)


### PR DESCRIPTION
Reproduces in testing and fixes the "identity and SSH principals mismatch"
device trust errors by making principal comparison independent of order.

As a precaution we also skip "-teleport-" identities, as these should not block
issuance of device-aware certificates, in case they do deviate between
certificates in the future.

Backport #21560 to branch/v12