### PR TITLE
Update download link

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -137,7 +137,7 @@ chart.
 
 The Teleport package in Homebrew is not maintained by Teleport and we can't
 guarantee its reliability or security. We recommend the use of our [official
-Teleport packages](https://goteleport.com/teleport/download?os=mac).
+Teleport packages](https://goteleport.com/download).
 
 <ScopedBlock scope={["enterprise", "cloud"]}>
 


### PR DESCRIPTION
This redirects to a different download page on goteleport.com now.
There doesn't seem to be a super obvious way to deeplink to a specified OS anymore :(