### PR TITLE
Fix known_hosts locking issue on Windows

### DIFF
--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -299,11 +299,6 @@ func (a *LocalKeyAgent) GetKey(clusterName string, opts ...CertOption) (*Key, er
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	trustedCerts, err := a.clientStore.GetTrustedCerts(idx.ProxyHost)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	key.TrustedCerts = trustedCerts
 	return key, nil
 }
 


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/19420 introduced a back-to-back file lock by mistake, by calling `GetTrustedCerts` twice for every `GetKey` call.

Locking files on windows seems to be slower and more error prone, leading to the above mistake causing the issue described in the ticket below.

Closes https://github.com/gravitational/teleport/issues/21529