### PR TITLE
Make UsageSessionStart report TCP app access separately

### DIFF
--- a/api/types/app.go
+++ b/api/types/app.go
@@ -251,7 +251,11 @@ func (a *AppV3) IsGCP() bool {
 
 // IsTCP returns true if this app represents a TCP endpoint.
 func (a *AppV3) IsTCP() bool {
-	return strings.HasPrefix(a.Spec.URI, "tcp://")
+	return IsAppTCP(a.Spec.URI)
+}
+
+func IsAppTCP(uri string) bool {
+	return strings.HasPrefix(uri, "tcp://")
 }
 
 // GetProtocol returns the application protocol.

--- a/lib/events/usageevents/usageevents.go
+++ b/lib/events/usageevents/usageevents.go
@@ -94,21 +94,16 @@ func (u *UsageLogger) reportAuditEvent(ctx context.Context, event apievents.Audi
 			SessionType: string(types.DatabaseSessionKind),
 		}))
 	case *apievents.AppSessionStart:
-		// app.session.start is inconsistently emitted for things that are quite
-		// different, so here we only select the ones we care about
-		var sessionType string
+		sessionType := string(types.AppSessionKind)
 		if e.AWSRoleARN != "" {
 			sessionType = awsConsoleSessionType
 		} else if strings.HasPrefix(e.AppURI, "tcp:") {
 			sessionType = tcpSessionType
 		}
-
-		if sessionType != "" {
-			return trace.Wrap(u.report(&services.UsageSessionStart{
-				UserName:    e.User,
-				SessionType: sessionType,
-			}))
-		}
+		return trace.Wrap(u.report(&services.UsageSessionStart{
+			UserName:    e.User,
+			SessionType: sessionType,
+		}))
 	case *apievents.WindowsDesktopSessionStart:
 		return trace.Wrap(u.report(&services.UsageSessionStart{
 			UserName:    e.User,

--- a/lib/events/usageevents/usageevents.go
+++ b/lib/events/usageevents/usageevents.go
@@ -18,7 +18,6 @@ package usageevents
 
 import (
 	"context"
-	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -92,7 +91,7 @@ func (u *UsageLogger) reportAuditEvent(ctx context.Context, event apievents.Audi
 		}))
 	case *apievents.AppSessionStart:
 		sessionType := string(types.AppSessionKind)
-		if strings.HasPrefix(e.AppURI, "tcp:") {
+		if types.IsAppTCP(e.AppURI) {
 			sessionType = tcpSessionType
 		}
 		return trace.Wrap(u.report(&services.UsageSessionStart{

--- a/lib/events/usageevents/usageevents.go
+++ b/lib/events/usageevents/usageevents.go
@@ -30,9 +30,6 @@ import (
 )
 
 const (
-	// awsConsoleSessionType is the session_type in tp.session.start for the AWS
-	// console access redirect
-	awsConsoleSessionType = "app_aws"
 	// tcpSessionType is the session_type in tp.session.start for TCP
 	// Application Access
 	tcpSessionType = "app_tcp"
@@ -95,9 +92,7 @@ func (u *UsageLogger) reportAuditEvent(ctx context.Context, event apievents.Audi
 		}))
 	case *apievents.AppSessionStart:
 		sessionType := string(types.AppSessionKind)
-		if e.AWSRoleARN != "" {
-			sessionType = awsConsoleSessionType
-		} else if strings.HasPrefix(e.AppURI, "tcp:") {
+		if strings.HasPrefix(e.AppURI, "tcp:") {
 			sessionType = tcpSessionType
 		}
 		return trace.Wrap(u.report(&services.UsageSessionStart{


### PR DESCRIPTION
This is a followup to #20662 that makes it so that we single out TCP app access in the `tp.session.start` event (by marking it with a type of `app_tcp`).