### PR TITLE
[v11] Skip deleting database servers on agent shutdown during binary upgrade

### DIFF
--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -196,12 +196,17 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 
 	// Execute this when the process running database proxy service exits.
 	process.OnExit("db.stop", func(payload interface{}) {
-		log.Info("Shutting down.")
 		if dbService != nil {
-			warnOnErr(dbService.Close(), process.log)
+			if payload == nil {
+				log.Info("Shutting down immediately.")
+				warnOnErr(dbService.Close(), log)
+			} else {
+				log.Info("Shutting down gracefully.")
+				warnOnErr(dbService.Shutdown(payloadContext(payload, log)), log)
+			}
 		}
 		if asyncEmitter != nil {
-			warnOnErr(asyncEmitter.Close(), process.log)
+			warnOnErr(asyncEmitter.Close(), log)
 		}
 		if agentPool != nil {
 			agentPool.Stop()

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4582,8 +4582,13 @@ func (process *TeleportProcess) initApps() {
 
 		// Execute this when process is asked to exit.
 		process.OnExit("apps.stop", func(payload interface{}) {
-			log.Infof("Shutting down.")
-			warnOnErr(appServer.Close(), log)
+			if payload == nil {
+				log.Infof("Shutting down immediately.")
+				warnOnErr(appServer.Close(), log)
+			} else {
+				log.Infof("Shutting down gracefully.")
+				warnOnErr(appServer.Shutdown(payloadContext(payload, log)), log)
+			}
 			if asyncEmitter != nil {
 				warnOnErr(asyncEmitter.Close(), log)
 			}
@@ -4677,6 +4682,11 @@ func (process *TeleportProcess) StartShutdown(ctx context.Context) context.Conte
 	// imported listeners that haven't been used so far
 	warnOnErr(process.closeImportedDescriptors(""), process.log)
 	warnOnErr(process.stopListeners(), process.log)
+
+	// populate context values
+	if len(process.getForkedPIDs()) > 0 {
+		ctx = services.ProcessForkedContext(ctx)
+	}
 
 	process.BroadcastEvent(Event{Name: TeleportExitEvent, Payload: ctx})
 	localCtx, cancel := context.WithCancel(ctx)

--- a/lib/services/process.go
+++ b/lib/services/process.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import "context"
+
+// ProcessForkedContext adds a flag to the context to indicate the Teleport
+// process has running forked child(ren).
+func ProcessForkedContext(parent context.Context) context.Context {
+	return addFlagToContext[processForkedFlag](parent)
+}
+
+// HasProcessForked returns true if the Teleport process has running forked
+// child(ren).
+func HasProcessForked(ctx context.Context) bool {
+	return getFlagFromContext[processForkedFlag](ctx)
+}
+
+// ShouldDeleteServerHeartbeatsOnShutdown checks whether server heartbeats
+// should be deleted based on the process shutdown context.
+func ShouldDeleteServerHeartbeatsOnShutdown(ctx context.Context) bool {
+	// A child process can be forked to upgrade the Teleport binary. The child
+	// will take over the heartbeats so do NOT delete them in that case. In
+	// worst case scenarios if the child fails to register new heartbeats, the
+	// old ones will get deleted automatically upon expiry.
+	return !HasProcessForked(ctx)
+}
+
+func addFlagToContext[FlagType any](parent context.Context) context.Context {
+	return context.WithValue(parent, (*FlagType)(nil), (*FlagType)(nil))
+}
+func getFlagFromContext[FlagType any](ctx context.Context) bool {
+	_, ok := ctx.Value((*FlagType)(nil)).(*FlagType)
+	return ok
+}
+
+type processForkedFlag struct{}

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -171,7 +171,7 @@ func (s *Server) onUpdate(ctx context.Context, resource types.ResourceWithLabels
 }
 
 func (s *Server) onDelete(ctx context.Context, resource types.ResourceWithLabels) error {
-	return s.unregisterApp(ctx, resource.GetName())
+	return s.unregisterAndRemoveApp(ctx, resource.GetName())
 }
 
 func (s *Server) matcher(resource types.ResourceWithLabels) bool {

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -474,16 +474,30 @@ func (s *Server) unregisterDatabase(ctx context.Context, database types.Database
 		s.log.Warnf("Failed to teardown IAM for %v: %v.", database, err)
 	}
 	// Stop heartbeat, labels, etc.
-	if err := s.stopProxyingDatabase(ctx, database); err != nil {
+	if err := s.stopProxyingAndDeleteDatabase(ctx, database); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
+
 }
 
 // stopProxyingDatabase winds down the proxied database instance by stopping
 // its heartbeat and dynamic labels and unregistering it from the list of
 // proxied databases.
 func (s *Server) stopProxyingDatabase(ctx context.Context, database types.Database) error {
+	// Stop heartbeat and dynamic labels updates.
+	if err := s.stopDatabase(ctx, database.GetName()); err != nil {
+		return trace.Wrap(err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.proxiedDatabases, database.GetName())
+	return nil
+}
+
+// stopProxyingAndDeleteDatabase stops and deletes the database, then
+// unregisters it from the list of proxied databases.
+func (s *Server) stopProxyingAndDeleteDatabase(ctx context.Context, database types.Database) error {
 	// Stop heartbeat and dynamic labels updates.
 	if err := s.stopDatabase(ctx, database.GetName()); err != nil {
 		return trace.Wrap(err)
@@ -699,12 +713,23 @@ func (s *Server) startServiceHeartbeat() error {
 
 // Close stops proxying all server's databases and frees up other resources.
 func (s *Server) Close() error {
+	return trace.Wrap(s.close(s.closeContext))
+}
+
+// Shutdown performs a graceful shutdown.
+func (s *Server) Shutdown(ctx context.Context) error {
+	// TODO wait active connections.
+	return trace.Wrap(s.close(ctx))
+}
+
+func (s *Server) close(ctx context.Context) error {
 	var errors []error
 	// Stop proxying all databases.
 	for _, database := range s.getProxiedDatabases() {
-		if err := s.stopProxyingDatabase(s.closeContext, database); err != nil {
-			errors = append(errors, trace.WrapWithMessage(
-				err, "stopping database %v", database.GetName()))
+		if services.ShouldDeleteServerHeartbeatsOnShutdown(ctx) {
+			errors = append(errors, trace.Wrap(s.stopProxyingAndDeleteDatabase(ctx, database)))
+		} else {
+			errors = append(errors, trace.Wrap(s.stopProxyingDatabase(ctx, database)))
 		}
 	}
 	// Signal to all goroutines to stop.

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // TestDatabaseServerStart validates that started database server updates its
@@ -249,6 +250,73 @@ func TestHeartbeatEvents(t *testing.T) {
 			require.Eventually(t, func() bool {
 				return atomic.LoadInt64(&heartbeatEvents) == expectedHeartbeatCount(test.staticDatabases)
 			}, 2*time.Second, 500*time.Millisecond)
+		})
+	}
+}
+
+func TestShutdown(t *testing.T) {
+	tests := []struct {
+		name                             string
+		hasForkedChild                   bool
+		wantDatabaseServersAfterShutdown bool
+	}{
+		{
+			name:                             "regular shutdown",
+			hasForkedChild:                   false,
+			wantDatabaseServersAfterShutdown: false,
+		},
+		{
+			name:                             "has forked child",
+			hasForkedChild:                   true,
+			wantDatabaseServersAfterShutdown: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			testCtx := setupTestContext(ctx, t)
+
+			db0, err := makeStaticDatabase("db0", nil)
+			require.NoError(t, err)
+
+			server := testCtx.setupDatabaseServer(ctx, t, agentParams{
+				Databases: []types.Database{db0},
+			})
+
+			// Validate that the server is proxying db0 after start.
+			require.Equal(t, server.getProxiedDatabases(), types.Databases{db0})
+
+			// Validate heartbeat is present after start.
+			server.ForceHeartbeat()
+			dbServers, err := testCtx.authClient.GetDatabaseServers(ctx, apidefaults.Namespace)
+			require.NoError(t, err)
+			require.Len(t, dbServers, 1)
+			require.Equal(t, dbServers[0].GetDatabase(), db0)
+
+			// Shutdown should not return error.
+			shutdownCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+			t.Cleanup(cancel)
+			if test.hasForkedChild {
+				shutdownCtx = services.ProcessForkedContext(shutdownCtx)
+			}
+
+			require.NoError(t, server.Shutdown(shutdownCtx))
+
+			// Validate that the server is not proxying db0 after close.
+			require.Empty(t, server.getProxiedDatabases())
+
+			// Validate database servers based on the test.
+			dbServersAfterShutdown, err := testCtx.authClient.GetDatabaseServers(ctx, apidefaults.Namespace)
+			require.NoError(t, err)
+			if test.wantDatabaseServersAfterShutdown {
+				require.Equal(t, dbServers, dbServersAfterShutdown)
+			} else {
+				require.Empty(t, dbServersAfterShutdown)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Backport #21156 to branch/v11

no cherry-pick conflict (not sure why bot backport says "Create Failed")

related backport #21616