### PR TITLE
Refresh the Access Controls menu

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -205,7 +205,7 @@
     },
     {
       "icon": "lock",
-      "title": "Configure Access",
+      "title": "Manage Access",
       "entries": [
         {
           "title": "Introduction",

--- a/docs/pages/access-controls/introduction.mdx
+++ b/docs/pages/access-controls/introduction.mdx
@@ -8,27 +8,27 @@ After [deploying a Teleport cluster](../deploy-a-cluster/introduction.mdx), the
 next step is to manage the access that Teleport users have to resources in your
 infrastructure. 
 
-Teleport's role-based access control (RBAC) system enables you to set
-fine-grained policies for who can perform certain actions against specific
-recesources. For example:
+Teleport's role-based access control (RBAC) enables you to set fine-grained
+policies for who can perform certain actions against specific recesources. For
+example:
 
 - Analytics team members can SSH into a MongoDB read replica, but not the main
   database.
 - Interns can't access production databases.
-- SREs can access a production server only when using a registered second-factor
-  hardware device.
+- SREs can access a production server only when using a [trusted hardware
+  device](./guides/device-trust.mdx).
 - Members of a team can access the production Kubernetes cluster if approved by
   someone else from the same team.
 
 ## Get started
 
-Configure Access Controls in a five-minute [Getting Started](./getting-started.mdx)
-guide.
+Configure Access Controls with our five-minute [Getting
+Started](./getting-started.mdx) guide.
 
 ## Set up Teleport roles
 
 The heart of Teleport's RBAC system is the **role**, a configuration document
-that specifies access restrictions to resources in your Teleport cluster.
+that specifies access policies for resources in your Teleport cluster.
 Assigning a role to a Teleport user applies the policies listed in the role to
 the user. 
 
@@ -61,7 +61,7 @@ You can integrate Teleport with your existing communication tool, e.g., Slack,
 PagerDuty, or Microsoft Teams, so Teleport users can easily create and approve
 Access Requests.
 
-[Get started with Access Request plugins](./access-request-plugins.mdx).
+[Get started with Access Request plugins](./access-request-plugins/index.mdx).
 
 ## Achieve compliance
 

--- a/docs/pages/access-controls/introduction.mdx
+++ b/docs/pages/access-controls/introduction.mdx
@@ -1,40 +1,80 @@
 ---
-title: Access Controls Introduction
-description: Provide Role-Based Access Control (RBAC) for SSH, Kubernetes, Databases, and Web Apps.
-h1: Access Controls for SSH, Kubernetes, Databases and Web Apps
+title: Manage Access to your Cluster
+description: How to provide role-based access control (RBAC) for servers, databases, Kubernetes clusters, and other resources in your infrastructure
+layout: tocless-doc
 ---
 
-## Introduction
+After [deploying a Teleport cluster](../deploy-a-cluster/introduction.mdx), the
+next step is to manage the access that Teleport users have to resources in your
+infrastructure. 
 
-Here are examples of access policies you can define with Teleport:
+Teleport's role-based access control (RBAC) system enables you to set
+fine-grained policies for who can perform certain actions against specific
+recesources. For example:
 
-- Analytics team members can SSH into the MongoDB read replica, but not the main database.
+- Analytics team members can SSH into a MongoDB read replica, but not the main
+  database.
 - Interns can't access production databases.
-- Devops can access the production server only when using a registered second factor hardware device.
-- Members of my team can access the production Kubernetes cluster if approved by someone else from the team.
+- SREs can access a production server only when using a registered second-factor
+  hardware device.
+- Members of a team can access the production Kubernetes cluster if approved by
+  someone else from the same team.
 
-Role-Based Access Control (RBAC) is almost always used in conjunction with Single Sign-On (SSO), GitHub (in the Teleport Open Source Edition), and OIDC or SAML (in the Teleport Enterprise editions).
+## Get started
 
-It also works with users stored in Teleport's internal database.
-
-## Getting started
-
-Configure Access Controls in a 5 minute [Getting Started](./getting-started.mdx)
+Configure Access Controls in a five-minute [Getting Started](./getting-started.mdx)
 guide.
 
-## Guides
+## Set up Teleport roles
 
-(!docs/pages/includes/access-control-guides.mdx!)
+The heart of Teleport's RBAC system is the **role**, a configuration document
+that specifies access restrictions to resources in your Teleport cluster.
+Assigning a role to a Teleport user applies the policies listed in the role to
+the user. 
 
-## How does it work?
+See the [Cluster Access and RBAC](./guides.mdx) section for instructions on
+setting up Teleport roles.
 
-Consider a company using [Okta](https://www.okta.com/) to authenticate users and place
-them into groups. A typical deployment of Teleport in this scenario
-would involve:
+## Integrate with your Single Sign-On provider
 
-1. Configuring Teleport to use existing user identities stored in Okta.
-2. Okta would have users placed in certain groups, perhaps `developers`, `admins`, `contractors`, and so on.
-3. Teleport would have certain Teleport *Roles* defined: `developers` and `admins`.
-4. Mappings would connect the Okta groups (SAML assertions) to the defined Teleport roles.
+While you can create Teleport users directly on the Auth Service, the more
+scalable approach is to integrate Teleport with a Single Sign-On identity
+provider (IdP), such as Okta or GitHub. 
 
-Every Teleport user will be assigned a Teleport role based on their Okta group membership.
+When a user authenticates to your Teleport cluster via your IdP, Teleport
+automatically assigns roles to the user based on data provided by the IdP. This
+means that you can implement a fully fledged infrastructure RBAC system based on
+your existing Single Sign-On solution.
+
+Read our [Single Sign-On guide](./sso.mdx) to get started.
+
+## Enable Access Requests
+
+With Access Requests, your Teleport cluster can grant a user temporary access to
+resources in your infrastructure based on the approval of other users. You can
+set up your RBAC so all privileged access is short lived, and there are no
+longstanding admin roles for attackers to hijack.
+
+[Get started with Access Requests](./access-requests.mdx).
+
+You can integrate Teleport with your existing communication tool, e.g., Slack,
+PagerDuty, or Microsoft Teams, so Teleport users can easily create and approve
+Access Requests.
+
+[Get started with Access Request plugins](./access-request-plugins.mdx).
+
+## Achieve compliance
+
+Teleport's RBAC features make it easier to manage access to your infrastructure
+in order to satisfy compliance requirements. Learn how to use Teleport to
+achieve compliance with:
+
+- [FedRAMP](./compliance-frameworks/fedramp.mdx)
+- [SOC 2](./compliance-frameworks/soc2.mdx)
+
+## Find out more
+
+Find out more information on Teleport's RBAC features:
+
+- [Access Controls Reference](./reference.mdx)
+- [Frequently Asked Questions](./faq.mdx)


### PR DESCRIPTION
Closes #19933

- Changes the "Configure Access" menu item to "Manage Access"
- The Access Controls menu page was out of date, so I changed it to reflect the current sequence of subsections. This more narrative approach also puts each subsection in the context of a user's overall Teleport setup.