### PR TITLE
Unify x86/ARM64 build process

### DIFF
--- a/.github/workflows/build-centos7-assets.yaml
+++ b/.github/workflows/build-centos7-assets.yaml
@@ -13,8 +13,8 @@ jobs:
     name: Build CentOS 7 Asset Buildbox
     strategy:
       matrix:
-        # Build assets on x86. TODO(jakule) Add ARM64 build.
-        runner: [ ubuntu-22.04-32core ]
+        # Build assets on x86 and ARM64.
+        runner: [ ubuntu-22.04-32core, ['self-hosted', 'linux', 'arm64'] ]
     # Use bigger worker. Clang takes a while to build.
     runs-on: ${{ matrix.runner }}
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -2,7 +2,7 @@ ARG RUST_VERSION
 
 ## GIT2 ###################################################################
 
-# git2 packages are not available on ARM64, so we need to buld it from source.
+# git2 packages are not available on ARM64, so we need to build it from source.
 FROM centos:7 AS git2
 
 ARG DEVTOOLSET

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -1,5 +1,38 @@
 ARG RUST_VERSION
 
+## GIT2 ###################################################################
+
+# git2 packages are not available on ARM64, so we need to buld it from source.
+FROM centos:7 AS git2
+
+ARG DEVTOOLSET
+
+RUN yum groupinstall -y 'Development Tools' && \
+    yum install -y \
+    ca-certificates  \
+    curl-devel  \
+    expat-devel  \
+    gettext-devel  \
+    openssl-devel  \
+    zlib-devel  \
+    perl-CPAN  \
+    perl-devel wget && \
+    yum update -y && \
+    yum -y install centos-release-scl-rh && \
+    yum install -y \
+    centos-release-scl \
+    ${DEVTOOLSET}-gcc* \
+    ${DEVTOOLSET}-make && \
+    yum clean all
+
+RUN wget https://github.com/git/git/archive/refs/tags/v2.39.1.tar.gz && \
+    tar xf v2.39.1.tar.gz && \
+    cd git-2.39.1/ && \
+    scl enable ${DEVTOOLSET} "make configure && \
+    ./configure --prefix=/opt/git && \
+    make -j6 all && \
+    make install"
+
 # Create an alias to the assets image. Ref: https://github.com/docker/for-mac/issues/2155
 ARG BUILDARCH
 FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport13-${BUILDARCH} AS teleport-buildbox-centos7-assets
@@ -9,13 +42,15 @@ FROM ghcr.io/gravitational/teleport-buildbox-centos7-assets:teleport13-${BUILDAR
 # Build libfido2 separately for isolation, speed and flexibility.
 FROM centos:7 AS libfido2
 
+ARG DEVTOOLSET
+
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
     yum install -y centos-release-scl-rh && \
     yum update -y && \
     yum install -y \
         cmake3 \
-        devtoolset-11-gcc* \
+        ${DEVTOOLSET}-gcc* \
         git \
         libudev-devel \
         zlib-devel && \
@@ -34,7 +69,7 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1t && \
     cd openssl && \
     [ "$(git rev-parse HEAD)" = '830bf8e1e4749ad65c51b6a1d0d769ae689404ba' ] && \
-    ./config --release && \
+    ./config --release --libdir=/usr/local/lib64 && \
     make && \
     make install_sw
 
@@ -55,7 +90,7 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
     [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
-    scl enable devtoolset-11 "\
+    scl enable ${DEVTOOLSET} "\
       cmake3 \
           -DBUILD_EXAMPLES=OFF \
           -DBUILD_MANPAGES=OFF \
@@ -69,6 +104,8 @@ RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
 
 FROM centos:7 AS libbpf
 
+ARG DEVTOOLSET
+
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
@@ -76,10 +113,10 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
         centos-release-scl \
-        devtoolset-11-gcc* \
-        devtoolset-11-make \
+        ${DEVTOOLSET}-gcc* \
+        ${DEVTOOLSET}-make \
         elfutils-libelf-devel-static \
-        scl-utils \
+        scl-utils && \
     yum clean all
 
 # Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
@@ -88,11 +125,13 @@ ARG LIBBPF_VERSION
 RUN mkdir -p /opt && cd /opt && \
     curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
-    scl enable devtoolset-11 "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
+    scl enable ${DEVTOOLSET} "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
 
 ## LIBPCSCLITE #####################################################################
 
 FROM centos:7 AS libpcsclite
+
+ARG DEVTOOLSET
 
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
@@ -103,7 +142,7 @@ RUN yum groupinstall -y 'Development Tools' && \
         libudev-devel \
         scl-utils \
         centos-release-scl \
-        devtoolset-11-gcc* && \
+        ${DEVTOOLSET}-gcc* && \
     yum clean all
 
 # Install libpcsclite - compile with a newer GCC. The one installed by default is not able to compile it.
@@ -112,7 +151,7 @@ RUN git clone --depth=1 https://github.com/gravitational/PCSC.git -b ${LIBPCSCLI
     cd PCSC && \
     ./bootstrap && \
     ./configure --enable-static --with-pic --disable-libsystemd && \
-    scl enable devtoolset-11 "make" && \
+    scl enable ${DEVTOOLSET} "make" && \
     make install
 
 ## BUILDBOX ###################################################################
@@ -126,6 +165,7 @@ ENV LANGUAGE=en_US.UTF-8 \
 
 ARG GOLANG_VERSION
 ARG RUST_VERSION
+ARG DEVTOOLSET
 
 ARG UID
 ARG GID
@@ -140,7 +180,7 @@ RUN yum groupinstall -y 'Development Tools' && \
     #required by libbpf
     centos-release-scl \
     # required by libbpf
-    devtoolset-11-* \
+    ${DEVTOOLSET}-* \
     # required by libbpf
     elfutils-libelf-devel-static \
     net-tools \
@@ -153,19 +193,21 @@ RUN yum groupinstall -y 'Development Tools' && \
     zip \
     # required by libbpf
     zlib-static && \
-    yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && \
-    yum -y install git && \
-    yum clean all
+    yum clean all && \
+    localedef -c -i en_US -f UTF-8 en_US.UTF-8
+
+# Override the old git installed by yum. We need git 2+ on GitHub Actions.
+COPY --from=git2 /opt/git /usr/local
 
 ARG BUILDARCH
 
 # Install etcd.
-RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
-     cp etcd-v3.3.9-linux-amd64/etcd* /bin/ && \
+RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-${BUILDARCH}.tar.gz | tar -xz && \
+     cp etcd-v3.3.9-linux-${BUILDARCH}/etcd* /bin/ && \
      rm -rf etcd-v3.3.9-linux-${BUILDARCH})
 
 # Install Go.
-RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-amd64.tar.gz | tar xz && \
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-${BUILDARCH}.tar.gz | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
@@ -181,7 +223,7 @@ ENV NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-lin
 ENV NODE_PATH="/usr/local/lib/nodejs-linux"
 ENV PATH="$PATH:${NODE_PATH}/bin"
 RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo "arm64"; fi) && \
-     export NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+     export NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
      mkdir -p ${NODE_PATH} && \
      curl -o /tmp/nodejs.tar.xz -L ${NODE_URL} && \
      tar -xJf /tmp/nodejs.tar.xz -C /usr/local/lib/nodejs-linux --strip-components=1
@@ -207,8 +249,7 @@ USER ci
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
     rustup --version && \
     cargo --version && \
-    rustc --version && \
-    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy
+    rustc --version
 
 # Do a quick switch back to root and copy/setup libfido2 and libpcsclite binaries.
 # Do this last to take better advantage of the multi-stage build.

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -1,5 +1,7 @@
 FROM centos:7 AS centos-devtoolset
 
+ARG DEVTOOLSET
+
 # Install required dependencies.
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
@@ -11,9 +13,9 @@ RUN yum groupinstall -y 'Development Tools' && \
         # required by Clang/LLVM
         cmake3 \
         # required by libbpf and Clang
-        devtoolset-11-gcc* \
+        ${DEVTOOLSET}-gcc* \
         # required by libbpf
-        devtoolset-11-make \
+        ${DEVTOOLSET}-make \
         # required by libbpf
         elfutils-libelf-devel \
         # required by libbpf
@@ -30,6 +32,8 @@ RUN yum groupinstall -y 'Development Tools' && \
 # Use just created devtool image with newer GCC and Cmake
 FROM centos-devtoolset as clang10
 
+ARG DEVTOOLSET
+
 # Compile Clang 10.0.1 from source. It is needed to create BPF files.
 # Centos 7 doesn't provide it as a package unfortunately.
 # LLVM_INCLUDE_BENCHMARKS must be off, otherwise compilation fails,
@@ -39,7 +43,7 @@ FROM centos-devtoolset as clang10
 RUN git clone --branch llvmorg-10.0.1 --depth=1 https://github.com/llvm/llvm-project.git && \
     cd llvm-project/ && \
     mkdir build && cd build/ && \
-    scl enable devtoolset-11 'bash -c "cmake3 \
+    scl enable ${DEVTOOLSET} 'bash -c "cmake3 \
     -DCLANG_BUILD_TOOLS=ON \
     -DCLANG_ENABLE_ARCMT=OFF \
     -DCLANG_ENABLE_STATIC_ANALYZER=OFF \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -73,6 +73,12 @@ endif
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(GOCACHE):/go/cache -e GOCACHE=/go/cache
 endif
 
+ifeq ("$(RUNTIME_ARCH)","arm64")
+	# devtootset-11 is not available on CentOS 7 aarch64
+	DEVTOOLSET ?= devtoolset-10
+else
+	DEVTOOLSET ?= devtoolset-11
+endif
 
 #
 # Build 'teleport' release inside a docker container
@@ -163,6 +169,7 @@ buildbox-centos7:
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
+		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg PROTOC_VER=$(PROTOC_VER) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg LIBPCSCLITE_VERSION=$(LIBPCSCLITE_VERSION) \
@@ -463,7 +470,7 @@ release-fips: buildbox-fips
 .PHONY:release-centos7
 release-centos7: buildbox-centos7
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
-		/usr/bin/scl enable devtoolset-11 'make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no'
+		/usr/bin/scl enable $(DEVTOOLSET) 'make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no'
 
 #
 # Create a Teleport FIPS package for CentOS 7 using the build container.
@@ -472,7 +479,7 @@ release-centos7: buildbox-centos7
 .PHONY:release-centos7-fips
 release-centos7-fips:
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
-		/usr/bin/scl enable devtoolset-11 '/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=no'
+		/usr/bin/scl enable $(DEVTOOLSET) '/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=no'
 
 #
 # Create a Windows Teleport package using the build container.
@@ -536,5 +543,6 @@ print-buildbox-version:
 .PHONY:build-centos7-assets
 build-centos7-assets:
 	docker build \
+		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--tag $(BUILDBOX_CENTOS7_ASSETS)-$(RUNTIME_ARCH) \
 		-f Dockerfile-centos7-assets .

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -74,7 +74,7 @@ DOCKERFLAGS := $(DOCKERFLAGS) -v $(GOCACHE):/go/cache -e GOCACHE=/go/cache
 endif
 
 ifeq ("$(RUNTIME_ARCH)","arm64")
-	# devtootset-11 is not available on CentOS 7 aarch64
+	# devtoolset-11 is not available on CentOS 7 aarch64
 	DEVTOOLSET ?= devtoolset-10
 else
 	DEVTOOLSET ?= devtoolset-11


### PR DESCRIPTION
Currently, our ARM64 pipeline builds limited subset of Teleport features as none of the 3rd party dependencies (openssh, libbpf etc) are not built on AMR64. This change build all dependencies on AMR64 in the same way as we do on x86.

FIPS changes are not included as we do not support FIPS on ARM64.