### PR TITLE
Improve webpack "exclude" expressions

### DIFF
--- a/web/packages/build/webpack/webpack.base.js
+++ b/web/packages/build/webpack/webpack.base.js
@@ -78,7 +78,7 @@ const configFactory = {
       return {
         test: /\.svg$/,
         type: 'asset/inline',
-        exclude: /node_modules/,
+        exclude: /[\\/]node_modules[\\/]/,
       };
     },
     css() {
@@ -104,7 +104,7 @@ const configFactory = {
     jsx() {
       return {
         test: /\.(ts|tsx|js|jsx)$/,
-        exclude: /(node_modules)|(assets)/,
+        exclude: /[\\/]node_modules[\\/]/,
         use: [
           {
             loader: 'babel-loader',


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/21662 by matching on the exact folder name `node_modules` (as we do in [another place](https://github.com/gravitational/teleport/issues/21662)). The existing version excludes anything that has substring `assets` or `node_modules` in any part of the full path.