### PR TITLE
[v11] Bump cloud version to 11.3.3

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1245,7 +1245,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "11.3.2",
+      "version": "11.3.3",
       "major_version": "11",
       "sla": {
         "monthly_percentage": "99.5%",


### PR DESCRIPTION
Backport #21666 to branch/v11. See: https://github.com/gravitational/cloud/issues/3375