### PR TITLE
[v10] Bump cloud version to 11.3.3

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1133,8 +1133,8 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "10.3.8",
-      "major_version": "10",
+      "version": "11.3.3",
+      "major_version": "11",
       "sla": {
         "monthly_percentage": "99.5%",
         "monthly_downtime": "3 hours 40 minutes"


### PR DESCRIPTION
Backport #21666 to branch/v10. See: https://github.com/gravitational/cloud/issues/3375