### PR TITLE
[v12] Bump cloud version to 11.3.3

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1295,7 +1295,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "11.2.1",
+      "version": "11.3.3",
       "major_version": "11",
       "sla": {
         "monthly_percentage": "99.5%",


### PR DESCRIPTION
Backport #21666 to branch/v12. See: https://github.com/gravitational/cloud/issues/3375