### PR TITLE
Delete assets/aws/cloudformation directory

### DIFF
--- a/assets/aws/cloudformation/README.md
+++ b/assets/aws/cloudformation/README.md
@@ -1,1 +1,0 @@
-Please see https://github.com/gravitational/teleport/tree/master/examples/aws/cloudformation instead.


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/20417 deleted the `examples/aws/cloudformation` directory which this README refers to, so it's no longer necessary to keep this here.

Follow up to #20417