### PR TITLE
[v12] Update Go toolchain to 1.20

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ name: push-build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
   UID: "1000"
 trigger:
   event:
@@ -144,7 +144,7 @@ name: push-build-linux-386
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
   UID: "1000"
 trigger:
   event:
@@ -247,7 +247,7 @@ name: push-build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
   UID: "1000"
 trigger:
   event:
@@ -354,7 +354,7 @@ name: push-build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
   UID: "1000"
 trigger:
   event:
@@ -512,7 +512,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.19.5
+    RUNTIME: go1.20
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -1122,7 +1122,7 @@ name: push-build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
   UID: "1000"
 trigger:
   event:
@@ -1225,7 +1225,7 @@ name: push-build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
   UID: "1000"
 trigger:
   event:
@@ -1641,7 +1641,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
 trigger:
   event:
     include:
@@ -1829,7 +1829,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
 trigger:
   event:
     include:
@@ -2016,7 +2016,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
 trigger:
   event:
     include:
@@ -2210,7 +2210,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
 trigger:
   event:
     include:
@@ -3413,7 +3413,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
 trigger:
   event:
     include:
@@ -4168,7 +4168,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.19.5
+    RUNTIME: go1.20
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -4760,7 +4760,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
 trigger:
   event:
     include:
@@ -4946,7 +4946,7 @@ name: build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
   UID: "1000"
 trigger:
   event:
@@ -6028,7 +6028,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.19.5
+  RUNTIME: go1.20
 trigger:
   event:
     include:
@@ -18925,6 +18925,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 3fb10ca7c4a6d18b7d3c37b3e9c8504da416f428e46a807055e52f90ef63e085
+hmac: 8af996e7302abeb45cdf79d0c273d2a3479dfdcf31a879bfd0d9ec44cca44226
 
 ...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,12 +10,6 @@ issues:
     - linters:
       - unused
       path: 'operator/controllers/resources/(.+)_controller_test\.go'
-    # TODO(codingllama): Remove ignore after the new golangci-lint image lands.
-    # For some reason this particular files causes problems between different
-    # goimports versions.
-    - path: lib/services/role_test.go
-      linters:
-      - goimports
   exclude-use-default: true
   max-same-issues: 0
   max-issues-per-linter: 0
@@ -42,13 +36,13 @@ linters-settings:
     list-type: denylist
     include-go-root: true # check against stdlib
     packages-with-error-message:
-    - io/ioutil: 'use "io" or "os" packages instead'
-    - github.com/golang/protobuf: 'use "google.golang.org/protobuf"'
-    - github.com/hashicorp/go-uuid: 'use "github.com/google/uuid" instead'
-    - github.com/pborman/uuid: 'use "github.com/google/uuid" instead'
-    - github.com/siddontang/go-log/log: 'use "github.com/sirupsen/logrus" instead'
-    - github.com/siddontang/go/log: 'use "github.com/sirupsen/logrus" instead'
-    - go.uber.org/atomic: 'use "sync/atomic" instead'
+      - io/ioutil: 'use "io" or "os" packages instead'
+      - github.com/golang/protobuf: 'use "google.golang.org/protobuf"'
+      - github.com/hashicorp/go-uuid: 'use "github.com/google/uuid" instead'
+      - github.com/pborman/uuid: 'use "github.com/google/uuid" instead'
+      - github.com/siddontang/go-log/log: 'use "github.com/sirupsen/logrus" instead'
+      - github.com/siddontang/go/log: 'use "github.com/sirupsen/logrus" instead'
+      - go.uber.org/atomic: 'use "sync/atomic" instead'
   misspell:
     locale: US
   gci:
@@ -66,6 +60,13 @@ output:
   uniq-by-line: false
 
 run:
+  go: '1.19'
+  skip-dirs:
+    - (^|/)node_modules/
+    - ^api/gen/
+    - ^docs/
+    - ^gen/
+    - ^rfd/
+    - ^web/
   skip-dirs-use-default: false
   timeout: 5m
-  go: '1.19'

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -279,7 +279,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.8.2
 
 # Install golangci-lint.
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -19,7 +19,7 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 
-GOLANG_VERSION ?= go1.19.5
+GOLANG_VERSION ?= go1.20
 
 NODE_VERSION ?= 16.18.1
 

--- a/lib/auth/windows/ldap.go
+++ b/lib/auth/windows/ldap.go
@@ -30,20 +30,20 @@ import (
 type LDAPConfig struct {
 	// Addr is the LDAP server address in the form host:port.
 	// Standard port is 636 for LDAPS.
-	Addr string
+	Addr string //nolint:unused // False-positive
 	// Domain is an Active Directory domain name, like "example.com".
-	Domain string
+	Domain string //nolint:unused // False-positive
 	// Username is an LDAP username, like "EXAMPLE\Administrator", where
 	// "EXAMPLE" is the NetBIOS version of Domain.
-	Username string
+	Username string //nolint:unused // False-positive
 	// SID is the SID for the user specified by Username.
-	SID string
+	SID string //nolint:unused // False-positive
 	// InsecureSkipVerify decides whether we skip verifying with the LDAP server's CA when making the LDAPS connection.
-	InsecureSkipVerify bool
+	InsecureSkipVerify bool //nolint:unused // False-positive
 	// ServerName is the name of the LDAP server for TLS.
-	ServerName string
+	ServerName string //nolint:unused // False-positive
 	// CA is an optional CA cert to be used for verification if InsecureSkipVerify is set to false.
-	CA *x509.Certificate
+	CA *x509.Certificate //nolint:unused // False-positive
 }
 
 // Check verifies this LDAPConfig

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -20,10 +20,10 @@ package test
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"

--- a/lib/events/auditwriter_test.go
+++ b/lib/events/auditwriter_test.go
@@ -19,9 +19,9 @@ package events
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"errors"
 	"io"
-	"math/rand"
 	"sync/atomic"
 	"testing"
 	"time"

--- a/lib/httplib/grpccreds.go
+++ b/lib/httplib/grpccreds.go
@@ -70,7 +70,8 @@ func (c *TLSCreds) OverrideServerName(serverNameOverride string) error {
 	return nil
 }
 
-type sysConn = syscall.Conn
+type sysConn = syscall.Conn //nolint:unused // sysConn is a type alias of syscall.Conn.
+// It's necessary because the name `Conn` collides with `net.Conn`.
 
 // syscallConn keeps reference of rawConn to support syscall.Conn for channelz.
 // SyscallConn() (the method in interface syscall.Conn) is explicitly

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:goimports // goimports disagree with gci on blank imports
 package proxy
 
-//nolint:goimports // goimports disagree with gci on blank imports
 import (
 	"context"
 	"fmt"

--- a/lib/reversetunnel/track/tracker_test.go
+++ b/lib/reversetunnel/track/tracker_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	pr "math/rand"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -140,11 +139,6 @@ func jitter(t time.Duration) time.Duration {
 	baseJitter := time.Duration(pr.Uint64())
 	j := baseJitter % maxJitter
 	return t + j
-}
-
-func TestMain(m *testing.M) {
-	pr.Seed(time.Now().UnixNano())
-	os.Exit(m.Run())
 }
 
 func TestBasic(t *testing.T) {

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -16,9 +16,9 @@ package desktop
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/x509"
 	"io"
-	"math/rand"
 	"testing"
 	"time"
 

--- a/lib/sshutils/x11/auth.go
+++ b/lib/sshutils/x11/auth.go
@@ -262,7 +262,7 @@ func readXauthPacketInitBuf(initBuf []byte) (protoLen int, dataLen int, err erro
 	// The first byte in the packet determines the
 	// byte order of the initial buffer's bytes.
 	var e binary.ByteOrder
-	binary.BigEndian.GoString()
+
 	switch initBuf[0] {
 	case bigEndian:
 		e = binary.BigEndian

--- a/lib/utils/concurrentqueue/queue_test.go
+++ b/lib/utils/concurrentqueue/queue_test.go
@@ -25,10 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 // TestOrdering verifies that the queue yields items in the order of
 // insertion, rather than the order of completion.
 func TestOrdering(t *testing.T) {

--- a/lib/utils/unpack.go
+++ b/lib/utils/unpack.go
@@ -63,7 +63,7 @@ func extractFile(tarball *tar.Reader, header *tar.Header, dir string) error {
 	switch header.Typeflag {
 	case tar.TypeDir:
 		return withDir(filepath.Join(dir, header.Name), nil)
-	case tar.TypeBlock, tar.TypeChar, tar.TypeReg, tar.TypeRegA, tar.TypeFifo:
+	case tar.TypeBlock, tar.TypeChar, tar.TypeReg, tar.TypeFifo:
 		return writeFile(filepath.Join(dir, header.Name), tarball, header.FileInfo().Mode())
 	case tar.TypeLink:
 		return writeHardLink(filepath.Join(dir, header.Name), filepath.Join(dir, header.Linkname))

--- a/operator/controllers/resources/suite_test.go
+++ b/operator/controllers/resources/suite_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:gci // Remove when GCI is fixed upstream https://github.com/daixiang0/gci/issues/135
 package resources
 
 import (

--- a/operator/main.go
+++ b/operator/main.go
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:goimports,gci // goimports disagree with gci on blank imports. Remove when GCI is fixed upstream https://github.com/daixiang0/gci/issues/135
 package main
 
-//nolint:goimports // goimports disagree with gci on blank imports
 import (
 	"flag"
 	"os"

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -17,9 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/tool/teleport/common"
@@ -27,7 +25,6 @@ import (
 
 func init() {
 	metrics.RegisterPrometheusCollectors(metrics.BuildCollector())
-	rand.Seed(time.Now().UnixNano())
 }
 
 func main() {


### PR DESCRIPTION
Update Go to 1.20 and golangci-lint to 1.51.1.

* https://go.dev/doc/go1.20

Backports #21111, #21440 and #21460 to branch/v12.