### PR TITLE
Switch to ghcr docs image

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -51,7 +51,7 @@ include images.mk
 BUILDBOX_NAME=$(BUILDBOX)
 BUILDBOX_FIPS_NAME=$(BUILDBOX_FIPS)
 
-DOCSBOX=public.ecr.aws/gravitational/docs
+DOCSBOX=ghcr.io/gravitational/docs
 
 ifneq ("$(KUBECONFIG)","")
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(KUBECONFIG):/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=$(TEST_KUBE)


### PR DESCRIPTION
Not sure if anything's still using `make -C build.assets test-docs` that uses this docs image but I've verified it works.