### PR TITLE
feat: early feedback for successful security key taps

### DIFF
--- a/lib/auth/webauthncli/prompt.go
+++ b/lib/auth/webauthncli/prompt.go
@@ -33,6 +33,7 @@ import (
 type DefaultPrompt struct {
 	PINMessage                            string
 	FirstTouchMessage, SecondTouchMessage string
+	AcknowledgeTouchMessage               string
 	PromptCredentialMessage               string
 
 	ctx context.Context
@@ -49,6 +50,7 @@ func NewDefaultPrompt(ctx context.Context, out io.Writer) *DefaultPrompt {
 		PINMessage:              "Enter your security key PIN",
 		FirstTouchMessage:       "Tap your security key",
 		SecondTouchMessage:      "Tap your security key again to complete login",
+		AcknowledgeTouchMessage: "Detected security key tap",
 		PromptCredentialMessage: "Choose the user for login",
 		ctx:                     ctx,
 		out:                     out,
@@ -62,17 +64,22 @@ func (p *DefaultPrompt) PromptPIN() (string, error) {
 
 // PromptTouch prompts the user for a security key touch, using different
 // messages for first and second prompts. Error is always nil.
-func (p *DefaultPrompt) PromptTouch() error {
+func (p *DefaultPrompt) PromptTouch() (TouchAcknowledger, error) {
 	if p.count == 0 {
 		p.count++
 		if p.FirstTouchMessage != "" {
 			fmt.Fprintln(p.out, p.FirstTouchMessage)
 		}
-		return nil
+		return p.ackTouch, nil
 	}
 	if p.SecondTouchMessage != "" {
 		fmt.Fprintln(p.out, p.SecondTouchMessage)
 	}
+	return p.ackTouch, nil
+}
+
+func (p *DefaultPrompt) ackTouch() error {
+	fmt.Fprintln(p.out, p.AcknowledgeTouchMessage)
 	return nil
 }
 

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -141,11 +141,16 @@ func TestTeleportClient_Login_local(t *testing.T) {
 		}
 
 		// Realistically, this would happen too.
-		if err := prompt.PromptTouch(); err != nil {
+		ackTouch, err := prompt.PromptTouch()
+		if err != nil {
 			return nil, err
 		}
 
-		return solveWebauthn(ctx, origin, assertion, prompt)
+		resp, err := solveWebauthn(ctx, origin, assertion, prompt)
+		if err != nil {
+			return nil, err
+		}
+		return resp, ackTouch()
 	}
 
 	ctx := context.Background()

--- a/lib/client/weblogin_test.go
+++ b/lib/client/weblogin_test.go
@@ -184,10 +184,14 @@ func TestSSHAgentPasswordlessLogin(t *testing.T) {
 				require.NoError(t, err)
 				require.Empty(t, creds)
 
-				require.NoError(t, p.PromptTouch())
+				ackTouch, err := p.PromptTouch()
+				require.NoError(t, err)
 
 				resp, err := solvePwdless(ctx, origin, assert, p)
-				return resp, "", err
+				if err != nil {
+					return nil, "", err
+				}
+				return resp, "", ackTouch()
 			},
 			customPromptLogin: &customPromptLogin{},
 		},
@@ -236,8 +240,8 @@ func (p *customPromptLogin) PromptPIN() (string, error) {
 	return "", nil
 }
 
-func (p *customPromptLogin) PromptTouch() error {
-	return nil
+func (p *customPromptLogin) PromptTouch() (wancli.TouchAcknowledger, error) {
+	return func() error { return nil }, nil
 }
 
 func (p *customPromptLogin) PromptCredential(deviceCreds []*wancli.CredentialInfo) (*wancli.CredentialInfo, error) {

--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
@@ -283,7 +284,7 @@ func (c *Cluster) passwordlessLogin(stream api.TerminalService_LoginPasswordless
 				KubernetesCluster: c.clusterClient.KubernetesCluster,
 			},
 			AuthenticatorAttachment: c.clusterClient.AuthenticatorAttachment,
-			CustomPrompt:            newPwdlessLoginPrompt(ctx, stream),
+			CustomPrompt:            newPwdlessLoginPrompt(ctx, c.Log, stream),
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -294,11 +295,13 @@ func (c *Cluster) passwordlessLogin(stream api.TerminalService_LoginPasswordless
 
 // pwdlessLoginPrompt is a implementation for wancli.LoginPrompt for teleterm passwordless logins.
 type pwdlessLoginPrompt struct {
+	log    *logrus.Entry
 	Stream api.TerminalService_LoginPasswordlessServer
 }
 
-func newPwdlessLoginPrompt(ctx context.Context, stream api.TerminalService_LoginPasswordlessServer) *pwdlessLoginPrompt {
+func newPwdlessLoginPrompt(ctx context.Context, log *logrus.Entry, stream api.TerminalService_LoginPasswordlessServer) *pwdlessLoginPrompt {
 	return &pwdlessLoginPrompt{
+		log:    log,
 		Stream: stream,
 	}
 }
@@ -325,8 +328,19 @@ func (p *pwdlessLoginPrompt) PromptPIN() (string, error) {
 }
 
 // PromptTouch prompts the user for a security key touch.
-func (p *pwdlessLoginPrompt) PromptTouch() error {
-	return trace.Wrap(p.Stream.Send(&api.LoginPasswordlessResponse{Prompt: api.PasswordlessPrompt_PASSWORDLESS_PROMPT_TAP}))
+func (p *pwdlessLoginPrompt) PromptTouch() (wancli.TouchAcknowledger, error) {
+	return p.ackTouch, trace.Wrap(p.Stream.Send(&api.LoginPasswordlessResponse{Prompt: api.PasswordlessPrompt_PASSWORDLESS_PROMPT_TAP}))
+}
+
+func (p *pwdlessLoginPrompt) ackTouch() error {
+	// TODO(nklaassen): Send touch acknowledgement if worth the effort, this is
+	// not strictly necessary but a nice-to-have acknowledgement to the user
+	// that we successfully detected their tap.
+	// The current gRPC message type switch in teleterm client code will reject
+	// any new message types, making this difficult to add without breaking
+	// older clients.
+	p.log.Debug("Detected security key tap")
+	return nil
 }
 
 // PromptCredential prompts the user to select a login name in the list of logins.

--- a/lib/teleterm/clusters/cluster_auth_test.go
+++ b/lib/teleterm/clusters/cluster_auth_test.go
@@ -21,12 +21,15 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
+
+var log = logrus.WithField(trace.Component, "cluster_auth_test")
 
 func TestPwdlessLoginPrompt_PromptPIN(t *testing.T) {
 	stream := &mockLoginPwdlessStream{}
@@ -43,7 +46,7 @@ func TestPwdlessLoginPrompt_PromptPIN(t *testing.T) {
 		}}, nil
 	}
 
-	prompt := newPwdlessLoginPrompt(context.Background(), stream)
+	prompt := newPwdlessLoginPrompt(context.Background(), log, stream)
 	pin, err := prompt.PromptPIN()
 	require.NoError(t, err)
 	require.Equal(t, "1234", pin)
@@ -68,9 +71,10 @@ func TestPwdlessLoginPrompt_PromptTouch(t *testing.T) {
 		return nil
 	}
 
-	prompt := newPwdlessLoginPrompt(context.Background(), stream)
-	err := prompt.PromptTouch()
+	prompt := newPwdlessLoginPrompt(context.Background(), log, stream)
+	ackTouch, err := prompt.PromptTouch()
 	require.NoError(t, err)
+	require.NoError(t, ackTouch())
 }
 
 func TestPwdlessLoginPrompt_PromptCredential(t *testing.T) {
@@ -103,7 +107,7 @@ func TestPwdlessLoginPrompt_PromptCredential(t *testing.T) {
 		}}, nil
 	}
 
-	prompt := newPwdlessLoginPrompt(context.Background(), stream)
+	prompt := newPwdlessLoginPrompt(context.Background(), log, stream)
 	cred, err := prompt.PromptCredential(unsortedCreds)
 	require.NoError(t, err)
 	require.Equal(t, "foo", cred.User.Name)


### PR DESCRIPTION
This commit adds a user message ("Detected security key tap") that is printed at the earliest opportunity after `tsh` succesfully detects a security key tap.

This solves a problem users have when there is significant latency in their connection to their teleport proxy, where there may be zero visible feedback to the user for upwards of 8 seconds after they tap their security key.
This often causes users to think that the tap was not detected or failed, and they attempt to tap again.
This can cause the user to accidentally paste a "yubisneeze" into their terminal, which is not great from a security perspective.

As an API choice here I added a `TouchAcknowledger` returned by they `PromptTouch` of the `LoginPrompt` interface.
It may seem like a bit of a weird API, but I did it this way so that all callers of `PromptTouch` are forced to explicitly acknowledge the touch or explicitly ignore that return value, they cannot simply forget to ack.

This applies to WebAuthn and Passwordless logins from `tsh`, no changes are made to Connect.

Solves https://github.com/gravitational/teleport/issues/20781