### PR TITLE
Relay child exit code in g-build

### DIFF
--- a/web/packages/build/bin/g-build.js
+++ b/web/packages/build/bin/g-build.js
@@ -12,4 +12,21 @@ if (!process.argv.some(arg => arg.startsWith('--config'))) {
 
 const args = process.argv.slice(2);
 
-spawn.sync('webpack', args, { stdio: 'inherit' });
+const result = spawn.sync('webpack', args, { stdio: 'inherit' });
+if (result.signal) {
+  if (result.signal === 'SIGKILL') {
+    console.log(
+      'The build failed because the process exited too early. ' +
+        'This probably means the system ran out of memory or someone called ' +
+        '`kill -9` on the process.'
+    );
+  } else if (result.signal === 'SIGTERM') {
+    console.log(
+      'The build failed because the process exited too early. ' +
+        'Someone might have called `kill` or `killall`, or the system could ' +
+        'be shutting down.'
+    );
+  }
+  process.exit(1);
+}
+process.exit(result.status);


### PR DESCRIPTION
Currently, g-build always exits with a status code of 0 (success), breaking the expectations in shell scripts or pipelines.

This borrows the child process handling code from [g-start](https://github.com/gravitational/teleport/blob/5c752c4df8987c16afa4c4c1ef6a00d2d21b73c6/web/packages/build/bin/g-start.js#L25-L42). In my eyes, it would be better to use `exec` rather than a child process in the first place, but there's probably a reason for this implementation.