### PR TITLE
Update docs link to db access rfd on master branch

### DIFF
--- a/docs/pages/database-access/architecture.mdx
+++ b/docs/pages/database-access/architecture.mdx
@@ -138,7 +138,7 @@ authentication.
 
 ## Next steps
 
-Please refer to the [RFD #11](https://github.com/gravitational/teleport/blob/024fd582e62560ffc925cd4b4d42c156043c041b/rfd/0011-database-access.md)
+Please refer to the [RFD #11](https://github.com/gravitational/teleport/blob/master/rfd/0011-database-access.md)
 for a more in-depth description of the feature scope and design.
 
 See [Core Concepts](../core-concepts.mdx) for general Teleport


### PR DESCRIPTION
Use `master` link instead of sep branch.