### PR TITLE
Adds a message in the case of new discovery token

### DIFF
--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -388,7 +388,7 @@ var discoveryMessageTemplate = template.Must(template.New("discovery").Parse(`Th
 This token will expire in {{.minutes}} minutes.
 
 This token enables the Discovery service.  See https://goteleport.com/docs/
-within the Discovery service Guide for the relevant service (Server, Kubernetes,...)
+within the Discovery service guide for the relevant service (Server, Kubernetes,...)
 for detailed information on enabling discovery and enrollment.
 
 `))


### PR DESCRIPTION
Currently generic output will occur with a new `discovery` token

```bash
tctl tokens add --type=discovery
The invite token: abc123
This token will expire in 60 minutes.

Run this on the new node to join the cluster:

> teleport start \
   --roles=discovery \
   --token=abc123
...
```

Now:

```bash
tctl tokens add --type=discovery,kube
The invite token: abc123
This token will expire in 60 minutes.

This token enables the Discovery service.  See https://goteleport.com/docs/
within the Discovery service Guide for the relevant service (Server, Kubernetes,...)
for detailed information on enabling discovery and enrollment.
```


