### PR TITLE
Turn off parallelization of teleterm's integration tests

### DIFF
--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -119,7 +119,7 @@ func testGatewayCertRenewal(t *testing.T, pack *dbhelpers.DatabasePack, creds *h
 		TargetURI:  databaseURI.String(),
 		TargetUser: "root",
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, trace.DebugReport(err))
 
 	// Open a new connection.
 	client, err := mysql.MakeTestClientWithoutTLS(

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -50,16 +50,12 @@ func testTeletermGatewaysCertRenewal(t *testing.T, pack *dbhelpers.DatabasePack)
 	require.NoError(t, err)
 
 	t.Run("root cluster", func(t *testing.T) {
-		t.Parallel()
-
 		databaseURI := uri.NewClusterURI(rootClusterName).
 			AppendDB(pack.Root.MysqlService.Name)
 
 		testGatewayCertRenewal(t, pack, creds, databaseURI)
 	})
 	t.Run("leaf cluster", func(t *testing.T) {
-		t.Parallel()
-
 		leafClusterName := pack.Leaf.Cluster.Secrets.SiteName
 		databaseURI := uri.NewClusterURI(rootClusterName).
 			AppendLeafCluster(leafClusterName).


### PR DESCRIPTION
The `TestALPNSNIProxyDatabaseAccess/teleterm_gateways_cert_renewal` family of tests is flaky (#20906).

Previously I thought it was the connection error from that first failed CI run in the list. However, today I went through the past couple of days of failed integration tests and I discovered that those tests seem to fail more frequently due to a data race.

There are two different races present in the underlying mysql code. I'll make an issue about one of them but in the mean time I want to turn off parallelization of teleterm's integration tests which will hopefully make them less flaky.

Other tests under `TestALPNSNIProxyDatabaseAccess` [don't use `t.Parallel` on purpose as well](https://gravitational.slack.com/archives/C02MEM3K2BA/p1670260945200479?thread_ts=1670259264.519579&cid=C02MEM3K2BA).

---

On top of that change, I want to add `trace.DebugReport` in case that connection error from the first failed CI run happens again.