### PR TITLE
Role access requests available for all scopes

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -318,8 +318,7 @@
           "entries": [
             {
               "title": "Role Requests",
-              "slug": "/access-controls/access-requests/role-requests/",
-              "forScopes": ["enterprise", "cloud"]
+              "slug": "/access-controls/access-requests/role-requests/"
             },
             {
               "title": "Resource Requests",

--- a/docs/pages/access-controls/access-requests/role-requests.mdx
+++ b/docs/pages/access-controls/access-requests/role-requests.mdx
@@ -20,7 +20,7 @@ available in Teleport Enterprise.
 
 ## Prerequisites
 
-(!docs/pages/includes/commercial-prereqs-tabs.mdx!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 (!docs/pages/includes/tctl.mdx!)
 


### PR DESCRIPTION
The docs had role requests just available for enterprise and cloud scope.  Role Requests are available for all scope, only resources are restricted.