### PR TITLE
Update to libbpf 1.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GOPATH ?= $(shell go env GOPATH)
 MAKE_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 # libbpf version required by the build.
-LIBBPF_VER := 0.7.0-teleport
+LIBBPF_VER := 1.0.1
 
 # These are standard autotools variables, don't change them please
 ifneq ("$(wildcard /bin/bash)","")
@@ -80,7 +80,7 @@ BPF_MESSAGE := without-BPF-support
 with_bpf := no
 ifeq ("$(OS)","linux")
 ifeq ("$(ARCH)","amd64")
-ifneq ("$(wildcard /usr/include/bpf/libbpf.h /usr/libbpf-${LIBBPF_VER}/include/bpf/bpf.h)","")
+ifneq ("$(wildcard /usr/libbpf-${LIBBPF_VER}/include/bpf/bpf.h)","")
 with_bpf := yes
 BPF_TAG := bpf
 BPF_MESSAGE := with-BPF-support

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -86,29 +86,8 @@ RUN yum groupinstall -y 'Development Tools' && \
 # BUILD_STATIC_ONLY disables libbpf.so build as we don't need it.
 ARG LIBBPF_VERSION
 RUN mkdir -p /opt && cd /opt && \
-    curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+    curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
-    scl enable devtoolset-11 "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
-
-# Install newer libbpf.
-FROM centos:7 AS libbpf-1-0-1
-
-# Install required dependencies.
-RUN yum groupinstall -y 'Development Tools' && \
-    yum install -y epel-release && \
-    yum update -y && \
-    yum -y install centos-release-scl-rh && \
-    yum install -y \
-        centos-release-scl \
-        devtoolset-11-gcc* \
-        devtoolset-11-make \
-        elfutils-libelf-devel-static \
-        scl-utils \
-    yum clean all
-
-RUN mkdir -p /opt && cd /opt && \
-    curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v1.0.1.tar.gz | tar xz && \
-    cd /opt/libbpf-1.0.1/src && \
     scl enable devtoolset-11 "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
 
 ## LIBPCSCLITE #####################################################################
@@ -268,7 +247,6 @@ COPY --from=libpcsclite \
 # Copy libbpf into the final image.
 ARG LIBBPF_VERSION
 COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
-COPY --from=libbpf-1-0-1 /opt/libbpf/usr /usr/libbpf-1.0.1
 
 # Download pre-built CentOS 7 assets with clang needed to build BPF tools.
 ARG BUILDARCH

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -25,7 +25,7 @@ NODE_VERSION ?= 16.18.1
 
 # run lint-rust check locally before merging code after you bump this
 RUST_VERSION ?= 1.67.0
-LIBBPF_VERSION ?= 0.7.0-teleport
+LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
 UID := $$(id -u)

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.0
 	github.com/ThalesIgnite/crypto11 v1.2.5
 	github.com/alicebob/miniredis/v2 v2.30.0
-	github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0
+	github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1
 	github.com/armon/go-radix v1.0.0
 	github.com/aws/aws-sdk-go v1.44.198
 	github.com/aws/aws-sdk-go-v2 v1.17.4

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 h1:q4dksr6IC
 github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40/go.mod h1:Q7yQnSMnLvcXlZ8RV+jwz/6y1rQTqbX6C82SndT52Zs=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0 h1:BpW7qxkveYXx8TCtvYWIvmliPqaTCz/IYs1i+Gyj0MQ=
-github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1 h1:Et7WT8CEpaO03v7FIVk85GMRRbwjF7sgoBgQhH5T30k=
+github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -1396,7 +1396,6 @@ golang.org/x/sys v0.0.0-20210304124612-50617c2ba197/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Update to libbpf 1.0.1 and github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1. As we're building our releases on CentOS 7 anyway, we can also switch to mainstream libbpf instead of using our fork.