### PR TITLE
Fix assets sha calculation to make it work equally on all platforms

### DIFF
--- a/build.assets/build-webassets-if-changed.sh
+++ b/build.assets/build-webassets-if-changed.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 
 ROOT_PATH="$(cd "$(dirname "$0")/.." && pwd -P)"
 MAKE="${MAKE:-make}"
-SHASUMS=("shasum -a 512" "sha512sum" "sha256sum")
+SHASUMS=("shasum -a 512" "sha512sum")
 
 if ! command -v "$MAKE" >/dev/null; then
   echo "Unable to find \"$MAKE\" on path."
@@ -53,7 +53,7 @@ done
 
 function calculate_sha() {
   #shellcheck disable=SC2005,SC2086
-  echo "$(find "${SRC_DIRECTORIES[@]}" "$ROOT_PATH/package.json" "$ROOT_PATH/yarn.lock" -not \( -type d -name node_modules -prune \) -print0 | LC_ALL=C sort -z | cpio -0 -o 2>/dev/null | $SHASUM | tr -d " -")"
+  echo "$(find "${SRC_DIRECTORIES[@]}" "$ROOT_PATH/package.json" "$ROOT_PATH/yarn.lock" -not \( -type d -name node_modules -prune \) -type f -print0 | LC_ALL=C sort -z | xargs -0 $SHASUM | awk '{print $1}' | $SHASUM | tr -d ' -')"  
 }
 
 # Calculate the current hash-of-hashes of the given source directories. Adds in package.json as well.


### PR DESCRIPTION
Problem:

We need to guarantee that assets sha sum is equal regardless of the platform it was calculated on.

I tried to run make `ensure-webassets` on Mac OS. Then I tried to run the same in Docker using `node:16.18.1` image, and then I tried to run it using centos buildbox. In each case the sha sum was different.

I think, that's because `cpio` produces a bit altering result depending on the platform.

I've changed it as following: I calculate the sum for each file in the list, then I get the sha of the list of the sha. I think, it's good enough for our case. I also removed `sha256` because we need to have the same hashing algorithm everywhere.

This is required for Drone/GHA replacement where assets would be built separately.