### PR TITLE
helm: fix proxy and auth config referring to the same subdict

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/config.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/config.yaml
@@ -1,4 +1,4 @@
-{{- $auth := mustMergeOverwrite .Values .Values.auth -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- $configTemplate := printf "teleport-cluster.auth.config.%s" $auth.chartMode -}}
 apiVersion: v1
 kind: ConfigMap

--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $auth := mustMergeOverwrite .Values .Values.auth -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- $replicated := gt (int $auth.highAvailability.replicaCount) 1 -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/chart/teleport-cluster/templates/auth/pdb.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/pdb.yaml
@@ -1,4 +1,4 @@
-{{- $auth := mustMergeOverwrite .Values .Values.auth -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- if $auth.highAvailability.podDisruptionBudget.enabled }}
 {{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1

--- a/examples/chart/teleport-cluster/templates/auth/predeploy_config.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_config.yaml
@@ -1,4 +1,4 @@
-{{- $auth := mustMergeOverwrite .Values .Values.auth -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- if $auth.validateConfigOnDeploy }}
 {{- $configTemplate := printf "teleport-cluster.auth.config.%s" $auth.chartMode -}}
 apiVersion: v1

--- a/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
@@ -1,4 +1,4 @@
-{{- $auth := mustMergeOverwrite .Values .Values.auth -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- if $auth.validateConfigOnDeploy }}
 apiVersion: batch/v1
 kind: Job

--- a/examples/chart/teleport-cluster/templates/auth/pvc.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/pvc.yaml
@@ -1,4 +1,4 @@
-{{- $auth := mustMergeOverwrite .Values .Values.auth -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- if $auth.persistence.enabled }}
   {{/* Disable persistence for aws and gcp modes */}}
   {{- if and (not (eq $auth.chartMode "aws")) (not (eq $auth.chartMode "gcp")) }}

--- a/examples/chart/teleport-cluster/templates/auth/service.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/service.yaml
@@ -1,4 +1,4 @@
-{{- $auth := mustMergeOverwrite .Values .Values.auth -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/examples/chart/teleport-cluster/templates/auth/serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- $auth := mustMergeOverwrite .Values .Values.auth -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- if $auth.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/chart/teleport-cluster/templates/proxy/certificate.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/certificate.yaml
@@ -1,4 +1,4 @@
-{{- $proxy := mustMergeOverwrite .Values .Values.proxy -}}
+{{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- if $proxy.highAvailability.certManager.enabled }}
   {{- $domain := (required "clusterName is required in chartValues when certManager is enabled" $proxy.clusterName) }}
   {{- $domainWildcard := printf "*.%s" (required "clusterName is required in chartValues when certManager is enabled" $proxy.clusterName) }}

--- a/examples/chart/teleport-cluster/templates/proxy/config.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/config.yaml
@@ -1,4 +1,4 @@
-{{- $proxy := mustMergeOverwrite .Values .Values.proxy -}}
+{{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- $configTemplate := printf "teleport-cluster.proxy.config.%s" $proxy.chartMode -}}
 apiVersion: v1
 kind: ConfigMap

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $proxy := mustMergeOverwrite .Values .Values.proxy -}}
+{{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- $replicable := or $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName -}}
 # Deployment is {{ if not $replicable }}not {{end}}replicable
 {{- if and $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName }}

--- a/examples/chart/teleport-cluster/templates/proxy/pdb.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/pdb.yaml
@@ -1,4 +1,4 @@
-{{- $proxy := mustMergeOverwrite .Values .Values.proxy -}}
+{{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- if $proxy.highAvailability.podDisruptionBudget.enabled }}
 {{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_config.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_config.yaml
@@ -1,4 +1,4 @@
-{{- $proxy := mustMergeOverwrite .Values .Values.proxy -}}
+{{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- if $proxy.validateConfigOnDeploy }}
 {{- $configTemplate := printf "teleport-cluster.proxy.config.%s" $proxy.chartMode -}}
 apiVersion: v1

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
@@ -1,4 +1,4 @@
-{{- $proxy := mustMergeOverwrite .Values .Values.proxy -}}
+{{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- if $proxy.validateConfigOnDeploy }}
 apiVersion: batch/v1
 kind: Job

--- a/examples/chart/teleport-cluster/templates/proxy/service.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/service.yaml
@@ -1,4 +1,4 @@
-{{- $proxy := mustMergeOverwrite .Values .Values.proxy -}}
+{{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- $backendProtocol := ternary "ssl" "tcp" (hasKey $proxy.annotations.service "service.beta.kubernetes.io/aws-load-balancer-ssl-cert") -}}
 apiVersion: v1
 kind: Service

--- a/examples/chart/teleport-cluster/templates/proxy/serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- $proxy := mustMergeOverwrite .Values .Values.proxy -}}
+{{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- if $proxy.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Fixes an issue where the dict merge between `.Values` and `.Values.auth` returns a new dict that contains references to the original `.Values` objects.

e.g. :

```
highAvailability:
  replicaCount: 2
  
proxy:
  highAvailability:
    replicaCount: 3
```

The following values will cause `$auth` and `$proxy` to share the same `.highAvailability`, causing 3 auth pods to be deployed instead of 2.