### PR TITLE
AWS app access Timestream Endpoint mode and JDBC support

### DIFF
--- a/lib/srv/app/aws/endpoints.go
+++ b/lib/srv/app/aws/endpoints.go
@@ -73,7 +73,7 @@ func (s *signerHandler) resolveEndpoint(r *http.Request) (*endpoints.ResolvedEnd
 		re, err := resolveEndpointByXForwardedHost(r, awsutils.AuthorizationHeader)
 		return re, trace.Wrap(err)
 
-	// Special handling for timestream in legacy Endpoint mode.
+	// Special handling for Timestream in legacy Endpoint mode.
 	case shouldDiscoverTimestreamEndpoint(r):
 		re, err := s.resolveTimestreamEndpoint(r)
 		return re, trace.Wrap(err)

--- a/lib/srv/app/aws/endpoints.go
+++ b/lib/srv/app/aws/endpoints.go
@@ -242,8 +242,8 @@ func isTimestreamWriteRequest(r *http.Request) bool {
 	// AWS SDK reference:
 	// https://github.com/aws/aws-sdk-go/blob/main/service/timestreamquery/api.go
 	case "CancelQuery", "CreateScheduledQuery", "DeleteScheduledQuery",
-		"DescribeEndpoints", "DescribeScheduledQuery", "ExecuteScheduledQuery",
-		"ListScheduledQueries", "PrepareQuery", "Query", "UpdateScheduledQuery":
+		"DescribeScheduledQuery", "ExecuteScheduledQuery", "ListScheduledQueries",
+		"PrepareQuery", "Query", "UpdateScheduledQuery":
 		return false
 	// Note that both timestream-query and timestream-write support these tag operations.
 	// For now, we assume they are used for timestream-query.

--- a/lib/srv/app/aws/endpoints_test.go
+++ b/lib/srv/app/aws/endpoints_test.go
@@ -18,19 +18,26 @@ package aws
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestResolveEndpoints(t *testing.T) {
 	signer := v4.NewSigner(credentials.NewStaticCredentials("fakeClientKeyID", "fakeClientSecret", ""))
 	region := "us-east-1"
 	now := time.Now()
+
+	suite := createSuite(t, nil, clockwork.NewRealClock())
 
 	t.Run("AWS SDK resolver", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "http://localhost", nil)
@@ -39,7 +46,7 @@ func TestResolveEndpoints(t *testing.T) {
 		_, err = signer.Sign(req, bytes.NewReader(nil), "ecr", "us-east-1", now)
 		require.NoError(t, err)
 
-		endpoint, err := resolveEndpoint(req)
+		endpoint, err := suite.handler.resolveEndpoint(req)
 		require.NoError(t, err)
 		require.Equal(t, "ecr", endpoint.SigningName)
 		require.Equal(t, "https://api.ecr.us-east-1.amazonaws.com", endpoint.URL)
@@ -53,9 +60,89 @@ func TestResolveEndpoints(t *testing.T) {
 		_, err = signer.Sign(req, bytes.NewReader(nil), "some-service", region, now)
 		require.NoError(t, err)
 
-		endpoint, err := resolveEndpoint(req)
+		endpoint, err := suite.handler.resolveEndpoint(req)
 		require.NoError(t, err)
 		require.Equal(t, "some-service", endpoint.SigningName)
 		require.Equal(t, "https://some-service.us-east-1.amazonaws.com", endpoint.URL)
+	})
+
+	t.Run("resolve Timestream endpoint", func(t *testing.T) {
+		// Pre-cache resolved endpoints for timestream to avoid making real API calls.
+		_, err := utils.FnCacheGet(
+			context.Background(),
+			suite.handler.cache,
+			resolveTimestreamEndpointCacheKey{
+				credentials:  staticAWSCredentials,
+				region:       region,
+				writeRequest: true,
+			},
+			func(context.Context) (*endpoints.ResolvedEndpoint, error) {
+				return &endpoints.ResolvedEndpoint{
+					URL:           "https://resolved.timestream-write.endpoint",
+					SigningRegion: region,
+					SigningName:   "timestream",
+				}, nil
+			},
+		)
+		require.NoError(t, err)
+		_, err = utils.FnCacheGet(
+			context.Background(),
+			suite.handler.cache,
+			resolveTimestreamEndpointCacheKey{
+				credentials:  staticAWSCredentials,
+				region:       region,
+				writeRequest: false,
+			},
+			func(context.Context) (*endpoints.ResolvedEndpoint, error) {
+				return &endpoints.ResolvedEndpoint{
+					URL:           "https://resolved.timestream-query.endpoint",
+					SigningRegion: region,
+					SigningName:   "timestream",
+				}, nil
+			},
+		)
+		require.NoError(t, err)
+
+		t.Run("DescribeEndpoints by AWS SDK resolver", func(t *testing.T) {
+			req, err := http.NewRequest("GET", "http://localhost", nil)
+			require.NoError(t, err)
+			req.Header.Add("X-Amz-Target", "Timestream_20181101.DescribeEndpoints")
+
+			_, err = signer.Sign(req, bytes.NewReader(nil), "timestream", "us-east-1", now)
+			require.NoError(t, err)
+
+			endpoint, err := suite.handler.resolveEndpoint(suite.withSessionContext(req))
+			require.NoError(t, err)
+			require.Equal(t, "timestream", endpoint.SigningName)
+			require.Equal(t, "https://query.timestream.us-east-1.amazonaws.com", endpoint.URL)
+		})
+
+		t.Run("timestream-write", func(t *testing.T) {
+			req, err := http.NewRequest("GET", "http://localhost", nil)
+			require.NoError(t, err)
+			req.Header.Add("X-Amz-Target", "Timestream_20181101.CreateDatabase")
+
+			_, err = signer.Sign(req, bytes.NewReader(nil), "timestream", "us-east-1", now)
+			require.NoError(t, err)
+
+			endpoint, err := suite.handler.resolveEndpoint(suite.withSessionContext(req))
+			require.NoError(t, err)
+			require.Equal(t, "timestream", endpoint.SigningName)
+			require.Equal(t, "https://resolved.timestream-write.endpoint", endpoint.URL)
+		})
+
+		t.Run("timestream-query", func(t *testing.T) {
+			req, err := http.NewRequest("GET", "http://localhost", nil)
+			require.NoError(t, err)
+			req.Header.Add("X-Amz-Target", "Timestream_20181101.Query")
+
+			_, err = signer.Sign(req, bytes.NewReader(nil), "timestream", "us-east-1", now)
+			require.NoError(t, err)
+
+			endpoint, err := suite.handler.resolveEndpoint(suite.withSessionContext(req))
+			require.NoError(t, err)
+			require.Equal(t, "timestream", endpoint.SigningName)
+			require.Equal(t, "https://resolved.timestream-query.endpoint", endpoint.URL)
+		})
 	})
 }

--- a/lib/srv/app/aws/endpoints_test.go
+++ b/lib/srv/app/aws/endpoints_test.go
@@ -67,14 +67,14 @@ func TestResolveEndpoints(t *testing.T) {
 	})
 
 	t.Run("resolve Timestream endpoint", func(t *testing.T) {
-		// Pre-cache resolved endpoints for timestream to avoid making real API calls.
+		// Pre-cache resolved endpoints for Timestream to avoid making real API calls.
 		_, err := utils.FnCacheGet(
 			context.Background(),
 			suite.handler.cache,
 			resolveTimestreamEndpointCacheKey{
-				credentials:  staticAWSCredentials,
-				region:       region,
-				writeRequest: true,
+				credentials:               staticAWSCredentials,
+				region:                    region,
+				isTimemstreamWriteRequest: true,
 			},
 			func(context.Context) (*endpoints.ResolvedEndpoint, error) {
 				return &endpoints.ResolvedEndpoint{
@@ -89,9 +89,9 @@ func TestResolveEndpoints(t *testing.T) {
 			context.Background(),
 			suite.handler.cache,
 			resolveTimestreamEndpointCacheKey{
-				credentials:  staticAWSCredentials,
-				region:       region,
-				writeRequest: false,
+				credentials:               staticAWSCredentials,
+				region:                    region,
+				isTimemstreamWriteRequest: false,
 			},
 			func(context.Context) (*endpoints.ResolvedEndpoint, error) {
 				return &endpoints.ResolvedEndpoint{
@@ -117,7 +117,7 @@ func TestResolveEndpoints(t *testing.T) {
 			require.Equal(t, "https://query.timestream.us-east-1.amazonaws.com", endpoint.URL)
 		})
 
-		t.Run("timestream-write", func(t *testing.T) {
+		t.Run("timestream-write operation", func(t *testing.T) {
 			req, err := http.NewRequest("GET", "http://localhost", nil)
 			require.NoError(t, err)
 			req.Header.Add("X-Amz-Target", "Timestream_20181101.CreateDatabase")
@@ -131,7 +131,7 @@ func TestResolveEndpoints(t *testing.T) {
 			require.Equal(t, "https://resolved.timestream-write.endpoint", endpoint.URL)
 		})
 
-		t.Run("timestream-query", func(t *testing.T) {
+		t.Run("timestream-query operation", func(t *testing.T) {
 			req, err := http.NewRequest("GET", "http://localhost", nil)
 			require.NoError(t, err)
 			req.Header.Add("X-Amz-Target", "Timestream_20181101.Query")

--- a/lib/srv/app/aws/endpoints_test.go
+++ b/lib/srv/app/aws/endpoints_test.go
@@ -72,9 +72,9 @@ func TestResolveEndpoints(t *testing.T) {
 			context.Background(),
 			suite.handler.cache,
 			resolveTimestreamEndpointCacheKey{
-				credentials:               staticAWSCredentials,
-				region:                    region,
-				isTimemstreamWriteRequest: true,
+				credentials:              staticAWSCredentials,
+				region:                   region,
+				isTimestreamWriteRequest: true,
 			},
 			func(context.Context) (*endpoints.ResolvedEndpoint, error) {
 				return &endpoints.ResolvedEndpoint{
@@ -89,9 +89,9 @@ func TestResolveEndpoints(t *testing.T) {
 			context.Background(),
 			suite.handler.cache,
 			resolveTimestreamEndpointCacheKey{
-				credentials:               staticAWSCredentials,
-				region:                    region,
-				isTimemstreamWriteRequest: false,
+				credentials:              staticAWSCredentials,
+				region:                   region,
+				isTimestreamWriteRequest: false,
 			},
 			func(context.Context) (*endpoints.ResolvedEndpoint, error) {
 				return &endpoints.ResolvedEndpoint{

--- a/lib/srv/app/aws/handler.go
+++ b/lib/srv/app/aws/handler.go
@@ -60,6 +60,8 @@ type SignerHandlerConfig struct {
 	*awsutils.SigningService
 	// Clock is used to override time in tests.
 	Clock clockwork.Clock
+	// CredentialsGetter is used to obtain STS credentials.
+	CredentialsGetter awsutils.CredentialsGetter
 }
 
 // CheckAndSetDefaults validates the AwsSignerHandlerConfig.

--- a/lib/srv/app/aws/handler.go
+++ b/lib/srv/app/aws/handler.go
@@ -119,7 +119,8 @@ func NewAWSSignerHandler(ctx context.Context, config SignerHandlerConfig) (http.
 	}
 
 	cache, err := utils.NewFnCache(utils.FnCacheConfig{
-		TTL: time.Minute,
+		Context: ctx,
+		TTL:     time.Minute,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -185,7 +186,7 @@ func (s *signerHandler) serveHTTP(w http.ResponseWriter, req *http.Request) erro
 func (s *signerHandler) serveCommonRequest(sessCtx *common.SessionContext, w http.ResponseWriter, req *http.Request) error {
 	// It's important that we resolve the endpoint before modifying the request headers,
 	// as they may be needed to resolve the endpoint correctly.
-	re, err := s.resolveEndpoint(sessCtx, req)
+	re, err := s.resolveEndpoint(req)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/app/aws/handler_test.go
+++ b/lib/srv/app/aws/handler_test.go
@@ -471,8 +471,11 @@ var staticAWSCredentialsForAssumedRole = credentials.NewStaticCredentials(assume
 var staticAWSCredentials = credentials.NewStaticCredentials("AKIDl", "SECRET", "SESSION")
 var staticAWSCredentialsForClient = credentials.NewStaticCredentials("fakeClientKeyID", "fakeClientSecret", "")
 
-func getStaticAWSCredentials(client.ConfigProvider, time.Time, string, string, string) *credentials.Credentials {
-	return staticAWSCredentials
+type fakeCredentialsGetter struct {
+}
+
+func (g *fakeCredentialsGetter) Get(context.Context, awsutils.GetCredentialsRequest) (*credentials.Credentials, error) {
+	return staticAWSCredentials, nil
 }
 
 type suite struct {
@@ -499,8 +502,8 @@ func createSuite(t *testing.T, mockAWSHandler http.HandlerFunc, app types.Applic
 	})
 
 	svc, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{
-		GetSigningCredentials: getStaticAWSCredentials,
-		Clock:                 clock,
+		CredentialsGetter: &fakeCredentialsGetter{},
+		Clock:             clock,
 	})
 	require.NoError(t, err)
 

--- a/lib/srv/app/aws/handler_test.go
+++ b/lib/srv/app/aws/handler_test.go
@@ -496,13 +496,6 @@ func createSuite(t *testing.T, mockAWSHandler http.HandlerFunc, clock clockwork.
 		awsAPIMock.Close()
 	})
 
-	svc, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{
-		Session:           hostSession,
-		CredentialsGetter: &fakeCredentialsGetter{},
-		Clock:             clock,
-	})
-	require.NoError(t, err)
-
 	audit, err := common.NewAudit(common.AuditConfig{
 		Emitter: emitter,
 	})
@@ -510,7 +503,6 @@ func createSuite(t *testing.T, mockAWSHandler http.HandlerFunc, clock clockwork.
 	handler, err := NewAWSSignerHandler(context.Background(),
 		SignerHandlerConfig{
 			Session:           hostSession,
-			SigningService:    svc,
 			CredentialsGetter: &fakeCredentialsGetter{},
 			RoundTripper: &http.Transport{
 				TLSClientConfig: &tls.Config{

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -265,7 +265,7 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		}
 	}()
 
-	awsCredentialsGetter, err := awsutils.NewCachedCredentialsGetter(closeContext, awsutils.CachedCredentialsGetterConfig{})
+	awsCredentialsGetter, err := awsutils.NewCachedCredentialsGetter(awsutils.CachedCredentialsGetterConfig{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -265,12 +265,19 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		}
 	}()
 
-	awsSigner, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{})
+	awsCredentialsGetter, err := awsutils.NewCachedCredentialsGetter(awsutils.CachedCredentialsGetterConfig{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	awsSigner, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{
+		CredentialsGetter: awsCredentialsGetter,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	awsHandler, err := appaws.NewAWSSignerHandler(closeContext, appaws.SignerHandlerConfig{
-		SigningService: awsSigner,
+		SigningService:    awsSigner,
+		CredentialsGetter: awsCredentialsGetter,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -265,7 +265,7 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		}
 	}()
 
-	awsCredentialsGetter, err := awsutils.NewCachedCredentialsGetter(awsutils.CachedCredentialsGetterConfig{})
+	awsCredentialsGetter, err := awsutils.NewCachedCredentialsGetter(closeContext, awsutils.CachedCredentialsGetterConfig{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -269,14 +269,7 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	awsSigner, err := awsutils.NewSigningService(awsutils.SigningServiceConfig{
-		CredentialsGetter: awsCredentialsGetter,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	awsHandler, err := appaws.NewAWSSignerHandler(closeContext, appaws.SignerHandlerConfig{
-		SigningService:    awsSigner,
 		CredentialsGetter: awsCredentialsGetter,
 	})
 	if err != nil {

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -265,13 +265,7 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		}
 	}()
 
-	awsCredentialsGetter, err := awsutils.NewCachedCredentialsGetter(awsutils.CachedCredentialsGetterConfig{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	awsHandler, err := appaws.NewAWSSignerHandler(closeContext, appaws.SignerHandlerConfig{
-		CredentialsGetter: awsCredentialsGetter,
-	})
+	awsHandler, err := appaws.NewAWSSignerHandler(closeContext, appaws.SignerHandlerConfig{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/dynamodb/engine.go
+++ b/lib/srv/db/dynamodb/engine.go
@@ -69,9 +69,8 @@ type Engine struct {
 	// RoundTrippers is a cache of RoundTrippers, mapped by service endpoint.
 	// It is not guarded by a mutex, since requests are processed serially.
 	RoundTrippers map[string]http.RoundTripper
-	// GetSigningCredsFn allows to set the function responsible for obtaining STS credentials.
-	// Used in tests to set static AWS credentials and skip API call.
-	GetSigningCredsFn libaws.GetSigningCredentialsFunc
+	// CredentialsGetter is used to obtain STS credentials.
+	CredentialsGetter libaws.CredentialsGetter
 }
 
 var _ common.Engine = (*Engine)(nil)
@@ -84,9 +83,9 @@ func (e *Engine) InitializeConnection(clientConn net.Conn, sessionCtx *common.Se
 		return trace.Wrap(err)
 	}
 	svc, err := libaws.NewSigningService(libaws.SigningServiceConfig{
-		Clock:                 e.Clock,
-		Session:               awsSession,
-		GetSigningCredentials: e.GetSigningCredsFn,
+		Clock:             e.Clock,
+		Session:           awsSession,
+		CredentialsGetter: e.CredentialsGetter,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/utils/aws/credentials.go
+++ b/lib/utils/aws/credentials.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type GetCredentialsRequest struct {
+	Provider    client.ConfigProvider
+	Expiry      time.Time
+	SessionName string
+	RoleARN     string
+	ExternalID  string
+}
+
+// CredentialsGetter defines an interface for obtaining STS credentials.
+type CredentialsGetter interface {
+	// Get obtains STS credentials.
+	Get(ctx context.Context, request GetCredentialsRequest) (*credentials.Credentials, error)
+}
+
+type credentialsGettter struct {
+}
+
+// NewCredentialsGetter returns a new CredentialsGetter.
+func NewCredentialsGetter() CredentialsGetter {
+	return &credentialsGettter{}
+}
+
+// Get obtains STS credentials.
+func (g *credentialsGettter) Get(_ context.Context, request GetCredentialsRequest) (*credentials.Credentials, error) {
+	logrus.Debugf("Creating STS session %q.", request.SessionName)
+	return stscreds.NewCredentials(request.Provider, request.RoleARN,
+		func(cred *stscreds.AssumeRoleProvider) {
+			cred.RoleSessionName = request.SessionName
+			cred.Expiry.SetExpiration(request.Expiry, 0)
+
+			if request.ExternalID != "" {
+				cred.ExternalID = aws.String(request.ExternalID)
+			}
+		},
+	), nil
+}
+
+type CachedCredentialsGetterConfig struct {
+	Getter   CredentialsGetter
+	CacheTTL time.Duration
+}
+
+// SetDefaults sets default values for CachedCredentialsGetterConfig.
+func (c *CachedCredentialsGetterConfig) SetDefaults() {
+	if c.Getter == nil {
+		c.Getter = NewCredentialsGetter()
+	}
+	if c.CacheTTL <= 0 {
+		c.CacheTTL = time.Minute
+	}
+}
+
+type cachedCredentialsGetter struct {
+	config CachedCredentialsGetterConfig
+	cache  *utils.FnCache
+}
+
+func NewCachedCredentialsGetter(config CachedCredentialsGetterConfig) (CredentialsGetter, error) {
+	config.SetDefaults()
+
+	cache, err := utils.NewFnCache(utils.FnCacheConfig{
+		TTL: config.CacheTTL,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &cachedCredentialsGetter{
+		config: config,
+		cache:  cache,
+	}, nil
+}
+
+// Get returns cached credentials if found, or fetch it from configured getter.
+func (g *cachedCredentialsGetter) Get(ctx context.Context, request GetCredentialsRequest) (*credentials.Credentials, error) {
+	credentials, err := utils.FnCacheGet(ctx, g.cache, request, func(ctx context.Context) (*credentials.Credentials, error) {
+		credentials, err := g.config.Getter.Get(ctx, request)
+		return credentials, trace.Wrap(err)
+	})
+	return credentials, trace.Wrap(err)
+}

--- a/lib/utils/aws/credentials.go
+++ b/lib/utils/aws/credentials.go
@@ -121,7 +121,8 @@ func NewCachedCredentialsGetter(config CachedCredentialsGetterConfig) (Credentia
 	}, nil
 }
 
-// Get returns cached credentials if found, or fetch it from configured getter.
+// Get returns cached credentials if found, or fetch it from the configured
+// getter.
 func (g *cachedCredentialsGetter) Get(ctx context.Context, request GetCredentialsRequest) (*credentials.Credentials, error) {
 	credentials, err := utils.FnCacheGet(ctx, g.cache, request, func(ctx context.Context) (*credentials.Credentials, error) {
 		credentials, err := g.config.Getter.Get(ctx, request)

--- a/lib/utils/aws/credentials.go
+++ b/lib/utils/aws/credentials.go
@@ -90,7 +90,8 @@ func (c *CachedCredentialsGetterConfig) SetDefaults() {
 		c.Getter = NewCredentialsGetter()
 	}
 	if c.CacheTTL <= 0 {
-		c.CacheTTL = time.Minute
+		// Minimum AssumeRole duration is 900 seconds. And leave some room for overhead.
+		c.CacheTTL = 800 * time.Second
 	}
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()

--- a/lib/utils/aws/credentials.go
+++ b/lib/utils/aws/credentials.go
@@ -90,8 +90,7 @@ func (c *CachedCredentialsGetterConfig) SetDefaults() {
 		c.Getter = NewCredentialsGetter()
 	}
 	if c.CacheTTL <= 0 {
-		// Minimum AssumeRole duration is 900 seconds. And leave some room for overhead.
-		c.CacheTTL = 800 * time.Second
+		c.CacheTTL = time.Minute
 	}
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()

--- a/lib/utils/aws/credentials.go
+++ b/lib/utils/aws/credentials.go
@@ -24,20 +24,25 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
-
-	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// GetCredentialsRequest is the request for obtains STS credentials.
 type GetCredentialsRequest struct {
-	Provider    client.ConfigProvider
-	Expiry      time.Time
+	// Provider is the user session used to create the STS client.
+	Provider client.ConfigProvider
+	// Expiry is session expiry to be requested.
+	Expiry time.Time
+	// SessionName is the session name to be requested.
 	SessionName string
-	RoleARN     string
-	ExternalID  string
+	// RoleARN is the role ARN to be requested.
+	RoleARN string
+	// ExternalID is the external ID to be requested, if not empty.
+	ExternalID string
 }
 
 // CredentialsGetter defines an interface for obtaining STS credentials.
@@ -69,10 +74,14 @@ func (g *credentialsGettter) Get(_ context.Context, request GetCredentialsReques
 	), nil
 }
 
+// CachedCredentialsGetterConfig is the config for creating a CredentialsGetter that caches credentials.
 type CachedCredentialsGetterConfig struct {
-	Getter   CredentialsGetter
+	// Getter is the CredentialsGetter for obtaining the STS credentials.
+	Getter CredentialsGetter
+	// CacheTTL is the cache TTL.
 	CacheTTL time.Duration
-	Clock    clockwork.Clock
+	// Clock is used to control time.
+	Clock clockwork.Clock
 }
 
 // SetDefaults sets default values for CachedCredentialsGetterConfig.
@@ -93,6 +102,7 @@ type cachedCredentialsGetter struct {
 	cache  *utils.FnCache
 }
 
+// NewCachedCredentialsGetter returns a CredentialsGetter that caches credentials.
 func NewCachedCredentialsGetter(config CachedCredentialsGetterConfig) (CredentialsGetter, error) {
 	config.SetDefaults()
 

--- a/lib/utils/aws/credentials_test.go
+++ b/lib/utils/aws/credentials_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCredentialsGetter struct {
+}
+
+func (f *fakeCredentialsGetter) Get(ctx context.Context, request GetCredentialsRequest) (*credentials.Credentials, error) {
+	return credentials.NewStaticCredentials(
+		fmt.Sprintf("%s-%s-%s", request.SessionName, request.RoleARN, request.ExternalID),
+		uuid.NewString(),
+		uuid.NewString(),
+	), nil
+}
+
+func TestCachedCredentialsGetter(t *testing.T) {
+	t.Parallel()
+
+	hostSession := session.Must(session.NewSession(&aws.Config{
+		Credentials: credentials.AnonymousCredentials,
+		Region:      aws.String("us-west-2"),
+	}))
+	fakeClock := clockwork.NewFakeClock()
+
+	getter, err := NewCachedCredentialsGetter(CachedCredentialsGetterConfig{
+		Getter:   &fakeCredentialsGetter{},
+		CacheTTL: time.Minute,
+		Clock:    fakeClock,
+	})
+	require.NoError(t, err)
+
+	cred1, err := getter.Get(context.Background(), GetCredentialsRequest{
+		Provider:    hostSession,
+		Expiry:      fakeClock.Now().Add(time.Hour),
+		SessionName: "test-session",
+		RoleARN:     "test-role",
+	})
+	require.NoError(t, err)
+	checkCredentialsAccessKeyID(t, cred1, "test-session-test-role-")
+
+	tests := []struct {
+		name         string
+		sessionName  string
+		roleARN      string
+		externalID   string
+		advanceClock time.Duration
+		compareCred1 require.ComparisonAssertionFunc
+	}{
+		{
+			name:         "cached",
+			sessionName:  "test-session",
+			roleARN:      "test-role",
+			compareCred1: require.Equal,
+		},
+		{
+			name:         "different session name",
+			sessionName:  "test-session-2",
+			roleARN:      "test-role",
+			compareCred1: require.NotEqual,
+		},
+		{
+			name:         "different role ARN",
+			sessionName:  "test-session",
+			roleARN:      "test-role-2",
+			compareCred1: require.NotEqual,
+		},
+		{
+			name:         "different external ID",
+			sessionName:  "test-session",
+			roleARN:      "test-role",
+			externalID:   "test-id",
+			compareCred1: require.NotEqual,
+		},
+		{
+			name:         "cache expired",
+			sessionName:  "test-session",
+			roleARN:      "test-role",
+			advanceClock: time.Hour,
+			compareCred1: require.NotEqual,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClock.Advance(test.advanceClock)
+
+			cred, err := getter.Get(context.Background(), GetCredentialsRequest{
+				Provider:    hostSession,
+				Expiry:      fakeClock.Now().Add(time.Hour),
+				SessionName: test.sessionName,
+				RoleARN:     test.roleARN,
+				ExternalID:  test.externalID,
+			})
+			require.NoError(t, err)
+			checkCredentialsAccessKeyID(t, cred, fmt.Sprintf("%s-%s-%s", test.sessionName, test.roleARN, test.externalID))
+			test.compareCred1(t, cred1, cred)
+		})
+	}
+}
+
+func checkCredentialsAccessKeyID(t *testing.T, cred *credentials.Credentials, wantAccessKeyID string) {
+	t.Helper()
+	value, err := cred.Get()
+	require.NoError(t, err)
+	require.Equal(t, wantAccessKeyID, value.AccessKeyID)
+}

--- a/lib/utils/aws/credentials_test.go
+++ b/lib/utils/aws/credentials_test.go
@@ -78,33 +78,33 @@ func TestCachedCredentialsGetter(t *testing.T) {
 			name:         "cached",
 			sessionName:  "test-session",
 			roleARN:      "test-role",
-			compareCred1: require.Equal,
+			compareCred1: require.Same,
 		},
 		{
 			name:         "different session name",
 			sessionName:  "test-session-2",
 			roleARN:      "test-role",
-			compareCred1: require.NotEqual,
+			compareCred1: require.NotSame,
 		},
 		{
 			name:         "different role ARN",
 			sessionName:  "test-session",
 			roleARN:      "test-role-2",
-			compareCred1: require.NotEqual,
+			compareCred1: require.NotSame,
 		},
 		{
 			name:         "different external ID",
 			sessionName:  "test-session",
 			roleARN:      "test-role",
 			externalID:   "test-id",
-			compareCred1: require.NotEqual,
+			compareCred1: require.NotSame,
 		},
 		{
 			name:         "cache expired",
 			sessionName:  "test-session",
 			roleARN:      "test-role",
 			advanceClock: time.Hour,
-			compareCred1: require.NotEqual,
+			compareCred1: require.NotSame,
 		},
 	}
 

--- a/lib/utils/aws/signing.go
+++ b/lib/utils/aws/signing.go
@@ -63,13 +63,7 @@ func (s *SigningServiceConfig) CheckAndSetDefaults() error {
 		s.Clock = clockwork.NewRealClock()
 	}
 	if s.Session == nil {
-		ses, err := awssession.NewSessionWithOptions(awssession.Options{
-			SharedConfigState: awssession.SharedConfigEnable,
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		s.Session = ses
+		return trace.BadParameter("missing session")
 	}
 	if s.CredentialsGetter == nil {
 		s.CredentialsGetter = NewCredentialsGetter()

--- a/lib/utils/aws/signing.go
+++ b/lib/utils/aws/signing.go
@@ -120,7 +120,7 @@ func (sc *SigningCtx) Check(clock clockwork.Clock) error {
 //	 4. Build AWS API endpoint based on extracted aws-region and aws-service fields.
 //	    Not that for endpoint resolving the https://github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
 //	    package is used and when Amazon releases a new API the dependency update is needed.
-//	 v. Sign HTTP request.
+//	 5. Sign HTTP request.
 func (s *SigningService) SignRequest(ctx context.Context, req *http.Request, signCtx *SigningCtx) (*http.Request, error) {
 	if signCtx == nil {
 		return nil, trace.BadParameter("missing signing context")

--- a/lib/utils/aws/signing.go
+++ b/lib/utils/aws/signing.go
@@ -23,10 +23,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -57,9 +53,8 @@ type SigningServiceConfig struct {
 	Session *awssession.Session
 	// Clock is used to override time in tests.
 	Clock clockwork.Clock
-	// GetSigningCredentials allows to set the function responsible for obtaining STS credentials.
-	// Used in tests to set static AWS credentials and skip API call.
-	GetSigningCredentials GetSigningCredentialsFunc
+	// CredentialsGetter is used to obtain STS credentials.
+	CredentialsGetter CredentialsGetter
 }
 
 // CheckAndSetDefaults validates the SigningServiceConfig config.
@@ -76,8 +71,8 @@ func (s *SigningServiceConfig) CheckAndSetDefaults() error {
 		}
 		s.Session = ses
 	}
-	if s.GetSigningCredentials == nil {
-		s.GetSigningCredentials = GetAWSCredentialsFromSTSAPI
+	if s.CredentialsGetter == nil {
+		s.CredentialsGetter = NewCredentialsGetter()
 	}
 	return nil
 }
@@ -131,7 +126,7 @@ func (sc *SigningCtx) Check(clock clockwork.Clock) error {
 //	 4. Build AWS API endpoint based on extracted aws-region and aws-service fields.
 //	    Not that for endpoint resolving the https://github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
 //	    package is used and when Amazon releases a new API the dependency update is needed.
-//	 5. Sign HTTP request.
+//	 v. Sign HTTP request.
 func (s *SigningService) SignRequest(ctx context.Context, req *http.Request, signCtx *SigningCtx) (*http.Request, error) {
 	if signCtx == nil {
 		return nil, trace.BadParameter("missing signing context")
@@ -154,7 +149,16 @@ func (s *SigningService) SignRequest(ctx context.Context, req *http.Request, sig
 	// 100-continue" headers without being signed, otherwise the Athena service
 	// would reject the requests.
 	unsignedHeaders := removeUnsignedHeaders(reqCopy)
-	credentials := s.GetSigningCredentials(s.Session, signCtx.Expiry, signCtx.SessionName, signCtx.AWSRoleArn, signCtx.AWSExternalID)
+	credentials, err := s.CredentialsGetter.Get(ctx, GetCredentialsRequest{
+		Provider:    s.Session,
+		Expiry:      signCtx.Expiry,
+		SessionName: signCtx.SessionName,
+		RoleARN:     signCtx.AWSRoleArn,
+		ExternalID:  signCtx.AWSExternalID,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	signer := NewSigner(credentials, signCtx.SigningName)
 	_, err = signer.Sign(reqCopy, bytes.NewReader(payload), signCtx.SigningName, signCtx.SigningRegion, s.Clock.Now())
 	if err != nil {
@@ -164,24 +168,6 @@ func (s *SigningService) SignRequest(ctx context.Context, req *http.Request, sig
 	// copy removed headers back to the request after signing it, but don't copy the old Authorization header.
 	copyHeaders(reqCopy, req, utils.RemoveFromSlice(unsignedHeaders, "Authorization"))
 	return reqCopy, nil
-}
-
-// GetSigningCredentialsFunc allows to set the function responsible for obtaining STS credentials.
-// Used in tests to set static AWS credentials and skip API call.
-type GetSigningCredentialsFunc func(provider client.ConfigProvider, expiry time.Time, sessName, roleARN, externalID string) *credentials.Credentials
-
-// GetAWSCredentialsFromSTSAPI obtains STS credentials.
-func GetAWSCredentialsFromSTSAPI(provider client.ConfigProvider, expiry time.Time, sessName, roleARN, externalID string) *credentials.Credentials {
-	return stscreds.NewCredentials(provider, roleARN,
-		func(cred *stscreds.AssumeRoleProvider) {
-			cred.RoleSessionName = sessName
-			cred.Expiry.SetExpiration(expiry, 0)
-
-			if externalID != "" {
-				cred.ExternalID = aws.String(externalID)
-			}
-		},
-	)
 }
 
 // removeUnsignedHeaders removes and returns header keys that are not included in SigV4 SignedHeaders.

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -697,11 +697,6 @@ func onProxyCommandAWS(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	proxyHost, proxyPort, err := net.SplitHostPort(awsApp.GetForwardProxyAddr())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	templateData := map[string]interface{}{
 		"envVars":     envVars,
 		"address":     awsApp.GetForwardProxyAddr(),
@@ -710,11 +705,18 @@ func onProxyCommandAWS(cf *CLIConf) error {
 		"randomPort":  cf.LocalProxyPort == "",
 		"appName":     awsApp.appName,
 		"proxyScheme": "http",
-		"proxyHost":   proxyHost,
-		"proxyPort":   proxyPort,
 		"region":      getEnvOrDefault(awsRegionEnvVar, "<region>"),
 		"keystore":    getEnvOrDefault(awsKeystoreEnvVar, "<keystore>"),
 		"workgroup":   getEnvOrDefault(awsWorkgroupEnvVar, "<workgroup>"),
+	}
+
+	if !cf.AWSEndpointURLMode {
+		proxyHost, proxyPort, err := net.SplitHostPort(awsApp.GetForwardProxyAddr())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		templateData["proxyHost"] = proxyHost
+		templateData["proxyPort"] = proxyPort
 	}
 
 	templates := []string{awsProxyHeaderTemplate}


### PR DESCRIPTION
This change fixes Timestream in Endpoint mode. 
```
$ tsh aws --endpoint-url timestream-query list-scheduled-queries --region us-west-2

An error occurred (UnknownOperationException) when calling the ListScheduledQueries operation: 
ERROR: exit status 254
```
Also, this change enables Timestream JDBC support as the Timestream JDBC drivers does NOT support HTTPS proxy so `--endpoint-url` must be used.

Also fixes #15574

## Testing
### Setup a Timestream database
https://github.com/awslabs/amazon-timestream-tools/tree/mainline/sample_apps/python
Note that not all regions support Timestream yet.

### Setup Teleport
Make sure the server is up-to-date (see #21766).

[optional] pre-populate defaults for `tsh` template values:
```
export TELEPORT_AWS_ACCESS_KEY_ID="example-access-key-id"
export TELEPORT_AWS_SECRET_ACCESS_KEY="example-secret-access-key"
export TELEPORT_AWS_REGION="us-west-2"
export TELEPORT_AWS_KEYSTORE=$(/usr/libexec/java_home)/lib/security/cacerts
```
Then login the AWS app. [optional] You can run `list-tables` to verify the table is there.
```
$ tsh login ....
$ tsh apps login aws
$ tsh aws timestream-write list-tables --region us-west-2
```
Then launch the local proxy
```
$ tsh proxy aws -p8888 -f timestream-jdbc --endpoint-url
```

Follow the instruction to add the CA to the keystore.

### Setup JDBC client
I personally find that [SquirrelSQL](https://squirrel-sql.sourceforge.io/) is pretty good on MacOS.

(If you have the official java 8.dmg installed on MacOS, SquirreSQL will not run as java 8 is old. Uninstall it and install a newer openjdk) 

First, add a driver in SquirrelSQL, the jar can be found [here](https://docs.aws.amazon.com/timestream/latest/developerguide/JDBC.configuring.html) (note, use the "shaded" jar)
<img width="540" alt="driver" src="https://user-images.githubusercontent.com/12417665/218803378-f45b39d3-31a6-463b-bb99-5b7fd2bedf1b.png">

Then, add an "alias" connection. You can just copy/paste the connection URL from `tsh proxy aws` command.
<img width="497" alt="alias" src="https://user-images.githubusercontent.com/12417665/218804379-b4936cd5-11c6-4203-ae04-9381c29b64b0.png">

Then connect. That's it!
<img width="820" alt="connect" src="https://user-images.githubusercontent.com/12417665/218804873-b0657b62-f7e8-44b7-8679-f6416f2cfed4.png">
