### PR TITLE
BPF build fix

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -69,21 +69,6 @@ RUN mkdir -p /opt && cd /opt &&  \
     make &&  \
     BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install
 
-# Install newer libbpf.
-FROM buildpack-deps:18.04 AS libbpf-1-0-1
-
-# Install required dependencies
-RUN apt-get update -y --fix-missing && \
-    apt-get -q -y upgrade && \
-    apt-get install -q -y --no-install-recommends \
-        libelf-dev
-
-RUN mkdir -p /opt && cd /opt && \
-    curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v1.0.1.tar.gz | tar xz && \
-    cd /opt/libbpf-1.0.1/src && \
-    make && \
-    BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install
-
 ## BUILDBOX ###################################################################
 #
 # Image layers are ordered according to how slow that layer takes to build and
@@ -310,7 +295,6 @@ RUN BIN="/usr/local/bin" && \
 # Copy BPF libraries.
 ARG LIBBPF_VERSION
 COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
-COPY --from=libbpf-1-0-1 /opt/libbpf/usr /usr/libbpf-1.0.1
 
 # Copy libfido2 libraries.
 # Do this near the end to take better advantage of the multi-stage build.

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update -y --fix-missing && \
 
 ARG LIBBPF_VERSION
 RUN mkdir -p /opt && cd /opt &&  \
-    curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+    curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make &&  \
     BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -27,7 +27,7 @@ RUN yum groupinstall -y 'Development Tools' && \
 # BUILD_STATIC_ONLY disables libbpf.so build as we don't need it.
 ARG LIBBPF_VERSION
 RUN mkdir -p /opt && cd /opt && \
-    curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+    curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     scl enable devtoolset-11 "make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install"
 

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -10,17 +10,11 @@ RUN yum groupinstall -y 'Development Tools' && \
     yum update -y && \
     yum -y install centos-release-scl-rh && \
     yum install -y \
-    # required by libbpf
-    centos-release-scl \
-    # required by libbpf
-    devtoolset-11-gcc* \
-    # required by libbpf
-    devtoolset-11-make \
-    # required by libbpf
-    elfutils-libelf-devel-static \
-    git \
-    # required by libbpf
-    scl-utils \
+        centos-release-scl \
+        devtoolset-11-gcc* \
+        devtoolset-11-make \
+        elfutils-libelf-devel-static \
+        scl-utils && \
     yum clean all
 
 # Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
@@ -155,9 +149,6 @@ RUN make -C /opt/pam_teleport install
 
 RUN chmod a-w /
 
-# Copy libbpf into the final image.
-COPY --from=libbpf /opt/libbpf/usr /usr
-
 ARG RUST_VERSION
 ENV RUSTUP_HOME=/usr/local/rustup \
      CARGO_HOME=/usr/local/cargo \
@@ -185,6 +176,9 @@ COPY --from=boringssl /opt/boringssl /opt/boringssl
 # https://github.com/cloudflare/boring#support-for-pre-built-binaries
 ENV BORING_BSSL_PATH=/opt/boringssl
 ENV BORING_BSSL_INCLUDE_PATH=/opt/boringssl/include
+
+ARG LIBBPF_VERSION
+COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
 
 # Download pre-built CentOS 7 assets with clang needed to build BPF tools.
 ARG BUILDARCH

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -147,7 +147,7 @@ RUN corepack enable yarn
 
 # Install libbpf
 ARG LIBBPF_VERSION
-RUN mkdir -p /opt && cd /opt && curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+RUN mkdir -p /opt && cd /opt && curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make && \
     make install


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/21745 switched CentOS 7 image to the upstream, but I missed a few other places were we're using our fork. This change fixes all places.