### PR TITLE
Use Helm DynamoDB policy in Backends reference

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -38,71 +38,7 @@ you'll need to configure AWS IAM policies to allow access.
 
 ### DynamoDB IAM policy
 
-You'll need to replace these values in the policy example below:
-
-| Placeholder value | Replace with |
-| - | - |
-| `us-west-2` | AWS region |
-| `1234567890` | AWS account ID | `1234567890` |
-| `teleport-helm-backend` | DynamoDB table name to use for the Teleport backend |
-| `teleport-helm-events` | DynamoDB table name to use for the Teleport audit log (**must** be different to the backend table)
-
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "ClusterStateStorage",
-            "Effect": "Allow",
-            "Action": [
-                "dynamodb:BatchWriteItem",
-                "dynamodb:UpdateTimeToLive",
-                "dynamodb:PutItem",
-                "dynamodb:DeleteItem",
-                "dynamodb:Scan",
-                "dynamodb:Query",
-                "dynamodb:DescribeStream",
-                "dynamodb:UpdateItem",
-                "dynamodb:DescribeTimeToLive",
-                "dynamodb:CreateTable",
-                "dynamodb:DescribeTable",
-                "dynamodb:GetShardIterator",
-                "dynamodb:GetItem",
-                "dynamodb:UpdateTable",
-                "dynamodb:GetRecords",
-                "dynamodb:UpdateContinuousBackups"
-            ],
-            "Resource": [
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-backend",
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-backend/stream/*"
-            ]
-        },
-        {
-            "Sid": "ClusterEventsStorage",
-            "Effect": "Allow",
-            "Action": [
-                "dynamodb:CreateTable",
-                "dynamodb:BatchWriteItem",
-                "dynamodb:UpdateTimeToLive",
-                "dynamodb:PutItem",
-                "dynamodb:DescribeTable",
-                "dynamodb:DeleteItem",
-                "dynamodb:GetItem",
-                "dynamodb:Scan",
-                "dynamodb:Query",
-                "dynamodb:UpdateItem",
-                "dynamodb:DescribeTimeToLive",
-                "dynamodb:UpdateTable",
-                "dynamodb:UpdateContinuousBackups"
-            ],
-            "Resource": [
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-events",
-                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-events/index/*"
-            ]
-        }
-    ]
-}
-```
+(!docs/pages/includes/dynamodb-iam-policy.mdx!)
 
 ### S3 IAM policy
 

--- a/docs/pages/includes/dynamodb-iam-policy.mdx
+++ b/docs/pages/includes/dynamodb-iam-policy.mdx
@@ -1,11 +1,11 @@
 You'll need to replace these values in the policy example below:
 
-| Placeholder value | Replace with |
-| - | - |
-| `us-west-2` | AWS region |
-| `1234567890` | AWS account ID | `1234567890` |
-| `teleport-helm-backend` | DynamoDB table name to use for the Teleport backend |
-| `teleport-helm-events` | DynamoDB table name to use for the Teleport audit log (**must** be different to the backend table)
+| Placeholder value       | Replace with                                                                                       |
+|-------------------------|----------------------------------------------------------------------------------------------------|
+| `us-west-2`             | AWS region                                                                                         |
+| `1234567890`            | AWS account ID                                                                                     |
+| `teleport-helm-backend` | DynamoDB table name to use for the Teleport backend                                                |
+| `teleport-helm-events`  | DynamoDB table name to use for the Teleport audit log (**must** be different to the backend table) |
 
 ```json
 {

--- a/docs/pages/includes/dynamodb-iam-policy.mdx
+++ b/docs/pages/includes/dynamodb-iam-policy.mdx
@@ -1,0 +1,66 @@
+You'll need to replace these values in the policy example below:
+
+| Placeholder value | Replace with |
+| - | - |
+| `us-west-2` | AWS region |
+| `1234567890` | AWS account ID | `1234567890` |
+| `teleport-helm-backend` | DynamoDB table name to use for the Teleport backend |
+| `teleport-helm-events` | DynamoDB table name to use for the Teleport audit log (**must** be different to the backend table)
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ClusterStateStorage",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:BatchWriteItem",
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:PutItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:DescribeStream",
+                "dynamodb:UpdateItem",
+                "dynamodb:DescribeTimeToLive",
+                "dynamodb:CreateTable",
+                "dynamodb:DescribeTable",
+                "dynamodb:GetShardIterator",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateTable",
+                "dynamodb:GetRecords",
+                "dynamodb:UpdateContinuousBackups"
+            ],
+            "Resource": [
+                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-backend",
+                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-backend/stream/*"
+            ]
+        },
+        {
+            "Sid": "ClusterEventsStorage",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:CreateTable",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:PutItem",
+                "dynamodb:DescribeTable",
+                "dynamodb:DeleteItem",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:UpdateItem",
+                "dynamodb:DescribeTimeToLive",
+                "dynamodb:UpdateTable",
+                "dynamodb:UpdateContinuousBackups"
+            ],
+            "Resource": [
+                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-events",
+                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-events/index/*"
+            ]
+        }
+    ]
+}
+```
+

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -395,7 +395,7 @@ For more information, see the [AWS Documentation](https://docs.aws.amazon.com/Am
   title="Tip"
 >
   Before continuing, please make sure to take a look at the [Cluster State section](../architecture/nodes.mdx#cluster-state)
-  in Teleport Architecture documentation.
+  in the Teleport Architecture documentation.
 </Admonition>
 
 If you are running Teleport on AWS, you can use
@@ -497,6 +497,13 @@ The optional `GET` parameters shown below control how Teleport interacts with a 
 - `region=us-east-1` - set the Amazon region to use.
 - `endpoint=dynamo.example.com` - connect to a custom S3 endpoint.
 - `use_fips_endpoint=true` -  [Configure DynamoDB FIPS endpoints](#configuring-aws-fips-endpoints).
+
+### Assigning permissions to the Teleport Auth Service
+
+Make sure that the IAM role assigned to Teleport is configured with sufficient
+access to DynamoDB. Below is an example of the IAM policy we recommend.
+
+(!docs/pages/includes/dynamodb-iam-policy.mdx!)
 
 ### DynamoDB autoscaling
 


### PR DESCRIPTION
- Extract the DynamoDB IAM policy in the Helm AWS guide into a partial
- Use this partial in the Backends refernece.

See this discussion for context:

https://github.com/gravitational/teleport/pull/20964#discussion_r1099051127