### PR TITLE
update `tsh proxy db` cert/key file flags logic

### DIFF
--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -658,11 +658,10 @@ type localProxyConfig struct {
 func prepareLocalProxyOptions(arg *localProxyConfig) (*localProxyOpts, error) {
 	certFile := arg.cliConf.LocalProxyCertFile
 	keyFile := arg.cliConf.LocalProxyKeyFile
-	if arg.routeToDatabase.Protocol == defaults.ProtocolSQLServer ||
-		arg.routeToDatabase.Protocol == defaults.ProtocolCassandra ||
-		(arg.localProxyTunnel && certFile == "") {
-		// For SQL Server and Cassandra connections, local proxy must be configured with the
-		// client certificate that will be used to route connections.
+	if arg.localProxyTunnel && certFile == "" && keyFile == "" {
+		// --tunnel implies the local proxy is configured with db certs.
+		// If db certs are not specified but exist in the user profile, load
+		// them from the profile.
 		certFile = arg.profile.DatabaseCertPathForCluster(arg.teleportClient.SiteName, arg.routeToDatabase.ServiceName)
 		keyFile = arg.profile.KeyPath()
 	}
@@ -671,7 +670,8 @@ func prepareLocalProxyOptions(arg *localProxyConfig) (*localProxyOpts, error) {
 		if !arg.localProxyTunnel {
 			return nil, trace.Wrap(err)
 		}
-		// local proxy with tunnel monitors its certs, so it's ok if a cert file can't be loaded.
+		// local proxy with --tunnel monitors and reissue its certs,
+		// so it's ok if certs can't be loaded here.
 		certs = nil
 	}
 
@@ -860,7 +860,12 @@ func getDatabase(cf *CLIConf, tc *client.TeleportClient, dbName string) (types.D
 	return databases[0], nil
 }
 
-func needDatabaseRelogin(cf *CLIConf, tc *client.TeleportClient, route *tlsca.RouteToDatabase, profile *client.ProfileStatus) (bool, error) {
+func needDatabaseRelogin(cf *CLIConf, tc *client.TeleportClient, route *tlsca.RouteToDatabase, profile *client.ProfileStatus, requires *dbLocalProxyRequirement) (bool, error) {
+	if (requires.localProxy && requires.tunnel) || isLocalProxyTunnelRequested(cf) {
+		// We don't need to login if using a local proxy tunnel,
+		// because a local proxy tunnel will handle db login itself.
+		return false, nil
+	}
 	found := false
 	activeDatabases, err := profile.DatabasesForCluster(tc.SiteName)
 	if err != nil {
@@ -894,12 +899,7 @@ func needDatabaseRelogin(cf *CLIConf, tc *client.TeleportClient, route *tlsca.Ro
 // maybeDatabaseLogin checks if cert is still valid. If not valid, trigger db login logic.
 // returns a true/false indicating whether database login was triggered.
 func maybeDatabaseLogin(cf *CLIConf, tc *client.TeleportClient, profile *client.ProfileStatus, route *tlsca.RouteToDatabase, requires *dbLocalProxyRequirement) error {
-	if requires.localProxy && requires.tunnel {
-		// We only need to (possibly) login if not using a local proxy tunnel,
-		// because a local proxy tunnel will handle db login itself.
-		return nil
-	}
-	reloginNeeded, err := needDatabaseRelogin(cf, tc, route, profile)
+	reloginNeeded, err := needDatabaseRelogin(cf, tc, route, profile, requires)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1078,7 +1078,7 @@ type dbLocalProxyRequirement struct {
 	localProxy bool
 	// localProxyReasons is a list of reasons for why local proxy is required.
 	localProxyReasons []string
-	// localProxy is whether a local proxy tunnel is required to connect.
+	// tunnel is whether a local proxy tunnel is required to connect.
 	tunnel bool
 	// tunnelReasons is a list of reasons for why a tunnel is required.
 	tunnelReasons []string
@@ -1111,12 +1111,13 @@ func getDBLocalProxyRequirement(tc *client.TeleportClient, route *tlsca.RouteToD
 		out.addLocalProxyWithTunnel(formatKeyPolicyReason(tc.PrivateKeyPolicy))
 	}
 
-	// Some protocols (Snowflake, DynamoDB) only works in the local tunnel mode.
 	switch route.Protocol {
-	case defaults.ProtocolSnowflake, defaults.ProtocolDynamoDB:
+	case defaults.ProtocolSnowflake,
+		defaults.ProtocolDynamoDB,
+		defaults.ProtocolSQLServer,
+		defaults.ProtocolCassandra:
+		// Some protocols only work in the local tunnel mode.
 		out.addLocalProxyWithTunnel(formatDBProtocolReason(route.Protocol))
-	case defaults.ProtocolSQLServer, defaults.ProtocolCassandra:
-		out.addLocalProxy(formatDBProtocolReason(route.Protocol))
 	case defaults.ProtocolMySQL:
 		if tc.TLSRoutingEnabled {
 			out.addLocalProxy(fmt.Sprintf("%v and %v",

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -386,8 +386,8 @@ func onProxyCommandDB(cf *CLIConf) error {
 	// These steps are not needed with `--tunnel`, because the local proxy tunnel
 	// will manage database certificates itself and reissue them as needed.
 	requires := getDBLocalProxyRequirement(client, route)
-	if requires.tunnel && !cf.LocalProxyTunnel {
-		// Some scenarios require the --tunnel flag, e.g.:
+	if requires.tunnel && !isLocalProxyTunnelRequested(cf) {
+		// Some scenarios require a local proxy tunnel, e.g.:
 		// - Snowflake, DynamoDB protocol
 		// - Hardware-backed private key policy
 		return trace.BadParameter(formatDbCmdUnsupported(cf, route, requires.tunnelReasons...))
@@ -422,6 +422,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 		teleportClient:   client,
 		profile:          profile,
 		routeToDatabase:  route,
+		database:         db,
 		listener:         listener,
 		localProxyTunnel: cf.LocalProxyTunnel,
 		rootClusterName:  rootCluster,
@@ -439,7 +440,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 		lp.Close()
 	}()
 
-	if cf.LocalProxyTunnel {
+	if isLocalProxyTunnelRequested(cf) {
 		addr, err := utils.ParseAddr(lp.GetAddr())
 		if err != nil {
 			return trace.Wrap(err)
@@ -856,6 +857,15 @@ func getEnvOrDefault(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// isLocalProxyTunnelRequested is a helper function that returns whether the user
+// requested a local proxy tunnel, either via --tunnel or equivalently by specifying
+// --cert-file/--key-file.
+func isLocalProxyTunnelRequested(cf *CLIConf) bool {
+	return cf.LocalProxyTunnel ||
+		cf.LocalProxyCertFile != "" ||
+		cf.LocalProxyKeyFile != ""
 }
 
 // dbProxyTpl is the message that gets printed to a user when a database proxy is started.

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -333,8 +333,10 @@ type CLIConf struct {
 	// LocalProxyPort is a port used by local proxy listener.
 	LocalProxyPort string
 	// LocalProxyCertFile is the client certificate used by local proxy.
+	// DEPRECATED DELETE IN 14.0
 	LocalProxyCertFile string
 	// LocalProxyKeyFile is the client key used by local proxy.
+	// DEPRECATED DELETE IN 14.0
 	LocalProxyKeyFile string
 	// LocalProxyTunnel specifies whether local proxy will open auth'd tunnel.
 	LocalProxyTunnel bool
@@ -710,8 +712,9 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	proxyDB := proxy.Command("db", "Start local TLS proxy for database connections when using Teleport in single-port mode")
 	proxyDB.Arg("db", "The name of the database to start local proxy for").Required().StringVar(&cf.DatabaseService)
 	proxyDB.Flag("port", "Specifies the source port used by proxy db listener").Short('p').StringVar(&cf.LocalProxyPort)
-	proxyDB.Flag("cert-file", "Certificate file for proxy client TLS configuration").StringVar(&cf.LocalProxyCertFile)
-	proxyDB.Flag("key-file", "Key file for proxy client TLS configuration").StringVar(&cf.LocalProxyKeyFile)
+	// --cert-file and --key-file are deprecated in favor of --tunnel flag.
+	proxyDB.Flag("cert-file", "Certificate file for proxy client TLS configuration").Hidden().StringVar(&cf.LocalProxyCertFile)
+	proxyDB.Flag("key-file", "Key file for proxy client TLS configuration").Hidden().StringVar(&cf.LocalProxyKeyFile)
 	proxyDB.Flag("tunnel", "Open authenticated tunnel using database's client certificate so clients don't need to authenticate").BoolVar(&cf.LocalProxyTunnel)
 	proxyDB.Flag("db-user", "Optional database user to log in as.").StringVar(&cf.DatabaseUser)
 	proxyDB.Flag("db-name", "Optional database name to log in to.").StringVar(&cf.DatabaseName)


### PR DESCRIPTION
This PR updates `tsh proxy db --cert-file=/some/cert --key-file=/some/key` logic and deprecates these flags in favor of `--tunnel` by hiding them.

## Context For Reviewers

The important thing to know here is that when `--cert-file` and `--key-file` are specified, the local proxy connection routing is the same as `tsh proxy db --tunnel`.

When the local proxy dials the upstream remote proxy, it can either do TLS handshake or mTLS handshake - the remote proxy client auth policy is to check client certs if they are given. The local proxy will provide whatever certs it was configured with, or no certs at all if they were not loaded into the local proxy config. This is *the* difference between a "tunnel" and "non-tunnel" local proxy setup.

* Specifying `tsh proxy db --tunnel` just tells `tsh` to load existing db cert/key (if they exist) into the local proxy config and and to renew certificates as needed during the lifetime of the local proxy.

* Specifying `tsh proxy db --cert-file=/some/cert --key-file=/some/key` tells `tsh` to load that cert/key pair into the local proxy, but does not renew certificates as needed during the lifetime of the local proxy.

* When the local proxy dials upstream and does mTLS handshake, the remote proxy gets `RouteToDatabase` routing info for the database connection from the certs provided by the local proxy. This info is needed to route the connection, and some database protocol cli/gui clients have no way to configure certs for mTLS. That's part of the reason why we have this notion of a "tunneled" local proxy - to allow those clients to connect through the "tunnel", so they don't have to worry about configuring client cert/key.

## What

Specifically, this PR:
1. checks if --cert-file, --key-file are given when tunnel is required, to avoid returning an error when a "tunnel" is required but `--tunnel` is not given. Since these flags are equivalent in meaning for the connection routing, we should not error when cert/key is given and a tunnel is required.
2. checks if --cert-file, --key-file are given and skips database relogin - it makes no sense to trigger database login when a user requests specific cert/key files. They should either already exist on disk and be valid or not - the user will not expect us to overwrite them with a relogin.
3. No longer automatically overrides the --cert-file, --key-file for SQL server and Cassandra. Previously, we would just always override these flags with certs from the tsh profile (silently). We were doing this because a local proxy tunnel is required for these protocols. Which leads to the next change:
4. require tunnel mode for SQL Server and Cassandra. Now `tsh proxy db some-mssql-server` will return an error and tell the user to either use `tsh db connect` or `tsh proxy db --tunnel`. It does not mention passing --cert-file or --key-file flags because we should deprecate these flags - they provide an inferior UX to `--tunnel` and offer no real advantage.
5. deprecate --cert-file and --key-file flags in favor of --tunnel. For this, I marked the flags hidden, so they will still work in v13, but we will be deleting them in a later major release.

## Why

1. Because we were really requiring a tunnel for sql server and cassandra, but in an unusual way that was inconsistent with other protocol requirements, so we were still printing a proxy template telling users to configure cert/key to connect to the local proxy, which doesn't actually make sense (and would do absolutely nothing for the connection, since we already silently loaded certs to dial the upstream proxy). Example PR changes diff:
```diff
$ tsh proxy db --db-user=sqlserver-alice --port 8000 --db-name=master teleport-sqlserver
-Started DB proxy on 127.0.0.1:8000
+ERROR: "tsh proxy db" is not supported when:
+  - database protocol is Microsoft SQL Server.

-Use following credentials to connect to the teleport-sqlserver proxy:
-  ca_file=/Users/gavin/.tsh/keys/gavin-dev.cloud.gravitational.io/cas/gavin-dev.cloud.gravitational.io.pem
-  cert_file=/Users/gavin/.tsh/keys/gavin-dev.cloud.gravitational.io/gavin.frazar@goteleport.com-db/gavin-dev.cloud.gravitational.io/teleport-sqlserver-x509.pem
-  key_file=/Users/gavin/.tsh/keys/gavin-dev.cloud.gravitational.io/gavin.frazar@goteleport.com
+Please use one of the following commands to connect to the database:
+    tsh db connect teleport-sqlserver
+    tsh proxy db --tunnel teleport-sqlserver
```
2. We were also printing instructions to use cert/key files when connecting to `tsh proxy db --cert-file=... --key-file...`, which again makes no sense since those flags already configured the local proxy with those certs. Example PR changes diff:
```diff
$ tsh proxy db --db-user=sqlserver-alice --port 8000 --db-name=master --cert-file ~/.tsh/keys/gavin-dev.cloud.gravitational.io/gavin.frazar@goteleport.com-db/gavin-dev.cloud.gravitational.io/teleport-sqlserver-x509.pem --key-file ~/.tsh/keys/gavin-dev.cloud.gravitational.io/gavin.frazar@goteleport.com teleport-sqlserver
-Started DB proxy on 127.0.0.1:8000
+Started authenticated tunnel for the Microsoft SQL Server database "teleport-sqlserver" in cluster "gavin-dev.cloud.gravitational.io" on 127.0.0.1:8000.

-Use following credentials to connect to the teleport-sqlserver proxy:
-  ca_file=/Users/gavin/.tsh/keys/gavin-dev.cloud.gravitational.io/cas/gavin-dev.cloud.gravitational.io.pem
-  cert_file=/Users/gavin/.tsh/keys/gavin-dev.cloud.gravitational.io/gavin.frazar@goteleport.com-db/gavin-dev.cloud.gravitational.io/teleport-sqlserver-x509.pem
-  key_file=/Users/gavin/.tsh/keys/gavin-dev.cloud.gravitational.io/gavin.frazar@goteleport.com
+Use the following command to connect to the database or to the address above using other database GUI/CLI clients:
+  $ mssql-cli -S localhost,8000 -U sqlserver-alice -P bb414136-f356-4a2a-a4bf-eb7af0e96f17 -d master
```

## Backporting

I will backport this change except for hiding these flags, as we should not hide flags in minor releases of Teleport.
