### PR TITLE
[v10] feat: early feedback for successful security key taps

### DIFF
--- a/lib/auth/webauthncli/api.go
+++ b/lib/auth/webauthncli/api.go
@@ -59,13 +59,21 @@ type LoginPrompt interface {
 	// PromptTouch prompts the user for a security key touch.
 	// In certain situations multiple touches may be required (PIN-protected
 	// devices, passwordless flows, etc).
-	PromptTouch() error
+	// Returns a TouchAcknowledger which should be called to signal to the user
+	// that the touch was successfully detected.
+	// Returns an error if the prompt fails to be sent to the user.
+	PromptTouch() (TouchAcknowledger, error)
 	// PromptCredential prompts the user to choose a credential, in case multiple
 	// credentials are available.
 	// Callers are free to modify the slice, such as by sorting the credentials,
 	// but must return one of the pointers contained within.
 	PromptCredential(creds []*CredentialInfo) (*CredentialInfo, error)
 }
+
+// TouchAcknowledger is a function type which should be called to signal to the
+// user that a security key touch was successfully detected.
+// May return an error if the acknowledgement fails to be sent to the user.
+type TouchAcknowledger func() error
 
 // LoginOpts groups non-mandatory options for Login.
 type LoginOpts struct {
@@ -138,10 +146,20 @@ func crossPlatformLogin(
 		return FIDO2Login(ctx, origin, assertion, prompt, opts)
 	}
 
-	if err := prompt.PromptTouch(); err != nil {
+	ackTouch, err := prompt.PromptTouch()
+	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
+
 	resp, err := U2FLogin(ctx, origin, assertion)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	if err := ackTouch(); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
 	return resp, "" /* credentialUser */, err
 }
 
@@ -164,9 +182,12 @@ type RegisterPrompt interface {
 	// PromptPIN prompts the user for their PIN.
 	PromptPIN() (string, error)
 	// PromptTouch prompts the user for a security key touch.
-	// In certain situations multiple touches may be required (eg, PIN-protected
-	// devices)
-	PromptTouch() error
+	// In certain situations multiple touches may be required (PIN-protected
+	// devices, passwordless flows, etc).
+	// Returns a TouchAcknowledger which should be called to signal to the user
+	// that the touch was successfully detected.
+	// Returns an error if the prompt fails to be sent to the user.
+	PromptTouch() (TouchAcknowledger, error)
 }
 
 // Register performs client-side, U2F-compatible, Webauthn registration.
@@ -184,8 +205,15 @@ func Register(
 		return FIDO2Register(ctx, origin, cc, prompt)
 	}
 
-	if err := prompt.PromptTouch(); err != nil {
+	ackTouch, err := prompt.PromptTouch()
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return U2FRegister(ctx, origin, cc)
+
+	resp, err := U2FRegister(ctx, origin, cc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return resp, trace.Wrap(ackTouch())
 }

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -554,17 +554,23 @@ func runOnFIDO2Devices(
 	filter deviceFilterFunc,
 	deviceCallback deviceCallbackFunc) error {
 	// About to select, prompt user.
-	if err := prompt.PromptTouch(); err != nil {
+	ackTouch, err := prompt.PromptTouch()
+	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// List/select devices.
 	cb := withPINHandler(withRetries(deviceCallback))
 	dev, requiresPIN, err := findAndSelectDevice(ctx, filter, cb)
-	switch {
-	case err != nil:
+	if err != nil {
 		return trace.Wrap(err)
-	case !requiresPIN:
+	}
+
+	if err := ackTouch(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if !requiresPIN {
 		return nil
 	}
 
@@ -579,7 +585,8 @@ func runOnFIDO2Devices(
 	}
 
 	// Prompt a second touch after reading the PIN.
-	if err := prompt.PromptTouch(); err != nil {
+	ackTouch, err = prompt.PromptTouch()
+	if err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -587,7 +594,11 @@ func runOnFIDO2Devices(
 	// selectDevice is used since it correctly deals with cancellation.
 	cb = withoutPINHandler(withRetries(deviceCallback))
 	_, err = selectDevice(ctx, pin, dev, cb)
-	return trace.Wrap(err)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(ackTouch())
 }
 
 // withRetries wraps callback with retries and error handling for commonly seen

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -120,7 +120,9 @@ func (p noopPrompt) PromptPIN() (string, error) {
 	return "", nil
 }
 
-func (p noopPrompt) PromptTouch() error { return nil }
+func (p noopPrompt) PromptTouch() (wancli.TouchAcknowledger, error) {
+	return func() error { return nil }, nil
+}
 
 // pinCancelPrompt exercises cancellation after device selection.
 type pinCancelPrompt struct {
@@ -135,9 +137,9 @@ func (p *pinCancelPrompt) PromptPIN() (string, error) {
 	return p.pin, nil
 }
 
-func (p pinCancelPrompt) PromptTouch() error {
+func (p pinCancelPrompt) PromptTouch() (wancli.TouchAcknowledger, error) {
 	// 2nd touch never happens
-	return nil
+	return func() error { return nil }, nil
 }
 
 func TestIsFIDO2Available(t *testing.T) {
@@ -809,12 +811,16 @@ func TestFIDO2Login_singleResidentCredential(t *testing.T) {
 
 type countingPrompt struct {
 	wancli.LoginPrompt
-	count int
+	count, ackCount int
 }
 
-func (cp *countingPrompt) PromptTouch() error {
+func (cp *countingPrompt) PromptTouch() (wancli.TouchAcknowledger, error) {
 	cp.count++
-	return cp.LoginPrompt.PromptTouch()
+	ack, err := cp.LoginPrompt.PromptTouch()
+	return func() error {
+		cp.ackCount++
+		return ack()
+	}, err
 }
 
 func TestFIDO2Login_PromptTouch(t *testing.T) {
@@ -941,6 +947,7 @@ func TestFIDO2Login_PromptTouch(t *testing.T) {
 			_, _, err := wancli.FIDO2Login(ctx, origin, test.assertion, prompt, test.opts)
 			require.NoError(t, err, "FIDO2Login errored")
 			assert.Equal(t, test.wantTouches, prompt.count, "FIDO2Login did an unexpected number of touch prompts")
+			assert.Equal(t, test.wantTouches, prompt.ackCount, "FIDO2Login did an unexpected number of touch acknowledgements")
 		})
 	}
 }
@@ -2031,9 +2038,9 @@ func (f *fakeFIDO2Device) PromptPIN() (string, error) {
 	return f.pin, nil
 }
 
-func (f *fakeFIDO2Device) PromptTouch() error {
+func (f *fakeFIDO2Device) PromptTouch() (wancli.TouchAcknowledger, error) {
 	f.setUP()
-	return nil
+	return func() error { return nil }, nil
 }
 
 func (f *fakeFIDO2Device) credentialID() []byte {

--- a/lib/auth/webauthncli/prompt.go
+++ b/lib/auth/webauthncli/prompt.go
@@ -33,6 +33,7 @@ import (
 type DefaultPrompt struct {
 	PINMessage                            string
 	FirstTouchMessage, SecondTouchMessage string
+	AcknowledgeTouchMessage               string
 	PromptCredentialMessage               string
 
 	ctx context.Context
@@ -49,6 +50,7 @@ func NewDefaultPrompt(ctx context.Context, out io.Writer) *DefaultPrompt {
 		PINMessage:              "Enter your security key PIN",
 		FirstTouchMessage:       "Tap your security key",
 		SecondTouchMessage:      "Tap your security key again to complete login",
+		AcknowledgeTouchMessage: "Detected security key tap",
 		PromptCredentialMessage: "Choose the user for login",
 		ctx:                     ctx,
 		out:                     out,
@@ -62,17 +64,22 @@ func (p *DefaultPrompt) PromptPIN() (string, error) {
 
 // PromptTouch prompts the user for a security key touch, using different
 // messages for first and second prompts. Error is always nil.
-func (p *DefaultPrompt) PromptTouch() error {
+func (p *DefaultPrompt) PromptTouch() (TouchAcknowledger, error) {
 	if p.count == 0 {
 		p.count++
 		if p.FirstTouchMessage != "" {
 			fmt.Fprintln(p.out, p.FirstTouchMessage)
 		}
-		return nil
+		return p.ackTouch, nil
 	}
 	if p.SecondTouchMessage != "" {
 		fmt.Fprintln(p.out, p.SecondTouchMessage)
 	}
+	return p.ackTouch, nil
+}
+
+func (p *DefaultPrompt) ackTouch() error {
+	fmt.Fprintln(p.out, p.AcknowledgeTouchMessage)
 	return nil
 }
 

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -132,11 +132,16 @@ func TestTeleportClient_Login_local(t *testing.T) {
 		}
 
 		// Realistically, this would happen too.
-		if err := prompt.PromptTouch(); err != nil {
+		ackTouch, err := prompt.PromptTouch()
+		if err != nil {
 			return nil, err
 		}
 
-		return solveWebauthn(ctx, origin, assertion, prompt)
+		resp, err := solveWebauthn(ctx, origin, assertion, prompt)
+		if err != nil {
+			return nil, err
+		}
+		return resp, ackTouch()
 	}
 
 	ctx := context.Background()

--- a/lib/client/weblogin_test.go
+++ b/lib/client/weblogin_test.go
@@ -184,10 +184,14 @@ func TestSSHAgentPasswordlessLogin(t *testing.T) {
 				require.NoError(t, err)
 				require.Empty(t, creds)
 
-				require.NoError(t, p.PromptTouch())
+				ackTouch, err := p.PromptTouch()
+				require.NoError(t, err)
 
 				resp, err := solvePwdless(ctx, origin, assert, p)
-				return resp, "", err
+				if err != nil {
+					return nil, "", err
+				}
+				return resp, "", ackTouch()
 			},
 			customPromptLogin: &customPromptLogin{},
 		},
@@ -236,8 +240,8 @@ func (p *customPromptLogin) PromptPIN() (string, error) {
 	return "", nil
 }
 
-func (p *customPromptLogin) PromptTouch() error {
-	return nil
+func (p *customPromptLogin) PromptTouch() (wancli.TouchAcknowledger, error) {
+	return func() error { return nil }, nil
 }
 
 func (p *customPromptLogin) PromptCredential(deviceCreds []*wancli.CredentialInfo) (*wancli.CredentialInfo, error) {

--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
@@ -311,7 +312,7 @@ func (c *Cluster) PasswordlessLogin(ctx context.Context, stream api.TerminalServ
 			KubernetesCluster: c.clusterClient.KubernetesCluster,
 		},
 		AuthenticatorAttachment: c.clusterClient.AuthenticatorAttachment,
-		CustomPrompt:            newPwdlessLoginPrompt(ctx, stream),
+		CustomPrompt:            newPwdlessLoginPrompt(ctx, c.Log, stream),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -326,11 +327,13 @@ func (c *Cluster) PasswordlessLogin(ctx context.Context, stream api.TerminalServ
 
 // pwdlessLoginPrompt is a implementation for wancli.LoginPrompt for teleterm passwordless logins.
 type pwdlessLoginPrompt struct {
+	log    *logrus.Entry
 	Stream api.TerminalService_LoginPasswordlessServer
 }
 
-func newPwdlessLoginPrompt(ctx context.Context, stream api.TerminalService_LoginPasswordlessServer) *pwdlessLoginPrompt {
+func newPwdlessLoginPrompt(ctx context.Context, log *logrus.Entry, stream api.TerminalService_LoginPasswordlessServer) *pwdlessLoginPrompt {
 	return &pwdlessLoginPrompt{
+		log:    log,
 		Stream: stream,
 	}
 }
@@ -357,8 +360,19 @@ func (p *pwdlessLoginPrompt) PromptPIN() (string, error) {
 }
 
 // PromptTouch prompts the user for a security key touch.
-func (p *pwdlessLoginPrompt) PromptTouch() error {
-	return trace.Wrap(p.Stream.Send(&api.LoginPasswordlessResponse{Prompt: api.PasswordlessPrompt_PASSWORDLESS_PROMPT_TAP}))
+func (p *pwdlessLoginPrompt) PromptTouch() (wancli.TouchAcknowledger, error) {
+	return p.ackTouch, trace.Wrap(p.Stream.Send(&api.LoginPasswordlessResponse{Prompt: api.PasswordlessPrompt_PASSWORDLESS_PROMPT_TAP}))
+}
+
+func (p *pwdlessLoginPrompt) ackTouch() error {
+	// TODO(nklaassen): Send touch acknowledgement if worth the effort, this is
+	// not strictly necessary but a nice-to-have acknowledgement to the user
+	// that we successfully detected their tap.
+	// The current gRPC message type switch in teleterm client code will reject
+	// any new message types, making this difficult to add without breaking
+	// older clients.
+	p.log.Debug("Detected security key tap")
+	return nil
 }
 
 // PromptCredential prompts the user to select a login name in the list of logins.

--- a/lib/teleterm/clusters/cluster_auth_test.go
+++ b/lib/teleterm/clusters/cluster_auth_test.go
@@ -21,12 +21,15 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
+
+var log = logrus.WithField(trace.Component, "cluster_auth_test")
 
 func TestPwdlessLoginPrompt_PromptPIN(t *testing.T) {
 	stream := &mockLoginPwdlessStream{}
@@ -43,7 +46,7 @@ func TestPwdlessLoginPrompt_PromptPIN(t *testing.T) {
 		}}, nil
 	}
 
-	prompt := newPwdlessLoginPrompt(context.Background(), stream)
+	prompt := newPwdlessLoginPrompt(context.Background(), log, stream)
 	pin, err := prompt.PromptPIN()
 	require.NoError(t, err)
 	require.Equal(t, "1234", pin)
@@ -68,9 +71,10 @@ func TestPwdlessLoginPrompt_PromptTouch(t *testing.T) {
 		return nil
 	}
 
-	prompt := newPwdlessLoginPrompt(context.Background(), stream)
-	err := prompt.PromptTouch()
+	prompt := newPwdlessLoginPrompt(context.Background(), log, stream)
+	ackTouch, err := prompt.PromptTouch()
 	require.NoError(t, err)
+	require.NoError(t, ackTouch())
 }
 
 func TestPwdlessLoginPrompt_PromptCredential(t *testing.T) {
@@ -103,7 +107,7 @@ func TestPwdlessLoginPrompt_PromptCredential(t *testing.T) {
 		}}, nil
 	}
 
-	prompt := newPwdlessLoginPrompt(context.Background(), stream)
+	prompt := newPwdlessLoginPrompt(context.Background(), log, stream)
 	cred, err := prompt.PromptCredential(unsortedCreds)
 	require.NoError(t, err)
 	require.Equal(t, "foo", cred.User.Name)


### PR DESCRIPTION
Backport #21691 to branch/v10

This commit adds a user message ("Detected security key tap") that is printed at the earliest opportunity after `tsh` succesfully detects a security key tap.

This solves a problem users have when there is significant latency in their connection to their teleport proxy, where there may be zero visible feedback to the user for upwards of 8 seconds after they tap their security key.
This often causes users to think that the tap was not detected or failed, and they attempt to tap again.
This can cause the user to accidentally paste a "yubisneeze" into their terminal, which is not great from a security perspective.

As an API choice here I added a `TouchAcknowledger` returned by they `PromptTouch` of the `LoginPrompt` interface.
It may seem like a bit of a weird API, but I did it this way so that all callers of `PromptTouch` are forced to explicitly acknowledge the touch or explicitly ignore that return value, they cannot simply forget to ack.

This applies to WebAuthn and Passwordless logins from `tsh`, no changes are made to Connect.