### PR TITLE
Workaround: Remove proprietary imports from Connect

### DIFF
--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/ban-ts-comment*/
-// @ts-ignore
-import { ResourceKind } from 'e-teleterm/ui/DocumentAccessRequests/NewRequest/useNewRequest';
-// @ts-ignore
-import { RequestState } from 'e-teleport/services/workflow';
 import { SortType } from 'design/DataTable/types';
 import { FileTransferListeners } from 'shared/components/FileTransfer';
 import apiCluster from 'gen-proto-js/teleport/lib/teleterm/v1/cluster_pb';
@@ -256,7 +251,7 @@ export type ServerSideParams = {
 };
 
 export type ReviewAccessRequestParams = {
-  state: RequestState;
+  state: any;
   reason: string;
   roles: string[];
   id: string;
@@ -267,12 +262,12 @@ export type CreateAccessRequestParams = {
   reason: string;
   roles: string[];
   suggestedReviewers: string[];
-  resourceIds: { kind: ResourceKind; clusterName: string; id: string }[];
+  resourceIds: { kind: any; clusterName: string; id: string }[];
 };
 
 export type GetRequestableRolesParams = {
   rootClusterUri: uri.RootClusterUri;
-  resourceIds?: { kind: ResourceKind; clusterName: string; id: string }[];
+  resourceIds?: { kind: any; clusterName: string; id: string }[];
 };
 
 export type AssumedRequest = {

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -17,9 +17,6 @@
 import React, { useMemo } from 'react';
 
 import styled from 'styled-components';
-/* eslint-disable @typescript-eslint/ban-ts-comment*/
-// @ts-ignore
-import { DocumentAccessRequests } from 'e-teleterm/ui/DocumentAccessRequests/DocumentAccessRequests';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import * as types from 'teleterm/ui/services/workspacesService';
@@ -100,8 +97,6 @@ function MemoizedDocument(props: { doc: types.Document; visible: boolean }) {
       case 'doc.terminal_tsh_node':
       case 'doc.terminal_tsh_kube':
         return <DocumentTerminal doc={doc} visible={visible} />;
-      case 'doc.access_requests':
-        return <DocumentAccessRequests doc={doc} visible={visible} />;
       default:
         return (
           <Document visible={visible}>

--- a/web/packages/teleterm/src/ui/LayoutManager.tsx
+++ b/web/packages/teleterm/src/ui/LayoutManager.tsx
@@ -15,9 +15,6 @@ limitations under the License.
 */
 import React from 'react';
 import { Flex } from 'design';
-/* eslint-disable @typescript-eslint/ban-ts-comment*/
-// @ts-ignore
-import { AccessRequestCheckout } from 'e-teleterm/ui/AccessRequestCheckout';
 
 import { TabHostContainer } from 'teleterm/ui/TabHost';
 import { TopBar } from 'teleterm/ui/TopBar';
@@ -38,7 +35,6 @@ export function LayoutManager() {
         <TabHostContainer />
         <NotificationsHost />
       </Flex>
-      <AccessRequestCheckout />
       <StatusBar />
     </Flex>
   );

--- a/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/ban-ts-comment*/
 import React from 'react';
 import { Flex, Text } from 'design';
-// @ts-ignore
-import { AccessRequestCheckoutButton } from 'e-teleterm/ui/StatusBar/AccessRequestCheckoutButton';
 
 import { useActiveDocumentClusterBreadcrumbs } from './useActiveDocumentClusterBreadcrumbs';
 import { ShareFeedback } from './ShareFeedback';
@@ -49,7 +46,6 @@ export function StatusBar() {
         {clusterBreadcrumbs}
       </Text>
       <Flex gap={2} alignItems="center">
-        <AccessRequestCheckoutButton />
         <ShareFeedback />
       </Flex>
     </Flex>

--- a/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
@@ -13,10 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* eslint-disable @typescript-eslint/ban-ts-comment*/
-// @ts-ignore
-import { ResourceKind } from 'e-teleterm/ui/DocumentAccessRequests/NewRequest/useNewRequest';
-
 import { PendingAccessRequest } from '../workspacesService';
 
 export class AccessRequestsService {
@@ -64,7 +60,7 @@ export class AccessRequestsService {
     );
   }
 
-  addOrRemoveResource(kind: ResourceKind, name: string, resourceName: string) {
+  addOrRemoveResource(kind: any, name: string, resourceName: string) {
     this.setState(draftState => {
       const kindIds = draftState.pending[kind];
       if (kindIds[name]) {


### PR DESCRIPTION
This PR is a workaround for #17706. It rips out any e-teleport and e-teleterm imports which fixes the compilation of the OSS version of Connect.