### PR TITLE
Remove deprecated warning when proxy starts

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1268,11 +1268,6 @@ func applyKubeConfig(fc *FileConfig, cfg *service.Config) error {
 		}
 	}
 
-	// Sanity check the local proxy config, so that users don't forget to
-	// enable the k8s endpoint there.
-	if fc.Proxy.Enabled() && fc.Proxy.Kube.Disabled() && fc.Proxy.KubeAddr == "" {
-		log.Warning("both kubernetes_service and proxy_service are enabled, but proxy_service doesn't set kube_listen_addr; consider setting kube_listen_addr on proxy_service, to handle incoming Kubernetes requests")
-	}
 	return nil
 }
 


### PR DESCRIPTION
This PR removes a misleading, wrong, and deprecated warning when the Teleport proxy starts. If the cluster runs in multiplex mode the warning is invalid because Kubernetes Proxy is enabled by default using ALPN proxy listener.