### PR TITLE
[v10] Docs: Remove version warnings for EOL Teleport versions from DB guides

### DIFF
--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -22,13 +22,6 @@ In this guide you will:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-<Notice type="warning">
-
-You will need to install Teleport version `7.0` or newer to access self-hosted
-MongoDB instances.
-
-</Notice>
-
 - MongoDB cluster (standalone or replica set) version `(=mongodb.min_version=)` or newer.
 
 <Admonition type="note">

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -28,9 +28,6 @@ This guide will help you to:
 
 ## Step 1/4. Set up the Teleport Database Service
 
-Teleport Database Access for MySQL is available starting from Teleport version
-`6.0` and MariaDB starting from version `9.0`.
-
 (!docs/pages/includes/database-access/token.mdx!)
 
 Install Teleport on the host where you will run the Teleport Database Service:

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -21,13 +21,6 @@ This guide will help you to:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-<Notice type="warning">
-
-Teleport Database Access for Cloud SQL PostgreSQL is available starting from
-the `6.2` Teleport release.
-
-</Notice>
-
 - Google Cloud account
 - Command-line client `psql` installed and added to your system's `PATH` environment variable.
 - A host, e.g., a Compute Engine instance, where you will run the Teleport Database

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -20,13 +20,6 @@ This guide will help you to:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-<Notice type="warning">
-
-Teleport Database Access for PostgreSQL is available starting from the `6.0`
-release.
-
-</Notice>
-
 - A self-hosted PostgreSQL instance.
 - Command-line client `psql` installed and added to your system's `PATH` environment variable.
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database


### PR DESCRIPTION
Backports #21539 to branch/v10