### PR TITLE
Run reviewers check on (un)labeled PR events

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,7 +11,7 @@ on:
   pull_request_review:
     type: [submitted, edited, dismissed]
   pull_request_target:
-    types: [opened, ready_for_review, synchronize]
+    types: [opened, ready_for_review, synchronize, labeled, unlabeled]
 
 # Limit the permissions on the GitHub token for this workflow to the subset
 # that is required. In this case, the check workflow needs to invalidate


### PR DESCRIPTION
Add `labeled` and `unlabeled` PR activity types to the reviewers check trigger to make sure the check runs when a label is placed on or removed from a PR. This is needed to better take advantage of the bot's feature that prevents PRs with `do-not-merge` labels from merging implemented in https://github.com/gravitational/shared-workflows/pull/72.