### PR TITLE
Preform RBAC checks before connecting to registered OpenSSH nodes

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -127,6 +127,12 @@ const (
 	// KindNode is node resource
 	KindNode = "node"
 
+	// KindOpenSSHNode is a registered OpenSSH node.
+	KindOpenSSHNode = "openssh"
+
+	// KindTeleportNode is a Teleport agent node.
+	KindTeleportNode = "teleport"
+
 	// KindAppServer is an application server resource.
 	KindAppServer = "app_server"
 

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -405,11 +405,10 @@ func TestRouter_DialHost(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			conn, err := tt.router.DialHost(ctx, &utils.NetAddr{}, "host", "0", "test", nil, nil)
+			conn, err := tt.router.DialHost(ctx, &utils.NetAddr{}, "host", "0", "test", IdentityInfo{}, nil)
 			tt.assertion(t, conn, err)
 		})
 	}
-
 }
 
 func TestRouter_DialSite(t *testing.T) {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3515,6 +3515,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		router, err := proxy.NewRouter(proxy.RouterConfig{
 			ClusterName:         clusterName,
 			Log:                 process.log.WithField(trace.Component, "router"),
+			Emitter:             asyncEmitter,
 			RemoteClusterGetter: accessPoint,
 			SiteGetter:          tsrv,
 			TracerProvider:      process.TracingProvider,

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -241,7 +241,13 @@ func (t *proxySubsys) proxyToSite(ctx context.Context, ch ssh.Channel, clusterNa
 func (t *proxySubsys) proxyToHost(ctx context.Context, ch ssh.Channel, remoteAddr net.Addr) error {
 	t.log.Debugf("proxy connecting to host=%v port=%v, exact port=%v", t.host, t.port, t.SpecifiedPort())
 
-	conn, err := t.router.DialHost(ctx, remoteAddr, t.host, t.port, t.clusterName, t.ctx.Identity.AccessChecker, t.ctx.StartAgentChannel)
+	idInfo := proxy.IdentityInfo{
+		TeleportUser:  t.ctx.Identity.TeleportUser,
+		Login:         t.ctx.Identity.Login,
+		Certificate:   t.ctx.Identity.Certificate,
+		AccessChecker: t.ctx.Identity.AccessChecker,
+	}
+	conn, err := t.router.DialHost(ctx, remoteAddr, t.host, t.port, t.clusterName, idInfo, t.ctx.StartAgentChannel)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1433,6 +1433,7 @@ func TestProxyRoundRobin(t *testing.T) {
 	router, err := libproxy.NewRouter(libproxy.RouterConfig{
 		ClusterName:         f.testSrv.ClusterName(),
 		Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+		Emitter:             proxyClient,
 		RemoteClusterGetter: proxyClient,
 		SiteGetter:          reverseTunnelServer,
 		TracerProvider:      tracing.NoopProvider(),
@@ -1574,6 +1575,7 @@ func TestProxyDirectAccess(t *testing.T) {
 	router, err := libproxy.NewRouter(libproxy.RouterConfig{
 		ClusterName:         f.testSrv.ClusterName(),
 		Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+		Emitter:             proxyClient,
 		RemoteClusterGetter: proxyClient,
 		SiteGetter:          reverseTunnelServer,
 		TracerProvider:      tracing.NoopProvider(),
@@ -2300,6 +2302,7 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	router, err := libproxy.NewRouter(libproxy.RouterConfig{
 		ClusterName:         f.testSrv.ClusterName(),
 		Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+		Emitter:             proxyClient,
 		RemoteClusterGetter: proxyClient,
 		SiteGetter:          reverseTunnelServer,
 		TracerProvider:      tracing.NoopProvider(),

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -380,6 +380,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	router, err := proxy.NewRouter(proxy.RouterConfig{
 		ClusterName:         s.server.ClusterName(),
 		Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+		Emitter:             s.proxyClient,
 		RemoteClusterGetter: s.proxyClient,
 		SiteGetter:          revTunServer,
 		TracerProvider:      tracing.NoopProvider(),
@@ -6916,6 +6917,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 	router, err := proxy.NewRouter(proxy.RouterConfig{
 		ClusterName:         authServer.ClusterName(),
 		Log:                 utils.NewLoggerForTests().WithField(trace.Component, "test"),
+		Emitter:             client,
 		RemoteClusterGetter: client,
 		SiteGetter:          revTunServer,
 		TracerProvider:      tracing.NoopProvider(),


### PR DESCRIPTION
Preform RBAC checks before connecting to registered OpenSSH nodes. Part of implementing https://github.com/gravitational/teleport/pull/19261. Connecting to registered OpenSSH nodes with cert signed by OpenSSH CA and conditional proxy recording will come in later PRs.