### PR TITLE
Add WEBASSETS_SKIP_BUILD to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1175,12 +1175,12 @@ test-compat:
 
 .PHONY: ensure-webassets
 ensure-webassets:
-	@if [[ "${WEBASSETS_SKIP_BUILD}" -eq 1 ]]; then mkdir -p webassets/teleport && touch webassets/teleport/index.html; \
+	@if [[ "${WEBASSETS_SKIP_BUILD}" -eq 1 ]]; then mkdir -p webassets/teleport && mkdir -p webassets/teleport && cp web/packages/build/index.ejs webassets/teleport/index.html; \
 	else MAKE="$(MAKE)" "$(MAKE_DIR)/build.assets/build-webassets-if-changed.sh" OSS webassets/oss-sha build-ui web; fi
 
 .PHONY: ensure-webassets-e
 ensure-webassets-e:
-	@if [[ "${WEBASSETS_SKIP_BUILD}" -eq 1 ]]; then mkdir -p webassets/teleport && touch webassets/teleport/index.html; \
+	@if [[ "${WEBASSETS_SKIP_BUILD}" -eq 1 ]]; then mkdir -p webassets/teleport && mkdir -p webassets/e/teleport && cp web/packages/build/index.ejs webassets/e/teleport/index.html; \
 	else MAKE="$(MAKE)" "$(MAKE_DIR)/build.assets/build-webassets-if-changed.sh" Enterprise webassets/e/e-sha build-ui-e web e/web; fi
 
 .PHONY: init-submodules-e


### PR DESCRIPTION
WEBASSETS_SKIP_BUILD allows skipping webassets build for development purposes. Teleport build in that mode displays a blank page instead of WebUI, but the build is significantly faster.

`make full` - always builds webassets
`make WEBASSETS_SKIP_BUILD=0` - works the same as `full`
`make WEBASSETS_SKIP_BUILD=1` - skips webassets build.