### PR TITLE
Add enter-root/centos7 to build.assets/makefile

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -354,8 +354,16 @@ enter-root: buildbox
 # Starts shell inside the centos7 container
 #
 .PHONY:enter/centos7
-enter/centos7: buildbox
+enter/centos7: buildbox-centos7
 	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
+		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_CENTOS7) /bin/bash
+
+#
+# Starts a root shell inside the centos7 container
+#
+.PHONY:enter-root/centos7
+enter-root/centos7: buildbox-centos7
+	docker run $(DOCKERFLAGS) -ti \
 		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_CENTOS7) /bin/bash
 
 #


### PR DESCRIPTION
Fix enter/centos7 to use centos instead of ubuntu.