### PR TITLE
[v10] Bump Buf to v1.14.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -261,7 +261,7 @@ RUN curl -L https://github.com/golangci/golangci-lint/releases/download/v1.46.0/
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.13.1" && \
+    VERSION="1.14.0" && \
       curl -sSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Keep up with latest releases.

No format, lint or codegen changes.

* https://github.com/bufbuild/buf/releases/tag/v1.14.0

Backport #21802 to branch/v10