### PR TITLE
Refactor auth gRPC middleware and transport credentials

### DIFF
--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -30,6 +30,7 @@ import (
 	om "github.com/grpc-ecosystem/go-grpc-middleware/providers/openmetrics/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/exp/slices"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
@@ -143,11 +144,17 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	localClusterName, err := cfg.AccessPoint.GetClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// authMiddleware authenticates request assuming TLS client authentication
 	// adds authentication information to the context
 	// and passes it to the API server
 	authMiddleware := &Middleware{
-		AccessPoint:   cfg.AccessPoint,
+		ClusterName:   localClusterName.GetClusterName(),
 		AcceptedUsage: cfg.AcceptedUsage,
 		Limiter:       limiter,
 		GRPCMetrics:   grpcMetrics,
@@ -182,6 +189,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 
 	server.grpcServer, err = NewGRPCServer(GRPCServerConfig{
 		TLS:               server.cfg.TLS,
+		Middleware:        authMiddleware,
 		APIConfig:         cfg.APIConfig,
 		UnaryInterceptor:  authMiddleware.UnaryInterceptor(),
 		StreamInterceptor: authMiddleware.StreamInterceptor(),
@@ -320,8 +328,7 @@ func (t *TLSServer) GetConfigForClient(info *tls.ClientHelloInfo) (*tls.Config, 
 
 // Middleware is authentication middleware checking every request
 type Middleware struct {
-	// AccessPoint is a caching access point for auth server
-	AccessPoint AccessCache
+	ClusterName string
 	// Handler is HTTP handler called after the middleware checks requests
 	Handler http.Handler
 	// AcceptedUsage restricts authentication
@@ -380,19 +387,38 @@ func (a *Middleware) withAuthenticatedUser(ctx context.Context) (context.Context
 	if !ok {
 		return nil, trace.AccessDenied("missing authentication")
 	}
-	tlsInfo, ok := peerInfo.AuthInfo.(credentials.TLSInfo)
-	if !ok {
+
+	var (
+		connState      *tls.ConnectionState
+		identityGetter IdentityGetter
+	)
+
+	switch info := peerInfo.AuthInfo.(type) {
+	// IdentityInfo is provided if the grpc server is configured with the
+	// TransportCredentials provided in this package.
+	case IdentityInfo:
+		connState = &info.TLSInfo.State
+		identityGetter = info.IdentityGetter
+	// credentials.TLSInfo is provided if the grpc server is configured with
+	// credentials.NewTLS.
+	case credentials.TLSInfo:
+		user, err := a.GetUser(info.State)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		connState = &info.State
+		identityGetter = user
+	default:
 		return nil, trace.AccessDenied("missing authentication")
 	}
-	user, err := a.GetUser(tlsInfo.State)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
-	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(&tlsInfo.State))
+	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(connState))
 	ctx = context.WithValue(ctx, ContextClientAddr, peerInfo.Addr)
-	ctx = context.WithValue(ctx, ContextUser, user)
+	ctx = context.WithValue(ctx, ContextUser, identityGetter)
+
 	return ctx, nil
+
 }
 
 func certFromConnState(state *tls.ConnectionState) *x509.Certificate {
@@ -430,15 +456,19 @@ func (a *Middleware) withAuthenticatedUserStreamInterceptor(srv interface{}, ser
 func (a *Middleware) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	if a.GRPCMetrics != nil {
 		return utils.ChainUnaryServerInterceptors(
+			otelgrpc.UnaryServerInterceptor(),
 			om.UnaryServerInterceptor(a.GRPCMetrics),
 			utils.GRPCServerUnaryErrorInterceptor,
 			a.Limiter.UnaryServerInterceptorWithCustomRate(getCustomRate),
-			a.withAuthenticatedUserUnaryInterceptor)
+			a.withAuthenticatedUserUnaryInterceptor,
+		)
 	}
 	return utils.ChainUnaryServerInterceptors(
+		otelgrpc.UnaryServerInterceptor(),
 		utils.GRPCServerUnaryErrorInterceptor,
 		a.Limiter.UnaryServerInterceptorWithCustomRate(getCustomRate),
-		a.withAuthenticatedUserUnaryInterceptor)
+		a.withAuthenticatedUserUnaryInterceptor,
+	)
 }
 
 // StreamInterceptor returns a gPRC stream interceptor which performs rate
@@ -447,15 +477,19 @@ func (a *Middleware) UnaryInterceptor() grpc.UnaryServerInterceptor {
 func (a *Middleware) StreamInterceptor() grpc.StreamServerInterceptor {
 	if a.GRPCMetrics != nil {
 		return utils.ChainStreamServerInterceptors(
+			otelgrpc.StreamServerInterceptor(),
 			om.StreamServerInterceptor(a.GRPCMetrics),
 			utils.GRPCServerStreamErrorInterceptor,
 			a.Limiter.StreamServerInterceptor,
-			a.withAuthenticatedUserStreamInterceptor)
+			a.withAuthenticatedUserStreamInterceptor,
+		)
 	}
 	return utils.ChainStreamServerInterceptors(
+		otelgrpc.StreamServerInterceptor(),
 		utils.GRPCServerStreamErrorInterceptor,
 		a.Limiter.StreamServerInterceptor,
-		a.withAuthenticatedUserStreamInterceptor)
+		a.withAuthenticatedUserStreamInterceptor,
+	)
 }
 
 // authenticatedStream wraps around the embedded grpc.ServerStream
@@ -470,7 +504,7 @@ func (a *authenticatedStream) Context() context.Context {
 	return a.ctx
 }
 
-// GetUser returns authenticated user based on request metadata set by HTTP server
+// GetUser returns authenticated user based on request TLS metadata
 func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, error) {
 	peers := connState.PeerCertificates
 	if len(peers) > 1 {
@@ -478,10 +512,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 		// https://github.com/kubernetes/kubernetes/pull/34524/files#diff-2b283dde198c92424df5355f39544aa4R59
 		return nil, trace.AccessDenied("access denied: intermediaries are not supported")
 	}
-	localClusterName, err := a.AccessPoint.GetClusterName()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+
 	// with no client authentication in place, middleware
 	// assumes not-privileged Nop role.
 	// it theoretically possible to use bearer token auth even
@@ -491,7 +522,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 		return BuiltinRole{
 			Role:        types.RoleNop,
 			Username:    string(types.RoleNop),
-			ClusterName: localClusterName.GetClusterName(),
+			ClusterName: a.ClusterName,
 			Identity:    tlsca.Identity{},
 		}, nil
 	}
@@ -531,7 +562,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 	// by creating a cert pool constructed of trusted certificate authorities
 	// 2. Remote CAs are not allowed to have the same cluster name
 	// as the local certificate authority
-	if certClusterName != localClusterName.GetClusterName() {
+	if certClusterName != a.ClusterName {
 		// make sure that this user does not have system role
 		// the local auth server can not truste remote servers
 		// to issue certificates with system roles (e.g. Admin),
@@ -568,7 +599,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 			Role:                  *systemRole,
 			AdditionalSystemRoles: extractAdditionalSystemRoles(identity.SystemRoles),
 			Username:              identity.Username,
-			ClusterName:           localClusterName.GetClusterName(),
+			ClusterName:           a.ClusterName,
 			Identity:              *identity,
 		}, nil
 	}

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -193,7 +193,7 @@ func TestMiddlewareGetUser(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 
 			m := &Middleware{
-				AccessPoint: s,
+				ClusterName: localClusterName,
 			}
 
 			id, err := m.GetUser(tls.ConnectionState{PeerCertificates: tt.peers})
@@ -271,10 +271,12 @@ func TestWrapContextWithUser(t *testing.T) {
 		},
 	}
 
+	clusterName, err := s.GetClusterName()
+	require.NoError(t, err)
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			m := &Middleware{
-				AccessPoint: s,
+				ClusterName: clusterName.GetClusterName(),
 			}
 
 			conn := &testConn{

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -191,7 +191,7 @@ func TestAcceptedUsage(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.GetNodes(ctx, apidefaults.Namespace)
-	require.True(t, trace.IsAccessDenied(err))
+	require.ErrorIs(t, err, trace.ConnectionProblem(nil, `connection error: desc = "error reading server preface: EOF"`))
 
 	// restricted clients can will be rejected, for now if there is any mismatch,
 	// including extra usage.
@@ -201,7 +201,7 @@ func TestAcceptedUsage(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.GetNodes(ctx, apidefaults.Namespace)
-	require.True(t, trace.IsAccessDenied(err))
+	require.ErrorIs(t, err, trace.ConnectionProblem(nil, `connection error: desc = "error reading server preface: EOF"`))
 }
 
 // TestRemoteRotation tests remote builtin role

--- a/lib/auth/transport_credentials.go
+++ b/lib/auth/transport_credentials.go
@@ -1,0 +1,252 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc/credentials"
+
+	apievents "github.com/gravitational/teleport/api/types/events"
+)
+
+// UserGetter is responsible for building an authenticated user based on TLS metadata
+type UserGetter interface {
+	GetUser(connState tls.ConnectionState) (IdentityGetter, error)
+}
+
+// ConnectionIdentity contains the identifying properties of a
+// client connection required to enforce connection limits.
+type ConnectionIdentity struct {
+	// Username is the name of the user
+	Username string
+	// MaxConnections the upper limit to number of open connections for a user
+	MaxConnections int64
+	// LocalAddr is the local address for the connection
+	LocalAddr string
+	// RemoteAddr is the remote address for the connection
+	RemoteAddr string
+	// UserMetadata contains metadata for a user
+	UserMetadata apievents.UserMetadata
+}
+
+// ConnectionEnforcer limits incoming connections based on
+// max connection settings.
+type ConnectionEnforcer interface {
+	EnforceConnectionLimits(ctx context.Context, identity ConnectionIdentity, closers ...io.Closer) (context.Context, error)
+}
+
+// TransportCredentialsConfig configures the behavior that occurs
+// during the server handshake by the TransportCredentials
+type TransportCredentialsConfig struct {
+	// TransportCredentials provide the credentials that are used to perform the TLS
+	// server and client handshakes as well as the [credentials.ProtocolInfo]. This
+	// **MUST** not be nil, and it must have its [credentials.ProtocolInfo.SecurityProtocol]
+	// equal to "tls".
+	TransportCredentials credentials.TransportCredentials
+	// UserGetter constructs the clients' [tlsca.Identity] from the [tls.ConnectionState]
+	// that is received from the TLS handshake. This
+	UserGetter UserGetter
+	// Authorizer prevents any connections from being established if the user is not
+	// authorized due to locks, private key policy, device trust, etc. If not set
+	// then no authorization is performed.
+	Authorizer Authorizer
+	// Enforcer prevents any connections from being established if the user would
+	// exceed their configured max connection limit. Any connections that are
+	// permitted may be terminated if there is an issue determining if the number
+	// of active connections is within the limit. If not set then no connection
+	// limits are enforced.
+	Enforcer ConnectionEnforcer
+}
+
+// Check validates that the configuration is valid for use and
+// that all supplied parameters are set accordingly.
+func (c *TransportCredentialsConfig) Check() error {
+	switch {
+	case c.TransportCredentials == nil:
+		return trace.BadParameter("parameter TransportCredentials required")
+	case c.TransportCredentials.Info().SecurityProtocol != "tls":
+		return trace.BadParameter("the TransportCredentials must be a tls security protocol, got %s", c.TransportCredentials.Info().SecurityProtocol)
+	case c.UserGetter == nil:
+		return trace.BadParameter("parameter UserGetter required")
+	case c.Authorizer != nil && c.UserGetter == nil:
+		return trace.BadParameter("a UserGetter is required to use validate identities with an Authorizer")
+	case c.Enforcer != nil && c.Authorizer == nil:
+		return trace.BadParameter("both a UserGetter and an Authorizer are required to enforce connection limits with an Enforcer")
+	default:
+		return nil
+	}
+}
+
+// TransportCredentials is a [credentials.TransportCredentials] that
+// enforces mTLS and retrieves the [IdentityGetter] for use by middleware
+// to perform authorization.
+type TransportCredentials struct {
+	credentials.TransportCredentials
+
+	userGetter UserGetter
+	authorizer Authorizer
+	enforcer   ConnectionEnforcer
+}
+
+// NewTransportCredentials returns a new TransportCredentials
+func NewTransportCredentials(cfg TransportCredentialsConfig) (*TransportCredentials, error) {
+	if err := cfg.Check(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &TransportCredentials{
+		TransportCredentials: cfg.TransportCredentials,
+		userGetter:           cfg.UserGetter,
+		authorizer:           cfg.Authorizer,
+		enforcer:             cfg.Enforcer,
+	}, nil
+}
+
+// IdentityInfo contains the auth information and identity
+// for an authenticated TLS connection. It implements the
+// [credentials.AuthInfo] interface and is returned from
+// [TransportCredentials.ServerHandshake].
+type IdentityInfo struct {
+	// TLSInfo contains TLS connection information.
+	*credentials.TLSInfo
+	// IdentityGetter provides a mechanism to retrieve the
+	// identity of the client.
+	IdentityGetter IdentityGetter
+	// AuthContext contains information about the traits and roles
+	// that an identity may have. This will be unset if the
+	// [TransportCredentialsConfig.Authorizer] provided to [NewTransportCredentials]
+	// was nil.
+	AuthContext *Context
+}
+
+// ServerHandshake does the authentication handshake for servers. It returns
+// the authenticated connection and the corresponding auth information about
+// the connection.
+// At minimum the TLS handshake is performed and the identity is built from
+// the [tls.ConnectionState]. If the TransportCredentials is configured with
+// and Authorizer and ConnectionEnforcer then additional session controls are
+// applied before the handshake completes.
+func (c *TransportCredentials) ServerHandshake(rawConn net.Conn) (_ net.Conn, _ credentials.AuthInfo, err error) {
+	conn, tlsInfo, err := c.performTLSHandshake(rawConn)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	defer func() {
+		if err != nil {
+			conn.Close()
+		}
+	}()
+
+	identityGetter, err := c.userGetter.GetUser(tlsInfo.State)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	ctx := context.Background()
+	authCtx, err := c.authorize(ctx, conn.RemoteAddr().String(), identityGetter, &tlsInfo.State)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	if err := c.enforceConnectionLimits(ctx, authCtx, conn); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return conn, IdentityInfo{
+		TLSInfo:        tlsInfo,
+		IdentityGetter: identityGetter,
+		AuthContext:    authCtx,
+	}, nil
+}
+
+// performTLSHandshake does the TLS handshake and validates the
+// returned [credentials.AuthInfo] are of type [credentials.TLSInfo].
+func (c *TransportCredentials) performTLSHandshake(rawConn net.Conn) (net.Conn, *credentials.TLSInfo, error) {
+	conn, info, err := c.TransportCredentials.ServerHandshake(rawConn)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	tlsInfo, ok := info.(credentials.TLSInfo)
+	if !ok {
+		conn.Close()
+		return nil, nil, trace.BadParameter("unexpected type in tls auth info %T", info)
+	}
+
+	return conn, &tlsInfo, nil
+}
+
+// authorize enforces that the identity is not restricted from connecting due
+// to things like locks, private key policy, device trust, etc. If the TransportCredentials
+// was not configured to do authorization then this is a noop and will return nil, nil.
+func (c *TransportCredentials) authorize(ctx context.Context, remoteAddr string, identityGetter IdentityGetter, connState *tls.ConnectionState) (*Context, error) {
+	if c.authorizer == nil {
+		return &Context{
+			Identity: identityGetter,
+		}, nil
+	}
+
+	// construct a context with the keys expected by the Authorizer
+	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(connState))
+	ctx = context.WithValue(ctx, ContextClientAddr, remoteAddr)
+	ctx = context.WithValue(ctx, ContextUser, identityGetter)
+
+	authCtx, err := c.authorizer.Authorize(ctx)
+	return authCtx, trace.Wrap(err)
+}
+
+// enforceConnectionLimits prevents the identity from exceeding any configured
+// connection limits. The provided connection will be closed by the enforcer
+// if connectivity to Auth is interrupted. If the TransportCredentials
+// was not configured to do connection limiting then this is a noop and will return nil.
+func (c *TransportCredentials) enforceConnectionLimits(ctx context.Context, authCtx *Context, conn net.Conn) error {
+	if c.enforcer == nil {
+		return nil
+	}
+
+	if authCtx == nil || authCtx.Checker == nil {
+		return trace.BadParameter("unable to determine connection limits without a valid auth context")
+	}
+
+	_, err := c.enforcer.EnforceConnectionLimits(
+		ctx,
+		ConnectionIdentity{
+			Username:       authCtx.User.GetName(),
+			MaxConnections: authCtx.Checker.MaxConnections(),
+			LocalAddr:      conn.LocalAddr().String(),
+			RemoteAddr:     conn.RemoteAddr().String(),
+			UserMetadata:   ClientUserMetadata(ctx),
+		},
+		conn,
+	)
+
+	return trace.Wrap(err)
+}
+
+// Clone makes a copy of this TransportCredentials.
+func (c *TransportCredentials) Clone() credentials.TransportCredentials {
+	return &TransportCredentials{
+		userGetter:           c.userGetter,
+		authorizer:           c.authorizer,
+		enforcer:             c.enforcer,
+		TransportCredentials: c.TransportCredentials.Clone(),
+	}
+}

--- a/lib/auth/transport_credentials_test.go
+++ b/lib/auth/transport_credentials_test.go
@@ -1,0 +1,430 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// TestTransportCredentials_Check validates the returned values
+// from [TransportCredentialsConfig.Check] based on various inputs.
+func TestTransportCredentials_Check(t *testing.T) {
+	tlsConf := newTLSConfig(t)
+
+	cases := []struct {
+		name                string
+		tlsConf             *tls.Config
+		conf                TransportCredentialsConfig
+		errAssertion        require.ErrorAssertionFunc
+		credentialAssertion require.ValueAssertionFunc
+	}{
+		{
+			name: "invalid configuration: no transport credentials",
+			errAssertion: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, trace.BadParameter("parameter TransportCredentials required"))
+			},
+			credentialAssertion: require.Nil,
+		},
+		{
+			name: "invalid configuration: bad transport credentials security protocol",
+			errAssertion: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, trace.BadParameter("the TransportCredentials must be a tls security protocol, got insecure"))
+			},
+			conf:                TransportCredentialsConfig{TransportCredentials: insecure.NewCredentials()},
+			credentialAssertion: require.Nil,
+		},
+		{
+			name: "invalid configuration: no user getter provided",
+			errAssertion: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, trace.BadParameter("parameter UserGetter required"))
+			},
+			conf:                TransportCredentialsConfig{TransportCredentials: credentials.NewTLS(tlsConf.Clone())},
+			credentialAssertion: require.Nil,
+		},
+		{
+			name: "invalid configuration: connection enforcer provided without an authorizer",
+			errAssertion: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, trace.BadParameter("both a UserGetter and an Authorizer are required to enforce connection limits with an Enforcer"))
+			},
+			conf: TransportCredentialsConfig{
+				TransportCredentials: credentials.NewTLS(tlsConf.Clone()),
+				UserGetter:           &Middleware{},
+				Enforcer:             &fakeEnforcer{},
+			},
+			credentialAssertion: require.Nil,
+		},
+		{
+			name:         "valid configuration: without connection limiter or authorizer",
+			errAssertion: require.NoError,
+			conf: TransportCredentialsConfig{
+				TransportCredentials: credentials.NewTLS(tlsConf.Clone()),
+				UserGetter:           &Middleware{},
+			},
+			credentialAssertion: require.NotNil,
+		},
+		{
+			name:         "valid configuration: without connection limiter",
+			errAssertion: require.NoError,
+			conf: TransportCredentialsConfig{
+				TransportCredentials: credentials.NewTLS(tlsConf.Clone()),
+				UserGetter:           &Middleware{},
+				Authorizer:           &fakeAuthorizer{},
+			},
+			credentialAssertion: require.NotNil,
+		},
+		{
+			name:         "valid configuration",
+			errAssertion: require.NoError,
+			conf: TransportCredentialsConfig{
+				TransportCredentials: credentials.NewTLS(tlsConf.Clone()),
+				UserGetter:           &Middleware{},
+				Authorizer:           &fakeAuthorizer{},
+			},
+			credentialAssertion: require.NotNil,
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			creds, err := NewTransportCredentials(test.conf)
+			test.errAssertion(t, err)
+			test.credentialAssertion(t, creds)
+		})
+	}
+}
+
+// TestTransportCredentials_ServerHandshake validates that the [TransportCredentials.ServerHandshake]
+// behaves as expected based on the TransportCredentialsConfig that were used to populate it and the
+// [tls.Config] used by the client.
+func TestTransportCredentials_ServerHandshake(t *testing.T) {
+	t.Parallel()
+
+	unauthorized := trace.AccessDenied("not authorized")
+	tooManyConnections := trace.LimitExceeded("too many connections")
+	tlsConf := newTLSConfig(t)
+
+	cases := []struct {
+		name               string
+		conf               TransportCredentialsConfig
+		clientTLSConf      *tls.Config
+		errAssertion       require.ErrorAssertionFunc
+		handshakeAssertion require.ErrorAssertionFunc
+		infoAssertion      func(t *testing.T, info credentials.AuthInfo)
+	}{
+		{
+			name: "valid connection without session control",
+			conf: TransportCredentialsConfig{
+				TransportCredentials: credentials.NewTLS(tlsConf.Clone()),
+				UserGetter:           &Middleware{ClusterName: "test"},
+			},
+			clientTLSConf:      &tls.Config{InsecureSkipVerify: true},
+			errAssertion:       require.NoError,
+			handshakeAssertion: require.NoError,
+			infoAssertion: func(t *testing.T, info credentials.AuthInfo) {
+				identityInfo, ok := info.(IdentityInfo)
+				require.True(t, ok)
+				require.NotNil(t, identityInfo.TLSInfo)
+				require.NotNil(t, identityInfo.IdentityGetter)
+				require.NotNil(t, identityInfo.AuthContext)
+				require.NotNil(t, identityInfo.AuthContext.Identity)
+				require.Nil(t, identityInfo.AuthContext.Checker)
+			},
+		},
+		{
+			name: "valid connection with authorization but no connection limiting",
+			conf: TransportCredentialsConfig{
+				TransportCredentials: credentials.NewTLS(tlsConf.Clone()),
+				UserGetter:           &Middleware{ClusterName: "test"},
+				Authorizer:           &fakeAuthorizer{},
+			},
+			clientTLSConf:      &tls.Config{InsecureSkipVerify: true},
+			errAssertion:       require.NoError,
+			handshakeAssertion: require.NoError,
+			infoAssertion: func(t *testing.T, info credentials.AuthInfo) {
+				identityInfo, ok := info.(IdentityInfo)
+				require.True(t, ok)
+				require.NotNil(t, identityInfo.IdentityGetter)
+				require.NotNil(t, identityInfo.AuthContext)
+			},
+		},
+		{
+			name: "valid connection with full session control",
+			conf: TransportCredentialsConfig{
+				TransportCredentials: credentials.NewTLS(tlsConf.Clone()),
+				UserGetter:           &Middleware{ClusterName: "test"},
+				Authorizer: &fakeAuthorizer{
+					checker: &fakeChecker{maxConnections: 1},
+				},
+				Enforcer: &fakeEnforcer{},
+			},
+			clientTLSConf:      &tls.Config{InsecureSkipVerify: true},
+			errAssertion:       require.NoError,
+			handshakeAssertion: require.NoError,
+			infoAssertion: func(t *testing.T, info credentials.AuthInfo) {
+				identityInfo, ok := info.(IdentityInfo)
+				require.True(t, ok)
+				require.NotNil(t, identityInfo.IdentityGetter)
+				require.NotNil(t, identityInfo.AuthContext)
+			},
+		},
+		{
+			name: "not authorized",
+			conf: TransportCredentialsConfig{
+				TransportCredentials: credentials.NewTLS(tlsConf.Clone()),
+				UserGetter:           &Middleware{ClusterName: "test"},
+				Authorizer:           &fakeAuthorizer{authorizeError: unauthorized},
+			},
+			clientTLSConf: &tls.Config{InsecureSkipVerify: true},
+			errAssertion: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, unauthorized)
+			},
+			handshakeAssertion: require.NoError,
+			infoAssertion: func(t *testing.T, info credentials.AuthInfo) {
+				require.Nil(t, info)
+			},
+		},
+		{
+			name: "connection limits exceeded",
+			conf: TransportCredentialsConfig{
+				TransportCredentials: credentials.NewTLS(tlsConf.Clone()),
+				UserGetter:           &Middleware{ClusterName: "test"},
+				Authorizer:           &fakeAuthorizer{checker: &fakeChecker{maxConnections: 1}},
+				Enforcer:             &fakeEnforcer{err: tooManyConnections},
+			},
+			clientTLSConf: &tls.Config{InsecureSkipVerify: true},
+			errAssertion: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, tooManyConnections)
+			},
+			handshakeAssertion: require.NoError,
+			infoAssertion: func(t *testing.T, info credentials.AuthInfo) {
+				require.Nil(t, info)
+			},
+		},
+		{
+			name: "tls handshake failure",
+			conf: TransportCredentialsConfig{
+				TransportCredentials: credentials.NewTLS(tlsConf.Clone()),
+				UserGetter:           &Middleware{ClusterName: "test"},
+			},
+			clientTLSConf:      &tls.Config{InsecureSkipVerify: false},
+			handshakeAssertion: require.Error,
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, ln.Close())
+			})
+
+			creds, err := NewTransportCredentials(test.conf)
+			require.NoError(t, err)
+
+			errC := make(chan error, 1)
+			doneC := make(chan credentials.AuthInfo, 1)
+			go func() {
+				conn, err := ln.Accept()
+				if err != nil {
+					errC <- err
+					return
+				}
+				defer conn.Close()
+
+				conn, info, err := creds.ServerHandshake(conn)
+				if err != nil {
+					errC <- err
+					return
+				}
+
+				conn.Close()
+				doneC <- info
+			}()
+
+			conn, err := net.Dial("tcp", ln.Addr().String())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+			clientConn := tls.Client(conn, test.clientTLSConf)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			err = clientConn.HandshakeContext(ctx)
+			test.handshakeAssertion(t, err)
+
+			if err != nil {
+				return
+			}
+
+			select {
+			case err := <-errC:
+				test.errAssertion(t, err)
+			case info := <-doneC:
+				test.infoAssertion(t, info)
+
+			}
+		})
+	}
+}
+
+type fakeChecker struct {
+	services.AccessChecker
+	maxConnections int64
+}
+
+func (c *fakeChecker) MaxConnections() int64 {
+	return c.maxConnections
+}
+
+type fakeAuthorizer struct {
+	authorizeError error
+	checker        services.AccessChecker
+}
+
+func (a *fakeAuthorizer) Authorize(ctx context.Context) (*Context, error) {
+	if a.authorizeError != nil {
+		return nil, a.authorizeError
+	}
+
+	user, err := types.NewUser("llama")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Context{
+		User:    user,
+		Checker: a.checker,
+	}, nil
+}
+
+type fakeEnforcer struct {
+	ctx context.Context
+	err error
+}
+
+func (e *fakeEnforcer) EnforceConnectionLimits(ctx context.Context, identity ConnectionIdentity, closers ...io.Closer) (context.Context, error) {
+	return e.ctx, e.err
+}
+
+func newTLSConfig(t *testing.T) *tls.Config {
+	cert, err := tls.X509KeyPair(tlsCert, keyPEM)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(tlsCACert))
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+	}
+}
+
+var (
+	tlsCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDyzCCArOgAwIBAgIQD3MiJ2Au8PicJpCNFbvcETANBgkqhkiG9w0BAQsFADBe
+MRQwEgYDVQQKEwtleGFtcGxlLmNvbTEUMBIGA1UEAxMLZXhhbXBsZS5jb20xMDAu
+BgNVBAUTJzIwNTIxNzE3NzMzMTIxNzQ2ODMyNjA5NjAxODEwODc0NTAzMjg1ODAe
+Fw0yMTAyMTcyMDI3MjFaFw0yMTAyMTgwODI4MjFaMIGCMRUwEwYDVQQHEwxhY2Nl
+c3MtYWRtaW4xCTAHBgNVBAkTADEYMBYGA1UEEQwPeyJsb2dpbnMiOm51bGx9MRUw
+EwYDVQQKEwxhY2Nlc3MtYWRtaW4xFTATBgNVBAMTDGFjY2Vzcy1hZG1pbjEWMBQG
+BSvODwEHEwtleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAM5FFaCeK59lwIthyXgSCMZbHTDxsy66Cbm/XhwFbKQLngyS0oKkHbh06INN
+UfTAAEaFlMG0CzdAyGyRSu9FK8BE127kRHBs6hb1pTgy2f6TFkFo/h4WTWW4GQSi
+O8Al7A2tuRjc3mAnk71q+kvpQYS7tnkhmFCYE8jKxMtlYG39x4kQ6btll7P9zI6X
+Zv5RRrlzqADuwZpEcLYVi0TjITqPbx3rDZT4l+EmslhaoG+xE5Vu+GYXLlvwB9E/
+amfN1Z9Kps4Ob6Jxxse9kjeMir9mwiNkBWVyhH/LETDA9Xa6sTQ2e75MYM7yXJLY
+OmBKV4g176Qf1T1ye7a/Ggn4t2UCAwEAAaNgMF4wDgYDVR0PAQH/BAQDAgWgMB0G
+A1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB8GA1Ud
+IwQYMBaAFJWqMooE05nf263F341pOO+mPMSqMA0GCSqGSIb3DQEBCwUAA4IBAQCK
+s0yPzkSuCY/LFeHJoJeNJ1SR+EKbk4zoAnD0nbbIsd2quyYIiojshlfehhuZE+8P
+bzpUNG2aYKq+8lb0NO+OdZW7kBEDWq7ZwC8OG8oMDrX385fLcicm7GfbGCmZ6286
+m1gfG9yqEte7pxv3yWM+7X2bzEjCBds4feahuKPNxOAOSfLUZiTpmOVlRzrpRIhu
+2XxiuH+E8n4AP8jf/9bGvKd8PyHohtHVf8HWuKLZxWznQhoKkcfmUmlz5q8ci4Bq
+WQdM2NXAMABGAofGrVklPIiraUoHzr0Xxpia4vQwRewYXv8bCPHW+8g8vGBGvoG2
+gtLit9DL5DR5ac/CRGJt
+-----END CERTIFICATE-----`)
+
+	keyPEM = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAzkUVoJ4rn2XAi2HJeBIIxlsdMPGzLroJub9eHAVspAueDJLS
+gqQduHTog01R9MAARoWUwbQLN0DIbJFK70UrwETXbuREcGzqFvWlODLZ/pMWQWj+
+HhZNZbgZBKI7wCXsDa25GNzeYCeTvWr6S+lBhLu2eSGYUJgTyMrEy2Vgbf3HiRDp
+u2WXs/3Mjpdm/lFGuXOoAO7BmkRwthWLROMhOo9vHesNlPiX4SayWFqgb7ETlW74
+ZhcuW/AH0T9qZ83Vn0qmzg5vonHGx72SN4yKv2bCI2QFZXKEf8sRMMD1drqxNDZ7
+vkxgzvJcktg6YEpXiDXvpB/VPXJ7tr8aCfi3ZQIDAQABAoIBAE1Vk207wAksAgt/
+5yQwRr/vizs9czuSnnDYsbT5x6idfm0iYvB+DXKJyl7oD1Ee5zuJe6NAGHBnxn0F
+4D1jBqs4ZDj8NjicbQucn4w5bIfIp7BwZ83p+KypYB/fn11EGoNqXZpXvLv6Oqbq
+w9rQIjNcmWZC1TNqQQioFS5Y3NV/gw5uYCRXZlSLMsRCvcX2+LN2EP76ZbkpIVpT
+CidC2TxwFPPbyMsG774Olfz4U2IDgX1mO+milF7RIa/vPADSeHAX6tJHmZ13GsyP
+0GAdPbFa0Ls/uykeGi1uGPFkdkNEqbWlDf1Z9IG0dr/ck2eh8G2X8E+VFgzsKp4k
+WtH9nGECgYEA53lFodLiKQjQR7IoUmGp+P6qnrDwOdU1RfT9jse35xOb9tYvZs3X
+kUXU+MEGAMW1Pvmo1v9xOjZbdFYB9I/tIYTSyjYQNaFjgJMPMLSx2qjMzhFXAY5f
+8t20/CBt2V1q46aa8tR2ll//QvY4mqvJUaaB0pkuasFbKMXJcGKdvdkCgYEA5CAo
+UI8NVA9GqAJfs7hkGHQwpX1X1+JpFhF4dZKsV40NReqaK0vd/mWTYjlMOPO6oolr
+PoCDUlQYU6poIDtEnfJ6KkYuLMgxZKnS2OlDthKoZJe9aUTCP1RhTVHyyABRXbGg
+tNMKFYkZ38C9+JM+X5T0eKZTHeK+wjiZd55+sm0CgYAmyp0PxI6gP9jf2wyE2dcp
+YkxnsdFgb8mwwqDnl7LLJ+8gS76/5Mk2kFRjp72AzaFVP3O7LC3miouDEJLdUG12
+C5NjzfGjezt4payLBg00Tsub0S4alaigw+T7x9eA8PXj1tzqyw5gnw/hQfA0g4uG
+gngJOiCcRXEogRUEH5K96QKBgFUnB8ViUHhTJ22pTS3Zo0tZe5saWYLVGaLKLKu+
+byRTG2RAuQF2VUwTgFtGxgPwPndTUjvHXr2JdHcugaWeWfOXQjCrd6rxozZPCcw7
+7jF1b3P1DBfSOavIBHYHI9ex/q05k6JLsFTvkz/pQ0AZPkwRXtv2QcpDDC+VTvvO
+pr5VAoGBAJBhNjs9wAu+ZoPcMZcjIXT/BAj2tQYiHoRnNpvQjDYbQueUBeI0Ry8d
+5QnKS2k9D278P6BiDBz1c+fS8UErOxY6CS0pi4x3fjMliPwXj/w7AzjlXgDBhRcp
+90Ns/9SamlBo9j8ETm9g9D3EVir9zF5XvoR13OdN9gabGy1GuubT
+-----END RSA PRIVATE KEY-----`)
+
+	tlsCACert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDiTCCAnGgAwIBAgIRAJlp/39yg8U604bjsxgcoC0wDQYJKoZIhvcNAQELBQAw
+XjEUMBIGA1UEChMLZXhhbXBsZS5jb20xFDASBgNVBAMTC2V4YW1wbGUuY29tMTAw
+LgYDVQQFEycyMDM5MjIyNTY2MzcxMDQ0NDc3MzYxNjA0MTk0NjU2MTgzMDA5NzMw
+HhcNMjEwMjAzMDAyOTQ2WhcNMzEwMjAxMDAyOTQ2WjBeMRQwEgYDVQQKEwtleGFt
+cGxlLmNvbTEUMBIGA1UEAxMLZXhhbXBsZS5jb20xMDAuBgNVBAUTJzIwMzkyMjI1
+NjYzNzEwNDQ0NzczNjE2MDQxOTQ2NTYxODMwMDk3MzCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBAKnIJmcKgzj/FbvF6/OYkw3owsS3XU6AcJZ7HmTfYpZF
+ozqTDVJdHMFQVfu6cp/6hkzoZ/t7hKT6Nd/O2mlIZdBCfT5ZKESRvTGAeCUANKA5
+/D4+6PDdW6AutOFUGbHQ1nYLB7HRgaXF/aZmzFPsPNwX8Wm8EByL+Dws61EmSBBv
+Soado5rPG78mAnRpFvyYbzBDkxzsgLIfv0EPw9jhSjrT3OVjCXnBv53u2S+UbJfR
+jmI7MutjNbJ/rIBp7JpRHJASmW7oj65WPH0SE0+67XwXYKbs0b7CcSuYW+1S+l9R
+uGswW4hqwMloP9sTZoWzgT+nCXQSYUavQF+UJZ/dklMCAwEAAaNCMEAwDgYDVR0P
+AQH/BAQDAgKkMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFC4555Otcq4GAYcc
+QQDJgh1TKrFvMA0GCSqGSIb3DQEBCwUAA4IBAQBYsEMJYmSD6Dc1suUEnkWo7kOw
+va/aaOu0Phy9SK3hCjg+tatHVVDHO2dZdVCAvCe36BcLiZL1ovFZAXzEzOovwLx/
+AVjXpMXTJj52RSMOAtRVSkk3/WOHrGOGIBW2bCKxF4ORXJfWJrdtaObwPPV5sbDC
+ACdlNMujdBfUM8EDNmvREI/sVmqL6FK9l6elO/bWLJoiaRTxI+CMixpfIYq8pAwJ
+UpgZGjcwco4eqXm7rgbQ4wLaMU6hyk8OE5Glk5E6qpnbVzlrL/jl2iE6EqvI6GJn
+Na6B0YR7mdrrL+lyzymnOr6UOrT5nUWRAB1QeY7dhBNnsvoZwaS3VLSc1KCk
+-----END CERTIFICATE-----`)
+)

--- a/lib/kube/grpc/grpc_test.go
+++ b/lib/kube/grpc/grpc_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"k8s.io/client-go/rest"
@@ -35,7 +34,6 @@ import (
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/limiter"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestListKubernetesResources(t *testing.T) {
@@ -386,25 +384,26 @@ func initGRPCServer(t *testing.T, testCtx *kubeproxy.TestContext, listener net.L
 	// adds authentication information to the context
 	// and passes it to the API server
 	authMiddleware := &auth.Middleware{
-		AccessPoint:   testCtx.AuthClient,
+		ClusterName:   clusterName,
 		Limiter:       limiter,
 		AcceptedUsage: []string{teleport.UsageKubeOnly},
 	}
 
+	tlsConf := copyAndConfigureTLS(tlsConfig, logrus.New(), testCtx.AuthClient, clusterName)
+	creds, err := auth.NewTransportCredentials(auth.TransportCredentialsConfig{
+		TransportCredentials: credentials.NewTLS(tlsConf),
+		UserGetter:           authMiddleware,
+	})
+	require.NoError(t, err)
+
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
-			utils.GRPCServerUnaryErrorInterceptor,
-			otelgrpc.UnaryServerInterceptor(),
 			authMiddleware.UnaryInterceptor(),
 		),
 		grpc.ChainStreamInterceptor(
-			utils.GRPCServerStreamErrorInterceptor,
-			otelgrpc.StreamServerInterceptor(),
 			authMiddleware.StreamInterceptor(),
 		),
-		grpc.Creds(credentials.NewTLS(
-			copyAndConfigureTLS(tlsConfig, logrus.New(), testCtx.AuthClient, clusterName),
-		)),
+		grpc.Creds(creds),
 	)
 	t.Cleanup(grpcServer.GracefulStop)
 	// Auth client, lock watcher and authorizer for Kube proxy.

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -173,11 +173,16 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		return nil, trace.BadParameter("kube_service won't start because it has neither static clusters nor a resource watcher configured.")
 	}
 
+	clustername, err := cfg.AccessPoint.GetClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// authMiddleware authenticates request assuming TLS client authentication
 	// adds authentication information to the context
 	// and passes it to the API server
 	authMiddleware := &auth.Middleware{
-		AccessPoint:   cfg.AccessPoint,
+		ClusterName:   clustername.GetClusterName(),
 		AcceptedUsage: []string{teleport.UsageKubeOnly},
 	}
 	authMiddleware.Wrap(fwd)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3753,6 +3753,32 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		return trace.Wrap(err)
 	}
 
+	authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+		ClusterName: clusterName,
+		AccessPoint: accessPoint,
+		LockWatcher: lockWatcher,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// authMiddleware authenticates request assuming TLS client authentication
+	// adds authentication information to the context
+	// and passes it to the API server
+	authMiddleware := &auth.Middleware{
+		ClusterName: clusterName,
+	}
+
+	creds, err := auth.NewTransportCredentials(auth.TransportCredentialsConfig{
+		TransportCredentials: credentials.NewTLS(serverTLSConfig),
+		UserGetter:           authMiddleware,
+		Authorizer:           authorizer,
+		Enforcer:             sessionController,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	sshGRPCServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			utils.GRPCServerUnaryErrorInterceptor,
@@ -3762,7 +3788,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			utils.GRPCServerStreamErrorInterceptor,
 			otelgrpc.StreamServerInterceptor(),
 		),
-		grpc.Creds(credentials.NewTLS(serverTLSConfig)),
+		grpc.Creds(creds),
 	)
 
 	process.RegisterCriticalFunc("proxy.ssh", func() error {
@@ -3779,7 +3805,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 		// start grpc server
 		go func() {
-			if err := sshGRPCServer.Serve(proxyLimiter.WrapListener(listeners.sshGRPC)); !errors.Is(err, grpc.ErrServerStopped) {
+			if err := sshGRPCServer.Serve(proxyLimiter.WrapListener(listeners.sshGRPC)); err != nil && !utils.IsOKNetworkError(err) && !errors.Is(err, grpc.ErrServerStopped) {
 				log.WithError(err).Error("SSH gRPC server terminated unexpectedly")
 			}
 		}()
@@ -5246,25 +5272,28 @@ func (process *TeleportProcess) initSecureGRPCServer(cfg initSecureGRPCServerCfg
 	// adds authentication information to the context
 	// and passes it to the API server
 	authMiddleware := &auth.Middleware{
-		AccessPoint:   cfg.accessPoint,
+		ClusterName:   clusterName,
 		Limiter:       cfg.limiter,
 		AcceptedUsage: []string{teleport.UsageKubeOnly},
 	}
 
+	tlsConf := copyAndConfigureTLS(serverTLSConfig, process.log, cfg.accessPoint, clusterName)
+	creds, err := auth.NewTransportCredentials(auth.TransportCredentialsConfig{
+		TransportCredentials: credentials.NewTLS(tlsConf),
+		UserGetter:           authMiddleware,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	server := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
-			utils.GRPCServerUnaryErrorInterceptor,
-			otelgrpc.UnaryServerInterceptor(),
 			authMiddleware.UnaryInterceptor(),
 		),
 		grpc.ChainStreamInterceptor(
-			utils.GRPCServerStreamErrorInterceptor,
-			otelgrpc.StreamServerInterceptor(),
 			authMiddleware.StreamInterceptor(),
 		),
-		grpc.Creds(credentials.NewTLS(
-			copyAndConfigureTLS(serverTLSConfig, process.log, cfg.accessPoint, clusterName),
-		)),
+		grpc.Creds(creds),
 	)
 
 	kubeServer, err := kubegprc.New(kubegprc.Config{

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -181,10 +181,16 @@ func NewProxyServer(ctx context.Context, config ProxyServerConfig) (*ProxyServer
 	if err := config.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	clustername, err := config.AccessPoint.GetClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	server := &ProxyServer{
 		cfg: config,
 		middleware: &auth.Middleware{
-			AccessPoint:   config.AccessPoint,
+			ClusterName:   clustername.GetClusterName(),
 			AcceptedUsage: []string{teleport.UsageDatabaseOnly},
 		},
 		closeCtx: ctx,

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -344,6 +344,11 @@ func New(ctx context.Context, config Config) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	clustername, err := config.AccessPoint.GetClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	server := &Server{
 		cfg:              config,
@@ -358,7 +363,7 @@ func New(ctx context.Context, config Config) (*Server, error) {
 		},
 		reconcileCh: make(chan struct{}),
 		middleware: &auth.Middleware{
-			AccessPoint:   config.AccessPoint,
+			ClusterName:   clustername.GetClusterName(),
 			AcceptedUsage: []string{teleport.UsageDatabaseOnly},
 		},
 	}

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -325,11 +325,16 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 		}
 	}
 
+	clustername, err := cfg.AccessPoint.GetClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	ctx, close := context.WithCancel(context.Background())
 	s := &WindowsService{
 		cfg: cfg,
 		middleware: &auth.Middleware{
-			AccessPoint:   cfg.AccessPoint,
+			ClusterName:   clustername.GetClusterName(),
 			AcceptedUsage: []string{teleport.UsageWindowsDesktopOnly},
 		},
 		dnsResolver: resolver,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7936,10 +7936,17 @@ func initGRPCServer(t *testing.T, env *webPack, listener net.Listener) {
 	// adds authentication information to the context
 	// and passes it to the API server
 	authMiddleware := &auth.Middleware{
-		AccessPoint:   proxyAuthClient,
+		ClusterName:   clusterName,
 		Limiter:       limiter,
 		AcceptedUsage: []string{teleport.UsageKubeOnly},
 	}
+
+	tlsConf := copyAndConfigureTLS(tlsConfig, logrus.New(), proxyAuthClient, clusterName)
+	creds, err := auth.NewTransportCredentials(auth.TransportCredentialsConfig{
+		TransportCredentials: credentials.NewTLS(tlsConf),
+		UserGetter:           authMiddleware,
+	})
+	require.NoError(t, err)
 
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
@@ -7948,9 +7955,7 @@ func initGRPCServer(t *testing.T, env *webPack, listener net.Listener) {
 		grpc.ChainStreamInterceptor(
 			authMiddleware.StreamInterceptor(),
 		),
-		grpc.Creds(credentials.NewTLS(
-			copyAndConfigureTLS(tlsConfig, logrus.New(), proxyAuthClient, clusterName),
-		)),
+		grpc.Creds(creds),
 	)
 
 	kubeproto.RegisterKubeServiceServer(grpcServer, &fakeKubeService{})


### PR DESCRIPTION
Adds a new `credentials.TransportCredentials` to auth and refactors
`auth.Middleware` to make use of them. This allows for less redundancy
per RPC and provides the ability to perform session control when grpc
connections are established.

The `auth.Middleware.withAuthenticatedUser` function was called from all
interceptors of any gRPC server that leveraged `auth.Middleware`. This
was constructing the identity of the client from the TLS certificate
per RPC. Since the identity of a connection cannot change between RPCs
there is no need to construct the identity in an interceptor. Instead,
the new `auth.TransportCredentials` can build the identity once after the
TLS handshake completes. When interceptors or gRPC handlers need to
acquire the identity they can do so using the same
mechanism via `peer.Peer.AuthInfo` and assert on the new `auth.IdentityInfo`
type:

```go
    peerInfo, ok := peer.FromContext(ctx)
	if !ok {
		return
	}

	connInfo, ok := peerInfo.AuthInfo.(auth.IdentityInfo)
	if !ok {
	    return
	}

	identity := connInfo.IdentityGetter.GetIdentity()
	connState := connInfo.TLSInfo.State
```

The gRPC server that is served on the Proxy ssh port needs to hold the
same invariants as the ssh server available on the same port. This
means that connection limits need to be enforced when new connections
are established. To achieve this the new `auth.TransportCredentials` can
be provided with an `auth.ConnectionEnforcer` and an `auth.Authorizer`
to first build an identity, then ensures that the user is authorized and
finally that the user has not exceeded their connection limits.

Other minor changes include providing the cluster name to the
`auth.Middleware` instead of it looking the value up from the cache every
time an identity is created. Some interceptors were also moved around or
removed to eliminate the chances of having duplicate interceptors end up in
the interceptor chain.

Part of #19812