### PR TITLE
[v12] Refer to tsh apps subcommand

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -617,12 +617,12 @@ Set `auth_service.authentication.require_session_mfa: hardware_key_touch` in you
 
 ## Moderated session
 
-Using `tsh` join an SSH session as two moderators (two separate terminals, role requires one moderator). 
- - [ ] `Ctrl+C` in the #1 terminal should disconnect the moderator. 
+Using `tsh` join an SSH session as two moderators (two separate terminals, role requires one moderator).
+ - [ ] `Ctrl+C` in the #1 terminal should disconnect the moderator.
  - [ ] `Ctrl+C` in the #2 terminal should disconnect the moderator and terminate the session as session has no moderator.
 
 Using `tsh` join an SSH session as two moderators (two separate terminals, role requires one moderator).
-- [ ] `t` in any terminal should terminate the session for all participants. 
+- [ ] `t` in any terminal should terminate the session for all participants.
 
 ## Performance
 
@@ -722,14 +722,14 @@ tsh bench sessions --max=5000 --web user ls
   - [ ] `tsh play <chunk-id>` can fetch and print a session chunk archive.
 - [ ] Verify JWT using [verify-jwt.go](https://github.com/gravitational/teleport/blob/master/examples/jwt/verify-jwt.go).
 - [ ] Verify RBAC.
-- [ ] Verify [CLI access](https://goteleport.com/docs/application-access/guides/api-access/) with `tsh app login`.
+- [ ] Verify [CLI access](https://goteleport.com/docs/application-access/guides/api-access/) with `tsh apps login`.
 - [ ] Verify [AWS console access](https://goteleport.com/docs/application-access/cloud-apis/aws-console/).
   - [ ] Can log into AWS web console through the web UI.
   - [ ] Can interact with AWS using `tsh aws` commands.
-- [ ] Verify [Azure CLI access](https://goteleport.com/docs/application-access/cloud-apis/azure/) with `tsh app login`.
+- [ ] Verify [Azure CLI access](https://goteleport.com/docs/application-access/cloud-apis/azure/) with `tsh apps login`.
   - [ ] Can interact with Azure using `tsh az` commands.
   - [ ] Can interact with Azure using a combination of `tsh proxy az` and `az` commands.
-- [ ] Verify [GCP CLI access](https://goteleport.com/docs/application-access/cloud-apis/google-cloud/) with `tsh app login`.
+- [ ] Verify [GCP CLI access](https://goteleport.com/docs/application-access/cloud-apis/google-cloud/) with `tsh apps login`.
   - [ ] Can interact with GCP using `tsh gcloud` commands.
   - [ ] Can interact with Google Cloud Storage using `tsh gsutil` commands.
   - [ ] Can interact with GCP/GCS using a combination of `tsh proxy gcloud` and `gcloud`/`gsutil` commands.
@@ -1088,7 +1088,7 @@ TODO(lxea): replace links with actual docs once merged
   - [ ] New SSH session in a child cluster on the previous major version
   - [ ] New SSH session from a parent cluster
   - [ ] Application access through a browser
-  - [ ] Application access through curl with `tsh app login`
+  - [ ] Application access through curl with `tsh apps login`
   - [ ] `kubectl get po` after `tsh kube login`
   - [ ] Database access (no configuration change should be necessary if the database CA isn't rotated, other Teleport functionality should not be affected if only the database CA is rotated)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1347,7 +1347,7 @@ proxy_service:
 #### AWS CLI
 
 Teleport application access extends AWS console support to CLI . Users are able
-to log into their AWS console using `tsh app login` and use `tsh aws` commands
+to log into their AWS console using `tsh apps login` and use `tsh aws` commands
 to interact with AWS APIs.
 
 See more info in the
@@ -2286,7 +2286,7 @@ Teleport's Web UI now exposes Teleport’s Audit log, letting auditors and admin
 Teleport 4.3 introduces four new plugins that work out of the box with [Approval Workflow](./docs/pages/access-controls/access-request-plugins/index.mdx). These plugins allow you to automatically support role escalation with commonly used third party services. The built-in plugins are listed below.
 
 *   [PagerDuty](./docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx)
-*   [Jira](./docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx) 
+*   [Jira](./docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx)
 *   [Slack](./docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx)
 *   [Mattermost](./docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx)
 

--- a/Makefile
+++ b/Makefile
@@ -1151,7 +1151,7 @@ init-submodules-e:
 #
 #    Usage:
 #    - tsh login --proxy=platform.teleport.sh
-#    - tsh app login drone
+#    - tsh apps login drone
 #    - set $DRONE_TOKEN and $DRONE_SERVER (http://localhost:8080)
 #    - tsh proxy app --port=8080 drone
 #    - make dronegen

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -9,7 +9,7 @@ It is a part of Gravitational CI/CD pipeline. To build Teleport type:
 make
 ```
 
-### DynamoDB static binary docker build 
+### DynamoDB static binary docker build
 
 The static binary will be built along with all nodejs assets inside the container.
 From the root directory of the source checkout run:
@@ -43,7 +43,7 @@ Multiple migrations can be performed at once. To run a migration do the followin
 6. Get your Drone credentials from here: https://drone.platform.teleport.sh/account.
 7. Export your drone credentials as shown under "Example CLI Usage" on the Drone account page
 8. Open a new terminal.
-9. Run `tsh app login drone` and follow any prompts.
+9. Run `tsh apps login drone` and follow any prompts.
 10. Run `tsh proxy app drone` and copy the printed socket. This should look something like `127.0.0.1:60982`
 11. Switch back to your previous terminal.
 12. Run `export DRONE_SERVER=http://{host:port}`, replacing `{host:port}` with the data you copied in (10)

--- a/docs/pages/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/application-access/cloud-apis/aws-console.mdx
@@ -293,7 +293,7 @@ Before beginning this step, make sure that the `aws` command line interface (CLI
 First, log into the previously configured AWS console app on your desktop:
 
 ```code
-$ tsh app login --aws-role ExamplePowerUser awsconsole-test
+$ tsh apps login --aws-role ExamplePowerUser awsconsole-test
 Logged into AWS app awsconsole-test. Example AWS CLI command:
 
 $ tsh aws s3 ls
@@ -311,7 +311,7 @@ $ tsh aws s3 ls
 To log out of the aws application and remove credentials:
 
 ```code
-$ tsh app logout awsconsole-test
+$ tsh apps logout awsconsole-test
 ```
 
 ## Step 9/9. Access applications using AWS SDKs
@@ -320,7 +320,7 @@ First, log into the previously configured console app if you haven't already
 done so:
 
 ```code
-$ tsh app login --aws-role ExamplePowerUser awsconsole-test
+$ tsh apps login --aws-role ExamplePowerUser awsconsole-test
 ```
 
 Now, use the following command to start a local HTTPS proxy server your
@@ -361,7 +361,7 @@ SDK for JavaScript).
 To log out of the AWS application and remove credentials:
 
 ```code
-$ tsh app logout awsconsole-test
+$ tsh apps logout awsconsole-test
 ```
 
 ## Next steps

--- a/docs/pages/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/application-access/cloud-apis/azure.mdx
@@ -18,7 +18,7 @@ levels of access to Azure CLIs.
 
 The Teleport Application Service connects to the Teleport Proxy Service over a
 reverse tunnel, so you can run the Application Service in a private network and
-prevent unauthorized access to your organization's Azure identities. 
+prevent unauthorized access to your organization's Azure identities.
 
 ## Prerequisites
 
@@ -35,12 +35,12 @@ prevent unauthorized access to your organization's Azure identities.
 - The ability to create a user-assigned Azure managed identity and attach it to
   your VM. Azure requires three role assignments in your Azure account in order
   to do this: Managed Identity Contributor, Managed Identity Operator, and
-  Virtual Machine Contributor. 
+  Virtual Machine Contributor.
 
   <Admonition type="tip" title="Using existing identities">
 
   In this guide, we will create a user-assigned managed identity to demonstrate
-  Azure CLI access with Teleport. 
+  Azure CLI access with Teleport.
 
   If you have another identity you would like Azure CLI users to assume via
   Teleport, you can use that instead. In this case, you will not need the
@@ -100,7 +100,7 @@ the **Access control (IAM)** tab. In the row of buttons at the top of the
 **Access control (IAM)** panel, click **Add > Add role assignment**.
 
 Within the **Add role assignment** screen, click **Reader**, a built-in role
-with view-only access to resources. 
+with view-only access to resources.
 
 ![Add a role
 assignment](../../../img/application-access/azure/add-role-assignment.png)
@@ -112,7 +112,7 @@ identity**. Click **Select members**.
 
 On the right sidebar, find the **Managed identity** dropdown menu and select
 **User-assigned managed identity**. Choose the `teleport-azure` identity you
-created earlier. 
+created earlier.
 
 ![Select managed
 identities](../../../img/application-access/azure/select-managed-identities.png)
@@ -134,7 +134,7 @@ identity in order to proxy Azure CLI traffic.
 In the [Virtual machines
 view](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Compute%2FVirtualMachines)
 of Azure Portal, click on the name of the VM you are using to host the Teleport
-Application Service. 
+Application Service.
 
 On the right side panel, click the **Identity** tab, then within the
 **Identity** view, click the **User assigned** tab. Click **+Add**, then select
@@ -152,7 +152,7 @@ identity](../../../img/application-access/azure/verify-id.png)
 ## Step 2/4. Deploy the Teleport Application Service
 
 In this step, you will run the Teleport Application Service on the Azure VM you
-assigned the `teleport-azure` identity to. 
+assigned the `teleport-azure` identity to.
 
 ### Get a join token
 
@@ -218,7 +218,7 @@ and port of your Teleport Proxy Service or Teleport Cloud tenant, e.g.,
 `mytenant.teleport.sh:443`.
 
 The `app_service` field configures the Teleport Application Service. Each item
-within `app_service.apps` is an application configuration. 
+within `app_service.apps` is an application configuration.
 
 In this example, we have enabled Azure CLI access by setting `cloud` to `Azure`.
 With this setting configured, the Application Service will proxy user commands
@@ -243,8 +243,8 @@ $ sudo systemctl start teleport
 
 ```code
 $ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
-$ sudo systemctl enable teleport; 
-$ sudo systemctl start teleport; 
+$ sudo systemctl enable teleport;
+$ sudo systemctl start teleport;
 ```
 </TabItem>
 </Tabs>
@@ -395,7 +395,7 @@ $ tctl create -f azure-cli-access.yaml
 
 You can define a Teleport role that denies a user access to one or more Azure
 identities. To do so, assign values to the `azure_identities` field within the
-`spec.deny` section of a `role` resource. 
+`spec.deny` section of a `role` resource.
 
 For example, this role denies the user access to all Azure identities:
 
@@ -416,7 +416,7 @@ spec:
 The `no-azure-identities` role enables the user to access all registered
 applications, but makes use of the wildcard character (`*`) within the
 `deny.azure_identities` field to prevent the user from assuming any Azure
-identity. 
+identity.
 
 Unlike values of `allow.azure_identities`, values of `deny.azure_identities` can
 include wildcard expressions in addition to the URIs of specific Azure
@@ -453,13 +453,13 @@ Log in to the application, specifying that you would like to assume the
 `teleport-azure` identity:
 
 ```code
-$ tsh app login azure-cli --azure-identity teleport-azure
+$ tsh apps login azure-cli --azure-identity teleport-azure
 ```
 
 This command validates the value of the `--azure-identity` flag against the ones
 the user is authorized to assume. The value of the flag can either be the full
 URI of the identity (e.g., the URI you copied earlier in this guide) or the name
-of the identity, e.g., `teleport-azure`. 
+of the identity, e.g., `teleport-azure`.
 
 A user can omit the `--azure-identity` flag if they are only authorized to
 access a single Azure identity, but otherwise an empty `--azure-identity` will
@@ -523,7 +523,7 @@ CLI application uses to authenticate requests to Azure's APIs.
 To start the local proxy, run the following `tsh` command:
 
 ```code
-$ tsh proxy azure 
+$ tsh proxy azure
 ```
 
 <Notice type="tip">

--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -18,7 +18,7 @@ interact with Google Cloud APIs.
 
 The Teleport Application Service connects to the Teleport Proxy Service over a
 reverse tunnel, so you can run the Application Service in a private network and
-prevent unauthorized access to your organization's Google Cloud service accounts. 
+prevent unauthorized access to your organization's Google Cloud service accounts.
 
 ## Prerequisites
 
@@ -27,10 +27,10 @@ prevent unauthorized access to your organization's Google Cloud service accounts
 - A Google Cloud account with permissions to create IAM roles and service
   accounts, as well as create IAM role bindings for service accounts and
   projects.
-  
+
 - The `gcloud` CLI tool. Follow the [Google Cloud documentation
   page](https://cloud.google.com/sdk/docs/install-sdk) to install and
-  authenticate to `gcloud`. 
+  authenticate to `gcloud`.
 
   <Notice type="tip">
 
@@ -160,13 +160,13 @@ $ gcloud iam service-accounts add-iam-policy-binding \
  teleport-vm-viewer@<Var name="google-cloud-project" />.iam.gserviceaccount.com \
  --member=serviceAccount:teleport-google-cloud-cli@<Var name="google-cloud-project" />.iam.gserviceaccount.com \
   --role="roles/iam.serviceAccountTokenCreator"
-```  
+```
 
 ## Step 2/4. Deploy the Teleport Application Service
 
 At this point, you have created a controlling service account and enabled this
 service account to impersonate the service accounts you would like Teleport
-users to access. 
+users to access.
 
 In this step, you will attach the controlling service account to a Google
 Compute Engine VM, then run the Teleport Application Service.
@@ -299,7 +299,7 @@ and port of your Teleport Proxy Service or Teleport Cloud tenant, e.g.,
 `mytenant.teleport.sh:443`.
 
 The `app_service` field configures the Teleport Application Service. Each item
-within `app_service.apps` is an application configuration. 
+within `app_service.apps` is an application configuration.
 
 In the example above, we have enabled Google Cloud CLI access by registering an
 application called `google-cloud-cli` with the `cloud` field set to `GCP`. The
@@ -323,8 +323,8 @@ $ sudo systemctl start teleport
 
 ```code
 $ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
-$ sudo systemctl enable teleport; 
-$ sudo systemctl start teleport; 
+$ sudo systemctl enable teleport;
+$ sudo systemctl start teleport;
 ```
 </TabItem>
 </Tabs>
@@ -482,7 +482,7 @@ $ tctl create -f google-cloud-cli-access.yaml
 
 You can define a Teleport role that denies a user access to one or more Google
 Cloud service accounts. To do so, assign values to the `gcp_service_accounts`
-field within the `spec.deny` section of a `role` resource. 
+field within the `spec.deny` section of a `role` resource.
 
 For example, this role denies the user access to all Google Cloud service accounts:
 
@@ -503,7 +503,7 @@ spec:
 The `no-google-cloud` role enables the user to access all registered
 applications, but makes use of the wildcard character (`*`) within the
 `deny.gcp_service_accounts` field to prevent the user from assuming any Google
-Cloud service account. 
+Cloud service account.
 
 Unlike values of `allow.gcp_service_accounts`, values of
 `deny.gcp_service_accounts` can include wildcard expressions in addition to the
@@ -540,13 +540,13 @@ Log in to the application, specifying that you would like to assume the
 `teleport-vm-viewer` service account:
 
 ```code
-$ tsh app login google-cloud-cli --gcp-service-account teleport-vm-viewer
+$ tsh apps login google-cloud-cli --gcp-service-account teleport-vm-viewer
 ```
 
 This command validates the value of the `--gcp-service-account` flag against the
 ones the user is authorized to assume. The value of the flag can either be the
 full URI of the service account or the name of the identity, e.g.,
-`teleport-vm-viewer`. 
+`teleport-vm-viewer`.
 
 A user can omit the `--gcp-service-account` flag if they are only authorized to
 access a single Google Cloud service account, but otherwise an empty
@@ -566,7 +566,7 @@ Example command: tsh gcloud compute instances list
 At this point, you can run `gcloud` commands using the Teleport Application
 Service by prefixing them with `tsh`. Since your user authenticated to your
 Google Cloud CLI application with a service account that can list VMs, for
-example, run this command to do so: 
+example, run this command to do so:
 
 ```code
 $ tsh gcloud compute instances list
@@ -612,7 +612,7 @@ authenticate requests to Google Cloud's APIs.
 To start the local proxy, run the following `tsh` command:
 
 ```code
-$ tsh proxy gcloud 
+$ tsh proxy gcloud
 ```
 
 The command will print the address of the local proxy server along with

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -43,7 +43,7 @@ Log into your Teleport cluster and view available applications:
 
 ```code
 $ tsh login --proxy=teleport.example.com
-$ tsh app ls
+$ tsh apps ls
 
 # Application Description         Public Address               Labels
 # ----------- ------------------- ---------------------------- -------
@@ -53,7 +53,7 @@ $ tsh app ls
 Retrieve short-lived X.509 certificate for the application:
 
 ```code
-$ tsh app login grafana
+$ tsh apps login grafana
 # Logged into app grafana. Example curl command:
 
 $ curl \
@@ -70,7 +70,7 @@ target application's API through Teleport App Access.
   title="CA and Key Pair Files"
 >
   Note the paths to your user's certificate/key pair in the command - `curl` will use a client certificate to authenticate with Teleport.
-  
+
   <ScopedBlock scope={["oss", "enterprise"]}>
     The Teleport Proxy Service is usually configured with a wildcard certificate issued by a public certificate authority such as Let's Encrypt. If your Teleport Proxy Service has been configured to use a self-signed certificate instead, you will need to include it in your `curl` command using `--cacert <path>`.
   </ScopedBlock>
@@ -93,14 +93,14 @@ The app's X.509 certificate will expire on its own after the TTL allowed by
 your user's role. You can also remove it explicitly:
 
 ```code
-$ tsh app logout
+$ tsh apps logout
 # Logged out of app "grafana"
 ```
 
 ## Application information
 
 ```code
-$ tsh app config
+$ tsh apps config
 ```
 
 shows current app URI and paths to the secrets.
@@ -110,7 +110,7 @@ This is useful when configuring CLI tools (such as `curl`) or GUI tools (such as
 Let's print the app information in a table format:
 
 ```code
-$ tsh app config
+$ tsh apps config
 
 # Name:      grafana
 # URI:       https://grafana.teleport.example.com:3080
@@ -123,16 +123,16 @@ We can also provide different `--format` values to print specific parts
 of the app configuration:
 
 ```code
-$ tsh app config --format=uri
+$ tsh apps config --format=uri
 # https://grafana-root.gravitational.io:3080
 
-$ tsh app config --format=ca
+$ tsh apps config --format=ca
 # /Users/alice/.tsh/keys/teleport.example.com/certs.pem
 
-$ tsh app config --format=cert
+$ tsh apps config --format=cert
 # /Users/alice/.tsh/keys/teleport.example.com/alice-app/cluster-name/grafana-x509.pem
 
-$ tsh app config --format=key
+$ tsh apps config --format=key
 # /Users/alice/.tsh/keys/teleport.example.com/alice
 ```
 
@@ -141,7 +141,7 @@ appropriate `curl` command. Using our Grafana `/api/users` example above:
 
 ```code
 $ curl --user admin:admin \
-  --cert $(tsh app config --format=cert) \
-  --key $(tsh app config --format=key) \
-    $(tsh app config --format=uri)/api/users
+  --cert $(tsh apps config --format=cert) \
+  --key $(tsh apps config --format=key) \
+    $(tsh apps config --format=uri)/api/users
 ```

--- a/docs/pages/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/application-access/guides/dynamic-registration.mdx
@@ -57,7 +57,7 @@ spec:
 
 See the full app resource spec [reference](../reference.mdx#application-resource).
 
-The user creating the dynamic registration needs to have a role with access to the 
+The user creating the dynamic registration needs to have a role with access to the
 application labels and the `app` resource.  In this example role the user can only
 create and maintain application services labeled `env: test`.
 ```yaml
@@ -66,7 +66,7 @@ metadata:
   name: dynamicappregexample
 spec:
   allow:
-    app_labels:      
+    app_labels:
       env: test
     rules:
     - resources:
@@ -105,7 +105,7 @@ $ tctl create app.yaml
 
 
 After the resource has been created, it will appear among the list of available
-apps (in `tsh app ls` or UI) as long as at least one Application Service
+apps (in `tsh apps ls` or UI) as long as at least one Application Service
 instance picks it up according to its label selectors.
 
 To update an existing application resource, run:

--- a/docs/pages/application-access/guides/dynamodb.mdx
+++ b/docs/pages/application-access/guides/dynamodb.mdx
@@ -231,7 +231,7 @@ Note that your federated login session is marked with your Teleport username.
 Now, log into the previously configured AWS DynamoDB app on your desktop:
 
 ```code
-$ tsh app login --aws-role ExampleTeleportDynamoDBRole aws-dynamodb
+$ tsh apps login --aws-role ExampleTeleportDynamoDBRole aws-dynamodb
 Logged into AWS app aws. Example AWS CLI command:
 
 $ tsh aws s3 ls
@@ -251,7 +251,7 @@ $ tsh aws dynamodb list-tables
 To log out of the `aws-dynamodb` application and remove credentials:
 
 ```code
-$ tsh app logout aws-dynamodb
+$ tsh apps logout aws-dynamodb
 ```
 
 ### Using other DynamoDB applications
@@ -260,7 +260,7 @@ First, log into the previously configured AWS DynamoDB app if you haven't
 already done so:
 
 ```code
-$ tsh app login --aws-role ExampleTeleportDynamoDBRole aws-dynamodb
+$ tsh apps login --aws-role ExampleTeleportDynamoDBRole aws-dynamodb
 ```
 
 To connect your DynamoDB application, you can start either a local HTTPS proxy
@@ -340,7 +340,7 @@ or a local AWS Service Endpoint proxy.
 To log out of the `aws-dynamodb` application and remove credentials:
 
 ```code
-$ tsh app logout aws-dynamodb
+$ tsh apps logout aws-dynamodb
 ```
 
 ## Next steps

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -109,7 +109,7 @@ Log into your Teleport cluster and view available applications:
 
 ```code
 $ tsh login --proxy=teleport.example.com
-$ tsh app ls
+$ tsh apps ls
 Application Description   Type Public Address                   Labels
 ----------- ------------- ---- -------------------------------- -----------
 tcp-app                   TCP  tcp-app.root.gravitational.io
@@ -120,7 +120,7 @@ Your TCP application should show up and be denoted with a `TCP` type.
 Now log into the application:
 
 ```code
-$ tsh app login tcp-app
+$ tsh apps login tcp-app
 Logged into TCP app tcp-app. Start the local TCP proxy for it:
 
   tsh proxy app tcp-app

--- a/docs/pages/application-access/jwt/elasticsearch.mdx
+++ b/docs/pages/application-access/jwt/elasticsearch.mdx
@@ -84,7 +84,7 @@ Log into your Teleport cluster with `tsh login` and make sure your Elasticsearch
 application is available:
 
 ```code
-$ tsh app ls
+$ tsh apps ls
 Application Description   Public Address               Labels
 ----------- ------------- ---------------------------- -------------------------------
 elastic                   elastic.teleport.example.com
@@ -93,7 +93,7 @@ elastic                   elastic.teleport.example.com
 Fetch a short-lived X.509 certificate for Elasticsearch:
 
 ```code
-$ tsh app login elastic
+$ tsh apps login elastic
 ```
 
 Then you can use the `curl` command to communicate with the Elasticsearch API,

--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -132,20 +132,20 @@ $ tctl create -f app.yaml
 
 This section shows CLI commands relevant for Application Access.
 
-### tsh app ls
+### tsh apps ls
 
 Lists available applications.
 
 ```code
-$ tsh app ls
+$ tsh apps ls
 ```
 
-### tsh app login
+### tsh apps login
 
 Retrieves short-lived X.509 certificate for CLI application access.
 
 ```code
-$ tsh app login grafana
+$ tsh apps login grafana
 ```
 
 | Flag | Description |
@@ -153,44 +153,44 @@ $ tsh app login grafana
 | `--aws-role` | For AWS CLI access, the role ARN or role name of an AWS IAM role. |
 | `--azure-identity` | For Azure CLI access, the name or URI of an Azure managed identity to use for accessing the Azure CLI. |
 
-### tsh app logout
+### tsh apps logout
 
 Removes CLI application access certificate.
 
 ```code
 # Log out of a particular app.
-$ tsh app logout grafana
+$ tsh apps logout grafana
 
 # Log out of all apps.
-$ tsh app logout
+$ tsh apps logout
 ```
 
-### tsh app config
+### tsh apps config
 
 Prints application connection information.
 
 ```code
 # Print app information in a table form.
-$ tsh app config
+$ tsh apps config
 
 # Print information for a particular app.
-$ tsh app config grafana
+$ tsh apps config grafana
 
 # Print an example curl command.
-$ tsh app config --format=curl
+$ tsh apps config --format=curl
 
 # Construct a curl command.
-$ curl $(tsh app config --format=uri) \
-  --cacert $(tsh app config --format=ca) \
-  --cert $(tsh app config --format=cert) \
-  --key $(tsh app config --format=key)
+$ curl $(tsh apps config --format=uri) \
+  --cacert $(tsh apps config --format=ca) \
+  --cert $(tsh apps config --format=cert) \
+  --key $(tsh apps config --format=key)
 ```
 
 | Flag | Description |
 | - | - |
 | `--format` | Optional print format, one of: `uri` to print app address, `ca` to print CA cert path, `cert` to print cert path, `key` print key path, `curl` to print example curl command.|
 
-### tsh az 
+### tsh az
 
 Run an Azure CLI command via the Teleport Application Service:
 

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -364,7 +364,7 @@ func (h *Handler) renewSession(r *http.Request) (*session, error) {
 // `http.Request`.
 func (h *Handler) getAppSession(r *http.Request) (ws types.WebSession, err error) {
 	// We have a client certificate with encoded session id in application
-	// access CLI flow i.e. when users log in using "tsh app login" and
+	// access CLI flow i.e. when users log in using "tsh apps login" and
 	// then connect to the apps with the issued certs.
 	if HasClientCert(r) {
 		ws, err = h.getAppSessionFromCert(r)

--- a/tool/tsh/app.go
+++ b/tool/tsh/app.go
@@ -41,7 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// onAppLogin implements "tsh app login" command.
+// onAppLogin implements "tsh apps login" command.
 func onAppLogin(cf *CLIConf) error {
 	tc, err := makeClient(cf, false)
 	if err != nil {
@@ -249,12 +249,12 @@ func getRegisteredApp(cf *CLIConf, tc *client.TeleportClient) (app types.Applica
 		return nil, trace.Wrap(err)
 	}
 	if len(apps) == 0 {
-		return nil, trace.NotFound("app %q not found, use `tsh app ls` to see registered apps", cf.AppName)
+		return nil, trace.NotFound("app %q not found, use `tsh apps ls` to see registered apps", cf.AppName)
 	}
 	return apps[0], nil
 }
 
-// onAppLogout implements "tsh app logout" command.
+// onAppLogout implements "tsh apps logout" command.
 func onAppLogout(cf *CLIConf) error {
 	tc, err := makeClient(cf, false)
 	if err != nil {
@@ -299,7 +299,7 @@ func onAppLogout(cf *CLIConf) error {
 	return nil
 }
 
-// onAppConfig implements "tsh app config" command.
+// onAppConfig implements "tsh apps config" command.
 func onAppConfig(cf *CLIConf) error {
 	tc, err := makeClient(cf, false)
 	if err != nil {
@@ -441,7 +441,7 @@ func pickActiveApp(cf *CLIConf) (*tlsca.RouteToApp, error) {
 		return nil, trace.Wrap(err)
 	}
 	if len(profile.Apps) == 0 {
-		return nil, trace.NotFound("please login using 'tsh app login' first")
+		return nil, trace.NotFound("please login using 'tsh apps login' first")
 	}
 	name := cf.AppName
 	if name == "" {

--- a/tool/tsh/aws.go
+++ b/tool/tsh/aws.go
@@ -425,14 +425,14 @@ func pickActiveAWSApp(cf *CLIConf) (*awsApp, error) {
 		return nil, trace.Wrap(err)
 	}
 	if len(profile.Apps) == 0 {
-		return nil, trace.NotFound("Please login to AWS app using 'tsh app login' first")
+		return nil, trace.NotFound("Please login to AWS app using 'tsh apps login' first")
 	}
 	name := cf.AppName
 	if name != "" {
 		app, err := findApp(profile.Apps, name)
 		if err != nil {
 			if trace.IsNotFound(err) {
-				return nil, trace.NotFound("Please login to AWS app using 'tsh app login' first")
+				return nil, trace.NotFound("Please login to AWS app using 'tsh apps login' first")
 			}
 			return nil, trace.Wrap(err)
 		}
@@ -446,7 +446,7 @@ func pickActiveAWSApp(cf *CLIConf) (*awsApp, error) {
 
 	awsApps := getAWSAppsName(profile.Apps)
 	if len(awsApps) == 0 {
-		return nil, trace.NotFound("Please login to AWS App using 'tsh app login' first")
+		return nil, trace.NotFound("Please login to AWS App using 'tsh apps login' first")
 	}
 	if len(awsApps) > 1 {
 		names := strings.Join(awsApps, ", ")

--- a/tool/tsh/azure.go
+++ b/tool/tsh/azure.go
@@ -400,14 +400,14 @@ func pickActiveAzureApp(cf *CLIConf) (*azureApp, error) {
 		return nil, trace.Wrap(err)
 	}
 	if len(profile.Apps) == 0 {
-		return nil, trace.NotFound("Please login to Azure app using 'tsh app login' first")
+		return nil, trace.NotFound("Please login to Azure app using 'tsh apps login' first")
 	}
 	name := cf.AppName
 	if name != "" {
 		app, err := findApp(profile.Apps, name)
 		if err != nil {
 			if trace.IsNotFound(err) {
-				return nil, trace.NotFound("Please login to Azure app using 'tsh app login' first")
+				return nil, trace.NotFound("Please login to Azure app using 'tsh apps login' first")
 			}
 			return nil, trace.Wrap(err)
 		}
@@ -420,7 +420,7 @@ func pickActiveAzureApp(cf *CLIConf) (*azureApp, error) {
 	}
 	azureApps := getAzureApps(profile.Apps)
 	if len(azureApps) == 0 {
-		return nil, trace.NotFound("Please login to Azure App using 'tsh app login' first")
+		return nil, trace.NotFound("Please login to Azure App using 'tsh apps login' first")
 	}
 	if len(azureApps) > 1 {
 		var names []string

--- a/tool/tsh/gcp.go
+++ b/tool/tsh/gcp.go
@@ -489,14 +489,14 @@ func pickActiveGCPApp(cf *CLIConf) (*gcpApp, error) {
 		return nil, trace.Wrap(err)
 	}
 	if len(profile.Apps) == 0 {
-		return nil, trace.NotFound("Please login to a GCP App using 'tsh app login' first")
+		return nil, trace.NotFound("Please login to a GCP App using 'tsh apps login' first")
 	}
 	name := cf.AppName
 	if name != "" {
 		app, err := findApp(profile.Apps, name)
 		if err != nil {
 			if trace.IsNotFound(err) {
-				return nil, trace.NotFound("Please login to a GCP App using 'tsh app login' first")
+				return nil, trace.NotFound("Please login to a GCP App using 'tsh apps login' first")
 			}
 			return nil, trace.Wrap(err)
 		}
@@ -509,7 +509,7 @@ func pickActiveGCPApp(cf *CLIConf) (*gcpApp, error) {
 	}
 	gcpApps := getGCPApps(profile.Apps)
 	if len(gcpApps) == 0 {
-		return nil, trace.NotFound("Please login to a GCP App using 'tsh app login' first")
+		return nil, trace.NotFound("Please login to a GCP App using 'tsh apps login' first")
 	}
 	if len(gcpApps) > 1 {
 		var names []string

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -799,7 +799,7 @@ func loadAppCertificate(tc *libclient.TeleportClient, appName string) (tls.Certi
 	}
 	cert, ok := key.AppTLSCerts[appName]
 	if !ok {
-		return tls.Certificate{}, trace.NotFound("please login into the application first. 'tsh app login'")
+		return tls.Certificate{}, trace.NotFound("please login into the application first. 'tsh apps login'")
 	}
 
 	tlsCert, err := key.TLSCertificate(cert)
@@ -809,11 +809,11 @@ func loadAppCertificate(tc *libclient.TeleportClient, appName string) (tls.Certi
 
 	expiresAt, err := getTLSCertExpireTime(tlsCert)
 	if err != nil {
-		return tls.Certificate{}, trace.WrapWithMessage(err, "invalid certificate - please login to the application again. 'tsh app login'")
+		return tls.Certificate{}, trace.WrapWithMessage(err, "invalid certificate - please login to the application again. 'tsh apps login'")
 	}
 	if time.Until(expiresAt) < 5*time.Second {
 		return tls.Certificate{}, trace.BadParameter(
-			"application %s certificate has expired, please re-login to the app using 'tsh app login'",
+			"application %s certificate has expired, please re-login to the app using 'tsh apps login'",
 			appName)
 	}
 	return tlsCert, nil
@@ -854,7 +854,7 @@ var dbProxyAuthMultiTpl = template.Must(template.New("").Parse(
 {{end}}
 Use one of the following commands to connect to the database or to the address above using other database GUI/CLI clients:
 {{range $item := .commands}}
-  * {{$item.Description}}: 
+  * {{$item.Description}}:
 
   $ {{$item.Command}}
 {{end}}

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -929,11 +929,11 @@ Use the following command to connect to the database or to the address above usi
 
 Use one of the following commands to connect to the database or to the address above using other database GUI/CLI clients:
 
-  * default: 
+  * default:
 
   $ echo "hello world"
 
-  * alternative: 
+  * alternative:
 
   $ echo "goodbye world"
 
@@ -982,11 +982,11 @@ To avoid port randomization, you can choose the listening port using the --port 
 
 Use one of the following commands to connect to the database or to the address above using other database GUI/CLI clients:
 
-  * default: 
+  * default:
 
   $ echo "hello world"
 
-  * alternative: 
+  * alternative:
 
   $ echo "goodbye world"
 


### PR DESCRIPTION
The `tsh app` family of subcommands is aliased to `tsh apps`, so both invocations work correctly. The command itself is defined as `tsh apps` so this is what appears in the help message.

Update references to `tsh app` so there isn't confusion when browsing `tsh help` and looking for a missing `tsh app` subcommand.

Backports #21431