### PR TITLE
[v11] Refer to tsh apps subcommand

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -548,11 +548,11 @@ spec:
   allow:
     app_labels:  # just example labels
       label1-key: label1-value
-      env: [dev, staging] 
+      env: [dev, staging]
     db_labels:
       '*': '*'   # asteriks gives user access to everything
     kubernetes_labels:
-      '*': '*' 
+      '*': '*'
     node_labels:
       '*': '*'
     windows_desktop_labels:
@@ -873,12 +873,12 @@ Add the following to enable read access to trusted clusters
 
 ## Moderated session
 
-Using `tsh` join an SSH session as two moderators (two separate terminals, role requires one moderator). 
- - [ ] `Ctrl+C` in the #1 terminal should disconnect the moderator. 
+Using `tsh` join an SSH session as two moderators (two separate terminals, role requires one moderator).
+ - [ ] `Ctrl+C` in the #1 terminal should disconnect the moderator.
  - [ ] `Ctrl+C` in the #2 terminal should disconnect the moderator and terminate the session as session has no moderator.
 
 Using `tsh` join an SSH session as two moderators (two separate terminals, role requires one moderator).
-- [ ] `t` in any terminal should terminate the session for all participants. 
+- [ ] `t` in any terminal should terminate the session for all participants.
 
 ## Performance
 
@@ -888,7 +888,7 @@ Perform all tests on the following configurations:
 - [ ] With Proxy Peering Enabled
 - [ ] With TLS Routing Enabled
 
-* Cluster with 10K direct dial nodes: 
+* Cluster with 10K direct dial nodes:
  - [ ] etcd
  - [ ] DynamoDB
  - [ ] Firestore
@@ -927,7 +927,7 @@ Run a concurrent session test that will spawn 5 interactive sessions per node in
 
 ```shell
 tsh bench sessions --max=5000 user ls
-tsh bench sessions --max=5000 --web user ls 
+tsh bench sessions --max=5000 --web user ls
 ```
 
 - [ ] Verify that all 5000 sessions are able to be established.
@@ -967,7 +967,7 @@ tsh bench sessions --max=5000 --web user ls
   - [ ] `tsh play <chunk-id>` can fetch and print a session chunk archive.
 - [ ] Verify JWT using [verify-jwt.go](https://github.com/gravitational/teleport/blob/master/examples/jwt/verify-jwt.go).
 - [ ] Verify RBAC.
-- [ ] Verify [CLI access](https://goteleport.com/docs/application-access/guides/api-access/) with `tsh app login`.
+- [ ] Verify [CLI access](https://goteleport.com/docs/application-access/guides/api-access/) with `tsh apps login`.
 - [ ] Verify AWS console access.
   - [ ] Can log into AWS web console through the web UI.
   - [ ] Can interact with AWS using `tsh aws` commands.
@@ -1044,7 +1044,7 @@ tsh bench sessions --max=5000 --web user ls
   - [ ] Can detect and register Azure Cache for Redis servers.
 - [ ] Verify Teleport managed users (password rotation, auto 'auth' on connection, etc.).
   - [ ] Can detect and manage ElastiCache users
-  - [ ] Can detect and manage MemoryDB users 
+  - [ ] Can detect and manage MemoryDB users
 - [ ] Test Databases screen in the web UI (tab is located on left side nav on dashboard):
   - [ ] Verify that all dbs registered are shown with correct `name`, `description`, `type`, and `labels`
   - [ ] Verify that clicking on a rows connect button renders a dialogue on manual instructions with `Step 2` login value matching the rows `name` column
@@ -1421,7 +1421,7 @@ TODO(lxea): replace links with actual docs once merged
   - [ ] New SSH session in a child cluster on the previous major version
   - [ ] New SSH session from a parent cluster
   - [ ] Application access through a browser
-  - [ ] Application access through curl with `tsh app login`
+  - [ ] Application access through curl with `tsh apps login`
   - [ ] `kubectl get po` after `tsh kube login`
   - [ ] Database access (no configuration change should be necessary if the database CA isn't rotated, other Teleport functionality should not be affected if only the database CA is rotated)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1254,7 +1254,7 @@ proxy_service:
 #### AWS CLI
 
 Teleport application access extends AWS console support to CLI . Users are able
-to log into their AWS console using `tsh app login` and use `tsh aws` commands
+to log into their AWS console using `tsh apps login` and use `tsh aws` commands
 to interact with AWS APIs.
 
 See more info in the
@@ -2193,7 +2193,7 @@ Teleport's Web UI now exposes Teleport’s Audit log, letting auditors and admin
 Teleport 4.3 introduces four new plugins that work out of the box with [Approval Workflow](./docs/pages/access-controls/access-request-plugins/index.mdx). These plugins allow you to automatically support role escalation with commonly used third party services. The built-in plugins are listed below.
 
 *   [PagerDuty](./docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx)
-*   [Jira](./docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx) 
+*   [Jira](./docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx)
 *   [Slack](./docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx)
 *   [Mattermost](./docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx)
 

--- a/Makefile
+++ b/Makefile
@@ -1152,7 +1152,7 @@ init-submodules-e:
 #    - install drone cli
 #    - set $DRONE_TOKEN
 #    - tsh login --proxy=platform.teleport.sh
-#    - tsh app login drone
+#    - tsh apps login drone
 #    - tsh proxy app drone
 #    - export DRONE_SERVER=https://localhost:$TSH_PROXY_PORT
 #    - make dronegen

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -9,7 +9,7 @@ It is a part of Gravitational CI/CD pipeline. To build Teleport type:
 make
 ```
 
-### DynamoDB static binary docker build 
+### DynamoDB static binary docker build
 
 The static binary will be built along with all nodejs assets inside the container.
 From the root directory of the source checkout run:
@@ -43,7 +43,7 @@ Multiple migrations can be performed at once. To run a migration do the followin
 6. Get your Drone credentials from here: https://drone.platform.teleport.sh/account.
 7. Export your drone credentials as shown under "Example CLI Usage" on the Drone account page
 8. Open a new terminal.
-9. Run `tsh app login drone` and follow any prompts.
+9. Run `tsh apps login drone` and follow any prompts.
 10. Run `tsh proxy app drone` and copy the printed socket. This should look something like `127.0.0.1:60982`
 11. Switch back to your previous terminal.
 12. Run `export DRONE_SERVER=http://{host:port}`, replacing `{host:port}` with the data you copied in (10)

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -43,7 +43,7 @@ Log into your Teleport cluster and view available applications:
 
 ```code
 $ tsh login --proxy=teleport.example.com
-$ tsh app ls
+$ tsh apps ls
 
 # Application Description         Public Address               Labels
 # ----------- ------------------- ---------------------------- -------
@@ -53,7 +53,7 @@ $ tsh app ls
 Retrieve short-lived X.509 certificate for the application:
 
 ```code
-$ tsh app login grafana
+$ tsh apps login grafana
 # Logged into app grafana. Example curl command:
 
 $ curl \
@@ -70,7 +70,7 @@ target application's API through Teleport App Access.
   title="CA and Key Pair Files"
 >
   Note the paths to your user's certificate/key pair in the command - `curl` will use a client certificate to authenticate with Teleport.
-  
+
   <ScopedBlock scope={["oss", "enterprise"]}>
     The Teleport Proxy Service is usually configured with a wildcard certificate issued by a public certificate authority such as Let's Encrypt. If your Teleport Proxy Service has been configured to use a self-signed certificate instead, you will need to include it in your `curl` command using `--cacert <path>`.
   </ScopedBlock>
@@ -93,14 +93,14 @@ The app's X.509 certificate will expire on its own after the TTL allowed by
 your user's role. You can also remove it explicitly:
 
 ```code
-$ tsh app logout
+$ tsh apps logout
 # Logged out of app "grafana"
 ```
 
 ## Application information
 
 ```code
-$ tsh app config
+$ tsh apps config
 ```
 
 shows current app URI and paths to the secrets.
@@ -110,7 +110,7 @@ This is useful when configuring CLI tools (such as `curl`) or GUI tools (such as
 Let's print the app information in a table format:
 
 ```code
-$ tsh app config
+$ tsh apps config
 
 # Name:      grafana
 # URI:       https://grafana.teleport.example.com:3080
@@ -123,16 +123,16 @@ We can also provide different `--format` values to print specific parts
 of the app configuration:
 
 ```code
-$ tsh app config --format=uri
+$ tsh apps config --format=uri
 # https://grafana-root.gravitational.io:3080
 
-$ tsh app config --format=ca
+$ tsh apps config --format=ca
 # /Users/alice/.tsh/keys/teleport.example.com/certs.pem
 
-$ tsh app config --format=cert
+$ tsh apps config --format=cert
 # /Users/alice/.tsh/keys/teleport.example.com/alice-app/cluster-name/grafana-x509.pem
 
-$ tsh app config --format=key
+$ tsh apps config --format=key
 # /Users/alice/.tsh/keys/teleport.example.com/alice
 ```
 
@@ -141,7 +141,7 @@ appropriate `curl` command. Using our Grafana `/api/users` example above:
 
 ```code
 $ curl --user admin:admin \
-  --cert $(tsh app config --format=cert) \
-  --key $(tsh app config --format=key) \
-    $(tsh app config --format=uri)/api/users
+  --cert $(tsh apps config --format=cert) \
+  --key $(tsh apps config --format=key) \
+    $(tsh apps config --format=uri)/api/users
 ```

--- a/docs/pages/application-access/guides/aws-console.mdx
+++ b/docs/pages/application-access/guides/aws-console.mdx
@@ -290,7 +290,7 @@ Before beginning this step, make sure that the `aws` command line interface (CLI
 First, log into the previously configured AWS console app on your desktop:
 
 ```code
-$ tsh app login --aws-role ExamplePowerUser awsconsole-test
+$ tsh apps login --aws-role ExamplePowerUser awsconsole-test
 Logged into AWS app awsconsole-test. Example AWS CLI command:
 
 $ tsh aws s3 ls
@@ -308,7 +308,7 @@ $ tsh aws s3 ls
 To log out of the aws application and remove credentials:
 
 ```code
-$ tsh app logout awsconsole-test
+$ tsh apps logout awsconsole-test
 ```
 
 ## Step 9/9. Access applications using AWS SDKs
@@ -317,7 +317,7 @@ First, log into the previously configured console app if you haven't already
 done so:
 
 ```code
-$ tsh app login --aws-role ExamplePowerUser awsconsole-test
+$ tsh apps login --aws-role ExamplePowerUser awsconsole-test
 ```
 
 Now, use the following command to start a local HTTPS proxy server your
@@ -358,7 +358,7 @@ SDK for JavaScript).
 To log out of the AWS application and remove credentials:
 
 ```code
-$ tsh app logout awsconsole-test
+$ tsh apps logout awsconsole-test
 ```
 
 ## Next steps

--- a/docs/pages/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/application-access/guides/dynamic-registration.mdx
@@ -57,7 +57,7 @@ spec:
 
 See the full app resource spec [reference](../reference.mdx#application-resource).
 
-The user creating the dynamic registration needs to have a role with access to the 
+The user creating the dynamic registration needs to have a role with access to the
 application labels and the `app` resource.  In this example role the user can only
 create and maintain application services labeled `env: test`.
 ```yaml
@@ -66,7 +66,7 @@ metadata:
   name: dynamicappregexample
 spec:
   allow:
-    app_labels:      
+    app_labels:
       env: test
     rules:
     - resources:
@@ -105,7 +105,7 @@ $ tctl create app.yaml
 
 
 After the resource has been created, it will appear among the list of available
-apps (in `tsh app ls` or UI) as long as at least one Application Service
+apps (in `tsh apps ls` or UI) as long as at least one Application Service
 instance picks it up according to its label selectors.
 
 To update an existing application resource, run:

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -109,7 +109,7 @@ Log into your Teleport cluster and view available applications:
 
 ```code
 $ tsh login --proxy=teleport.example.com
-$ tsh app ls
+$ tsh apps ls
 Application Description   Type Public Address                   Labels
 ----------- ------------- ---- -------------------------------- -----------
 tcp-app                   TCP  tcp-app.root.gravitational.io
@@ -120,7 +120,7 @@ Your TCP application should show up and be denoted with a `TCP` type.
 Now log into the application:
 
 ```code
-$ tsh app login tcp-app
+$ tsh apps login tcp-app
 Logged into TCP app tcp-app. Start the local TCP proxy for it:
 
   tsh proxy app tcp-app

--- a/docs/pages/application-access/jwt/elasticsearch.mdx
+++ b/docs/pages/application-access/jwt/elasticsearch.mdx
@@ -84,7 +84,7 @@ Log into your Teleport cluster with `tsh login` and make sure your Elasticsearch
 application is available:
 
 ```code
-$ tsh app ls
+$ tsh apps ls
 Application Description   Public Address               Labels
 ----------- ------------- ---------------------------- -------------------------------
 elastic                   elastic.teleport.example.com
@@ -93,7 +93,7 @@ elastic                   elastic.teleport.example.com
 Fetch a short-lived X.509 certificate for Elasticsearch:
 
 ```code
-$ tsh app login elastic
+$ tsh apps login elastic
 ```
 
 Then you can use the `curl` command to communicate with the Elasticsearch API,

--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -128,53 +128,53 @@ $ tctl create -f app.yaml
 
 This section shows CLI commands relevant for Application Access.
 
-### tsh app ls
+### tsh apps ls
 
 Lists available applications.
 
 ```code
-$ tsh app ls
+$ tsh apps ls
 ```
 
-### tsh app login
+### tsh apps login
 
 Retrieves short-lived X.509 certificate for CLI application access.
 
 ```code
-$ tsh app login grafana
+$ tsh apps login grafana
 ```
 
-### tsh app logout
+### tsh apps logout
 
 Removes CLI application access certificate.
 
 ```code
 # Log out of a particular app.
-$ tsh app logout grafana
+$ tsh apps logout grafana
 
 # Log out of all apps.
-$ tsh app logout
+$ tsh apps logout
 ```
 
-### tsh app config
+### tsh apps config
 
 Prints application connection information.
 
 ```code
 # Print app information in a table form.
-$ tsh app config
+$ tsh apps config
 
 # Print information for a particular app.
-$ tsh app config grafana
+$ tsh apps config grafana
 
 # Print an example curl command.
-$ tsh app config --format=curl
+$ tsh apps config --format=curl
 
 # Construct a curl command.
-$ curl $(tsh app config --format=uri) \
-  --cacert $(tsh app config --format=ca) \
-  --cert $(tsh app config --format=cert) \
-  --key $(tsh app config --format=key)
+$ curl $(tsh apps config --format=uri) \
+  --cacert $(tsh apps config --format=ca) \
+  --cert $(tsh apps config --format=cert) \
+  --key $(tsh apps config --format=key)
 ```
 
 | Flag | Description |

--- a/docs/pages/database-access/guides/dynamodb.mdx
+++ b/docs/pages/database-access/guides/dynamodb.mdx
@@ -205,7 +205,7 @@ Note that your federated login session is marked with your Teleport username.
 Now, log into the previously configured AWS DynamoDB app on your desktop:
 
 ```code
-$ tsh app login --aws-role ExampleTeleportDynamoDBRole aws-dynamodb
+$ tsh apps login --aws-role ExampleTeleportDynamoDBRole aws-dynamodb
 Logged into AWS app aws. Example AWS CLI command:
 
 $ tsh aws s3 ls
@@ -225,7 +225,7 @@ $ tsh aws dynamodb list-tables
 To log out of the `aws-dynamodb` application and remove credentials:
 
 ```code
-$ tsh app logout aws-dynamodb
+$ tsh apps logout aws-dynamodb
 ```
 
 ### Using other DynamoDB applications
@@ -234,7 +234,7 @@ First, log into the previously configured AWS DynamoDB app if you haven't
 already done so:
 
 ```code
-$ tsh app login --aws-role ExampleTeleportDynamoDBRole aws-dynamodb
+$ tsh apps login --aws-role ExampleTeleportDynamoDBRole aws-dynamodb
 ```
 
 To connect your DynamoDB application, you can start either a local HTTPS proxy
@@ -314,7 +314,7 @@ or a local AWS Service Endpoint proxy.
 To log out of the `aws-dynamodb` application and remove credentials:
 
 ```code
-$ tsh app logout aws-dynamodb
+$ tsh apps logout aws-dynamodb
 ```
 
 ## Next steps

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -364,7 +364,7 @@ func (h *Handler) renewSession(r *http.Request) (*session, error) {
 // `http.Request`.
 func (h *Handler) getAppSession(r *http.Request) (ws types.WebSession, err error) {
 	// We have a client certificate with encoded session id in application
-	// access CLI flow i.e. when users log in using "tsh app login" and
+	// access CLI flow i.e. when users log in using "tsh apps login" and
 	// then connect to the apps with the issued certs.
 	if HasClientCert(r) {
 		ws, err = h.getAppSessionFromCert(r)

--- a/tool/tsh/app.go
+++ b/tool/tsh/app.go
@@ -39,7 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// onAppLogin implements "tsh app login" command.
+// onAppLogin implements "tsh apps login" command.
 func onAppLogin(cf *CLIConf) error {
 	tc, err := makeClient(cf, false)
 	if err != nil {
@@ -160,12 +160,12 @@ func getRegisteredApp(cf *CLIConf, tc *client.TeleportClient) (app types.Applica
 		return nil, trace.Wrap(err)
 	}
 	if len(apps) == 0 {
-		return nil, trace.NotFound("app %q not found, use `tsh app ls` to see registered apps", cf.AppName)
+		return nil, trace.NotFound("app %q not found, use `tsh apps ls` to see registered apps", cf.AppName)
 	}
 	return apps[0], nil
 }
 
-// onAppLogout implements "tsh app logout" command.
+// onAppLogout implements "tsh apps logout" command.
 func onAppLogout(cf *CLIConf) error {
 	tc, err := makeClient(cf, false)
 	if err != nil {
@@ -210,7 +210,7 @@ func onAppLogout(cf *CLIConf) error {
 	return nil
 }
 
-// onAppConfig implements "tsh app config" command.
+// onAppConfig implements "tsh apps config" command.
 func onAppConfig(cf *CLIConf) error {
 	tc, err := makeClient(cf, false)
 	if err != nil {
@@ -320,7 +320,7 @@ func pickActiveApp(cf *CLIConf) (*tlsca.RouteToApp, error) {
 		return nil, trace.Wrap(err)
 	}
 	if len(profile.Apps) == 0 {
-		return nil, trace.NotFound("please login using 'tsh app login' first")
+		return nil, trace.NotFound("please login using 'tsh apps login' first")
 	}
 	name := cf.AppName
 	if name == "" {

--- a/tool/tsh/aws.go
+++ b/tool/tsh/aws.go
@@ -425,14 +425,14 @@ func pickActiveAWSApp(cf *CLIConf) (*awsApp, error) {
 		return nil, trace.Wrap(err)
 	}
 	if len(profile.Apps) == 0 {
-		return nil, trace.NotFound("Please login to AWS app using 'tsh app login' first")
+		return nil, trace.NotFound("Please login to AWS app using 'tsh apps login' first")
 	}
 	name := cf.AppName
 	if name != "" {
 		app, err := findApp(profile.Apps, name)
 		if err != nil {
 			if trace.IsNotFound(err) {
-				return nil, trace.NotFound("Please login to AWS app using 'tsh app login' first")
+				return nil, trace.NotFound("Please login to AWS app using 'tsh apps login' first")
 			}
 			return nil, trace.Wrap(err)
 		}
@@ -446,7 +446,7 @@ func pickActiveAWSApp(cf *CLIConf) (*awsApp, error) {
 
 	awsApps := getAWSAppsName(profile.Apps)
 	if len(awsApps) == 0 {
-		return nil, trace.NotFound("Please login to AWS App using 'tsh app login' first")
+		return nil, trace.NotFound("Please login to AWS App using 'tsh apps login' first")
 	}
 	if len(awsApps) > 1 {
 		names := strings.Join(awsApps, ", ")

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -725,7 +725,7 @@ func loadAppCertificate(tc *libclient.TeleportClient, appName string) (tls.Certi
 	}
 	cert, ok := key.AppTLSCerts[appName]
 	if !ok {
-		return tls.Certificate{}, trace.NotFound("please login into the application first. 'tsh app login'")
+		return tls.Certificate{}, trace.NotFound("please login into the application first. 'tsh apps login'")
 	}
 
 	tlsCert, err := key.TLSCertificate(cert)
@@ -735,11 +735,11 @@ func loadAppCertificate(tc *libclient.TeleportClient, appName string) (tls.Certi
 
 	expiresAt, err := getTLSCertExpireTime(tlsCert)
 	if err != nil {
-		return tls.Certificate{}, trace.WrapWithMessage(err, "invalid certificate - please login to the application again. 'tsh app login'")
+		return tls.Certificate{}, trace.WrapWithMessage(err, "invalid certificate - please login to the application again. 'tsh apps login'")
 	}
 	if time.Until(expiresAt) < 5*time.Second {
 		return tls.Certificate{}, trace.BadParameter(
-			"application %s certificate has expired, please re-login to the app using 'tsh app login'",
+			"application %s certificate has expired, please re-login to the app using 'tsh apps login'",
 			appName)
 	}
 	return tlsCert, nil
@@ -780,7 +780,7 @@ var dbProxyAuthMultiTpl = template.Must(template.New("").Parse(
 {{end}}
 Use one of the following commands to connect to the database or to the address above using other database GUI/CLI clients:
 {{range $item := .commands}}
-  * {{$item.Description}}: 
+  * {{$item.Description}}:
 
   $ {{$item.Command}}
 {{end}}

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -929,11 +929,11 @@ Use the following command to connect to the database or to the address above usi
 
 Use one of the following commands to connect to the database or to the address above using other database GUI/CLI clients:
 
-  * default: 
+  * default:
 
   $ echo "hello world"
 
-  * alternative: 
+  * alternative:
 
   $ echo "goodbye world"
 
@@ -982,11 +982,11 @@ To avoid port randomization, you can choose the listening port using the --port 
 
 Use one of the following commands to connect to the database or to the address above using other database GUI/CLI clients:
 
-  * default: 
+  * default:
 
   $ echo "hello world"
 
-  * alternative: 
+  * alternative:
 
   $ echo "goodbye world"
 


### PR DESCRIPTION
The `tsh app` family of subcommands is aliased to `tsh apps`, so both invocations work correctly. The command itself is defined as `tsh apps` so this is what appears in the help message.

Update references to `tsh app` so there isn't confusion when browsing `tsh help` and looking for a missing `tsh app` subcommand.

Backports #21431