### PR TITLE
Add teleport config v4, set install_teleport to false by default

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -661,7 +661,7 @@ func (i *TeleInstance) StartNodeWithTargetPort(tconf *service.Config, authPort s
 
 	tconf.DataDir = dataDir
 
-	if tconf.Version == defaults.TeleportConfigVersionV3 {
+	if tconf.Version == defaults.TeleportConfigVersionV3 || tconf.Version == defaults.TeleportConfigVersionV4 {
 		if tconf.ProxyServer.IsEmpty() {
 			authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
 			tconf.SetAuthServerAddress(*authServer)

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -661,12 +661,13 @@ func (i *TeleInstance) StartNodeWithTargetPort(tconf *service.Config, authPort s
 
 	tconf.DataDir = dataDir
 
-	if tconf.Version == defaults.TeleportConfigVersionV3 || tconf.Version == defaults.TeleportConfigVersionV4 {
+	switch tconf.Version {
+	case defaults.TeleportConfigVersionV3, defaults.TeleportConfigVersionV4:
 		if tconf.ProxyServer.IsEmpty() {
 			authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
 			tconf.SetAuthServerAddress(*authServer)
 		}
-	} else {
+	default:
 		authServer := utils.MustParseAddr(net.JoinHostPort(i.Hostname, authPort))
 		if err := tconf.SetAuthServerAddresses(append(tconf.AuthServerAddresses(), *authServer)); err != nil {
 			return nil, err

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -512,7 +512,7 @@ func mustStartALPNLocalProxyWithConfig(t *testing.T, config alpnproxy.LocalProxy
 
 func makeNodeConfig(nodeName, proxyAddr string) *service.Config {
 	nodeConfig := service.MakeDefaultConfig()
-	nodeConfig.Version = defaults.TeleportConfigVersionV3
+	nodeConfig.Version = defaults.TeleportConfigVersionV4
 	nodeConfig.Hostname = nodeName
 	nodeConfig.SetToken("token")
 	nodeConfig.ProxyServer = *utils.MustParseAddr(proxyAddr)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -490,7 +490,7 @@ func applyAuthOrProxyAddress(fc *FileConfig, cfg *service.Config) error {
 		}
 
 	// From v3 onwards, either auth_server or proxy_server should be set
-	case defaults.TeleportConfigVersionV3:
+	case defaults.TeleportConfigVersionV3, defaults.TeleportConfigVersionV4:
 		if len(fc.AuthServers) > 0 {
 			return trace.BadParameter("config v3 has replaced auth_servers with either auth_server or proxy_server")
 		}
@@ -1178,7 +1178,7 @@ func applySSHConfig(fc *FileConfig, cfg *service.Config) (err error) {
 func applyDiscoveryConfig(fc *FileConfig, cfg *service.Config) error {
 	cfg.Discovery.Enabled = fc.Discovery.Enabled()
 	for _, matcher := range fc.Discovery.AWSMatchers {
-		installParams, err := matcher.InstallParams.Parse()
+		installParams, err := matcher.InstallParams.Parse(fc.Version)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -222,8 +222,8 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 		Method:    types.JoinMethod(joinMethod),
 	}
 
-	if flags.Version == defaults.TeleportConfigVersionV3 ||
-		flags.Version == defaults.TeleportConfigVersionV4 {
+	switch flags.Version {
+	case defaults.TeleportConfigVersionV3, defaults.TeleportConfigVersionV4:
 
 		if flags.AuthServer != "" && flags.ProxyAddress != "" {
 			return nil, trace.BadParameter("--proxy and --auth-server cannot both be set")
@@ -232,7 +232,7 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 		} else if flags.ProxyAddress != "" {
 			g.ProxyServer = flags.ProxyAddress
 		}
-	} else {
+	default:
 		if flags.AuthServer != "" {
 			g.AuthServers = []string{flags.AuthServer}
 		}
@@ -1547,7 +1547,7 @@ type InstallParams struct {
 	SSHDConfig string `yaml:"sshd_config,omitempty"`
 }
 
-func ConfigVersionGTE(minVersion, version string) (bool, error) {
+func configVersionGTE(minVersion, version string) (bool, error) {
 	ver, err := strconv.Atoi(version[1:])
 	if err != nil {
 		return false, trace.Wrap(err)
@@ -1568,7 +1568,7 @@ func (ip *InstallParams) Parse(version string) (services.InstallerParams, error)
 		SSHDConfig:      ip.SSHDConfig,
 	}
 
-	isV4OrGreater, err := ConfigVersionGTE(defaults.TeleportConfigVersionV4, version)
+	isV4OrGreater, err := configVersionGTE(defaults.TeleportConfigVersionV4, version)
 	if err != nil {
 		return services.InstallerParams{}, trace.Wrap(err)
 	}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -761,6 +761,8 @@ const (
 	TeleportConfigVersionV2 string = "v2"
 	// TeleportConfigVersionV3 is the teleport proxy configuration v3 version.
 	TeleportConfigVersionV3 string = "v3"
+	// TeleportConfigVersionV3 is the teleport proxy configuration v4 version.
+	TeleportConfigVersionV4 string = "v4"
 )
 
 // TeleportConfigVersions is an exported slice of the allowed versions in the config file,
@@ -769,6 +771,7 @@ var TeleportConfigVersions = []string{
 	TeleportConfigVersionV1,
 	TeleportConfigVersionV2,
 	TeleportConfigVersionV3,
+	TeleportConfigVersionV4,
 }
 
 func ValidateConfigVersion(version string) error {

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -761,7 +761,7 @@ const (
 	TeleportConfigVersionV2 string = "v2"
 	// TeleportConfigVersionV3 is the teleport proxy configuration v3 version.
 	TeleportConfigVersionV3 string = "v3"
-	// TeleportConfigVersionV3 is the teleport proxy configuration v4 version.
+	// TeleportConfigVersionV4 is the teleport proxy configuration v4 version.
 	TeleportConfigVersionV4 string = "v4"
 )
 

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -117,7 +117,8 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			process.log.Error("Can not join the cluster as node, the token expired or not found. Regenerate the token and try again.")
 		case connectErr != nil:
 			process.log.Errorf("%v failed to establish connection to cluster: %v.", role, connectErr)
-			if process.Config.Version == defaults.TeleportConfigVersionV3 && process.Config.ProxyServer.IsEmpty() {
+			if (process.Config.Version == defaults.TeleportConfigVersionV3 || process.Config.Version == defaults.TeleportConfigVersionV4) &&
+				process.Config.ProxyServer.IsEmpty() {
 				process.log.Errorf("Check to see if the config has auth_server pointing to a Teleport Proxy. If it does, use proxy_server instead of auth_server.")
 			}
 		}
@@ -1128,7 +1129,7 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 		return tunnelClient, nil
 
 	// for config v3, either tunnel to the given proxy server or directly connect to the given auth server
-	case defaults.TeleportConfigVersionV3:
+	case defaults.TeleportConfigVersionV3, defaults.TeleportConfigVersionV4:
 		proxyServer := process.Config.ProxyServer
 		if !proxyServer.IsEmpty() {
 			logger := process.log.WithField("proxy-server", proxyServer.String())

--- a/lib/service/proxy_settings.go
+++ b/lib/service/proxy_settings.go
@@ -48,7 +48,7 @@ func (p *proxySettings) GetProxySettings(ctx context.Context) (*webclient.ProxyS
 	}
 
 	switch p.cfg.Version {
-	case defaults.TeleportConfigVersionV2, defaults.TeleportConfigVersionV3:
+	case defaults.TeleportConfigVersionV2, defaults.TeleportConfigVersionV3, defaults.TeleportConfigVersionV4:
 		return p.buildProxySettingsV2(resp.GetProxyListenerMode()), nil
 	default:
 		return p.buildProxySettings(resp.GetProxyListenerMode()), nil

--- a/lib/service/validateconfig.go
+++ b/lib/service/validateconfig.go
@@ -86,7 +86,7 @@ func validateAuthOrProxyServices(cfg *Config) error {
 	haveAuthServers := len(cfg.authServers) > 0
 	haveProxyServer := !cfg.ProxyServer.IsEmpty()
 
-	if cfg.Version == defaults.TeleportConfigVersionV3 {
+	if cfg.Version == defaults.TeleportConfigVersionV3 || cfg.Version == defaults.TeleportConfigVersionV4 {
 		if haveAuthServers && haveProxyServer {
 			return trace.BadParameter("config: cannot use both auth_server and proxy_server")
 		}

--- a/lib/service/validateconfig.go
+++ b/lib/service/validateconfig.go
@@ -86,7 +86,8 @@ func validateAuthOrProxyServices(cfg *Config) error {
 	haveAuthServers := len(cfg.authServers) > 0
 	haveProxyServer := !cfg.ProxyServer.IsEmpty()
 
-	if cfg.Version == defaults.TeleportConfigVersionV3 || cfg.Version == defaults.TeleportConfigVersionV4 {
+	switch cfg.Version {
+	case defaults.TeleportConfigVersionV3, defaults.TeleportConfigVersionV4:
 		if haveAuthServers && haveProxyServer {
 			return trace.BadParameter("config: cannot use both auth_server and proxy_server")
 		}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -368,7 +368,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dump.Flag("acme-email",
 		"Email to receive updates from Letsencrypt.org.").StringVar(&dumpFlags.ACMEEmail)
 	dump.Flag("test", "Path to a configuration file to test.").ExistingFileVar(&dumpFlags.testConfigFile)
-	dump.Flag("version", "Teleport configuration version.").Default(defaults.TeleportConfigVersionV3).StringVar(&dumpFlags.Version)
+	dump.Flag("version", "Teleport configuration version.").Default(defaults.TeleportConfigVersionV4).StringVar(&dumpFlags.Version)
 	dump.Flag("public-addr", "The hostport that the proxy advertises for the HTTP endpoint.").StringVar(&dumpFlags.PublicAddr)
 	dump.Flag("cert-file", "Path to a TLS certificate file for the proxy.").ExistingFileVar(&dumpFlags.CertFile)
 	dump.Flag("key-file", "Path to a TLS key file for the proxy.").ExistingFileVar(&dumpFlags.KeyFile)
@@ -388,7 +388,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dumpNodeConfigure.Flag("output",
 		"Write to stdout with -o=stdout, default config file with -o=file or custom path with -o=file:///path").Short('o').Default(
 		teleport.SchemeStdout).StringVar(&dumpFlags.output)
-	dumpNodeConfigure.Flag("version", "Teleport configuration version.").Default(defaults.TeleportConfigVersionV3).StringVar(&dumpFlags.Version)
+	dumpNodeConfigure.Flag("version", "Teleport configuration version.").Default(defaults.TeleportConfigVersionV4).StringVar(&dumpFlags.Version)
 	dumpNodeConfigure.Flag("public-addr", "The hostport that the node advertises for the SSH endpoint.").StringVar(&dumpFlags.PublicAddr)
 	dumpNodeConfigure.Flag("data-dir", "Path to a directory where Teleport keep its data.").Default(defaults.DataDir).StringVar(&dumpFlags.DataDir)
 	dumpNodeConfigure.Flag("token", "Invitation token to register with an auth server.").StringVar(&dumpFlags.AuthToken)


### PR DESCRIPTION
This introduces a new teleport config version. A new config version is warranted as the desired behavior of teleport server discovery is to do an agentless install, however currently `install_teleport` will default to true in existing teleport config files/installations 
