### PR TITLE
Switch CodeQL to scheduled

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,18 +1,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches:
-      - master
-      - branch/*
-  pull_request:
-    branches:
-      - master
-      - branch/*
-    paths-ignore:
-      - 'docs/**'
-      - 'rfd/**'
-      - '**.md'
+  schedule:
+    - cron: '0 13 * * *' # At 1:00 PM UTC every day
 
 jobs:
   analyze:
@@ -59,4 +49,4 @@ jobs:
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"
-      timeout-minutes: 30
+      timeout-minutes: 240


### PR DESCRIPTION
We still plan to address this root issue, and are tracking making CodeQL faster so it can be a required PR check: https://github.com/gravitational/SecOps/issues/269

However, until then we need to switch this job to be a scheduled task rather than on every PR and push.  This is partly cost motivated, but also we are already hitting our timeouts.  This PR also increases the analysis timeout so that the daily job can be sure to complete.