### PR TITLE
Fix git installation path - Docker CentOS 7 image

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -29,9 +29,9 @@ RUN wget https://github.com/git/git/archive/refs/tags/v2.39.1.tar.gz && \
     tar xf v2.39.1.tar.gz && \
     cd git-2.39.1/ && \
     scl enable ${DEVTOOLSET} "make configure && \
-    ./configure --prefix=/opt/git && \
+    ./configure --prefix=/usr/local && \
     make -j6 all && \
-    make install"
+    DESTDIR=/opt/git make install"
 
 # Create an alias to the assets image. Ref: https://github.com/docker/for-mac/issues/2155
 ARG BUILDARCH


### PR DESCRIPTION
My previous PR https://github.com/gravitational/teleport/pull/21660 broke the git installation path, as `git` compiles in the `--prefix` provided during configuration. Using`DESTDIR` with `make install` instead of `--prefix` copies the file in the intermediate container with the correct path. 