### PR TITLE
Include enterprise in tctl prereqs for ent  and cloud

### DIFF
--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -6,7 +6,7 @@
   details on how to set this up, see our Enterprise [Getting
   Started](/docs/enterprise/getting-started) guide.
 
-- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=),
+- The Enterprise `tctl` admin tool and `tsh` client tool version >= (=teleport.version=),
   which you can download by visiting the
   [customer portal](https://dashboard.gravitational.com/web/login).
 
@@ -15,7 +15,7 @@
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   
   $ tsh version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
   ```
 
 </TabItem>

--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -31,10 +31,10 @@
 
   ```code
   $ tctl version
-  # Teleport v(=cloud.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
   
   $ tsh version
-  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
+  # Teleport v(=cloud.version=) go(=teleport.golang=)
   ```
 
 </TabItem>

--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -15,7 +15,7 @@
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   
   $ tsh version
-  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
 
 </TabItem>

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -28,7 +28,7 @@ files in partials, this partial uses relative URL paths instead.
 - A running Teleport cluster. For details on how to set this up, see our Enterprise
   [Getting Started](/docs/enterprise/getting-started) guide.
 
-- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=),
+- The Enterprise `tctl` admin tool and `tsh` client tool version >= (=teleport.version=),
   which you can download by visiting the
   [customer portal](https://dashboard.gravitational.com/web/login).
 
@@ -37,7 +37,7 @@ files in partials, this partial uses relative URL paths instead.
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   
   $ tsh version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
   ```
 
 </TabItem>
@@ -47,7 +47,7 @@ files in partials, this partial uses relative URL paths instead.
 - A Teleport Cloud account. If you do not have one, visit the
   [sign up page](https://goteleport.com/signup/) to begin your free trial.
 
-- The `tctl` admin tool and `tsh` client tool version >= (=cloud.version=).
+- The Enterprise `tctl` admin tool and `tsh` client tool version >= (=cloud.version=).
   To download these tools, visit the [Downloads](../choose-an-edition/teleport-cloud/downloads.mdx) page.
 
 
@@ -56,7 +56,7 @@ files in partials, this partial uses relative URL paths instead.
   # Teleport v(=cloud.version=) go(=teleport.golang=)
   
   $ tsh version
-  # Teleport v(=cloud.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
   ```
 
 </TabItem>

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -34,10 +34,10 @@ files in partials, this partial uses relative URL paths instead.
 
   ```code
   $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
   
   $ tsh version
-  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
 
 </TabItem>
@@ -53,10 +53,10 @@ files in partials, this partial uses relative URL paths instead.
 
   ```code
   $ tctl version
-  # Teleport v(=cloud.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
   
   $ tsh version
-  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
+  # Teleport v(=cloud.version=) go(=teleport.golang=)
   ```
 
 </TabItem>


### PR DESCRIPTION
- Gives the title of enterprise for the `tctl` version 
- Includes Enterprise in `tctl version` example