### PR TITLE
Disable instance heartbeats by default

### DIFF
--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -18,6 +18,7 @@ package inventory
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -284,7 +285,17 @@ func (c *Controller) handleControlStream(handle *upstreamHandle) {
 	}
 }
 
+// instanceHeartbeatDisabled allows users to opt into using instance heartbeats.
+// TODO(tross,fspmarshal): remove this once issues with etcd stability are resolved.
+func instanceHeartbeatDisabled() bool {
+	return os.Getenv("TELEPORT_UNSTABLE_ENABLE_INSTANCE_HB") != "yes"
+}
+
 func (c *Controller) heartbeatInstanceState(handle *upstreamHandle, now time.Time) error {
+	if instanceHeartbeatDisabled() {
+		return nil
+	}
+
 	tracker := &handle.stateTracker
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -269,12 +269,47 @@ func TestSSHServerBasics(t *testing.T) {
 }
 
 // TestInstanceHeartbeat verifies basic expected behaviors for instance heartbeat.
+func TestInstanceHeartbeat_Disabled(t *testing.T) {
+	const serverID = "test-instance"
+	const peerAddr = "1.2.3.4:456"
+
+	events := make(chan testEvent, 1024)
+
+	auth := &fakeAuth{}
+
+	controller := NewController(
+		auth,
+		withInstanceHBInterval(time.Millisecond*200),
+		withTestEventsChannel(events),
+	)
+	defer controller.Close()
+
+	// set up fake in-memory control stream
+	upstream, _ := client.InventoryControlStreamPipe(client.ICSPipePeerAddr(peerAddr))
+
+	controller.RegisterControlStream(upstream, proto.UpstreamInventoryHello{
+		ServerID: serverID,
+		Version:  teleport.Version,
+		Services: []types.SystemRole{types.RoleNode},
+	})
+
+	// verify that control stream handle is now accessible
+	_, ok := controller.GetControlStream(serverID)
+	require.True(t, ok)
+
+	// verify that no instance heartbeats are emitted
+	awaitEvents(t, events,
+		deny(instanceHeartbeatOk, instanceHeartbeatErr, instanceCompareFailed, handlerClose),
+	)
+}
+
+// TestInstanceHeartbeat verifies basic expected behaviors for instance heartbeat.
 func TestInstanceHeartbeat(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_ENABLE_INSTANCE_HB", "yes")
+
 	const serverID = "test-instance"
 	const peerAddr = "1.2.3.4:456"
 	const includeAttempts = 16
-
-	t.Parallel()
 
 	events := make(chan testEvent, 1024)
 


### PR DESCRIPTION
Instance heartbeats have caused significant etcd instability in larger clusters. This makes the instance heartbeat a noop unless the `TELEPORT_UNSTABLE_ENABLE_INSTANCE_HB` is explicitly set.

This allows for us to keep the instance heartbeats to continue to test and determine the underlying problem without rolling back the entire feature, while also preventing it from impacting users.