### PR TITLE
Updates discover logic to check can add token and can query agents

### DIFF
--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -167,6 +167,6 @@ export default class StoreUserContext extends Store<UserContext> {
   }
 
   hasDiscoverAccess() {
-    return this.hasPrereqAccessToAddAgents() || this.hasAccessToQueryAgent();
+    return this.hasPrereqAccessToAddAgents() && this.hasAccessToQueryAgent();
   }
 }


### PR DESCRIPTION
Enroll new resources was showing when user didn't have token rights.  It should only show for users who have token create rights and can query the agents.