### PR TITLE
Docs/TF: Identity as b64

### DIFF
--- a/docs/pages/reference/terraform-provider.mdx
+++ b/docs/pages/reference/terraform-provider.mdx
@@ -31,28 +31,30 @@ terraform {
 
 The provider supports the following options:
 
-| Name                  | Type   | Description                                                                     | Environment Variable              |
-|-----------------------|--------|---------------------------------------------------------------------------------|-----------------------------------|
-| `addr`                | string | Teleport auth or proxy address in "host:port" format.                           | `TF_TELEPORT_ADDR`                |
-| `cert_path`           | string | Path to Teleport certificate file.                                              | `TF_TELEPORT_CERT`                |
-| `cert_base64`         | string | Teleport certificate as base64.                                                 | `TF_TELEPORT_CERT_BASE64`         |
-| `identity_file_path`  | string | Path to Teleport identity file.                                                 | `TF_TELEPORT_IDENTITY_FILE_PATH`  |
-| `key_path`            | string | Path to Teleport key file.                                                      | `TF_TELEPORT_KEY`                 |
-| `key_base64`          | string | Teleport key as base64.                                                         | `TF_TELEPORT_KEY_BASE64`          |
-| `profile_dir`         | string | Teleport profile path.                                                          | `TF_TELEPORT_PROFILE_PATH`        |
-| `profile_name`        | string | Teleport profile name.                                                          | `TF_TELEPORT_PROFILE_NAME`        |
-| `root_ca_path`        | string | Path to Teleport CA file.                                                       | `TF_TELEPORT_ROOT_CA`             |
-| `root_ca_base64`      | string | Teleport CA as base64.                                                          | `TF_TELEPORT_ROOT_CA_BASE64`      |
-| `retry_base_duration` | string | Base duration between retries. [Format](https://pkg.go.dev/time#ParseDuration) | `TF_TELEPORT_RETRY_BASE_DURATION` |
-| `retry_cap_duration`  | string | Max duration between retries. [Format](https://pkg.go.dev/time#ParseDuration)   | `TF_TELEPORT_RETRY_CAP_DURATION`  |
-| `retry_max_tries`     | string | Max number of retries.                                                          | `TF_TELEPORT_RETRY_MAX_TRIES`     |
+
+| Name                   | Type   | Description                                                                    | Environment Variable               |
+| ---------------------- | ------ | ------------------------------------------------------------------------------ | ---------------------------------- |
+| `addr`                 | string | Teleport auth or proxy address in "host:port" format.                          | `TF_TELEPORT_ADDR`                 |
+| `cert_path`            | string | Path to Teleport certificate file.                                             | `TF_TELEPORT_CERT`                 |
+| `cert_base64`          | string | Teleport certificate as base64.                                                | `TF_TELEPORT_CERT_BASE64`          |
+| `identity_file_path`   | string | Path to Teleport identity file.                                                | `TF_TELEPORT_IDENTITY_FILE_PATH`   |
+| `identity_file_base64` | string | Teleport identity file as base64.                                              | `TF_TELEPORT_IDENTITY_FILE_BASE64` |
+| `key_path`             | string | Path to Teleport key file.                                                     | `TF_TELEPORT_KEY`                  |
+| `key_base64`           | string | Teleport key as base64.                                                        | `TF_TELEPORT_KEY_BASE64`           |
+| `profile_dir`          | string | Teleport profile path.                                                         | `TF_TELEPORT_PROFILE_PATH`         |
+| `profile_name`         | string | Teleport profile name.                                                         | `TF_TELEPORT_PROFILE_NAME`         |
+| `root_ca_path`         | string | Path to Teleport CA file.                                                      | `TF_TELEPORT_ROOT_CA`              |
+| `root_ca_base64`       | string | Teleport CA as base64.                                                         | `TF_TELEPORT_ROOT_CA_BASE64`       |
+| `retry_base_duration`  | string | Base duration between retries. [Format](https://pkg.go.dev/time#ParseDuration) | `TF_TELEPORT_RETRY_BASE_DURATION`  |
+| `retry_cap_duration`   | string | Max duration between retries. [Format](https://pkg.go.dev/time#ParseDuration)  | `TF_TELEPORT_RETRY_CAP_DURATION`   |
+| `retry_max_tries`      | string | Max number of retries.                                                         | `TF_TELEPORT_RETRY_MAX_TRIES`      |
 
 
 You need to specify at least one of:
 
 - `cert_path`, `key_path`,`root_ca_path` and `addr` to connect using key files.
 - `cert_base64`, `key_base64`,`root_ca_base64` and `addr` to connect using a base64-encoded key.
-- `identity_file_path` and `addr` to connect using identity file.
+- `identity_file_path` or `identity_file_base64` and `addr` to connect using identity file.
 - `profile_name` and `profile_dir` (both can be empty) and Teleport will try to connect using current profile from `~/.tsh`
 
 The `retry_*` values are used to retry the API calls to Teleport when the cache is stale.

--- a/docs/pages/reference/terraform-provider.mdx
+++ b/docs/pages/reference/terraform-provider.mdx
@@ -54,7 +54,7 @@ You need to specify at least one of:
 
 - `cert_path`, `key_path`,`root_ca_path` and `addr` to connect using key files.
 - `cert_base64`, `key_base64`,`root_ca_base64` and `addr` to connect using a base64-encoded key.
-- `identity_file_path` or `identity_file_base64` and `addr` to connect using identity file.
+- `identity_file_path` or `identity_file_base64` and `addr` to connect using an identity file.
 - `profile_name` and `profile_dir` (both can be empty) and Teleport will try to connect using current profile from `~/.tsh`
 
 The `retry_*` values are used to retry the API calls to Teleport when the cache is stale.


### PR DESCRIPTION
It was not documented but the teleport provider supports loading an identity file as base64.
https://github.com/gravitational/teleport-plugins/blob/bc85392dc3b03bedcd963709d3ef4bba2af37b2d/terraform/provider/provider.go#L234