### PR TITLE
Expose access point in web handler.

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -710,6 +710,11 @@ func (h *Handler) GetProxyClient() auth.ClientI {
 	return h.cfg.ProxyClient
 }
 
+// GetAccessPoint returns the caching access point.
+func (h *Handler) GetAccessPoint() auth.ProxyAccessPoint {
+	return h.cfg.AccessPoint
+}
+
 // Close closes associated session cache operations
 func (h *Handler) Close() error {
 	return h.auth.Close()


### PR DESCRIPTION
The web handler now has its access point exposed. This will allow for using it for enterprise functionality. In particular, this will allow us to use it for auth.Middleware for enterprise web plugins.