### PR TITLE
Add new `reporting` license flag

### DIFF
--- a/api/types/license.go
+++ b/api/types/license.go
@@ -71,6 +71,21 @@ type License interface {
 	// SetSupportsDesktopAccess sets desktop access support flag
 	SetSupportsDesktopAccess(Bool)
 
+	// GetSupportsModeratedSessions returns moderated sessions support flag
+	GetSupportsModeratedSessions() Bool
+	// SetSupportsModeratedSessions sets moderated sessions support flag
+	SetSupportsModeratedSessions(Bool)
+
+	// GetSupportsMachineID returns MachineID support flag
+	GetSupportsMachineID() Bool
+	// SetSupportsMachineID sets MachineID support flag
+	SetSupportsMachineID(Bool)
+
+	// GetSupportsResourceAccessRequests returns resource access requests support flag
+	GetSupportsResourceAccessRequests() Bool
+	// SetSupportsResourceAccessRequests sets resource access requests support flag
+	SetSupportsResourceAccessRequests(Bool)
+
 	// GetTrial returns the trial flag.
 	//  Note: This is not applicable to Cloud licenses
 	GetTrial() Bool
@@ -292,6 +307,36 @@ func (c *LicenseV3) SetSupportsDesktopAccess(value Bool) {
 	c.Spec.SupportsDesktopAccess = value
 }
 
+// GetSupportsModeratedSessions returns moderated sessions support flag
+func (c *LicenseV3) GetSupportsModeratedSessions() Bool {
+	return c.Spec.SupportsModeratedSessions
+}
+
+// SetSupportsModeratedSessions sets moderated sessions support flag
+func (c *LicenseV3) SetSupportsModeratedSessions(value Bool) {
+	c.Spec.SupportsModeratedSessions = value
+}
+
+// GetSupportsMachineID returns MachineID support flag
+func (c *LicenseV3) GetSupportsMachineID() Bool {
+	return c.Spec.SupportsMachineID
+}
+
+// SetSupportsMachineID sets MachineID support flag
+func (c *LicenseV3) SetSupportsMachineID(value Bool) {
+	c.Spec.SupportsMachineID = value
+}
+
+// GetSupportsResourceAccessRequests returns resource access requests support flag
+func (c *LicenseV3) GetSupportsResourceAccessRequests() Bool {
+	return c.Spec.SupportsResourceAccessRequests
+}
+
+// SetSupportsResourceAccessRequests sets resource access requests support flag
+func (c *LicenseV3) SetSupportsResourceAccessRequests(value Bool) {
+	c.Spec.SupportsResourceAccessRequests = value
+}
+
 // GetTrial returns the trial flag
 func (c *LicenseV3) GetTrial() Bool {
 	return c.Spec.Trial
@@ -325,6 +370,15 @@ func (c *LicenseV3) String() string {
 	}
 	if c.GetSupportsDesktopAccess() {
 		features = append(features, "supports desktop access")
+	}
+	if c.GetSupportsModeratedSessions() {
+		features = append(features, "supports moderated sessions")
+	}
+	if c.GetSupportsMachineID() {
+		features = append(features, "supports Machine ID")
+	}
+	if c.GetSupportsResourceAccessRequests() {
+		features = append(features, "supports resource access requests")
 	}
 	if c.GetCloud() {
 		features = append(features, "is hosted by Gravitational")
@@ -362,5 +416,12 @@ type LicenseSpecV3 struct {
 	ReportsUsage Bool `json:"usage,omitempty"`
 	// Cloud is turned on when teleport is hosted by Gravitational
 	Cloud Bool `json:"cloud,omitempty"`
+	// SupportsModeratedSessions turns on moderated sessions
+	SupportsModeratedSessions Bool `json:"moderated_sessions,omitempty"`
+	// SupportsMachineID turns MachineID support on or off
+	SupportsMachineID Bool `json:"machine_id,omitempty"`
+	// SupportsResourceAccessRequests turns resource access request support on or off
+	SupportsResourceAccessRequests Bool `json:"resource_access_requests,omitempty"`
+	// Trial is true for trial licenses
 	Trial Bool `json:"trial,omitempty"`
 }

--- a/api/types/license.go
+++ b/api/types/license.go
@@ -77,24 +77,30 @@ type License interface {
 	SetSupportsDesktopAccess(Bool)
 
 	// GetSupportsModeratedSessions returns moderated sessions support flag
-	// Note: this field is unused in Teleport v11+
+	// Note: this flag is unused in Teleport v11+ but it's still used to
+	// generate licenses that support older versions of Teleport
 	GetSupportsModeratedSessions() Bool
 	// SetSupportsModeratedSessions sets moderated sessions support flag
-	// Note: this field is unused in Teleport v11+
+	// Note: this flag is unused in Teleport v11+ but it's still used to
+	// generate licenses that support older versions of Teleport
 	SetSupportsModeratedSessions(Bool)
 
 	// GetSupportsMachineID returns MachineID support flag
-	// Note: this field is unused in Teleport v11+
+	// Note: this flag is unused in Teleport v11+ but it's still used to
+	// generate licenses that support older versions of Teleport
 	GetSupportsMachineID() Bool
 	// SetSupportsMachineID sets MachineID support flag
-	// Note: this field is unused in Teleport v11+
+	// Note: this flag is unused in Teleport v11+ but it's still used to
+	// generate licenses that support older versions of Teleport
 	SetSupportsMachineID(Bool)
 
 	// GetSupportsResourceAccessRequests returns resource access requests support flag
-	// Note: this field is unused in Teleport v11+
+	// Note: this flag is unused in Teleport v11+ but it's still used to
+	// generate licenses that support older versions of Teleport
 	GetSupportsResourceAccessRequests() Bool
 	// SetSupportsResourceAccessRequests sets resource access requests support flag
-	// Note: this field is unused in Teleport v11+
+	// Note: this flag is unused in Teleport v11+ but it's still used to
+	// generate licenses that support older versions of Teleport
 	SetSupportsResourceAccessRequests(Bool)
 
 	// GetTrial returns the trial flag.

--- a/api/types/license.go
+++ b/api/types/license.go
@@ -126,7 +126,9 @@ func NewLicense(name string, spec LicenseSpecV3) (License, error) {
 	return l, nil
 }
 
-// LicenseV3 represents License resource version V3
+// LicenseV3 represents License resource version V3. When changing this, keep in
+// mind that other consumers of teleport/api (Houston, Sales Center) might still
+// need to generate or parse licenses for older versions of Teleport.
 type LicenseV3 struct {
 	// Kind is a resource kind - always resource.
 	Kind string `json:"kind"`
@@ -408,7 +410,10 @@ func (c *LicenseV3) String() string {
 	return strings.Join(features, ",")
 }
 
-// LicenseSpecV3 is the actual data we care about for LicenseV3.
+// LicenseSpecV3 is the actual data we care about for LicenseV3. When changing
+// this, keep in mind that other consumers of teleport/api (Houston, Sales
+// Center) might still need to generate or parse licenses for older versions of
+// Teleport.
 type LicenseSpecV3 struct {
 	// AccountID is a customer account ID
 	AccountID string `json:"account_id,omitempty"`

--- a/api/types/license.go
+++ b/api/types/license.go
@@ -33,11 +33,11 @@ type License interface {
 	GetReportsUsage() Bool
 	// SetReportsUsage sets the Houston usage reporting flag.
 	SetReportsUsage(Bool)
-	// GetUsageReporting returns true if the Teleport cluster should report
-	// usage to Sales Center.
-	GetUsageReporting() Bool
-	// SetUsageReporting sets the Sales Center usage reporting flag.
-	SetUsageReporting(Bool)
+	// GetSalesCenterReporting returns true if the Teleport cluster should
+	// report usage to Sales Center.
+	GetSalesCenterReporting() Bool
+	// SetSalesCenterReporting sets the Sales Center usage reporting flag.
+	SetSalesCenterReporting(Bool)
 
 	// GetCloud returns true if teleport cluster is hosted by Gravitational
 	GetCloud() Bool
@@ -217,10 +217,10 @@ func (c *LicenseV3) GetReportsUsage() Bool {
 	return c.Spec.ReportsUsage
 }
 
-// GetUsageReporting returns true if the Teleport cluster should report usage to
-// Sales Center.
-func (c *LicenseV3) GetUsageReporting() Bool {
-	return c.Spec.UsageReporting
+// GetSalesCenterReporting returns true if the Teleport cluster should report
+// usage to Sales Center.
+func (c *LicenseV3) GetSalesCenterReporting() Bool {
+	return c.Spec.SalesCenterReporting
 }
 
 // GetCloud returns true if teleport cluster is hosted by Gravitational
@@ -238,9 +238,9 @@ func (c *LicenseV3) SetReportsUsage(reports Bool) {
 	c.Spec.ReportsUsage = reports
 }
 
-// SetUsageReporting sets the Sales Center usage reporting flag.
-func (c *LicenseV3) SetUsageReporting(reports Bool) {
-	c.Spec.UsageReporting = reports
+// SetSalesCenterReporting sets the Sales Center usage reporting flag.
+func (c *LicenseV3) SetSalesCenterReporting(reports Bool) {
+	c.Spec.SalesCenterReporting = reports
 }
 
 // setStaticFields sets static resource header and metadata fields.
@@ -432,8 +432,8 @@ type LicenseSpecV3 struct {
 	SupportsDesktopAccess Bool `json:"desktop,omitempty"`
 	// ReportsUsage turns Houston usage reporting on or off
 	ReportsUsage Bool `json:"usage,omitempty"`
-	// UsageReporting turns Sales Center usage reporting on or off
-	UsageReporting Bool `json:"reporting,omitempty"`
+	// SalesCenterReporting turns Sales Center usage reporting on or off
+	SalesCenterReporting Bool `json:"reporting,omitempty"`
 	// Cloud is turned on when teleport is hosted by Gravitational
 	Cloud Bool `json:"cloud,omitempty"`
 	// SupportsModeratedSessions turns on moderated sessions

--- a/api/types/license.go
+++ b/api/types/license.go
@@ -72,18 +72,24 @@ type License interface {
 	SetSupportsDesktopAccess(Bool)
 
 	// GetSupportsModeratedSessions returns moderated sessions support flag
+	// Note: this field is unused in Teleport v11+
 	GetSupportsModeratedSessions() Bool
 	// SetSupportsModeratedSessions sets moderated sessions support flag
+	// Note: this field is unused in Teleport v11+
 	SetSupportsModeratedSessions(Bool)
 
 	// GetSupportsMachineID returns MachineID support flag
+	// Note: this field is unused in Teleport v11+
 	GetSupportsMachineID() Bool
 	// SetSupportsMachineID sets MachineID support flag
+	// Note: this field is unused in Teleport v11+
 	SetSupportsMachineID(Bool)
 
 	// GetSupportsResourceAccessRequests returns resource access requests support flag
+	// Note: this field is unused in Teleport v11+
 	GetSupportsResourceAccessRequests() Bool
 	// SetSupportsResourceAccessRequests sets resource access requests support flag
+	// Note: this field is unused in Teleport v11+
 	SetSupportsResourceAccessRequests(Bool)
 
 	// GetTrial returns the trial flag.
@@ -370,15 +376,6 @@ func (c *LicenseV3) String() string {
 	}
 	if c.GetSupportsDesktopAccess() {
 		features = append(features, "supports desktop access")
-	}
-	if c.GetSupportsModeratedSessions() {
-		features = append(features, "supports moderated sessions")
-	}
-	if c.GetSupportsMachineID() {
-		features = append(features, "supports Machine ID")
-	}
-	if c.GetSupportsResourceAccessRequests() {
-		features = append(features, "supports resource access requests")
 	}
 	if c.GetCloud() {
 		features = append(features, "is hosted by Gravitational")

--- a/api/types/license.go
+++ b/api/types/license.go
@@ -28,11 +28,16 @@ import (
 type License interface {
 	Resource
 
-	// GetReportsUsage returns true if teleport cluster reports usage
-	// to control plane
+	// GetReportsUsage returns true if the Teleport cluster should report usage
+	// to the Houston control plane.
 	GetReportsUsage() Bool
-	// SetReportsUsage sets usage report
+	// SetReportsUsage sets the Houston usage reporting flag.
 	SetReportsUsage(Bool)
+	// GetUsageReporting returns true if the Teleport cluster should report
+	// usage to Sales Center.
+	GetUsageReporting() Bool
+	// SetUsageReporting sets the Sales Center usage reporting flag.
+	SetUsageReporting(Bool)
 
 	// GetCloud returns true if teleport cluster is hosted by Gravitational
 	GetCloud() Bool
@@ -204,10 +209,16 @@ func (c *LicenseV3) GetMetadata() Metadata {
 	return c.Metadata
 }
 
-// GetReportsUsage returns true if teleport cluster reports usage
-// to control plane
+// GetReportsUsage returns true if the Teleport cluster should report usage to
+// the Houston control plane.
 func (c *LicenseV3) GetReportsUsage() Bool {
 	return c.Spec.ReportsUsage
+}
+
+// GetUsageReporting returns true if the Teleport cluster should report usage to
+// Sales Center.
+func (c *LicenseV3) GetUsageReporting() Bool {
+	return c.Spec.UsageReporting
 }
 
 // GetCloud returns true if teleport cluster is hosted by Gravitational
@@ -220,9 +231,14 @@ func (c *LicenseV3) SetCloud(cloud Bool) {
 	c.Spec.Cloud = cloud
 }
 
-// SetReportsUsage sets usage report
+// SetReportsUsage sets the Houston usage reporting flag.
 func (c *LicenseV3) SetReportsUsage(reports Bool) {
 	c.Spec.ReportsUsage = reports
+}
+
+// SetUsageReporting sets the Sales Center usage reporting flag.
+func (c *LicenseV3) SetUsageReporting(reports Bool) {
+	c.Spec.UsageReporting = reports
 }
 
 // setStaticFields sets static resource header and metadata fields.
@@ -409,8 +425,10 @@ type LicenseSpecV3 struct {
 	SupportsDatabaseAccess Bool `json:"db,omitempty"`
 	// SupportsDesktopAccess turns desktop access on or off
 	SupportsDesktopAccess Bool `json:"desktop,omitempty"`
-	// ReportsUsage turns usage reporting on or off
+	// ReportsUsage turns Houston usage reporting on or off
 	ReportsUsage Bool `json:"usage,omitempty"`
+	// UsageReporting turns Sales Center usage reporting on or off
+	UsageReporting Bool `json:"reporting,omitempty"`
 	// Cloud is turned on when teleport is hosted by Gravitational
 	Cloud Bool `json:"cloud,omitempty"`
 	// SupportsModeratedSessions turns on moderated sessions

--- a/api/types/license_test.go
+++ b/api/types/license_test.go
@@ -33,6 +33,9 @@ func TestLicenseSettersAndGetters(t *testing.T) {
 		License.GetSupportsApplicationAccess,
 		License.GetSupportsDatabaseAccess,
 		License.GetSupportsDesktopAccess,
+		License.GetSupportsModeratedSessions,
+		License.GetSupportsMachineID,
+		License.GetSupportsResourceAccessRequests,
 		License.GetTrial,
 	}
 
@@ -91,6 +94,24 @@ func TestLicenseSettersAndGetters(t *testing.T) {
 			unsetFields: unsetFields(License.GetSupportsDesktopAccess),
 		},
 		{
+			name:        "Set Moderated Sessions Support",
+			setter:      License.SetSupportsModeratedSessions,
+			getter:      License.GetSupportsModeratedSessions,
+			unsetFields: unsetFields(License.GetSupportsModeratedSessions),
+		},
+		{
+			name:        "Set Machine ID Support",
+			setter:      License.SetSupportsMachineID,
+			getter:      License.GetSupportsMachineID,
+			unsetFields: unsetFields(License.GetSupportsMachineID),
+		},
+		{
+			name:        "Set Resource Access Request Support",
+			setter:      License.SetSupportsResourceAccessRequests,
+			getter:      License.GetSupportsResourceAccessRequests,
+			unsetFields: unsetFields(License.GetSupportsResourceAccessRequests),
+		},
+		{
 			name:        "Set Trial Support",
 			setter:      License.SetTrial,
 			getter:      License.GetTrial,
@@ -122,6 +143,9 @@ func TestLicenseSettersAndGetters(t *testing.T) {
 	require.False(t, bool(license.GetSupportsKubernetes()))
 	require.False(t, bool(license.GetSupportsDatabaseAccess()))
 	require.False(t, bool(license.GetSupportsDesktopAccess()))
+	require.False(t, bool(license.GetSupportsModeratedSessions()))
+	require.False(t, bool(license.GetSupportsMachineID()))
+	require.False(t, bool(license.GetSupportsResourceAccessRequests()))
 	require.False(t, bool(license.GetTrial()))
 }
 

--- a/api/types/license_test.go
+++ b/api/types/license_test.go
@@ -28,7 +28,7 @@ func TestLicenseSettersAndGetters(t *testing.T) {
 	// All getters inspected in this test.
 	allFields := []func(License) Bool{
 		License.GetReportsUsage,
-		License.GetUsageReporting,
+		License.GetSalesCenterReporting,
 		License.GetCloud,
 		License.GetSupportsKubernetes,
 		License.GetSupportsApplicationAccess,
@@ -65,10 +65,10 @@ func TestLicenseSettersAndGetters(t *testing.T) {
 			unsetFields: unsetFields(License.GetReportsUsage),
 		},
 		{
-			name:        "Set UsageReporting",
-			setter:      License.SetUsageReporting,
-			getter:      License.GetUsageReporting,
-			unsetFields: unsetFields(License.GetUsageReporting),
+			name:        "Set SalesCenterReporting",
+			setter:      License.SetSalesCenterReporting,
+			getter:      License.GetSalesCenterReporting,
+			unsetFields: unsetFields(License.GetSalesCenterReporting),
 		},
 		{
 			name:        "Set Cloud",
@@ -146,7 +146,7 @@ func TestLicenseSettersAndGetters(t *testing.T) {
 	license := &LicenseV3{}
 	require.True(t, bool(license.GetSupportsApplicationAccess()))
 	require.False(t, bool(license.GetReportsUsage()))
-	require.False(t, bool(license.GetUsageReporting()))
+	require.False(t, bool(license.GetSalesCenterReporting()))
 	require.False(t, bool(license.GetCloud()))
 	require.False(t, bool(license.GetSupportsKubernetes()))
 	require.False(t, bool(license.GetSupportsDatabaseAccess()))

--- a/api/types/license_test.go
+++ b/api/types/license_test.go
@@ -28,6 +28,7 @@ func TestLicenseSettersAndGetters(t *testing.T) {
 	// All getters inspected in this test.
 	allFields := []func(License) Bool{
 		License.GetReportsUsage,
+		License.GetUsageReporting,
 		License.GetCloud,
 		License.GetSupportsKubernetes,
 		License.GetSupportsApplicationAccess,
@@ -62,6 +63,12 @@ func TestLicenseSettersAndGetters(t *testing.T) {
 			setter:      License.SetReportsUsage,
 			getter:      License.GetReportsUsage,
 			unsetFields: unsetFields(License.GetReportsUsage),
+		},
+		{
+			name:        "Set UsageReporting",
+			setter:      License.SetUsageReporting,
+			getter:      License.GetUsageReporting,
+			unsetFields: unsetFields(License.GetUsageReporting),
 		},
 		{
 			name:        "Set Cloud",
@@ -139,6 +146,7 @@ func TestLicenseSettersAndGetters(t *testing.T) {
 	license := &LicenseV3{}
 	require.True(t, bool(license.GetSupportsApplicationAccess()))
 	require.False(t, bool(license.GetReportsUsage()))
+	require.False(t, bool(license.GetUsageReporting()))
 	require.False(t, bool(license.GetCloud()))
 	require.False(t, bool(license.GetSupportsKubernetes()))
 	require.False(t, bool(license.GetSupportsDatabaseAccess()))


### PR DESCRIPTION
This PR reverts the changes to `api/types.License`/`LicenseV3`/`LicenseSpecV3` in #16585 and adds a new `reporting` license flag.

Reverting the changes to the type definition is a prerequisite to add a new flag because the `api/types` package is imported by cloud, which uses it to both verify and generate new license payloads, and we still need to be able to generate licenses that have the old `machine_id`, `moderated_sessions` and `resource_access_requests` flags there.