### PR TITLE
[v11] Update Go toolchain to 1.20.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ name: push-build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
   UID: "1000"
 trigger:
   event:
@@ -144,7 +144,7 @@ name: push-build-linux-386
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
   UID: "1000"
 trigger:
   event:
@@ -247,7 +247,7 @@ name: push-build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
   UID: "1000"
 trigger:
   event:
@@ -354,7 +354,7 @@ name: push-build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
   UID: "1000"
 trigger:
   event:
@@ -512,7 +512,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.20
+    RUNTIME: go1.20.1
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -1120,7 +1120,7 @@ name: push-build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
   UID: "1000"
 trigger:
   event:
@@ -1223,7 +1223,7 @@ name: push-build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
   UID: "1000"
 trigger:
   event:
@@ -1639,7 +1639,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
 trigger:
   event:
     include:
@@ -1827,7 +1827,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
 trigger:
   event:
     include:
@@ -2014,7 +2014,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
 trigger:
   event:
     include:
@@ -2208,7 +2208,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
 trigger:
   event:
     include:
@@ -3411,7 +3411,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
 trigger:
   event:
     include:
@@ -4166,7 +4166,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.20
+    RUNTIME: go1.20.1
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -4758,7 +4758,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
 trigger:
   event:
     include:
@@ -4944,7 +4944,7 @@ name: build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport11
   GID: "1000"
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
   UID: "1000"
 trigger:
   event:
@@ -6026,7 +6026,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20
+  RUNTIME: go1.20.1
 trigger:
   event:
     include:
@@ -18293,6 +18293,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 92e185c59ff98204c2ac9a8007afba6db9c0bc51ad7278dc14739df24a9ff974
+hmac: aad8a7e55b8ed12a764bafa4dfea2eb6dada0954e0e1e59c900f313e99f505e6
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -18,7 +18,7 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 
-GOLANG_VERSION ?= go1.20
+GOLANG_VERSION ?= go1.20.1
 
 NODE_VERSION ?= 16.18.1
 


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/21911 to v11