### PR TITLE
[v10] Update Go toolchain to 1.19.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ name: push-build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
   UID: "1000"
 trigger:
   event:
@@ -144,7 +144,7 @@ name: push-build-linux-386
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
   UID: "1000"
 trigger:
   event:
@@ -247,7 +247,7 @@ name: push-build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
   UID: "1000"
 trigger:
   event:
@@ -354,7 +354,7 @@ name: push-build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
   UID: "1000"
 trigger:
   event:
@@ -512,7 +512,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.19.5
+    RUNTIME: go1.19.6
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -1076,7 +1076,7 @@ name: push-build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
   UID: "1000"
 trigger:
   event:
@@ -1179,7 +1179,7 @@ name: push-build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
   UID: "1000"
 trigger:
   event:
@@ -1594,7 +1594,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
 trigger:
   event:
     include:
@@ -1782,7 +1782,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
 trigger:
   event:
     include:
@@ -1969,7 +1969,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
 trigger:
   event:
     include:
@@ -2163,7 +2163,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
 trigger:
   event:
     include:
@@ -3366,7 +3366,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
 trigger:
   event:
     include:
@@ -4121,7 +4121,7 @@ steps:
   - tar -C  /tmp/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED/toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
   - rm -rf $RUNTIME.darwin-amd64.tar.gz
   environment:
-    RUNTIME: go1.19.5
+    RUNTIME: go1.19.6
 - name: Install Rust Toolchain
   commands:
   - set -u
@@ -4713,7 +4713,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
 trigger:
   event:
     include:
@@ -4899,7 +4899,7 @@ name: build-linux-arm64
 environment:
   BUILDBOX_VERSION: teleport10
   GID: "1000"
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
   UID: "1000"
 trigger:
   event:
@@ -5981,7 +5981,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport10
-  RUNTIME: go1.19.5
+  RUNTIME: go1.19.6
 trigger:
   event:
     include:
@@ -18249,6 +18249,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: a021f33422fb7f0a79adc6666d2c3f2f22d57de156b356168b8fdef5aeedfa51
+hmac: bf637de459794d33cc0e6d7f3e9e6164d3dac5566528b95eb3ac051fe6194dba
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -17,7 +17,7 @@ TEST_KUBE ?=
 
 OS ?= linux
 ARCH ?= amd64
-GOLANG_VERSION ?= go1.19.5
+GOLANG_VERSION ?= go1.19.6
 # run lint-rust check locally before merging code after you bump this
 RUST_VERSION ?= 1.67.0
 NODE_VERSION ?= 16.13.2


### PR DESCRIPTION
Partial backport of https://github.com/gravitational/teleport/pull/21911,
but applied security patch for go1.19.6, same release notes there:

https://go.dev/doc/devel/release#go1.19.6

> These minor releases include 4 security fixes following the [security policy](https://go.dev/security):
> 
> path/filepath: path traversal in filepath.Clean on Windows
> 
> On Windows, the filepath.Clean function could transform an invalid path such as a/../c:/b into the valid path c:\b. This transformation of a relative (if invalid) path into an absolute path could enable a directory traversal attack. The filepath.Clean function will now transform this path into the relative (but still invalid) path .\c:\b.
> 
> Thanks to RyotaK (https://ryotak.net/) for reporting this issue.
> 
> This is CVE-2022-41722 and Go issue https://go.dev/issue/57274.
> 
> net/http, mime/multipart: denial of service from excessive resource consumption
> 
> Multipart form parsing with mime/multipart.Reader.ReadForm can consume largely unlimited amounts of memory and disk files. This also affects form parsing in the net/http package with the Request methods FormFile, FormValue, ParseMultipartForm, and PostFormValue.
> 
> ReadForm takes a maxMemory parameter, and is documented as storing "up to maxMemory bytes +10MB (reserved for non-file parts) in memory". File parts which cannot be stored in memory are stored on disk in temporary files. The unconfigurable 10MB reserved for non-file parts is excessively large and can potentially open a denial of service vector on its own. However, ReadForm did not properly account for all memory consumed by a parsed form, such as map entry overhead, part names, and MIME headers, permitting a maliciously crafted form to consume well over 10MB. In addition, ReadForm contained no limit on the number of disk files created, permitting a relatively small request body to create a large number of disk temporary files.
> 
> ReadForm now properly accounts for various forms of memory overhead, and should now stay within its documented limit of 10MB + maxMemory bytes of memory consumption. Users should still be aware that this limit is high and may still be hazardous.
> 
> ReadForm now creates at most one on-disk temporary file, combining multiple form parts into a single temporary file. The mime/multipart.File interface type's documentation states, "If stored on disk, the File's underlying concrete type will be an *os.File.". This is no longer the case when a form contains more than one file part, due to this coalescing of parts into a single file. The previous behavior of using distinct files for each form part may be reenabled with the environment variable GODEBUG=multipartfiles=distinct.
> 
> Users should be aware that multipart.ReadForm and the http.Request methods that call it do not limit the amount of disk consumed by temporary files. Callers can limit the size of form data with http.MaxBytesReader.
> 
> Thanks to Ameya Darshan and Jakob Ackermann (@das7pad) for reporting this issue.
> 
> This is CVE-2022-41725 and Go issue https://go.dev/issue/58006.
> 
> crypto/tls: large handshake records may cause panics
> 
> Both clients and servers may send large TLS handshake records which cause servers and clients,
> respectively, to panic when attempting to construct responses.
> 
> This affects all TLS 1.3 clients, TLS 1.2 clients which explicitly enable session resumption
> (by setting Config.ClientSessionCache to a non-nil value), and TLS 1.3 servers which request
> client certificates (by setting Config.ClientAuth >= RequestClientCert).
> 
> Thanks to Marten Seemann for reporting this issue.
> 
> This is CVE-2022-41724 and Go issue https://go.dev/issue/58001.
> 
> net/http: avoid quadratic complexity in HPACK decoding
> 
> A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.
> 
> This issue is also fixed in [golang.org/x/net/http2](http://golang.org/x/net/http2) v0.7.0, for users manually configuring HTTP/2.
> 
> Thanks to Philippe Antoine (Catena cyber) for reporting this issue.
> 
> This is CVE-2022-41723 and Go issue https://go.dev/issue/57855.