### PR TITLE
prototype aws access behind AWS ALB

### DIFF
--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -250,12 +250,16 @@ func (l *LocalProxy) StartHTTPAccessProxy(ctx context.Context) error {
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			NextProtos:         l.cfg.GetProtocols(),
-			InsecureSkipVerify: l.cfg.InsecureSkipVerify,
-			ServerName:         l.cfg.SNI,
-			Certificates:       l.getCerts(),
-		},
+		DialTLSContext: NewALPNDialer(ALPNDialerConfig{
+			ALPNConnUpgradeRequired: l.cfg.ALPNConnUpgradeRequired,
+			TLSConfig: &tls.Config{
+				NextProtos:         l.cfg.GetProtocols(),
+				InsecureSkipVerify: l.cfg.InsecureSkipVerify,
+				ServerName:         l.cfg.SNI,
+				Certificates:       l.getCerts(),
+				RootCAs:            l.cfg.RootCAs,
+			},
+		}).DialContext,
 	}
 	proxy := &httputil.ReverseProxy{
 		Director: func(outReq *http.Request) {


### PR DESCRIPTION
Related issue:

- https://github.com/gravitational/teleport/issues/21870


```
$ tsh aws -d -- s3 ls
...
DEBU             ALPN connection upgrade required for "teleport.root.dev.aws.stevexin.me:443": true. alpnproxy/conn_upgrade.go:74
...
DEBU             ALPN connection upgrade for teleport.root.dev.aws.stevexin.me:443. alpnproxy/conn_upgrade.go:95
...
(success aws s3 ls output)