### PR TITLE
Preform RBAC checks before connecting to registered OpenSSH nodes

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -127,6 +127,9 @@ const (
 	// KindNode is node resource
 	KindNode = "node"
 
+	// KindOpenSSHNode is a registered OpenSSH (agentless) node.
+	KindOpenSSHNode = "openssh"
+
 	// KindAppServer is an application server resource.
 	KindAppServer = "app_server"
 

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -187,7 +187,6 @@ func NewRouter(cfg RouterConfig) (*Router, error) {
 		tracer:         cfg.TracerProvider.Tracer("Router"),
 		serverResolver: cfg.serverResolver,
 	}, nil
-
 }
 
 // DialHost dials the node that matches the provided host, port and cluster. If no matching node
@@ -275,11 +274,12 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 		OriginalClientDstAddr: clientDstAddr,
 		GetUserAgent:          agentGetter,
 		Address:               host,
+		Principals:            principals,
 		ServerID:              serverID,
 		ProxyIDs:              proxyIDs,
-		Principals:            principals,
 		TeleportVersion:       targetTeleportVersion,
 		ConnType:              types.NodeTunnel,
+		TargetServer:          target,
 	})
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -427,7 +427,6 @@ func getServer(ctx context.Context, host, port string, site site) (types.Server,
 	}
 
 	return server, nil
-
 }
 
 // DialSite establishes a connection to the auth server in the provided

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -409,7 +409,6 @@ func TestRouter_DialHost(t *testing.T) {
 			tt.assertion(t, conn, err)
 		})
 	}
-
 }
 
 func TestRouter_DialSite(t *testing.T) {

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -64,6 +64,11 @@ type DialParams struct {
 	// Only used when connecting through a tunnel.
 	ConnType types.TunnelType
 
+	// TargetServer is the host that the connection is being established for.
+	// It **MUST** only be populated when the target is a teleport ssh server
+	// or an agentless server.
+	TargetServer types.Server
+
 	// FromPeerProxy indicates that the dial request is being tunneled from
 	// a peer proxy.
 	FromPeerProxy bool

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -384,6 +384,7 @@ func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 		TargetID:        params.ServerID,
 		TargetAddr:      params.To.String(),
 		TargetHostname:  params.Address,
+		TargetServer:    params.TargetServer,
 		Clock:           s.clock,
 	}
 	remoteServer, err := forward.New(serverConfig)

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -880,6 +880,7 @@ func (s *remoteSite) dialWithAgent(params DialParams) (net.Conn, error) {
 		TargetID:        params.ServerID,
 		TargetAddr:      params.To.String(),
 		TargetHostname:  params.Address,
+		TargetServer:    params.TargetServer,
 		Clock:           s.clock,
 	}
 	remoteServer, err := forward.New(serverConfig)

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -79,6 +79,11 @@ type AuthHandlerConfig struct {
 	// AccessPoint is used to access the Auth Server.
 	AccessPoint AccessPoint
 
+	// TargetServer is the host that the connection is being established for.
+	// It **MUST** only be populated when the target is a teleport ssh server
+	// or an agentless server.
+	TargetServer types.Server
+
 	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
 	// configuration.
 	FIPS bool
@@ -112,6 +117,8 @@ func (c *AuthHandlerConfig) CheckAndSetDefaults() error {
 // AuthHandlers are common authorization and authentication related handlers
 // used by the regular and forwarding server.
 type AuthHandlers struct {
+	loginChecker
+
 	log *log.Entry
 
 	c *AuthHandlerConfig
@@ -127,10 +134,16 @@ func NewAuthHandlers(config *AuthHandlerConfig) (*AuthHandlers, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	return &AuthHandlers{
+	ah := &AuthHandlers{
 		c:   config,
 		log: log.WithField(trace.Component, config.Component),
-	}, nil
+	}
+	ah.loginChecker = &ahLoginChecker{
+		log: ah.log,
+		c:   ah.c,
+	}
+
+	return ah, nil
 }
 
 // CreateIdentityContext returns an IdentityContext populated with information
@@ -167,7 +180,7 @@ func (h *AuthHandlers) CreateIdentityContext(sconn *ssh.ServerConn) (IdentityCon
 		return IdentityContext{}, trace.Wrap(err)
 	}
 
-	accessInfo, err := h.fetchAccessInfo(certificate, certAuthority, identity.TeleportUser, clusterName.GetClusterName())
+	accessInfo, err := fetchAccessInfo(certificate, certAuthority, identity.TeleportUser, clusterName.GetClusterName())
 	if err != nil {
 		return IdentityContext{}, trace.Wrap(err)
 	}
@@ -404,12 +417,28 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 		return permissions, nil
 	}
 
+	// even if the returned CA isn't used when a RBAC check isn't
+	// preformed, we still need to verify that User CA signed the
+	// client's certificate
+	ca, err := h.authorityForCert(types.UserCA, cert.SignatureKey)
+	if err != nil {
+		log.Errorf("Permission denied: %v", err)
+		recordFailedLogin(err)
+		return nil, trace.Wrap(err)
+	}
+
 	// check if the user has permission to log into the node.
-	switch {
-	case h.c.Component == teleport.ComponentForwardingNode:
-		err = h.canLoginWithoutRBAC(cert, clusterName.GetClusterName(), teleportUser, conn.User())
-	default:
-		err = h.canLoginWithRBAC(cert, clusterName.GetClusterName(), teleportUser, conn.User())
+	if h.c.Component == teleport.ComponentForwardingNode {
+		// If we are forwarding the connection, the target node
+		// exists and it is an agentless node, preform an RBAC check.
+		// Otherwise if the target node does not exist the node is
+		// probably an unregistered SSH node; do not preform an RBAC check
+		if h.c.TargetServer != nil && h.c.TargetServer.GetSubKind() == types.KindOpenSSHNode {
+			err = h.canLoginWithRBAC(cert, ca, clusterName.GetClusterName(), h.c.TargetServer, teleportUser, conn.User())
+		}
+	} else {
+		// the SSH server is a Teleport node, preform an RBAC check now
+		err = h.canLoginWithRBAC(cert, ca, clusterName.GetClusterName(), h.c.Server.GetInfo(), teleportUser, conn.User())
 	}
 	if err != nil {
 		log.Errorf("Permission denied: %v", err)
@@ -521,42 +550,35 @@ func (h *AuthHandlers) IsHostAuthority(cert ssh.PublicKey, address string) bool 
 	return true
 }
 
-// canLoginWithoutRBAC checks the given certificate (supplied by a connected
-// client) to see if this certificate can be allowed to login as user:login
-// pair to requested server.
-func (h *AuthHandlers) canLoginWithoutRBAC(cert *ssh.Certificate, clusterName string, teleportUser, osUser string) error {
-	h.log.Debugf("Checking permissions for (%v,%v) to login to node without RBAC checks.", teleportUser, osUser)
+// loginChecker checks if the Teleport user should be able to login to
+// a target.
+type loginChecker interface {
+	// canLoginWithRBAC checks the given certificate (supplied by a connected
+	// client) to see if this certificate can be allowed to login as user:login
+	// pair to requested server and if RBAC rules allow login.
+	canLoginWithRBAC(cert *ssh.Certificate, ca types.CertAuthority, clusterName string, target types.Server, teleportUser, osUser string) error
+}
 
-	// check if the ca that signed the certificate is known to the cluster
-	_, err := h.authorityForCert(types.UserCA, cert.SignatureKey)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
+type ahLoginChecker struct {
+	log *log.Entry
+	c   *AuthHandlerConfig
 }
 
 // canLoginWithRBAC checks the given certificate (supplied by a connected
 // client) to see if this certificate can be allowed to login as user:login
 // pair to requested server and if RBAC rules allow login.
-func (h *AuthHandlers) canLoginWithRBAC(cert *ssh.Certificate, clusterName string, teleportUser, osUser string) error {
+func (a *ahLoginChecker) canLoginWithRBAC(cert *ssh.Certificate, ca types.CertAuthority, clusterName string, target types.Server, teleportUser, osUser string) error {
 	// Use the server's shutdown context.
-	ctx := h.c.Server.Context()
+	ctx := a.c.Server.Context()
 
-	h.log.Debugf("Checking permissions for (%v,%v) to login to node with RBAC checks.", teleportUser, osUser)
-
-	// get the ca that signd the users certificate
-	ca, err := h.authorityForCert(types.UserCA, cert.SignatureKey)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	a.log.Debugf("Checking permissions for (%v,%v) to login to node with RBAC checks.", teleportUser, osUser)
 
 	// get roles assigned to this user
-	accessInfo, err := h.fetchAccessInfo(cert, ca, teleportUser, clusterName)
+	accessInfo, err := fetchAccessInfo(cert, ca, teleportUser, clusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	accessChecker, err := services.NewAccessChecker(accessInfo, clusterName, h.c.AccessPoint)
+	accessChecker, err := services.NewAccessChecker(accessInfo, clusterName, a.c.AccessPoint)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -566,7 +588,7 @@ func (h *AuthHandlers) canLoginWithRBAC(cert *ssh.Certificate, clusterName strin
 		return nil
 	}
 
-	authPref, err := h.c.AccessPoint.GetAuthPreference(ctx)
+	authPref, err := a.c.AccessPoint.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -577,7 +599,7 @@ func (h *AuthHandlers) canLoginWithRBAC(cert *ssh.Certificate, clusterName strin
 
 	// check if roles allow access to server
 	if err := accessChecker.CheckAccess(
-		h.c.Server.GetInfo(),
+		target,
 		state,
 		services.NewLoginMatcher(osUser),
 	); err != nil {
@@ -591,7 +613,7 @@ func (h *AuthHandlers) canLoginWithRBAC(cert *ssh.Certificate, clusterName strin
 // fetchAccessInfo fetches the services.AccessChecker (after role mapping)
 // together with the original roles (prior to role mapping) assigned to a
 // Teleport user.
-func (h *AuthHandlers) fetchAccessInfo(cert *ssh.Certificate, ca types.CertAuthority, teleportUser string, clusterName string) (*services.AccessInfo, error) {
+func fetchAccessInfo(cert *ssh.Certificate, ca types.CertAuthority, teleportUser string, clusterName string) (*services.AccessInfo, error) {
 	var accessInfo *services.AccessInfo
 	var err error
 	if clusterName == ca.GetClusterName() {

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package srv
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type mockCAGetter struct {
+	AccessPoint
+
+	cas map[types.CertAuthType]types.CertAuthority
+}
+
+func (m mockCAGetter) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
+	ca, ok := m.cas[caType]
+	if !ok {
+		return nil, trace.NotFound("CA not found")
+	}
+
+	return []types.CertAuthority{ca}, nil
+}
+
+type mockLoginChecker struct {
+	rbacChecked bool
+}
+
+func (m *mockLoginChecker) canLoginWithRBAC(_ *ssh.Certificate, _ types.CertAuthority, _ string, _ types.Server, _, _ string) error {
+	m.rbacChecked = true
+	return nil
+}
+
+type mockConnMetadata struct{}
+
+func (m mockConnMetadata) User() string {
+	return "testuser"
+}
+
+func (m mockConnMetadata) SessionID() []byte {
+	return nil
+}
+
+func (m mockConnMetadata) ClientVersion() []byte {
+	return nil
+}
+
+func (m mockConnMetadata) ServerVersion() []byte {
+	return nil
+}
+
+func (m mockConnMetadata) LocalAddr() net.Addr {
+	return &net.TCPAddr{
+		IP:   net.ParseIP("1.2.3.4"),
+		Port: 22,
+	}
+}
+
+func (m mockConnMetadata) RemoteAddr() net.Addr {
+	return &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 9001,
+	}
+}
+
+func TestRBAC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		component       string
+		nodeExists      bool
+		openSSHNode     bool
+		assertRBACCheck require.BoolAssertionFunc
+	}{
+		{
+			name:            "teleport node, regular server",
+			component:       teleport.ComponentNode,
+			nodeExists:      true,
+			openSSHNode:     false,
+			assertRBACCheck: require.True,
+		},
+		{
+			name:            "teleport node, forwarding server",
+			component:       teleport.ComponentForwardingNode,
+			nodeExists:      true,
+			openSSHNode:     false,
+			assertRBACCheck: require.False,
+		},
+		{
+			name:            "registered openssh node, forwarding server",
+			component:       teleport.ComponentForwardingNode,
+			nodeExists:      true,
+			openSSHNode:     true,
+			assertRBACCheck: require.True,
+		},
+		{
+			name:            "unregistered openssh node, forwarding server",
+			component:       teleport.ComponentForwardingNode,
+			nodeExists:      false,
+			assertRBACCheck: require.False,
+		},
+	}
+
+	// create User CA
+	userTA := testauthority.New()
+	userCAPriv, err := userTA.GeneratePrivateKey()
+	require.NoError(t, err)
+	userCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.UserCA,
+		ClusterName: "localhost",
+		ActiveKeys: types.CAKeySet{
+			SSH: []*types.SSHKeyPair{
+				{
+					PublicKey:      userCAPriv.MarshalSSHPublicKey(),
+					PrivateKey:     userCAPriv.PrivateKeyPEM(),
+					PrivateKeyType: types.PrivateKeyType_RAW,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// create mock SSH server and add a cluster name
+	server := newMockServer(t)
+	clusterName, err := types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: "localhost",
+		ClusterID:   "cluster_id",
+	})
+	require.NoError(t, err)
+	err = server.auth.SetClusterName(clusterName)
+	require.NoError(t, err)
+
+	accessPoint := mockCAGetter{
+		AccessPoint: server.auth,
+		cas: map[types.CertAuthType]types.CertAuthority{
+			types.UserCA: userCA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// create node resource
+			var target types.Server
+			if tt.nodeExists {
+				n, err := types.NewServer("testie_node", types.KindNode, types.ServerSpecV2{
+					Addr:     "1.2.3.4:22",
+					Hostname: "testie",
+					Version:  types.V2,
+				})
+				require.NoError(t, err)
+				server, ok := n.(*types.ServerV2)
+				require.True(t, ok)
+				if tt.openSSHNode {
+					server.SubKind = types.KindOpenSSHNode
+				}
+				target = server
+			}
+
+			config := &AuthHandlerConfig{
+				Server:       server,
+				Component:    tt.component,
+				Emitter:      &eventstest.MockEmitter{},
+				AccessPoint:  accessPoint,
+				TargetServer: target,
+			}
+			ah, err := NewAuthHandlers(config)
+			require.NoError(t, err)
+
+			lc := mockLoginChecker{}
+			ah.loginChecker = &lc
+
+			// create SSH certificate
+			caSigner, err := ssh.NewSignerFromKey(userCAPriv)
+			require.NoError(t, err)
+			keygen := testauthority.New()
+			privateKey, err := native.GeneratePrivateKey()
+			require.NoError(t, err)
+
+			c, err := keygen.GenerateUserCert(services.UserCertParams{
+				CASigner:      caSigner,
+				PublicUserKey: ssh.MarshalAuthorizedKey(privateKey.SSHPublicKey()),
+				Username:      "testuser",
+				AllowedLogins: []string{"testuser"},
+			})
+			require.NoError(t, err)
+
+			cert, err := sshutils.ParseCertificate(c)
+			require.NoError(t, err)
+
+			// preform public key authentication
+			_, err = ah.UserKeyAuth(&mockConnMetadata{}, cert)
+			require.NoError(t, err)
+
+			tt.assertRBACCheck(t, lc.rbacChecked)
+		})
+	}
+}

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -163,6 +163,11 @@ type Server struct {
 	tracerProvider oteltrace.TracerProvider
 
 	targetID, targetAddr, targetHostname string
+
+	// targetServer is the host that the connection is being established for.
+	// It **MUST** only be populated when the target is a teleport ssh server
+	// or an agentless server.
+	targetServer types.Server
 }
 
 // ServerConfig is the configuration needed to create an instance of a Server.
@@ -221,6 +226,11 @@ type ServerConfig struct {
 	TracerProvider oteltrace.TracerProvider
 
 	TargetID, TargetAddr, TargetHostname string
+
+	// TargetServer is the host that the connection is being established for.
+	// It **MUST** only be populated when the target is a teleport ssh server
+	// or an agentless server.
+	TargetServer types.Server
 }
 
 // CheckDefaults makes sure all required parameters are passed in.
@@ -308,6 +318,7 @@ func New(c ServerConfig) (*Server, error) {
 		targetID:        c.TargetID,
 		targetAddr:      c.TargetAddr,
 		targetHostname:  c.TargetHostname,
+		targetServer:    c.TargetServer,
 	}
 
 	// Set the ciphers, KEX, and MACs that the in-memory server will send to the
@@ -326,12 +337,13 @@ func New(c ServerConfig) (*Server, error) {
 
 	// Common auth handlers.
 	authHandlerConfig := srv.AuthHandlerConfig{
-		Server:      s,
-		Component:   teleport.ComponentForwardingNode,
-		Emitter:     c.Emitter,
-		AccessPoint: c.AuthClient,
-		FIPS:        c.FIPS,
-		Clock:       c.Clock,
+		Server:       s,
+		Component:    teleport.ComponentForwardingNode,
+		Emitter:      c.Emitter,
+		AccessPoint:  c.AuthClient,
+		TargetServer: c.TargetServer,
+		FIPS:         c.FIPS,
+		Clock:        c.Clock,
 	}
 
 	s.authHandlers, err = srv.NewAuthHandlers(&authHandlerConfig)

--- a/lib/srv/forward/sshserver_test.go
+++ b/lib/srv/forward/sshserver_test.go
@@ -146,7 +146,7 @@ func (n *newChannelMock) ExtraData() []byte {
 // TestDirectTCPIP ensures that ssh client using SessionJoinPrincipal as Login
 // cannot connect using "direct-tcpip" on forward mode.
 //
-// Forward requires a lot of depependencies and we don't have top level tests
+// Forward requires a lot of dependencies and we don't have top level tests
 // yet here. If we add it in future, test should be rework to use public methods
 // instead of internals.
 func TestDirectTCPIP(t *testing.T) {


### PR DESCRIPTION
Part of implementing https://github.com/gravitational/teleport/pull/19261. 

Preform RBAC checks before connecting to registered OpenSSH nodes. The RBAC logic assumes that SSH connections to registered OpenSSH nodes will always be proxied and terminated, which will come in a future PR.