### PR TITLE
Support proxy reading of SAML IdP CA.

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -602,15 +602,21 @@ func (a *ServerWithRoles) GetCertAuthorities(ctx context.Context, caType types.C
 }
 
 func (a *ServerWithRoles) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
-	if err := a.action(apidefaults.Namespace, types.KindCertAuthority, types.VerbReadNoSecrets); err != nil {
+	readVerb := types.VerbReadNoSecrets
+	if loadKeys {
+		readVerb = types.VerbRead
+	}
+
+	ca, err := a.authServer.GetCertAuthority(ctx, id, loadKeys, opts...)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if loadKeys {
-		if err := a.action(apidefaults.Namespace, types.KindCertAuthority, types.VerbRead); err != nil {
-			return nil, trace.Wrap(err)
-		}
+	sctx := &services.Context{User: a.context.User, Resource: ca}
+	if err := a.actionWithContext(sctx, apidefaults.Namespace, types.KindCertAuthority, readVerb); err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetCertAuthority(ctx, id, loadKeys, opts...)
+
+	return ca, nil
 }
 
 func (a *ServerWithRoles) GetDomainName(ctx context.Context) (string, error) {

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -513,6 +513,18 @@ func roleSpecForProxy(clusterName string) types.RoleSpecV6 {
 						),
 					).String(),
 				},
+				// this rule allows the local proxy to read the local SAML IdP CA.
+				{
+					Resources: []string{types.KindCertAuthority},
+					Verbs:     []string{types.VerbRead},
+					Where: builder.And(
+						builder.Equals(services.CertAuthorityTypeExpr, builder.String(string(types.SAMLIDPCA))),
+						builder.Equals(
+							services.ResourceNameExpr,
+							builder.String(clusterName),
+						),
+					).String(),
+				},
 			},
 		},
 	}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1698,7 +1698,7 @@ func TestGetCertAuthority(t *testing.T) {
 	// generate server keys for node
 	nodeClt, err := tt.server.NewClient(TestIdentity{I: BuiltinRole{Username: "00000000-0000-0000-0000-000000000000", Role: types.RoleNode}})
 	require.NoError(t, err)
-	defer nodeClt.Close()
+	t.Cleanup(func() { require.NoError(t, nodeClt.Close()) })
 
 	// node is authorized to fetch CA without secrets
 	ca, err := nodeClt.GetCertAuthority(ctx, types.CertAuthID{
@@ -1719,6 +1719,32 @@ func TestGetCertAuthority(t *testing.T) {
 		Type:       types.HostCA,
 	}, true)
 	require.True(t, trace.IsAccessDenied(err))
+
+	// generate server keys for proxy
+	proxyClt, err := tt.server.NewClient(TestIdentity{I: BuiltinRole{Username: "00000000-0000-0000-0000-000000000001", Role: types.RoleProxy}})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, proxyClt.Close()) })
+
+	// proxy can't fetch the host CA with secrets
+	_, err = proxyClt.GetCertAuthority(ctx, types.CertAuthID{
+		DomainName: tt.server.ClusterName(),
+		Type:       types.HostCA,
+	}, true)
+	require.Error(t, err)
+
+	// proxy can fetch SAML IdP CA with secrets
+	_, err = proxyClt.GetCertAuthority(ctx, types.CertAuthID{
+		DomainName: tt.server.ClusterName(),
+		Type:       types.SAMLIDPCA,
+	}, true)
+	require.NoError(t, err)
+
+	// proxy can't fetch anything else with secrets
+	_, err = proxyClt.GetCertAuthority(ctx, types.CertAuthID{
+		DomainName: tt.server.ClusterName(),
+		Type:       types.DatabaseCA,
+	}, true)
+	require.Error(t, err)
 
 	// non-admin users are not allowed to get access to private key material
 	user, err := types.NewUser("bob")

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1724,7 +1724,7 @@ func TestGetCertAuthority(t *testing.T) {
 	proxyClt, err := tt.server.NewClient(TestIdentity{
 		I: BuiltinRole{
 			Username: "00000000-0000-0000-0000-000000000001",
-			Role: types.RoleProxy,
+			Role:     types.RoleProxy,
 		},
 	})
 	require.NoError(t, err)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1721,7 +1721,12 @@ func TestGetCertAuthority(t *testing.T) {
 	require.True(t, trace.IsAccessDenied(err))
 
 	// generate server keys for proxy
-	proxyClt, err := tt.server.NewClient(TestIdentity{I: BuiltinRole{Username: "00000000-0000-0000-0000-000000000001", Role: types.RoleProxy}})
+	proxyClt, err := tt.server.NewClient(TestIdentity{
+		I: BuiltinRole{
+			Username: "00000000-0000-0000-0000-000000000001",
+			Role: types.RoleProxy,
+		},
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, proxyClt.Close()) })
 

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -129,10 +129,11 @@ func checkDatabaseCA(cai types.CertAuthority) error {
 			if err != nil {
 				return trace.Wrap(err)
 			}
-		}
-		_, err := tlsca.ParseCertificatePEM(pair.Cert)
-		if err != nil {
-			return trace.Wrap(err)
+		} else {
+			_, err := tlsca.ParseCertificatePEM(pair.Cert)
+			if err != nil {
+				return trace.Wrap(err)
+			}
 		}
 	}
 

--- a/lib/services/authority_test.go
+++ b/lib/services/authority_test.go
@@ -207,14 +207,14 @@ func TestCheckSAMLIDPCA(t *testing.T) {
 			name: "multiple active keys",
 			keyset: types.CAKeySet{
 				TLS: []*types.TLSKeyPair{{
-					Cert: bytes.Repeat([]byte{49}, 1666),
-					Key:  bytes.Repeat([]byte{49}, 1222),
+					Cert: cert,
+					Key:  key,
 				}, {
-					Cert: bytes.Repeat([]byte{49}, 1666),
-					Key:  bytes.Repeat([]byte{49}, 1222),
+					Cert: cert,
+					Key:  key,
 				}},
 			},
-			errAssertionFunc: require.Error,
+			errAssertionFunc: require.NoError,
 		},
 		{
 			name: "empty key",


### PR DESCRIPTION
GetCertAuthority was not respecting CA type where clauses because the CA was not being passed into the AccessChecker properly. This has been fixed. Additionally, the SAML IdP CA's validation has been fixed so that it supports more than 1 active key pair during key rotations.

With all this, the proxy will now be able to read the SAML IdP CA.