### PR TITLE
Improve formatting for TLS cert requests

### DIFF
--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1099,13 +1099,10 @@ func (ca *CertAuthority) GenerateCertificate(req CertificateRequest) ([]byte, er
 	}
 
 	log.WithFields(logrus.Fields{
-		"not_after":   req.NotAfter,
-		"dns_names":   req.DNSNames,
-		"common_name": req.Subject.CommonName,
-		"org":         req.Subject.Organization,
-		"org_unit":    req.Subject.OrganizationalUnit,
-		"locality":    req.Subject.Locality,
-	}).Infof("Generating TLS certificate %v.", req)
+		"not_after": req.NotAfter,
+		"dns_names": req.DNSNames,
+		"key_usage": req.KeyUsage,
+	}).Infof("Generating TLS certificate %v", req.Subject.String())
 
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,


### PR DESCRIPTION
The deafult string formating cluttered the logs with a bunch of raw bytes and memory addresses, which aren't helpful.

Before:
```
2023-02-16T17:05:17-07:00 [CA]        INFO Generating TLS certificate {0x10b7ff328 0x14003a31080 CN=Administrator 2023-02-17 08:05:17.258294 +0000 UTC [] [{2.5.29.37 false [48 22 6 8 43 6 1 5 5 7 3 2 6 10 43 6 1 4 1 130 55 20 2 2]} {2.5.29.17 false [48 46 160 44 6 10 43 6 1 4 1 130 55 20 2 3 160 30 12 28 65 100 109 105 110 105 115 116 114 97 116 111 114 64 122 97 99 101 120 97 109 112 108 101 46 99 111 109]} {1.3.6.1.4.1.311.25.2 false [48 63 160 61 6 10 43 6 1 4 1 130 55 25 2 1 160 47 4 45 83 45 49 45 53 45 50 49 45 50 57 48 49 57 56 51 53 53 53 45 51 50 54 50 52 53 55 49 55 50 45 52 50 49 53 54 48 50 51 54 53 45 53 48 48]} {1.3.9999.2.14 false [111 115 115]}] 1 [ldap:///CN=zac-local,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=zacexample,DC=com?certificateRevocationList?base?objectClass=cRLDistributionPoint]}. common_name:Administrator dns_names:[] locality:[] not_after:2023-02-17 08:05:17.258294 +0000 UTC org:[] org_unit:[] tlsca/ca.go:1091
```

After:
```
2023-02-16T17:21:20-07:00 INFO [CA]        Generating TLS certificate CN=Administrator dns_names:[] key_usage:1 not_after:2023-02-17 08:21:20.338929 +0000 UTC tlsca/ca.go:1105
```