### PR TITLE
tsh proxy: pass original remote hostname in ProxyCommand

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -157,7 +157,7 @@ as well as an upgrade of the previous version of Teleport.
     log:
 
     ```shell
-    sftp -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@proxy.example.com -s proxy:%h:%p" root@node1
+    sftp -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@proxy.example.com -s proxy:%n:%p" root@node1
     ```
 
 - [ ] Interact with a cluster using `tsh`
@@ -352,18 +352,18 @@ When interacting with a cluster, the following command templates are useful:
 
 ```
 # when connecting to the recording proxy, `-o 'ForwardAgent yes'` is required.
-ssh -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@proxy.example.com -s proxy:%h:%p" \
+ssh -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@proxy.example.com -s proxy:%n:%p" \
   node.example.com
 
 # the above command only forwards the agent to the proxy, to forward the agent
 # to the target node, `-o 'ForwardAgent yes'` needs to be passed twice.
 ssh -o "ForwardAgent yes" \
-  -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@proxy.example.com -s proxy:%h:%p" \
+  -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@proxy.example.com -s proxy:%n:%p" \
   node.example.com
 
 # when connecting to a remote cluster using OpenSSH, the subsystem request is
 # updated with the name of the remote cluster.
-ssh -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@proxy.example.com -s proxy:%h:%p@foo.com" \
+ssh -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@proxy.example.com -s proxy:%n:%p@foo.com" \
   node.foo.com
 ```
 
@@ -944,7 +944,7 @@ tsh bench sessions --max=5000 --web user ls
   - [ ] Verify app access through proxy running in `multiplex` mode
 - [ ] SSH Access
   - [ ] Connect to a OpenSSH server through a local ssh proxy `ssh -o "ForwardAgent yes" -o "ProxyCommand tsh proxy ssh" user@host.example.com`
-  - [ ] Connect to a OpenSSH server on leaf-cluster through a local ssh proxy`ssh -o "ForwardAgent yes" -o "ProxyCommand tsh proxy ssh --user=%r --cluster=leaf-cluster %h:%p" user@node.foo.com`
+  - [ ] Connect to a OpenSSH server on leaf-cluster through a local ssh proxy`ssh -o "ForwardAgent yes" -o "ProxyCommand tsh proxy ssh --user=%r --cluster=leaf-cluster %n:%p" user@node.foo.com`
   - [ ] Verify `tsh ssh` access through proxy running in multiplex mode
 - [ ] Kubernetes access:
   - [ ] Verify kubernetes access through proxy running in `multiplex` mode

--- a/docker/README.md
+++ b/docker/README.md
@@ -110,7 +110,7 @@ To setup Ansible:
     echo "172.10.1.2:3022" >> /etc/ansible/hosts
 
     # setup ssh_args that ansible will use to access trusted cluster nodes
-    sed -i '/ssh_args = -o ControlMaster=auto -o ControlPersist=60s/assh_args = -o "ProxyCommand ssh -p 3023 one -s proxy:%h:%p@two"' /etc/ansible/ansible.cfg
+    sed -i '/ssh_args = -o ControlMaster=auto -o ControlPersist=60s/assh_args = -o "ProxyCommand ssh -p 3023 one -s proxy:%n:%p@two"' /etc/ansible/ansible.cfg
 
     # use scp over sftp
     sed -i '/scp_if_ssh/s/^#//g' /etc/ansible/ansible.cfg

--- a/docker/sshd/scripts/ssh.cfg
+++ b/docker/sshd/scripts/ssh.cfg
@@ -1,7 +1,7 @@
 ## Hosts with openssh suffix are OpenSSH nodes listening on port 22 as usual
 Host *.openssh.teleport
-    ProxyCommand ssh -o "ForwardAgent yes" -p 3023 proxy.luna.teleport -s proxy:%h:22
+    ProxyCommand ssh -o "ForwardAgent yes" -p 3023 proxy.luna.teleport -s proxy:%n:22
 
 # Hosts without openssh suffix are Teleport nodes listening on port 3022
 Host *.teleport !proxy.luna.teleport
-    ProxyCommand ssh -o "ForwardAgent yes" -p 3023 proxy.luna.teleport -s proxy:%h:3022
+    ProxyCommand ssh -o "ForwardAgent yes" -p 3023 proxy.luna.teleport -s proxy:%n:3022

--- a/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
@@ -464,7 +464,7 @@ $ echo ${AUTH_IP}
 [`key_name`](#key_name) variable is available in the current directory, or update the `-i` parameter to point to it:
 
 ```code
-$ ssh -i ${TF_VAR_key_name}.pem -o ProxyCommand="ssh -i ${TF_VAR_key_name}.pem -W '[%h]:%p' ec2-user@${BASTION_IP}" ec2-user@${AUTH_IP}
+$ ssh -i ${TF_VAR_key_name}.pem -o ProxyCommand="ssh -i ${TF_VAR_key_name}.pem -W '[%n]:%p' ec2-user@${BASTION_IP}" ec2-user@${AUTH_IP}
 # The authenticity of host '1.2.3.4 (1.2.3.4)' can't be established.
 # ECDSA key fingerprint is SHA256:vFPnCFliRsRQ1Dk+muIv2B1Owm96hXiihlOUsj5H3bg.
 # Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
@@ -833,7 +833,7 @@ elif [[ "${INSTANCE_TYPE}" == "node" ]]; then
 fi
 
 echo "Keypair name: ${TF_VAR_key_name}"
-ssh -i ${TF_VAR_key_name}.pem -o ProxyCommand="ssh -i ${TF_VAR_key_name}.pem -W '[%h]:%p' ec2-user@${BASTION_IP}" ec2-user@${SERVER_IP}
+ssh -i ${TF_VAR_key_name}.pem -o ProxyCommand="ssh -i ${TF_VAR_key_name}.pem -W '[%n]:%p' ec2-user@${BASTION_IP}" ec2-user@${SERVER_IP}
 ```
 
 Save this as `connect.sh`, run `chmod +x connect.sh` to make it executable, then use it like so:

--- a/docs/pages/machine-id/guides/host-certificate.mdx
+++ b/docs/pages/machine-id/guides/host-certificate.mdx
@@ -20,7 +20,7 @@ and reducing risk by ensuring that short-lived certificates adhering to the prin
 (!/docs/pages/includes/tctl.mdx!)
 
 - A Linux based host that can support Machine ID. This "Machine ID Host" is the host that will be used to create Host Certificates using `tbot`.
-  This host should additionally have OpenSSH server `sshd` version 6.9 or above running. The SSH port on this host must be open to traffic from the Teleport Proxy Service host.
+  This host should additionally have OpenSSH server `sshd` version 8.1 or above running. The SSH port on this host must be open to traffic from the Teleport Proxy Service host.
 
   ```code
   $ ssh -V

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -553,7 +553,7 @@ Host *.example.com example.com
 # Flags for all example.com hosts except the proxy
 Host *.example.com !example.com
     Port 3022
-    ProxyCommand "/usr/local/bin/tsh" proxy ssh --cluster=example.com --proxy=example.com %r@%h:%p
+    ProxyCommand "/usr/local/bin/tsh" proxy ssh --cluster=example.com --proxy=example.com %r@%n:%p
 ```
 
 This output should be placed into the default SSH Config for environment, `~/.ssh/config` for Mac/Linux or

--- a/docs/pages/server-access/guides/openssh.mdx
+++ b/docs/pages/server-access/guides/openssh.mdx
@@ -14,7 +14,7 @@ We've outlined these reasons in [OpenSSH vs Teleport SSH for Servers?](https://g
 
 ## Prerequisites
 
-- OpenSSH version 6.9 or above on your local machine. View your OpenSSH version
+- OpenSSH version 8.1 or above on your local machine. View your OpenSSH version
   with the command:
   
   ```code
@@ -277,7 +277,7 @@ directory.
 # Flags for all {{ .ClusterName }} hosts except the proxy
 Host *.{{ .ClusterName }} !{{ .ProxyHost }}
     Port 3022
-    ProxyCommand "{{ .TSHPath }}" proxy ssh --cluster={{ .ClusterName }} --proxy={{ .ProxyHost }} %r@%h:%p
+    ProxyCommand "{{ .TSHPath }}" proxy ssh --cluster={{ .ClusterName }} --proxy={{ .ProxyHost }} %r@%n:%p
 ```
 
 If the host that you are `ssh`ing into belongs to your Teleport cluster, the
@@ -330,7 +330,7 @@ a jumphost, using the `-J` flag.
 ```txt
 Host *.{{ .NodeName }}.leaf1.example.com
    Port 3022
-   ProxyCommand tsh proxy ssh -J proxy.leaf1.example.com:443 %r@%h:%p
+   ProxyCommand tsh proxy ssh -J proxy.leaf1.example.com:443 %r@%n:%p
 ```
 
 ### Proxy Templates
@@ -345,7 +345,7 @@ your `~/.ssh/config`.
 ```txt
 Host *.example.com
    Port 3022
-   ProxyCommand tsh proxy ssh -J {{proxy}} %r@%h:%p
+   ProxyCommand tsh proxy ssh -J {{proxy}} %r@%n:%p
 ```
 
 Then, add `proxy_templates` to your `tsh` configuration file (`~/.tsh/config/config.yaml`
@@ -357,16 +357,16 @@ proxy_templates:
   proxy: "$2:443"
 ```
 
-`tsh proxy ssh -J {{proxy}}` will attempt to match the host server address `%h:%p` with the 
+`tsh proxy ssh -J {{proxy}}` will attempt to match the host server address `%n:%p` with the
 configured templates. If there is a match, then the jump proxy address `{{proxy}}` will
-be replaced using the template's `proxy` field and the host server address `%h:%p` will be 
+be replaced using the template's `proxy` field and the host server address `%n:%p` will be
 replaced using the template's `host` field if set.
 
 | Field      | Description |
 | ---------- | ----------- |
-| `template` | (Required) Regular expression that the host server address `%h:%p` is matched against. |
+| `template` | (Required) Regular expression that the host server address `%n:%p` is matched against. |
 | `proxy`    | (Required) Proxy Service address to use for proxy jump. Can reference capturing groups from the regular expression in `template` (e.g., `$1` or `$2`). |
-| `host`     | (Optional) Host Server address to connect to. Can reference capturing groups from the regular expression in `template` (e.g., `$1` or `$2`). Defaults to full host spec `%h:%p`. |
+| `host`     | (Optional) Host Server address to connect to. Can reference capturing groups from the regular expression in `template` (e.g., `$1` or `$2`). Defaults to full host spec `%n:%p`. |
 
 ### Example configuration
 

--- a/docs/pages/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/server-access/guides/recording-proxy-mode.mdx
@@ -200,7 +200,7 @@ terminate the SSH connection to record it:
 # (mandatory if using a recording proxy), and then optionally from a proxy
 # to the end server if you want your agent running on the end server
 $ ssh -o "ForwardAgent yes" \
-    -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@p.example.com -s proxy:%h:%p" \
+    -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@p.example.com -s proxy:%n:%p" \
     user@host.example.com
 ```
 

--- a/docs/pages/try-out-teleport/docker-compose.mdx
+++ b/docs/pages/try-out-teleport/docker-compose.mdx
@@ -159,11 +159,11 @@ as a bastion server:
 ```
 ## Hosts with openssh suffix are OpenSSH nodes listening on port 22 as usual
 Host *.openssh.teleport
-    ProxyCommand ssh -o "ForwardAgent yes" -p 3023 proxy.luna.teleport -s proxy:%h:22
+    ProxyCommand ssh -o "ForwardAgent yes" -p 3023 proxy.luna.teleport -s proxy:%n:22
 
 # Hosts without openssh suffix are Teleport Nodes listening on port 3022
 Host *.teleport !proxy.luna.teleport
-    ProxyCommand ssh -o "ForwardAgent yes" -p 3023 proxy.luna.teleport -s proxy:%h:3022
+    ProxyCommand ssh -o "ForwardAgent yes" -p 3023 proxy.luna.teleport -s proxy:%n:3022
 ```
 
 Ansible is set up to use ssh config above:

--- a/examples/aws/terraform/ha-autoscale-cluster/ansible/ec2.py
+++ b/examples/aws/terraform/ha-autoscale-cluster/ansible/ec2.py
@@ -66,7 +66,7 @@ Host {bastion}
 Host *.compute.internal
     HostName %h
     Port 22
-    ProxyCommand ssh {ssh_key_path} -p 22 %r@{bastion} nc %h %p
+    ProxyCommand ssh {ssh_key_path} -p 22 %r@{bastion} nc %n %p
 '''
 
 def generate_ssh_cfg(cluster, ssh_key=None):

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -100,7 +100,7 @@ func ExternalSSHCommand(o CommandOptions) (*exec.Cmd, error) {
 		proxyCommand = append(proxyCommand, "-oForwardAgent=yes")
 	}
 	proxyCommand = append(proxyCommand, fmt.Sprintf("-p %v", o.ProxyPort))
-	proxyCommand = append(proxyCommand, `%r@localhost -s proxy:%h:%p`)
+	proxyCommand = append(proxyCommand, `%r@localhost -s proxy:%n:%p`)
 
 	// Add in ProxyCommand option, needed for all Teleport connections.
 	execArgs = append(execArgs, fmt.Sprintf("-oProxyCommand=%v", strings.Join(proxyCommand, " ")))

--- a/lib/config/openssh/openssh.go
+++ b/lib/config/openssh/openssh.go
@@ -49,9 +49,9 @@ Host *.{{ $clusterName }} {{ $dot.ProxyHost }}
 Host *.{{ $clusterName }} !{{ $dot.ProxyHost }}
     Port 3022
     {{- if eq $dot.AppName "tsh" }}
-    ProxyCommand "{{ $dot.ExecutablePath }}" proxy ssh --cluster={{ $clusterName }} --proxy={{ $dot.ProxyHost }} %r@%h:%p
+    ProxyCommand "{{ $dot.ExecutablePath }}" proxy ssh --cluster={{ $clusterName }} --proxy={{ $dot.ProxyHost }} %r@%n:%p
 {{- end }}{{- if eq $dot.AppName "tbot" }}
-    ProxyCommand "{{ $dot.ExecutablePath }}" proxy --destination-dir={{ $dot.DestinationDir }} --proxy={{ $dot.ProxyHost }} ssh --cluster={{ $clusterName }}  %r@%h:%p
+    ProxyCommand "{{ $dot.ExecutablePath }}" proxy --destination-dir={{ $dot.DestinationDir }} --proxy={{ $dot.ProxyHost }} ssh --cluster={{ $clusterName }}  %r@%n:%p
 {{- end }}
 {{- end }}
 

--- a/lib/config/openssh/testdata/TestSSHConfig_GetSSHConfig/legacy_OpenSSH_-_single_cluster.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetSSHConfig/legacy_OpenSSH_-_single_cluster.golden
@@ -10,6 +10,6 @@ Host *.example.com proxy.example.com
 # Flags for all example.com hosts except the proxy
 Host *.example.com !proxy.example.com
     Port 3022
-    ProxyCommand "/tmp/tsh" proxy ssh --cluster=example.com --proxy=proxy.example.com %r@%h:%p
+    ProxyCommand "/tmp/tsh" proxy ssh --cluster=example.com --proxy=proxy.example.com %r@%n:%p
 
 # End generated Teleport configuration

--- a/lib/config/openssh/testdata/TestSSHConfig_GetSSHConfig/modern_OpenSSH_-_multiple_clusters.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetSSHConfig/modern_OpenSSH_-_multiple_clusters.golden
@@ -10,7 +10,7 @@ Host *.root proxy.example.com
 # Flags for all root hosts except the proxy
 Host *.root !proxy.example.com
     Port 3022
-    ProxyCommand "/tmp/tsh" proxy ssh --cluster=root --proxy=proxy.example.com %r@%h:%p
+    ProxyCommand "/tmp/tsh" proxy ssh --cluster=root --proxy=proxy.example.com %r@%n:%p
 # Common flags for all leaf hosts
 Host *.leaf proxy.example.com
     UserKnownHostsFile "/home/alice/.tsh/known_hosts"
@@ -21,6 +21,6 @@ Host *.leaf proxy.example.com
 # Flags for all leaf hosts except the proxy
 Host *.leaf !proxy.example.com
     Port 3022
-    ProxyCommand "/tmp/tsh" proxy ssh --cluster=leaf --proxy=proxy.example.com %r@%h:%p
+    ProxyCommand "/tmp/tsh" proxy ssh --cluster=leaf --proxy=proxy.example.com %r@%n:%p
 
 # End generated Teleport configuration

--- a/lib/config/openssh/testdata/TestSSHConfig_GetSSHConfig/modern_OpenSSH_-_single_cluster.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetSSHConfig/modern_OpenSSH_-_single_cluster.golden
@@ -10,6 +10,6 @@ Host *.example.com proxy.example.com
 # Flags for all example.com hosts except the proxy
 Host *.example.com !proxy.example.com
     Port 3022
-    ProxyCommand "/tmp/tsh" proxy ssh --cluster=example.com --proxy=proxy.example.com %r@%h:%p
+    ProxyCommand "/tmp/tsh" proxy ssh --cluster=example.com --proxy=proxy.example.com %r@%n:%p
 
 # End generated Teleport configuration

--- a/lib/tbot/config/testdata/TestTemplateSSHClient_Render/latest_OpenSSH/ssh_config.golden
+++ b/lib/tbot/config/testdata/TestTemplateSSHClient_Render/latest_OpenSSH/ssh_config.golden
@@ -10,6 +10,6 @@ Host *.tele.blackmesa.gov tele.blackmesa.gov
 # Flags for all tele.blackmesa.gov hosts except the proxy
 Host *.tele.blackmesa.gov !tele.blackmesa.gov
     Port 3022
-    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov ssh --cluster=tele.blackmesa.gov  %r@%h:%p
+    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov ssh --cluster=tele.blackmesa.gov  %r@%n:%p
 
 # End generated Teleport configuration

--- a/lib/tbot/config/testdata/TestTemplateSSHClient_Render/legacy_OpenSSH/ssh_config.golden
+++ b/lib/tbot/config/testdata/TestTemplateSSHClient_Render/legacy_OpenSSH/ssh_config.golden
@@ -10,6 +10,6 @@ Host *.tele.blackmesa.gov tele.blackmesa.gov
 # Flags for all tele.blackmesa.gov hosts except the proxy
 Host *.tele.blackmesa.gov !tele.blackmesa.gov
     Port 3022
-    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov ssh --cluster=tele.blackmesa.gov  %r@%h:%p
+    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov ssh --cluster=tele.blackmesa.gov  %r@%n:%p
 
 # End generated Teleport configuration

--- a/rfd/0039-sni-alpn-teleport-proxy-routing.md
+++ b/rfd/0039-sni-alpn-teleport-proxy-routing.md
@@ -158,14 +158,14 @@ UX remains unchanged. The `onSSH` and `onSCP` tsh commands handlers will be exte
 A new `tsh proxy ssh` command will be introduced allowing for injection to `ProxyCommand` openssh client command:
 ```
 ssh -o "ForwardAgent yes" \
-    -o "ProxyCommand tsh proxy ssh --user=%r %h:%p" \
+    -o "ProxyCommand tsh proxy ssh --user=%r %n:%p" \
     alice@node.example.teleport.sh
 ```
 
 `--cluster` flag allows connecting to a node within a trusted cluster:
 ```
  ssh -o "ForwardAgent yes" \
-     -o "ProxyCommand tsh proxy ssh --user=%r --cluster=leaf1.example.teleport.sh %h:%p" \
+     -o "ProxyCommand tsh proxy ssh --user=%r --cluster=leaf1.example.teleport.sh %n:%p" \
      alice@node.leaf1.example.teleport.sh
 ```
 

--- a/tool/tsh/config_test.go
+++ b/tool/tsh/config_test.go
@@ -42,7 +42,7 @@ Host *.test-cluster localhost
 # Flags for all test-cluster hosts except the proxy
 Host *.test-cluster !localhost
     Port 3022
-    ProxyCommand "/bin/tsh" proxy ssh --cluster=test-cluster --proxy=localhost %r@%h:%p
+    ProxyCommand "/bin/tsh" proxy ssh --cluster=test-cluster --proxy=localhost %r@%n:%p
 
 # End generated Teleport configuration
 `

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -178,7 +178,7 @@ func setupJumpHost(cf *CLIConf, tc *libclient.TeleportClient, sp sshProxyParams)
 }
 
 // sshProxy opens up a new SSH session connected to the Teleport Proxy's SSH proxy subsystem,
-// This is the equivalent of `ssh -o 'ForwardAgent yes' -p port %r@host -s proxy:%h:%p`.
+// This is the equivalent of `ssh -o 'ForwardAgent yes' -p port %r@host -s proxy:%n:%p`.
 // If tls routing is enabled, the connection to RemoteProxyAddr is wrapped with TLS protocol.
 func sshProxy(ctx context.Context, tc *libclient.TeleportClient, sp sshProxyParams) error {
 	upstreamConn, err := dialSSHProxy(ctx, tc, sp)

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -469,7 +469,7 @@ proxy_templates:
 Host *
   HostName %%h
   StrictHostKeyChecking no
-  ProxyCommand %v -d --insecure proxy ssh -J {{proxy}} %%r@%%h:%%p
+  ProxyCommand %v -d --insecure proxy ssh -J {{proxy}} %%r@%%n:%%p
 `, tshPath)), 0o644)
 	require.NoError(t, err)
 


### PR DESCRIPTION
As per man sshd_config, there is a difference in hostname formatting when using '%h' or '%n'. This can lead hostnames with uppercases to be changed to lowercases and the connection to fail.

Rather than change it only on openssh.go,
I choose to change it everywhere it's used because I can't see
cases where it would be beneficial to have the extra formatting provided by '%h'.

Fixes: https://github.com/gravitational/teleport/issues/21939