### PR TITLE
Removed node from multiarch buildbox, added i386 and amd64 targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,9 +207,9 @@ ifeq ("$(ARCH)","arm64")
 		CGOFLAG += CC=aarch64-linux-gnu-gcc
 	endif
 else ifeq ("$(ARCH)","arm")
-# ARM builds need to specify the correct C compiler
 CGOFLAG = CGO_ENABLED=1 
 
+# ARM builds need to specify the correct C compiler
 ifeq ($(IS_NATIVE_BUILD),"no")
 CC=arm-linux-gnueabihf-gcc
 endif

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,12 @@ ifeq ("$(ARCH)","arm64")
 	endif
 else ifeq ("$(ARCH)","arm")
 # ARM builds need to specify the correct C compiler
-CGOFLAG = CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc
+CGOFLAG = CGO_ENABLED=1 
+
+ifeq ($(IS_NATIVE_BUILD),"no")
+CC=arm-linux-gnueabihf-gcc
+endif
+
 # Add -debugtramp=2 to work around 24 bit CALL/JMP instruction offset.
 BUILDFLAGS = $(ADDFLAGS) -ldflags '-w -s -debugtramp=2' -trimpath
 endif

--- a/build.assets/Dockerfile-multiarch
+++ b/build.assets/Dockerfile-multiarch
@@ -1,88 +1,238 @@
 # #############################################################################
 # This Dockerfile aims to be the single source of truth for linux buildboxes on
-# all supported architectures. This is still wildly aspirational, and
-#   a) currently only supports ARM32 & ARM64, and
-#   b) is currently only used for ARM64 builds
-# #############################################################################
+# all supported architectures.
+## #############################################################################
+
+ARG BUILDBOX_VERSION
+ARG BUILDBOX_PREFIX
 
 FROM centos:7 AS base
 
 # Automatically supplied by the Docker buildkit
 ARG TARGETARCH
 
-# #############################################################################
-# Platform-specific customisation.
-# #############################################################################
+# Aliases
+FROM $BUILDBOX_PREFIX/buildbox-multiarch-clang7:$BUILDBOX_VERSION-$TARGETARCH AS clang7-boringcrypto
+FROM $BUILDBOX_PREFIX/buildbox-multiarch-clang10:$BUILDBOX_VERSION-$TARGETARCH AS clang10
 
-## ARM 32 #####################################################################
-FROM base AS platform-setup-arm
-ARG GOLANG_ARCH=armv6l
-ARG RUST_ARCH=armv7-unknown-linux-gnueabihf
+# Root target with ci user
+FROM $BUILDBOX_PREFIX/buildbox-multiarch-base:$BUILDBOX_VERSION-$TARGETARCH AS gcc
 
-ARG YUM_UPDATE_FLAGS=""
-RUN echo "armhfp" > /etc/yum/vars/basearch && \
-    echo "armv7hl" > /etc/yum/vars/arch && \
-    echo "armv7hl-redhat-linux-gnu" > /etc/rpm/platform
-
-## ARM 64 #####################################################################
-FROM base AS platform-setup-arm64
-ARG GOLANG_ARCH=arm64
-ARG RUST_ARCH=aarch64-unknown-linux-gnu
-
-# Installing the kerenel packages causes the update to hang on aarch64, so we
-# skip upgrading them.
-ARG YUM_UPDATE_FLAGS="--exclude kernel-*"
-RUN echo "aarch64-redhat-linux-gnu" > /etc/rpm/platform
-
-## 386 ########################################################################
-FROM base AS platform-setup-386
-ARG GOLANG_ARCH=386
-ARG RUST_ARCH=i686-unknown-linux-gnu
-
-## AMD 64 #####################################################################
-FROM base AS platform-setup-amd64
-ARG GOLANG_ARCH=amd64
-ARG RUST_ARCH=x86_64-unknown-linux-gnu
-
-# #############################################################################
-# The minimal buildbox contains the resources required to build a minimal
-# version of Teleport, with no optional features (e.g. BPF)
-# #############################################################################
-
-FROM platform-setup-$TARGETARCH AS minimal-buildbox
-
-# NOTE: We expect the GOLANG_VERSION to contain the leading `go` in the version
-#       string (e,g, go1.19), as produced by `go version`
-ARG GOLANG_VERSION
-ARG RUST_VERSION
 ARG UID
 ARG GID
-ARG RUSTUP_VERSION=1.25.2
 
 RUN groupadd ci --gid=$GID -o && \
     useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh
 
 RUN install --directory --mode=0700 --owner=ci --group=ci /var/lib/teleport
 
-ENV LANGUAGE=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LC_ALL=en_US.UTF-8 \
-    LC_CTYPE=en_US.UTF-8
+## LIBPCSCLITE ################################################################
+# 
+FROM gcc AS libpcsclite
+ARG LIBPCSCLITE_VERSION
 
-RUN yum update -y $YUM_UPDATE_FLAGS && \
-    yum install -y     \
-        git \
-        gcc \
-        gcc-c++ \
-        make \
-        pam-devel \
-        perl-IPC-Cmd \
-        tree \
-        which \
-        zip \
-        zlib-static && \
-    yum clean all && \
-    localedef -c -i en_US -f UTF-8 en_US.UTF-8
+# Configure fails to determine correct std on ARM
+ENV CFLAGS="-std=gnu99"
+
+# Install libpcsclite - compile with a newer GCC. The one installed by default is not able to compile it.
+RUN git clone --depth=1 https://github.com/gravitational/PCSC.git -b ${LIBPCSCLITE_VERSION} && \
+    cd PCSC && \
+    ./bootstrap && \
+    ./configure --enable-static --with-pic --disable-libsystemd && \
+    make install && \
+    rm -rf PCSC
+
+## LIBFIDO2 ###################################################################
+#
+
+# Build libfido2 separately for isolation, speed and flexibility.
+FROM gcc AS libfido2
+
+# Install libudev-zero.
+# libudev-zero replaces systemd's libudev.
+RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 && \
+    cd libudev-zero && \
+    [ "$(git rev-parse HEAD)" = '4154cf252c17297f98a8ca33693ead003b4509da' ] && \
+    make install-static LIBDIR='$(PREFIX)/lib64'
+
+# Install openssl.
+# Pulled from source because repository versions are too old.
+# install_sw install only binaries, skips docs.
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1t && \
+    cd openssl && \
+    [ "$(git rev-parse HEAD)" = '830bf8e1e4749ad65c51b6a1d0d769ae689404ba' ] && \
+    ./config --release --libdir=/usr/local/lib64 && \
+    make && \
+    make install_sw
+
+# Install libcbor.
+RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
+    cd libcbor && \
+    [ "$(git rev-parse HEAD)" = 'efa6c0886bae46bdaef9b679f61f4b9d8bc296ae' ] && \
+    cmake3 \
+        -DCMAKE_CXX_FLAGS=-lpthread \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DWITH_EXAMPLES=OFF . && \
+    make && \
+    make install
+
+# Install libfido2.
+# Depends on libcbor, openssl, zlib-devel and libudev.
+# Linked so `make build/tsh` finds the library where it expects it.
+RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
+    cd libfido2 && \
+    [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
+      LDFLAGS="-lpthread" cmake3 \
+          -DBUILD_EXAMPLES=OFF \
+          -DBUILD_MANPAGES=OFF \
+          -DBUILD_TOOLS=OFF \
+          -DCMAKE_BUILD_TYPE=Release . && \
+      make && \
+    make install && \
+    make clean
+
+## LIBBPF ########################################################################
+#
+FROM gcc AS libbpf
+
+# Install libbpf - compile with a newer GCC. The one installed by default is not able to compile it.
+# BUILD_STATIC_ONLY disables libbpf.so build as we don't need it.
+ARG LIBBPF_VERSION
+RUN mkdir -p /opt && cd /opt && \
+    curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+    cd /opt/libbpf-${LIBBPF_VERSION}/src && \
+    make && BUILD_STATIC_ONLY=y DESTDIR=/opt/libbpf make install
+
+## Integral image for 64-bit targets #############################################
+#
+FROM gcc AS deps-64
+
+# Make clang10 available
+COPY --from=clang10 /opt/llvm /opt/llvm
+ENV PATH="/opt/llvm/bin:$PATH"
+
+ARG RUST_VERSION
+
+## Install Rust ###############################################################
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=$RUST_VERSION
+
+RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
+    mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
+
+USER ci
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain ${RUST_VERSION} --default-host ${RUST_ARCH} && \
+    rustup --version && \
+    cargo --version && \
+    rustc --version && \
+    rustup target add ${RUST_ARCH}
+    
+USER root
+
+# Copy dependencies
+COPY --from=libfido2 /usr/local/include/ /usr/local/include/
+COPY --from=libfido2 /usr/local/lib64/pkgconfig/ /usr/local/lib64/pkgconfig/
+COPY --from=libfido2 \
+    /usr/local/lib64/libcbor.a \
+    /usr/local/lib64/libcrypto.a \
+    /usr/local/lib64/libcrypto.so.1.1 \
+    /usr/local/lib64/libfido2.a \
+    /usr/local/lib64/libfido2.so.1.12.0 \
+    /usr/local/lib64/libssl.a \
+    /usr/local/lib64/libssl.so.1.1 \
+    /usr/local/lib64/libudev.a \
+    /usr/local/lib64/
+# Re-create usual lib64 links.
+RUN cd /usr/local/lib64 && \
+    ln -s libcrypto.so.1.1 libcrypto.so && \
+    ln -s libfido2.so.1.12.0 libfido2.so.1 && \
+    ln -s libfido2.so.1 libfido2.so && \
+    ln -s libssl.so.1.1 libssl.so && \
+# Update ld.
+    echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
+    ldconfig
+
+COPY pkgconfig/centos7/ /
+ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
+
+COPY --from=libpcsclite /usr/local/include/ /usr/local/include/
+COPY --from=libpcsclite /usr/local/lib/pkgconfig/ /usr/local/lib64/pkgconfig/
+COPY --from=libpcsclite \
+    /usr/local/lib/libpcsclite.a \
+    /usr/local/lib/
+
+ARG LIBBPF_VERSION
+COPY --from=libbpf /opt/libbpf/usr /usr/libbpf-${LIBBPF_VERSION}
+
+## BORINGSSL ########################################################################
+#
+FROM clang7-boringcrypto AS boringssl
+# The below tools are required in order to build and compile the module:
+# Clang compiler version 7.0.1
+# Go programming language version 1.12.7
+# Ninja build system version 1.9.0
+#
+# We also need the FIPS 140-2 validated release of BoringSSL: ae223d6138807a13006342edfeef32e813246b39
+# For more information please refer to the section 12. Guidance and Secure Operation of:
+# https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3678.pdf
+
+RUN mkdir -p /opt && cd /opt && \
+    curl -sLO https://go.dev/dl/go1.12.7.linux-$GOLANG_ARCH.tar.gz && \
+    tar xf go1.12.7.linux-$GOLANG_ARCH.tar.gz && \
+    rm -f go1.12.7.linux-$GOLANG_ARCH.tar.gz && \
+    chmod a+w /opt/go && \
+    chmod a+w /var/lib && \
+    chmod a-w /
+ENV GOEXPERIMENT=boringcrypto \
+    GOPATH="/go" \
+    GOROOT="/opt/go" \
+    PATH="$PATH:/opt/go/bin:/go/bin"
+
+RUN git clone https://github.com/ninja-build/ninja.git && \
+    cd ninja && \
+    git checkout v1.9.0 && \
+    ./configure.py --bootstrap && \
+    mv ninja /usr/bin
+
+RUN mkdir -p /opt && cd /opt && \
+    git clone https://github.com/google/boringssl.git && \
+    cd boringssl && \
+    git checkout ae223d6138807a13006342edfeef32e813246b39 && \
+    mkdir build && \
+    cd build && \
+    cd /opt/boringssl/build && cmake3 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -GNinja .. && ninja
+
+## Intermediate targets ########################################################
+#
+FROM gcc AS deps-arm
+
+ENV GOARCH=arm
+ENV GOARM=7
+
+FROM gcc AS deps-386
+
+FROM deps-64 AS deps-arm64
+FROM deps-64 AS deps-amd64
+
+# Copy BoringSSL into the final image
+COPY --from=boringssl /opt/boringssl /opt/boringssl
+
+# set boring-rs crate env variables to point to pre-built binaries
+# https://github.com/cloudflare/boring#support-for-pre-built-binaries
+ENV BORING_BSSL_PATH=/opt/boringssl
+ENV BORING_BSSL_INCLUDE_PATH=/opt/boringssl/include
+ENV GOEXPERIMENT=boringcrypto
+
+## Final target image with go #################################################
+#
+FROM deps-$TARGETARCH
+
+# NOTE: We expect the GOLANG_VERSION to contain the leading `go` in the version
+#       string (e,g, go1.19), as produced by `go version`
+ARG GOLANG_VERSION
 
 ## Install Go #################################################################
 RUN mkdir -p /opt && \
@@ -95,22 +245,10 @@ ENV GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="$PATH:/opt/go/bin:/go/bin"
 
-## Install Rust ###############################################################
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=$RUST_VERSION
-
-RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
-    mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
+# Install PAM module and policies for testing.
+COPY pam/ /opt/pam_teleport/
+RUN make -C /opt/pam_teleport install
 
 RUN chmod a-w /
 
 USER ci
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION --default-host $RUST_ARCH && \
-    rustup --version && \
-    cargo --version && \
-    rustc --version && \
-    rustup component add rustfmt clippy && \
-    rustup target add $RUST_ARCH

--- a/build.assets/Dockerfile-multiarch
+++ b/build.assets/Dockerfile-multiarch
@@ -17,6 +17,8 @@ ARG TARGETARCH
 ## ARM 32 #####################################################################
 FROM base AS platform-setup-arm
 ARG GOLANG_ARCH=armv6l
+ARG RUST_ARCH=armv7-unknown-linux-gnueabihf
+
 ARG YUM_UPDATE_FLAGS=""
 RUN echo "armhfp" > /etc/yum/vars/basearch && \
     echo "armv7hl" > /etc/yum/vars/arch && \
@@ -25,11 +27,22 @@ RUN echo "armhfp" > /etc/yum/vars/basearch && \
 ## ARM 64 #####################################################################
 FROM base AS platform-setup-arm64
 ARG GOLANG_ARCH=arm64
+ARG RUST_ARCH=aarch64-unknown-linux-gnu
 
 # Installing the kerenel packages causes the update to hang on aarch64, so we
 # skip upgrading them.
 ARG YUM_UPDATE_FLAGS="--exclude kernel-*"
 RUN echo "aarch64-redhat-linux-gnu" > /etc/rpm/platform
+
+## 386 ########################################################################
+FROM base AS platform-setup-386
+ARG GOLANG_ARCH=386
+ARG RUST_ARCH=i686-unknown-linux-gnu
+
+## AMD 64 #####################################################################
+FROM base AS platform-setup-amd64
+ARG GOLANG_ARCH=amd64
+ARG RUST_ARCH=x86_64-unknown-linux-gnu
 
 # #############################################################################
 # The minimal buildbox contains the resources required to build a minimal
@@ -44,6 +57,7 @@ ARG GOLANG_VERSION
 ARG RUST_VERSION
 ARG UID
 ARG GID
+ARG RUSTUP_VERSION=1.25.2
 
 RUN groupadd ci --gid=$GID -o && \
     useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh
@@ -81,19 +95,6 @@ ENV GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="$PATH:/opt/go/bin:/go/bin"
 
-## Install Node ###############################################################
-RUN yum install -y python3
-ARG NODE_VERSION
-ENV NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${BUILDARCH}.tar.xz"
-ENV NODE_PATH="/usr/local/lib/nodejs-linux"
-ENV PATH="$PATH:${NODE_PATH}/bin"
-RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo "arm64"; fi) && \
-     export NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
-     mkdir -p ${NODE_PATH} && \
-     curl -o /tmp/nodejs.tar.xz -L ${NODE_URL} && \
-     tar -xJf /tmp/nodejs.tar.xz -C /usr/local/lib/nodejs-linux --strip-components=1
-RUN corepack enable yarn
-
 ## Install Rust ###############################################################
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -107,8 +108,9 @@ RUN chmod a-w /
 
 USER ci
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION --default-host $RUST_ARCH && \
     rustup --version && \
     cargo --version && \
     rustc --version && \
-    rustup component add rustfmt clippy
+    rustup component add rustfmt clippy && \
+    rustup target add $RUST_ARCH

--- a/build.assets/Dockerfile-multiarch-base
+++ b/build.assets/Dockerfile-multiarch-base
@@ -1,0 +1,124 @@
+# #############################################################################
+# This image provides platform setup and GCC required for all platforms.
+#
+# 64-bit centos7 provides devtools-10 for arm64, devtools-11 for amd64 and 
+# gcc 4.8 for 32-bit archs. This image builds modern gcc from sources. 
+# It guarantees that we would use the same GCC version for all builds, 
+# and we would be able to upgrade GCC to a newer version if required.
+# #############################################################################
+
+FROM centos:7 AS base
+
+# Automatically supplied by the Docker buildkit
+ARG TARGETARCH
+
+ARG GCC_VERSION=10.4.0
+ARG CMAKE3_VERSION=3.12.3
+
+# #############################################################################
+# Platform-specific customisation.
+# #############################################################################
+
+## ARM 32 #####################################################################
+FROM base AS platform-setup-arm
+ENV GCC_BUILD_FLAGS="--build arm-unknown-linux-gnueabi --with-float=hard --with-mode=arm"
+ENV GOLANG_ARCH=armv6l
+ENV RUST_ARCH=armv7-unknown-linux-gnueabihf
+
+RUN echo "armhfp" > /etc/yum/vars/basearch && \
+    echo "armv7hl" > /etc/yum/vars/arch && \
+    echo "armv7hl-redhat-linux-gnu" > /etc/rpm/platform
+
+## ARM 64 #####################################################################
+FROM base AS platform-setup-arm64
+ENV GCC_BUILD_FLAGS="--build aarch64-unknown-linux-gnu"
+ENV GOLANG_ARCH=arm64
+ENV RUST_ARCH=aarch64-unknown-linux-gnu
+
+# Installing the kerenel packages causes the update to hang on aarch64, so we
+# skip upgrading them.
+RUN echo "aarch64-redhat-linux-gnu" > /etc/rpm/platform
+
+## 386 ########################################################################
+FROM base AS platform-setup-386
+ENV GCC_BUILD_FLAGS="--build i386-unknown-linux-gnu"
+ENV GOLANG_ARCH=386
+ENV RUST_ARCH=i686-unknown-linux-gnu
+
+## AMD 64 #####################################################################
+FROM base AS platform-setup-amd64
+ENV GCC_BUILD_FLAGS="--build x86_64-unknown-linux-gnu"
+ENV GOLANG_ARCH=amd64
+ENV RUST_ARCH=x86_64-unknown-linux-gnu
+
+## GCC built from sources #####################################################
+FROM platform-setup-$TARGETARCH AS gcc
+
+ENV LANGUAGE=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LC_CTYPE=en_US.UTF-8
+
+RUN yum update -y && \
+    yum install -y     \
+        autoconf-archive \
+        automake \
+        binutils \
+        bzip2 \
+        elfutils-libelf-devel-static \
+        file \
+        flex \        
+        gcc \
+        gcc-c++ \
+        git \
+        glibc-devel \
+        glibc-static \
+        libstdc++-devel \
+        libstdc++-static \
+        libtool \
+        libudev-devel \
+        make \
+        pam-devel \
+        perl-IPC-Cmd \
+        texinfo \
+        wget \
+        which \
+        zip \
+        zlib-devel \
+        zlib-static && \
+    yum clean all && \
+    localedef -c -i en_US -f UTF-8 en_US.UTF-8
+
+#tree \
+# \
+
+# Compile & install GCC
+RUN wget https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.gz && \
+    tar -zxvf gcc-${GCC_VERSION}.tar.gz && \
+    cd gcc-${GCC_VERSION} && \
+    ./contrib/download_prerequisites && \
+    ./configure --disable-checking --enable-languages=c,c++ --disable-multilib ${GCC_BUILD_FLAGS} || : && \
+    cat config.log && \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+    rm -rf gcc-${GCC_VERSION}.tar.gz gcc-${GCC_VERSION}
+
+# Use the new compiler
+ENV LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib32:/usr/local/lib:$LD_LIBRARY_PATH
+ENV CC=/usr/local/bin/gcc
+ENV CXX=/usr/local/bin/g++
+ENV PATH=/usr/local/bin:$PATH
+
+# Install CMake3. CMake3 is required for most dependencies.
+RUN wget https://cmake.org/files/v3.12/cmake-${CMAKE3_VERSION}.tar.gz && \
+    tar xzvf cmake-${CMAKE3_VERSION}.tar.gz && \
+    cd cmake-${CMAKE3_VERSION} && \
+    ./bootstrap --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+    rm -rf cmake-${CMAKE3_VERSION}.tar.gz cmake-${CMAKE3_VERSION}
+
+# Provide cmake3 alias executable
+RUN ln -s /usr/local/bin/cmake /usr/bin/cmake3

--- a/build.assets/Dockerfile-multiarch-clang
+++ b/build.assets/Dockerfile-multiarch-clang
@@ -1,0 +1,38 @@
+# This image builds clang from source. clang7 is required to build boringssl, clang10 is required for BPF.
+ARG BUILDBOX_VERSION
+ARG BUILDBOX_PREFIX
+
+FROM centos:7 AS base
+
+# Automatically supplied by the Docker buildkit
+ARG TARGETARCH
+
+## GCC built from sources #####################################################
+FROM $BUILDBOX_PREFIX/buildbox-multiarch-base:$BUILDBOX_VERSION-$TARGETARCH
+
+ARG CLANG_VERSION
+
+RUN git clone --branch llvmorg-${CLANG_VERSION} --depth=1 https://github.com/llvm/llvm-project.git && \
+    cd llvm-project/ && \
+    mkdir build && cd build/ && \
+    cmake3 \
+        -DCLANG_BUILD_TOOLS=ON \
+        -DCLANG_ENABLE_ARCMT=OFF \
+        -DCLANG_ENABLE_STATIC_ANALYZER=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/opt/llvm \
+        -DLLVM_BUILD_TOOLS=ON \
+        -DLLVM_BUILD_UTILS=OFF \
+        -DLLVM_ENABLE_BINDINGS=OFF \
+        -DLLVM_ENABLE_PROJECTS=clang \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        -DLLVM_INCLUDE_GO_TESTS=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_TOOL_LLI_BUILD=OFF \
+        -G "Unix Makefiles" ../llvm && \
+    make -j$(grep -c processor /proc/cpuinfo) &&  \
+    make install && \
+    cd ../.. && \
+    rm -rf llvm-project
+
+ENV PATH="/opt/llvm/bin:$PATH"

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -562,3 +562,73 @@ build-centos7-assets:
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--tag $(BUILDBOX_CENTOS7_ASSETS)-$(RUNTIME_ARCH) \
 		-f Dockerfile-centos7-assets .
+
+#################################################################################
+# Multiarch build steps
+#################################################################################
+
+GCC_VERSION ?= 10.4.0
+CLANG_BPF_VERSION ?= 10.0.1
+CLANG_FIPS_VERSION ?= 7.0.1
+BUILDBOX_PREFIX ?= ghcr.io/gravitational
+
+#
+# Build Dockerfile-multiarch-base on GHA
+#
+.PHONY:build-multiarch-base
+build-multiarch-base: BUILDBOX=$(BUILDBOX_PREFIX)/buildbox-multiarch-base:$(BUILDBOX_VERSION)-$(ARCH)
+build-multiarch-base:
+	DOCKER_BUILDKIT=1 docker build --platform=$(PLATFORM) \
+		--cache-from type=gha \
+		--build-arg GCC_VERSION=$(GCC_VERSION) \
+		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
+		--build-arg BUILDBOX_PREFIX=$(BUILDBOX_PREFIX) \
+		--tag $(BUILDBOX) \
+		--file Dockerfile-multiarch-base .
+
+#
+# Build Dockerfile-multiarch-clang on GHA with clang-10, based on -base
+#
+.PHONY:build-multiarch-clang10
+build-multiarch-clang10: BUILDBOX=$(BUILDBOX_PREFIX)/buildbox-multiarch-clang10:$(BUILDBOX_VERSION)-$(ARCH)
+build-multiarch-clang10:
+	DOCKER_BUILDKIT=1 docker build --platform=$(PLATFORM) \
+		--cache-from type=gha \
+		--build-arg CLANG_VERSION=$(CLANG_BPF_VERSION) \
+		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
+		--build-arg BUILDBOX_PREFIX=$(BUILDBOX_PREFIX) \
+		--tag $(BUILDBOX) \
+		--file Dockerfile-multiarch-clang .
+
+#
+# Build Dockerfile-multiarch-clang on GHA with clang-7, based on -base
+#
+.PHONY:build-multiarch-clang7
+build-multiarch-clang7: BUILDBOX=$(BUILDBOX_PREFIX)/buildbox-multiarch-clang7:$(BUILDBOX_VERSION)-$(ARCH)
+build-multiarch-clang7:
+	DOCKER_BUILDKIT=1 docker build --platform=$(PLATFORM) \
+		--cache-from type=gha \
+		--build-arg CLANG_VERSION=$(CLANG_FIPS_VERSION) \
+		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
+		--build-arg BUILDBOX_PREFIX=$(BUILDBOX_PREFIX) \
+		--tag $(BUILDBOX) \
+		--file Dockerfile-multiarch-clang .
+
+#
+# Build Dockerfile-multiarch on GHA, based on -base
+#
+.PHONY:build-multiarch
+build-multiarch: BUILDBOX=$(BUILDBOX_PREFIX)/buildbox-multiarch:$(BUILDBOX_VERSION)-$(ARCH)
+build-multiarch:
+	DOCKER_BUILDKIT=1 docker build --platform=$(PLATFORM) \
+		--cache-from type=gha \
+		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
+		--build-arg BUILDBOX_PREFIX=$(BUILDBOX_PREFIX) \
+		--build-arg LIBPCSCLITE_VERSION=$(LIBPCSCLITE_VERSION) \
+		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
+		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+		--build-arg RUST_VERSION=$(RUST_VERSION) \
+		--build-arg UID=$(shell id -u) \
+		--build-arg GID=$(shell id -g) \
+		--tag $(BUILDBOX) \
+		--file Dockerfile-multiarch .

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -446,10 +446,18 @@ define RELEASE_RECIPE
 			-v "/tmp:/tmp" \
 			-v "$(WORKSPACE):/go/teleport" \
 			-w /go/teleport \
-			-u 1000:1000 \
 			$(BUILDBOX) \
 		make $(1) ARCH=$(ARCH) ADDFLAGS="$(ADDFLAGS)" OS=$(OS) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no
 endef
+
+# It's ok to ignore `go: command not found`. Makefile's $(shell go env)-line commands are producing it.
+.PHONY: release-oss-ensure-webassets
+release-oss-ensure-webassets:
+	$(call RELEASE_RECIPE,ensure-webassets)
+
+.PHONY: release-enterprise-ensure-webassets
+release-enterprise-ensure-webassets:
+	$(call RELEASE_RECIPE,ensure-webassets-e)
 
 .PHONY: release-oss
 release-oss:

--- a/build.assets/build-webassets-if-changed.sh
+++ b/build.assets/build-webassets-if-changed.sh
@@ -78,7 +78,8 @@ if [ "$BUILD" = "true" ]; then \
   # created any necessary directories here. The recalculation is necessary as yarn.lock may have been
   # updated by the build process.
   mkdir -p "$(dirname "$LAST_SHA_FILE")"
-  calculate_sha > "$LAST_SHA_FILE"
+  # Save SHA with yarn.lock before yarn install
+  echo $CURRENT_SHA > "$LAST_SHA_FILE"
   echo "$TYPE webassets successfully updated."
 else
   echo "$TYPE webassets up to date."


### PR DESCRIPTION
What's inside:
- [x] Changes required for GHA multistage/multiplatform build
- [x] Another fix for assets SHA calculation. Problem is that `yarn.lock` may change on `yarn install`. We calculate initial sha before `yarn install`, and save the resulting checksum with the changed `yarn.lock`. Therefore, the resulting checksum never matches the initial value.
- [x] Dockerfile-multiarch: Dockerfile-multiarch-base (gcc), Dockerfile-multiarch-clang (10 + 7 for boringcrypto), Dockerfile-multiarch
- [x] build.assets Makefile changes