### PR TITLE
Discover: install ent image when cluster is enterprise

### DIFF
--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -118,6 +118,9 @@ caPin: []
 # certificate.
 insecureSkipProxyTLSVerify: false
 
+# Set enterprise to true to use enterprise image.
+enterprise: false
+
 # teleportConfig contains additional teleport configuration
 # The configuration will be merged with the chart-generated configuration
 # and will take precedence in case of conflict
@@ -184,9 +187,10 @@ storage:
 # Values that you shouldn't need to change.
 ################################################################
 
-# Container image for the agent. Since this runs without the auth_service, we
-# don't need the enterprise version.
+# Container image for the cluster.
 image: public.ecr.aws/gravitational/teleport
+# Enterprise version of the image
+enterpriseImage: public.ecr.aws/gravitational/teleport-ent
 # Optional array of imagePullSecrets, to use when pulling from a private registry
 imagePullSecrets: []
 # - name: myRegistryKeySecretName

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -302,6 +302,7 @@ const generateCmd = (data: {
   tokenId: string;
   clusterVersion: string;
   resourceId: string;
+  isEnterprise: boolean;
 }) => {
   return `cat << EOF > prod-cluster-values.yaml
 roles: kube
@@ -309,6 +310,7 @@ authToken: ${data.tokenId}
 proxyAddr: ${data.proxyAddr}
 kubeClusterName: ${data.clusterName}
 teleportVersionOverride: ${data.clusterVersion}
+enterprise: ${data.isEnterprise}
 labels:
     teleport.internal/resource-id: ${data.resourceId}
 EOF
@@ -403,6 +405,7 @@ const InstallHelmChart = ({
     tokenId: joinToken.id,
     clusterVersion: version,
     resourceId: joinToken.internalResourceId,
+    isEnterprise: ctx.isEnterprise,
   });
 
   return (


### PR DESCRIPTION
Update the helm chart for kube-agent.
The image swap logic was already there.

Update the UI to include `enterprise: <isEnterprise>` when installing the kube-agent.

Demo
![image](https://user-images.githubusercontent.com/689271/219692621-18c32d0c-9c91-48b2-8c89-3e1db1f0da12.png)

![image](https://user-images.githubusercontent.com/689271/219692631-e81872b9-ec5b-43b1-b13b-8654306c9036.png)

Fixes https://github.com/gravitational/teleport/issues/21952