### PR TITLE
Connect: Make `tsh ssh` in command bar not depend on resource cache

### DIFF
--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -247,11 +247,13 @@ export type CreateGatewayParams = {
 
 export type ServerSideParams = {
   clusterUri: uri.ClusterUri;
+  // search is used for regular search.
   search?: string;
   searchAsRoles?: string;
   sort?: SortType;
   startKey?: string;
   limit?: number;
+  // query is used for advanced search.
   query?: string;
 };
 

--- a/web/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
+++ b/web/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
@@ -62,7 +62,7 @@ export default function useQuickInput() {
       const [, err] = await getSuggestions();
       if (err && !(err instanceof CanceledError)) {
         appContext.notificationsService.notifyError({
-          title: 'Error fetching suggestions',
+          title: 'Could not fetch command bar suggestions',
           description: err.message,
         });
       }

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AmbiguousHostnameError, ResourcesService } from './resourcesService';
+
+import type * as tsh from 'teleterm/services/tshd/types';
+
+const expectedServer: tsh.Server = {
+  uri: '/clusters/bar/servers/foo',
+  tunnel: false,
+  name: 'foo',
+  hostname: 'foo',
+  addr: 'localhost',
+  labelsList: [],
+};
+
+test('getServerByHostname returns a server when the hostname matches a single server', async () => {
+  const tshClient: Partial<tsh.TshClient> = {
+    getServers: jest.fn().mockResolvedValueOnce({
+      agentsList: [expectedServer],
+      totalCount: 1,
+      startKey: 'foo',
+    } as Awaited<ReturnType<tsh.TshClient['getServers']>>),
+  };
+  const service = new ResourcesService(tshClient as tsh.TshClient);
+
+  const actualServer = await service.getServerByHostname(
+    '/clusters/bar',
+    'foo'
+  );
+  expect(actualServer).toStrictEqual(expectedServer);
+  expect(tshClient.getServers).toHaveBeenCalledWith({
+    clusterUri: '/clusters/bar',
+    query: 'name == "foo"',
+    limit: 2,
+  });
+});
+
+test('getServerByHostname returns an error when the hostname matches multiple servers', async () => {
+  const tshClient: Partial<tsh.TshClient> = {
+    getServers: jest.fn().mockResolvedValueOnce({
+      agentsList: [expectedServer, expectedServer],
+      totalCount: 2,
+      startKey: 'foo',
+    } as Awaited<ReturnType<tsh.TshClient['getServers']>>),
+  };
+  const service = new ResourcesService(tshClient as tsh.TshClient);
+
+  await expect(
+    service.getServerByHostname('/clusters/bar', 'foo')
+  ).rejects.toThrow(AmbiguousHostnameError);
+
+  expect(tshClient.getServers).toHaveBeenCalledWith({
+    clusterUri: '/clusters/bar',
+    query: 'name == "foo"',
+    limit: 2,
+  });
+});
+
+test('getServerByHostname returns nothing if the hostname does not match any servers', async () => {
+  const tshClient: Partial<tsh.TshClient> = {
+    getServers: jest.fn().mockResolvedValueOnce({
+      agentsList: [],
+      totalCount: 0,
+      startKey: 'foo',
+    } as Awaited<ReturnType<tsh.TshClient['getServers']>>),
+  };
+  const service = new ResourcesService(tshClient as tsh.TshClient);
+
+  const actualServer = await service.getServerByHostname(
+    '/clusters/bar',
+    'foo'
+  );
+
+  expect(actualServer).toBeFalsy();
+  expect(tshClient.getServers).toHaveBeenCalledWith({
+    clusterUri: '/clusters/bar',
+    query: 'name == "foo"',
+    limit: 2,
+  });
+});

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-import { ServerSideParams, TshClient } from 'teleterm/services/tshd/types';
-
+import type * as types from 'teleterm/services/tshd/types';
 import type * as uri from 'teleterm/ui/uri';
 
 export class ResourcesService {
-  constructor(private tshClient: TshClient) {}
+  constructor(private tshClient: types.TshClient) {}
 
-  fetchServers(params: ServerSideParams) {
+  fetchServers(params: types.ServerSideParams) {
     return this.tshClient.getServers(params);
   }
 
-  async getServerByHostname(clusterUri: uri.ClusterUri, hostname: string) {
+  async getServerByHostname(
+    clusterUri: uri.ClusterUri,
+    hostname: string
+  ): Promise<types.Server | undefined> {
     const query = `name == "${hostname}"`;
     const { agentsList: servers } = await this.fetchServers({
       clusterUri,
@@ -40,11 +42,11 @@ export class ResourcesService {
     return servers[0];
   }
 
-  fetchDatabases(params: ServerSideParams) {
+  fetchDatabases(params: types.ServerSideParams) {
     return this.tshClient.getDatabases(params);
   }
 
-  fetchKubes(params: ServerSideParams) {
+  fetchKubes(params: types.ServerSideParams) {
     return this.tshClient.getKubes(params);
   }
 }

--- a/web/packages/teleterm/src/ui/uri.test.ts
+++ b/web/packages/teleterm/src/ui/uri.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Params, routing } from './uri';
+
+const getServerUriTests: Array<
+  { name: string; input: Params } & (
+    | { output: string; wantErr?: never }
+    | { wantErr: any; output?: never }
+  )
+> = [
+  {
+    name: 'returns a server URI for a root cluster',
+    input: { rootClusterId: 'foo', serverId: 'ubuntu' },
+    output: '/clusters/foo/servers/ubuntu',
+  },
+  {
+    name: 'returns a server URI for a leaf cluster',
+    input: { rootClusterId: 'foo', leafClusterId: 'bar', serverId: 'ubuntu' },
+    output: '/clusters/foo/leaves/bar/servers/ubuntu',
+  },
+  {
+    name: 'throws an error if serverId is missing from the root cluster URI',
+    input: { rootClusterId: 'foo' },
+    wantErr: new TypeError('Expected "serverId" to be defined'),
+  },
+  {
+    name: 'throws an error if serverId is missing from the leaf cluster URI',
+    input: { rootClusterId: 'foo', leafClusterId: 'bar' },
+    wantErr: new TypeError('Expected "serverId" to be defined'),
+  },
+  {
+    // This isn't necessarily a behavior which we should depend on, but we should document it
+    // nonetheless.
+    name: 'returns a server URI if extra params are included',
+    input: { rootClusterId: 'foo', serverId: 'ubuntu', dbId: 'postgres' },
+    output: '/clusters/foo/servers/ubuntu',
+  },
+];
+/* eslint-disable jest/no-conditional-expect */
+test.each(getServerUriTests)(
+  'getServerUri $name',
+  ({ input, output, wantErr }) => {
+    if (wantErr) {
+      expect(() => routing.getServerUri(input)).toThrow(wantErr);
+    } else {
+      expect(routing.getServerUri(input)).toEqual(output);
+    }
+  }
+);
+/* eslint-enable jest/no-conditional-expect */

--- a/web/packages/teleterm/src/ui/uri.ts
+++ b/web/packages/teleterm/src/ui/uri.ts
@@ -23,6 +23,8 @@ export const paths = {
   leafCluster: '/clusters/:rootClusterId/leaves/:leafClusterId',
   server:
     '/clusters/:rootClusterId/(leaves)?/:leafClusterId?/servers/:serverId',
+  serverLeaf:
+    '/clusters/:rootClusterId/leaves/:leafClusterId/servers/:serverId',
   kube: '/clusters/:rootClusterId/(leaves)?/:leafClusterId?/kubes/:kubeId',
   db: '/clusters/:rootClusterId/(leaves)?/:leafClusterId?/dbs/:dbId',
   gateway: '/gateways/:gatewayId',
@@ -137,7 +139,18 @@ export const routing = {
   },
 
   getServerUri(params: Params) {
-    return generatePath(paths.server, params as any) as ServerUri;
+    if (params.leafClusterId) {
+      // paths.serverLeaf is needed as path-to-regexp used by react-router doesn't support
+      // optional groups with params. https://github.com/pillarjs/path-to-regexp/issues/142
+      //
+      // If we used paths.server instead, then the /leaves/ part of the URI would be missing.
+      return generatePath(
+        paths.serverLeaf,
+        params as any
+      ) as LeafClusterServerUri;
+    } else {
+      return generatePath(paths.server, params as any) as RootClusterServerUri;
+    }
   },
 
   isClusterServer(clusterUri: ClusterUri, serverUri: ServerUri) {


### PR DESCRIPTION
Part of #21964.

Executing `tsh ssh` from the command bar depends on the resource cache as it needs to translate the resource hostname from the command (e.g. `tsh ssh root@ubuntu`) into a server UUID that's necessary to open a new terminal tab.

Since we want to remove the cache, there's no way of obtaining the UUID from the hostname other than hitting the proxy. Which is what this PR accomplishes.

It does so in a rather naive way. The next PR is going to move the whole logic of resolving the hostname from the command launcher to `useDocumentTerminal`. This way the `tsh ssh` command in the command bar itself will stay synchronous and all the waiting will be done in `DocumentTerminal`.

If you want to check how the final "product" feels like, check out the branch of #22182.