### PR TITLE
[v12] Align AWS assume-role request duration with cert expiration

### DIFF
--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -270,6 +270,9 @@ func (l *LocalProxy) StartHTTPAccessProxy(ctx context.Context) error {
 				errHeader = strings.Replace(errHeader, " User Message:", "\n\n\tUser Message:", -1)
 				l.cfg.Log.Warn(errHeader)
 			}
+			for _, infoHeader := range response.Header.Values(commonApp.TeleportAPIInfoHeader) {
+				l.cfg.Log.Infof("Server response info: %v.", infoHeader)
+			}
 
 			if err := l.cfg.HTTPMiddleware.HandleResponse(response); err != nil {
 				return trace.Wrap(err)

--- a/lib/srv/app/aws/assume_role.go
+++ b/lib/srv/app/aws/assume_role.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/lib/srv/app/common"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func updateAssumeRoleDuration(identity *tlsca.Identity, w http.ResponseWriter, req *http.Request, clock clockwork.Clock) error {
+	// Skip non-AssumeRole request
+	query, found, err := getAssumeRoleQuery(req)
+	if err != nil || !found {
+		return trace.Wrap(err)
+	}
+
+	// Deny access if identity duration is shorter than the minimum that can be
+	// requested.
+	identityTTL := identity.Expires.Sub(clock.Now())
+	if identityTTL < assumeRoleMinDuration {
+		// TODO write error message in XML so the client can understand.
+		return trace.AccessDenied("minimum AWS session duration is %v but Teleport identity expires in %v. Please re-login the app and try again.", assumeRoleMinDuration, identityTTL)
+	}
+
+	// Use shorter requested duration (no update required).
+	if getAssumeRoleQueryDuration(query) <= identityTTL {
+		return nil
+	}
+
+	// Rewrite the request.
+	if err := rewriteAssumeRoleQuery(req, withAssumeRoleQueryDuration(query, identityTTL)); err != nil {
+		return trace.Wrap(err)
+	}
+	w.Header().Add(common.TeleportAPIInfoHeader, fmt.Sprintf("requested DurationSeconds of AssumeRole is lowered to \"%d\" as the Teleport identity will expire at %v", int(identityTTL.Seconds()), identity.Expires))
+	return nil
+}
+
+// getAssumeRoleQuery extracts AssumeRole query values from provided request.
+//
+// AWS SDK reference:
+// https://github.com/aws/aws-sdk-go/blob/main/private/protocol/query/build.go
+// https://github.com/aws/aws-sdk-go/blob/main/service/sts/api.go
+func getAssumeRoleQuery(req *http.Request) (url.Values, bool, error) {
+	// http.Request.ParseForm may drain the body. Use a clone.
+	clone, err := cloneRequest(req)
+	if err != nil {
+		return nil, false, trace.Wrap(err)
+	}
+	if err := clone.ParseForm(); err != nil || clone.PostForm == nil {
+		return nil, false, nil
+	}
+	if clone.PostForm.Get("Action") != "AssumeRole" {
+		return nil, false, nil
+	}
+	return clone.PostForm, true, nil
+}
+
+func getAssumeRoleQueryDuration(query url.Values) time.Duration {
+	if durationSeconds, err := strconv.ParseInt(query.Get(assumeRoleQueryKeyDurationSeconds), 10, 32); err == nil {
+		return time.Duration(durationSeconds) * time.Second
+	}
+	return assumeRoleDefaultDuration
+}
+func withAssumeRoleQueryDuration(query url.Values, duration time.Duration) url.Values {
+	query.Set(assumeRoleQueryKeyDurationSeconds, strconv.Itoa(int(duration.Seconds())))
+	return query
+}
+
+func rewriteAssumeRoleQuery(req *http.Request, query url.Values) error {
+	return trace.Wrap(utils.ReplaceRequestBody(req, io.NopCloser(strings.NewReader(query.Encode()))))
+}
+
+const (
+	// assumeRoleQueryKeyDurationSeconds is the query key for the duration
+	// seconds for the AssumeRole request.
+	assumeRoleQueryKeyDurationSeconds = "DurationSeconds"
+
+	// assumeRoleMinDuration is the minimum duration that can be set for
+	// the AssumeRole request.
+	//
+	// https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
+	assumeRoleMinDuration = 15 * time.Minute
+	// assumeRoleMinDuration is the default duration if DurationSeconds is not
+	// explicitly set in the AssumeRole request.
+	//
+	// https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
+	assumeRoleDefaultDuration = 1 * time.Hour
+)

--- a/lib/srv/app/common/header.go
+++ b/lib/srv/app/common/header.go
@@ -42,6 +42,9 @@ const (
 	// TeleportAPIErrorHeader is Teleport-specific error header, optionally holding background error information.
 	TeleportAPIErrorHeader = "X-Teleport-Api-Error"
 
+	// TeleportAPIInfoHeader is Teleport-specific info header, optionally holding background information.
+	TeleportAPIInfoHeader = "X-Teleport-Api-Info"
+
 	// TeleportAWSAssumedRole indicates that the incoming requests are signed
 	// with real AWS credentials of the specified assumed role by the AWS client.
 	TeleportAWSAssumedRole = "X-Teleport-Aws-Assumed-Role"
@@ -57,6 +60,7 @@ var ReservedHeaders = append([]string{
 	teleport.AppCFHeader,
 	XForwardedSSL,
 	TeleportAPIErrorHeader,
+	TeleportAPIInfoHeader,
 	TeleportAWSAssumedRole,
 	TeleportAWSAssumedRoleAuthorization,
 },

--- a/lib/utils/http.go
+++ b/lib/utils/http.go
@@ -60,9 +60,21 @@ func GetAndReplaceResponseBody(response *http.Response) ([]byte, error) {
 	return payload, nil
 }
 
+// ReplaceRequestBody drains the old request body and replaces it with a new one.
+func ReplaceRequestBody(req *http.Request, newBody io.ReadCloser) error {
+	if _, err := tryDrainBody(req.Body); err != nil {
+		return trace.Wrap(err)
+	}
+	req.Body = newBody
+	return nil
+}
+
 // tryDrainBody tries to drain and close the body, returning the read bytes.
 // It may fail to completely drain the body if the size of the body exceeds MaxHTTPRequestSize.
 func tryDrainBody(b io.ReadCloser) (payload []byte, err error) {
+	if b == nil {
+		return nil, nil
+	}
 	defer func() {
 		if closeErr := b.Close(); closeErr != nil {
 			err = trace.NewAggregate(err, closeErr)


### PR DESCRIPTION
backport of #21670

no cherry-pick conflict. will rebase once parent backport #21990 is merged.