### PR TITLE
[v11] Include Enterprise in output of tctl version for commercial pre-req

### DIFF
--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -12,7 +12,7 @@
 
   ```code
   $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
   
   $ tsh version
   # Teleport v(=teleport.version=) go(=teleport.golang=)


### PR DESCRIPTION
Backport #21998 to branch/v11