### PR TITLE
Mention --mfa-mode in the `tsh mfa add` flow

### DIFF
--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -173,10 +173,6 @@ $ tsh mfa add
 # MFA device "desktop yubikey" added.
 ```
 
-<Admonition type="warning" title="Windows support">
-  WebAuthn devices are currently not supported in `tsh` on Windows.
-</Admonition>
-
 ## Step 3/3. Log in using WebAuthn
 
 Once a WebAuthn device is registered, the user will be prompted for it on login:

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -173,6 +173,16 @@ $ tsh mfa add
 # MFA device "desktop yubikey" added.
 ```
 
+<Admonition type="tip">
+`tsh mfa` picks the strongest known second factor you have for the "Tap any
+*registered* security key" step. This may be undesirable at times, so you may
+fallback to a weaker second factor, like OTP, using `tsh mfa add
+--mfa-mode=otp`.
+
+See the possible `--mfa-mode` values in the [Teleport CLI
+Reference](../../reference/cli.mdx#tsh-global-flags) page.
+</Admonition>
+
 ## Step 3/3. Log in using WebAuthn
 
 Once a WebAuthn device is registered, the user will be prompted for it on login:


### PR DESCRIPTION
Mention `--mfa-mode=otp` as a fallback to register alternative MFA devices.

Users can sometimes get stuck in a state where it's impossible to register a new MFA device using `tsh` without this flag; for example, if there is a leftover, outdated Touch ID key in the Secure Enclave.