### PR TITLE
[v11] CI: bypass OS compatibility check for some changes

### DIFF
--- a/.github/workflows/os-compatibility-test-bypass.yaml
+++ b/.github/workflows/os-compatibility-test-bypass.yaml
@@ -1,0 +1,46 @@
+# This workflow is required to ensure that required check passes even if
+# the actual "OS Compatibility Test" workflow is skipped due to path filtering.
+# Otherwise it will stay pending forever.
+#
+# See "Handling skipped but required checks" for more info:
+#
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Note both workflows must have the same name.
+name: OS Compatibility Test
+run-name: OS Compatibility Test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+   paths:
+      - 'docs/**'
+      - 'web/**'
+      - 'rfd/**'
+  merge_group:
+   paths:
+      - 'docs/**'
+      - 'web/**'
+      - 'rfd/**'
+
+jobs:
+  build:
+    name: OS Compatibility Build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: none
+
+    steps:
+    - run: 'echo "No changes to verify"'  
+
+  test-compat:
+    name: OS Compatibility Test
+    runs-on: ubuntu-latest  
+    
+    permissions:
+      contents: none
+
+    steps:
+    - run: 'echo "No changes to verify"' 

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -5,7 +5,15 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'web/**'
+      - 'rfd/**'
   merge_group:
+    paths-ignore:
+      - 'docs/**'
+      - 'web/**'
+      - 'rfd/**'
 
 jobs:
   build:


### PR DESCRIPTION
Docs changes, web UI changes, or RFD updates cannot change the OS compatibility of Teleport, so allow them to bypass the OS compatibility check.

Backports #21989 