### PR TITLE
Ensure UpdateRemoteCluster updates all fields

### DIFF
--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -532,6 +532,7 @@ func (a *Server) validateTrustedCluster(ctx context.Context, validateRequest *Va
 		meta.Labels = utils.CopyStringsMap(tokenLabels)
 		remoteCluster.SetMetadata(meta)
 	}
+	remoteCluster.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
 
 	err = a.CreateRemoteCluster(remoteCluster)
 	if err != nil {

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -602,15 +602,14 @@ func (s *PresenceService) UpdateRemoteCluster(ctx context.Context, rc types.Remo
 	if err := rc.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
-	existingItem, update, err := s.getRemoteCluster(rc.GetName())
+	existingItem, update, err := s.getRemoteCluster(ctx, rc.GetName())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	update.SetExpiry(rc.Expiry())
 	update.SetLastHeartbeat(rc.GetLastHeartbeat())
-	meta := rc.GetMetadata()
-	meta.Labels = rc.GetMetadata().Labels
-	update.SetMetadata(meta)
+	update.SetConnectionStatus(rc.GetConnectionStatus())
+	update.SetMetadata(rc.GetMetadata())
 
 	updateValue, err := services.MarshalRemoteCluster(update)
 	if err != nil {
@@ -653,11 +652,11 @@ func (s *PresenceService) GetRemoteClusters(opts ...services.MarshalOption) ([]t
 }
 
 // getRemoteCluster returns a remote cluster in raw form and unmarshaled
-func (s *PresenceService) getRemoteCluster(clusterName string) (*backend.Item, types.RemoteCluster, error) {
+func (s *PresenceService) getRemoteCluster(ctx context.Context, clusterName string) (*backend.Item, types.RemoteCluster, error) {
 	if clusterName == "" {
 		return nil, nil, trace.BadParameter("missing parameter cluster name")
 	}
-	item, err := s.Get(context.TODO(), backend.Key(remoteClustersPrefix, clusterName))
+	item, err := s.Get(ctx, backend.Key(remoteClustersPrefix, clusterName))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, nil, trace.NotFound("remote cluster %q is not found", clusterName)
@@ -674,7 +673,7 @@ func (s *PresenceService) getRemoteCluster(clusterName string) (*backend.Item, t
 
 // GetRemoteCluster returns a remote cluster by name
 func (s *PresenceService) GetRemoteCluster(clusterName string) (types.RemoteCluster, error) {
-	_, rc, err := s.getRemoteCluster(clusterName)
+	_, rc, err := s.getRemoteCluster(context.TODO(), clusterName)
 	return rc, trace.Wrap(err)
 }
 

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -39,7 +39,101 @@ import (
 	"github.com/gravitational/teleport/lib/services/suite"
 )
 
+func TestRemoteClusterCRUD(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	bk, err := lite.New(ctx, backend.Params{"path": t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bk.Close()) })
+
+	presenceBackend := NewPresenceService(bk)
+	clock := clockwork.NewFakeClockAt(time.Now())
+
+	originalLabels := map[string]string{
+		"a": "b",
+		"c": "d",
+	}
+
+	rc, err := types.NewRemoteCluster("foo")
+	require.NoError(t, err)
+	rc.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
+	rc.SetLastHeartbeat(clock.Now())
+	rc.SetMetadata(types.Metadata{
+		Name:   "foo",
+		Labels: originalLabels,
+	})
+
+	src, err := types.NewRemoteCluster("bar")
+	require.NoError(t, err)
+	src.SetConnectionStatus(teleport.RemoteClusterStatusOnline)
+	src.SetLastHeartbeat(clock.Now().Add(-time.Hour))
+
+	// create remote clusters
+	err = presenceBackend.CreateRemoteCluster(rc)
+	require.NoError(t, err)
+	err = presenceBackend.CreateRemoteCluster(src)
+	require.NoError(t, err)
+
+	// get remote cluster make sure it's correct
+	gotRC, err := presenceBackend.GetRemoteCluster("foo")
+	require.NoError(t, err)
+	require.Equal(t, "foo", gotRC.GetName())
+	require.Equal(t, teleport.RemoteClusterStatusOffline, gotRC.GetConnectionStatus())
+	require.Equal(t, clock.Now().Nanosecond(), gotRC.GetLastHeartbeat().Nanosecond())
+	require.Equal(t, originalLabels, gotRC.GetMetadata().Labels)
+
+	updatedLabels := map[string]string{
+		"e": "f",
+		"g": "h",
+	}
+
+	// update remote clusters
+	rc.SetConnectionStatus(teleport.RemoteClusterStatusOnline)
+	rc.SetLastHeartbeat(clock.Now().Add(time.Hour))
+	rc.SetMetadata(types.Metadata{
+		Name:   "foo",
+		Labels: updatedLabels,
+	})
+	err = presenceBackend.UpdateRemoteCluster(ctx, rc)
+	require.NoError(t, err)
+
+	src.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
+	src.SetLastHeartbeat(clock.Now())
+	err = presenceBackend.UpdateRemoteCluster(ctx, src)
+	require.NoError(t, err)
+
+	// get remote cluster make sure it's correct
+	gotRC, err = presenceBackend.GetRemoteCluster("foo")
+	require.NoError(t, err)
+	require.Equal(t, "foo", gotRC.GetName())
+	require.Equal(t, teleport.RemoteClusterStatusOnline, gotRC.GetConnectionStatus())
+	require.Equal(t, clock.Now().Add(time.Hour).Nanosecond(), gotRC.GetLastHeartbeat().Nanosecond())
+	require.Equal(t, updatedLabels, gotRC.GetMetadata().Labels)
+
+	gotRC, err = presenceBackend.GetRemoteCluster("bar")
+	require.NoError(t, err)
+	require.Equal(t, "bar", gotRC.GetName())
+	require.Equal(t, teleport.RemoteClusterStatusOffline, gotRC.GetConnectionStatus())
+	require.Equal(t, clock.Now().Nanosecond(), gotRC.GetLastHeartbeat().Nanosecond())
+
+	// get all clusters
+	allRC, err := presenceBackend.GetRemoteClusters()
+	require.NoError(t, err)
+	require.Len(t, allRC, 2)
+
+	// delete cluster
+	err = presenceBackend.DeleteRemoteCluster("foo")
+	require.NoError(t, err)
+
+	// make sure it's really gone
+	err = presenceBackend.DeleteRemoteCluster("foo")
+	require.Error(t, err)
+	require.ErrorIs(t, err, trace.NotFound("key /remoteClusters/foo is not found"))
+}
+
 func TestTrustedClusterCRUD(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	bk, err := lite.New(ctx, backend.Params{"path": t.TempDir()})
@@ -100,6 +194,7 @@ func TestTrustedClusterCRUD(t *testing.T) {
 
 // TestApplicationServersCRUD verifies backend operations on app servers.
 func TestApplicationServersCRUD(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
@@ -192,6 +287,7 @@ func TestApplicationServersCRUD(t *testing.T) {
 }
 
 func TestDatabaseServersCRUD(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
@@ -279,6 +375,7 @@ func TestDatabaseServersCRUD(t *testing.T) {
 }
 
 func TestNodeCRUD(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	lite, err := lite.NewWithConfig(ctx, lite.Config{Path: t.TempDir()})
 	require.NoError(t, err)
@@ -1020,6 +1117,7 @@ func TestFakePaginate_TotalCount(t *testing.T) {
 }
 
 func TestPresenceService_CancelSemaphoreLease(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	bk, err := lite.New(ctx, backend.Params{"path": t.TempDir()})
 	require.NoError(t, err)


### PR DESCRIPTION
The ConnectionStatus of the RemoteCluster resource was never being set in UpdateRemoteCluster causing the backend to always contain the original value. GetRemoteCluster, unfortunately, does an update of the resource, yet it always returned the correct information, which made things very confusing since `tctl get` didn't reflect the actual backend. To make matters worse the initial value was not explicitly set which meant it defaulted to an empty string.

A call to SetConnectionStatus was added to UpdateRemoteCluster so it's value is actually persisted. Remote Clusters are also now explicitly initialized with status offline to avoid ambiguity. The actual status of the resource will be updated appropriately when the tunnel connections are verified.

Additionally TestRemoteClustersCRUD was added to capture this issue and prevent any regressions.

Fixes #22006