### PR TITLE
Enable xterm web links addon

### DIFF
--- a/web/packages/teleport/package.json
+++ b/web/packages/teleport/package.json
@@ -20,7 +20,8 @@
     "@gravitational/design": "1.0.0",
     "@gravitational/shared": "1.0.0",
     "xterm": "^5.0.0",
-    "xterm-addon-fit": "^0.7.0"
+    "xterm-addon-fit": "^0.7.0",
+    "xterm-addon-web-links": "^0.8.0"
   },
   "devDependencies": {
     "@gravitational/build": "^1.0.0",

--- a/web/packages/teleport/src/lib/term/terminal.ts
+++ b/web/packages/teleport/src/lib/term/terminal.ts
@@ -17,6 +17,7 @@ import 'xterm/css/xterm.css';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { debounce, isInteger } from 'shared/utils/highbar';
+import { WebLinksAddon } from 'xterm-addon-web-links';
 import Logger from 'shared/libs/logger';
 
 import { TermEvent } from './enums';
@@ -41,6 +42,7 @@ export default class TtyTerminal {
   _fontSize: number;
   _debouncedResize: DebouncedFunc<() => void>;
   _fitAddon = new FitAddon();
+  _webLinksAddon = new WebLinksAddon();
 
   constructor(tty: Tty, options: Options) {
     const { el, scrollBack, fontFamily, fontSize } = options;
@@ -67,6 +69,7 @@ export default class TtyTerminal {
     });
 
     this.term.loadAddon(this._fitAddon);
+    this.term.loadAddon(this._webLinksAddon);
     this.term.open(this._el);
     this._fitAddon.fit();
     this.term.focus();

--- a/yarn.lock
+++ b/yarn.lock
@@ -15684,6 +15684,11 @@ xterm-addon-fit@^0.7.0:
   resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz#b8ade6d96e63b47443862088f6670b49fb752c6a"
   integrity sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==
 
+xterm-addon-web-links@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.8.0.tgz#2cb1d57129271022569208578b0bf4774e7e6ea9"
+  integrity sha512-J4tKngmIu20ytX9SEJjAP3UGksah7iALqBtfTwT9ZnmFHVplCumYQsUJfKuS+JwMhjsjH61YXfndenLNvjRrEw==
+
 xterm@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.1.0.tgz#3e160d60e6801c864b55adf19171c49d2ff2b4fc"


### PR DESCRIPTION
This renders links as <a> elements in the web-based terminal, making them true clickable links.

Closes #7569