### PR TITLE
Clean up the MFA modal

### DIFF
--- a/web/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
+++ b/web/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
@@ -2550,7 +2550,7 @@ exports[`webauthn prompt 1`] = `
           class="c5"
           color="text.primary"
         >
-          Verify Your Identity
+          Multi-factor authentication
         </div>
       </div>
       <div
@@ -2560,7 +2560,7 @@ exports[`webauthn prompt 1`] = `
         <div
           class="c7"
         >
-          Re-authentication is required. Follow the prompts given by your browser to complete authentication.
+          Re-enter your multi-factor authentication in the browser to continue.
         </div>
       </div>
       <div
@@ -2571,7 +2571,7 @@ exports[`webauthn prompt 1`] = `
           kind="primary"
           width="130px"
         >
-          Verify
+          OK
         </button>
         <button
           class="c10"

--- a/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.tsx
+++ b/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.tsx
@@ -32,7 +32,9 @@ export default function AuthnDialog({
   return (
     <Dialog dialogCss={() => ({ width: '400px' })} open={true}>
       <DialogHeader style={{ flexDirection: 'column' }}>
-        <DialogTitle textAlign="center">Verify Your Identity</DialogTitle>
+        <DialogTitle textAlign="center">
+          Multi-factor authentication
+        </DialogTitle>
       </DialogHeader>
       <DialogContent mb={6}>
         {errorText && (
@@ -41,13 +43,12 @@ export default function AuthnDialog({
           </Danger>
         )}
         <Text textAlign="center">
-          Re-authentication is required. Follow the prompts given by your
-          browser to complete authentication.
+          Re-enter your multi-factor authentication in the browser to continue.
         </Text>
       </DialogContent>
       <DialogFooter textAlign="center">
-        <ButtonPrimary onClick={onContinue} mr={3} width="130px">
-          {errorText ? 'Retry' : 'Verify'}
+        <ButtonPrimary onClick={onContinue} autoFocus mr={3} width="130px">
+          {errorText ? 'Retry' : 'OK'}
         </ButtonPrimary>
         <ButtonSecondary onClick={onCancel}>Cancel</ButtonSecondary>
       </DialogFooter>


### PR DESCRIPTION
Change the text on the MFA dialog to be less alarming. Additionally, focus the OK button by default, so that users can press enter to go straight to the MFA prompt without manually clicking a button.

Closes #19042