### PR TITLE
Import jest-canvas-mock in teleport tests which import xterm paths

### DIFF
--- a/web/packages/teleport/src/Console/DocumentBlank/DocumentBlank.story.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentBlank/DocumentBlank.story.test.tsx
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import 'jest-canvas-mock';
 import { render } from 'design/utils/testing';
 
 import { Blank } from './DocumentBlank.story';

--- a/web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-
+import 'jest-canvas-mock';
 import { waitFor, render } from 'design/utils/testing';
 
 import { Document, createContext } from './DocumentNodes.story';

--- a/web/packages/teleport/src/Console/Tabs/Tabs.story.test.tsx
+++ b/web/packages/teleport/src/Console/Tabs/Tabs.story.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-
+import 'jest-canvas-mock';
 import { render } from 'design/utils/testing';
 
 import { ConsoleTabs } from './Tabs.story';


### PR DESCRIPTION
Without this import, the tests throw the following warning when running Jest:

```
 PASS  web/packages/teleport/src/Console/Tabs/Tabs.story.test.tsx
  ● Console

    console.error
      Error: Not implemented: HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)
          at module.exports (/Users/rav/Projects/teleport/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
          at HTMLCanvasElementImpl.getContext (/Users/rav/Projects/teleport/node_modules/jsdom/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js:42:5)
          at HTMLCanvasElement.getContext (/Users/rav/Projects/teleport/node_modules/jsdom/lib/jsdom/living/generated/HTMLCanvasElement.js:131:58)
          at /Users/rav/Projects/teleport/node_modules/xterm/lib/webpack:/xterm/src/common/Color.ts:123:39
          at Object.8055 (/Users/rav/Projects/teleport/node_modules/xterm/lib/webpack:/xterm/src/common/Color.ts:238:5)
          at DIM_CLASS (/Users/rav/Projects/teleport/node_modules/xterm/lib/xterm.js:1:271008)
          at Object.3787 (/Users/rav/Projects/teleport/node_modules/xterm/lib/webpack:/xterm/src/browser/renderer/dom/DomRendererRowFactory.ts:19:14)
          at i (/Users/rav/Projects/teleport/node_modules/xterm/lib/xterm.js:1:271008)
          at Object.1296 (/Users/rav/Projects/teleport/node_modules/xterm/lib/webpack:/xterm/src/browser/renderer/dom/DomRenderer.ts:18:31)
          at i (/Users/rav/Projects/teleport/node_modules/xterm/lib/xterm.js:1:271008) undefined
```

I ran into this when I was adding a new test in teleterm. I don't fully understand why this error happens, as in my case I'm not using xterm to render anything. My current hypothesis is that the given file under tests imports xterm in one way or another which triggers the warning.

In any case, [importing jest-canvas-mock gets rid of the error](https://stackoverflow.com/a/62768292/742872).