### PR TITLE
refactor: audit interface

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -43,7 +43,7 @@ import (
 type APIConfig struct {
 	PluginRegistry plugin.Registry
 	AuthServer     *Server
-	AuditLog       events.IAuditLog
+	AuditLog       events.AuditLogSessionStreamer
 	Authorizer     Authorizer
 	Emitter        apievents.Emitter
 	// KeepAlivePeriod defines period between keep alives

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -245,7 +245,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		Kubernetes:              cfg.Kubernetes,
 		Databases:               cfg.Databases,
 		DatabaseServices:        cfg.DatabaseServices,
-		IAuditLog:               cfg.AuditLog,
+		AuditLogSessionStreamer: cfg.AuditLog,
 		Events:                  cfg.Events,
 		WindowsDesktops:         cfg.WindowsDesktops,
 		SAMLIdPServiceProviders: cfg.SAMLIdPServiceProviders,
@@ -343,7 +343,7 @@ type Services struct {
 	services.StatusInternal
 	services.UsageReporter
 	types.Events
-	events.IAuditLog
+	events.AuditLogSessionStreamer
 }
 
 // GetWebSession returns existing web session described by req.
@@ -932,8 +932,8 @@ func (a *Server) SetClock(clock clockwork.Clock) {
 }
 
 // SetAuditLog sets the server's audit log
-func (a *Server) SetAuditLog(auditLog events.IAuditLog) {
-	a.Services.IAuditLog = auditLog
+func (a *Server) SetAuditLog(auditLog events.AuditLogSessionStreamer) {
+	a.Services.AuditLogSessionStreamer = auditLog
 }
 
 // GetEmitter fetches the current audit log emitter implementation.

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -2619,15 +2619,15 @@ func newTestServices(t *testing.T) Services {
 	require.NoError(t, err)
 
 	return Services{
-		Trust:                local.NewCAService(bk),
-		PresenceInternal:     local.NewPresenceService(bk),
-		Provisioner:          local.NewProvisioningService(bk),
-		Identity:             local.NewIdentityService(bk),
-		Access:               local.NewAccessService(bk),
-		DynamicAccessExt:     local.NewDynamicAccessService(bk),
-		ClusterConfiguration: configService,
-		Events:               local.NewEventsService(bk),
-		IAuditLog:            events.NewDiscardAuditLog(),
+		Trust:                   local.NewCAService(bk),
+		PresenceInternal:        local.NewPresenceService(bk),
+		Provisioner:             local.NewProvisioningService(bk),
+		Identity:                local.NewIdentityService(bk),
+		Access:                  local.NewAccessService(bk),
+		DynamicAccessExt:        local.NewDynamicAccessService(bk),
+		ClusterConfiguration:    configService,
+		Events:                  local.NewEventsService(bk),
+		AuditLogSessionStreamer: events.NewDiscardAuditLog(),
 	}
 }
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -58,7 +58,7 @@ import (
 // methods that focuses on authorizing every request
 type ServerWithRoles struct {
 	authServer *Server
-	alog       events.IAuditLog
+	alog       events.AuditLogSessionStreamer
 	// context holds authorization context
 	context Context
 }
@@ -5512,7 +5512,7 @@ func (a *ServerWithRoles) DeleteAllSAMLIdPServiceProviders(ctx context.Context) 
 
 // NewAdminAuthServer returns auth server authorized as admin,
 // used for auth server cached access
-func NewAdminAuthServer(authServer *Server, alog events.IAuditLog) (ClientI, error) {
+func NewAdminAuthServer(authServer *Server, alog events.AuditLogSessionStreamer) (ClientI, error) {
 	ctx, err := NewAdminContext()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1565,7 +1565,7 @@ type ClientI interface {
 	IdentityService
 	ProvisioningService
 	services.Trust
-	events.IAuditLog
+	events.AuditLogSessionStreamer
 	events.Streamer
 	apievents.Emitter
 	services.Presence

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -69,7 +69,7 @@ type TestAuthServerConfig struct {
 	// Streamer allows a test to set its own audit events streamer.
 	Streamer events.Streamer
 	// AuditLog allows a test to configure its own audit log.
-	AuditLog events.IAuditLog
+	AuditLog events.AuditLogSessionStreamer
 	// TraceClient allows a test to configure the trace client
 	TraceClient otlptrace.Client
 	// AuthPreferenceSpec is custom initial AuthPreference spec for the test.
@@ -194,7 +194,7 @@ type TestAuthServer struct {
 	// AuthServer is an auth server
 	AuthServer *Server
 	// AuditLog is an event audit log
-	AuditLog events.IAuditLog
+	AuditLog events.AuditLogSessionStreamer
 	// Backend is a backend for auth server
 	Backend backend.Backend
 	// Authorizer is an authorizer used in tests

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -153,7 +153,7 @@ type InitConfig struct {
 	AuthPreference types.AuthPreference
 
 	// AuditLog is used for emitting events to audit log.
-	AuditLog events.IAuditLog
+	AuditLog events.AuditLogSessionStreamer
 
 	// ClusterAuditConfig holds cluster audit configuration.
 	ClusterAuditConfig types.ClusterAuditConfig

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -757,14 +757,8 @@ type StreamEmitter interface {
 }
 
 // IAuditLog is the primary (and the only external-facing) interface for AuditLogger.
-// If you wish to implement a different kind of logger (not filesystem-based), you
-// have to implement this interface
 type IAuditLog interface {
-	// Closer releases connection and resources associated with log if any
-	io.Closer
-
-	// EmitAuditEvent emits audit event
-	EmitAuditEvent(context.Context, apievents.AuditEvent) error
+	ExternalAuditLogger
 
 	// GetSessionChunk returns a reader which can be used to read a byte stream
 	// of a recorded session starting from 'offsetBytes' (pass 0 to start from the
@@ -772,6 +766,16 @@ type IAuditLog interface {
 	//
 	// If maxBytes > MaxChunkBytes, it gets rounded down to MaxChunkBytes
 	GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error)
+}
+
+// ExternalAuditLogger defines which methods need to implemented by external
+// audit loggers.
+type ExternalAuditLogger interface {
+	// Closer releases connection and resources associated with log if any
+	io.Closer
+
+	// EmitAuditEvent emits audit event
+	EmitAuditEvent(context.Context, apievents.AuditEvent) error
 
 	// Returns all events that happen during a session sorted by time
 	// (oldest first).
@@ -815,7 +819,6 @@ func (f EventFields) AsString() string {
 		f.GetString(EventLogin),
 		f.GetInt(EventCursor),
 		f.GetInt(SessionPrintEventBytes))
-
 }
 
 // GetType returns the type (string) of the event

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -756,10 +756,15 @@ type StreamEmitter interface {
 	Streamer
 }
 
-// IAuditLog is the primary (and the only external-facing) interface for AuditLogger.
-type IAuditLog interface {
-	ExternalAuditLogger
+// AuditLogSessionStreamer is the primary (and the only external-facing)
+// interface for AuditLogger and SessionStreamer.
+type AuditLogSessionStreamer interface {
+	AuditLogger
+	SessionStreamer
+}
 
+// SessionStreamer supports streaming session chunks or events.
+type SessionStreamer interface {
 	// GetSessionChunk returns a reader which can be used to read a byte stream
 	// of a recorded session starting from 'offsetBytes' (pass 0 to start from the
 	// beginning) up to maxBytes bytes.
@@ -773,14 +778,15 @@ type IAuditLog interface {
 	StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error)
 }
 
-// ExternalAuditLogger defines which methods need to implemented by external
-// audit loggers.
-type ExternalAuditLogger interface {
+// AuditLogger defines which methods need to implemented by audit loggers.
+type AuditLogger interface {
 	// Closer releases connection and resources associated with log if any
 	io.Closer
 
 	// EmitAuditEvent emits audit event
 	EmitAuditEvent(context.Context, apievents.AuditEvent) error
+
+	// TODO(tobiaszheller): move GetSessionEvents into SessionStreamer.
 
 	// Returns all events that happen during a session sorted by time
 	// (oldest first).

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -766,6 +766,11 @@ type IAuditLog interface {
 	//
 	// If maxBytes > MaxChunkBytes, it gets rounded down to MaxChunkBytes
 	GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error)
+
+	// StreamSessionEvents streams all events from a given session recording. An error is returned on the first
+	// channel if one is encountered. Otherwise the event channel is closed when the stream ends.
+	// The event channel is not closed on error to prevent race conditions in downstream select statements.
+	StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error)
 }
 
 // ExternalAuditLogger defines which methods need to implemented by external
@@ -802,11 +807,6 @@ type ExternalAuditLogger interface {
 	//
 	// This function may never return more than 1 MiB of event data.
 	SearchSessionEvents(fromUTC, toUTC time.Time, limit int, order types.EventOrder, startKey string, cond *types.WhereExpr, sessionID string) ([]apievents.AuditEvent, string, error)
-
-	// StreamSessionEvents streams all events from a given session recording. An error is returned on the first
-	// channel if one is encountered. Otherwise the event channel is closed when the stream ends.
-	// The event channel is not closed on error to prevent race conditions in downstream select statements.
-	StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error)
 }
 
 // EventFields instance is attached to every logged event

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -215,7 +215,7 @@ type AuditLogConfig struct {
 	UploadHandler MultipartHandler
 
 	// ExternalLog is a pluggable external log service
-	ExternalLog IAuditLog
+	ExternalLog ExternalAuditLogger
 
 	// Context is audit log context
 	Context context.Context
@@ -454,7 +454,7 @@ func readSessionIndex(dataDir string, authServers []string, namespace string, si
 	}
 	for _, authServer := range authServers {
 		indexFileName := filepath.Join(dataDir, authServer, SessionLogsDir, namespace, fmt.Sprintf("%v.index", sid))
-		indexFile, err := os.OpenFile(indexFileName, os.O_RDONLY, 0640)
+		indexFile, err := os.OpenFile(indexFileName, os.O_RDONLY, 0o640)
 		err = trace.ConvertSystemError(err)
 		if err != nil {
 			if !trace.IsNotFound(err) {
@@ -561,7 +561,7 @@ func (l *AuditLog) downloadSession(namespace string, sid session.ID) error {
 	}
 	start := time.Now()
 	l.log.Debugf("Starting download of %v.", sid)
-	tarball, err := os.OpenFile(tarballPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0640)
+	tarball, err := os.OpenFile(tarballPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o640)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
@@ -714,16 +714,16 @@ func (l *AuditLog) unpackFile(fileName string) (readSeekCloser, error) {
 		}
 		// no new data has been added
 		if unpackedInfo.ModTime().Unix() >= packedInfo.ModTime().Unix() {
-			return os.OpenFile(unpackedFile, os.O_RDONLY, 0640)
+			return os.OpenFile(unpackedFile, os.O_RDONLY, 0o640)
 		}
 	}
 
 	start := l.Clock.Now()
-	dest, err := os.OpenFile(unpackedFile, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0640)
+	dest, err := os.OpenFile(unpackedFile, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o640)
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
-	source, err := os.OpenFile(fileName, os.O_RDONLY, 0640)
+	source, err := os.OpenFile(fileName, os.O_RDONLY, 0o640)
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
@@ -829,7 +829,7 @@ func (l *AuditLog) GetSessionEvents(namespace string, sid session.ID, afterN int
 }
 
 func (l *AuditLog) fetchSessionEvents(fileName string, afterN int) ([]EventFields, error) {
-	logFile, err := os.OpenFile(fileName, os.O_RDONLY, 0640)
+	logFile, err := os.OpenFile(fileName, os.O_RDONLY, 0o640)
 	if err != nil {
 		// no file found? this means no events have been logged yet
 		if os.IsNotExist(err) {
@@ -941,7 +941,7 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 		defer cancel()
 	}
 
-	rawSession, err := os.OpenFile(tarballPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0640)
+	rawSession, err := os.OpenFile(tarballPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o640)
 	if err != nil {
 		e <- trace.Wrap(err)
 		return c, e
@@ -1000,7 +1000,7 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 }
 
 // getLocalLog returns the local (file based) audit log.
-func (l *AuditLog) getLocalLog() IAuditLog {
+func (l *AuditLog) getLocalLog() ExternalAuditLogger {
 	l.RLock()
 	defer l.RUnlock()
 

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -151,7 +151,7 @@ var (
 )
 
 // AuditLog is a new combined facility to record Teleport events and
-// sessions. It implements IAuditLog
+// sessions. It implements AuditLogSessionStreamer
 type AuditLog struct {
 	sync.RWMutex
 	AuditLogConfig
@@ -215,7 +215,7 @@ type AuditLogConfig struct {
 	UploadHandler MultipartHandler
 
 	// ExternalLog is a pluggable external log service
-	ExternalLog ExternalAuditLogger
+	ExternalLog AuditLogger
 
 	// Context is audit log context
 	Context context.Context
@@ -999,8 +999,8 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 	return c, e
 }
 
-// getLocalLog returns the local (file based) ExternalAuditLogger.
-func (l *AuditLog) getLocalLog() ExternalAuditLogger {
+// getLocalLog returns the local (file based) AuditLogger.
+func (l *AuditLog) getLocalLog() AuditLogger {
 	l.RLock()
 	defer l.RUnlock()
 

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -999,7 +999,7 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 	return c, e
 }
 
-// getLocalLog returns the local (file based) audit log.
+// getLocalLog returns the local (file based) ExternalAuditLogger.
 func (l *AuditLog) getLocalLog() ExternalAuditLogger {
 	l.RLock()
 	defer l.RUnlock()

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -40,7 +40,7 @@ import (
 // UploadCompleterConfig specifies configuration for the uploader
 type UploadCompleterConfig struct {
 	// AuditLog is used for storing logs
-	AuditLog IAuditLog
+	AuditLog AuditLogSessionStreamer
 	// Uploader allows the completer to list and complete uploads
 	Uploader MultipartUploader
 	// SessionTracker is used to discover the current state of a
@@ -79,14 +79,12 @@ func (cfg *UploadCompleterConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-var (
-	incompleteSessionUploads = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "teleport",
-			Name:      teleport.MetricIncompleteSessionUploads,
-			Help:      "Number of sessions not yet uploaded to auth",
-		},
-	)
+var incompleteSessionUploads = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Namespace: "teleport",
+		Name:      teleport.MetricIncompleteSessionUploads,
+		Help:      "Number of sessions not yet uploaded to auth",
+	},
 )
 
 // NewUploadCompleter returns a new UploadCompleter.

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -453,15 +453,6 @@ func (l *Log) setExpiry(e *event) {
 	e.Expires = aws.Int64(l.Clock.Now().UTC().Add(l.RetentionPeriod.Value()).Unix())
 }
 
-// GetSessionChunk returns a reader which can be used to read a byte stream
-// of a recorded session starting from 'offsetBytes' (pass 0 to start from the
-// beginning) up to maxBytes bytes.
-//
-// If maxBytes > MaxChunkBytes, it gets rounded down to MaxChunkBytes
-func (l *Log) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
-	return nil, nil
-}
-
 // GetSessionEvents Returns all events that happen during a session sorted by time
 // (oldest first).
 //

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1023,15 +1023,6 @@ func convertError(err error) error {
 	}
 }
 
-// StreamSessionEvents streams all events from a given session recording. An error is returned on the first
-// channel if one is encountered. Otherwise the event channel is closed when the stream ends.
-// The event channel is not closed on error to prevent race conditions in downstream select statements.
-func (l *Log) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
-	c, e := make(chan apievents.AuditEvent), make(chan error, 1)
-	e <- trace.NotImplemented("not implemented")
-	return c, e
-}
-
 type query interface {
 	QueryWithContext(ctx context.Context, input *dynamodb.QueryInput, opts ...request.Option) (*dynamodb.QueryOutput, error)
 }

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -609,15 +609,6 @@ func (l *FileLog) findInFile(path string, filter searchEventsFilter) ([]EventFie
 	return retval, nil
 }
 
-// StreamSessionEvents streams all events from a given session recording. An error is returned on the first
-// channel if one is encountered. Otherwise the event channel is closed when the stream ends.
-// The event channel is not closed on error to prevent race conditions in downstream select statements.
-func (l *FileLog) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
-	c, e := make(chan apievents.AuditEvent), make(chan error, 1)
-	e <- trace.NotImplemented("not implemented")
-	return c, e
-}
-
 type eventFile struct {
 	os.FileInfo
 	path string

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -395,10 +395,6 @@ func (l *FileLog) Close() error {
 	return err
 }
 
-func (l *FileLog) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
-	return nil, trace.NotImplemented("not implemented")
-}
-
 func (l *FileLog) GetSessionEvents(namespace string, sid session.ID, after int, fetchPrintEvents bool) ([]EventFields, error) {
 	return nil, trace.NotImplemented("not implemented")
 }
@@ -407,7 +403,6 @@ func (l *FileLog) GetSessionEvents(namespace string, sid session.ID, after int, 
 // used by rotateLog to decide if it should acquire a write lock.  Must be called under
 // read lock.
 func (l *FileLog) mightNeedRotation() bool {
-
 	if l.file == nil {
 		return true
 	}
@@ -421,7 +416,6 @@ func (l *FileLog) mightNeedRotation() bool {
 // rotateLog checks if the current log file is older than a given duration,
 // and if it is, closes it and opens a new one.  Must be called under write lock.
 func (l *FileLog) rotateLog() (err error) {
-
 	// determine the timestamp for the current log file rounded to the day.
 	fileTime := l.Clock.Now().UTC().Truncate(24 * time.Hour)
 
@@ -429,7 +423,7 @@ func (l *FileLog) rotateLog() (err error) {
 		fileTime.Format(defaults.AuditLogTimeFormat)+LogfileExt)
 
 	openLogFile := func() error {
-		l.file, err = os.OpenFile(logFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
+		l.file, err = os.OpenFile(logFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o640)
 		if err != nil {
 			log.Error(err)
 		}

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -610,12 +610,3 @@ func (l *Log) purgeExpiredEvents() error {
 		}
 	}
 }
-
-// StreamSessionEvents streams all events from a given session recording. An error is returned on the first
-// channel if one is encountered. Otherwise the event channel is closed when the stream ends.
-// The event channel is not closed on error to prevent race conditions in downstream select statements.
-func (l *Log) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
-	c, e := make(chan apievents.AuditEvent), make(chan error, 1)
-	e <- trace.NotImplemented("not implemented")
-	return c, e
-}

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -340,15 +340,6 @@ func (l *Log) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error
 	return nil
 }
 
-// GetSessionChunk returns a reader which can be used to read a byte stream
-// of a recorded session starting from 'offsetBytes' (pass 0 to start from the
-// beginning) up to maxBytes bytes.
-//
-// If maxBytes > MaxChunkBytes, it gets rounded down to MaxChunkBytes
-func (l *Log) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
-	return nil, trace.NotImplemented("GetSessionChunk not implemented for firestore backend")
-}
-
 // Returns all events that happen during a session sorted by time
 // (oldest first).
 //

--- a/lib/events/multilog.go
+++ b/lib/events/multilog.go
@@ -27,7 +27,7 @@ import (
 )
 
 // NewMultiLog returns a new instance of a multi logger
-func NewMultiLog(loggers ...ExternalAuditLogger) (*MultiLog, error) {
+func NewMultiLog(loggers ...AuditLogger) (*MultiLog, error) {
 	emitters := make([]apievents.Emitter, 0, len(loggers))
 	for _, logger := range loggers {
 		emitter, ok := logger.(apievents.Emitter)
@@ -46,7 +46,7 @@ func NewMultiLog(loggers ...ExternalAuditLogger) (*MultiLog, error) {
 // to all loggers, and performs all read and search operations
 // on the first logger that implements the operation
 type MultiLog struct {
-	loggers []ExternalAuditLogger
+	loggers []AuditLogger
 	*MultiEmitter
 }
 

--- a/lib/events/multilog.go
+++ b/lib/events/multilog.go
@@ -17,7 +17,6 @@ limitations under the License.
 package events
 
 import (
-	"context"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -106,39 +105,4 @@ func (m *MultiLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, orde
 		}
 	}
 	return events, lastKey, err
-}
-
-// StreamSessionEvents streams all events from a given session recording. An error is returned on the first
-// channel if one is encountered. Otherwise the event channel is closed when the stream ends.
-// The event channel is not closed on error to prevent race conditions in downstream select statements.
-func (m *MultiLog) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
-	c, e := make(chan apievents.AuditEvent), make(chan error, 1)
-
-	go func() {
-	loggers:
-		for _, log := range m.loggers {
-			subCh, subErrCh := log.StreamSessionEvents(ctx, sessionID, startIndex)
-
-			for {
-				select {
-				case event, more := <-subCh:
-					if !more {
-						close(c)
-						return
-					}
-
-					c <- event
-				case err := <-subErrCh:
-					if !trace.IsNotImplemented(err) {
-						e <- trace.Wrap(err)
-						return
-					}
-
-					continue loggers
-				}
-			}
-		}
-	}()
-
-	return c, e
 }

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -77,7 +77,7 @@ func DownloadNotFound(t *testing.T, handler events.MultipartHandler) {
 
 // EventsSuite is a conformance test suite to verify external event backends
 type EventsSuite struct {
-	Log        events.ExternalAuditLogger
+	Log        events.AuditLogger
 	Clock      clockwork.Clock
 	QueryDelay time.Duration
 }

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -77,7 +77,7 @@ func DownloadNotFound(t *testing.T, handler events.MultipartHandler) {
 
 // EventsSuite is a conformance test suite to verify external event backends
 type EventsSuite struct {
-	Log        events.IAuditLog
+	Log        events.ExternalAuditLogger
 	Clock      clockwork.Clock
 	QueryDelay time.Duration
 }

--- a/lib/events/writer.go
+++ b/lib/events/writer.go
@@ -53,15 +53,6 @@ func (w *WriterLog) Close() error {
 	return w.w.Close()
 }
 
-// GetSessionChunk returns a reader which can be used to read a byte stream
-// of a recorded session starting from 'offsetBytes' (pass 0 to start from the
-// beginning) up to maxBytes bytes.
-//
-// If maxBytes > MaxChunkBytes, it gets rounded down to MaxChunkBytes
-func (w *WriterLog) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
-	return nil, trace.NotImplemented("not implemented")
-}
-
 // Returns all events that happen during a session sorted by time
 // (oldest first).
 //

--- a/lib/events/writer.go
+++ b/lib/events/writer.go
@@ -17,7 +17,6 @@ limitations under the License.
 package events
 
 import (
-	"context"
 	"io"
 	"time"
 
@@ -80,13 +79,4 @@ func (w *WriterLog) SearchEvents(fromUTC, toUTC time.Time, namespace string, eve
 // a query to be resumed.
 func (w *WriterLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, order types.EventOrder, startKey string, cond *types.WhereExpr, sessionID string) (events []apievents.AuditEvent, lastKey string, err error) {
 	return nil, "", trace.NotImplemented("not implemented")
-}
-
-// StreamSessionEvents streams all events from a given session recording. An error is returned on the first
-// channel if one is encountered. Otherwise the event channel is closed when the stream ends.
-// The event channel is not closed on error to prevent race conditions in downstream select statements.
-func (w *WriterLog) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
-	c, e := make(chan apievents.AuditEvent), make(chan error, 1)
-	e <- trace.NotImplemented("not implemented")
-	return c, e
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -317,7 +317,7 @@ type TeleportProcess struct {
 	// backend is the process' backend
 	backend backend.Backend
 	// auditLog is the initialized audit log
-	auditLog events.IAuditLog
+	auditLog events.AuditLogSessionStreamer
 
 	// inventorySetupDelay lets us inject a one-time delay in the makeInventoryControlStream
 	// method that helps reduce log spam in the event of slow instance cert acquisition.
@@ -411,7 +411,7 @@ func (process *TeleportProcess) GetAuthServer() *auth.Server {
 }
 
 // GetAuditLog returns the process' audit log
-func (process *TeleportProcess) GetAuditLog() events.IAuditLog {
+func (process *TeleportProcess) GetAuditLog() events.AuditLogSessionStreamer {
 	return process.auditLog
 }
 
@@ -1306,9 +1306,9 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 }
 
 // initAuthExternalAuditLog initializes the auth server's audit log.
-func initAuthExternalAuditLog(ctx context.Context, auditConfig types.ClusterAuditConfig, backend backend.Backend) (events.ExternalAuditLogger, error) {
+func initAuthExternalAuditLog(ctx context.Context, auditConfig types.ClusterAuditConfig, backend backend.Backend) (events.AuditLogger, error) {
 	var hasNonFileLog bool
-	var loggers []events.ExternalAuditLogger
+	var loggers []events.AuditLogger
 	for _, eventsURI := range auditConfig.AuditEventsURIs() {
 		uri, err := apiutils.ParseSessionsURI(eventsURI)
 		if err != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1305,10 +1305,10 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 	}
 }
 
-// initAuthAuditLog initializes the auth server's audit log.
-func initAuthAuditLog(ctx context.Context, auditConfig types.ClusterAuditConfig, backend backend.Backend) (events.IAuditLog, error) {
+// initAuthExternalAuditLog initializes the auth server's audit log.
+func initAuthExternalAuditLog(ctx context.Context, auditConfig types.ClusterAuditConfig, backend backend.Backend) (events.ExternalAuditLogger, error) {
 	var hasNonFileLog bool
-	var loggers []events.IAuditLog
+	var loggers []events.ExternalAuditLogger
 	for _, eventsURI := range auditConfig.AuditEventsURIs() {
 		uri, err := apiutils.ParseSessionsURI(eventsURI)
 		if err != nil {
@@ -1454,7 +1454,7 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 		// initialize external loggers.  may return (nil, nil) if no
 		// external loggers have been defined.
-		externalLog, err := initAuthAuditLog(process.ExitContext(), cfg.Auth.AuditConfig, process.backend)
+		externalLog, err := initAuthExternalAuditLog(process.ExitContext(), cfg.Auth.AuditConfig, process.backend)
 		if err != nil {
 			if !trace.IsNotFound(err) {
 				return trace.Wrap(err)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -278,7 +278,7 @@ func TestServiceInitExternalLog(t *testing.T) {
 				AuditEventsURI: tt.events,
 			})
 			require.NoError(t, err)
-			loggers, err := initAuthAuditLog(context.Background(), auditConfig, backend)
+			loggers, err := initAuthExternalAuditLog(context.Background(), auditConfig, backend)
 			if tt.isErr {
 				require.Error(t, err)
 			} else {

--- a/lib/sshutils/scp/http.go
+++ b/lib/sshutils/scp/http.go
@@ -36,7 +36,7 @@ const (
 	// 644 means that files are readable and writeable by the owner of
 	// the file and readable by users in the group owner of that file
 	// and readable by everyone else.
-	httpUploadFileMode = 0644
+	httpUploadFileMode = 0o644
 )
 
 // HTTPTransferRequest describes HTTP file transfer request
@@ -54,7 +54,7 @@ type HTTPTransferRequest struct {
 	// User is a username
 	User string
 	// AuditLog is AuditLog log
-	AuditLog events.IAuditLog
+	AuditLog events.AuditLogSessionStreamer
 }
 
 func (r *HTTPTransferRequest) parseRemoteLocation() (string, string, error) {

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -79,7 +79,7 @@ type Config struct {
 	// User is a user who runs SCP command
 	User string
 	// AuditLog is AuditLog log
-	AuditLog events.IAuditLog
+	AuditLog events.AuditLogSessionStreamer
 	// ProgressWriter is a writer for printing the progress
 	// (used only on the client)
 	ProgressWriter io.Writer


### PR DESCRIPTION
Currently in every external audit implementation both `GetSessionChunk` and `StreamSessionEvents` are either not implemented or are returning nil.

The only one who implements it is main `AuditLog` struct from lib/events package: [GetSessionChunk](https://github.com/gravitational/teleport/blob/a15e987476a0cf78b84aa7751f0b0eee06ff3640/lib/events/auditlog.go#L638-L658) and [StreamSessionEvents](https://github.com/gravitational/teleport/blob/a15e987476a0cf78b84aa7751f0b0eee06ff3640/lib/events/auditlog.go#L923-L1000). Both endpoints are implemented if used with "external log" via downloading recording first.

I have created new interface `ExternalAuditLogger`, which will be embeded into `IAuditLog` and will simplify implementations of external loggers. 

In separate PR I am planning to tackle `GetSessionEvents` methods. 
