### PR TITLE
Remove GetSessionEvents from external loggers

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -517,7 +517,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 					select {
 					case <-tickCh:
 						// Get all session events from the backend.
-						sessionEvents, err := site.GetSessionEvents(apidefaults.Namespace, session.ID(tracker.GetSessionID()), 0, false)
+						sessionEvents, err := site.GetSessionEvents(apidefaults.Namespace, session.ID(tracker.GetSessionID()), 0)
 						if err != nil {
 							return nil, trace.Wrap(err)
 						}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -928,12 +928,8 @@ func (s *APIServer) getSessionEvents(auth ClientI, w http.ResponseWriter, r *htt
 	if err != nil {
 		afterN = 0
 	}
-	includePrintEvents, err := strconv.ParseBool(r.URL.Query().Get("print"))
-	if err != nil {
-		includePrintEvents = false
-	}
 
-	return auth.GetSessionEvents(namespace, *sid, afterN, includePrintEvents)
+	return auth.GetSessionEvents(namespace, *sid, afterN)
 }
 
 type upsertNamespaceReq struct {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3346,7 +3346,7 @@ func (a *ServerWithRoles) GetSessionChunk(namespace string, sid session.ID, offs
 	return a.alog.GetSessionChunk(namespace, sid, offsetBytes, maxBytes)
 }
 
-func (a *ServerWithRoles) GetSessionEvents(namespace string, sid session.ID, afterN int, includePrintEvents bool) ([]events.EventFields, error) {
+func (a *ServerWithRoles) GetSessionEvents(namespace string, sid session.ID, afterN int) ([]events.EventFields, error) {
 	if err := a.actionForKindSession(namespace, sid); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3363,7 +3363,7 @@ func (a *ServerWithRoles) GetSessionEvents(namespace string, sid session.ID, aft
 		return nil, trace.Wrap(err)
 	}
 
-	return a.alog.GetSessionEvents(namespace, sid, afterN, includePrintEvents)
+	return a.alog.GetSessionEvents(namespace, sid, afterN)
 }
 
 func (a *ServerWithRoles) findSessionEndEvent(namespace string, sid session.ID) (apievents.AuditEvent, error) {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1279,7 +1279,7 @@ func TestGetSessionEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	// ignore the response as we don't want the events or the error (the session will not exist)
-	_, _ = clt.GetSessionEvents(defaults.Namespace, "44c6cea8-362f-11ea-83aa-125400432324", 0, false)
+	_, _ = clt.GetSessionEvents(defaults.Namespace, "44c6cea8-362f-11ea-83aa-125400432324", 0)
 
 	// we need to wait for a short period to ensure the event is returned
 	time.Sleep(500 * time.Millisecond)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1008,16 +1008,13 @@ func (c *Client) GetSessionChunk(namespace string, sid session.ID, offsetBytes, 
 //
 // afterN allows to filter by "newer than N" value where N is the cursor ID
 // of previously returned bunch (good for polling for latest)
-func (c *Client) GetSessionEvents(namespace string, sid session.ID, afterN int, includePrintEvents bool) (retval []events.EventFields, err error) {
+func (c *Client) GetSessionEvents(namespace string, sid session.ID, afterN int) (retval []events.EventFields, err error) {
 	if namespace == "" {
 		return nil, trace.BadParameter(MissingNamespaceError)
 	}
 	query := make(url.Values)
 	if afterN > 0 {
 		query.Set("after", strconv.Itoa(afterN))
-	}
-	if includePrintEvents {
-		query.Set("print", fmt.Sprintf("%v", includePrintEvents))
 	}
 	response, err := c.Get(context.TODO(), c.Endpoint("namespaces", namespace, "sessions", string(sid), "events"), query)
 	if err != nil {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1739,7 +1739,7 @@ func (tc *TeleportClient) Play(ctx context.Context, namespace, sessionID string)
 	site := proxyClient.CurrentCluster()
 
 	// request events for that session (to get timing data)
-	sessionEvents, err = site.GetSessionEvents(namespace, *sid, 0, true)
+	sessionEvents, err = site.GetSessionEvents(namespace, *sid, 0)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1797,7 +1797,7 @@ func (tc *TeleportClient) GetSessionEvents(ctx context.Context, namespace, sessi
 
 	site := proxyClient.CurrentCluster()
 
-	events, err := site.GetSessionEvents(namespace, *sid, 0, true)
+	events, err := site.GetSessionEvents(namespace, *sid, 0)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -772,6 +772,12 @@ type SessionStreamer interface {
 	// If maxBytes > MaxChunkBytes, it gets rounded down to MaxChunkBytes
 	GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error)
 
+	// Returns all events that happen during a session sorted by time
+	// (oldest first).
+	//
+	// after is used to return events after a specified cursor ID
+	GetSessionEvents(namespace string, sid session.ID, after int, includePrintEvents bool) ([]EventFields, error)
+
 	// StreamSessionEvents streams all events from a given session recording. An error is returned on the first
 	// channel if one is encountered. Otherwise the event channel is closed when the stream ends.
 	// The event channel is not closed on error to prevent race conditions in downstream select statements.
@@ -785,14 +791,6 @@ type AuditLogger interface {
 
 	// EmitAuditEvent emits audit event
 	EmitAuditEvent(context.Context, apievents.AuditEvent) error
-
-	// TODO(tobiaszheller): move GetSessionEvents into SessionStreamer.
-
-	// Returns all events that happen during a session sorted by time
-	// (oldest first).
-	//
-	// after is used to return events after a specified cursor ID
-	GetSessionEvents(namespace string, sid session.ID, after int, includePrintEvents bool) ([]EventFields, error)
 
 	// SearchEvents is a flexible way to find events.
 	//

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -776,7 +776,7 @@ type SessionStreamer interface {
 	// (oldest first).
 	//
 	// after is used to return events after a specified cursor ID
-	GetSessionEvents(namespace string, sid session.ID, after int, includePrintEvents bool) ([]EventFields, error)
+	GetSessionEvents(namespace string, sid session.ID, after int) ([]EventFields, error)
 
 	// StreamSessionEvents streams all events from a given session recording. An error is returned on the first
 	// channel if one is encountered. Otherwise the event channel is closed when the stream ends.

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -789,17 +789,7 @@ func (l *AuditLog) GetSessionEvents(namespace string, sid session.ID, afterN int
 	if namespace == "" {
 		return nil, trace.BadParameter("missing parameter namespace")
 	}
-	// Print events are stored in the context of the downloaded session
-	// so pull them
-	if !includePrintEvents && l.ExternalLog != nil {
-		events, err := l.ExternalLog.GetSessionEvents(namespace, sid, afterN, includePrintEvents)
-		// some loggers (e.g. FileLog) do not support retrieving session only print events,
-		// in this case rely on local fallback to download the session,
-		// unpack it and use local search
-		if !trace.IsNotImplemented(err) {
-			return events, err
-		}
-	}
+
 	// If code has to fetch print events (for playback) it has to download
 	// the playback from external storage first
 	if err := l.downloadSession(namespace, sid); err != nil {

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -784,8 +784,8 @@ func (l *AuditLog) getSessionChunk(namespace string, sid session.ID, offsetBytes
 //
 // Can be filtered by 'after' (cursor value to return events newer than)
 
-func (l *AuditLog) GetSessionEvents(namespace string, sid session.ID, afterN int, includePrintEvents bool) ([]EventFields, error) {
-	l.log.WithFields(log.Fields{"sid": string(sid), "afterN": afterN, "printEvents": includePrintEvents}).Debugf("GetSessionEvents.")
+func (l *AuditLog) GetSessionEvents(namespace string, sid session.ID, afterN int) ([]EventFields, error) {
+	l.log.WithFields(log.Fields{"sid": string(sid), "afterN": afterN}).Debugf("GetSessionEvents.")
 	if namespace == "" {
 		return nil, trace.BadParameter("missing parameter namespace")
 	}

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -39,21 +39,27 @@ func NewDiscardAuditLog() *DiscardAuditLog {
 func (d *DiscardAuditLog) Close() error {
 	return nil
 }
+
 func (d *DiscardAuditLog) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
 	return make([]byte, 0), nil
 }
-func (d *DiscardAuditLog) GetSessionEvents(namespace string, sid session.ID, after int, includePrintEvents bool) ([]EventFields, error) {
+
+func (d *DiscardAuditLog) GetSessionEvents(namespace string, sid session.ID, after int) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
 }
+
 func (d *DiscardAuditLog) SearchEvents(fromUTC, toUTC time.Time, namespace string, eventType []string, limit int, order types.EventOrder, startKey string) ([]apievents.AuditEvent, string, error) {
 	return make([]apievents.AuditEvent, 0), "", nil
 }
+
 func (d *DiscardAuditLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, order types.EventOrder, startKey string, cond *types.WhereExpr, sessionID string) ([]apievents.AuditEvent, string, error) {
 	return make([]apievents.AuditEvent, 0), "", nil
 }
+
 func (d *DiscardAuditLog) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
 	return nil
 }
+
 func (d *DiscardAuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
 	c, e := make(chan apievents.AuditEvent), make(chan error, 1)
 	close(c)

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -50,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/lib/backend/dynamo"
 	"github.com/gravitational/teleport/lib/events"
 	dynamometrics "github.com/gravitational/teleport/lib/observability/metrics/dynamo"
-	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -451,41 +450,6 @@ func (l *Log) setExpiry(e *event) {
 	}
 
 	e.Expires = aws.Int64(l.Clock.Now().UTC().Add(l.RetentionPeriod.Value()).Unix())
-}
-
-// GetSessionEvents Returns all events that happen during a session sorted by time
-// (oldest first).
-//
-// after is used to return events after a specified cursor ID
-func (l *Log) GetSessionEvents(namespace string, sid session.ID, after int, includePrintEvents bool) ([]events.EventFields, error) {
-	var values []events.EventFields
-	query := "SessionID = :sessionID AND EventIndex >= :eventIndex"
-	attributes := map[string]interface{}{
-		":sessionID":  string(sid),
-		":eventIndex": after,
-	}
-	attributeValues, err := dynamodbattribute.MarshalMap(attributes)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	input := dynamodb.QueryInput{
-		KeyConditionExpression:    aws.String(query),
-		TableName:                 aws.String(l.Tablename),
-		ExpressionAttributeValues: attributeValues,
-	}
-	out, err := l.svc.Query(&input)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	for _, item := range out.Items {
-		var e event
-		if err := dynamodbattribute.UnmarshalMap(item, &e); err != nil {
-			return nil, trace.BadParameter("failed to unmarshal event for session %q: %v", string(sid), err)
-		}
-		values = append(values, e.FieldsMap)
-	}
-	sort.Sort(events.ByTimeAndIndex(values))
-	return values, nil
 }
 
 func daysSinceEpoch(timestamp time.Time) int64 {

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -39,7 +39,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -393,10 +392,6 @@ func (l *FileLog) Close() error {
 		l.file = nil
 	}
 	return err
-}
-
-func (l *FileLog) GetSessionEvents(namespace string, sid session.ID, after int, fetchPrintEvents bool) ([]EventFields, error) {
-	return nil, trace.NotImplemented("not implemented")
 }
 
 // mightNeedRotation checks if the current log file looks older than a given duration,

--- a/lib/events/multilog.go
+++ b/lib/events/multilog.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
-	"github.com/gravitational/teleport/lib/session"
 )
 
 // NewMultiLog returns a new instance of a multi logger
@@ -57,20 +56,6 @@ func (m *MultiLog) Close() error {
 		errors = append(errors, log.Close())
 	}
 	return trace.NewAggregate(errors...)
-}
-
-// Returns all events that happen during a session sorted by time
-// (oldest first).
-//
-// after is used to return events after a specified cursor ID
-func (m *MultiLog) GetSessionEvents(namespace string, sid session.ID, after int, fetchPrintEvents bool) (events []EventFields, err error) {
-	for _, log := range m.loggers {
-		events, err = log.GetSessionEvents(namespace, sid, after, fetchPrintEvents)
-		if !trace.IsNotImplemented(err) {
-			return events, err
-		}
-	}
-	return events, err
 }
 
 // SearchEvents is a flexible way to find events.

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -266,12 +266,16 @@ func (s *EventsSuite) SessionEventsCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// read the session event
-	historyEvents, err := s.Log.GetSessionEvents(apidefaults.Namespace, sessionID, 0, false)
+	// search for the session event.
+	err = retryutils.RetryStaticFor(time.Minute*5, time.Second*5, func() error {
+		history, _, err = s.Log.SearchEvents(s.Clock.Now().Add(-1*time.Hour), s.Clock.Now().Add(time.Hour), apidefaults.Namespace, nil, 100, types.EventOrderAscending, "")
+		return err
+	})
 	require.NoError(t, err)
-	require.Len(t, historyEvents, 2)
-	require.Equal(t, historyEvents[0].GetString(events.EventType), events.SessionStartEvent)
-	require.Equal(t, historyEvents[1].GetString(events.EventType), events.SessionEndEvent)
+	require.Len(t, history, 3)
+
+	require.Equal(t, history[1].GetType(), events.SessionStartEvent)
+	require.Equal(t, history[2].GetType(), events.SessionEndEvent)
 
 	history, _, err = s.Log.SearchSessionEvents(s.Clock.Now().Add(-1*time.Hour), s.Clock.Now().Add(2*time.Hour), 100, types.EventOrderAscending, "", nil, "")
 	require.NoError(t, err)

--- a/lib/events/writer.go
+++ b/lib/events/writer.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
-	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -50,14 +49,6 @@ type WriterLog struct {
 // Close releases connection and resources associated with log if any
 func (w *WriterLog) Close() error {
 	return w.w.Close()
-}
-
-// Returns all events that happen during a session sorted by time
-// (oldest first).
-//
-// after is used to return events after a specified cursor ID
-func (w *WriterLog) GetSessionEvents(namespace string, sid session.ID, after int, includePrintEvents bool) ([]EventFields, error) {
-	return nil, trace.NotImplemented("not implemented")
 }
 
 // SearchEvents is a flexible way to find events.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3017,7 +3017,7 @@ func (h *Handler) siteSessionEventsGet(w http.ResponseWriter, r *http.Request, p
 		afterN = 0
 	}
 
-	e, err := clt.GetSessionEvents(apidefaults.Namespace, *sessionID, afterN, true)
+	e, err := clt.GetSessionEvents(apidefaults.Namespace, *sessionID, afterN)
 	if err != nil {
 		h.log.WithError(err).Debugf("Unable to find events for session %v.", sessionID)
 		if trace.IsNotFound(err) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -6503,7 +6503,7 @@ func (mock authProviderMock) GetNodes(ctx context.Context, n string) ([]types.Se
 	return []types.Server{&mock.server}, nil
 }
 
-func (mock authProviderMock) GetSessionEvents(n string, s session.ID, c int, p bool) ([]events.EventFields, error) {
+func (mock authProviderMock) GetSessionEvents(n string, s session.ID, c int) ([]events.EventFields, error) {
 	return []events.EventFields{}, nil
 }
 

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -89,7 +89,7 @@ type TerminalRequest struct {
 // AuthProvider is a subset of the full Auth API.
 type AuthProvider interface {
 	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
-	GetSessionEvents(namespace string, sid session.ID, after int, includePrintEvents bool) ([]events.EventFields, error)
+	GetSessionEvents(namespace string, sid session.ID, after int) ([]events.EventFields, error)
 	GetSessionTracker(ctx context.Context, sessionID string) (types.SessionTracker, error)
 	IsMFARequired(ctx context.Context, req *authproto.IsMFARequiredRequest) (*authproto.IsMFARequiredResponse, error)
 	GenerateUserSingleUseCerts(ctx context.Context) (authproto.AuthService_GenerateUserSingleUseCertsClient, error)


### PR DESCRIPTION
Requires: https://github.com/gravitational/teleport/pull/22070/

Moves `GetSessionEvents` methods from `ExternalAuditLogger` into `IAuditLog` and removes it implementation from every external audit logger.

[GetSessionEvents](https://github.com/gravitational/teleport/blob/a15e987476a0cf78b84aa7751f0b0eee06ff3640/lib/events/auditlog.go#L787-L807) from AuditLog method works in following way:
```
if ! includePrintEvents && external.IsConfigured() {
   err = external.GetSessionEvents()
   if err == notImplemented {
      // fallback via download session
   }
}

events:=uploader.DownloadSession()
return events
```

Whole teleport codebase use `includePrintEvents = True`. I believe it was used before for listing active sessions, but after introducing moderated sessions and SessionTracker, we no longer use `GetSessionEvents` for listing active sessions on webapi. 

It seems that `GetSessionEvents` is not used with `includePrintEvents=True` which means we can remove it from External Interface and let `AuditLog` implement it by downloading session and listing events out of it.

**Important**: `GetSessionEvents` is exposed by our auth API server on [http method](https://github.com/gravitational/teleport/blob/a15e987476a0cf78b84aa7751f0b0eee06ff3640/lib/auth/apiserver.go#L147). `includePrintEvents` is passed there as query arg. No client in teleport codebase is passing that value as false, however it may be that some customer integrate directly with that API. 
`AuditLog` implementes GetSessionEvents but because it is possible to download only completed session, it will mean that behaviour of that endpoint will change. Theoretically customers using that API after change won't receive there active sessions anymore, only completed. 

I am not sure what's the approach for doing small behaviour changes in auth server API.

