### PR TITLE
[v11] Import jest-canvas-mock in teleport tests which import xterm paths

### DIFF
--- a/web/packages/teleport/src/Console/DocumentBlank/DocumentBlank.story.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentBlank/DocumentBlank.story.test.tsx
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import 'jest-canvas-mock';
 import { render } from 'design/utils/testing';
 
 import { Blank } from './DocumentBlank.story';

--- a/web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-
+import 'jest-canvas-mock';
 import { waitFor, render } from 'design/utils/testing';
 
 import { Document, createContext } from './DocumentNodes.story';

--- a/web/packages/teleport/src/Console/Tabs/Tabs.story.test.tsx
+++ b/web/packages/teleport/src/Console/Tabs/Tabs.story.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-
+import 'jest-canvas-mock';
 import { render } from 'design/utils/testing';
 
 import { ConsoleTabs } from './Tabs.story';


### PR DESCRIPTION
Backport #22063 to branch/v11