### PR TITLE
[v10] Import jest-canvas-mock in teleport tests which import xterm paths

### DIFF
--- a/web/packages/teleport/src/Console/DocumentBlank/DocumentBlank.story.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentBlank/DocumentBlank.story.test.tsx
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import 'jest-canvas-mock';
 import { render } from 'design/utils/testing';
 
 import { Blank } from './DocumentBlank.story';

--- a/web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import 'jest-canvas-mock';
 import { waitFor, render } from 'design/utils/testing';
 
 import {

--- a/web/packages/teleport/src/Console/Tabs/Tabs.story.test.tsx
+++ b/web/packages/teleport/src/Console/Tabs/Tabs.story.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-
+import 'jest-canvas-mock';
 import { render } from 'design/utils/testing';
 
 import { ConsoleTabs } from './Tabs.story';

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
@@ -16,6 +16,7 @@
 
 import { fireEvent, render } from 'design/utils/testing';
 import React from 'react';
+import 'jest-canvas-mock';
 
 import { TabHost } from 'teleterm/ui/TabHost/TabHost';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';


### PR DESCRIPTION
Backport #22063.

There was a small whitespace conflict plus I added the import to one teleterm test that was missing it on branch/v10.