### PR TITLE
Correctly handle LOCAL command of PROXY protocol v2 in multiplexer

### DIFF
--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -355,6 +355,9 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
+			if newProxyLine == nil {
+				continue
+			}
 
 			// If TLVs are empty we know it can't be signed, so we don't try to verify to avoid unnecessary load
 			if m.CertAuthorityGetter != nil && m.LocalClusterName != "" && len(newProxyLine.TLVs) > 0 {


### PR DESCRIPTION
Correctly handle situation when new proxy line is nil (because of LOCAL command), even though there's no error.