### PR TITLE
Bump cloud version to 11.3.4

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1311,7 +1311,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "11.3.3",
+      "version": "11.3.4",
       "major_version": "11",
       "sla": {
         "monthly_percentage": "99.5%",


### PR DESCRIPTION
Upgrading Teleport version in cloud to 11.3.4

Related to https://github.com/gravitational/cloud/issues/3573