### PR TITLE
Added `--artifact-version` flag to OS package repo tool

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6925,7 +6925,7 @@ steps:
   - export VERSION="${DRONE_TAG}"
   - export RELEASE_CHANNEL="stable"
   - go run ./cmd/build-os-package-repos apt -bucket "$REPO_S3_BUCKET" -local-bucket-path
-    "$BUCKET_CACHE_PATH" -artifact-version "$VERSION" -release-channel "$RELEASE_CHANNEL"
+    "$BUCKET_CACHE_PATH" -version-channel "$VERSION" -release-channel "$RELEASE_CHANNEL"
     -artifact-path "$ARTIFACT_PATH" -log-level 4 -aptly-root-dir "$APTLY_ROOT_DIR"
   environment:
     APTLY_ROOT_DIR: /mnt/aptly
@@ -7129,7 +7129,7 @@ steps:
   - export VERSION="${DRONE_TAG}"
   - export RELEASE_CHANNEL="stable"
   - go run ./cmd/build-os-package-repos yum -bucket "$REPO_S3_BUCKET" -local-bucket-path
-    "$BUCKET_CACHE_PATH" -artifact-version "$VERSION" -release-channel "$RELEASE_CHANNEL"
+    "$BUCKET_CACHE_PATH" -version-channel "$VERSION" -release-channel "$RELEASE_CHANNEL"
     -artifact-path "$ARTIFACT_PATH" -log-level 4 -cache-dir "$CACHE_DIR"
   environment:
     ARTIFACT_PATH: /go/artifacts
@@ -18925,6 +18925,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: 39c40129c9a9837beebf450fac24e8938ec1e1f1c467dd0a334ee58718f3433b
+hmac: bc40ded3c6c520d2f5f3578625115b2acb610f79565ec98abab420b955c0737b
 
 ...

--- a/build.assets/tooling/cmd/build-os-package-repos/apt_repo_tool.go
+++ b/build.assets/tooling/cmd/build-os-package-repos/apt_repo_tool.go
@@ -25,7 +25,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/mod/semver"
 )
 
 type AptRepoTool struct {
@@ -184,13 +183,8 @@ func (art *AptRepoTool) recreateExistingRepos(localPublishedPath string) ([]*Rep
 func (art *AptRepoTool) getArtifactRepos() ([]*Repo, error) {
 	logrus.Infoln("Creating or getting Aptly repos for artifact requirements...")
 
-	majorVersion := semver.Major(art.config.artifactVersion)
-	if art.config.targetCloud {
-		majorVersion = "cloud"
-	}
-
 	artifactRepos, err := art.aptly.CreateReposFromArtifactRequirements(art.supportedOSs,
-		art.config.releaseChannel, majorVersion)
+		art.config.releaseChannel, art.config.versionChannel)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to create or get repos from artifact requirements")
 	}
@@ -232,7 +226,7 @@ func (art *AptRepoTool) importNewDebsWalker(debPath string, d fs.DirEntry, err e
 	for _, repo := range repos {
 		// Other checks could be added here to ensure that a given deb gets added to the correct repo
 		// such as name or parent directory, facilitating os-specific artifacts
-		if repo.majorVersion != semver.Major(art.config.artifactVersion) || repo.releaseChannel != art.config.releaseChannel {
+		if repo.versionChannel != art.config.versionChannel || repo.releaseChannel != art.config.releaseChannel {
 			continue
 		}
 

--- a/build.assets/tooling/cmd/build-os-package-repos/apt_repo_tool.go
+++ b/build.assets/tooling/cmd/build-os-package-repos/apt_repo_tool.go
@@ -184,8 +184,13 @@ func (art *AptRepoTool) recreateExistingRepos(localPublishedPath string) ([]*Rep
 func (art *AptRepoTool) getArtifactRepos() ([]*Repo, error) {
 	logrus.Infoln("Creating or getting Aptly repos for artifact requirements...")
 
+	majorVersion := semver.Major(art.config.artifactVersion)
+	if art.config.targetCloud {
+		majorVersion = "cloud"
+	}
+
 	artifactRepos, err := art.aptly.CreateReposFromArtifactRequirements(art.supportedOSs,
-		art.config.releaseChannel, semver.Major(art.config.artifactVersion))
+		art.config.releaseChannel, majorVersion)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to create or get repos from artifact requirements")
 	}

--- a/build.assets/tooling/cmd/build-os-package-repos/aptly.go
+++ b/build.assets/tooling/cmd/build-os-package-repos/aptly.go
@@ -189,7 +189,7 @@ func (a *Aptly) CreateRepoIfNotExists(r *Repo) (bool, error) {
 	}
 
 	distributionArg := fmt.Sprintf("-distribution=%s", r.osVersion)
-	componentArg := fmt.Sprintf("-component=%s/%s", r.releaseChannel, r.majorVersion)
+	componentArg := fmt.Sprintf("-component=%s/%s", r.releaseChannel, r.versionChannel)
 	_, err = BuildAndRunCommand("aptly", "repo", "create", distributionArg, componentArg, r.Name())
 	if err != nil {
 		return false, trace.Wrap(err, "failed to create repo %q", r.Name())
@@ -567,18 +567,18 @@ func (a *Aptly) CreateReposFromPublishedPath(localPublishedPath string) ([]*Repo
 			}
 
 			for _, releaseChannel := range releaseChannelSubdirectories {
-				majorVersionParentDirectory := filepath.Join(releaseChannelParentDirectory, releaseChannel)
-				majorVersionSubdirectories, err := getSubdirectories(majorVersionParentDirectory)
+				versionChannelParentDirectory := filepath.Join(releaseChannelParentDirectory, releaseChannel)
+				versionChannelSubdirectories, err := getSubdirectories(versionChannelParentDirectory)
 				if err != nil {
-					return nil, trace.Wrap(err, "failed to get major version subdirectories in %s", localPublishedPath)
+					return nil, trace.Wrap(err, "failed to get version channel subdirectories in %s", localPublishedPath)
 				}
 
-				for _, majorVersion := range majorVersionSubdirectories {
+				for _, versionChannel := range versionChannelSubdirectories {
 					r := &Repo{
 						os:                  os,
 						osVersion:           osVersion,
 						releaseChannel:      releaseChannel,
-						majorVersion:        majorVersion,
+						versionChannel:      versionChannel,
 						publishedSourcePath: localPublishedPath,
 					}
 
@@ -606,11 +606,11 @@ func (a *Aptly) CreateReposFromPublishedPath(localPublishedPath string) ([]*Repo
 // supportedOSInfo should be a dictionary keyed by OS name, with values being a list of
 // supported OS version codenames.
 func (a *Aptly) CreateReposFromArtifactRequirements(supportedOSInfo map[string][]string,
-	releaseChannel string, majorVersion string) ([]*Repo, error) {
+	releaseChannel string, versionChannel string) ([]*Repo, error) {
 	logrus.Infoln("Creating new repos from artifact requirements:")
 	logrus.Infof("Supported OSs: %+v", supportedOSInfo)
 	logrus.Infof("Release channel: %q", releaseChannel)
-	logrus.Infof("Artifact major version: %q", majorVersion)
+	logrus.Infof("Version channel: %q", versionChannel)
 
 	artifactRequirementRepos := []*Repo{}
 	for os, osVersions := range supportedOSInfo {
@@ -619,7 +619,7 @@ func (a *Aptly) CreateReposFromArtifactRequirements(supportedOSInfo map[string][
 				os:             os,
 				osVersion:      osVersion,
 				releaseChannel: releaseChannel,
-				majorVersion:   majorVersion,
+				versionChannel: versionChannel,
 			}
 
 			_, err := a.CreateRepoIfNotExists(r)

--- a/build.assets/tooling/cmd/build-os-package-repos/config.go
+++ b/build.assets/tooling/cmd/build-os-package-repos/config.go
@@ -122,6 +122,7 @@ type Config struct {
 	artifactVersion string
 	printHelp       bool
 	releaseChannel  string
+	targetCloud     bool
 }
 
 func NewConfigWithFlagset(fs *flag.FlagSet) *Config {
@@ -137,6 +138,7 @@ func NewConfigWithFlagset(fs *flag.FlagSet) *Config {
 		}
 	})
 	fs.StringVar(&c.releaseChannel, "release-channel", "", "The release channel of the repos that the artifacts should be added to")
+	fs.BoolVar(&c.targetCloud, "target-cloud", false, "True to target a \"cloud\" release channel, false otherewise")
 
 	return c
 }

--- a/build.assets/tooling/cmd/build-os-package-repos/config.go
+++ b/build.assets/tooling/cmd/build-os-package-repos/config.go
@@ -136,7 +136,7 @@ func NewConfigWithFlagset(fs *flag.FlagSet) *Config {
 		}
 	})
 	fs.StringVar(&c.releaseChannel, "release-channel", "", "The release channel of the repos that the artifacts should be added to")
-	fs.StringVar(&c.versionChannel, "version-channel", "", "The version channel of the repos that the artifacts should be added to. Semver values will be truncated to major version.")
+	fs.StringVar(&c.versionChannel, "version-channel", "", "The version channel of the repos that the artifacts should be added to. Semver values will be truncated to major version. Examples: \"v1.2.3\" (truncated to \"v1\"), \"cloud\".")
 
 	return c
 }

--- a/build.assets/tooling/cmd/build-os-package-repos/repo.go
+++ b/build.assets/tooling/cmd/build-os-package-repos/repo.go
@@ -29,13 +29,13 @@ type Repo struct {
 	os                  string
 	osVersion           string
 	releaseChannel      string
-	majorVersion        string
+	versionChannel      string
 	publishedSourcePath string
 }
 
 // Returns a unique name for the repo.
 func (r *Repo) Name() string {
-	return fmt.Sprintf("%s-%s-%s-%s", r.os, r.osVersion, r.releaseChannel, r.majorVersion)
+	return fmt.Sprintf("%s-%s-%s-%s", r.os, r.osVersion, r.releaseChannel, r.versionChannel)
 }
 
 func NewRepoFromName(name string) (*Repo, error) {
@@ -48,13 +48,13 @@ func NewRepoFromName(name string) (*Repo, error) {
 		os:             splitName[0],
 		osVersion:      splitName[1],
 		releaseChannel: splitName[2],
-		majorVersion:   splitName[3],
+		versionChannel: splitName[3],
 	}, nil
 }
 
 // Returns the APT component to be associated with all debs in the Aptly repo.
 func (r *Repo) Component() string {
-	return fmt.Sprintf("%s/%s", r.releaseChannel, r.majorVersion)
+	return fmt.Sprintf("%s/%s", r.releaseChannel, r.versionChannel)
 }
 
 // Returns a string that identifies the specific OS and OS version the Aptly repo targets.
@@ -89,7 +89,7 @@ func (r *Repo) PublishedRepoAbsolutePath() (string, error) {
 	}
 
 	// `/<publishedSourcePath>/<os>/dists/<os version>/<release channel>/<major version>/`
-	return filepath.Join(r.publishedSourcePath, r.os, "dists", r.osVersion, r.releaseChannel, r.majorVersion), nil
+	return filepath.Join(r.publishedSourcePath, r.os, "dists", r.osVersion, r.releaseChannel, r.versionChannel), nil
 }
 
 // Helper function that calls `Name()` on all repos in the provided list.

--- a/build.assets/tooling/cmd/build-os-package-repos/yum_repo_tool.go
+++ b/build.assets/tooling/cmd/build-os-package-repos/yum_repo_tool.go
@@ -264,6 +264,11 @@ func (yrt *YumRepoTool) addArtifacts(bucketArtifactPaths []string, relativeGpgPu
 		return trace.Wrap(err, "failed to get artifacts by architecture")
 	}
 
+	majorVersion := semver.Major(yrt.config.artifactVersion)
+	if yrt.config.targetCloud {
+		majorVersion = "cloud"
+	}
+
 	repoCount := 0
 	for os, osVersions := range yrt.supportedOSs {
 		osPath := path.Join(yrt.config.localBucketPath, os)
@@ -274,7 +279,7 @@ func (yrt *YumRepoTool) addArtifacts(bucketArtifactPaths []string, relativeGpgPu
 					"Teleport",
 					arch,
 					yrt.config.releaseChannel,
-					semver.Major(yrt.config.artifactVersion),
+					majorVersion,
 				)
 				repoPath := path.Join(osPath, relativeRepoPath)
 

--- a/build.assets/tooling/cmd/build-os-package-repos/yum_repo_tool.go
+++ b/build.assets/tooling/cmd/build-os-package-repos/yum_repo_tool.go
@@ -31,7 +31,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/mod/semver"
 )
 
 type YumRepoTool struct {
@@ -264,11 +263,6 @@ func (yrt *YumRepoTool) addArtifacts(bucketArtifactPaths []string, relativeGpgPu
 		return trace.Wrap(err, "failed to get artifacts by architecture")
 	}
 
-	majorVersion := semver.Major(yrt.config.artifactVersion)
-	if yrt.config.targetCloud {
-		majorVersion = "cloud"
-	}
-
 	repoCount := 0
 	for os, osVersions := range yrt.supportedOSs {
 		osPath := path.Join(yrt.config.localBucketPath, os)
@@ -279,7 +273,7 @@ func (yrt *YumRepoTool) addArtifacts(bucketArtifactPaths []string, relativeGpgPu
 					"Teleport",
 					arch,
 					yrt.config.releaseChannel,
-					majorVersion,
+					yrt.config.versionChannel,
 				)
 				repoPath := path.Join(osPath, relativeRepoPath)
 
@@ -426,7 +420,7 @@ func (yrt *YumRepoTool) createRepoFile(filePath, osName, osVersion, arch, relati
 					"Teleport",
 					arch,
 					yrt.config.releaseChannel,
-					semver.Major(yrt.config.artifactVersion),
+					yrt.config.versionChannel,
 				},
 				"/",
 			),

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -413,7 +413,7 @@ func (optpb *OsPackageToolPipelineBuilder) getVersionSteps(codePath, version str
 							optpb.packageManagerName,
 							"-bucket \"$REPO_S3_BUCKET\"",
 							"-local-bucket-path \"$BUCKET_CACHE_PATH\"",
-							"-artifact-version \"$VERSION\"",
+							"-version-channel \"$VERSION\"",
 							"-release-channel \"$RELEASE_CHANNEL\"",
 							"-artifact-path \"$ARTIFACT_PATH\"",
 							"-log-level 4", // Set this to 5 for debug logging


### PR DESCRIPTION
This PR changes the "--artifact-version" flag in the OS package repo tool to "--version-channel". When setting this flag, the release being published will be pushed to `<release channel>/<version channel>`, where version channel can be values other than the artifact version, such as "cloud". If the flag is provided a full or partial semver, it's value will be truncated to the major version.

Related issue: https://github.com/gravitational/teleport/issues/21863