### PR TITLE
Add expire time to SAML session creation.

### DIFF
--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -340,6 +340,7 @@ func (s *Server) CreateSAMLIdPSession(ctx context.Context, req types.CreateSAMLI
 	// Create services.WebSession for this session.
 	session, err := types.NewWebSession(req.SessionID, types.KindSAMLIdPSession, types.WebSessionSpecV2{
 		User:        req.Username,
+		Expires:     req.SAMLSession.ExpireTime,
 		SAMLSession: req.SAMLSession,
 	})
 	if err != nil {


### PR DESCRIPTION
SAML session creation was missing setting the expire time from the SAML session data.