### PR TITLE
Remove Azure install params from `teleport node configure` output

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -652,7 +652,7 @@ func checkAndSetDefaultsForGCPMatchers(matcherInput []GCPMatcher) error {
 type JoinParams struct {
 	TokenName string           `yaml:"token_name"`
 	Method    types.JoinMethod `yaml:"method"`
-	Azure     AzureJoinParams  `yaml:"azure"`
+	Azure     AzureJoinParams  `yaml:"azure,omitempty"`
 }
 
 // AzureJoinParams configures the parameters specific to the Azure join method.


### PR DESCRIPTION
This PR fixes a bug where Azure join params would incorrectly appear in the output of `teleport node configure`.