### PR TITLE
Inherit `kubernetes_resources` from roles when using access requests to `kube_cluster`

### DIFF
--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -318,8 +318,19 @@ func newKubeConfigFile(ctx context.Context, t *testing.T, clusters ...KubeCluste
 	return kubeConfigLocation
 }
 
+// GenTestKubeClientTLSCertOptions is a function that can be used to modify the
+// identity used to generate the kube client certificate.
+type GenTestKubeClientTLSCertOptions func(*tlsca.Identity)
+
+// WithResourceAccessRequests adds resource access requests to the identity.
+func WithResourceAccessRequests(r ...types.ResourceID) GenTestKubeClientTLSCertOptions {
+	return func(identity *tlsca.Identity) {
+		identity.AllowedResourceIDs = r
+	}
+}
+
 // GenTestKubeClientTLSCert generates a kube client to access kube service
-func (c *TestContext) GenTestKubeClientTLSCert(t *testing.T, userName, kubeCluster string) (*kubernetes.Clientset, *rest.Config) {
+func (c *TestContext) GenTestKubeClientTLSCert(t *testing.T, userName, kubeCluster string, opts ...GenTestKubeClientTLSCertOptions) (*kubernetes.Clientset, *rest.Config) {
 	authServer := c.AuthServer
 	clusterName, err := authServer.GetClusterName()
 	require.NoError(t, err)
@@ -358,6 +369,9 @@ func (c *TestContext) GenTestKubeClientTLSCert(t *testing.T, userName, kubeClust
 		KubernetesGroups:  user.GetKubeGroups(),
 		KubernetesCluster: kubeCluster,
 		RouteToCluster:    c.ClusterName,
+	}
+	for _, opt := range opts {
+		opt(&id)
 	}
 	subj, err := id.Subject()
 	require.NoError(t, err)

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -23,12 +23,14 @@ import (
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // AccessChecker interface checks access to resources based on roles, traits,
@@ -319,30 +321,67 @@ func (a *accessChecker) CheckAccess(r AccessCheckable, state AccessState, matche
 // GetKubeResources returns the allowed and denied Kubernetes Resources configured
 // for a user.
 func (a *accessChecker) GetKubeResources(cluster types.KubeCluster) (allowed, denied []types.KubernetesResource) {
-	if len(a.info.AllowedResourceIDs) > 0 {
-		for _, r := range a.info.AllowedResourceIDs {
-			if r.Kind == types.KindKubePod && r.Name == cluster.GetName() && r.ClusterName == a.localCluster {
-				splitted := strings.SplitN(r.SubResourceName, "/", 3)
-				// This condition should never happen since SubResourceName is validated
-				// but it's better to validate it.
-				if len(splitted) != 2 {
-					continue
-				}
-				allowed = append(allowed,
-					types.KubernetesResource{
-						Kind:      r.Kind,
-						Namespace: splitted[0],
-						Name:      splitted[1],
-					},
-				)
-			}
-		}
-		// When the user is granted access through a resource access request,
-		// he has no denied resources, which results in the denied being an empty slice.
-		return
+	if len(a.info.AllowedResourceIDs) == 0 {
+		return a.RoleSet.GetKubeResources(cluster)
 	}
 
-	return a.RoleSet.GetKubeResources(cluster)
+	rolesAllowed, rolesDenied := a.RoleSet.GetKubeResources(cluster)
+	// Allways append the denied resources from the roles. This is because
+	// the denied resources from the roles take precedence over the allowed
+	// resources from the certificate.
+	denied = rolesDenied
+	for _, r := range a.info.AllowedResourceIDs {
+		if r.Name != cluster.GetName() || r.ClusterName != a.localCluster {
+			continue
+		}
+		switch {
+		case slices.Contains(types.KubernetesResourcesKinds, r.Kind):
+			splitted := strings.SplitN(r.SubResourceName, "/", 3)
+			// This condition should never happen since SubResourceName is validated
+			// but it's better to validate it.
+			if len(splitted) != 2 {
+				continue
+			}
+
+			r := types.KubernetesResource{
+				Kind:      r.Kind,
+				Namespace: splitted[0],
+				Name:      splitted[1],
+			}
+
+			if matchKubernetesResource(r, rolesAllowed, rolesDenied) == nil {
+				allowed = append(allowed, r)
+			}
+		case r.Kind == types.KindKubernetesCluster:
+			// When a user has access to a Kubernetes cluster through Resource Access request,
+			// he has access to all resources in that cluster that he has access to through his roles.
+			// In that case, we append the allowed and denied resources from the roles.
+			return rolesAllowed, rolesDenied
+		}
+	}
+	return
+}
+
+// matchKubernetesResource checks if the Kubernetes Resource does not match any
+// entry from the deny list and matches at least one entry from the allowed list.
+func matchKubernetesResource(resource types.KubernetesResource, allowed, denied []types.KubernetesResource) error {
+	// utils.KubeResourceMatchesRegex checks if the resource.Kind is strictly equal
+	// to each entry and validates if the Name and Namespace fields matches the
+	// regex allowed by each entry.
+	result, err := utils.KubeResourceMatchesRegex(resource, denied)
+	if err != nil {
+		return trace.Wrap(err)
+	} else if result {
+		return trace.AccessDenied("access to %s %q denied", resource.Kind, resource.ClusterResource())
+	}
+
+	result, err = utils.KubeResourceMatchesRegex(resource, allowed)
+	if err != nil {
+		return trace.Wrap(err)
+	} else if !result {
+		return trace.AccessDenied("access to %s %q denied", resource.Kind, resource.ClusterResource())
+	}
+	return nil
 }
 
 // GetAllowedResourceIDs returns the list of allowed resources the identity for


### PR DESCRIPTION
This PR fixes the inheritance of `kubernetes_resources` from the user's roles when the user has active access requests to a `kube_cluster`.

If the user had an active request to a `kube_cluster`, Teleport ignored the role's `kubernetes_resources` and returned an empty set for the allowed and denied pods. This resulted in the user being unable to see any pods in the cluster.

Fixes #22126