### PR TITLE
Docs: test keyword frontmatter

### DIFF
--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -1,6 +1,7 @@
 ---
 title: Teleport Configuration Reference
 description: The detailed guide and reference documentation for configuring Teleport for SSH and Kubernetes access.
+keywords: [config, file, reference, yaml, etc]
 ---
 
 Teleport uses the YAML file format for configuration. A full configuration


### PR DESCRIPTION
This PR adds a `keywords` frontmatter field to a test page. This accompanies https://github.com/gravitational/docs/pull/239 from the docs repo, which adds the content of this field to a keyword meta tag.

These values will also be used to optimize search.