### PR TITLE
kube-updater: add HTTP triggers and maintenance getters

### DIFF
--- a/integrations/kube-agent-updater/pkg/basichttp/client.go
+++ b/integrations/kube-agent-updater/pkg/basichttp/client.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basichttp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/gravitational/trace"
+)
+
+// Client extends the regular http.Client by adding a GetContent method that does
+// a GET query to a given URL and returns an error if the status is non-200.
+// This is typically used to retrieve small files stored in a S3 bucket like the
+// maintenance.BasicHTTPMaintenanceTrigger or the version.BasicHTTPVersionGetter
+// are doing.
+type Client struct {
+	*http.Client
+}
+
+// GetContent sends a GET HTTP request and fails if the response is not 200.
+func (c *Client) GetContent(ctx context.Context, targetURL url.URL) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL.String(), nil)
+	if err != nil {
+		return []byte{}, trace.Wrap(err)
+	}
+	res, err := c.Do(req)
+	if err != nil {
+		return []byte{}, trace.Wrap(err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return []byte{}, trace.Wrap(err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return []byte{}, trace.Errorf("non-200 status code received: '%d'", res.StatusCode)
+	}
+
+	return body, nil
+}

--- a/integrations/kube-agent-updater/pkg/basichttp/servermock.go
+++ b/integrations/kube-agent-updater/pkg/basichttp/servermock.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basichttp
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ServerMock is a HTTP server whose response can be controlled from the tests.
+// This is used to mock external dependencies like s3 buckets or a remote HTTP server.
+type ServerMock struct {
+	Srv *httptest.Server
+
+	t        *testing.T
+	code     int
+	response string
+	path     string
+}
+
+// SetResponse sets the ServerMock's reponse.
+func (m *ServerMock) SetResponse(t *testing.T, code int, response string) {
+	m.t = t
+	m.code = code
+	m.response = response
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (m *ServerMock) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	require.Equal(m.t, m.path, r.URL.Path)
+	w.WriteHeader(m.code)
+	_, err := io.WriteString(w, m.response)
+	require.NoError(m.t, err)
+}
+
+// NewServerMock builds and returns a
+func NewServerMock(path string) *ServerMock {
+	mock := ServerMock{path: path}
+	mock.Srv = httptest.NewServer(http.HandlerFunc(mock.ServeHTTP))
+	return &mock
+}

--- a/integrations/kube-agent-updater/pkg/cache/cache.go
+++ b/integrations/kube-agent-updater/pkg/cache/cache.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+// TimedMemoize wraps a function returning (value, error) and caches the
+// value AND the error for a specific time. This cache is mainly used to ensure
+// external calls rates are reasonable. The cache is thread-safe.
+type TimedMemoize[T any] struct {
+	clock         clockwork.Clock
+	mutex         sync.Mutex
+	cachedValue   T
+	cachedError   error
+	validUntil    time.Time
+	cacheDuration time.Duration
+	getter        func(ctx context.Context) (T, error)
+}
+
+// Get does a cache lookup and updates the cache in case of cache miss.
+func (c *TimedMemoize[T]) Get(ctx context.Context) (T, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.validUntil.After(c.clock.Now()) {
+		// TimedMemoize hit, we return cached result
+		return c.cachedValue, trace.Wrap(c.cachedError)
+	}
+
+	// Cache miss, we do a query and update the cache
+	value, err := c.getter(ctx)
+	c.validUntil = c.clock.Now().Add(c.cacheDuration)
+	c.cachedValue = value
+	c.cachedError = newCachedError(err, c.validUntil)
+	return value, trace.Wrap(err)
+}
+
+// NewTimedMemoize builds and returns a TimedMemoize
+func NewTimedMemoize[T any](getter func(ctx context.Context) (T, error), duration time.Duration) *TimedMemoize[T] {
+	return &TimedMemoize[T]{
+		clock:         clockwork.NewRealClock(),
+		getter:        getter,
+		cacheDuration: duration,
+	}
+}

--- a/integrations/kube-agent-updater/pkg/cache/cache_test.go
+++ b/integrations/kube-agent-updater/pkg/cache/cache_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func failIfCalled(t *testing.T, value string, err error) func(context.Context) (string, error) {
+	return func(_ context.Context) (string, error) {
+		require.Fail(t, "should not be called")
+		return value, err
+	}
+}
+
+func failIfCalledTwice(t *testing.T, value string, err error) func(context.Context) (string, error) {
+	var fuse bool
+	return func(_ context.Context) (string, error) {
+		if !fuse {
+			fuse = true
+			return value, err
+		}
+		require.Fail(t, "should not be called twice")
+		return value, err
+	}
+}
+
+func TestTimedMemoize_Get(t *testing.T) {
+	ctx := context.Background()
+
+	now := time.Now()
+	longBefore := now.Add(-2 * time.Hour)
+	longAfter := now.Add(2 * time.Hour)
+
+	upstreamValue := "upstream"
+	cachedValue := "cached"
+	upstreamError := trace.LimitExceeded("rate-limited")
+	oldUpstreamError := trace.CompareFailed("comparison failed")
+
+	assertUncachedError := func(t2 require.TestingT, err error, _ ...interface{}) {
+		require.Equal(t2, err, upstreamError)
+	}
+	assertCachedError := func(t2 require.TestingT, err error, _ ...interface{}) {
+		_, ok := trace.Unwrap(err).(cachedError)
+		require.True(t2, ok)
+	}
+
+	tests := []struct {
+		name          string
+		cachedValue   string
+		cachedError   error
+		validUntil    time.Time
+		getter        func(*testing.T, string, error) func(context.Context) (string, error)
+		expectedValue string
+		assertErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:          "fresh cache",
+			cachedValue:   "",
+			cachedError:   nil,
+			validUntil:    time.Time{},
+			getter:        failIfCalledTwice,
+			expectedValue: upstreamValue,
+			assertErr:     assertUncachedError,
+		},
+		{
+			name:          "valid cache",
+			cachedValue:   cachedValue,
+			cachedError:   newCachedError(oldUpstreamError, longAfter),
+			validUntil:    longAfter,
+			getter:        failIfCalled,
+			expectedValue: cachedValue,
+			assertErr:     assertCachedError,
+		},
+		{
+			name:          "expired cache",
+			cachedValue:   cachedValue,
+			cachedError:   newCachedError(oldUpstreamError, longBefore),
+			validUntil:    longBefore,
+			getter:        failIfCalledTwice,
+			expectedValue: upstreamValue,
+			assertErr:     assertUncachedError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := TimedMemoize[string]{
+				cachedValue:   tt.cachedValue,
+				cachedError:   tt.cachedError,
+				validUntil:    tt.validUntil,
+				clock:         clockwork.NewFakeClockAt(now),
+				cacheDuration: 30 * time.Minute,
+				getter:        tt.getter(t, upstreamValue, upstreamError),
+			}
+			result, err := cache.Get(ctx)
+			require.Equal(t, tt.expectedValue, result)
+			// The first error might or might not be cached
+			tt.assertErr(t, err)
+			result, err = cache.Get(ctx)
+			require.Equal(t, tt.expectedValue, result)
+			// The second error must be cached
+			assertCachedError(t, err)
+		})
+	}
+}

--- a/integrations/kube-agent-updater/pkg/cache/error.go
+++ b/integrations/kube-agent-updater/pkg/cache/error.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"time"
+)
+
+// cachedError wraps an error before storing it into cache. This adds more
+// context into the original error by clearly indicating the error have been
+// cached and for how long.
+type cachedError struct {
+	err   error
+	until time.Time
+}
+
+func (e cachedError) Error() string {
+	return fmt.Sprintf("error cached until '%s': %s", e.until, e.err)
+}
+
+// OrigError returns the original error. This implements trace.ErrorWrapper
+// and allows to be unwrapped by trace.Unwrap().
+func (e cachedError) OrigError() error {
+	return e.err
+}
+
+// Unwrap returns the original error.
+func (e cachedError) Unwrap() error {
+	return e.err
+}
+
+// newCachedError takes an error and wraps it into a cachedError. If there is no
+// error, it returns nothing.
+func newCachedError(err error, until time.Time) error {
+	if err == nil {
+		return nil
+	}
+	return cachedError{err, until}
+}

--- a/integrations/kube-agent-updater/pkg/constants/constants.go
+++ b/integrations/kube-agent-updater/pkg/constants/constants.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+import "time"
+
+const (
+	// MaintenancePath is the version discovery endpoint representing if the
+	// target version represents a critical update as defined in
+	// https://github.com/gravitational/teleport/blob/master/rfd/0109-cloud-agent-upgrades.md#version-discovery-endpoint
+	MaintenancePath = "critical"
+	// VersionPath is the version discovery endpoint returning the current
+	// target version as defined in
+	// https://github.com/gravitational/teleport/blob/master/rfd/0109-cloud-agent-upgrades.md#version-discovery-endpoint
+	VersionPath   = "version"
+	HTTPTimeout   = 10 * time.Second
+	CacheDuration = time.Minute
+)

--- a/integrations/kube-agent-updater/pkg/controller/deployment.go
+++ b/integrations/kube-agent-updater/pkg/controller/deployment.go
@@ -28,6 +28,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/version"
 )
 
 // DeploymentVersionUpdater Reconciles a deployment by changing its image
@@ -126,7 +128,7 @@ func getDeploymentVersion(deployment *appsv1.Deployment) (string, error) {
 		return "", trace.BadParameter("imageRef %s is not tagged", imageRef)
 	}
 	current = taggedImageRef.Tag()
-	current, err = ensureSemver(current)
+	current, err = version.EnsureSemver(current)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/integrations/kube-agent-updater/pkg/controller/utils.go
+++ b/integrations/kube-agent-updater/pkg/controller/utils.go
@@ -17,10 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	"strings"
-
 	"github.com/gravitational/trace"
-	"golang.org/x/mod/semver"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -41,16 +38,4 @@ func setContainerImageFromPodSpec(spec *v1.PodSpec, container, image string) err
 		}
 	}
 	return trace.NotFound("container %q not found in podSpec", container)
-}
-
-// ensureSemver adds the 'v' prefix if needed and ensures the provided version
-// is semver-compliant.
-func ensureSemver(current string) (string, error) {
-	if !strings.HasPrefix(current, "v") {
-		current = "v" + current
-	}
-	if !semver.IsValid(current) {
-		return "", trace.BadParameter("tag %s is not following semver", current)
-	}
-	return current, nil
 }

--- a/integrations/kube-agent-updater/pkg/maintenance/basichttp.go
+++ b/integrations/kube-agent-updater/pkg/maintenance/basichttp.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maintenance
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/basichttp"
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/cache"
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/constants"
+)
+
+// basicHTTPMaintenanceClient retrieves whether the target version represents a
+// critical update from an HTTP endpoint. It should not be invoked immediately
+// and must be wrapped in a cache layer in order to avoid spamming the version
+// server in case of reconciliation errors.
+// use BasicHTTPMaintenanceTrigger if you need to check if an update is critical.
+type basicHTTPMaintenanceClient struct {
+	baseURL *url.URL
+	client  *basichttp.Client
+}
+
+// Get sends an HTTP GET request and returns whether the current target version
+// represents a critical update.
+func (b *basicHTTPMaintenanceClient) Get(ctx context.Context) (bool, error) {
+	versionURL := b.baseURL.JoinPath(constants.MaintenancePath)
+	body, err := b.client.GetContent(ctx, *versionURL)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	// Validating early that the payload can be converted to a boolean allows to
+	// gracefully catch connectivity error caused by mitm infrastructure such as
+	// corporate proxies.
+	result, err := stringToBool(strings.TrimSpace(string(body)))
+	return result, trace.Wrap(err)
+}
+
+// BasicHTTPMaintenanceTrigger gets the critical status from an HTTP response
+// containing only a truthy or falsy string.
+// This is used typically to trigger emergency maintenances from a file hosted
+// in a s3 bucket or raw file served over HTTP.
+// BasicHTTPMaintenanceTrigger uses basicHTTPMaintenanceClient and wraps it in a cache
+// in order to mitigate the impact of too frequent reconciliations.
+// The structure implements the maintenance.Trigger interface.
+type BasicHTTPMaintenanceTrigger struct {
+	name         string
+	cachedGetter func(context.Context) (bool, error)
+}
+
+// Name implements maintenance.Triggernd returns the trigger name for logging
+// and debugging pursposes.
+func (g BasicHTTPMaintenanceTrigger) Name() string {
+	return g.name
+}
+
+// Default returns what to do if the trigger can't be evaluated.
+// BasicHTTPMaintenanceTrigger should fail open, so the function returns true.
+func (g BasicHTTPMaintenanceTrigger) Default() bool {
+	return false
+}
+
+// CanStart implements maintenance.Trigger
+func (g BasicHTTPMaintenanceTrigger) CanStart(ctx context.Context, _ client.Object) (bool, error) {
+	result, err := g.cachedGetter(ctx)
+	return result, trace.Wrap(err)
+}
+
+// NewBasicHTTPMaintenanceTrigger builds and return a Trigger checking a public HTTP endpoint.
+func NewBasicHTTPMaintenanceTrigger(name string, baseURL *url.URL) Trigger {
+	client := &http.Client{
+		Timeout: constants.HTTPTimeout,
+	}
+	httpMaintenanceClient := &basicHTTPMaintenanceClient{
+		baseURL: baseURL,
+		client:  &basichttp.Client{Client: client},
+	}
+
+	return BasicHTTPMaintenanceTrigger{name, cache.NewTimedMemoize[bool](httpMaintenanceClient.Get, constants.CacheDuration).Get}
+}
+
+func stringToBool(input string) (bool, error) {
+	switch {
+	case strings.EqualFold("true", input), strings.EqualFold("yes", input):
+		return true, nil
+	case strings.EqualFold("false", input), strings.EqualFold("no", input):
+		return false, nil
+	default:
+		return false, trace.BadParameter("cannot convert input to boolean: %s", input)
+	}
+}

--- a/integrations/kube-agent-updater/pkg/maintenance/basichttp_test.go
+++ b/integrations/kube-agent-updater/pkg/maintenance/basichttp_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maintenance
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/basichttp"
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/constants"
+)
+
+const basicHTTPTestPath = "/v1/cloud-stable"
+
+func Test_basicHTTPMaintenanceClient_Get(t *testing.T) {
+	mock := basichttp.NewServerMock(basicHTTPTestPath + "/" + constants.MaintenancePath)
+	t.Cleanup(mock.Srv.Close)
+	serverUrl, err := url.Parse(mock.Srv.URL)
+	serverUrl.Path = basicHTTPTestPath
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		response   string
+		expected   bool
+		assertErr  require.ErrorAssertionFunc
+	}{
+		{
+			name:       "all good - no maintenance",
+			statusCode: http.StatusOK,
+			response:   "no",
+			expected:   false,
+			assertErr:  require.NoError,
+		},
+		{
+			name:       "all good - maintenance",
+			statusCode: http.StatusOK,
+			response:   "yes",
+			expected:   true,
+			assertErr:  require.NoError,
+		},
+		{
+			name:       "all good with newline",
+			statusCode: http.StatusOK,
+			response:   "yes\n",
+			expected:   true,
+			assertErr:  require.NoError,
+		},
+		{
+			name:       "invalid response",
+			statusCode: http.StatusOK,
+			response:   "hello",
+			expected:   false,
+			assertErr:  require.Error,
+		},
+		{
+			name:       "empty",
+			statusCode: http.StatusOK,
+			response:   "",
+			expected:   false,
+			assertErr: func(t2 require.TestingT, err2 error, _ ...interface{}) {
+				require.IsType(t2, &trace.BadParameterError{}, trace.Unwrap(err2))
+			},
+		},
+		{
+			name:       "non-200 response",
+			statusCode: http.StatusInternalServerError,
+			response:   "ERROR - SOMETHING WENT WRONG",
+			expected:   false,
+			assertErr:  require.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &basicHTTPMaintenanceClient{
+				baseURL: serverUrl,
+				client:  &basichttp.Client{Client: mock.Srv.Client()},
+			}
+			mock.SetResponse(t, tt.statusCode, tt.response)
+			result, err := b.Get(ctx)
+			tt.assertErr(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/integrations/kube-agent-updater/pkg/version/basichttp.go
+++ b/integrations/kube-agent-updater/pkg/version/basichttp.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/basichttp"
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/cache"
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/constants"
+)
+
+// basicHTTPVersionClient retrieves the version from an HTTP endpoint
+// it should not be invoked immediately and must be wrapped in a cache layer in
+// order to avoid spamming the version server in case of reconciliation errors.
+// use BasicHTTPVersionGetter if you need to get a version.
+type basicHTTPVersionClient struct {
+	baseURL *url.URL
+	client  *basichttp.Client
+}
+
+// Get sends an HTTP GET request and returns the version prefixed by "v".
+// It expects the endpoint to be unauthenticated, return 200 and the response
+// body to contain a valid semver tag without the "v".
+func (b *basicHTTPVersionClient) Get(ctx context.Context) (string, error) {
+	versionURL := b.baseURL.JoinPath(constants.VersionPath)
+	body, err := b.client.GetContent(ctx, *versionURL)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	// We trim spaces because the value might end with one or many newlines
+	version, err := EnsureSemver(strings.TrimSpace(string(body)))
+	return version, trace.Wrap(err)
+}
+
+// BasicHTTPVersionGetter gets the version from an HTTP response containing
+// only the version. This is used typically to get version from a file hosted
+// in a s3 bucket or raw file served over HTTP.
+// BasicHTTPVersionGetter uses basicHTTPVersionClient and wraps it in a cache
+// in order to mitigate the impact of too frequent reconciliations.
+// The structure implements the version.Getter interface.
+type BasicHTTPVersionGetter struct {
+	versionGetter func(context.Context) (string, error)
+}
+
+func (g BasicHTTPVersionGetter) GetVersion(ctx context.Context) (string, error) {
+	return g.versionGetter(ctx)
+}
+
+func NewBasicHTTPVersionGetter(baseURL *url.URL) Getter {
+	client := &http.Client{
+		Timeout: constants.HTTPTimeout,
+	}
+	httpVersionClient := &basicHTTPVersionClient{
+		baseURL: baseURL,
+		client:  &basichttp.Client{Client: client},
+	}
+
+	return BasicHTTPVersionGetter{cache.NewTimedMemoize[string](httpVersionClient.Get, constants.CacheDuration).Get}
+}

--- a/integrations/kube-agent-updater/pkg/version/basichttp_test.go
+++ b/integrations/kube-agent-updater/pkg/version/basichttp_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/basichttp"
+	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/constants"
+)
+
+const basicHTTPTestPath = "/v1/cloud-stable"
+
+func Test_basicHTTPVersionClient_Get(t *testing.T) {
+	mock := basichttp.NewServerMock(basicHTTPTestPath + "/" + constants.VersionPath)
+	t.Cleanup(mock.Srv.Close)
+	serverUrl, err := url.Parse(mock.Srv.URL)
+	serverUrl.Path = basicHTTPTestPath
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		response   string
+		expected   string
+		assertErr  require.ErrorAssertionFunc
+	}{
+		{
+			name:       "all good",
+			statusCode: http.StatusOK,
+			response:   "12.0.3",
+			expected:   "v12.0.3",
+			assertErr:  require.NoError,
+		},
+		{
+			name:       "all good with newline",
+			statusCode: http.StatusOK,
+			response:   "12.0.3\n",
+			expected:   "v12.0.3",
+			assertErr:  require.NoError,
+		},
+		{
+			name:       "non-semver",
+			statusCode: http.StatusOK,
+			response:   "hello",
+			expected:   "",
+			assertErr: func(t2 require.TestingT, err2 error, _ ...interface{}) {
+				require.IsType(t2, &trace.BadParameterError{}, trace.Unwrap(err2))
+			},
+		},
+		{
+			name:       "empty",
+			statusCode: http.StatusOK,
+			response:   "",
+			expected:   "",
+			assertErr: func(t2 require.TestingT, err2 error, _ ...interface{}) {
+				require.IsType(t2, &trace.BadParameterError{}, trace.Unwrap(err2))
+			},
+		},
+		{
+			name:       "non-200 response",
+			statusCode: http.StatusInternalServerError,
+			response:   "ERROR - SOMETHING WENT WRONG",
+			expected:   "",
+			assertErr:  require.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &basicHTTPVersionClient{
+				baseURL: serverUrl,
+				client:  &basichttp.Client{Client: mock.Srv.Client()},
+			}
+			mock.SetResponse(t, tt.statusCode, tt.response)
+			result, err := b.Get(ctx)
+			tt.assertErr(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/integrations/kube-agent-updater/pkg/version/versionget.go
+++ b/integrations/kube-agent-updater/pkg/version/versionget.go
@@ -18,6 +18,7 @@ package version
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/mod/semver"
@@ -48,4 +49,16 @@ func ValidVersionChange(ctx context.Context, current, next string) bool {
 	default:
 		return true
 	}
+}
+
+// EnsureSemver adds the 'v' prefix if needed and ensures the provided version
+// is semver-compliant.
+func EnsureSemver(current string) (string, error) {
+	if !strings.HasPrefix(current, "v") {
+		current = "v" + current
+	}
+	if !semver.IsValid(current) {
+		return "", trace.BadParameter("tag %s is not following semver", current)
+	}
+	return current, nil
 }


### PR DESCRIPTION
This PR adds the following version getters:
- basic HTTP (getting version from an s3 bucket)

Also the following maintenance triggers:
- basic HTTP (getting maintenance from an s3 bucket)

It also adds the following changes:
- add a common `cache` package to cache the lookups involving network requests to ensure we don't issue too many calls to external resources
- add a common `testutil` package providing a test HTTP server

Part of https://github.com/gravitational/teleport/issues/22450