### PR TITLE
Connect: Enable fonts configuration

### DIFF
--- a/web/packages/shared/components/Notification/Notification.tsx
+++ b/web/packages/shared/components/Notification/Notification.tsx
@@ -14,12 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, isValidElement } from 'react';
 import styled, { css, useTheme } from 'styled-components';
 import { ButtonIcon, Flex, Text } from 'design';
 import { Close } from 'design/Icon';
 
-import type { NotificationItem, NotificationItemContent } from './types';
+import type {
+  NotificationItem,
+  NotificationItemContent,
+  NotificationItemObjectContent,
+} from './types';
 
 interface NotificationProps {
   item: NotificationItem;
@@ -122,7 +126,7 @@ function getRenderedContent(
 ) {
   const longerTextCss = isExpanded ? textCss : shortTextCss;
 
-  if (typeof content === 'string') {
+  if (typeof content === 'string' || isValidElement(content)) {
     return (
       <Flex alignItems="center" justifyContent="space-between" width="100%">
         <Text
@@ -137,7 +141,7 @@ function getRenderedContent(
       </Flex>
     );
   }
-  if (typeof content === 'object') {
+  if (isContentAnObject(content)) {
     return (
       <Flex flexDirection="column" minWidth="0" width="100%">
         <div
@@ -176,6 +180,16 @@ function getRenderedContent(
       </Flex>
     );
   }
+}
+
+function isContentAnObject(
+  content: NotificationItemContent
+): content is NotificationItemObjectContent {
+  return (
+    typeof content === 'object' &&
+    (content as NotificationItemObjectContent).title !== undefined &&
+    (content as NotificationItemObjectContent).description !== undefined
+  );
 }
 
 const textCss = css`

--- a/web/packages/shared/components/Notification/types.ts
+++ b/web/packages/shared/components/Notification/types.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { ReactNode } from 'react';
+
 export interface NotificationItem {
   content: NotificationItemContent;
   severity: 'info' | 'warn' | 'error';
@@ -22,4 +24,10 @@ export interface NotificationItem {
 
 export type NotificationItemContent =
   | string
-  | { title: string; description: string };
+  | ReactNode
+  | NotificationItemObjectContent;
+
+export type NotificationItemObjectContent = {
+  title: string;
+  description: string | ReactNode;
+};

--- a/web/packages/teleterm/src/services/config/configService.ts
+++ b/web/packages/teleterm/src/services/config/configService.ts
@@ -20,6 +20,7 @@ import { FileStorage } from 'teleterm/services/fileStorage';
 import { Platform } from 'teleterm/mainProcess/types';
 
 import { createConfigStore } from './configStore';
+import { getKeyboardShortcutSchema } from './getKeyboardShortcutSchema';
 
 const createAppConfigSchema = (platform: Platform) => {
   const defaultKeymap = getDefaultKeymap(platform);
@@ -34,56 +35,56 @@ const createAppConfigSchema = (platform: Platform) => {
   // them here, but we do not read their value from the stored config.
   return z.object({
     'usageReporting.enabled': z.boolean().default(false),
-    'keymap.tab1': omitStoredConfigValue(
-      z.string().default(defaultKeymap['tab1'])
+    'keymap.tab1': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['tab1']
     ),
-    'keymap.tab2': omitStoredConfigValue(
-      z.string().default(defaultKeymap['tab2'])
+    'keymap.tab2': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['tab2']
     ),
-    'keymap.tab3': omitStoredConfigValue(
-      z.string().default(defaultKeymap['tab3'])
+    'keymap.tab3': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['tab3']
     ),
-    'keymap.tab4': omitStoredConfigValue(
-      z.string().default(defaultKeymap['tab4'])
+    'keymap.tab4': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['tab4']
     ),
-    'keymap.tab5': omitStoredConfigValue(
-      z.string().default(defaultKeymap['tab5'])
+    'keymap.tab5': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['tab5']
     ),
-    'keymap.tab6': omitStoredConfigValue(
-      z.string().default(defaultKeymap['tab6'])
+    'keymap.tab6': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['tab6']
     ),
-    'keymap.tab7': omitStoredConfigValue(
-      z.string().default(defaultKeymap['tab7'])
+    'keymap.tab7': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['tab7']
     ),
-    'keymap.tab8': omitStoredConfigValue(
-      z.string().default(defaultKeymap['tab8'])
+    'keymap.tab8': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['tab8']
     ),
-    'keymap.tab9': omitStoredConfigValue(
-      z.string().default(defaultKeymap['tab9'])
+    'keymap.tab9': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['tab9']
     ),
-    'keymap.closeTab': omitStoredConfigValue(
-      z.string().default(defaultKeymap['closeTab'])
+    'keymap.closeTab': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['closeTab']
     ),
-    'keymap.newTab': omitStoredConfigValue(
-      z.string().default(defaultKeymap['newTab'])
+    'keymap.newTab': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['newTab']
     ),
-    'keymap.previousTab': omitStoredConfigValue(
-      z.string().default(defaultKeymap['previousTab'])
+    'keymap.previousTab': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['previousTab']
     ),
-    'keymap.nextTab': omitStoredConfigValue(
-      z.string().default(defaultKeymap['nextTab'])
+    'keymap.nextTab': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['nextTab']
     ),
-    'keymap.openConnections': omitStoredConfigValue(
-      z.string().default(defaultKeymap['openConnections'])
+    'keymap.openConnections': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['openConnections']
     ),
-    'keymap.openClusters': omitStoredConfigValue(
-      z.string().default(defaultKeymap['openClusters'])
+    'keymap.openClusters': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['openClusters']
     ),
-    'keymap.openProfiles': omitStoredConfigValue(
-      z.string().default(defaultKeymap['openProfiles'])
+    'keymap.openProfiles': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['openProfiles']
     ),
-    'keymap.openQuickInput': omitStoredConfigValue(
-      z.string().default(defaultKeymap['openQuickInput'])
+    'keymap.openQuickInput': getKeyboardShortcutSchema(platform).default(
+      defaultKeymap['openQuickInput']
     ),
     /**
      * This value can be provided by the user and is unsanitized. This means that it cannot be directly interpolated
@@ -96,16 +97,8 @@ const createAppConfigSchema = (platform: Platform) => {
   });
 };
 
-const omitStoredConfigValue = <T>(schema: z.ZodType<T>) =>
-  z.preprocess(() => undefined, schema);
-
 export type AppConfig = z.infer<ReturnType<typeof createAppConfigSchema>>;
 
-/**
- * Modifier keys must be defined in the following order:
- * Command-Control-Option-Shift for macOS
- * Ctrl-Alt-Shift for other platforms
- */
 export type KeyboardShortcutAction =
   | 'tab1'
   | 'tab2'

--- a/web/packages/teleterm/src/services/config/configStore.ts
+++ b/web/packages/teleterm/src/services/config/configStore.ts
@@ -77,7 +77,9 @@ export function createConfigStore<
     const reParsed = parse(withoutInvalidKeys);
     if (reParsed.success === false) {
       // it should not occur after removing invalid keys, but just in case
-      throw new Error('Re-parsing config file failed', reParsed.error.cause);
+      throw new Error(
+        `Re-parsing config file failed \n${reParsed.error.message}`
+      );
     }
     return {
       storedConfig: withoutInvalidKeys,

--- a/web/packages/teleterm/src/services/config/getKeyboardShortcutSchema.test.ts
+++ b/web/packages/teleterm/src/services/config/getKeyboardShortcutSchema.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z, ZodError } from 'zod';
+
+import {
+  getKeyboardShortcutSchema,
+  invalidModifierIssue,
+  invalidKeyCodeIssue,
+  duplicatedModifierIssue,
+} from './getKeyboardShortcutSchema';
+
+const schema = z.object({
+  'keymap.tab1': getKeyboardShortcutSchema('darwin'),
+});
+
+function getZodError(issue: any): z.ZodError {
+  return new ZodError([
+    {
+      ...issue,
+      path: ['keymap.tab1'],
+    },
+  ]);
+}
+
+test('multi-parts shortcuts are parsed correctly', () => {
+  const parsed = schema.parse({ 'keymap.tab1': 'Command+Shift+1' });
+  expect(parsed).toStrictEqual({ 'keymap.tab1': 'Command+Shift+1' });
+});
+
+test('single-parts shortcuts are parsed correctly', () => {
+  const parsed = schema.parse({ 'keymap.tab1': '1' });
+  expect(parsed).toStrictEqual({ 'keymap.tab1': '1' });
+});
+
+test('shortcuts parts are sorted in a correct order', () => {
+  const parsed = schema.parse({ 'keymap.tab1': 'Shift+1+Command' });
+  expect(parsed).toStrictEqual({ 'keymap.tab1': 'Command+Shift+1' });
+});
+
+test('empty shortcut is allowed', () => {
+  const parsed = schema.parse({ 'keymap.tab1': '' });
+  expect(parsed).toStrictEqual({ 'keymap.tab1': '' });
+});
+
+test('fails when incorrect physical key is passed', () => {
+  const parse = () => schema.parse({ 'keymap.tab1': 'Shift+12' });
+  expect(parse).toThrow(getZodError(invalidKeyCodeIssue('12')));
+});
+
+test('fails when multiple key codes are passed', () => {
+  const parse = () => schema.parse({ 'keymap.tab1': 'Shift+Space+Tab' });
+  expect(parse).toThrow(getZodError(invalidModifierIssue('Space')));
+});
+
+test('fails when only modifiers are passed', () => {
+  const parse = () => schema.parse({ 'keymap.tab1': 'Command+Shift' });
+  expect(parse).toThrow(getZodError(invalidKeyCodeIssue('Shift')));
+});
+
+test('fails when duplicated modifiers are passed', () => {
+  const parse = () => schema.parse({ 'keymap.tab1': 'Command+I+Command' });
+  expect(parse).toThrow(getZodError(duplicatedModifierIssue()));
+});

--- a/web/packages/teleterm/src/services/config/getKeyboardShortcutSchema.ts
+++ b/web/packages/teleterm/src/services/config/getKeyboardShortcutSchema.ts
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'zod';
+
+import { Platform } from 'teleterm/mainProcess/types';
+
+const VALID_SHORTCUT_MESSAGE =
+  'Valid shortcut can contain multiple modifiers (like "Shift") and a single key code (like "A" or "Tab"), combined by the "+" character.';
+
+export function invalidKeyCodeIssue(wrongKeyCode: string): z.IssueData {
+  return {
+    code: z.ZodIssueCode.custom,
+    message: `"${wrongKeyCode}" cannot be used as a key code. ${VALID_SHORTCUT_MESSAGE}`,
+  };
+}
+
+export function invalidModifierIssue(wrongModifier: string): z.IssueData {
+  return {
+    code: z.ZodIssueCode.custom,
+    message: `"${wrongModifier}" cannot be used as a modifier. ${VALID_SHORTCUT_MESSAGE}`,
+  };
+}
+
+export function duplicatedModifierIssue(): z.IssueData {
+  return {
+    code: z.ZodIssueCode.custom,
+    message: `Duplicated modifier found. ${VALID_SHORTCUT_MESSAGE}`,
+  };
+}
+
+export function getKeyboardShortcutSchema(platform: Platform) {
+  const allowedModifiers = getAllowedModifiers(platform);
+
+  return z
+    .string()
+    .transform(s => s.split('+'))
+    .transform(putModifiersFirst(allowedModifiers))
+    .superRefine(validateKeyCodeAndModifiers(allowedModifiers))
+    .transform(s => s.join('+'));
+}
+
+function putModifiersFirst(
+  allowedModifiers: string[]
+): (tokens: string[]) => string[] {
+  return tokens =>
+    tokens.sort((a, b) => {
+      if (allowedModifiers.indexOf(a) === -1) {
+        return 1;
+      }
+      if (allowedModifiers.indexOf(b) === -1) {
+        return -1;
+      }
+      return allowedModifiers.indexOf(a) - allowedModifiers.indexOf(b);
+    });
+}
+
+function validateKeyCodeAndModifiers(
+  allowedModifiers: string[]
+): (tokens: string[], ctx: z.RefinementCtx) => void {
+  return (tokens, ctx) => {
+    // empty accelerator disables the shortcut
+    if (tokens.join('') === '') {
+      return z.NEVER;
+    }
+
+    const [expectedKeyCode, ...expectedModifiers] = [...tokens].reverse();
+
+    if (!ALLOWED_KEY_CODES.includes(expectedKeyCode)) {
+      ctx.addIssue(invalidKeyCodeIssue(expectedKeyCode));
+      return z.NEVER;
+    }
+
+    if (expectedModifiers.length !== new Set(expectedModifiers).size) {
+      ctx.addIssue(duplicatedModifierIssue());
+      return z.NEVER;
+    }
+
+    expectedModifiers.forEach(expectedModifier => {
+      if (!allowedModifiers.includes(expectedModifier)) {
+        ctx.addIssue(invalidModifierIssue(expectedModifier));
+      }
+    });
+  };
+}
+
+/** Returns allowed modifiers for a given platform in a correct order. */
+function getAllowedModifiers(platform: Platform): string[] {
+  switch (platform) {
+    case 'win32':
+    case 'linux':
+      return ['Ctrl', 'Alt', 'Shift'];
+    case 'darwin':
+      return ['Command', 'Control', 'Option', 'Shift'];
+  }
+}
+
+function generateRange(start: number, end: number): string[] {
+  return new Array(end - start + 1)
+    .fill(undefined)
+    .map((_, i) => (i + start).toString());
+}
+
+const ALLOWED_KEY_CODES = [
+  ...generateRange(0, 9), // 0-9 range
+  ...generateRange(1, 24).map(key => `F${key}`), // F1-F24 keys
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'G',
+  'H',
+  'I',
+  'J',
+  'K',
+  'L',
+  'M',
+  'N',
+  'O',
+  'P',
+  'Q',
+  'R',
+  'S',
+  'T',
+  'U',
+  'V',
+  'W',
+  'X',
+  'Y',
+  'Z',
+  'Space',
+  'Tab',
+  'CapsLock',
+  'NumLock',
+  'ScrollLock',
+  'Backspace',
+  'Delete',
+  'Insert',
+  'Enter',
+  'Up',
+  'Down',
+  'Left',
+  'Right',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+  'Escape',
+  ',',
+  '.',
+  '/',
+  '\\',
+  '`',
+  '-',
+  '=',
+  ';',
+  "'",
+  '[',
+  ']',
+];

--- a/web/packages/teleterm/src/ui/initUi.tsx
+++ b/web/packages/teleterm/src/ui/initUi.tsx
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import React from 'react';
+import { Link } from 'design';
+
 import {
   askAboutUserJobRoleIfNeeded,
   setUpUsageReporting,
@@ -53,9 +56,42 @@ function notifyAboutStoredConfigErrors(
   if (errors) {
     notificationsService.notifyError({
       title: 'Encountered errors in config file',
-      description: errors
-        .map(error => `${error.path[0]}: ${error.message}`)
-        .join('\n'),
+      description: (
+        <span>
+          <ErrorsRenderer
+            errors={errors.map(e => `${e.path[0].toString()}: ${e.message}`)}
+          />
+          {/**TODO(gzdunek): point to the properer section */}
+          <Link
+            href={
+              'https://goteleport.com/docs/connect-your-client/teleport-connect/'
+            }
+            target="_blank"
+          >
+            See documentation for the app config.
+          </Link>
+        </span>
+      ),
     });
   }
+}
+
+function ErrorsRenderer(props: { errors: string[] }) {
+  if (props.errors.length === 1) {
+    const error = props.errors[0];
+    return <div>{error}</div>;
+  }
+  return (
+    <ul
+      css={`
+        margin: 0;
+        padding-inline-start: 13px;
+        white-space: normal;
+      `}
+    >
+      {props.errors.map(error => (
+        <li key={error}>{error}</li>
+      ))}
+    </ul>
+  );
 }

--- a/web/packages/teleterm/src/ui/services/keyboardShortcuts/getKeyCode.ts
+++ b/web/packages/teleterm/src/ui/services/keyboardShortcuts/getKeyCode.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Based on tabby https://github.com/Eugeny/tabby/blob/7a8108b20d9cbaab636c932ceaf4bacc710d6a40/tabby-core/src/services/hotkeys.util.ts
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Eugene Pankov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+
+const REGEX_LATIN_KEYNAME = /^[A-Za-z]$/;
+
+export function getKeyCode(event: KeyboardEvent): string {
+  if (REGEX_LATIN_KEYNAME.test(event.key)) {
+    // Handle Dvorak etc. via the reported "character" instead of the scancode
+    return event.key.toUpperCase();
+  }
+  let key = event.code;
+  key = key.replace('Key', '');
+  key = key.replace('Arrow', '');
+  key = key.replace('Digit', '');
+  key =
+    {
+      Comma: ',',
+      Period: '.',
+      Slash: '/',
+      Backslash: '\\',
+      IntlBackslash: '`',
+      Minus: '-',
+      Equal: '=',
+      Semicolon: ';',
+      Quote: "'",
+      BracketLeft: '[',
+      BracketRight: ']',
+    }[key] ?? key;
+  return key;
+}

--- a/web/packages/teleterm/src/ui/services/keyboardShortcuts/keyboardShortcutsService.test.ts
+++ b/web/packages/teleterm/src/ui/services/keyboardShortcuts/keyboardShortcutsService.test.ts
@@ -39,6 +39,21 @@ test('do not call subscriber after it has been unsubscribed', () => {
   expect(subscriber).not.toHaveBeenCalled();
 });
 
+test('duplicated accelerators are returned', () => {
+  const service = new KeyboardShortcutsService(
+    'darwin',
+    createMockConfigService({
+      'keymap.tab1': 'Command+1',
+      'keymap.tab2': 'Command+1',
+      'keymap.tab3': 'Command+2',
+    })
+  );
+
+  expect(service.getDuplicatedAccelerators()).toStrictEqual({
+    'Command+1': ['tab1', 'tab2'],
+  });
+});
+
 function getTestSetup() {
   const service = new KeyboardShortcutsService(
     'darwin',

--- a/web/packages/teleterm/src/ui/services/keyboardShortcuts/keyboardShortcutsService.test.ts
+++ b/web/packages/teleterm/src/ui/services/keyboardShortcuts/keyboardShortcutsService.test.ts
@@ -50,5 +50,5 @@ function getTestSetup() {
 }
 
 function dispatchEventCommand1() {
-  dispatchEvent(new KeyboardEvent('keydown', { metaKey: true, key: '1' }));
+  dispatchEvent(new KeyboardEvent('keydown', { metaKey: true, code: '1' }));
 }

--- a/web/packages/teleterm/src/ui/services/keyboardShortcuts/keyboardShortcutsService.ts
+++ b/web/packages/teleterm/src/ui/services/keyboardShortcuts/keyboardShortcutsService.ts
@@ -20,6 +20,7 @@ import {
   ConfigService,
 } from 'teleterm/services/config';
 
+import { getKeyCode } from './getKeyCode';
 import {
   KeyboardShortcutEvent,
   KeyboardShortcutEventSubscriber,
@@ -89,10 +90,19 @@ export class KeyboardShortcutsService {
   private getShortcutAction(
     event: KeyboardEvent
   ): KeyboardShortcutAction | undefined {
-    const getEventKey = () =>
-      event.key.length === 1 ? event.key.toUpperCase() : event.key;
-
-    const accelerator = [...this.getPlatformModifierKeys(event), getEventKey()]
+    // skip modifier-only events
+    if (
+      event.code.includes('Shift') ||
+      event.code.includes('Meta') ||
+      event.code.includes('Alt') ||
+      event.code.includes('Control')
+    ) {
+      return;
+    }
+    const accelerator = [
+      ...this.getPlatformModifierKeys(event),
+      getKeyCode(event),
+    ]
       .filter(Boolean)
       .join('+');
 

--- a/web/packages/teleterm/src/ui/services/keyboardShortcuts/keyboardShortcutsService.ts
+++ b/web/packages/teleterm/src/ui/services/keyboardShortcuts/keyboardShortcutsService.ts
@@ -28,7 +28,12 @@ import {
 
 export class KeyboardShortcutsService {
   private eventsSubscribers = new Set<KeyboardShortcutEventSubscriber>();
-  private acceleratorsToActions = new Map<string, KeyboardShortcutAction>();
+  private acceleratorsToActions = new Map<string, KeyboardShortcutAction[]>();
+  /**
+   * Modifier keys must be defined in the following order:
+   * Command-Control-Option-Shift for macOS
+   * Ctrl-Alt-Shift for other platforms
+   */
   private readonly shortcutsConfig: Record<KeyboardShortcutAction, string>;
 
   constructor(


### PR DESCRIPTION
2/2 (1/2 is [here](https://github.com/gravitational/teleport/pull/22176))
Part of https://github.com/gravitational/teleport/issues/21914

This PR actually enables fonts configuration (with proper validation).

Note to Rafał: 
I played a bit with with `z.union` and `z.literal`, but I encountered some problems. First, the value in `z.literal` can't be generated, so I would have to have much longer list of possible options. Second, I think the approach with `superRefine` is simpler and at the same time allows for more sophisticated validation.
Also in DM I wrote that validating shortcuts like `Command-Control` or `Tab-Space` is more complicated and maybe could be skipped.
Fortunately, I realized that if we sort the tokens first, it is really easy to validate the "key code" and "modifiers" separately.    
(And that's another advantage, you can provide a shortcut as "1+Shift+Ctrl" and it will work!)

I think we have validation for almost all possible cases, please take a look at `getKeyboardShortcutSchema.test.ts`. 
In case of an error the user will see a notification:
<img width="464" alt="image" src="https://user-images.githubusercontent.com/20583051/220887121-4eb62c15-8bf8-478a-b564-f45998ffde03.png">

I also added a check for duplicated keys - a user can assign an accelerator that is used for some other action. In that case they will see a warning: 
<img width="464" alt="image" src="https://user-images.githubusercontent.com/20583051/220886914-9351962f-873d-4772-9e8f-eb3892de02da.png">

I had some troubles with the naming. Keys like "Shift" or "Control" are modifiers. But what's the name of the key that goes after them (like "A" or "Tab")? A main key? I use "key code", hopefully it is clear enough. 

Best to review commit by commit.