### PR TITLE
ClustersService: Remove internal logins when syncing root clusters

### DIFF
--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -185,7 +185,9 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     try {
       const clusters = await this.client.listRootClusters();
       this.setState(draft => {
-        draft.clusters = new Map(clusters.map(c => [c.uri, c]));
+        draft.clusters = new Map(
+          clusters.map(c => [c.uri, this.removeInternalLoginsFromCluster(c)])
+        );
       });
       clusters
         .filter(c => c.connected)


### PR DESCRIPTION
On app start, Connect synchronizes the list of all root clusters with basic details (the equivalent of `tsh status`) and then begins to synchronize full details of each cluster in parallel – this requires reaching out to the proxy.

The synchronization of full details [is already removing internal logins from the list](https://github.com/gravitational/teleport/blob/2a2f4c9f4416d9df9048cac0d423cd65e16a02a1/web/packages/teleterm/src/ui/services/clusters/clustersService.ts#L691-L698). The method which syncs just the list doesn't do that, which means there's a brief window between the sync of the list and the sync of full details where those internal logins are visible in the UI when trying to execute `tsh ssh` from the command bar.