### PR TITLE
createPtyProcess: Return early on error

### DIFF
--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyHostService.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyHostService.ts
@@ -42,6 +42,7 @@ export function createPtyHostService(): IPtyHostServer {
       } catch (error) {
         logger.error(`failed to create PTY process for id ${ptyId}`, error);
         callback(error);
+        return;
       }
       callback(null, new PtyId().setId(ptyId));
       logger.info(`created PTY process for id ${ptyId}`);


### PR DESCRIPTION
Without this early return, createPtyProcess of PtyHostService would call the callback twice on error. This doesn't have much negative implications since the gRPC implementation will simply ignore the second call, however it does pose some problems when trying to manually test PTY failures by making `new PtyProcess` return an error.