### PR TITLE
Connect: Move resolving hostname from command launcher to useDocumentTerminal

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,10 +8,6 @@ module.exports = {
   globals: {
     electron: {},
   },
-  testPathIgnorePatterns: [
-    // Skipped until e files are removed from teleterm.
-    'web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx',
-  ],
   collectCoverageFrom: [
     // comment out until shared directory is finished testing
     // '**/packages/design/src/**/*.jsx',

--- a/web/packages/shared/hooks/useAsync.ts
+++ b/web/packages/shared/hooks/useAsync.ts
@@ -153,6 +153,10 @@ export type Attempt<T> = {
   statusText: string;
 };
 
+export function hasFinished<T>(attempt: Attempt<T>): boolean {
+  return attempt.status === 'success' || attempt.status === 'error';
+}
+
 export function makeEmptyAttempt<T>(): Attempt<T> {
   return {
     data: null,

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -47,6 +47,7 @@
     "eslint-loader": "3.0.3",
     "google-protobuf": "^3.20.1",
     "immer": "^9.0.7",
+    "jest-canvas-mock": "^2.3.1",
     "node-forge": "^1.3.1",
     "react-dnd": "^14.0.4",
     "react-dnd-html5-backend": "^14.0.2",

--- a/web/packages/teleterm/src/services/pty/types.ts
+++ b/web/packages/teleterm/src/services/pty/types.ts
@@ -46,10 +46,14 @@ export type ShellCommand = PtyCommandBase & {
 
 export type TshLoginCommand = PtyCommandBase & {
   kind: 'pty.tsh-login';
-  login?: string;
+  // login is missing when the user executes `tsh ssh user` from the command bar without supplying
+  // the hostname. In that case, login will be undefined and serverId will be equal to "user".
+  //
+  // We will execute `tsh ssh user` anyway and let tsh show an appropriate error message.
+  login: string | undefined;
   serverId: string;
   rootClusterId: string;
-  leafClusterId?: string;
+  leafClusterId: string | undefined;
 };
 
 export type TshKubeLoginCommand = PtyCommandBase & {

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -99,6 +99,16 @@ export interface Database extends apiDb.Database.AsObject {
 }
 
 export interface Cluster extends apiCluster.Cluster.AsObject {
+  /**
+   * The URI of the cluster.
+   *
+   * For root clusters, it has the form of `/clusters/:rootClusterId` where `rootClusterId` is the
+   * name of the profile, that is the hostname of the proxy used to connect to the root cluster.
+   * `rootClusterId` is not equal to the name of the root cluster.
+   *
+   * For leaf clusters, it has the form of `/clusters/:rootClusterId/leaves/:leafClusterId` where
+   * `leafClusterId` is equal to the `name` property of the cluster.
+   */
   uri: uri.ClusterUri;
   loggedInUser?: LoggedInUser;
 }

--- a/web/packages/teleterm/src/ui/DocumentTerminal/DocumentTerminal.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/DocumentTerminal.tsx
@@ -27,7 +27,7 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 
 import { Terminal } from './Terminal';
 import DocumentReconnect from './DocumentReconnect';
-import useDocTerminal, { Props } from './useDocumentTerminal';
+import { Props, useDocumentTerminal } from './useDocumentTerminal';
 import { useTshFileTransferHandlers } from './useTshFileTransferHandlers';
 
 export default function DocumentTerminalContainer({ doc, visible }: Props) {
@@ -42,7 +42,7 @@ export function DocumentTerminal(props: Props & { visible: boolean }) {
   const ctx = useAppContext();
   const { configService } = ctx.mainProcessClient;
   const { visible, doc } = props;
-  const state = useDocTerminal(doc);
+  const state = useDocumentTerminal(doc);
   const ptyProcess = state.data?.ptyProcess;
   const { upload, download } = useTshFileTransferHandlers();
   const unsanitizedTerminalFontFamily = configService.get(

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
@@ -25,16 +25,21 @@ import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvi
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import {
   DocumentTerminal,
+  DocumentTshNode,
   DocumentTshNodeWithLoginHost,
   DocumentTshNodeWithServerId,
 } from 'teleterm/ui/services/workspacesService';
+import {
+  ResourcesService,
+  AmbiguousHostnameError,
+} from 'teleterm/ui/services/resources';
+import { NotificationsService } from 'teleterm/ui/services/notifications';
 
 import { WorkspaceContextProvider } from '../Documents';
 
-import { AmbiguousHostnameError } from '../services/resources';
-
 import useDocumentTerminal from './useDocumentTerminal';
 
+import type { IAppContext } from 'teleterm/ui/types';
 import type * as tsh from 'teleterm/services/tshd/types';
 import type * as uri from 'teleterm/ui/uri';
 
@@ -49,6 +54,16 @@ afterEach(() => {
 const rootClusterUri = '/clusters/test' as const;
 const leafClusterUri = `${rootClusterUri}/leaves/leaf` as const;
 const serverUUID = 'bed30649-3af5-40f1-a832-54ff4adcca41';
+const server: tsh.Server = {
+  uri: `${rootClusterUri}/servers/${serverUUID}`,
+  tunnel: false,
+  name: serverUUID,
+  hostname: 'foo',
+  addr: 'foo.localhost',
+  labelsList: [],
+};
+const leafServer = { ...server };
+leafServer.uri = `${leafClusterUri}/servers/${serverUUID}`;
 
 const getDocTshNodeWithServerId: () => DocumentTshNodeWithServerId = () => ({
   kind: 'doc.terminal_tsh_node',
@@ -239,376 +254,310 @@ test('useDocumentTerminal shows a warning notification if the call to TerminalsS
   expect(notificationsService.notifyWarning).toHaveBeenCalledTimes(1);
 });
 
-describe('calling useDocumentTerminal with a doc without server URI', () => {
-  test('calls ResourcesService to resolve the hostname of a root cluster SSH server to a UUID', async () => {
-    const doc = getDocTshNodeWithLoginHost();
-    const { wrapper, appContext, documentsService } = testSetup(doc);
-    const { resourcesService, terminalsService } = appContext;
-    jest
-      .spyOn(resourcesService, 'getServerByHostname')
-      .mockResolvedValueOnce(server);
-    jest.spyOn(documentsService, 'update');
+describe('calling useDocumentTerminal with a doc with a loginHost', () => {
+  const tests: Array<
+    {
+      name: string;
+      prepareDoc?: (doc: DocumentTshNodeWithLoginHost) => void;
+      prepareContext?: (ctx: IAppContext) => void;
+      mockGetServerByHostname:
+        | Awaited<ReturnType<ResourcesService['getServerByHostname']>>
+        | AmbiguousHostnameError
+        | Error;
+      expectedDocumentUpdate: Partial<DocumentTshNode>;
+      expectedArgsOfGetServerByHostname: Parameters<
+        ResourcesService['getServerByHostname']
+      >;
+      expectedErrorNotification?: Parameters<
+        NotificationsService['notifyError']
+      >[0];
+    } & (
+      | { expectedPtyCommand: PtyCommand; expectedError?: never }
+      | { expectedPtyCommand?: never; expectedError: string }
+    )
+  > = [
+    {
+      name: 'calls ResourcesService to resolve the hostname of a root cluster SSH server to a UUID',
+      mockGetServerByHostname: server,
+      expectedPtyCommand: {
+        kind: 'pty.tsh-login',
+        proxyHost: 'localhost:3080',
+        clusterName: 'Test',
+        login: 'user',
+        serverId: serverUUID,
+        rootClusterId: 'test',
+        leafClusterId: undefined,
+      },
+      expectedDocumentUpdate: {
+        serverId: serverUUID,
+        serverUri: server.uri,
+        login: 'user',
+        loginHost: undefined,
+        title: 'user@foo',
+      },
+      expectedArgsOfGetServerByHostname: [rootClusterUri, 'foo'],
+    },
+    {
+      name: 'calls ResourcesService to resolve the hostname of a leaf cluster SSH server to a UUID',
+      prepareDoc: doc => {
+        doc.leafClusterId = 'leaf';
+      },
+      mockGetServerByHostname: leafServer,
+      expectedPtyCommand: {
+        kind: 'pty.tsh-login',
+        proxyHost: 'localhost:3080',
+        clusterName: 'leaf',
+        login: 'user',
+        serverId: serverUUID,
+        rootClusterId: 'test',
+        leafClusterId: 'leaf',
+      },
+      expectedDocumentUpdate: {
+        serverId: serverUUID,
+        serverUri: leafServer.uri,
+        login: 'user',
+        loginHost: undefined,
+        title: 'user@foo',
+      },
+      expectedArgsOfGetServerByHostname: [leafClusterUri, 'foo'],
+    },
+    {
+      name: 'starts the session even if the leaf cluster is not synced yet',
+      prepareDoc: doc => {
+        doc.leafClusterId = 'leaf';
+      },
+      prepareContext: ctx => {
+        ctx.clustersService.setState(draft => {
+          draft.clusters.delete(leafClusterUri);
+        });
+      },
+      mockGetServerByHostname: leafServer,
+      expectedPtyCommand: {
+        kind: 'pty.tsh-login',
+        proxyHost: 'localhost:3080',
+        clusterName: 'leaf',
+        login: 'user',
+        serverId: serverUUID,
+        rootClusterId: 'test',
+        leafClusterId: 'leaf',
+      },
+      expectedDocumentUpdate: {
+        serverId: serverUUID,
+        serverUri: leafServer.uri,
+        login: 'user',
+        loginHost: undefined,
+        title: 'user@foo',
+      },
+      expectedArgsOfGetServerByHostname: [leafClusterUri, 'foo'],
+    },
+    {
+      name: 'maintains incorrect loginHost with too many parts',
+      prepareDoc: doc => {
+        doc.loginHost = 'user@foo@baz';
+      },
+      mockGetServerByHostname: undefined,
+      expectedPtyCommand: {
+        kind: 'pty.tsh-login',
+        proxyHost: 'localhost:3080',
+        clusterName: 'Test',
+        login: 'user@foo',
+        serverId: 'baz',
+        rootClusterId: 'test',
+        leafClusterId: undefined,
+      },
+      expectedDocumentUpdate: {
+        serverId: 'baz',
+        serverUri: `${rootClusterUri}/servers/baz`,
+        login: 'user@foo',
+        loginHost: undefined,
+        title: 'user@foo@baz',
+      },
+      expectedArgsOfGetServerByHostname: [rootClusterUri, 'baz'],
+    },
+    {
+      // This is in order to call `tsh ssh user@foo` anyway and make tsh show an appropriate error.
+      name: 'uses hostname as serverId if no matching server was found',
+      mockGetServerByHostname: undefined,
+      expectedPtyCommand: {
+        kind: 'pty.tsh-login',
+        proxyHost: 'localhost:3080',
+        clusterName: 'Test',
+        login: 'user',
+        serverId: 'foo',
+        rootClusterId: 'test',
+        leafClusterId: undefined,
+      },
+      expectedDocumentUpdate: {
+        serverId: 'foo',
+        serverUri: `${rootClusterUri}/servers/foo`,
+        login: 'user',
+        loginHost: undefined,
+        title: 'user@foo',
+      },
+      expectedArgsOfGetServerByHostname: [rootClusterUri, 'foo'],
+    },
+    {
+      // This is the case when the user tries to execute `tsh ssh host`. We want to call `tsh ssh
+      // host` anyway and make tsh show an appropriate error. But…
+      name: 'attempts to connect even if only the host was supplied and the server was not resolved',
+      prepareDoc: doc => {
+        doc.loginHost = 'host';
+      },
+      mockGetServerByHostname: undefined,
+      expectedPtyCommand: {
+        kind: 'pty.tsh-login',
+        proxyHost: 'localhost:3080',
+        clusterName: 'Test',
+        login: undefined,
+        serverId: 'host',
+        rootClusterId: 'test',
+        leafClusterId: undefined,
+      },
+      expectedDocumentUpdate: {
+        serverId: 'host',
+        serverUri: `${rootClusterUri}/servers/host`,
+        login: undefined,
+        loginHost: undefined,
+        title: 'host',
+      },
+      expectedArgsOfGetServerByHostname: [rootClusterUri, 'host'],
+    },
+    {
+      // …it might also be the case that the username of a Teleport user is equal to a user on the
+      // host, in which case explicitly providing the username is not necessary.
+      name: 'attempts to connect even if only the host was supplied and the server was resolved',
+      prepareDoc: doc => {
+        doc.loginHost = 'foo';
+      },
+      mockGetServerByHostname: server,
+      expectedPtyCommand: {
+        kind: 'pty.tsh-login',
+        proxyHost: 'localhost:3080',
+        clusterName: 'Test',
+        login: undefined,
+        serverId: serverUUID,
+        rootClusterId: 'test',
+        leafClusterId: undefined,
+      },
+      expectedDocumentUpdate: {
+        serverId: serverUUID,
+        serverUri: server.uri,
+        login: undefined,
+        loginHost: undefined,
+        title: 'foo',
+      },
+      expectedArgsOfGetServerByHostname: [rootClusterUri, 'foo'],
+    },
+    {
+      // As in other scenarios, we execute `tsh ssh user@ambiguous-host` anyway and let tsh show the
+      // error message.
+      name: 'silently ignores an ambiguous hostname error',
+      prepareDoc: doc => {
+        doc.loginHost = 'user@ambiguous-host';
+      },
+      mockGetServerByHostname: new AmbiguousHostnameError('ambiguous-host'),
+      expectedPtyCommand: {
+        kind: 'pty.tsh-login',
+        proxyHost: 'localhost:3080',
+        clusterName: 'Test',
+        login: 'user',
+        serverId: 'ambiguous-host',
+        rootClusterId: 'test',
+        leafClusterId: undefined,
+      },
+      expectedDocumentUpdate: {
+        serverId: 'ambiguous-host',
+        serverUri: `${rootClusterUri}/servers/ambiguous-host`,
+        login: 'user',
+        loginHost: undefined,
+        title: 'user@ambiguous-host',
+      },
+      expectedArgsOfGetServerByHostname: [rootClusterUri, 'ambiguous-host'],
+    },
+    {
+      name: 'shows an error notification and updates doc state if there was an error when resolving hostname',
+      mockGetServerByHostname: new Error('oops'),
+      expectedError: 'oops',
+      expectedDocumentUpdate: {
+        status: 'disconnected',
+      },
+      expectedArgsOfGetServerByHostname: [rootClusterUri, 'foo'],
+      expectedErrorNotification: {
+        title: expect.stringContaining('connection to user@foo'),
+        description: 'oops',
+      },
+    },
+  ];
 
-    const { result, waitForValueToChange } = renderHook(
-      () => useDocumentTerminal(doc),
-      { wrapper }
-    );
+  test.each(tests)(
+    '$name',
+    async ({
+      prepareDoc,
+      prepareContext,
+      mockGetServerByHostname,
+      expectedPtyCommand,
+      expectedDocumentUpdate,
+      expectedArgsOfGetServerByHostname,
+      expectedError,
+      expectedErrorNotification,
+    }) => {
+      const doc = getDocTshNodeWithLoginHost();
+      prepareDoc?.(doc);
+      const { wrapper, appContext, documentsService } = testSetup(doc);
+      prepareContext?.(appContext);
+      const { resourcesService, terminalsService, notificationsService } =
+        appContext;
 
-    await waitForValueToChange(() => useAsync.hasFinished(result.current));
+      jest.spyOn(documentsService, 'update');
+      jest.spyOn(notificationsService, 'notifyError');
 
-    const expectedPtyCommand: PtyCommand = {
-      kind: 'pty.tsh-login',
-      proxyHost: 'localhost:3080',
-      clusterName: 'Test',
-      login: 'user',
-      serverId: serverUUID,
-      rootClusterId: 'test',
-      leafClusterId: undefined,
-    };
+      if (mockGetServerByHostname instanceof Error) {
+        jest
+          .spyOn(resourcesService, 'getServerByHostname')
+          .mockRejectedValueOnce(mockGetServerByHostname);
+      } else {
+        jest
+          .spyOn(resourcesService, 'getServerByHostname')
+          .mockResolvedValueOnce(mockGetServerByHostname);
+      }
 
-    expect(result.current.statusText).toBeFalsy();
-    expect(result.current.status).toBe('success');
-    expect(terminalsService.createPtyProcess).toHaveBeenCalledWith(
-      expectedPtyCommand
-    );
-    expect(resourcesService.getServerByHostname).toHaveBeenCalledWith(
-      rootClusterUri,
-      'foo'
-    );
-    expect(documentsService.update).toHaveBeenCalledWith(doc.uri, {
-      serverId: serverUUID,
-      serverUri: server.uri,
-      login: 'user',
-      loginHost: undefined,
-      title: 'user@foo',
-    });
-  });
+      const { result, waitForValueToChange } = renderHook(
+        () => useDocumentTerminal(doc),
+        { wrapper }
+      );
 
-  test('calls ResourcesService to resolve the hostname of a leaf cluster SSH server to a UUID', async () => {
-    const doc = getDocTshNodeWithLoginHost();
-    doc.leafClusterId = 'leaf';
-    const { wrapper, appContext, documentsService } = testSetup(
-      doc,
-      leafClusterUri
-    );
-    const { resourcesService, terminalsService } = appContext;
-    const leafServer = { ...server };
-    leafServer.uri = `${leafClusterUri}/servers/${serverUUID}`;
-    jest
-      .spyOn(resourcesService, 'getServerByHostname')
-      .mockResolvedValueOnce(leafServer);
-    jest.spyOn(documentsService, 'update');
+      await waitForValueToChange(() => useAsync.hasFinished(result.current));
 
-    const { result, waitForValueToChange } = renderHook(
-      () => useDocumentTerminal(doc),
-      { wrapper }
-    );
+      /* eslint-disable jest/no-conditional-expect */
+      if (expectedError) {
+        expect(result.current.statusText).toEqual(expectedError);
+        expect(result.current.status).toBe('error');
+        expect(terminalsService.createPtyProcess).not.toHaveBeenCalled();
+      } else {
+        expect(result.current.statusText).toBeFalsy();
+        expect(result.current.status).toBe('success');
+        expect(terminalsService.createPtyProcess).toHaveBeenCalledWith(
+          expectedPtyCommand
+        );
+      }
+      /* eslint-enable jest/no-conditional-expect */
 
-    await waitForValueToChange(() => useAsync.hasFinished(result.current));
+      expect(resourcesService.getServerByHostname).toHaveBeenCalledWith(
+        ...expectedArgsOfGetServerByHostname
+      );
+      expect(documentsService.update).toHaveBeenCalledWith(
+        doc.uri,
+        expectedDocumentUpdate
+      );
 
-    const expectedPtyCommand: PtyCommand = {
-      kind: 'pty.tsh-login',
-      proxyHost: 'localhost:3080',
-      clusterName: 'leaf',
-      login: 'user',
-      serverId: serverUUID,
-      rootClusterId: 'test',
-      leafClusterId: 'leaf',
-    };
-
-    expect(result.current.statusText).toBeFalsy();
-    expect(result.current.status).toBe('success');
-    expect(terminalsService.createPtyProcess).toHaveBeenCalledWith(
-      expectedPtyCommand
-    );
-    expect(resourcesService.getServerByHostname).toHaveBeenCalledWith(
-      leafClusterUri,
-      'foo'
-    );
-    expect(documentsService.update).toHaveBeenCalledWith(doc.uri, {
-      serverId: serverUUID,
-      serverUri: leafServer.uri,
-      login: 'user',
-      loginHost: undefined,
-      title: 'user@foo',
-    });
-  });
-
-  test('starts the session even if the leaf cluster is not synced yet', async () => {
-    const doc = getDocTshNodeWithLoginHost();
-    doc.leafClusterId = 'leaf';
-    const { wrapper, appContext, documentsService } = testSetup(
-      doc,
-      leafClusterUri
-    );
-    appContext.clustersService.setState(draft => {
-      draft.clusters.delete(leafClusterUri);
-    });
-    const { resourcesService, terminalsService } = appContext;
-    const leafServer = { ...server };
-    leafServer.uri = `${leafClusterUri}/servers/${serverUUID}`;
-    jest
-      .spyOn(resourcesService, 'getServerByHostname')
-      .mockResolvedValueOnce(leafServer);
-    jest.spyOn(documentsService, 'update');
-
-    const { result, waitForValueToChange } = renderHook(
-      () => useDocumentTerminal(doc),
-      { wrapper }
-    );
-
-    await waitForValueToChange(() => useAsync.hasFinished(result.current));
-
-    const expectedPtyCommand: PtyCommand = {
-      kind: 'pty.tsh-login',
-      proxyHost: 'localhost:3080',
-      clusterName: 'leaf',
-      login: 'user',
-      serverId: serverUUID,
-      rootClusterId: 'test',
-      leafClusterId: 'leaf',
-    };
-
-    expect(result.current.statusText).toBeFalsy();
-    expect(result.current.status).toBe('success');
-    expect(terminalsService.createPtyProcess).toHaveBeenCalledWith(
-      expectedPtyCommand
-    );
-    expect(resourcesService.getServerByHostname).toHaveBeenCalledWith(
-      leafClusterUri,
-      'foo'
-    );
-    expect(documentsService.update).toHaveBeenCalledWith(doc.uri, {
-      serverId: serverUUID,
-      serverUri: leafServer.uri,
-      login: 'user',
-      loginHost: undefined,
-      title: 'user@foo',
-    });
-  });
-
-  test('maintains incorrect loginHost with too many parts', async () => {
-    const doc = getDocTshNodeWithLoginHost();
-    doc.loginHost = 'user@foo@baz';
-    const { wrapper, appContext, documentsService } = testSetup(doc);
-    const { terminalsService } = appContext;
-    jest
-      .spyOn(appContext.resourcesService, 'getServerByHostname')
-      .mockResolvedValueOnce(undefined);
-    jest.spyOn(documentsService, 'update');
-
-    const { result, waitForValueToChange } = renderHook(
-      () => useDocumentTerminal(doc),
-      { wrapper }
-    );
-
-    await waitForValueToChange(() => useAsync.hasFinished(result.current));
-
-    const expectedPtyCommand: PtyCommand = {
-      kind: 'pty.tsh-login',
-      proxyHost: 'localhost:3080',
-      clusterName: 'Test',
-      login: 'user@foo',
-      serverId: 'baz',
-      rootClusterId: 'test',
-      leafClusterId: undefined,
-    };
-
-    expect(result.current.statusText).toBeFalsy();
-    expect(result.current.status).toBe('success');
-    expect(terminalsService.createPtyProcess).toHaveBeenCalledWith(
-      expectedPtyCommand
-    );
-    expect(documentsService.update).toHaveBeenCalledWith(doc.uri, {
-      serverId: 'baz',
-      serverUri: `${rootClusterUri}/servers/baz`,
-      login: 'user@foo',
-      loginHost: undefined,
-      title: 'user@foo@baz',
-    });
-  });
-
-  // This is in order to call `tsh ssh user@foo` anyway and make tsh show an appropriate error.
-  test('uses hostname as serverId if no matching server was found', async () => {
-    const doc = getDocTshNodeWithLoginHost();
-    const { wrapper, appContext, documentsService } = testSetup(doc);
-    const { resourcesService, terminalsService } = appContext;
-    jest
-      .spyOn(resourcesService, 'getServerByHostname')
-      .mockResolvedValueOnce(undefined);
-    jest.spyOn(documentsService, 'update');
-
-    const { result, waitForValueToChange } = renderHook(
-      () => useDocumentTerminal(doc),
-      { wrapper }
-    );
-
-    await waitForValueToChange(() => useAsync.hasFinished(result.current));
-
-    const expectedPtyCommand: PtyCommand = {
-      kind: 'pty.tsh-login',
-      proxyHost: 'localhost:3080',
-      clusterName: 'Test',
-      login: 'user',
-      serverId: 'foo',
-      rootClusterId: 'test',
-      leafClusterId: undefined,
-    };
-
-    expect(result.current.statusText).toBeFalsy();
-    expect(result.current.status).toBe('success');
-    expect(terminalsService.createPtyProcess).toHaveBeenCalledWith(
-      expectedPtyCommand
-    );
-    expect(resourcesService.getServerByHostname).toHaveBeenCalledWith(
-      rootClusterUri,
-      'foo'
-    );
-    expect(documentsService.update).toHaveBeenCalledWith(doc.uri, {
-      serverId: 'foo',
-      serverUri: `${rootClusterUri}/servers/foo`,
-      login: 'user',
-      loginHost: undefined,
-      title: 'user@foo',
-    });
-  });
-
-  // This is the case when the user tries to execute `tsh ssh user`. We want to call `tsh ssh user`
-  // anyway and make tsh show an appropriate error.
-  //
-  // It might also be the case that the username of a Teleport user is equal to a user on the host,
-  // in which case explicitly providing the username is not necessary.
-  test('attempts to connect even if only the login was supplied', async () => {
-    const doc = getDocTshNodeWithLoginHost();
-    doc.loginHost = 'user';
-    const { wrapper, appContext, documentsService } = testSetup(doc);
-    const { resourcesService, terminalsService } = appContext;
-    jest
-      .spyOn(resourcesService, 'getServerByHostname')
-      .mockResolvedValueOnce(undefined);
-    jest.spyOn(documentsService, 'update');
-
-    const { result, waitForValueToChange } = renderHook(
-      () => useDocumentTerminal(doc),
-      { wrapper }
-    );
-
-    await waitForValueToChange(() => useAsync.hasFinished(result.current));
-
-    const expectedPtyCommand: PtyCommand = {
-      kind: 'pty.tsh-login',
-      proxyHost: 'localhost:3080',
-      clusterName: 'Test',
-      login: undefined,
-      serverId: 'user',
-      rootClusterId: 'test',
-      leafClusterId: undefined,
-    };
-
-    expect(result.current.statusText).toBeFalsy();
-    expect(result.current.status).toBe('success');
-    expect(terminalsService.createPtyProcess).toHaveBeenCalledWith(
-      expectedPtyCommand
-    );
-    expect(resourcesService.getServerByHostname).toHaveBeenCalledWith(
-      rootClusterUri,
-      'user'
-    );
-    expect(documentsService.update).toHaveBeenCalledWith(doc.uri, {
-      serverId: 'user',
-      serverUri: `${rootClusterUri}/servers/user`,
-      login: undefined,
-      loginHost: undefined,
-      title: 'user',
-    });
-  });
-
-  // As in other scenarios, we execute `tsh ssh user@ambiguous-host` anyway and let tsh show the
-  // error message.
-  test('silently ignores an error due to an ambiguous hostname', async () => {
-    const doc = getDocTshNodeWithLoginHost();
-    doc.loginHost = 'user@ambiguous-host';
-    const { wrapper, appContext, documentsService } = testSetup(doc);
-    const { resourcesService, terminalsService, notificationsService } =
-      appContext;
-    jest.spyOn(notificationsService, 'notifyError');
-    jest.spyOn(notificationsService, 'notifyWarning');
-    jest
-      .spyOn(resourcesService, 'getServerByHostname')
-      .mockRejectedValueOnce(new AmbiguousHostnameError('ambiguous-host'));
-    jest.spyOn(documentsService, 'update');
-
-    const { result, waitForValueToChange } = renderHook(
-      () => useDocumentTerminal(doc),
-      { wrapper }
-    );
-
-    await waitForValueToChange(() => useAsync.hasFinished(result.current));
-
-    const expectedPtyCommand: PtyCommand = {
-      kind: 'pty.tsh-login',
-      proxyHost: 'localhost:3080',
-      clusterName: 'Test',
-      login: 'user',
-      serverId: 'ambiguous-host',
-      rootClusterId: 'test',
-      leafClusterId: undefined,
-    };
-
-    expect(result.current.statusText).toBeFalsy();
-    expect(result.current.status).toBe('success');
-    expect(terminalsService.createPtyProcess).toHaveBeenCalledWith(
-      expectedPtyCommand
-    );
-    expect(resourcesService.getServerByHostname).toHaveBeenCalledWith(
-      rootClusterUri,
-      'ambiguous-host'
-    );
-    expect(notificationsService.notifyError).not.toHaveBeenCalled();
-    expect(notificationsService.notifyWarning).not.toHaveBeenCalled();
-    expect(documentsService.update).toHaveBeenCalledWith(doc.uri, {
-      serverId: 'ambiguous-host',
-      serverUri: `${rootClusterUri}/servers/ambiguous-host`,
-      login: 'user',
-      loginHost: undefined,
-      title: 'user@ambiguous-host',
-    });
-  });
-
-  test('shows an error notification and updates doc state if there was an error when resolving hostname', async () => {
-    const error = new Error('oops');
-    const doc = getDocTshNodeWithLoginHost();
-    const { wrapper, appContext, documentsService } = testSetup(doc);
-    const { resourcesService, terminalsService, notificationsService } =
-      appContext;
-    jest.spyOn(notificationsService, 'notifyError');
-    jest
-      .spyOn(resourcesService, 'getServerByHostname')
-      .mockRejectedValueOnce(error);
-    jest.spyOn(documentsService, 'update');
-
-    const { result, waitForValueToChange } = renderHook(
-      () => useDocumentTerminal(doc),
-      { wrapper }
-    );
-
-    await waitForValueToChange(() => useAsync.hasFinished(result.current));
-
-    expect(result.current.statusText).toBe(error.message);
-    expect(result.current.status).toBe('error');
-    expect(terminalsService.createPtyProcess).not.toHaveBeenCalled();
-    expect(resourcesService.getServerByHostname).toHaveBeenCalledWith(
-      rootClusterUri,
-      'foo'
-    );
-    expect(notificationsService.notifyError).toHaveBeenCalledWith({
-      title: expect.stringContaining('connection to user@foo'),
-      description: error.message,
-    });
-    expect(documentsService.update).toHaveBeenCalledWith(doc.uri, {
-      status: 'disconnected',
-    });
-  });
+      if (expectedErrorNotification) {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(notificationsService.notifyError).toHaveBeenCalledWith(
+          expectedErrorNotification
+        );
+      }
+    }
+  );
 });
 
 // testSetup adds a cluster to ClustersService and WorkspacesService.
@@ -687,15 +636,6 @@ const testSetup = (
   );
 
   return { appContext, wrapper, documentsService };
-};
-
-const server: tsh.Server = {
-  uri: `${rootClusterUri}/servers/${serverUUID}`,
-  tunnel: false,
-  name: serverUUID,
-  hostname: 'foo',
-  addr: 'foo.localhost',
-  labelsList: [],
 };
 
 // TODO(ravicious): Add tests for the following cases:

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
@@ -62,8 +62,10 @@ const server: tsh.Server = {
   addr: 'foo.localhost',
   labelsList: [],
 };
-const leafServer = { ...server };
-leafServer.uri = `${leafClusterUri}/servers/${serverUUID}`;
+const leafServer = {
+  ...server,
+  uri: `${leafClusterUri}/servers/${serverUUID}`,
+};
 
 const getDocTshNodeWithServerId: () => DocumentTshNodeWithServerId = () => ({
   kind: 'doc.terminal_tsh_node',

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
@@ -37,7 +37,7 @@ import { NotificationsService } from 'teleterm/ui/services/notifications';
 
 import { WorkspaceContextProvider } from '../Documents';
 
-import useDocumentTerminal from './useDocumentTerminal';
+import { useDocumentTerminal } from './useDocumentTerminal';
 
 import type { IAppContext } from 'teleterm/ui/types';
 import type * as tsh from 'teleterm/services/tshd/types';

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import 'jest-canvas-mock';
+import * as useAsync from 'shared/hooks/useAsync';
+
+import Logger, { NullService } from 'teleterm/logger';
+import { PtyCommand, PtyProcessCreationStatus } from 'teleterm/services/pty';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { DocumentTshNode } from 'teleterm/ui/services/workspacesService';
+
+import { WorkspaceContextProvider } from '../Documents';
+
+import useDocumentTerminal from './useDocumentTerminal';
+
+import type * as tsh from 'teleterm/services/tshd/types';
+import type * as uri from 'teleterm/ui/uri';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const rootClusterUri = '/clusters/test' as const;
+const leafClusterUri = `${rootClusterUri}/leaves/leaf` as const;
+const serverUUID = 'bed30649-3af5-40f1-a832-54ff4adcca41';
+
+const getDocTshNode: () => DocumentTshNode = () => ({
+  kind: 'doc.terminal_tsh_node',
+  uri: '/docs/123',
+  title: '',
+  status: '',
+  serverId: serverUUID,
+  serverUri: `${rootClusterUri}/servers/${serverUUID}`,
+  rootClusterId: 'test',
+  login: 'user',
+});
+
+test('useDocumentTerminal calls TerminalsService during init', async () => {
+  const doc = getDocTshNode();
+  const { wrapper, appContext } = testSetup();
+
+  const { result, waitForValueToChange } = renderHook(
+    () => useDocumentTerminal(doc),
+    { wrapper }
+  );
+
+  await waitForValueToChange(() => useAsync.hasFinished(result.current));
+
+  const expectedPtyCommand: PtyCommand = {
+    kind: 'pty.tsh-login',
+    proxyHost: 'localhost:3080',
+    clusterName: 'Test',
+    login: 'user',
+    serverId: serverUUID,
+    rootClusterId: 'test',
+  };
+
+  expect(result.current.statusText).toBeFalsy();
+  expect(result.current.status).toBe('success');
+  expect(appContext.terminalsService.createPtyProcess).toHaveBeenCalledWith(
+    expect.objectContaining(expectedPtyCommand)
+  );
+});
+
+test('useDocumentTerminal calls TerminalsService only once', async () => {
+  const doc = getDocTshNode();
+  const { wrapper, appContext } = testSetup();
+
+  const { result, waitForValueToChange, rerender } = renderHook(
+    () => useDocumentTerminal(doc),
+    { wrapper }
+  );
+
+  await waitForValueToChange(() => useAsync.hasFinished(result.current));
+  expect(result.current.statusText).toBeFalsy();
+  expect(result.current.status).toBe('success');
+  rerender();
+
+  expect(appContext.terminalsService.createPtyProcess).toHaveBeenCalledTimes(1);
+});
+
+test('useDocumentTerminal gets leaf cluster ID from ClustersService when the leaf cluster is in ClustersService', async () => {
+  const doc = getDocTshNode();
+  doc.leafClusterId = 'leaf';
+  doc.serverUri = `${leafClusterUri}/servers/${doc.serverId}`;
+  const { wrapper, appContext } = testSetup(leafClusterUri);
+
+  const { result, waitForValueToChange } = renderHook(
+    () => useDocumentTerminal(doc),
+    { wrapper }
+  );
+
+  await waitForValueToChange(() => useAsync.hasFinished(result.current));
+
+  const expectedPtyCommand: PtyCommand = {
+    kind: 'pty.tsh-login',
+    proxyHost: 'localhost:3080',
+    clusterName: 'leaf',
+    login: 'user',
+    serverId: serverUUID,
+    rootClusterId: 'test',
+    leafClusterId: 'leaf',
+  };
+
+  expect(result.current.statusText).toBeFalsy();
+  expect(result.current.status).toBe('success');
+  expect(appContext.terminalsService.createPtyProcess).toHaveBeenCalledWith(
+    expect.objectContaining(expectedPtyCommand)
+  );
+});
+
+test('useDocumentTerminal gets leaf cluster ID from doc.leafClusterId if the leaf cluster is not synced yet', async () => {
+  const doc = getDocTshNode();
+  doc.leafClusterId = 'leaf';
+  doc.serverUri = `${leafClusterUri}/servers/${doc.serverId}`;
+  const { wrapper, appContext } = testSetup(leafClusterUri);
+  appContext.clustersService.setState(draft => {
+    draft.clusters.delete(leafClusterUri);
+  });
+
+  const { result, waitForValueToChange } = renderHook(
+    () => useDocumentTerminal(doc),
+    { wrapper }
+  );
+
+  await waitForValueToChange(() => useAsync.hasFinished(result.current));
+
+  const expectedPtyCommand: PtyCommand = {
+    kind: 'pty.tsh-login',
+    proxyHost: 'localhost:3080',
+    clusterName: 'leaf',
+    login: 'user',
+    serverId: serverUUID,
+    rootClusterId: 'test',
+    leafClusterId: 'leaf',
+  };
+
+  expect(result.current.statusText).toBeFalsy();
+  expect(result.current.status).toBe('success');
+  expect(appContext.terminalsService.createPtyProcess).toHaveBeenCalledWith(
+    expect.objectContaining(expectedPtyCommand)
+  );
+});
+
+test('useDocumentTerminal shows an error notification if the call to TerminalsService fails', async () => {
+  const doc = getDocTshNode();
+  const { wrapper, appContext } = testSetup();
+  const { terminalsService, notificationsService } = appContext;
+
+  (
+    terminalsService.createPtyProcess as jest.MockedFunction<
+      typeof terminalsService.createPtyProcess
+    >
+  ).mockReset();
+  jest
+    .spyOn(terminalsService, 'createPtyProcess')
+    .mockRejectedValue(new Error('whoops'));
+  jest.spyOn(notificationsService, 'notifyError');
+
+  const { result, waitForValueToChange } = renderHook(
+    () => useDocumentTerminal(doc),
+    { wrapper }
+  );
+
+  await waitForValueToChange(() => useAsync.hasFinished(result.current));
+  expect(result.current.statusText).toBeFalsy();
+  expect(result.current.status).toBe('success');
+
+  expect(notificationsService.notifyError).toHaveBeenCalledWith('whoops');
+  expect(notificationsService.notifyError).toHaveBeenCalledTimes(1);
+});
+
+test('useDocumentTerminal shows a warning notification if the call to TerminalsService fails due to resolving env timeout', async () => {
+  const doc = getDocTshNode();
+  const { wrapper, appContext } = testSetup();
+  const { terminalsService, notificationsService } = appContext;
+
+  (
+    terminalsService.createPtyProcess as jest.MockedFunction<
+      typeof terminalsService.createPtyProcess
+    >
+  ).mockReset();
+  jest.spyOn(terminalsService, 'createPtyProcess').mockResolvedValue({
+    process: undefined,
+    creationStatus: PtyProcessCreationStatus.ResolveShellEnvTimeout,
+  });
+  jest.spyOn(notificationsService, 'notifyWarning');
+
+  const { result, waitForValueToChange } = renderHook(
+    () => useDocumentTerminal(doc),
+    { wrapper }
+  );
+
+  await waitForValueToChange(() => useAsync.hasFinished(result.current));
+  expect(result.current.statusText).toBeFalsy();
+  expect(result.current.status).toBe('success');
+
+  expect(notificationsService.notifyWarning).toHaveBeenCalledWith({
+    title: expect.stringContaining('Could not source environment variables'),
+    description: expect.stringContaining('shell startup'),
+  });
+  expect(notificationsService.notifyWarning).toHaveBeenCalledTimes(1);
+});
+
+// testSetup adds a cluster to ClustersService and WorkspacesService.
+// It also makes TerminalsService.prototype.createPtyProcess a noop.
+const testSetup = (localClusterUri: uri.ClusterUri = clusterUri) => {
+  const cluster: tsh.Cluster = {
+    uri: rootClusterUri,
+    name: 'Test',
+    connected: true,
+    leaf: false,
+    proxyHost: 'localhost:3080',
+    authClusterId: '73c4746b-d956-4f16-9848-4e3469f70762',
+    loggedInUser: {
+      activeRequestsList: [],
+      assumedRequests: {},
+      name: 'admin',
+      acl: {},
+      sshLoginsList: [],
+      rolesList: [],
+      requestableRolesList: [],
+      suggestedReviewersList: [],
+    },
+  };
+  const leafCluster: tsh.Cluster = {
+    uri: leafClusterUri,
+    name: 'leaf',
+    connected: true,
+    leaf: true,
+    proxyHost: '',
+    authClusterId: '5408fc2f-a452-4bde-bda2-b3b918c635ad',
+    loggedInUser: {
+      activeRequestsList: [],
+      assumedRequests: {},
+      name: 'admin',
+      acl: {},
+      sshLoginsList: [],
+      rolesList: [],
+      requestableRolesList: [],
+      suggestedReviewersList: [],
+    },
+  };
+  const appContext = new MockAppContext();
+  appContext.clustersService.setState(draftState => {
+    draftState.clusters.set(rootClusterUri, cluster);
+    draftState.clusters.set(leafCluster.uri, leafCluster);
+  });
+  appContext.workspacesService.setActiveWorkspace(rootClusterUri);
+  const documentsService =
+    appContext.workspacesService.getWorkspaceDocumentService(rootClusterUri);
+  documentsService.add(doc);
+  jest
+    .spyOn(appContext.terminalsService, 'createPtyProcess')
+    .mockImplementationOnce(async () => {
+      return {
+        process: undefined,
+        creationStatus: PtyProcessCreationStatus.Ok,
+      };
+    });
+
+  const wrapper = ({ children }) => (
+    <MockAppContextProvider appContext={appContext}>
+      <WorkspaceContextProvider
+        value={{
+          rootClusterUri: rootClusterUri,
+          localClusterUri,
+          documentsService,
+          accessRequestsService: undefined,
+        }}
+      >
+        {children}
+      </WorkspaceContextProvider>
+    </MockAppContextProvider>
+  );
+
+  return { appContext, wrapper };
+};
+
+// TODO(ravicious): Add tests for the following cases:
+// * dispose on unmount when state is success
+// * removing init command from doc
+// * marking the doc as connected when data arrives
+// * closing the doc with 0 exit code
+// * not closing the doc with non-zero exit code

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
@@ -157,9 +157,9 @@ async function resolveLoginHost(
   } else {
     // If we can't find a server by the given hostname, we still want to create a document to
     // handle the error further down the line.
-    const clusterParams = routing.parseClusterUri(clusterUri).params;
     serverUri = routing.getServerUri({
-      ...clusterParams,
+      rootClusterId: doc.rootClusterId,
+      leafClusterId: doc.leafClusterId,
       serverId: host,
     });
     serverHostname = host;

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
@@ -33,7 +33,7 @@ import type * as types from 'teleterm/ui/services/workspacesService';
 import type * as uri from 'teleterm/ui/uri';
 import type * as tsh from 'teleterm/services/tshd/types';
 
-export default function useDocumentTerminal(doc: types.DocumentTerminal) {
+export function useDocumentTerminal(doc: types.DocumentTerminal) {
   const logger = useRef(new Logger('useDocumentTerminal'));
   const ctx = useAppContext();
   const { documentsService } = useWorkspaceContext();

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
@@ -31,9 +31,9 @@ import { PtyCommand, PtyProcessCreationStatus } from 'teleterm/services/pty';
 
 export default function useDocumentTerminal(doc: Doc) {
   const ctx = useAppContext();
-  const { documentsService: workspaceDocumentsService } = useWorkspaceContext();
+  const { documentsService } = useWorkspaceContext();
   const [state, init] = useAsync(async () =>
-    initState(ctx, workspaceDocumentsService, doc)
+    initState(ctx, documentsService, doc)
   );
 
   useEffect(() => {
@@ -63,7 +63,7 @@ export default function useDocumentTerminal(doc: Doc) {
 
 async function initState(
   ctx: IAppContext,
-  docsService: DocumentsService,
+  documentsService: DocumentsService,
   doc: Doc
 ) {
   const getClusterName = () => {
@@ -112,7 +112,7 @@ async function initState(
     }
 
     const cwd = await ptyProcess.getCwd();
-    docsService.update(doc.uri, {
+    documentsService.update(doc.uri, {
       cwd,
       title: `${cwd || 'Terminal'} · ${getClusterName()}`,
     });
@@ -128,7 +128,7 @@ async function initState(
     // Imagine that someone creates a new terminal document with `rm -rf /tmp` as initCommand.
     // We'd execute the command each time the document gets recreated from the state, which is not
     // what the user would expect.
-    docsService.update(doc.uri, { initCommand: undefined });
+    documentsService.update(doc.uri, { initCommand: undefined });
   };
 
   ptyProcess.onOpen(() => {
@@ -137,7 +137,7 @@ async function initState(
   });
 
   const markDocumentAsConnectedOnce = runOnce(() => {
-    docsService.update(doc.uri, { status: 'connected' });
+    documentsService.update(doc.uri, { status: 'connected' });
   });
 
   // mark document as connected when first data arrives
@@ -154,7 +154,7 @@ async function initState(
     // We can look up how the terminal in vscode handles this problem, since in the scenario
     // described above they do close the tab correctly.
     if (event.exitCode === 0) {
-      docsService.close(doc.uri);
+      documentsService.close(doc.uri);
     }
   });
 

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
@@ -48,6 +48,7 @@ export default function useDocumentTerminal(doc: Doc) {
     };
   }, [state]);
 
+  // TODO: Move this within the call to initState in useAsync.
   useEffect(() => {
     if (state.status === 'error') {
       ctx.notificationsService.notifyError({
@@ -123,6 +124,10 @@ async function initState(
     }
     // The initCommand has to be launched only once, not every time we recreate the document from
     // the state.
+    //
+    // Imagine that someone creates a new terminal document with `rm -rf /tmp` as initCommand.
+    // We'd execute the command each time the document gets recreated from the state, which is not
+    // what the user would expect.
     docsService.update(doc.uri, { initCommand: undefined });
   };
 
@@ -189,6 +194,8 @@ function createCmd(
 ): PtyCommand {
   if (doc.kind === 'doc.terminal_tsh_node') {
     return {
+      // TODO(ravicious): Pick relevant field from doc rather than destructuring.
+      // Change tests to not use `objectContaining`.
       ...doc,
       proxyHost,
       clusterName,

--- a/web/packages/teleterm/src/ui/Documents/index.ts
+++ b/web/packages/teleterm/src/ui/Documents/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
-export * from './DocumentsRenderer';
 export * from './workspaceContext';
+// Explicitly not exporting DocumentsRenderer here because it imports e-teleterm components causing
+// OSS tests to fail.

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
@@ -36,6 +36,15 @@ import AppContext from 'teleterm/ui/appContext';
 
 import { getEmptyPendingAccessRequest } from '../services/workspacesService/accessRequestsService';
 
+// TODO(ravicious): Remove the mock once a separate entry point for e-teleterm is created.
+//
+// Mocking out DocumentsRenderer because it imports an e-teleterm component which breaks CI tests
+// for the OSS version. The tests here don't test the behavior of DocumentsRenderer so the only
+// thing we lose by adding the mock is "smoke tests" of different document kinds.
+jest.mock('teleterm/ui/Documents/DocumentsRenderer', () => ({
+  DocumentsRenderer: ({ children }) => <>{children}</>,
+}));
+
 function getMockDocuments(): Document[] {
   return [
     {

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.tsx
@@ -21,7 +21,7 @@ import { Flex } from 'design';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import * as types from 'teleterm/ui/services/workspacesService/documentsService/types';
 import { Tabs } from 'teleterm/ui/Tabs';
-import { DocumentsRenderer } from 'teleterm/ui/Documents';
+import { DocumentsRenderer } from 'teleterm/ui/Documents/DocumentsRenderer';
 import { IAppContext } from 'teleterm/ui/types';
 import { useKeyboardShortcutFormatters } from 'teleterm/ui/services/keyboardShortcuts';
 

--- a/web/packages/teleterm/src/ui/commandLauncher.ts
+++ b/web/packages/teleterm/src/ui/commandLauncher.ts
@@ -24,7 +24,7 @@ const commands = {
   'tsh-ssh': {
     displayName: '',
     description: '',
-    async run(
+    run(
       ctx: IAppContext,
       args: { loginHost: string; localClusterUri: ClusterUri }
     ) {

--- a/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
@@ -17,7 +17,7 @@ limitations under the License.
 // @ts-ignore
 import { ResourceKind } from 'e-teleterm/ui/DocumentAccessRequests/NewRequest/useNewRequest';
 
-import { PendingAccessRequest } from '../workspacesService';
+import type { PendingAccessRequest } from '../workspacesService';
 
 export class AccessRequestsService {
   constructor(

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.test.ts
@@ -130,6 +130,7 @@ test('only TSH node documents should be returned', () => {
     serverUri: '/clusters/foo/servers/bar',
     status: 'connecting',
     rootClusterId: '',
+    leafClusterId: undefined,
   };
 
   service.add(tshNodeDocument);

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -15,7 +15,13 @@ limitations under the License.
 */
 
 import { unique } from 'teleterm/ui/utils/uid';
-import { DocumentUri, paths, routing, ServerUri } from 'teleterm/ui/uri';
+import {
+  ClusterUri,
+  DocumentUri,
+  ServerUri,
+  paths,
+  routing,
+} from 'teleterm/ui/uri';
 
 import {
   CreateAccessRequestDocumentOpts,
@@ -29,6 +35,8 @@ import {
   DocumentGateway,
   DocumentTshKube,
   DocumentTshNode,
+  DocumentTshNodeWithLoginHost,
+  DocumentTshNodeWithServerId,
 } from './types';
 
 export class DocumentsService {
@@ -99,9 +107,10 @@ export class DocumentsService {
     };
   }
 
-  createTshNodeDocument(serverUri: ServerUri): DocumentTshNode {
+  createTshNodeDocument(serverUri: ServerUri): DocumentTshNodeWithServerId {
     const { params } = routing.parseServerUri(serverUri);
     const uri = routing.getDocUri({ docId: unique() });
+
     return {
       uri,
       kind: 'doc.terminal_tsh_node',
@@ -112,6 +121,33 @@ export class DocumentsService {
       serverUri,
       title: '',
       login: '',
+    };
+  }
+
+  /**
+   * createTshNodeDocumentFromLoginHost handles creation of the doc when the server URI is not
+   * available, for example when executing `tsh ssh user@host` from the command bar.
+   *
+   * @param {string} clusterUri - the URI of the cluster which should be used for hostname lookup.
+   * That is, the command will succeed only if the given cluster has only a single server with the
+   * hostname matching `host`.
+   * @param {string} loginHost - the "user@host" pair.
+   */
+  createTshNodeDocumentFromLoginHost(
+    clusterUri: ClusterUri,
+    loginHost: string
+  ): DocumentTshNodeWithLoginHost {
+    const { params } = routing.parseClusterUri(clusterUri);
+    const uri = routing.getDocUri({ docId: unique() });
+
+    return {
+      uri,
+      kind: 'doc.terminal_tsh_node',
+      title: loginHost,
+      status: 'connecting',
+      rootClusterId: params.rootClusterId,
+      leafClusterId: params.leafClusterId,
+      loginHost,
     };
   }
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -128,10 +128,10 @@ export class DocumentsService {
    * createTshNodeDocumentFromLoginHost handles creation of the doc when the server URI is not
    * available, for example when executing `tsh ssh user@host` from the command bar.
    *
-   * @param {string} clusterUri - the URI of the cluster which should be used for hostname lookup.
-   * That is, the command will succeed only if the given cluster has only a single server with the
-   * hostname matching `host`.
-   * @param {string} loginHost - the "user@host" pair.
+   * @param clusterUri - the URI of the cluster which should be used for hostname lookup. That is,
+   * the command will succeed only if the given cluster has only a single server with the hostname
+   * matching `host`.
+   * @param loginHost - the "user@host" pair.
    */
   createTshNodeDocumentFromLoginHost(
     clusterUri: ClusterUri,

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -35,18 +35,39 @@ export interface DocumentBlank extends DocumentBase {
   kind: 'doc.blank';
 }
 
-export interface DocumentTshNode extends DocumentBase {
+export type DocumentTshNode =
+  | DocumentTshNodeWithServerId
+  | DocumentTshNodeWithLoginHost;
+
+interface DocumentTshNodeBase extends DocumentBase {
   kind: 'doc.terminal_tsh_node';
   status: '' | 'connecting' | 'connected' | 'disconnected';
-  serverId: string;
-  serverUri: uri.ServerUri;
   rootClusterId: string;
-  leafClusterId?: string;
+  leafClusterId: string | undefined;
+}
+
+export interface DocumentTshNodeWithServerId extends DocumentTshNodeBase {
+  // serverId is the UUID of the SSH server. If it's is present, we can immediately start an SSH
+  // session.
+  //
+  // serverId is available when connecting to a server from the resource table.
+  serverId: string;
+  // serverUri is used for file transfer and for identifying a specific server among different
+  // profiles and clusters.
+  serverUri: uri.ServerUri;
   // login is missing when the user executes `tsh ssh user` from the command bar without supplying
   // the hostname. In that case, login will be undefined and serverId will be equal to "user".
   //
   // We will execute `tsh ssh user` anyway and let tsh show an appropriate error message.
   login?: string;
+  loginHost?: string;
+}
+
+export interface DocumentTshNodeWithLoginHost extends DocumentTshNodeBase {
+  // serverId is missing, so we need to resolve loginHost to a server UUID.
+  loginHost: string;
+  // We don't provide types for other fields on purpose (such as serverId?: undefined) in order to
+  // force places which use DocumentTshNode to narrow down the type before using it.
 }
 
 export interface DocumentTshKube extends DocumentBase {

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -37,11 +37,15 @@ export interface DocumentBlank extends DocumentBase {
 
 export interface DocumentTshNode extends DocumentBase {
   kind: 'doc.terminal_tsh_node';
-  status: 'connecting' | 'connected' | 'disconnected';
+  status: '' | 'connecting' | 'connected' | 'disconnected';
   serverId: string;
   serverUri: uri.ServerUri;
   rootClusterId: string;
   leafClusterId?: string;
+  // login is missing when the user executes `tsh ssh user` from the command bar without supplying
+  // the hostname. In that case, login will be undefined and serverId will be equal to "user".
+  //
+  // We will execute `tsh ssh user` anyway and let tsh show an appropriate error message.
   login?: string;
 }
 


### PR DESCRIPTION
Part of #21964.

#21976 made it so that when executing `tsh ssh` from the command bar, instead of using the resource cache we hit the proxy.

However, we don't want to do this inside the command launcher itself because it means that there's a delay between typing `tsh ssh user@host`, pressing enter and actually seeing a new tab being opened.

Instead, this PR moves the whole logic related to resolving the hostname to `useDocumentTerminal`. This balloons the size of this hook, but it guarantees that the new tab gets opened right after pressing enter.

Best reviewed commit-by-commit with some precautions, see the Tests section.

This PR merely moves the logic, the rest of the project will be adjusted in #22182.

## How it's done

In short, I take the existing `DocumentTshNode` type and split it into two separate types. One has the `loginHost` field and the other one has `serverId`, `serverUri` and `login`. When `useDocumentTerminal` receives a `DocumentTshNode` that doesn't have `serverId`, it attempts to resolve `loginHost` to a UUID.

This is what we have now:

https://github.com/gravitational/teleport/blob/2a2f4c9f4416d9df9048cac0d423cd65e16a02a1/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts#L38-L46

This is what this PR introduces:

https://github.com/gravitational/teleport/blob/af245c83bfed1e432c41d1011e1591fa4b692746/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts#L38-L71

### Why are we reusing the same `doc.kind` for two different things?

Instead of creating those two "subtypes", I could've introduced a new document kind for this purpose. Conceptually though, I don't think we should change the `kind` of document after it's created. On top of that, `DocumentTerminal` and `useDocumentTerminal` are written around the function in `useEffect` being executed only once. Taking this into account, I feel like this short-lived state of `DocumentTshNode` where `loginHost` is present but we're yet to get `serverId` is better represented as those two "subtypes".

This still gives us benefits related to type checking – any place using `DocumentTshNode` has to narrow down the type before using `serverId`.

## Tests

Before this PR, neither the hostname resolving behavior in the command launcher nor `useDocumentTerminal` had tests. Before moving hostname resolving to `useDocumentTerminal`, I added some basic tests for the existing `useDocumentTerminal` behavior.

Now, when moving the logic I added the tests by copy-pasting a lot of test cases. Later I rewrote them to table tests as this was a very good use case for them. So, when you get to the commit which moves the whole logic to `useDocumentTerminal`, I recommend switching to the view with full changes and opening the file with the tests and reviewing them this way.