### PR TITLE
Fix an issue Redis protocol not handling nil response

### DIFF
--- a/lib/srv/db/redis/protocol/resp2.go
+++ b/lib/srv/db/redis/protocol/resp2.go
@@ -40,6 +40,12 @@ var ErrCmdNotSupported = trace.NotImplemented("command not supported")
 // * slices: arrays are recursively converted to RESP responses.
 func WriteCmd(wr *redis.Writer, vals interface{}) error {
 	switch val := vals.(type) {
+	case nil:
+		// Note: RESP3 has different sequence for nil, current nil is RESP2 compatible as the rest
+		// of our implementation.
+		if _, err := wr.WriteString("$-1\r\n"); err != nil {
+			return trace.Wrap(err)
+		}
 	case redis.Error:
 		if val == redis.Nil {
 			// go-redis returns nil value as errors, but Redis Wire protocol decodes them differently.
@@ -112,12 +118,6 @@ func WriteCmd(wr *redis.Writer, vals interface{}) error {
 		}
 
 		if err != nil {
-			return trace.Wrap(err)
-		}
-	case nil:
-		// Note: RESP3 has different sequence for nil, current nil is RESP2 compatible as the rest
-		// of our implementation.
-		if _, err := wr.WriteString("$-1\r\n"); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/lib/srv/db/redis/protocol/resp2_test.go
+++ b/lib/srv/db/redis/protocol/resp2_test.go
@@ -69,6 +69,11 @@ func TestWriteCmd(t *testing.T) {
 			expected: []byte("*2\r\n$9\r\ntest val1\r\n$10\r\ntest val 2\r\n"),
 		},
 		{
+			name:     "[]nil",
+			val:      []interface{}{nil},
+			expected: []byte("*1\r\n$-1\r\n"),
+		},
+		{
 			name:     "[]bool",
 			val:      []bool{true, false},
 			expected: []byte("*2\r\n$1\r\n1\r\n$1\r\n0\r\n"),


### PR DESCRIPTION
Fixes #22078

```
$ tsh db connect self-hosted-redis
localhost:56844> auth <token>
OK
localhost:56844> command info ai.info
1) (nil)
```
