### PR TITLE
Connect: Reenable TabHost tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,10 +8,6 @@ module.exports = {
   globals: {
     electron: {},
   },
-  testPathIgnorePatterns: [
-    // Skipped until e files are removed from teleterm.
-    'web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx',
-  ],
   collectCoverageFrom: [
     // comment out until shared directory is finished testing
     // '**/packages/design/src/**/*.jsx',

--- a/web/packages/teleterm/src/ui/Documents/index.ts
+++ b/web/packages/teleterm/src/ui/Documents/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
-export * from './DocumentsRenderer';
 export * from './workspaceContext';
+// Explicitly not exporting DocumentsRenderer here because it imports e-teleterm components causing
+// OSS tests to fail.

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
@@ -36,6 +36,15 @@ import AppContext from 'teleterm/ui/appContext';
 
 import { getEmptyPendingAccessRequest } from '../services/workspacesService/accessRequestsService';
 
+// TODO(ravicious): Remove the mock once a separate entry point for e-teleterm is created.
+//
+// Mocking out DocumentsRenderer because it imports an e-teleterm component which breaks CI tests
+// for the OSS version. The tests here don't test the behavior of DocumentsRenderer so the only
+// thing we lose by adding the mock is "smoke tests" of different document kinds.
+jest.mock('teleterm/ui/Documents/DocumentsRenderer', () => ({
+  DocumentsRenderer: ({ children }) => <>{children}</>,
+}));
+
 function getMockDocuments(): Document[] {
   return [
     {

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.tsx
@@ -21,7 +21,7 @@ import { Flex } from 'design';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import * as types from 'teleterm/ui/services/workspacesService/documentsService/types';
 import { Tabs } from 'teleterm/ui/Tabs';
-import { DocumentsRenderer } from 'teleterm/ui/Documents';
+import { DocumentsRenderer } from 'teleterm/ui/Documents/DocumentsRenderer';
 import { IAppContext } from 'teleterm/ui/types';
 import { useKeyboardShortcutFormatters } from 'teleterm/ui/services/keyboardShortcuts';
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
@@ -17,7 +17,7 @@ limitations under the License.
 // @ts-ignore
 import { ResourceKind } from 'e-teleterm/ui/DocumentAccessRequests/NewRequest/useNewRequest';
 
-import { PendingAccessRequest } from '../workspacesService';
+import type { PendingAccessRequest } from '../workspacesService';
 
 export class AccessRequestsService {
   constructor(


### PR DESCRIPTION
They were disabled due to importing e-teleterm components and thus making OSS tests fail.

I wrote tests for `useDocumentTerminal` which also fail for the same reason. In case of `useDocumentTerminal`, I'm not using `DocumentsRenderer` at all. But since one of the imported files imports `WorkspaceContext` through `teleterm/ui/Documents`, it triggers the `DocumentsRenderer` import as well.

To solve this, I temporarily removed `DocumentsRenderer` import from `Documents/index.ts` and mocked out `DocumentsRenderer` in `TabHost` tests.