### PR TITLE
Create a ChannelEventEmitter for testing.

### DIFF
--- a/lib/events/channel.go
+++ b/lib/events/channel.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	apievents "github.com/gravitational/teleport/api/types/events"
+)
+
+var _ apievents.Emitter = &ChannelEmitter{}
+
+// ChannelEmitterConfig is a configuration for channel emitter. This is primarily
+// of interest for testing.
+type ChannelEmitterConfig struct {
+	Channel chan apievents.AuditEvent
+}
+
+// SetDefaults sets config defaults.
+func (c *ChannelEmitterConfig) SetDefaults() {
+	if c.Channel == nil {
+		c.Channel = make(chan apievents.AuditEvent)
+	}
+}
+
+// NewChannelEmitter returns an emitter where events are sent to a configured channel.
+func NewChannelEmitter(cfg ChannelEmitterConfig) *ChannelEmitter {
+	cfg.SetDefaults()
+
+	return &ChannelEmitter{
+		channel: cfg.Channel,
+	}
+}
+
+// ChannelEmitter sends all events to a configured channel.
+type ChannelEmitter struct {
+	channel chan apievents.AuditEvent
+}
+
+// EmitAuditEvent sends the given event to a channel.
+func (c *ChannelEmitter) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+	select {
+	case c.channel <- event:
+	case <-ctx.Done():
+		return trace.BadParameter("context cancelled")
+	}
+	return nil
+}

--- a/lib/events/channel.go
+++ b/lib/events/channel.go
@@ -58,7 +58,7 @@ func (c *ChannelEmitter) EmitAuditEvent(ctx context.Context, event apievents.Aud
 	select {
 	case c.channel <- event:
 	case <-ctx.Done():
-		return trace.BadParameter("context cancelled")
+		return trace.BadParameter("context canceled")
 	}
 	return nil
 }

--- a/lib/events/channel_test.go
+++ b/lib/events/channel_test.go
@@ -72,5 +72,5 @@ func TestChannelEmitter(t *testing.T) {
 
 	cancel()
 	wg.Wait()
-	require.ErrorIs(t, trace.BadParameter("context cancelled"), err)
+	require.ErrorIs(t, trace.BadParameter("context canceled"), err)
 }

--- a/lib/events/channel_test.go
+++ b/lib/events/channel_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/events"
+)
+
+func TestChannelEmitter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	clock := clockwork.NewFakeClock()
+
+	// Use a blocking channel for testing.
+	channel := make(chan events.AuditEvent, 1)
+	t.Cleanup(func() {
+		close(channel)
+	})
+
+	emitter := NewChannelEmitter(ChannelEmitterConfig{
+		Channel: channel,
+	})
+
+	// Make sure the event has been emitted to the channel.
+	expectedEvent := &events.SessionJoin{
+		Metadata: events.Metadata{
+			ID:   "b",
+			Type: SessionJoinEvent,
+			Time: clock.Now().Add(time.Minute).UTC(),
+		},
+		UserMetadata: events.UserMetadata{
+			User: "alice",
+		},
+	}
+	require.NoError(t, emitter.EmitAuditEvent(ctx, expectedEvent))
+
+	emittedEvent := <-channel
+	require.Empty(t, cmp.Diff(expectedEvent, emittedEvent))
+
+	// Make sure the context cancel works.
+	require.NoError(t, emitter.EmitAuditEvent(ctx, expectedEvent))
+	var err error
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		err = emitter.EmitAuditEvent(ctx, expectedEvent)
+		wg.Done()
+	}()
+
+	cancel()
+	wg.Wait()
+	require.ErrorIs(t, trace.BadParameter("context cancelled"), err)
+}


### PR DESCRIPTION
A ChannelEventEmitter has been created to make testing of emitted events easier. Tests will be able to wait on a channel as opposed to needing to set up emitter infra/boilerplate in order to verify events.