### PR TITLE
[v10] Ignore all node_module paths when running shellcheck lint.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -737,7 +737,7 @@ lint-api:
 .PHONY: lint-sh
 lint-sh: SH_LINT_FLAGS ?=
 lint-sh:
-	find . -type f -name '*.sh' | xargs \
+	find . -type f -name '*.sh' -not -path "*/node_modules/*" | xargs \
 		shellcheck \
 		--exclude=SC2086 \
 		$(SH_LINT_FLAGS)


### PR DESCRIPTION
Backport #22195 to branch/v10