### PR TITLE
[v10] Fix Kube impersonation header overwrite when dealing with remote clusters

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1549,7 +1549,7 @@ func setupImpersonationHeaders(log log.FieldLogger, ctx authContext, headers htt
 
 		// Make sure to overwrite the exiting headers, instead of appending to
 		// them.
-		headers[ImpersonateGroupHeader] = nil
+		headers.Del(ImpersonateGroupHeader)
 		for _, group := range impersonateGroups {
 			headers.Add(ImpersonateGroupHeader, group)
 		}

--- a/lib/kube/proxy/roundtrip.go
+++ b/lib/kube/proxy/roundtrip.go
@@ -155,8 +155,8 @@ func (s *SpdyRoundTripper) dial(url *url.URL) (net.Conn, error) {
 // copyImpersonationHeaders copies the impersonation headers from the source
 // request to the destination request.
 func copyImpersonationHeaders(dst, src http.Header) {
-	dst[ImpersonateUserHeader] = nil
-	dst[ImpersonateGroupHeader] = nil
+	dst.Del(ImpersonateUserHeader)
+	dst.Del(ImpersonateGroupHeader)
 
 	for _, v := range src.Values(ImpersonateUserHeader) {
 		dst.Add(ImpersonateUserHeader, v)


### PR DESCRIPTION
Backport of #22240 to branch/v10
