### PR TITLE
Fix SAML IdP service provider CLI bug.

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1007,19 +1007,20 @@ func (l *loginRuleCollection) resources() []types.Resource {
 	return resources
 }
 
-type samlIDPServiceProviderCollection struct {
+//nolint:revive // Because we want this to be IdP.
+type samlIdPServiceProviderCollection struct {
 	serviceProviders []types.SAMLIdPServiceProvider
 }
 
-func (c *samlIDPServiceProviderCollection) resources() []types.Resource {
+func (c *samlIdPServiceProviderCollection) resources() []types.Resource {
 	r := make([]types.Resource, len(c.serviceProviders))
-	for _, resource := range c.serviceProviders {
-		r = append(r, resource)
+	for i, resource := range c.serviceProviders {
+		r[i] = resource
 	}
 	return r
 }
 
-func (c *samlIDPServiceProviderCollection) writeText(w io.Writer) error {
+func (c *samlIdPServiceProviderCollection) writeText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, serviceProvider := range c.serviceProviders {
 		t.AddRow([]string{serviceProvider.GetName()})

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1598,7 +1598,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			return &samlIDPServiceProviderCollection{serviceProviders: []types.SAMLIdPServiceProvider{serviceProvider}}, nil
+			return &samlIdPServiceProviderCollection{serviceProviders: []types.SAMLIdPServiceProvider{serviceProvider}}, nil
 		}
 		var resources []types.SAMLIdPServiceProvider
 		nextKey := ""
@@ -1615,7 +1615,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 				break
 			}
 		}
-		return &samlIDPServiceProviderCollection{serviceProviders: resources}, nil
+		return &samlIdPServiceProviderCollection{serviceProviders: resources}, nil
 	case types.KindDevice:
 		remote := client.DevicesClient()
 		if rc.ref.Name != "" {

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -538,6 +538,52 @@ version: v2`,
 	}
 }
 
+func TestCreateSAMLIdPServiceProvider(t *testing.T) {
+	dynAddr := newDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.authAddr,
+			},
+		},
+	}
+
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+
+	input := `
+kind: saml_idp_service_provider
+version: v1
+metadata:
+  name: test1
+spec:
+  entity_id: IAMShowcase
+  entity_descriptor: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="IAMShowcase" validUntil="2025-12-09T09:13:31.006Z">
+       <md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+          <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+          <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+          <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sptest.iamshowcase.com/acs" index="0" isDefault="true"/>
+       </md:SPSSODescriptor>
+    </md:EntityDescriptor>
+`
+	spYAMLPath := filepath.Join(t.TempDir(), "sp.yaml")
+	require.NoError(t, os.WriteFile(spYAMLPath, []byte(input), 0644))
+
+	_, err := runResourceCommand(t, fileConfig, []string{"create", "-f", spYAMLPath})
+	require.NoError(t, err)
+
+	buf, err := runResourceCommand(t, fileConfig, []string{"get", "saml_sp/test1", "--format=json"})
+	require.NoError(t, err)
+	sps := []*types.SAMLIdPServiceProviderV1{}
+	mustDecodeJSON(t, buf, &sps)
+	require.Equal(t, "IAMShowcase", sps[0].GetEntityID())
+}
+
 func TestUpsertVerb(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
The SAML IdP service provider collections object in the CLI was inadvertently appending to the end of a preallocated array instead of using the array directly.

Some linting issues were additionally addressed.