### PR TITLE
[web]: Fix regression for not able to create or reset users

### DIFF
--- a/web/packages/teleport/src/services/user/makeResetToken.ts
+++ b/web/packages/teleport/src/services/user/makeResetToken.ts
@@ -16,11 +16,12 @@
 
 import { ResetToken } from './types';
 
-export default function makeResetToken(json): ResetToken {
-  const { expires, username, value } = json;
+export function makeResetToken(json): ResetToken {
+  json = json || {};
+  const { expiry, user, tokenId } = json;
   return {
-    username,
-    expires: new Date(expires),
-    value,
+    username: user || '',
+    expires: expiry ? new Date(expiry) : null,
+    value: tokenId || '',
   };
 }

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -232,3 +232,27 @@ test('fetch users, null response values gives empty array', async () => {
     },
   ]);
 });
+
+test('createResetPasswordToken', async () => {
+  // Test null response.
+  jest.spyOn(api, 'post').mockResolvedValue(null);
+  let response = await user.createResetPasswordToken('name', 'invite');
+  expect(response).toStrictEqual({
+    username: '',
+    expires: null,
+    value: '',
+  });
+
+  // Test with a valid response.
+  jest.spyOn(api, 'post').mockResolvedValue({
+    expiry: 1677273148317,
+    user: 'llama',
+    tokenId: 'some-id',
+  });
+  response = await user.createResetPasswordToken('name', 'invite');
+  expect(response).toStrictEqual({
+    username: 'llama',
+    expires: new Date(1677273148317),
+    value: 'some-id',
+  });
+});

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -19,7 +19,7 @@ import cfg from 'teleport/config';
 import session from 'teleport/services/websession';
 
 import makeUserContext from './makeUserContext';
-import makeResetToken from './makeResetToken';
+import { makeResetToken } from './makeResetToken';
 import makeUser, { makeUsers } from './makeUser';
 import { User, UserContext, ResetPasswordType } from './types';
 


### PR DESCRIPTION
#### Description
fix regression resulting from https://github.com/gravitational/teleport/pull/21567, which prevented resetting users and new users from being created

we read the actual json fields backward, so we were not grabbing any values from the api response