### PR TITLE
Remove non-applicable roles from teleport start --roles reference

### DIFF
--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -62,7 +62,7 @@ we recommend using a [configuration file](https://goteleport.com/docs/reference/
 | - | - | - | - |
 | `-d, --debug` | none | none | enable verbose logging to stderr |
 | `--insecure-no-tls` | `false` | `true` or `false` | Tells proxy to not generate default self-signed TLS certificates. This is useful when running Teleport on kubernetes (behind reverse proxy) or behind things like AWS ELBs, GCP LBs or Azure Load Balancers where SSL termination is provided externally. |
-| `-r, --roles` | `proxy`, `node`, `auth`, `app`, `db`, `kube`, `windowsdesktop` | **string** comma-separated list of `proxy, auth, node, db, app` or `windowsdesktop` | start listed services/roles. These roles are explained in the [Core Concepts](../core-concepts.mdx) document. |
+| `-r, --roles` | `proxy`, `node`, `auth` | **string** comma-separated list of `proxy, node, auth, db, or app` | start listed services/roles. These roles are explained in the [Core Concepts](../core-concepts.mdx) document. |
 | `--pid-file` | none | **string** filepath | create a PID file at the path |
 | `--advertise-ip` | none | **string** IP | advertise IP to clients, often used behind NAT |
 | `-l, --listen-ip` | `0.0.0.0` | [**net. IP**](https://golang.org/pkg/net/#IP) | binds services to IP |


### PR DESCRIPTION
Only proxy, node, auth, db, or app are applicable roles.  Windows desktop and kube are not supported roles with `teleport start --roles=...`.   The default roles if none is specified is proxy, node and auth.

  Previously the tokens add would show the command to include these as a role.  That was incorrect and has been corrected.