### PR TITLE
[v11] Add `isDashboard` to web config object (#20830)

### DIFF
--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -55,6 +55,10 @@ type WebConfig struct {
 	TunnelPublicAddress string `json:"tunnelPublicAddress,omitempty"`
 	// RecoveryCodesEnabled is a flag that determines if recovery codes are enabled in the cluster.
 	RecoveryCodesEnabled bool `json:"recoveryCodesEnabled,omitempty"`
+	// IsDashboard is a flag that determines if the cluster is running as a "dashboard".
+	// The web UI for dashboards provides functionality for downloading self-hosted licenses and
+	// Teleport Enterprise binaries.
+	IsDashboard bool `json:"isDashboard,omitempty"`
 }
 
 // WebConfigAuthProvider describes auth. provider

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1284,6 +1284,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		IsCloud:              h.ClusterFeatures.GetCloud(),
 		TunnelPublicAddress:  tunnelPublicAddr,
 		RecoveryCodesEnabled: h.ClusterFeatures.GetRecoveryCodes(),
+		IsDashboard:          isDashboard(h.ClusterFeatures),
 	}
 
 	resource, err := h.cfg.ProxyClient.GetClusterName()
@@ -3715,4 +3716,15 @@ func ssoSetWebSessionAndRedirectURL(w http.ResponseWriter, r *http.Request, resp
 	response.clientRedirectURL = parsedURL.RequestURI()
 
 	return nil
+}
+
+// isDashboard returns a bool indicating if the cluster is a
+// dashboard cluster.
+// Dashboard is a cluster running on cloud infrastructure that
+// isn't a Teleport Cloud cluster
+func isDashboard(features proto.Features) bool {
+	// TODO(matheus): for now, we assume dashboard based on
+	// the presence of recovery codes, which are never enabled
+	// in OSS or self-hosted Teleport.
+	return !features.GetCloud() && features.GetRecoveryCodes()
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -80,6 +80,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
 	authproto "github.com/gravitational/teleport/api/client/proto"
+	clientproto "github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -7614,4 +7615,52 @@ func TestLogout(t *testing.T) {
 	_, err = clt2.Get(ctx, clt2.Endpoint("webapi", "sites"), url.Values{})
 	require.True(t, trace.IsAccessDenied(err))
 	require.ErrorIs(t, err, trace.AccessDenied("need auth"))
+}
+
+func TestGetIsDashboard(t *testing.T) {
+	tt := []struct {
+		name     string
+		features clientproto.Features
+		expected bool
+	}{
+		{
+			name: "not cloud nor recovery codes is not dashboard",
+			features: clientproto.Features{
+				Cloud:         false,
+				RecoveryCodes: false,
+			},
+			expected: false,
+		},
+		{
+			name: "not cloud, with recovery codes is dashboard",
+			features: clientproto.Features{
+				Cloud:         false,
+				RecoveryCodes: true,
+			},
+			expected: true,
+		},
+		{
+			name: "cloud, with recovery codes is not dashboard",
+			features: clientproto.Features{
+				Cloud:         true,
+				RecoveryCodes: true,
+			},
+			expected: false,
+		},
+		{
+			name: "cloud, without recovery codes is not dashboard",
+			features: clientproto.Features{
+				Cloud:         true,
+				RecoveryCodes: false,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isDashboard(tc.features)
+			require.Equal(t, tc.expected, result)
+		})
+	}
 }

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -36,6 +36,7 @@ import type { ParticipantMode } from 'teleport/services/session';
 const cfg = {
   isEnterprise: false,
   isCloud: false,
+  isDashboard: false,
   tunnelPublicAddress: '',
   recoveryCodesEnabled: false,
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/20830 to v11