### PR TITLE
Enable IP pinning enforcement for Kube and DB

### DIFF
--- a/integration/kube/fixtures.go
+++ b/integration/kube/fixtures.go
@@ -38,6 +38,7 @@ const TestImpersonationGroup = "teleport-ci-test-group"
 type ProxyConfig struct {
 	T                   *helpers.TeleInstance
 	Username            string
+	PinnedIP            string
 	KubeUsers           []string
 	KubeGroups          []string
 	Impersonation       *rest.ImpersonationConfig
@@ -96,6 +97,7 @@ func ProxyClient(cfg ProxyConfig) (*kubernetes.Clientset, *rest.Config, error) {
 		KubernetesUsers:  cfg.KubeUsers,
 		KubernetesGroups: cfg.KubeGroups,
 		RouteToCluster:   cfg.RouteToCluster,
+		PinnedIP:         cfg.PinnedIP,
 	}
 	subj, err := id.Subject()
 	if err != nil {

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -317,6 +317,9 @@ func TestALPNSNIProxyKube(t *testing.T) {
 				},
 			},
 		},
+		Options: types.RoleOptions{
+			PinSourceIP: true,
+		},
 	}
 	kubeRole, err := types.NewRole(k8RoleName, kubeRoleSpec)
 	require.NoError(t, err)
@@ -335,6 +338,7 @@ func TestALPNSNIProxyKube(t *testing.T) {
 	k8Client, _, err := kube.ProxyClient(kube.ProxyConfig{
 		T:                   suite.root,
 		Username:            kubeRoleSpec.Allow.Logins[0],
+		PinnedIP:            "127.0.0.1",
 		KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
 		KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
 		CustomTLSServerName: localK8SNI,
@@ -375,6 +379,9 @@ func TestALPNSNIProxyKubeV2Leaf(t *testing.T) {
 				},
 			},
 		},
+		Options: types.RoleOptions{
+			PinSourceIP: true,
+		},
 	}
 	kubeRole, err := types.NewRole(k8RoleName, kubeRoleSpec)
 	require.NoError(t, err)
@@ -402,6 +409,7 @@ func TestALPNSNIProxyKubeV2Leaf(t *testing.T) {
 	k8Client, _, err := kube.ProxyClient(kube.ProxyConfig{
 		T:                   suite.root,
 		Username:            kubeRoleSpec.Allow.Logins[0],
+		PinnedIP:            "127.0.0.1",
 		KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
 		KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
 		CustomTLSServerName: localK8SNI,
@@ -413,6 +421,131 @@ func TestALPNSNIProxyKubeV2Leaf(t *testing.T) {
 	resp, err := k8Client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(resp.Items), "pods item length mismatch")
+}
+
+func TestKubeIPPinning(t *testing.T) {
+	lib.SetInsecureDevMode(true)
+	defer lib.SetInsecureDevMode(false)
+
+	const (
+		kubeCluster = "kube.teleport.cluster.local"
+		k8User      = "alice@example.com"
+		k8RoleName  = "kubemaster"
+	)
+
+	kubeAPIMockSvrRoot := startKubeAPIMock(t)
+	kubeAPIMockSvrLeaf := startKubeAPIMock(t)
+	kubeConfigPathRoot := mustCreateKubeConfigFile(t, k8ClientConfig(kubeAPIMockSvrRoot.URL, kubeCluster))
+	kubeConfigPathLeaf := mustCreateKubeConfigFile(t, k8ClientConfig(kubeAPIMockSvrLeaf.URL, kubeCluster))
+
+	username := helpers.MustGetCurrentUser(t).Username
+	kubeRoleSpec := types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:           []string{username, username + "2", username + "3"},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubeGroups:       []string{kube.TestImpersonationGroup},
+			KubeUsers:        []string{k8User},
+			KubernetesResources: []types.KubernetesResource{
+				{
+					Kind: types.KindKubePod, Name: types.Wildcard, Namespace: types.Wildcard,
+				},
+			},
+		},
+		Options: types.RoleOptions{
+			PinSourceIP: true,
+		},
+	}
+	kubeRole, err := types.NewRole(k8RoleName, kubeRoleSpec)
+	require.NoError(t, err)
+
+	suite := newSuite(t,
+		withRootClusterConfig(rootClusterStandardConfig(t), func(config *service.Config) {
+			config.Proxy.Kube.Enabled = true
+			config.Version = defaults.TeleportConfigVersionV3
+
+			config.Kube.Enabled = true
+			config.Kube.KubeconfigPath = kubeConfigPathRoot
+			config.Kube.ListenAddr = utils.MustParseAddr(
+				helpers.NewListener(t, service.ListenerKube, &config.FileDescriptors))
+		}),
+		withLeafClusterConfig(leafClusterStandardConfig(t), func(config *service.Config) {
+			config.Version = defaults.TeleportConfigVersionV3
+			config.Proxy.Kube.Enabled = true
+
+			config.Kube.Enabled = true
+			config.Kube.KubeconfigPath = kubeConfigPathLeaf
+			config.Kube.ListenAddr = utils.MustParseAddr(
+				helpers.NewListener(t, service.ListenerKube, &config.FileDescriptors))
+		}),
+		withRootClusterRoles(kubeRole),
+		withLeafClusterRoles(kubeRole),
+		withRootAndLeafTrustedClusterReset(),
+		withTrustedCluster(),
+	)
+
+	testCases := []struct {
+		desc           string
+		pinnedIP       string
+		routeToCluster string
+		wantClientErr  string
+	}{
+		{
+			desc:           "root cluster missing pinned IP",
+			routeToCluster: suite.root.Secrets.SiteName,
+			wantClientErr:  "pinned IP is required for the user, but is not present on identity",
+		},
+		{
+			desc:           "root cluster wrong pinned IP",
+			pinnedIP:       "127.0.0.2",
+			routeToCluster: suite.root.Secrets.SiteName,
+			wantClientErr:  "pinned IP doesn't match observed client IP",
+		},
+		{
+			desc:           "root cluster pinned IP",
+			pinnedIP:       "127.0.0.1",
+			routeToCluster: suite.root.Secrets.SiteName,
+		},
+		{
+			desc:           "leaf cluster missing pinned IP",
+			routeToCluster: suite.leaf.Secrets.SiteName,
+			wantClientErr:  "pinned IP is required for the user, but is not present on identity",
+		},
+		{
+			desc:           "leaf cluster wrong pinned IP",
+			pinnedIP:       "127.0.0.2",
+			routeToCluster: suite.leaf.Secrets.SiteName,
+			wantClientErr:  "pinned IP doesn't match observed client IP",
+		},
+		{
+			desc:           "leaf cluster pinned IP",
+			pinnedIP:       "127.0.0.1",
+			routeToCluster: suite.leaf.Secrets.SiteName,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			k8Client, _, err := kube.ProxyClient(kube.ProxyConfig{
+				T:                   suite.root,
+				Username:            kubeRoleSpec.Allow.Logins[0],
+				PinnedIP:            tc.pinnedIP,
+				KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
+				KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
+				CustomTLSServerName: kubeCluster,
+				TargetAddress:       suite.root.Config.Proxy.WebAddr,
+				RouteToCluster:      tc.routeToCluster,
+			})
+			require.NoError(t, err)
+
+			resp, err := k8Client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+			if tc.wantClientErr != "" {
+				require.ErrorContains(t, err, tc.wantClientErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, 1, len(resp.Items), "pods item length mismatch")
+		})
+	}
 }
 
 // TestALPNSNIProxyDatabaseAccess test DB connection forwarded through local SNI ALPN proxy where

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1380,6 +1380,8 @@ type DatabaseTestCertRequest struct {
 	Username string
 	// RouteToDatabase contains database routing information.
 	RouteToDatabase tlsca.RouteToDatabase
+	// PinnedIP is an IP new certificate should be pinned to.
+	PinnedIP string
 }
 
 // GenerateDatabaseTestCert generates a database access certificate for the
@@ -1401,6 +1403,8 @@ func (a *Server) GenerateDatabaseTestCert(req DatabaseTestCertRequest) ([]byte, 
 	certs, err := a.generateUserCert(certRequest{
 		user:      user,
 		publicKey: req.PublicKey,
+		loginIP:   req.PinnedIP,
+		pinIP:     req.PinnedIP != "",
 		checker:   checker,
 		ttl:       time.Hour,
 		traits: map[string][]string{

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -653,6 +653,10 @@ func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// determine authenticated user based on the request parameters
 	ctx := r.Context()
 	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(r.TLS))
+	clientSrcAddr, err := utils.ParseAddr(r.RemoteAddr)
+	if err == nil {
+		ctx = context.WithValue(ctx, ContextClientAddr, clientSrcAddr)
+	}
 	ctx = context.WithValue(ctx, ContextUser, user)
 	a.Handler.ServeHTTP(w, r.WithContext(ctx))
 }
@@ -668,20 +672,52 @@ func (a *Middleware) WrapContextWithUser(ctx context.Context, conn utils.TLSConn
 		}
 	}
 
-	return a.WrapContextWithUserFromTLSConnState(ctx, conn.ConnectionState())
+	return a.WrapContextWithUserFromTLSConnState(ctx, conn.ConnectionState(), conn.RemoteAddr())
 }
 
 // WrapContextWithUserFromTLSConnState enriches the provided context with the identity information
 // extracted from the provided TLS connection state.
-func (a *Middleware) WrapContextWithUserFromTLSConnState(ctx context.Context, tlsState tls.ConnectionState) (context.Context, error) {
+func (a *Middleware) WrapContextWithUserFromTLSConnState(ctx context.Context, tlsState tls.ConnectionState, remoteAddr net.Addr) (context.Context, error) {
 	user, err := a.GetUser(tlsState)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(&tlsState))
+	ctx = context.WithValue(ctx, ContextClientAddr, remoteAddr)
 	ctx = context.WithValue(ctx, ContextUser, user)
 	return ctx, nil
+}
+
+// CheckIPPinning verifies IP pinning for the identity, using the client ip taken from context.
+// Check is considered successful if no error is returned.
+func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bool) error {
+	if identity.PinnedIP == "" {
+		if pinSourceIP {
+			return trace.AccessDenied("pinned IP is required for the user, but is not present on identity")
+		}
+		return nil
+	}
+
+	clientSrcAddr, ok := ctx.Value(ContextClientAddr).(net.Addr)
+	if !ok {
+		return trace.BadParameter("missing observed client IP while checking IP pinning")
+	}
+
+	clientIP, _, err := net.SplitHostPort(clientSrcAddr.String())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if clientIP != identity.PinnedIP {
+		log.WithFields(logrus.Fields{
+			"client_ip": clientIP,
+			"pinned_ip": identity.PinnedIP,
+		}).Debug("Pinned IP and client IP mismatch")
+		return trace.AccessDenied("pinned IP doesn't match observed client IP")
+	}
+
+	return nil
 }
 
 // ClientCertPool returns trusted x509 certificate authority pool with CAs provided as caTypes.

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"net"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestMiddlewareGetUser(t *testing.T) {
@@ -206,17 +208,86 @@ func TestMiddlewareGetUser(t *testing.T) {
 	}
 }
 
+func TestCheckIPPinning(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		clientAddr string
+		pinnedIP   string
+		pinIP      bool
+		wantErr    string
+	}{
+		{
+			desc:       "no IP pinning",
+			clientAddr: "127.0.0.1:444",
+			pinnedIP:   "",
+			pinIP:      false,
+		},
+		{
+			desc:       "IP pinning, no pinned IP",
+			clientAddr: "127.0.0.1:444",
+			pinnedIP:   "",
+			pinIP:      true,
+			wantErr:    "pinned IP is required for the user, but is not present on identity",
+		},
+		{
+			desc:       "Pinned IP doesn't match",
+			clientAddr: "127.0.0.1:444",
+			pinnedIP:   "127.0.0.2",
+			pinIP:      true,
+			wantErr:    "pinned IP doesn't match observed client IP",
+		},
+		{
+			desc:       "Role doesn't require IP pinning now, but old certificate still pinned",
+			clientAddr: "127.0.0.1:444",
+			pinnedIP:   "127.0.0.2",
+			pinIP:      false,
+			wantErr:    "pinned IP doesn't match observed client IP",
+		},
+		{
+			desc:     "IP pinning enabled, missing client IP",
+			pinnedIP: "127.0.0.1",
+			pinIP:    true,
+			wantErr:  "missing observed client IP while checking IP pinning",
+		},
+		{
+			desc:       "correct IP pinning",
+			clientAddr: "127.0.0.1:444",
+			pinnedIP:   "127.0.0.1",
+			pinIP:      true,
+		},
+	}
+
+	for _, tt := range testCases {
+		ctx := context.Background()
+		if tt.clientAddr != "" {
+			ctx = context.WithValue(ctx, ContextClientAddr, utils.MustParseAddr(tt.clientAddr))
+		}
+		identity := tlsca.Identity{PinnedIP: tt.pinnedIP}
+
+		err := CheckIPPinning(ctx, identity, tt.pinIP)
+
+		if tt.wantErr != "" {
+			require.ErrorContains(t, err, tt.wantErr)
+		} else {
+			require.NoError(t, err)
+		}
+
+	}
+}
+
 // testConn is a connection that implements utils.TLSConn for testing WrapContextWithUser.
 type testConn struct {
 	tls.Conn
 
 	state           tls.ConnectionState
 	handshakeCalled bool
+	remoteAddr      net.Addr
 }
 
 func (t *testConn) ConnectionState() tls.ConnectionState   { return t.state }
 func (t *testConn) Handshake() error                       { t.handshakeCalled = true; return nil }
 func (t *testConn) HandshakeContext(context.Context) error { return t.Handshake() }
+func (t *testConn) RemoteAddr() net.Addr                   { return t.remoteAddr }
 
 func TestWrapContextWithUser(t *testing.T) {
 	localClusterName := "local"
@@ -282,6 +353,7 @@ func TestWrapContextWithUser(t *testing.T) {
 			conn := &testConn{
 				state: tls.ConnectionState{PeerCertificates: tt.peers,
 					HandshakeComplete: !tt.needsHandshake},
+				remoteAddr: utils.MustParseAddr("127.0.0.1:4242"),
 			}
 
 			parentCtx := context.Background()

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -348,7 +348,11 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 		RouteToDatabase:   u.Identity.RouteToDatabase,
 		MFAVerified:       u.Identity.MFAVerified,
 		LoginIP:           u.Identity.LoginIP,
+		PinnedIP:          u.Identity.PinnedIP,
 		PrivateKeyPolicy:  u.Identity.PrivateKeyPolicy,
+	}
+	if checker.PinSourceIP() && identity.PinnedIP == "" {
+		return nil, trace.AccessDenied("pinned IP is required for the user, but is not present on identity")
 	}
 
 	return &Context{

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -199,6 +199,9 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 			ReadHeaderTimeout: apidefaults.DefaultDialTimeout * 2,
 			TLSConfig:         cfg.TLS,
 			ConnState:         ingress.HTTPConnStateReporter(ingress.Kube, cfg.IngressReporter),
+			ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+				return utils.ClientAddrContext(ctx, c.RemoteAddr(), c.LocalAddr())
+			},
 		},
 		heartbeats: make(map[string]*srv.Heartbeat),
 		monitoredKubeClusters: monitoredKubeClusters{
@@ -215,6 +218,9 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 
 // Serve takes TCP listener, upgrades to TLS using config and starts serving
 func (t *TLSServer) Serve(listener net.Listener) error {
+	caGetter := func(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
+		return t.CachingAuthClient.GetCertAuthority(ctx, id, loadKeys)
+	}
 	// Wrap listener with a multiplexer to get Proxy Protocol support.
 	mux, err := multiplexer.New(multiplexer.Config{
 		Context:                     t.Context,
@@ -222,6 +228,8 @@ func (t *TLSServer) Serve(listener net.Listener) error {
 		Clock:                       t.Clock,
 		EnableExternalProxyProtocol: true,
 		ID:                          t.Component,
+		CertAuthorityGetter:         caGetter,
+		LocalClusterName:            t.ClusterName,
 		// Increases deadline until the agent receives the first byte to 10s.
 		// It's required to accommodate setups with high latency and where the time
 		// between the TCP being accepted and the time for the first byte is longer

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -287,7 +287,8 @@ func (s *localSite) DialTCP(params DialParams) (net.Conn, error) {
 	}
 	s.log.Debugf("Succeeded dialing %v.", params)
 
-	if err := s.maybeSendSignedPROXYHeader(params, conn, useTunnel, true); err != nil {
+	isKubeOrDB := params.ConnType == types.KubeTunnel || params.ConnType == types.DatabaseTunnel
+	if err := s.maybeSendSignedPROXYHeader(params, conn, useTunnel, !isKubeOrDB); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3921,6 +3921,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				KubeServiceType:               kubeServiceType,
 				LockWatcher:                   lockWatcher,
 				CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
+				PROXYSigner:                   proxySigner,
 			},
 			TLS:             tlsConfig,
 			LimiterConfig:   cfg.Proxy.Limiter,

--- a/lib/srv/db/common/test.go
+++ b/lib/srv/db/common/test.go
@@ -159,6 +159,8 @@ type TestClientConfig struct {
 	Cluster string
 	// Username is the Teleport user name.
 	Username string
+	// PinnedIP is an IP client's certificate should be pinned to.
+	PinnedIP string
 	// RouteToDatabase contains database routing information.
 	RouteToDatabase tlsca.RouteToDatabase
 }
@@ -176,6 +178,7 @@ func MakeTestClientTLSCert(config TestClientConfig) (*tls.Certificate, error) {
 		Cluster:         config.Cluster,
 		Username:        config.Username,
 		RouteToDatabase: config.RouteToDatabase,
+		PinnedIP:        config.PinnedIP,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -609,6 +609,12 @@ func (s *ProxyServer) Authorize(ctx context.Context, tlsConn utils.TLSConn, para
 		return nil, trace.Wrap(err)
 	}
 	identity := authContext.Identity.GetIdentity()
+
+	// TODO(anton): Move this into authorizer.Authorize when we can enable it for all protocols
+	if err := auth.CheckIPPinning(ctx, identity, authContext.Checker.PinSourceIP()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	if params.User != "" {
 		identity.RouteToDatabase.Username = params.User
 	}

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -1007,6 +1007,12 @@ func (s *Server) authorize(ctx context.Context) (*common.Session, error) {
 	}
 	identity := authContext.Identity.GetIdentity()
 	s.log.Debugf("Client identity: %#v.", identity)
+
+	// TODO(anton): Move this into authorizer.Authorize when we can enable it for all protocols
+	if err := auth.CheckIPPinning(ctx, identity, authContext.Checker.PinSourceIP()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Fetch the requested database server.
 	var database types.Database
 	registeredDatabases := s.getProxiedDatabases()

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7532,6 +7532,11 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 		component = teleport.ComponentKube
 	}
 
+	proxySigner := &mockPROXYSigner{}
+	if cfg.serviceType == kubeproxy.KubeService {
+		proxySigner = nil
+	}
+
 	kubeServer, err := kubeproxy.NewTLSServer(kubeproxy.TLSServerConfig{
 		ForwarderConfig: kubeproxy.ForwarderConfig{
 			Namespace:         apidefaults.Namespace,
@@ -7549,6 +7554,7 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 			Component:         component,
 			LockWatcher:       proxyLockWatcher,
 			ReverseTunnelSrv:  cfg.revTunnel,
+			PROXYSigner:       proxySigner,
 			// skip Impersonation validation
 			CheckImpersonationPermissions: func(ctx context.Context, clusterName string, sarClient authztypes.SelfSubjectAccessReviewInterface) error {
 				return nil
@@ -7856,6 +7862,14 @@ func TestForwardingTraces(t *testing.T) {
 			tt.assertion(t, clt.spans, err, recorder.Code)
 		})
 	}
+}
+
+type mockPROXYSigner struct {
+}
+
+func (m *mockPROXYSigner) SignPROXYHeader(source, destination net.Addr) ([]byte, error) {
+	return nil, nil
+
 }
 
 type mockTraceClient struct {


### PR DESCRIPTION
This PR enables enforcement of IP pinning for Kube and DB services (as part of https://github.com/gravitational/teleport/issues/22061).
Should be merged after #21080 .
I've included both Kube and DB in one PR since they share checking function and actual functionality changes are not that large, only ~150 lines, most of the changes are tests.