### PR TITLE
(v10) Updates to enable merge queue

### DIFF
--- a/.github/workflows/check-merge-queue.yaml
+++ b/.github/workflows/check-merge-queue.yaml
@@ -1,0 +1,25 @@
+# This check runs only on PRs that are in the merge queue.
+#
+# PRs in the merge queue have already been approved but the reviewers check
+# is still required so this workflow allows the required check to succeed,
+# otherwise PRs in the merge queue would be blocked indefinitely.
+#
+# See "Handling skipped but required checks" for more info:
+#
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Note both workflows must have the same name.
+name: Check
+on:
+  merge_group:
+
+jobs:
+  test:
+    name: Checking reviewers
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: none
+
+    steps:
+      - run: 'echo "Skipping reviewers check in merge queue"'

--- a/.github/workflows/lint-ui-bypass.yaml
+++ b/.github/workflows/lint-ui-bypass.yaml
@@ -15,6 +15,9 @@ on:
   pull_request:
     paths-ignore:
       - 'web/**'
+  merge_group:
+    paths-ignore:
+      - 'web/**'
 
 jobs:
   lint:

--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -8,6 +8,9 @@ on:
   pull_request:
     paths:
       - 'web/**'
+  merge_group:
+    paths:
+      - 'web/**'
 
 jobs:
   lint:

--- a/.github/workflows/unit-tests-ui-bypass.yaml
+++ b/.github/workflows/unit-tests-ui-bypass.yaml
@@ -15,6 +15,9 @@ on:
   pull_request:
     paths-ignore:
       - 'web/**'
+  merge_group:
+    paths-ignore:
+      - 'web/**'
 
 jobs:
   lint:

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -8,6 +8,9 @@ on:
   pull_request:
     paths:
       - 'web/**'
+  merge_group:
+    paths:
+      - 'web/**'
 
 jobs:
   test:


### PR DESCRIPTION
This should be the final set of updates to GHA checks before we can enable merge queue on `branch/v10`:
- Add merge_group trigger to web UI checks
- Add bypass merge_group workflow for the reviewers check