### PR TITLE
Use developer-friendly and precise technical language in docs

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -10,7 +10,7 @@ Teleport is an identity-native infrastructure access platform. With Teleport you
 
 - Replace a mix of vaults, passwords, API keys and tokens with short-lived SSH and X.509 certs.
 - Have a single access point and Single-Sign-On for all of your infrastructure - SSH servers, Kubernetes clusters, databases, desktops, web applications, and more.
-- Write policies with Terraform or K8s CRDs for all clouds, environments and protocols and apply them with PR flow.
+- Write policies with Terraform or Kubernetes resources for all clouds, environments and protocols and apply them with PR flow.
 - Record SSH and `kube exec` sessions, DB queries, Desktop recordings, web services and apps.
 - Use mutual TLS tunnels to protect your infrastructure endpoints.
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -9,7 +9,7 @@ videoBanner: fSgCnQrNu78
 Teleport is an identity-native infrastructure access platform. With Teleport you can:
 
 - Replace a mix of vaults, passwords, API keys and tokens with short-lived SSH and X.509 certs.
-- Have a single access point and Single-Sign-On for all your infrastructure - SSH, Kubernetes, databases, desktops, web applications, and more.
+- Have a single access point and Single-Sign-On for all of your infrastructure - SSH servers, Kubernetes clusters, databases, desktops, web applications, and more.
 - Write policies with Terraform or K8s CRDs for all clouds, environments and protocols and apply them with PR flow.
 - Record SSH and `kube exec` sessions, DB queries, Desktop recordings, web services and apps.
 - Use mutual TLS tunnels to protect your infrastructure endpoints.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -6,12 +6,14 @@ layout: tocless-doc
 videoBanner: fSgCnQrNu78
 ---
 
-Teleport is an identity-native infrastructure access platform. With Teleport you can:
+Teleport is an identity-aware, multi-protocol access proxy which understands SSH, HTTPS, RDP, Kubernetes API, MySQL, MongoDB and PostgreSQL wire protocols and many others.
+
+With Teleport you can:
 
 - Replace a mix of vaults, passwords, API keys and tokens with short-lived SSH and X.509 certs.
 - Have a single access point and Single-Sign-On for all of your infrastructure - SSH servers, Kubernetes clusters, databases, desktops, web applications, and more.
-- Write policies with Terraform or Kubernetes resources for all clouds, environments and protocols and apply them with PR flow.
-- Record SSH and `kube exec` sessions, DB queries, Desktop recordings, web services and apps.
+- Write policies with Terraform or Kubernetes resources for all clouds, environments and protocols and manage them with GitOps.
+- Record SSH and `kubectl exec` sessions, DB queries, Windows desktop sessions, web sessions and API requests.
 - Use mutual TLS tunnels to protect your infrastructure endpoints.
 
 ## Try out Teleport

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -8,11 +8,11 @@ videoBanner: fSgCnQrNu78
 
 Teleport is an identity-native infrastructure access platform. With Teleport you can:
 
-- Replace insecure secrets with true identity.
-- Have a single access solution for SSH, Kubernetes, databases, desktops, web applications, and more.
-- Define RBAC for every component of your infrastructure.
-- Gather audit events and session recordings to understand how users are interacting with your infrastructure.
-- Automatically onboard and offboard users with integrations such as Okta, GitHub, and Google Workspace.
+- Replace a mix of shared passwords, API keys and shared tokens with short-lived SSH and X.509 certs.
+- Have a single access point and Single-Sign-On for all infrastructure - SSH, Kubernetes, databases, desktops, web applications, and more.
+- Write policies with Terraform or K8s CRDs for all clouds, environments and protocols.
+- Record SSH and `kube exec` sessions, DB queries, Desktop recordings and web services and applications.
+- Never expose your infrastructure resources on the public internet.
 
 ## Try out Teleport
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -8,11 +8,11 @@ videoBanner: fSgCnQrNu78
 
 Teleport is an identity-native infrastructure access platform. With Teleport you can:
 
-- Replace a mix of shared passwords, API keys and shared tokens with short-lived SSH and X.509 certs.
-- Have a single access point and Single-Sign-On for all infrastructure - SSH, Kubernetes, databases, desktops, web applications, and more.
-- Write policies with Terraform or K8s CRDs for all clouds, environments and protocols.
-- Record SSH and `kube exec` sessions, DB queries, Desktop recordings and web services and applications.
-- Never expose your infrastructure resources on the public internet.
+- Replace a mix of vaults, passwords, API keys and tokens with short-lived SSH and X.509 certs.
+- Have a single access point and Single-Sign-On for all your infrastructure - SSH, Kubernetes, databases, desktops, web applications, and more.
+- Write policies with Terraform or K8s CRDs for all clouds, environments and protocols and apply them with PR flow.
+- Record SSH and `kube exec` sessions, DB queries, Desktop recordings, web services and apps.
+- Use mutual TLS tunnels to protect your infrastructure endpoints.
 
 ## Try out Teleport
 


### PR DESCRIPTION
Hi Team,

While it's true that we should use unified vocabulary (similar naming of products) on the marketing website and docs, it's also true that on our developer documentation we should use crisp, precise developer language without marketing happy talk.

For example,

"Insecure secrets with true identity" is OK for enterprise website, but for engineers this creates a lot of questions.

Instead, be very specific - "Replace shared secrets with X.509 and SSH short-lived certs" is very specific, practical and avoids qualifiers like "insecure" without explaining why they are insecure.

