### PR TITLE
Add delay for the test when expired token is deleted in background

### DIFF
--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -77,6 +77,7 @@ func TestAuth_RegisterUsingToken(t *testing.T) {
 		certsAssertion func(*proto.Certs)
 		errorAssertion func(error) bool
 		clock          clockwork.Clock
+		delay          time.Duration // Expired tokens are deleted in background, might need slight delay in relevant test
 	}{
 		{
 			desc:           "reject empty",
@@ -238,6 +239,7 @@ func TestAuth_RegisterUsingToken(t *testing.T) {
 			},
 			clock:          clockwork.NewRealClock(),
 			errorAssertion: trace.IsAccessDenied,
+			delay:          time.Millisecond * 100,
 		},
 	}
 
@@ -247,6 +249,7 @@ func TestAuth_RegisterUsingToken(t *testing.T) {
 				tc.clock = clockwork.NewRealClock()
 			}
 			a.SetClock(tc.clock)
+			time.Sleep(tc.delay)
 			certs, err := a.RegisterUsingToken(ctx, tc.req)
 			if tc.errorAssertion != nil {
 				require.True(t, tc.errorAssertion(err))


### PR DESCRIPTION
Last test case relied on expired token to be deleted by previous test case. But deletion of expired tokens was recently changed to happen in background, so there was now race condition. There's still possibility for race condition, but probably 100ms will be enough in vast majority of cases, at least this change was in master for two weeks without any delay and didn't cause any massive unit tests fails (I caught a fail in CI though and it is failing consistently in local).