### PR TITLE
[v12] docs: use approved terminology for desktop access w/ local users

### DIFF
--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -13,8 +13,8 @@ Starting with Teleport 10.2.6, you can install Active Directory and configure
 Teleport Desktop Access through the web UI. See [Desktop Access with Active
 Directory](active-directory.mdx) for more information.
 
-Teleport Enterprise users can configure Windows Access without Active Directory
-integration by following [Getting Started with Windows Access](getting-started.mdx).
+Teleport Enterprise users can configure Windows Access for local users by
+following [Getting Started with Windows Access](getting-started.mdx).
 
 Continue with this guide if:
 
@@ -333,7 +333,7 @@ Computer Configuration > Policies > Administrative Templates > Windows Component
 Select:
 
 ```text
-Computer Configuration > Administrative Templates > Windows Components > Remote Desktop Services > Remote Desktop Session Host > Security > "Always prompt for password upon connection" 
+Computer Configuration > Administrative Templates > Windows Components > Remote Desktop Services > Remote Desktop Session Host > Security > "Always prompt for password upon connection"
 ```
 
 Set to `Disabled` and click `OK`.
@@ -524,7 +524,7 @@ auth_service:
 proxy_service:
   enabled: no
 ssh_service:
-  enabled: no    
+  enabled: no
 ```
 </TabItem>
 <TabItem scope={["cloud"]} label="Cloud">
@@ -565,7 +565,7 @@ auth_service:
 proxy_service:
   enabled: no
 ssh_service:
-  enabled: no    
+  enabled: no
 ```
 </TabItem>
 </Tabs>
@@ -581,7 +581,7 @@ sudo teleport start -c /etc/teleport.yaml
 ### Create a Teleport user/role for Windows Desktop Access
 
 In order to gain access to a remote desktop, a Teleport user needs to have the
-appropriate permissions for that desktop. 
+appropriate permissions for that desktop.
 
 For example, you can create a role that gives its users access to all Windows
 desktop labels and the `"Administrator"` user. To do so, create a file called

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -1,13 +1,14 @@
 ---
 title: Getting Started with Desktop Access
-description: Access Windows systems through Teleport using passwordless authentication.
+description: Passwordless access to Windows systems for local users
+videoBanner: 9DyKQbg4ORc
 ---
 
 This guide will help you configure Teleport to provide secure, passwordless access
 to Windows desktops. This configuration does not require an Active Directory domain.
 
 <Admonition type="note">
-Windows Access without Active Directory is an Enterprise only feature.
+Passwordless access for local users is an Enterprise-only feature.
 
 For open source Teleport, consider integrating Teleport with Active Directory
 for automatic discovery by reading [Desktop Access with Active Directory](./active-directory.mdx).
@@ -23,13 +24,13 @@ with the static host definitions described below.
   scopeOnly={true}
   min="12.0"
 >
-Windows Access without Active Directory is available starting from Teleport `v12`.
+Passwordless access for local users is available starting from Teleport `v12`.
 Previous versions of Teleport can implement Windows Access by integrating with
 an [Active Directory domain](./active-directory.mdx).
 </Details>
 
 <Admonition type="warning">
-Teleport Desktop Access is not yet compatible with Windows Server 2022.
+Passwordless access for local users is not yet compatible with Windows Server 2022.
 </Admonition>
 
 ## Prerequisites
@@ -123,7 +124,8 @@ ssh_service:
 Note that without Active Directory, Teleport cannot automatically discover your
 Desktops. Instead you must define the Windows systems configured for access through
 Teleport in your config file, or use Teleport's [API](../api/introduction.mdx)
-to build your own integration.
+to build your own integration. An example API integration is available on
+[GitHub](https://github.com/gravitational/teleport/tree/master/examples/desktop-registration).
 
 <Details title="Add labels to hosts">
 You can attach labels to your Windows hosts by matching to their hostnames.
@@ -132,7 +134,7 @@ For example, to add the `cloud: ec2` label to hosts with EC2 private IP DNS name
 ```diff
 version: v3
 teleport:
-  nodename: example.teleport.com
+  nodename: windows.teleport.example.com
   proxy_server: teleport-proxy.example.com:443
 windows_desktop_service:
   enabled: yes

--- a/docs/pages/desktop-access/introduction.mdx
+++ b/docs/pages/desktop-access/introduction.mdx
@@ -22,14 +22,14 @@ Desktop Access, you get:
 | Teleport Version              | Windows Desktop                                           | Active Directory |
 |-------------------------------|-----------------------------------------------------------|------------------|
 | Open source Teleport          | Windows Server 2012 R2 / Windows 10 or newer              | Required         |
-| Cloud and Enterprise Teleport | Windows Server 2012 R2 / Windows 10 or newer | Optional         |
+| Cloud and Enterprise Teleport | Windows Server 2012 R2 / Windows 10 or newer              | Optional         |
 
 </Admonition>
 
 ## Getting started
 
-- [Getting started](./getting-started.mdx): Connect any Windows system to Teleport Cloud or Enterprise.
-- [Active Directory](./active-directory.mdx): Connect an Active Directory domain to Teleport.
+- [Local users](./getting-started.mdx): Use Teleport Cloud or Enterprise to connect to Windows systems with local users.
+- [Active Directory](./active-directory.mdx): Use Teleport to connect to Windows systems with Active Directory users.
 
 ## Resources
 


### PR DESCRIPTION
Backports #22403 