### PR TITLE
[v11] sshserver: Correctly handle PuTTY winadj channel requests

### DIFF
--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1061,10 +1061,6 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			}
 			return nil
 		case sshutils.PuTTYWinadjRequest:
-			// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
-			// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
-			// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
-			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
 			return s.handlePuTTYWinadj(ch, req)
 		default:
 			return trace.AccessDenied("attempted %v request in join-only mode", req.Type)
@@ -1100,10 +1096,6 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		}
 		return nil
 	case sshutils.PuTTYWinadjRequest:
-		// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
-		// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
-		// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
-		// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
 		return s.handlePuTTYWinadj(ch, req)
 	default:
 		return trace.BadParameter(
@@ -1314,9 +1306,13 @@ func parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext) (*remoteSub
 }
 
 // handlePuTTYWinadj replies with failure to a PuTTY winadj request as required.
-// it returns an error if the reply fails.
+// it returns an error if the reply fails. context from the PuTTY documentation:
+// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
+// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
+// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
+// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
 func (s *Server) handlePuTTYWinadj(ch ssh.Channel, req *ssh.Request) error {
-	if err := req.Reply(false, []byte{}); err != nil {
+	if err := req.Reply(false, nil); err != nil {
 		s.log.Warnf("Failed to reply to %q request: %v", req.Type, err)
 		return err
 	}

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1001,7 +1001,7 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 			// dispatch returns an additional bool which indicates whether the reply has already been handled inside
 			// the dispatch function itself. if this is set to true, we avoid sending a second response in violation
 			// of the SSH protocol specification.
-			err, replyAlreadyHandled := s.dispatch(ctx, ch, req, scx)
+			replyAlreadyHandled, err := s.dispatch(ctx, ch, req, scx)
 			if err != nil {
 				s.replyError(ch, req, err)
 				span.End()
@@ -1030,7 +1030,7 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 	}
 }
 
-func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request, scx *srv.ServerContext) (err error, replyHandled bool) {
+func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request, scx *srv.ServerContext) (replyHandled bool, err error) {
 	scx.Debugf("Handling request %v, want reply %v.", req.Type, req.WantReply)
 
 	// Certs with a join-only principal can only use a
@@ -1038,20 +1038,20 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 	if scx.JoinOnly {
 		switch req.Type {
 		case tracessh.TracingRequest:
-			return s.handleTracingRequest(ctx, req, scx), false
+			return false, s.handleTracingRequest(ctx, req, scx)
 		case sshutils.PTYRequest:
-			return s.termHandlers.HandlePTYReq(ctx, ch, req, scx), false
+			return false, s.termHandlers.HandlePTYReq(ctx, ch, req, scx)
 		case sshutils.ShellRequest:
-			return s.termHandlers.HandleShell(ctx, ch, req, scx), false
+			return false, s.termHandlers.HandleShell(ctx, ch, req, scx)
 		case sshutils.WindowChangeRequest:
-			return s.termHandlers.HandleWinChange(ctx, ch, req, scx), false
+			return false, s.termHandlers.HandleWinChange(ctx, ch, req, scx)
 		case teleport.ForceTerminateRequest:
-			return s.termHandlers.HandleForceTerminate(ch, req, scx), false
+			return false, s.termHandlers.HandleForceTerminate(ch, req, scx)
 		case sshutils.EnvRequest:
 			// We ignore all SSH setenv requests for join-only principals.
 			// SSH will send them anyway but it seems fine to silently drop them.
 		case sshutils.SubsystemRequest:
-			return s.handleSubsystem(ctx, ch, req, scx), false
+			return false, s.handleSubsystem(ctx, ch, req, scx)
 		case sshutils.AgentForwardRequest:
 			// to maintain interoperability with OpenSSH, agent forwarding requests
 			// should never fail, all errors should be logged and we should continue
@@ -1060,31 +1060,31 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			if err != nil {
 				s.log.Debug(err)
 			}
-			return nil, false
+			return false, nil
 		default:
-			return trace.AccessDenied("attempted %v request in join-only mode", req.Type), false
+			return false, trace.AccessDenied("attempted %v request in join-only mode", req.Type)
 		}
 	}
 
 	switch req.Type {
 	case tracessh.TracingRequest:
-		return s.handleTracingRequest(ctx, req, scx), false
+		return false, s.handleTracingRequest(ctx, req, scx)
 	case sshutils.ExecRequest:
-		return s.termHandlers.HandleExec(ctx, ch, req, scx), false
+		return false, s.termHandlers.HandleExec(ctx, ch, req, scx)
 	case sshutils.PTYRequest:
-		return s.termHandlers.HandlePTYReq(ctx, ch, req, scx), false
+		return false, s.termHandlers.HandlePTYReq(ctx, ch, req, scx)
 	case sshutils.ShellRequest:
-		return s.termHandlers.HandleShell(ctx, ch, req, scx), false
+		return false, s.termHandlers.HandleShell(ctx, ch, req, scx)
 	case sshutils.WindowChangeRequest:
-		return s.termHandlers.HandleWinChange(ctx, ch, req, scx), false
+		return false, s.termHandlers.HandleWinChange(ctx, ch, req, scx)
 	case teleport.ForceTerminateRequest:
-		return s.termHandlers.HandleForceTerminate(ch, req, scx), false
+		return false, s.termHandlers.HandleForceTerminate(ch, req, scx)
 	case sshutils.EnvRequest:
-		return s.handleEnv(ctx, ch, req, scx), false
+		return false, s.handleEnv(ctx, ch, req, scx)
 	case sshutils.SubsystemRequest:
-		return s.handleSubsystem(ctx, ch, req, scx), false
+		return false, s.handleSubsystem(ctx, ch, req, scx)
 	case sshutils.X11ForwardRequest:
-		return s.handleX11Forward(ctx, ch, req, scx), false
+		return false, s.handleX11Forward(ctx, ch, req, scx)
 	case sshutils.AgentForwardRequest:
 		// to maintain interoperability with OpenSSH, agent forwarding requests
 		// should never fail, all errors should be logged and we should continue
@@ -1093,16 +1093,16 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		if err != nil {
 			s.log.Debug(err)
 		}
-		return nil, false
+		return false, nil
 	case sshutils.PuTTYWinadjRequest:
 		// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
 		// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
 		// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
 		// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
-		return s.handlePuTTYWinadj(ch, req), true
+		return true, s.handlePuTTYWinadj(ch, req)
 	default:
-		return trace.BadParameter(
-			"%v doesn't support request type '%v'", s.Component(), req.Type), false
+		return false, trace.BadParameter(
+			"%v doesn't support request type '%v'", s.Component(), req.Type)
 	}
 }
 

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1000,7 +1000,7 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 
 			// dispatch returns an additional bool which indicates whether the reply has already been handled inside
 			// the dispatch function itself. if this is set to true, we avoid sending a second response in violation
-			// of the SSH protocol specifcation.
+			// of the SSH protocol specification.
 			err, replyAlreadyHandled := s.dispatch(ctx, ch, req, scx)
 			if err != nil {
 				s.replyError(ch, req, err)

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1320,7 +1320,7 @@ func (s *Server) handlePuTTYWinadj(ch ssh.Channel, req *ssh.Request) error {
 		s.log.Warnf("Failed to reply to %q request: %v", req.Type, err)
 		return err
 	}
-	// the reply has been handled inside this function (rather than relying on the standard behaviour
+	// the reply has been handled inside this function (rather than relying on the standard behavior
 	// of leaving handleSessionRequests to do it) so set the WantReply flag to false here.
 	req.WantReply = false
 	return nil

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -2074,7 +2074,7 @@ func rejectChannel(ch ssh.NewChannel, reason ssh.RejectionReason, msg string) {
 // handlePuTTYWinadj replies with failure to a PuTTY winadj request as required.
 // it returns an error if the reply fails.
 func (s *Server) handlePuTTYWinadj(ch ssh.Channel, req *ssh.Request) error {
-	if err := req.Reply(false, []byte{}); err != nil {
+	if err := req.Reply(false, nil); err != nil {
 		s.Logger.Warnf("Failed to reply to %q request: %v", req.Type, err)
 		return err
 	}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -2077,7 +2077,7 @@ func (s *Server) handlePuTTYWinadj(ch ssh.Channel, req *ssh.Request) error {
 		s.Logger.Warnf("Failed to reply to %q request: %v", req.Type, err)
 		return err
 	}
-	// the reply has been handled inside this function (rather than relying on the standard behaviour
+	// the reply has been handled inside this function (rather than relying on the standard behavior
 	// of leaving handleSessionRequests to do it) so set the WantReply flag to false here.
 	req.WantReply = false
 	return nil

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1498,11 +1498,11 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 					semconv.RPCSystemKey.String("ssh"),
 				),
 			)
-
-			if err := s.dispatch(ctx, ch, req, scx); err != nil {
-				// a trace.NotImplemented error here indicates that a reply to the request was already handled inside
-				// the dispatch method, so we set the wantReply flag to false to avoid sending a second reply below.
-				if trace.IsNotImplemented(err) {
+			if err, replyAlreadyHandled := s.dispatch(ctx, ch, req, scx); err != nil {
+				// dispatch returns a boolean which indicates whether the reply has already been handled inside the dispatch function
+				// itself. if this is set to true, we set the wantReply flag to false so we don't send two responses in violation of
+				// the SSH protocol spec (which PuTTY is very fussy about)
+				if replyAlreadyHandled {
 					req.WantReply = false
 				} else {
 					s.replyError(ch, req, err)
@@ -1536,7 +1536,7 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 
 // dispatch receives an SSH request for a subsystem and dispatches the request to the
 // appropriate subsystem implementation
-func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) error {
+func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) (err error, replyHandled bool) {
 	serverContext.Debugf("Handling request %v, want reply %v.", req.Type, req.WantReply)
 
 	// If this SSH server is configured to only proxy, we do not support anything
@@ -1544,12 +1544,12 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 	if s.proxyMode {
 		switch req.Type {
 		case tracessh.TracingRequest:
-			return nil
+			return nil, false
 		case sshutils.SubsystemRequest:
-			return s.handleSubsystem(ctx, ch, req, serverContext)
+			return s.handleSubsystem(ctx, ch, req, serverContext), false
 		case sshutils.EnvRequest:
 			// we currently ignore setting any environment variables via SSH for security purposes
-			return s.handleEnv(ch, req, serverContext)
+			return s.handleEnv(ch, req, serverContext), false
 		case sshutils.AgentForwardRequest:
 			// process agent forwarding, but we will only forward agent to proxy in
 			// recording proxy mode.
@@ -1557,17 +1557,17 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			if err != nil {
 				s.Logger.Warn(err)
 			}
-			return nil
+			return nil, false
 		case sshutils.PuTTYSimpleRequest:
 			// PuTTY automatically requests a named 'simple@putty.projects.tartarus.org' channel any time it connects to a server
 			// as a proxy to indicate that it's in "simple" node and won't be requesting any other channels.
 			// As we don't support this request, we ignore it.
 			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
 			s.Logger.Debugf("%v: deliberately ignoring request for '%v' channel", s.Component(), sshutils.PuTTYSimpleRequest)
-			return nil
+			return nil, false
 		default:
 			return trace.BadParameter(
-				"(%v) proxy doesn't support request type '%v'", s.Component(), req.Type)
+				"(%v) proxy doesn't support request type '%v'", s.Component(), req.Type), false
 		}
 	}
 
@@ -1576,20 +1576,20 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 	if serverContext.JoinOnly {
 		switch req.Type {
 		case tracessh.TracingRequest:
-			return nil
+			return nil, false
 		case sshutils.PTYRequest:
-			return s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext)
+			return s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext), false
 		case sshutils.ShellRequest:
-			return s.termHandlers.HandleShell(ctx, ch, req, serverContext)
+			return s.termHandlers.HandleShell(ctx, ch, req, serverContext), false
 		case sshutils.WindowChangeRequest:
-			return s.termHandlers.HandleWinChange(ctx, ch, req, serverContext)
+			return s.termHandlers.HandleWinChange(ctx, ch, req, serverContext), false
 		case teleport.ForceTerminateRequest:
-			return s.termHandlers.HandleForceTerminate(ch, req, serverContext)
+			return s.termHandlers.HandleForceTerminate(ch, req, serverContext), false
 		case sshutils.EnvRequest:
 			// We ignore all SSH setenv requests for join-only principals.
 			// SSH will send them anyway but it seems fine to silently drop them.
 		case sshutils.SubsystemRequest:
-			return s.handleSubsystem(ctx, ch, req, serverContext)
+			return s.handleSubsystem(ctx, ch, req, serverContext), false
 		case sshutils.AgentForwardRequest:
 			// This happens when SSH client has agent forwarding enabled, in this case
 			// client sends a special request, in return SSH server opens new channel
@@ -1605,44 +1605,44 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			if err != nil {
 				s.Logger.Warn(err)
 			}
-			return nil
+			return nil, false
 		case sshutils.PuTTYWinadjRequest:
 			// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
 			// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
 			// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
 			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
-			return s.handlePuTTYWinadj(ch, req)
+			return s.handlePuTTYWinadj(ch, req), true
 		default:
-			return trace.AccessDenied("attempted %v request in join-only mode", req.Type)
+			return trace.AccessDenied("attempted %v request in join-only mode", req.Type), false
 		}
 	}
 	switch req.Type {
 	case tracessh.TracingRequest:
-		return nil
+		return nil, false
 	case sshutils.ExecRequest:
 		if _, err := s.termHandlers.SessionRegistry.TryCreateHostUser(serverContext); err != nil {
-			return trace.Wrap(err)
+			return trace.Wrap(err), false
 		}
-		return s.termHandlers.HandleExec(ctx, ch, req, serverContext)
+		return s.termHandlers.HandleExec(ctx, ch, req, serverContext), false
 	case sshutils.PTYRequest:
-		return s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext)
+		return s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext), false
 	case sshutils.ShellRequest:
 		if _, err := s.termHandlers.SessionRegistry.TryCreateHostUser(serverContext); err != nil {
-			return trace.Wrap(err)
+			return trace.Wrap(err), false
 		}
-		return s.termHandlers.HandleShell(ctx, ch, req, serverContext)
+		return s.termHandlers.HandleShell(ctx, ch, req, serverContext), false
 	case sshutils.WindowChangeRequest:
-		return s.termHandlers.HandleWinChange(ctx, ch, req, serverContext)
+		return s.termHandlers.HandleWinChange(ctx, ch, req, serverContext), false
 	case teleport.ForceTerminateRequest:
-		return s.termHandlers.HandleForceTerminate(ch, req, serverContext)
+		return s.termHandlers.HandleForceTerminate(ch, req, serverContext), false
 	case sshutils.EnvRequest:
-		return s.handleEnv(ch, req, serverContext)
+		return s.handleEnv(ch, req, serverContext), false
 	case sshutils.SubsystemRequest:
 		// subsystems are SSH subsystems defined in http://tools.ietf.org/html/rfc4254 6.6
 		// they are in essence SSH session extensions, allowing to implement new SSH commands
-		return s.handleSubsystem(ctx, ch, req, serverContext)
+		return s.handleSubsystem(ctx, ch, req, serverContext), false
 	case sshutils.X11ForwardRequest:
-		return s.handleX11Forward(ch, req, serverContext)
+		return s.handleX11Forward(ch, req, serverContext), false
 	case sshutils.AgentForwardRequest:
 		// This happens when SSH client has agent forwarding enabled, in this case
 		// client sends a special request, in return SSH server opens new channel
@@ -1652,7 +1652,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		// http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.agent
 		if _, err := s.termHandlers.SessionRegistry.TryCreateHostUser(serverContext); err != nil {
 			s.Logger.Warn(err)
-			return nil
+			return nil, false
 		}
 
 		// to maintain interoperability with OpenSSH, agent forwarding requests
@@ -1662,16 +1662,16 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		if err != nil {
 			s.Logger.Warn(err)
 		}
-		return nil
+		return nil, false
 	case sshutils.PuTTYWinadjRequest:
 		// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
 		// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
 		// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
 		// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
-		return s.handlePuTTYWinadj(ch, req)
+		return s.handlePuTTYWinadj(ch, req), true
 	default:
 		return trace.BadParameter(
-			"%v doesn't support request type '%v'", s.Component(), req.Type)
+			"%v doesn't support request type '%v'", s.Component(), req.Type), false
 	}
 }
 
@@ -2075,12 +2075,11 @@ func rejectChannel(ch ssh.NewChannel, reason ssh.RejectionReason, msg string) {
 }
 
 // handlePuTTYWinadj replies with failure to a PuTTY winadj request as required.
-// it overloads a trace.NotImplemented error to indicate that the reply has already
-// been processed, so we don't handle it twice.
+// it returns an error if the reply fails.
 func (s *Server) handlePuTTYWinadj(ch ssh.Channel, req *ssh.Request) error {
 	if err := req.Reply(false, []byte{}); err != nil {
 		s.Logger.Warnf("Failed to reply to %q request: %v", req.Type, err)
 		return err
 	}
-	return trace.NotImplemented("%v requests must always fail", req.Type)
+	return nil
 }

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1500,7 +1500,7 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 			)
 			// dispatch returns an additional bool which indicates whether the reply has already been handled inside
 			// the dispatch function itself. if this is set to true, we avoid sending a second response in violation
-			// of the SSH protocol specifcation.
+			// of the SSH protocol specification.
 			err, replyAlreadyHandled := s.dispatch(ctx, ch, req, scx)
 			if err != nil {
 				s.replyError(ch, req, err)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1498,19 +1498,16 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 					semconv.RPCSystemKey.String("ssh"),
 				),
 			)
-			if err, replyAlreadyHandled := s.dispatch(ctx, ch, req, scx); err != nil {
-				// dispatch returns a boolean which indicates whether the reply has already been handled inside the dispatch function
-				// itself. if this is set to true, we set the wantReply flag to false so we don't send two responses in violation of
-				// the SSH protocol spec (which PuTTY is very fussy about)
-				if replyAlreadyHandled {
-					req.WantReply = false
-				} else {
-					s.replyError(ch, req, err)
-					span.End()
-					return
-				}
+			// dispatch returns an additional bool which indicates whether the reply has already been handled inside
+			// the dispatch function itself. if this is set to true, we avoid sending a second response in violation
+			// of the SSH protocol specifcation.
+			err, replyAlreadyHandled := s.dispatch(ctx, ch, req, scx)
+			if err != nil {
+				s.replyError(ch, req, err)
+				span.End()
+				return
 			}
-			if req.WantReply {
+			if !replyAlreadyHandled && req.WantReply {
 				if err := req.Reply(true, nil); err != nil {
 					s.Logger.Warnf("Failed to reply to %q request: %v", req.Type, err)
 				}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1498,16 +1498,18 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 					semconv.RPCSystemKey.String("ssh"),
 				),
 			)
-			// dispatch returns an additional bool which indicates whether the reply has already been handled inside
-			// the dispatch function itself. if this is set to true, we avoid sending a second response in violation
-			// of the SSH protocol specification.
-			replyAlreadyHandled, err := s.dispatch(ctx, ch, req, scx)
-			if err != nil {
+			// some functions called inside dispatch() may handle replies to SSH channel requests internally,
+			// rather than leaving the reply to be handled inside this loop. in that case, those functions are
+			// expected to return a ReplyAlreadyHandled error to halt the default behaviour.
+			err := s.dispatch(ctx, ch, req, scx)
+			if trace.IsReplyAlreadyHandled(err) {
+				req.WantReply = false
+			} else if err != nil {
 				s.replyError(ch, req, err)
 				span.End()
 				return
 			}
-			if !replyAlreadyHandled && req.WantReply {
+			if req.WantReply {
 				if err := req.Reply(true, nil); err != nil {
 					s.Logger.Warnf("Failed to reply to %q request: %v", req.Type, err)
 				}
@@ -1533,7 +1535,7 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 
 // dispatch receives an SSH request for a subsystem and dispatches the request to the
 // appropriate subsystem implementation
-func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) (replyHandled bool, err error) {
+func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) error {
 	serverContext.Debugf("Handling request %v, want reply %v.", req.Type, req.WantReply)
 
 	// If this SSH server is configured to only proxy, we do not support anything
@@ -1541,12 +1543,12 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 	if s.proxyMode {
 		switch req.Type {
 		case tracessh.TracingRequest:
-			return false, nil
+			return nil
 		case sshutils.SubsystemRequest:
-			return false, s.handleSubsystem(ctx, ch, req, serverContext)
+			return s.handleSubsystem(ctx, ch, req, serverContext)
 		case sshutils.EnvRequest:
 			// we currently ignore setting any environment variables via SSH for security purposes
-			return false, s.handleEnv(ch, req, serverContext)
+			return s.handleEnv(ch, req, serverContext)
 		case sshutils.AgentForwardRequest:
 			// process agent forwarding, but we will only forward agent to proxy in
 			// recording proxy mode.
@@ -1554,16 +1556,16 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			if err != nil {
 				s.Logger.Warn(err)
 			}
-			return false, nil
+			return nil
 		case sshutils.PuTTYSimpleRequest:
 			// PuTTY automatically requests a named 'simple@putty.projects.tartarus.org' channel any time it connects to a server
 			// as a proxy to indicate that it's in "simple" node and won't be requesting any other channels.
 			// As we don't support this request, we ignore it.
 			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
 			s.Logger.Debugf("%v: deliberately ignoring request for '%v' channel", s.Component(), sshutils.PuTTYSimpleRequest)
-			return false, nil
+			return nil
 		default:
-			return false, trace.BadParameter(
+			return trace.BadParameter(
 				"(%v) proxy doesn't support request type '%v'", s.Component(), req.Type)
 		}
 	}
@@ -1573,20 +1575,20 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 	if serverContext.JoinOnly {
 		switch req.Type {
 		case tracessh.TracingRequest:
-			return false, nil
+			return nil
 		case sshutils.PTYRequest:
-			return false, s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext)
+			return s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext)
 		case sshutils.ShellRequest:
-			return false, s.termHandlers.HandleShell(ctx, ch, req, serverContext)
+			return s.termHandlers.HandleShell(ctx, ch, req, serverContext)
 		case sshutils.WindowChangeRequest:
-			return false, s.termHandlers.HandleWinChange(ctx, ch, req, serverContext)
+			return s.termHandlers.HandleWinChange(ctx, ch, req, serverContext)
 		case teleport.ForceTerminateRequest:
-			return false, s.termHandlers.HandleForceTerminate(ch, req, serverContext)
+			return s.termHandlers.HandleForceTerminate(ch, req, serverContext)
 		case sshutils.EnvRequest:
 			// We ignore all SSH setenv requests for join-only principals.
 			// SSH will send them anyway but it seems fine to silently drop them.
 		case sshutils.SubsystemRequest:
-			return false, s.handleSubsystem(ctx, ch, req, serverContext)
+			return s.handleSubsystem(ctx, ch, req, serverContext)
 		case sshutils.AgentForwardRequest:
 			// This happens when SSH client has agent forwarding enabled, in this case
 			// client sends a special request, in return SSH server opens new channel
@@ -1602,44 +1604,48 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			if err != nil {
 				s.Logger.Warn(err)
 			}
-			return false, nil
+			return nil
 		case sshutils.PuTTYWinadjRequest:
 			// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
 			// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
 			// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
 			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
-			return true, s.handlePuTTYWinadj(ch, req)
+			err := s.handlePuTTYWinadj(ch, req)
+			if err != nil {
+				return err
+			}
+			return nil
 		default:
-			return false, trace.AccessDenied("attempted %v request in join-only mode", req.Type)
+			return trace.AccessDenied("attempted %v request in join-only mode", req.Type)
 		}
 	}
 	switch req.Type {
 	case tracessh.TracingRequest:
-		return false, nil
+		return nil
 	case sshutils.ExecRequest:
 		if _, err := s.termHandlers.SessionRegistry.TryCreateHostUser(serverContext); err != nil {
-			return false, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
-		return false, s.termHandlers.HandleExec(ctx, ch, req, serverContext)
+		return s.termHandlers.HandleExec(ctx, ch, req, serverContext)
 	case sshutils.PTYRequest:
-		return false, s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext)
+		return s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext)
 	case sshutils.ShellRequest:
 		if _, err := s.termHandlers.SessionRegistry.TryCreateHostUser(serverContext); err != nil {
-			return false, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
-		return false, s.termHandlers.HandleShell(ctx, ch, req, serverContext)
+		return s.termHandlers.HandleShell(ctx, ch, req, serverContext)
 	case sshutils.WindowChangeRequest:
-		return false, s.termHandlers.HandleWinChange(ctx, ch, req, serverContext)
+		return s.termHandlers.HandleWinChange(ctx, ch, req, serverContext)
 	case teleport.ForceTerminateRequest:
-		return false, s.termHandlers.HandleForceTerminate(ch, req, serverContext)
+		return s.termHandlers.HandleForceTerminate(ch, req, serverContext)
 	case sshutils.EnvRequest:
-		return false, s.handleEnv(ch, req, serverContext)
+		return s.handleEnv(ch, req, serverContext)
 	case sshutils.SubsystemRequest:
 		// subsystems are SSH subsystems defined in http://tools.ietf.org/html/rfc4254 6.6
 		// they are in essence SSH session extensions, allowing to implement new SSH commands
-		return false, s.handleSubsystem(ctx, ch, req, serverContext)
+		return s.handleSubsystem(ctx, ch, req, serverContext)
 	case sshutils.X11ForwardRequest:
-		return false, s.handleX11Forward(ch, req, serverContext)
+		return s.handleX11Forward(ch, req, serverContext)
 	case sshutils.AgentForwardRequest:
 		// This happens when SSH client has agent forwarding enabled, in this case
 		// client sends a special request, in return SSH server opens new channel
@@ -1649,7 +1655,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		// http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.agent
 		if _, err := s.termHandlers.SessionRegistry.TryCreateHostUser(serverContext); err != nil {
 			s.Logger.Warn(err)
-			return false, nil
+			return nil
 		}
 
 		// to maintain interoperability with OpenSSH, agent forwarding requests
@@ -1659,15 +1665,15 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		if err != nil {
 			s.Logger.Warn(err)
 		}
-		return false, nil
+		return nil
 	case sshutils.PuTTYWinadjRequest:
 		// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
 		// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
 		// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
 		// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
-		return true, s.handlePuTTYWinadj(ch, req)
+		return s.handlePuTTYWinadj(ch, req)
 	default:
-		return false, trace.BadParameter(
+		return trace.BadParameter(
 			"%v doesn't support request type '%v'", s.Component(), req.Type)
 	}
 }
@@ -2078,5 +2084,5 @@ func (s *Server) handlePuTTYWinadj(ch ssh.Channel, req *ssh.Request) error {
 		s.Logger.Warnf("Failed to reply to %q request: %v", req.Type, err)
 		return err
 	}
-	return nil
+	return trace.ReplyAlreadyHandled("reply handled by handlePuTTYWinadj")
 }

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1603,10 +1603,6 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			}
 			return nil
 		case sshutils.PuTTYWinadjRequest:
-			// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
-			// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
-			// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
-			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
 			return s.handlePuTTYWinadj(ch, req)
 		default:
 			return trace.AccessDenied("attempted %v request in join-only mode", req.Type)
@@ -1660,10 +1656,6 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		}
 		return nil
 	case sshutils.PuTTYWinadjRequest:
-		// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
-		// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
-		// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
-		// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
 		return s.handlePuTTYWinadj(ch, req)
 	default:
 		return trace.BadParameter(
@@ -2071,7 +2063,11 @@ func rejectChannel(ch ssh.NewChannel, reason ssh.RejectionReason, msg string) {
 }
 
 // handlePuTTYWinadj replies with failure to a PuTTY winadj request as required.
-// it returns an error if the reply fails.
+// it returns an error if the reply fails. context from the PuTTY documentation:
+// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
+// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
+// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
+// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
 func (s *Server) handlePuTTYWinadj(ch ssh.Channel, req *ssh.Request) error {
 	if err := req.Reply(false, nil); err != nil {
 		s.Logger.Warnf("Failed to reply to %q request: %v", req.Type, err)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1600,6 +1600,12 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 				s.Logger.Warn(err)
 			}
 			return nil
+		case sshutils.PuTTYWinadjRequest:
+			// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
+			// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
+			// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
+			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
+			return nil
 		default:
 			return trace.AccessDenied("attempted %v request in join-only mode", req.Type)
 		}
@@ -1650,6 +1656,12 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		if err != nil {
 			s.Logger.Warn(err)
 		}
+		return nil
+	case sshutils.PuTTYWinadjRequest:
+		// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
+		// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
+		// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
+		// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
 		return nil
 	default:
 		return trace.BadParameter(

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1500,9 +1500,15 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 			)
 
 			if err := s.dispatch(ctx, ch, req, scx); err != nil {
-				s.replyError(ch, req, err)
-				span.End()
-				return
+				// a trace.NotImplemented error here indicates that a reply to the request was already handled inside
+				// the dispatch method, so we set the wantReply flag to false to avoid sending a second reply below.
+				if trace.IsNotImplemented(err) {
+					req.WantReply = false
+				} else {
+					s.replyError(ch, req, err)
+					span.End()
+					return
+				}
 			}
 			if req.WantReply {
 				if err := req.Reply(true, nil); err != nil {
@@ -1605,7 +1611,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
 			// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
 			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
-			return nil
+			return s.handlePuTTYWinadj(ch, req)
 		default:
 			return trace.AccessDenied("attempted %v request in join-only mode", req.Type)
 		}
@@ -1662,7 +1668,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
 		// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
 		// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
-		return nil
+		return s.handlePuTTYWinadj(ch, req)
 	default:
 		return trace.BadParameter(
 			"%v doesn't support request type '%v'", s.Component(), req.Type)
@@ -2066,4 +2072,15 @@ func rejectChannel(ch ssh.NewChannel, reason ssh.RejectionReason, msg string) {
 	if err := ch.Reject(reason, msg); err != nil {
 		log.Warnf("Failed to reject new ssh.Channel: %v", err)
 	}
+}
+
+// handlePuTTYWinadj replies with failure to a PuTTY winadj request as required.
+// it overloads a trace.NotImplemented error to indicate that the reply has already
+// been processed, so we don't handle it twice.
+func (s *Server) handlePuTTYWinadj(ch ssh.Channel, req *ssh.Request) error {
+	if err := req.Reply(false, []byte{}); err != nil {
+		s.Logger.Warnf("Failed to reply to %q request: %v", req.Type, err)
+		return err
+	}
+	return trace.NotImplemented("%v requests must always fail", req.Type)
 }

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1501,7 +1501,7 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 			// dispatch returns an additional bool which indicates whether the reply has already been handled inside
 			// the dispatch function itself. if this is set to true, we avoid sending a second response in violation
 			// of the SSH protocol specification.
-			err, replyAlreadyHandled := s.dispatch(ctx, ch, req, scx)
+			replyAlreadyHandled, err := s.dispatch(ctx, ch, req, scx)
 			if err != nil {
 				s.replyError(ch, req, err)
 				span.End()
@@ -1533,7 +1533,7 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 
 // dispatch receives an SSH request for a subsystem and dispatches the request to the
 // appropriate subsystem implementation
-func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) (err error, replyHandled bool) {
+func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) (replyHandled bool, err error) {
 	serverContext.Debugf("Handling request %v, want reply %v.", req.Type, req.WantReply)
 
 	// If this SSH server is configured to only proxy, we do not support anything
@@ -1541,12 +1541,12 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 	if s.proxyMode {
 		switch req.Type {
 		case tracessh.TracingRequest:
-			return nil, false
+			return false, nil
 		case sshutils.SubsystemRequest:
-			return s.handleSubsystem(ctx, ch, req, serverContext), false
+			return false, s.handleSubsystem(ctx, ch, req, serverContext)
 		case sshutils.EnvRequest:
 			// we currently ignore setting any environment variables via SSH for security purposes
-			return s.handleEnv(ch, req, serverContext), false
+			return false, s.handleEnv(ch, req, serverContext)
 		case sshutils.AgentForwardRequest:
 			// process agent forwarding, but we will only forward agent to proxy in
 			// recording proxy mode.
@@ -1554,17 +1554,17 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			if err != nil {
 				s.Logger.Warn(err)
 			}
-			return nil, false
+			return false, nil
 		case sshutils.PuTTYSimpleRequest:
 			// PuTTY automatically requests a named 'simple@putty.projects.tartarus.org' channel any time it connects to a server
 			// as a proxy to indicate that it's in "simple" node and won't be requesting any other channels.
 			// As we don't support this request, we ignore it.
 			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
 			s.Logger.Debugf("%v: deliberately ignoring request for '%v' channel", s.Component(), sshutils.PuTTYSimpleRequest)
-			return nil, false
+			return false, nil
 		default:
-			return trace.BadParameter(
-				"(%v) proxy doesn't support request type '%v'", s.Component(), req.Type), false
+			return false, trace.BadParameter(
+				"(%v) proxy doesn't support request type '%v'", s.Component(), req.Type)
 		}
 	}
 
@@ -1573,20 +1573,20 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 	if serverContext.JoinOnly {
 		switch req.Type {
 		case tracessh.TracingRequest:
-			return nil, false
+			return false, nil
 		case sshutils.PTYRequest:
-			return s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext), false
+			return false, s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext)
 		case sshutils.ShellRequest:
-			return s.termHandlers.HandleShell(ctx, ch, req, serverContext), false
+			return false, s.termHandlers.HandleShell(ctx, ch, req, serverContext)
 		case sshutils.WindowChangeRequest:
-			return s.termHandlers.HandleWinChange(ctx, ch, req, serverContext), false
+			return false, s.termHandlers.HandleWinChange(ctx, ch, req, serverContext)
 		case teleport.ForceTerminateRequest:
-			return s.termHandlers.HandleForceTerminate(ch, req, serverContext), false
+			return false, s.termHandlers.HandleForceTerminate(ch, req, serverContext)
 		case sshutils.EnvRequest:
 			// We ignore all SSH setenv requests for join-only principals.
 			// SSH will send them anyway but it seems fine to silently drop them.
 		case sshutils.SubsystemRequest:
-			return s.handleSubsystem(ctx, ch, req, serverContext), false
+			return false, s.handleSubsystem(ctx, ch, req, serverContext)
 		case sshutils.AgentForwardRequest:
 			// This happens when SSH client has agent forwarding enabled, in this case
 			// client sends a special request, in return SSH server opens new channel
@@ -1602,44 +1602,44 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			if err != nil {
 				s.Logger.Warn(err)
 			}
-			return nil, false
+			return false, nil
 		case sshutils.PuTTYWinadjRequest:
 			// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
 			// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
 			// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
 			// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
-			return s.handlePuTTYWinadj(ch, req), true
+			return true, s.handlePuTTYWinadj(ch, req)
 		default:
-			return trace.AccessDenied("attempted %v request in join-only mode", req.Type), false
+			return false, trace.AccessDenied("attempted %v request in join-only mode", req.Type)
 		}
 	}
 	switch req.Type {
 	case tracessh.TracingRequest:
-		return nil, false
+		return false, nil
 	case sshutils.ExecRequest:
 		if _, err := s.termHandlers.SessionRegistry.TryCreateHostUser(serverContext); err != nil {
-			return trace.Wrap(err), false
+			return false, trace.Wrap(err)
 		}
-		return s.termHandlers.HandleExec(ctx, ch, req, serverContext), false
+		return false, s.termHandlers.HandleExec(ctx, ch, req, serverContext)
 	case sshutils.PTYRequest:
-		return s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext), false
+		return false, s.termHandlers.HandlePTYReq(ctx, ch, req, serverContext)
 	case sshutils.ShellRequest:
 		if _, err := s.termHandlers.SessionRegistry.TryCreateHostUser(serverContext); err != nil {
-			return trace.Wrap(err), false
+			return false, trace.Wrap(err)
 		}
-		return s.termHandlers.HandleShell(ctx, ch, req, serverContext), false
+		return false, s.termHandlers.HandleShell(ctx, ch, req, serverContext)
 	case sshutils.WindowChangeRequest:
-		return s.termHandlers.HandleWinChange(ctx, ch, req, serverContext), false
+		return false, s.termHandlers.HandleWinChange(ctx, ch, req, serverContext)
 	case teleport.ForceTerminateRequest:
-		return s.termHandlers.HandleForceTerminate(ch, req, serverContext), false
+		return false, s.termHandlers.HandleForceTerminate(ch, req, serverContext)
 	case sshutils.EnvRequest:
-		return s.handleEnv(ch, req, serverContext), false
+		return false, s.handleEnv(ch, req, serverContext)
 	case sshutils.SubsystemRequest:
 		// subsystems are SSH subsystems defined in http://tools.ietf.org/html/rfc4254 6.6
 		// they are in essence SSH session extensions, allowing to implement new SSH commands
-		return s.handleSubsystem(ctx, ch, req, serverContext), false
+		return false, s.handleSubsystem(ctx, ch, req, serverContext)
 	case sshutils.X11ForwardRequest:
-		return s.handleX11Forward(ch, req, serverContext), false
+		return false, s.handleX11Forward(ch, req, serverContext)
 	case sshutils.AgentForwardRequest:
 		// This happens when SSH client has agent forwarding enabled, in this case
 		// client sends a special request, in return SSH server opens new channel
@@ -1649,7 +1649,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		// http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.agent
 		if _, err := s.termHandlers.SessionRegistry.TryCreateHostUser(serverContext); err != nil {
 			s.Logger.Warn(err)
-			return nil, false
+			return false, nil
 		}
 
 		// to maintain interoperability with OpenSSH, agent forwarding requests
@@ -1659,16 +1659,16 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		if err != nil {
 			s.Logger.Warn(err)
 		}
-		return nil, false
+		return false, nil
 	case sshutils.PuTTYWinadjRequest:
 		// PuTTY sends this request along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its window-size
 		// tuning. It can be sent on any type of channel. There is no message-specific data. Servers MUST treat it
 		// as an unrecognized request and respond with SSH_MSG_CHANNEL_FAILURE.
 		// https://the.earth.li/~sgtatham/putty/0.76/htmldoc/AppendixG.html#sshnames-channel
-		return s.handlePuTTYWinadj(ch, req), true
+		return true, s.handlePuTTYWinadj(ch, req)
 	default:
-		return trace.BadParameter(
-			"%v doesn't support request type '%v'", s.Component(), req.Type), false
+		return false, trace.BadParameter(
+			"%v doesn't support request type '%v'", s.Component(), req.Type)
 	}
 }
 

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2466,10 +2466,11 @@ func TestHandlePuTTYWinadj(t *testing.T) {
 	require.NoError(t, err)
 	defer se.Close()
 
-	// send a PuTTY winadj request to the server, there should be no errors
+	// send a PuTTY winadj request to the server. it shouldn't error, but the response
+	// should be a failure.
 	ok, err := se.SendRequest(ctx, sshutils.PuTTYWinadjRequest, true, nil)
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.False(t, ok)
 
 	// echo something to make sure the connection is still alive following the request
 	out, err := se.Output(ctx, "echo hello once more")

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2455,6 +2455,28 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	require.Equal(t, "hello again\n", string(out))
 }
 
+// TestHandlePuTTYWinadj verifies that any request from the PuTTY SSH client for its "winadj"
+// channel is correctly responded to with a failure message and connections remain open.
+func TestHandlePuTTYWinadj(t *testing.T) {
+	t.Parallel()
+	f := newFixtureWithoutDiskBasedLogging(t)
+	ctx := context.Background()
+
+	se, err := f.ssh.clt.NewSession(ctx)
+	require.NoError(t, err)
+	defer se.Close()
+
+	// send a PuTTY winadj request to the server, there should be no errors
+	ok, err := se.SendRequest(ctx, sshutils.PuTTYWinadjRequest, true, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// echo something to make sure the connection is still alive following the request
+	out, err := se.Output(ctx, "echo hello once more")
+	require.NoError(t, err)
+	require.Equal(t, "hello once more\n", string(out))
+}
+
 // upack holds all ssh signing artifacts needed for signing and checking user keys
 type upack struct {
 	// key is a raw private user key

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2464,7 +2464,7 @@ func TestHandlePuTTYWinadj(t *testing.T) {
 
 	se, err := f.ssh.clt.NewSession(ctx)
 	require.NoError(t, err)
-	defer se.Close()
+	t.Cleanup(func() { se.Close() })
 
 	// send a PuTTY winadj request to the server. it shouldn't error, but the response
 	// should be a failure.

--- a/lib/sshutils/req.go
+++ b/lib/sshutils/req.go
@@ -168,6 +168,10 @@ const (
 	// PuTTYSimpleRequest is a PuTTY-specific channel name which it automatically requests when it proxies
 	// connections. Teleport does not support this channel type, so deliberately ignores requests for it.
 	PuTTYSimpleRequest = "simple@putty.projects.tartarus.org"
+
+	// PuTTYWinadjRequest is a PuTTY-specific channel name which it automatically requests to measure window
+	// size on active connections, expecting a failure response from the server.
+	PuTTYWinadjRequest = "winadj@putty.projects.tartarus.org"
 )
 
 const (


### PR DESCRIPTION
Backport #19468 to branch/v11