### PR TITLE
Add TLS support for HTTP(S) proxies

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -316,7 +316,7 @@ type (
 
 // authConnect connects to the Teleport Auth Server directly.
 func authConnect(ctx context.Context, params connectParams) (*Client, error) {
-	dialer := NewDialer(ctx, params.cfg.KeepAlivePeriod, params.cfg.DialTimeout)
+	dialer := NewDialer(ctx, params.cfg.KeepAlivePeriod, params.cfg.DialTimeout, WithTLSConfig(params.tlsConfig))
 	clt := newClient(params.cfg, dialer, params.tlsConfig)
 	if err := clt.dialGRPC(ctx, params.addr); err != nil {
 		return nil, trace.Wrap(err, "failed to connect to addr %v as an auth server", params.addr)
@@ -329,7 +329,7 @@ func tunnelConnect(ctx context.Context, params connectParams) (*Client, error) {
 	if params.sshConfig == nil {
 		return nil, trace.BadParameter("must provide ssh client config")
 	}
-	dialer := newTunnelDialer(*params.sshConfig, params.cfg.KeepAlivePeriod, params.cfg.DialTimeout)
+	dialer := newTunnelDialer(*params.sshConfig, params.cfg.KeepAlivePeriod, params.cfg.DialTimeout, WithTLSConfig(params.tlsConfig))
 	clt := newClient(params.cfg, dialer, params.tlsConfig)
 	if err := clt.dialGRPC(ctx, params.addr); err != nil {
 		return nil, trace.Wrap(err, "failed to connect to addr %v as a reverse tunnel proxy", params.addr)
@@ -342,7 +342,7 @@ func proxyConnect(ctx context.Context, params connectParams) (*Client, error) {
 	if params.sshConfig == nil {
 		return nil, trace.BadParameter("must provide ssh client config")
 	}
-	dialer := NewProxyDialer(*params.sshConfig, params.cfg.KeepAlivePeriod, params.cfg.DialTimeout, params.addr, params.cfg.InsecureAddressDiscovery)
+	dialer := NewProxyDialer(*params.sshConfig, params.cfg.KeepAlivePeriod, params.cfg.DialTimeout, params.addr, params.cfg.InsecureAddressDiscovery, WithTLSConfig(params.tlsConfig))
 	clt := newClient(params.cfg, dialer, params.tlsConfig)
 	if err := clt.dialGRPC(ctx, params.addr); err != nil {
 		return nil, trace.Wrap(err, "failed to connect to addr %v as a web proxy", params.addr)

--- a/api/client/contextdialer.go
+++ b/api/client/contextdialer.go
@@ -78,11 +78,11 @@ func tracedDialer(ctx context.Context, fn ContextDialerFunc) ContextDialerFunc {
 
 // NewDialer makes a new dialer that connects to an Auth server either directly or via an HTTP proxy, depending
 // on the environment.
-func NewDialer(ctx context.Context, keepAlivePeriod, dialTimeout time.Duration) ContextDialer {
+func NewDialer(ctx context.Context, keepAlivePeriod, dialTimeout time.Duration, opts ...DialProxyOption) ContextDialer {
 	return tracedDialer(ctx, func(ctx context.Context, network, addr string) (net.Conn, error) {
 		dialer := newDirectDialer(keepAlivePeriod, dialTimeout)
 		if proxyURL := proxy.GetProxyURL(addr); proxyURL != nil {
-			return DialProxyWithDialer(ctx, proxyURL, addr, dialer)
+			return DialProxyWithDialer(ctx, proxyURL, addr, dialer, opts...)
 		}
 		return dialer.DialContext(ctx, network, addr)
 	})
@@ -90,8 +90,8 @@ func NewDialer(ctx context.Context, keepAlivePeriod, dialTimeout time.Duration) 
 
 // NewProxyDialer makes a dialer to connect to an Auth server through the SSH reverse tunnel on the proxy.
 // The dialer will ping the web client to discover the tunnel proxy address on each dial.
-func NewProxyDialer(ssh ssh.ClientConfig, keepAlivePeriod, dialTimeout time.Duration, discoveryAddr string, insecure bool) ContextDialer {
-	dialer := newTunnelDialer(ssh, keepAlivePeriod, dialTimeout)
+func NewProxyDialer(ssh ssh.ClientConfig, keepAlivePeriod, dialTimeout time.Duration, discoveryAddr string, insecure bool, opts ...DialProxyOption) ContextDialer {
+	dialer := newTunnelDialer(ssh, keepAlivePeriod, dialTimeout, opts...)
 	return ContextDialerFunc(func(ctx context.Context, network, _ string) (conn net.Conn, err error) {
 		resp, err := webclient.Find(&webclient.Config{Context: ctx, ProxyAddr: discoveryAddr, Insecure: insecure})
 		if err != nil {
@@ -113,11 +113,11 @@ func NewProxyDialer(ssh ssh.ClientConfig, keepAlivePeriod, dialTimeout time.Dura
 }
 
 // newTunnelDialer makes a dialer to connect to an Auth server through the SSH reverse tunnel on the proxy.
-func newTunnelDialer(ssh ssh.ClientConfig, keepAlivePeriod, dialTimeout time.Duration) ContextDialer {
+func newTunnelDialer(ssh ssh.ClientConfig, keepAlivePeriod, dialTimeout time.Duration, opts ...DialProxyOption) ContextDialer {
 	dialer := newDirectDialer(keepAlivePeriod, dialTimeout)
 	return ContextDialerFunc(func(ctx context.Context, network, addr string) (conn net.Conn, err error) {
 		if proxyURL := proxy.GetProxyURL(addr); proxyURL != nil {
-			conn, err = DialProxyWithDialer(ctx, proxyURL, addr, dialer)
+			conn, err = DialProxyWithDialer(ctx, proxyURL, addr, dialer, opts...)
 		} else {
 			conn, err = dialer.DialContext(ctx, network, addr)
 		}

--- a/api/client/credentials.go
+++ b/api/client/credentials.go
@@ -314,12 +314,18 @@ func (c *profileCreds) Dialer(cfg Config) (ContextDialer, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	tlsConfig, err := c.profile.TLSConfig()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return NewProxyDialer(
 		*sshConfig,
 		cfg.KeepAlivePeriod,
 		cfg.DialTimeout,
 		c.profile.WebProxyAddr,
 		cfg.InsecureAddressDiscovery,
+		WithTLSConfig(tlsConfig),
 	), nil
 }
 

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -138,7 +138,7 @@ func NewHTTPClient(cfg client.Config, tls *tls.Config, params ...roundtrip.Clien
 		if len(cfg.Addrs) == 0 {
 			return nil, trace.BadParameter("no addresses to dial")
 		}
-		contextDialer := client.NewDialer(cfg.Context, cfg.KeepAlivePeriod, cfg.DialTimeout)
+		contextDialer := client.NewDialer(cfg.Context, cfg.KeepAlivePeriod, cfg.DialTimeout, client.WithTLSConfig(tls))
 		dialer = client.ContextDialerFunc(func(ctx context.Context, network, _ string) (conn net.Conn, err error) {
 			for _, addr := range cfg.Addrs {
 				conn, err = contextDialer.DialContext(ctx, network, addr)

--- a/lib/srv/alpnproxy/conn_upgrade_test.go
+++ b/lib/srv/alpnproxy/conn_upgrade_test.go
@@ -84,8 +84,9 @@ func TestALPNConnUpgradeDialer(t *testing.T) {
 		pool := x509.NewCertPool()
 		pool.AddCert(server.Certificate())
 
-		preDialer := apiclient.NewDialer(ctx, 0, 5*time.Second)
-		dialer := newALPNConnUpgradeDialer(preDialer, &tls.Config{RootCAs: pool})
+		tlsConfig := &tls.Config{RootCAs: pool}
+		preDialer := apiclient.NewDialer(ctx, 0, 5*time.Second, apiclient.WithTLSConfig(tlsConfig))
+		dialer := newALPNConnUpgradeDialer(preDialer, tlsConfig)
 		conn, err := dialer.DialContext(ctx, "tcp", addr.Host)
 		require.NoError(t, err)
 
@@ -103,8 +104,9 @@ func TestALPNConnUpgradeDialer(t *testing.T) {
 		addr, err := url.Parse(server.URL)
 		require.NoError(t, err)
 
-		preDialer := apiclient.NewDialer(ctx, 0, 5*time.Second)
-		dialer := newALPNConnUpgradeDialer(preDialer, &tls.Config{InsecureSkipVerify: true})
+		tlsConfig := &tls.Config{InsecureSkipVerify: true}
+		preDialer := apiclient.NewDialer(ctx, 0, 5*time.Second, apiclient.WithTLSConfig(tlsConfig))
+		dialer := newALPNConnUpgradeDialer(preDialer, tlsConfig)
 		_, err = dialer.DialContext(ctx, "tcp", addr.Host)
 		require.Error(t, err)
 	})

--- a/lib/srv/alpnproxy/dialer.go
+++ b/lib/srv/alpnproxy/dialer.go
@@ -66,7 +66,7 @@ func (d ALPNDialer) DialContext(ctx context.Context, network, addr string) (net.
 		return nil, trace.BadParameter("missing TLS config")
 	}
 
-	dialer := apiclient.NewDialer(ctx, d.cfg.DialTimeout, d.cfg.DialTimeout)
+	dialer := apiclient.NewDialer(ctx, d.cfg.DialTimeout, d.cfg.DialTimeout, apiclient.WithTLSConfig(d.cfg.TLSConfig))
 	if d.cfg.ALPNConnUpgradeRequired {
 		dialer = newALPNConnUpgradeDialer(dialer, &tls.Config{
 			InsecureSkipVerify: d.cfg.TLSConfig.InsecureSkipVerify,

--- a/lib/utils/proxy/proxy.go
+++ b/lib/utils/proxy/proxy.go
@@ -186,6 +186,23 @@ func (d proxyDial) getTLSConfig(addr *utils.NetAddr) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// getTLSConfigForProxy configures the dialer's TLS config for the HTTPS proxy
+// address. If the proxy is HTTP, a nil error and nil config are returned.
+func (d proxyDial) getTLSConfigForProxy() (*tls.Config, error) {
+	if d.proxyURL.Scheme != "https" {
+		return nil, nil
+	}
+	netAddr, err := utils.ParseAddr(d.proxyURL.String())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsConfig, err := d.getTLSConfig(netAddr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return tlsConfig, nil
+}
+
 // DialTimeout acts like Dial but takes a timeout.
 func (d proxyDial) DialTimeout(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error) {
 	// Build a proxy connection first.
@@ -194,7 +211,13 @@ func (d proxyDial) DialTimeout(ctx context.Context, network, address string, tim
 		defer cancel()
 		ctx = timeoutCtx
 	}
-	conn, err := apiclient.DialProxy(ctx, d.proxyURL, address)
+
+	tlsConfig, err := d.getTLSConfigForProxy()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	conn, err := apiclient.DialProxy(ctx, d.proxyURL, address, apiclient.WithTLSConfig(tlsConfig))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -220,8 +243,12 @@ func (d proxyDial) DialTimeout(ctx context.Context, network, address string, tim
 // Dial first connects to a proxy, then uses the connection to establish a new
 // SSH connection.
 func (d proxyDial) Dial(ctx context.Context, network string, addr string, config *ssh.ClientConfig) (*tracessh.Client, error) {
+	tlsConfig, err := d.getTLSConfigForProxy()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	// Build a proxy connection first.
-	pconn, err := apiclient.DialProxy(ctx, d.proxyURL, addr)
+	pconn, err := apiclient.DialProxy(ctx, d.proxyURL, addr, apiclient.WithTLSConfig(tlsConfig))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR adds support for HTTPS proxies (i.e. `HTTPS_PROXY=https://...`).

Resolves #19860.