### PR TITLE
Add known STS endpoint for ap-southeast-4

### DIFF
--- a/lib/auth/sts_endpoints.go
+++ b/lib/auth/sts_endpoints.go
@@ -37,6 +37,7 @@ var (
 		"sts.ap-southeast-1.amazonaws.com",
 		"sts.ap-southeast-2.amazonaws.com",
 		"sts.ap-southeast-3.amazonaws.com",
+		"sts.ap-southeast-4.amazonaws.com",
 		"sts.ca-central-1.amazonaws.com",
 		"sts.cn-north-1.amazonaws.com.cn",
 		"sts.cn-northwest-1.amazonaws.com.cn",


### PR DESCRIPTION
This is necessary to allow nodes in ap-southeast-4 to join using the IAM method.