### PR TITLE
Refresh remote cluster connection status periodically

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -646,6 +646,7 @@ func (a *Server) runPeriodicOperations() {
 		FirstDuration: firstReleaseCheck,
 		Jitter:        retryutils.NewFullJitter(),
 	})
+	defer releaseCheck.Stop()
 
 	// more frequent release check that just re-calculates alerts based on previously
 	// pulled versioning info.
@@ -654,7 +655,27 @@ func (a *Server) runPeriodicOperations() {
 		FirstDuration: utils.HalfJitter(time.Second * 10),
 		Jitter:        retryutils.NewHalfJitter(),
 	})
-	defer releaseCheck.Stop()
+	defer localReleaseCheck.Stop()
+
+	// isolate the schedule of potentially long-running refreshRemoteClusters() from other tasks
+	go func() {
+		// reasonably small interval to ensure that users observe clusters as online within 1 minute of adding them.
+		remoteClustersRefresh := interval.New(interval.Config{
+			Duration: time.Second * 40,
+			Jitter:   retryutils.NewSeventhJitter(),
+		})
+		defer remoteClustersRefresh.Stop()
+
+		for {
+			select {
+			case <-a.closeCtx.Done():
+				return
+			case <-remoteClustersRefresh.Next():
+				a.refreshRemoteClusters(ctx, r)
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-a.closeCtx.Done():
@@ -907,6 +928,57 @@ func (a *Server) updateVersionMetrics() {
 	registeredAgents.Reset()
 	for version, count := range versionCount {
 		registeredAgents.WithLabelValues(version).Set(float64(count))
+	}
+}
+
+var (
+	// remoteClusterRefreshLimit is the maximum number of backend updates that will be performed
+	// during periodic remote cluster connection status refresh.
+	remoteClusterRefreshLimit = 50
+
+	// remoteClusterRefreshBuckets is the maximum number of refresh cycles that should guarantee the status update
+	// of all remote clusters if their number exceeds remoteClusterRefreshLimit × remoteClusterRefreshBuckets.
+	remoteClusterRefreshBuckets = 12
+)
+
+// refreshRemoteClusters updates connection status of all remote clusters.
+func (a *Server) refreshRemoteClusters(ctx context.Context, rnd *insecurerand.Rand) {
+	remoteClusters, err := a.Services.GetRemoteClusters()
+	if err != nil {
+		log.WithError(err).Error("Failed to load remote clusters for status refresh")
+		return
+	}
+
+	netConfig, err := a.GetClusterNetworkingConfig(ctx)
+	if err != nil {
+		log.WithError(err).Error("Failed to load networking config for remote cluster status refresh")
+		return
+	}
+
+	// randomize the order to optimize for multiple auth servers running in parallel
+	rnd.Shuffle(len(remoteClusters), func(i, j int) {
+		remoteClusters[i], remoteClusters[j] = remoteClusters[j], remoteClusters[i]
+	})
+
+	// we want to limit the number of backend updates performed on each refresh to avoid overwhelming the backend.
+	updateLimit := remoteClusterRefreshLimit
+	if dynamicLimit := (len(remoteClusters) / remoteClusterRefreshBuckets) + 1; dynamicLimit > updateLimit {
+		// if the number of remote clusters is larger than remoteClusterRefreshLimit × remoteClusterRefreshBuckets,
+		// bump the limit to make sure all remote clusters will be updated within reasonable time.
+		updateLimit = dynamicLimit
+	}
+
+	var updateCount int
+	for _, remoteCluster := range remoteClusters {
+		if updated, err := a.updateRemoteClusterStatus(ctx, netConfig, remoteCluster); err != nil {
+			log.WithError(err).Error("Failed to perform remote cluster status refresh")
+		} else if updated {
+			updateCount++
+		}
+
+		if updateCount >= updateLimit {
+			break
+		}
 	}
 }
 

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -16,6 +16,8 @@ package auth
 
 import (
 	"context"
+	"fmt"
+	insecurerand "math/rand"
 	"testing"
 	"time"
 
@@ -35,10 +37,15 @@ import (
 func TestRemoteClusterStatus(t *testing.T) {
 	ctx := context.Background()
 	a := newTestAuthServer(ctx, t)
+	rnd := insecurerand.New(insecurerand.NewSource(a.GetClock().Now().UnixNano()))
 
 	rc, err := types.NewRemoteCluster("rc")
 	require.NoError(t, err)
 	require.NoError(t, a.CreateRemoteCluster(rc))
+
+	// This scenario deals with only one remote cluster, so it never hits the limit on status updates.
+	// TestRefreshRemoteClusters focuses on verifying the update limit logic.
+	a.refreshRemoteClusters(ctx, rnd)
 
 	wantRC := rc
 	// Initially, no tunnels exist and status should be "offline".
@@ -69,6 +76,8 @@ func TestRemoteClusterStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, a.UpsertTunnelConnection(tc2))
 
+	a.refreshRemoteClusters(ctx, rnd)
+
 	// With active tunnels, the status is "online" and last_heartbeat is set to
 	// the latest tunnel heartbeat.
 	wantRC.SetConnectionStatus(teleport.RemoteClusterStatusOnline)
@@ -80,6 +89,8 @@ func TestRemoteClusterStatus(t *testing.T) {
 
 	// Delete the latest connection.
 	require.NoError(t, a.DeleteTunnelConnection(tc2.GetClusterName(), tc2.GetName()))
+
+	a.refreshRemoteClusters(ctx, rnd)
 
 	// The status should remain the same, since tc1 still exists.
 	// The last_heartbeat should remain the same, since tc1 has an older
@@ -93,6 +104,8 @@ func TestRemoteClusterStatus(t *testing.T) {
 	// Delete the remaining connection
 	require.NoError(t, a.DeleteTunnelConnection(tc1.GetClusterName(), tc1.GetName()))
 
+	a.refreshRemoteClusters(ctx, rnd)
+
 	// The status should switch to "offline".
 	// The last_heartbeat should remain the same.
 	wantRC.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
@@ -100,6 +113,90 @@ func TestRemoteClusterStatus(t *testing.T) {
 	gotRC.SetResourceID(0)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(rc, gotRC))
+}
+
+func TestRefreshRemoteClusters(t *testing.T) {
+	ctx := context.Background()
+
+	remoteClusterRefreshLimit = 10
+	remoteClusterRefreshBuckets = 5
+
+	tests := []struct {
+		name               string
+		clustersTotal      int
+		clustersNeedUpdate int
+		expectedUpdates    int
+	}{
+		{
+			name:               "updates all when below the limit",
+			clustersTotal:      20,
+			clustersNeedUpdate: 7,
+			expectedUpdates:    7,
+		},
+		{
+			name:               "updates all when exactly at the limit",
+			clustersTotal:      20,
+			clustersNeedUpdate: 10,
+			expectedUpdates:    10,
+		},
+		{
+			name:               "stops updating after hitting the default limit",
+			clustersTotal:      40,
+			clustersNeedUpdate: 15,
+			expectedUpdates:    10,
+		},
+		{
+			name:               "stops updating after hitting the dynamic limit",
+			clustersTotal:      60,
+			clustersNeedUpdate: 15,
+			expectedUpdates:    13,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.LessOrEqual(t, tt.clustersNeedUpdate, tt.clustersTotal)
+
+			a := newTestAuthServer(ctx, t)
+			rnd := insecurerand.New(insecurerand.NewSource(a.GetClock().Now().UnixNano()))
+
+			allClusters := make(map[string]types.RemoteCluster)
+			for i := 0; i < tt.clustersTotal; i++ {
+				rc, err := types.NewRemoteCluster(fmt.Sprintf("rc-%03d", i))
+				rc.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
+				require.NoError(t, err)
+				require.NoError(t, a.CreateRemoteCluster(rc))
+				allClusters[rc.GetName()] = rc
+
+				if i < tt.clustersNeedUpdate {
+					lastHeartbeat := a.clock.Now().UTC()
+					tc, err := types.NewTunnelConnection(fmt.Sprintf("conn-%03d", i), types.TunnelConnectionSpecV2{
+						ClusterName:   rc.GetName(),
+						ProxyName:     fmt.Sprintf("proxy-%03d", i),
+						LastHeartbeat: lastHeartbeat,
+						Type:          types.ProxyTunnel,
+					})
+					require.NoError(t, err)
+					require.NoError(t, a.UpsertTunnelConnection(tc))
+				}
+			}
+
+			a.refreshRemoteClusters(ctx, rnd)
+
+			clusters, err := a.GetRemoteClusters()
+			require.NoError(t, err)
+
+			var updated int
+			for _, cluster := range clusters {
+				old := allClusters[cluster.GetName()]
+				if cmp.Diff(old, cluster) != "" {
+					updated++
+				}
+			}
+
+			require.Equal(t, tt.expectedUpdates, updated)
+		})
+	}
 }
 
 func TestValidateTrustedCluster(t *testing.T) {


### PR DESCRIPTION
Implements solution no. 1 to https://github.com/gravitational/teleport/issues/22008

Presently, each API call to Auth.GetRemoteCluster() or Auth.GetRemoteClusters() has to recalculate connection statuses and save those to the backend. This approach doesn't scale well with a large number of remote clusters or high request rate.

This PR changes the behaviour so that Auth service would refresh connection status of all remote clusters every ~40s and let the above API calls serve directly from the backend.