### PR TITLE
[v11] chore: Bump Buf to v1.15.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -267,10 +267,10 @@ RUN go install github.com/daixiang0/gci@v0.8.2
 # Install golangci-lint.
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
 
-# Install buf
+# Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.14.0" && \
-      curl -sSL \
+    VERSION="1.15.0" && \
+      curl -sSLf \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \
       chmod +x "${BIN}/buf"


### PR DESCRIPTION
Upgrade to latest release.

No format, lint or codegen changes.

Backport #22430 to branch/v11