### PR TITLE
Move makefile BPF to common.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,6 @@ GOPATH ?= $(shell go env GOPATH)
 # This directory will be the real path of the directory of the first Makefile in the list.
 MAKE_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
-# libbpf version required by the build.
-LIBBPF_VER := 1.0.1
-
 # If set to 1, webassets are not built.
 WEBASSETS_SKIP_BUILD ?= 0
 
@@ -53,6 +50,9 @@ ARCH ?= $(shell go env GOARCH)
 FIPS ?=
 RELEASE = teleport-$(GITTAG)-$(OS)-$(ARCH)-bin
 
+# Include common makefile shared between OSS and Ent.
+include common.mk
+
 # FIPS support must be requested at build time.
 FIPS_MESSAGE := without-FIPS-support
 ifneq ("$(FIPS)","")
@@ -72,42 +72,6 @@ else
 ifneq ("$(wildcard /usr/local/include/security/pam_appl.h)","")
 PAM_TAG := pam
 PAM_MESSAGE := with-PAM-support
-endif
-endif
-
-# BPF support will only be built into Teleport if headers exist at build time.
-BPF_MESSAGE := without-BPF-support
-
-# We don't compile BPF for anything except regular non-FIPS linux/amd64 for now, as other builds
-# have compilation issues that require fixing.
-with_bpf := no
-ifeq ("$(OS)","linux")
-# True if $ARCH == amd64 || $ARCH == arm64
-ifneq (,$(filter "$(ARCH)","amd64" "arm64"))
-ifneq ("$(wildcard /usr/libbpf-${LIBBPF_VER}/include/bpf/bpf.h)","")
-with_bpf := yes
-BPF_TAG := bpf
-BPF_MESSAGE := with-BPF-support
-CLANG ?= $(shell which clang || which clang-10)
-LLVM_STRIP ?= $(shell which llvm-strip || which llvm-strip-10)
-KERNEL_ARCH := $(shell uname -m | sed 's/x86_64/x86/g; s/aarch64/arm64/g')
-INCLUDES :=
-ER_BPF_BUILDDIR := lib/bpf/bytecode
-RS_BPF_BUILDDIR := lib/restrictedsession/bytecode
-
-# Get Clang's default includes on this system. We'll explicitly add these dirs
-# to the includes list when compiling with `-target bpf` because otherwise some
-# architecture-specific dirs will be "missing" on some architectures/distros -
-# headers such as asm/types.h, asm/byteorder.h, asm/socket.h, asm/sockios.h,
-# sys/cdefs.h etc. might be missing.
-#
-# Use '-idirafter': Don't interfere with include mechanics except where the
-# build would have failed anyways.
-CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
-	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
-
-STATIC_LIBS += -L/usr/libbpf-${LIBBPF_VER}/lib64/ -lbpf -lelf -lz
-endif
 endif
 endif
 
@@ -235,21 +199,12 @@ export
 
 TEST_LOG_DIR = ${abspath ./test-logs}
 
-# Is this build targeting the same OS & architecture it is being compiled on, or
-# will it require cross-compilation? We need to know this (especially for ARM) so we
-# can set the cross-compiler path (and possibly feature flags) correctly.
-IS_NATIVE_BUILD ?= $(if $(filter $(ARCH), $(shell go env GOARCH)),"yes","no")
-
 # Set CGOFLAG and BUILDFLAGS as needed for the OS/ARCH.
 ifeq ("$(OS)","linux")
 # True if $ARCH == amd64 || $ARCH == arm64
-ifneq (,$(filter "$(ARCH)","amd64" "arm64"))
-	ifeq ($(IS_NATIVE_BUILD),"yes")
-	# Link static version of libraries required by Teleport (bpf, pcsc) to reduce system dependencies. Avoid dependencies on dynamic libraries if we already link the static version using --as-needed.
-	CGOFLAG = CGO_ENABLED=1 CGO_CFLAGS="-I/usr/libbpf-${LIBBPF_VER}/include" CGO_LDFLAGS="-Wl,-Bstatic $(STATIC_LIBS) -Wl,-Bdynamic -Wl,--as-needed"
-	CGOFLAG_TSH = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic $(STATIC_LIBS_TSH) -Wl,-Bdynamic -Wl,--as-needed"
-	else
-	CGOFLAG += CC=aarch64-linux-gnu-gcc
+ifeq ("$(ARCH)","arm64")
+	ifeq ($(IS_NATIVE_BUILD),"no")
+		CGOFLAG += CC=aarch64-linux-gnu-gcc
 	endif
 else ifeq ("$(ARCH)","arm")
 # ARM builds need to specify the correct C compiler

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,51 @@
+# Common makefile shared between Teleport OSS and Ent.
+
+# libbpf version required by the build.
+LIBBPF_VER := 1.0.1
+
+# Is this build targeting the same OS & architecture it is being compiled on, or
+# will it require cross-compilation? We need to know this (especially for ARM) so we
+# can set the cross-compiler path (and possibly feature flags) correctly.
+IS_NATIVE_BUILD ?= $(if $(filter $(ARCH), $(shell go env GOARCH)),"yes","no")
+
+# BPF support will only be built into Teleport if headers exist at build time.
+BPF_MESSAGE := without-BPF-support
+
+# We don't compile BPF for anything except regular non-FIPS linux/amd64 for now, as other builds
+# have compilation issues that require fixing.
+with_bpf := no
+ifeq ("$(OS)","linux")
+# True if $ARCH == amd64 || $ARCH == arm64
+ifneq (,$(filter "$(ARCH)","amd64" "arm64"))
+# We only support BPF in native builds
+ifeq ($(IS_NATIVE_BUILD),"yes")
+ifneq ("$(wildcard /usr/libbpf-${LIBBPF_VER}/include/bpf/bpf.h)","")
+with_bpf := yes
+BPF_TAG := bpf
+BPF_MESSAGE := with-BPF-support
+CLANG ?= $(shell which clang || which clang-10)
+LLVM_STRIP ?= $(shell which llvm-strip || which llvm-strip-10)
+KERNEL_ARCH := $(shell uname -m | sed 's/x86_64/x86/g; s/aarch64/arm64/g')
+INCLUDES :=
+ER_BPF_BUILDDIR := lib/bpf/bytecode
+RS_BPF_BUILDDIR := lib/restrictedsession/bytecode
+
+# Get Clang's default includes on this system. We'll explicitly add these dirs
+# to the includes list when compiling with `-target bpf` because otherwise some
+# architecture-specific dirs will be "missing" on some architectures/distros -
+# headers such as asm/types.h, asm/byteorder.h, asm/socket.h, asm/sockios.h,
+# sys/cdefs.h etc. might be missing.
+#
+# Use '-idirafter': Don't interfere with include mechanics except where the
+# build would have failed anyways.
+CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
+	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
+
+STATIC_LIBS += -L/usr/libbpf-${LIBBPF_VER}/lib64/ -lbpf -lelf -lz
+# Link static version of libraries required by Teleport (bpf, pcsc) to reduce system dependencies. Avoid dependencies on dynamic libraries if we already link the static version using --as-needed.
+CGOFLAG = CGO_ENABLED=1 CGO_CFLAGS="-I/usr/libbpf-${LIBBPF_VER}/include" CGO_LDFLAGS="-Wl,-Bstatic $(STATIC_LIBS) -Wl,-Bdynamic -Wl,--as-needed"
+CGOFLAG_TSH = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic $(STATIC_LIBS_TSH) -Wl,-Bdynamic -Wl,--as-needed"
+endif # bpf/bpf.h found
+endif # IS_NATIVE_BUILD == yes
+endif # ARCH == amd64 OR arm64
+endif # OS == linux


### PR DESCRIPTION
Currently, a lot of makefile logic is copied between OSS end Ent repo. This PR moves BPF-related code to common.mk, so it doesn't need to be copied between reports. I'll move more code in the following PRs. I just want to keep diffs small.