### PR TITLE
Provide more context in the docs intro page

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -440,6 +440,10 @@
       "icon": "wrench",
       "title": "Manage your Cluster",
       "entries": [
+      	{
+      	  "title": "Introduction",
+      	  "slug": "/management/introduction/"
+	},
         {
           "title": "Admin Guides",
           "slug": "/management/admin/",
@@ -1189,6 +1193,10 @@
       "title": "Reference",
       "entries": [
         {
+	  "title": "Introduction",
+	  "slug": "/reference/introduction/"
+	},
+        {
           "title": "Config File",
           "slug": "/reference/config/"
         },
@@ -1273,6 +1281,10 @@
       "icon": "integrations",
       "title": "Architecture",
       "entries": [
+      	{
+      	  "title": "Introduction",
+      	  "slug": "architecture/introduction/"
+      	},
         {
           "title": "Authentication",
           "slug": "/architecture/authentication/"

--- a/docs/config.json
+++ b/docs/config.json
@@ -1283,7 +1283,7 @@
       "entries": [
       	{
       	  "title": "Introduction",
-      	  "slug": "architecture/introduction/"
+      	  "slug": "/architecture/introduction/"
       	},
         {
           "title": "Authentication",

--- a/docs/pages/architecture/introduction.mdx
+++ b/docs/pages/architecture/introduction.mdx
@@ -1,0 +1,17 @@
+---
+title: Teleport Architecture Guides
+description: Get detailed information about how Teleport works
+---
+
+In this section, you will find detailed information about Teleport's internal
+architecture. Read these guides if you are interested in learning how Teleport
+works.
+
+- [Trusted Clusters](./trustedclusters.mdx)
+- [TLS Routing](./tls-routing.mdx)
+- [Authentication](./authentication.mdx)
+- [Proxy Peering](./proxy-peering.mdx)
+- [Teleport Nodes](./nodes.mdx)
+- [Authorization](./authorization.mdx)
+- [The Teleport Proxy Service](./proxy.mdx)
+- [Session Recording](./session-recording.mdx)

--- a/docs/pages/architecture/introduction.mdx
+++ b/docs/pages/architecture/introduction.mdx
@@ -7,11 +7,11 @@ In this section, you will find detailed information about Teleport's internal
 architecture. Read these guides if you are interested in learning how Teleport
 works.
 
-- [Trusted Clusters](./trustedclusters.mdx)
-- [TLS Routing](./tls-routing.mdx)
 - [Authentication](./authentication.mdx)
-- [Proxy Peering](./proxy-peering.mdx)
-- [Teleport Nodes](./nodes.mdx)
 - [Authorization](./authorization.mdx)
 - [The Teleport Proxy Service](./proxy.mdx)
+- [Teleport Nodes](./nodes.mdx)
 - [Session Recording](./session-recording.mdx)
+- [TLS Routing](./tls-routing.mdx)
+- [Proxy Peering](./proxy-peering.mdx)
+- [Trusted Clusters](./trustedclusters.mdx)

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -1,55 +1,131 @@
 ---
 title: Introduction to Teleport
 description: How to install and quickly get up and running with Teleport.
-h1: Introduction
 layout: tocless-doc
 videoBanner: ki-uVTSocGE
 ---
 
-Teleport is an identity-aware, multi-protocol access proxy which understands SSH, HTTPS, RDP, Kubernetes API, MySQL, MongoDB and PostgreSQL wire protocols and many others.
+Teleport is an identity-aware, multi-protocol access proxy. Teleport understands
+the SSH, HTTPS, RDP, Kubernetes API, MySQL, MongoDB and PostgreSQL wire
+protocols, plus many others.
 
 With Teleport you can:
 
 - Replace a mix of vaults, passwords, API keys and tokens with short-lived SSH and X.509 certs.
-- Have a single access point and Single-Sign-On for all of your infrastructure - SSH servers, Kubernetes clusters, databases, desktops, web applications, and more.
-- Write policies with Terraform or Kubernetes resources for all clouds, environments and protocols and manage them with GitOps.
-- Record SSH and `kubectl exec` sessions, DB queries, Windows desktop sessions, web sessions and API requests.
+- Have a single access point and Single-Sign-On provider for all of your
+  infrastructure, including SSH servers, Kubernetes clusters, databases,
+  desktops, web applications, and more.
+- Write policies with Terraform or Kubernetes resources for all clouds,
+  environments and protocols and manage them with GitOps.
+- Record SSH and `kubectl exec` sessions, DB queries, Windows desktop sessions,
+  web sessions and API requests.
 - Use mutual TLS tunnels to protect your infrastructure endpoints.
+
+<Notice type="info">
+
+If you want to use Teleport to access infrastructure, rather than set up
+Teleport, read our [Connect your Client](./connect-your-client/introduction.mdx)
+guides for instructions.
+
+</Notice>
 
 ## Try out Teleport
 
-- [Teleport Enterprise Cloud](./choose-an-edition/teleport-cloud/getting-started.mdx): Start a free trial of Teleport Enterprise Cloud so you can quickly enable secure access to your infrastructure.
-- [Linux Server](./try-out-teleport/linux-server.mdx): Deploy on a Linux Server.
-- [Docker Compose](./try-out-teleport/docker-compose.mdx): Deploy locally with Docker Compose.
-- [Kubernetes](./try-out-teleport/local-kubernetes.mdx): Deploy locally with Kubernetes.
-- [DigitalOcean](./try-out-teleport/digitalocean.mdx): Deploy with our 1-Click DigitalOcean droplet.
+The fastest way to try out Teleport is to sign up for a free trial of Teleport
+Enterprise Cloud and add your first resource. In our [getting started
+guide](./choose-an-edition/teleport-cloud/getting-started.mdx), you will
+register a local container, access it securely from your browser, record your
+SSH session, and play it back.
 
-## Configure access
+After getting acquainted with how Teleport enables secure access to your
+infrastructure, follow our [Try out
+Teleport](./try-out-teleport/introduction.mdx) guides to set up a demo Teleport
+cluster in an environment that works best for you, whether this is a
+browser-based lab, virtual machine, or local Kubernetes cluster.
 
-Secure your infrastructure while keeping your engineers productive.
+Once you are ready to learn more about Teleport, read our [Core Concepts
+guide](./core-concepts.mdx), which introduces the components of a Teleport
+cluster. You can refer to this glossary as you continue through the
+documentation.
 
-<ScopedBlock scope={["cloud", "enterprise"]}>
-- [Set up SSO](./access-controls/sso.mdx): Configure Teleport's integration with your SSO provider so you can automatically on– and off-board users.
-</ScopedBlock>
-<ScopedBlock scope={["oss"]}>
-- [Set up SSO](./access-controls/sso/github-sso.mdx): Configure Teleport's integration with GitHub so you can automatically on– and off-board users.
-</ScopedBlock>
-- [Define roles](./access-controls/guides/role-templates.mdx): Manage who can access which parts of your infrastructure.
+## Choose an edition
+
+After trying out Teleport, you are ready to deploy a cluster to your
+infrastructure. Teleport has three editions, Teleport Enterprise, Teleport
+Enterprise Cloud, and Teleport Community Edition, and you can compare these in
+our [Choose an Edition](./choose-an-edition/introduction.mdx) section.
+
+<Notice type="tip">
+
+You can view information specific to an edition of Teleport by using the
+dropdown menu at the top of the page.
+
+</Notice>
+
+## Deploy a cluster
+
+Once you know which edition you would like to deploy, read our [Deploy a
+Cluster](./deploy-a-cluster/introduction.mdx) documentation for how to launch a
+fully fledged Teleport cluster in production. (If you are using Teleport
+Enterprise Cloud, you can skip this step.) This section shows you the best
+practices to follow for a high-availability Teleport cluster, and how to deploy
+Teleport on your cloud provider of choice.
+
+## Manage access
+
+Now that you have a running Teleport cluster, set up role-based access controls
+to enable secure access to your infrastructure.  You can define roles with
+granular permissions, and use Teleport's integrations with Single Sign-On
+providers to automatically map these roles to users. You can also set up Access
+Requests to enable just-in-time access to your infrastructure. Read [Manage
+Access](./access-controls/introduction.mdx) to get started.
+
+## Manage your cluster
+
+With your Teleport cluster configured, you can now begin Day Two operations
+such as upgrades, adding agents to the cluster, and integrating Teleport with
+third-party tools. Read [Manage your
+Cluster](./manage-your-cluster/introduction.mdx) for more information.
 
 ## Add your infrastructure
 
-Use Teleport to provide secure access to all of your infrastructure.
+Teleport is protocol aware and provides functionality that is unique to each
+protocol it supports. To enable access to a protocol, deploy the appropriate
+Teleport service and configure it to communicate with resources in your
+infrastructure. 
 
-- [Server Access](./server-access/getting-started.mdx): Single sign-on, short-lived certificates, and auditing for SSH servers.
-- [Application Access](./application-access/introduction.mdx): Secure access to internal dashboards and web applications.
-- [Kubernetes Access](./kubernetes-access/introduction.mdx): Single sign-on, auditing, and unified access for Kubernetes clusters.
-- [Database Access](./database-access/introduction.mdx): Secure access to SQL and NoSQL databases.
-- [Desktop Access](./desktop-access/introduction.mdx): Secure browser-based access to desktop environments.
+Read about how to enable access to:
 
-## Connect to Teleport
+- [Servers](./server-access/getting-started.mdx)
+- [Applications](./application-access/introduction.mdx)
+- [Kubernetes clusters](./kubernetes-access/introduction.mdx)
+- [Databases](./database-access/introduction.mdx)
+- [Remote desktops](./desktop-access/introduction.mdx)
 
-- [Teleport Clients](./connect-your-client/introduction.mdx): Access your infrastructure over the command line or UI.
-- [Database Access GUI Clients](./connect-your-client/gui-clients.mdx): Use your favorite database GUI tool to connect to databases behind Teleport.
+You can also set up [Machine ID](./machine-id/introduction.mdx) to enable
+service accounts to access resources in your infrastructure with short-lived
+credentials.
+
+## Extend Teleport for your organization
+
+Teleport is highly customizable, exposing much of its functionality via a gRPC
+API. For example, you can build API clients to register infrastructure
+automatically or manage Access Requests using your organization's unique
+workflows. Read how to build applications that interact with Teleport's API in
+our [API guides](./api/introduction.mdx).
+
+## Learn more about Teleport
+
+Get more information about Teleport by reading our library of architecture,
+reference, and developer guides. See the
+[Preview](./preview/upcoming-releases.mdx) section for a glimpse of features we
+will release in the next Teleport version. Consult our
+[Reference](./reference/introduction.mdx) guides for comprehensive lists of
+configuration options, CLI flags, and more. For detailed explanations of how
+Teleport works, see the [Architecture](./architecture/introduction.mdx) section.
+
+Finally, if you're interested in adding to Teleport's documentation, view
+our [contribution guide](./contributing/documentation.mdx). 
 
 <TileSet>
     <TileList title="For developers" icon="stack">

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -23,9 +23,9 @@ With Teleport you can:
 
 <Notice type="info">
 
-If you want to use Teleport to access infrastructure, rather than set up
-Teleport, read our [Connect your Client](./connect-your-client/introduction.mdx)
-guides for instructions.
+If your organization is already using Teleport and you want to learn how to
+access infrastructure, read our [Connect your
+Client](./connect-your-client/introduction.mdx) guides for instructions.
 
 </Notice>
 
@@ -57,8 +57,8 @@ our [Choose an Edition](./choose-an-edition/introduction.mdx) section.
 
 <Notice type="tip">
 
-You can view information specific to an edition of Teleport by using the
-dropdown menu at the top of the page.
+You can view information specific to an edition of Teleport by using the "Open
+Source", "Enterprise", and "Cloud" buttons at the top of the page.
 
 </Notice>
 
@@ -75,7 +75,7 @@ Teleport on your cloud provider of choice.
 
 Now that you have a running Teleport cluster, set up role-based access controls
 to enable secure access to your infrastructure.  You can define roles with
-granular permissions, and use Teleport's integrations with Single Sign-On
+granular permissions and use Teleport's integrations with Single Sign-On
 providers to automatically map these roles to users. You can also set up Access
 Requests to enable just-in-time access to your infrastructure. Read [Manage
 Access](./access-controls/introduction.mdx) to get started.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -85,7 +85,7 @@ Access](./access-controls/introduction.mdx) to get started.
 With your Teleport cluster configured, you can now begin Day Two operations
 such as upgrades, adding agents to the cluster, and integrating Teleport with
 third-party tools. Read [Manage your
-Cluster](./manage-your-cluster/introduction.mdx) for more information.
+Cluster](./management/introduction.mdx) for more information.
 
 ## Add your infrastructure
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -97,9 +97,9 @@ infrastructure.
 Read about how to enable access to:
 
 - [Servers](./server-access/getting-started.mdx)
-- [Applications](./application-access/introduction.mdx)
 - [Kubernetes clusters](./kubernetes-access/introduction.mdx)
 - [Databases](./database-access/introduction.mdx)
+- [Applications](./application-access/introduction.mdx)
 - [Remote desktops](./desktop-access/introduction.mdx)
 
 You can also set up [Machine ID](./machine-id/introduction.mdx) to enable

--- a/docs/pages/management/introduction.mdx
+++ b/docs/pages/management/introduction.mdx
@@ -4,16 +4,16 @@ description: "Guides for performing day-two operations on your Teleport cluster.
 layout: tocless-doc
 ---
 
-In this section, you can find guides for how to manage a Teleport cluster after
+In this section, you can find guides on managing a Teleport cluster after
 deploying it. 
 
 ## Export audit events
 
 Teleport's Auth Service maintains an audit log that tracks events in your
-cluster, such as newly issued certificates. You can get insight into how users
-are interacting with your Teleport cluster by exporting audit events to your log
-management solution. See how in the [Exporting Audit
-Events](./export-audit-events.mdx) guides.
+cluster, such when a user begins an SSH session or attempts to authenticate. You
+can get insight into how users are interacting with your Teleport cluster by
+exporting audit events to your log management solution. See how in the
+[Exporting Audit Events](./export-audit-events.mdx) guides.
 
 ## Security
 
@@ -23,14 +23,14 @@ to ensure that your cluster is as secure as possible. Read about these in the
 
 ## Admin guides
 
-This section describes how to perform routine administrative tasks in your
-Teleport cluster, such as upgrading the `teleport` binary or adding labels to
-Teleport resources. Read the [Admin Guides](./admin.mdx) section.
+The [Admin Guides](./admin.mdx) section describes how to perform routine
+administrative tasks in your Teleport cluster, such as upgrading the `teleport`
+binary or adding labels to Teleport resources.
 
 ## Operations
 
 The [Operations](./operations.mdx) section describes how to perform critical,
-infrequent tasks, such as achieving scalability, upgrading a cluster, and
+infrequent tasks such as achieving scalability, upgrading a cluster, and
 rotating Teleport's certificate authority.
 
 ## Integrations

--- a/docs/pages/management/introduction.mdx
+++ b/docs/pages/management/introduction.mdx
@@ -1,0 +1,47 @@
+---
+title: "Manage your Cluster"
+description: "Guides for performing day-two operations on your Teleport cluster."
+layout: tocless-doc
+---
+
+In this section, you can find guides for how to manage a Teleport cluster after
+deploying it. 
+
+## Export audit events
+
+Teleport's Auth Service maintains an audit log that tracks events in your
+cluster, such as newly issued certificates. You can get insight into how users
+are interacting with your Teleport cluster by exporting audit events to your log
+management solution. See how in the [Exporting Audit
+Events](./export-audit-events.mdx) guides.
+
+## Security
+
+While Teleport is designed with security in mind, there are steps you can take
+to ensure that your cluster is as secure as possible. Read about these in the
+[Security](./security.mdx) section.
+
+## Admin guides
+
+This section describes how to perform routine administrative tasks in your
+Teleport cluster, such as upgrading the `teleport` binary or adding labels to
+Teleport resources. Read the [Admin Guides](./admin.mdx) section.
+
+## Operations
+
+The [Operations](./operations.mdx) section describes how to perform critical,
+infrequent tasks, such as achieving scalability, upgrading a cluster, and
+rotating Teleport's certificate authority.
+
+## Integrations
+
+Teleport integrates with third-party software in order to enable secure access
+to your infrastructure. The [Integrations](./guides.mdx) section describes
+Teleport's Kubernetes Operator, Terraform Provider, and other integrations.
+
+## Diagnostics
+
+To get visibility into the performance of the Teleport services running in your
+infrastructure, you can use Teleport's built-in metrics, traces, and profiling.
+Learn more in the [Diagnostics](./diagnostics.mdx) section.
+

--- a/docs/pages/reference/introduction.mdx
+++ b/docs/pages/reference/introduction.mdx
@@ -20,7 +20,7 @@ running Teleport.
 - [Signals](./signals.mdx): The signals you can use to control a Teleport
   binary.
 - [Backends](./backends.mdx): Configuration options and required setup steps for
-  Teleport's Auth Service backends.
+  Teleport's Auth Service storage backends.
 - [Terraform Provider](./terraform-provider.mdx): Configuration options and
   resources for the Teleport Terraform provider.
 - [Metrics](./metrics.mdx): All metrics available in Teleport.

--- a/docs/pages/reference/introduction.mdx
+++ b/docs/pages/reference/introduction.mdx
@@ -21,7 +21,7 @@ running Teleport.
   binary.
 - [Backends](./backends.mdx): Configuration options and required setup steps for
   Teleport's Auth Service backends.
-- [Terraform Provider](./teleport-provider.mdx): Configuration options and
+- [Terraform Provider](./terraform-provider.mdx): Configuration options and
   resources for the Teleport Terraform provider.
 - [Metrics](./metrics.mdx): All metrics available in Teleport.
 - [Resources](./resources.mdx): Configuration resources you can apply in
@@ -38,7 +38,7 @@ the appropriate section of the documentation:
 - [Teleport Desktop Service](../desktop-access/reference.mdx)
 - [Machine ID](../machine-id/reference.mdx)
 - [RBAC](../access-controls/reference.mdx)
-- [Login Rules](../login-rules/reference.mdx)
+- [Login Rules](../access-controls/login-rules/reference.mdx)
 
 </Admonition>
 

--- a/docs/pages/reference/introduction.mdx
+++ b/docs/pages/reference/introduction.mdx
@@ -1,0 +1,44 @@
+---
+title: Reference
+description: Comprehensive guides to configuring and running Teleport
+---
+
+Teleport's reference guides provide comprehensive resources for configuring and
+running Teleport.
+
+- [Configuration](./config.mdx): All configuration options for the `teleport`
+  binary.
+- [CLI](./cli.mdx): Commands, flags, and arguments for Teleport's CLI tools.
+- [Predicate Language](./predicate-language.mdx): The syntax for Teleport's
+  predicate language, which is used to define RBAC policies and search for
+  resources.
+- [Audit Events](./audit.mdx): A reference of Teleport's audit events.
+- [Helm Reference](./helm-reference.mdx): References for Teleport's Helm charts.
+- [Networking](./networking.mdx): Ports that Teleport services listen on, plus
+  other information about how Teleport services communicate.
+- [Authentication](./authentication.mdx): Teleport's authentication connectors.
+- [Signals](./signals.mdx): The signals you can use to control a Teleport
+  binary.
+- [Backends](./backends.mdx): Configuration options and required setup steps for
+  Teleport's Auth Service backends.
+- [Terraform Provider](./teleport-provider.mdx): Configuration options and
+  resources for the Teleport Terraform provider.
+- [Metrics](./metrics.mdx): All metrics available in Teleport.
+- [Resources](./resources.mdx): Configuration resources you can apply in
+  Teleport.
+
+<Admonition type="tip">
+
+This section contains references that apply to all Teleport services. For
+references that are relevant to a single Teleport service or use case, consult
+the appropriate section of the documentation:
+
+- [Teleport Application Service](../application-access/reference.mdx)
+- [Teleport Database Service](../database-access/reference.mdx)
+- [Teleport Desktop Service](../desktop-access/reference.mdx)
+- [Machine ID](../machine-id/reference.mdx)
+- [RBAC](../access-controls/reference.mdx)
+- [Login Rules](../login-rules/reference.mdx)
+
+</Admonition>
+


### PR DESCRIPTION
Closes #22469

The current docs landing page does not include enough context for new readers. After the general description of Teleport, the rest of the landing page is series of links, with little guidance for what a new user should do first (or what an intermediate user should do after completing the initial setup steps).

This change takes a more narrative approach to the landing page, briefly describing the content of each top-level docs section and putting it in context with the rest of the docs. This also helps users find the right top-level docs section for their needs, since otherwise the only way to do this is to visit each section.

This change is also more opinionated about which guide new users should begin with. It recommends the guide to getting started with Teleport Cloud, since this doesn't require setting up a Teleport cluster and helps a user register a resource quickly.

The landing page links to the introduction page of each top-level docs section. If a section does not have an introduction page, this change adds one.