### PR TITLE
Consolidate context usage for client src/dst addresses into authz package

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -7111,7 +7111,7 @@ func emitHeadlessLoginEvent(ctx context.Context, code string, emitter apievents.
 	clientAddr := ""
 	if code == events.UserHeadlessLoginRequestedCode {
 		clientAddr = headlessAuthn.ClientIpAddress
-	} else if c, err := authz.ClientAddrFromContext(ctx); err == nil {
+	} else if c, err := authz.ClientSrcAddrFromContext(ctx); err == nil {
 		clientAddr = c.String()
 	}
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -4336,7 +4336,7 @@ func (g *GRPCServer) UpsertWindowsDesktopService(ctx context.Context, service *t
 	// the server.Addr field. It's not useful for other services that want to
 	// connect to it (like a proxy). Remote address of the gRPC connection is
 	// the closest thing we have to a public IP for the service.
-	clientAddr, err := authz.ClientAddrFromContext(ctx)
+	clientAddr, err := authz.ClientSrcAddrFromContext(ctx)
 	if err != nil {
 		g.Logger.WithError(err).Warn("error getting client address from context")
 		return nil, status.Errorf(codes.FailedPrecondition, "client address not found in request context")

--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -348,7 +348,7 @@ func (a *Server) RegisterUsingAzureMethod(ctx context.Context, challengeResponse
 		return nil, trace.Wrap(err)
 	}
 
-	clientAddr, err := authz.ClientAddrFromContext(ctx)
+	clientAddr, err := authz.ClientSrcAddrFromContext(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/join_azure_test.go
+++ b/lib/auth/join_azure_test.go
@@ -385,7 +385,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			require.NoError(t, err)
 
 			reqCtx := context.Background()
-			reqCtx = authz.ContextWithClientAddr(reqCtx, &net.IPAddr{})
+			reqCtx = authz.ContextWithClientSrcAddr(reqCtx, &net.IPAddr{})
 
 			vmResult := tc.vmResult
 			if vmResult == nil {

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -354,7 +354,7 @@ func (a *Server) RegisterUsingIAMMethod(ctx context.Context, challengeResponse c
 		opt(cfg)
 	}
 
-	clientAddr, err := authz.ClientAddrFromContext(ctx)
+	clientAddr, err := authz.ClientSrcAddrFromContext(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/join_iam_test.go
+++ b/lib/auth/join_iam_test.go
@@ -506,7 +506,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			}()
 
 			requestContext := context.Background()
-			requestContext = authz.ContextWithClientAddr(requestContext, &net.IPAddr{})
+			requestContext = authz.ContextWithClientSrcAddr(requestContext, &net.IPAddr{})
 
 			_, err = a.RegisterUsingIAMMethod(requestContext, func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {
 				templateInput := defaultIdentityRequestTemplateInput(challenge)

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -433,7 +433,7 @@ func (a *Middleware) withAuthenticatedUser(ctx context.Context) (context.Context
 	}
 
 	ctx = authz.ContextWithUserCertificate(ctx, certFromConnState(connState))
-	ctx = authz.ContextWithClientAddr(ctx, peerInfo.Addr)
+	ctx = authz.ContextWithClientSrcAddr(ctx, peerInfo.Addr)
 	ctx = authz.ContextWithUser(ctx, identityGetter)
 
 	return ctx, nil
@@ -686,7 +686,7 @@ func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = authz.ContextWithUserCertificate(ctx, certFromConnState(r.TLS))
 	clientSrcAddr, err := utils.ParseAddr(remoteAddr)
 	if err == nil {
-		ctx = authz.ContextWithClientAddr(ctx, clientSrcAddr)
+		ctx = authz.ContextWithClientSrcAddr(ctx, clientSrcAddr)
 	}
 	ctx = authz.ContextWithUser(ctx, user)
 	a.Handler.ServeHTTP(w, r.WithContext(ctx))
@@ -715,7 +715,7 @@ func (a *Middleware) WrapContextWithUserFromTLSConnState(ctx context.Context, tl
 	}
 
 	ctx = authz.ContextWithUserCertificate(ctx, certFromConnState(&tlsState))
-	ctx = authz.ContextWithClientAddr(ctx, remoteAddr)
+	ctx = authz.ContextWithClientSrcAddr(ctx, remoteAddr)
 	ctx = authz.ContextWithUser(ctx, user)
 	return ctx, nil
 }
@@ -869,7 +869,7 @@ func (r *ImpersonatorRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	req.Header.Set(TeleportImpersonateUserHeader, string(b))
 	defer req.Header.Del(TeleportImpersonateUserHeader)
 
-	clientSrcAddr, err := authz.ClientAddrFromContext(req.Context())
+	clientSrcAddr, err := authz.ClientSrcAddrFromContext(req.Context())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -909,7 +909,7 @@ func IdentityForwardingHeaders(ctx context.Context, originalHeaders http.Header)
 	headers := originalHeaders.Clone()
 	headers.Set(TeleportImpersonateUserHeader, string(b))
 
-	clientSrcAddr, err := authz.ClientAddrFromContext(ctx)
+	clientSrcAddr, err := authz.ClientSrcAddrFromContext(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -644,7 +644,7 @@ func (h *fakeHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	user, err := authz.UserFromContext(r.Context())
 	require.NoError(h.t, err)
 	require.Equal(h.t, h.expectedUser, user)
-	clientSrcAddr, err := authz.ClientAddrFromContext(r.Context())
+	clientSrcAddr, err := authz.ClientSrcAddrFromContext(r.Context())
 	require.NoError(h.t, err)
 	require.Equal(h.t, h.userIP, clientSrcAddr.String())
 	// Ensure that the Teleport-Impersonate-User header is not set on the request

--- a/lib/auth/transport_credentials.go
+++ b/lib/auth/transport_credentials.go
@@ -207,7 +207,7 @@ func (c *TransportCredentials) authorize(ctx context.Context, remoteAddr net.Add
 
 	// construct a context with the keys expected by the Authorizer
 	ctx = authz.ContextWithUserCertificate(ctx, certFromConnState(connState))
-	ctx = authz.ContextWithClientAddr(ctx, remoteAddr)
+	ctx = authz.ContextWithClientSrcAddr(ctx, remoteAddr)
 	ctx = authz.ContextWithUser(ctx, identityGetter)
 
 	authCtx, err := c.authorizer.Authorize(ctx)

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -352,7 +352,7 @@ func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bo
 		return nil
 	}
 
-	clientSrcAddr, err := ClientAddrFromContext(ctx)
+	clientSrcAddr, err := ClientSrcAddrFromContext(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1030,8 +1030,11 @@ const (
 	// contextUser is a user set in the context of the request
 	contextUser contextKey = "teleport-user"
 
-	// contextClientAddr is a client address set in the context of the request
-	contextClientAddr contextKey = "client-addr"
+	// contextClientSrcAddr is a client source address set in the context of the request
+	contextClientSrcAddr contextKey = "teleport-client-src-addr"
+
+	// contextClientDstAddr is a client destination address set in the context of the request
+	contextClientDstAddr contextKey = "teleport-client-dst-addr"
 )
 
 // WithDelegator alias for backwards compatibility
@@ -1343,25 +1346,53 @@ func ContextWithUserCertificate(ctx context.Context, cert *x509.Certificate) con
 
 // UserCertificateFromContext returns the user certificate from the context.
 func UserCertificateFromContext(ctx context.Context) (*x509.Certificate, error) {
+	if ctx == nil {
+		return nil, trace.BadParameter("context is nil")
+	}
 	cert, ok := ctx.Value(contextUserCertificate).(*x509.Certificate)
 	if !ok {
-		return nil, trace.BadParameter("expected type *x509.Certificate, got %T", cert)
+		return nil, trace.BadParameter("user certificate was not found in the context")
 	}
 	return cert, nil
 }
 
-// ContextWithClientAddr returns the context with the address embedded.
-func ContextWithClientAddr(ctx context.Context, addr net.Addr) context.Context {
-	return context.WithValue(ctx, contextClientAddr, addr)
+// ContextWithClientSrcAddr returns the context with the address embedded.
+func ContextWithClientSrcAddr(ctx context.Context, addr net.Addr) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	return context.WithValue(ctx, contextClientSrcAddr, addr)
 }
 
-// ClientAddrFromContext returns the client address from the context.
-func ClientAddrFromContext(ctx context.Context) (net.Addr, error) {
-	addr, ok := ctx.Value(contextClientAddr).(net.Addr)
+// ClientSrcAddrFromContext returns the client address from the context.
+func ClientSrcAddrFromContext(ctx context.Context) (net.Addr, error) {
+	if ctx == nil {
+		return nil, trace.BadParameter("context is nil")
+	}
+	addr, ok := ctx.Value(contextClientSrcAddr).(net.Addr)
 	if !ok {
-		return nil, trace.BadParameter("expected type net.Addr, got %T", addr)
+		return nil, trace.BadParameter("client source address was not found in the context")
 	}
 	return addr, nil
+}
+
+// ContextWithClientAddrs returns the context with the client source and destination addresses embedded.
+func ContextWithClientAddrs(ctx context.Context, src, dst net.Addr) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	ctx = context.WithValue(ctx, contextClientSrcAddr, src)
+	return context.WithValue(ctx, contextClientDstAddr, dst)
+}
+
+// ClientAddrsFromContext returns the client address from the context.
+func ClientAddrsFromContext(ctx context.Context) (src net.Addr, dst net.Addr) {
+	if ctx == nil {
+		return nil, nil
+	}
+	src, _ = ctx.Value(contextClientSrcAddr).(net.Addr)
+	dst, _ = ctx.Value(contextClientDstAddr).(net.Addr)
+	return
 }
 
 // ContextWithUser returns the context with the user embedded.
@@ -1371,9 +1402,12 @@ func ContextWithUser(ctx context.Context, user IdentityGetter) context.Context {
 
 // UserFromContext returns the user from the context.
 func UserFromContext(ctx context.Context) (IdentityGetter, error) {
+	if ctx == nil {
+		return nil, trace.BadParameter("context is nil")
+	}
 	user, ok := ctx.Value(contextUser).(IdentityGetter)
 	if !ok {
-		return nil, trace.BadParameter("expected type IdentityGetter, got %T", user)
+		return nil, trace.BadParameter("user identity was not found in the context")
 	}
 	return user, nil
 }

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -562,7 +562,7 @@ func TestCheckIPPinning(t *testing.T) {
 			desc:     "IP pinning enabled, missing client IP",
 			pinnedIP: "127.0.0.1",
 			pinIP:    true,
-			wantErr:  "expected type net.Addr, got <nil>",
+			wantErr:  "client source address was not found in the context",
 		},
 		{
 			desc:       "IP pinning enabled, port=0 (marked by proxyProtocolMode unspecified)",
@@ -582,7 +582,7 @@ func TestCheckIPPinning(t *testing.T) {
 	for _, tt := range testCases {
 		ctx := context.Background()
 		if tt.clientAddr != "" {
-			ctx = ContextWithClientAddr(ctx, utils.MustParseAddr(tt.clientAddr))
+			ctx = ContextWithClientSrcAddr(ctx, utils.MustParseAddr(tt.clientAddr))
 		}
 		identity := tlsca.Identity{PinnedIP: tt.pinnedIP}
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -68,6 +68,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/touchid"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client/mfa"
 	"github.com/gravitational/teleport/lib/client/terminal"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -3211,7 +3212,7 @@ func CreatePROXYHeaderGetter(ctx context.Context, proxySigner multiplexer.PROXYH
 		return nil
 	}
 
-	src, dst := utils.ClientAddrFromContext(ctx)
+	src, dst := authz.ClientAddrsFromContext(ctx)
 	if src != nil && dst != nil {
 		return func() ([]byte, error) {
 			return proxySigner.SignPROXYHeader(src, dst)

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -33,6 +33,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -248,7 +249,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 			TLSConfig:   cfg.TLS,
 			ConnState:   ingress.HTTPConnStateReporter(ingress.Kube, cfg.IngressReporter),
 			ConnContext: func(ctx context.Context, c net.Conn) context.Context {
-				return utils.ClientAddrContext(ctx, c.RemoteAddr(), c.LocalAddr())
+				return authz.ContextWithClientAddrs(ctx, c.RemoteAddr(), c.LocalAddr())
 			},
 		},
 		heartbeats: make(map[string]*srv.Heartbeat),

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4104,7 +4104,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentProxy),
 				ConnState:         ingress.HTTPConnStateReporter(ingress.Web, ingressReporter),
 				ConnContext: func(ctx context.Context, c net.Conn) context.Context {
-					return utils.ClientAddrContext(ctx, c.RemoteAddr(), c.LocalAddr())
+					return authz.ContextWithClientAddrs(ctx, c.RemoteAddr(), c.LocalAddr())
 				},
 			},
 			Handler: webHandler,

--- a/lib/srv/alpnproxy/proxy.go
+++ b/lib/srv/alpnproxy/proxy.go
@@ -378,7 +378,7 @@ func (p *Proxy) handleConn(ctx context.Context, clientConn net.Conn, defaultOver
 		SNI:  hello.ServerName,
 		ALPN: hello.SupportedProtos,
 	}
-	ctx = utils.ClientAddrContext(ctx, clientConn.RemoteAddr(), clientConn.LocalAddr())
+	ctx = authz.ContextWithClientAddrs(ctx, clientConn.RemoteAddr(), clientConn.LocalAddr())
 
 	if handlerDesc.ForwardTLS {
 		return trace.Wrap(handlerDesc.handle(ctx, conn, connInfo))

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -721,7 +721,7 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 	}
 
 	ctx = authz.ContextWithUser(s.closeContext, user)
-	ctx = authz.ContextWithClientAddr(ctx, conn.RemoteAddr())
+	ctx = authz.ContextWithClientSrcAddr(ctx, conn.RemoteAddr())
 	authCtx, _, err := s.authorizeContext(ctx)
 
 	// The behavior here is a little hard to track. To be clear here, if authorization fails

--- a/lib/utils/net.go
+++ b/lib/utils/net.go
@@ -17,45 +17,10 @@ limitations under the License.
 package utils
 
 import (
-	"context"
 	"net"
 
 	"github.com/gravitational/trace"
 )
-
-type webContextKey string
-
-const (
-	// ClientSrcAddrContextKey is context key for client source address
-	ClientSrcAddrContextKey webContextKey = "teleport-clientSrcAddrContextKey"
-	// ClientDstAddrContextKey is context key for client destination address
-	ClientDstAddrContextKey webContextKey = "teleport-clientDstAddrContextKey"
-)
-
-// ClientAddrContext is used by server that accepts connections from clients to set incoming
-// client's connection source and destination addresses to the context, so it could be later used
-// for IP propagation purpose. It is used when we don't have other source for client source/destination
-// addresses (don't have direct access to net.Conn)
-func ClientAddrContext(ctx context.Context, src net.Addr, dst net.Addr) context.Context {
-	ctx = context.WithValue(ctx, ClientSrcAddrContextKey, src)
-	return context.WithValue(ctx, ClientDstAddrContextKey, dst)
-}
-
-// ClientSrcAddrContext sets client source address.
-func ClientSrcAddrContext(ctx context.Context, src net.Addr) context.Context {
-	return context.WithValue(ctx, ClientSrcAddrContextKey, src)
-}
-
-// ClientAddrFromContext gets client source address and destination addresses from the context. If an address is
-// not present, nil will be returned
-func ClientAddrFromContext(ctx context.Context) (src net.Addr, dst net.Addr) {
-	if ctx == nil {
-		return nil, nil
-	}
-	src, _ = ctx.Value(ClientSrcAddrContextKey).(net.Addr)
-	dst, _ = ctx.Value(ClientDstAddrContextKey).(net.Addr)
-	return
-}
 
 // ClientIPFromConn extracts host from provided remote address.
 func ClientIPFromConn(conn net.Conn) (string, error) {

--- a/lib/web/addr.go
+++ b/lib/web/addr.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -104,7 +105,7 @@ func parseXForwardedForHeaders(observedAddr string, xForwardedForHeaders []strin
 }
 
 func requestWithClientSrcAddr(r *http.Request, clientSrcAddr net.Addr) *http.Request {
-	ctx := utils.ClientSrcAddrContext(r.Context(), clientSrcAddr)
+	ctx := authz.ContextWithClientSrcAddr(r.Context(), clientSrcAddr)
 	r = r.WithContext(ctx)
 	r.RemoteAddr = clientSrcAddr.String()
 	return r

--- a/lib/web/addr_test.go
+++ b/lib/web/addr_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -39,7 +40,7 @@ func TestNewXForwardedForMiddleware(t *testing.T) {
 
 	// Setup request with observeredAddr.
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req = req.WithContext(utils.ClientSrcAddrContext(req.Context(), observeredAddr))
+	req = req.WithContext(authz.ContextWithClientSrcAddr(req.Context(), observeredAddr))
 	req.RemoteAddr = observeredAddr.String()
 
 	// Setup other requests for testing.
@@ -87,7 +88,8 @@ func TestNewXForwardedForMiddleware(t *testing.T) {
 				require.Equal(t, test.wantRemoteAddr, outputReq.RemoteAddr)
 
 				// Verify request context.
-				clientSrcAddr, _ := utils.ClientAddrFromContext(outputReq.Context())
+				clientSrcAddr, err := authz.ClientSrcAddrFromContext(outputReq.Context())
+				require.NoError(t, err)
 				require.Equal(t, test.wantRemoteAddr, clientSrcAddr.String())
 
 				outputRW.WriteHeader(http.StatusAccepted)

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
@@ -284,7 +285,7 @@ func dialAppServer(ctx context.Context, proxyClient reversetunnelclient.Tunnel, 
 
 	var from net.Addr
 	from = &utils.NetAddr{AddrNetwork: "tcp", Addr: "@web-proxy"}
-	clientSrcAddr, originalDst := utils.ClientAddrFromContext(ctx)
+	clientSrcAddr, originalDst := authz.ClientAddrsFromContext(ctx)
 	if clientSrcAddr != nil {
 		from = clientSrcAddr
 	}

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -173,7 +174,7 @@ func (h *Handler) createDesktopConnection(
 		return sendTDPError(err)
 	}
 
-	clientSrcAddr, clientDstAddr := utils.ClientAddrFromContext(r.Context())
+	clientSrcAddr, clientDstAddr := authz.ClientAddrsFromContext(r.Context())
 
 	c := &connector{
 		log:           log,

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -47,6 +47,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -297,7 +298,7 @@ func clusterDialer(remoteCluster reversetunnelclient.RemoteSite, src, dst net.Ad
 			OriginalClientDstAddr: dst,
 		}
 
-		clientSrcAddr, clientDstAddr := utils.ClientAddrFromContext(in)
+		clientSrcAddr, clientDstAddr := authz.ClientAddrsFromContext(in)
 		if dialParams.From == nil && clientSrcAddr != nil {
 			dialParams.From = clientSrcAddr
 		}
@@ -391,7 +392,7 @@ func (c *SessionContext) newRemoteTLSClient(ctx context.Context, cluster reverse
 		return nil, trace.Wrap(err)
 	}
 
-	clientSrcAddr, clientDstAddr := utils.ClientAddrFromContext(ctx)
+	clientSrcAddr, clientDstAddr := authz.ClientAddrsFromContext(ctx)
 
 	return auth.NewClient(apiclient.Config{
 		Context: ctx,


### PR DESCRIPTION
We had two places that were used for putting client connection IP addresses to the context - one in `utils` and one in `authz`. This PR consolidates usages of contexts and puts everything into `authz`, plus a bit of refactoring.

`e` repo counterpart (very small function name adjustment) - https://github.com/gravitational/teleport.e/pull/2542