### PR TITLE
Update SAML IdP auth attempt code variable name.

### DIFF
--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -404,7 +404,7 @@ const (
 	// LoginRuleDeleteCode is the login rule delete code.
 	LoginRuleDeleteCode = "TLR01I"
 
-	// SAMLIdPAuthAttemptCode is the SAML IdP auth code.
+	// SAMLIdPAuthAttemptCode is the SAML IdP auth attempt code.
 	SAMLIdPAuthAttemptCode = "TSI000I"
 
 	// SAMLIdPServiceProviderCreateCode is the SAML IdP service provider create code.

--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -404,8 +404,8 @@ const (
 	// LoginRuleDeleteCode is the login rule delete code.
 	LoginRuleDeleteCode = "TLR01I"
 
-	// SAMLIdPAuthEventCode is the SAML IdP auth code.
-	SAMLIdPAuthCode = "TSI000I"
+	// SAMLIdPAuthAttemptCode is the SAML IdP auth code.
+	SAMLIdPAuthAttemptCode = "TSI000I"
 
 	// SAMLIdPServiceProviderCreateCode is the SAML IdP service provider create code.
 	SAMLIdPServiceProviderCreateCode = "TSI001I"


### PR DESCRIPTION
The SAML IdP auth attempt code variable name now accurately mirrors the event name.