### PR TITLE
[v12] bump cloud version

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1315,7 +1315,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "11.3.4",
+      "version": "11.3.5",
       "major_version": "11",
       "sla": {
         "monthly_percentage": "99.5%",


### PR DESCRIPTION
Backports to #22449 to `branch/v12`.