### PR TITLE
Add SAML IdP service providers to default allow rules.

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -198,6 +198,7 @@ func defaultAllowRules() map[string][]types.Rule {
 			types.NewRule(types.KindDatabaseService, RO()),
 			types.NewRule(types.KindLoginRule, RW()),
 			types.NewRule(types.KindPlugin, RW()),
+			types.NewRule(types.KindSAMLIdPServiceProvider, RW()),
 		},
 	}
 }


### PR DESCRIPTION
SAML IdP service providers have been added to the default allow rules to ensure that the editor role has access to the SAML IdP service providers during a migration.