### PR TITLE
SCP - Change file attrs only when requested

### DIFF
--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -517,12 +517,12 @@ func (cmd *command) receiveFile(st *state, fc newFileCmd, ch io.ReadWriter) erro
 		return trace.Errorf("unexpected file copy length: %v", n)
 	}
 
-  // Change the file permissions only when client requested it.
-  if cmd.Flags.PreserveAttrs {
-    if err := cmd.FileSystem.Chmod(path, int(fc.Mode)); err != nil {
-      return trace.Wrap(err)
-    }
-  }
+	// Change the file permissions only when client requested it.
+	if cmd.Flags.PreserveAttrs {
+		if err := cmd.FileSystem.Chmod(path, int(fc.Mode)); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 
 	if st.stat != nil {
 		err = cmd.FileSystem.Chtimes(path, st.stat.Atime, st.stat.Mtime)

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -517,9 +517,13 @@ func (cmd *command) receiveFile(st *state, fc newFileCmd, ch io.ReadWriter) erro
 		return trace.Errorf("unexpected file copy length: %v", n)
 	}
 
-	if err := cmd.FileSystem.Chmod(path, int(fc.Mode)); err != nil {
-		return trace.Wrap(err)
-	}
+  // Change the file permissions only when client requested it.
+  if cmd.Flags.PreserveAttrs {
+    if err := cmd.FileSystem.Chmod(path, int(fc.Mode)); err != nil {
+      return trace.Wrap(err)
+    }
+  }
+
 	if st.stat != nil {
 		err = cmd.FileSystem.Chtimes(path, st.stat.Atime, st.stat.Mtime)
 		if err != nil {


### PR DESCRIPTION
OpenSSH sets 0644 by default and allows copying the source permissions by passing `-p` flag. Our current implementation sets the file permissions even when the client didn't use `-p` flag, which can fail if the user doesn't have permission to set it. This patch matches the OpenSSH behavior.

Closes https://github.com/gravitational/teleport/issues/22265