### PR TITLE
Always return unauthorized if the user doesn't have access to the cert.

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -625,7 +625,8 @@ func (a *ServerWithRoles) GetCertAuthority(ctx context.Context, id types.CertAut
 
 	ca, err := a.authServer.GetCertAuthority(ctx, id, loadKeys, opts...)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		log.WithError(err).Warn("error getting cert authority")
+		return nil, trace.AccessDenied("access denied")
 	}
 	sctx := &services.Context{User: a.context.User, Resource: ca}
 	if err := a.actionWithContext(sctx, apidefaults.Namespace, types.KindCertAuthority, readVerb); err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -637,7 +637,7 @@ func (a *ServerWithRoles) GetCertAuthority(ctx context.Context, id types.CertAut
 		return nil, trace.Wrap(err)
 	}
 
-	// Call actionWithContext on the CA itself to ensure that we've got permission to this specific CA>
+	// Call actionWithContext on the CA itself to ensure that we've got permission to this specific CA.
 	ca, err := a.authServer.GetCertAuthority(ctx, id, loadKeys, opts...)
 	sctx = &services.Context{User: a.context.User, Resource: ca}
 	if err := a.actionWithContext(sctx, apidefaults.Namespace, types.KindCertAuthority, readVerb); err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -637,7 +637,13 @@ func (a *ServerWithRoles) GetCertAuthority(ctx context.Context, id types.CertAut
 		return nil, trace.Wrap(err)
 	}
 
+	// Call actionWithContext on the CA itself to ensure that we've got permission to this specific CA>
 	ca, err := a.authServer.GetCertAuthority(ctx, id, loadKeys, opts...)
+	sctx = &services.Context{User: a.context.User, Resource: ca}
+	if err := a.actionWithContext(sctx, apidefaults.Namespace, types.KindCertAuthority, readVerb); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return ca, trace.Wrap(err)
 }
 


### PR DESCRIPTION
In order to avoid exposing whether or not a cert authority exists, we should return Unauthorized if the cert authority shouldn't be accessible. Prior to this, the recent change would expose `NotFound` even if the user didn't have permission to it.