### PR TITLE
[v12] Add SAML IdP service providers to default allow rules.

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -196,6 +196,7 @@ func defaultAllowRules() map[string][]types.Rule {
 			types.NewRule(types.KindDatabase, RW()),
 			types.NewRule(types.KindDatabaseService, RO()),
 			types.NewRule(types.KindLoginRule, RW()),
+			types.NewRule(types.KindSAMLIdPServiceProvider, RW()),
 		},
 	}
 }


### PR DESCRIPTION
Backporting https://github.com/gravitational/teleport/pull/22577 to branch/v12