### PR TITLE
Flaky tests detector tweaks

### DIFF
--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -7,12 +7,12 @@ on:
       - '**.go'
 
 env:
-  ATTEMPTS: 30
+  ATTEMPTS: 100
 
 jobs:
   test:
     name: Flaky tests detector
-    runs-on: ubuntu-22.04-32core
+    runs-on: ubuntu-latest # do not use large runner to catch more issues
 
     permissions:
       contents: read


### PR DESCRIPTION
Couple of tweaks to hopefully increase its effectiveness:

- Increase number of test runs to 100.
- Use standard runner instead of large one. We can see how long it takes and revert back to a larger runner if it becomes untenable (it's still an optional check).