### PR TITLE
Make it easier to create registered openssh nodes with 'tctl'

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-piv/piv-go v1.10.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.5.9
+	github.com/google/uuid v1.3.0
 	github.com/gravitational/trace v1.2.1
 	github.com/jonboulle/clockwork v0.3.0
 	github.com/russellhaering/gosaml2 v0.9.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -145,6 +145,8 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gravitational/crypto v0.0.0-20221221152432-903e65687e59 h1:BzLRQAkAmmY2cZjVb8zEEG1dBkCxtJcBQyHnwKG+Qw0=

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -124,14 +124,15 @@ const (
 	// KindProxy is proxy resource
 	KindProxy = "proxy"
 
-	// KindNode is node resource
+	// KindNode is node resource. It can be either a Teleport node or
+	// a registered OpenSSH (agentless) node.
 	KindNode = "node"
 
-	// KindOpenSSHNode is a Teleport node.
-	KindTeleportNode = "teleport"
+	// SubKindTeleportNode is a Teleport node.
+	SubKindTeleportNode = "teleport"
 
-	// KindOpenSSHNode is a registered OpenSSH (agentless) node.
-	KindOpenSSHNode = "openssh"
+	// SubKindOpenSSHNode is a registered OpenSSH (agentless) node.
+	SubKindOpenSSHNode = "openssh"
 
 	// KindAppServer is an application server resource.
 	KindAppServer = "app_server"

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -127,6 +127,9 @@ const (
 	// KindNode is node resource
 	KindNode = "node"
 
+	// KindOpenSSHNode is a Teleport node.
+	KindTeleportNode = "teleport"
+
 	// KindOpenSSHNode is a registered OpenSSH (agentless) node.
 	KindOpenSSHNode = "openssh"
 

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -138,6 +138,11 @@ func (s *ServerV2) GetKind() string {
 
 // GetSubKind returns resource sub kind
 func (s *ServerV2) GetSubKind() string {
+	// if the server is a node subkind isn't set, this is a teleport node.
+	if s.Kind == KindNode && s.SubKind == "" {
+		return SubKindTeleportNode
+	}
+
 	return s.SubKind
 }
 
@@ -407,10 +412,12 @@ func (s *ServerV2) CheckAndSetDefaults() error {
 	if s.Kind == "" {
 		return trace.BadParameter("server Kind is empty")
 	}
+	if s.Kind != KindNode && s.SubKind != "" {
+		return trace.BadParameter(`server SubKind must only be set when Kind is "node"`)
+	}
+
 	switch s.SubKind {
-	case "":
-		s.SubKind = SubKindTeleportNode
-	case SubKindTeleportNode:
+	case "", SubKindTeleportNode:
 		// allow but do nothing
 	case SubKindOpenSSHNode:
 		if s.Spec.Addr == "" {

--- a/api/types/server_test.go
+++ b/api/types/server_test.go
@@ -164,7 +164,6 @@ func TestServerCheckAndSetDefaults(t *testing.T) {
 				require.NoError(t, err)
 				expectedServer := &ServerV2{
 					Kind:    KindNode,
-					SubKind: SubKindTeleportNode,
 					Version: V2,
 					Metadata: Metadata{
 						Name:      "5da56852-2adb-4540-a37c-80790203f6a9",

--- a/api/types/server_test.go
+++ b/api/types/server_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/defaults"
 )
 
 func getTestVal(isTestField bool, testVal string) string {
@@ -98,4 +100,234 @@ func TestServerSorter(t *testing.T) {
 	sortBy := SortBy{Field: "unsupported"}
 	servers := makeServers(testValsUnordered, "does-not-matter")
 	require.True(t, trace.IsNotImplemented(Servers(servers).SortByCustom(sortBy)))
+}
+
+func TestServerCheckAndSetDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		server    *ServerV2
+		assertion func(t *testing.T, s *ServerV2, err error)
+	}{
+		{
+			name: "Teleport node",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindTeleportNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:       "1.2.3.4:3022",
+					Hostname:   "teleport-node",
+					PublicAddr: "1.2.3.4:3080",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.NoError(t, err)
+				expectedServer := &ServerV2{
+					Kind:    KindNode,
+					SubKind: SubKindTeleportNode,
+					Version: V2,
+					Metadata: Metadata{
+						Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+						Namespace: defaults.Namespace,
+					},
+					Spec: ServerSpecV2{
+						Addr:       "1.2.3.4:3022",
+						Hostname:   "teleport-node",
+						PublicAddr: "1.2.3.4:3080",
+					},
+				}
+				require.Equal(t, expectedServer, s)
+			},
+		},
+		{
+			name: "Teleport node subkind unset",
+			server: &ServerV2{
+				Kind:    KindNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:       "1.2.3.4:3022",
+					Hostname:   "teleport-node",
+					PublicAddr: "1.2.3.4:3080",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.NoError(t, err)
+				expectedServer := &ServerV2{
+					Kind:    KindNode,
+					SubKind: SubKindTeleportNode,
+					Version: V2,
+					Metadata: Metadata{
+						Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+						Namespace: defaults.Namespace,
+					},
+					Spec: ServerSpecV2{
+						Addr:       "1.2.3.4:3022",
+						Hostname:   "teleport-node",
+						PublicAddr: "1.2.3.4:3080",
+					},
+				}
+				require.Equal(t, expectedServer, s)
+			},
+		},
+		{
+			name: "OpenSSH node",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:     "1.2.3.4:3022",
+					Hostname: "openssh-node",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.NoError(t, err)
+				expectedServer := &ServerV2{
+					Kind:    KindNode,
+					SubKind: SubKindOpenSSHNode,
+					Version: V2,
+					Metadata: Metadata{
+						Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+						Namespace: defaults.Namespace,
+					},
+					Spec: ServerSpecV2{
+						Addr:     "1.2.3.4:3022",
+						Hostname: "openssh-node",
+					},
+				}
+				require.Equal(t, expectedServer, s)
+			},
+		},
+		{
+			name: "OpenSSH node with unset name",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Spec: ServerSpecV2{
+					Addr:     "1.2.3.4:22",
+					Hostname: "openssh-node",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.NoError(t, err)
+				require.NotEmpty(t, s.Metadata.Name)
+			},
+		},
+		{
+			name: "OpenSSH node with unset addr",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Hostname: "openssh-node",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.EqualError(t, err, `Addr must be set when server SubKind is "openssh"`)
+			},
+		},
+		{
+			name: "OpenSSH node with unset hostname",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr: "1.2.3.4:3022",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.EqualError(t, err, `Hostname must be set when server SubKind is "openssh"`)
+			},
+		},
+		{
+			name: "OpenSSH node with public addr",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:       "1.2.3.4:3022",
+					Hostname:   "openssh-node",
+					PublicAddr: "1.2.3.4:80",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.EqualError(t, err, `PublicAddr must not be set when server SubKind is "openssh"`)
+			},
+		},
+		{
+			name: "OpenSSH node with invalid addr",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:     "invalid-addr",
+					Hostname: "openssh-node",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.ErrorContains(t, err, `invalid Addr "invalid-addr"`)
+			},
+		},
+		{
+			name: "node with invalid subkind",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: "invalid-subkind",
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:     "1.2.3.4:22",
+					Hostname: "node",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.EqualError(t, err, `invalid SubKind "invalid-subkind"`)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.server.CheckAndSetDefaults()
+			tt.assertion(t, tt.server, err)
+		})
+	}
 }

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1905,13 +1905,6 @@ waitLoop:
 				continue
 			}
 
-			// Server resources may have subkind set, but the backend
-			// generating this delete event doesn't know the subkind.
-			// Set it to prevent the check below from failing.
-			if event.Resource.GetKind() == types.KindNode || event.Resource.GetKind() == types.KindProxy {
-				event.Resource.SetSubKind(resource.GetSubKind())
-			}
-
 			require.Empty(t, cmp.Diff(resource, event.Resource))
 			break waitLoop
 		}

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1904,6 +1904,14 @@ waitLoop:
 				log.Debugf("Skipping stale event %v %v", event.Type, event.Resource.GetName())
 				continue
 			}
+
+			// Server resources may have subkind set, but the backend
+			// generating this delete event doesn't know the subkind.
+			// Set it to prevent the check below from failing.
+			if event.Resource.GetKind() == types.KindNode || event.Resource.GetKind() == types.KindProxy {
+				event.Resource.SetSubKind(resource.GetSubKind())
+			}
+
 			require.Empty(t, cmp.Diff(resource, event.Resource))
 			break waitLoop
 		}

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1905,6 +1905,13 @@ waitLoop:
 				continue
 			}
 
+			// Server resources may have subkind set, but the backend
+			// generating this delete event doesn't know the subkind.
+			// Set it to prevent the check below from failing.
+			if event.Resource.GetKind() == types.KindNode {
+				event.Resource.SetSubKind(resource.GetSubKind())
+			}
+
 			require.Empty(t, cmp.Diff(resource, event.Resource))
 			break waitLoop
 		}

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -433,7 +433,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 		// exists and it is an agentless node, preform an RBAC check.
 		// Otherwise if the target node does not exist the node is
 		// probably an unregistered SSH node; do not preform an RBAC check
-		if h.c.TargetServer != nil && h.c.TargetServer.GetSubKind() == types.KindOpenSSHNode {
+		if h.c.TargetServer != nil && h.c.TargetServer.GetSubKind() == types.SubKindOpenSSHNode {
 			err = h.canLoginWithRBAC(cert, ca, clusterName.GetClusterName(), h.c.TargetServer, teleportUser, conn.User())
 		}
 	} else {

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -179,7 +179,7 @@ func TestRBAC(t *testing.T) {
 				server, ok := n.(*types.ServerV2)
 				require.True(t, ok)
 				if tt.openSSHNode {
-					server.SubKind = types.KindOpenSSHNode
+					server.SubKind = types.SubKindOpenSSHNode
 				}
 				target = server
 			}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -665,7 +665,11 @@ func (rc *ResourceCommand) createNode(ctx context.Context, client auth.ClientI, 
 	}
 	exists := (err == nil)
 	if !rc.IsForced() && exists {
-		return trace.AlreadyExists("node %q already exists, use -f flag to override", name)
+		return trace.AlreadyExists("node %q with Hostname %q and Addr %q already exists, use --force flag to override",
+			name,
+			server.GetHostname(),
+			server.GetAddr(),
+		)
 	}
 
 	_, err = client.UpsertNode(ctx, server)


### PR DESCRIPTION
Metadata.Name is set to a random UUID if it's unset, the requirement to use '--force' when creating node resources is dropped, and more checks for openssh node resources are added.

Part of implementing Agentless RFD: https://github.com/gravitational/teleport/blob/master/rfd/0098-registered-openssh-nodes.md#registering-with-tctl