### PR TITLE
Add MaxRetryPeriod for cachePolicy config to use in tests

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3235,6 +3235,7 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 		tconf.Proxy.DisableWebService = false
 		tconf.Proxy.DisableWebInterface = true
 		tconf.SSH.Enabled = enableSSH
+		tconf.CachePolicy.MaxRetryPeriod = time.Millisecond * 500
 		return t, nil, tconf
 	}
 	lib.SetInsecureDevMode(true)
@@ -6940,6 +6941,7 @@ func createTrustedClusterPair(t *testing.T, suite *integrationTestSuite, extraSe
 		tconf.Proxy.DisableWebService = false
 		tconf.Proxy.DisableWebInterface = true
 		tconf.SSH.Enabled = false
+		tconf.CachePolicy.MaxRetryPeriod = time.Millisecond * 500
 		return t, nil, tconf
 	}
 

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -414,6 +414,9 @@ func (cfg *Config) DebugDumpToYAML() string {
 type CachePolicy struct {
 	// Enabled enables or disables caching
 	Enabled bool
+	// MaxRetryPeriod is maximum period cache waits before retrying on failure.
+	// Not exposed through the config file, used in tests.
+	MaxRetryPeriod time.Duration
 }
 
 // CheckAndSetDefaults checks and sets default values

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1929,6 +1929,7 @@ func (process *TeleportProcess) newAccessCache(cfg accessCacheConfig) (*cache.Ca
 		Component:               teleport.Component(append(cfg.cacheName, process.id, teleport.ComponentCache)...),
 		MetricComponent:         teleport.Component(append(cfg.cacheName, teleport.ComponentCache)...),
 		Tracer:                  process.TracingProvider.Tracer(teleport.ComponentCache),
+		MaxRetryPeriod:          process.Config.CachePolicy.MaxRetryPeriod,
 		Unstarted:               cfg.unstarted,
 	}))
 }


### PR DESCRIPTION
This fixes flakiness in couple of integration tests that surfaced after recent changes to the retry logic/timeouts in https://github.com/gravitational/teleport/pull/21490 because router couldn't resolve nodes by name - when it was used cache for remote cluster was still not initialized, so router didn't have information about nodes.