### PR TITLE
[v12] temporarily disable TestHSMDualAuthRotation

### DIFF
--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -428,6 +428,10 @@ func TestHSMRotation(t *testing.T) {
 
 // Tests multiple CA rotations and rollbacks with 2 HSM auth servers in an HA configuration
 func TestHSMDualAuthRotation(t *testing.T) {
+	// TODO(nklaassen): fix this test and re-enable it.
+	// https://github.com/gravitational/teleport/issues/20217
+	t.Skip("TestHSMDualAuthRotation is temporarily disabled due to flakiness")
+
 	requireHSMAvailable(t)
 	requireETCDAvailable(t)
 


### PR DESCRIPTION
Backport #22568 to branch/v12

This test has become pretty flaky recently, disabling it for now until I can find the root cause or fix the test.

Flaky test issue: https://github.com/gravitational/teleport/issues/20217