### PR TITLE
Do not check os groups when user exits

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -379,6 +379,9 @@ type ServerContext struct {
 
 	// JoinOnly is set if the connection was created using a join-only principal and may only be used to join other sessions.
 	JoinOnly bool
+
+	// UserCreatedByTeleport is true when the system user was created by Teleport user auto-provision.
+	UserCreatedByTeleport bool
 }
 
 // NewServerContext creates a new *ServerContext which is used to pass and
@@ -1062,6 +1065,7 @@ func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 		ClientAddress:         c.ServerConn.RemoteAddr().String(),
 		RequestType:           requestType,
 		PermitUserEnvironment: c.srv.PermitUserEnvironment(),
+		UserCreatedByTeleport: c.UserCreatedByTeleport,
 		Environment:           buildEnvironment(c),
 		PAMConfig:             pamConfig,
 		IsTestStub:            c.IsTestStub,

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -130,6 +130,9 @@ type ExecCommand struct {
 	// IsTestStub is used by tests to mock the shell.
 	IsTestStub bool `json:"is_test_stub"`
 
+	// UserCreatedByTeleport is true when the system user was created by Teleport user auto-provision.
+	UserCreatedByTeleport bool
+
 	// UaccMetadata contains metadata needed for user accounting.
 	UaccMetadata UaccMetadata `json:"uacc_meta"`
 
@@ -330,9 +333,15 @@ func RunCommand() (errw io.Writer, code int, err error) {
 	defer parkerCancel()
 
 	osPack := newOsWrapper()
-	if err := osPack.startNewParker(parkerCtx, cmd.SysProcAttr.Credential,
-		c.Login, &systemUser{u: localUser}); err != nil {
-		return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
+	if c.UserCreatedByTeleport {
+		// Parker is only needed when the user was created by Teleport.
+		err := osPack.startNewParker(
+			parkerCtx,
+			cmd.SysProcAttr.Credential,
+			c.Login, &systemUser{u: localUser})
+		if err != nil {
+			return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
+		}
 	}
 
 	if c.X11Config.XServerUnixSocket != "" {

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -211,6 +211,10 @@ func (s *SessionRegistry) TryCreateHostUser(ctx *ServerContext) (*user.User, err
 	if userCloser != nil {
 		ctx.AddCloser(userCloser)
 	}
+
+	// Indicate that the user was created by Teleport.
+	ctx.UserCreatedByTeleport = true
+
 	return tempUser, nil
 }
 


### PR DESCRIPTION
In some cases checking the user group when starting SSH session can cause problems (ex. LDAP check). Disable OS group check when it's not needed.

Closes https://github.com/gravitational/teleport/issues/22671