### PR TITLE
[v12] Make it easier to create registered openssh nodes with 'tctl'

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-piv/piv-go v1.10.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.5.9
+	github.com/google/uuid v1.3.0
 	github.com/gravitational/trace v1.2.1
 	github.com/jonboulle/clockwork v0.3.0
 	github.com/russellhaering/gosaml2 v0.8.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -143,6 +143,8 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gravitational/crypto v0.0.0-20221221152432-903e65687e59 h1:BzLRQAkAmmY2cZjVb8zEEG1dBkCxtJcBQyHnwKG+Qw0=

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -124,8 +124,15 @@ const (
 	// KindProxy is proxy resource
 	KindProxy = "proxy"
 
-	// KindNode is node resource
+	// KindNode is node resource. It can be either a Teleport node or
+	// a registered OpenSSH (agentless) node.
 	KindNode = "node"
+
+	// SubKindTeleportNode is a Teleport node.
+	SubKindTeleportNode = "teleport"
+
+	// SubKindOpenSSHNode is a registered OpenSSH (agentless) node.
+	SubKindOpenSSHNode = "openssh"
 
 	// KindAppServer is an application server resource.
 	KindAppServer = "app_server"

--- a/api/types/server_test.go
+++ b/api/types/server_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/defaults"
 )
 
 func getTestVal(isTestField bool, testVal string) string {
@@ -98,4 +100,233 @@ func TestServerSorter(t *testing.T) {
 	sortBy := SortBy{Field: "unsupported"}
 	servers := makeServers(testValsUnordered, "does-not-matter")
 	require.True(t, trace.IsNotImplemented(Servers(servers).SortByCustom(sortBy)))
+}
+
+func TestServerCheckAndSetDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		server    *ServerV2
+		assertion func(t *testing.T, s *ServerV2, err error)
+	}{
+		{
+			name: "Teleport node",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindTeleportNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:       "1.2.3.4:3022",
+					Hostname:   "teleport-node",
+					PublicAddr: "1.2.3.4:3080",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.NoError(t, err)
+				expectedServer := &ServerV2{
+					Kind:    KindNode,
+					SubKind: SubKindTeleportNode,
+					Version: V2,
+					Metadata: Metadata{
+						Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+						Namespace: defaults.Namespace,
+					},
+					Spec: ServerSpecV2{
+						Addr:       "1.2.3.4:3022",
+						Hostname:   "teleport-node",
+						PublicAddr: "1.2.3.4:3080",
+					},
+				}
+				require.Equal(t, expectedServer, s)
+			},
+		},
+		{
+			name: "Teleport node subkind unset",
+			server: &ServerV2{
+				Kind:    KindNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:       "1.2.3.4:3022",
+					Hostname:   "teleport-node",
+					PublicAddr: "1.2.3.4:3080",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.NoError(t, err)
+				expectedServer := &ServerV2{
+					Kind:    KindNode,
+					Version: V2,
+					Metadata: Metadata{
+						Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+						Namespace: defaults.Namespace,
+					},
+					Spec: ServerSpecV2{
+						Addr:       "1.2.3.4:3022",
+						Hostname:   "teleport-node",
+						PublicAddr: "1.2.3.4:3080",
+					},
+				}
+				require.Equal(t, expectedServer, s)
+			},
+		},
+		{
+			name: "OpenSSH node",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:     "1.2.3.4:3022",
+					Hostname: "openssh-node",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.NoError(t, err)
+				expectedServer := &ServerV2{
+					Kind:    KindNode,
+					SubKind: SubKindOpenSSHNode,
+					Version: V2,
+					Metadata: Metadata{
+						Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+						Namespace: defaults.Namespace,
+					},
+					Spec: ServerSpecV2{
+						Addr:     "1.2.3.4:3022",
+						Hostname: "openssh-node",
+					},
+				}
+				require.Equal(t, expectedServer, s)
+			},
+		},
+		{
+			name: "OpenSSH node with unset name",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Spec: ServerSpecV2{
+					Addr:     "1.2.3.4:22",
+					Hostname: "openssh-node",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.NoError(t, err)
+				require.NotEmpty(t, s.Metadata.Name)
+			},
+		},
+		{
+			name: "OpenSSH node with unset addr",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Hostname: "openssh-node",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.EqualError(t, err, `Addr must be set when server SubKind is "openssh"`)
+			},
+		},
+		{
+			name: "OpenSSH node with unset hostname",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr: "1.2.3.4:3022",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.EqualError(t, err, `Hostname must be set when server SubKind is "openssh"`)
+			},
+		},
+		{
+			name: "OpenSSH node with public addr",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:       "1.2.3.4:3022",
+					Hostname:   "openssh-node",
+					PublicAddr: "1.2.3.4:80",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.EqualError(t, err, `PublicAddr must not be set when server SubKind is "openssh"`)
+			},
+		},
+		{
+			name: "OpenSSH node with invalid addr",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: SubKindOpenSSHNode,
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:     "invalid-addr",
+					Hostname: "openssh-node",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.ErrorContains(t, err, `invalid Addr "invalid-addr"`)
+			},
+		},
+		{
+			name: "node with invalid subkind",
+			server: &ServerV2{
+				Kind:    KindNode,
+				SubKind: "invalid-subkind",
+				Version: V2,
+				Metadata: Metadata{
+					Name:      "5da56852-2adb-4540-a37c-80790203f6a9",
+					Namespace: defaults.Namespace,
+				},
+				Spec: ServerSpecV2{
+					Addr:     "1.2.3.4:22",
+					Hostname: "node",
+				},
+			},
+			assertion: func(t *testing.T, s *ServerV2, err error) {
+				require.EqualError(t, err, `invalid SubKind "invalid-subkind"`)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.server.CheckAndSetDefaults()
+			tt.assertion(t, tt.server, err)
+		})
+	}
 }

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1904,6 +1904,14 @@ waitLoop:
 				log.Debugf("Skipping stale event %v %v", event.Type, event.Resource.GetName())
 				continue
 			}
+
+			// Server resources may have subkind set, but the backend
+			// generating this delete event doesn't know the subkind.
+			// Set it to prevent the check below from failing.
+			if event.Resource.GetKind() == types.KindNode {
+				event.Resource.SetSubKind(resource.GetSubKind())
+			}
+
 			require.Empty(t, cmp.Diff(resource, event.Resource))
 			break waitLoop
 		}

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package srv
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type mockCAGetter struct {
+	AccessPoint
+
+	cas map[types.CertAuthType]types.CertAuthority
+}
+
+func (m mockCAGetter) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
+	ca, ok := m.cas[caType]
+	if !ok {
+		return nil, trace.NotFound("CA not found")
+	}
+
+	return []types.CertAuthority{ca}, nil
+}
+
+type mockLoginChecker struct {
+	rbacChecked bool
+}
+
+func (m *mockLoginChecker) canLoginWithRBAC(_ *ssh.Certificate, _ types.CertAuthority, _ string, _ types.Server, _, _ string) error {
+	m.rbacChecked = true
+	return nil
+}
+
+type mockConnMetadata struct{}
+
+func (m mockConnMetadata) User() string {
+	return "testuser"
+}
+
+func (m mockConnMetadata) SessionID() []byte {
+	return nil
+}
+
+func (m mockConnMetadata) ClientVersion() []byte {
+	return nil
+}
+
+func (m mockConnMetadata) ServerVersion() []byte {
+	return nil
+}
+
+func (m mockConnMetadata) LocalAddr() net.Addr {
+	return &net.TCPAddr{
+		IP:   net.ParseIP("1.2.3.4"),
+		Port: 22,
+	}
+}
+
+func (m mockConnMetadata) RemoteAddr() net.Addr {
+	return &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 9001,
+	}
+}
+
+func TestRBAC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		component       string
+		nodeExists      bool
+		openSSHNode     bool
+		assertRBACCheck require.BoolAssertionFunc
+	}{
+		{
+			name:            "teleport node, regular server",
+			component:       teleport.ComponentNode,
+			nodeExists:      true,
+			openSSHNode:     false,
+			assertRBACCheck: require.True,
+		},
+		{
+			name:            "teleport node, forwarding server",
+			component:       teleport.ComponentForwardingNode,
+			nodeExists:      true,
+			openSSHNode:     false,
+			assertRBACCheck: require.False,
+		},
+		{
+			name:            "registered openssh node, forwarding server",
+			component:       teleport.ComponentForwardingNode,
+			nodeExists:      true,
+			openSSHNode:     true,
+			assertRBACCheck: require.True,
+		},
+		{
+			name:            "unregistered openssh node, forwarding server",
+			component:       teleport.ComponentForwardingNode,
+			nodeExists:      false,
+			assertRBACCheck: require.False,
+		},
+	}
+
+	// create User CA
+	userTA := testauthority.New()
+	userCAPriv, err := userTA.GeneratePrivateKey()
+	require.NoError(t, err)
+	userCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.UserCA,
+		ClusterName: "localhost",
+		ActiveKeys: types.CAKeySet{
+			SSH: []*types.SSHKeyPair{
+				{
+					PublicKey:      userCAPriv.MarshalSSHPublicKey(),
+					PrivateKey:     userCAPriv.PrivateKeyPEM(),
+					PrivateKeyType: types.PrivateKeyType_RAW,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// create mock SSH server and add a cluster name
+	server := newMockServer(t)
+	clusterName, err := types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: "localhost",
+		ClusterID:   "cluster_id",
+	})
+	require.NoError(t, err)
+	err = server.auth.SetClusterName(clusterName)
+	require.NoError(t, err)
+
+	accessPoint := mockCAGetter{
+		AccessPoint: server.auth,
+		cas: map[types.CertAuthType]types.CertAuthority{
+			types.UserCA: userCA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// create node resource
+			var target types.Server
+			if tt.nodeExists {
+				n, err := types.NewServer("testie_node", types.KindNode, types.ServerSpecV2{
+					Addr:     "1.2.3.4:22",
+					Hostname: "testie",
+					Version:  types.V2,
+				})
+				require.NoError(t, err)
+				server, ok := n.(*types.ServerV2)
+				require.True(t, ok)
+				if tt.openSSHNode {
+					server.SubKind = types.SubKindOpenSSHNode
+				}
+				target = server
+			}
+
+			config := &AuthHandlerConfig{
+				Server:       server,
+				Component:    tt.component,
+				Emitter:      &eventstest.MockEmitter{},
+				AccessPoint:  accessPoint,
+				TargetServer: target,
+			}
+			ah, err := NewAuthHandlers(config)
+			require.NoError(t, err)
+
+			lc := mockLoginChecker{}
+			ah.loginChecker = &lc
+
+			// create SSH certificate
+			caSigner, err := ssh.NewSignerFromKey(userCAPriv)
+			require.NoError(t, err)
+			keygen := testauthority.New()
+			privateKey, err := native.GeneratePrivateKey()
+			require.NoError(t, err)
+
+			c, err := keygen.GenerateUserCert(services.UserCertParams{
+				CASigner:      caSigner,
+				PublicUserKey: ssh.MarshalAuthorizedKey(privateKey.SSHPublicKey()),
+				Username:      "testuser",
+				AllowedLogins: []string{"testuser"},
+			})
+			require.NoError(t, err)
+
+			cert, err := sshutils.ParseCertificate(c)
+			require.NoError(t, err)
+
+			// preform public key authentication
+			_, err = ah.UserKeyAuth(&mockConnMetadata{}, cert)
+			require.NoError(t, err)
+
+			tt.assertRBACCheck(t, lc.rbacChecked)
+		})
+	}
+}


### PR DESCRIPTION
Backport of #22615.

Needs https://github.com/gravitational/teleport/pull/22708 to be merged first.