### PR TITLE
Don't allow different tcp version IP addresses in signed PROXY headers

### DIFF
--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -49,7 +49,8 @@ import (
 
 var (
 	// ErrBadIP is returned when there's a problem with client source or destination IP address
-	ErrBadIP = trace.BadParameter("client source and destination addresses should be valid non-nil IP addresses")
+	ErrBadIP = trace.BadParameter(
+		"client source and destination addresses should be valid same TCP version non-nil IP addresses")
 )
 
 // CertAuthorityGetter allows to get cluster's host CA for verification of signed PROXY headers.
@@ -296,10 +297,14 @@ func getTCPAddr(a net.Addr) net.TCPAddr {
 	}
 }
 
+func isDifferentTCPVersion(addr1, addr2 net.TCPAddr) bool {
+	return (addr1.IP.To4() != nil && addr2.IP.To4() == nil) || (addr2.IP.To4() != nil && addr1.IP.To4() == nil)
+}
+
 func signPROXYHeader(sourceAddress, destinationAddress net.Addr, clusterName string, signingCert []byte, signer JWTPROXYSigner) ([]byte, error) {
 	sAddr := getTCPAddr(sourceAddress)
 	dAddr := getTCPAddr(destinationAddress)
-	if sAddr.IP == nil || dAddr.IP == nil {
+	if sAddr.IP == nil || dAddr.IP == nil || isDifferentTCPVersion(sAddr, dAddr) {
 		return nil, trace.Wrap(ErrBadIP, "source address: %s, destination address: %s", sourceAddress, destinationAddress)
 	}
 	if sAddr.Port < 0 || dAddr.Port < 0 {

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -1235,7 +1235,7 @@ func Test_GetTcpAddr(t *testing.T) {
 	}
 }
 
-func Test_IsDifferentTCPVersion(t *testing.T) {
+func TestIsDifferentTCPVersion(t *testing.T) {
 	testCases := []struct {
 		addr1    string
 		addr2    string

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -1234,3 +1234,59 @@ func Test_GetTcpAddr(t *testing.T) {
 		require.Equal(t, tt.expected, result.String())
 	}
 }
+
+func Test_IsDifferentTCPVersion(t *testing.T) {
+	testCases := []struct {
+		addr1    string
+		addr2    string
+		expected bool
+	}{
+		{
+			addr1:    "8.8.8.8:42",
+			addr2:    "8.8.8.8:42",
+			expected: false,
+		},
+		{
+			addr1:    "[2601:602:8700:4470:a3:813c:1d8c:30b9]:42",
+			addr2:    "[2607:f8b0:4005:80a::200e]:42",
+			expected: false,
+		},
+		{
+			addr1:    "127.0.0.1:42",
+			addr2:    "[::1]:42",
+			expected: true,
+		},
+		{
+			addr1:    "[::1]:42",
+			addr2:    "127.0.0.1:42",
+			expected: true,
+		},
+		{
+			addr1:    "::ffff:39.156.68.48:42",
+			addr2:    "39.156.68.48:42",
+			expected: true,
+		},
+		{
+			addr1:    "[2607:f8b0:4005:80a::200e]:42",
+			addr2:    "1.1.1.1:42",
+			expected: true,
+		},
+		{
+			addr1:    "127.0.0.1:42",
+			addr2:    "[2607:f8b0:4005:80a::200e]:42",
+			expected: true,
+		},
+		{
+			addr1:    "::ffff:39.156.68.48:42",
+			addr2:    "[2607:f8b0:4005:80a::200e]:42",
+			expected: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		addr1 := getTCPAddr(utils.MustParseAddr(tt.addr1))
+		addr2 := getTCPAddr(utils.MustParseAddr(tt.addr2))
+		require.Equal(t, tt.expected, isDifferentTCPVersion(addr1, addr2),
+			fmt.Sprintf("Unexpected result for %q, %q", tt.addr1, tt.addr2))
+	}
+}


### PR DESCRIPTION
This PR makes sure that we only create signed PROXY headers if both source and destination IP addresses are same TCP version (This was causing problems for web UI file transfers).