### PR TITLE
Connect: Show config file errors

### DIFF
--- a/web/packages/shared/components/Notification/Notification.tsx
+++ b/web/packages/shared/components/Notification/Notification.tsx
@@ -150,7 +150,7 @@ function getRenderedContent(
           `}
         >
           <Text
-            fontSize={13}
+            fontSize={14}
             bold
             mr="30px"
             css={`

--- a/web/packages/shared/components/Notification/Notification.tsx
+++ b/web/packages/shared/components/Notification/Notification.tsx
@@ -150,7 +150,7 @@ function getRenderedContent(
           `}
         >
           <Text
-            fontSize={14}
+            fontSize={13}
             bold
             mr="30px"
             css={`

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -50,6 +50,7 @@ function initializeApp(): void {
   const configFileStorage = createFileStorage({
     filePath: path.join(settings.userDataDir, 'app_config.json'),
     debounceWrites: false,
+    discardUpdatesWhenLoadingFileFailed: true,
   });
   const configJsonSchemaFileStorage = createFileStorage({
     filePath: path.join(settings.userDataDir, 'schema_app_config.json'),

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -207,7 +207,7 @@ function createFileStorages(userDataDir: string) {
     createFileStorage({
       filePath: path.join(userDataDir, 'app_config.json'),
       debounceWrites: false,
-      discardUpdatesWhenLoadingFileFailed: true,
+      discardUpdatesOnLoadError: true,
     }),
     createFileStorage({
       filePath: path.join(userDataDir, 'schema_app_config.json'),

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -131,7 +131,7 @@ export enum ConfigServiceEventType {
 export enum FileStorageEventType {
   Get = 'Get',
   Put = 'Put',
-  WriteSync = 'WriteSync',
+  Write = 'Write',
   Replace = 'Replace',
   GetFilePath = 'GetFilePath',
   GetFileLoadingError = 'GetFileLoadingError',

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -125,7 +125,7 @@ export enum TabContextMenuEventType {
 export enum ConfigServiceEventType {
   Get = 'Get',
   Set = 'Set',
-  GetStoredConfigErrors = 'GetStoredConfigErrors',
+  GetConfigError = 'GetConfigError',
 }
 
 export enum FileStorageEventType {

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -134,4 +134,5 @@ export enum FileStorageEventType {
   WriteSync = 'WriteSync',
   Replace = 'Replace',
   GetFilePath = 'GetFilePath',
+  GetFileLoadingError = 'GetFileLoadingError',
 }

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -197,7 +197,7 @@ export class WindowsManager {
   }
 
   private getWindowState(): WindowState {
-    const windowState = this.fileStorage.get<WindowState>(this.storageKey);
+    const windowState = this.fileStorage.get(this.storageKey) as WindowState;
     const getDefaults = () => ({
       height: 720,
       width: 1280,

--- a/web/packages/teleterm/src/services/config/configService.ts
+++ b/web/packages/teleterm/src/services/config/configService.ts
@@ -52,8 +52,12 @@ export interface ConfigService {
 
   /**
    * Returns validation errors or an error that occurred during loading the config file (this means IO and syntax errors).
-   * If validation errors occur, the incorrect values are replaced with the defaults.
-   * In case of an error coming from loading the file, all values are replaced with the defaults.
+   * This error has to be checked during the initialization of the app.
+   *
+   * The reason we have a getter for this error instead of making `createConfigService` fail with an error
+   * is that in the presence of this error we want to notify about it and then continue with default values:
+   * - If validation errors occur, the incorrect values are replaced with the defaults.
+   * - In case of an error coming from loading the file, all values are replaced with the defaults.
    * */
   getConfigError(): ConfigError | undefined;
 }

--- a/web/packages/teleterm/src/services/config/configService.ts
+++ b/web/packages/teleterm/src/services/config/configService.ts
@@ -31,6 +31,18 @@ import {
 
 const logger = new Logger('ConfigService');
 
+type FileLoadingError = {
+  source: 'file-loading';
+  error: Error;
+};
+
+type ValidationError = {
+  source: 'validation';
+  errors: ZodIssue[];
+};
+
+type ConfigError = FileLoadingError | ValidationError;
+
 export interface ConfigService {
   get<K extends keyof AppConfig>(
     key: K
@@ -38,7 +50,12 @@ export interface ConfigService {
 
   set<K extends keyof AppConfig>(key: K, value: AppConfig[K]): void;
 
-  getStoredConfigErrors(): ZodIssue[] | undefined;
+  /**
+   * Returns validation errors or an error that occurred during loading the config file (this means IO and syntax errors).
+   * If validation errors occur, the incorrect values are replaced with the defaults.
+   * In case of an error coming from loading the file, all values are replaced with the defaults.
+   * */
+  getConfigError(): ConfigError | undefined;
 }
 
 export function createConfigService({
@@ -53,10 +70,11 @@ export function createConfigService({
   const schema = createAppConfigSchema(platform);
   updateJsonSchema({ schema, configFile, jsonSchemaFile });
 
-  const { storedConfig, configWithDefaults, errors } = validateStoredConfig(
-    schema,
-    configFile
-  );
+  const {
+    storedConfig,
+    configWithDefaults,
+    errors: validationErrors,
+  } = validateStoredConfig(schema, configFile);
 
   return {
     get: key => ({
@@ -68,7 +86,21 @@ export function createConfigService({
       configWithDefaults[key] = value;
       storedConfig[key] = value;
     },
-    getStoredConfigErrors: () => errors,
+    getConfigError: () => {
+      const fileLoadingError = configFile.getFileLoadingError();
+      if (fileLoadingError) {
+        return {
+          source: 'file-loading',
+          error: fileLoadingError,
+        };
+      }
+      if (validationErrors) {
+        return {
+          source: 'validation',
+          errors: validationErrors,
+        };
+      }
+    },
   };
 }
 
@@ -96,8 +128,6 @@ function updateJsonSchema({
   }
 }
 
-//TODO (gzdunek): syntax errors of the JSON file are silently ignored, report
-// them to the user too
 function validateStoredConfig(
   schema: AppConfigSchema,
   configFile: FileStorage

--- a/web/packages/teleterm/src/services/config/configService.ts
+++ b/web/packages/teleterm/src/services/config/configService.ts
@@ -142,7 +142,7 @@ function validateStoredConfig(
 } {
   const parse = (data: Partial<AppConfig>) => schema.safeParse(data);
 
-  const storedConfig = configFile.get<Partial<AppConfig>>();
+  const storedConfig = configFile.get() as Partial<AppConfig>;
   const parsed = parse(storedConfig);
   if (parsed.success === true) {
     return {

--- a/web/packages/teleterm/src/services/config/configServiceClient.ts
+++ b/web/packages/teleterm/src/services/config/configServiceClient.ts
@@ -33,8 +33,8 @@ export function subscribeToConfigServiceEvents(
           return (event.returnValue = configService.get(item.path));
         case ConfigServiceEventType.Set:
           return configService.set(item.path, item.value);
-        case ConfigServiceEventType.GetStoredConfigErrors:
-          return (event.returnValue = configService.getStoredConfigErrors());
+        case ConfigServiceEventType.GetConfigError:
+          return (event.returnValue = configService.getConfigError());
       }
     }
   );
@@ -54,10 +54,10 @@ export function createConfigServiceClient(): ConfigService {
         value,
       });
     },
-    getStoredConfigErrors: () => {
+    getConfigError: () => {
       return ipcRenderer.sendSync(
         ConfigServiceEventChannel,
-        ConfigServiceEventType.GetStoredConfigErrors
+        ConfigServiceEventType.GetConfigError
       );
     },
   };

--- a/web/packages/teleterm/src/services/config/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/config/fixtures/mocks.ts
@@ -27,8 +27,8 @@ export function createMockConfigService(
     set(key, value) {
       values[key] = value;
     },
-    getStoredConfigErrors() {
-      return [];
+    getConfigError() {
+      return undefined;
     },
   };
 }

--- a/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
@@ -33,6 +33,8 @@ export interface FileStorage {
   write(): Promise<void>;
 
   /** Returns value for a given key. If the key is omitted, the entire storage state is returned. */
+  // TODO(ravicious): Add a generic type to createFileStorage rather than returning `unknown`.
+  // https://github.com/gravitational/teleport/pull/22728#discussion_r1129566566
   get(key?: string): unknown;
 
   /** Returns the file path used to create the storage. */

--- a/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
@@ -53,7 +53,16 @@ export async function createFileStorage(opts: {
   }
 
   const { filePath } = opts;
-  let { state, error } = await loadState(opts.filePath);
+
+  let state: any, error: Error | undefined;
+  try {
+    state = await loadState(filePath);
+  } catch (e) {
+    state = {};
+    error = e;
+    logger.error(`Cannot read ${filePath} file`, e);
+  }
+
   const discardUpdates = error && opts.discardUpdatesWhenLoadingFileFailed;
 
   function put(key: string, json: any): void {
@@ -114,22 +123,9 @@ export async function createFileStorage(opts: {
   };
 }
 
-async function loadState(
-  filePath: string
-): Promise<{ state: any; error: Error | undefined }> {
-  try {
-    const file = await readOrCreateFile(filePath);
-    return {
-      state: JSON.parse(file),
-      error: undefined,
-    };
-  } catch (error) {
-    logger.error(`Cannot read ${filePath} file`, error);
-    return {
-      state: {},
-      error: error,
-    };
-  }
+async function loadState(filePath: string): Promise<any> {
+  const file = await readOrCreateFile(filePath);
+  return JSON.parse(file);
 }
 
 async function readOrCreateFile(filePath: string): Promise<string> {

--- a/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
@@ -33,7 +33,7 @@ export interface FileStorage {
   write(): Promise<void>;
 
   /** Returns value for a given key. If the key is omitted, the entire storage state is returned. */
-  get<T>(key?: string): T;
+  get(key?: string): unknown;
 
   /** Returns the file path used to create the storage. */
   getFilePath(): string;
@@ -89,8 +89,8 @@ export async function createFileStorage(opts: {
     stringifyAndWrite();
   }
 
-  function get<T>(key?: string): T {
-    return key ? state[key] : (state as T);
+  function get(key?: string): unknown {
+    return key ? state[key] : state;
   }
 
   function getFilePath(): string {

--- a/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fileStorage.ts
@@ -46,7 +46,7 @@ export async function createFileStorage(opts: {
   filePath: string;
   debounceWrites: boolean;
   /** Prevents state updates when the file has not been loaded correctly, so its content will not be overwritten. */
-  discardUpdatesWhenLoadingFileFailed?: boolean;
+  discardUpdatesOnLoadError?: boolean;
 }): Promise<FileStorage> {
   if (!opts || !opts.filePath) {
     throw Error('missing filePath');
@@ -63,7 +63,7 @@ export async function createFileStorage(opts: {
     logger.error(`Cannot read ${filePath} file`, e);
   }
 
-  const discardUpdates = error && opts.discardUpdatesWhenLoadingFileFailed;
+  const discardUpdates = error && opts.discardUpdatesOnLoadError;
 
   function put(key: string, json: any): void {
     if (discardUpdates) {

--- a/web/packages/teleterm/src/services/fileStorage/fileStorageClient.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fileStorageClient.ts
@@ -32,8 +32,8 @@ export function subscribeToFileStorageEvents(configService: FileStorage): void {
           return (event.returnValue = configService.get(item.key));
         case FileStorageEventType.Put:
           return configService.put(item.key, item.json);
-        case FileStorageEventType.WriteSync:
-          return configService.writeSync();
+        case FileStorageEventType.Write:
+          return configService.write();
         case FileStorageEventType.Replace:
           return configService.replace(item.json);
         case FileStorageEventType.GetFilePath:
@@ -56,10 +56,10 @@ export function createFileStorageClient(): FileStorage {
         key,
         json,
       }),
-    writeSync: () =>
-      ipcRenderer.send(
+    write: () =>
+      ipcRenderer.invoke(
         FileStorageEventChannel,
-        FileStorageEventType.WriteSync,
+        FileStorageEventType.Write,
         {}
       ),
     replace: json =>

--- a/web/packages/teleterm/src/services/fileStorage/fileStorageClient.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fileStorageClient.ts
@@ -38,6 +38,8 @@ export function subscribeToFileStorageEvents(configService: FileStorage): void {
           return configService.replace(item.json);
         case FileStorageEventType.GetFilePath:
           return configService.getFilePath();
+        case FileStorageEventType.GetFileLoadingError:
+          return configService.getFileLoadingError();
       }
     }
   );
@@ -68,6 +70,12 @@ export function createFileStorageClient(): FileStorage {
       ipcRenderer.sendSync(
         FileStorageEventChannel,
         FileStorageEventType.GetFilePath,
+        {}
+      ),
+    getFileLoadingError: () =>
+      ipcRenderer.sendSync(
+        FileStorageEventChannel,
+        FileStorageEventType.GetFileLoadingError,
         {}
       ),
   };

--- a/web/packages/teleterm/src/services/fileStorage/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fixtures/mocks.ts
@@ -35,8 +35,12 @@ export function createMockFileStorage(opts?: {
       state = json;
     },
 
-    getFilePath(): string {
+    getFilePath() {
       return opts?.filePath || '';
+    },
+
+    getFileLoadingError() {
+      return undefined;
     },
   };
 }

--- a/web/packages/teleterm/src/services/fileStorage/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/fileStorage/fixtures/mocks.ts
@@ -29,7 +29,7 @@ export function createMockFileStorage(opts?: {
       return key ? state[key] : (state as T);
     },
 
-    writeSync() {},
+    async write() {},
 
     replace(json: any) {
       state = json;

--- a/web/packages/teleterm/src/ui/initUi.test.ts
+++ b/web/packages/teleterm/src/ui/initUi.test.ts
@@ -109,6 +109,25 @@ describe('usage reporting dialogs', () => {
   });
 });
 
+test('no dialog is shown when config file did not load properly', async () => {
+  const mockedAppContext = new MockAppContext();
+  jest
+    .spyOn(mockedAppContext.mainProcessClient.configService, 'getConfigError')
+    .mockImplementation(() => ({ source: 'file-loading', error: new Error() }));
+  mockOpenRegularDialog(mockedAppContext);
+
+  await initUi(mockedAppContext);
+
+  expect(
+    mockedAppContext.modalsService.openRegularDialog
+  ).not.toHaveBeenCalledWith(expect.objectContaining({ kind: 'usage-data' }));
+  expect(
+    mockedAppContext.modalsService.openRegularDialog
+  ).not.toHaveBeenCalledWith(
+    expect.objectContaining({ kind: 'user-job-role' })
+  );
+});
+
 function mockUsageReportingEnabled(
   mockedAppContext: AppContext,
   options: { enabled: boolean }

--- a/web/packages/teleterm/src/ui/initUi.ts
+++ b/web/packages/teleterm/src/ui/initUi.ts
@@ -60,7 +60,7 @@ function notifyAboutConfigErrors(
       case 'file-loading': {
         notificationsService.notifyError({
           title: 'Failed to load config file',
-          description: `Using default config instead.\n${configError.error.toString()}`,
+          description: `Using the default config instead.\n${configError.error.toString()}`,
         });
         break;
       }

--- a/web/packages/teleterm/src/ui/initUi.ts
+++ b/web/packages/teleterm/src/ui/initUi.ts
@@ -60,7 +60,7 @@ function notifyAboutConfigErrors(
       case 'file-loading': {
         notificationsService.notifyError({
           title: 'Failed to load config file',
-          description: `Using the default config instead.\n${configError.error.toString()}`,
+          description: `Using the default config instead.\n${configError.error}`,
         });
         break;
       }

--- a/web/packages/teleterm/src/ui/initUi.ts
+++ b/web/packages/teleterm/src/ui/initUi.ts
@@ -43,34 +43,47 @@ export async function initUi(ctx: IAppContext): Promise<void> {
   // "User job role" dialog is shown on the second launch (only if user agreed to reporting earlier).
   await setUpUsageReporting(configService, ctx.modalsService);
   ctx.workspacesService.restorePersistedState();
-  notifyAboutStoredConfigErrors(configService, ctx.notificationsService);
+  notifyAboutConfigErrors(configService, ctx.notificationsService);
   notifyAboutDuplicatedShortcutsCombinations(
     ctx.keyboardShortcutsService,
     ctx.notificationsService
   );
 }
 
-function notifyAboutStoredConfigErrors(
+function notifyAboutConfigErrors(
   configService: ConfigService,
   notificationsService: NotificationsService
 ): void {
-  const errors = configService.getStoredConfigErrors();
-  if (errors) {
-    const isKeymapError = errors.some(e =>
-      e.path[0].toString().startsWith('keymap.')
-    );
-    notificationsService.notifyError({
-      title: 'Encountered errors in config file',
-      list: errors.map(e => `${e.path[0].toString()}: ${e.message}`),
-      description:
-        isKeymapError &&
-        'A valid shortcut contains at least one modifier and a single key code, for example "Shift+Tab".\nFunction keys do not require a modifier.',
-      link: {
-        // TODO(gzdunek): point to the properer section
-        href: 'https://goteleport.com/docs/connect-your-client/teleport-connect/',
-        text: 'See the config file documentation',
-      },
-    });
+  const configError = configService.getConfigError();
+  if (configError) {
+    switch (configError.source) {
+      case 'file-loading': {
+        notificationsService.notifyError({
+          title: 'Failed to load config file, using the default config',
+          description: configError.error.toString(),
+        });
+        break;
+      }
+      case 'validation': {
+        const isKeymapError = configError.errors.some(e =>
+          e.path[0].toString().startsWith('keymap.')
+        );
+        notificationsService.notifyError({
+          title: 'Encountered errors in config file',
+          list: configError.errors.map(
+            e => `${e.path[0].toString()}: ${e.message}`
+          ),
+          description:
+            isKeymapError &&
+            'A valid shortcut contains at least one modifier and a single key code, for example "Shift+Tab".\nFunction keys do not require a modifier.',
+          link: {
+            // TODO(gzdunek): point to the properer section
+            href: 'https://goteleport.com/docs/connect-your-client/teleport-connect/',
+            text: 'See the config file documentation',
+          },
+        });
+      }
+    }
   }
 }
 

--- a/web/packages/teleterm/src/ui/initUi.ts
+++ b/web/packages/teleterm/src/ui/initUi.ts
@@ -59,8 +59,8 @@ function notifyAboutConfigErrors(
     switch (configError.source) {
       case 'file-loading': {
         notificationsService.notifyError({
-          title: 'Failed to load config file, using the default config',
-          description: configError.error.toString(),
+          title: 'Failed to load config file',
+          description: `Using default config instead.\n${configError.error.toString()}`,
         });
         break;
       }

--- a/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
+++ b/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
@@ -106,7 +106,10 @@ export class StatePersistenceService {
         askedForUserJobRole: false,
       },
     };
-    return { ...defaultState, ...this._fileStorage.get('state') };
+    return {
+      ...defaultState,
+      ...(this._fileStorage.get('state') as StatePersistenceState),
+    };
   }
 
   private putState(state: StatePersistenceState): void {

--- a/web/packages/teleterm/src/ui/services/usage/setUpUsageReporting.ts
+++ b/web/packages/teleterm/src/ui/services/usage/setUpUsageReporting.ts
@@ -29,6 +29,11 @@ export async function setUpUsageReporting(
     return;
   }
 
+  if (configService.getConfigError()?.source === 'file-loading') {
+    // do not show the dialog, response cannot be saved to the file
+    return;
+  }
+
   if (configService.get('usageReporting.enabled').metadata.isStored) {
     return;
   }


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/21914

I changed `getStoredConfigErrors` (now `getConfigError`) to return a union of two types of errors: `validation` (Zod errors) and `file-loading` (IO and JSON syntax errors).  

I also noticed that when the config file is corrupted, updating its contents (for example by linking to the JSON schema) removes all values from it. That is because when we can’t read the file, our logic creates an empty object in memory, which is then written to disk with the first update. To remedy this, I created a new flag: `discardUpdatesWhenLoadingFileFailed` (a better name is welcome) for the `FileStorage`. Enabling it discards all updates to the file. We don't want to enable it for all the files; for app state or json schema it is okay to overwrite them.

Technically, thanks to this flag, we don't have to hide the usage reporting dialog (normally a response from the user would overwrite the file), but I decided to do it because:
- we won't store the response anyway 
- the error notification is covered by the dialog backdrop

If you think that hiding the dialog is not needed then I am happy to discuss it.

Other than that, I refactored `FileStorage` to use async FS functions (suggested by @ravicious). 

Example notification:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/20583051/223523832-5b571e57-f764-4d05-b971-b727e9d74185.png">

