### PR TITLE
Connect: Add "Open Config File" item to menu

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -66,7 +66,8 @@ async function initializeApp(): Promise<void> {
     settings,
     logger,
     configService,
-    fileStorage: appStateFileStorage,
+    appStateFileStorage,
+    configFileStorage,
     windowsManager,
   });
 

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -64,6 +64,8 @@ export class MockMainProcessClient implements MainProcessClient {
   async removeTshSymlinkMacOs() {
     return true;
   }
+
+  openConfigFile() {}
 }
 
 const defaultRuntimeSettings = {

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -65,7 +65,9 @@ export class MockMainProcessClient implements MainProcessClient {
     return true;
   }
 
-  openConfigFile() {}
+  async openConfigFile() {
+    return '';
+  }
 }
 
 const defaultRuntimeSettings = {

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -279,8 +279,10 @@ export default class MainProcess {
       }
     });
 
-    ipcMain.handle('main-process-open-config-file', () => {
-      shell.openPath(this.configFileStorage.getFilePath());
+    ipcMain.handle('main-process-open-config-file', async () => {
+      const path = this.configFileStorage.getFilePath();
+      await shell.openPath(path);
+      return path;
     });
 
     subscribeToTerminalContextMenuEvent();

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -50,7 +50,8 @@ type Options = {
   settings: RuntimeSettings;
   logger: Logger;
   configService: ConfigService;
-  fileStorage: FileStorage;
+  appStateFileStorage: FileStorage;
+  configFileStorage: FileStorage;
   windowsManager: WindowsManager;
 };
 
@@ -60,7 +61,8 @@ export default class MainProcess {
   private readonly configService: ConfigService;
   private tshdProcess: ChildProcess;
   private sharedProcess: ChildProcess;
-  private fileStorage: FileStorage;
+  private appStateFileStorage: FileStorage;
+  private configFileStorage: FileStorage;
   private resolvedChildProcessAddresses: Promise<ChildProcessAddresses>;
   private windowsManager: WindowsManager;
 
@@ -68,7 +70,8 @@ export default class MainProcess {
     this.settings = opts.settings;
     this.logger = opts.logger;
     this.configService = opts.configService;
-    this.fileStorage = opts.fileStorage;
+    this.appStateFileStorage = opts.appStateFileStorage;
+    this.configFileStorage = opts.configFileStorage;
     this.windowsManager = opts.windowsManager;
   }
 
@@ -276,10 +279,14 @@ export default class MainProcess {
       }
     });
 
+    ipcMain.handle('main-process-open-config-file', () => {
+      shell.openPath(this.configFileStorage.getFilePath());
+    });
+
     subscribeToTerminalContextMenuEvent();
     subscribeToTabContextMenuEvent();
     subscribeToConfigServiceEvents(this.configService);
-    subscribeToFileStorageEvents(this.fileStorage);
+    subscribeToFileStorageEvents(this.appStateFileStorage);
   }
 
   private _setAppMenu() {

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -53,5 +53,8 @@ export default function createMainProcessClient(): MainProcessClient {
     removeTshSymlinkMacOs() {
       return ipcRenderer.invoke('main-process-remove-tsh-symlink-macos');
     },
+    openConfigFile() {
+      return ipcRenderer.invoke('main-process-open-config-file');
+    },
   };
 }

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -53,7 +53,7 @@ export default function createMainProcessClient(): MainProcessClient {
     removeTshSymlinkMacOs() {
       return ipcRenderer.invoke('main-process-remove-tsh-symlink-macos');
     },
-    openConfigFile() {
+    openConfigFile(): Promise<string> {
       return ipcRenderer.invoke('main-process-open-config-file');
     },
   };

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -73,7 +73,8 @@ export type MainProcessClient = {
    */
   removeTshSymlinkMacOs(): Promise<boolean>;
 
-  openConfigFile(): void;
+  /** Opens config file and returns a path to it. */
+  openConfigFile(): Promise<string>;
 };
 
 export type ChildProcessAddresses = {

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -72,6 +72,8 @@ export type MainProcessClient = {
    * prompt. The promise gets rejected if osascript encountered an error.
    */
   removeTshSymlinkMacOs(): Promise<boolean>;
+
+  openConfigFile(): void;
 };
 
 export type ChildProcessAddresses = {

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationItem.tsx
@@ -17,7 +17,9 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Box, Text, Flex } from 'design';
+import { Text } from 'design';
+
+import { ListItem } from 'teleterm/ui/components/ListItem';
 
 export function NavigationItem({ item, closeMenu }: NavigationItemProps) {
   const handleClick = () => {
@@ -26,28 +28,18 @@ export function NavigationItem({ item, closeMenu }: NavigationItemProps) {
   };
 
   return (
-    <ListItem p={2} pl={0} gap={2} onClick={handleClick}>
-      <IconBox p={2}>{item.Icon}</IconBox>
+    <StyledListItem onClick={handleClick}>
+      {item.Icon}
       <Text>{item.title}</Text>
-    </ListItem>
+    </StyledListItem>
   );
 }
 
-const ListItem = styled(Flex)`
-  border-radius: 4px;
-  align-items: center;
-  justify-content: start;
-  cursor: pointer;
-  &:hover {
-    background: ${props => props.theme.colors.primary.lighter};
-  }
-`;
-
-const IconBox = styled(Box)`
-  display: flex;
-  align-items: center;
-  border-radius: 4px;
-  background-color: ${props => props.theme.colors.primary.lighter};
+const StyledListItem = styled(ListItem)`
+  height: 38px;
+  gap: 12px;
+  padding: 0 12px;
+  border-radius: 0;
 `;
 
 type NavigationItemProps = {

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationItem.tsx
@@ -29,7 +29,7 @@ export function NavigationItem({ item, closeMenu }: NavigationItemProps) {
 
   return (
     <StyledListItem onClick={handleClick}>
-      {item.Icon}
+      <item.Icon fontSize={2} />
       <Text>{item.title}</Text>
     </StyledListItem>
   );
@@ -45,7 +45,7 @@ const StyledListItem = styled(ListItem)`
 type NavigationItemProps = {
   item: {
     title: string;
-    Icon: JSX.Element;
+    Icon: React.ComponentType<{ fontSize: number }>;
     onNavigate: () => void;
   };
   closeMenu: () => void;

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationItem.tsx
@@ -28,7 +28,7 @@ export function NavigationItem({ item, closeMenu }: NavigationItemProps) {
   };
 
   return (
-    <StyledListItem onClick={handleClick}>
+    <StyledListItem as="button" type="button" onClick={handleClick}>
       <item.Icon fontSize={2} />
       <Text>{item.title}</Text>
     </StyledListItem>

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
@@ -113,7 +113,7 @@ export function NavigationMenu() {
       <TopBarButton
         ref={selectorRef}
         isOpened={isPopoverOpened}
-        title="See more"
+        title="More Options"
         onClick={() => setIsPopoverOpened(true)}
       >
         <MoreVert fontSize={6} />

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
@@ -19,7 +19,6 @@ import styled from 'styled-components';
 
 import Popover from 'design/Popover';
 import { MoreVert, OpenBox, Add, Config } from 'design/Icon';
-import { Box, Flex } from 'design';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { TopBarButton } from 'teleterm/ui/TopBar/TopBarButton';

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
@@ -31,7 +31,7 @@ function useNavigationItems(): (
   | {
       type?: 'normal';
       title: string;
-      Icon: JSX.Element;
+      Icon: React.ComponentType<{ fontSize: number }>;
       onNavigate: () => void;
     }
   | { type: 'separator' }
@@ -49,7 +49,7 @@ function useNavigationItems(): (
   return [
     {
       title: 'Open Config File',
-      Icon: <Config fontSize={2} />,
+      Icon: Config,
       onNavigate: async () => {
         const path = await ctx.mainProcessClient.openConfigFile();
         ctx.notificationsService.notifyInfo(
@@ -60,7 +60,7 @@ function useNavigationItems(): (
     { type: 'separator' as const },
     accessRequestsAllowed && {
       title: 'New Access Request',
-      Icon: <Add fontSize={2} />,
+      Icon: Add,
       onNavigate: () => {
         const doc = documentsService.createAccessRequestDocument({
           clusterUri: activeRootCluster.uri,
@@ -73,7 +73,7 @@ function useNavigationItems(): (
     },
     accessRequestsAllowed && {
       title: 'Review Access Requests',
-      Icon: <OpenBox fontSize={2} />,
+      Icon: OpenBox,
       onNavigate: () => {
         const doc = documentsService.createAccessRequestDocument({
           clusterUri: activeRootCluster.uri,

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
@@ -29,12 +29,11 @@ import { NavigationItem } from './NavigationItem';
 
 function useNavigationItems(): (
   | {
-      type?: 'normal';
       title: string;
       Icon: React.ComponentType<{ fontSize: number }>;
       onNavigate: () => void;
     }
-  | { type: 'separator' }
+  | 'separator'
 )[] {
   const ctx = useAppContext();
   ctx.workspacesService.useState();
@@ -59,7 +58,7 @@ function useNavigationItems(): (
     },
     ...(areAccessRequestsSupported
       ? [
-          { type: 'separator' as const },
+          'separator' as const,
           {
             title: 'New Access Request',
             Icon: Add,
@@ -103,7 +102,7 @@ export function NavigationMenu() {
   const selectorRef = useRef<HTMLButtonElement>();
 
   const items = useNavigationItems().map((item, index) => {
-    if (item.type === 'separator') {
+    if (item === 'separator') {
       return <Separator key={index} />;
     }
     return (

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
@@ -43,7 +43,7 @@ function useNavigationItems(): (
   const documentsService =
     ctx.workspacesService.getActiveWorkspaceDocumentService();
   const activeRootCluster = getActiveRootCluster(ctx);
-  const accessRequestsAllowed =
+  const areAccessRequestsSupported =
     !!activeRootCluster?.features?.advancedAccessWorkflows;
 
   return [
@@ -57,32 +57,36 @@ function useNavigationItems(): (
         );
       },
     },
-    { type: 'separator' as const },
-    accessRequestsAllowed && {
-      title: 'New Access Request',
-      Icon: Add,
-      onNavigate: () => {
-        const doc = documentsService.createAccessRequestDocument({
-          clusterUri: activeRootCluster.uri,
-          state: 'creating',
-          title: 'New Access Request',
-        });
-        documentsService.add(doc);
-        documentsService.open(doc.uri);
-      },
-    },
-    accessRequestsAllowed && {
-      title: 'Review Access Requests',
-      Icon: OpenBox,
-      onNavigate: () => {
-        const doc = documentsService.createAccessRequestDocument({
-          clusterUri: activeRootCluster.uri,
-          state: 'browsing',
-        });
-        documentsService.add(doc);
-        documentsService.open(doc.uri);
-      },
-    },
+    ...(areAccessRequestsSupported
+      ? [
+          { type: 'separator' as const },
+          {
+            title: 'New Access Request',
+            Icon: Add,
+            onNavigate: () => {
+              const doc = documentsService.createAccessRequestDocument({
+                clusterUri: activeRootCluster.uri,
+                state: 'creating',
+                title: 'New Access Request',
+              });
+              documentsService.add(doc);
+              documentsService.open(doc.uri);
+            },
+          },
+          {
+            title: 'Review Access Requests',
+            Icon: OpenBox,
+            onNavigate: () => {
+              const doc = documentsService.createAccessRequestDocument({
+                clusterUri: activeRootCluster.uri,
+                state: 'browsing',
+              });
+              documentsService.add(doc);
+              documentsService.open(doc.uri);
+            },
+          },
+        ]
+      : []),
   ].filter(Boolean);
 }
 
@@ -98,9 +102,9 @@ export function NavigationMenu() {
   const [isPopoverOpened, setIsPopoverOpened] = useState(false);
   const selectorRef = useRef<HTMLButtonElement>();
 
-  const items = useNavigationItems().map((item, index, items) => {
+  const items = useNavigationItems().map((item, index) => {
     if (item.type === 'separator') {
-      return index !== items.length - 1 && <Separator key={index} />; // if not the last element
+      return <Separator key={index} />;
     }
     return (
       <NavigationItem

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
@@ -114,7 +114,7 @@ export function NavigationMenu() {
       <TopBarButton
         ref={selectorRef}
         isOpened={isPopoverOpened}
-        title="Go To Access Requests"
+        title="See more"
         onClick={() => setIsPopoverOpened(true)}
       >
         <MoreVert fontSize={6} />
@@ -127,19 +127,19 @@ export function NavigationMenu() {
         onClose={() => setIsPopoverOpened(false)}
         popoverCss={() => `max-width: min(560px, 90%)`}
       >
-        <MenuContainer p={3}>
-          <Box minWidth="280px">
-            <Flex flexDirection="column" minWidth="280px">
-              {items}
-            </Flex>
-          </Box>
-        </MenuContainer>
+        <Menu>{items}</Menu>
       </Popover>
     </>
   );
 }
 
-const MenuContainer = styled(Box)`
+const Menu = styled.menu`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 280px;
   background: ${props => props.theme.colors.primary.light};
 `;
 

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
@@ -50,8 +50,11 @@ function useNavigationItems(): (
     {
       title: 'Open Config File',
       Icon: <Config fontSize={2} />,
-      onNavigate: () => {
-        ctx.mainProcessClient.openConfigFile();
+      onNavigate: async () => {
+        const path = await ctx.mainProcessClient.openConfigFile();
+        ctx.notificationsService.notifyInfo(
+          `Opened the config file at ${path} in the default editor.`
+        );
       },
     },
     { type: 'separator' as const },

--- a/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/NavigationMenu/NavigationMenu.tsx
@@ -52,7 +52,7 @@ function useNavigationItems(): (
       onNavigate: async () => {
         const path = await ctx.mainProcessClient.openConfigFile();
         ctx.notificationsService.notifyInfo(
-          `Opened the config file at ${path} in the default editor.`
+          `Opened the config file at ${path}.`
         );
       },
     },


### PR DESCRIPTION
The last part of https://github.com/gravitational/teleport/issues/21914

**EDIT:** in the first version I added this new item to the app menu. Unfortunately, the menu doesn't look good on Windows and Linux (and is hidden by default), so we decided to put that new item in the "thee dot menu".

I played a bit with CSS and made the menu more concise, I also got rid of the icons background, it looked quite strange when hovered. 

Before:
<img width="407" alt="image" src="https://user-images.githubusercontent.com/20583051/224270515-3bd2a5b3-c64c-43dc-b95e-3dd23ee5263d.png">

After:
<img width="468" alt="image" src="https://user-images.githubusercontent.com/20583051/224281295-6c32feaa-c5b3-4e66-b7ee-a3e92e48362e.png">

