### PR TITLE
Docs: Fix leave session command

### DIFF
--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -176,7 +176,7 @@ mode with the `--mode <mode>` flag , where the mode is one of `peer`,
 `moderator` or `observer`. By default, the mode is `peer` for SSH and
 `moderator` for Kubernetes sessions.
 
-A participant may leave a session with the shortcut `c` while in observer or
+A participant may leave a session with the shortcut `^c` (Control + c) while in observer or
 moderator mode. When in moderator mode, a participant may also forcefully
 terminate the session at any point in time with the shortcut `t`.
 


### PR DESCRIPTION
The moderated session guide was saying the command `c` would leave a moderated session as a reviewer, but it's `^c`.