### PR TITLE
Loop for `poll`

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -859,31 +859,31 @@ fn wait_for_fd(fd: usize) -> RdpResult<()> {
     };
     let res = unsafe { libc::poll(fds, 1, -1) };
 
-    // We only use one fd and we should never timeout.
-    if res == 1 {
-        // POLLIN means that the fd is ready to be read from,
-        // POLLHUP means that the other side of the pipe was closed,
-        // but we still may have data to read.
-        if fds.revents & (libc::POLLIN | libc::POLLHUP) != 0 {
-            return Ok(());
-        } else if fds.revents & libc::POLLNVAL != 0 {
-            return Err(RdpError::Io(IoError::new(
-                std::io::ErrorKind::InvalidInput,
-                "invalid fd",
-            )));
-        } else if fds.revents & libc::POLLERR != 0 {
-            return Err(RdpError::Io(IoError::new(
-                std::io::ErrorKind::Other,
-                "error on fd",
-            )));
-        }
+    // We only use a single fd and can't timeout, so
+    // res will either be 1 for success or -1 for failure.
+    if res != 1 {
+        error!("poll failed: {res}");
+        return Err(RdpError::Io(std::io::Error::last_os_error()));
     }
 
-    // res == -1
-    Err(RdpError::Io(IoError::new(
-        std::io::ErrorKind::Other,
-        "poll failed",
-    )))
+    // res == 1
+    // POLLIN means that the fd is ready to be read from,
+    // POLLHUP means that the other side of the pipe was closed,
+    // but we still may have data to read.
+    if fds.revents & (libc::POLLIN | libc::POLLHUP) != 0 {
+        Ok(()) // ready for a read
+    } else if fds.revents & libc::POLLNVAL != 0 {
+        return Err(RdpError::Io(IoError::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid fd",
+        )));
+    } else {
+        // fds.revents & libc::POLLERR != 0
+        return Err(RdpError::Io(IoError::new(
+            std::io::ErrorKind::Other,
+            "error on fd",
+        )));
+    }
 }
 
 /// `update_clipboard` is called from Go, and caches data that was copied

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -857,32 +857,37 @@ fn wait_for_fd(fd: usize) -> RdpResult<()> {
         events: libc::POLLIN,
         revents: 0,
     };
-    let res = unsafe { libc::poll(fds, 1, -1) };
+    loop {
+        let res = unsafe { libc::poll(fds, 1, -1) };
 
-    // We only use a single fd and can't timeout, so
-    // res will either be 1 for success or -1 for failure.
-    if res != 1 {
-        error!("poll failed: {res}");
-        return Err(RdpError::Io(std::io::Error::last_os_error()));
-    }
+        // We only use a single fd and can't timeout, so
+        // res will either be 1 for success or -1 for failure.
+        if res != 1 {
+            let os_err = std::io::Error::last_os_error();
+            match os_err.raw_os_error() {
+                Some(libc::EINTR) | Some(libc::EAGAIN) => continue,
+                _ => return Err(RdpError::Io(os_err)),
+            }
+        }
 
-    // res == 1
-    // POLLIN means that the fd is ready to be read from,
-    // POLLHUP means that the other side of the pipe was closed,
-    // but we still may have data to read.
-    if fds.revents & (libc::POLLIN | libc::POLLHUP) != 0 {
-        Ok(()) // ready for a read
-    } else if fds.revents & libc::POLLNVAL != 0 {
-        return Err(RdpError::Io(IoError::new(
-            std::io::ErrorKind::InvalidInput,
-            "invalid fd",
-        )));
-    } else {
-        // fds.revents & libc::POLLERR != 0
-        return Err(RdpError::Io(IoError::new(
-            std::io::ErrorKind::Other,
-            "error on fd",
-        )));
+        // res == 1
+        // POLLIN means that the fd is ready to be read from,
+        // POLLHUP means that the other side of the pipe was closed,
+        // but we still may have data to read.
+        if fds.revents & (libc::POLLIN | libc::POLLHUP) != 0 {
+            return Ok(()); // ready for a read
+        } else if fds.revents & libc::POLLNVAL != 0 {
+            return Err(RdpError::Io(IoError::new(
+                std::io::ErrorKind::InvalidInput,
+                "invalid fd",
+            )));
+        } else {
+            // fds.revents & libc::POLLERR != 0
+            return Err(RdpError::Io(IoError::new(
+                std::io::ErrorKind::Other,
+                "error on fd",
+            )));
+        }
     }
 }
 


### PR DESCRIPTION
Addition to https://github.com/gravitational/teleport/pull/22676 -- we now call `poll` in a loop and check for potential non-fatal system errors before considering the call an error.

From the [poll man page](https://man7.org/linux/man-pages/man2/poll.2.html):

> On some other UNIX systems, poll() can fail with the error EAGAIN
if the system fails to allocate kernel-internal resources, rather
than ENOMEM as Linux does.  POSIX permits this behavior.
Portable programs may wish to check for EAGAIN and loop, just as
with EINTR.