### PR TITLE
[v10] Use the teleport-ent package on enterprise clusters in the discovery installer

### DIFF
--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -26,14 +26,14 @@
       echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/{{ .MajorVersion }}" | sudo tee /etc/apt/sources.list.d/teleport.list >/dev/null
     fi
     sudo apt-get update
-    sudo apt-get install -y teleport jq
+    sudo apt-get install -y {{ .TeleportPackage }} jq
   elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ]; then
     if [ "$ID" = "rhel" ]; then
       VERSION_ID=$(echo "$VERSION_ID" | sed 's/\..*//') # convert version numbers like '7.2' to only include the major version
     fi
     sudo yum-config-manager --add-repo \
       "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/{{ .MajorVersion }}/teleport.repo")"
-    sudo yum install -y teleport jq
+    sudo yum install -y {{ .TeleportPackage }} jq
   else
     echo "Unsupported distro: $ID"
     exit 1

--- a/api/types/installers/installers.go
+++ b/api/types/installers/installers.go
@@ -40,4 +40,7 @@ type Template struct {
 	PublicProxyAddr string
 	// MajorVersion is the major version of the Teleport auth node
 	MajorVersion string
+	// TeleportPackage is the teleport package to use. `teleport` or
+	// `teleport-ent` depending on if the cluster is enterprise or not.
+	TeleportPackage string
 }

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -65,6 +65,7 @@ import (
 	"github.com/gravitational/teleport/lib/httplib/csrf"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/plugin"
 	"github.com/gravitational/teleport/lib/proxy"
@@ -1504,9 +1505,16 @@ func (h *Handler) installer(w http.ResponseWriter, r *http.Request, p httprouter
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	teleportPackage := teleport.ComponentTeleport
+	if modules.GetModules().BuildType() == modules.BuildEnterprise {
+		teleportPackage = fmt.Sprintf("%s-%s", teleport.ComponentTeleport, modules.BuildEnterprise)
+	}
+
 	tmpl := installers.Template{
 		PublicProxyAddr: h.cfg.PublicProxyAddr,
 		MajorVersion:    version,
+		TeleportPackage: teleportPackage,
 	}
 	err = instTmpl.Execute(w, tmpl)
 	return nil, trace.Wrap(err)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1506,8 +1506,9 @@ func (h *Handler) installer(w http.ResponseWriter, r *http.Request, p httprouter
 		return nil, trace.Wrap(err)
 	}
 
+	feats := modules.GetModules().Features()
 	teleportPackage := teleport.ComponentTeleport
-	if modules.GetModules().BuildType() == modules.BuildEnterprise {
+	if modules.GetModules().BuildType() == modules.BuildEnterprise || feats.Cloud {
 		teleportPackage = fmt.Sprintf("%s-%s", teleport.ComponentTeleport, modules.BuildEnterprise)
 	}
 


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/22464