### PR TITLE
Move the authorizer into its own package.

### DIFF
--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/pam"
 	restricted "github.com/gravitational/teleport/lib/restrictedsession"
@@ -233,7 +234,7 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 
 	s.nodeID = uuid.New().String()
 	s.nodeClient, err = s.server.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     types.RoleNode,
 			Username: s.nodeID,
 		},

--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 )
 
@@ -37,7 +38,7 @@ func (a *Server) UpsertRole(ctx context.Context, role types.Role) error {
 			Type: events.RoleCreatedEvent,
 			Code: events.RoleCreatedCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: role.GetName(),
 		},
@@ -90,7 +91,7 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 			Type: events.RoleDeletedEvent,
 			Code: events.RoleDeletedCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: name,
 		},
@@ -106,7 +107,7 @@ func (a *Server) UpsertLock(ctx context.Context, lock types.Lock) error {
 		return trace.Wrap(err)
 	}
 
-	um := ClientUserMetadata(ctx)
+	um := authz.ClientUserMetadata(ctx)
 	if err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.LockCreate{
 		Metadata: apievents.Metadata{
 			Type: events.LockCreatedEvent,
@@ -135,7 +136,7 @@ func (a *Server) DeleteLock(ctx context.Context, lockName string) error {
 			Type: events.LockDeletedEvent,
 			Code: events.LockDeletedCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: lockName,
 		},

--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
@@ -187,7 +188,7 @@ func (s *Server) verifyRecoveryCode(ctx context.Context, user string, givenCode 
 			Type: events.RecoveryCodeUsedEvent,
 			Code: events.RecoveryCodeUseSuccessCode,
 		},
-		UserMetadata: ClientUserMetadataWithUser(ctx, user),
+		UserMetadata: authz.ClientUserMetadataWithUser(ctx, user),
 		Status: apievents.Status{
 			Success: true,
 		},
@@ -507,7 +508,7 @@ func (s *Server) GetAccountRecoveryToken(ctx context.Context, req *proto.GetAcco
 
 // GetAccountRecoveryCodes implements AuthService.GetAccountRecoveryCodes.
 func (s *Server) GetAccountRecoveryCodes(ctx context.Context, req *proto.GetAccountRecoveryCodesRequest) (*proto.RecoveryCodes, error) {
-	username, err := GetClientUsername(ctx)
+	username, err := authz.GetClientUsername(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -552,7 +553,7 @@ func (s *Server) generateAndUpsertRecoveryCodes(ctx context.Context, username st
 			Type: events.RecoveryCodeGeneratedEvent,
 			Code: events.RecoveryCodesGenerateCode,
 		},
-		UserMetadata: ClientUserMetadataWithUser(ctx, username),
+		UserMetadata: authz.ClientUserMetadataWithUser(ctx, username),
 	}); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{"user": username}).Warn("Failed to emit recovery tokens generate event.")
 	}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/plugin"
@@ -44,7 +45,7 @@ type APIConfig struct {
 	PluginRegistry plugin.Registry
 	AuthServer     *Server
 	AuditLog       events.AuditLogSessionStreamer
-	Authorizer     Authorizer
+	Authorizer     authz.Authorizer
 	Emitter        apievents.Emitter
 	// KeepAlivePeriod defines period between keep alives
 	KeepAlivePeriod time.Duration

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1483,9 +1483,9 @@ func (a *Server) AugmentContextUserCertificates(
 	}
 
 	// Fetch user TLS certificate.
-	x509Cert, ok := ctx.Value(authz.ContextUserCertificate).(*x509.Certificate)
-	if !ok {
-		return nil, trace.BadParameter("user certificate missing from context")
+	x509Cert, err := authz.UserCertificateFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// Sanity check: x509Cert matches identity.

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -68,6 +68,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/native"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/circleci"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -1452,7 +1453,7 @@ type AugmentUserCertificateOpts struct {
 // Used by Device Trust to add device extensions to the user certificate.
 func (a *Server) AugmentContextUserCertificates(
 	ctx context.Context,
-	authCtx *Context, opts *AugmentUserCertificateOpts,
+	authCtx *authz.Context, opts *AugmentUserCertificateOpts,
 ) (*proto.Certs, error) {
 	switch {
 	case authCtx == nil:
@@ -1482,7 +1483,7 @@ func (a *Server) AugmentContextUserCertificates(
 	}
 
 	// Fetch user TLS certificate.
-	x509Cert, ok := ctx.Value(contextUserCertificate).(*x509.Certificate)
+	x509Cert, ok := ctx.Value(authz.ContextUserCertificate).(*x509.Certificate)
 	if !ok {
 		return nil, trace.BadParameter("user certificate missing from context")
 	}
@@ -2237,7 +2238,7 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 
 	default: // unset or CreateAuthenticateChallengeRequest_ContextUser.
 		var err error
-		username, err = GetClientUsername(ctx)
+		username, err = authz.GetClientUsername(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2388,7 +2389,7 @@ func (a *Server) GetMFADevices(ctx context.Context, req *proto.GetMFADevicesRequ
 
 	if username == "" {
 		var err error
-		username, err = GetClientUsername(ctx)
+		username, err = authz.GetClientUsername(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2498,7 +2499,7 @@ func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName str
 			Code:        events.MFADeviceDeleteEventCode,
 			ClusterName: clusterName.GetClusterName(),
 		},
-		UserMetadata:      ClientUserMetadataWithUser(ctx, user),
+		UserMetadata:      authz.ClientUserMetadataWithUser(ctx, user),
 		MFADeviceMetadata: mfaDeviceEventMetadata(deviceToDelete),
 	}); err != nil {
 		return nil, trace.Wrap(err)
@@ -2599,7 +2600,7 @@ func (a *Server) verifyMFARespAndAddDevice(ctx context.Context, req *newMFADevic
 			Code:        events.MFADeviceAddEventCode,
 			ClusterName: clusterName.GetClusterName(),
 		},
-		UserMetadata:      ClientUserMetadataWithUser(ctx, req.username),
+		UserMetadata:      authz.ClientUserMetadataWithUser(ctx, req.username),
 		MFADeviceMetadata: mfaDeviceEventMetadata(dev),
 	}); err != nil {
 		log.WithError(err).Warn("Failed to emit add mfa device event.")
@@ -2892,7 +2893,7 @@ func (a *Server) GenerateToken(ctx context.Context, req *proto.GenerateTokenRequ
 		return "", trace.Wrap(err)
 	}
 
-	userMetadata := ClientUserMetadata(ctx)
+	userMetadata := authz.ClientUserMetadata(ctx)
 	for _, role := range req.Roles {
 		if role == types.RoleTrustedCluster {
 			if err := a.emitter.EmitAuditEvent(ctx, &apievents.TrustedClusterTokenCreate{
@@ -3510,7 +3511,7 @@ func (a *Server) CreateAccessRequest(ctx context.Context, req types.AccessReques
 			Type: events.AccessRequestCreateEvent,
 			Code: events.AccessRequestCreateCode,
 		},
-		UserMetadata: ClientUserMetadataWithUser(ctx, req.GetUser()),
+		UserMetadata: authz.ClientUserMetadataWithUser(ctx, req.GetUser()),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Expires: req.GetAccessExpiry(),
 		},
@@ -3535,7 +3536,7 @@ func (a *Server) DeleteAccessRequest(ctx context.Context, name string) error {
 			Type: events.AccessRequestDeleteEvent,
 			Code: events.AccessRequestDeleteCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		RequestID:    name,
 	}); err != nil {
 		log.WithError(err).Warn("Failed to emit access request delete event.")
@@ -3554,7 +3555,7 @@ func (a *Server) SetAccessRequestState(ctx context.Context, params types.AccessR
 			Code: events.AccessRequestUpdateCode,
 		},
 		ResourceMetadata: apievents.ResourceMetadata{
-			UpdatedBy: ClientUsername(ctx),
+			UpdatedBy: authz.ClientUsername(ctx),
 			Expires:   req.GetAccessExpiry(),
 		},
 		RequestID:    params.RequestID,
@@ -3784,7 +3785,7 @@ func (a *Server) CreateApp(ctx context.Context, app types.Application) error {
 			Type: events.AppCreateEvent,
 			Code: events.AppCreateCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    app.GetName(),
 			Expires: app.Expiry(),
@@ -3810,7 +3811,7 @@ func (a *Server) UpdateApp(ctx context.Context, app types.Application) error {
 			Type: events.AppUpdateEvent,
 			Code: events.AppUpdateCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    app.GetName(),
 			Expires: app.Expiry(),
@@ -3836,7 +3837,7 @@ func (a *Server) DeleteApp(ctx context.Context, name string) error {
 			Type: events.AppDeleteEvent,
 			Code: events.AppDeleteCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: name,
 		},
@@ -3870,7 +3871,7 @@ func (a *Server) CreateDatabase(ctx context.Context, database types.Database) er
 			Type: events.DatabaseCreateEvent,
 			Code: events.DatabaseCreateCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    database.GetName(),
 			Expires: database.Expiry(),
@@ -3900,7 +3901,7 @@ func (a *Server) UpdateDatabase(ctx context.Context, database types.Database) er
 			Type: events.DatabaseUpdateEvent,
 			Code: events.DatabaseUpdateCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    database.GetName(),
 			Expires: database.Expiry(),
@@ -3930,7 +3931,7 @@ func (a *Server) DeleteDatabase(ctx context.Context, name string) error {
 			Type: events.DatabaseDeleteEvent,
 			Code: events.DatabaseDeleteCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: name,
 		},
@@ -3991,7 +3992,7 @@ func (a *Server) CreateKubernetesCluster(ctx context.Context, kubeCluster types.
 			Type: events.KubernetesClusterCreateEvent,
 			Code: events.KubernetesClusterCreateCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    kubeCluster.GetName(),
 			Expires: kubeCluster.Expiry(),
@@ -4015,7 +4016,7 @@ func (a *Server) UpdateKubernetesCluster(ctx context.Context, kubeCluster types.
 			Type: events.KubernetesClusterUpdateEvent,
 			Code: events.KubernetesClusterUpdateCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    kubeCluster.GetName(),
 			Expires: kubeCluster.Expiry(),
@@ -4039,7 +4040,7 @@ func (a *Server) DeleteKubernetesCluster(ctx context.Context, name string) error
 			Type: events.KubernetesClusterDeleteEvent,
 			Code: events.KubernetesClusterDeleteCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: name,
 		},
@@ -4051,7 +4052,7 @@ func (a *Server) DeleteKubernetesCluster(ctx context.Context, name string) error
 
 // SubmitUsageEvent submits an external usage event.
 func (a *Server) SubmitUsageEvent(ctx context.Context, req *proto.SubmitUsageEventRequest) error {
-	username, err := GetClientUsername(ctx)
+	username, err := authz.GetClientUsername(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1223,8 +1223,8 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 			xCert, identity := parseX509PEMAndIdentity(t, test.x509PEM)
 
 			// Prepare ctx and authz.Context.
-			ctx = context.WithValue(ctx, authz.ContextUserCertificate, xCert)
-			ctx = context.WithValue(ctx, authz.ContextUser, authz.LocalUser{
+			ctx = authz.ContextWithUserCertificate(ctx, xCert)
+			ctx = authz.ContextWithUser(ctx, authz.LocalUser{
 				Username: username,
 				Identity: *identity,
 			})
@@ -1369,8 +1369,8 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	// Issue augmented certs for user1.
 	// Used to test that re-issue of augmented certs is not allowed.
 	ctxFromAuthorize := testServer.APIConfig.Authorizer.Authorize
-	aCtx := context.WithValue(context.Background(), authz.ContextUserCertificate, xCert1)
-	aCtx = context.WithValue(aCtx, authz.ContextUser, authz.LocalUser{
+	aCtx := authz.ContextWithUserCertificate(ctx, xCert1)
+	aCtx = authz.ContextWithUser(ctx, authz.LocalUser{
 		Username: identity1.Username,
 		Identity: *identity1,
 	})
@@ -1699,8 +1699,8 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			}
 
 			// Prepare ctx and authz.Context.
-			ctx = context.WithValue(ctx, authz.ContextUserCertificate, test.x509Cert)
-			ctx = context.WithValue(ctx, authz.ContextUser, authz.LocalUser{
+			ctx = authz.ContextWithUserCertificate(ctx, test.x509Cert)
+			ctx = authz.ContextWithUser(ctx, authz.LocalUser{
 				Username: test.identity.Username,
 				Identity: *test.identity,
 			})

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1369,8 +1369,8 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	// Issue augmented certs for user1.
 	// Used to test that re-issue of augmented certs is not allowed.
 	ctxFromAuthorize := testServer.APIConfig.Authorizer.Authorize
-	aCtx := authz.ContextWithUserCertificate(ctx, xCert1)
-	aCtx = authz.ContextWithUser(ctx, authz.LocalUser{
+	aCtx := authz.ContextWithUserCertificate(context.Background(), xCert1)
+	aCtx = authz.ContextWithUser(aCtx, authz.LocalUser{
 		Username: identity1.Username,
 		Identity: *identity1,
 	})

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -1221,9 +1222,9 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			xCert, identity := parseX509PEMAndIdentity(t, test.x509PEM)
 
-			// Prepare ctx and auth.Context.
-			ctx = context.WithValue(ctx, contextUserCertificate, xCert)
-			ctx = context.WithValue(ctx, ContextUser, LocalUser{
+			// Prepare ctx and authz.Context.
+			ctx = context.WithValue(ctx, authz.ContextUserCertificate, xCert)
+			ctx = context.WithValue(ctx, authz.ContextUser, authz.LocalUser{
 				Username: username,
 				Identity: *identity,
 			})
@@ -1368,8 +1369,8 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	// Issue augmented certs for user1.
 	// Used to test that re-issue of augmented certs is not allowed.
 	ctxFromAuthorize := testServer.APIConfig.Authorizer.Authorize
-	aCtx := context.WithValue(context.Background(), contextUserCertificate, xCert1)
-	aCtx = context.WithValue(aCtx, ContextUser, LocalUser{
+	aCtx := context.WithValue(context.Background(), authz.ContextUserCertificate, xCert1)
+	aCtx = context.WithValue(aCtx, authz.ContextUser, authz.LocalUser{
 		Username: identity1.Username,
 		Identity: *identity1,
 	})
@@ -1413,7 +1414,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 		x509Cert *x509.Certificate
 		identity *tlsca.Identity
 		// createAuthCtx defaults to ctxFromAuthorize.
-		createAuthCtx func(ctx context.Context) (*Context, error)
+		createAuthCtx func(ctx context.Context) (*authz.Context, error)
 		// createOpts defaults to optsFromBase.
 		createOpts func(t *testing.T) *AugmentUserCertificateOpts
 		wantErr    string
@@ -1423,7 +1424,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:          "authCtx nil",
 			x509Cert:      xCert1,
 			identity:      identity1,
-			createAuthCtx: func(ctx context.Context) (*Context, error) { return nil, nil },
+			createAuthCtx: func(ctx context.Context) (*authz.Context, error) { return nil, nil },
 			wantErr:       "authCtx",
 		},
 		{
@@ -1616,7 +1617,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "locked user",
 			x509Cert: xCert3,
 			identity: identity3, // user3 locked below.
-			createAuthCtx: func(ctx context.Context) (*Context, error) {
+			createAuthCtx: func(ctx context.Context) (*authz.Context, error) {
 				// Authorize user3...
 				authCtx, err := ctxFromAuthorize(ctx)
 				if err != nil {
@@ -1697,9 +1698,9 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 				test.createOpts = optsFromBase
 			}
 
-			// Prepare ctx and auth.Context.
-			ctx = context.WithValue(ctx, contextUserCertificate, test.x509Cert)
-			ctx = context.WithValue(ctx, ContextUser, LocalUser{
+			// Prepare ctx and authz.Context.
+			ctx = context.WithValue(ctx, authz.ContextUserCertificate, test.x509Cert)
+			ctx = context.WithValue(ctx, authz.ContextUser, authz.LocalUser{
 				Username: test.identity.Username,
 				Identity: *test.identity,
 			})

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -44,6 +44,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
@@ -62,7 +63,7 @@ type ServerWithRoles struct {
 	authServer *Server
 	alog       events.AuditLogSessionStreamer
 	// context holds authorization context
-	context Context
+	context authz.Context
 }
 
 // CloseContext is closed when the auth server shuts down
@@ -87,7 +88,7 @@ func (a *ServerWithRoles) actionWithContext(ctx *services.Context, namespace, re
 
 type actionConfig struct {
 	quiet   bool
-	context Context
+	context authz.Context
 }
 
 type actionOption func(*actionConfig)
@@ -195,7 +196,7 @@ func (a *ServerWithRoles) actionForKindSession(namespace string, sid session.ID)
 
 // serverAction returns an access denied error if the role is not one of the builtin server roles.
 func (a *ServerWithRoles) serverAction() error {
-	role, ok := a.context.Identity.(BuiltinRole)
+	role, ok := a.context.Identity.(authz.BuiltinRole)
 	if !ok || !role.IsServer() {
 		return trace.AccessDenied("this request can be only executed by a teleport built-in server")
 	}
@@ -215,8 +216,8 @@ func (a *ServerWithRoles) hasBuiltinRole(roles ...types.SystemRole) bool {
 
 // HasBuiltinRole checks if the identity is a builtin role with the matching
 // name.
-func HasBuiltinRole(authContext Context, name string) bool {
-	if _, ok := authContext.Identity.(BuiltinRole); !ok {
+func HasBuiltinRole(authContext authz.Context, name string) bool {
+	if _, ok := authContext.Identity.(authz.BuiltinRole); !ok {
 		return false
 	}
 	if !authContext.Checker.HasRole(name) {
@@ -228,8 +229,8 @@ func HasBuiltinRole(authContext Context, name string) bool {
 
 // HasRemoteBuiltinRole checks if the identity is a remote builtin role with the
 // matching name.
-func HasRemoteBuiltinRole(authContext Context, name string) bool {
-	if _, ok := authContext.UnmappedIdentity.(RemoteBuiltinRole); !ok {
+func HasRemoteBuiltinRole(authContext authz.Context, name string) bool {
+	if _, ok := authContext.UnmappedIdentity.(authz.RemoteBuiltinRole); !ok {
 		return false
 	}
 	if !authContext.Checker.HasRole(name) {
@@ -245,14 +246,14 @@ func (a *ServerWithRoles) hasRemoteBuiltinRole(name string) bool {
 }
 
 // hasRemoteUserRole checks if the identity is a remote user or not.
-func hasRemoteUserRole(authContext Context) bool {
-	_, ok := authContext.UnmappedIdentity.(RemoteUser)
+func hasRemoteUserRole(authContext authz.Context) bool {
+	_, ok := authContext.UnmappedIdentity.(authz.RemoteUser)
 	return ok
 }
 
 // hasLocalUserRole checks if the identity is a local user or not.
-func hasLocalUserRole(authContext Context) bool {
-	_, ok := authContext.UnmappedIdentity.(LocalUser)
+func hasLocalUserRole(authContext authz.Context) bool {
+	_, ok := authContext.UnmappedIdentity.(authz.LocalUser)
 	return ok
 }
 
@@ -367,7 +368,7 @@ func (a *ServerWithRoles) Export(ctx context.Context, req *collectortracev1.Expo
 	sb.WriteString(a.context.User.GetName())
 
 	// if forwarded on behalf of a Teleport service add its system roles
-	if role, ok := a.context.Identity.(BuiltinRole); ok {
+	if role, ok := a.context.Identity.(authz.BuiltinRole); ok {
 		sb.WriteRune(':')
 		sb.WriteString(role.Role.String())
 		if len(role.AdditionalSystemRoles) > 0 {
@@ -770,7 +771,7 @@ func (a *ServerWithRoles) GenerateHostCerts(ctx context.Context, req *proto.Host
 // checkAdditionalSystemRoles verifies additional system roles in host cert request.
 func (a *ServerWithRoles) checkAdditionalSystemRoles(ctx context.Context, req *proto.HostCertsRequest) error {
 	// ensure requesting cert's primary role is a server role.
-	role, ok := a.context.Identity.(BuiltinRole)
+	role, ok := a.context.Identity.(authz.BuiltinRole)
 	if !ok || !role.IsServer() {
 		return trace.AccessDenied("additional system roles can only be claimed by a teleport built-in server")
 	}
@@ -821,7 +822,7 @@ Outer:
 }
 
 func (a *ServerWithRoles) UnstableAssertSystemRole(ctx context.Context, req proto.UnstableSystemRoleAssertion) error {
-	role, ok := a.context.Identity.(BuiltinRole)
+	role, ok := a.context.Identity.(authz.BuiltinRole)
 	if !ok || !role.IsServer() {
 		return trace.AccessDenied("system role assertions can only be executed by a teleport built-in server")
 	}
@@ -849,7 +850,7 @@ func (a *ServerWithRoles) RegisterInventoryControlStream(ics client.UpstreamInve
 	var hello proto.UpstreamInventoryHello
 
 	// Ensure that caller is a teleport server
-	role, ok := a.context.Identity.(BuiltinRole)
+	role, ok := a.context.Identity.(authz.BuiltinRole)
 	if !ok || !role.IsServer() {
 		return hello, trace.AccessDenied("inventory control streams can only be created by a teleport built-in server")
 	}
@@ -1368,7 +1369,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 				Type: events.AccessRequestResourceSearch,
 				Code: events.AccessRequestResourceSearchCode,
 			},
-			UserMetadata:        ClientUserMetadata(ctx),
+			UserMetadata:        authz.ClientUserMetadata(ctx),
 			SearchAsRoles:       a.context.Checker.RoleNames(),
 			ResourceType:        req.ResourceType,
 			Namespace:           req.Namespace,
@@ -1517,7 +1518,7 @@ type kubeChecker struct {
 	localUser bool
 }
 
-func newKubeChecker(authContext Context) *kubeChecker {
+func newKubeChecker(authContext authz.Context) *kubeChecker {
 	return &kubeChecker{
 		checker:   authContext.Checker,
 		localUser: hasLocalUserRole(authContext),
@@ -1846,7 +1847,7 @@ func enforceEnterpriseJoinMethodCreation(token types.ProvisionToken) error {
 // emitTokenEvent is called by Create/Upsert Token in order to emit any relevant
 // events. For now, this just emits trusted_cluster_token.create.
 func emitTokenEvent(ctx context.Context, e apievents.Emitter, token types.ProvisionToken) {
-	userMetadata := ClientUserMetadata(ctx)
+	userMetadata := authz.ClientUserMetadata(ctx)
 	for _, role := range token.GetRoles() {
 		if role == types.RoleTrustedCluster {
 			if err := e.EmitAuditEvent(ctx, &apievents.TrustedClusterTokenCreate{
@@ -3288,7 +3289,7 @@ func (a *ServerWithRoles) EmitAuditEvent(ctx context.Context, event apievents.Au
 	if err := a.action(apidefaults.Namespace, types.KindEvent, types.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
-	role, ok := a.context.Identity.(BuiltinRole)
+	role, ok := a.context.Identity.(authz.BuiltinRole)
 	if !ok || !role.IsServer() {
 		return trace.AccessDenied("this request can be only executed by a teleport built-in server")
 	}
@@ -3310,7 +3311,7 @@ func (a *ServerWithRoles) CreateAuditStream(ctx context.Context, sid session.ID)
 	if err := a.action(apidefaults.Namespace, types.KindEvent, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	role, ok := a.context.Identity.(BuiltinRole)
+	role, ok := a.context.Identity.(authz.BuiltinRole)
 	if !ok || !role.IsServer() {
 		return nil, trace.AccessDenied("this request can be only executed by a Teleport server")
 	}
@@ -3330,7 +3331,7 @@ func (a *ServerWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID,
 	if err := a.action(apidefaults.Namespace, types.KindEvent, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	role, ok := a.context.Identity.(BuiltinRole)
+	role, ok := a.context.Identity.(authz.BuiltinRole)
 	if !ok || !role.IsServer() {
 		return nil, trace.AccessDenied("this request can be only executed by a Teleport server")
 	}
@@ -4237,7 +4238,7 @@ func (a *ServerWithRoles) GenerateSnowflakeJWT(ctx context.Context, req *proto.S
 // canImpersonateBuiltinRole checks if the current user can impersonate the
 // provided system role.
 func (a *ServerWithRoles) canImpersonateBuiltinRole(role types.SystemRole) error {
-	roleCtx, err := NewBuiltinRoleContext(role)
+	roleCtx, err := authz.NewBuiltinRoleContext(role)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -4873,7 +4874,7 @@ func (a *ServerWithRoles) DeleteAllLocks(context.Context) error {
 
 // ReplaceRemoteLocks replaces the set of locks associated with a remote cluster.
 func (a *ServerWithRoles) ReplaceRemoteLocks(ctx context.Context, clusterName string, locks []types.Lock) error {
-	role, ok := a.context.Identity.(RemoteBuiltinRole)
+	role, ok := a.context.Identity.(authz.RemoteBuiltinRole)
 	if !a.hasRemoteBuiltinRole(string(types.RoleRemoteProxy)) || !ok || role.ClusterName != clusterName {
 		return trace.AccessDenied("this request can be only executed by a remote proxy of cluster %q", clusterName)
 	}
@@ -5652,7 +5653,7 @@ func (a *ServerWithRoles) CreateSAMLIdPServiceProvider(ctx context.Context, sp t
 		},
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:      sp.GetName(),
-			UpdatedBy: ClientUsername(ctx),
+			UpdatedBy: authz.ClientUsername(ctx),
 		},
 		SAMLIdPServiceProviderMetadata: apievents.SAMLIdPServiceProviderMetadata{
 			ServiceProviderEntityID: sp.GetEntityID(),
@@ -5682,7 +5683,7 @@ func (a *ServerWithRoles) UpdateSAMLIdPServiceProvider(ctx context.Context, sp t
 		},
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:      sp.GetName(),
-			UpdatedBy: ClientUsername(ctx),
+			UpdatedBy: authz.ClientUsername(ctx),
 		},
 		SAMLIdPServiceProviderMetadata: apievents.SAMLIdPServiceProviderMetadata{
 			ServiceProviderEntityID: sp.GetEntityID(),
@@ -5722,7 +5723,7 @@ func (a *ServerWithRoles) DeleteSAMLIdPServiceProvider(ctx context.Context, name
 		},
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:      name,
-			UpdatedBy: ClientUsername(ctx),
+			UpdatedBy: authz.ClientUsername(ctx),
 		},
 		SAMLIdPServiceProviderMetadata: apievents.SAMLIdPServiceProviderMetadata{
 			ServiceProviderEntityID: entityID,
@@ -5751,7 +5752,7 @@ func (a *ServerWithRoles) DeleteAllSAMLIdPServiceProviders(ctx context.Context) 
 			Code: code,
 		},
 		ResourceMetadata: apievents.ResourceMetadata{
-			UpdatedBy: ClientUsername(ctx),
+			UpdatedBy: authz.ClientUsername(ctx),
 		},
 	}); emitErr != nil {
 		log.WithError(trace.NewAggregate(emitErr, err)).Warn("Failed to emit SAML IdP service provider deleted all event.")
@@ -5817,7 +5818,7 @@ func (a *ServerWithRoles) DeleteAllUserGroups(ctx context.Context) error {
 // NewAdminAuthServer returns auth server authorized as admin,
 // used for auth server cached access
 func NewAdminAuthServer(authServer *Server, alog events.AuditLogSessionStreamer) (ClientI, error) {
-	ctx, err := NewAdminContext()
+	ctx, err := authz.NewAdminContext()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -1350,8 +1351,8 @@ func serverWithAllowRules(t *testing.T, srv *TestAuthServer, allowRules []types.
 	err = srv.AuthServer.UpsertRole(context.TODO(), role)
 	require.NoError(t, err)
 
-	localUser := LocalUser{Username: username, Identity: tlsca.Identity{Username: username}}
-	authContext, err := contextForLocalUser(localUser, srv.AuthServer, srv.ClusterName, true /* disableDeviceAuthz */)
+	localUser := authz.LocalUser{Username: username, Identity: tlsca.Identity{Username: username}}
+	authContext, err := authz.ContextForLocalUser(localUser, srv.AuthServer, srv.ClusterName, true /* disableDeviceAuthz */)
 	require.NoError(t, err)
 
 	return &ServerWithRoles{
@@ -1927,7 +1928,7 @@ func TestReplaceRemoteLocksRBAC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, test.identity.I))
+			authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, authz.ContextUser, test.identity.I))
 			require.NoError(t, err)
 
 			s := &ServerWithRoles{
@@ -2121,7 +2122,7 @@ func TestKindClusterConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	getClusterConfigResources := func(ctx context.Context, user types.User) []error {
-		authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, TestUser(user.GetName()).I))
+		authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, authz.ContextUser, TestUser(user.GetName()).I))
 		require.NoError(t, err, trace.DebugReport(err))
 		s := &ServerWithRoles{
 			authServer: srv.AuthServer,
@@ -2863,7 +2864,7 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 
-	authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, TestBuiltin(types.RoleProxy).I))
+	authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, authz.ContextUser, TestBuiltin(types.RoleProxy).I))
 	require.NoError(t, err)
 
 	s := &ServerWithRoles{
@@ -3594,7 +3595,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 			ctx := context.Background()
 
 			identity := TestBuiltin(role)
-			authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, identity.I))
+			authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, authz.ContextUser, identity.I))
 			require.NoError(t, err)
 
 			s := &ServerWithRoles{

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1928,7 +1928,7 @@ func TestReplaceRemoteLocksRBAC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, authz.ContextUser, test.identity.I))
+			authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, test.identity.I))
 			require.NoError(t, err)
 
 			s := &ServerWithRoles{
@@ -2122,7 +2122,7 @@ func TestKindClusterConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	getClusterConfigResources := func(ctx context.Context, user types.User) []error {
-		authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, authz.ContextUser, TestUser(user.GetName()).I))
+		authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, TestUser(user.GetName()).I))
 		require.NoError(t, err, trace.DebugReport(err))
 		s := &ServerWithRoles{
 			authServer: srv.AuthServer,
@@ -2864,7 +2864,7 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 
-	authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, authz.ContextUser, TestBuiltin(types.RoleProxy).I))
+	authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, TestBuiltin(types.RoleProxy).I))
 	require.NoError(t, err)
 
 	s := &ServerWithRoles{
@@ -3595,7 +3595,8 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 			ctx := context.Background()
 
 			identity := TestBuiltin(role)
-			authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, authz.ContextUser, identity.I))
+
+			authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, identity.I))
 			require.NoError(t, err)
 
 			s := &ServerWithRoles{

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
@@ -410,7 +411,7 @@ func (s *Server) validateGenerationLabel(ctx context.Context, user types.User, c
 		}
 
 		// Emit an audit event.
-		userMetadata := ClientUserMetadata(ctx)
+		userMetadata := authz.ClientUserMetadata(ctx)
 		if err := s.emitter.EmitAuditEvent(s.closeCtx, &apievents.RenewableCertificateGenerationMismatch{
 			Metadata: apievents.Metadata{
 				Type: events.RenewableCertificateGenerationMismatchEvent,

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/loginrule"
@@ -138,7 +139,7 @@ func (a *Server) upsertGithubConnector(ctx context.Context, connector types.Gith
 			Type: events.GithubConnectorCreatedEvent,
 			Code: events.GithubConnectorCreatedCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: connector.GetName(),
 		},
@@ -289,7 +290,7 @@ func (a *Server) deleteGithubConnector(ctx context.Context, connectorName string
 			Type: events.GithubConnectorDeletedEvent,
 			Code: events.GithubConnectorDeletedCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: connectorName,
 		},

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -1935,8 +1935,9 @@ func (g *GRPCServer) UpsertKubeService(ctx context.Context, req *proto.UpsertKub
 	// the server.Addr field. It's not useful for other services that want to
 	// connect to it (like a proxy). Remote address of the gRPC connection is
 	// the closest thing we have to a public IP for the service.
-	clientAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
-	if !ok {
+	clientAddr, err := authz.ClientAddrFromContext(ctx)
+	if err != nil {
+		g.Logger.WithError(err).Warn("error getting client address from context")
 		return nil, status.Errorf(codes.FailedPrecondition, "bug: client address not found in request context")
 	}
 	server.SetAddr(utils.ReplaceLocalhost(server.GetAddr(), clientAddr.String()))
@@ -1962,8 +1963,9 @@ func (g *GRPCServer) UpsertKubeServiceV2(ctx context.Context, req *proto.UpsertK
 	// the server.Addr field. It's not useful for other services that want to
 	// connect to it (like a proxy). Remote address of the gRPC connection is
 	// the closest thing we have to a public IP for the service.
-	clientAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
-	if !ok {
+	clientAddr, err := authz.ClientAddrFromContext(ctx)
+	if err != nil {
+		g.Logger.WithError(err).Warn("error getting client address from context")
 		return nil, status.Errorf(codes.FailedPrecondition, "bug: client address not found in request context")
 	}
 	server.SetAddr(utils.ReplaceLocalhost(server.GetAddr(), clientAddr.String()))
@@ -3904,8 +3906,9 @@ func (g *GRPCServer) UpsertWindowsDesktopService(ctx context.Context, service *t
 	// the server.Addr field. It's not useful for other services that want to
 	// connect to it (like a proxy). Remote address of the gRPC connection is
 	// the closest thing we have to a public IP for the service.
-	clientAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
-	if !ok {
+	clientAddr, err := authz.ClientAddrFromContext(ctx)
+	if err != nil {
+		g.Logger.WithError(err).Warn("error getting client address from context")
 		return nil, status.Errorf(codes.FailedPrecondition, "client address not found in request context")
 	}
 	service.Spec.Addr = utils.ReplaceLocalhost(service.GetAddr(), clientAddr.String())

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -862,7 +863,7 @@ func (g *GRPCServer) SetAccessRequestState(ctx context.Context, req *proto.Reque
 		return nil, trace.Wrap(err)
 	}
 	if req.Delegator != "" {
-		ctx = WithDelegator(ctx, req.Delegator)
+		ctx = authz.WithDelegator(ctx, req.Delegator)
 	}
 	if err := auth.ServerWithRoles.SetAccessRequestState(ctx, types.AccessRequestUpdate{
 		RequestID:   req.ID,
@@ -1934,7 +1935,7 @@ func (g *GRPCServer) UpsertKubeService(ctx context.Context, req *proto.UpsertKub
 	// the server.Addr field. It's not useful for other services that want to
 	// connect to it (like a proxy). Remote address of the gRPC connection is
 	// the closest thing we have to a public IP for the service.
-	clientAddr, ok := ctx.Value(ContextClientAddr).(net.Addr)
+	clientAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
 	if !ok {
 		return nil, status.Errorf(codes.FailedPrecondition, "bug: client address not found in request context")
 	}
@@ -1961,7 +1962,7 @@ func (g *GRPCServer) UpsertKubeServiceV2(ctx context.Context, req *proto.UpsertK
 	// the server.Addr field. It's not useful for other services that want to
 	// connect to it (like a proxy). Remote address of the gRPC connection is
 	// the closest thing we have to a public IP for the service.
-	clientAddr, ok := ctx.Value(ContextClientAddr).(net.Addr)
+	clientAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
 	if !ok {
 		return nil, status.Errorf(codes.FailedPrecondition, "bug: client address not found in request context")
 	}
@@ -3903,7 +3904,7 @@ func (g *GRPCServer) UpsertWindowsDesktopService(ctx context.Context, service *t
 	// the server.Addr field. It's not useful for other services that want to
 	// connect to it (like a proxy). Remote address of the gRPC connection is
 	// the closest thing we have to a public IP for the service.
-	clientAddr, ok := ctx.Value(ContextClientAddr).(net.Addr)
+	clientAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
 	if !ok {
 		return nil, status.Errorf(codes.FailedPrecondition, "client address not found in request context")
 	}
@@ -5065,7 +5066,7 @@ func serverWithNopRole(cfg GRPCServerConfig) (*ServerWithRoles, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	nopRole := BuiltinRole{
+	nopRole := authz.BuiltinRole{
 		Role:        types.RoleNop,
 		Username:    string(types.RoleNop),
 		ClusterName: clusterName.GetClusterName(),
@@ -5074,7 +5075,7 @@ func serverWithNopRole(cfg GRPCServerConfig) (*ServerWithRoles, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	nopCtx, err := contextForBuiltinRole(nopRole, recConfig)
+	nopCtx, err := authz.ContextForBuiltinRole(nopRole, recConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -5086,7 +5087,7 @@ func serverWithNopRole(cfg GRPCServerConfig) (*ServerWithRoles, error) {
 }
 
 type grpcContext struct {
-	*Context
+	*authz.Context
 	*ServerWithRoles
 }
 

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -3316,7 +3316,7 @@ func TestGRPCServer_CreateToken(t *testing.T) {
 	// Allow us to directly invoke the deprecated gRPC methods with
 	// authentication.
 	user := TestAdmin()
-	ctx = context.WithValue(ctx, authz.ContextUser, user.I)
+	ctx = authz.ContextWithUser(ctx, user.I)
 
 	// Test default expiry is applied.
 	t.Run("undefined-expiry", func(t *testing.T) {
@@ -3403,7 +3403,7 @@ func TestGRPCServer_UpsertToken(t *testing.T) {
 	// Allow us to directly invoke the deprecated gRPC methods with
 	// authentication.
 	user := TestAdmin()
-	ctx = context.WithValue(ctx, authz.ContextUser, user.I)
+	ctx = authz.ContextWithUser(ctx, user.I)
 
 	// Test default expiry is applied.
 	t.Run("undefined-expiry", func(t *testing.T) {
@@ -3604,7 +3604,7 @@ func TestGRPCServer_GetInstallers(t *testing.T) {
 	grpc := server.TLSServer.grpcServer
 
 	user := TestAdmin()
-	ctx = context.WithValue(ctx, authz.ContextUser, user.I)
+	ctx = authz.ContextWithUser(ctx, user.I)
 
 	tests := []struct {
 		name               string

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
@@ -791,7 +792,7 @@ func TestCreateAppSession_deviceExtensions(t *testing.T) {
 		{
 			name: "user with device extensions",
 			modifyUser: func(u *TestIdentity) {
-				lu := u.I.(LocalUser)
+				lu := u.I.(authz.LocalUser)
 				lu.Identity.DeviceExtensions = *wantExtensions
 				u.I = lu
 			},
@@ -864,7 +865,7 @@ func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
 		{
 			name: "user with device extensions",
 			modifyUser: func(u *TestIdentity) {
-				lu := u.I.(LocalUser)
+				lu := u.I.(authz.LocalUser)
 				lu.Identity.DeviceExtensions = *wantExtensions
 				u.I = lu
 			},
@@ -1444,7 +1445,7 @@ func TestGenerateUserSingleUseCert(t *testing.T) {
 				u.TTL = 1 * time.Hour
 
 				// Add device extensions to the fake user's identity.
-				localUser := u.I.(LocalUser)
+				localUser := u.I.(authz.LocalUser)
 				localUser.Identity.DeviceExtensions = wantDeviceExtensions
 				u.I = localUser
 
@@ -1487,7 +1488,7 @@ func TestGenerateUserSingleUseCert(t *testing.T) {
 				u.TTL = 1 * time.Hour
 
 				// Add device extensions to the fake user's identity.
-				localUser := u.I.(LocalUser)
+				localUser := u.I.(authz.LocalUser)
 				localUser.Identity.DeviceExtensions = wantDeviceExtensions
 				u.I = localUser
 
@@ -3014,11 +3015,11 @@ func TestCustomRateLimiting(t *testing.T) {
 }
 
 type mockAuthorizer struct {
-	ctx *Context
+	ctx *authz.Context
 	err error
 }
 
-func (a mockAuthorizer) Authorize(context.Context) (*Context, error) {
+func (a mockAuthorizer) Authorize(context.Context) (*authz.Context, error) {
 	return a.ctx, a.err
 }
 
@@ -3217,7 +3218,7 @@ func TestExport(t *testing.T) {
 		errAssertion      require.ErrorAssertionFunc
 		uploadedAssertion require.ValueAssertionFunc
 		spans             []*otlptracev1.ResourceSpans
-		authorizer        Authorizer
+		authorizer        authz.Authorizer
 		mockTraceClient   mockTraceClient
 	}{
 		{
@@ -3315,7 +3316,7 @@ func TestGRPCServer_CreateToken(t *testing.T) {
 	// Allow us to directly invoke the deprecated gRPC methods with
 	// authentication.
 	user := TestAdmin()
-	ctx = context.WithValue(ctx, ContextUser, user.I)
+	ctx = context.WithValue(ctx, authz.ContextUser, user.I)
 
 	// Test default expiry is applied.
 	t.Run("undefined-expiry", func(t *testing.T) {
@@ -3402,7 +3403,7 @@ func TestGRPCServer_UpsertToken(t *testing.T) {
 	// Allow us to directly invoke the deprecated gRPC methods with
 	// authentication.
 	user := TestAdmin()
-	ctx = context.WithValue(ctx, ContextUser, user.I)
+	ctx = context.WithValue(ctx, authz.ContextUser, user.I)
 
 	// Test default expiry is applied.
 	t.Run("undefined-expiry", func(t *testing.T) {
@@ -3603,7 +3604,7 @@ func TestGRPCServer_GetInstallers(t *testing.T) {
 	grpc := server.TLSServer.grpcServer
 
 	user := TestAdmin()
-	ctx = context.WithValue(ctx, ContextUser, user.I)
+	ctx = context.WithValue(ctx, authz.ContextUser, user.I)
 
 	tests := []struct {
 		name               string

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -716,7 +716,7 @@ func NewTestTLSServer(cfg TestTLSServerConfig) (*TestTLSServer, error) {
 
 // TestIdentity is test identity spec used to generate identities in tests
 type TestIdentity struct {
-	I              interface{}
+	I              authz.IdentityGetter
 	TTL            time.Duration
 	AcceptedUsage  []string
 	RouteToCluster string

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/native"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -198,7 +199,7 @@ type TestAuthServer struct {
 	// Backend is a backend for auth server
 	Backend backend.Backend
 	// Authorizer is an authorizer used in tests
-	Authorizer Authorizer
+	Authorizer authz.Authorizer
 	// LockWatcher is a lock watcher used in tests.
 	LockWatcher *services.LockWatcher
 }
@@ -353,7 +354,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	}
 	srv.AuthServer.SetLockWatcher(srv.LockWatcher)
 
-	srv.Authorizer, err = NewAuthorizer(AuthorizerOpts{
+	srv.Authorizer, err = authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: srv.ClusterName,
 		AccessPoint: srv.AuthServer,
 		LockWatcher: srv.LockWatcher,
@@ -438,7 +439,7 @@ func generateCertificate(authServer *Server, identity TestIdentity) ([]byte, []b
 	}
 
 	switch id := identity.I.(type) {
-	case LocalUser:
+	case authz.LocalUser:
 		user, err := authServer.GetUser(id.Username, false)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
@@ -468,7 +469,7 @@ func generateCertificate(authServer *Server, identity TestIdentity) ([]byte, []b
 			return nil, nil, trace.Wrap(err)
 		}
 		return certs.TLS, priv, nil
-	case BuiltinRole:
+	case authz.BuiltinRole:
 		certs, err := authServer.GenerateHostCerts(context.Background(),
 			&proto.HostCertsRequest{
 				HostID:       id.Username,
@@ -481,7 +482,7 @@ func generateCertificate(authServer *Server, identity TestIdentity) ([]byte, []b
 			return nil, nil, trace.Wrap(err)
 		}
 		return certs.TLS, priv, nil
-	case RemoteBuiltinRole:
+	case authz.RemoteBuiltinRole:
 		certs, err := authServer.GenerateHostCerts(context.Background(),
 			&proto.HostCertsRequest{
 				HostID:       id.Username,
@@ -726,7 +727,7 @@ type TestIdentity struct {
 // TestUser returns TestIdentity for local user
 func TestUser(username string) TestIdentity {
 	return TestIdentity{
-		I: LocalUser{
+		I: authz.LocalUser{
 			Username: username,
 			Identity: tlsca.Identity{Username: username},
 		},
@@ -737,7 +738,7 @@ func TestUser(username string) TestIdentity {
 // including the supplied device extensions in the tlsca.Identity.
 func TestUserWithDeviceExtensions(username string, exts tlsca.DeviceExtensions) TestIdentity {
 	return TestIdentity{
-		I: LocalUser{
+		I: authz.LocalUser{
 			Username: username,
 			Identity: tlsca.Identity{
 				Username:         username,
@@ -751,7 +752,7 @@ func TestUserWithDeviceExtensions(username string, exts tlsca.DeviceExtensions) 
 // with renewable credentials.
 func TestRenewableUser(username string, generation uint64) TestIdentity {
 	return TestIdentity{
-		I: LocalUser{
+		I: authz.LocalUser{
 			Username: username,
 			Identity: tlsca.Identity{
 				Username: username,
@@ -777,7 +778,7 @@ func TestAdmin() TestIdentity {
 // TestBuiltin returns TestIdentity for builtin user
 func TestBuiltin(role types.SystemRole) TestIdentity {
 	return TestIdentity{
-		I: BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     role,
 			Username: string(role),
 		},
@@ -787,7 +788,7 @@ func TestBuiltin(role types.SystemRole) TestIdentity {
 // TestServerID returns a TestIdentity for a node with the passed in serverID.
 func TestServerID(role types.SystemRole, serverID string) TestIdentity {
 	return TestIdentity{
-		I: BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     role,
 			Username: serverID,
 		},
@@ -797,7 +798,7 @@ func TestServerID(role types.SystemRole, serverID string) TestIdentity {
 // TestRemoteBuiltin returns TestIdentity for a remote builtin role.
 func TestRemoteBuiltin(role types.SystemRole, remoteCluster string) TestIdentity {
 	return TestIdentity{
-		I: RemoteBuiltinRole{
+		I: authz.RemoteBuiltinRole{
 			Role:        role,
 			Username:    string(role),
 			ClusterName: remoteCluster,

--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
-	"net"
 	"net/url"
 	"time"
 
@@ -349,10 +348,11 @@ func (a *Server) RegisterUsingAzureMethod(ctx context.Context, challengeResponse
 		return nil, trace.Wrap(err)
 	}
 
-	clientAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
-	if !ok {
-		return nil, trace.BadParameter("logic error: client address was not set")
+	clientAddr, err := authz.ClientAddrFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
+
 	challenge, err := generateAzureChallenge()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -348,7 +349,7 @@ func (a *Server) RegisterUsingAzureMethod(ctx context.Context, challengeResponse
 		return nil, trace.Wrap(err)
 	}
 
-	clientAddr, ok := ctx.Value(ContextClientAddr).(net.Addr)
+	clientAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
 	if !ok {
 		return nil, trace.BadParameter("logic error: client address was not set")
 	}

--- a/lib/auth/join_azure_test.go
+++ b/lib/auth/join_azure_test.go
@@ -385,7 +385,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			require.NoError(t, err)
 
 			reqCtx := context.Background()
-			reqCtx = authz.ContextWithClientAddr(ctx, &net.IPAddr{})
+			reqCtx = authz.ContextWithClientAddr(reqCtx, &net.IPAddr{})
 
 			vmResult := tc.vmResult
 			if vmResult == nil {

--- a/lib/auth/join_azure_test.go
+++ b/lib/auth/join_azure_test.go
@@ -385,7 +385,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			require.NoError(t, err)
 
 			reqCtx := context.Background()
-			reqCtx = context.WithValue(reqCtx, authz.ContextClientAddr, &net.IPAddr{})
+			reqCtx = authz.ContextWithClientAddr(ctx, &net.IPAddr{})
 
 			vmResult := tc.vmResult
 			if vmResult == nil {

--- a/lib/auth/join_azure_test.go
+++ b/lib/auth/join_azure_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/fixtures"
 )
@@ -384,7 +385,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			require.NoError(t, err)
 
 			reqCtx := context.Background()
-			reqCtx = context.WithValue(reqCtx, ContextClientAddr, &net.IPAddr{})
+			reqCtx = context.WithValue(reqCtx, authz.ContextClientAddr, &net.IPAddr{})
 
 			vmResult := tc.vmResult
 			if vmResult == nil {

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
 	cloudaws "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/aws"
@@ -376,7 +377,7 @@ func (a *Server) RegisterUsingIAMMethod(ctx context.Context, challengeResponse c
 		opt(cfg)
 	}
 
-	clientAddr, ok := ctx.Value(ContextClientAddr).(net.Addr)
+	clientAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
 	if !ok {
 		return nil, trace.BadParameter("logic error: client address was not set")
 	}

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -23,7 +23,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -377,9 +376,9 @@ func (a *Server) RegisterUsingIAMMethod(ctx context.Context, challengeResponse c
 		opt(cfg)
 	}
 
-	clientAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
-	if !ok {
-		return nil, trace.BadParameter("logic error: client address was not set")
+	clientAddr, err := authz.ClientAddrFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	challenge, err := generateIAMChallenge()

--- a/lib/auth/join_iam_test.go
+++ b/lib/auth/join_iam_test.go
@@ -532,7 +532,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			}()
 
 			requestContext := context.Background()
-			requestContext = context.WithValue(requestContext, authz.ContextClientAddr, &net.IPAddr{})
+			requestContext = authz.ContextWithClientAddr(ctx, &net.IPAddr{})
 			requestContext = context.WithValue(requestContext, stsClientKey{}, tc.stsClient)
 
 			_, err = a.RegisterUsingIAMMethod(requestContext, func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {

--- a/lib/auth/join_iam_test.go
+++ b/lib/auth/join_iam_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 )
 
 func responseFromAWSIdentity(id awsIdentity) string {
@@ -531,7 +532,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			}()
 
 			requestContext := context.Background()
-			requestContext = context.WithValue(requestContext, ContextClientAddr, &net.IPAddr{})
+			requestContext = context.WithValue(requestContext, authz.ContextClientAddr, &net.IPAddr{})
 			requestContext = context.WithValue(requestContext, stsClientKey{}, tc.stsClient)
 
 			_, err = a.RegisterUsingIAMMethod(requestContext, func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {

--- a/lib/auth/join_iam_test.go
+++ b/lib/auth/join_iam_test.go
@@ -532,7 +532,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			}()
 
 			requestContext := context.Background()
-			requestContext = authz.ContextWithClientAddr(ctx, &net.IPAddr{})
+			requestContext = authz.ContextWithClientAddr(requestContext, &net.IPAddr{})
 			requestContext = context.WithValue(requestContext, stsClientKey{}, tc.stsClient)
 
 			_, err = a.RegisterUsingIAMMethod(requestContext, func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -41,6 +41,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/limiter"
@@ -390,7 +391,7 @@ func (a *Middleware) withAuthenticatedUser(ctx context.Context) (context.Context
 
 	var (
 		connState      *tls.ConnectionState
-		identityGetter IdentityGetter
+		identityGetter authz.IdentityGetter
 	)
 
 	switch info := peerInfo.AuthInfo.(type) {
@@ -413,9 +414,9 @@ func (a *Middleware) withAuthenticatedUser(ctx context.Context) (context.Context
 		return nil, trace.AccessDenied("missing authentication")
 	}
 
-	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(connState))
-	ctx = context.WithValue(ctx, ContextClientAddr, peerInfo.Addr)
-	ctx = context.WithValue(ctx, ContextUser, identityGetter)
+	ctx = context.WithValue(ctx, authz.ContextUserCertificate, certFromConnState(connState))
+	ctx = context.WithValue(ctx, authz.ContextClientAddr, peerInfo.Addr)
+	ctx = context.WithValue(ctx, authz.ContextUser, identityGetter)
 
 	return ctx, nil
 
@@ -505,7 +506,7 @@ func (a *authenticatedStream) Context() context.Context {
 }
 
 // GetUser returns authenticated user based on request TLS metadata
-func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, error) {
+func (a *Middleware) GetUser(connState tls.ConnectionState) (authz.IdentityGetter, error) {
 	peers := connState.PeerCertificates
 	if len(peers) > 1 {
 		// when turning intermediaries on, don't forget to verify
@@ -519,7 +520,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 	// for connections without auth, but this is not active use-case
 	// therefore it is not allowed to reduce scope
 	if len(peers) == 0 {
-		return BuiltinRole{
+		return authz.BuiltinRole{
 			Role:        types.RoleNop,
 			Username:    string(types.RoleNop),
 			ClusterName: a.ClusterName,
@@ -569,14 +570,14 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 		// to get unrestricted access to the local cluster
 		systemRole := findPrimarySystemRole(identity.Groups)
 		if systemRole != nil {
-			return RemoteBuiltinRole{
+			return authz.RemoteBuiltinRole{
 				Role:        *systemRole,
 				Username:    identity.Username,
 				ClusterName: certClusterName,
 				Identity:    *identity,
 			}, nil
 		}
-		return RemoteUser{
+		return authz.RemoteUser{
 			ClusterName:      certClusterName,
 			Username:         identity.Username,
 			Principals:       identity.Principals,
@@ -595,7 +596,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 	// in case if the system role is present, assume this is a service
 	// agent, e.g. Proxy, connecting to the cluster
 	if systemRole != nil {
-		return BuiltinRole{
+		return authz.BuiltinRole{
 			Role:                  *systemRole,
 			AdditionalSystemRoles: extractAdditionalSystemRoles(identity.SystemRoles),
 			Username:              identity.Username,
@@ -605,7 +606,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 	}
 	// otherwise assume that is a local role, no need to pass the roles
 	// as it will be fetched from the local database
-	return LocalUser{
+	return authz.LocalUser{
 		Username: identity.Username,
 		Identity: *identity,
 	}, nil
@@ -652,12 +653,12 @@ func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// determine authenticated user based on the request parameters
 	ctx := r.Context()
-	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(r.TLS))
+	ctx = context.WithValue(ctx, authz.ContextUserCertificate, certFromConnState(r.TLS))
 	clientSrcAddr, err := utils.ParseAddr(r.RemoteAddr)
 	if err == nil {
-		ctx = context.WithValue(ctx, ContextClientAddr, clientSrcAddr)
+		ctx = context.WithValue(ctx, authz.ContextClientAddr, clientSrcAddr)
 	}
-	ctx = context.WithValue(ctx, ContextUser, user)
+	ctx = context.WithValue(ctx, authz.ContextUser, user)
 	a.Handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
@@ -683,9 +684,9 @@ func (a *Middleware) WrapContextWithUserFromTLSConnState(ctx context.Context, tl
 		return nil, trace.Wrap(err)
 	}
 
-	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(&tlsState))
-	ctx = context.WithValue(ctx, ContextClientAddr, remoteAddr)
-	ctx = context.WithValue(ctx, ContextUser, user)
+	ctx = context.WithValue(ctx, authz.ContextUserCertificate, certFromConnState(&tlsState))
+	ctx = context.WithValue(ctx, authz.ContextClientAddr, remoteAddr)
+	ctx = context.WithValue(ctx, authz.ContextUser, user)
 	return ctx, nil
 }
 
@@ -699,7 +700,7 @@ func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bo
 		return nil
 	}
 
-	clientSrcAddr, ok := ctx.Value(ContextClientAddr).(net.Addr)
+	clientSrcAddr, ok := ctx.Value(authz.ContextClientAddr).(net.Addr)
 	if !ok {
 		return trace.BadParameter("missing observed client IP while checking IP pinning")
 	}

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -653,7 +653,7 @@ func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// determine authenticated user based on the request parameters
 	ctx := r.Context()
-	authz.ContextWithUserCertificate(ctx, certFromConnState(r.TLS))
+	ctx = authz.ContextWithUserCertificate(ctx, certFromConnState(r.TLS))
 	clientSrcAddr, err := utils.ParseAddr(r.RemoteAddr)
 	if err == nil {
 		ctx = authz.ContextWithClientAddr(ctx, clientSrcAddr)

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -248,7 +248,7 @@ func TestCheckIPPinning(t *testing.T) {
 			desc:     "IP pinning enabled, missing client IP",
 			pinnedIP: "127.0.0.1",
 			pinIP:    true,
-			wantErr:  "missing observed client IP while checking IP pinning",
+			wantErr:  "expected type net.Addr, got <nil>",
 		},
 		{
 			desc:       "correct IP pinning",

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -261,7 +261,7 @@ func TestCheckIPPinning(t *testing.T) {
 	for _, tt := range testCases {
 		ctx := context.Background()
 		if tt.clientAddr != "" {
-			ctx = context.WithValue(ctx, authz.ContextClientAddr, utils.MustParseAddr(tt.clientAddr))
+			ctx = authz.ContextWithClientAddr(ctx, utils.MustParseAddr(tt.clientAddr))
 		}
 		identity := tlsca.Identity{PinnedIP: tt.pinnedIP}
 
@@ -362,8 +362,10 @@ func TestWrapContextWithUser(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.needsHandshake, conn.handshakeCalled)
 
-			cert := ctx.Value(authz.ContextUserCertificate)
-			user := ctx.Value(authz.ContextUser)
+			cert, err := authz.UserCertificateFromContext(ctx)
+			require.NoError(t, err)
+			user, err := authz.UserFromContext(ctx)
+			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(cert, tt.peers[0], cmpopts.EquateEmpty()))
 			require.Empty(t, cmp.Diff(user, tt.wantID, cmpopts.EquateEmpty()))
 		})

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 )
 
@@ -45,7 +46,7 @@ func (a *Server) UpsertOIDCConnector(ctx context.Context, connector types.OIDCCo
 			Type: events.OIDCConnectorCreatedEvent,
 			Code: events.OIDCConnectorCreatedCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: connector.GetName(),
 		},
@@ -66,7 +67,7 @@ func (a *Server) DeleteOIDCConnector(ctx context.Context, connectorName string) 
 			Type: events.OIDCConnectorDeletedEvent,
 			Code: events.OIDCConnectorDeletedCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: connectorName,
 		},

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -31,6 +31,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
@@ -148,7 +149,7 @@ func (s *Server) ChangePassword(ctx context.Context, req *proto.ChangePasswordRe
 			Type: events.UserPasswordChangeEvent,
 			Code: events.UserPasswordChangeCode,
 		},
-		UserMetadata: ClientUserMetadataWithUser(ctx, user),
+		UserMetadata: authz.ClientUserMetadataWithUser(ctx, user),
 	}); err != nil {
 		log.WithError(err).Warn("Failed to emit password change event.")
 	}

--- a/lib/auth/permissionsalias.go
+++ b/lib/auth/permissionsalias.go
@@ -14,7 +14,12 @@
 
 package auth
 
-import "github.com/gravitational/teleport/lib/authz"
+import (
+	"context"
+
+	"github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/authz"
+)
 
 // The following are all temporary aliases to ensure that e still compiles
 // while we migrate it over.
@@ -23,5 +28,10 @@ type Context = authz.Context
 type LocalUser = authz.LocalUser
 type AuthorizerOpts = authz.AuthorizerOpts
 
-var NewAuthorizer = authz.NewAuthorizer
-var ClientUserMetadata = authz.ClientUserMetadata
+func NewAuthorizer(opts AuthorizerOpts) (Authorizer, error) {
+	return authz.NewAuthorizer(opts)
+}
+
+func ClientUserMetadata(ctx context.Context) events.UserMetadata {
+	return authz.ClientUserMetadata(ctx)
+}

--- a/lib/auth/permissionsalias.go
+++ b/lib/auth/permissionsalias.go
@@ -24,9 +24,12 @@ import (
 // The following are all temporary aliases to ensure that e still compiles
 // while we migrate it over.
 // TODO(mdwn): Cleanup authorizer aliases after transition.
+const ContextUser authz.ContextKey = "teleport-user"
+
 type Authorizer = authz.Authorizer
 type Context = authz.Context
 type LocalUser = authz.LocalUser
+type BuiltinRole = authz.BuiltinRole
 type AuthorizerOpts = authz.AuthorizerOpts
 
 func NewAuthorizer(opts AuthorizerOpts) (Authorizer, error) {

--- a/lib/auth/permissionsalias.go
+++ b/lib/auth/permissionsalias.go
@@ -23,6 +23,7 @@ import (
 
 // The following are all temporary aliases to ensure that e still compiles
 // while we migrate it over.
+// TODO(mdwn): Cleanup authorizer aliases after transition.
 type Authorizer = authz.Authorizer
 type Context = authz.Context
 type LocalUser = authz.LocalUser

--- a/lib/auth/permissionsalias.go
+++ b/lib/auth/permissionsalias.go
@@ -1,0 +1,27 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import "github.com/gravitational/teleport/lib/authz"
+
+// The following are all temporary aliases to ensure that e still compiles
+// while we migrate it over.
+type Authorizer = authz.Authorizer
+type Context = authz.Context
+type LocalUser = authz.LocalUser
+type AuthorizerOpts = authz.AuthorizerOpts
+
+var NewAuthorizer = authz.NewAuthorizer
+var ClientUserMetadata = authz.ClientUserMetadata

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -63,7 +64,7 @@ func (a *Server) UpsertSAMLConnector(ctx context.Context, connector types.SAMLCo
 			Type: events.SAMLConnectorCreatedEvent,
 			Code: events.SAMLConnectorCreatedCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: connector.GetName(),
 		},
@@ -84,7 +85,7 @@ func (a *Server) DeleteSAMLConnector(ctx context.Context, connectorID string) er
 			Type: events.SAMLConnectorDeletedEvent,
 			Code: events.SAMLConnectorDeletedCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: connectorID,
 		},

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -50,6 +50,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -969,7 +970,7 @@ func TestReadOwnRole(t *testing.T) {
 	require.NoError(t, err)
 
 	// user2 can't read user1 role
-	userClient2, err := tt.server.NewClient(TestIdentity{I: LocalUser{Username: user2.GetName()}})
+	userClient2, err := tt.server.NewClient(TestIdentity{I: authz.LocalUser{Username: user2.GetName()}})
 	require.NoError(t, err)
 
 	_, err = userClient2.GetRole(ctx, userRole.GetName())
@@ -985,7 +986,7 @@ func TestGetCurrentUser(t *testing.T) {
 	user1, _, err := CreateUserAndRole(srv.Auth(), "user1", []string{"user1"}, nil)
 	require.NoError(t, err)
 
-	client1, err := srv.NewClient(TestIdentity{I: LocalUser{Username: user1.GetName()}})
+	client1, err := srv.NewClient(TestIdentity{I: authz.LocalUser{Username: user1.GetName()}})
 	require.NoError(t, err)
 
 	currentUser, err := client1.GetCurrentUser(ctx)
@@ -1015,7 +1016,7 @@ func TestGetCurrentUserRoles(t *testing.T) {
 	user1, user1Role, err := CreateUserAndRole(srv.Auth(), "user1", []string{"user-role"}, nil)
 	require.NoError(t, err)
 
-	client1, err := srv.NewClient(TestIdentity{I: LocalUser{Username: user1.GetName()}})
+	client1, err := srv.NewClient(TestIdentity{I: authz.LocalUser{Username: user1.GetName()}})
 	require.NoError(t, err)
 
 	roles, err := client1.GetCurrentUserRoles(ctx)
@@ -1696,7 +1697,7 @@ func TestGetCertAuthority(t *testing.T) {
 	tt := setupAuthContext(ctx, t)
 
 	// generate server keys for node
-	nodeClt, err := tt.server.NewClient(TestIdentity{I: BuiltinRole{Username: "00000000-0000-0000-0000-000000000000", Role: types.RoleNode}})
+	nodeClt, err := tt.server.NewClient(TestIdentity{I: authz.BuiltinRole{Username: "00000000-0000-0000-0000-000000000000", Role: types.RoleNode}})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, nodeClt.Close()) })
 
@@ -1721,7 +1722,7 @@ func TestGetCertAuthority(t *testing.T) {
 
 	// generate server keys for proxy
 	proxyClt, err := tt.server.NewClient(TestIdentity{
-		I: BuiltinRole{
+		I: authz.BuiltinRole{
 			Username: "00000000-0000-0000-0000-000000000001",
 			Role:     types.RoleProxy,
 		},
@@ -1895,7 +1896,7 @@ func TestGenerateCerts(t *testing.T) {
 
 	// generate server keys for node
 	hostID := "00000000-0000-0000-0000-000000000000"
-	hostClient, err := srv.NewClient(TestIdentity{I: BuiltinRole{Username: hostID, Role: types.RoleNode}})
+	hostClient, err := srv.NewClient(TestIdentity{I: authz.BuiltinRole{Username: hostID, Role: types.RoleNode}})
 	require.NoError(t, err)
 
 	certs, err := hostClient.GenerateHostCerts(context.Background(),
@@ -1915,7 +1916,7 @@ func TestGenerateCerts(t *testing.T) {
 
 	// sign server public keys for node
 	hostID = "00000000-0000-0000-0000-000000000000"
-	hostClient, err = srv.NewClient(TestIdentity{I: BuiltinRole{Username: hostID, Role: types.RoleNode}})
+	hostClient, err = srv.NewClient(TestIdentity{I: authz.BuiltinRole{Username: hostID, Role: types.RoleNode}})
 	require.NoError(t, err)
 
 	certs, err = hostClient.GenerateHostCerts(context.Background(),
@@ -3206,7 +3207,7 @@ func TestEventsNodePresence(t *testing.T) {
 	}
 	node.SetExpiry(time.Now().Add(2 * time.Second))
 	clt, err := tt.server.NewClient(TestIdentity{
-		I: BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     types.RoleNode,
 			Username: fmt.Sprintf("%v.%v", node.Metadata.Name, tt.server.ClusterName()),
 		},

--- a/lib/auth/transport_credentials.go
+++ b/lib/auth/transport_credentials.go
@@ -24,11 +24,12 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/authz"
 )
 
 // UserGetter is responsible for building an authenticated user based on TLS metadata
 type UserGetter interface {
-	GetUser(connState tls.ConnectionState) (IdentityGetter, error)
+	GetUser(connState tls.ConnectionState) (authz.IdentityGetter, error)
 }
 
 // ConnectionIdentity contains the identifying properties of a
@@ -66,7 +67,7 @@ type TransportCredentialsConfig struct {
 	// Authorizer prevents any connections from being established if the user is not
 	// authorized due to locks, private key policy, device trust, etc. If not set
 	// then no authorization is performed.
-	Authorizer Authorizer
+	Authorizer authz.Authorizer
 	// Enforcer prevents any connections from being established if the user would
 	// exceed their configured max connection limit. Any connections that are
 	// permitted may be terminated if there is an issue determining if the number
@@ -101,7 +102,7 @@ type TransportCredentials struct {
 	credentials.TransportCredentials
 
 	userGetter UserGetter
-	authorizer Authorizer
+	authorizer authz.Authorizer
 	enforcer   ConnectionEnforcer
 }
 
@@ -128,12 +129,12 @@ type IdentityInfo struct {
 	*credentials.TLSInfo
 	// IdentityGetter provides a mechanism to retrieve the
 	// identity of the client.
-	IdentityGetter IdentityGetter
+	IdentityGetter authz.IdentityGetter
 	// AuthContext contains information about the traits and roles
 	// that an identity may have. This will be unset if the
 	// [TransportCredentialsConfig.Authorizer] provided to [NewTransportCredentials]
 	// was nil.
-	AuthContext *Context
+	AuthContext *authz.Context
 }
 
 // ServerHandshake does the authentication handshake for servers. It returns
@@ -197,17 +198,17 @@ func (c *TransportCredentials) performTLSHandshake(rawConn net.Conn) (net.Conn, 
 // authorize enforces that the identity is not restricted from connecting due
 // to things like locks, private key policy, device trust, etc. If the TransportCredentials
 // was not configured to do authorization then this is a noop and will return nil, nil.
-func (c *TransportCredentials) authorize(ctx context.Context, remoteAddr string, identityGetter IdentityGetter, connState *tls.ConnectionState) (*Context, error) {
+func (c *TransportCredentials) authorize(ctx context.Context, remoteAddr string, identityGetter authz.IdentityGetter, connState *tls.ConnectionState) (*authz.Context, error) {
 	if c.authorizer == nil {
-		return &Context{
+		return &authz.Context{
 			Identity: identityGetter,
 		}, nil
 	}
 
 	// construct a context with the keys expected by the Authorizer
-	ctx = context.WithValue(ctx, contextUserCertificate, certFromConnState(connState))
-	ctx = context.WithValue(ctx, ContextClientAddr, remoteAddr)
-	ctx = context.WithValue(ctx, ContextUser, identityGetter)
+	ctx = context.WithValue(ctx, authz.ContextUserCertificate, certFromConnState(connState))
+	ctx = context.WithValue(ctx, authz.ContextClientAddr, remoteAddr)
+	ctx = context.WithValue(ctx, authz.ContextUser, identityGetter)
 
 	authCtx, err := c.authorizer.Authorize(ctx)
 	return authCtx, trace.Wrap(err)
@@ -217,7 +218,7 @@ func (c *TransportCredentials) authorize(ctx context.Context, remoteAddr string,
 // connection limits. The provided connection will be closed by the enforcer
 // if connectivity to Auth is interrupted. If the TransportCredentials
 // was not configured to do connection limiting then this is a noop and will return nil.
-func (c *TransportCredentials) enforceConnectionLimits(ctx context.Context, authCtx *Context, conn net.Conn) error {
+func (c *TransportCredentials) enforceConnectionLimits(ctx context.Context, authCtx *authz.Context, conn net.Conn) error {
 	if c.enforcer == nil {
 		return nil
 	}
@@ -233,7 +234,7 @@ func (c *TransportCredentials) enforceConnectionLimits(ctx context.Context, auth
 			MaxConnections: authCtx.Checker.MaxConnections(),
 			LocalAddr:      conn.LocalAddr().String(),
 			RemoteAddr:     conn.RemoteAddr().String(),
-			UserMetadata:   ClientUserMetadata(ctx),
+			UserMetadata:   authz.ClientUserMetadata(ctx),
 		},
 		conn,
 	)

--- a/lib/auth/transport_credentials_test.go
+++ b/lib/auth/transport_credentials_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -315,7 +316,7 @@ type fakeAuthorizer struct {
 	checker        services.AccessChecker
 }
 
-func (a *fakeAuthorizer) Authorize(ctx context.Context) (*Context, error) {
+func (a *fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
 	if a.authorizeError != nil {
 		return nil, a.authorizeError
 	}
@@ -325,7 +326,7 @@ func (a *fakeAuthorizer) Authorize(ctx context.Context) (*Context, error) {
 		return nil, err
 	}
 
-	return &Context{
+	return &authz.Context{
 		User:    user,
 		Checker: a.checker,
 	}, nil

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -174,7 +175,7 @@ func (a *Server) UpsertTrustedCluster(ctx context.Context, trustedCluster types.
 			Type: events.TrustedClusterCreateEvent,
 			Code: events.TrustedClusterCreateCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: trustedCluster.GetName(),
 		},
@@ -242,7 +243,7 @@ func (a *Server) DeleteTrustedCluster(ctx context.Context, name string) error {
 			Type: events.TrustedClusterDeleteEvent,
 			Code: events.TrustedClusterDeleteCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: name,
 		},

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -38,7 +39,7 @@ import (
 func (s *Server) CreateUser(ctx context.Context, user types.User) error {
 	if user.GetCreatedBy().IsEmpty() {
 		user.SetCreatedBy(types.CreatedBy{
-			User: types.UserRef{Name: ClientUsername(ctx)},
+			User: types.UserRef{Name: authz.ClientUsername(ctx)},
 			Time: s.GetClock().Now().UTC(),
 		})
 	}
@@ -62,7 +63,7 @@ func (s *Server) CreateUser(ctx context.Context, user types.User) error {
 			Type: events.UserCreateEvent,
 			Code: events.UserCreateCode,
 		},
-		UserMetadata: ClientUserMetadataWithUser(ctx, user.GetCreatedBy().User.Name),
+		UserMetadata: authz.ClientUserMetadataWithUser(ctx, user.GetCreatedBy().User.Name),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    user.GetName(),
 			Expires: user.Expiry(),
@@ -94,7 +95,7 @@ func (s *Server) UpdateUser(ctx context.Context, user types.User) error {
 			Type: events.UserUpdatedEvent,
 			Code: events.UserUpdateCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    user.GetName(),
 			Expires: user.Expiry(),
@@ -163,7 +164,7 @@ func (s *Server) CompareAndSwapUser(ctx context.Context, new, existing types.Use
 			Type: events.UserUpdatedEvent,
 			Code: events.UserUpdateCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    new.GetName(),
 			Expires: new.Expiry(),
@@ -203,7 +204,7 @@ func (s *Server) DeleteUser(ctx context.Context, user string) error {
 			Type: events.UserDeleteEvent,
 			Code: events.UserDeleteCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: user,
 		},

--- a/lib/auth/usertoken.go
+++ b/lib/auth/usertoken.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
@@ -173,7 +174,7 @@ func (s *Server) CreateResetPasswordToken(ctx context.Context, req CreateUserTok
 			Type: events.ResetPasswordTokenCreateEvent,
 			Code: events.ResetPasswordTokenCreateCode,
 		},
-		UserMetadata: ClientUserMetadata(ctx),
+		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    req.Name,
 			TTL:     req.TTL.String(),
@@ -433,7 +434,7 @@ func (s *Server) createRecoveryToken(ctx context.Context, username, tokenType st
 			Type: events.RecoveryTokenCreateEvent,
 			Code: events.RecoveryTokenCreateCode,
 		},
-		UserMetadata: ClientUserMetadataWithUser(ctx, username),
+		UserMetadata: authz.ClientUserMetadataWithUser(ctx, username),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    req.Name,
 			TTL:     req.TTL.String(),
@@ -448,7 +449,7 @@ func (s *Server) createRecoveryToken(ctx context.Context, username, tokenType st
 
 // CreatePrivilegeToken implements AuthService.CreatePrivilegeToken.
 func (s *Server) CreatePrivilegeToken(ctx context.Context, req *proto.CreatePrivilegeTokenRequest) (*types.UserTokenV3, error) {
-	username, err := GetClientUsername(ctx)
+	username, err := authz.GetClientUsername(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -528,7 +529,7 @@ func (s *Server) createPrivilegeToken(ctx context.Context, username, tokenKind s
 			Type: events.PrivilegeTokenCreateEvent,
 			Code: events.PrivilegeTokenCreateCode,
 		},
-		UserMetadata: ClientUserMetadataWithUser(ctx, username),
+		UserMetadata: authz.ClientUserMetadataWithUser(ctx, username),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    req.Name,
 			TTL:     req.TTL.String(),

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1124,7 +1124,7 @@ func ContextWithUser(ctx context.Context, user IdentityGetter) context.Context {
 
 // UserFromContext returns the user from the context.
 func UserFromContext(ctx context.Context) (IdentityGetter, error) {
-	user, ok := ctx.Value(contextClientAddr).(IdentityGetter)
+	user, ok := ctx.Value(contextUser).(IdentityGetter)
 	if !ok {
 		return nil, trace.BadParameter("expected type IdentityGetter, got %T", user)
 	}

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -873,19 +873,20 @@ func ContextForLocalUser(u LocalUser, accessPoint AuthorizerAccessPoint, cluster
 	}, nil
 }
 
-type contextKey string
+// TODO(mdwn): unexport this once enterprise has been moved.
+type ContextKey string
 
 const (
-	// contextUserCertificate is the X.509 certificate used by the ContextUser to
+	// contextUserCertificate is the X.509 certificate used by the contextUser to
 	// establish the mTLS connection.
 	// Holds a *x509.Certificate.
-	contextUserCertificate contextKey = "teleport-user-cert"
+	contextUserCertificate ContextKey = "teleport-user-cert"
 
 	// contextUser is a user set in the context of the request
-	contextUser contextKey = "teleport-user"
+	contextUser ContextKey = "teleport-user"
 
 	// contextClientAddr is a client address set in the context of the request
-	contextClientAddr contextKey = "client-addr"
+	contextClientAddr ContextKey = "client-addr"
 )
 
 // WithDelegator alias for backwards compatibility

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -797,6 +797,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 	return nil, trace.NotFound("builtin role %q is not recognized", role.String())
 }
 
+// ContextForBuiltinRole returns a context with the builtin role information embedded.
 func ContextForBuiltinRole(r BuiltinRole, recConfig types.SessionRecordingConfig) (*Context, error) {
 	var systemRoles []types.SystemRole
 	if r.Role == types.RoleInstance {
@@ -838,6 +839,7 @@ func ContextForBuiltinRole(r BuiltinRole, recConfig types.SessionRecordingConfig
 	}, nil
 }
 
+// ContextForLocalUser returns a context with the local user info embedded.
 func ContextForLocalUser(u LocalUser, accessPoint AuthorizerAccessPoint, clusterName string, disableDeviceAuthz bool) (*Context, error) {
 	// User has to be fetched to check if it's a blocked username
 	user, err := accessPoint.GetUser(u.Username, false)

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package auth
+package authz
 
 import (
 	"context"
@@ -41,7 +41,7 @@ func NewAdminContext() (*Context, error) {
 
 // NewBuiltinRoleContext create auth context for the provided builtin role.
 func NewBuiltinRoleContext(role types.SystemRole) (*Context, error) {
-	authContext, err := contextForBuiltinRole(BuiltinRole{Role: role, Username: fmt.Sprintf("%v", role)}, nil)
+	authContext, err := ContextForBuiltinRole(BuiltinRole{Role: role, Username: fmt.Sprintf("%v", role)}, nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -272,7 +272,7 @@ func (a *authorizer) fromUser(ctx context.Context, userI interface{}) (*Context,
 
 // authorizeLocalUser returns authz context based on the username
 func (a *authorizer) authorizeLocalUser(u LocalUser) (*Context, error) {
-	return contextForLocalUser(u, a.accessPoint, a.clusterName, a.disableDeviceAuthorization)
+	return ContextForLocalUser(u, a.accessPoint, a.clusterName, a.disableDeviceAuthorization)
 }
 
 // authorizeRemoteUser returns checker based on cert authority roles
@@ -370,7 +370,7 @@ func (a *authorizer) authorizeBuiltinRole(ctx context.Context, r BuiltinRole) (*
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return contextForBuiltinRole(r, recConfig)
+	return ContextForBuiltinRole(r, recConfig)
 }
 
 func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, error) {
@@ -792,7 +792,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 	return nil, trace.NotFound("builtin role %q is not recognized", role.String())
 }
 
-func contextForBuiltinRole(r BuiltinRole, recConfig types.SessionRecordingConfig) (*Context, error) {
+func ContextForBuiltinRole(r BuiltinRole, recConfig types.SessionRecordingConfig) (*Context, error) {
 	var systemRoles []types.SystemRole
 	if r.Role == types.RoleInstance {
 		// instance certs encode multiple system roles in a separate field
@@ -833,7 +833,7 @@ func contextForBuiltinRole(r BuiltinRole, recConfig types.SessionRecordingConfig
 	}, nil
 }
 
-func contextForLocalUser(u LocalUser, accessPoint AuthorizerAccessPoint, clusterName string, disableDeviceAuthz bool) (*Context, error) {
+func ContextForLocalUser(u LocalUser, accessPoint AuthorizerAccessPoint, clusterName string, disableDeviceAuthz bool) (*Context, error) {
 	// User has to be fetched to check if it's a blocked username
 	user, err := accessPoint.GetUser(u.Username, false)
 	if err != nil {
@@ -869,10 +869,10 @@ func contextForLocalUser(u LocalUser, accessPoint AuthorizerAccessPoint, cluster
 type contextKey string
 
 const (
-	// contextUserCertificate is the X.509 certificate used by the ContextUser to
+	// ContextUserCertificate is the X.509 certificate used by the ContextUser to
 	// establish the mTLS connection.
 	// Holds a *x509.Certificate.
-	contextUserCertificate contextKey = "teleport-user-cert"
+	ContextUserCertificate contextKey = "teleport-user-cert"
 
 	// ContextUser is a user set in the context of the request
 	ContextUser contextKey = "teleport-user"

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -96,13 +96,13 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 	require.NoError(t, err)
 	upsertLockWithPutEvent(ctx, t, client, watcher, mfaLock)
 
-	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
+	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, localUser))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Remove the MFA record from the user value being authorized.
 	localUser.Identity.MFAVerified = ""
-	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
+	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, localUser))
 	require.NoError(t, err)
 
 	// Add an access request lock.
@@ -113,13 +113,13 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 	upsertLockWithPutEvent(ctx, t, client, watcher, requestLock)
 
 	// localUser's identity with a locked access request is locked out.
-	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
+	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, localUser))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Not locked out without the request.
 	localUser.Identity.ActiveRequests = nil
-	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
+	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, localUser))
 	require.NoError(t, err)
 
 	// Create a lock targeting the role written in the user's identity.
@@ -129,7 +129,7 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 	require.NoError(t, err)
 	upsertLockWithPutEvent(ctx, t, client, watcher, roleLock)
 
-	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
+	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, localUser))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 }
@@ -155,12 +155,12 @@ func TestAuthorizeWithLocksForBuiltinRole(t *testing.T) {
 	require.NoError(t, err)
 	upsertLockWithPutEvent(ctx, t, client, watcher, nodeLock)
 
-	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, builtinRole))
+	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, builtinRole))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 
 	builtinRole.Identity.Username = ""
-	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, builtinRole))
+	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, builtinRole))
 	require.NoError(t, err)
 }
 
@@ -295,7 +295,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			require.NoError(t, err, "NewAuthorizer failed")
 
 			// Test!
-			userCtx := context.WithValue(ctx, ContextUser, test.user)
+			userCtx := context.WithValue(ctx, contextUser, test.user)
 			authCtx, gotErr := authorizer.Authorize(userCtx)
 			if test.wantErr == "" {
 				assert.NoError(t, gotErr, "Authorize returned unexpected error")

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package auth
+package authz
 
 import (
 	"context"
@@ -22,16 +22,22 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+const (
+	clusterName = "test-cluster"
 )
 
 func TestContextLockTargets(t *testing.T) {
@@ -69,13 +75,9 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	srv, err := NewTestAuthServer(TestAuthServerConfig{
-		Dir:   t.TempDir(),
-		Clock: clockwork.NewFakeClock(),
-	})
-	require.NoError(t, err)
+	client, watcher, authorizer := newTestResources(t)
 
-	user, role, err := CreateUserAndRole(srv.AuthServer, "test-user", []string{}, nil)
+	user, role, err := createUserAndRole(client, "test-user", []string{}, nil)
 	require.NoError(t, err)
 	localUser := LocalUser{
 		Username: user.GetName(),
@@ -92,15 +94,15 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 		Target: types.LockTarget{MFADevice: localUser.Identity.MFAVerified},
 	})
 	require.NoError(t, err)
-	upsertLockWithPutEvent(ctx, t, srv, mfaLock)
+	upsertLockWithPutEvent(ctx, t, client, watcher, mfaLock)
 
-	_, err = srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
+	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Remove the MFA record from the user value being authorized.
 	localUser.Identity.MFAVerified = ""
-	_, err = srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
+	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
 	require.NoError(t, err)
 
 	// Add an access request lock.
@@ -108,16 +110,16 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 		Target: types.LockTarget{AccessRequest: localUser.Identity.ActiveRequests[0]},
 	})
 	require.NoError(t, err)
-	upsertLockWithPutEvent(ctx, t, srv, requestLock)
+	upsertLockWithPutEvent(ctx, t, client, watcher, requestLock)
 
 	// localUser's identity with a locked access request is locked out.
-	_, err = srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
+	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Not locked out without the request.
 	localUser.Identity.ActiveRequests = nil
-	_, err = srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
+	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
 	require.NoError(t, err)
 
 	// Create a lock targeting the role written in the user's identity.
@@ -125,9 +127,9 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 		Target: types.LockTarget{Role: localUser.Identity.Groups[0]},
 	})
 	require.NoError(t, err)
-	upsertLockWithPutEvent(ctx, t, srv, roleLock)
+	upsertLockWithPutEvent(ctx, t, client, watcher, roleLock)
 
-	_, err = srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
+	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, localUser))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 }
@@ -136,11 +138,7 @@ func TestAuthorizeWithLocksForBuiltinRole(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	srv, err := NewTestAuthServer(TestAuthServerConfig{
-		Dir:   t.TempDir(),
-		Clock: clockwork.NewFakeClock(),
-	})
-	require.NoError(t, err)
+	client, watcher, authorizer := newTestResources(t)
 
 	builtinRole := BuiltinRole{
 		Username: "node",
@@ -155,23 +153,23 @@ func TestAuthorizeWithLocksForBuiltinRole(t *testing.T) {
 		Target: types.LockTarget{Node: builtinRole.Identity.Username},
 	})
 	require.NoError(t, err)
-	upsertLockWithPutEvent(ctx, t, srv, nodeLock)
+	upsertLockWithPutEvent(ctx, t, client, watcher, nodeLock)
 
-	_, err = srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, builtinRole))
+	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, builtinRole))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 
 	builtinRole.Identity.Username = ""
-	_, err = srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, builtinRole))
+	_, err = authorizer.Authorize(context.WithValue(ctx, ContextUser, builtinRole))
 	require.NoError(t, err)
 }
 
-func upsertLockWithPutEvent(ctx context.Context, t *testing.T, srv *TestAuthServer, lock types.Lock) {
-	lockWatch, err := srv.LockWatcher.Subscribe(ctx)
+func upsertLockWithPutEvent(ctx context.Context, t *testing.T, client *testClient, watcher *services.LockWatcher, lock types.Lock) {
+	lockWatch, err := watcher.Subscribe(ctx)
 	require.NoError(t, err)
 	defer lockWatch.Close()
 
-	require.NoError(t, srv.AuthServer.UpsertLock(ctx, lock))
+	require.NoError(t, client.UpsertLock(ctx, lock))
 	select {
 	case event := <-lockWatch.Events():
 		require.Equal(t, types.OpPut, event.Type)
@@ -186,16 +184,11 @@ func upsertLockWithPutEvent(ctx context.Context, t *testing.T, srv *TestAuthServ
 func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 	t.Parallel()
 
-	testServer, err := NewTestAuthServer(TestAuthServerConfig{
-		Dir:   t.TempDir(),
-		Clock: clockwork.NewFakeClock(),
-	})
-	require.NoError(t, err, "NewTestAuthServer failed")
+	client, watcher, _ := newTestResources(t)
 
-	authServer := testServer.AuthServer
 	ctx := context.Background()
 
-	user, role, err := CreateUserAndRole(authServer, "llama", []string{"llama"}, nil)
+	user, role, err := createUserAndRole(client, "llama", []string{"llama"}, nil)
 	require.NoError(t, err, "CreateUserAndRole")
 
 	userWithoutExtensions := LocalUser{
@@ -253,7 +246,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			user: BuiltinRole{
 				Role:        types.RoleProxy,
 				Username:    user.GetName(),
-				ClusterName: testServer.ClusterName,
+				ClusterName: clusterName,
 				Identity:    userWithoutExtensions.Identity,
 			},
 			wantCtxAuthnDisabled: true, // BuiltinRole ctx validation disabled by default
@@ -264,7 +257,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			user: BuiltinRole{
 				Role:        types.RoleProxy,
 				Username:    user.GetName(),
-				ClusterName: testServer.ClusterName,
+				ClusterName: clusterName,
 				Identity:    userWithoutExtensions.Identity,
 			},
 		},
@@ -274,7 +267,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			user: RemoteBuiltinRole{
 				Role:        types.RoleProxy,
 				Username:    user.GetName(),
-				ClusterName: testServer.ClusterName,
+				ClusterName: clusterName,
 				Identity:    userWithoutExtensions.Identity,
 			},
 		},
@@ -282,21 +275,21 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Update device trust mode.
-			authPref, err := authServer.GetAuthPreference(ctx)
+			authPref, err := client.GetAuthPreference(ctx)
 			require.NoError(t, err, "GetAuthPreference failed")
 			apV2 := authPref.(*types.AuthPreferenceV2)
 			apV2.Spec.DeviceTrust = &types.DeviceTrust{
 				Mode: test.deviceMode,
 			}
 			require.NoError(t,
-				authServer.SetAuthPreference(ctx, apV2),
+				client.SetAuthPreference(ctx, apV2),
 				"SetAuthPreference failed")
 
 			// Create a new authorizer.
 			authorizer, err := NewAuthorizer(AuthorizerOpts{
-				ClusterName:                testServer.ClusterName,
-				AccessPoint:                authServer,
-				LockWatcher:                testServer.LockWatcher,
+				ClusterName:                clusterName,
+				AccessPoint:                client,
+				LockWatcher:                watcher,
 				DisableDeviceAuthorization: test.disableDeviceAuthz,
 			})
 			require.NoError(t, err, "NewAuthorizer failed")
@@ -450,4 +443,91 @@ type fakeCtxChecker struct {
 
 func (c *fakeCtxChecker) GetAccessState(_ types.AuthPreference) services.AccessState {
 	return c.state
+}
+
+type testClient struct {
+	services.ClusterConfiguration
+	services.Trust
+	services.Access
+	services.Identity
+	types.Events
+}
+
+func newTestResources(t *testing.T) (*testClient, *services.LockWatcher, Authorizer) {
+	backend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	clusterConfig, err := local.NewClusterConfigurationService(backend)
+	require.NoError(t, err)
+	caSvc := local.NewCAService(backend)
+	accessSvc := local.NewAccessService(backend)
+	identitySvc := local.NewIdentityService(backend)
+	eventsSvc := local.NewEventsService(backend)
+
+	testClient := &testClient{
+		ClusterConfiguration: clusterConfig,
+		Trust:                caSvc,
+		Access:               accessSvc,
+		Identity:             identitySvc,
+		Events:               eventsSvc,
+	}
+
+	// Set default singletons
+	ctx := context.Background()
+	testClient.SetAuthPreference(ctx, types.DefaultAuthPreference())
+	testClient.SetClusterAuditConfig(ctx, types.DefaultClusterAuditConfig())
+	testClient.SetClusterNetworkingConfig(ctx, types.DefaultClusterNetworkingConfig())
+	testClient.SetSessionRecordingConfig(ctx, types.DefaultSessionRecordingConfig())
+
+	lockSvc := local.NewAccessService(backend)
+
+	lockWatcher, err := services.NewLockWatcher(ctx, services.LockWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: "test",
+			Client:    testClient,
+		},
+		LockGetter: lockSvc,
+	})
+	require.NoError(t, err)
+
+	authorizer, err := NewAuthorizer(AuthorizerOpts{
+		ClusterName: clusterName,
+		AccessPoint: testClient,
+		LockWatcher: lockWatcher,
+	})
+	require.NoError(t, err)
+
+	return testClient, lockWatcher, authorizer
+}
+
+func createUserAndRole(client *testClient, username string, allowedLogins []string, allowRules []types.Rule) (types.User, types.Role, error) {
+	ctx := context.TODO()
+	user, err := types.NewUser(username)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	role := services.RoleForUser(user)
+	role.SetLogins(types.Allow, allowedLogins)
+	if allowRules != nil {
+		role.SetRules(types.Allow, allowRules)
+	}
+
+	err = client.UpsertRole(ctx, role)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	user.AddRole(role.GetName())
+	err = client.UpsertUser(user)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return user, role, nil
+}
+
+func resourceDiff(res1, res2 types.Resource) string {
+	return cmp.Diff(res1, res2,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Namespace"),
+		cmpopts.EquateEmpty())
 }

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -466,8 +466,6 @@ func newTestResources(t *testing.T) (*testClient, *services.LockWatcher, Authori
 	identitySvc := local.NewIdentityService(backend)
 	eventsSvc := local.NewEventsService(backend)
 
-	accessSvc.Close()
-
 	client := &testClient{
 		ClusterConfiguration: clusterConfig,
 		Trust:                caSvc,

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -74,6 +74,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/filesessions"
@@ -116,7 +117,7 @@ type ForwarderConfig struct {
 	// Keygen points to a key generator implementation
 	Keygen sshca.Authority
 	// Authz authenticates user
-	Authz auth.Authorizer
+	Authz authz.Authorizer
 	// AuthClient is a auth server client.
 	AuthClient auth.ClientI
 	// CachingAuthClient is a caching auth server client for read-only access.
@@ -366,7 +367,7 @@ func (f *Forwarder) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 // authContext is a context of authenticated user,
 // contains information about user, target cluster and authenticated groups
 type authContext struct {
-	auth.Context
+	authz.Context
 	kubeGroups        map[string]struct{}
 	kubeUsers         map[string]struct{}
 	kubeClusterLabels map[string]string
@@ -467,13 +468,13 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 
 	const accessDeniedMsg = "[00] access denied"
 	var isRemoteUser bool
-	userTypeI := req.Context().Value(auth.ContextUser)
+	userTypeI := req.Context().Value(authz.ContextUser)
 	switch userTypeI.(type) {
-	case auth.LocalUser:
+	case authz.LocalUser:
 
-	case auth.RemoteUser:
+	case authz.RemoteUser:
 		isRemoteUser = true
-	case auth.BuiltinRole:
+	case authz.BuiltinRole:
 		f.log.Warningf("Denying proxy access to unauthenticated user of type %T - this can sometimes be caused by inadvertently using an HTTP load balancer instead of a TCP load balancer on the Kubernetes port.", userTypeI)
 		return nil, trace.AccessDenied(accessDeniedMsg)
 	default:
@@ -707,7 +708,7 @@ func (f *Forwarder) formatStatusResponseError(rw http.ResponseWriter, respErr er
 	}
 }
 
-func (f *Forwarder) setupContext(ctx context.Context, authCtx auth.Context, req *http.Request, isRemoteUser bool, clientIdentity *tlsca.Identity, kubeResource *types.KubernetesResource) (*authContext, error) {
+func (f *Forwarder) setupContext(ctx context.Context, authCtx authz.Context, req *http.Request, isRemoteUser bool, clientIdentity *tlsca.Identity, kubeResource *types.KubernetesResource) (*authContext, error) {
 	ctx, span := f.cfg.tracer.Start(
 		ctx,
 		"kube.Forwarder/setupContext",

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -468,7 +468,11 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 
 	const accessDeniedMsg = "[00] access denied"
 	var isRemoteUser bool
-	userTypeI := req.Context().Value(authz.ContextUser)
+	userTypeI, err := authz.UserFromContext(ctx)
+	if err != nil {
+		f.log.WithError(err).Warn("error getting user from context")
+		return nil, trace.AccessDenied(accessDeniedMsg)
+	}
 	switch userTypeI.(type) {
 	case authz.LocalUser:
 

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -627,7 +627,7 @@ func TestAuthenticate(t *testing.T) {
 					},
 				},
 			}
-			ctx := context.WithValue(context.Background(), authz.ContextUser, tt.user)
+			ctx := authz.ContextWithUser(context.Background(), tt.user)
 			req = req.WithContext(ctx)
 
 			if tt.haveKubeCreds {

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -60,7 +61,7 @@ import (
 )
 
 var (
-	identity = auth.WrapIdentity(tlsca.Identity{
+	identity = authz.WrapIdentity(tlsca.Identity{
 		Username:         "remote-bob",
 		Groups:           []string{"remote group a", "remote group b"},
 		Usage:            []string{"usage a", "usage b"},
@@ -68,7 +69,7 @@ var (
 		KubernetesGroups: []string{"remote k8s group a", "remote k8s group b"},
 		Traits:           map[string][]string{"trait a": {"b", "c"}},
 	})
-	unmappedIdentity = auth.WrapIdentity(tlsca.Identity{
+	unmappedIdentity = authz.WrapIdentity(tlsca.Identity{
 		Username:         "bob",
 		Groups:           []string{"group a", "group b"},
 		Usage:            []string{"usage a", "usage b"},
@@ -96,7 +97,7 @@ func TestRequestCertificate(t *testing.T) {
 		teleportCluster: teleportClusterClient{
 			name: "site a",
 		},
-		Context: auth.Context{
+		Context: authz.Context{
 			User:             user,
 			Identity:         identity,
 			UnmappedIdentity: unmappedIdentity,
@@ -168,7 +169,7 @@ func TestAuthenticate(t *testing.T) {
 	activeAccessRequests := []string{uuid.NewString(), uuid.NewString()}
 	tests := []struct {
 		desc              string
-		user              auth.IdentityGetter
+		user              authz.IdentityGetter
 		authzErr          bool
 		roleKubeUsers     []string
 		roleKubeGroups    []string
@@ -185,7 +186,7 @@ func TestAuthenticate(t *testing.T) {
 	}{
 		{
 			desc:           "local user and cluster with active access request",
-			user:           auth.LocalUser{},
+			user:           authz.LocalUser{},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "local",
 			haveKubeCreds:  true,
@@ -223,7 +224,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "local user and cluster",
-			user:           auth.LocalUser{},
+			user:           authz.LocalUser{},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "local",
 			haveKubeCreds:  true,
@@ -260,7 +261,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "local user and cluster, no kubeconfig",
-			user:           auth.LocalUser{},
+			user:           authz.LocalUser{},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "local",
 			haveKubeCreds:  false,
@@ -292,7 +293,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "remote user and local cluster",
-			user:           auth.RemoteUser{},
+			user:           authz.RemoteUser{},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "local",
 			haveKubeCreds:  true,
@@ -323,7 +324,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "remote user and local cluster with active request id",
-			user:           auth.RemoteUser{},
+			user:           authz.RemoteUser{},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "local",
 			haveKubeCreds:  true,
@@ -355,7 +356,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "local user and remote cluster",
-			user:           auth.LocalUser{},
+			user:           authz.LocalUser{},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "remote",
 			haveKubeCreds:  true,
@@ -374,7 +375,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "local user and remote cluster, no kubeconfig",
-			user:           auth.LocalUser{},
+			user:           authz.LocalUser{},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "remote",
 			haveKubeCreds:  false,
@@ -393,7 +394,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "local user and remote cluster, no local kube users or groups",
-			user:           auth.LocalUser{},
+			user:           authz.LocalUser{},
 			roleKubeGroups: nil,
 			routeToCluster: "remote",
 			haveKubeCreds:  true,
@@ -412,7 +413,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "remote user and remote cluster",
-			user:           auth.RemoteUser{},
+			user:           authz.RemoteUser{},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "remote",
 			haveKubeCreds:  true,
@@ -423,7 +424,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "kube users passed in request",
-			user:           auth.LocalUser{},
+			user:           authz.LocalUser{},
 			roleKubeUsers:  []string{"kube-user-a", "kube-user-b"},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "local",
@@ -456,7 +457,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:     "authorization failure",
-			user:     auth.LocalUser{},
+			user:     authz.LocalUser{},
 			authzErr: true,
 			tunnel:   tun,
 
@@ -465,7 +466,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:   "unsupported user type",
-			user:   auth.BuiltinRole{},
+			user:   authz.BuiltinRole{},
 			tunnel: tun,
 
 			wantErr:     true,
@@ -473,7 +474,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "local user and cluster, no tunnel",
-			user:           auth.LocalUser{},
+			user:           authz.LocalUser{},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "local",
 			haveKubeCreds:  true,
@@ -504,7 +505,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:           "local user and remote cluster, no tunnel",
-			user:           auth.LocalUser{},
+			user:           authz.LocalUser{},
 			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
 			routeToCluster: "remote",
 			haveKubeCreds:  true,
@@ -513,7 +514,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:              "unknown kubernetes cluster in local cluster",
-			user:              auth.LocalUser{},
+			user:              authz.LocalUser{},
 			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
 			routeToCluster:    "local",
 			kubernetesCluster: "foo",
@@ -524,7 +525,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:              "custom kubernetes cluster in local cluster",
-			user:              auth.LocalUser{},
+			user:              authz.LocalUser{},
 			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
 			routeToCluster:    "local",
 			kubernetesCluster: "foo",
@@ -562,7 +563,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 		{
 			desc:              "custom kubernetes cluster in remote cluster",
-			user:              auth.LocalUser{},
+			user:              authz.LocalUser{},
 			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
 			routeToCluster:    "remote",
 			kubernetesCluster: "foo",
@@ -594,22 +595,22 @@ func TestAuthenticate(t *testing.T) {
 				},
 			})
 			require.NoError(t, err)
-			authCtx := auth.Context{
+			authCtx := authz.Context{
 				User: user,
 				Checker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
 					Roles: roles.RoleNames(),
 				}, "local", roles),
-				Identity: auth.WrapIdentity(tlsca.Identity{
+				Identity: authz.WrapIdentity(tlsca.Identity{
 					RouteToCluster:    tt.routeToCluster,
 					KubernetesCluster: tt.kubernetesCluster,
 					ActiveRequests:    tt.activeRequests,
 				}),
 			}
-			authz := mockAuthorizer{ctx: &authCtx}
+			authorizer := mockAuthorizer{ctx: &authCtx}
 			if tt.authzErr {
-				authz.err = trace.AccessDenied("denied!")
+				authorizer.err = trace.AccessDenied("denied!")
 			}
-			f.cfg.Authz = authz
+			f.cfg.Authz = authorizer
 
 			req := &http.Request{
 				Host:       "example.com",
@@ -626,7 +627,7 @@ func TestAuthenticate(t *testing.T) {
 					},
 				},
 			}
-			ctx := context.WithValue(context.Background(), auth.ContextUser, tt.user)
+			ctx := context.WithValue(context.Background(), authz.ContextUser, tt.user)
 			req = req.WithContext(ctx)
 
 			if tt.haveKubeCreds {
@@ -824,7 +825,7 @@ func mockAuthCtx(ctx context.Context, t *testing.T, kubeCluster string, isRemote
 	require.NoError(t, err)
 
 	return authContext{
-		Context: auth.Context{
+		Context: authz.Context{
 			User:             user,
 			Identity:         identity,
 			UnmappedIdentity: unmappedIdentity,
@@ -1237,11 +1238,11 @@ func (t mockRevTunnel) GetSites() ([]reversetunnel.RemoteSite, error) {
 }
 
 type mockAuthorizer struct {
-	ctx *auth.Context
+	ctx *authz.Context
 	err error
 }
 
-func (a mockAuthorizer) Authorize(context.Context) (*auth.Context, error) {
+func (a mockAuthorizer) Authorize(context.Context) (*authz.Context, error) {
 	return a.ctx, a.err
 }
 
@@ -1378,9 +1379,9 @@ func TestKubernetesConnectionLimit(t *testing.T) {
 			})
 
 			identity := &authContext{
-				Context: auth.Context{
+				Context: authz.Context{
 					User: user,
-					Identity: auth.WrapIdentity(tlsca.Identity{
+					Identity: authz.WrapIdentity(tlsca.Identity{
 						Username: user.GetName(),
 						Groups:   []string{testCase.role.GetName()},
 					}),
@@ -1443,7 +1444,7 @@ func TestForwarder_clientCreds_cache(t *testing.T) {
 					kubeUsers:       utils.StringsSet([]string{"user-a"}),
 					kubeGroups:      utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
 					kubeClusterName: "local",
-					Context: auth.Context{
+					Context: authz.Context{
 						User: &types.UserV2{
 							Metadata: types.Metadata{
 								Name: "user-a",
@@ -1468,7 +1469,7 @@ func TestForwarder_clientCreds_cache(t *testing.T) {
 					kubeUsers:       utils.StringsSet([]string{"user-a"}),
 					kubeGroups:      utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
 					kubeClusterName: "local",
-					Context: auth.Context{
+					Context: authz.Context{
 						User: &types.UserV2{
 							Metadata: types.Metadata{
 								Name: "user-a",
@@ -1493,7 +1494,7 @@ func TestForwarder_clientCreds_cache(t *testing.T) {
 					kubeUsers:       utils.StringsSet([]string{"user-a"}),
 					kubeGroups:      utils.StringsSet([]string{"kube-group-b", teleport.KubeSystemAuthenticated}),
 					kubeClusterName: "local",
-					Context: auth.Context{
+					Context: authz.Context{
 						User: &types.UserV2{
 							Metadata: types.Metadata{
 								Name: "user-a",
@@ -1518,7 +1519,7 @@ func TestForwarder_clientCreds_cache(t *testing.T) {
 					kubeUsers:       utils.StringsSet([]string{"user-test"}),
 					kubeGroups:      utils.StringsSet([]string{"kube-group-b", teleport.KubeSystemAuthenticated}),
 					kubeClusterName: "local",
-					Context: auth.Context{
+					Context: authz.Context{
 						User: &types.UserV2{
 							Metadata: types.Metadata{
 								Name: "user-a",
@@ -1543,7 +1544,7 @@ func TestForwarder_clientCreds_cache(t *testing.T) {
 					kubeUsers:       utils.StringsSet([]string{"user-test"}),
 					kubeGroups:      utils.StringsSet([]string{"kube-group-b", teleport.KubeSystemAuthenticated}),
 					kubeClusterName: "local",
-					Context: auth.Context{
+					Context: authz.Context{
 						User: &types.UserV2{
 							Metadata: types.Metadata{
 								Name: "user-b",

--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
@@ -59,7 +60,7 @@ type TestContext struct {
 	TLSServer   *auth.TestTLSServer
 	AuthServer  *auth.Server
 	AuthClient  *auth.Client
-	Authz       auth.Authorizer
+	Authz       authz.Authorizer
 	KubeServer  *TLSServer
 	Emitter     *eventstest.ChannelEmitter
 	Context     context.Context
@@ -140,7 +141,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	t.Cleanup(func() {
 		proxyLockWatcher.Close()
 	})
-	testCtx.Authz, err = auth.NewAuthorizer(auth.AuthorizerOpts{
+	testCtx.Authz, err = authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: testCtx.ClusterName,
 		AccessPoint: proxyAuthClient,
 		LockWatcher: proxyLockWatcher,

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -95,7 +95,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 	}
 
 	clusterName := conn.ServerIdentity.ClusterName
-	authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: clusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -30,6 +30,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/windows"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -151,7 +152,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 
 	clusterName := conn.ServerIdentity.Cert.Extensions[utils.CertExtensionAuthority]
 
-	authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: clusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
 	"github.com/gravitational/teleport/lib/labels"
@@ -174,7 +174,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 	}
 
 	// Create the kube server to service listener.
-	authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: teleportClusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -69,6 +69,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/dynamo"
 	"github.com/gravitational/teleport/lib/backend/etcdbk"
@@ -1623,7 +1624,7 @@ func (process *TeleportProcess) initAuthService() error {
 	// second, create the API Server: it's actually a collection of API servers,
 	// each serving requests for a "role" which is assigned to every connected
 	// client based on their certificate (user, server, admin, etc)
-	authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: clusterName,
 		AccessPoint: authServer,
 		LockWatcher: lockWatcher,
@@ -3787,7 +3788,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		return trace.Wrap(err)
 	}
 
-	authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: clusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
@@ -3885,7 +3886,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	var kubeServer *kubeproxy.TLSServer
 	if listeners.kube != nil && !process.Config.Proxy.DisableReverseTunnel {
-		authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
@@ -3953,7 +3954,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	// then routing them to a respective database server over the reverse tunnel
 	// framework.
 	if (!listeners.db.Empty() || alpnRouter != nil) && !process.Config.Proxy.DisableReverseTunnel {
-		authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
@@ -4679,7 +4680,7 @@ func (process *TeleportProcess) initApps() {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
@@ -5296,7 +5297,7 @@ func (process *TeleportProcess) initSecureGRPCServer(cfg initSecureGRPCServerCfg
 		return nil, trace.Wrap(err)
 	}
 
-	authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: clusterName,
 		AccessPoint: cfg.accessPoint,
 		LockWatcher: cfg.lockWatcher,

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/labels"
@@ -88,7 +89,7 @@ type Config struct {
 	HostID string
 
 	// Authorizer is used to authorize requests.
-	Authorizer auth.Authorizer
+	Authorizer authz.Authorizer
 
 	// GetRotation returns the certificate rotation state.
 	GetRotation services.RotationGetter
@@ -712,7 +713,7 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	authCtx, _, err := s.authorizeContext(context.WithValue(ctx, auth.ContextUser, user))
+	authCtx, _, err := s.authorizeContext(context.WithValue(ctx, authz.ContextUser, user))
 
 	// The behavior here is a little hard to track. To be clear here, if authorization fails
 	// the following will occur:
@@ -747,7 +748,7 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 
 // monitorConn takes a TrackingReadConn and starts a connection monitor. The tracking connection will be
 // auto-terminated if disconnect_expired_cert or idle timeout is configured.
-func (s *Server) monitorConn(ctx context.Context, tc *srv.TrackingReadConn, authCtx *auth.Context) error {
+func (s *Server) monitorConn(ctx context.Context, tc *srv.TrackingReadConn, authCtx *authz.Context) error {
 	authPref, err := s.c.AuthClient.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -917,7 +918,7 @@ func (s *Server) serveSession(w http.ResponseWriter, r *http.Request, identity *
 //
 // The connection comes from the reverse tunnel and is expected to be TLS and
 // carry identity in the client certificate.
-func (s *Server) getConnectionInfo(ctx context.Context, conn net.Conn) (*tls.Conn, auth.IdentityGetter, types.Application, error) {
+func (s *Server) getConnectionInfo(ctx context.Context, conn net.Conn) (*tls.Conn, authz.IdentityGetter, types.Application, error) {
 	tlsConn := tls.Server(conn, s.tlsConfig)
 	if err := tlsConn.Handshake(); err != nil {
 		return nil, nil, nil, trace.Wrap(err, "TLS handshake failed")
@@ -938,11 +939,11 @@ func (s *Server) getConnectionInfo(ctx context.Context, conn net.Conn) (*tls.Con
 
 // authorizeContext will check if the context carries identity information and
 // runs authorization checks on it.
-func (s *Server) authorizeContext(ctx context.Context) (*auth.Context, types.Application, error) {
+func (s *Server) authorizeContext(ctx context.Context) (*authz.Context, types.Application, error) {
 	// Only allow local and remote identities to proxy to an application.
-	userType := ctx.Value(auth.ContextUser)
+	userType := ctx.Value(authz.ContextUser)
 	switch userType.(type) {
-	case auth.LocalUser, auth.RemoteUser:
+	case authz.LocalUser, authz.RemoteUser:
 	default:
 		return nil, nil, trace.BadParameter("invalid identity: %T", userType)
 	}

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -713,7 +713,7 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	authCtx, _, err := s.authorizeContext(context.WithValue(ctx, authz.ContextUser, user))
+	authCtx, _, err := s.authorizeContext(authz.ContextWithUser(ctx, user))
 
 	// The behavior here is a little hard to track. To be clear here, if authorization fails
 	// the following will occur:
@@ -941,7 +941,11 @@ func (s *Server) getConnectionInfo(ctx context.Context, conn net.Conn) (*tls.Con
 // runs authorization checks on it.
 func (s *Server) authorizeContext(ctx context.Context) (*authz.Context, types.Application, error) {
 	// Only allow local and remote identities to proxy to an application.
-	userType := ctx.Value(authz.ContextUser)
+	userType, err := authz.UserFromContext(ctx)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
 	switch userType.(type) {
 	case authz.LocalUser, authz.RemoteUser:
 	default:

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/services"
@@ -290,7 +291,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		},
 	})
 	require.NoError(t, err)
-	authorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: "cluster-name",
 		AccessPoint: s.authClient,
 		LockWatcher: lockWatcher,

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client"
 	clients "github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
@@ -1900,7 +1901,7 @@ func setupTestContext(ctx context.Context, t *testing.T, withDatabases ...withDa
 		},
 	})
 	require.NoError(t, err)
-	proxyAuthorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+	proxyAuthorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: testCtx.clusterName,
 		AccessPoint: proxyAuthClient,
 		LockWatcher: proxyLockWatcher,
@@ -2040,7 +2041,7 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t *testing.T, p a
 		},
 	})
 	require.NoError(t, err)
-	dbAuthorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+	dbAuthorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: c.clusterName,
 		AccessPoint: c.authClient,
 		LockWatcher: lockWatcher,

--- a/lib/srv/db/common/interfaces.go
+++ b/lib/srv/db/common/interfaces.go
@@ -21,7 +21,7 @@ import (
 	"net"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -63,7 +63,7 @@ type ProxyContext struct {
 	// Servers is a list of database Servers that proxy the requested database.
 	Servers []types.DatabaseServer
 	// AuthContext is a context of authenticated user.
-	AuthContext *auth.Context
+	AuthContext *authz.Context
 }
 
 // Engine defines an interface for specific database protocol engine such

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -42,6 +42,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -78,7 +79,7 @@ type ProxyServerConfig struct {
 	// AccessPoint is the caching client connected to the auth server.
 	AccessPoint auth.ReadDatabaseAccessPoint
 	// Authorizer is responsible for authorizing user identities.
-	Authorizer auth.Authorizer
+	Authorizer authz.Authorizer
 	// Tunnel is the reverse tunnel server.
 	Tunnel reversetunnel.Server
 	// TLSConfig is the proxy server TLS configuration.

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	clients "github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -89,7 +90,7 @@ type Config struct {
 	// Limiter limits the number of connections per client IP.
 	Limiter *limiter.Limiter
 	// Authorizer is used to authorize requests coming from proxy.
-	Authorizer auth.Authorizer
+	Authorizer authz.Authorizer
 	// GetRotation returns the certificate rotation state.
 	GetRotation func(role types.SystemRole) (*types.Rotation, error)
 	// GetServerInfoFn returns function that returns database info for heartbeats.
@@ -994,9 +995,9 @@ func (s *Server) createEngine(sessionCtx *common.Session, audit common.Audit) (c
 
 func (s *Server) authorize(ctx context.Context) (*common.Session, error) {
 	// Only allow local and remote identities to proxy to a database.
-	userType := ctx.Value(auth.ContextUser)
+	userType := ctx.Value(authz.ContextUser)
 	switch userType.(type) {
-	case auth.LocalUser, auth.RemoteUser:
+	case authz.LocalUser, authz.RemoteUser:
 	default:
 		return nil, trace.BadParameter("invalid identity: %T", userType)
 	}

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -995,7 +995,11 @@ func (s *Server) createEngine(sessionCtx *common.Session, audit common.Audit) (c
 
 func (s *Server) authorize(ctx context.Context) (*common.Session, error) {
 	// Only allow local and remote identities to proxy to a database.
-	userType := ctx.Value(authz.ContextUser)
+	userType, err := authz.UserFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	switch userType.(type) {
 	case authz.LocalUser, authz.RemoteUser:
 	default:

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/windows"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/filesessions"
@@ -146,7 +147,7 @@ type WindowsServiceConfig struct {
 	Clock   clockwork.Clock
 	DataDir string
 	// Authorizer is used to authorize requests.
-	Authorizer auth.Authorizer
+	Authorizer authz.Authorizer
 	// LockWatcher is used to monitor for new locks.
 	LockWatcher *services.LockWatcher
 	// Emitter emits audit log events.
@@ -782,7 +783,7 @@ func (s *WindowsService) handleConnection(proxyConn *tls.Conn) {
 	}
 }
 
-func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger, tdpConn *tdp.Conn, desktop types.WindowsDesktop, authCtx *auth.Context) error {
+func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger, tdpConn *tdp.Conn, desktop types.WindowsDesktop, authCtx *authz.Context) error {
 	identity := authCtx.Identity.GetIdentity()
 
 	netConfig, err := s.cfg.AccessPoint.GetClusterNetworkingConfig(ctx)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -55,6 +55,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -206,7 +207,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 
 	nodeID := uuid.New().String()
 	nodeClient, err := testServer.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     types.RoleNode,
 			Username: nodeID,
 		},
@@ -398,7 +399,7 @@ func newProxyClient(t *testing.T, testSvr *auth.TestServer) (*auth.Client, strin
 	// create proxy client used in some tests
 	proxyID := uuid.New().String()
 	proxyClient, err := testSvr.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     types.RoleProxy,
 			Username: proxyID,
 		},
@@ -410,7 +411,7 @@ func newProxyClient(t *testing.T, testSvr *auth.TestServer) (*auth.Client, strin
 func newNodeClient(t *testing.T, testSvr *auth.TestServer) (*auth.Client, string) {
 	nodeID := uuid.New().String()
 	nodeClient, err := testSvr.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     types.RoleNode,
 			Username: nodeID,
 		},

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -95,6 +95,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/conntest"
@@ -267,7 +268,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	require.NoError(t, err)
 
 	nodeClient, err := s.server.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     types.RoleNode,
 			Username: nodeID,
 		},
@@ -323,7 +324,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	// create reverse tunnel service:
 	proxyID := "proxy"
 	s.proxyClient, err = s.server.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     types.RoleProxy,
 			Username: proxyID,
 		},
@@ -530,7 +531,7 @@ func (s *WebSuite) addNode(t *testing.T, uuid string, hostname string, address s
 	require.NoError(t, err)
 
 	nodeClient, err := s.server.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     types.RoleNode,
 			Username: uuid,
 		},
@@ -6784,7 +6785,7 @@ func newWebPack(t *testing.T, numProxies int) *webPack {
 	hostSigners := []ssh.Signer{signer}
 
 	nodeClient, err := server.TLS.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     types.RoleNode,
 			Username: nodeID,
 		},
@@ -6870,7 +6871,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 ) *testProxy {
 	// create reverse tunnel service:
 	client, err := authServer.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
+		I: authz.BuiltinRole{
 			Role:     types.RoleProxy,
 			Username: proxyID,
 		},
@@ -7507,7 +7508,7 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 		},
 	})
 	require.NoError(t, err)
-	proxyAuthorizer, err := auth.NewAuthorizer(auth.AuthorizerOpts{
+	proxyAuthorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: cfg.authServer.ClusterName(),
 		AccessPoint: proxyAuthClient,
 		LockWatcher: proxyLockWatcher,

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -217,7 +218,7 @@ func (c *AccessRequestCommand) splitRoles() []string {
 
 func (c *AccessRequestCommand) Approve(ctx context.Context, client auth.ClientI) error {
 	if c.delegator != "" {
-		ctx = auth.WithDelegator(ctx, c.delegator)
+		ctx = authz.WithDelegator(ctx, c.delegator)
 	}
 	annotations, err := c.splitAnnotations()
 	if err != nil {
@@ -239,7 +240,7 @@ func (c *AccessRequestCommand) Approve(ctx context.Context, client auth.ClientI)
 
 func (c *AccessRequestCommand) Deny(ctx context.Context, client auth.ClientI) error {
 	if c.delegator != "" {
-		ctx = auth.WithDelegator(ctx, c.delegator)
+		ctx = authz.WithDelegator(ctx, c.delegator)
 	}
 	annotations, err := c.splitAnnotations()
 	if err != nil {


### PR DESCRIPTION
The Authorizer and associated functions and constants have been moved into their own package `authz`. This will allow us to more easily create separate services for gRPC functionality so that we're not pushing as much into the `lib/auth` package.
    
Though this PR is large, the changes are minimal. It's mostly a rename with some changes for the `permissions_test.go` file and an adjustment so that the `context` setters and getters are wrapped in functions as opposed to relying on all users of these to unwrap the context manually.