### PR TITLE
[v11] Validate static labels assigned to Kubernetes service 

### DIFF
--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -113,6 +113,11 @@ func (c *TLSServerConfig) CheckAndSetDefaults() error {
 	if c.AccessPoint == nil {
 		return trace.BadParameter("missing parameter AccessPoint")
 	}
+
+	if err := c.validateLabelKeys(); err != nil {
+		return trace.Wrap(err)
+	}
+
 	if c.Log == nil {
 		c.Log = logrus.New()
 	}
@@ -121,6 +126,17 @@ func (c *TLSServerConfig) CheckAndSetDefaults() error {
 	}
 	if c.ConnectedProxyGetter == nil {
 		c.ConnectedProxyGetter = reversetunnel.NewConnectedProxyGetter()
+	}
+	return nil
+}
+
+// validateLabelKeys checks that all labels keys are valid.
+// Dynamic labels are validated in labels.NewDynamicLabels.
+func (c *TLSServerConfig) validateLabelKeys() error {
+	for name := range c.StaticLabels {
+		if !types.IsValidLabelKey(name) {
+			return trace.BadParameter("invalid label key: %q", name)
+		}
 	}
 	return nil
 }

--- a/lib/kube/proxy/server_test.go
+++ b/lib/kube/proxy/server_test.go
@@ -318,3 +318,54 @@ func TestHeartbeat(t *testing.T) {
 	}
 
 }
+
+func TestTLSServerConfig_validateLabelsKey(t *testing.T) {
+	type fields struct {
+		staticLabels map[string]string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		errorAssertion require.ErrorAssertionFunc
+	}{
+		{
+			name: "valid labels",
+			fields: fields{
+				staticLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			errorAssertion: require.NoError,
+		},
+		{
+			name: "invalid labels",
+			fields: fields{
+				staticLabels: map[string]string{
+					"key 1": "value1",
+					"key2":  "value2",
+				},
+			},
+			errorAssertion: require.Error,
+		},
+		{
+			name: "invalid labels",
+			fields: fields{
+				staticLabels: map[string]string{
+					"key\\1": "value1",
+					"key2":   "value2",
+				},
+			},
+			errorAssertion: require.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &TLSServerConfig{
+				StaticLabels: tt.fields.staticLabels,
+			}
+			err := c.validateLabelKeys()
+			tt.errorAssertion(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Backport of #22701 to branch/v11