### PR TITLE
Add a temporary alias for service.Cfg

### DIFF
--- a/lib/service/servicecfg/alias.go
+++ b/lib/service/servicecfg/alias.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecfg
+
+import "github.com/gravitational/teleport/lib/service"
+
+// Config is a temporary alias to aid in migrating configuration
+// from lib/service to lib/service/servicecfg.
+type Config = service.Config


### PR DESCRIPTION
This is necessary in order to merge updates to e before the old types are moved in teleport.

Once this is merged, we'll be able to merge gravitational/teleport.e#962 cleanly, then we'll be able to merge #22693.