### PR TITLE
chore: Bump Buf to v1.15.1

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -286,7 +286,7 @@ RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.15.0" && \
+    VERSION="1.15.1" && \
       curl -sSLf \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Update Buf to the latest version.

No format, lint or codegen changes.

https://github.com/bufbuild/buf/releases/tag/v1.15.1