### PR TITLE
Use 13px font size in a `Notification` title

### DIFF
--- a/web/packages/shared/components/Notification/Notification.tsx
+++ b/web/packages/shared/components/Notification/Notification.tsx
@@ -150,7 +150,7 @@ function getRenderedContent(
           `}
         >
           <Text
-            fontSize={14}
+            fontSize={13}
             bold
             mr="30px"
             css={`


### PR DESCRIPTION
Using the same (smaller) font size in the title and in the content looks better, especially for longer titles.

Before:
<img width="348" alt="image" src="https://user-images.githubusercontent.com/20583051/224104562-325d534b-7ee7-4fdc-a1a5-03f82b368389.png">

After:
<img width="348" alt="image" src="https://user-images.githubusercontent.com/20583051/224104483-f010d2ec-470e-476c-acab-e5ac003e20e4.png">
