### PR TITLE
Introduce the Okta client.

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -42,6 +42,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/gravitational/teleport/api/breaker"
+	"github.com/gravitational/teleport/api/client/okta"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
@@ -3401,6 +3402,6 @@ func (c *Client) DeleteLoginRule(ctx context.Context, name string) error {
 // Clients connecting older Teleport versions still get an okta client when
 // calling this method, but all RPCs will return "not implemented" errors (as per
 // the default gRPC behavior).
-func (c *Client) OktaClient() oktapb.OktaServiceClient {
-	return oktapb.NewOktaServiceClient(c.conn)
+func (c *Client) OktaClient() *okta.Client {
+	return okta.NewClient(oktapb.NewOktaServiceClient(c.conn))
 }

--- a/api/client/okta/okta.go
+++ b/api/client/okta/okta.go
@@ -1,0 +1,166 @@
+// Copyright 2023 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package okta
+
+import (
+	"context"
+
+	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"github.com/gravitational/trace/trail"
+)
+
+// Client is an Okta client that conforms to the following lib/services interfaces:
+// * services.OktaImportRules
+// * services.OktaAssignments
+type Client struct {
+	grpcClient oktapb.OktaServiceClient
+}
+
+// NewClient creates a new Okta client.
+func NewClient(grpcClient oktapb.OktaServiceClient) *Client {
+	return &Client{
+		grpcClient: grpcClient,
+	}
+}
+
+// ListOktaImportRules returns a paginated list of all Okta import rule resources.
+func (c *Client) ListOktaImportRules(ctx context.Context, pageSize int, pageToken string) ([]types.OktaImportRule, string, error) {
+	resp, err := c.grpcClient.ListOktaImportRules(ctx, &oktapb.ListOktaImportRulesRequest{
+		PageSize:  int32(pageSize),
+		PageToken: pageToken,
+	})
+	if err != nil {
+		return nil, "", trail.FromGRPC(err)
+	}
+
+	importRules := make([]types.OktaImportRule, len(resp.ImportRules))
+	for i, importRule := range resp.ImportRules {
+		importRules[i] = importRule
+	}
+
+	return importRules, resp.NextPageToken, nil
+}
+
+// GetOktaImportRule returns the specified Okta import rule resources.
+func (c *Client) GetOktaImportRule(ctx context.Context, name string) (types.OktaImportRule, error) {
+	resp, err := c.grpcClient.GetOktaImportRule(ctx, &oktapb.GetOktaImportRuleRequest{
+		Name: name,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// CreateOktaImportRule creates a new Okta import rule resource.
+func (c *Client) CreateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) (types.OktaImportRule, error) {
+	importRuleV1, ok := importRule.(*types.OktaImportRuleV1)
+	if !ok {
+		return nil, trace.BadParameter("import rule expected to be OktaImportRuleV1, got %T", importRule)
+	}
+	resp, err := c.grpcClient.CreateOktaImportRule(ctx, &oktapb.CreateOktaImportRuleRequest{
+		ImportRule: importRuleV1,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// UpdateOktaImportRule updates an existing Okta import rule resource.
+func (c *Client) UpdateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) (types.OktaImportRule, error) {
+	importRuleV1, ok := importRule.(*types.OktaImportRuleV1)
+	if !ok {
+		return nil, trace.BadParameter("import rule expected to be OktaImportRuleV1, got %T", importRule)
+	}
+	resp, err := c.grpcClient.UpdateOktaImportRule(ctx, &oktapb.UpdateOktaImportRuleRequest{
+		ImportRule: importRuleV1,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// DeleteOktaImportRule removes the specified Okta import rule resource.
+func (c *Client) DeleteOktaImportRule(ctx context.Context, name string) error {
+	_, err := c.grpcClient.DeleteOktaImportRule(ctx, &oktapb.DeleteOktaImportRuleRequest{
+		Name: name,
+	})
+	return trail.FromGRPC(err)
+}
+
+// DeleteAllOktaImportRules removes all Okta import rules.
+func (c *Client) DeleteAllOktaImportRules(ctx context.Context) error {
+	_, err := c.grpcClient.DeleteAllOktaImportRules(ctx, &oktapb.DeleteAllOktaImportRulesRequest{})
+	return trail.FromGRPC(err)
+}
+
+// ListOktaAssignments returns a paginated list of all Okta assignment resources.
+func (c *Client) ListOktaAssignments(ctx context.Context, pageSize int, pageToken string) ([]types.OktaAssignment, string, error) {
+	resp, err := c.grpcClient.ListOktaAssignments(ctx, &oktapb.ListOktaAssignmentsRequest{
+		PageSize:  int32(pageSize),
+		PageToken: pageToken,
+	})
+	if err != nil {
+		return nil, "", trail.FromGRPC(err)
+	}
+
+	assignments := make([]types.OktaAssignment, len(resp.Assignments))
+	for i, assignment := range resp.Assignments {
+		assignments[i] = assignment
+	}
+
+	return assignments, resp.NextPageToken, nil
+}
+
+// GetOktaAssignmentreturns the specified Okta assignment resources.
+func (c *Client) GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error) {
+	resp, err := c.grpcClient.GetOktaAssignment(ctx, &oktapb.GetOktaAssignmentRequest{
+		Name: name,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// CreateOktaAssignmentcreates a new Okta assignment resource.
+func (c *Client) CreateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
+	assignmentV1, ok := assignment.(*types.OktaAssignmentV1)
+	if !ok {
+		return nil, trace.BadParameter("import rule expected to be OktaAssignmentV1, got %T", assignment)
+	}
+	resp, err := c.grpcClient.CreateOktaAssignment(ctx, &oktapb.CreateOktaAssignmentRequest{
+		Assignment: assignmentV1,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// UpdateOktaAssignmentupdates an existing Okta assignment resource.
+func (c *Client) UpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
+	assignmentV1, ok := assignment.(*types.OktaAssignmentV1)
+	if !ok {
+		return nil, trace.BadParameter("import rule expected to be OktaAssignmentV1, got %T", assignment)
+	}
+	resp, err := c.grpcClient.UpdateOktaAssignment(ctx, &oktapb.UpdateOktaAssignmentRequest{
+		Assignment: assignmentV1,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// DeleteOktaAssignmentremoves the specified Okta assignment resource.
+func (c *Client) DeleteOktaAssignment(ctx context.Context, name string) error {
+	_, err := c.grpcClient.DeleteOktaAssignment(ctx, &oktapb.DeleteOktaAssignmentRequest{
+		Name: name,
+	})
+	return trail.FromGRPC(err)
+}
+
+// DeleteAllOktaAssignments removes all Okta assignments.
+func (c *Client) DeleteAllOktaAssignments(ctx context.Context) error {
+	_, err := c.grpcClient.DeleteAllOktaAssignments(ctx, &oktapb.DeleteAllOktaAssignmentsRequest{})
+	return trail.FromGRPC(err)
+}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/okta"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -279,10 +280,9 @@ func (a *ServerWithRoles) LoginRuleClient() loginrulepb.LoginRuleServiceClient {
 // OktaClient allows ServerWithRoles to implement ClientI.
 // It should not be called through ServerWithRoles,
 // as it returns a dummy client that will always respond with "not implemented".
-func (a *ServerWithRoles) OktaClient() oktapb.OktaServiceClient {
-	return oktapb.NewOktaServiceClient(
-		utils.NewGRPCDummyClientConnection("OktaClient() should not be called on ServerWithRoles"),
-	)
+func (a *ServerWithRoles) OktaClient() *okta.Client {
+	return okta.NewClient(oktapb.NewOktaServiceClient(
+		utils.NewGRPCDummyClientConnection("OktaClient() should not be called on ServerWithRoles")))
 }
 
 // PluginsClient allows ServerWithRoles to implement ClientI.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -35,12 +35,12 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/okta"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
-	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
 	pluginspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
 	samlidppb "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
 	"github.com/gravitational/teleport/api/observability/tracing"
@@ -1718,5 +1718,5 @@ type ClientI interface {
 	// Clients connecting to non-Enterprise clusters, or older Teleport versions,
 	// still get an Okta client when calling this method, but all RPCs will return
 	// "not implemented" errors (as per the default gRPC behavior).
-	OktaClient() oktapb.OktaServiceClient
+	OktaClient() *okta.Client
 }

--- a/lib/client/checks.go
+++ b/lib/client/checks.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"github.com/gravitational/teleport/api/client/okta"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// Compile time checks for the Okta client.
+var _ services.OktaImportRules = &okta.Client{}
+var _ services.OktaAssignments = &okta.Client{}

--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -83,13 +83,13 @@ func (o *OktaService) GetOktaImportRule(ctx context.Context, name string) (types
 }
 
 // CreateOktaImportRule creates a new Okta import rule resource.
-func (o *OktaService) CreateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) error {
-	return o.importRuleSvc.CreateResource(ctx, importRule)
+func (o *OktaService) CreateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) (types.OktaImportRule, error) {
+	return importRule, o.importRuleSvc.CreateResource(ctx, importRule)
 }
 
 // UpdateOktaImportRule updates an existing Okta import rule resource.
-func (o *OktaService) UpdateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) error {
-	return o.importRuleSvc.UpdateResource(ctx, importRule)
+func (o *OktaService) UpdateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) (types.OktaImportRule, error) {
+	return importRule, o.importRuleSvc.UpdateResource(ctx, importRule)
 }
 
 // DeleteOktaImportRule removes the specified Okta import rule resource.
@@ -113,13 +113,13 @@ func (o *OktaService) GetOktaAssignment(ctx context.Context, name string) (types
 }
 
 // CreateOktaAssignmentcreates a new Okta assignment resource.
-func (o *OktaService) CreateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) error {
-	return o.assignmentSvc.CreateResource(ctx, assignment)
+func (o *OktaService) CreateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
+	return assignment, o.assignmentSvc.CreateResource(ctx, assignment)
 }
 
 // UpdateOktaAssignmentupdates an existing Okta assignment resource.
-func (o *OktaService) UpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) error {
-	return o.assignmentSvc.UpdateResource(ctx, assignment)
+func (o *OktaService) UpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
+	return assignment, o.assignmentSvc.UpdateResource(ctx, assignment)
 }
 
 // DeleteOktaAssignmentremoves the specified Okta assignment resource.

--- a/lib/services/okta.go
+++ b/lib/services/okta.go
@@ -32,9 +32,9 @@ type OktaImportRules interface {
 	// GetOktaImportRule returns the specified Okta import rule resources.
 	GetOktaImportRule(ctx context.Context, name string) (types.OktaImportRule, error)
 	// CreateOktaImportRule creates a new Okta import rule resource.
-	CreateOktaImportRule(context.Context, types.OktaImportRule) error
+	CreateOktaImportRule(context.Context, types.OktaImportRule) (types.OktaImportRule, error)
 	// UpdateOktaImportRule updates an existing Okta import rule resource.
-	UpdateOktaImportRule(context.Context, types.OktaImportRule) error
+	UpdateOktaImportRule(context.Context, types.OktaImportRule) (types.OktaImportRule, error)
 	// DeleteOktaImportRule removes the specified Okta import rule resource.
 	DeleteOktaImportRule(ctx context.Context, name string) error
 	// DeleteAllOktaImportRules removes all Okta import rules.
@@ -48,9 +48,9 @@ type OktaAssignments interface {
 	// GetOktaAssignmentreturns the specified Okta assignment resources.
 	GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error)
 	// CreateOktaAssignmentcreates a new Okta assignment resource.
-	CreateOktaAssignment(context.Context, types.OktaAssignment) error
+	CreateOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
 	// UpdateOktaAssignmentupdates an existing Okta assignment resource.
-	UpdateOktaAssignment(context.Context, types.OktaAssignment) error
+	UpdateOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
 	// DeleteOktaAssignmentremoves the specified Okta assignment resource.
 	DeleteOktaAssignment(ctx context.Context, name string) error
 	// DeleteAllOktaAssignments removes all Okta assignments.


### PR DESCRIPTION
An Okta client has been introduced that maintains the interfaces defined in `lib/services`. Though the gRPC implementation for this client lives outside of `lib/auth`, this implementation allows the `ClientI` interface to be maintained by not adding the okta specific CRUD operations explicitly to `ServerWithRoles`.