### PR TITLE
Integrations: CRUD operations

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
@@ -3268,6 +3269,87 @@ func (c *Client) DeleteAllUserGroups(ctx context.Context) error {
 		return trail.FromGRPC(err)
 	}
 	return nil
+}
+
+// integrationsClient returns an unadorned Integration client, using the underlying
+// Auth gRPC connection.
+func (c *Client) integrationsClient() integrationpb.IntegrationServiceClient {
+	return integrationpb.NewIntegrationServiceClient(c.conn)
+}
+
+// ListIntegrations returns a paginated list of Integrations.
+// The response includes a nextKey which must be used to fetch the next page.
+func (c *Client) ListIntegrations(ctx context.Context, pageSize int, nextKey string) ([]types.Integration, string, error) {
+	resp, err := c.integrationsClient().ListIntegrations(ctx, &integrationpb.ListIntegrationsRequest{
+		Limit:   int32(pageSize),
+		NextKey: nextKey,
+	}, c.callOpts...)
+	if err != nil {
+		return nil, "", trail.FromGRPC(err)
+	}
+
+	integrations := make([]types.Integration, 0, len(resp.GetIntegrations()))
+	for _, ig := range resp.GetIntegrations() {
+		integrations = append(integrations, ig)
+	}
+
+	return integrations, resp.GetNextKey(), nil
+}
+
+// GetIntegration returns an Integration by its name.
+func (c *Client) GetIntegration(ctx context.Context, name string) (types.Integration, error) {
+	ig, err := c.integrationsClient().GetIntegration(ctx, &integrationpb.GetIntegrationRequest{
+		Name: name,
+	}, c.callOpts...)
+	if err != nil {
+		return nil, trail.FromGRPC(err)
+	}
+
+	return ig, nil
+}
+
+// CreateIntegration creates a new Integration.
+func (c *Client) CreateIntegration(ctx context.Context, ig types.Integration) (types.Integration, error) {
+	igV1, ok := ig.(*types.IntegrationV1)
+	if !ok {
+		return nil, trace.BadParameter("unsupported integration type %T", ig)
+	}
+
+	ig, err := c.integrationsClient().CreateIntegration(ctx, &integrationpb.CreateIntegrationRequest{Integration: igV1}, c.callOpts...)
+	if err != nil {
+		return nil, trail.FromGRPC(err)
+	}
+
+	return ig, nil
+}
+
+// UpdateIntegration updates an existing Integration.
+func (c *Client) UpdateIntegration(ctx context.Context, ig types.Integration) (types.Integration, error) {
+	igV1, ok := ig.(*types.IntegrationV1)
+	if !ok {
+		return nil, trace.BadParameter("unsupported integration type %T", ig)
+	}
+
+	ig, err := c.integrationsClient().UpdateIntegration(ctx, &integrationpb.UpdateIntegrationRequest{Integration: igV1}, c.callOpts...)
+	if err != nil {
+		return nil, trail.FromGRPC(err)
+	}
+
+	return ig, nil
+}
+
+// DeleteIntegration removes an Integration by its name.
+func (c *Client) DeleteIntegration(ctx context.Context, name string) error {
+	_, err := c.integrationsClient().DeleteIntegration(ctx, &integrationpb.DeleteIntegrationRequest{
+		Name: name,
+	}, c.callOpts...)
+	return trail.FromGRPC(err)
+}
+
+// DeleteAllIntegrations removes all Integrations.
+func (c *Client) DeleteAllIntegrations(ctx context.Context) error {
+	_, err := c.integrationsClient().DeleteAllIntegrations(ctx, &integrationpb.DeleteAllIntegrationsRequest{}, c.callOpts...)
+	return trail.FromGRPC(err)
 }
 
 // PluginsClient returns an unadorned Plugins client, using the underlying

--- a/api/client/events.go
+++ b/api/client/events.go
@@ -195,6 +195,10 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 		out.Resource = &proto.Event_OktaAssignment{
 			OktaAssignment: r,
 		}
+	case *types.IntegrationV1:
+		out.Resource = &proto.Event_Integration{
+			Integration: r,
+		}
 	default:
 		return nil, trace.BadParameter("resource type %T is not supported", in.Resource)
 	}
@@ -339,6 +343,9 @@ func EventFromGRPC(in proto.Event) (*types.Event, error) {
 		out.Resource = r
 		return &out, nil
 	} else if r := in.GetOktaAssignment(); r != nil {
+		out.Resource = r
+		return &out, nil
+	} else if r := in.GetIntegration(); r != nil {
 		out.Resource = r
 		return &out, nil
 	} else {

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -394,6 +394,10 @@ const (
 	// VerbEnroll allows enrollment of trusted devices.
 	// Device Trust is a Teleport Enterprise feature.
 	VerbEnroll = "enroll"
+
+	// VerbUse allows the usage of an Integration.
+	// Roles with this verb can issue API calls using the integration.
+	VerbUse = "use"
 )
 
 const (

--- a/integration/integrations/integration_test.go
+++ b/integration/integrations/integration_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integrations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/web/ui"
+)
+
+// TestIntegraitionCRUD starts a Teleport cluster and using its Proxy Web server,
+// tests the CRUD operations over the Integration resource.
+func TestIntegrationCRUD(t *testing.T) {
+	ctx := context.Background()
+
+	// Start Teleport Auth and Proxy services
+	authProcess, proxyProcess, _ := helpers.MakeTestServers(t)
+	authServer := authProcess.GetAuthServer()
+	proxyAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	roleWithFullAccess, err := types.NewRole("fullaccess", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Namespaces: []string{apidefaults.Namespace},
+			Rules: []types.Rule{
+				types.NewRule(types.KindIntegration, services.RW()),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authServer.UpsertRole(ctx, roleWithFullAccess))
+
+	integrationsEndpoint := strings.Join([]string{"sites", "$site", "integrations"}, "/")
+
+	// Set up User
+	username := "fullaccess"
+	user, err := types.NewUser(username)
+	require.NoError(t, err)
+
+	user.AddRole(roleWithFullAccess.GetName())
+	require.NoError(t, authServer.UpsertUser(user))
+
+	userPassword := uuid.NewString()
+	require.NoError(t, authServer.UpsertPassword(username, []byte(userPassword)))
+
+	webPack := helpers.LoginWebClient(t, proxyAddr.String(), username, userPassword)
+
+	// List integrations should return empty
+	resp, err := webPack.DoRequest(http.MethodGet, integrationsEndpoint, nil)
+	require.NoError(t, err)
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+
+	listResp := ui.IntegrationsListResponse{}
+	require.NoError(t, json.Unmarshal(respBody, &listResp))
+
+	require.Empty(t, listResp.Items)
+
+	// Create Integration
+	createIntegrationReq := ui.Integration{
+		Name:    "MyAWSAccount",
+		SubKind: types.IntegrationSubKindAWSOIDC,
+		AWSOIDC: &ui.IntegrationAWSOIDCSpec{
+			RoleARN: "arn:aws:iam::123456789012:role/DevTeam",
+		},
+	}
+
+	resp, err = webPack.DoRequest(http.MethodPost, integrationsEndpoint, createIntegrationReq)
+	require.NoError(t, err)
+
+	respBody, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+
+	// Get One Integration by name
+	resp, err = webPack.DoRequest(http.MethodGet, integrationsEndpoint+"/MyAWSAccount", nil)
+	require.NoError(t, err)
+
+	respBody, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+
+	integrationResp := ui.Integration{}
+	require.NoError(t, json.Unmarshal(respBody, &integrationResp))
+
+	require.Equal(t, ui.Integration{
+		Name:    "MyAWSAccount",
+		SubKind: types.IntegrationSubKindAWSOIDC,
+		AWSOIDC: &ui.IntegrationAWSOIDCSpec{
+			RoleARN: "arn:aws:iam::123456789012:role/DevTeam",
+		},
+	}, integrationResp, string(respBody))
+
+	// Update the integration to another RoleARN
+	resp, err = webPack.DoRequest(http.MethodPut, integrationsEndpoint+"/MyAWSAccount", ui.UpdateIntegrationRequest{
+		AWSOIDC: &ui.IntegrationAWSOIDCSpec{
+			RoleARN: "arn:aws:iam::123456789012:role/OpsTeam",
+		},
+	})
+	require.NoError(t, err)
+
+	respBody, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+
+	integrationResp = ui.Integration{}
+	require.NoError(t, json.Unmarshal(respBody, &integrationResp))
+
+	require.Equal(t, ui.Integration{
+		Name:    "MyAWSAccount",
+		SubKind: types.IntegrationSubKindAWSOIDC,
+		AWSOIDC: &ui.IntegrationAWSOIDCSpec{
+			RoleARN: "arn:aws:iam::123456789012:role/OpsTeam",
+		},
+	}, integrationResp, string(respBody))
+
+	// Delete resource
+	resp, err = webPack.DoRequest(http.MethodDelete, integrationsEndpoint+"/MyAWSAccount", nil)
+	require.NoError(t, err)
+
+	respBody, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+
+	// Add multiple integrations to test pagination
+	// Tests two full pages + 1 item to prevent off by one errors.
+	pageSize := 10
+	totalItems := pageSize*2 + 1
+	for i := 0; i < totalItems; i++ {
+		createIntegrationReq := ui.Integration{
+			Name:    fmt.Sprintf("AWSIntegration%d", i),
+			SubKind: types.IntegrationSubKindAWSOIDC,
+			AWSOIDC: &ui.IntegrationAWSOIDCSpec{
+				RoleARN: "arn:aws:iam::123456789012:role/DevTeam",
+			},
+		}
+
+		resp, err = webPack.DoRequest(http.MethodPost, integrationsEndpoint, createIntegrationReq)
+		require.NoError(t, err)
+
+		respBody, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+	}
+
+	// List integrations should return a full page
+	resp, err = webPack.DoRequest(http.MethodGet, integrationsEndpoint+"?limit=10", nil)
+	require.NoError(t, err)
+
+	respBody, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+
+	listResp = ui.IntegrationsListResponse{}
+	require.NoError(t, json.Unmarshal(respBody, &listResp))
+
+	require.Len(t, listResp.Items, pageSize)
+
+	// Requesting the 2nd page should return a full page
+	resp, err = webPack.DoRequest(http.MethodGet, integrationsEndpoint+"?limit=10&startKey="+listResp.NextKey, nil)
+	require.NoError(t, err)
+
+	respBody, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+
+	listResp = ui.IntegrationsListResponse{}
+	require.NoError(t, json.Unmarshal(respBody, &listResp))
+
+	require.Len(t, listResp.Items, pageSize)
+
+	// Requesting the 3rd page should return a single item and empty StartKey
+	resp, err = webPack.DoRequest(http.MethodGet, integrationsEndpoint+"?limit=10&startKey="+listResp.NextKey, nil)
+	require.NoError(t, err)
+
+	respBody, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+
+	listResp = ui.IntegrationsListResponse{}
+	require.NoError(t, json.Unmarshal(respBody, &listResp))
+
+	require.Len(t, listResp.Items, 1)
+	require.Empty(t, listResp.NextKey)
+}

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -995,6 +995,9 @@ type Cache interface {
 	ListSAMLIdPServiceProviders(ctx context.Context, pageSize int, nextKey string) ([]types.SAMLIdPServiceProvider, string, error)
 	// GetSAMLIdPServiceProvider returns the specified SAML IdP service provider resources.
 	GetSAMLIdPServiceProvider(ctx context.Context, name string) (types.SAMLIdPServiceProvider, error)
+
+	// IntegrationsGetter defines read/list methods for integrations.
+	services.IntegrationsGetter
 }
 
 type NodeWrapper struct {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -219,6 +219,12 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 			return nil, trace.Wrap(err)
 		}
 	}
+	if cfg.Integrations == nil {
+		cfg.Integrations, err = local.NewIntegrationsService(cfg.Backend)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
 
 	limiter, err := limiter.NewConnectionsLimiter(limiter.Config{
 		MaxConnections: defaults.LimiterMaxConcurrentSignatures,
@@ -267,6 +273,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		UserGroups:              cfg.UserGroups,
 		SessionTrackerService:   cfg.SessionTrackerService,
 		ConnectionsDiagnostic:   cfg.ConnectionsDiagnostic,
+		Integrations:            cfg.Integrations,
 		StatusInternal:          cfg.Status,
 		UsageReporter:           cfg.UsageReporter,
 
@@ -370,6 +377,7 @@ type Services struct {
 	services.SessionTrackerService
 	services.ConnectionsDiagnostic
 	services.StatusInternal
+	services.Integrations
 	usagereporter.UsageReporter
 	types.Events
 	events.AuditLogSessionStreamer

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -711,6 +711,7 @@ type ClientI interface {
 	services.SessionTrackerService
 	services.ConnectionsDiagnostic
 	services.SAMLIdPSession
+	services.Integrations
 	types.Events
 
 	types.WebSessionsGetter

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/metadata"
@@ -51,6 +52,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	integrationService "github.com/gravitational/teleport/lib/auth/integration/integrationv1"
 	"github.com/gravitational/teleport/lib/auth/okta"
 	"github.com/gravitational/teleport/lib/auth/trust/trustv1"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
@@ -5019,6 +5021,16 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		return nil, trace.Wrap(err)
 	}
 	oktapb.RegisterOktaServiceServer(server, oktaServiceServer)
+
+	integrationServiceServer, err := integrationService.NewService(&integrationService.ServiceConfig{
+		Authorizer: cfg.Authorizer,
+		Backend:    cfg.AuthServer.Services,
+		Cache:      cfg.AuthServer.Cache,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	integrationpb.RegisterIntegrationServiceServer(server, integrationServiceServer)
 
 	return authServer, nil
 }

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -189,6 +189,9 @@ type InitConfig struct {
 	// UserGroups is a service that manages user groups.
 	UserGroups services.UserGroups
 
+	// Integrations is a service that manages Integrations.
+	Integrations services.Integrations
+
 	// SessionTrackerService is a service that manages trackers for all active sessions.
 	SessionTrackerService services.SessionTrackerService
 

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -86,6 +86,7 @@ type testPack struct {
 	samlIDPServiceProviders services.SAMLIdPServiceProviders
 	userGroups              services.UserGroups
 	okta                    services.Okta
+	integrations            services.Integrations
 }
 
 // testFuncs are functions to support testing an object in a cache.
@@ -222,6 +223,12 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	}
 	p.okta = oktaSvc
 
+	igSvc, err := local.NewIntegrationsService(p.backend)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	p.integrations = igSvc
+
 	return p, nil
 }
 
@@ -258,6 +265,7 @@ func newPack(dir string, setupConfig func(c Config) Config, opts ...packOption) 
 		SAMLIdPServiceProviders: p.samlIDPServiceProviders,
 		UserGroups:              p.userGroups,
 		Okta:                    p.okta,
+		Integrations:            p.integrations,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
 	}))
@@ -645,6 +653,7 @@ func TestCompletenessInit(t *testing.T) {
 			SAMLIdPServiceProviders: p.samlIDPServiceProviders,
 			UserGroups:              p.userGroups,
 			Okta:                    p.okta,
+			Integrations:            p.integrations,
 			MaxRetryPeriod:          200 * time.Millisecond,
 			EventsC:                 p.eventsC,
 		}))
@@ -712,6 +721,7 @@ func TestCompletenessReset(t *testing.T) {
 		SAMLIdPServiceProviders: p.samlIDPServiceProviders,
 		UserGroups:              p.userGroups,
 		Okta:                    p.okta,
+		Integrations:            p.integrations,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
 	}))
@@ -891,6 +901,7 @@ func TestListResources_NodesTTLVariant(t *testing.T) {
 		SAMLIdPServiceProviders: p.samlIDPServiceProviders,
 		UserGroups:              p.userGroups,
 		Okta:                    p.okta,
+		Integrations:            p.integrations,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
 		neverOK:                 true, // ensure reads are never healthy
@@ -968,6 +979,7 @@ func initStrategy(t *testing.T) {
 		SAMLIdPServiceProviders: p.samlIDPServiceProviders,
 		UserGroups:              p.userGroups,
 		Okta:                    p.okta,
+		Integrations:            p.integrations,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
 	}))
@@ -1991,6 +2003,44 @@ func TestOktaAssignments(t *testing.T) {
 	})
 }
 
+// TestIntegrations tests that CRUD operations on integrations resources are
+// replicated from the backend to the cache.
+func TestIntegrations(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[types.Integration]{
+		newResource: func(name string) (types.Integration, error) {
+			return types.NewIntegrationAWSOIDC(
+				types.Metadata{Name: name},
+				&types.AWSOIDCIntegrationSpecV1{
+					RoleARN: "arn:aws:iam::123456789012:role/OpsTeam",
+				},
+			)
+		},
+		create: func(ctx context.Context, i types.Integration) error {
+			_, err := p.integrations.CreateIntegration(ctx, i)
+			return err
+		},
+		list: func(ctx context.Context) ([]types.Integration, error) {
+			results, _, err := p.integrations.ListIntegrations(ctx, 0, "")
+			return results, err
+		},
+		cacheGet: p.cache.GetIntegration,
+		cacheList: func(ctx context.Context) ([]types.Integration, error) {
+			results, _, err := p.cache.ListIntegrations(ctx, 0, "")
+			return results, err
+		},
+		update: func(ctx context.Context, i types.Integration) error {
+			_, err := p.integrations.UpdateIntegration(ctx, i)
+			return err
+		},
+		deleteAll: p.integrations.DeleteAllIntegrations,
+	})
+}
+
 // testResources is a generic tester for resources.
 func testResources[T types.Resource](t *testing.T, p *testPack, funcs testFuncs[T]) {
 	ctx := context.Background()
@@ -2398,6 +2448,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindUserGroup:               &types.UserGroupV1{},
 		types.KindOktaImportRule:          &types.OktaImportRuleV1{},
 		types.KindOktaAssignment:          &types.OktaAssignmentV1{},
+		types.KindIntegration:             &types.IntegrationV1{},
 	}
 
 	for name, cfg := range cases {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1957,6 +1957,7 @@ func (process *TeleportProcess) newAccessCache(cfg accessCacheConfig) (*cache.Ca
 		SAMLIdPServiceProviders: cfg.services,
 		UserGroups:              cfg.services,
 		Okta:                    cfg.services.OktaClient(),
+		Integrations:            cfg.services,
 		WebSession:              cfg.services.WebSessions(),
 		WebToken:                cfg.services.WebTokens(),
 		Component:               teleport.Component(append(cfg.cacheName, process.id, teleport.ComponentCache)...),

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -154,6 +154,8 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newOktaImportRuleParser()
 		case types.KindOktaAssignment:
 			parser = newOktaAssignmentParser()
+		case types.KindIntegration:
+			parser = newIntegrationParser()
 		default:
 			return nil, trace.BadParameter("watcher on object kind %q is not supported", kind.Kind)
 		}
@@ -1515,6 +1517,30 @@ func (p *oktaAssignmentParser) parse(event backend.Event) (types.Resource, error
 		return resourceHeader(event, types.KindOktaAssignment, types.V1, 0)
 	case types.OpPut:
 		return services.UnmarshalOktaAssignment(event.Item.Value,
+			services.WithResourceID(event.Item.ID),
+			services.WithExpires(event.Item.Expires),
+		)
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+func newIntegrationParser() *integrationParser {
+	return &integrationParser{
+		baseParser: newBaseParser(backend.Key(integrationsPrefix)),
+	}
+}
+
+type integrationParser struct {
+	baseParser
+}
+
+func (p *integrationParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		return resourceHeader(event, types.KindIntegration, types.V1, 0)
+	case types.OpPut:
+		return services.UnmarshalIntegration(event.Item.Value,
 			services.WithResourceID(event.Item.ID),
 			services.WithExpires(event.Item.Expires),
 		)

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -85,6 +85,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindOktaImportRule, RW()),
 					types.NewRule(types.KindOktaAssignment, RW()),
 					types.NewRule(types.KindLock, RW()),
+					types.NewRule(types.KindIntegration, append(RW(), types.VerbUse)),
 					// Please see defaultAllowRules when adding a new rule.
 				},
 			},
@@ -209,6 +210,7 @@ func defaultAllowRules() map[string][]types.Rule {
 			types.NewRule(types.KindOktaAssignment, RW()),
 			types.NewRule(types.KindDevice, append(RW(), types.VerbCreateEnrollToken, types.VerbEnroll)),
 			types.NewRule(types.KindLock, RW()),
+			types.NewRule(types.KindIntegration, append(RW(), types.VerbUse)),
 		},
 	}
 }

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -193,6 +193,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindOktaImportRule, nil
 	case types.KindOktaAssignment, types.KindOktaAssignment + "s", "oktaassignment", "oktaassignments":
 		return types.KindOktaAssignment, nil
+	case types.KindIntegration, types.KindIntegration + "s":
+		return types.KindIntegration, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/lib/services/services.go
+++ b/lib/services/services.go
@@ -43,6 +43,7 @@ type Services interface {
 	WindowsDesktops
 	SAMLIdPServiceProviders
 	UserGroups
+	Integrations
 
 	OktaClient() Okta
 }

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -703,6 +703,13 @@ func (h *Handler) bindDefaultEndpoints() {
 	// Diagnose a Connection
 	h.POST("/webapi/sites/:site/diagnostics/connections", h.WithClusterAuth(h.diagnoseConnection))
 
+	// Integrations CRUD
+	h.GET("/webapi/sites/:site/integrations", h.WithClusterAuth(h.integrationsList))
+	h.POST("/webapi/sites/:site/integrations", h.WithClusterAuth(h.integrationsCreate))
+	h.GET("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsGet))
+	h.PUT("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsUpdate))
+	h.DELETE("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsDelete))
+
 	// Connection upgrades.
 	h.GET("/webapi/connectionupgrade", httplib.MakeHandler(h.connectionUpgrade))
 

--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package web
+
+import (
+	"net/http"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/web/ui"
+)
+
+// integrationsCreate creates an Integration
+func (h *Handler) integrationsCreate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	var req *ui.Integration
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var ig *types.IntegrationV1
+	var err error
+
+	switch req.SubKind {
+	case types.IntegrationSubKindAWSOIDC:
+		ig, err = types.NewIntegrationAWSOIDC(
+			types.Metadata{Name: req.Name},
+			&types.AWSOIDCIntegrationSpecV1{
+				RoleARN: req.AWSOIDC.RoleARN,
+			},
+		)
+
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+	default:
+		return nil, trace.BadParameter("subkind %q is not supported", req.SubKind)
+	}
+
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	storedIntegration, err := clt.CreateIntegration(r.Context(), ig)
+	if err != nil {
+		if trace.IsAlreadyExists(err) {
+			return nil, trace.AlreadyExists("failed to create Integration (%q already exists), please use another name", req.Name)
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.MakeIntegration(storedIntegration), nil
+}
+
+// integrationsUpdate updates the Integration based on its name
+func (h *Handler) integrationsUpdate(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	integrationName := p.ByName("name")
+	if integrationName == "" {
+		return nil, trace.BadParameter("an integration name is required")
+	}
+
+	var req *ui.UpdateIntegrationRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	integration, err := clt.GetIntegration(r.Context(), integrationName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if req.AWSOIDC != nil {
+		if integration.GetSubKind() != types.IntegrationSubKindAWSOIDC {
+			return nil, trace.BadParameter("cannot update %q fields for a %q integration", types.IntegrationSubKindAWSOIDC, integration.GetSubKind())
+		}
+
+		spec := integration.GetAWSOIDCIntegrationSpec()
+		spec.RoleARN = req.AWSOIDC.RoleARN
+		integration.SetAWSOIDCIntegrationSpec(spec)
+	}
+
+	if _, err := clt.UpdateIntegration(r.Context(), integration); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.MakeIntegration(integration), nil
+}
+
+// integrationsDelete removes an Integration based on its name
+func (h *Handler) integrationsDelete(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	integrationName := p.ByName("name")
+	if integrationName == "" {
+		return nil, trace.BadParameter("an integration name is required")
+	}
+
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := clt.DeleteIntegration(r.Context(), integrationName); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return nil, nil
+}
+
+// integrationsGet returns an Integration based on its name
+func (h *Handler) integrationsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	integrationName := p.ByName("name")
+	if integrationName == "" {
+		return nil, trace.BadParameter("an integration name is required")
+	}
+
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ig, err := clt.GetIntegration(r.Context(), integrationName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.MakeIntegration(ig), nil
+}
+
+// integrationsList returns a page of Integrations
+func (h *Handler) integrationsList(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	values := r.URL.Query()
+	limit, err := queryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	startKey := values.Get("startKey")
+
+	igs, nextKey, err := clt.ListIntegrations(r.Context(), int(limit), startKey)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.IntegrationsListResponse{
+		Items:   ui.MakeIntegrations(igs),
+		NextKey: nextKey,
+	}, nil
+}

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ui
+
+import (
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// IntegrationAWSOIDCSpec contain the specific fields for the `aws-oidc` subkind integration.
+type IntegrationAWSOIDCSpec struct {
+	// RoleARN is the role associated with the integration when SubKind is `aws-oidc`
+	RoleARN string `json:"roleARN,omitempty"`
+}
+
+// Integration describes the base Integration fields (can be read or wri) Integration
+type Integration struct {
+	// Name is the Integration name.
+	Name string `json:"name"`
+	// SubKind is the Integration SubKind.
+	SubKind string `json:"subKind"`
+	// AWSOIDC contains the fields for `aws-oidc` subkind integration.
+	AWSOIDC *IntegrationAWSOIDCSpec `json:"awsOIDC"`
+}
+
+// CheckAndSetDefaults for the create request.
+// Name and SubKind is required.
+func (r *Integration) CheckAndSetDefaults() error {
+	if r.Name == "" {
+		return trace.BadParameter("missing integration name")
+	}
+
+	if r.SubKind == "" {
+		return trace.BadParameter("missing subKind")
+	}
+
+	if r.AWSOIDC != nil && r.AWSOIDC.RoleARN == "" {
+		return trace.BadParameter("missing awsOIDC.roleARN field")
+	}
+
+	return nil
+}
+
+// UpdateIntegrationRequest is a request to update an Integration
+type UpdateIntegrationRequest struct {
+	// AWSOIDC contains the fields for `aws-oidc` subkind integration.
+	AWSOIDC *IntegrationAWSOIDCSpec `json:"awsOIDC"`
+}
+
+// CheckAndSetDefaults checks if the provided values are valid.
+func (r *UpdateIntegrationRequest) CheckAndSetDefaults() error {
+	if r.AWSOIDC != nil && r.AWSOIDC.RoleARN == "" {
+		return trace.BadParameter("missing awsOIDC.roleARN field")
+	}
+
+	return nil
+}
+
+// IntegrationsListResponse contains a list of Integrations.
+// In case of exceeding the pagination limit (either via query param `limit` or the default 1000)
+// a `nextToken` is provided and should be used to obtain the next page (as a query param `startKey`)
+type IntegrationsListResponse struct {
+	// Items is a list of resources retrieved.
+	Items interface{} `json:"items"`
+	// NextKey is the position to resume listing events.
+	NextKey string `json:"nextKey"`
+}
+
+// MakeIntegrations creates a UI list of Integrations.
+func MakeIntegrations(igs []types.Integration) []Integration {
+	uiList := make([]Integration, 0, len(igs))
+
+	for _, ig := range igs {
+		uiList = append(uiList, MakeIntegration(ig))
+	}
+
+	return uiList
+}
+
+// MakeIntegration creates a UI Integration representation.
+func MakeIntegration(ig types.Integration) Integration {
+	return Integration{
+		Name:    ig.GetName(),
+		SubKind: ig.GetSubKind(),
+		AWSOIDC: &IntegrationAWSOIDCSpec{
+			RoleARN: ig.GetAWSOIDCIntegrationSpec().RoleARN,
+		},
+	}
+}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -951,6 +951,36 @@ func (c *installerCollection) writeText(w io.Writer) error {
 	return nil
 }
 
+type integrationCollection struct {
+	integrations []types.Integration
+}
+
+func (c *integrationCollection) resources() (r []types.Resource) {
+	for _, ig := range c.integrations {
+		r = append(r, ig)
+	}
+	return r
+}
+func (c *integrationCollection) writeText(w io.Writer) error {
+	sort.Sort(types.Integrations(c.integrations))
+	var rows [][]string
+	for _, ig := range c.integrations {
+		specProps := []string{}
+		switch ig.GetSubKind() {
+		case types.IntegrationSubKindAWSOIDC:
+			specProps = append(specProps, fmt.Sprintf("RoleARN=%s", ig.GetAWSOIDCIntegrationSpec().RoleARN))
+		}
+
+		rows = append(rows, []string{
+			ig.GetName(), ig.GetSubKind(), strings.Join(specProps, ","),
+		})
+	}
+	headers := []string{"Name", "SubKind", "Spec"}
+	t := asciitable.MakeTable(headers, rows...)
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
 type databaseServiceCollection struct {
 	databaseServices []types.DatabaseService
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -123,6 +123,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *servicec
 		types.KindSAMLIdPServiceProvider:  rc.createSAMLIdPServiceProvider,
 		types.KindDevice:                  rc.createDevice,
 		types.KindOktaImportRule:          rc.createOktaImportRule,
+		types.KindIntegration:             rc.createIntegration,
 	}
 	rc.config = config
 
@@ -847,6 +848,51 @@ func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client auth
 	return nil
 }
 
+func (rc *ResourceCommand) createIntegration(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+	integration, err := services.UnmarshalIntegration(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	existingIntegration, err := client.GetIntegration(ctx, integration.GetName())
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	exists := (err == nil)
+
+	if exists {
+		if !rc.force {
+			return trace.AlreadyExists("Integration %q already exists", integration.GetName())
+		}
+
+		switch integration.GetSubKind() {
+		case types.IntegrationSubKindAWSOIDC:
+			existingIntegration.SetAWSOIDCIntegrationSpec(integration.GetAWSOIDCIntegrationSpec())
+
+		default:
+			return trace.BadParameter("subkind %q is not supported", integration.GetSubKind())
+		}
+
+		if _, err := client.UpdateIntegration(ctx, existingIntegration); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("Integration %q has been updated\n", integration.GetName())
+		return nil
+	}
+
+	igV1, ok := integration.(*types.IntegrationV1)
+	if !ok {
+		return trace.BadParameter("unexpected Integration type %T", integration)
+	}
+
+	if _, err := client.CreateIntegration(ctx, igV1); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Integration %q has been created\n", integration.GetName())
+
+	return nil
+}
+
 // Delete deletes resource by name
 func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err error) {
 	singletonResources := []string{
@@ -1100,6 +1146,12 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err
 			return trace.Wrap(err)
 		}
 		fmt.Printf("Device %q removed\n", rc.ref.Name)
+
+	case types.KindIntegration:
+		if err := client.DeleteIntegration(ctx, rc.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("Integration %q removed\n", rc.ref.Name)
 
 	case types.KindAppServer:
 		appServers, err := client.GetApplicationServers(ctx, rc.namespace)
@@ -1847,6 +1899,32 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 			}
 		}
 		return &userGroupCollection{userGroups: resources}, nil
+
+	case types.KindIntegration:
+		if rc.ref.Name != "" {
+			ig, err := client.GetIntegration(ctx, rc.ref.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &integrationCollection{integrations: []types.Integration{ig}}, nil
+		}
+
+		var resources []types.Integration
+		var igs []types.Integration
+		var err error
+		var nextKey string
+		for {
+			igs, nextKey, err = client.ListIntegrations(ctx, 0, nextKey)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			resources = append(resources, igs...)
+			if nextKey == "" {
+				break
+			}
+		}
+
+		return &integrationCollection{integrations: resources}, nil
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -320,6 +321,120 @@ func TestDatabaseServiceResource(t *testing.T) {
 	})
 }
 
+// TestIntegrationResource tests tctl integration commands.
+func TestIntegrationResource(t *testing.T) {
+	dynAddr := newDynamicServiceAddr(t)
+
+	ctx := context.Background()
+	fileConfig := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Proxy: config.Proxy{
+			Service: config.Service{
+				EnabledFlag: "true",
+			},
+			WebAddr: dynAddr.webAddr,
+			TunAddr: dynAddr.tunnelAddr,
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.authAddr,
+			},
+		},
+	}
+
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+
+	t.Run("get", func(t *testing.T) {
+
+		var out []types.IntegrationV1
+
+		// Add a lot of Integrations to test pagination
+		ig1, err := types.NewIntegrationAWSOIDC(
+			types.Metadata{Name: uuid.NewString()},
+			&types.AWSOIDCIntegrationSpecV1{
+				RoleARN: "arn:aws:iam::123456789012:role/OpsTeam",
+			},
+		)
+		require.NoError(t, err)
+
+		randomIntegrationName := ""
+		totalIntegrations := apidefaults.DefaultChunkSize*2 + 20 // testing partial pages
+		for i := 0; i < totalIntegrations; i++ {
+			ig1.SetName(uuid.NewString())
+			if i == apidefaults.DefaultChunkSize { // A "random" integration name
+				randomIntegrationName = ig1.GetName()
+			}
+			_, err = auth.GetAuthServer().CreateIntegration(ctx, ig1)
+			require.NoError(t, err)
+		}
+
+		t.Run("test pagination of integrations ", func(t *testing.T) {
+			buff, err := runResourceCommand(t, fileConfig, []string{"get", types.KindIntegration, "--format=json"})
+			require.NoError(t, err)
+			mustDecodeJSON(t, buff, &out)
+			require.Len(t, out, totalIntegrations)
+		})
+
+		igName := fmt.Sprintf("%v/%v", types.KindIntegration, randomIntegrationName)
+
+		t.Run("get specific integration", func(t *testing.T) {
+			buff, err := runResourceCommand(t, fileConfig, []string{"get", igName, "--format=json"})
+			require.NoError(t, err)
+			mustDecodeJSON(t, buff, &out)
+			require.Len(t, out, 1)
+			require.Equal(t, randomIntegrationName, out[0].GetName())
+		})
+
+		t.Run("get unknown integration", func(t *testing.T) {
+			unknownIntegration := fmt.Sprintf("%v/%v", types.KindIntegration, "unknown")
+			_, err := runResourceCommand(t, fileConfig, []string{"get", unknownIntegration, "--format=json"})
+			require.True(t, trace.IsNotFound(err), "expected a NotFound error, got %v", err)
+		})
+
+		t.Run("get specific integration with human output", func(t *testing.T) {
+			buff, err := runResourceCommand(t, fileConfig, []string{"get", igName, "--format=text"})
+			require.NoError(t, err)
+			outputString := buff.String()
+			require.Contains(t, outputString, "RoleARN=arn:aws:iam::123456789012:role/OpsTeam")
+			require.Contains(t, outputString, randomIntegrationName)
+		})
+	})
+
+	t.Run("create", func(t *testing.T) {
+		integrationYAMLPath := filepath.Join(t.TempDir(), "integration.yaml")
+		require.NoError(t, os.WriteFile(integrationYAMLPath, []byte(integrationYAML), 0644))
+		_, err := runResourceCommand(t, fileConfig, []string{"create", integrationYAMLPath})
+		require.NoError(t, err)
+
+		buff, err := runResourceCommand(t, fileConfig, []string{"get", "integration/myawsint", "--format=text"})
+		require.NoError(t, err)
+		outputString := buff.String()
+		require.Contains(t, outputString, "RoleARN=arn:aws:iam::123456789012:role/OpsTeam")
+		require.Contains(t, outputString, "myawsint")
+
+		// Update the RoleARN to another role
+		integrationYAMLV2 := strings.ReplaceAll(integrationYAML, "OpsTeam", "DevTeam")
+		require.NoError(t, os.WriteFile(integrationYAMLPath, []byte(integrationYAMLV2), 0644))
+
+		// Trying to create it again should return an error
+		_, err = runResourceCommand(t, fileConfig, []string{"create", integrationYAMLPath})
+		require.True(t, trace.IsAlreadyExists(err), "expected already exists error, got %v", err)
+
+		// Using the force should be ok and replace the current object
+		_, err = runResourceCommand(t, fileConfig, []string{"create", "--force", integrationYAMLPath})
+		require.NoError(t, err)
+
+		// The RoleARN must be updated
+		buff, err = runResourceCommand(t, fileConfig, []string{"get", "integration/myawsint", "--format=text"})
+		require.NoError(t, err)
+		outputString = buff.String()
+		require.Contains(t, outputString, "RoleARN=arn:aws:iam::123456789012:role/DevTeam")
+	})
+}
+
 // TestAppResource tests tctl commands that manage application resources.
 func TestAppResource(t *testing.T) {
 	dynAddr := newDynamicServiceAddr(t)
@@ -561,6 +676,17 @@ spec:
   target:
     user: "bad@actor"
   message: "Come see me"`
+
+	integrationYAML = `kind: integration
+sub_kind: aws-oidc
+version: v1
+metadata:
+  name: myawsint
+spec:
+  subkind_spec:
+    aws_oidc:
+      role_arn: "arn:aws:iam::123456789012:role/OpsTeam"
+`
 )
 
 func TestCreateClusterAuthPreference_WithSupportForSecondFactorWithoutQuotes(t *testing.T) {


### PR DESCRIPTION
This PR adds the Integration Resource.
This is the first development for this RFD.

Even though this PR is quite large, it only adds the Integration CRUD operations:
- gRPC methods to AuthService
- Proxy's webapi endpoints
- `tctl create` and `tctl get` operations

It also adds cache to the Auth Service.

Demo
WebAPI:
```
dinis@lenix ~> curl 'https://127.0.0.1.nip.io:3080/v1/webapi/sites/lenix/integrations --compressed -k | jq
{
  "items": [
    {
      "name": "myawsint",
      "subKind": "aws-oidc",
      "awsRoleARN": "arn:aws:iam::123456789012:role/DevTeam"
    }
  ],
  "nextKey": ""
}
```

`tctl`

```
dinis@lenix ~/p/integration-resource (master)> make bootstrap 
tctl create -f bootstrap-integration.yaml --config teleport.yaml
Integration "myawsint" has been created

dinis@lenix ~/p/integration-resource (master)> cat bootstrap-integration.yaml 
kind: integration
sub_kind: aws-oidc
version: v1
metadata:
  name: myawsint
spec:
  aws_role_arn: "arn:aws:iam::123456789012:role/DevTeam"

dinis@lenix ~/p/integration-resource (master)> make list/integrations 
tctl get integrations --config teleport.yaml --format text
Name     SubKind  Properties                                        
-------- -------- ------------------------------------------------- 
myawsint aws-oidc AWSRoleARN=arn:aws:iam::123456789012:role/DevTeam 

dinis@lenix ~/p/integration-resource (master)> make list/integration
tctl get integration/myawsint --config teleport.yaml --format text
Name     SubKind  Properties                                        
-------- -------- ------------------------------------------------- 
myawsint aws-oidc AWSRoleARN=arn:aws:iam::123456789012:role/DevTeam 
```