### PR TITLE
Drop local_auth/second_factor warning

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -668,13 +668,6 @@ func applyAuthConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		cfg.Auth.Preference.SetDisconnectExpiredCert(fc.Auth.DisconnectExpiredCert.Value)
 	}
 
-	if !cfg.Auth.Preference.GetAllowLocalAuth() && cfg.Auth.Preference.GetSecondFactor() != constants.SecondFactorOff {
-		warningMessage := "Second factor settings will have no affect because local " +
-			"authentication is disabled. Update file configuration and remove " +
-			"\"second_factor\" field to get rid of this error message."
-		log.Warnf(warningMessage)
-	}
-
 	// Set cluster audit configuration from file configuration.
 	auditConfigSpec, err := services.ClusterAuditConfigSpecFromObject(fc.Storage.Params)
 	if err != nil {


### PR DESCRIPTION
Drop warning about second_factor configured in clusters with local_auth:false.
This is a valid configuration for clusters with session MFA, regardless if their
authn method.