### PR TITLE
Create the auth server in the startup function.

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1815,13 +1815,12 @@ func (process *TeleportProcess) initAuthService() error {
 		if listener != nil {
 			warnOnErr(listener.Close(), log)
 		}
+		tlsServerMu.Lock()
 		if payload == nil {
 			log.Info("Shutting down immediately.")
-			tlsServerMu.Lock()
 			if tlsServer != nil {
 				warnOnErr(tlsServer.Close(), log)
 			}
-			tlsServerMu.Unlock()
 		} else {
 			log.Info("Shutting down immediately (auth service does not currently support graceful shutdown).")
 			// NOTE: Graceful shutdown of auth.TLSServer is disabled right now, because we don't
@@ -1832,6 +1831,7 @@ func (process *TeleportProcess) initAuthService() error {
 			// of the auth server basically never exits.
 			warnOnErr(tlsServer.Close(), log)
 		}
+		tlsServerMu.Unlock()
 		log.Info("Exited.")
 	})
 	return nil


### PR DESCRIPTION
In enterprise, the auth plugins require access to the backend. Currently, when the TLS server is created, auth plugins are registered prior to the `TeleportProcess` being returned from `service.NewTeleport`. This results in the auth plugins needing to lazily evaluate the getter for the `backend`, which subsequently makes an awakward interface for enterprise plugins that rely on backend storage.

This creates the TLS server in the first critical function for the auth server, which will be executed by `service.Run` after the `TeleportProcess` has been returned. This ensures that the backend is available when the enterprise auth plugins are registered, which will simplify enterprise auth plugin implementations.