### PR TITLE
Fix panic when `NewAuditWriter`  fails on moderated sessions

### DIFF
--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -683,12 +683,12 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 		Component:    teleport.Component(teleport.ComponentSession, teleport.ComponentProxyKube),
 		ClusterName:  s.forwarder.cfg.ClusterName,
 	})
-
-	s.recorder = recorder
-	s.emitter = recorder
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	s.recorder = recorder
+	s.emitter = recorder
 
 	s.io.AddWriter(sessionRecorderID, recorder)
 


### PR DESCRIPTION
An assignment before checking the error was replacing the default session event emitter - `DiscardEmitter` -  with a `nil` value which eventually panics when the caller function tries to close the session.
