### PR TITLE
Make the NodeWatcher more robust

### DIFF
--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -320,7 +320,7 @@ func (r *Router) getRemoteCluster(ctx context.Context, clusterName string, check
 // site is the minimum interface needed to match servers
 // for a reversetunnel.RemoteSite. It makes testing easier.
 type site interface {
-	GetNodes(fn func(n services.Node) bool) ([]types.Server, error)
+	GetNodes(ctx context.Context, fn func(n services.Node) bool) ([]types.Server, error)
 	GetClusterNetworkingConfig(ctx context.Context, opts ...services.MarshalOption) (types.ClusterNetworkingConfig, error)
 }
 
@@ -331,13 +331,13 @@ type remoteSite struct {
 }
 
 // GetNodes uses the wrapped sites NodeWatcher to filter nodes
-func (r remoteSite) GetNodes(fn func(n services.Node) bool) ([]types.Server, error) {
+func (r remoteSite) GetNodes(ctx context.Context, fn func(n services.Node) bool) ([]types.Server, error) {
 	watcher, err := r.site.NodeWatcher()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return watcher.GetNodes(fn), nil
+	return watcher.GetNodes(ctx, fn), nil
 }
 
 // GetClusterNetworkingConfig uses the wrapped sites cache to retrieve the ClusterNetworkingConfig
@@ -369,7 +369,7 @@ func getServer(ctx context.Context, host, port string, site site) (types.Server,
 	ips, _ := net.LookupHost(host)
 
 	var unambiguousIDMatch bool
-	matches, err := site.GetNodes(func(server services.Node) bool {
+	matches, err := site.GetNodes(ctx, func(server services.Node) bool {
 		if unambiguousIDMatch {
 			return false
 		}

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -40,7 +40,7 @@ func (t testSite) GetClusterNetworkingConfig(ctx context.Context, opts ...servic
 	return t.cfg, nil
 }
 
-func (t testSite) GetNodes(fn func(n services.Node) bool) ([]types.Server, error) {
+func (t testSite) GetNodes(ctx context.Context, fn func(n services.Node) bool) ([]types.Server, error) {
 	var out []types.Server
 	for _, s := range t.nodes {
 		if fn(s) {

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -811,7 +811,7 @@ func (s *localSite) periodicFunctions() {
 
 // sshTunnelStats reports SSH tunnel statistics for the cluster.
 func (s *localSite) sshTunnelStats() error {
-	missing := s.srv.NodeWatcher.GetNodes(func(server services.Node) bool {
+	missing := s.srv.NodeWatcher.GetNodes(s.srv.ctx, func(server services.Node) bool {
 		// Skip over any servers that have a TTL larger than announce TTL (10
 		// minutes) and are non-IoT SSH servers (they won't have tunnels).
 		//

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1142,10 +1142,12 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 	remoteSite.remoteAccessPoint = accessPoint
 	nodeWatcher, err := services.NewNodeWatcher(closeContext, services.NodeWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: srv.Component,
-			Client:    accessPoint,
-			Log:       srv.Log,
+			Component:    srv.Component,
+			Client:       accessPoint,
+			Log:          srv.Log,
+			MaxStaleness: time.Minute,
 		},
+		NodesGetter: accessPoint,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3409,11 +3409,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	nodeWatcher, err := services.NewNodeWatcher(process.ExitContext(), services.NodeWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: teleport.ComponentProxy,
-			Log:       process.log.WithField(trace.Component, teleport.ComponentProxy),
-			Client:    accessPoint,
+			Component:    teleport.ComponentProxy,
+			Log:          process.log.WithField(trace.Component, teleport.ComponentProxy),
+			Client:       accessPoint,
+			MaxStaleness: time.Minute,
 		},
-		NodesGetter: conn.Client,
+		NodesGetter: accessPoint,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1380,16 +1380,30 @@ func NewNodeWatcher(ctx context.Context, cfg NodeWatcherConfig) (*NodeWatcher, e
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	cache, err := utils.NewFnCache(utils.FnCacheConfig{
+		Context: ctx,
+		TTL:     3 * time.Second,
+		Clock:   cfg.Clock,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	collector := &nodeCollector{
 		NodeWatcherConfig: cfg,
 		current:           map[string]types.Server{},
 		initializationC:   make(chan struct{}),
+		cache:             cache,
+		stale:             true,
 	}
+
 	watcher, err := newResourceWatcher(ctx, collector, cfg.ResourceWatcherConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &NodeWatcher{watcher, collector}, nil
+
+	return &NodeWatcher{resourceWatcher: watcher, nodeCollector: collector}, nil
 }
 
 // NodeWatcher is built on top of resourceWatcher to monitor additions
@@ -1402,13 +1416,17 @@ type NodeWatcher struct {
 // nodeCollector accompanies resourceWatcher when monitoring nodes.
 type nodeCollector struct {
 	NodeWatcherConfig
-	// current holds a map of the currently known nodes (keyed by server name,
-	// RWMutex protected).
-	current map[string]types.Server
-	rw      sync.RWMutex
+
 	// initializationC is used to check whether the initial sync has completed
 	initializationC chan struct{}
 	once            sync.Once
+
+	cache *utils.FnCache
+
+	rw sync.RWMutex
+	// current holds a map of the currently known nodes keyed by server name
+	current map[string]types.Server
+	stale   bool
 }
 
 // Node is a readonly subset of the types.Server interface which
@@ -1440,7 +1458,10 @@ type Node interface {
 // returned servers are a copy and can be safely modified. It is intentionally hard to retrieve
 // the full set of nodes to reduce the number of copies needed since the number of nodes can get
 // quite large and doing so can be expensive.
-func (n *nodeCollector) GetNodes(fn func(n Node) bool) []types.Server {
+func (n *nodeCollector) GetNodes(ctx context.Context, fn func(n Node) bool) []types.Server {
+	// Attempt to freshen our data first.
+	n.refreshStaleNodes(ctx)
+
 	n.rw.RLock()
 	defer n.rw.RUnlock()
 
@@ -1452,6 +1473,42 @@ func (n *nodeCollector) GetNodes(fn func(n Node) bool) []types.Server {
 	}
 
 	return matched
+}
+
+// refreshStaleNodes attempts to reload nodes from the NodeGetter if
+// the collecter is stale. This ensures that no matter the health of
+// the collecter callers will be returned the most up to date node
+// set as possible.
+func (n *nodeCollector) refreshStaleNodes(ctx context.Context) error {
+	n.rw.RLock()
+	if !n.stale {
+		n.rw.RUnlock()
+		return nil
+	}
+	n.rw.RUnlock()
+
+	_, err := utils.FnCacheGet(ctx, n.cache, "nodes", func(ctx context.Context) (any, error) {
+		current, err := n.getNodes(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		n.rw.Lock()
+		defer n.rw.Unlock()
+
+		// There is a chance that the watcher reinitialized while
+		// getting nodes happened above. Check if we are still stale
+		// now that the lock is held to ensure that the refresh is
+		// still necessary.
+		if !n.stale {
+			return nil, nil
+		}
+
+		n.current = current
+		return nil, trace.Wrap(err)
+	})
+
+	return trace.Wrap(err)
 }
 
 func (n *nodeCollector) NodeCount() int {
@@ -1468,23 +1525,39 @@ func (n *nodeCollector) resourceKind() string {
 // getResourcesAndUpdateCurrent is called when the resources should be
 // (re-)fetched directly.
 func (n *nodeCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
-	nodes, err := n.NodesGetter.GetNodes(ctx, apidefaults.Namespace)
+	newCurrent, err := n.getNodes(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	defer n.defineCollectorAsInitialized()
 
-	if len(nodes) == 0 {
+	if len(newCurrent) == 0 {
 		return nil
 	}
-	newCurrent := make(map[string]types.Server, len(nodes))
-	for _, node := range nodes {
-		newCurrent[node.GetName()] = node
-	}
+
 	n.rw.Lock()
 	defer n.rw.Unlock()
 	n.current = newCurrent
+	n.stale = false
 	return nil
+}
+
+func (n *nodeCollector) getNodes(ctx context.Context) (map[string]types.Server, error) {
+	nodes, err := n.NodesGetter.GetNodes(ctx, apidefaults.Namespace)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if len(nodes) == 0 {
+		return map[string]types.Server{}, nil
+	}
+
+	current := make(map[string]types.Server, len(nodes))
+	for _, node := range nodes {
+		current[node.GetName()] = node
+	}
+
+	return current, nil
 }
 
 func (n *nodeCollector) defineCollectorAsInitialized() {
@@ -1501,19 +1574,21 @@ func (n *nodeCollector) processEventAndUpdateCurrent(ctx context.Context, event 
 		return
 	}
 
-	n.rw.Lock()
-	defer n.rw.Unlock()
-
 	switch event.Type {
 	case types.OpDelete:
+		n.rw.Lock()
 		delete(n.current, event.Resource.GetName())
+		n.rw.Unlock()
 	case types.OpPut:
 		server, ok := event.Resource.(types.Server)
 		if !ok {
 			n.Log.Warningf("Unexpected type %T.", event.Resource)
 			return
 		}
+
+		n.rw.Lock()
 		n.current[server.GetName()] = server
+		n.rw.Unlock()
 	default:
 		n.Log.Warningf("Skipping unsupported event type %s.", event.Type)
 	}
@@ -1523,7 +1598,11 @@ func (n *nodeCollector) initializationChan() <-chan struct{} {
 	return n.initializationC
 }
 
-func (n *nodeCollector) notifyStale() {}
+func (n *nodeCollector) notifyStale() {
+	n.rw.Lock()
+	defer n.rw.Unlock()
+	n.stale = true
+}
 
 // AccessRequestWatcherConfig is a AccessRequestWatcher configuration.
 type AccessRequestWatcherConfig struct {


### PR DESCRIPTION
Prior to the NodeWatcher being successfully initialized, or when it became stale any calls to `GetNodes` would return no data or stale data. This behavior results in the problems described in #22672.

The NodeWatcher will now fallback to pulling data from the cache in the event that it has no data or stale data when callers attempt to retrieve nodes. This should reduce the time that it takes the a new Proxy or a Proxy with intermittent connectivity issues to Auth be able to route to nodes.

The impact of this change should be noticeable in tests that create a Proxy and several Nodes and then immediately try to open a session on the Nodes.

Closes #22672