### PR TITLE
chore: Bump gci and golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -777,7 +777,7 @@ fix-imports/host:
 		echo 'gci is not installed or is missing from PATH, consider installing it ("go install github.com/daixiang0/gci@latest") or use "make -C build.assets/ fix-imports"';\
 		exit 1;\
 	fi
-	gci write -s 'standard,default,prefix(github.com/gravitational/teleport)' --skip-generated .
+	gci write -s standard -s default -s 'prefix(github.com/gravitational/teleport)' --skip-generated .
 
 .PHONY: lint-build-tooling
 lint-build-tooling: GO_LINT_FLAGS ?=

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -282,7 +282,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -279,7 +279,7 @@ ENV PROTO_INCLUDE "/usr/local/include":"/go/src":"/go/src/github.com/gogo/protob
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install GCI.
-RUN go install github.com/daixiang0/gci@v0.8.2
+RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1


### PR DESCRIPTION
Update gci to v0.9.1 and golangci-lint to v1.51.2.

* https://github.com/daixiang0/gci/releases/tag/v0.9.1
* https://github.com/golangci/golangci-lint/releases/tag/v1.51.2