### PR TITLE
Introduce the Okta service.

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -42,6 +42,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/gravitational/teleport/api/breaker"
+	"github.com/gravitational/teleport/api/client/okta"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
@@ -3278,8 +3279,8 @@ func (c *Client) DeleteLoginRule(ctx context.Context, name string) error {
 // Clients connecting older Teleport versions still get an okta client when
 // calling this method, but all RPCs will return "not implemented" errors (as per
 // the default gRPC behavior).
-func (c *Client) OktaClient() oktapb.OktaServiceClient {
-	return oktapb.NewOktaServiceClient(c.conn)
+func (c *Client) OktaClient() *okta.Client {
+	return okta.NewClient(oktapb.NewOktaServiceClient(c.conn))
 }
 
 // GetCertAuthority retrieves a CA by type and domain.

--- a/api/client/okta/okta.go
+++ b/api/client/okta/okta.go
@@ -1,0 +1,167 @@
+// Copyright 2023 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package okta
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"github.com/gravitational/trace/trail"
+
+	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// Client is an Okta client that conforms to the following lib/services interfaces:
+// * services.OktaImportRules
+// * services.OktaAssignments
+type Client struct {
+	grpcClient oktapb.OktaServiceClient
+}
+
+// NewClient creates a new Okta client.
+func NewClient(grpcClient oktapb.OktaServiceClient) *Client {
+	return &Client{
+		grpcClient: grpcClient,
+	}
+}
+
+// ListOktaImportRules returns a paginated list of all Okta import rule resources.
+func (c *Client) ListOktaImportRules(ctx context.Context, pageSize int, pageToken string) ([]types.OktaImportRule, string, error) {
+	resp, err := c.grpcClient.ListOktaImportRules(ctx, &oktapb.ListOktaImportRulesRequest{
+		PageSize:  int32(pageSize),
+		PageToken: pageToken,
+	})
+	if err != nil {
+		return nil, "", trail.FromGRPC(err)
+	}
+
+	importRules := make([]types.OktaImportRule, len(resp.ImportRules))
+	for i, importRule := range resp.ImportRules {
+		importRules[i] = importRule
+	}
+
+	return importRules, resp.NextPageToken, nil
+}
+
+// GetOktaImportRule returns the specified Okta import rule resources.
+func (c *Client) GetOktaImportRule(ctx context.Context, name string) (types.OktaImportRule, error) {
+	resp, err := c.grpcClient.GetOktaImportRule(ctx, &oktapb.GetOktaImportRuleRequest{
+		Name: name,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// CreateOktaImportRule creates a new Okta import rule resource.
+func (c *Client) CreateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) (types.OktaImportRule, error) {
+	importRuleV1, ok := importRule.(*types.OktaImportRuleV1)
+	if !ok {
+		return nil, trace.BadParameter("import rule expected to be OktaImportRuleV1, got %T", importRule)
+	}
+	resp, err := c.grpcClient.CreateOktaImportRule(ctx, &oktapb.CreateOktaImportRuleRequest{
+		ImportRule: importRuleV1,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// UpdateOktaImportRule updates an existing Okta import rule resource.
+func (c *Client) UpdateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) (types.OktaImportRule, error) {
+	importRuleV1, ok := importRule.(*types.OktaImportRuleV1)
+	if !ok {
+		return nil, trace.BadParameter("import rule expected to be OktaImportRuleV1, got %T", importRule)
+	}
+	resp, err := c.grpcClient.UpdateOktaImportRule(ctx, &oktapb.UpdateOktaImportRuleRequest{
+		ImportRule: importRuleV1,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// DeleteOktaImportRule removes the specified Okta import rule resource.
+func (c *Client) DeleteOktaImportRule(ctx context.Context, name string) error {
+	_, err := c.grpcClient.DeleteOktaImportRule(ctx, &oktapb.DeleteOktaImportRuleRequest{
+		Name: name,
+	})
+	return trail.FromGRPC(err)
+}
+
+// DeleteAllOktaImportRules removes all Okta import rules.
+func (c *Client) DeleteAllOktaImportRules(ctx context.Context) error {
+	_, err := c.grpcClient.DeleteAllOktaImportRules(ctx, &oktapb.DeleteAllOktaImportRulesRequest{})
+	return trail.FromGRPC(err)
+}
+
+// ListOktaAssignments returns a paginated list of all Okta assignment resources.
+func (c *Client) ListOktaAssignments(ctx context.Context, pageSize int, pageToken string) ([]types.OktaAssignment, string, error) {
+	resp, err := c.grpcClient.ListOktaAssignments(ctx, &oktapb.ListOktaAssignmentsRequest{
+		PageSize:  int32(pageSize),
+		PageToken: pageToken,
+	})
+	if err != nil {
+		return nil, "", trail.FromGRPC(err)
+	}
+
+	assignments := make([]types.OktaAssignment, len(resp.Assignments))
+	for i, assignment := range resp.Assignments {
+		assignments[i] = assignment
+	}
+
+	return assignments, resp.NextPageToken, nil
+}
+
+// GetOktaAssignmentreturns the specified Okta assignment resources.
+func (c *Client) GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error) {
+	resp, err := c.grpcClient.GetOktaAssignment(ctx, &oktapb.GetOktaAssignmentRequest{
+		Name: name,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// CreateOktaAssignmentcreates a new Okta assignment resource.
+func (c *Client) CreateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
+	assignmentV1, ok := assignment.(*types.OktaAssignmentV1)
+	if !ok {
+		return nil, trace.BadParameter("import rule expected to be OktaAssignmentV1, got %T", assignment)
+	}
+	resp, err := c.grpcClient.CreateOktaAssignment(ctx, &oktapb.CreateOktaAssignmentRequest{
+		Assignment: assignmentV1,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// UpdateOktaAssignmentupdates an existing Okta assignment resource.
+func (c *Client) UpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
+	assignmentV1, ok := assignment.(*types.OktaAssignmentV1)
+	if !ok {
+		return nil, trace.BadParameter("import rule expected to be OktaAssignmentV1, got %T", assignment)
+	}
+	resp, err := c.grpcClient.UpdateOktaAssignment(ctx, &oktapb.UpdateOktaAssignmentRequest{
+		Assignment: assignmentV1,
+	})
+	return resp, trail.FromGRPC(err)
+}
+
+// DeleteOktaAssignmentremoves the specified Okta assignment resource.
+func (c *Client) DeleteOktaAssignment(ctx context.Context, name string) error {
+	_, err := c.grpcClient.DeleteOktaAssignment(ctx, &oktapb.DeleteOktaAssignmentRequest{
+		Name: name,
+	})
+	return trail.FromGRPC(err)
+}
+
+// DeleteAllOktaAssignments removes all Okta assignments.
+func (c *Client) DeleteAllOktaAssignments(ctx context.Context) error {
+	_, err := c.grpcClient.DeleteAllOktaAssignments(ctx, &oktapb.DeleteAllOktaAssignmentsRequest{})
+	return trail.FromGRPC(err)
+}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/okta"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -280,10 +281,9 @@ func (a *ServerWithRoles) LoginRuleClient() loginrulepb.LoginRuleServiceClient {
 // OktaClient allows ServerWithRoles to implement ClientI.
 // It should not be called through ServerWithRoles,
 // as it returns a dummy client that will always respond with "not implemented".
-func (a *ServerWithRoles) OktaClient() oktapb.OktaServiceClient {
-	return oktapb.NewOktaServiceClient(
-		utils.NewGRPCDummyClientConnection("OktaClient() should not be called on ServerWithRoles"),
-	)
+func (a *ServerWithRoles) OktaClient() *okta.Client {
+	return okta.NewClient(oktapb.NewOktaServiceClient(
+		utils.NewGRPCDummyClientConnection("OktaClient() should not be called on ServerWithRoles")))
 }
 
 // PluginsClient allows ServerWithRoles to implement ClientI.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -34,12 +34,12 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/okta"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
-	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
 	pluginspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
 	samlidppb "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
 	tracehttp "github.com/gravitational/teleport/api/observability/tracing/http"
@@ -1740,5 +1740,5 @@ type ClientI interface {
 	// Clients connecting to non-Enterprise clusters, or older Teleport versions,
 	// still get an Okta client when calling this method, but all RPCs will return
 	// "not implemented" errors (as per the default gRPC behavior).
-	OktaClient() oktapb.OktaServiceClient
+	OktaClient() *okta.Client
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -44,13 +44,14 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/types/wrappers"
-	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/okta"
 	"github.com/gravitational/teleport/lib/auth/trust/trustv1"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 	"github.com/gravitational/teleport/lib/authz"
@@ -4979,6 +4980,9 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 			},
 		),
 	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	authServer := &GRPCServer{
 		APIConfig: cfg.APIConfig,
 		Entry: logrus.WithFields(logrus.Fields{
@@ -5007,6 +5011,15 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	}
 	joinServiceServer := joinserver.NewJoinServiceGRPCServer(serverWithNopRole)
 	proto.RegisterJoinServiceServer(server, joinServiceServer)
+
+	oktaServiceServer, err := okta.NewService(okta.ServiceConfig{
+		Backend:    cfg.AuthServer.bk,
+		Authorizer: cfg.Authorizer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	oktapb.RegisterOktaServiceServer(server, oktaServiceServer)
 
 	return authServer, nil
 }
@@ -5046,25 +5059,7 @@ func (g *GRPCServer) authenticate(ctx context.Context) (*grpcContext, error) {
 	// HTTPS server expects auth context to be set by the auth middleware
 	authContext, err := g.Authorizer.Authorize(ctx)
 	if err != nil {
-		switch {
-		// propagate connection problem error so we can differentiate
-		// between connection failed and access denied
-		case trace.IsConnectionProblem(err):
-			return nil, trace.ConnectionProblem(err, "[10] failed to connect to the database")
-		case trace.IsNotFound(err):
-			// user not found, wrap error with access denied
-			return nil, trace.Wrap(err, "[10] access denied")
-		case trace.IsAccessDenied(err):
-			// don't print stack trace, just log the warning
-			log.Warn(err)
-		case keys.IsPrivateKeyPolicyError(err):
-			// private key policy errors should be returned to the client
-			// unaltered so that they know to reauthenticate with a valid key.
-			return nil, trace.Unwrap(err)
-		default:
-			log.Warn(trace.DebugReport(err))
-		}
-		return nil, trace.AccessDenied("[10] access denied")
+		return nil, authz.ConvertAuthorizerError(ctx, g.Logger, err)
 	}
 	return &grpcContext{
 		Context: authContext,

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -3296,6 +3296,7 @@ func TestExport(t *testing.T) {
 			// Setup the server
 			if tt.authorizer != nil {
 				srv.TLSServer.grpcServer.Authorizer = tt.authorizer
+				require.NoError(t, err)
 			}
 
 			// Get a client for the test identity

--- a/lib/auth/okta/service.go
+++ b/lib/auth/okta/service.go
@@ -1,0 +1,302 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package okta
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+// ServiceConfig is the service config for the Okta gRPC service.
+type ServiceConfig struct {
+	// Backend is the backend to use.
+	Backend backend.Backend
+
+	// Logger is the logger to use.
+	Logger logrus.FieldLogger
+
+	// Authorizer is the authorizer to use.
+	Authorizer authz.Authorizer
+
+	// OktaImportRules is the Okta import rules service to use.
+	OktaImportRules services.OktaImportRules
+
+	// OktaAssignments is the Okta assignments service to use.
+	OktaAssignments services.OktaAssignments
+}
+
+func (c *ServiceConfig) CheckAndSetDefaults() error {
+	if c.Backend == nil {
+		return trace.BadParameter("backend is missing")
+	}
+
+	if c.Logger == nil {
+		c.Logger = logrus.New().WithField(trace.Component, "okta_crud_service")
+	}
+
+	if c.Authorizer == nil {
+		return trace.BadParameter("authorizer is missing")
+	}
+
+	var err error
+	var oktaSvc *local.OktaService
+	if c.OktaImportRules == nil || c.OktaAssignments == nil {
+		oktaSvc, err = local.NewOktaService(c.Backend)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	if c.OktaImportRules == nil {
+		c.OktaImportRules = oktaSvc
+	}
+
+	if c.OktaAssignments == nil {
+		c.OktaAssignments = oktaSvc
+	}
+
+	return nil
+}
+
+var _ oktapb.OktaServiceServer = (*Service)(nil)
+
+type Service struct {
+	oktapb.UnimplementedOktaServiceServer
+
+	log             logrus.FieldLogger
+	authorizer      authz.Authorizer
+	oktaImportRules services.OktaImportRules
+	oktaAssignments services.OktaAssignments
+}
+
+// NewService creates a new Okta gRPC service.
+func NewService(cfg ServiceConfig) (*Service, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &Service{
+		log:             cfg.Logger,
+		authorizer:      cfg.Authorizer,
+		oktaImportRules: cfg.OktaImportRules,
+		oktaAssignments: cfg.OktaAssignments,
+	}, nil
+}
+
+// ListOktaImportRules returns a paginated list of all Okta import rule resources.
+func (s *Service) ListOktaImportRules(ctx context.Context, req *oktapb.ListOktaImportRulesRequest) (*oktapb.ListOktaImportRulesResponse, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbRead, types.VerbList)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	results, nextPageToken, err := s.oktaImportRules.ListOktaImportRules(ctx, int(req.GetPageSize()), req.GetPageToken())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	importRulesV1 := make([]*types.OktaImportRuleV1, len(results))
+	for i, r := range results {
+		v1, ok := r.(*types.OktaImportRuleV1)
+		if !ok {
+			return nil, trace.BadParameter("unexpected Okta import rule type %T", r)
+		}
+		importRulesV1[i] = v1
+	}
+
+	return &oktapb.ListOktaImportRulesResponse{
+		ImportRules:   importRulesV1,
+		NextPageToken: nextPageToken,
+	}, nil
+}
+
+// GetOktaImportRule returns the specified Okta import rule resources.
+func (s *Service) GetOktaImportRule(ctx context.Context, req *oktapb.GetOktaImportRuleRequest) (*types.OktaImportRuleV1, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbRead)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	importRule, err := s.oktaImportRules.GetOktaImportRule(ctx, req.GetName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	importRuleV1, ok := importRule.(*types.OktaImportRuleV1)
+	if !ok {
+		return nil, trace.BadParameter("unexpected Okta import rule type %T", importRule)
+	}
+
+	return importRuleV1, nil
+}
+
+// CreateOktaImportRule creates a new Okta import rule resource.
+func (s *Service) CreateOktaImportRule(ctx context.Context, req *oktapb.CreateOktaImportRuleRequest) (*types.OktaImportRuleV1, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbCreate)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	returnedRule, err := s.oktaImportRules.CreateOktaImportRule(ctx, req.GetImportRule())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	returnedRuleV1, ok := returnedRule.(*types.OktaImportRuleV1)
+	if !ok {
+		return nil, trace.BadParameter("expected returned import rule of OktaImportRuleV1, got %T", returnedRuleV1)
+	}
+	return returnedRuleV1, trace.Wrap(err)
+}
+
+// UpdateOktaImportRule updates an existing Okta import rule resource.
+func (s *Service) UpdateOktaImportRule(ctx context.Context, req *oktapb.UpdateOktaImportRuleRequest) (*types.OktaImportRuleV1, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbUpdate)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	returnedRule, err := s.oktaImportRules.UpdateOktaImportRule(ctx, req.GetImportRule())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	returnedRuleV1, ok := returnedRule.(*types.OktaImportRuleV1)
+	if !ok {
+		return nil, trace.BadParameter("expected returned import rule of OktaImportRuleV1, got %T", returnedRuleV1)
+	}
+	return returnedRuleV1, trace.Wrap(err)
+}
+
+// DeleteOktaImportRule removes the specified Okta import rule resource.
+func (s *Service) DeleteOktaImportRule(ctx context.Context, req *oktapb.DeleteOktaImportRuleRequest) (*emptypb.Empty, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbDelete)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &emptypb.Empty{}, trace.Wrap(s.oktaImportRules.DeleteOktaImportRule(ctx, req.GetName()))
+}
+
+// DeleteAllOktaImportRules removes all Okta import rules.
+func (s *Service) DeleteAllOktaImportRules(ctx context.Context, _ *oktapb.DeleteAllOktaImportRulesRequest) (*emptypb.Empty, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaImportRule, types.VerbDelete)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &emptypb.Empty{}, trace.Wrap(s.oktaImportRules.DeleteAllOktaImportRules(ctx))
+}
+
+// ListOktaAssignments returns a paginated list of all Okta assignment resources.
+func (s *Service) ListOktaAssignments(ctx context.Context, req *oktapb.ListOktaAssignmentsRequest) (*oktapb.ListOktaAssignmentsResponse, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbList, types.VerbRead)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	results, nextPageToken, err := s.oktaAssignments.ListOktaAssignments(ctx, int(req.GetPageSize()), req.GetPageToken())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	assignmentsV1 := make([]*types.OktaAssignmentV1, len(results))
+	for i, a := range results {
+		v1, ok := a.(*types.OktaAssignmentV1)
+		if !ok {
+			return nil, trace.BadParameter("unexpected Okta assignment type %T", a)
+		}
+		assignmentsV1[i] = v1
+	}
+
+	return &oktapb.ListOktaAssignmentsResponse{
+		Assignments:   assignmentsV1,
+		NextPageToken: nextPageToken,
+	}, nil
+}
+
+// GetOktaAssignment returns the specified Okta assignment resources.
+func (s *Service) GetOktaAssignment(ctx context.Context, req *oktapb.GetOktaAssignmentRequest) (*types.OktaAssignmentV1, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbRead)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	assignment, err := s.oktaAssignments.GetOktaAssignment(ctx, req.GetName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	assignmentV1, ok := assignment.(*types.OktaAssignmentV1)
+	if !ok {
+		return nil, trace.BadParameter("unexpected Okta assignment type %T", assignment)
+	}
+
+	return assignmentV1, nil
+}
+
+// CreateOktaAssignment creates a new Okta assignment resource.
+func (s *Service) CreateOktaAssignment(ctx context.Context, req *oktapb.CreateOktaAssignmentRequest) (*types.OktaAssignmentV1, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbCreate)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	returnedAssignment, err := s.oktaAssignments.CreateOktaAssignment(ctx, req.GetAssignment())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	returnedAssignmentV1, ok := returnedAssignment.(*types.OktaAssignmentV1)
+	if !ok {
+		return nil, trace.BadParameter("expected returned import rule of OktaAssignmentV1, got %T", returnedAssignmentV1)
+	}
+	return returnedAssignmentV1, trace.Wrap(err)
+}
+
+// UpdateOktaAssignment updates an existing Okta assignment resource.
+func (s *Service) UpdateOktaAssignment(ctx context.Context, req *oktapb.UpdateOktaAssignmentRequest) (*types.OktaAssignmentV1, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbUpdate)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	returnedAssignment, err := s.oktaAssignments.UpdateOktaAssignment(ctx, req.GetAssignment())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	returnedAssignmentV1, ok := returnedAssignment.(*types.OktaAssignmentV1)
+	if !ok {
+		return nil, trace.BadParameter("expected returned import rule of OktaAssignmentV1, got %T", returnedAssignmentV1)
+	}
+	return returnedAssignmentV1, trace.Wrap(err)
+}
+
+// DeleteOktaAssignment removes the specified Okta assignment resource.
+func (s *Service) DeleteOktaAssignment(ctx context.Context, req *oktapb.DeleteOktaAssignmentRequest) (*emptypb.Empty, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbDelete)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &emptypb.Empty{}, trace.Wrap(s.oktaAssignments.DeleteOktaAssignment(ctx, req.GetName()))
+}
+
+// DeleteAllOktaAssignments removes all Okta assignments.
+func (s *Service) DeleteAllOktaAssignments(ctx context.Context, _ *oktapb.DeleteAllOktaAssignmentsRequest) (*emptypb.Empty, error) {
+	_, err := authz.AuthorizeWithVerbs(ctx, s.log, s.authorizer, true, types.KindOktaAssignment, types.VerbDelete)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &emptypb.Empty{}, trace.Wrap(s.oktaAssignments.DeleteAllOktaAssignments(ctx))
+}

--- a/lib/auth/okta/service_test.go
+++ b/lib/auth/okta/service_test.go
@@ -1,0 +1,297 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package okta
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+
+	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestOktaImportRules(t *testing.T) {
+	ctx, svc := initSvc(t, types.KindOktaImportRule)
+
+	listResp, err := svc.ListOktaImportRules(ctx, &oktapb.ListOktaImportRulesRequest{})
+	require.NoError(t, err)
+	require.Empty(t, listResp.NextPageToken)
+	require.Empty(t, listResp.ImportRules)
+
+	r1 := newOktaImportRule(t, "1")
+	r2 := newOktaImportRule(t, "2")
+	r3 := newOktaImportRule(t, "3")
+
+	createResp, err := svc.CreateOktaImportRule(ctx, &oktapb.CreateOktaImportRuleRequest{ImportRule: r1})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(r1, createResp))
+
+	createResp, err = svc.CreateOktaImportRule(ctx, &oktapb.CreateOktaImportRuleRequest{ImportRule: r2})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(r2, createResp))
+
+	createResp, err = svc.CreateOktaImportRule(ctx, &oktapb.CreateOktaImportRuleRequest{ImportRule: r3})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(r3, createResp))
+
+	listResp, err = svc.ListOktaImportRules(ctx, &oktapb.ListOktaImportRulesRequest{})
+	require.NoError(t, err)
+	require.Empty(t, listResp.NextPageToken)
+	require.Empty(t, cmp.Diff([]*types.OktaImportRuleV1{r1, r2, r3}, listResp.ImportRules,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID")))
+
+	r1.SetExpiry(time.Now().Add(30 * time.Minute))
+	updateResp, err := svc.UpdateOktaImportRule(ctx, &oktapb.UpdateOktaImportRuleRequest{ImportRule: r1})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(r1, updateResp))
+
+	r, err := svc.GetOktaImportRule(ctx, &oktapb.GetOktaImportRuleRequest{Name: r1.GetName()})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(r1, r,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID")))
+
+	_, err = svc.DeleteOktaImportRule(ctx, &oktapb.DeleteOktaImportRuleRequest{Name: r1.GetName()})
+	require.NoError(t, err)
+
+	listResp, err = svc.ListOktaImportRules(ctx, &oktapb.ListOktaImportRulesRequest{})
+	require.NoError(t, err)
+	require.Empty(t, listResp.NextPageToken)
+	require.Empty(t, cmp.Diff([]*types.OktaImportRuleV1{r2, r3}, listResp.ImportRules,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID")))
+
+	_, err = svc.DeleteAllOktaImportRules(ctx, &oktapb.DeleteAllOktaImportRulesRequest{})
+	require.NoError(t, err)
+
+	listResp, err = svc.ListOktaImportRules(ctx, &oktapb.ListOktaImportRulesRequest{})
+	require.NoError(t, err)
+	require.Empty(t, listResp.NextPageToken)
+	require.Empty(t, listResp.ImportRules)
+}
+
+func TestOktaAssignments(t *testing.T) {
+	ctx, svc := initSvc(t, types.KindOktaAssignment)
+
+	listResp, err := svc.ListOktaAssignments(ctx, &oktapb.ListOktaAssignmentsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, listResp.NextPageToken)
+	require.Empty(t, listResp.Assignments)
+
+	a1 := newOktaAssignment(t, "1")
+	a2 := newOktaAssignment(t, "2")
+	a3 := newOktaAssignment(t, "3")
+
+	createResp, err := svc.CreateOktaAssignment(ctx, &oktapb.CreateOktaAssignmentRequest{Assignment: a1})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(a1, createResp))
+
+	createResp, err = svc.CreateOktaAssignment(ctx, &oktapb.CreateOktaAssignmentRequest{Assignment: a2})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(a2, createResp))
+
+	createResp, err = svc.CreateOktaAssignment(ctx, &oktapb.CreateOktaAssignmentRequest{Assignment: a3})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(a3, createResp))
+
+	listResp, err = svc.ListOktaAssignments(ctx, &oktapb.ListOktaAssignmentsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, listResp.NextPageToken)
+	require.Empty(t, cmp.Diff([]*types.OktaAssignmentV1{a1, a2, a3}, listResp.Assignments,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID")))
+
+	a1.SetExpiry(time.Now().Add(30 * time.Minute))
+	updateResp, err := svc.UpdateOktaAssignment(ctx, &oktapb.UpdateOktaAssignmentRequest{Assignment: a1})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(a1, updateResp))
+
+	a, err := svc.GetOktaAssignment(ctx, &oktapb.GetOktaAssignmentRequest{Name: a1.GetName()})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(a1, a,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID")))
+
+	_, err = svc.DeleteOktaAssignment(ctx, &oktapb.DeleteOktaAssignmentRequest{Name: a1.GetName()})
+	require.NoError(t, err)
+
+	listResp, err = svc.ListOktaAssignments(ctx, &oktapb.ListOktaAssignmentsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, listResp.NextPageToken)
+	require.Empty(t, cmp.Diff([]*types.OktaAssignmentV1{a2, a3}, listResp.Assignments,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID")))
+
+	_, err = svc.DeleteAllOktaAssignments(ctx, &oktapb.DeleteAllOktaAssignmentsRequest{})
+	require.NoError(t, err)
+
+	listResp, err = svc.ListOktaAssignments(ctx, &oktapb.ListOktaAssignmentsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, listResp.NextPageToken)
+	require.Empty(t, listResp.Assignments)
+}
+
+func initSvc(t *testing.T, kind string) (context.Context, *Service) {
+	ctx := context.Background()
+	backend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	clusterConfigSvc, err := local.NewClusterConfigurationService(backend)
+	require.NoError(t, err)
+	trustSvc := local.NewCAService(backend)
+	roleSvc := local.NewAccessService(backend)
+	userSvc := local.NewIdentityService(backend)
+
+	require.NoError(t, clusterConfigSvc.SetAuthPreference(ctx, types.DefaultAuthPreference()))
+	require.NoError(t, clusterConfigSvc.SetClusterAuditConfig(ctx, types.DefaultClusterAuditConfig()))
+	require.NoError(t, clusterConfigSvc.SetClusterNetworkingConfig(ctx, types.DefaultClusterNetworkingConfig()))
+	require.NoError(t, clusterConfigSvc.SetSessionRecordingConfig(ctx, types.DefaultSessionRecordingConfig()))
+
+	accessPoint := struct {
+		services.ClusterConfiguration
+		services.Trust
+		services.RoleGetter
+		services.UserGetter
+	}{
+		ClusterConfiguration: clusterConfigSvc,
+		Trust:                trustSvc,
+		RoleGetter:           roleSvc,
+		UserGetter:           userSvc,
+	}
+
+	accessService := local.NewAccessService(backend)
+	eventService := local.NewEventsService(backend)
+	lockWatcher, err := services.NewLockWatcher(ctx, services.LockWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Client:    eventService,
+			Component: "test",
+		},
+		LockGetter: accessService,
+	})
+	require.NoError(t, err)
+
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
+		ClusterName: "test-cluster",
+		AccessPoint: accessPoint,
+		LockWatcher: lockWatcher,
+	})
+	require.NoError(t, err)
+
+	role, err := types.NewRole("import-rules", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{
+				{
+					Resources: []string{kind},
+					Verbs:     []string{types.VerbList, types.VerbRead, types.VerbUpdate, types.VerbCreate, types.VerbDelete},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	roleSvc.CreateRole(ctx, role)
+	require.NoError(t, err)
+
+	user, err := types.NewUser("test-user")
+	user.AddRole(role.GetName())
+	require.NoError(t, err)
+	userSvc.CreateUser(user)
+	require.NoError(t, err)
+
+	svc, err := NewService(ServiceConfig{
+		Backend:    backend,
+		Authorizer: authorizer,
+	})
+	require.NoError(t, err)
+
+	ctx = authz.ContextWithUser(ctx, authz.LocalUser{
+		Username: user.GetName(),
+		Identity: tlsca.Identity{
+			Username: user.GetName(),
+			Groups:   []string{role.GetName()},
+		},
+	})
+
+	return ctx, svc
+}
+
+func newOktaImportRule(t *testing.T, name string) *types.OktaImportRuleV1 {
+	importRule, err := types.NewOktaImportRule(
+		types.Metadata{
+			Name: name,
+		},
+		types.OktaImportRuleSpecV1{
+			Mappings: []*types.OktaImportRuleMappingV1{
+				{
+					Match: []*types.OktaImportRuleMatchV1{
+						{
+							AppIDs: []string{"yes"},
+						},
+					},
+					AddLabels: map[string]string{
+						"label1": "value1",
+					},
+				},
+				{
+					Match: []*types.OktaImportRuleMatchV1{
+						{
+							GroupIDs: []string{"yes"},
+						},
+					},
+					AddLabels: map[string]string{
+						"label1": "value1",
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	return importRule.(*types.OktaImportRuleV1)
+}
+
+func newOktaAssignment(t *testing.T, name string) *types.OktaAssignmentV1 {
+	assignment, err := types.NewOktaAssignment(
+		types.Metadata{
+			Name: name,
+		},
+		types.OktaAssignmentSpecV1{
+			User: "test-user@test.user",
+			Actions: []*types.OktaAssignmentActionV1{
+				{
+					Status: types.OktaAssignmentActionV1_PENDING,
+					Target: &types.OktaAssignmentActionTargetV1{
+						Type: types.OktaAssignmentActionTargetV1_APPLICATION,
+						Id:   "123456",
+					},
+				},
+				{
+					Status: types.OktaAssignmentActionV1_SUCCESSFUL,
+					Target: &types.OktaAssignmentActionTargetV1{
+						Type: types.OktaAssignmentActionTargetV1_GROUP,
+						Id:   "234567",
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	return assignment.(*types.OktaAssignmentV1)
+}

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -20,10 +20,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
-	"github.com/gravitational/teleport/api/defaults"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -69,11 +67,6 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 
 // GetCertAuthority retrieves the matching certificate authority.
 func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuthorityRequest) (*types.CertAuthorityV2, error) {
-	authorizer, err := s.authorize(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	readVerb := types.VerbReadNoSecrets
 	if req.IncludeKey {
 		readVerb = types.VerbRead
@@ -91,7 +84,8 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authorizer.action(ctx, contextCA, readVerb); err != nil {
+	_, err = authz.AuthorizeResourceWithVerbs(ctx, s.logger, s.authorizer, false, contextCA, readVerb)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -102,7 +96,8 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authorizer.action(ctx, ca, readVerb); err != nil {
+	_, err = authz.AuthorizeResourceWithVerbs(ctx, s.logger, s.authorizer, false, ca, readVerb)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -116,19 +111,15 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 
 // GetCertAuthorities retrieves the cert authorities with the specified type.
 func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAuthoritiesRequest) (*trustpb.GetCertAuthoritiesResponse, error) {
-	authorizer, err := s.authorize(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authorizer.action(ctx, nil, types.VerbList, types.VerbReadNoSecrets); err != nil {
-		return nil, trace.Wrap(err)
-	}
+	verbs := []string{types.VerbList, types.VerbReadNoSecrets}
 
 	if req.IncludeKey {
-		if err := authorizer.action(ctx, nil, types.VerbRead); err != nil {
-			return nil, trace.Wrap(err)
-		}
+		verbs = append(verbs, types.VerbRead)
+	}
+
+	_, err := authz.AuthorizeWithVerbs(ctx, s.logger, s.authorizer, false, types.KindCertAuthority, verbs...)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	cas, err := s.cache.GetCertAuthorities(ctx, types.CertAuthType(req.Type), req.IncludeKey)
@@ -148,57 +139,4 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 	}
 
 	return resp, nil
-}
-
-func (s *Service) authorize(ctx context.Context) (*authorizer, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
-	if err != nil {
-		switch {
-		// propagate connection problem errors, so we can differentiate
-		// between connection failed and access denied
-		case trace.IsConnectionProblem(err):
-			return nil, trace.ConnectionProblem(err, "failed to connect to the database")
-		case trace.IsNotFound(err):
-			// user not found, wrap error with access denied
-			return nil, trace.Wrap(err, "access denied")
-		case trace.IsAccessDenied(err):
-			// don't print stack trace, just log the warning
-			s.logger.Warn(err)
-		case keys.IsPrivateKeyPolicyError(err):
-			// private key policy errors should be returned to the client
-			// unaltered so that they know to reauthenticate with a valid key.
-			return nil, trace.Unwrap(err)
-		default:
-			s.logger.Warn(trace.DebugReport(err))
-		}
-
-		return nil, trace.AccessDenied("access denied")
-	}
-
-	return &authorizer{Context: authCtx}, nil
-}
-
-type authorizer struct {
-	*authz.Context
-}
-
-// authorize ensures the client has access to perform the requested
-// actions on the certificate on the provided certificate authority.
-func (a *authorizer) action(ctx context.Context, ca types.CertAuthority, verbs ...string) error {
-	ruleCtx := &services.Context{
-		User:     a.User,
-		Resource: ca,
-	}
-
-	var errs []error
-	for _, verb := range verbs {
-		errs = append(errs, a.Checker.CheckAccessToRule(ruleCtx, defaults.Namespace, types.KindCertAuthority, verb, false))
-	}
-
-	// Convert generic aggregate error to AccessDenied.
-	if err := trace.NewAggregate(errs...); err != nil {
-		return trace.AccessDenied(err.Error())
-	}
-
-	return nil
 }

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -25,12 +25,15 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"github.com/vulcand/predicate/builder"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/keys"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -965,6 +968,75 @@ func ClientUserMetadataWithUser(ctx context.Context, user string) apievents.User
 	meta := ClientUserMetadata(ctx)
 	meta.User = user
 	return meta
+}
+
+// ConvertAuthorizerError will take an authorizer error and convert it into an error easily
+// handled by gRPC services.
+func ConvertAuthorizerError(ctx context.Context, log logrus.FieldLogger, err error) error {
+	switch {
+	case err == nil:
+		return nil
+	// propagate connection problem error so we can differentiate
+	// between connection failed and access denied
+	case trace.IsConnectionProblem(err):
+		return trace.ConnectionProblem(err, "failed to connect to the database")
+	case trace.IsNotFound(err):
+		// user not found, wrap error with access denied
+		return trace.Wrap(err, "access denied")
+	case trace.IsAccessDenied(err):
+		// don't print stack trace, just log the warning
+		log.Warn(err)
+	case keys.IsPrivateKeyPolicyError(err):
+		// private key policy errors should be returned to the client
+		// unaltered so that they know to reauthenticate with a valid key.
+		return trace.Unwrap(err)
+	default:
+		log.Warn(trace.DebugReport(err))
+	}
+	return trace.AccessDenied("access denied")
+}
+
+// AuthorizeResourceWithVerbs will ensure that the user has access to the given verbs for the given kind.
+func AuthorizeResourceWithVerbs(ctx context.Context, log logrus.FieldLogger, authorizer Authorizer, quiet bool, resource types.Resource, verbs ...string) (*Context, error) {
+	authCtx, err := authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, ConvertAuthorizerError(ctx, log, err)
+	}
+
+	ruleCtx := &services.Context{
+		User:     authCtx.User,
+		Resource: resource,
+	}
+
+	return authorizeContextWithVerbs(ctx, log, authCtx, quiet, ruleCtx, resource.GetKind(), verbs...)
+}
+
+// AuthorizeWithVerbs will ensure that the user has access to the given verbs for the given kind.
+func AuthorizeWithVerbs(ctx context.Context, log logrus.FieldLogger, authorizer Authorizer, quiet bool, kind string, verbs ...string) (*Context, error) {
+	authCtx, err := authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, ConvertAuthorizerError(ctx, log, err)
+	}
+
+	ruleCtx := &services.Context{
+		User: authCtx.User,
+	}
+
+	return authorizeContextWithVerbs(ctx, log, authCtx, quiet, ruleCtx, kind, verbs...)
+}
+
+// authorizeContextWithVerbs will ensure that the user has access to the given verbs for the given services.context.
+func authorizeContextWithVerbs(ctx context.Context, log logrus.FieldLogger, authCtx *Context, quiet bool, ruleCtx *services.Context, kind string, verbs ...string) (*Context, error) {
+	errs := make([]error, len(verbs))
+	for i, verb := range verbs {
+		errs[i] = authCtx.Checker.CheckAccessToRule(ruleCtx, defaults.Namespace, kind, verb, quiet)
+	}
+
+	// Convert generic aggregate error to AccessDenied (auth_with_roles also does this).
+	if err := trace.NewAggregate(errs...); err != nil {
+		return nil, trace.AccessDenied(err.Error())
+	}
+	return authCtx, nil
 }
 
 // LocalUser is a local user

--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -83,13 +83,13 @@ func (o *OktaService) GetOktaImportRule(ctx context.Context, name string) (types
 }
 
 // CreateOktaImportRule creates a new Okta import rule resource.
-func (o *OktaService) CreateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) error {
-	return o.importRuleSvc.CreateResource(ctx, importRule)
+func (o *OktaService) CreateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) (types.OktaImportRule, error) {
+	return importRule, o.importRuleSvc.CreateResource(ctx, importRule)
 }
 
 // UpdateOktaImportRule updates an existing Okta import rule resource.
-func (o *OktaService) UpdateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) error {
-	return o.importRuleSvc.UpdateResource(ctx, importRule)
+func (o *OktaService) UpdateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) (types.OktaImportRule, error) {
+	return importRule, o.importRuleSvc.UpdateResource(ctx, importRule)
 }
 
 // DeleteOktaImportRule removes the specified Okta import rule resource.
@@ -113,13 +113,13 @@ func (o *OktaService) GetOktaAssignment(ctx context.Context, name string) (types
 }
 
 // CreateOktaAssignmentcreates a new Okta assignment resource.
-func (o *OktaService) CreateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) error {
-	return o.assignmentSvc.CreateResource(ctx, assignment)
+func (o *OktaService) CreateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
+	return assignment, o.assignmentSvc.CreateResource(ctx, assignment)
 }
 
 // UpdateOktaAssignmentupdates an existing Okta assignment resource.
-func (o *OktaService) UpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) error {
-	return o.assignmentSvc.UpdateResource(ctx, assignment)
+func (o *OktaService) UpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
+	return assignment, o.assignmentSvc.UpdateResource(ctx, assignment)
 }
 
 // DeleteOktaAssignmentremoves the specified Okta assignment resource.

--- a/lib/services/local/okta_test.go
+++ b/lib/services/local/okta_test.go
@@ -114,10 +114,17 @@ func TestOktaImportRuleCRUD(t *testing.T) {
 	require.Empty(t, out)
 
 	// Create both import rules.
-	err = service.CreateOktaImportRule(ctx, importRule1)
+	importRule, err := service.CreateOktaImportRule(ctx, importRule1)
 	require.NoError(t, err)
-	err = service.CreateOktaImportRule(ctx, importRule2)
+	require.Empty(t, cmp.Diff(importRule1, importRule,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+	))
+
+	importRule, err = service.CreateOktaImportRule(ctx, importRule2)
 	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(importRule2, importRule,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+	))
 
 	// Fetch all import rules.
 	out, nextToken, err = service.ListOktaImportRules(ctx, 200, "")
@@ -156,12 +163,12 @@ func TestOktaImportRuleCRUD(t *testing.T) {
 	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
 
 	// Try to create the same import rule.
-	err = service.CreateOktaImportRule(ctx, importRule1)
+	_, err = service.CreateOktaImportRule(ctx, importRule1)
 	require.True(t, trace.IsAlreadyExists(err), "expected already exists error, got %v", err)
 
 	// Update an import rule.
 	importRule1.SetExpiry(clock.Now().Add(30 * time.Minute))
-	err = service.UpdateOktaImportRule(ctx, importRule1)
+	_, err = service.UpdateOktaImportRule(ctx, importRule1)
 	require.NoError(t, err)
 	sp, err = service.GetOktaImportRule(ctx, importRule1.GetName())
 	require.NoError(t, err)
@@ -265,10 +272,17 @@ func TestOktaAssignmentCRUD(t *testing.T) {
 	require.Empty(t, out)
 
 	// Create both assignments.
-	err = service.CreateOktaAssignment(ctx, assignment1)
+	assignment, err := service.CreateOktaAssignment(ctx, assignment1)
 	require.NoError(t, err)
-	err = service.CreateOktaAssignment(ctx, assignment2)
+	require.Empty(t, cmp.Diff(assignment1, assignment,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+	))
+
+	assignment, err = service.CreateOktaAssignment(ctx, assignment2)
 	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(assignment2, assignment,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+	))
 
 	// Fetch all assignments.
 	out, nextToken, err = service.ListOktaAssignments(ctx, 200, "")
@@ -309,12 +323,12 @@ func TestOktaAssignmentCRUD(t *testing.T) {
 	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
 
 	// Try to create the same assignment.
-	err = service.CreateOktaAssignment(ctx, assignment1)
+	_, err = service.CreateOktaAssignment(ctx, assignment1)
 	require.True(t, trace.IsAlreadyExists(err), "expected already exists error, got %v", err)
 
 	// Update an assignment.
 	assignment1.SetExpiry(clock.Now().Add(30 * time.Minute))
-	err = service.UpdateOktaAssignment(ctx, assignment1)
+	_, err = service.UpdateOktaAssignment(ctx, assignment1)
 	require.NoError(t, err)
 	sp, err = service.GetOktaAssignment(ctx, assignment1.GetName())
 	require.NoError(t, err)

--- a/lib/services/okta.go
+++ b/lib/services/okta.go
@@ -21,9 +21,14 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/client/okta"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+// Compile time checks for the Okta client.
+var _ OktaImportRules = (*okta.Client)(nil)
+var _ OktaAssignments = (*okta.Client)(nil)
 
 // OktaImportRules defines an interface for managing OktaImportRules.
 type OktaImportRules interface {
@@ -32,9 +37,9 @@ type OktaImportRules interface {
 	// GetOktaImportRule returns the specified Okta import rule resources.
 	GetOktaImportRule(ctx context.Context, name string) (types.OktaImportRule, error)
 	// CreateOktaImportRule creates a new Okta import rule resource.
-	CreateOktaImportRule(context.Context, types.OktaImportRule) error
+	CreateOktaImportRule(context.Context, types.OktaImportRule) (types.OktaImportRule, error)
 	// UpdateOktaImportRule updates an existing Okta import rule resource.
-	UpdateOktaImportRule(context.Context, types.OktaImportRule) error
+	UpdateOktaImportRule(context.Context, types.OktaImportRule) (types.OktaImportRule, error)
 	// DeleteOktaImportRule removes the specified Okta import rule resource.
 	DeleteOktaImportRule(ctx context.Context, name string) error
 	// DeleteAllOktaImportRules removes all Okta import rules.
@@ -45,13 +50,13 @@ type OktaImportRules interface {
 type OktaAssignments interface {
 	// ListOktaAssignments returns a paginated list of all Okta assignment resources.
 	ListOktaAssignments(context.Context, int, string) ([]types.OktaAssignment, string, error)
-	// GetOktaAssignmentreturns the specified Okta assignment resources.
+	// GetOktaAssignmen treturns the specified Okta assignment resources.
 	GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error)
-	// CreateOktaAssignmentcreates a new Okta assignment resource.
-	CreateOktaAssignment(context.Context, types.OktaAssignment) error
-	// UpdateOktaAssignmentupdates an existing Okta assignment resource.
-	UpdateOktaAssignment(context.Context, types.OktaAssignment) error
-	// DeleteOktaAssignmentremoves the specified Okta assignment resource.
+	// CreateOktaAssignment creates a new Okta assignment resource.
+	CreateOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
+	// UpdateOktaAssignment updates an existing Okta assignment resource.
+	UpdateOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
+	// DeleteOktaAssignment removes the specified Okta assignment resource.
 	DeleteOktaAssignment(ctx context.Context, name string) error
 	// DeleteAllOktaAssignments removes all Okta assignments.
 	DeleteAllOktaAssignments(context.Context) error


### PR DESCRIPTION
The Okta service and client have been introduced. This will allow for the maintenance of Okta objects via our gRPC server and auth client. Some additional improvements have been made so that the local okta service now better reflects the gRPC definition.

Additionally, the gRPC authorization mechanism has been lifted out of `lib/auth/grpcserver.go` and moved into a common authorizer. Finally, the ability to check access to verbs has been lifted out of the `pluginsv1` service into that same authorizer. This will hopefully provide a good base for separate gRPC services in the future.