### PR TITLE
[v12] chore: Bump gci and golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -732,7 +732,7 @@ fix-imports/host:
 		echo 'gci is not installed or is missing from PATH, consider installing it ("go install github.com/daixiang0/gci@latest") or use "make -C build.assets/ fix-imports"';\
 		exit 1;\
 	fi
-	gci write -s 'standard,default,prefix(github.com/gravitational/teleport)' --skip-generated .
+	gci write -s standard -s default -s 'prefix(github.com/gravitational/teleport)' --skip-generated .
 
 .PHONY: lint-build-tooling
 lint-build-tooling: GO_LINT_FLAGS ?=

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -280,7 +280,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -277,7 +277,7 @@ ENV PROTO_INCLUDE "/usr/local/include":"/go/src":"/go/src/github.com/gogo/protob
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install GCI.
-RUN go install github.com/daixiang0/gci@v0.8.2
+RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1


### PR DESCRIPTION
Backport #22881 to branch/v12