### PR TITLE
Increase GHA build timeout

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1263,7 +1263,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -workflow release-linux-arm64.yml -workflow-ref=${DRONE_BRANCH}
+    -tag-workflow -timeout 1h0m0s -workflow release-linux-arm64.yml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
     -input "upload-artifacts=false" '
   environment:
@@ -4979,8 +4979,9 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -workflow release-linux-arm64.yml -workflow-ref=${DRONE_TAG} -input
-    oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input "upload-artifacts=true" '
+    -tag-workflow -timeout 1h0m0s -workflow release-linux-arm64.yml -workflow-ref=${DRONE_TAG}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
+    "upload-artifacts=true" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -7743,7 +7744,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -workflow promote-teleport-oci-distroless.yml -workflow-ref=${DRONE_TAG}
+    -tag-workflow -timeout 1h0m0s -workflow promote-teleport-oci-distroless.yml -workflow-ref=${DRONE_TAG}
     -input "release-source-tag=${DRONE_TAG}" '
   environment:
     GHA_APP_KEY:
@@ -9184,7 +9185,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -workflow release-teleport-oci-distroless.yml -workflow-ref=${DRONE_TAG}
+    -tag-workflow -timeout 1h0m0s -workflow release-teleport-oci-distroless.yml -workflow-ref=${DRONE_TAG}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} '
   environment:
     GHA_APP_KEY:
@@ -19038,6 +19039,6 @@ volumes:
   temp: {}
 ---
 kind: signature
-hmac: d17f0dff7d28b2f0beed2fbef216d59e77ac6ea4ba542f9fdc4ab9f57ecd58d0
+hmac: e4246ddf96b001ad16148b53df25b46cfea9a9073ee53314e4072b345b2e2a3f
 
 ...

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 type ghaBuildType struct {
@@ -26,6 +27,7 @@ type ghaBuildType struct {
 	ghaWorkflow  string
 	srcRefVar    string
 	workflowRef  string
+	timeout      time.Duration
 	slackOnError bool
 	dependsOn    []string
 	inputs       map[string]string
@@ -42,6 +44,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 	cmd.WriteString(`-owner ${DRONE_REPO_OWNER} `)
 	cmd.WriteString(`-repo teleport.e `)
 	cmd.WriteString(`-tag-workflow `)
+	fmt.Fprintf(&cmd, `-timeout %s `, b.timeout.String())
 	fmt.Fprintf(&cmd, `-workflow %s `, b.ghaWorkflow)
 	fmt.Fprintf(&cmd, `-workflow-ref=%s `, b.workflowRef)
 

--- a/dronegen/promote.go
+++ b/dronegen/promote.go
@@ -14,6 +14,8 @@
 
 package main
 
+import "time"
+
 func promoteBuildPipelines() []pipeline {
 	promotePipelines := make([]pipeline, 0)
 	promotePipelines = append(promotePipelines, promoteBuildOsRepoPipelines()...)
@@ -23,6 +25,7 @@ func promoteBuildPipelines() []pipeline {
 		trigger:      triggerPromote,
 		pipelineName: "promote-teleport-oci-distroless-images",
 		ghaWorkflow:  "promote-teleport-oci-distroless.yml",
+		timeout:      60 * time.Minute,
 		workflowRef:  "${DRONE_TAG}",
 		inputs: map[string]string{
 			"release-source-tag": "${DRONE_TAG}",

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -14,7 +14,10 @@
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // pushCheckoutCommands builds a list of commands for Drone to check out a git commit on a push build
 func pushCheckoutCommands(b buildType) []string {
@@ -76,6 +79,7 @@ func pushPipelines() []pipeline {
 		trigger:      triggerPush,
 		pipelineName: "push-build-linux-arm64",
 		ghaWorkflow:  "release-linux-arm64.yml",
+		timeout:      60 * time.Minute,
 		slackOnError: true,
 		srcRefVar:    "DRONE_COMMIT",
 		workflowRef:  "${DRONE_BRANCH}",

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 const (
@@ -195,6 +196,7 @@ func tagPipelines() []pipeline {
 		ghaWorkflow:  "release-linux-arm64.yml",
 		srcRefVar:    "DRONE_TAG",
 		workflowRef:  "${DRONE_TAG}",
+		timeout:      60 * time.Minute,
 		dependsOn:    []string{tagCleanupPipelineName},
 		inputs:       map[string]string{"upload-artifacts": "true"},
 	}))
@@ -206,6 +208,7 @@ func tagPipelines() []pipeline {
 		ghaWorkflow:  "release-teleport-oci-distroless.yml",
 		srcRefVar:    "DRONE_TAG",
 		workflowRef:  "${DRONE_TAG}",
+		timeout:      60 * time.Minute,
 		dependsOn: []string{
 			tagCleanupPipelineName,
 			"build-linux-amd64-deb",


### PR DESCRIPTION
Our ARM64 build fails quite frequently due to 30 minutes timeout. This PR increases the build timeout to one hour.