### PR TITLE
Add SFTP subsystem fails note to server access FAQ

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -64,8 +64,8 @@ multiplexing with that configuration.
 
 ## I'm getting `ssh: subsystem request failed` while I try to copy files, what to do?
 
-Make sure that all Teleport components are at lease in version 10.3.0. Older versions
-don't support SFTP protocol enabled by default in `tsh` v11.0.0 and OpenSSH v9.0.
+Make sure that all Teleport components are at least at version 10.3.0. Older versions
+don't support the SFTP protocol, and it's enabled by default in `tsh` v11.0.0 and OpenSSH v9.0.
 
 ## How is Open Source different from Enterprise?
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -62,6 +62,11 @@ Yes, Teleport supports tunnel multiplexing on a single port. Set the
 setting in the `proxy_service` configuration. Teleport will automatically use
 multiplexing with that configuration.
 
+## I'm getting `ssh: subsystem request failed` while I try to copy files, what to do?
+
+Make sure that all Teleport components are at lease in version 10.3.0. Older versions
+don't support SFTP protocol enabled by default in `tsh` v11.0.0 and OpenSSH v9.0.
+
 ## How is Open Source different from Enterprise?
 
 Teleport provides three editions:


### PR DESCRIPTION
In many cases, we see people trying to use `tsh` v11 with Teleport Node v9. In this combination, `ssh: subsystem request failed`, which is very confusing for users. As we're not able to make sure that all Teleport installations are up-to-date, we at least can we mention the most common solution in our FAQ.

Updates https://github.com/gravitational/teleport/issues/22456