### PR TITLE
Fix uncaught exception handling in Connect's shared process

### DIFF
--- a/web/packages/teleterm/src/logger.ts
+++ b/web/packages/teleterm/src/logger.ts
@@ -26,15 +26,15 @@ export default class Logger {
   // Logger.init has already been called
   constructor(private context = '') {}
 
-  warn(message: string, ...args: any[]) {
+  warn(message: any, ...args: any[]) {
     this.getLogger().warn(message, ...args);
   }
 
-  info(message: string, ...args: any[]) {
+  info(message: any, ...args: any[]) {
     this.getLogger().info(message, ...args);
   }
 
-  error(message: string, ...args: any[]) {
+  error(message: any, ...args: any[]) {
     this.getLogger().error(message, ...args);
   }
 

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -63,8 +63,8 @@ function initializeApp(): void {
   });
   const windowsManager = new WindowsManager(appStateFileStorage, settings);
 
-  process.on('uncaughtException', error => {
-    logger.error(error);
+  process.on('uncaughtException', (error, origin) => {
+    logger.error(origin, error);
     app.quit();
   });
 

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -64,7 +64,7 @@ function initializeApp(): void {
   const windowsManager = new WindowsManager(appStateFileStorage, settings);
 
   process.on('uncaughtException', error => {
-    logger.error('', error);
+    logger.error(error);
     app.quit();
   });
 

--- a/web/packages/teleterm/src/mainProcess/protocolHandler.ts
+++ b/web/packages/teleterm/src/mainProcess/protocolHandler.ts
@@ -22,7 +22,7 @@ import { protocol, app } from 'electron';
 
 import Logger from 'teleterm/logger';
 
-const logger = new Logger('');
+const logger = new Logger('protocol handler');
 const disabledSchemes = [
   'about',
   'content',

--- a/web/packages/teleterm/src/sharedProcess/sharedProcess.ts
+++ b/web/packages/teleterm/src/sharedProcess/sharedProcess.ts
@@ -53,10 +53,10 @@ function getRuntimeSettings(): RuntimeSettings {
 
 function initializeLogger(): void {
   const loggerService = createStdoutLoggerService();
-
   Logger.init(loggerService);
-  const logger = new Logger();
-  process.on('uncaughtException', logger.error);
+  const logger = new Logger('uncaught exception');
+
+  process.on('uncaughtException', error => logger.error(error));
 }
 
 async function initializeServer(

--- a/web/packages/teleterm/src/sharedProcess/sharedProcess.ts
+++ b/web/packages/teleterm/src/sharedProcess/sharedProcess.ts
@@ -56,7 +56,9 @@ function initializeLogger(): void {
   Logger.init(loggerService);
   const logger = new Logger('uncaught exception');
 
-  process.on('uncaughtException', error => logger.error(error));
+  process.on('uncaughtException', (error, origin) => {
+    logger.error(origin, error);
+  });
 }
 
 async function initializeServer(


### PR DESCRIPTION
Without this patch, an uncaught exception being thrown would result in the following error due to how binding methods to class instances works:

```
C:\Users\rav\AppData\Local\Programs\teleport-connect\resources\app.asar\ build\app\dist\main\sharedProcess.js:73614
    this.getLogger().error(message, ...args);
         ^

TypeError: this.getLogger is not a function
    at process.error (C:\Users\rav\AppData\Local\Programs\teleport-connect\
       resources\app.asar\build\app\dist\main\sharedProcess.js:73614:10)
    at process.emit (node:events:513:28)
    at process._fatalException (node:internal/process/execution:167:25)
```