### PR TITLE
Fix `lib/usagereporter` tests

### DIFF
--- a/lib/usagereporter/usagereporter_test.go
+++ b/lib/usagereporter/usagereporter_test.go
@@ -92,9 +92,6 @@ func newTestingUsageReporter(
 
 	go reporter.Run(ctx)
 
-	// Wait for timers to init.
-	clock.BlockUntil(1)
-
 	return reporter, cancel, receiveChan
 }
 
@@ -164,7 +161,6 @@ func TestUsageReporterTimeSubmit(t *testing.T) {
 	// clock.
 	fakeClock.BlockUntil(1)
 	advanceClocks(2*testMaxBatchAge, fakeClock, fakeSubmitClock)
-	fakeSubmitClock.BlockUntil(1)
 
 	select {
 	case e := <-batchChan:
@@ -407,6 +403,13 @@ func TestUsageReporterErrorReenqueue(t *testing.T) {
 	for _, event := range prev {
 		require.Equal(t, 0, event.retriesRemaining)
 	}
+	// this will unblock the submission queue goroutine so that we can
+	// gracefully exit it
+	fakeSubmitClock.Advance(testSubmitDelay)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, reporter.GracefulStop(ctx))
 
 	// All events should have been dropped.
 	require.Empty(t, reporter.buf)


### PR DESCRIPTION
This fixes a data race in `TestUsageReporterErrorReenqueue` and a deadlock in `TestUsageReporterTimeSubmit`.