### PR TITLE
Fix unresponsive terminal in Connect on Windows Server 2019

### DIFF
--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://goteleport.com",
   "dependencies": {
     "emittery": "^1.0.1",
-    "node-pty": "0.10.0"
+    "node-pty": "0.11.0-beta29"
   },
   "devDependencies": {
     "@gravitational/build": "^1.0.0",

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
@@ -54,6 +54,8 @@ export class PtyProcess extends EventEmitter implements IPtyProcess {
       // https://unix.stackexchange.com/questions/123858
       cwd: this.options.cwd || getDefaultCwd(this.options.env),
       env: this.options.env,
+      // Turn off ConPTY due to an uncaught exception being thrown when a PTY is closed.
+      useConpty: false,
     });
 
     this._setStatus('open');

--- a/yarn.lock
+++ b/yarn.lock
@@ -10530,7 +10530,7 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.12.1, nan@^2.14.0:
+nan@^2.12.1, nan@^2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
@@ -10693,12 +10693,12 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-pty@0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.10.0.tgz#c98d23967b076b35c9fb216c542a04d0b5db4821"
-  integrity sha512-Q65ookKbjhqWUYKmtZ6iPn0nnqNdzpm3YJOBmzwWJde/TrenBxK9FgqGGtSW0Wjz4YsR1grQF4a7RS5nBwuW9A==
+node-pty@0.11.0-beta29:
+  version "0.11.0-beta29"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.11.0-beta29.tgz#863bce79346b453ed199614686008d1a3220abe8"
+  integrity sha512-pkSldLXjjwFrGd3EJWI0Pu1jnxeQaW0P9i2EQtO2RaK/pZ22pf99lQ8OfptYTPK2oKZbkjwzqh05uJJ2krH9iA==
   dependencies:
-    nan "^2.14.0"
+    nan "^2.17.0"
 
 node-releases@^2.0.8:
   version "2.0.10"


### PR DESCRIPTION
Closes #22845.

Updating node-pty alone fixes the aforementioned issue. However, when running on Windows 11 with ConPTY enabled, node-pty would throw an uncaught exception when closing the shell by closing the tab (`EPIPE`, exactly the same as https://github.com/microsoft/node-pty/issues/512). On top of that, closing the shell by executing `exit` would cause another uncaught exception, `AttachConsole failed`. 

<details>
<summary>AttachConsole failed stack trace</summary>

```
C:\Users\rav\AppData\Local\Programs\teleport-connect\resources\app.asar\node_modules\node-pty\lib\conpty_console_list_agent.js:17
var consoleProcessList = getConsoleProcessList(shellPid);
                         ^

Error: AttachConsole failed
    at Object.<anonymous> (C:\Users\rav\AppData\Local\Programs\teleport-connect\resources\app.asar\node_modules\node-pty\lib\conpty_console_list_agent.js:17:26)
    at Module._compile (node:internal/modules/cjs/loader:1141:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1196:10)
    at Module.load (node:internal/modules/cjs/loader:1011:32)
    at Module._load (node:internal/modules/cjs/loader:846:12)
    at f._load (node:electron/js2c/asar_bundle:2:13328)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```
</details>

Those issues are not present on Windows Server 2019 running the same version of Connect with just node-pty updated ([v11.3.8-dev.ravicious.2](https://cdn.teleport.dev/Teleport%20Connect%20Setup-11.3.8-dev.ravicious.2.exe)). Both problems are also not present on Windows 11 if ConPTY is not used.

node-pty uses ConPTY by default where available (as far as I know, this means [both Windows 11 and Windows Server 2019](https://en.wikipedia.org/wiki/Windows_10,_version_1809)).

> Windows support is possible by utilizing the [Windows conpty API](https://blogs.msdn.microsoft.com/commandline/2018/08/02/windows-command-line-introducing-the-windows-pseudo-console-conpty/) on Windows 1809+ and the [winpty](https://github.com/rprichard/winpty) library in older version.

The unfortunate downside of turning off ConPTY is that the winpty solution is worse at handling the terminal being resized. I think our best bet here is waiting for updates to ConPTY and node-pty and re-enable ConPTY in the future.

---

Backporting to v11 and v12 only because v10 uses an older Electron version and I didn't check if that version node-pty is compatible with it. We should aim to update the Electron version across all supported versions in the future.