### PR TITLE
Add EKS guide to install agents using IAM joining

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1548,11 +1548,6 @@
       "permanent": true
     },
     {
-      "source": "/kubernetes-access/guides/standalone-teleport/",
-      "destination": "/kubernetes-access/register-clusters/iam-joining/",
-      "permanent": true
-    },
-    {
       "source": "/kubernetes-access/",
       "destination": "/kubernetes-access/introduction/",
       "permanent": true

--- a/docs/config.json
+++ b/docs/config.json
@@ -833,6 +833,10 @@
               "slug": "/kubernetes-access/register-clusters/static-kubeconfig/"
             },
             {
+              "title": "Register a Cluster with IAM joining",
+              "slug": "/kubernetes-access/register-clusters/iam-joining/"
+            },
+            {
               "title": "Register Clusters Dynamically",
               "slug": "/kubernetes-access/register-clusters/dynamic-registration/"
             }
@@ -1541,6 +1545,11 @@
     {
       "source": "/database-access/",
       "destination": "/database-access/introduction/",
+      "permanent": true
+    },
+    {
+      "source": "/kubernetes-access/guides/standalone-teleport/",
+      "destination": "/kubernetes-access/register-clusters/iam-joining/",
       "permanent": true
     },
     {

--- a/docs/config.json
+++ b/docs/config.json
@@ -833,7 +833,7 @@
               "slug": "/kubernetes-access/register-clusters/static-kubeconfig/"
             },
             {
-              "title": "Register a Cluster with IAM joining",
+              "title": "Register a Cluster with IAM Joining",
               "slug": "/kubernetes-access/register-clusters/iam-joining/"
             },
             {

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -51,7 +51,7 @@ join token from the Teleport Auth Service:
 
 ```code
 # Create a join token for the Teleport Kubernetes Service to authenticate
-$ TOKEN=$(tctl nodes add --roles=kube --ttl=10000h --format=json | jq -r '.[0]')
+$ TOKEN=$(tctl nodes add --roles=kube --ttl=1h --format=json | jq -r '.[0]')
 $ echo $TOKEN
 ```
 
@@ -59,7 +59,7 @@ $ echo $TOKEN
 
 <Notice type="tip" >
 
-The Teleport Kubernetes Service version should be the same as the Teleport Cluster version 
+The Teleport Kubernetes Service version should be the same as the Teleport Cluster version
 or up to one major version back. You can set the version override with the override variable, ex: `--set teleportVersionOverride=(=teleport.version=)`.
 
 </Notice>
@@ -84,7 +84,7 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
   --set authToken=${TOKEN?} \
   --create-namespace \
   --namespace=teleport-agent \
-  --version (=teleport.version=) 
+  --version (=teleport.version=)
 ```
 
 </TabItem>
@@ -123,8 +123,8 @@ them using `tsh kube login`:
 ```code
 $ tsh kube ls
 
-# Kube Cluster Name Selected 
-# ----------------- -------- 
+# Kube Cluster Name Selected
+# ----------------- --------
 # cookie
 
 # kubeconfig now points to the cookie cluster

--- a/docs/pages/kubernetes-access/introduction.mdx
+++ b/docs/pages/kubernetes-access/introduction.mdx
@@ -65,6 +65,9 @@ manually when you create the cluster. There are a few ways to do this:
 - [Deploy the Teleport Kubernetes
   Service](./register-clusters/register-via-deployment.mdx) on your cluster of
   choice.
+- [Deploy the Teleport Kubernetes
+  Service with IAM Joining](./register-clusters/iam-joining.mdx) on your cluster of
+  choice.
 - Deploy the Teleport Kubernetes Service outside your Kubernetes cluster (e.g.,
   directly on a virtual machine) and [give it access to a
   kubeconfig](./register-clusters/static-kubeconfig.mdx).

--- a/docs/pages/kubernetes-access/manage-access/rbac.mdx
+++ b/docs/pages/kubernetes-access/manage-access/rbac.mdx
@@ -1,5 +1,5 @@
 ---
-title: Setting Up Teleport Access Controls for Kubernetes 
+title: Setting Up Teleport Access Controls for Kubernetes
 description: How to configure Teleport roles to access clusters, groups, users, and resources in Kubernetes.
 ---
 
@@ -213,7 +213,7 @@ Request a token that the Kubernetes Service will use to join your Teleport
 cluster:
 
 ```code
-$ tctl nodes add --roles=kube --ttl=10000h --format=json
+$ tctl nodes add --roles=kube --ttl=1h --format=json
 ```
 
 Copy this token so you can use it when running the Teleport Kubernetes Service.
@@ -231,7 +231,7 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
   --set labels.region=local --set labels.platform=minikube \
   --create-namespace \
   --namespace=teleport \
-  --version (=teleport.version=) 
+  --version (=teleport.version=)
 ```
 
 This `tctl nodes add` command supplies the soon-to-be-added Kubernetes Service
@@ -290,7 +290,7 @@ version: v3
 
 The Teleport Kubernetes Service determines how to proxy a Teleport user's
 requests to a Kubernetes API server by looking up the user's roles. Based on
-this information, the Kubernetes Service accepts or denies the request. 
+this information, the Kubernetes Service accepts or denies the request.
 
 For valid requests, the Kubernetes Service rewrites the request headers to
 impersonate the Teleport user's desired Kubernetes user and groups, and forwards
@@ -300,7 +300,7 @@ In this section, we will define a Teleport role that:
 
 - Authenticates the user to a Kubernetes cluster as a member of the `developers`
   group. In the previous section, we authorized members of this group to view
-  pods in all namespaces. 
+  pods in all namespaces.
 - Enables the user to access `webapp` pods in the `production` namespace and all
   pods in the `development` namespace.
 - Denies the user access to all other pods.
@@ -346,7 +346,7 @@ In this role, we have defined the following `allow` rules:
   `pod-viewer` Kubernetes `Role` earlier in this guide.
 - `kubernetes_users`: Authenticates the user to your Kubernetes cluster as the
   default `minikube` user.
-  
+
 ### Create the role
 
 Once you have finished configuring the `kube-access` role, create it using the
@@ -443,7 +443,7 @@ $ kubectl config use-context minikube
 For more detailed information on how Teleport RBAC for Kubernetes works, consult
 the Kubernetes [Access Controls Guide](../controls.mdx). You can leave your
 `minikube` cluster running so you can try out different Teleport and Kubernetes
-RBAC configurations. 
+RBAC configurations.
 
 Now that you know how to configure Teleport's RBAC system to control access to
 Kubernetes clusters, learn how to set up [Resource Access

--- a/docs/pages/kubernetes-access/register-clusters.mdx
+++ b/docs/pages/kubernetes-access/register-clusters.mdx
@@ -11,6 +11,9 @@ automatically](./discovery.mdx). There are a few ways to do this:
 - [Deploy the Teleport Kubernetes
   Service](./register-clusters/register-via-deployment.mdx) on your cluster of
   choice.
+- [Deploy the Teleport Kubernetes
+  Service with IAM Joining](./register-clusters/iam-joining.mdx) on your cluster of
+  choice.
 - Deploy the Teleport Kubernetes Service outside your Kubernetes cluster (e.g.,
   directly  on a virtual machine) and [give it access to a
   kubeconfig](./register-clusters/static-kubeconfig.mdx).

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -18,11 +18,7 @@ to automatically join the cluster on subsequent restarts.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- The Teleport Kubernetes Service running in a Kubernetes cluster, version >=
-  v(=kubernetes.major_version=).(=kubernetes.minor_version=).0. We will assume
-  that you have already followed
-  [Connect a Kubernetes Cluster to Teleport](../getting-started.mdx)
-- An additional Kubernetes cluster version >=
+- A Kubernetes cluster version >=
   v(=kubernetes.major_version=).(=kubernetes.minor_version=).0
 - An existing [IAM OpenID Connect (OIDC)](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) provider for your cluster
 - Helm >= (=helm.version=)
@@ -41,15 +37,15 @@ clusters running in AWS without having to distribute a joining secret to the
 Kubernetes cluster.
 
 To securely join the cluster without relying on the EKS node's Identity, a Teleport agent
-must run as a separate Kubernetes Service Account with an attached IAM role. Relying
+must run as a separate Kubernetes service sccount with an attached IAM role. Relying
 on the node's identity is not recommended as it can be easily compromised since every
 pod running on the node has access to the node's identity if IAM Roles for Service Accounts
 (IRSA) is not configured.
 
 For IRSA to work correctly, it requires the Kubernetes cluster to have an IAM OpenID Connect
-that maps IAM roles to Kubernetes Service Accounts.
+that maps IAM roles to Kubernetes service accounts.
 
-The Kubernetes Service Account must have access to the `sts:GetCallerIdentity` API but
+The Kubernetes service account must have access to the `sts:GetCallerIdentity` API but
 does not require any other permissions.
 
 To create the IAM policy, run the following command:
@@ -90,7 +86,7 @@ $ aws iam create-policy --policy-name <Var name="kube-iam-policy"/> --policy-doc
 }
 ```
 
-Now we need to create the Kubernetes Service Account and map it to the IAM role. There
+Now we need to create the Kubernetes service account and map it to the IAM role. There
 are two ways of doing this. You can use `eksctl` if your cluster was provisioned
 using it or you can use the AWS CLI method.
 
@@ -111,7 +107,7 @@ $ eksctl create iamserviceaccount \
 ```
 
 The referemced parameters are:
-- <Var name="teleport-kube-agent-sa"/> is the name of the Kubernetes Service Account.
+- <Var name="teleport-kube-agent-sa"/> is the name of the Kubernetes service account.
 - <Var name="teleport-agent"/> is the namespace where the Teleport Kubernetes Service is
   running.
 - <Var name="aws-region"/> is the AWS region where the cluster is running.
@@ -120,17 +116,17 @@ The referemced parameters are:
 - <Var name="kube-iam-role"/> is the name of the IAM role to create.
 
 Once the command completes, you should see a new IAM role created in your AWS account
-and a new Kubernetes Service Account created in the target namespace.
+and a new Kubernetes service account created in the target namespace.
 
 </TabItem>
 
 <TabItem label="Using AWS CLI">
 
-Creating a new IAM role and mapping it into the Kubernetes Service Account in the
+Creating a new IAM role and mapping it into the Kubernetes service account in the
 target namespace using the AWS CLI requires some aditional steps.
 
 First, we need to create the target namespace in the Kubernetes cluster and the
-Kubernetes Service Account.
+Kubernetes service account.
 
 ```code
 $ kubectl create ns <Var name="teleport-agent"/>

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -277,6 +277,12 @@ $ tsh kube login iam-cluster
 $ kubectl get pods
 ```
 
+If the agent pod is healthy and ready but you cannot see your Kubernetes cluster,
+it is likely related to RBAC permissions associated with your roles.
+On the other hand, if you can see your Kubernetes cluster but unable to see any pods,
+it's likely that your Teleport role does not allow access to pods in the Kubernetes cluster.
+For both cases, please refer to the section below.
+
 <Details title="Not seeing Kubernetes clusters?">
 
 (!docs/pages/includes/kubernetes-access/rbac.mdx!)

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -220,8 +220,6 @@ metadata:
   # the token name is not a secret because instances must prove that they are
   # running in your AWS account to use this token
   name: <Var name="kube-iam-token"/>
-  # set a long expiry time, the default for tokens is only 30 minutes
-  expires: "3000-01-01T00:00:00Z"
 spec:
   # use the minimal set of roles required
   roles: [Kube]

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -24,7 +24,7 @@ to automatically join the cluster on subsequent restarts.
   [Connect a Kubernetes Cluster to Teleport](../getting-started.mdx)
 - An additional Kubernetes cluster version >=
   v(=kubernetes.major_version=).(=kubernetes.minor_version=).0
-- An existing [IAM OpenID Connect (OIDC)](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) provider for your cluster.
+- An existing [IAM OpenID Connect (OIDC)](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) provider for your cluster
 - Helm >= (=helm.version=)
 - AWS CLI >= `2.10.3` or `1.27.81`
 
@@ -33,23 +33,23 @@ to automatically join the cluster on subsequent restarts.
 (!docs/pages/includes/tctl.mdx!)
 
 
-## Step 1/3. Create a Kubernetes Service Account with IAM Identity
+## Step 1/3. Create a Kubernetes service account with an IAM identity
 
 Teleport supports a mode where agents running in AWS can join the cluster using the
 IAM identity they are running as. It allows you to register Kubernetes
 clusters running in AWS without having to distribute a joining secret to the
 Kubernetes cluster.
 
-To securely join the cluster without relying on the EKS node's Identity, Teleport agent
+To securely join the cluster without relying on the EKS node's Identity, a Teleport agent
 must run as a separate Kubernetes Service Account with an attached IAM role. Relying
 on the node's identity is not recommended as it can be easily compromised since every
 pod running on the node has access to the node's identity if IAM Roles for Service Accounts
 (IRSA) is not configured.
 
-For IRSA to work correctly, it requires the Kubernetes cluster must have an IAM OpenID Connect
+For IRSA to work correctly, it requires the Kubernetes cluster to have an IAM OpenID Connect
 that maps IAM roles to Kubernetes Service Accounts.
 
-The Kubernetes Service Account must have access to `sts:GetCallerIdentity` API but
+The Kubernetes Service Account must have access to the `sts:GetCallerIdentity` API but
 does not require any other permissions.
 
 To create the IAM policy, run the following command:
@@ -198,18 +198,18 @@ Then attach the service account with the IAM role annotation:
 $ kubectl annotate serviceaccount -n <Var name="teleport-agent"/> <Var name="teleport-kube-agent-sa"/> eks.amazonaws.com/role-arn=arn:aws:iam::$account_id:role/<Var name="kube-iam-role"/>
 ```
 
-At this point, the IAM role is ready to be used by the Teleport Kubernetes Agent Service Account.
+At this point, the IAM role is ready to be used by the Teleport Kubernetes Service's service account.
 
 </TabItem>
 </Tabs>
 
 ## Step 2/3. Create the AWS joining token
 
-Configure your Teleport Auth Server with a special dynamic token which will
+Configure your Teleport Auth Service with a special dynamic token which will
 allow agents from your AWS account to join your Teleport cluster using the roles
 defined.
 
-Under the hood, Kubernetes Agents will prove that they are running in your AWS account by
+Under the hood, Kubernetes Service instances will prove that they are running in your AWS account by
 sending a signed Identity Document which matches an allow rule
 configured in your AWS joining token.
 
@@ -241,7 +241,7 @@ EOF
 
 Run `tctl create token.yaml` to create the token.
 
-## Step 3/3. Deploy the Teleport Kubernetes Agent
+## Step 3/3. Deploy the Teleport Kubernetes Service
 
 (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -1,0 +1,295 @@
+---
+title: Register a Kubernetes Cluster using IAM Joining
+description: Connecting a Kubernetes cluster to Teleport with IAM joining.
+---
+
+In this guide, we will show you how to register a Kubernetes cluster with
+Teleport by using the agent's IAM identity to automatically join the Teleport cluster.
+
+You can register multiple Kubernetes clusters with Teleport by deploying the
+Teleport Kubernetes Service on each cluster you want to register without having
+to distribute a joining secret to the Kubernetes cluster.
+
+Once the Kubernetes cluster is registered for the first time, the agent will store
+its Teleport identity in a Kubernetes secret. The agent will use this identity
+to automatically join the cluster on subsequent restarts.
+
+## Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+- The Teleport Kubernetes Service running in a Kubernetes cluster, version >=
+  v(=kubernetes.major_version=).(=kubernetes.minor_version=).0. We will assume
+  that you have already followed
+  [Connect a Kubernetes Cluster to Teleport](../getting-started.mdx)
+- An additional Kubernetes cluster version >=
+  v(=kubernetes.major_version=).(=kubernetes.minor_version=).0
+- An existing [IAM OpenID Connect (OIDC)](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) provider for your cluster.
+- Helm >= (=helm.version=)
+- AWS CLI >= `2.10.3` or `1.27.81`
+
+(!docs/pages/includes/helm.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
+
+
+## Step 1/3. Create a Kubernetes Service Account with IAM Identity
+
+Teleport supports a mode where agents running in AWS can join the cluster using the
+IAM identity they are running as. It allows you to register Kubernetes
+clusters running in AWS without having to distribute a joining secret to the
+Kubernetes cluster.
+
+To securely join the cluster without relying on the EKS node's Identity, Teleport agent
+must run as a separate Kubernetes Service Account with an attached IAM role. Relying
+on the node's identity is not recommended as it can be easily compromised since every
+pod running on the node has access to the node's identity if IAM Roles for Service Accounts
+(IRSA) is not configured.
+
+For IRSA to work correctly, it requires the Kubernetes cluster must have an IAM OpenID Connect
+that maps IAM roles to Kubernetes Service Accounts.
+
+The Kubernetes Service Account must have access to `sts:GetCallerIdentity` API but
+does not require any other permissions.
+
+To create the IAM policy, run the following command:
+
+```code
+$ cat >iam-policy.json <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "sts:GetCallerIdentity",
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+```
+
+Then create the IAM policy:
+
+```code
+$ aws iam create-policy --policy-name <Var name="kube-iam-policy"/> --policy-document file://iam-policy.json
+{
+    "Policy": {
+        "PolicyName": "<Var name="kube-iam-policy"/>",
+        "PolicyId": "ANPAW2Y2Q2Y2Y2Y2Y2Y2Y",
+        "Arn": "arn:aws:iam::aws:policy/<Var name="kube-iam-policy"/>",
+        "Path": "/",
+        "DefaultVersionId": "v1",
+        "AttachmentCount": 0,
+        "PermissionsBoundaryUsageCount": 0,
+        "IsAttachable": true,
+        "Description": "",
+        "CreateDate": "2021-03-18T15:12:00+00:00",
+        "UpdateDate": "2021-03-18T15:12:00+00:00"
+    }
+}
+```
+
+Now we need to create the Kubernetes Service Account and map it to the IAM role. There
+are two ways of doing this. You can use `eksctl` if your cluster was provisioned
+using it or you can use the AWS CLI method.
+
+<Tabs>
+<TabItem label="Using eksctl">
+`eksctl` supports automatic creation of new IAM roles and mapping it into the Kubernetes Service
+  Account in the target namespace.
+
+```code
+$ eksctl create iamserviceaccount \
+    --name <Var name="teleport-kube-agent-sa"/> \
+    --namespace <Var name="teleport-agent"/> \
+    --cluster <Var name="kube-cluster"/> \
+    --region <Var name="aws-region"/> \
+    --attach-policy-arn arn:aws:iam::aws:policy/<Var name="kube-iam-policy"/> \
+    --role-name <Var name="kube-iam-role"/> \
+    --approve
+```
+
+The referemced parameters are:
+- <Var name="teleport-kube-agent-sa"/> is the name of the Kubernetes Service Account.
+- <Var name="teleport-agent"/> is the namespace where the Teleport Kubernetes Service is
+  running.
+- <Var name="aws-region"/> is the AWS region where the cluster is running.
+- <Var name="kube-iam-policy"/> is the name of the IAM policy created in the previous step.
+- <Var name="kube-cluster"/>  is the name of the Kubernetes cluster.
+- <Var name="kube-iam-role"/> is the name of the IAM role to create.
+
+Once the command completes, you should see a new IAM role created in your AWS account
+and a new Kubernetes Service Account created in the target namespace.
+
+</TabItem>
+
+<TabItem label="Using AWS CLI">
+
+Creating a new IAM role and mapping it into the Kubernetes Service Account in the
+target namespace using the AWS CLI requires some aditional steps.
+
+First, we need to create the target namespace in the Kubernetes cluster and the
+Kubernetes Service Account.
+
+```code
+$ kubectl create ns <Var name="teleport-agent"/>
+namespace/<Var name="teleport-agent"/> created
+
+$ kubectl create sa <Var name="teleport-kube-agent-sa"/> -n  <Var name="teleport-agent"/>
+serviceaccount/<Var name="teleport-kube-agent-sa"/> created
+```
+
+Then we need to create the IAM role and trust relationship. For that, we need
+to get the AWS account ID and the OIDC provider URL. If your cluster doesn't have
+one configured check the following guide: [IAM OpenID Connect (OIDC)](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+
+To extract the AWS account ID you can use the following command:
+
+```code
+$ account_id=$(aws sts get-caller-identity --query "Account" --output text)
+```
+
+The OICD provider URL can be extracted from the cluster configuration:
+
+```code
+$ oidc_provider=$(aws eks describe-cluster --name <Var name="kube-cluster"/> --region <Var name="aws-region"/> --query "cluster.identity.oidc.issuer" --output text | sed -e "s/^https:\/\///")
+$ echo $oidc_provider
+oidc.eks.eu-west-1.amazonaws.com/id/[...]
+```
+
+If the output of the command is empty, you need to configure the OIDC provider as
+mentioned above.
+
+To create the IAM role and trust relationship, run the following command:
+
+```code
+$ cat >trust-relationship.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::$account_id:oidc-provider/$oidc_provider"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "$oidc_provider:aud": "sts.amazonaws.com",
+          "$oidc_provider:sub": "system:serviceaccount:<Var name="teleport-agent"/>:<Var name="teleport-kube-agent-sa"/>"
+        }
+      }
+    }
+  ]
+}
+EOF
+```
+
+To create the IAM role, run the following command:
+
+```code
+$ aws iam create-role --role-name <Var name="kube-iam-role"/> --assume-role-policy-document file://trust-relationship.json --description "my-role-description"
+```
+
+Then attach the service account with the IAM role annotation:
+
+```code
+$ kubectl annotate serviceaccount -n <Var name="teleport-agent"/> <Var name="teleport-kube-agent-sa"/> eks.amazonaws.com/role-arn=arn:aws:iam::$account_id:role/<Var name="kube-iam-role"/>
+```
+
+At this point, the IAM role is ready to be used by the Teleport Kubernetes Agent Service Account.
+
+</TabItem>
+</Tabs>
+
+## Step 2/3. Create the AWS joining token
+
+Configure your Teleport Auth Server with a special dynamic token which will
+allow agents from your AWS account to join your Teleport cluster using the roles
+defined.
+
+Under the hood, Kubernetes Agents will prove that they are running in your AWS account by
+sending a signed Identity Document which matches an allow rule
+configured in your AWS joining token.
+
+Create the following `token.yaml` with an `allow` rule specifying your AWS
+account and the AWS ARN the agents will be running as.
+
+```code
+$ cat >token.yaml <<EOF
+kind: token
+version: v2
+metadata:
+  # the token name is not a secret because instances must prove that they are
+  # running in your AWS account to use this token
+  name: <Var name="kube-iam-token"/>
+  # set a long expiry time, the default for tokens is only 30 minutes
+  expires: "3000-01-01T00:00:00Z"
+spec:
+  # use the minimal set of roles required
+  roles: [Kube]
+  # set the join method allowed for this token
+  join_method: iam
+  allow:
+  # aws_arn is optional and allows you to restrict the IAM role of joining Agents
+  # to a specific IAM role
+  - aws_account: "$account_id"
+    aws_arn: "arn:aws:sts::$account_id:assumed-role/<Var name="kube-iam-role"/>/*"
+EOF
+```
+
+Run `tctl create token.yaml` to create the token.
+
+## Step 3/3. Deploy the Teleport Kubernetes Agent
+
+(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
+
+Switch `kubectl` to the Kubernetes cluster and run:
+
+```code
+# Deploy a Kubernetes agent. It dials back to the Teleport cluster tele.example.com.
+$ CLUSTER=iam-cluster
+$ PROXY=tele.example.com:443
+$ helm install teleport-agent teleport/teleport-kube-agent \
+  --set kubeClusterName=${CLUSTER?} \
+  --set proxyAddr=${PROXY?} \
+  --set joinParams.method=iam \
+  --set joinParams.tokenName=<Var name="kube-iam-token"/> \
+  --set serviceAccount.create=false # do not create a new service account # \
+  --set serviceAccount.name=<Var name="teleport-kube-agent-sa"/> # use the existing service account # \
+  --create-namespace \
+  --namespace=<Var name="teleport-agent"/> \
+  --version (=teleport.version=)
+```
+
+List connected clusters using `tsh kube ls` and switch between
+them using `tsh kube login`:
+
+```code
+$ tsh kube ls
+
+# Kube Cluster Name Selected
+# ----------------- --------
+# iam-cluster
+
+# kubeconfig now points to the iam-cluster cluster
+$ tsh kube login iam-cluster
+# Logged into Kubernetes cluster "iam-cluster". Try 'kubectl version' to test the connection.
+
+# kubectl command executed on `iam-cluster` but is routed through the `tele.example.com` cluster.
+$ kubectl get pods
+```
+
+<Details title="Not seeing Kubernetes clusters?">
+
+(!docs/pages/includes/kubernetes-access/rbac.mdx!)
+
+</Details>
+
+## Next steps
+
+To see all of the options you can set in the values file for the
+`teleport-kube-agent` Helm chart, consult our [reference
+guide](../../reference/helm-reference/teleport-kube-agent.mdx).
+

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -23,6 +23,7 @@ to automatically join the cluster on subsequent restarts.
 - An existing [IAM OpenID Connect (OIDC)](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) provider for your cluster
 - Helm >= (=helm.version=)
 - AWS CLI >= `2.10.3` or `1.27.81`
+- A Teleport cluster with TLS multiplexing
 
 (!docs/pages/includes/helm.mdx!)
 
@@ -201,9 +202,8 @@ At this point, the IAM role is ready to be used by the Teleport Kubernetes Servi
 
 ## Step 2/3. Create the AWS joining token
 
-Configure your Teleport Auth Service with a special dynamic token which will
-allow agents from your AWS account to join your Teleport cluster using the roles
-defined.
+Create a dynamic token which will allow agents from your AWS account to join
+your Teleport cluster using the roles defined.
 
 Under the hood, Kubernetes Service instances will prove that they are running in your AWS account by
 sending a signed Identity Document which matches an allow rule

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -37,7 +37,7 @@ clusters running in AWS without having to distribute a joining secret to the
 Kubernetes cluster.
 
 To securely join the cluster without relying on the EKS node's Identity, a Teleport agent
-must run as a separate Kubernetes service sccount with an attached IAM role. Relying
+must run as a separate Kubernetes service account with an attached IAM role. Relying
 on the node's identity is not recommended as it can be easily compromised since every
 pod running on the node has access to the node's identity if IAM Roles for Service Accounts
 (IRSA) is not configured.

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -23,7 +23,7 @@ to automatically join the cluster on subsequent restarts.
 - An existing [IAM OpenID Connect (OIDC)](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) provider for your cluster
 - Helm >= (=helm.version=)
 - AWS CLI >= `2.10.3` or `1.27.81`
-- A Teleport cluster with TLS multiplexing
+- A Teleport cluster with [TLS multiplexing](../../management/operations/tls-routing.mdx)
 
 (!docs/pages/includes/helm.mdx!)
 

--- a/docs/pages/kubernetes-access/register-clusters/register-via-deployment.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/register-via-deployment.mdx
@@ -9,7 +9,7 @@ Kubernetes Service automatically determines that it is running a Kubernetes
 cluster and, if so, registers itself with Teleport.
 
 You can register multiple Kubernetes clusters with Teleport by deploying the
-Teleport Kubernetes Service on each cluster you want to register. 
+Teleport Kubernetes Service on each cluster you want to register.
 
 ## Prerequisites
 
@@ -34,7 +34,7 @@ Teleport Kubernetes Service on each cluster you want to register.
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
-Teleport can act as an access plane for multiple Kubernetes clusters. 
+Teleport can act as an access plane for multiple Kubernetes clusters.
 
 We will assume that the domain of your Teleport cluster is `tele.example.com`.
 
@@ -47,7 +47,7 @@ We will need a join token from `tele.example.com`:
 # A trick to save the pod ID in tele.example.com
 $ POD=$(kubectl get pod -l app=teleport-cluster -o jsonpath='{.items[0].metadata.name}')
 # Create a join token for the cluster cookie to authenticate
-$ TOKEN=$(kubectl exec -ti "${POD?}" -- tctl nodes add --roles=kube --ttl=10000h --format=json | jq -r '.[0]')
+$ TOKEN=$(kubectl exec -ti "${POD?}" -- tctl nodes add --roles=kube --ttl=1h --format=json | jq -r '.[0]')
 $ echo $TOKEN
 ```
 
@@ -74,8 +74,8 @@ them using `tsh kube login`:
 ```code
 $ tsh kube ls
 
-# Kube Cluster Name Selected 
-# ----------------- -------- 
+# Kube Cluster Name Selected
+# ----------------- --------
 # cookie
 # tele.example.com    *
 
@@ -90,7 +90,7 @@ $ kubectl get pods
 </TabItem>
 <TabItem scope={["cloud"]} label="Teleport Cloud">
 
-Teleport can act as an access plane for multiple Kubernetes clusters. 
+Teleport can act as an access plane for multiple Kubernetes clusters.
 
 We will assume that the domain of your Teleport cluster is `mytenant.teleport.sh`.
 
@@ -101,7 +101,7 @@ We will need a join token from `mytenant.teleport.sh`:
 
 ```code
 # Create a join token for the cluster cookie to authenticate
-$ TOKEN=$(tctl nodes add --roles=kube --ttl=10000h --format=json | jq -r '.[0]')
+$ TOKEN=$(tctl nodes add --roles=kube --ttl=1h --format=json | jq -r '.[0]')
 $ echo $TOKEN
 ```
 
@@ -128,8 +128,8 @@ them using `tsh kube login`:
 ```code
 $ tsh kube ls
 
-# Kube Cluster Name Selected 
-# ----------------- -------- 
+# Kube Cluster Name Selected
+# ----------------- --------
 # cookie
 # mytenant.teleport.sh    *
 


### PR DESCRIPTION
This PR adds a guide to help users deploy Teleport Kubernetes agents without sharing secrets or rotating them.

This step-by-step guide helps users configure IAM roles and force Kubernetes Service Accounts to use them. The kube-agent will present its identity to the auth server and be allowed to join the Teleport cluster.

Fixes #22849