### PR TITLE
[v11] Hide download center when not on dashboards and prevent license gRPC endpoint from being called (#22965)

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4225,8 +4225,11 @@ func (a *Server) deleteUnusedKeys(ctx context.Context) error {
 	return trace.Wrap(a.keyStore.DeleteUnusedKeys(ctx, usedKeys))
 }
 
-// GetLicense return the license used the star the teleport enterprise auth server
+// GetLicense return the license used the start the teleport enterprise auth server
 func (a *Server) GetLicense(ctx context.Context) (string, error) {
+	if modules.GetModules().Features().Cloud {
+		return "", trace.AccessDenied("license cannot be downloaded on Cloud")
+	}
 	if a.license == nil {
 		return "", trace.NotFound("license not found")
 	}

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -13,6 +13,8 @@ limitations under the License.
 
 import { Store } from 'shared/libs/stores';
 
+import cfg from 'teleport/config';
+
 import { UserContext } from 'teleport/services/user';
 
 export default class StoreUserContext extends Store<UserContext> {
@@ -142,8 +144,12 @@ export default class StoreUserContext extends Store<UserContext> {
   // has access to download either teleport binaries or the license.
   // Since the page is used to download both of them, having access to one
   // is enough to show access this page.
+  // This page is only available for `dashboards`.
   hasDownloadCenterListAccess() {
-    return this.state.acl.license.read || this.state.acl.download.list;
+    return (
+      cfg.isDashboard &&
+      (this.state.acl.license.read || this.state.acl.download.list)
+    );
   }
 
   // hasAccessToAgentQuery checks for at least one valid query permission.


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/22965 to v11