### PR TITLE
docs: Add instructions on uninstalling Teleport

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -482,6 +482,10 @@
             {
               "title": "Run Teleport with Self-Signed Certificates",
               "slug": "/management/admin/self-signed-certs/"
+            },
+            {
+              "title": "Uninstall Teleport",
+              "slug": "/management/admin/uninstall-teleport/"
             }
           ]
         },

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -116,12 +116,12 @@ chart.
   |[`teleport-(=teleport.version=).pkg`](https://cdn.teleport.dev/teleport-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`|
   |[`tsh-(=teleport.version=).pkg`](https://cdn.teleport.dev/tsh-(=teleport.version=).pkg)|`tsh`|
 
-  You can also fetch an installer via the command line: 
+  You can also fetch an installer via the command line:
 
   ```code
   $ curl -O https://cdn.teleport.dev/teleport-(=teleport.version=).pkg
   # Installs on Macintosh HD
-  $ sudo installer -pkg teleport-(=teleport.version=).pkg -target / 
+  $ sudo installer -pkg teleport-(=teleport.version=).pkg -target /
   # Password:
   # installer: Package name is teleport-(=teleport.version=)
   # installer: Upgrading at base path /
@@ -171,7 +171,7 @@ against `tsh version` and `tctl version`.
   (!docs/pages/includes/enterprise/install-macos.mdx!)
 </TabItem>
 <TabItem label="Cloud" scope="cloud">
-  (!docs/pages/includes/enterprise/install-macos.mdx!)  
+  (!docs/pages/includes/enterprise/install-macos.mdx!)
 </TabItem>
 </Tabs>
 
@@ -201,12 +201,16 @@ shown in the installation examples.
 ```code
 $ export version=v(=teleport.version=)
 # 'darwin' 'linux' or 'windows'
-$ export os=linux 
+$ export os=linux
 # '386' 'arm' on linux or 'amd64' for all distros
-$ export arch=amd64 
+$ export arch=amd64
 $ curl https://get.gravitational.com/teleport-$version-$os-$arch-bin.tar.gz.sha256
 # <checksum> <filename>
 ```
+
+## Uninstalling Teleport
+
+If you wish to uninstall Teleport at any time, see our documentation on [Uninstalling Teleport](./management/admin/uninstall-teleport.mdx).
 
 ## Next steps
 

--- a/docs/pages/management/admin.mdx
+++ b/docs/pages/management/admin.mdx
@@ -16,7 +16,7 @@ cluster maintenance tasks.
 
 - [Teleport Daemon](./admin/daemon.mdx): Set up Teleport as a daemon on Linux with systemd.
 - [Upgrade the Teleport Binary](./admin/upgrading-the-teleport-binary.mdx): Upgrade the `teleport` binary without losing connections.
-- [Run Teleport with Self-Signed Certificates](./admin/self-signed-certs.mdx): Set up Teleport in a local 
+- [Run Teleport with Self-Signed Certificates](./admin/self-signed-certs.mdx): Set up Teleport in a local
 environment without configuring TLS certificates.
 
 ## Manage users and resources
@@ -30,5 +30,4 @@ environment without configuring TLS certificates.
 ## Troubleshoot issues
 
 - [Troubleshooting](./admin/troubleshooting.mdx): Collect metrics and diagnostic information from Teleport.
-
-
+- [Uninstall Teleport](./admin/uninstall-teleport.mdx): Uninstall Teleport from your system.

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -10,7 +10,7 @@ This guide explains how to uninstall Teleport binaries completely.
 - A Node with Teleport installed.
 
 <Admonition type="warning">
-These instructions apply to bare-metal installations of Teleport only.
+These instructions only apply to non-containerized installations of Teleport.
 
 If you are running Teleport in Kubernetes, you should uninstall the Helm chart release instead:
 
@@ -122,6 +122,11 @@ $ docker stop teleport
   </TabItem>
   <TabItem label="Linux Tarball" scope="oss">
 
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
+
   Remove the Teleport binaries from the machine:
 
   ```code
@@ -133,6 +138,11 @@ $ docker stop teleport
 
   </TabItem>
   <TabItem label="MacOS" scope="oss">
+
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
 
   Remove the Teleport binaries from the machine:
 
@@ -228,6 +238,11 @@ $ docker stop teleport
   </TabItem>
   <TabItem label="Linux Tarball" scope="enterprise">
 
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
+
   Remove the Teleport binaries from the machine:
 
   ```code
@@ -238,7 +253,12 @@ $ docker stop teleport
   ```
 
   </TabItem>
-    <TabItem label="MacOS" scope="enterprise">
+  <TabItem label="MacOS" scope="enterprise">
+
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
 
   Remove the Teleport binaries from the machine:
 
@@ -332,6 +352,11 @@ $ docker stop teleport
   </TabItem>
   <TabItem label="Linux Tarball" scope="cloud">
 
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
+
   Remove the Teleport binaries from the machine:
 
   ```code
@@ -343,6 +368,11 @@ $ docker stop teleport
 
   </TabItem>
   <TabItem label="MacOS" scope="cloud">
+
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
 
   Remove the Teleport binaries from the machine:
 
@@ -398,10 +428,21 @@ $ docker stop teleport
     ```
     $ sudo rm -rf /var/lib/teleport
     ```
+
+    Optionally, also remove the global config file and local user data directory for `tsh`:
+
+    ```
+    $ sudo rm -f /etc/tsh.yaml
+    $ sudo rm -rf ~/.tsh
+    ```
   </TabItem>
   <TabItem label="Windows">
 
-   There are no further steps needed to remove Teleport on a Windows machine.
+   Remove the `tsh` data directory:
+
+   ```
+   $ rmdir /s /q %USERPROFILE%\.tsh
+   ```
 
   </TabItem>
 </Tabs>

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -1,5 +1,5 @@
 ---
-title: Uninstalling Teleport
+title: Uninstall Teleport
 description: How to remove Teleport from your systems
 ---
 
@@ -86,6 +86,14 @@ $ docker stop teleport
   $ sudo rm -f /etc/apt/sources.list.d/teleport.list
   ```
 
+  <Admonition type="notice" title="Uninstall standalone DEB package">
+  If the commands above do not work, you may have installed Teleport using a standalone DEB package. Remove it with:
+
+  ```code
+  $ sudo dpkg -r teleport
+  ```
+  </Admonition>
+
   </TabItem>
   <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="oss">
 
@@ -102,6 +110,14 @@ $ docker stop teleport
   ```code
   $ sudo rm -f /etc/yum.repos.d/teleport.repo
   ```
+
+  <Admonition type="notice" title="Uninstall standalone RPM package">
+  If the commands above do not work, you may have installed Teleport using a standalone RPM package. Remove it with:
+
+  ```code
+  $ sudo rpm -e teleport
+  ```
+  </Admonition>
 
   </TabItem>
   <TabItem label="Linux Tarball" scope="oss">
@@ -125,11 +141,16 @@ $ docker stop teleport
   $ sudo rm -f /usr/local/bin/tctl
   $ sudo rm -f /usr/local/bin/teleport
   $ sudo rm -f /usr/local/bin/tsh
-  # Optional: Also remove the signed MacOS tsh application if you installed it
-  # $ sudo rm -f /Applications/tsh.app
-  # Optional: Also remove Teleport Connect if you installed it
-  # $ sudo rm -f /Applications/Teleport\ Connect.app
   ```
+
+  <Admonition type="notice" title="Uninstall MacOS client tools">
+  If you installed the MacOS `tsh`-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
+
+  ```code
+  $ sudo rm -f /Applications/tsh.app
+  $ sudo rm -f /Applications/Teleport\ Connect.app
+  ```
+  </Admonition>
 
   </TabItem>
   <TabItem label="Windows" scope="oss">
@@ -162,6 +183,17 @@ $ docker stop teleport
   $ sudo rm -f /etc/apt/sources.list.d/teleport.list
   ```
 
+  <Admonition type="notice" title="Uninstall standalone DEB package">
+  If the commands above do not work, you may have installed Teleport using a standalone DEB package. Remove it with:
+
+  ```code
+  # Enterprise
+  $ sudo dpkg -r teleport-ent
+  # Enterprise FIPS
+  # $ sudo dpkg -r teleport-ent-fips
+  ```
+  </Admonition>
+
   </TabItem>
   <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="enterprise">
 
@@ -181,6 +213,17 @@ $ docker stop teleport
   ```code
   $ sudo rm -f /etc/yum.repos.d/teleport.repo
   ```
+
+  <Admonition type="notice" title="Uninstall standalone RPM package">
+  If the commands above do not work, you may have installed Teleport using a standalone RPM package. Remove it with:
+
+  ```code
+  # Enterprise
+  $ sudo rpm -e teleport-ent
+  # Enterprise FIPS
+  # $ sudo rpm -e teleport-ent-fips
+  ```
+  </Admonition>
 
   </TabItem>
   <TabItem label="Linux Tarball" scope="enterprise">
@@ -204,11 +247,16 @@ $ docker stop teleport
   $ sudo rm -f /usr/local/bin/tctl
   $ sudo rm -f /usr/local/bin/teleport
   $ sudo rm -f /usr/local/bin/tsh
-  # Optional: Also remove the signed MacOS tsh application if you installed it
-  # $ sudo rm -f /Applications/tsh.app
-  # Optional: Also remove Teleport Connect if you installed it
-  # $ sudo rm -f /Applications/Teleport\ Connect.app
   ```
+
+  <Admonition type="notice" title="Uninstall MacOS client tools">
+  If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
+
+  ```code
+  $ sudo rm -f /Applications/tsh.app
+  $ sudo rm -f /Applications/Teleport\ Connect.app
+  ```
+  </Admonition>
 
   </TabItem>
   <TabItem label="Windows" scope="enterprise">
@@ -241,6 +289,16 @@ $ docker stop teleport
   $ sudo rm -f /etc/apt/sources.list.d/teleport.list
   ```
 
+  <Admonition type="notice" title="Uninstall standalone DEB package">
+  If the commands above do not work, you may have installed Teleport using a standalone DEB package. Remove it with:
+
+  ```code
+  $ sudo dpkg -r teleport-ent
+  # NOTE: Older Cloud users may be running OSS binaries instead
+  # $ sudo dpkg -r teleport
+  ```
+  </Admonition>
+
   </TabItem>
   <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="cloud">
 
@@ -260,6 +318,16 @@ $ docker stop teleport
   ```code
   $ sudo rm -f /etc/yum.repos.d/teleport.repo
   ```
+
+  <Admonition type="notice" title="Uninstall standalone RPM package">
+  If the commands above do not work, you may have installed Teleport using a standalone RPM package. Remove it with:
+
+  ```code
+  $ sudo rpm -e teleport-ent
+  # NOTE: Older Cloud users may be running OSS binaries instead
+  # $ sudo rpm -e teleport
+  ```
+  </Admonition>
 
   </TabItem>
   <TabItem label="Linux Tarball" scope="cloud">
@@ -283,11 +351,16 @@ $ docker stop teleport
   $ sudo rm -f /usr/local/bin/tctl
   $ sudo rm -f /usr/local/bin/teleport
   $ sudo rm -f /usr/local/bin/tsh
-  # Optional: Also remove the signed MacOS tsh application if you installed it
-  # $ sudo rm -f /Applications/tsh.app
-  # Optional: Also remove Teleport Connect if you installed it
-  # $ sudo rm -f /Applications/Teleport\ Connect.app
   ```
+
+  <Admonition type="notice" title="Uninstall MacOS client tools">
+  If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
+
+  ```code
+  $ sudo rm -f /Applications/tsh.app
+  $ sudo rm -f /Applications/Teleport\ Connect.app
+  ```
+  </Admonition>
 
   </TabItem>
   <TabItem label="Windows" scope="cloud">
@@ -305,25 +378,34 @@ $ docker stop teleport
 
 ## Step 3/3. Remove Teleport data and configuration files
 
-<Admonition type="notice">
-These are the default paths to the Teleport config files and data directory.
-If you have changed these from the defaults on your system, substitute those paths here.
-</Admonition>
+<Tabs>
+  <TabItem label="Linux/MacOS">
+    <Admonition type="notice">
+    These are the default paths to the Teleport config files and data directory.
+    If you have changed these from the defaults on your system, substitute those paths here.
+    </Admonition>
 
-Remove the Teleport config file:
+    Remove the Teleport config file:
 
-```code
-$ sudo rm -f /etc/teleport.yaml
-# Optional: Also remove the Machine ID config file, if you used it
-# $ sudo rm -f /etc/tbot.yaml
-```
+    ```code
+    $ sudo rm -f /etc/teleport.yaml
+    # Optional: Also remove the Machine ID config file, if you used it
+    # $ sudo rm -f /etc/tbot.yaml
+    ```
 
-Remove the Teleport data directory:
+    Remove the Teleport data directory:
 
-```
-$ sudo rm -rf /var/lib/teleport
-```
+    ```
+    $ sudo rm -rf /var/lib/teleport
+    ```
+  </TabItem>
+  <TabItem label="Windows">
+
+   There are no further steps needed to remove Teleport on a Windows machine.
+
+  </TabItem>
+</Tabs>
 
 Teleport is now removed from your system.
 
-Any Teleport Nodes will stop appearing in your Teleport web UI or the output of `tsh ls` once their last heartbeat has timed out. This usually occurs within 10-15 minutes of stopping the Teleport process.
+Any Teleport Services will stop appearing in your Teleport web UI or the output of `tsh ls` once their last heartbeat has timed out. This usually occurs within 10-15 minutes of stopping the Teleport process.

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -7,7 +7,7 @@ This guide explains how to uninstall Teleport binaries completely.
 
 ## Prerequisites
 
-- A Node with Teleport installed.
+- A system with Teleport installed.
 
 <Admonition type="warning">
 These instructions only apply to non-containerized installations of Teleport.
@@ -67,7 +67,7 @@ $ docker stop teleport
   </TabItem>
 </Tabs>
 
-## Step 2/3. Remove Teleport binaries from the Node
+## Step 2/3. Remove Teleport binaries
 
 <Tabs dropdownView dropdownCaption="Teleport Edition">
   <TabItem label="Open Source" scope="oss">
@@ -170,6 +170,10 @@ $ docker stop teleport
   ```code
   $ del C:\Path\To\tsh.exe
   ```
+
+  You can uninstall Teleport Connect from the "Apps and Features" section of the Control Panel.
+
+  For reference, Teleport Connect binaries are installed to `%LOCALAPPDATA%\Programs\teleport-connect`.
 
   </TabItem>
   </Tabs>
@@ -287,6 +291,10 @@ $ docker stop teleport
   $ del C:\Path\To\tsh.exe
   ```
 
+  You can uninstall Teleport Connect from the "Apps and Features" section of the Control Panel.
+
+  For reference, Teleport Connect binaries are installed to `%LOCALAPPDATA%\Programs\teleport-connect`.
+
   </TabItem>
   </Tabs>
   </TabItem>
@@ -401,6 +409,10 @@ $ docker stop teleport
   $ del C:\Path\To\tsh.exe
   ```
 
+  You can uninstall Teleport Connect from the "Apps and Features" section of the Control Panel.
+
+  For reference, Teleport Connect binaries are installed to `%LOCALAPPDATA%\Programs\teleport-connect`.
+
   </TabItem>
   </Tabs>
   </TabItem>
@@ -409,7 +421,7 @@ $ docker stop teleport
 ## Step 3/3. Remove Teleport data and configuration files
 
 <Tabs>
-  <TabItem label="Linux/MacOS">
+  <TabItem label="Linux">
     <Admonition type="notice">
     These are the default paths to the Teleport config files and data directory.
     If you have changed these from the defaults on your system, substitute those paths here.
@@ -425,23 +437,61 @@ $ docker stop teleport
 
     Remove the Teleport data directory:
 
-    ```
+    ```code
     $ sudo rm -rf /var/lib/teleport
     ```
 
-    Optionally, also remove the global config file and local user data directory for `tsh`:
+     Optionally, also remove the global config file and local user data directory for `tsh`:
 
-    ```
+    ```code
     $ sudo rm -f /etc/tsh.yaml
     $ sudo rm -rf ~/.tsh
     ```
   </TabItem>
+  <TabItem label="MacOS">
+    <Admonition type="notice">
+    These are the default paths to the Teleport config files and data directory.
+    If you have changed these from the defaults on your system, substitute those paths here.
+    </Admonition>
+
+    Remove the Teleport config file:
+
+    ```code
+    $ sudo rm -f /etc/teleport.yaml
+    # Optional: Also remove the Machine ID config file, if you used it
+    # $ sudo rm -f /etc/tbot.yaml
+    ```
+
+    Remove the Teleport data directory:
+
+    ```code
+    $ sudo rm -rf /var/lib/teleport
+    ```
+
+    Optionally, also remove:
+    - the global config file and local user data directory for `tsh`
+    - the local user data directory for Teleport Connect
+
+    ```code
+    # tsh
+    $ sudo rm -f /etc/tsh.yaml
+    $ sudo rm -rf ~/.tsh
+    # Teleport Connect
+    $ sudo rm -rf ~/Library/Application\ Support/Teleport\ Connect
+    ```
+  </TabItem>
   <TabItem label="Windows">
 
-   Remove the `tsh` data directory:
+   Remove the local user data directory for `tsh`:
 
-   ```
+   ```code
    $ rmdir /s /q %USERPROFILE%\.tsh
+   ```
+
+   Optionally, also remove the local user data directory for Teleport Connect:
+
+   ```code
+   $ rmdir /s /q "%APPDATA%\Teleport Connect"
    ```
 
   </TabItem>

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -499,4 +499,4 @@ $ docker stop teleport
 
 Teleport is now removed from your system.
 
-Any Teleport Services will stop appearing in your Teleport web UI or the output of `tsh ls` once their last heartbeat has timed out. This usually occurs within 10-15 minutes of stopping the Teleport process.
+Any Teleport Services will stop appearing in your Teleport Web UI or the output of `tsh ls` once their last heartbeat has timed out. This usually occurs within 10-15 minutes of stopping the Teleport process.

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -1,6 +1,6 @@
 ---
 title: Uninstall Teleport
-description: How to remove Teleport from your systems
+description: How to remove Teleport from your system
 ---
 
 This guide explains how to uninstall Teleport binaries completely.

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -1,0 +1,329 @@
+---
+title: Uninstalling Teleport
+description: How to remove Teleport from your systems
+---
+
+This guide explains how to uninstall Teleport binaries completely.
+
+## Prerequisites
+
+- A Node with Teleport installed.
+
+<Admonition type="warning">
+These instructions apply to bare-metal installations of Teleport only.
+
+If you are running Teleport in Kubernetes, you should uninstall the Helm chart release instead:
+
+```code
+# Example: uninstall the Helm release named 'teleport-kube-agent' in the 'teleport' namespace
+$ helm uninstall --namespace teleport teleport-kube-agent
+```
+
+If you are running Teleport in Docker, you should stop the Teleport Docker container:
+
+```code
+# Example: Stop the Docker container named 'teleport'
+$ docker stop teleport
+```
+</Admonition>
+
+## Step 1/3. Stop any running Teleport processes
+
+<Tabs>
+  <TabItem label="Linux">
+    Instruct `systemd` to stop the Teleport process, and disable it from automatically starting:
+
+    ```code
+    $ sudo systemctl stop teleport
+    $ sudo systemctl disable teleport
+    ```
+
+    If these `systemd` commands do not work, you can "kill" all the running Teleport processes instead:
+
+    ```code
+    $ sudo killall teleport
+    ```
+  </TabItem>
+  <TabItem label="MacOS">
+
+    Instruct `launchd` to stop the Teleport process, and disable it from automatically starting:
+
+    ```code
+    $ sudo launchctl unload -w /Library/LaunchDaemons/com.goteleport.teleport.plist
+    $ sudo rm -f /Library/LaunchDaemons/com.goteleport.teleport.plist
+    ```
+
+   If these commands do not work, you can "kill" all the running Teleport processes instead:
+
+    ```code
+    $ sudo killall teleport
+    ```
+
+  </TabItem>
+  <TabItem label="Windows">
+
+    There are currently no long-running Teleport processes on Windows machines.
+
+  </TabItem>
+</Tabs>
+
+## Step 2/3. Remove Teleport binaries from the Node
+
+<Tabs dropdownView dropdownCaption="Teleport Edition">
+  <TabItem label="Open Source" scope="oss">
+  <Tabs>
+  <TabItem label="Debian/Ubuntu Linux (DEB)" scope="oss">
+
+  Uninstall the Teleport binary using APT:
+
+  ```code
+  $ sudo apt-get -y remove teleport
+  ```
+
+  Uninstall the Teleport APT repo:
+
+  ```code
+  $ sudo rm -f /etc/apt/sources.list.d/teleport.list
+  ```
+
+  </TabItem>
+  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="oss">
+
+  Uninstall the Teleport binary using YUM:
+
+  ```code
+  $ sudo yum -y remove teleport
+  # Optional: Use DNF on newer distributions
+  # $ sudo dnf -y remove teleport
+  ```
+
+  Uninstall the Teleport YUM repo:
+
+  ```code
+  $ sudo rm -f /etc/yum.repos.d/teleport.repo
+  ```
+
+  </TabItem>
+  <TabItem label="Linux Tarball" scope="oss">
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  ```
+
+  </TabItem>
+  <TabItem label="MacOS" scope="oss">
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  # Optional: Also remove the signed MacOS tsh application if you installed it
+  # $ sudo rm -f /Applications/tsh.app
+  # Optional: Also remove Teleport Connect if you installed it
+  # $ sudo rm -f /Applications/Teleport\ Connect.app
+  ```
+
+  </TabItem>
+  <TabItem label="Windows" scope="oss">
+
+  Remove the `tsh.exe` binary from the machine:
+
+  ```code
+  $ del C:\Path\To\tsh.exe
+  ```
+
+  </TabItem>
+  </Tabs>
+  </TabItem>
+  <TabItem label="Enterprise" scope="enterprise">
+
+  <Tabs>
+  <TabItem label="Debian/Ubuntu Linux (DEB)" scope="enterprise">
+
+  Uninstall the Teleport binary using APT:
+
+  ```code
+  $ sudo apt-get -y remove teleport-ent
+  # Optional: If using the Teleport FIPS package
+  # $ sudo apt-get -y remove teleport-ent-fips
+  ```
+
+  Uninstall the Teleport APT repo:
+
+  ```code
+  $ sudo rm -f /etc/apt/sources.list.d/teleport.list
+  ```
+
+  </TabItem>
+  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="enterprise">
+
+  Uninstall the Teleport binary using YUM:
+
+  ```code
+  $ sudo yum -y remove teleport-ent
+  # Optional: Use DNF on newer distributions
+  # $ sudo dnf -y remove teleport-ent
+  # Optional: If using the Teleport FIPS package
+  # $ sudo yum -y remove teleport-ent-fips
+  # $ sudo dnf -y remove teleport-ent-fips
+  ```
+
+  Uninstall the Teleport YUM repo:
+
+  ```code
+  $ sudo rm -f /etc/yum.repos.d/teleport.repo
+  ```
+
+  </TabItem>
+  <TabItem label="Linux Tarball" scope="enterprise">
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  ```
+
+  </TabItem>
+    <TabItem label="MacOS" scope="enterprise">
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  # Optional: Also remove the signed MacOS tsh application if you installed it
+  # $ sudo rm -f /Applications/tsh.app
+  # Optional: Also remove Teleport Connect if you installed it
+  # $ sudo rm -f /Applications/Teleport\ Connect.app
+  ```
+
+  </TabItem>
+  <TabItem label="Windows" scope="enterprise">
+
+  Remove the `tsh.exe` binary from the machine:
+
+  ```code
+  $ del C:\Path\To\tsh.exe
+  ```
+
+  </TabItem>
+  </Tabs>
+  </TabItem>
+  <TabItem label="Cloud" scope="cloud">
+
+  <Tabs>
+  <TabItem label="Debian/Ubuntu Linux (DEB)" scope="cloud">
+
+  Uninstall the Teleport binary using APT:
+
+  ```code
+  $ sudo apt-get -y remove teleport-ent
+  # NOTE: Older Cloud users may be running OSS binaries instead
+  # $ sudo apt-get -y remove teleport
+  ```
+
+  Uninstall the Teleport APT repo:
+
+  ```code
+  $ sudo rm -f /etc/apt/sources.list.d/teleport.list
+  ```
+
+  </TabItem>
+  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="cloud">
+
+  Uninstall the Teleport binary using YUM:
+
+  ```code
+  $ sudo yum -y remove teleport-ent
+  # Optional: Use DNF on newer distributions
+  # $ sudo dnf -y remove teleport-ent
+  # NOTE: Older Cloud users may be running OSS binaries instead
+  # $ sudo yum -y remove teleport
+  # $ sudo dnf -y remove teleport
+  ```
+
+  Uninstall the Teleport YUM repo:
+
+  ```code
+  $ sudo rm -f /etc/yum.repos.d/teleport.repo
+  ```
+
+  </TabItem>
+  <TabItem label="Linux Tarball" scope="cloud">
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  ```
+
+  </TabItem>
+  <TabItem label="MacOS" scope="cloud">
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  # Optional: Also remove the signed MacOS tsh application if you installed it
+  # $ sudo rm -f /Applications/tsh.app
+  # Optional: Also remove Teleport Connect if you installed it
+  # $ sudo rm -f /Applications/Teleport\ Connect.app
+  ```
+
+  </TabItem>
+  <TabItem label="Windows" scope="cloud">
+
+  Remove the `tsh.exe` binary from the machine:
+
+  ```code
+  $ del C:\Path\To\tsh.exe
+  ```
+
+  </TabItem>
+  </Tabs>
+  </TabItem>
+</Tabs>
+
+## Step 3/3. Remove Teleport data and configuration files
+
+<Admonition type="notice">
+These are the default paths to the Teleport config files and data directory.
+If you have changed these from the defaults on your system, substitute those paths here.
+</Admonition>
+
+Remove the Teleport config file:
+
+```code
+$ sudo rm -f /etc/teleport.yaml
+# Optional: Also remove the Machine ID config file, if you used it
+# $ sudo rm -f /etc/tbot.yaml
+```
+
+Remove the Teleport data directory:
+
+```
+$ sudo rm -rf /var/lib/teleport
+```
+
+Teleport is now removed from your system.
+
+Any Teleport Nodes will stop appearing in your Teleport web UI or the output of `tsh ls` once their last heartbeat has timed out. This usually occurs within 10-15 minutes of stopping the Teleport process.


### PR DESCRIPTION
Converts https://github.com/gravitational/teleport/discussions/9920 into a proper documentation page

Fixes https://github.com/gravitational/teleport/issues/22862