### PR TITLE
Fix locks not propagating in cache.

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1797,6 +1797,40 @@ func TestUserGroups(t *testing.T) {
 	})
 }
 
+// TestLocks tests that CRUD operations on lock resources are
+// replicated from the backend to the cache.
+func TestLocks(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[types.Lock]{
+		newResource: func(name string) (types.Lock, error) {
+			return types.NewLock(
+				name,
+				types.LockSpecV2{
+					Target: types.LockTarget{
+						Role: "target-role",
+					},
+				},
+			)
+		},
+		create: p.accessS.UpsertLock,
+		list: func(ctx context.Context) ([]types.Lock, error) {
+			results, err := p.accessS.GetLocks(ctx, false)
+			return results, err
+		},
+		cacheGet: p.cache.GetLock,
+		cacheList: func(ctx context.Context) ([]types.Lock, error) {
+			results, err := p.cache.GetLocks(ctx, false)
+			return results, err
+		},
+		update:    p.accessS.UpsertLock,
+		deleteAll: p.accessS.DeleteAllLocks,
+	})
+}
+
 // testResources is a generic tester for resources.
 func testResources[T types.Resource](t *testing.T, p *testPack, funcs testFuncs[T]) {
 	ctx := context.Background()

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -1293,7 +1293,7 @@ func (lockExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) 
 }
 
 func (lockExecutor) upsert(ctx context.Context, cache *Cache, resource types.Lock) error {
-	return cache.Access.UpsertLock(ctx, resource)
+	return cache.accessCache.UpsertLock(ctx, resource)
 }
 
 func (lockExecutor) deleteAll(ctx context.Context, cache *Cache) error {


### PR DESCRIPTION
The locks were not being properly upserted to the cache after the collections refactor. This was due to a typo when writing the `upsert` logic for the locks collection.

Closes https://github.com/gravitational/teleport/issues/23007