### PR TITLE
Update Rust to 1.68.0

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -24,7 +24,7 @@ GOLANG_VERSION ?= go1.20.2
 NODE_VERSION ?= 16.18.1
 
 # run lint-rust check locally before merging code after you bump this
-RUST_VERSION ?= 1.67.0
+RUST_VERSION ?= 1.68.0
 LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 


### PR DESCRIPTION
I ran the rust-lint and there weren't any new clippy warnings.