### PR TITLE
Connect: Add useSearch hook

### DIFF
--- a/web/packages/teleterm/src/services/tshd/createClient.ts
+++ b/web/packages/teleterm/src/services/tshd/createClient.ts
@@ -66,7 +66,7 @@ export default function createClient(
       searchAsRoles,
       startKey,
       limit,
-    }: types.ServerSideParams) {
+    }: types.GetResourcesParams) {
       const req = new api.GetKubesRequest()
         .setClusterUri(clusterUri)
         .setSearchAsRoles(searchAsRoles)
@@ -133,7 +133,7 @@ export default function createClient(
       searchAsRoles,
       startKey,
       limit,
-    }: types.ServerSideParams) {
+    }: types.GetResourcesParams) {
       const req = new api.GetDatabasesRequest()
         .setClusterUri(clusterUri)
         .setSearchAsRoles(searchAsRoles)
@@ -202,7 +202,7 @@ export default function createClient(
       searchAsRoles,
       startKey,
       limit,
-    }: types.ServerSideParams) {
+    }: types.GetResourcesParams) {
       const req = new api.GetServersRequest()
         .setClusterUri(clusterUri)
         .setSearchAsRoles(searchAsRoles)

--- a/web/packages/teleterm/src/services/tshd/createClient.ts
+++ b/web/packages/teleterm/src/services/tshd/createClient.ts
@@ -61,7 +61,7 @@ export default function createClient(
     async getKubes({
       clusterUri,
       search,
-      sort = { fieldName: 'name', dir: 'ASC' },
+      sort,
       query,
       searchAsRoles,
       startKey,
@@ -71,10 +71,14 @@ export default function createClient(
         .setClusterUri(clusterUri)
         .setSearchAsRoles(searchAsRoles)
         .setStartKey(startKey)
-        .setSortBy(`${sort.fieldName}:${sort.dir.toLowerCase()}`)
         .setSearch(search)
         .setQuery(query)
         .setLimit(limit);
+
+      if (sort) {
+        req.setSortBy(`${sort.fieldName}:${sort.dir.toLowerCase()}`);
+      }
+
       return new Promise<types.GetKubesResponse>((resolve, reject) => {
         tshd.getKubes(req, (err, response) => {
           if (err) {
@@ -128,7 +132,7 @@ export default function createClient(
     async getDatabases({
       clusterUri,
       search,
-      sort = { fieldName: 'name', dir: 'ASC' },
+      sort,
       query,
       searchAsRoles,
       startKey,
@@ -138,10 +142,14 @@ export default function createClient(
         .setClusterUri(clusterUri)
         .setSearchAsRoles(searchAsRoles)
         .setStartKey(startKey)
-        .setSortBy(`${sort.fieldName}:${sort.dir.toLowerCase()}`)
         .setSearch(search)
         .setQuery(query)
         .setLimit(limit);
+
+      if (sort) {
+        req.setSortBy(`${sort.fieldName}:${sort.dir.toLowerCase()}`);
+      }
+
       return new Promise<types.GetDatabasesResponse>((resolve, reject) => {
         tshd.getDatabases(req, (err, response) => {
           if (err) {
@@ -198,7 +206,7 @@ export default function createClient(
       clusterUri,
       search,
       query,
-      sort = { fieldName: 'hostname', dir: 'ASC' },
+      sort,
       searchAsRoles,
       startKey,
       limit,
@@ -207,10 +215,14 @@ export default function createClient(
         .setClusterUri(clusterUri)
         .setSearchAsRoles(searchAsRoles)
         .setStartKey(startKey)
-        .setSortBy(`${sort.fieldName}:${sort.dir.toLowerCase()}`)
         .setSearch(search)
         .setQuery(query)
         .setLimit(limit);
+
+      if (sort) {
+        req.setSortBy(`${sort.fieldName}:${sort.dir.toLowerCase()}`);
+      }
+
       return new Promise<types.GetServersResponse>((resolve, reject) => {
         tshd.getServers(req, (err, response) => {
           if (err) {

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -29,7 +29,7 @@ import {
   LoginPasswordlessParams,
   LoginSsoParams,
   ReviewAccessRequestParams,
-  ServerSideParams,
+  GetResourcesParams,
   TshAbortController,
   TshAbortSignal,
   TshClient,
@@ -39,13 +39,13 @@ import {
 export class MockTshClient implements TshClient {
   listRootClusters: () => Promise<Cluster[]>;
   listLeafClusters: (clusterUri: string) => Promise<Cluster[]>;
-  getKubes: (params: ServerSideParams) => Promise<GetKubesResponse>;
-  getDatabases: (params: ServerSideParams) => Promise<GetDatabasesResponse>;
+  getKubes: (params: GetResourcesParams) => Promise<GetKubesResponse>;
+  getDatabases: (params: GetResourcesParams) => Promise<GetDatabasesResponse>;
   listDatabaseUsers: (dbUri: string) => Promise<string[]>;
   getRequestableRoles: (
     params: GetRequestableRolesParams
   ) => Promise<GetRequestableRolesResponse>;
-  getServers: (params: ServerSideParams) => Promise<GetServersResponse>;
+  getServers: (params: GetResourcesParams) => Promise<GetServersResponse>;
   assumeRole: (
     clusterUri: string,
     requestIds: string[],

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -250,12 +250,15 @@ export type CreateGatewayParams = {
 
 export type GetResourcesParams = {
   clusterUri: uri.ClusterUri;
+  // sort is a required field because it has direct implications on performance of ListResources.
+  sort: SortType | null;
+  // limit cannot be omitted and must be greater than zero, otherwise ListResources is going to
+  // return an error.
+  limit: number;
   // search is used for regular search.
   search?: string;
   searchAsRoles?: string;
-  sort?: SortType;
   startKey?: string;
-  limit?: number;
   // query is used for advanced search.
   query?: string;
 };

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -144,8 +144,8 @@ export type LoginPasswordlessRequest =
 export type TshClient = {
   listRootClusters: () => Promise<Cluster[]>;
   listLeafClusters: (clusterUri: uri.RootClusterUri) => Promise<Cluster[]>;
-  getKubes: (params: ServerSideParams) => Promise<GetKubesResponse>;
-  getDatabases: (params: ServerSideParams) => Promise<GetDatabasesResponse>;
+  getKubes: (params: GetResourcesParams) => Promise<GetKubesResponse>;
+  getDatabases: (params: GetResourcesParams) => Promise<GetDatabasesResponse>;
   listDatabaseUsers: (dbUri: uri.DatabaseUri) => Promise<string[]>;
   assumeRole: (
     clusterUri: uri.RootClusterUri,
@@ -155,7 +155,7 @@ export type TshClient = {
   getRequestableRoles: (
     params: GetRequestableRolesParams
   ) => Promise<GetRequestableRolesResponse>;
-  getServers: (params: ServerSideParams) => Promise<GetServersResponse>;
+  getServers: (params: GetResourcesParams) => Promise<GetServersResponse>;
   getAccessRequests: (
     clusterUri: uri.RootClusterUri
   ) => Promise<AccessRequest[]>;
@@ -248,7 +248,7 @@ export type CreateGatewayParams = {
   subresource_name?: string;
 };
 
-export type ServerSideParams = {
+export type GetResourcesParams = {
   clusterUri: uri.ClusterUri;
   // search is used for regular search.
   search?: string;
@@ -259,6 +259,10 @@ export type ServerSideParams = {
   // query is used for advanced search.
   query?: string;
 };
+
+// Compatibility type to make sure teleport.e doesn't break.
+// TODO(ravicious): Remove after teleterm.e is updated to use GetResourcesParams.
+export type ServerSideParams = GetResourcesParams;
 
 export type ReviewAccessRequestParams = {
   state: RequestState;

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
@@ -170,7 +170,7 @@ function getMenuLoginOptions(
 async function getDatabaseUsers(appContext: IAppContext, dbUri: DatabaseUri) {
   try {
     const dbUsers = await retryWithRelogin(appContext, dbUri, () =>
-      appContext.clustersService.getDbUsers(dbUri)
+      appContext.resourcesService.getDbUsers(dbUri)
     );
     return dbUsers.map(user => ({ login: user, url: '' }));
   } catch (e) {

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/useDatabases.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/useDatabases.ts
@@ -18,7 +18,7 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 import {
   Database,
   GatewayProtocol,
-  ServerSideParams,
+  GetResourcesParams,
 } from 'teleterm/services/tshd/types';
 import { routing } from 'teleterm/ui/uri';
 import { makeDatabase } from 'teleterm/ui/services/clusters';
@@ -31,7 +31,7 @@ export function useDatabases() {
   const { fetchAttempt, ...serverSideResources } =
     useServerSideResources<Database>(
       { fieldName: 'name', dir: 'ASC' }, // default sort
-      (params: ServerSideParams) =>
+      (params: GetResourcesParams) =>
         appContext.resourcesService.fetchDatabases(params)
     );
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/useKubes.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/useKubes.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Kube, ServerSideParams } from 'teleterm/services/tshd/types';
+import { Kube, GetResourcesParams } from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useClusterContext } from 'teleterm/ui/DocumentCluster/clusterContext';
 
@@ -25,7 +25,8 @@ export function useKubes() {
   const ctx = useClusterContext();
   const { fetchAttempt, ...serversideResources } = useServerSideResources<Kube>(
     { fieldName: 'name', dir: 'ASC' }, // default sort
-    (params: ServerSideParams) => appContext.resourcesService.fetchKubes(params)
+    (params: GetResourcesParams) =>
+      appContext.resourcesService.fetchKubes(params)
   );
 
   return {

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/useServers.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/useServers.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { Server, ServerSideParams } from 'teleterm/services/tshd/types';
+import { Server, GetResourcesParams } from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { makeServer } from 'teleterm/ui/services/clusters';
 
@@ -27,7 +27,7 @@ export function useServers() {
   const { fetchAttempt, ...serversideResources } =
     useServerSideResources<Server>(
       { fieldName: 'hostname', dir: 'ASC' }, // default sort
-      (params: ServerSideParams) =>
+      (params: GetResourcesParams) =>
         appContext.resourcesService.fetchServers(params)
     );
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/useServerSideResources.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/useServerSideResources.ts
@@ -19,7 +19,7 @@ import { SortType } from 'design/DataTable/types';
 import { useAsync } from 'shared/hooks/useAsync';
 import { AgentFilter, AgentLabel } from 'teleport/services/agents';
 
-import { ServerSideParams } from 'teleterm/services/tshd/types';
+import { GetResourcesParams } from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 
@@ -49,7 +49,7 @@ const limit = 15;
 
 export function useServerSideResources<Agent>(
   defaultSort: SortType,
-  fetchFunction: (params: ServerSideParams) => Promise<FetchResponse<Agent>>
+  fetchFunction: (params: GetResourcesParams) => Promise<FetchResponse<Agent>>
 ) {
   const ctx = useAppContext();
   const { clusterUri } = useClusterContext();

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/useServerSideResources.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/useServerSideResources.ts
@@ -17,13 +17,18 @@
 import { useState, useEffect, useMemo } from 'react';
 import { SortType } from 'design/DataTable/types';
 import { useAsync } from 'shared/hooks/useAsync';
-import { AgentFilter, AgentLabel } from 'teleport/services/agents';
+import {
+  AgentFilter as WeakAgentFilter,
+  AgentLabel,
+} from 'teleport/services/agents';
 
 import { GetResourcesParams } from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 
 import { useClusterContext } from '../clusterContext';
+
+type AgentFilter = WeakAgentFilter & { sort: SortType };
 
 function addAgentLabelToQuery(filter: AgentFilter, label: AgentLabel) {
   const queryParts = [];

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback } from 'react';
+
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+
+/**
+ * useSearch returns a function which searches for the given list of space-separated keywords across
+ * all root and leaf clusters that the user is currently logged in to.
+ *
+ * It does so by issuing a separate request for each resource type to each cluster. It fails if any
+ * of those requests fail.
+ */
+export function useSearch() {
+  const { clustersService, resourcesService } = useAppContext();
+  clustersService.useState();
+
+  return useCallback(
+    async (search: string) => {
+      const connectedClusters = clustersService
+        .getClusters()
+        .filter(c => c.connected);
+      const searchPromises = connectedClusters.map(cluster =>
+        resourcesService.searchResources(cluster.uri, search)
+      );
+
+      return (await Promise.all(searchPromises)).flat();
+    },
+    [clustersService, resourcesService]
+  );
+}

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -196,6 +196,8 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   async getRequestableRoles(params: GetRequestableRolesParams) {
     const cluster = this.state.clusters.get(params.rootClusterUri);
+    // TODO(ravicious): Remove check for cluster.connected. This check should be done earlier in the
+    // UI rather than be repeated in each ClustersService method.
     if (!cluster.connected) {
       return;
     }
@@ -205,6 +207,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   getAssumedRequests(rootClusterUri: uri.RootClusterUri) {
     const cluster = this.state.clusters.get(rootClusterUri);
+    // TODO(ravicious): Remove check for cluster.connected. See the comment in getRequestableRoles.
     if (!cluster?.connected) {
       return {};
     }
@@ -218,6 +221,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   async getAccessRequests(rootClusterUri: uri.RootClusterUri) {
     const cluster = this.state.clusters.get(rootClusterUri);
+    // TODO(ravicious): Remove check for cluster.connected. See the comment in getRequestableRoles.
     if (!cluster.connected) {
       return;
     }
@@ -230,6 +234,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
     requestId: string
   ) {
     const cluster = this.state.clusters.get(rootClusterUri);
+    // TODO(ravicious): Remove check for cluster.connected. See the comment in getRequestableRoles.
     if (!cluster.connected) {
       return;
     }
@@ -242,6 +247,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
     dropIds: string[]
   ) {
     const cluster = this.state.clusters.get(rootClusterUri);
+    // TODO(ravicious): Remove check for cluster.connected. See the comment in getRequestableRoles.
     if (!cluster.connected) {
       return;
     }
@@ -255,6 +261,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
     requestId: string
   ) {
     const cluster = this.state.clusters.get(rootClusterUri);
+    // TODO(ravicious): Remove check for cluster.connected. See the comment in getRequestableRoles.
     if (!cluster.connected) {
       return;
     }
@@ -267,6 +274,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
     params: ReviewAccessRequestParams
   ) {
     const cluster = this.state.clusters.get(rootClusterUri);
+    // TODO(ravicious): Remove check for cluster.connected. See the comment in getRequestableRoles.
     if (!cluster.connected) {
       return;
     }
@@ -281,6 +289,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
   async createAccessRequest(params: CreateAccessRequestParams) {
     const cluster = this.state.clusters.get(params.rootClusterUri);
+    // TODO(ravicious): Remove check for cluster.connected. See the comment in getRequestableRoles.
     if (!cluster.connected) {
       return;
     }

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -29,7 +29,7 @@ import {
   CreateAccessRequestParams,
   GetRequestableRolesParams,
   ReviewAccessRequestParams,
-  ServerSideParams,
+  GetResourcesParams,
 } from 'teleterm/services/tshd/types';
 import { MainProcessClient } from 'teleterm/mainProcess/types';
 import { UsageService } from 'teleterm/ui/services/usage';
@@ -427,7 +427,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
   }
 
   // TODO(ravicious): Use ResourcesService instead.
-  async fetchKubes(params: ServerSideParams) {
+  async fetchKubes(params: GetResourcesParams) {
     return await this.client.getKubes(params);
   }
 

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -435,16 +435,6 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
     return this.getClusters().filter(c => !c.leaf);
   }
 
-  // TODO(ravicious): Use ResourcesService instead.
-  async fetchKubes(params: GetResourcesParams) {
-    return await this.client.getKubes(params);
-  }
-
-  // TODO(ravicious): Move to ResourceService.
-  async getDbUsers(dbUri: uri.DatabaseUri): Promise<string[]> {
-    return await this.client.listDatabaseUsers(dbUri);
-  }
-
   async removeClusterKubeConfigs(clusterUri: string): Promise<void> {
     const {
       params: { rootClusterId },

--- a/web/packages/teleterm/src/ui/services/quickInput/suggesters.ts
+++ b/web/packages/teleterm/src/ui/services/quickInput/suggesters.ts
@@ -83,6 +83,7 @@ export class QuickServerSuggester
       clusterUri: localClusterUri,
       search: input,
       limit,
+      sort: { fieldName: 'hostname', dir: 'ASC' },
     });
 
     return servers.agentsList.map(server => ({
@@ -111,6 +112,7 @@ export class QuickDatabaseSuggester
       clusterUri: localClusterUri,
       search: input,
       limit,
+      sort: { fieldName: 'name', dir: 'ASC' },
     });
 
     return databases.agentsList.map(database => ({

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.test.ts
@@ -86,6 +86,7 @@ test.each(getServerByHostnameTests)(
       clusterUri: '/clusters/bar',
       query: 'name == "foo"',
       limit: 2,
+      sort: null,
     });
   }
 );

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -53,6 +53,10 @@ export class ResourcesService {
     return this.tshClient.getKubes(params);
   }
 
+  async getDbUsers(dbUri: uri.DatabaseUri): Promise<string[]> {
+    return await this.tshClient.listDatabaseUsers(dbUri);
+  }
+
   /**
    * searchResources searches for the given list of space-separated keywords across all resource
    * types on the given cluster.

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -20,7 +20,7 @@ import type * as uri from 'teleterm/ui/uri';
 export class ResourcesService {
   constructor(private tshClient: types.TshClient) {}
 
-  fetchServers(params: types.ServerSideParams) {
+  fetchServers(params: types.GetResourcesParams) {
     return this.tshClient.getServers(params);
   }
 
@@ -42,11 +42,11 @@ export class ResourcesService {
     return servers[0];
   }
 
-  fetchDatabases(params: types.ServerSideParams) {
+  fetchDatabases(params: types.GetResourcesParams) {
     return this.tshClient.getDatabases(params);
   }
 
-  fetchKubes(params: types.ServerSideParams) {
+  fetchKubes(params: types.GetResourcesParams) {
     return this.tshClient.getKubes(params);
   }
 }

--- a/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
+++ b/web/packages/teleterm/src/ui/services/resources/resourcesService.ts
@@ -24,6 +24,8 @@ export class ResourcesService {
     return this.tshClient.getServers(params);
   }
 
+  // TODO(ravicious): Refactor it to use logic similar to that in the Web UI.
+  // https://github.com/gravitational/teleport/blob/2a2b08dbfdaf71706a5af3812d3a7ec843d099b4/lib/web/apiserver.go#L2471
   async getServerByHostname(
     clusterUri: uri.ClusterUri,
     hostname: string
@@ -33,6 +35,7 @@ export class ResourcesService {
       clusterUri,
       query,
       limit: 2,
+      sort: null,
     });
 
     if (servers.length > 1) {


### PR DESCRIPTION
gravitational/teleport.e#991 needs to be merged first, otherwise merging this PR is going to break type check in e.

This PR adds a new hook which we can use for the search bar.

Before implementing the hook I had to make a couple of small changes related to how we provide the sort param to `ResourcesService`.

If you want to check out the hook in action, take a look at `ravicious/spotlight-prototype`.