### PR TITLE
Handle getBackend() or backend argument for plugins.

### DIFF
--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gravitational/trace"
 

--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -45,7 +45,7 @@ func NewPluginsService(input any) *PluginsService {
 		return &PluginsService{backend: value}
 	}
 
-	panic("Unrecognized plugins service backend type")
+	panic(fmt.Sprintf("Unrecognized plugins service backend type: %T", input))
 }
 
 // CreatePlugin implements services.Plugins

--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -31,16 +31,21 @@ const pluginsPrefix = "plugins"
 
 // PluginsService manages plugin instances in the backend.
 type PluginsService struct {
-	getBackend func() backend.Backend
+	backend backend.Backend
 }
 
 // NewPluginsService constructs a new PluginsService
-func NewPluginsService(getBackend func() backend.Backend) *PluginsService {
-	return &PluginsService{getBackend: getBackend}
-}
+// todo(mdwn): make the argument here just a backend.Backend once the
+// reference to getBackend() has been removed in e.
+func NewPluginsService(input any) *PluginsService {
+	switch value := input.(type) {
+	case func() backend.Backend:
+		return &PluginsService{backend: value()}
+	case backend.Backend:
+		return &PluginsService{backend: value}
+	}
 
-func (s *PluginsService) backend() backend.Backend {
-	return s.getBackend()
+	panic("Unrecognized plugins service backend type")
 }
 
 // CreatePlugin implements services.Plugins
@@ -55,7 +60,7 @@ func (s *PluginsService) CreatePlugin(ctx context.Context, plugin types.Plugin) 
 		Expires: plugin.Expiry(),
 		ID:      plugin.GetResourceID(),
 	}
-	_, err = s.backend().Create(ctx, item)
+	_, err = s.backend.Create(ctx, item)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -65,7 +70,7 @@ func (s *PluginsService) CreatePlugin(ctx context.Context, plugin types.Plugin) 
 
 // DeletePlugin implements service.Plugins
 func (s *PluginsService) DeletePlugin(ctx context.Context, name string) error {
-	err := s.backend().Delete(ctx, backend.Key(pluginsPrefix, name))
+	err := s.backend.Delete(ctx, backend.Key(pluginsPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("plugin %q doesn't exist", name)
@@ -78,7 +83,7 @@ func (s *PluginsService) DeletePlugin(ctx context.Context, name string) error {
 // DeleteAllPlugins implements service.Plugins
 func (s *PluginsService) DeleteAllPlugins(ctx context.Context) error {
 	startKey := backend.Key(pluginsPrefix, "")
-	err := s.backend().DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
+	err := s.backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -87,7 +92,7 @@ func (s *PluginsService) DeleteAllPlugins(ctx context.Context) error {
 
 // GetPlugin implements services.Plugins
 func (s *PluginsService) GetPlugin(ctx context.Context, name string, withSecrets bool) (types.Plugin, error) {
-	item, err := s.backend().Get(ctx, backend.Key(pluginsPrefix, name))
+	item, err := s.backend.Get(ctx, backend.Key(pluginsPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("plugin %q doesn't exist", name)
@@ -136,7 +141,7 @@ func (s *PluginsService) ListPlugins(ctx context.Context, limit int, startKey st
 
 	startKeyBytes := backend.Key(pluginsPrefix, startKey)
 	endKey := backend.RangeEnd(backend.Key(pluginsPrefix, ""))
-	result, err := s.backend().GetRange(ctx, startKeyBytes, endKey, maxLimit)
+	result, err := s.backend.GetRange(ctx, startKeyBytes, endKey, maxLimit)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -178,7 +183,7 @@ func (s *PluginsService) SetPluginStatus(ctx context.Context, name string, statu
 
 func (s *PluginsService) updateAndSwap(ctx context.Context, name string, modify func(types.Plugin) error) error {
 	key := backend.Key(pluginsPrefix, name)
-	item, err := s.backend().Get(ctx, key)
+	item, err := s.backend.Get(ctx, key)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("plugin %q doesn't exist", name)
@@ -204,7 +209,7 @@ func (s *PluginsService) updateAndSwap(ctx context.Context, name string, modify 
 		return trace.Wrap(err)
 	}
 
-	_, err = s.backend().CompareAndSwap(ctx, *item, backend.Item{
+	_, err = s.backend.CompareAndSwap(ctx, *item, backend.Item{
 		Key:     backend.Key(pluginsPrefix, plugin.GetName()),
 		Value:   value,
 		Expires: plugin.Expiry(),

--- a/lib/services/local/plugins_test.go
+++ b/lib/services/local/plugins_test.go
@@ -143,7 +143,7 @@ func TestListPlugins(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { mem.Close() })
 
-	service := NewPluginsService(func() backend.Backend { return mem })
+	service := NewPluginsService(mem)
 
 	var insertedPlugins []types.Plugin
 	for i := 0; i < numPlugins; i++ {


### PR DESCRIPTION
Now that the enterprise code no longer needs this lazily evaluated backend function, the plugins local services has been temporarily changed to handle both `getBackend()` and a regular `backend.Backend` argument until the reference to it can be removed in enterprise. Then, a follow on will be submitted to only support the `backend.Backend` argument.

Note: I've intentionally only modified one of the tests to use the updated `NewPluginsService` argument type to ensure that both work.

Related PR: https://github.com/gravitational/teleport.e/pull/979