### PR TITLE
maintenance window agent export logic

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -124,6 +124,7 @@ import (
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/cert"
+	uw "github.com/gravitational/teleport/lib/versioncontrol/upgradewindow"
 	"github.com/gravitational/teleport/lib/web"
 )
 
@@ -962,6 +963,34 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		}
 	})
 
+	// if an external upgrader is defined, we need to set up an appropriate upgrade window exporter.
+	if upgraderKind := os.Getenv("TELEPORT_EXT_UPGRADER"); upgraderKind != "" {
+		if process.Config.Auth.Enabled || process.Config.Proxy.Enabled {
+			process.log.Warnf("Use of external upgraders on control-plane instances is not recommended.")
+		}
+
+		driver, err := uw.NewDriver(upgraderKind)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		exporter, err := uw.NewExporter(uw.ExporterConfig[inventory.DownstreamSender]{
+			Driver:                   driver,
+			ExportFunc:               process.exportUpgradeWindows,
+			AuthConnectivitySentinel: process.inventoryHandle.Sender(),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		process.RegisterCriticalFunc("upgradeewindow.export", exporter.Run)
+		process.OnExit("upgradewindow.export.stop", func(_ interface{}) {
+			exporter.Close()
+		})
+
+		process.log.Infof("Configured upgrade window exporter for external upgrader. kind=%s", upgraderKind)
+	}
+
 	serviceStarted := false
 
 	if !cfg.DiagnosticAddr.IsEmpty() {
@@ -1226,6 +1255,20 @@ func (process *TeleportProcess) makeInventoryControlStream(ctx context.Context) 
 		return nil, trace.Errorf("instance client not yet initialized")
 	}
 	return clt.InventoryControlStream(ctx)
+}
+
+// exportUpgradeWindow is a helper for calling ExportUpgradeWindows either on the local in-memory auth server, or via the instance client, depending on
+// which is available.
+func (process *TeleportProcess) exportUpgradeWindows(ctx context.Context, req proto.ExportUpgradeWindowsRequest) (proto.ExportUpgradeWindowsResponse, error) {
+	if auth := process.getLocalAuth(); auth != nil {
+		return auth.ExportUpgradeWindows(ctx, req)
+	}
+
+	clt := process.getInstanceClient()
+	if clt == nil {
+		return proto.ExportUpgradeWindowsResponse{}, trace.Errorf("instance client not yet initialized")
+	}
+	return clt.ExportUpgradeWindows(ctx, req)
 }
 
 // adminCreds returns admin UID and GID settings based on the OS

--- a/lib/versioncontrol/upgradewindow/upgradewindow.go
+++ b/lib/versioncontrol/upgradewindow/upgradewindow.go
@@ -1,0 +1,442 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgradewindow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/kubernetes"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/interval"
+)
+
+const (
+	// kubeSchedKey is the key under which the kube controller schedule is exported
+	kubeSchedKey = "agent-maintenance-schedule"
+
+	// unitScheduleFile is the name of the file to which the unit schedule is exported.
+	unitScheduleFile = "schedule"
+
+	// unitConfigDir is the configuration directory of the teleport-upgrade unit.
+	unitConfigDir = "/etc/teleport-upgrade.d"
+)
+
+// ExportFunc represents the ExportUpgradeWindows rpc exposed by auth servers.
+type ExportFunc func(ctx context.Context, req proto.ExportUpgradeWindowsRequest) (proto.ExportUpgradeWindowsResponse, error)
+
+// contextLike lets us abstract over the difference between basic contexts and context-like values such
+// as control stream senders or resource watchers. the exporter uses a contextLike value to decide wether
+// or not auth connectivity appears healthy. during normal runtime, we end up using the inventory control
+// stream send handle.
+type contextLike interface {
+	Done() <-chan struct{}
+}
+
+type testEvent string
+
+const (
+	resetFromExport  testEvent = "reset-from-export"
+	resetFromRun     testEvent = "reset-from-run"
+	exportAttempt    testEvent = "export-attempt"
+	exportSuccess    testEvent = "export-success"
+	exportFailure    testEvent = "export-failure"
+	getExportErr     testEvent = "get-export-err"
+	syncExportErr    testEvent = "sync-export-err"
+	sentinelAcquired testEvent = "sentinel-acquired"
+	sentinelLost     testEvent = "sentinel-lost"
+)
+
+// ExporterConfig configures a maintenance window exporter.
+type ExporterConfig[C contextLike] struct {
+	// Driver is the underlying export driver.
+	Driver Driver
+
+	// ExportFunc gets the current maintenance window.
+	ExportFunc ExportFunc
+
+	// AuthConnectivitySentinel is a channel that yields context-like values indicating the current health of
+	// auth connectivity. When connectivity to auth is established, a context-like value should be sent over
+	// the channel. If auth connectivity is subsequently lost, that context-like value must be canceled.
+	// During normal runtime, this should use DownstreamInventoryHandle.Sender(). During tests
+	// it can just be a stream of context.Context values.
+	AuthConnectivitySentinel <-chan C
+
+	// --- below fields are all optional
+
+	// UnhealthyThreshold is the threshold after which failure to export
+	// is treated as an unhealthy event.
+	UnhealthyThreshold time.Duration
+
+	// ExportInterval is the interval at which exports are attempted
+	ExportInterval time.Duration
+
+	// FirstExport is a custom duration used for firt export attempt.
+	FirstExport time.Duration
+
+	testEvents chan testEvent
+}
+
+func (c *ExporterConfig[C]) CheckAndSetDefaults() error {
+	if c.Driver == nil {
+		return trace.BadParameter("exporter config missing required parameter 'Driver'")
+	}
+
+	if c.ExportFunc == nil {
+		return trace.BadParameter("exporter config missing required parameter 'ExportFunc'")
+	}
+
+	if c.AuthConnectivitySentinel == nil {
+		return trace.BadParameter("exporter config missing required parameter 'AuthConnectivitySentinel'")
+	}
+
+	// allow switching to faster default duration values for testing purposes
+	fastExport := os.Getenv("TELEPORT_UNSTABLE_FAST_MW_EXPORT") == "yes"
+
+	if c.UnhealthyThreshold == 0 {
+		// 9m is fairly arbitrary, but was picked based on the the idea that a good unhealthy threshold aught to be
+		// long enough to minimize sensitivity to control plane restarts, but short enough that by the time an instance
+		// appears offline in the teleport UI, we aught to be able to assume that its unhealthy status has been propagated
+		// to its upgrader.
+		c.UnhealthyThreshold = 9 * time.Minute
+
+		if fastExport {
+			c.UnhealthyThreshold = 9 * time.Second
+		}
+	}
+
+	if c.ExportInterval == 0 {
+		// 40m is fairly arbitrary, but was picked on the basis that we want to keep exports pretty infrequent, but still frequent
+		// *enough* that one should be able to be fairly confident of full propagation to all agents within an hour, even assuming
+		// some amount of errors/retries.
+		c.ExportInterval = 40 * time.Minute
+
+		if fastExport {
+			c.ExportInterval = 40 * time.Second
+		}
+	}
+
+	if c.FirstExport == 0 {
+		// note: we add an extra millisecond since FullJitter can sometimes return 0, but our interval helpers interpret FirstDuration=0
+		// as meaning that we don't want a custom first duration. this is usually fine, but since the actual export interval is so long,
+		// it is important that a shorter first duration is always observed.
+		c.FirstExport = time.Millisecond + utils.FullJitter(c.UnhealthyThreshold/2)
+	}
+
+	return nil
+}
+
+// Exporter is a helper used to export maintenance window schedule values to external upgraders.
+type Exporter[C contextLike] struct {
+	cfg          ExporterConfig[C]
+	closeContext context.Context
+	cancel       context.CancelFunc
+	retry        retryutils.Retry
+}
+
+// NewExporter builds an exporter. Start must be called in order to begin export operations.
+func NewExporter[C contextLike](cfg ExporterConfig[C]) (*Exporter[C], error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
+		Driver: retryutils.NewExponentialDriver(cfg.UnhealthyThreshold / 16),
+		Max:    cfg.UnhealthyThreshold,
+		Jitter: retryutils.NewHalfJitter(),
+	})
+
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &Exporter[C]{
+		cfg:          cfg,
+		retry:        retry,
+		closeContext: ctx,
+		cancel:       cancel,
+	}, nil
+}
+
+func (e *Exporter[C]) Run() error {
+	e.run(e.closeContext)
+	return nil
+}
+
+func (e *Exporter[C]) Close() error {
+	e.cancel()
+	return nil
+}
+
+func (e *Exporter[C]) event(event testEvent) {
+	if e.cfg.testEvents == nil {
+		return
+	}
+	e.cfg.testEvents <- event
+}
+
+func (e *Exporter[C]) run(ctx context.Context) {
+	exportInterval := interval.New(interval.Config{
+		FirstDuration: utils.FullJitter(e.cfg.FirstExport),
+		Duration:      e.cfg.ExportInterval,
+		Jitter:        retryutils.NewSeventhJitter(),
+	})
+	defer exportInterval.Stop()
+
+Outer:
+	for {
+		select {
+		case sentinel := <-e.cfg.AuthConnectivitySentinel:
+			e.event(sentinelAcquired)
+			// auth connectivity is healthy, we can now perform
+			// periodic export operations.
+			for {
+				select {
+				case <-exportInterval.Next():
+					e.exportWithRetry(ctx) // errors handled internally
+				case <-sentinel.Done():
+					e.event(sentinelLost)
+					// auth connectivity has been lost, resume outer loop
+					continue Outer
+				case <-ctx.Done():
+					return
+				}
+			}
+		case <-time.After(e.cfg.UnhealthyThreshold):
+			// if we lose connectivity with auth for too long, forcibly reset any existing schedule.
+			// this frees up the upgrader to attempt an upgrade at its discretion.
+			if err := e.cfg.Driver.Reset(ctx); err != nil {
+				log.Warnf("Failed to perform %q maintenance window reset: %v", e.cfg.Driver.Kind(), err)
+			}
+			e.event(resetFromRun)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// exportWithRetry attempts to get an exported schedule value and sync it with the appropriate upgrader, retrying
+// until UnhealthyThreshold is exceeded.
+func (e *Exporter[C]) exportWithRetry(ctx context.Context) {
+	start := time.Now()
+	defer e.retry.Reset()
+	for {
+
+		if time.Now().After(start.Add(e.cfg.UnhealthyThreshold)) {
+			// failure state appears persistent. reset and yield back
+			// to outer loop to wait for our next scheduled attempt.
+			if err := e.cfg.Driver.Reset(ctx); err != nil {
+				log.Warnf("Failed to perform %q maintenance window reset: %v", e.cfg.Driver.Kind(), err)
+			}
+			e.event(resetFromExport)
+			e.event(exportFailure)
+			return
+		}
+
+		// note that we don't bother tracking the state of the auth connectivity sentinel here. while doing
+		// so would theoretically be more optimal, doing so in a way that doesn't cause odd behaviors under
+		// highly intermittent auth connectivity is *tricky*. the state-machine is much simpler and has a lot
+		// less edge-cases if we only care about the sentinel when deciding when to *start* our export attempt.
+		select {
+		case <-e.retry.After():
+		case <-ctx.Done():
+			return
+		}
+
+		e.event(exportAttempt)
+
+		// ask auth server to export upcoming windows
+		rsp, err := e.cfg.ExportFunc(ctx, proto.ExportUpgradeWindowsRequest{
+			TeleportVersion: teleport.Version,
+			UpgraderKind:    e.cfg.Driver.Kind(),
+		})
+
+		if err != nil {
+			log.Warnf("Failed to import %q maintenance window from auth: %v", e.cfg.Driver.Kind(), err)
+			e.retry.Inc()
+			e.event(getExportErr)
+			continue
+		}
+
+		// sync exported windows out to our upgrader
+		if err := e.cfg.Driver.Sync(ctx, rsp); err != nil {
+			log.Warnf("Failed to sync %q maintenance window: %v", e.cfg.Driver.Kind(), err)
+			e.retry.Inc()
+			e.event(syncExportErr)
+			continue
+		}
+
+		log.Infof("Successfully synced %q upgrader maintenance window value.", e.cfg.Driver.Kind())
+		e.event(exportSuccess)
+		return
+	}
+}
+
+// Driver represents a type capable of exporting the maintenance window schedule to an external
+// upgrader, such as the teleport-upgrade systemd timer or the kube-updater controller.
+type Driver interface {
+	// Kind gets the upgrader kind associated with this export driver.
+	Kind() string
+
+	// Sync exports the appropriate maintenance window schedule if one is present, or
+	// resets/clears the maintenance window if the schedule response returns no viable scheduling
+	// info.
+	Sync(ctx context.Context, rsp proto.ExportUpgradeWindowsResponse) error
+
+	// Reset forcibly clears any previously exported maintenance window values. This should be
+	// called if teleport experiences prolonged loss of auth connectivity, which may be an indicator
+	// that the control plane has been upgraded s.t. this agent is no longer compatible.
+	Reset(ctx context.Context) error
+}
+
+// NewDriver sets up a new export driver corresponding to the specified upgrader kind.
+func NewDriver(kind string) (Driver, error) {
+	switch kind {
+	case types.UpgraderKindKubeController:
+		return NewKubeControllerDriver(KubeControllerDriverConfig{})
+	case types.UpgraderKindSystemdUnit:
+		return NewSystemdUnitDriver(SystemdUnitDriverConfig{})
+	default:
+		return nil, trace.BadParameter("unsupported upgrader kind: %q", kind)
+	}
+}
+
+type KubeControllerDriverConfig struct {
+	// Backend is an optional backend. Must be an instance of the kuberenets shared-state backend
+	// if not nil.
+	Backend KubernetesBackend
+}
+
+// KubernetesBackend interface for kube shared storage backend.
+type KubernetesBackend interface {
+	// Put puts value into backend (creates if it does not
+	// exists, updates it otherwise)
+	Put(ctx context.Context, i backend.Item) (*backend.Lease, error)
+}
+
+type kubeDriver struct {
+	cfg KubeControllerDriverConfig
+}
+
+func NewKubeControllerDriver(cfg KubeControllerDriverConfig) (Driver, error) {
+	if cfg.Backend == nil {
+		var err error
+		cfg.Backend, err = kubernetes.NewShared()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return &kubeDriver{cfg: cfg}, nil
+}
+
+func (e *kubeDriver) Kind() string {
+	return types.UpgraderKindKubeController
+}
+
+func (e *kubeDriver) Sync(ctx context.Context, rsp proto.ExportUpgradeWindowsResponse) error {
+	if rsp.KubeControllerSchedule == "" {
+		return e.Reset(ctx)
+	}
+
+	_, err := e.cfg.Backend.Put(ctx, backend.Item{
+		Key:   []byte(kubeSchedKey),
+		Value: []byte(rsp.KubeControllerSchedule),
+	})
+
+	return trace.Wrap(err)
+}
+
+func (e *kubeDriver) Reset(ctx context.Context) error {
+	// kube backend doesn't support deletes right now, so just set
+	// the key to empty.
+	_, err := e.cfg.Backend.Put(ctx, backend.Item{
+		Key:   []byte(kubeSchedKey),
+		Value: []byte{},
+	})
+
+	return trace.Wrap(err)
+}
+
+type SystemdUnitDriverConfig struct {
+	// ConfigDir is the directory from which the teleport-upgrade periodic loads its
+	// configuration parameters. Most notably, the 'schedule' file.
+	ConfigDir string
+}
+
+type systemdDriver struct {
+	cfg SystemdUnitDriverConfig
+}
+
+func NewSystemdUnitDriver(cfg SystemdUnitDriverConfig) (Driver, error) {
+	if cfg.ConfigDir == "" {
+		cfg.ConfigDir = unitConfigDir
+	}
+
+	return &systemdDriver{cfg: cfg}, nil
+}
+
+func (e *systemdDriver) Kind() string {
+	return types.UpgraderKindSystemdUnit
+}
+
+func (e *systemdDriver) Sync(ctx context.Context, rsp proto.ExportUpgradeWindowsResponse) error {
+	if len(rsp.SystemdUnitSchedule) == 0 {
+		// treat an empty schedule value as equivalent to a reset
+		return e.Reset(ctx)
+	}
+
+	// ensure config dir exists
+	if err := os.MkdirAll(e.cfg.ConfigDir, teleport.PrivateDirMode); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// export schedule file
+	if err := os.WriteFile(e.scheduleFile(), []byte(rsp.SystemdUnitSchedule), teleport.FileMaskOwnerOnly); err != nil {
+		return trace.Errorf("failed to write schedule file: %v", err)
+	}
+
+	return nil
+}
+
+func (e *systemdDriver) Reset(_ context.Context) error {
+	if err := os.Remove(e.scheduleFile()); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return trace.Errorf("failed to reset schedule file: %v", err)
+	}
+
+	return nil
+}
+
+func (e *systemdDriver) scheduleFile() string {
+	return filepath.Join(e.cfg.ConfigDir, unitScheduleFile)
+}

--- a/lib/versioncontrol/upgradewindow/upgradewindow_test.go
+++ b/lib/versioncontrol/upgradewindow/upgradewindow_test.go
@@ -1,0 +1,476 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgradewindow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+type fakeKubeBackend struct {
+	data map[string]string
+}
+
+func newFakeKubeBackend() *fakeKubeBackend {
+	return &fakeKubeBackend{
+		data: make(map[string]string),
+	}
+}
+
+func (b *fakeKubeBackend) Put(ctx context.Context, item backend.Item) (*backend.Lease, error) {
+	b.data[string(item.Key)] = string(item.Value)
+	return nil, nil
+}
+
+func TestKubeControllerDriver(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bk := newFakeKubeBackend()
+
+	driver, err := NewKubeControllerDriver(KubeControllerDriverConfig{
+		Backend: bk,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "kube", driver.Kind())
+
+	// verify basic schedule creation
+	err = driver.Sync(ctx, proto.ExportUpgradeWindowsResponse{
+		KubeControllerSchedule: "fake-schedule",
+	})
+	require.NoError(t, err)
+
+	key := "agent-maintenance-schedule"
+
+	require.Equal(t, "fake-schedule", bk.data[key])
+
+	// verify overwrite of existing schedule
+	err = driver.Sync(ctx, proto.ExportUpgradeWindowsResponse{
+		KubeControllerSchedule: "fake-schedule-2",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "fake-schedule-2", bk.data[key])
+
+	// verify reset of schedule
+	err = driver.Reset(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "", bk.data[key])
+
+	// verify reset of empty schedule has no effect
+	err = driver.Reset(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "", bk.data[key])
+
+	// setup another fake schedule
+	err = driver.Sync(ctx, proto.ExportUpgradeWindowsResponse{
+		KubeControllerSchedule: "fake-schedule-3",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "fake-schedule-3", bk.data[key])
+
+	// verify that empty schedule is equivalent to reset
+	err = driver.Sync(ctx, proto.ExportUpgradeWindowsResponse{})
+	require.NoError(t, err)
+
+	require.Equal(t, "", bk.data[key])
+}
+
+// TestSystemdUnitDriver verifies the basic behavior of the systemd unit export driver.
+func TestSystemdUnitDriver(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// use a sub-directory of a temp dir in order to verify that
+	// driver creates dir when needed.
+	dir := filepath.Join(t.TempDir(), "config")
+
+	driver, err := NewSystemdUnitDriver(SystemdUnitDriverConfig{
+		ConfigDir: dir,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, driver.Kind(), "unit")
+
+	// verify basic schedule creation
+	err = driver.Sync(ctx, proto.ExportUpgradeWindowsResponse{
+		SystemdUnitSchedule: "fake-schedule",
+	})
+	require.NoError(t, err)
+
+	schedPath := filepath.Join(dir, "schedule")
+
+	sb, err := os.ReadFile(schedPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "fake-schedule", string(sb))
+
+	// verify overwrite of existing schedule
+	err = driver.Sync(ctx, proto.ExportUpgradeWindowsResponse{
+		SystemdUnitSchedule: "fake-schedule-2",
+	})
+	require.NoError(t, err)
+
+	sb, err = os.ReadFile(schedPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "fake-schedule-2", string(sb))
+
+	// verify reset/deletion of schedule
+	err = driver.Reset(ctx)
+	require.NoError(t, err)
+
+	_, err = os.ReadFile(schedPath)
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+
+	// verify that NotExist error is suppressed
+	err = driver.Reset(ctx)
+	require.NoError(t, err)
+
+	// set up another schedule
+	err = driver.Sync(ctx, proto.ExportUpgradeWindowsResponse{
+		SystemdUnitSchedule: "fake-schedule-3",
+	})
+	require.NoError(t, err)
+
+	sb, err = os.ReadFile(schedPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "fake-schedule-3", string(sb))
+
+	// verify that an empty schedule value is treated equivalent to a reset
+	err = driver.Sync(ctx, proto.ExportUpgradeWindowsResponse{})
+	require.NoError(t, err)
+
+	_, err = os.ReadFile(schedPath)
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+}
+
+// fakeDriver is used to inject custom behavior into a dummy Driver instance.
+type fakeDriver struct {
+	mu    sync.Mutex
+	kind  string
+	sync  func(context.Context, proto.ExportUpgradeWindowsResponse) error
+	reset func(context.Context) error
+}
+
+func (d *fakeDriver) Kind() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.kind != "" {
+		return d.kind
+	}
+	return "fake"
+}
+
+func (d *fakeDriver) Sync(ctx context.Context, rsp proto.ExportUpgradeWindowsResponse) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.sync != nil {
+		return d.sync(ctx, rsp)
+	}
+
+	return nil
+}
+
+func (d *fakeDriver) Reset(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.reset != nil {
+		return d.reset(ctx)
+	}
+
+	return nil
+}
+
+func (d *fakeDriver) withLock(fn func()) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	fn()
+}
+
+func TestExporterBasics(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sc := make(chan context.Context)
+
+	testEvents := make(chan testEvent, 1024)
+
+	// set up fake export func that can be set to fail multiple times in sequence
+	var exportCount int
+	var exportFail bool
+	var exportFlaky bool
+	var exportLock sync.Mutex
+	export := func(ctx context.Context, req proto.ExportUpgradeWindowsRequest) (rsp proto.ExportUpgradeWindowsResponse, err error) {
+		if req.UpgraderKind != "fake" {
+			panic("unexpected upgrader kind") // sanity check, shouldn't ever happen in practice
+		}
+		rsp.SystemdUnitSchedule = "fake-schedule"
+		exportLock.Lock()
+		exportCount++
+		if exportFlaky && exportCount%2 == 0 {
+			err = fmt.Errorf("fake-export-flaky")
+		}
+		if exportFail {
+			err = fmt.Errorf("fake-export-fail")
+		}
+		exportLock.Unlock()
+		return
+	}
+
+	driver := new(fakeDriver)
+
+	driver.withLock(func() {
+		driver.sync = func(ctx context.Context, rsp proto.ExportUpgradeWindowsResponse) error {
+			if rsp.SystemdUnitSchedule != "fake-schedule" {
+				panic("unexpected schedule value") // sanity check, shouldn't ever happen in practice
+			}
+			return nil
+		}
+	})
+
+	exporter, err := NewExporter(ExporterConfig[context.Context]{
+		Driver:                   driver,
+		ExportFunc:               export,
+		AuthConnectivitySentinel: sc,
+		UnhealthyThreshold:       time.Millisecond * 200,
+		ExportInterval:           time.Millisecond * 300,
+		FirstExport:              time.Millisecond * 10,
+		testEvents:               testEvents,
+	})
+	require.NoError(t, err)
+
+	go exporter.Run()
+	defer exporter.Close()
+
+	// without connection sentinel, exporter is unable to make progress. eventually forces reset.
+	awaitEvents(t, testEvents,
+		expect(resetFromRun),
+		deny(sentinelAcquired, exportAttempt),
+	)
+
+	s1, s1Cancel := context.WithCancel(ctx)
+
+	// provide a connection sentinel
+	sc <- s1
+
+	// wait until sentinel is acquired
+	awaitEvents(t, testEvents,
+		expect(sentinelAcquired),
+	)
+
+	// everything should now appear healthy/normal for multiple export cycles
+	awaitEvents(t, testEvents,
+		expect(exportAttempt, exportSuccess, exportSuccess),
+		deny(resetFromRun, resetFromExport, getExportErr, syncExportErr, sentinelLost),
+	)
+
+	// introduce intermittent sync failures
+	driver.withLock(func() {
+		var si int
+		driver.sync = func(ctx context.Context, rsp proto.ExportUpgradeWindowsResponse) error {
+			si++
+			if si%2 == 0 {
+				return fmt.Errorf("some-fake-error")
+			}
+			return nil
+		}
+	})
+
+	// we should see intermittent failures, but no resets
+	awaitEvents(t, testEvents,
+		expect(syncExportErr, syncExportErr, exportSuccess, exportSuccess),
+		deny(resetFromExport, resetFromRun, sentinelLost),
+	)
+
+	// remove intermittent sync failures
+	driver.withLock(func() {
+		driver.sync = nil
+	})
+
+	// drain remaining failures and ensure that we hit at least one success
+	awaitEvents(t, testEvents,
+		expect(exportSuccess),
+		deny(resetFromExport, resetFromRun, sentinelLost),
+		drain(true),
+	)
+
+	// introduce intermittent failure to the export fn
+	exportLock.Lock()
+	exportFlaky = true
+	exportLock.Unlock()
+
+	// we should see intermittent failures, but no resets
+	awaitEvents(t, testEvents,
+		expect(getExportErr, getExportErr, exportSuccess, exportSuccess),
+		deny(resetFromExport, resetFromRun, sentinelLost),
+	)
+
+	// introduce persistent failure to the export fn
+	exportLock.Lock()
+	exportFlaky = false
+	exportFail = true
+	exportLock.Unlock()
+
+	// drain remaining successes and wait for next failure
+	awaitEvents(t, testEvents,
+		expect(getExportErr),
+		deny(resetFromRun, sentinelLost),
+		drain(true),
+	)
+
+	// ensure that we now observe frequent resets and no successes
+	awaitEvents(t, testEvents,
+		expect(resetFromExport, resetFromExport),
+		deny(resetFromRun, sentinelLost, exportSuccess),
+	)
+
+	// clear export fail state
+	exportLock.Lock()
+	exportFail = false
+	exportLock.Unlock()
+
+	// terminate our first connection sentinel
+	s1Cancel()
+
+	// wait until we lose the sentinel
+	awaitEvents(t, testEvents,
+		expect(sentinelLost),
+	)
+
+	// we should revert to periodic resets
+	awaitEvents(t, testEvents,
+		expect(resetFromRun),
+		deny(sentinelAcquired, exportAttempt),
+	)
+
+	// provide another sentinel
+	s2, s2Cancel := context.WithCancel(ctx)
+	sc <- s2
+
+	// healthy operation should resume
+	awaitEvents(t, testEvents,
+		expect(sentinelAcquired, exportSuccess),
+		deny(resetFromExport, exportFailure),
+	)
+
+	s2Cancel()
+}
+
+type eventOpts struct {
+	expect map[testEvent]int
+	deny   map[testEvent]struct{}
+	drain  bool
+}
+
+type eventOption func(*eventOpts)
+
+func expect(events ...testEvent) eventOption {
+	return func(opts *eventOpts) {
+		for _, event := range events {
+			opts.expect[event] = opts.expect[event] + 1
+		}
+	}
+}
+
+func deny(events ...testEvent) eventOption {
+	return func(opts *eventOpts) {
+		for _, event := range events {
+			opts.deny[event] = struct{}{}
+		}
+	}
+}
+
+func drain(d bool) eventOption {
+	return func(opts *eventOpts) {
+		opts.drain = d
+	}
+}
+
+func awaitEvents(t *testing.T, ch <-chan testEvent, opts ...eventOption) {
+	options := eventOpts{
+		expect: make(map[testEvent]int),
+		deny:   make(map[testEvent]struct{}),
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if options.drain {
+		drainEvents(t, ch, options)
+	}
+
+	timeout := time.After(time.Second * 5)
+	for {
+		if len(options.expect) == 0 {
+			return
+		}
+
+		select {
+		case event := <-ch:
+			if _, ok := options.deny[event]; ok {
+				require.Failf(t, "unexpected event", "event=%v", event)
+			}
+
+			options.expect[event] = options.expect[event] - 1
+			if options.expect[event] < 1 {
+				delete(options.expect, event)
+			}
+		case <-timeout:
+			require.Failf(t, "timeout waiting for events", "expect=%+v", options.expect)
+		}
+	}
+}
+
+func drainEvents(t *testing.T, ch <-chan testEvent, options eventOpts) {
+	timeout := time.After(time.Second * 5)
+	for {
+		select {
+		case event := <-ch:
+			if _, ok := options.deny[event]; ok {
+				require.Failf(t, "unexpected event", "event=%v", event)
+			}
+		case <-timeout:
+			require.Fail(t, "timeout attempting to drain events channel")
+		default:
+			return
+		}
+	}
+}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -92,6 +92,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		dbConfigCreateFlags              createDatabaseConfigFlags
 		systemdInstallFlags              installSystemdFlags
 		waitFlags                        waitFlags
+		rawVersion                       bool
 	)
 
 	// define commands:
@@ -384,6 +385,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dump.Flag("app-uri", "Internal address of the application to proxy.").StringVar(&dumpFlags.AppURI)
 	dump.Flag("node-labels", "Comma-separated list of labels to add to newly created nodes, for example env=staging,cloud=aws.").StringVar(&dumpFlags.NodeLabels)
 
+	ver.Flag("raw", "Print the raw teleport version string.").BoolVar(&rawVersion)
+
 	dumpNode := app.Command("node", "SSH Node configuration commands")
 	dumpNodeConfigure := dumpNode.Command("configure", "Generate a configuration file for an SSH node.")
 	dumpNodeConfigure.Flag("cluster-name",
@@ -486,7 +489,13 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	case kubeStateDelete.FullCommand():
 		err = onKubeStateDelete()
 	case ver.FullCommand():
-		utils.PrintVersion()
+		if rawVersion {
+			// raw version must print the exact version string (relied upon
+			// by the systemd unit upgrader).
+			fmt.Printf("%s\n", teleport.Version)
+		} else {
+			utils.PrintVersion()
+		}
 	case dbConfigureCreate.FullCommand():
 		err = onDumpDatabaseConfig(dbConfigCreateFlags)
 	case dbConfigureAWSPrintIAM.FullCommand():


### PR DESCRIPTION
Implementation of the agent-side logic corresponding to https://github.com/gravitational/teleport/pull/22850

This PR introduces maintenance window export logic for the kube controller and systemd unit based external upgraders. When enabled, the teleport agent periodically loads maintenance window info from auth and exports it to an appropriate location for the upgrader to consume it.

The behavior is toggled by setting an environment variable (`TELEPORT_EXT_UPGRADER=kube|unit`). This flag is not intended to be set by users.  Upgrader packages will set the appropriate value automatically.

Note: this PR is currently pointing toward [fspmarshall/maintenance-window-auth-v2](https://github.com/gravitational/teleport/tree/fspmarshall/maintenance-window-auth-v2) and will be rebased to master once the changes it depends on get merged.
