### PR TITLE
Use `UpsertWindowsDesktop` for `WindowsDesktop` heartbeats

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -57,10 +57,8 @@ type Announcer interface {
 	// UpsertWindowsDesktopService registers a Windows desktop service.
 	UpsertWindowsDesktopService(context.Context, types.WindowsDesktopService) (*types.KeepAlive, error)
 
-	// CreateWindowsDesktop registers a Windows desktop host.
-	CreateWindowsDesktop(context.Context, types.WindowsDesktop) error
-	// UpdateWindowsDesktop updates a Windows desktop host.
-	UpdateWindowsDesktop(context.Context, types.WindowsDesktop) error
+	// UpsertWindowsDesktop registers a Windows desktop host.
+	UpsertWindowsDesktop(context.Context, types.WindowsDesktop) error
 
 	// UpsertDatabaseService registers a DatabaseService.
 	UpsertDatabaseService(context.Context, types.DatabaseService) (*types.KeepAlive, error)

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -546,10 +546,7 @@ func (h *Heartbeat) announce() error {
 			if !ok {
 				return trace.BadParameter("expected types.WindowsDesktop, got %#v", h.current)
 			}
-			err := h.Announcer.CreateWindowsDesktop(h.cancelCtx, desktop)
-			if trace.IsAlreadyExists(err) {
-				err = h.Announcer.UpdateWindowsDesktop(h.cancelCtx, desktop)
-			}
+			err := h.Announcer.UpsertWindowsDesktop(h.cancelCtx, desktop)
 			if err != nil {
 				h.nextAnnounce = h.Clock.Now().UTC().Add(h.KeepAlivePeriod)
 				h.setState(HeartbeatStateAnnounceWait)

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -379,12 +379,7 @@ func (f *fakeAnnouncer) UpsertWindowsDesktopService(ctx context.Context, s types
 	return &types.KeepAlive{}, nil
 }
 
-func (f *fakeAnnouncer) CreateWindowsDesktop(ctx context.Context, s types.WindowsDesktop) error {
-	f.upsertCalls[HeartbeatModeWindowsDesktop]++
-	return f.err
-}
-
-func (f *fakeAnnouncer) UpdateWindowsDesktop(ctx context.Context, s types.WindowsDesktop) error {
+func (f *fakeAnnouncer) UpsertWindowsDesktop(ctx context.Context, s types.WindowsDesktop) error {
 	f.upsertCalls[HeartbeatModeWindowsDesktop]++
 	return f.err
 }


### PR DESCRIPTION
This PR makes it so that we use `UpsertWindowsDesktop` in `srv.Heartbeat` to heartbeat for `WindowsDesktop` resources, rather than attempting to use `Create`, almost always failing, and falling back to `Update`.