### PR TITLE
Establish the Okta service role.

### DIFF
--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -70,6 +70,8 @@ const (
 	RoleInstance SystemRole = "Instance"
 	// RoleDiscovery is a role for discovery nodes in the cluster
 	RoleDiscovery SystemRole = "Discovery"
+	// RoleOkta is a role for Okta nodes in the cluster
+	RoleOkta SystemRole = "Okta"
 )
 
 // roleMappings maps a set of allowed lowercase system role names
@@ -94,6 +96,7 @@ var roleMappings = map[string]SystemRole{
 	"bot":             RoleBot,
 	"instance":        RoleInstance,
 	"discovery":       RoleDiscovery,
+	"okta":            RoleOkta,
 }
 
 // localServiceMappings is the subset of role mappings which happen to be true
@@ -108,6 +111,7 @@ var localServiceMappings = map[SystemRole]struct{}{
 	RoleDatabase:       {},
 	RoleWindowsDesktop: {},
 	RoleDiscovery:      {},
+	RoleOkta:           {},
 }
 
 // LocalServiceMappings returns the subset of role mappings which happen

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -797,6 +797,21 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
+	case types.RoleOkta:
+		return services.RoleFromSpec(
+			role.String(),
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					Namespaces: []string{types.Wildcard},
+					Rules: []types.Rule{
+						types.NewRule(types.KindEvent, services.RW()),
+						types.NewRule(types.KindAccessRequest, services.RO()),
+						types.NewRule(types.KindUser, services.RO()),
+						types.NewRule(types.KindOktaImportRule, services.RO()),
+						types.NewRule(types.KindOktaAssignment, services.RW()),
+					},
+				},
+			})
 	}
 
 	return nil, trace.NotFound("builtin role %q is not recognized", role.String())


### PR DESCRIPTION
This commit introduces the Okta service role, which will be necessary for the Okta service to have appropriate access to the auth server endpoints.