### PR TITLE
notarize: Accept parameters for dev and bundle ID

### DIFF
--- a/build.assets/tooling/cmd/notarize-apple-binaries/gon_wrapper.go
+++ b/build.assets/tooling/cmd/notarize-apple-binaries/gon_wrapper.go
@@ -31,25 +31,24 @@ import (
 	"github.com/gravitational/teleport/build.assets/tooling/lib/logging"
 )
 
-const (
-	DeveloperIdentity string = "0FFD3E3413AB4C599C53FBB1D8CA690915E33D83"
-	BundleID          string = "com.gravitational.teleport"
-)
-
 type GonWrapper struct {
 	ctx           context.Context
 	logger        hclog.Logger
 	AppleUsername string
 	ApplePassword string
+	DeveloperID   string
+	BundleID      string
 	BinaryPaths   []string
 }
 
-func NewGonWrapper(appleUsername, applePassword string, BinaryPaths []string) *GonWrapper {
+func NewGonWrapper(appleUsername, applePassword, developerID, bundleID string, BinaryPaths []string) *GonWrapper {
 	return &GonWrapper{
 		ctx:           context.Background(),
 		logger:        logging.NewHCLogLogrusAdapter(logrus.StandardLogger()),
 		AppleUsername: appleUsername,
 		ApplePassword: applePassword,
+		DeveloperID:   developerID,
+		BundleID:      bundleID,
 		BinaryPaths:   BinaryPaths,
 	}
 }
@@ -79,7 +78,7 @@ func (gw *GonWrapper) SignBinaries() error {
 	gw.logger.Info("Signing binaries %v...", gw.BinaryPaths)
 	err := sign.Sign(gw.ctx, &sign.Options{
 		Files:    gw.BinaryPaths,
-		Identity: DeveloperIdentity,
+		Identity: gw.DeveloperID,
 		Logger:   gw.logger,
 	})
 
@@ -119,7 +118,7 @@ func (gw *GonWrapper) NotarizeBinaries(zipPath string) error {
 	gw.logger.Info("Uploading %q to Apple for notarization ticket issuance. This may take awhile...", zipPath)
 	notarizationInfo, err := notarize.Notarize(gw.ctx, &notarize.Options{
 		File:     zipPath,
-		BundleId: BundleID,
+		BundleId: gw.BundleID,
 		Username: gw.AppleUsername,
 		Password: gw.ApplePassword,
 		Logger:   gw.logger,

--- a/build.assets/tooling/cmd/notarize-apple-binaries/main.go
+++ b/build.assets/tooling/cmd/notarize-apple-binaries/main.go
@@ -27,11 +27,20 @@ import (
 
 const binaryArgName string = "binaries"
 
+// Default values for flags.
+// TODO(camh): Remove when all call sites pass the correct values.
+const (
+	DeveloperIdentity string = "0FFD3E3413AB4C599C53FBB1D8CA690915E33D83"
+	BundleID          string = "com.gravitational.teleport"
+)
+
 type Config struct {
 	LogLevel      string
 	LogJSON       bool
 	AppleUsername string
 	ApplePassword string
+	DeveloperID   string
+	BundleID      string
 	BinaryPaths   []string
 }
 
@@ -41,6 +50,8 @@ func main() {
 	kingpin.Flag("log-json", "Enable JSON logging").Default(fmt.Sprintf("%v", false)).BoolVar(&config.LogJSON)
 	kingpin.Flag("apple-username", "Apple Connect username used for notarization").Required().Envar("APPLE_USERNAME").StringVar(&config.AppleUsername)
 	kingpin.Flag("apple-password", "Apple Connect password used for notarization").Required().Envar("APPLE_PASSWORD").StringVar(&config.ApplePassword)
+	kingpin.Flag("developer-id", "Key ID for signing binaries").Default(DeveloperIdentity).StringVar(&config.DeveloperID)
+	kingpin.Flag("bundle-id", "Bundle ID of application").Default(BundleID).StringVar(&config.BundleID)
 	kingpin.Arg(binaryArgName, "Path to Apple binaries for signing and notarization").Required().Action(binaryArgValidatiorAction).ExistingFilesVar(&config.BinaryPaths)
 	kingpin.Parse()
 
@@ -113,7 +124,7 @@ func run(config *Config) error {
 	}
 	NewLoggerConfig(parsedLogLevel, config.LogJSON).setupLogger()
 
-	err = NewGonWrapper(config.AppleUsername, config.ApplePassword, config.BinaryPaths).SignAndNotarizeBinaries()
+	err = NewGonWrapper(config.AppleUsername, config.ApplePassword, config.DeveloperID, config.BundleID, config.BinaryPaths).SignAndNotarizeBinaries()
 	if err != nil {
 		return trace.Wrap(err, "failed to sign and notarize binaries")
 	}


### PR DESCRIPTION
Add a couple of parameters for the developer key ID and bundle ID for
signing/notarizing binaries. Keep the hard-coded values as defaults for
now, but we will remove these soon when all the call sites of the tool
have been updated to pass these values.

We want to parameterize these values so we can use different signing
keys in GitHub Actions and to make the tool agnostic to which binaries
it is signing.

Issue: https://github.com/gravitational/teleport/issues/20319