### PR TITLE
Fix GetCertAuthorities client method gRPC error conversion

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3311,7 +3311,7 @@ func (c *Client) GetCertAuthorities(ctx context.Context, caType types.CertAuthTy
 		IncludeKey: loadKeys,
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trail.FromGRPC(err)
 	}
 
 	cas := make([]types.CertAuthority, 0, len(resp.CertAuthoritiesV2))
@@ -3319,7 +3319,7 @@ func (c *Client) GetCertAuthorities(ctx context.Context, caType types.CertAuthTy
 		cas = append(cas, ca)
 	}
 
-	return cas, trail.FromGRPC(err)
+	return cas, nil
 }
 
 // UpdateHeadlessAuthenticationState updates a headless authentication state.


### PR DESCRIPTION
Ran a newer `tbot` instance against an older server in my GitLab testing and came across this:
<img width="1455" alt="image" src="https://user-images.githubusercontent.com/16336790/225286824-59149f3b-d38c-4576-8b2c-b6eda8ad9b86.png">
