### PR TITLE
Replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 	github.com/flynn/u2f v0.0.0-20180613185708-15554eb68e5d
 	github.com/fsouza/fake-gcs-server v1.47.6
 	github.com/fxamacker/cbor/v2 v2.5.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/go-ldap/ldap/v3 v3.4.6
 	github.com/go-logr/logr v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -483,7 +483,6 @@ github.com/fxamacker/cbor/v2 v2.5.0 h1:oHsG0V/Q6E/wqTS2O1Cozzsy69nqCiguo5Q1a1ADi
 github.com/fxamacker/cbor/v2 v2.5.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gizak/termui/v3 v3.1.0 h1:ZZmVDgwHl7gR7elfKf1xc4IudXZ5qqfDh4wExk4Iajc=
 github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmyFlkYTrY=

--- a/integrations/lib/tctl/resources.go
+++ b/integrations/lib/tctl/resources.go
@@ -23,9 +23,9 @@ import (
 	"errors"
 	"io"
 
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport/api/types"
 )

--- a/lib/client/db/opensearch/profile.go
+++ b/lib/client/db/opensearch/profile.go
@@ -24,8 +24,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
+	"sigs.k8s.io/yaml"
 )
 
 // ProfileName is the name of the opensearch-cli that will be created for Teleport usage
@@ -105,14 +105,14 @@ func WriteConfig(baseDir string, cfg Config) (string, error) {
 
 	// create config directory if it doesn't exist
 	configDir := path.Join(baseDir, "opensearch-cli")
-	err = os.MkdirAll(configDir, 0700)
+	err = os.MkdirAll(configDir, 0o700)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
 
 	// write config to file
 	fn := path.Join(configDir, fmt.Sprintf("%x.yml", hash))
-	err = os.WriteFile(fn, bytes, 0600)
+	err = os.WriteFile(fn, bytes, 0o600)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -29,12 +29,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sashabaranov/go-openai"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"

--- a/lib/srv/db/elasticsearch/util.go
+++ b/lib/srv/db/elasticsearch/util.go
@@ -21,7 +21,7 @@ package elasticsearch
 import (
 	"encoding/json"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport/lib/srv/db/common"
 )

--- a/lib/srv/db/elasticsearch/util_test.go
+++ b/lib/srv/db/elasticsearch/util_test.go
@@ -21,9 +21,9 @@ package elasticsearch
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestEngineGetQueryFromRequestBody(t *testing.T) {

--- a/lib/utils/jsontools.go
+++ b/lib/utils/jsontools.go
@@ -24,10 +24,10 @@ import (
 	"reflect"
 	"unicode"
 
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	jsoniter "github.com/json-iterator/go"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport/api/internalutils/stream"
 )

--- a/lib/web/ui/resource.go
+++ b/lib/web/ui/resource.go
@@ -21,8 +21,8 @@ package ui
 import (
 	"fmt"
 
-	yaml "github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport/api/types"
 )

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -30,9 +30,9 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"

--- a/tool/tctl/sso/tester/format.go
+++ b/tool/tctl/sso/tester/format.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport/api/types"
 )

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/accessrequest"

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -30,8 +30,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -32,11 +32,11 @@ import (
 	"sync"
 	"text/template"
 
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	dockerterm "github.com/moby/term"
 	corev1 "k8s.io/api/core/v1"
@@ -53,6 +52,7 @@ import (
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/term"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"

--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -48,10 +48,10 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -46,7 +46,6 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
@@ -55,6 +54,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -45,13 +45,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	otlp "go.opentelemetry.io/proto/otlp/trace/v1"
 	"golang.org/x/crypto/ssh"
 	yamlv2 "gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"


### PR DESCRIPTION
The package `github.com/ghodss/yaml` is no longer actively maintained. See discussion in https://github.com/ghodss/yaml/issues/75 and https://github.com/ghodss/yaml/issues/80. [`sigs.k8s.io/yaml`](https://github.com/kubernetes-sigs/yaml) is a permanent fork of `github.com/ghodss/yaml`.

The notable change is that `github.com/ghodss/yaml` uses `gopkg.in/yaml.v2 v2.2.2`, but `sigs.k8s.io/yaml` uses `gopkg.in/yaml.v2 v2.4.0`. Changes can be seen here [v2.2.2...v2.4.0](https://github.com/go-yaml/yaml/compare/v2.2.2...v2.4.0), mostly bug fixes.