### PR TITLE
tsh: Silent webauthnwin warning on app init

### DIFF
--- a/lib/auth/webauthnwin/api.go
+++ b/lib/auth/webauthnwin/api.go
@@ -25,11 +25,10 @@ import (
 	"io"
 	"os"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"

--- a/lib/auth/webauthnwin/api.go
+++ b/lib/auth/webauthnwin/api.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"os"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 	"github.com/gravitational/trace"
@@ -188,7 +190,12 @@ type CheckSupportResult struct {
 // false positives.
 // See CheckSupport.
 func IsAvailable() bool {
-	return CheckSupport().IsAvailable
+	supports := CheckSupport()
+	if supports.HasCompileSupport && !supports.IsAvailable {
+		log.Warn("WebAuthnWin: not supported on your windows version, supported from version 1903")
+	}
+
+	return supports.IsAvailable
 }
 
 // CheckSupport return information whether Windows Webauthn is supported and

--- a/lib/auth/webauthnwin/api.go
+++ b/lib/auth/webauthnwin/api.go
@@ -192,7 +192,7 @@ type CheckSupportResult struct {
 func IsAvailable() bool {
 	supports := CheckSupport()
 	if supports.HasCompileSupport && !supports.IsAvailable {
-		log.Warn("WebAuthnWin: not supported on your windows version, supported from version 1903")
+		log.Warn("Webauthn is not supported on this version of Windows, supported from version 1903")
 	}
 
 	return supports.IsAvailable

--- a/lib/auth/webauthnwin/webauthn_windows.go
+++ b/lib/auth/webauthnwin/webauthn_windows.go
@@ -63,7 +63,7 @@ type nativeImpl struct {
 func newNativeImpl() *nativeImpl {
 	v, err := checkIfDLLExistsAndGetAPIVersionNumber()
 	if err != nil {
-		log.WithError(err).Warn("WebAuthnWin: failed to check version")
+		log.WithError(err).Debug("WebAuthnWin: failed to check version")
 		return &nativeImpl{
 			hasCompileSupport: true,
 			isAvailable:       false,
@@ -73,7 +73,7 @@ func newNativeImpl() *nativeImpl {
 	if err != nil {
 		// This should not happen if dll exists, however we are fine with
 		// to proceed without uvPlatform.
-		log.WithError(err).Warn("WebAuthnWin: failed to check isUVPlatformAuthenticatorAvailable")
+		log.WithError(err).Debug("WebAuthnWin: failed to check isUVPlatformAuthenticatorAvailable")
 	}
 
 	return &nativeImpl{


### PR DESCRIPTION
Previously if webauthn.dll is missing on windows machine, we will print warning on every command.

This PR changes warning to debug. Additionally if someone tried to login/register via local auth, if dll is missing, we will print warning.

Fixes: https://github.com/gravitational/teleport/issues/22833