### PR TITLE
Add `app_server` support to tctl get/rm commands

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -169,6 +169,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindDatabase, nil
 	case types.KindApp, "apps":
 		return types.KindApp, nil
+	case types.KindAppServer, "app_servers":
+		return types.KindAppServer, nil
 	case types.KindWindowsDesktopService, "windows_service", "win_desktop_service", "win_service":
 		return types.KindWindowsDesktopService, nil
 	case types.KindWindowsDesktop, "win_desktop":

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -67,7 +67,8 @@ func (r *roleCollection) writeText(w io.Writer) error {
 			r.GetMetadata().Name,
 			strings.Join(r.GetLogins(types.Allow), ","),
 			printNodeLabels(r.GetNodeLabels(types.Allow)),
-			printActions(r.GetRules(types.Allow))})
+			printActions(r.GetRules(types.Allow)),
+		})
 	}
 
 	headers := []string{"Role", "Allowed to login as", "Node Labels", "Access to resources"}
@@ -362,7 +363,8 @@ func (c *trustedClusterCollection) resources() (r []types.Resource) {
 
 func (c *trustedClusterCollection) writeText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{
-		"Name", "Enabled", "Token", "Proxy Address", "Reverse Tunnel Address", "Role Map"})
+		"Name", "Enabled", "Token", "Proxy Address", "Reverse Tunnel Address", "Role Map",
+	})
 	for _, tc := range c.trustedClusters {
 		t.AddRow([]string{
 			tc.GetName(),
@@ -485,7 +487,8 @@ func (a *appServerCollection) writeText(w io.Writer) error {
 		app := server.GetApp()
 		labels := stripInternalTeleportLabels(a.verbose, app.GetAllLabels())
 		rows = append(rows, []string{
-			server.GetHostname(), app.GetName(), app.GetProtocol(), app.GetPublicAddr(), app.GetURI(), labels, server.GetTeleportVersion()})
+			server.GetHostname(), app.GetName(), app.GetProtocol(), app.GetPublicAddr(), app.GetURI(), labels, server.GetTeleportVersion(),
+		})
 	}
 	var t asciitable.Table
 	headers := []string{"Host", "Name", "Type", "Public Address", "URI", "Labels", "Version"}
@@ -524,7 +527,8 @@ func (c *appCollection) writeText(w io.Writer) error {
 	for _, app := range c.apps {
 		labels := stripInternalTeleportLabels(c.verbose, app.GetAllLabels())
 		rows = append(rows, []string{
-			app.GetName(), app.GetDescription(), app.GetURI(), app.GetPublicAddr(), labels, app.GetVersion()})
+			app.GetName(), app.GetDescription(), app.GetURI(), app.GetPublicAddr(), labels, app.GetVersion(),
+		})
 	}
 	headers := []string{"Name", "Description", "URI", "Public Address", "Labels", "Version"}
 	var t asciitable.Table

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1058,6 +1058,25 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err
 			return trace.Wrap(err)
 		}
 		fmt.Printf("Device %q removed\n", rc.ref.Name)
+
+	case types.KindAppServer:
+		appServers, err := client.GetApplicationServers(ctx, rc.namespace)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		deleted := false
+		for _, server := range appServers {
+			if server.GetName() == rc.ref.Name {
+				if err := client.DeleteApplicationServer(ctx, server.GetNamespace(), server.GetHostID(), server.GetName()); err != nil {
+					return trace.Wrap(err)
+				}
+				deleted = true
+			}
+		}
+		if !deleted {
+			return trace.NotFound("application server %q not found", rc.ref.Name)
+		}
+		fmt.Printf("application server %q has been deleted\n", rc.ref.Name)
 	default:
 		return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
 	}
@@ -1447,6 +1466,26 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 			return nil, trace.NotFound("kubernetes server %q not found", rc.ref.Name)
 		}
 		return &kubeServerCollection{servers: out}, nil
+
+	case types.KindAppServer:
+		servers, err := client.GetApplicationServers(ctx, rc.namespace)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if rc.ref.Name == "" {
+			return &appServerCollection{servers: servers}, nil
+		}
+
+		var out []types.AppServer
+		for _, server := range servers {
+			if server.GetName() == rc.ref.Name || server.GetHostname() == rc.ref.Name {
+				out = append(out, server)
+			}
+		}
+		if len(out) == 0 {
+			return nil, trace.NotFound("application server %q not found", rc.ref.Name)
+		}
+		return &appServerCollection{servers: out}, nil
 	case types.KindNetworkRestrictions:
 		nr, err := client.GetNetworkRestrictions(ctx)
 		if err != nil {


### PR DESCRIPTION
This PR adds support for `app_server` get and remove commands through `tctl`.