### PR TITLE
Add audit event section to RFD template

### DIFF
--- a/rfd/0000-rfds.md
+++ b/rfd/0000-rfds.md
@@ -164,6 +164,13 @@ include any migration steps.
 * Are there any backend migrations required?
 * How will changes be rolled out across future versions?
 
+
+### Audit Events
+
+Include any new events that are required to audit the behavior
+introduced in your design doc and the criteria required to emit them.
+
+
 ### Test Plan
 
 Include any changes or additions that will need to be made to


### PR DESCRIPTION
Attempts to prevent the audit log from being an after thought by incorporating them into the RFD template.