### PR TITLE
[v10] docs: Add instructions on uninstalling Teleport

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -393,6 +393,10 @@
             {
               "title": "Run Teleport as a Daemon",
               "slug": "/management/admin/daemon/"
+            },
+            {
+              "title": "Uninstall Teleport",
+              "slug": "/management/admin/uninstall-teleport/"
             }
           ]
         },
@@ -1030,7 +1034,7 @@
 	    {
 	    	"title": "teleport-plugin-jira",
 	    	"slug": "/reference/helm-reference/teleport-plugin-jira/"
-            }, 
+            },
             {
               "title": "teleport-plugin-event-handler",
               "slug": "/reference/helm-reference/teleport-plugin-event-handler/"

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -29,7 +29,7 @@ any OS supported by the [Golang toolchain](https://github.com/golang/go/wiki/Min
 
 \[2] *`tsh` is a Command Line Client (CLI) and Teleport Connect is a Graphical User Interface (GUI) desktop client. See
   [Using Teleport Connect](connect-your-client/teleport-connect.mdx) for usage and installation*.
-  
+
 \[3] *Enhanced Session Recording requires Linux kernel v5.8+*.
 
 \[4] *Teleport server does not run on Windows yet, but `tsh` and Teleport Connect (the Teleport desktop clients)
@@ -144,12 +144,12 @@ chart.
   |[`teleport-(=teleport.version=).pkg`](https://get.gravitational.com/teleport-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`|
   |[`tsh-(=teleport.version=).pkg`](https://get.gravitational.com/tsh-(=teleport.version=).pkg)|`tsh`|
 
-  You can also fetch an installer via the command line: 
+  You can also fetch an installer via the command line:
 
   ```code
   $ curl -O https://get.gravitational.com/teleport-(=teleport.version=).pkg
   # Installs on Macintosh HD
-  $ sudo installer -pkg teleport-(=teleport.version=).pkg -target / 
+  $ sudo installer -pkg teleport-(=teleport.version=).pkg -target /
   # Password:
   # installer: Package name is teleport-(=teleport.version=)
   # installer: Upgrading at base path /
@@ -206,11 +206,11 @@ chart.
     ```code
     $ tctl status
     tctl status
-    Cluster  mytenant.teleport.sh                                           
-    Version  (=teleport.version=)                                                                   
-    Host CA  never updated                                                           
-    User CA  never updated                                                           
-    Jwt CA   never updated                                                           
+    Cluster  mytenant.teleport.sh
+    Version  (=teleport.version=)
+    Host CA  never updated
+    User CA  never updated
+    Jwt CA   never updated
     CA pin   (=presets.ca_pin=)
     ```
 
@@ -221,10 +221,10 @@ chart.
     $ tctl status
     tctl status
     Cluster  teleport.example.com
-    Version  (=teleport.version=)                                                                   
-    Host CA  never updated                                                           
-    User CA  never updated                                                           
-    Jwt CA   never updated                                                           
+    Version  (=teleport.version=)
+    Host CA  never updated
+    User CA  never updated
+    Jwt CA   never updated
     CA pin   (=presets.ca_pin=)
     ```
 
@@ -236,14 +236,14 @@ chart.
     $ tsh version
     Teleport v(=teleport.version=) git:v(=teleport.version=) go(=teleport.golang=)
     ```
-    
+
     Get your local tctl version:
 
     ```code
     $ tctl version
     Teleport v(=teleport.version=) git:v(=teleport.version=) go(=teleport.golang=)
     ```
-    
+
   </TabItem>
 
 </Tabs>
@@ -256,12 +256,12 @@ chart.
   |[`teleport-ent-(=teleport.version=).pkg`](https://get.gravitational.com/teleport-ent-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`|
   |[`tsh-(=teleport.version=).pkg`](https://get.gravitational.com/tsh-(=teleport.version=).pkg)|`tsh`|
 
-  You can also fetch an installer via the command line: 
+  You can also fetch an installer via the command line:
 
   ```code
   $ curl -O https://get.gravitational.com/teleport-ent-(=teleport.version=).pkg
   # Installs on Macintosh HD
-  $ sudo installer -pkg teleport-ent-(=teleport.version=).pkg -target / 
+  $ sudo installer -pkg teleport-ent-(=teleport.version=).pkg -target /
   # Password:
   # installer: Package name is teleport-ent-(=teleport.version=)
   # installer: Upgrading at base path /
@@ -329,12 +329,16 @@ shown in the installation examples.
 ```code
 $ export version=v(=teleport.version=)
 # 'darwin' 'linux' or 'windows'
-$ export os=linux 
+$ export os=linux
 # '386' 'arm' on linux or 'amd64' for all distros
-$ export arch=amd64 
+$ export arch=amd64
 $ curl https://get.gravitational.com/teleport-$version-$os-$arch-bin.tar.gz.sha256
 # <checksum> <filename>
 ```
+
+## Uninstalling Teleport
+
+If you wish to uninstall Teleport at any time, see our documentation on [Uninstalling Teleport](./management/admin/uninstall-teleport.mdx).
 
 ## Next steps
 

--- a/docs/pages/management/admin.mdx
+++ b/docs/pages/management/admin.mdx
@@ -27,5 +27,4 @@ cluster maintenance tasks.
 ## Troubleshoot issues
 
 - [Troubleshooting](./admin/troubleshooting.mdx): Collect metrics and diagnostic information from Teleport.
-
-
+- [Uninstall Teleport](./admin/uninstall-teleport.mdx): Uninstall Teleport from your system.

--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -1,0 +1,502 @@
+---
+title: Uninstall Teleport
+description: How to remove Teleport from your system
+---
+
+This guide explains how to uninstall Teleport binaries completely.
+
+## Prerequisites
+
+- A system with Teleport installed.
+
+<Admonition type="warning">
+These instructions only apply to non-containerized installations of Teleport.
+
+If you are running Teleport in Kubernetes, you should uninstall the Helm chart release instead:
+
+```code
+# Example: uninstall the Helm release named 'teleport-kube-agent' in the 'teleport' namespace
+$ helm uninstall --namespace teleport teleport-kube-agent
+```
+
+If you are running Teleport in Docker, you should stop the Teleport Docker container:
+
+```code
+# Example: Stop the Docker container named 'teleport'
+$ docker stop teleport
+```
+</Admonition>
+
+## Step 1/3. Stop any running Teleport processes
+
+<Tabs>
+  <TabItem label="Linux">
+    Instruct `systemd` to stop the Teleport process, and disable it from automatically starting:
+
+    ```code
+    $ sudo systemctl stop teleport
+    $ sudo systemctl disable teleport
+    ```
+
+    If these `systemd` commands do not work, you can "kill" all the running Teleport processes instead:
+
+    ```code
+    $ sudo killall teleport
+    ```
+  </TabItem>
+  <TabItem label="MacOS">
+
+    Instruct `launchd` to stop the Teleport process, and disable it from automatically starting:
+
+    ```code
+    $ sudo launchctl unload -w /Library/LaunchDaemons/com.goteleport.teleport.plist
+    $ sudo rm -f /Library/LaunchDaemons/com.goteleport.teleport.plist
+    ```
+
+   If these commands do not work, you can "kill" all the running Teleport processes instead:
+
+    ```code
+    $ sudo killall teleport
+    ```
+
+  </TabItem>
+  <TabItem label="Windows">
+
+    There are currently no long-running Teleport processes on Windows machines.
+
+  </TabItem>
+</Tabs>
+
+## Step 2/3. Remove Teleport binaries
+
+<Tabs dropdownView dropdownCaption="Teleport Edition">
+  <TabItem label="Open Source" scope="oss">
+  <Tabs>
+  <TabItem label="Debian/Ubuntu Linux (DEB)" scope="oss">
+
+  Uninstall the Teleport binary using APT:
+
+  ```code
+  $ sudo apt-get -y remove teleport
+  ```
+
+  Uninstall the Teleport APT repo:
+
+  ```code
+  $ sudo rm -f /etc/apt/sources.list.d/teleport.list
+  ```
+
+  <Admonition type="notice" title="Uninstall standalone DEB package">
+  If the commands above do not work, you may have installed Teleport using a standalone DEB package. Remove it with:
+
+  ```code
+  $ sudo dpkg -r teleport
+  ```
+  </Admonition>
+
+  </TabItem>
+  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="oss">
+
+  Uninstall the Teleport binary using YUM:
+
+  ```code
+  $ sudo yum -y remove teleport
+  # Optional: Use DNF on newer distributions
+  # $ sudo dnf -y remove teleport
+  ```
+
+  Uninstall the Teleport YUM repo:
+
+  ```code
+  $ sudo rm -f /etc/yum.repos.d/teleport.repo
+  ```
+
+  <Admonition type="notice" title="Uninstall standalone RPM package">
+  If the commands above do not work, you may have installed Teleport using a standalone RPM package. Remove it with:
+
+  ```code
+  $ sudo rpm -e teleport
+  ```
+  </Admonition>
+
+  </TabItem>
+  <TabItem label="Linux Tarball" scope="oss">
+
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  ```
+
+  </TabItem>
+  <TabItem label="MacOS" scope="oss">
+
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  ```
+
+  <Admonition type="notice" title="Uninstall MacOS client tools">
+  If you installed the MacOS `tsh`-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
+
+  ```code
+  $ sudo rm -f /Applications/tsh.app
+  $ sudo rm -f /Applications/Teleport\ Connect.app
+  ```
+  </Admonition>
+
+  </TabItem>
+  <TabItem label="Windows" scope="oss">
+
+  Remove the `tsh.exe` binary from the machine:
+
+  ```code
+  $ del C:\Path\To\tsh.exe
+  ```
+
+  You can uninstall Teleport Connect from the "Apps and Features" section of the Control Panel.
+
+  For reference, Teleport Connect binaries are installed to `%LOCALAPPDATA%\Programs\teleport-connect`.
+
+  </TabItem>
+  </Tabs>
+  </TabItem>
+  <TabItem label="Enterprise" scope="enterprise">
+
+  <Tabs>
+  <TabItem label="Debian/Ubuntu Linux (DEB)" scope="enterprise">
+
+  Uninstall the Teleport binary using APT:
+
+  ```code
+  $ sudo apt-get -y remove teleport-ent
+  # Optional: If using the Teleport FIPS package
+  # $ sudo apt-get -y remove teleport-ent-fips
+  ```
+
+  Uninstall the Teleport APT repo:
+
+  ```code
+  $ sudo rm -f /etc/apt/sources.list.d/teleport.list
+  ```
+
+  <Admonition type="notice" title="Uninstall standalone DEB package">
+  If the commands above do not work, you may have installed Teleport using a standalone DEB package. Remove it with:
+
+  ```code
+  # Enterprise
+  $ sudo dpkg -r teleport-ent
+  # Enterprise FIPS
+  # $ sudo dpkg -r teleport-ent-fips
+  ```
+  </Admonition>
+
+  </TabItem>
+  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="enterprise">
+
+  Uninstall the Teleport binary using YUM:
+
+  ```code
+  $ sudo yum -y remove teleport-ent
+  # Optional: Use DNF on newer distributions
+  # $ sudo dnf -y remove teleport-ent
+  # Optional: If using the Teleport FIPS package
+  # $ sudo yum -y remove teleport-ent-fips
+  # $ sudo dnf -y remove teleport-ent-fips
+  ```
+
+  Uninstall the Teleport YUM repo:
+
+  ```code
+  $ sudo rm -f /etc/yum.repos.d/teleport.repo
+  ```
+
+  <Admonition type="notice" title="Uninstall standalone RPM package">
+  If the commands above do not work, you may have installed Teleport using a standalone RPM package. Remove it with:
+
+  ```code
+  # Enterprise
+  $ sudo rpm -e teleport-ent
+  # Enterprise FIPS
+  # $ sudo rpm -e teleport-ent-fips
+  ```
+  </Admonition>
+
+  </TabItem>
+  <TabItem label="Linux Tarball" scope="enterprise">
+
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  ```
+
+  </TabItem>
+  <TabItem label="MacOS" scope="enterprise">
+
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  ```
+
+  <Admonition type="notice" title="Uninstall MacOS client tools">
+  If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
+
+  ```code
+  $ sudo rm -f /Applications/tsh.app
+  $ sudo rm -f /Applications/Teleport\ Connect.app
+  ```
+  </Admonition>
+
+  </TabItem>
+  <TabItem label="Windows" scope="enterprise">
+
+  Remove the `tsh.exe` binary from the machine:
+
+  ```code
+  $ del C:\Path\To\tsh.exe
+  ```
+
+  You can uninstall Teleport Connect from the "Apps and Features" section of the Control Panel.
+
+  For reference, Teleport Connect binaries are installed to `%LOCALAPPDATA%\Programs\teleport-connect`.
+
+  </TabItem>
+  </Tabs>
+  </TabItem>
+  <TabItem label="Cloud" scope="cloud">
+
+  <Tabs>
+  <TabItem label="Debian/Ubuntu Linux (DEB)" scope="cloud">
+
+  Uninstall the Teleport binary using APT:
+
+  ```code
+  $ sudo apt-get -y remove teleport-ent
+  # NOTE: Older Cloud users may be running OSS binaries instead
+  # $ sudo apt-get -y remove teleport
+  ```
+
+  Uninstall the Teleport APT repo:
+
+  ```code
+  $ sudo rm -f /etc/apt/sources.list.d/teleport.list
+  ```
+
+  <Admonition type="notice" title="Uninstall standalone DEB package">
+  If the commands above do not work, you may have installed Teleport using a standalone DEB package. Remove it with:
+
+  ```code
+  $ sudo dpkg -r teleport-ent
+  # NOTE: Older Cloud users may be running OSS binaries instead
+  # $ sudo dpkg -r teleport
+  ```
+  </Admonition>
+
+  </TabItem>
+  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="cloud">
+
+  Uninstall the Teleport binary using YUM:
+
+  ```code
+  $ sudo yum -y remove teleport-ent
+  # Optional: Use DNF on newer distributions
+  # $ sudo dnf -y remove teleport-ent
+  # NOTE: Older Cloud users may be running OSS binaries instead
+  # $ sudo yum -y remove teleport
+  # $ sudo dnf -y remove teleport
+  ```
+
+  Uninstall the Teleport YUM repo:
+
+  ```code
+  $ sudo rm -f /etc/yum.repos.d/teleport.repo
+  ```
+
+  <Admonition type="notice" title="Uninstall standalone RPM package">
+  If the commands above do not work, you may have installed Teleport using a standalone RPM package. Remove it with:
+
+  ```code
+  $ sudo rpm -e teleport-ent
+  # NOTE: Older Cloud users may be running OSS binaries instead
+  # $ sudo rpm -e teleport
+  ```
+  </Admonition>
+
+  </TabItem>
+  <TabItem label="Linux Tarball" scope="cloud">
+
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  ```
+
+  </TabItem>
+  <TabItem label="MacOS" scope="cloud">
+
+  <Admonition type="notice">
+  These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
+  You can use `dirname $(which teleport)` to look this up automatically.
+  </Admonition>
+
+  Remove the Teleport binaries from the machine:
+
+  ```code
+  $ sudo rm -f /usr/local/bin/tbot
+  $ sudo rm -f /usr/local/bin/tctl
+  $ sudo rm -f /usr/local/bin/teleport
+  $ sudo rm -f /usr/local/bin/tsh
+  ```
+
+  <Admonition type="notice" title="Uninstall MacOS client tools">
+  If you installed the MacOS `tsh` client-only package and/or Teleport Connect for MacOS, you can optionally remove those too:
+
+  ```code
+  $ sudo rm -f /Applications/tsh.app
+  $ sudo rm -f /Applications/Teleport\ Connect.app
+  ```
+  </Admonition>
+
+  </TabItem>
+  <TabItem label="Windows" scope="cloud">
+
+  Remove the `tsh.exe` binary from the machine:
+
+  ```code
+  $ del C:\Path\To\tsh.exe
+  ```
+
+  You can uninstall Teleport Connect from the "Apps and Features" section of the Control Panel.
+
+  For reference, Teleport Connect binaries are installed to `%LOCALAPPDATA%\Programs\teleport-connect`.
+
+  </TabItem>
+  </Tabs>
+  </TabItem>
+</Tabs>
+
+## Step 3/3. Remove Teleport data and configuration files
+
+<Tabs>
+  <TabItem label="Linux">
+    <Admonition type="notice">
+    These are the default paths to the Teleport config files and data directory.
+    If you have changed these from the defaults on your system, substitute those paths here.
+    </Admonition>
+
+    Remove the Teleport config file:
+
+    ```code
+    $ sudo rm -f /etc/teleport.yaml
+    # Optional: Also remove the Machine ID config file, if you used it
+    # $ sudo rm -f /etc/tbot.yaml
+    ```
+
+    Remove the Teleport data directory:
+
+    ```code
+    $ sudo rm -rf /var/lib/teleport
+    ```
+
+     Optionally, also remove the global config file and local user data directory for `tsh`:
+
+    ```code
+    $ sudo rm -f /etc/tsh.yaml
+    $ sudo rm -rf ~/.tsh
+    ```
+  </TabItem>
+  <TabItem label="MacOS">
+    <Admonition type="notice">
+    These are the default paths to the Teleport config files and data directory.
+    If you have changed these from the defaults on your system, substitute those paths here.
+    </Admonition>
+
+    Remove the Teleport config file:
+
+    ```code
+    $ sudo rm -f /etc/teleport.yaml
+    # Optional: Also remove the Machine ID config file, if you used it
+    # $ sudo rm -f /etc/tbot.yaml
+    ```
+
+    Remove the Teleport data directory:
+
+    ```code
+    $ sudo rm -rf /var/lib/teleport
+    ```
+
+    Optionally, also remove:
+    - the global config file and local user data directory for `tsh`
+    - the local user data directory for Teleport Connect
+
+    ```code
+    # tsh
+    $ sudo rm -f /etc/tsh.yaml
+    $ sudo rm -rf ~/.tsh
+    # Teleport Connect
+    $ sudo rm -rf ~/Library/Application\ Support/Teleport\ Connect
+    ```
+  </TabItem>
+  <TabItem label="Windows">
+
+   Remove the local user data directory for `tsh`:
+
+   ```code
+   $ rmdir /s /q %USERPROFILE%\.tsh
+   ```
+
+   Optionally, also remove the local user data directory for Teleport Connect:
+
+   ```code
+   $ rmdir /s /q "%APPDATA%\Teleport Connect"
+   ```
+
+  </TabItem>
+</Tabs>
+
+Teleport is now removed from your system.
+
+Any Teleport Services will stop appearing in your Teleport Web UI or the output of `tsh ls` once their last heartbeat has timed out. This usually occurs within 10-15 minutes of stopping the Teleport process.


### PR DESCRIPTION
Backport #22989 to `branch/v10`

All the whitespace changes are automatically done by my editor.