### PR TITLE
improve aws utils and database validation

### DIFF
--- a/api/types/database_test.go
+++ b/api/types/database_test.go
@@ -555,48 +555,48 @@ func TestDynamoDBConfig(t *testing.T) {
 		{
 			desc:    "account and region and empty URI is correct",
 			region:  "us-west-1",
-			account: "12345",
+			account: "123456789012",
 			wantSpec: DatabaseSpecV3{
 				URI: "aws://dynamodb.us-west-1.amazonaws.com",
 				AWS: AWS{
 					Region:    "us-west-1",
-					AccountID: "12345",
+					AccountID: "123456789012",
 				},
 			},
 		},
 		{
 			desc:    "account and AWS URI and empty region is correct",
 			uri:     "dynamodb.us-west-1.amazonaws.com",
-			account: "12345",
+			account: "123456789012",
 			wantSpec: DatabaseSpecV3{
 				URI: "dynamodb.us-west-1.amazonaws.com",
 				AWS: AWS{
 					Region:    "us-west-1",
-					AccountID: "12345",
+					AccountID: "123456789012",
 				},
 			},
 		},
 		{
 			desc:    "account and AWS streams dynamodb URI and empty region is correct",
 			uri:     "streams.dynamodb.us-west-1.amazonaws.com",
-			account: "12345",
+			account: "123456789012",
 			wantSpec: DatabaseSpecV3{
 				URI: "streams.dynamodb.us-west-1.amazonaws.com",
 				AWS: AWS{
 					Region:    "us-west-1",
-					AccountID: "12345",
+					AccountID: "123456789012",
 				},
 			},
 		},
 		{
 			desc:    "account and AWS dax URI and empty region is correct",
 			uri:     "dax.us-west-1.amazonaws.com",
-			account: "12345",
+			account: "123456789012",
 			wantSpec: DatabaseSpecV3{
 				URI: "dax.us-west-1.amazonaws.com",
 				AWS: AWS{
 					Region:    "us-west-1",
-					AccountID: "12345",
+					AccountID: "123456789012",
 				},
 			},
 		},
@@ -604,12 +604,12 @@ func TestDynamoDBConfig(t *testing.T) {
 			desc:    "account and region and matching AWS URI region is correct",
 			uri:     "dynamodb.us-west-1.amazonaws.com",
 			region:  "us-west-1",
-			account: "12345",
+			account: "123456789012",
 			wantSpec: DatabaseSpecV3{
 				URI: "dynamodb.us-west-1.amazonaws.com",
 				AWS: AWS{
 					Region:    "us-west-1",
-					AccountID: "12345",
+					AccountID: "123456789012",
 				},
 			},
 		},
@@ -617,12 +617,12 @@ func TestDynamoDBConfig(t *testing.T) {
 			desc:    "account and region and custom URI is correct",
 			uri:     "localhost:8080",
 			region:  "us-west-1",
-			account: "12345",
+			account: "123456789012",
 			wantSpec: DatabaseSpecV3{
 				URI: "localhost:8080",
 				AWS: AWS{
 					Region:    "us-west-1",
-					AccountID: "12345",
+					AccountID: "123456789012",
 				},
 			},
 		},
@@ -630,30 +630,33 @@ func TestDynamoDBConfig(t *testing.T) {
 			desc:       "region and different AWS URI region is an error",
 			uri:        "dynamodb.us-west-2.amazonaws.com",
 			region:     "us-west-1",
-			account:    "12345",
+			account:    "123456789012",
 			wantErrMsg: "does not match the configured URI",
 		},
 		{
 			desc:       "invalid AWS URI is an error",
 			uri:        "a.streams.dynamodb.us-west-1.amazonaws.com",
 			region:     "us-west-1",
-			account:    "12345",
+			account:    "123456789012",
 			wantErrMsg: "invalid DynamoDB endpoint",
 		},
 		{
-			desc:       "custom URI and empty region is an error",
+			desc:       "custom URI and missing region is an error",
 			uri:        "localhost:8080",
-			account:    "12345",
-			wantErrMsg: "region is empty",
+			account:    "123456789012",
+			wantErrMsg: "region is missing",
 		},
 		{
-			desc:       "empty URI and empty region is an error",
-			account:    "12345",
-			wantErrMsg: "region is empty",
+			desc:       "missing URI and missing region is an error",
+			account:    "123456789012",
+			wantErrMsg: "URI is missing",
 		},
 		{
-			desc:       "missing account id",
-			wantErrMsg: "account ID is empty",
+			desc:       "invalid AWS account ID is an error",
+			uri:        "localhost:8080",
+			region:     "us-west-1",
+			account:    "12345",
+			wantErrMsg: "must be 12-digit",
 		},
 	}
 

--- a/lib/cloud/mocks/aws.go
+++ b/lib/cloud/mocks/aws.go
@@ -243,11 +243,11 @@ func (m *IAMMock) GetRolePolicyWithContext(ctx aws.Context, input *iam.GetRolePo
 	defer m.mu.RUnlock()
 	policy, ok := m.attachedRolePolicies[*input.RoleName]
 	if !ok {
-		return nil, trace.NotFound("policy not found")
+		return nil, trace.NotFound("role policy %v not found", *input.RoleName)
 	}
 	policyDocument, ok := policy[*input.PolicyName]
 	if !ok {
-		return nil, trace.NotFound("policy not found")
+		return nil, trace.NotFound("role %v policy name %v not found", *input.RoleName, *input.PolicyName)
 	}
 	return &iam.GetRolePolicyOutput{
 		PolicyDocument: &policyDocument,
@@ -283,11 +283,11 @@ func (m *IAMMock) GetUserPolicyWithContext(ctx aws.Context, input *iam.GetUserPo
 	defer m.mu.RUnlock()
 	policy, ok := m.attachedUserPolicies[*input.UserName]
 	if !ok {
-		return nil, trace.NotFound("policy not found")
+		return nil, trace.NotFound("user policy %v not found", *input.UserName)
 	}
 	policyDocument, ok := policy[*input.PolicyName]
 	if !ok {
-		return nil, trace.NotFound("policy not found")
+		return nil, trace.NotFound("user %v policy name %v not found", *input.UserName, *input.PolicyName)
 	}
 	return &iam.GetUserPolicyOutput{
 		PolicyDocument: &policyDocument,

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -66,7 +67,7 @@ func TestDatabaseUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 	actual, err := UnmarshalDatabase(data)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 // TestDatabaseMarshal verifies a marshaled database resource can be unmarshaled back.
@@ -85,7 +86,7 @@ func TestDatabaseMarshal(t *testing.T) {
 	require.NoError(t, err)
 	actual, err := UnmarshalDatabase(data)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 func TestValidateDatabase(t *testing.T) {
@@ -217,7 +218,7 @@ func TestValidateDatabase(t *testing.T) {
 				Protocol: defaults.ProtocolDynamoDB,
 				AWS: types.AWS{
 					Region:    "us-east-1",
-					AccountID: "1234567890",
+					AccountID: "123456789012",
 				},
 			},
 			expectError: false,
@@ -318,7 +319,7 @@ func TestDatabaseFromAzureDBServer(t *testing.T) {
 
 	actual, err := NewDatabaseFromAzureServer(&server)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 func TestDatabaseFromAzureRedis(t *testing.T) {
@@ -366,7 +367,7 @@ func TestDatabaseFromAzureRedis(t *testing.T) {
 
 	actual, err := NewDatabaseFromAzureRedis(resourceInfo)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 func TestDatabaseFromAzureRedisEnterprise(t *testing.T) {
@@ -428,7 +429,7 @@ func TestDatabaseFromAzureRedisEnterprise(t *testing.T) {
 
 	actual, err := NewDatabaseFromAzureRedisEnterprise(armCluster, armDatabase)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 // TestDatabaseFromRDSInstance tests converting an RDS instance to a database resource.
@@ -479,7 +480,7 @@ func TestDatabaseFromRDSInstance(t *testing.T) {
 	require.NoError(t, err)
 	actual, err := NewDatabaseFromRDSInstance(instance)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 // TestDatabaseFromRDSInstance tests converting an RDS instance to a database resource.
@@ -531,7 +532,7 @@ func TestDatabaseFromRDSInstanceNameOverride(t *testing.T) {
 	require.NoError(t, err)
 	actual, err := NewDatabaseFromRDSInstance(instance)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 // TestDatabaseFromRDSCluster tests converting an RDS cluster to a database resource.
@@ -587,7 +588,7 @@ func TestDatabaseFromRDSCluster(t *testing.T) {
 		require.NoError(t, err)
 		actual, err := NewDatabaseFromRDSCluster(cluster)
 		require.NoError(t, err)
-		require.Equal(t, expected, actual)
+		require.Empty(t, cmp.Diff(expected, actual))
 	})
 
 	t.Run("reader", func(t *testing.T) {
@@ -611,7 +612,7 @@ func TestDatabaseFromRDSCluster(t *testing.T) {
 		require.NoError(t, err)
 		actual, err := NewDatabaseFromRDSClusterReaderEndpoint(cluster)
 		require.NoError(t, err)
-		require.Equal(t, expected, actual)
+		require.Empty(t, cmp.Diff(expected, actual))
 	})
 
 	t.Run("custom endpoints", func(t *testing.T) {
@@ -723,7 +724,7 @@ func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
 		require.NoError(t, err)
 		actual, err := NewDatabaseFromRDSCluster(cluster)
 		require.NoError(t, err)
-		require.Equal(t, expected, actual)
+		require.Empty(t, cmp.Diff(expected, actual))
 	})
 
 	t.Run("reader", func(t *testing.T) {
@@ -748,7 +749,7 @@ func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
 		require.NoError(t, err)
 		actual, err := NewDatabaseFromRDSClusterReaderEndpoint(cluster)
 		require.NoError(t, err)
-		require.Equal(t, expected, actual)
+		require.Empty(t, cmp.Diff(expected, actual))
 	})
 
 	t.Run("custom endpoints", func(t *testing.T) {
@@ -858,7 +859,7 @@ func TestDatabaseFromRDSProxy(t *testing.T) {
 
 		actual, err := NewDatabaseFromRDSProxy(dbProxy, port, tags)
 		require.NoError(t, err)
-		require.Equal(t, expected, actual)
+		require.Empty(t, cmp.Diff(expected, actual))
 	})
 
 	t.Run("custom endpoint", func(t *testing.T) {
@@ -894,7 +895,7 @@ func TestDatabaseFromRDSProxy(t *testing.T) {
 
 		actual, err := NewDatabaseFromRDSProxyCustomEndpoint(dbProxy, dbProxyEndpoint, port, tags)
 		require.NoError(t, err)
-		require.Equal(t, expected, actual)
+		require.Empty(t, cmp.Diff(expected, actual))
 	})
 }
 
@@ -1080,7 +1081,7 @@ func TestDatabaseFromRedshiftCluster(t *testing.T) {
 
 		actual, err := NewDatabaseFromRedshiftCluster(cluster)
 		require.NoError(t, err)
-		require.Equal(t, expected, actual)
+		require.Empty(t, cmp.Diff(expected, actual))
 	})
 
 	t.Run("success with name override", func(t *testing.T) {
@@ -1133,7 +1134,7 @@ func TestDatabaseFromRedshiftCluster(t *testing.T) {
 
 		actual, err := NewDatabaseFromRedshiftCluster(cluster)
 		require.NoError(t, err)
-		require.Equal(t, expected, actual)
+		require.Empty(t, cmp.Diff(expected, actual))
 	})
 
 	t.Run("missing endpoint", func(t *testing.T) {
@@ -1212,7 +1213,7 @@ func TestDatabaseFromElastiCacheConfigurationEndpoint(t *testing.T) {
 
 	actual, err := NewDatabaseFromElastiCacheConfigurationEndpoint(cluster, extraLabels)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 func TestDatabaseFromElastiCacheConfigurationEndpointNameOverride(t *testing.T) {
@@ -1286,7 +1287,7 @@ func TestDatabaseFromElastiCacheConfigurationEndpointNameOverride(t *testing.T) 
 
 	actual, err := NewDatabaseFromElastiCacheConfigurationEndpoint(cluster, extraLabels)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 func TestDatabaseFromElastiCacheNodeGroups(t *testing.T) {
@@ -1498,7 +1499,7 @@ func TestDatabaseFromMemoryDBCluster(t *testing.T) {
 
 	actual, err := NewDatabaseFromMemoryDBCluster(cluster, extraLabels)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 func TestDatabaseFromRedshiftServerlessWorkgroup(t *testing.T) {
@@ -1532,7 +1533,7 @@ func TestDatabaseFromRedshiftServerlessWorkgroup(t *testing.T) {
 
 	actual, err := NewDatabaseFromRedshiftServerlessWorkgroup(workgroup, tags)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 func TestDatabaseFromRedshiftServerlessVPCEndpoint(t *testing.T) {
@@ -1572,7 +1573,7 @@ func TestDatabaseFromRedshiftServerlessVPCEndpoint(t *testing.T) {
 
 	actual, err := NewDatabaseFromRedshiftServerlessVPCEndpoint(endpoint, workgroup, tags)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 func TestDatabaseFromMemoryDBClusterNameOverride(t *testing.T) {
@@ -1621,7 +1622,7 @@ func TestDatabaseFromMemoryDBClusterNameOverride(t *testing.T) {
 
 	actual, err := NewDatabaseFromMemoryDBCluster(cluster, extraLabels)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 func TestExtraElastiCacheLabels(t *testing.T) {
@@ -1750,7 +1751,7 @@ func TestExtraMemoryDBLabels(t *testing.T) {
 	}
 
 	actual := ExtraMemoryDBLabels(cluster, resourceTags, allSubnetGroups)
-	require.Equal(t, expected, actual)
+	require.Empty(t, cmp.Diff(expected, actual))
 }
 
 func TestGetLabelEngineVersion(t *testing.T) {

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2174,7 +2174,11 @@ func makeAlternativeNamesForAWSRole(db types.Database, user string) []string {
 	}
 
 	// If input database user is the short role name, try the full ARN.
-	return []string{awsutils.BuildRoleARN(user, metadata.Region, metadata.AccountID)}
+	roleARN, err := awsutils.BuildRoleARN(user, metadata.Region, metadata.AccountID)
+	if err != nil {
+		return nil
+	}
+	return []string{roleARN}
 }
 
 // DatabaseNameMatcher matches a role against database name.

--- a/lib/srv/app/cloud.go
+++ b/lib/srv/app/cloud.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/ssocreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
@@ -37,6 +36,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/lib/tlsca"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
 // Cloud provides cloud provider access related methods such as generating
@@ -63,7 +63,7 @@ func (r *AWSSigninRequest) CheckAndSetDefaults() error {
 	if r.Identity == nil {
 		return trace.BadParameter("missing Identity")
 	}
-	_, err := arn.Parse(r.Identity.RouteToApp.AWSRoleARN)
+	_, err := awsutils.ParseRoleARN(r.Identity.RouteToApp.AWSRoleARN)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -188,7 +188,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
 				AppLabels:   roleAppLabels,
-				AWSRoleARNs: []string{"readonly"},
+				AWSRoleARNs: []string{"arn:aws:iam::123456789012:role/readonly"},
 			},
 		},
 	}
@@ -282,7 +282,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	s.clientCertificate = s.generateCertificate(t, s.user, "foo.example.com", "")
 
 	// Generate certificate for AWS console application.
-	s.awsConsoleCertificate = s.generateCertificate(t, s.user, "aws.example.com", "readonly")
+	s.awsConsoleCertificate = s.generateCertificate(t, s.user, "aws.example.com", "arn:aws:iam::123456789012:role/readonly")
 
 	lockWatcher, err := services.NewLockWatcher(s.closeContext, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{

--- a/lib/srv/db/cassandra/handshake.go
+++ b/lib/srv/db/cassandra/handshake.go
@@ -199,7 +199,11 @@ func (a *authAWSSigV4Auth) getSigV4Authenticator(username string) (gocql.Authent
 	}
 	region := a.ses.Database.GetAWS().Region
 	accountID := a.ses.Database.GetAWS().AccountID
-	cred, err := stscreds.NewCredentials(session, awsutils.BuildRoleARN(username, region, accountID)).Get()
+	roleARN, err := awsutils.BuildRoleARN(username, region, accountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cred, err := stscreds.NewCredentials(session, roleARN).Get()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/users/elasticache.go
+++ b/lib/srv/db/cloud/users/elasticache.go
@@ -66,11 +66,12 @@ func (f *elastiCacheFetcher) GetType() string {
 
 // FetchDatabaseUsers fetches users for provided database. Implements Fetcher.
 func (f *elastiCacheFetcher) FetchDatabaseUsers(ctx context.Context, database types.Database) ([]User, error) {
-	if len(database.GetAWS().ElastiCache.UserGroupIDs) == 0 {
+	meta := database.GetAWS()
+	if len(meta.ElastiCache.UserGroupIDs) == 0 {
 		return nil, nil
 	}
 
-	client, err := f.cfg.Clients.GetAWSElastiCacheClient(database.GetAWS().Region)
+	client, err := f.cfg.Clients.GetAWSElastiCacheClient(meta.Region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -81,8 +82,8 @@ func (f *elastiCacheFetcher) FetchDatabaseUsers(ctx context.Context, database ty
 	}
 
 	users := []User{}
-	for _, userGroupID := range database.GetAWS().ElastiCache.UserGroupIDs {
-		managedUsers, err := f.getManagedUsersForGroup(ctx, database.GetAWS().Region, userGroupID, client)
+	for _, userGroupID := range meta.ElastiCache.UserGroupIDs {
+		managedUsers, err := f.getManagedUsersForGroup(ctx, meta.Region, userGroupID, client)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/db/cloud/users/helpers.go
+++ b/lib/srv/db/cloud/users/helpers.go
@@ -155,7 +155,8 @@ func genRandomPassword(length int) (string, error) {
 func newSecretStore(database types.Database, clients cloud.Clients) (secrets.Secrets, error) {
 	secretStoreConfig := database.GetSecretStore()
 
-	client, err := clients.GetAWSSecretsManagerClient(database.GetAWS().Region)
+	meta := database.GetAWS()
+	client, err := clients.GetAWSSecretsManagerClient(meta.Region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/users/memorydb.go
+++ b/lib/srv/db/cloud/users/memorydb.go
@@ -67,11 +67,12 @@ func (f *memoryDBFetcher) GetType() string {
 
 // FetchDatabaseUsers fetches users for provided database. Implements Fetcher.
 func (f *memoryDBFetcher) FetchDatabaseUsers(ctx context.Context, database types.Database) ([]User, error) {
-	if database.GetAWS().MemoryDB.ACLName == "" {
+	meta := database.GetAWS()
+	if meta.MemoryDB.ACLName == "" {
 		return nil, nil
 	}
 
-	client, err := f.cfg.Clients.GetAWSMemoryDBClient(database.GetAWS().Region)
+	client, err := f.cfg.Clients.GetAWSMemoryDBClient(meta.Region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -82,7 +83,7 @@ func (f *memoryDBFetcher) FetchDatabaseUsers(ctx context.Context, database types
 	}
 
 	users := []User{}
-	mdbUsers, err := f.getManagedUsersForACL(ctx, database.GetAWS().Region, database.GetAWS().MemoryDB.ACLName, client)
+	mdbUsers, err := f.getManagedUsersForACL(ctx, meta.Region, meta.MemoryDB.ACLName, client)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/dynamodb/engine.go
+++ b/lib/srv/db/dynamodb/engine.go
@@ -171,15 +171,15 @@ func (e *Engine) process(ctx context.Context, req *http.Request) (err error) {
 		defer req.Body.Close()
 	}
 
-	var responseStatusCode uint32
 	re, err := e.resolveEndpoint(req)
 	if err != nil {
 		// special error case where we couldn't resolve the endpoint, just emit using the configured URI.
-		e.emitAuditEvent(req, e.sessionCtx.Database.GetURI(), responseStatusCode, err)
+		e.emitAuditEvent(req, e.sessionCtx.Database.GetURI(), 0, err)
 		return trace.Wrap(err)
 	}
 
 	// emit an audit event regardless of failure, but using the resolved endpoint.
+	var responseStatusCode uint32
 	defer func() {
 		e.emitAuditEvent(req, re.URL, responseStatusCode, err)
 	}()
@@ -199,7 +199,11 @@ func (e *Engine) process(ctx context.Context, req *http.Request) (err error) {
 		return trace.Wrap(err)
 	}
 
-	roleArn := libaws.BuildRoleARN(e.sessionCtx.DatabaseUser, re.SigningRegion, e.sessionCtx.Database.GetAWS().AccountID)
+	roleArn, err := libaws.BuildRoleARN(e.sessionCtx.DatabaseUser,
+		re.SigningRegion, e.sessionCtx.Database.GetAWS().AccountID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	signedReq, err := e.signingSvc.SignRequest(e.Context, outReq,
 		&libaws.SigningCtx{
 			SigningName:   re.SigningName,

--- a/lib/srv/db/dynamodb_test.go
+++ b/lib/srv/db/dynamodb_test.go
@@ -223,7 +223,7 @@ func withDynamoDB(name string, opts ...dynamodb.TestServerOption) withDatabaseOp
 			DynamicLabels: dynamicLabels,
 			AWS: types.AWS{
 				Region:    "us-west-1",
-				AccountID: "12345",
+				AccountID: "123456789012",
 			},
 			TLS: types.DatabaseTLS{
 				// Set CA, otherwise the engine will attempt to download and use the AWS CA.

--- a/lib/utils/aws/aws_test.go
+++ b/lib/utils/aws/aws_test.go
@@ -255,3 +255,140 @@ func TestValidateRoleARNAndExtractRoleName(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRoleARN(t *testing.T) {
+	tests := map[string]struct {
+		arn             string
+		wantErrContains string
+	}{
+		"valid role arn": {
+			arn: "arn:aws:iam::123456789012:role/test-role",
+		},
+		"valid sso role arn": {
+			arn: "arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/us-west-2/AWSReservedSSO_AWSPowerUserAccess_xxxxxxxxx",
+		},
+		"valid service role arn": {
+			arn: "arn:aws:iam::123456789012:role/aws-service-role/redshift.amazonaws.com/AWSServiceRoleForRedshift",
+		},
+		"arn fails to parse": {
+			arn:             "foobar",
+			wantErrContains: "invalid AWS ARN",
+		},
+		"sts arn is not iam": {
+			arn:             "arn:aws:sts::123456789012:federated-user/Alice",
+			wantErrContains: "not an AWS IAM role",
+		},
+		"iam arn is not a role": {
+			arn:             "arn:aws:iam::123456789012:user/test-user",
+			wantErrContains: "not an AWS IAM role",
+		},
+		"iam role arn is missing role name": {
+			arn:             "arn:aws:iam::123456789012:role",
+			wantErrContains: "missing AWS IAM role name",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseRoleARN(tt.arn)
+			if tt.wantErrContains != "" {
+				require.Error(t, err, err.Error())
+				require.ErrorContains(t, err, tt.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+		})
+	}
+}
+
+func TestBuildRoleARN(t *testing.T) {
+	tests := map[string]struct {
+		user            string
+		region          string
+		accountID       string
+		wantErrContains string
+		wantARN         string
+	}{
+		"valid role arn in correct partition and account": {
+			user:      "arn:aws:iam::123456789012:role/test-role",
+			region:    "us-west-1",
+			accountID: "123456789012",
+			wantARN:   "arn:aws:iam::123456789012:role/test-role",
+		},
+		"valid role arn in correct account and default partition": {
+			user:      "arn:aws:iam::123456789012:role/test-role",
+			region:    "",
+			accountID: "123456789012",
+			wantARN:   "arn:aws:iam::123456789012:role/test-role",
+		},
+		"valid role arn in default partition and account": {
+			user:      "arn:aws:iam::123456789012:role/test-role",
+			region:    "",
+			accountID: "",
+			wantARN:   "arn:aws:iam::123456789012:role/test-role",
+		},
+		"role name with prefix in default partition and account": {
+			user:      "role/test-role",
+			region:    "",
+			accountID: "123456789012",
+			wantARN:   "arn:aws:iam::123456789012:role/test-role",
+		},
+		"role name in default partition and account": {
+			user:      "test-role",
+			region:    "",
+			accountID: "123456789012",
+			wantARN:   "arn:aws:iam::123456789012:role/test-role",
+		},
+		"role name in china partition and account": {
+			user:      "test-role",
+			region:    "cn-north-1",
+			accountID: "123456789012",
+			wantARN:   "arn:aws-cn:iam::123456789012:role/test-role",
+		},
+		"valid ARN is not an IAM role ARN": {
+			user:            "arn:aws:iam::123456789012:user/test-user",
+			region:          "",
+			accountID:       "",
+			wantErrContains: "not an AWS IAM role",
+		},
+		"valid role arn in different partition": {
+			user:            "arn:aws-cn:iam::123456789012:role/test-role",
+			region:          "us-west-1",
+			accountID:       "",
+			wantErrContains: `expected AWS partition "aws" but got "aws-cn"`,
+		},
+		"valid role arn in different account": {
+			user:            "arn:aws:iam::123456789012:role/test-role",
+			region:          "us-west-1",
+			accountID:       "111222333444",
+			wantErrContains: `expected AWS account ID "111222333444" but got "123456789012"`,
+		},
+		"role name with invalid account characters": {
+			user:            "test-role",
+			region:          "",
+			accountID:       "12345678901f",
+			wantErrContains: "must be 12-digit",
+		},
+		"role name with invalid account id length": {
+			user:            "test-role",
+			region:          "",
+			accountID:       "1234567890123",
+			wantErrContains: "must be 12-digit",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := BuildRoleARN(tt.user, tt.region, tt.accountID)
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			require.NotEmpty(t, got)
+			require.Equal(t, tt.wantARN, got)
+		})
+	}
+}

--- a/lib/utils/aws/signing.go
+++ b/lib/utils/aws/signing.go
@@ -111,9 +111,12 @@ func (sc *SigningCtx) Check(clock clockwork.Clock) error {
 		return trace.BadParameter("missing AWS Role ARN")
 	case sc.Expiry.Before(clock.Now()):
 		return trace.BadParameter("AWS SigV4 expiry has already expired")
-	default:
-		return nil
 	}
+	_, err := ParseRoleARN(sc.AWSRoleArn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 // SignRequest creates a new HTTP request and rewrites the header from the original request and returns a new

--- a/tool/tsh/app_aws_test.go
+++ b/tool/tsh/app_aws_test.go
@@ -139,7 +139,7 @@ func makeUserWithAWSRole(t *testing.T) (types.User, types.Role) {
 				types.Wildcard: apiutils.Strings{types.Wildcard},
 			},
 			AWSRoleARNs: []string{
-				"arn:aws:iam::123456890:role/some-aws-role",
+				"arn:aws:iam::123456789012:role/some-aws-role",
 			},
 		},
 	})

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -93,7 +93,7 @@ func TestDatabaseLogin(t *testing.T) {
 			Protocol: defaults.ProtocolDynamoDB,
 			URI:      "", // uri can be blank for DynamoDB, it will be derived from the region and requests.
 			AWS: servicecfg.DatabaseAWS{
-				AccountID:  "12345",
+				AccountID:  "123456789012",
 				ExternalID: "123123123",
 				Region:     "us-west-1",
 			},


### PR DESCRIPTION
This PR is kind of a grab-bag of changes that I want to backport.

It's all work I pulled out of changes I'm preparing for https://github.com/gravitational/teleport/issues/21872

May be best reviewed commit-by-commit, since I organized the commits by purpose with explanations.

Edit: seems this broke some app access tests. Need to check if we allow a short role name like "test-role" instead of requiring the full role arn like "arn:aws:iam::123456789012::roles/test-role". I'm not sure we support that for app access, so the tests themselves could just need fixing.

Edit2: okay we do allow the short name. This regression is from changes in `FilterAWSRoles` which is used by `tsh app` when searching the .tsh profile trying to find an AWS role ARN. The profile's role ARNs should always be saved fully specified though. So I think this is just a test bug. Will fix tomorrow.