### PR TITLE
Notification improvements

### DIFF
--- a/web/packages/shared/components/Notification/Notification.story.tsx
+++ b/web/packages/shared/components/Notification/Notification.story.tsx
@@ -257,6 +257,21 @@ export const Notifications = () => {
           isAutoRemovable={false}
         />
       </Flex>
+
+      <Flex flexDirection="column" gap={4}>
+        <Notification
+          item={{
+            id: crypto.randomUUID(),
+            severity: 'info',
+            content:
+              'Unbreakable text. /Users/test/Library/ApplicationSupport/Electron/configuration.json',
+          }}
+          Icon={Info}
+          getColor={theme => theme.colors.info}
+          onRemove={() => {}}
+          isAutoRemovable={false}
+        />
+      </Flex>
     </div>
   );
 };

--- a/web/packages/shared/components/Notification/Notification.tsx
+++ b/web/packages/shared/components/Notification/Notification.tsx
@@ -217,7 +217,7 @@ function List(props: { items: string[] }) {
 
 const textCss = css`
   line-height: 20px;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   white-space: pre-line;
 `;
 

--- a/web/packages/shared/components/Notification/Notification.tsx
+++ b/web/packages/shared/components/Notification/Notification.tsx
@@ -184,6 +184,7 @@ function getRenderedContent(
               `}
               href={content.link.href}
               target="_blank"
+              onClick={e => e.stopPropagation()} // prevents notification from collapsing
             >
               {content.link.text}
             </Link>


### PR DESCRIPTION
Unbreakable text was breaking the layout:
<img width="380" alt="image" src="https://user-images.githubusercontent.com/20583051/225558887-086e9d02-4e3d-4481-9b89-58614c7a152d.png">

After fix:
<img width="380" alt="image" src="https://user-images.githubusercontent.com/20583051/225558808-16a97f49-ca85-404a-ae32-831330a56b8a.png">

Also fixed clicking on a link - it should not cause the notification to collapse.