### PR TITLE
Revert "Skip unparsable events when decoding searchevents results (#18599)"

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
@@ -2024,10 +2023,6 @@ func (c *Client) SearchEvents(ctx context.Context, fromUTC, toUTC time.Time, nam
 	for _, rawEvent := range response.Items {
 		event, err := events.FromOneOf(*rawEvent)
 		if err != nil {
-			if trace.IsBadParameter(err) {
-				log.Warnf("skipping unknown event: %v", err)
-				continue
-			}
 			return nil, "", trace.Wrap(err)
 		}
 		decodedEvents = append(decodedEvents, event)


### PR DESCRIPTION
By skipping events, clients can miss them and eventually have an audit exporter that strays from the Teleport audit log. Depending on what the customer considers the truth of the data, some audit events may be lost forever.

`teleport-plugins` will warn users that they must update the event handler to the same version of Teleport as they have in the Auth service.

`teleport-plugins` breaks our compatibility guide as they must run with the same version as the Auth service runs to avoid the problem of introducing new audit logs and the plugin's protobuf doesn't know how to represent incompatible messages

Part of https://github.com/gravitational/teleport-plugins/issues/783
Plugins fix: https://github.com/gravitational/teleport-plugins/pull/789

This reverts commit a3d7c1b200189e830377198960dd535bee7f95b9.