### PR TITLE
Update CodeQL Schedule to scan release branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,12 @@ jobs:
       with:
         ref: ${{ matrix.branch }}
 
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        cache-dependency-path: '**/go.sum'
+      if: ${{ matrix.language == 'go' }}
+
     - name: Initialize the CodeQL tools for scanning
       uses: github/codeql-action/init@v2
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,11 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        branch: [ 'master', 'branch/v10', 'branch/v11', 'branch/v12' ]
         language: [ 'go', 'javascript' ]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        ref: ${{ matrix.branch }}
 
     - name: Initialize the CodeQL tools for scanning
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
This allows us to switch our release branches to also use the scheduled CodeQL check so we can remove CodeQL from the PR flow for our release branches too.

While testing this PR I also tested how much speed we can gain by using go dependency caching.  That commit was retained in this PR after witnessing a 2 minute improvement (10% of the build time).

Done as part of this issue: https://github.com/gravitational/SecOps/issues/269