### PR TITLE
Build API on root go.mod changes

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -8,12 +8,16 @@ on:
       - 'api/**/*.go'
       - 'api/go.mod'
       - 'api/go.sum'
+      - 'go.mod'
+      - 'go.sum'
   merge_group:
     paths:
       - .github/workflows/build-api.yaml
       - 'api/**/*.go'
       - 'api/go.mod'
       - 'api/go.sum'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
   build:


### PR DESCRIPTION
Without this build step when the root go.mod is changed it's possible to merge a change that will result in api dependencies being out of sync.

This was the root cause of why this PR did not fail until merged: https://github.com/gravitational/teleport/pull/22564