### PR TITLE
Fix navigation redirecting to the wrong page on category change

### DIFF
--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -89,7 +89,7 @@ function getCategoryForRoute(
     );
 
   if (!feature) {
-    return NavigationCategory.Resources;
+    return;
   }
 
   return feature.category;
@@ -114,13 +114,17 @@ export function Navigation() {
       const previousPathName = location.pathname;
 
       const category = getCategoryForRoute(features, next);
+      const previousCategory = getCategoryForRoute(features, location);
 
       if (category && category !== view) {
-        setPreviousRoute(previous => ({
-          ...previous,
-          [view]: previousPathName,
-        }));
         setView(category);
+
+        if (previousCategory) {
+          setPreviousRoute(previous => ({
+            ...previous,
+            [previousCategory]: previousPathName,
+          }));
+        }
       }
     },
     [location, view]

--- a/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
@@ -167,7 +167,6 @@ export function NavigationSwitcher(props: NavigationSwitcherProps) {
     (event: React.KeyboardEvent<HTMLDivElement>, item: NavigationCategory) => {
       switch (event.key) {
         case 'Enter':
-          console.log('handle change', item);
           handleChange(item);
 
           break;


### PR DESCRIPTION
Previously, if we couldn't find the category for a route (i.e. `/web/support`, `/web/account`) we'd store it under the `Resources` category when tracking the last visited route.

This resulted in us not being able to get back to resources when going to the support or account page, switching from "Resources" to "Management" and back again, as it would redirect to either support or account page instead of the "Servers" page.

Fixes #22755 