### PR TITLE
AMI workflow

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -1,0 +1,56 @@
+name: Release workflow
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    name: Determine required args
+    outputs:
+      type: ${{ steps.artifacts.outputs.type }}
+      version: ${{ steps.artifacts.outputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ vars.GITHUB_REF }}        
+
+      - name: Determine release latest flag and version
+        id: artifacts
+        run: |
+          LATEST_RELEASE_ID=$(gh release view --json id | jq '.id' | tr -d \")
+          CURRENT_RELEASE_ID=${{ github.event.release.node_id }}
+          
+          if [ $LATEST_RELEASE_ID == $CURRENT_RELEASE_ID ]; then
+            echo "type=latest" >> $GITHUB_OUTPUT
+          else
+            echo "type=other" >> $GITHUB_OUTPUT
+          fi
+
+          echo "version=$(make --no-print-directory print-version)" >> $GITHUB_OUTPUT          
+        env:
+          GITHUB_TOKEN: ${{ github.token }}          
+
+  # test-outputs:
+  #   runs-on: ubuntu-latest
+  #   needs: release
+  #   steps:
+  #     - env:
+  #         VERSION: ${{ needs.release.outputs.version }}
+  #         TYPE: ${{ needs.release.outputs.type }}
+  #       run: echo "$VERSION $TYPE"
+
+  update-ami:
+    name: Update AMI
+    needs: release    
+    if: needs.release.outputs.type == 'latest'
+    uses: ./.github/workflows/update-ami.yml
+    with:
+      version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/update-ami.yml
+++ b/.github/workflows/update-ami.yml
@@ -1,0 +1,60 @@
+name: Update AMI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: Release version tag
+
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: Release version tag
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  create-pr:
+    name: Update AMI
+    runs-on: ubuntu-latest
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ vars.GITHUB_REF }}        
+
+      - name: Assume AWS Promotion Role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region:  us-west-2
+          # https://github.com/gravitational/teleport/issues/23066
+          role-to-assume: "arn:aws:iam::126027368216:role/tf-teleport-ami-gha-role"
+          role-session-name: "gha-docker-image-promotion-${{ github.run_number }}"
+          # Promotion should take roughly a minute, so 15 mins gives us plenty
+          # of leeway (and is the miminum value we can ask for).
+          role-duration-seconds: 900
+
+      - name: Update AMI
+        run: |
+          TELEPORT_VERSION=${{ inputs.version }} make -C assets/aws update-ami-ids-terraform
+
+      - name: Create Pull Request
+        if: steps.get_release.outputs.release == 'latest' || inputs.version != ''
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ github.token }}
+          commit-message: "[auto] Update AMI IDs for ${{ inputs.version }}"
+          title: "[auto] Update AMI IDs for ${{ inputs.version }}"
+          committer: GitHub <noreply@github.com>
+          branch: ami-auto-branch
+          branch-suffix: timestamp
+          delete-branch: true
+          labels: automated, terraform


### PR DESCRIPTION
There's no way of getting 'latest' type over the GitHub API or via workflow payload. I've found a way to determine if a release created is the latest. It's a bit weird, but working. 

Closes #23066