### PR TITLE
[docs] Add documentation page for IP pinning

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -262,6 +262,11 @@
               "title": "Device Trust (Preview)",
               "slug": "/access-controls/guides/device-trust/",
               "forScopes": ["enterprise", "cloud"]
+            },
+            {
+              "title": "IP Pinning (Preview)",
+              "slug": "/access-controls/guides/ip-pinning/",
+              "forScopes": ["enterprise", "cloud"]
             }
           ]
         },

--- a/docs/pages/access-controls/guides/ip-pinning.mdx
+++ b/docs/pages/access-controls/guides/ip-pinning.mdx
@@ -1,0 +1,108 @@
+---
+title: "IP Pinning (Preview)"
+description: How to enable IP pinning for Teleport users
+---
+
+<Admonition type="warning">
+IP Pinning is currently in Preview mode.
+
+IP Pinning requires Teleport Enterprise.
+</Admonition>
+
+IP Pinning is a security feature that helps protect against unauthorized access by ensuring that 
+Teleport users can only access resources from the IP address they used during the login process. 
+This helps minimize the risk of compromised credentials being used from different locations.
+
+The IP pinning preview currently supports the
+following Teleport features:
+
+- SSH access 
+- Database access 
+- Kubernetes access 
+
+Support for other access features is planned for upcoming Teleport versions.
+
+## How it works
+<Admonition type="note">
+  **Observed IP** - IP of the client. Teleport records this from the direct connection of
+  the user or, if it's enabled, a load balancer through the PROXY protocol.
+
+  **Pinned IP** - IP of the client, observed during the login process and embedded in the user's certificates.
+</Admonition>
+
+When IP pinning is enabled for at least one of a user's roles, the IP address observed by Teleport during the login process will
+ be embedded into the user's certificates. Later, whenever the user attempts to access Teleport resources, the system will compare 
+ the observed IP address with the pinned IP address stored in the certificate. If the IP addresses do not match, access will be denied.
+
+If the user's role requires IP pinning, but the user's certificate that is presented to a Teleport service doesn't have pinned IP information embedded,
+access will be denied. This means that if you enable IP pinning for some role, any users that are already authenticated with that role will have to log in again in
+order to regenerate their certificates. A client's observed IP will be propagated internally between Teleport services
+ if needed, so Teleport performs the IP pinning check against the correct IP.
+
+IP pinning can work across Trusted Clusters, but be aware that if a user tries to access a leaf cluster's resources through the root cluster, and their
+mapped role on the leaf cluster has IP pinning enabled, they should also have IP pinning enabled on their root cluster roles. Otherwise, their 
+certificates will not contain pinned IP information.
+
+## Configure IP Pinning
+
+To enable IP pinning, update the role to contain `pin_source_ip` option:
+
+```yaml
+kind: role
+version: v6
+metadata:
+  name: example-role-with-ip-pinning
+spec:
+  options:
+    # require IP pinning for this role
+    pin_source_ip: true
+  allow:
+    ...
+  deny:
+    ...
+```
+
+
+## Role example
+
+Let's walk through an example of setting up IP pinning for a role.
+
+A Teleport admin adds the following role, which enforces IP pinning for users:
+
+```yaml
+# pinned-ip.yaml
+kind: role
+version: v6
+metadata:
+  name: pinned-ip
+spec:
+  options:
+    pin_source_ip: true
+```
+The admin assigns this role to the user Alice, who then logs into Teleport using the 'tsh' command and tries 
+to access a node from the same IP address she logged in with:
+
+```code
+$ curl ifconfig.me
+
+# 198.51.111.1
+
+$ tsh ssh telenode.example.com
+
+# alice@telenode.example.com >
+```
+
+As with Alice's usual attempts to access a node, this one is successful.
+
+Later, Alice changes her IP address, and her attempt to access the same node will fail due to the IP address mismatch.
+This will trigger the relogin process, prompting Alice to authenticate again.
+
+```code
+$ curl ifconfig.me
+
+# 198.51.222.2
+
+$ tsh ssh telenode.example.com
+
+# Enter password for Teleport user alice:
+```

--- a/docs/pages/includes/access-control-guides.mdx
+++ b/docs/pages/includes/access-control-guides.mdx
@@ -8,3 +8,4 @@
 - [Moderated Sessions](../access-controls/guides/moderated-sessions.mdx): Require session auditors and allow fine-grained live session access.
 - [Hardware Key Support (Preview)](../access-controls/guides/hardware-key-support.mdx): Enforce the use of hardware-based private keys.
 - [Device Trust (Preview)](../access-controls/guides/device-trust.mdx): Register and enforce trusted devices.
+- [IP Pinning (Preview)](../access-controls/guides/ip-pinning.mdx): Pin a user's certificates to a login IP address.

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -83,9 +83,9 @@ spec:
     # if unspecified. If one or more of the user's roles has disabled
     # the clipboard, then it will be disabled.
     desktop_clipboard: true
-    # enterprise-only: when enabled, the source IP that was used to log in is embedded in the SSH
-    # certificate, preventing a compromised certificate from being used on other
-    # devices. The default is false.
+    # enterprise-only: when enabled, the source IP that was used to log in is embedded in the user
+    # certificates, preventing a compromised certificate from being used on another
+    # network. The default is false.
     # Note: Source IP pinning is currently in Preview mode.
     pin_source_ip: true
     # Specify a list of names and associated values to be included in user SSH keys.

--- a/docs/pages/server-access/rbac.mdx
+++ b/docs/pages/server-access/rbac.mdx
@@ -169,9 +169,9 @@ spec:
       # Optional: Session recording mode for SSH sessions. 
       # If not set, the value set on default will be used.
       ssh: best_effort|strict
-    # Enterprise-only: when enabled, the source IP that was used to log in is embedded in the SSH
-    # certificate, preventing a compromised certificate from being used on other
-    # devices. The default is false.
+    # Enterprise-only: when enabled, the source IP that was used to log in is embedded in the user
+    # certificates, preventing a compromised certificate from being used on another
+    # network. The default is false.
     # Note: Source IP pinning is currently in Preview mode.
     pin_source_ip: true
     # Specify a list of names and associated values to be included in user SSH keys.


### PR DESCRIPTION
This PR adds a dedicated documentation page for IP pinning in the RBAC section of the docs.

Part of https://github.com/gravitational/teleport/issues/22061