### PR TITLE
[v11] App access: rewrite redirects to public app address from leaf cluster

### DIFF
--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -76,6 +77,11 @@ func (c *transportConfig) Check() error {
 	}
 
 	return nil
+}
+
+// isRemoteApp returns true if the route to app points at remote cluster.
+func (c *transportConfig) isRemoteApp() bool {
+	return c.clusterName != c.identity.RouteToApp.ClusterName
 }
 
 // transport is a rewriting http.RoundTripper that can forward requests to
@@ -139,7 +145,64 @@ func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	// When proxying app in leaf cluster, the app will have PublicAddr
+	// possibly unreachable to the clients connecting to the root cluster.
+	// We want to rewrite any redirects to that PublicAddr to equivalent redirect for root cluster.
+	if err = t.rewriteRedirect(resp); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return resp, nil
+}
+
+// rewriteRedirect rewrites redirect to a public address of downstream app.
+func (t *transport) rewriteRedirect(resp *http.Response) error {
+	if !t.c.isRemoteApp() {
+		// Not a downstream app, short circuit.
+		return nil
+	}
+
+	if !isRedirect(resp.StatusCode) {
+		return nil
+	}
+
+	location := resp.Header.Get("Location")
+	// nothing to do without Location.
+	if location == "" {
+		return nil
+	}
+
+	// Parse the "Location" header.
+	u, err := url.Parse(location)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	host, _, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		host = u.Host
+	}
+
+	// If this is a redirect to a public addr of a leaf cluster, rewrite it.
+	// We want the rewrite to happen using our own public address.
+	if host == t.c.identity.RouteToApp.PublicAddr {
+		// drop scheme and host, leaving only the relative path.
+		// since the path can be an empty string, canonicalize it as "/".
+		if u.Path == "" {
+			resp.Header.Set("Location", "/")
+		} else {
+			resp.Header.Set("Location", u.Path)
+		}
+	}
+	return nil
+}
+
+// isRedirect returns true if the status code is a 3xx code.
+func isRedirect(code int) bool {
+	if code >= http.StatusMultipleChoices && code <= http.StatusPermanentRedirect {
+		return true
+	}
+	return false
 }
 
 // rewriteRequest applies any rewriting rules to the request before it's forwarded.

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -1,0 +1,171 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"crypto/x509/pkix"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func Test_transport_rewriteRedirect(t *testing.T) {
+	rootCluster := "root.teleport.example.com"
+	leafCluster := "leaf.teleport.example.com"
+
+	caKey, caCert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: rootCluster},
+		[]string{rootCluster, apiutils.EncodeClusterName(rootCluster)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	makeAppServer := func(cluster, appName string) types.AppServer {
+		app, err := types.NewAppV3(types.Metadata{Name: appName},
+			types.AppSpecV3{
+				PublicAddr: fmt.Sprintf("%v.%v", appName, cluster),
+				URI:        fmt.Sprintf("https://%v.internal.example.com:8888", appName),
+			},
+		)
+		require.NoError(t, err)
+
+		appServer, err := types.NewAppServerV3FromApp(app, cluster, "dummy")
+		require.NoError(t, err)
+
+		return appServer
+	}
+
+	clock := clockwork.NewFakeClock()
+
+	makeTransportConfig := func(clusterName string, identity *tlsca.Identity, server types.AppServer) transportConfig {
+		return transportConfig{
+			clusterName: clusterName,
+			identity:    identity,
+			servers:     []types.AppServer{server},
+
+			cipherSuites: utils.DefaultCipherSuites(),
+			proxyClient:  &mockProxyClient{},
+			accessPoint: &mockAuthClient{
+				caKey:       caKey,
+				caCert:      caCert,
+				clusterName: clusterName,
+			},
+			ws: createAppSession(t, clock, caKey, caCert, clusterName, clusterName),
+		}
+	}
+
+	tests := []struct {
+		name            string
+		transportConfig transportConfig
+		respStatusCode  int
+		respLocation    string
+		wantLocation    string
+	}{
+		{
+			name: "local app, no redirect",
+			transportConfig: makeTransportConfig(
+				rootCluster,
+				&tlsca.Identity{RouteToApp: tlsca.RouteToApp{ClusterName: rootCluster}},
+				makeAppServer(rootCluster, "dumper")),
+			respStatusCode: 200,
+			respLocation:   "",
+			wantLocation:   "",
+		},
+		{
+			name: "local app, redirect",
+			transportConfig: makeTransportConfig(
+				rootCluster,
+				&tlsca.Identity{RouteToApp: tlsca.RouteToApp{ClusterName: rootCluster}},
+				makeAppServer(rootCluster, "dumper")),
+			respStatusCode: 302,
+			respLocation:   "/foo/bar/baz",
+			wantLocation:   "/foo/bar/baz",
+		},
+		{
+			name: "remote app, no redirect",
+			transportConfig: makeTransportConfig(
+				rootCluster,
+				&tlsca.Identity{RouteToApp: tlsca.RouteToApp{ClusterName: leafCluster}},
+				makeAppServer(leafCluster, "dumper")),
+			respStatusCode: 200,
+			respLocation:   "",
+			wantLocation:   "",
+		},
+		{
+			name: "remote app, redirect to non-app addr",
+			transportConfig: makeTransportConfig(
+				rootCluster,
+				&tlsca.Identity{RouteToApp: tlsca.RouteToApp{
+					ClusterName: leafCluster,
+					PublicAddr:  "dumper.leaf.teleport.example.com",
+				}},
+				makeAppServer(leafCluster, "dumper")),
+			respStatusCode: 302,
+			respLocation:   "https://google.com",
+			wantLocation:   "https://google.com",
+		},
+		{
+			name: "remote app, redirect to app public addr",
+			transportConfig: makeTransportConfig(
+				rootCluster,
+				&tlsca.Identity{RouteToApp: tlsca.RouteToApp{
+					ClusterName: leafCluster,
+					PublicAddr:  "dumper.leaf.teleport.example.com",
+				}},
+				makeAppServer(leafCluster, "dumper")),
+			respStatusCode: 302,
+			respLocation:   "https://dumper.leaf.teleport.example.com:3080/admin/blah",
+			wantLocation:   "/admin/blah",
+		},
+		{
+			name: "canonicalize empty location to /",
+			transportConfig: makeTransportConfig(
+				rootCluster,
+				&tlsca.Identity{RouteToApp: tlsca.RouteToApp{
+					ClusterName: leafCluster,
+					PublicAddr:  "dumper.leaf.teleport.example.com",
+				}},
+				makeAppServer(leafCluster, "dumper")),
+			respStatusCode: 302,
+			respLocation:   "https://dumper.leaf.teleport.example.com:3080",
+			wantLocation:   "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			tr, err := newTransport(&tt.transportConfig)
+			require.NoError(t, err)
+
+			response := &http.Response{Header: make(http.Header)}
+			response.Header.Set("Location", tt.respLocation)
+			response.StatusCode = tt.respStatusCode
+			err = tr.rewriteRedirect(response)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.wantLocation, response.Header.Get("Location"))
+		})
+	}
+}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/21067.