### PR TITLE
fix link for troubleshooting guide in Machine ID intro doc

### DIFF
--- a/docs/pages/machine-id/introduction.mdx
+++ b/docs/pages/machine-id/introduction.mdx
@@ -69,4 +69,4 @@ Let's create a bot and use the machine identity to connect to a server.
 ## FAQ & Troubleshooting
 
 Finally, check out [Frequently Asked Questions](./faq.mdx) and the 
-[troubleshooting guide](./faq.mdx) for common questions and issues.
+[troubleshooting guide](./troubleshooting.mdx) for common questions and issues.


### PR DESCRIPTION
update the troubleshooting guide link from the FAQ to the actual troubleshooting guide