### PR TITLE
[v11] Update CodeQL workflow to match `master` (scheduled)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,23 +1,14 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches:
-      - master
-      - branch/*
-  pull_request:
-    branches:
-      - master
-      - branch/*
-    paths-ignore:
-      - 'docs/**'
-      - 'rfd/**'
-      - '**.md'
+  schedule:
+    - cron: '0 13 * * *' # At 1:00 PM UTC every day
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04-32core
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
+    runs-on: ubuntu-22.04-16core
     permissions:
       actions: read
       contents: read
@@ -26,36 +17,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        branch: [ 'master', 'branch/v10', 'branch/v11', 'branch/v12' ]
         language: [ 'go', 'javascript' ]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        ref: ${{ matrix.branch }}
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version-file: 'go.mod'
+        cache-dependency-path: '**/go.sum'
       if: ${{ matrix.language == 'go' }}
 
     - name: Initialize the CodeQL tools for scanning
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-      timeout-minutes: 10
+      timeout-minutes: 5
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-      if: ${{ matrix.language != 'go' }}
       timeout-minutes: 30
-
-    - name: Build Teleport OSS
-      run: |
-        make full
-      if: ${{ matrix.language == 'go' }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"
-      timeout-minutes: 30
+      timeout-minutes: 10


### PR DESCRIPTION
Backport of this PR: https://github.com/gravitational/teleport/pull/23169

The removal of CodeQL PR validation was never backported to v11. This commit syncs the config with `master` to remove the CodeQL action for v11 merges.