### PR TITLE
[Docs] Fix documentation for the `roles` field in the Moderated Sessions join policy reference

### DIFF
--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -101,9 +101,9 @@ The following are required options for `join_sessions`:
 |Option|Type|Description|
 |---|---|---|
 |`name`|String|The name of the allow policy|
-|`roles`|[]String|A list of names of Teleport roles whose sessions this policy applies to. Moderated Sessions created by users with these roles can be joined under this policy.|
+|`roles`|[]String|A list of names of Teleport roles whose sessions this policy applies to. Active sessions created by users with these roles can be joined under this policy.|
 |`kinds`|`[]`[Session kind](#session-kinds)|The kind of session that the policy applies to|
-|`modes`|`[]`[Participant mode](#participant-modes)|The participant mode that applies to the user joining the Moderated Session under this policy|
+|`modes`|`[]`[Participant mode](#participant-modes)|The participant mode that applies to the user joining the session under this policy|
 
 #### Example
 

--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -101,7 +101,7 @@ The following are required options for `join_sessions`:
 |Option|Type|Description|
 |---|---|---|
 |`name`|String|The name of the allow policy|
-|`roles`|[]String|A list of names for Teleport roles that this policy applies to. Users with this role are eligible to join a Moderated Session under this policy.|
+|`roles`|[]String|A list of names of Teleport roles whose sessions this policy applies to. Moderated Sessions created by users with these roles can be joined under this policy.|
 |`kinds`|`[]`[Session kind](#session-kinds)|The kind of session that the policy applies to|
 |`modes`|`[]`[Participant mode](#participant-modes)|The participant mode that applies to the user joining the Moderated Session under this policy|
 


### PR DESCRIPTION
## Purpose

The current explanation for the `roles` field under the `join_sessions` policy in the docs is incorrect. It states that `roles` field is a list of roles who can join sessions under the policy. In actuality, it is a list of roles whose sessions can be joined with the policy.