### PR TITLE
Fix tsh kube credentials may fail on remote cluster on 1st call

### DIFF
--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -493,6 +493,15 @@ func (a *LocalKeyAgent) AddDatabaseKey(key *Key) error {
 	return a.addKey(key)
 }
 
+// AddKubeKey activates a new signed Kubernetes key by adding it into the keystore.
+// key must contain at least one Kubernetes cert. ssh cert is not required.
+func (a *LocalKeyAgent) AddKubeKey(key *Key) error {
+	if len(key.KubeTLSCerts) == 0 {
+		return trace.BadParameter("key must contains at least one Kubernetes access certificate")
+	}
+	return a.addKey(key)
+}
+
 // addKey activates a new signed session key by adding it into the keystore.
 func (a *LocalKeyAgent) addKey(key *Key) error {
 	if key == nil {

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -168,7 +168,7 @@ func (c *kubeJoinCommand) run(cf *CLIConf) error {
 			}
 
 			// Cache the new cert on disk for reuse.
-			if err := tc.LocalAgent().AddKey(k); err != nil {
+			if err := tc.LocalAgent().AddKubeKey(k); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -646,7 +646,7 @@ func (c *kubeCredentialsCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 	// Cache the new cert on disk for reuse.
-	if err := tc.LocalAgent().AddKey(k); err != nil {
+	if err := tc.LocalAgent().AddKubeKey(k); err != nil {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Fixes #23250

`tc.LocalAgent().AddKey` tries to load SSH cert after adding a key but failed as the SSH cert is missing for the remote cluster.

Note that only first run fails. The kube cert is saved properly so subsequent calls are fine.

Made the same fix as database access to only write the Kube key without reloading.