### PR TITLE
move credential events to auth service

### DIFF
--- a/lib/usagereporter/web/userevent.go
+++ b/lib/usagereporter/web/userevent.go
@@ -87,10 +87,10 @@ type CreatePreUserEventRequest struct {
 	Alert string `json:"alert"`
 	// MfaType is the type of MFA used
 	// MfaType is only set for registerChallenge events
-	MfaType string `json:"mfa_type"`
+	MfaType string `json:"mfaType"`
 	// LoginFlow is the login flow used
 	// LoginFlow is only set for registerChallenge events
-	LoginFlow string `json:"login_flow"`
+	LoginFlow string `json:"loginFlow"`
 }
 
 // CheckAndSetDefaults validates the Request has the required fields.

--- a/web/packages/design/src/StepSlider/StepSlider.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.tsx
@@ -110,7 +110,6 @@ export function StepSlider<T>(props: Props<T>) {
     return (
       <View
         key={step}
-        currFlow={currFlow}
         refCallback={requirePreMount ? setHeightOnPreMount : null}
         next={() => {
           preMountState.current.step = step + 1;

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.tsx
@@ -136,5 +136,4 @@ export function NewCredentials(props: State & Props) {
 
 export type Props = State & {
   resetMode?: boolean;
-  currFlow?: LoginFlow;
 };

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewMfaDevice.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewMfaDevice.tsx
@@ -30,8 +30,6 @@ import createMfaOptions from 'shared/utils/createMfaOptions';
 import { useRefAutoFocus } from 'shared/hooks';
 import { Auth2faType } from 'shared/services';
 
-import { CaptureEvent, userEventService } from 'teleport/services/userEvent';
-
 import { Props as CredentialsProps, SliderProps } from './NewCredentials';
 import secKeyGraphic from './sec-key-with-bg.png';
 
@@ -47,7 +45,6 @@ export function NewMfaDevice(props: Props) {
     prev,
     refCallback,
     hasTransitionEnded,
-    currFlow,
   } = props;
   const [otp, setOtp] = useState('');
   const mfaOptions = createMfaOptions({
@@ -68,13 +65,6 @@ export function NewMfaDevice(props: Props) {
     validator: Validator
   ) {
     e.preventDefault(); // prevent form submit default
-
-    userEventService.capturePreUserEvent({
-      event: CaptureEvent.PreUserOnboardRegisterChallengeSubmitEvent,
-      username: resetToken.user,
-      mfaType: mfaType.value,
-      loginFlow: currFlow,
-    });
 
     if (!validator.validate()) {
       return;
@@ -251,5 +241,4 @@ type Props = CredentialsProps &
   SliderProps & {
     password: string;
     updatePassword(pwd: string): void;
-    currFlow?: string;
   };

--- a/web/packages/teleport/src/Welcome/Welcome.test.tsx
+++ b/web/packages/teleport/src/Welcome/Welcome.test.tsx
@@ -132,12 +132,16 @@ describe('teleport/components/Welcome', () => {
     fireEvent.change(pwdConfirmField, { target: { value: 'pwd_value' } });
     fireEvent.click(screen.getByRole('button'));
 
-    expect(auth.resetPassword).toHaveBeenCalledWith({
-      tokenId: '5182',
-      password: 'pwd_value',
-      otpCode: '',
-      deviceName: '',
-    });
+    expect(auth.resetPassword).toHaveBeenCalledWith(
+      expect.objectContaining({
+        req: {
+          tokenId: '5182',
+          password: 'pwd_value',
+          otpCode: '',
+          deviceName: '',
+        },
+      })
+    );
   });
 
   it('reset password with otp', async () => {
@@ -162,12 +166,16 @@ describe('teleport/components/Welcome', () => {
     fireEvent.change(otpField, { target: { value: '2222' } });
     fireEvent.click(screen.getByText(/submit/i));
 
-    expect(auth.resetPassword).toHaveBeenCalledWith({
-      tokenId: '5182',
-      password: 'pwd_value',
-      otpCode: '2222',
-      deviceName: 'otp-device',
-    });
+    expect(auth.resetPassword).toHaveBeenCalledWith(
+      expect.objectContaining({
+        req: {
+          tokenId: '5182',
+          password: 'pwd_value',
+          otpCode: '2222',
+          deviceName: 'otp-device',
+        },
+      })
+    );
   });
 
   it('reset password with webauthn', async () => {
@@ -190,11 +198,15 @@ describe('teleport/components/Welcome', () => {
     // Trigger submit.
     fireEvent.click(screen.getByText(/submit/i));
 
-    expect(auth.resetPasswordWithWebauthn).toHaveBeenCalledWith({
-      tokenId: '5182',
-      password: 'pwd_value',
-      deviceName: 'webauthn-device',
-    });
+    expect(auth.resetPasswordWithWebauthn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        req: {
+          tokenId: '5182',
+          password: 'pwd_value',
+          deviceName: 'webauthn-device',
+        },
+      })
+    );
   });
 
   it('reset password with passwordless', async () => {
@@ -210,11 +222,15 @@ describe('teleport/components/Welcome', () => {
     // Trigger submit.
     fireEvent.click(await screen.findByText(/submit/i));
 
-    expect(auth.resetPasswordWithWebauthn).toHaveBeenCalledWith({
-      tokenId: '5182',
-      password: '',
-      deviceName: 'passwordless-device',
-    });
+    expect(auth.resetPasswordWithWebauthn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        req: {
+          tokenId: '5182',
+          password: '',
+          deviceName: 'passwordless-device',
+        },
+      })
+    );
   });
 
   it('switch between primary password to passwordless and vice versa', async () => {

--- a/web/packages/teleport/src/services/auth/auth.test.ts
+++ b/web/packages/teleport/src/services/auth/auth.test.ts
@@ -61,10 +61,15 @@ describe('services/auth', () => {
     };
 
     await auth.resetPassword({
-      tokenId: 'tokenId',
-      password,
-      otpCode: '2fa_token',
+      req: {
+        tokenId: 'tokenId',
+        password: password,
+        otpCode: '2fa_token',
+      },
     });
-    expect(api.put).toHaveBeenCalledWith(cfg.getPasswordTokenUrl(), submitData);
+    expect(api.put).toHaveBeenCalledWith(
+      cfg.getPasswordTokenUrl(),
+      expect.objectContaining(submitData)
+    );
   });
 });

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -18,6 +18,8 @@ import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import { DeviceType, DeviceUsage } from 'teleport/services/mfa';
 
+import { CaptureEvent, userEventService } from 'teleport/services/userEvent';
+
 import makePasswordToken from './makePasswordToken';
 import { makeChangedUserAuthn } from './make';
 import {
@@ -26,7 +28,11 @@ import {
   makeWebauthnAssertionResponse,
   makeWebauthnCreationResponse,
 } from './makeMfa';
-import { NewCredentialRequest, UserCredentials } from './types';
+import {
+  ResetPasswordReqWithEvent,
+  ResetPasswordWithWebauthnReqWithEvent,
+  UserCredentials,
+} from './types';
 
 const auth = {
   checkWebauthnSupport() {
@@ -124,14 +130,17 @@ const auth = {
   // resetPasswordWithWebauthn either sets a new password and a new webauthn device,
   // or if passwordless is requested (indicated by empty password param),
   // skips setting a new password and only sets a passwordless device.
-  resetPasswordWithWebauthn(req: NewCredentialRequest) {
+  resetPasswordWithWebauthn(props: ResetPasswordWithWebauthnReqWithEvent) {
+    const { req, eventMeta } = props;
+    const deviceUsage: DeviceUsage = req.password ? 'mfa' : 'passwordless';
+
     return auth
       .checkWebauthnSupport()
       .then(() =>
         auth.createMfaRegistrationChallenge(
           req.tokenId,
           'webauthn',
-          req.password ? 'mfa' : 'passwordless'
+          deviceUsage
         )
       )
       .then(res =>
@@ -149,10 +158,27 @@ const auth = {
 
         return api.put(cfg.getPasswordTokenUrl(), request);
       })
-      .then(makeChangedUserAuthn);
+      .then(j => {
+        if (eventMeta) {
+          userEventService.capturePreUserEvent({
+            event: CaptureEvent.PreUserOnboardSetCredentialSubmitEvent,
+            username: eventMeta.username,
+          });
+
+          userEventService.capturePreUserEvent({
+            event: CaptureEvent.PreUserOnboardRegisterChallengeSubmitEvent,
+            username: eventMeta.username,
+            mfaType: eventMeta.mfaType,
+            loginFlow: deviceUsage,
+          });
+        }
+        return makeChangedUserAuthn(j);
+      });
   },
 
-  resetPassword(req: NewCredentialRequest) {
+  resetPassword(props: ResetPasswordReqWithEvent) {
+    const { req, eventMeta } = props;
+
     const request = {
       password: base64EncodeUnicode(req.password),
       second_factor_token: req.otpCode,
@@ -160,9 +186,15 @@ const auth = {
       deviceName: req.deviceName,
     };
 
-    return api
-      .put(cfg.getPasswordTokenUrl(), request)
-      .then(makeChangedUserAuthn);
+    return api.put(cfg.getPasswordTokenUrl(), request).then(j => {
+      if (eventMeta) {
+        userEventService.capturePreUserEvent({
+          event: CaptureEvent.PreUserOnboardSetCredentialSubmitEvent,
+          username: eventMeta.username,
+        });
+      }
+      return makeChangedUserAuthn(j);
+    });
   },
 
   changePassword(oldPass: string, newPass: string, token: string) {

--- a/web/packages/teleport/src/services/auth/types.ts
+++ b/web/packages/teleport/src/services/auth/types.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { EventMeta } from 'teleport/services/userEvent';
 
 export type Base64urlString = string;
 
@@ -56,4 +57,14 @@ export type ResetToken = {
   tokenId: string;
   qrCode: string;
   user: string;
+};
+
+export type ResetPasswordReqWithEvent = {
+  req: NewCredentialRequest;
+  eventMeta?: EventMeta;
+};
+
+export type ResetPasswordWithWebauthnReqWithEvent = {
+  req: NewCredentialRequest;
+  eventMeta?: EventMeta;
 };

--- a/web/packages/teleport/src/services/userEvent/types.ts
+++ b/web/packages/teleport/src/services/userEvent/types.ts
@@ -91,11 +91,13 @@ export type UserEvent = {
   alert?: string;
 };
 
-export type PreUserEvent = UserEvent & {
+export type EventMeta = {
   username: string;
   mfaType?: string;
   loginFlow?: string;
 };
+
+export type PreUserEvent = UserEvent & EventMeta;
 
 export type DiscoverEventRequest = Omit<UserEvent, 'event'> & {
   event: DiscoverEvent;


### PR DESCRIPTION
Previously we were emitting:
- credentials event on success (after validation)
- register challenge event on click

Since these two events boil down to the same API call, the register challenge event is always submitted before the credentials event (which is chronologically incorrect).

This PR moves both events out of components and into the auth service to reliably emit the events.
