### PR TITLE
Fix flaky test `TestGetHeadlessAuthentication`

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4298,7 +4298,7 @@ func TestGetHeadlessAuthentication(t *testing.T) {
 			client, err := srv.NewClient(tc.identity)
 			require.NoError(t, err)
 
-			ctx, cancel := context.WithTimeout(ctx, time.Millisecond*100)
+			ctx, cancel := context.WithTimeout(ctx, time.Second)
 			defer cancel()
 
 			// default to same headlessAuthn


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/23258