### PR TITLE
docs: clarify app access debug app

### DIFF
--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -126,9 +126,9 @@ teleport:
   proxy_server: teleport.example.com:3080
 app_service:
     enabled: yes
-    # Teleport provides a small debug app that can be used to make sure application
-    # access is working correctly. It'll output JWTs so it can be useful
-    # when extending your application.
+    # Teleport provides a small debug app called "dumper" that can be used
+    # to make sure application access is working correctly. It outputs JWTs,
+    #  so it can be useful when extending your application.
     debug_app: true
     # This section contains definitions of all applications proxied by this
     # service. It can contain multiple items.
@@ -163,10 +163,10 @@ $ sudo teleport start --config=/path/to/teleport.yaml
 
 ## Advanced options
 
-### Running the debug application
+### Running the dumper application
 
-For testing and debugging purposes, we provide a built-in debug app. It can
-be turned on using `debug_app: true`.
+For testing and debugging purposes, we provide a built-in debug app called "dumper".
+It can be turned on using `debug_app: true`.
 
 ```yaml
 app_service:
@@ -174,7 +174,7 @@ app_service:
    debug_app: true
 ```
 
-The app will dump all the request headers in the response.
+The dumper app will dump all the request headers in the response.
 
 ### Customize public address
 

--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -14,9 +14,9 @@ appearing in the `teleport.yaml` configuration file:
 app_service:
   # Enables application proxy service.
   enabled: yes
-  # Enable debug app that can be used to make sure application access is
-  # working correctly. It'll output JWTs so it can be useful for when
-  # extending your application.
+  # Teleport provides a small debug app called "dumper" that can be used
+  # to make sure application access is working correctly. It outputs JWTs,
+  #  so it can be useful when extending your application.
   debug_app: true
   # Matchers for application resources created with "tctl create" command.
   resources:
@@ -190,7 +190,7 @@ $ curl $(tsh apps config --format=uri) \
 | - | - |
 | `--format` | Optional print format, one of: `uri` to print app address, `ca` to print CA cert path, `cert` to print cert path, `key` print key path, `curl` to print example curl command.|
 
-### tsh az 
+### tsh az
 
 Run an Azure CLI command via the Teleport Application Service:
 
@@ -208,4 +208,3 @@ To run this command, one of the user's roles must include the
 Application Service. To learn how to set up secure access to Azure via Teleport,
 read [Protect the Azure CLI with Teleport Application
 Access](cloud-apis/azure.mdx).
-


### PR DESCRIPTION
App access ships with a built-in debug app called "dumper". The docs refer to the debug app, but never mention it by name, which confuses some users who see a dumper app show up in their cluster.

Closes #20678