### PR TITLE
kube-updater: implement the maintenance window trigger

### DIFF
--- a/integrations/kube-agent-updater/pkg/maintenance/window.go
+++ b/integrations/kube-agent-updater/pkg/maintenance/window.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	v1 "k8s.io/api/core/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const maintenanceScheduleKeyName = "agent-maintenance-schedule"
+
+// windowTrigger allows a maintenance to start if we are in a planned
+// maintenance window. Maintenance windows are discovered by the agent and
+// written to a secret (shared for all the agents). If the secret is stale or
+// missing the trigger will assume the agent is not working properly and allow
+// maintenance.
+type windowTrigger struct {
+	name string
+	kclient.Client
+	clock clockwork.Clock
+}
+
+// Name returns the trigger name.
+func (w windowTrigger) Name() string {
+	return w.name
+}
+
+// CanStart implements maintenance.Trigger and checks if we are in a
+// maintenance window.
+func (w windowTrigger) CanStart(ctx context.Context, object kclient.Object) (bool, error) {
+	log := ctrllog.FromContext(ctx).V(1)
+	secretName := fmt.Sprintf("%s-shared-state", object.GetName())
+	var secret v1.Secret
+	err := w.Get(ctx, kclient.ObjectKey{Namespace: object.GetNamespace(), Name: secretName}, &secret)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	rawData, ok := secret.Data[maintenanceScheduleKeyName]
+	if !ok {
+		return false, trace.Errorf("secret %s does not have key %s", secretName, maintenanceScheduleKeyName)
+	}
+	var maintenanceSchedule kubeScheduleRepr
+	err = json.Unmarshal(rawData, &maintenanceSchedule)
+	if err != nil {
+		return false, trace.WrapWithMessage(err, "failed to unmarshall schedule")
+	}
+	now := w.clock.Now()
+	if !maintenanceSchedule.isValid(now) {
+		return false, trace.Errorf("maintenance schedule is stale or invalid")
+	}
+	for _, window := range maintenanceSchedule.Windows {
+		if window.inWindow(now) {
+			log.Info("maintenance window active", "start", window.Start, "end", window.Stop)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Default defines what to do in case of failure. The windowTrigger should
+// trigger a maintenance if it fails to evaluate the next maintenance windows.
+// Not having a sane and up-to-date secret means the agent might not work as
+// intended.
+func (w windowTrigger) Default() bool {
+	return true
+}
+
+// kubeSchedulerRepr is the structure containing the maintenance schedule
+// sent by the agent through a Kubernetes secret.
+type kubeScheduleRepr struct {
+	Windows []windowRepr `json:"windows"`
+}
+
+// isValid checks if the schedule is valid. A schedule is considered invalid if
+// it has no upcoming or ongoing maintenance window, or if it contains a window
+// whose start is after its end. This could happen if the agent looses
+// connectivity to its cluster or if we have a bug in the window calculation.
+// In this case we don't want to honour the schedule and will consider the
+// agent is not working properly.
+func (s kubeScheduleRepr) isValid(now time.Time) bool {
+	valid := false
+	for _, window := range s.Windows {
+		if window.Start.After(window.Stop) {
+			return false
+		}
+		if window.Stop.After(now) {
+			valid = true
+		}
+	}
+	return valid
+}
+
+type windowRepr struct {
+	Start time.Time `json:"start"`
+	Stop  time.Time `json:"stop"`
+}
+
+// inWindow checks if a given time is in the window.
+func (w windowRepr) inWindow(now time.Time) bool {
+	return now.After(w.Start) && now.Before(w.Stop)
+}
+
+// NewWindowTrigger returns a new Trigger validating if the agent is within its
+// maintenance window.
+func NewWindowTrigger(name string, client kclient.Client) Trigger {
+	return windowTrigger{
+		name:   name,
+		Client: client,
+		clock:  clockwork.NewRealClock(),
+	}
+}

--- a/integrations/kube-agent-updater/pkg/maintenance/window_test.go
+++ b/integrations/kube-agent-updater/pkg/maintenance/window_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_kubeScheduleRepr_isValid(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	now := clock.Now()
+
+	tests := []struct {
+		name    string
+		windows []windowRepr
+		want    bool
+	}{
+		{
+			name: "one future window",
+			windows: []windowRepr{
+				{Start: now.Add(time.Hour), Stop: now.Add(2 * time.Hour)},
+			},
+			want: true,
+		},
+		{
+			name: "past and future windows",
+			windows: []windowRepr{
+				{Start: now.Add(-2 * time.Hour), Stop: now.Add(-time.Hour)},
+				{Start: now.Add(time.Hour), Stop: now.Add(2 * time.Hour)},
+			},
+			want: true,
+		},
+		{
+			name: "one active window",
+			windows: []windowRepr{
+				{Start: now.Add(-time.Hour), Stop: now.Add(time.Hour)},
+			},
+			want: true,
+		},
+		{
+			name: "only past window",
+			windows: []windowRepr{
+				{Start: now.Add(-2 * time.Hour), Stop: now.Add(-time.Hour)},
+			},
+			want: false,
+		},
+		{
+			name:    "no window",
+			windows: []windowRepr{},
+			want:    false,
+		},
+		{
+			name: "one broken window",
+			windows: []windowRepr{
+				{Start: now.Add(time.Hour), Stop: now.Add(-time.Hour)},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := kubeScheduleRepr{
+				Windows: tt.windows,
+			}
+			require.Equal(t, tt.want, s.isValid(now))
+		})
+	}
+}
+
+func Test_windowRepr_inWindow(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	now := clock.Now()
+
+	tests := []struct {
+		name  string
+		start time.Time
+		stop  time.Time
+		want  bool
+	}{
+		{
+			name:  "before window",
+			start: now.Add(time.Hour),
+			stop:  now.Add(2 * time.Hour),
+			want:  false,
+		},
+		{
+			name:  "after window",
+			start: now.Add(-2 * time.Hour),
+			stop:  now.Add(-time.Hour),
+			want:  false,
+		},
+		{
+			name:  "in window",
+			start: now.Add(-time.Hour),
+			stop:  now.Add(time.Hour),
+			want:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := windowRepr{Start: tt.start, Stop: tt.stop}
+			require.Equal(t, tt.want, w.inWindow(now))
+		})
+	}
+}
+
+func TestWindowTrigger_CanStart(t *testing.T) {
+	// Test setup: generating and loading fixtures
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+	now := clock.Now()
+	namespace := "bar"
+
+	invalidSchedule, err := json.Marshal(kubeScheduleRepr{Windows: []windowRepr{
+		{Start: now.Add(-time.Hour), Stop: now.Add(time.Hour)},
+		{Start: now.Add(time.Hour), Stop: now.Add(-time.Hour)},
+	}})
+	require.NoError(t, err)
+	futureSchedule, err := json.Marshal(kubeScheduleRepr{Windows: []windowRepr{
+		{Start: now.Add(time.Hour), Stop: now.Add(2 * time.Hour)},
+	}})
+	require.NoError(t, err)
+	activeSchedule, err := json.Marshal(kubeScheduleRepr{Windows: []windowRepr{
+		{Start: now.Add(-time.Hour), Stop: now.Add(time.Hour)},
+	}})
+	require.NoError(t, err)
+
+	fixtures := &v1.SecretList{Items: []v1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-key-shared-state", Namespace: namespace},
+			Data:       map[string][]byte{"foo": []byte("bar")},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid-json-shared-state", Namespace: namespace},
+			Data:       map[string][]byte{maintenanceScheduleKeyName: []byte(`{"foo": "bar"}`)},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid-schedule-shared-state", Namespace: namespace},
+			Data:       map[string][]byte{maintenanceScheduleKeyName: invalidSchedule},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "in-maintenance-shared-state", Namespace: namespace},
+			Data:       map[string][]byte{maintenanceScheduleKeyName: activeSchedule},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "not-in-maintenance-shared-state", Namespace: namespace},
+			Data:       map[string][]byte{maintenanceScheduleKeyName: futureSchedule},
+		},
+	}}
+
+	clientBuilder := fake.NewClientBuilder()
+	clientBuilder.WithLists(fixtures)
+	client := clientBuilder.Build()
+
+	tests := []struct {
+		name      string
+		object    kclient.Object
+		want      bool
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "no secret",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "not-found", Namespace: namespace}},
+			assertErr: require.Error,
+		},
+		{
+			name:      "secret no key",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "no-key", Namespace: namespace}},
+			assertErr: require.Error,
+		},
+		{
+			name:      "secret invalid JSON",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "invalid-json", Namespace: namespace}},
+			assertErr: require.Error,
+		},
+		{
+			name:      "secret invalid schedule",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "invalid-schedule", Namespace: namespace}},
+			assertErr: require.Error,
+		},
+		{
+			name:      "in maintenance window",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "in-maintenance", Namespace: namespace}},
+			want:      true,
+			assertErr: require.NoError,
+		},
+		{
+			name:      "not in maintenance window",
+			object:    &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "not-in-maintenance", Namespace: namespace}},
+			want:      false,
+			assertErr: require.NoError,
+		},
+	}
+	// Doing the real test
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := windowTrigger{
+				Client: client,
+				clock:  clock,
+			}
+			got, err := w.CanStart(ctx, tt.object)
+			tt.assertErr(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This trigger allows a maintenance to start if the teleport-kube-agent is within a maintenance window. The teleport-kube-agent writes its maintenance schedule to a Kubernetes secret which the updater checks. If the secret is not here, not under the right format, or does not contain future maintenances, it is considered invalid and the maintenance is allowed.


Part of https://github.com/gravitational/teleport/issues/22450