### PR TITLE
Update docs version workflow

### DIFF
--- a/.github/workflows/update-docs-version.yaml
+++ b/.github/workflows/update-docs-version.yaml
@@ -1,0 +1,41 @@
+name: Update docs version
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Teleport version to update to (ex. 12.11.1)
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-pr:
+    name: Create PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout OSS Teleport
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ vars.GITHUB_REF }}
+
+      - name: Update versions
+        run: |
+          cat docs/config.json | \
+            jq '.variables.teleport.version = "${{ inputs.version }}"' | \
+            jq '.variables.teleport.plugin.version = "${{ inputs.version }}"' | \
+            jq '.variables.teleport.latest_ent_docker_image = "public.ecr.aws/gravitational/teleport-ent:${{ inputs.version }}"' | \
+            jq '.variables.teleport.latest_oss_docker_image = "public.ecr.aws/gravitational/teleport:${{ inputs.version }}"' \
+            > docs/config.json
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ github.token }}
+          commit-message: Update docs versions to ${{ inputs.version }}
+          title: "[auto] Update docs versions to ${{ inputs.version }}"
+          committer: GitHub <noreply@github.com>
+          branch: docs-update
+          branch-suffix: timestamp
+          delete-branch: true


### PR DESCRIPTION
Workflow, which updates `docs/config.json` to match Teleport version specified in the input arg. It must be run manually  over `release/v<XX>` branch. jq has the side effect: it pretty prints `docs/config.json` fixing all format errors (https://github.com/gzigzigzeo/teleport/pull/11/commits/cd68ef036f48a4011d9ff7ed1d42097e3e5d43a2) Unfortunately, there is no way to force jq to preserve whitespace and IMO it won't be reliable to use regexes here.