### PR TITLE
Clarify Auth Service backend permissions

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -29,8 +29,9 @@ cluster to Teleport.
 
 ## Step 3/7. Set up AWS IAM configuration
 
-For Teleport to be able to create the DynamoDB tables, indexes, and the S3 storage bucket it needs,
-you'll need to configure AWS IAM policies to allow access.
+For Teleport to be able to manage the DynamoDB tables, indexes, and the S3
+storage bucket it needs, you'll need to configure AWS IAM policies to allow
+access.
 
 <Admonition type="note">
   These IAM policies should be added to your AWS account, then granted to the instance role associated with the
@@ -44,10 +45,6 @@ you'll need to configure AWS IAM policies to allow access.
 ### S3 IAM policy
 
 (!docs/pages/includes/s3-iam-policy.mdx!)
-
-Note that Teleport will only use S3 buckets with versioning enabled. This
-ensures that a session log cannot be permanently altered or deleted, as
-Teleport will always look at the oldest version of a recording.
 
 ## Step 4/7. Configure TLS certificates for Teleport
 

--- a/docs/pages/deploy-a-cluster/high-availability.mdx
+++ b/docs/pages/deploy-a-cluster/high-availability.mdx
@@ -126,24 +126,28 @@ events:
 - Google Cloud Firestore
 - etcd (cluster state only)
 
-For Amazon DynamoDB and Google Cloud Firestore, your Teleport configuration (which
-we will describe in more detail in the [Configuration](#configuration) section)
-names a table or collection where Teleport stores cluster state and audit
-events. 
-
-The Teleport Auth Service manages the creation of any required DynamoDB tables
-or Firestore collections itself, and does not require them to exist in advance.
+For Amazon DynamoDB and Google Cloud Firestore, your Teleport configuration
+(which we will describe in more detail in the [Configuration](#configuration)
+section) names a table or collection where Teleport stores cluster state and
+audit events. 
 
 The Auth Service can also store cluster state in self-hosted
 [etcd](https://etcd.io/) deployments. In this case, Teleport uses namespaces
 within item keys to identify cluster state data.
 
+When you configure the Teleport Auth Service to access a table or collection,
+the Auth Service will check that the table or collection exists on startup. If
+it does not, the Auth Service attempts to create it.
+
 <Admonition title="Required permissions">
 
 In your cloud provider's RBAC solution (e.g., AWS or Google Cloud IAM), your
 Auth Service instances need permissions to read from and write to your chosen
-key/value store, as well as to create tables and collections (if your key/value
-store supports them).
+key/value store. 
+
+Unless you have a pre-existing table or collection for the Auth Service to use,
+it must also have permissions to create tables and collections (if your
+key/value store supports them).
 
 </Admonition>
 
@@ -158,19 +162,21 @@ storage services:
 
 In your Teleport configuration (described in the [Configuration](#configuration)
 section), you must name a bucket within Google Cloud Storage or an Amazon
-S3-compatible service to use for managing session recordings. The Teleport Auth
-Service creates this bucket, so to prevent unexpected behavior, you should not
-create it in advance. 
+S3-compatible service to use for managing session recordings. 
+
+The Auth Service will check that the bucket exists on startup. If it does not,
+the Auth Service attempts to create it.
 
 <Admonition title="Required permissions">
 
 In your cloud provider's RBAC solution, your Auth Service instances need
 permissions to get buckets as well as to create, get, list, and update objects.
-Since this setup lets Teleport create buckets for you, you should also assign
-Auth Service instances permissions to create buckets
 
 In Google Cloud Storage, Auth Service instances also need permissions to delete
 objects. 
+
+Unless you plan to configure the Auth Service to access a pre-existing bucket,
+you must also assign Auth Service instances permissions to create buckets
 
 </Admonition>
 

--- a/docs/pages/deploy-a-cluster/high-availability.mdx
+++ b/docs/pages/deploy-a-cluster/high-availability.mdx
@@ -128,8 +128,8 @@ events:
 
 For Amazon DynamoDB and Google Cloud Firestore, your Teleport configuration
 (which we will describe in more detail in the [Configuration](#configuration)
-section) names a table or collection where Teleport stores cluster state and
-audit events. 
+section) names the two tables or collections where Teleport stores cluster state
+and audit events. 
 
 The Auth Service can also store cluster state in self-hosted
 [etcd](https://etcd.io/) deployments. In this case, Teleport uses namespaces
@@ -176,7 +176,7 @@ In Google Cloud Storage, Auth Service instances also need permissions to delete
 objects. 
 
 Unless you plan to configure the Auth Service to access a pre-existing bucket,
-you must also assign Auth Service instances permissions to create buckets
+you must also assign Auth Service instances permissions to create buckets.
 
 </Admonition>
 

--- a/docs/pages/deploy-a-cluster/high-availability.mdx
+++ b/docs/pages/deploy-a-cluster/high-availability.mdx
@@ -136,14 +136,14 @@ The Auth Service can also store cluster state in self-hosted
 within item keys to identify cluster state data.
 
 When you configure the Teleport Auth Service to access a table or collection,
-the Auth Service will check that the table or collection exists on startup. If
-it does not, the Auth Service attempts to create it.
+the Auth Service checks that the table or collection exists on startup. If it
+does not, the Auth Service attempts to create it.
 
 <Admonition title="Required permissions">
 
-In your cloud provider's RBAC solution (e.g., AWS or Google Cloud IAM), your
-Auth Service instances need permissions to read from and write to your chosen
-key/value store. 
+Make sure you configure your cloud provider's RBAC solution (e.g., AWS or Google
+Cloud IAM) so that your Auth Service instances have permissions to read from and
+write to your chosen key/value store. 
 
 Unless you have a pre-existing table or collection for the Auth Service to use,
 it must also have permissions to create tables and collections (if your

--- a/docs/pages/deploy-a-cluster/high-availability.mdx
+++ b/docs/pages/deploy-a-cluster/high-availability.mdx
@@ -145,9 +145,9 @@ Make sure you configure your cloud provider's RBAC solution (e.g., AWS or Google
 Cloud IAM) so that your Auth Service instances have permissions to read from and
 write to your chosen key/value store. 
 
-Unless you have a pre-existing table or collection for the Auth Service to use,
-it must also have permissions to create tables and collections (if your
-key/value store supports them).
+Unless you have a pre-existing table or collection to use, the Auth Service
+must also have permissions to create tables and collections (if your key/value
+store supports them).
 
 </Admonition>
 

--- a/docs/pages/includes/dynamodb-iam-policy.mdx
+++ b/docs/pages/includes/dynamodb-iam-policy.mdx
@@ -1,3 +1,99 @@
+On startup, the Teleport Auth Service checks whether the DynamoDB table you have
+specified in its configuration file exists. If the table does not exist, the
+Auth Service attempts to create one.
+
+The IAM permissions that the Auth Service requires to manage DynamoDB tables
+depends on whether you expect to create a table yourself or enable the Auth
+Service to create and configure one for you:
+
+<Tabs>
+<TabItem label="Manage a Table Yourself">
+
+If you choose to manage a DynamoDB table yourself, the table must have the
+following attribute definitions:
+
+|Name|Type|
+|---|---|
+|`HashKey`|`S`|
+|`FullPath`|`S`|
+
+The table must also have the following key schema elements:
+
+|Name|Type|
+|---|---|
+|`HashKey`|`HASH`|
+|`FullPath`|`RANGE`|
+
+You'll need to replace these values in the policy example below:
+
+| Placeholder value       | Replace with                                                                                       |
+|-------------------------|----------------------------------------------------------------------------------------------------|
+| `us-west-2`             | AWS region                                                                                         |
+| `1234567890`            | AWS account ID                                                                                     |
+| `teleport-helm-backend` | DynamoDB table name to use for the Teleport backend                                                |
+| `teleport-helm-events`  | DynamoDB table name to use for the Teleport audit log (**must** be different to the backend table) |
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ClusterStateStorage",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:BatchWriteItem",
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:PutItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:DescribeStream",
+                "dynamodb:UpdateItem",
+                "dynamodb:DescribeTimeToLive",
+                "dynamodb:DescribeTable",
+                "dynamodb:GetShardIterator",
+                "dynamodb:GetItem",
+                "dynamodb:UpdateTable",
+                "dynamodb:GetRecords",
+                "dynamodb:UpdateContinuousBackups"
+            ],
+            "Resource": [
+                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-backend",
+                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-backend/stream/*"
+            ]
+        },
+        {
+            "Sid": "ClusterEventsStorage",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:BatchWriteItem",
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:PutItem",
+                "dynamodb:DescribeTable",
+                "dynamodb:DeleteItem",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:UpdateItem",
+                "dynamodb:DescribeTimeToLive",
+                "dynamodb:UpdateTable",
+                "dynamodb:UpdateContinuousBackups"
+            ],
+            "Resource": [
+                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-events",
+                "arn:aws:dynamodb:us-west-2:1234567890:table/teleport-helm-events/index/*"
+            ]
+        }
+    ]
+}
+```
+
+Note that you can omit the `dynamodb:UpdateContinuousBackups` permission if
+disabling continuous backups.
+
+</TabItem>
+<TabItem label="Auth Service Creates a Table">
+
 You'll need to replace these values in the policy example below:
 
 | Placeholder value       | Replace with                                                                                       |
@@ -64,3 +160,5 @@ You'll need to replace these values in the policy example below:
 }
 ```
 
+</TabItem>
+</Tabs>

--- a/docs/pages/includes/s3-iam-policy.mdx
+++ b/docs/pages/includes/s3-iam-policy.mdx
@@ -1,3 +1,59 @@
+On startup, the Teleport Auth Service checks whether the S3 bucket you have
+configured for session recording storage exists. If it does not, the Auth
+Service attempts to create and configure the bucket.
+
+The IAM permissions that the Auth Service requires to manage its session
+recording bucket depends on whether you expect to create the bucket yourself or
+enable the Auth Service to create and configure it for you:
+
+<Tabs>
+<TabItem label="Manage the Bucket Yourself">
+
+Note that Teleport will only use S3 buckets with versioning enabled. This
+ensures that a session log cannot be permanently altered or deleted, as
+Teleport will always look at the oldest version of a recording.
+
+You'll need to replace these values in the policy example below:
+
+| Placeholder value | Replace with |
+| - | - |
+| `your-sessions-bucket` | Name to use for the Teleport S3 session recording bucket |
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "BucketActions",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucketVersions",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListBucket",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetBucketVersioning"
+            ],
+            "Resource": "arn:aws:s3:::your-sessions-bucket"
+        },
+        {
+            "Sid": "ObjectActions",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObjectVersion",
+                "s3:GetObjectRetention",
+                "s3:*Object",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload"
+            ],
+            "Resource": "arn:aws:s3:::your-sessions-bucket/*"
+        }
+    ]
+}
+```
+
+</TabItem>
+<TabItem label="Auth Service Creates a Bucket">
+
 You'll need to replace these values in the policy example below:
 
 | Placeholder value | Replace with |
@@ -38,3 +94,5 @@ You'll need to replace these values in the policy example below:
     ]
 }
 ```
+</TabItem>
+</Tabs>

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -421,28 +421,10 @@ policies specified in the next section.
 
 ### IAM policies
 
-Make sure that the IAM role assigned to the Teleport Auth Service is configured
-with sufficient access to DynamoDB. Below is the example of the IAM policy you
-can use: 
+Make sure that the IAM role assigned to Teleport is configured with sufficient
+access to DynamoDB.
 
-```js
-{
-    "Version": "2012-10-17",
-    "Statement": [{
-            "Sid": "AllAPIActionsOnTeleportAuth",
-            "Effect": "Allow",
-            "Action": "dynamodb:*",
-            "Resource": "arn:aws:dynamodb:eu-west-1:123456789012:table/prod.teleport.auth"
-        },
-        {
-            "Sid": "AllAPIActionsOnTeleportStreams",
-            "Effect": "Allow",
-            "Action": "dynamodb:*",
-            "Resource": "arn:aws:dynamodb:eu-west-1:123456789012:table/prod.teleport.auth/stream/*"
-        }
-    ]
-}
-```
+(!docs/pages/includes/dynamodb-iam-policy.mdx!)
 
 ### Configuring the DynamoDB backend
 
@@ -498,13 +480,6 @@ The optional `GET` parameters shown below control how Teleport interacts with a 
 - `region=us-east-1` - set the Amazon region to use.
 - `endpoint=dynamo.example.com` - connect to a custom S3 endpoint.
 - `use_fips_endpoint=true` -  [Configure DynamoDB FIPS endpoints](#configuring-aws-fips-endpoints).
-
-### Assigning permissions to the Teleport Auth Service
-
-Make sure that the IAM role assigned to Teleport is configured with sufficient
-access to DynamoDB. Below is an example of the IAM policy we recommend.
-
-(!docs/pages/includes/dynamodb-iam-policy.mdx!)
 
 ### DynamoDB autoscaling
 

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -649,6 +649,11 @@ func (b *Backend) getTableStatus(ctx context.Context, tableName string) (tableSt
 // rangeKey is the name of the 'range key' the schema requires.
 // currently is always set to "FullPath" (used to be something else, that's
 // why it's a parameter for migration purposes)
+//
+// Note: If we change DynamoDB table schemas, we must also update the
+// documentation in case users want to set up DynamoDB tables manually. Edit the
+// following docs partial:
+// docs/pages/includes/dynamodb-iam-policy.mdx
 func (b *Backend) createTable(ctx context.Context, tableName string, rangeKey string) error {
 	pThroughput := dynamodb.ProvisionedThroughput{
 		ReadCapacityUnits:  aws.Int64(b.ReadCapacityUnits),


### PR DESCRIPTION
Closes #22482

This change clarifies descriptions of:

- IAM permissions that the Auth Service requires in order to manage S3 buckets and DynamoDB tables
- When the Auth Service needs to create an S3 bucket/DynamoDB table

Specific edits:

- Add tabs to the partials we use to describe S3 and DynamoDB IAM policies. One tab item is for cases where the Auth Service creates a bucket/table, and another tab item is for when you have a pre-existing bucket/table.
- Remove an extraneous H3 in the Backends Reference re: the required DynamoDB policy. This H3 includes a very permissive policy, while another H3 in the same page includes a policy with more reasonable permissions. The more permissive H3 must have been left in the page by mistake.
- Clarify permissions in the HA guide.

**Note to reviewers:** I haven't tested this change, but made it based on studying the code the Auth Service uses to create DynamoDB tables and S3 buckets (`dynamo.New`, `s3sessions.NewHandler`). I'd appreciate your input on the accuracy of the IAM policies and table/bucket requirements in this PR.