### PR TITLE
[v12] chore: Bump protoc-gen-go and protoc-gen-grpc-go

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -268,8 +268,8 @@ RUN (git clone https://github.com/gogo/protobuf.git --branch ${GOGO_PROTO_TAG} -
      cd ${GOPATH}/src/github.com/gogo/protobuf && \
      make install && \
      make clean)
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1 && \
-    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0 && \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
 ENV PROTO_INCLUDE "/usr/local/include":"/go/src":"/go/src/github.com/gogo/protobuf/protobuf":"${GOGOPROTO_ROOT}":"${GOGOPROTO_ROOT}/protobuf"
 
 # Install addlicense.


### PR DESCRIPTION
Update to versions 1.30.0 and 1.3.0, respectively.

* https://github.com/protocolbuffers/protobuf-go/releases/tag/v1.30.0
* https://github.com/protocolbuffers/protobuf-go/releases/tag/v1.29.1
* https://github.com/protocolbuffers/protobuf-go/releases/tag/v1.29.0
* https://github.com/grpc/grpc-go/releases/tag/cmd%2Fprotoc-gen-go-grpc%2Fv1.3.0

This does bring codegen changes, but generated code is functionally equivalent.

Backports #22976 to branch/v12.