### PR TITLE
Add a nix shell for development.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ webassets/
 
 # jest --coverage
 coverage
+
+.direnv

--- a/build.assets/nix-shell/flake.nix
+++ b/build.assets/nix-shell/flake.nix
@@ -1,0 +1,236 @@
+# Copyright 2023 Gravitational, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This file contains the dependencies for the Teleport nix shell, which contains
+# all of the utilities for building and linting Teleport.
+#
+
+{
+  description = "Teleport shell dependencies";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # general packages
+
+    # Linting dependencies
+    helmPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # helm 3.11.1
+    golangci-lintPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # golangci-lint 1.51.2
+    shellcheckPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # shellcheck 0.9.0
+    yamllintPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # yamllint 1.28.0
+    gciPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # gci 0.9.1
+    addlicensePkgs.url = "github:nixos/nixpkgs/f597e7e9fcf37d8ed14a12835ede0a7d362314bd"; # addlicense 1.0.0
+
+    # Rust and GCC dependencies
+    gccPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # gcc 12.2.0
+    libiconvPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # libiconv 1.16
+    libbpfPkgs.url = "github:nixos/nixpkgs/79b3d4bcae8c7007c9fd51c279a8a67acfa73a2a"; # libbpf 1.0.1
+    libfido2Pkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # libfido2 1.12.0
+
+    # UI dependencies
+    pythonPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # python 3.11.2
+    nodePkgs.url = "github:nixos/nixpkgs/a3d5f09dfd7134153136d3153820a0642898cc9d"; # node 16.18.1
+    yarnPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # yarn 1.22.19
+
+    # GRPC dependencies
+    protobufPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # protobuf 3.20.3
+    protoc-gen-goPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # protoc-gen-go 1.28.1
+    bufPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # buf 1.15.1
+
+    # Go dependencies
+    patchelfPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # patchelf 0.15.0
+    goPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # go 1.20.2
+  };
+
+  outputs = { self,
+              flake-utils,
+              nixpkgs,
+
+              helmPkgs,
+              golangci-lintPkgs,
+              shellcheckPkgs,
+              yamllintPkgs,
+              gciPkgs,
+              addlicensePkgs,
+
+              gccPkgs,
+              libiconvPkgs,
+              libbpfPkgs,
+              libfido2Pkgs,
+
+              pythonPkgs,
+              nodePkgs,
+              yarnPkgs,
+
+              protobufPkgs,
+              protoc-gen-goPkgs,
+              bufPkgs,
+
+              patchelfPkgs,
+              goPkgs
+     }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          # These versions are not available from nixpkgs
+          rustVersion = "1.68.0";
+          gogoVersion = "v1.3.2";
+          helmUnittestVersion = "v1.0.16";
+          nodeProtocTsVersion = "5.0.1";
+          grpcToolsVersion = "1.12.4";
+
+          # Package aliases to make reusing these packages easier.
+          # The individual package names here have been determined by using
+          # https://lazamar.co.uk/nix-versions/
+
+          # Wrap helm with the unittest plugin.
+          helm = (pkgs.wrapHelm helmPkgs.legacyPackages.${system}.kubernetes-helm {plugins = [helm-unittest];});
+          golangci-lint = golangci-lintPkgs.legacyPackages.${system}.golangci-lint;
+          shellcheck = shellcheckPkgs.legacyPackages.${system}.shellcheck;
+          yamllint = yamllintPkgs.legacyPackages.${system}.yamllint;
+          gci = gciPkgs.legacyPackages.${system}.gci;
+          addlicense = addlicensePkgs.legacyPackages.${system}.addlicense;
+
+          gcc = gccPkgs.legacyPackages.${system}.gcc-unwrapped;
+          libiconv = libiconvPkgs.legacyPackages.${system}.libiconvReal;
+          libbpf = libbpfPkgs.legacyPackages.${system}.libbpf;
+          libfido2 = libfido2Pkgs.legacyPackages.${system}.libfido2;
+
+          python = pythonPkgs.legacyPackages.${system}.python311;
+          node = nodePkgs.legacyPackages.${system}.nodejs-16_x;
+          yarn = yarnPkgs.legacyPackages.${system}.yarn;
+
+          protobuf = protobufPkgs.legacyPackages.${system}.protobuf3_20;
+          protoc-gen-go = protoc-gen-goPkgs.legacyPackages.${system}.protoc-gen-go;
+          buf = bufPkgs.legacyPackages.${system}.buf;
+
+          patchelf = patchelfPkgs.legacyPackages.${system}.patchelf;
+          go = goPkgs.legacyPackages.${system}.go_1_20;
+
+          # pkgs is an alias for the nixpkgs at the system level. This will be used
+          # for general utilities.
+          pkgs = nixpkgs.legacyPackages.${system};
+
+          # Compile protoc-gen-gogo for golang protobuf compilation.
+          protoc-gen-gogo = pkgs.stdenv.mkDerivation {
+            name = "protoc-gen-gogo";
+            src = pkgs.fetchFromGitHub {
+              owner = "gogo";
+              repo = "protobuf";
+              rev = gogoVersion;
+              sha256 = "sha256-CoUqgLFnLNCS9OxKFS7XwjE17SlH6iL1Kgv+0uEK2zU=";
+            };
+            buildInputs = [
+              pkgs.cacert
+              go
+            ];
+            buildPhase = ''
+              export GOBIN="$out/bin"
+              export GOCACHE="$(mktemp -d)"
+              make install
+              cp -R protobuf "$out/protobuf"
+            '';
+          };
+
+          # Compile grpc-tools for nodejs protobuf compilation.
+          grpc-tools = pkgs.stdenv.mkDerivation {
+            name = "grpc-tools";
+            dontUnpack = true;
+            buildInputs = [
+              node
+            ];
+            buildPhase = ''
+              export HOME="$(mktemp -d)"
+              export TEMPDIR="$(mktemp -d)"
+              npm install --prefix "$TEMPDIR" grpc_tools_node_protoc_ts@${nodeProtocTsVersion} grpc-tools@${grpcToolsVersion}
+              mv "$TEMPDIR" "$out"
+              mkdir "$out/bin"
+              cd "$out/bin"
+              ln -s ../node_modules/.bin/* "$out/bin/"
+            '';
+          };
+
+          # Rust and cargo binaries.
+          rust = pkgs.stdenv.mkDerivation {
+            name = "rust";
+            dontUnpack = true;
+            buildInputs = [
+              pkgs.cacert
+              pkgs.curl
+            ];
+            buildPhase = ''
+              export RUSTUP_HOME="$out"
+              export CARGO_HOME="$out"
+              curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain "${rustVersion}"
+            '';
+          };
+
+          # The helm unittest plugin.
+          helm-unittest = pkgs.buildGoModule rec {
+            name = "helm-unittest";
+          
+            src = pkgs.fetchFromGitHub {
+              owner = "vbehar";
+              repo = "helm3-unittest";
+              rev = helmUnittestVersion;
+              sha256 = "sha256-2UfQimIlA+hb1CpQrWfMh5iBEvgdnrkCGYaTJC3Bzpo=";
+            };
+
+            vendorSha256 = null;
+          
+            postInstall = ''
+              install -Dm644 plugin.yaml $out/helm-unittest/plugin.yaml
+              mkdir "$out/helm-unittest/bin"
+              mv $out/bin/helm3-unittest $out/helm-unittest/bin/unittest
+            '';
+          
+            doCheck = false;
+          };
+
+          # These inputs are given to the devShell
+          baseInputs = [
+              helm
+              golangci-lint
+              shellcheck
+              yamllint
+              gci
+              addlicense
+
+              gcc
+              libiconv
+              libfido2
+              rust
+
+              python
+              node
+              yarn
+
+              protobuf
+              protoc-gen-go
+              protoc-gen-gogo
+              grpc-tools
+              buf
+
+              go
+          ];
+          conditionalInputs = if pkgs.stdenv.isLinux then
+          [
+            libbpf
+          ] else [];
+        in {
+          # All of the Teleport shell dependencies for this system.
+          teleportShellDeps = baseInputs ++ conditionalInputs;
+        }
+      );
+}

--- a/build.assets/nix-shell/flake.nix
+++ b/build.assets/nix-shell/flake.nix
@@ -26,7 +26,7 @@
 
     # Linting dependencies
     helmPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # helm 3.11.1
-    golangci-lintPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # golangci-lint 1.51.2
+    #golangci-lintPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # golangci-lint 1.51.2
     shellcheckPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # shellcheck 0.9.0
     yamllintPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # yamllint 1.28.0
     gciPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # gci 0.9.1
@@ -58,7 +58,7 @@
               nixpkgs,
 
               helmPkgs,
-              golangci-lintPkgs,
+              #golangci-lintPkgs,
               shellcheckPkgs,
               yamllintPkgs,
               gciPkgs,
@@ -96,7 +96,7 @@
 
           # Wrap helm with the unittest plugin.
           helm = (pkgs.wrapHelm helmPkgs.legacyPackages.${system}.kubernetes-helm {plugins = [helm-unittest];});
-          golangci-lint = golangci-lintPkgs.legacyPackages.${system}.golangci-lint;
+          #golangci-lint = golangci-lintPkgs.legacyPackages.${system}.golangci-lint;
           shellcheck = shellcheckPkgs.legacyPackages.${system}.shellcheck;
           yamllint = yamllintPkgs.legacyPackages.${system}.yamllint;
           gci = gciPkgs.legacyPackages.${system}.gci;
@@ -121,6 +121,19 @@
           # pkgs is an alias for the nixpkgs at the system level. This will be used
           # for general utilities.
           pkgs = nixpkgs.legacyPackages.${system};
+
+          # Install golangci-lint
+          golangci-lint = pkgs.stdenv.mkDerivation {
+            name = "golangci-lint";
+            buildInputs = [
+              pkgs.cacert
+              pkgs.curl
+            ];
+            dontUnpack = true;
+            buildPhase = ''
+              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $out/bin v1.52.0
+            '';
+          };
 
           # Compile protoc-gen-gogo for golang protobuf compilation.
           protoc-gen-gogo = pkgs.stdenv.mkDerivation {

--- a/flake.lock
+++ b/flake.lock
@@ -47,6 +47,21 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gccPkgs": {
       "locked": {
         "lastModified": 1678571061,
@@ -76,26 +91,6 @@
         "owner": "nixos",
         "repo": "nixpkgs",
         "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -195,7 +190,57 @@
         "type": "github"
       }
     },
+    "nix-shell": {
+      "inputs": {
+        "addlicensePkgs": "addlicensePkgs",
+        "bufPkgs": "bufPkgs",
+        "flake-utils": "flake-utils_2",
+        "gccPkgs": "gccPkgs",
+        "gciPkgs": "gciPkgs",
+        "goPkgs": "goPkgs",
+        "golangci-lintPkgs": "golangci-lintPkgs",
+        "helmPkgs": "helmPkgs",
+        "libbpfPkgs": "libbpfPkgs",
+        "libfido2Pkgs": "libfido2Pkgs",
+        "libiconvPkgs": "libiconvPkgs",
+        "nixpkgs": "nixpkgs",
+        "nodePkgs": "nodePkgs",
+        "patchelfPkgs": "patchelfPkgs",
+        "protobufPkgs": "protobufPkgs",
+        "protoc-gen-goPkgs": "protoc-gen-goPkgs",
+        "pythonPkgs": "pythonPkgs",
+        "shellcheckPkgs": "shellcheckPkgs",
+        "yamllintPkgs": "yamllintPkgs",
+        "yarnPkgs": "yarnPkgs"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-ltXARE+urKxofFrf2IAMeGQ/iPW5k0lFzPNnW6w7uxU=",
+        "path": "./build.assets/nix-shell",
+        "type": "path"
+      },
+      "original": {
+        "path": "./build.assets/nix-shell",
+        "type": "path"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1678571061,
         "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
@@ -293,27 +338,9 @@
     },
     "root": {
       "inputs": {
-        "addlicensePkgs": "addlicensePkgs",
-        "bufPkgs": "bufPkgs",
         "flake-utils": "flake-utils",
-        "gccPkgs": "gccPkgs",
-        "gciPkgs": "gciPkgs",
-        "gitignore": "gitignore",
-        "goPkgs": "goPkgs",
-        "golangci-lintPkgs": "golangci-lintPkgs",
-        "helmPkgs": "helmPkgs",
-        "libbpfPkgs": "libbpfPkgs",
-        "libfido2Pkgs": "libfido2Pkgs",
-        "libiconvPkgs": "libiconvPkgs",
-        "nixpkgs": "nixpkgs",
-        "nodePkgs": "nodePkgs",
-        "patchelfPkgs": "patchelfPkgs",
-        "protobufPkgs": "protobufPkgs",
-        "protoc-gen-goPkgs": "protoc-gen-goPkgs",
-        "pythonPkgs": "pythonPkgs",
-        "shellcheckPkgs": "shellcheckPkgs",
-        "yamllintPkgs": "yamllintPkgs",
-        "yarnPkgs": "yarnPkgs"
+        "nix-shell": "nix-shell",
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "shellcheckPkgs": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,370 @@
+{
+  "nodes": {
+    "addlicensePkgs": {
+      "locked": {
+        "lastModified": 1655496630,
+        "narHash": "sha256-GZVgHf8Lx9wPcJOkVN8Cw2WkzVsNsV0L86geKA+E6dA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f597e7e9fcf37d8ed14a12835ede0a7d362314bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f597e7e9fcf37d8ed14a12835ede0a7d362314bd",
+        "type": "github"
+      }
+    },
+    "bufPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gccPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "gciPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "goPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "golangci-lintPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "helmPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "libbpfPkgs": {
+      "locked": {
+        "lastModified": 1671056470,
+        "narHash": "sha256-rrcDHjRX9R8qXvkcGvKunsw3mf7zyPJzx1y8TPqjWdM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "79b3d4bcae8c7007c9fd51c279a8a67acfa73a2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "79b3d4bcae8c7007c9fd51c279a8a67acfa73a2a",
+        "type": "github"
+      }
+    },
+    "libfido2Pkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "libiconvPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "nodePkgs": {
+      "locked": {
+        "lastModified": 1667535600,
+        "narHash": "sha256-K/9VcMlBN/phavUVFeKzY2mLheR9bpV9E+TOABvH5tI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a3d5f09dfd7134153136d3153820a0642898cc9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a3d5f09dfd7134153136d3153820a0642898cc9d",
+        "type": "github"
+      }
+    },
+    "patchelfPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "protobufPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "protoc-gen-goPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "pythonPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "addlicensePkgs": "addlicensePkgs",
+        "bufPkgs": "bufPkgs",
+        "flake-utils": "flake-utils",
+        "gccPkgs": "gccPkgs",
+        "gciPkgs": "gciPkgs",
+        "gitignore": "gitignore",
+        "goPkgs": "goPkgs",
+        "golangci-lintPkgs": "golangci-lintPkgs",
+        "helmPkgs": "helmPkgs",
+        "libbpfPkgs": "libbpfPkgs",
+        "libfido2Pkgs": "libfido2Pkgs",
+        "libiconvPkgs": "libiconvPkgs",
+        "nixpkgs": "nixpkgs",
+        "nodePkgs": "nodePkgs",
+        "patchelfPkgs": "patchelfPkgs",
+        "protobufPkgs": "protobufPkgs",
+        "protoc-gen-goPkgs": "protoc-gen-goPkgs",
+        "pythonPkgs": "pythonPkgs",
+        "shellcheckPkgs": "shellcheckPkgs",
+        "yamllintPkgs": "yamllintPkgs",
+        "yarnPkgs": "yarnPkgs"
+      }
+    },
+    "shellcheckPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "yamllintPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "yarnPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -110,22 +110,6 @@
         "type": "github"
       }
     },
-    "golangci-lintPkgs": {
-      "locked": {
-        "lastModified": 1678571061,
-        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
-        "type": "github"
-      }
-    },
     "helmPkgs": {
       "locked": {
         "lastModified": 1678571061,
@@ -198,7 +182,6 @@
         "gccPkgs": "gccPkgs",
         "gciPkgs": "gciPkgs",
         "goPkgs": "goPkgs",
-        "golangci-lintPkgs": "golangci-lintPkgs",
         "helmPkgs": "helmPkgs",
         "libbpfPkgs": "libbpfPkgs",
         "libfido2Pkgs": "libfido2Pkgs",
@@ -215,7 +198,7 @@
       },
       "locked": {
         "lastModified": 1,
-        "narHash": "sha256-ltXARE+urKxofFrf2IAMeGQ/iPW5k0lFzPNnW6w7uxU=",
+        "narHash": "sha256-H8oU5HlHd6Dh3wWlqCKfvT9SPkwE0casByvdvO169C8=",
         "path": "./build.assets/nix-shell",
         "type": "path"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,224 @@
+{
+  description = "Flakes";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # general packages
+    gitignore = {
+      url = "github:hercules-ci/gitignore.nix";
+      # Use the same nixpkgs
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+
+    # Linting dependencies
+    helmPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # helm 3.11.1
+    golangci-lintPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # golangci-lint 1.51.2
+    shellcheckPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # shellcheck 0.9.0
+    yamllintPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # yamllint 1.28.0
+    gciPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # gci 0.9.1
+    addlicensePkgs.url = "github:nixos/nixpkgs/f597e7e9fcf37d8ed14a12835ede0a7d362314bd"; # addlicense 1.0.0
+
+    # Rust and GCC dependencies
+    gccPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # gcc 12.2.0
+    libiconvPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # libiconv 1.16
+    libbpfPkgs.url = "github:nixos/nixpkgs/79b3d4bcae8c7007c9fd51c279a8a67acfa73a2a"; # libbpf 1.0.1
+    libfido2Pkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # libfido2 1.12.0
+
+    # UI dependencies
+    pythonPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # python 3.11.2
+    nodePkgs.url = "github:nixos/nixpkgs/a3d5f09dfd7134153136d3153820a0642898cc9d"; # node 16.18.1
+    yarnPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # yarn 1.22.19
+
+    # GRPC dependencies
+    protobufPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # protobuf 3.20.3
+    protoc-gen-goPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # protoc-gen-go 1.28.1
+    bufPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # buf 1.15.1
+
+    # Go dependencies
+    patchelfPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # patchelf 0.15.0
+    goPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # go 1.20.2
+  };
+
+  outputs = { self,
+              flake-utils,
+              nixpkgs,
+              gitignore,
+
+              helmPkgs,
+              golangci-lintPkgs,
+              shellcheckPkgs,
+              yamllintPkgs,
+              gciPkgs,
+              addlicensePkgs,
+
+              gccPkgs,
+              libiconvPkgs,
+              libbpfPkgs,
+              libfido2Pkgs,
+
+              pythonPkgs,
+              nodePkgs,
+              yarnPkgs,
+
+              protobufPkgs,
+              protoc-gen-goPkgs,
+              bufPkgs,
+
+              patchelfPkgs,
+              goPkgs
+     }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          rustVersion = "1.68.0";
+          gogoVersion = "v1.3.2";
+          helmUnittestVersion = "v1.0.16";
+          nodeProtocTsVersion = "5.0.1";
+          grpcToolsVersion = "1.12.4";
+
+          # Package aliases
+          helm = (pkgs.wrapHelm helmPkgs.legacyPackages.${system}.kubernetes-helm {plugins = [helm-unittest];});
+          golangci-lint = golangci-lintPkgs.legacyPackages.${system}.golangci-lint;
+          shellcheck = shellcheckPkgs.legacyPackages.${system}.shellcheck;
+          yamllint = yamllintPkgs.legacyPackages.${system}.yamllint;
+          gci = gciPkgs.legacyPackages.${system}.gci;
+          addlicense = addlicensePkgs.legacyPackages.${system}.addlicense;
+
+          gcc = gccPkgs.legacyPackages.${system}.gcc-unwrapped;
+          libiconv = libiconvPkgs.legacyPackages.${system}.libiconvReal;
+          libbpf = libbpfPkgs.legacyPackages.${system}.libbpf;
+          libfido2 = libfido2Pkgs.legacyPackages.${system}.libfido2;
+
+          python = pythonPkgs.legacyPackages.${system}.python311;
+          node = nodePkgs.legacyPackages.${system}.nodejs-16_x;
+          yarn = yarnPkgs.legacyPackages.${system}.yarn;
+
+          protobuf = protobufPkgs.legacyPackages.${system}.protobuf3_20;
+          protoc-gen-go = protoc-gen-goPkgs.legacyPackages.${system}.protoc-gen-go;
+          buf = bufPkgs.legacyPackages.${system}.buf;
+
+          patchelf = patchelfPkgs.legacyPackages.${system}.patchelf;
+          go = goPkgs.legacyPackages.${system}.go_1_20;
+
+          inherit (gitignore.lib) gitignoreSource;
+
+          pkgs = nixpkgs.legacyPackages.${system};
+
+          protoc-gen-gogo = pkgs.stdenv.mkDerivation {
+            name = "protoc-gen-gogo";
+            src = pkgs.fetchFromGitHub {
+              owner = "gogo";
+              repo = "protobuf";
+              rev = gogoVersion;
+              sha256 = "sha256-CoUqgLFnLNCS9OxKFS7XwjE17SlH6iL1Kgv+0uEK2zU=";
+            };
+            buildInputs = [
+              pkgs.cacert
+              go
+            ];
+            buildPhase = ''
+              export GOBIN="$out/bin"
+              export GOCACHE="$(mktemp -d)"
+              make install
+              cp -R protobuf "$out/protobuf"
+            '';
+          };
+
+          grpc-tools = pkgs.stdenv.mkDerivation {
+            name = "grpc-tools";
+            dontUnpack = true;
+            buildInputs = [
+              node
+            ];
+            buildPhase = ''
+              export HOME="$(mktemp -d)"
+              export TEMPDIR="$(mktemp -d)"
+              npm install --prefix "$TEMPDIR" grpc_tools_node_protoc_ts@${nodeProtocTsVersion} grpc-tools@${grpcToolsVersion}
+              mv "$TEMPDIR" "$out"
+              mkdir "$out/bin"
+              cd "$out/bin"
+              ln -s ../node_modules/.bin/* "$out/bin/"
+            '';
+          };
+
+          rust = pkgs.stdenv.mkDerivation {
+            name = "rust";
+            dontUnpack = true;
+            buildInputs = [
+              pkgs.cacert
+              pkgs.curl
+            ];
+            buildPhase = ''
+              export RUSTUP_HOME="$out"
+              export CARGO_HOME="$out"
+              curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain "${rustVersion}"
+            '';
+          };
+
+          helm-unittest = pkgs.buildGoModule rec {
+            name = "helm-unittest";
+          
+            src = pkgs.fetchFromGitHub {
+              owner = "vbehar";
+              repo = "helm3-unittest";
+              rev = helmUnittestVersion;
+              sha256 = "sha256-2UfQimIlA+hb1CpQrWfMh5iBEvgdnrkCGYaTJC3Bzpo=";
+            };
+
+            vendorSha256 = null;
+          
+            postInstall = ''
+              install -Dm644 plugin.yaml $out/helm-unittest/plugin.yaml
+              mkdir "$out/helm-unittest/bin"
+              mv $out/bin/helm3-unittest $out/helm-unittest/bin/unittest
+            '';
+          
+            doCheck = false;
+          };
+
+          baseInputs = [
+              # Wrap helm with the unittest plugin
+              helm
+              golangci-lint
+              shellcheck
+              yamllint
+              gci
+              addlicense
+
+              gcc
+              libiconv
+              libfido2
+              rust
+
+              python
+              node
+              yarn
+
+              protobuf
+              protoc-gen-go
+              protoc-gen-gogo
+              grpc-tools
+              buf
+
+              go
+          ];
+          conditionalInputs = if pkgs.stdenv.isLinux then
+          [
+            libbpf
+          ] else [];
+        in {
+          devShells.default = pkgs.mkShell {
+            buildInputs = baseInputs ++ conditionalInputs;
+            shellHook = ''
+              export GOMODCACHE="/tmp/nix-shell/gomodcache-$(id -u)"
+              export GOCACHE="/tmp/nix-shell/gocache-$(id -u)"
+              export GOLANGCI_LINT_CACHE="/tmp/nix-shell/golangci-lint-cache-$(id -u)"
+              mkdir -p "$GOMODCACHE"
+              mkdir -p "$GOCACHE"
+              mkdir -p "$GOLANGCI_LINT_CACHE"
+            '';
+          };
+        }
+      );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,215 +1,43 @@
+# Copyright 2023 Gravitational, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This file contains the dev shell definition for Teleport.
+#
+
 {
-  description = "Flakes";
+  description = "Teleport dev shell";
 
   inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # general packages
-    gitignore = {
-      url = "github:hercules-ci/gitignore.nix";
-      # Use the same nixpkgs
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-
-    # Linting dependencies
-    helmPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # helm 3.11.1
-    golangci-lintPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # golangci-lint 1.51.2
-    shellcheckPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # shellcheck 0.9.0
-    yamllintPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # yamllint 1.28.0
-    gciPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # gci 0.9.1
-    addlicensePkgs.url = "github:nixos/nixpkgs/f597e7e9fcf37d8ed14a12835ede0a7d362314bd"; # addlicense 1.0.0
-
-    # Rust and GCC dependencies
-    gccPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # gcc 12.2.0
-    libiconvPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # libiconv 1.16
-    libbpfPkgs.url = "github:nixos/nixpkgs/79b3d4bcae8c7007c9fd51c279a8a67acfa73a2a"; # libbpf 1.0.1
-    libfido2Pkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # libfido2 1.12.0
-
-    # UI dependencies
-    pythonPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # python 3.11.2
-    nodePkgs.url = "github:nixos/nixpkgs/a3d5f09dfd7134153136d3153820a0642898cc9d"; # node 16.18.1
-    yarnPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # yarn 1.22.19
-
-    # GRPC dependencies
-    protobufPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # protobuf 3.20.3
-    protoc-gen-goPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # protoc-gen-go 1.28.1
-    bufPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # buf 1.15.1
-
-    # Go dependencies
-    patchelfPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # patchelf 0.15.0
-    goPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # go 1.20.2
+    flake-utils.url = "github:numtide/flake-utils";
+    nix-shell.url = "path:./build.assets/nix-shell";
   };
 
   outputs = { self,
-              flake-utils,
               nixpkgs,
-              gitignore,
-
-              helmPkgs,
-              golangci-lintPkgs,
-              shellcheckPkgs,
-              yamllintPkgs,
-              gciPkgs,
-              addlicensePkgs,
-
-              gccPkgs,
-              libiconvPkgs,
-              libbpfPkgs,
-              libfido2Pkgs,
-
-              pythonPkgs,
-              nodePkgs,
-              yarnPkgs,
-
-              protobufPkgs,
-              protoc-gen-goPkgs,
-              bufPkgs,
-
-              patchelfPkgs,
-              goPkgs
+              flake-utils,
+              nix-shell,
      }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
-          rustVersion = "1.68.0";
-          gogoVersion = "v1.3.2";
-          helmUnittestVersion = "v1.0.16";
-          nodeProtocTsVersion = "5.0.1";
-          grpcToolsVersion = "1.12.4";
-
-          # Package aliases
-          helm = (pkgs.wrapHelm helmPkgs.legacyPackages.${system}.kubernetes-helm {plugins = [helm-unittest];});
-          golangci-lint = golangci-lintPkgs.legacyPackages.${system}.golangci-lint;
-          shellcheck = shellcheckPkgs.legacyPackages.${system}.shellcheck;
-          yamllint = yamllintPkgs.legacyPackages.${system}.yamllint;
-          gci = gciPkgs.legacyPackages.${system}.gci;
-          addlicense = addlicensePkgs.legacyPackages.${system}.addlicense;
-
-          gcc = gccPkgs.legacyPackages.${system}.gcc-unwrapped;
-          libiconv = libiconvPkgs.legacyPackages.${system}.libiconvReal;
-          libbpf = libbpfPkgs.legacyPackages.${system}.libbpf;
-          libfido2 = libfido2Pkgs.legacyPackages.${system}.libfido2;
-
-          python = pythonPkgs.legacyPackages.${system}.python311;
-          node = nodePkgs.legacyPackages.${system}.nodejs-16_x;
-          yarn = yarnPkgs.legacyPackages.${system}.yarn;
-
-          protobuf = protobufPkgs.legacyPackages.${system}.protobuf3_20;
-          protoc-gen-go = protoc-gen-goPkgs.legacyPackages.${system}.protoc-gen-go;
-          buf = bufPkgs.legacyPackages.${system}.buf;
-
-          patchelf = patchelfPkgs.legacyPackages.${system}.patchelf;
-          go = goPkgs.legacyPackages.${system}.go_1_20;
-
-          inherit (gitignore.lib) gitignoreSource;
-
           pkgs = nixpkgs.legacyPackages.${system};
-
-          protoc-gen-gogo = pkgs.stdenv.mkDerivation {
-            name = "protoc-gen-gogo";
-            src = pkgs.fetchFromGitHub {
-              owner = "gogo";
-              repo = "protobuf";
-              rev = gogoVersion;
-              sha256 = "sha256-CoUqgLFnLNCS9OxKFS7XwjE17SlH6iL1Kgv+0uEK2zU=";
-            };
-            buildInputs = [
-              pkgs.cacert
-              go
-            ];
-            buildPhase = ''
-              export GOBIN="$out/bin"
-              export GOCACHE="$(mktemp -d)"
-              make install
-              cp -R protobuf "$out/protobuf"
-            '';
-          };
-
-          grpc-tools = pkgs.stdenv.mkDerivation {
-            name = "grpc-tools";
-            dontUnpack = true;
-            buildInputs = [
-              node
-            ];
-            buildPhase = ''
-              export HOME="$(mktemp -d)"
-              export TEMPDIR="$(mktemp -d)"
-              npm install --prefix "$TEMPDIR" grpc_tools_node_protoc_ts@${nodeProtocTsVersion} grpc-tools@${grpcToolsVersion}
-              mv "$TEMPDIR" "$out"
-              mkdir "$out/bin"
-              cd "$out/bin"
-              ln -s ../node_modules/.bin/* "$out/bin/"
-            '';
-          };
-
-          rust = pkgs.stdenv.mkDerivation {
-            name = "rust";
-            dontUnpack = true;
-            buildInputs = [
-              pkgs.cacert
-              pkgs.curl
-            ];
-            buildPhase = ''
-              export RUSTUP_HOME="$out"
-              export CARGO_HOME="$out"
-              curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain "${rustVersion}"
-            '';
-          };
-
-          helm-unittest = pkgs.buildGoModule rec {
-            name = "helm-unittest";
-          
-            src = pkgs.fetchFromGitHub {
-              owner = "vbehar";
-              repo = "helm3-unittest";
-              rev = helmUnittestVersion;
-              sha256 = "sha256-2UfQimIlA+hb1CpQrWfMh5iBEvgdnrkCGYaTJC3Bzpo=";
-            };
-
-            vendorSha256 = null;
-          
-            postInstall = ''
-              install -Dm644 plugin.yaml $out/helm-unittest/plugin.yaml
-              mkdir "$out/helm-unittest/bin"
-              mv $out/bin/helm3-unittest $out/helm-unittest/bin/unittest
-            '';
-          
-            doCheck = false;
-          };
-
-          baseInputs = [
-              # Wrap helm with the unittest plugin
-              helm
-              golangci-lint
-              shellcheck
-              yamllint
-              gci
-              addlicense
-
-              gcc
-              libiconv
-              libfido2
-              rust
-
-              python
-              node
-              yarn
-
-              protobuf
-              protoc-gen-go
-              protoc-gen-gogo
-              grpc-tools
-              buf
-
-              go
-          ];
-          conditionalInputs = if pkgs.stdenv.isLinux then
-          [
-            libbpf
-          ] else [];
+          teleportShellDeps = nix-shell.teleportShellDeps.${system};
         in {
           devShells.default = pkgs.mkShell {
-            buildInputs = baseInputs ++ conditionalInputs;
+            buildInputs = teleportShellDeps;
             shellHook = ''
               export GOMODCACHE="/tmp/nix-shell/gomodcache-$(id -u)"
               export GOCACHE="/tmp/nix-shell/gocache-$(id -u)"


### PR DESCRIPTION
A nix shell has been added for development that packages in the various dependencies necessary for building Teleport. Additionally, direnv support has been added which will work well with nix-direnv.

To test this:

1. Install nix:
```
$ sh <(curl -L https://nixos.org/nix/install)
```
2. Enable nix flakes:
```
$ mkdir -p ~/.config/nix
$ echo "extra-experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
```
3. Try out the shell from the root of the source repo.
```
$ nix develop -i
```