### PR TITLE
Cleanup kubeconfig by kube cluster addr on tsh logout

### DIFF
--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -19,7 +19,6 @@ package clusters
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 
 	"github.com/gravitational/trace"
@@ -65,15 +64,8 @@ func (c *Cluster) Logout(ctx context.Context) error {
 		}
 	}
 
-	// Get the address of the active Kubernetes proxy to find AuthInfos,
-	// Clusters, and Contexts in kubeconfig.
-	clusterName, _ := c.clusterClient.KubeProxyHostPort()
-	if c.clusterClient.SiteName != "" {
-		clusterName = fmt.Sprintf("%v.%v", c.clusterClient.SiteName, clusterName)
-	}
-
 	// Remove cluster entries from kubeconfig
-	if err := kubeconfig.Remove("", clusterName); err != nil {
+	if err := kubeconfig.RemoveByServerAddr("", c.clusterClient.KubeClusterAddr()); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1893,16 +1893,9 @@ func onLogout(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 
-		// Get the address of the active Kubernetes proxy to find AuthInfos,
-		// Clusters, and Contexts in kubeconfig.
-		clusterName, _ := tc.KubeProxyHostPort()
-		if tc.SiteName != "" {
-			clusterName = fmt.Sprintf("%v.%v", tc.SiteName, clusterName)
-		}
-
 		// Remove Teleport related entries from kubeconfig.
-		log.Debugf("Removing Teleport related entries for '%v' from kubeconfig.", clusterName)
-		err = kubeconfig.Remove("", clusterName)
+		log.Debugf("Removing Teleport related entries with server '%v' from kubeconfig.", tc.KubeClusterAddr())
+		err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr())
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1915,10 +1908,15 @@ func onLogout(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 
+		log.Debugf("Removing Teleport related entries with server '%v' from kubeconfig.", tc.KubeClusterAddr())
+		if err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr()); err != nil {
+			return trace.Wrap(err)
+		}
+
 		// Remove Teleport related entries from kubeconfig for all clusters.
 		for _, profile := range profiles {
-			log.Debugf("Removing Teleport related entries for '%v' from kubeconfig.", profile.Cluster)
-			err = kubeconfig.Remove("", profile.Cluster)
+			log.Debugf("Removing Teleport related entries for cluster '%v' from kubeconfig.", profile.Cluster)
+			err = kubeconfig.RemoveByClusterName("", profile.Cluster)
 			if err != nil {
 				return trace.Wrap(err)
 			}


### PR DESCRIPTION
Change `tsh` to logout Teleport clusters from kubeconfig by matching all clusters with server addresses that use `tc.KubeClusterAddr()`.

This ensures remote clusters logged in by `tsh kube login --cluster <remote-cluster> <cluster-name>` also gets cleaned up on logout.