### PR TITLE
Docs: remove extraneous H1s

### DIFF
--- a/docs/pages/access-controls/faq.mdx
+++ b/docs/pages/access-controls/faq.mdx
@@ -3,8 +3,6 @@ title: Access Controls FAQ
 description: Frequently asked questions about Teleport RBAC
 ---
 
-# Access Controls FAQ
-
 ## What if a node has multiple labels?
 
 In this case, the access will be granted only if **all of the labels** defined in the

--- a/docs/pages/api/getting-started.mdx
+++ b/docs/pages/api/getting-started.mdx
@@ -3,7 +3,7 @@ title: API Getting Started Guide
 description: Get started working with the Teleport API programmatically using Go.
 ---
 
-# Getting Started
+## Getting Started
 
 In this getting started guide we will use the Teleport API Go client to connect
 to a Teleport Auth Service.

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -4,7 +4,7 @@ description: Getting started with Teleport Application Access.
 videoBanner: 5Uwhp3IQMHY
 ---
 
-# Getting Started
+## Getting Started
 
 Let's connect to Grafana using Teleport Application Access in three steps:
 

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -3,8 +3,6 @@ title: Access REST APIs With Teleport Application Access
 description: How to access REST APIs with Teleport Application Access.
 ---
 
-# Application API Access
-
 Teleport Application Access can be used to access applications' (REST or Teleport's own gRPC) APIs with
 tools like [curl](https://man7.org/linux/man-pages/man1/curl.1.html) or Postman.
 

--- a/docs/pages/application-access/jwt/introduction.mdx
+++ b/docs/pages/application-access/jwt/introduction.mdx
@@ -3,8 +3,6 @@ title: Use JWT Tokens With Application Access
 description: How to use JWT tokens for authentication with Teleport Application Access.
 ---
 
-# Integrating with JWTs
-
 Teleport sends a JWT token signed with Teleport's authority with each request
 to a target application in a `Teleport-Jwt-Assertion` header.
 

--- a/docs/pages/database-access/reference.mdx
+++ b/docs/pages/database-access/reference.mdx
@@ -3,8 +3,6 @@ title: Database Access Reference
 description: Configuration and CLI reference for Teleport Database Access.
 ---
 
-# Database Access Reference
-
 - [Configuration](./reference/configuration.mdx)
 - [CLI](./reference/cli.mdx)
 - [Audit Events](./reference/audit.mdx)

--- a/docs/pages/database-access/reference/audit.mdx
+++ b/docs/pages/database-access/reference/audit.mdx
@@ -3,8 +3,6 @@ title: Database Access Audit Events Reference
 description: Audit events reference for Teleport Database Access.
 ---
 
-# Database Access Audit Events Reference
-
 ## db.session.start (TDB00I/W)
 
 Emitted when a client successfully connects to a database, or when a connection

--- a/docs/pages/machine-id/introduction.mdx
+++ b/docs/pages/machine-id/introduction.mdx
@@ -3,8 +3,6 @@ title: Machine ID
 description: Teleport Machine ID introduction, demo and resources.
 ---
 
-# Machine ID
-
 Machine ID is a service that programmatically issues and renews short-lived
 certificates to any service account (e.g., a CI/CD server) by retrieving
 credentials from the Teleport Auth Service. This enables fine-grained

--- a/docs/pages/server-access/introduction.mdx
+++ b/docs/pages/server-access/introduction.mdx
@@ -4,8 +4,6 @@ description: Teleport Server Access features and introduction.
 videoBanner: EsEvO5ndNDI
 ---
 
-# Server Access
-
 Teleport Server Access consolidates SSH access across all environments, decreases configuration complexity, supports industry best practices and compliance while giving complete visibility over all sessions and events.
 
 Teleport Server Access is designed for the following kinds of scenarios:


### PR DESCRIPTION
Removes extra H1s from docs pages, since the title in metadata already creates an H1 title.