### PR TITLE
Fix docs mentioning connectors updates without secrets

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -231,8 +231,8 @@ following commands for the different protocols we support.
 
 ```code
 $ tctl get nodes --format=text
-$ tctl get kube_service --format=text
-$ tctl get apps --format=text
+$ tctl get kube_server --format=text
+$ tctl get app_server --format=text
 $ tctl get db_server --format=text
 $ tctl get windows_desktop_service --format=text
 ```

--- a/docs/pages/includes/add-role-to-user.mdx
+++ b/docs/pages/includes/add-role-to-user.mdx
@@ -1,7 +1,7 @@
 {{ role="myrole" }}
 Assign the `{{ role }}` role to your Teleport user by running the following
 commands, depending on whether you authenticate as a local Teleport user or via
-the `github`, `saml`, or `oidc` authentication connectors: 
+the `github`, `saml`, or `oidc` authentication connectors:
 
 <Tabs>
 <TabItem label="Local User">
@@ -34,7 +34,7 @@ $ tctl create -f out.yaml
 Retrieve your `github`  configuration resource:
 
 ```code
-$ tctl get github/github > github.yaml
+$ tctl get github/github --with-secrets > github.yaml
 ```
 
 Edit `github.yaml`, adding `{{ role }}` to the
@@ -46,8 +46,8 @@ Here is an example:
 
 ```diff
   teams_to_roles:
-    - organization: octocats 
-      team: admins 
+    - organization: octocats
+      team: admins
       roles:
         - access
 +       - {{ role }}
@@ -65,7 +65,7 @@ $ tctl create -f github.yaml
 Retrieve your `saml`  configuration resource:
 
 ```code
-$ tctl get saml/mysaml > saml.yaml
+$ tctl get saml/mysaml --with-secrets > saml.yaml
 ```
 
 Edit `saml.yaml`, adding `{{ role }}` to the
@@ -78,8 +78,8 @@ Here is an example:
 
 ```diff
   attributes_to_roles:
-    - name: "groups" 
-      value: "my-group" 
+    - name: "groups"
+      value: "my-group"
       roles:
         - access
 +       - {{ role }}
@@ -97,7 +97,7 @@ $ tctl create -f saml.yaml
 Retrieve your `oidc`  configuration resource:
 
 ```code
-$ tctl get oidc/myoidc > oidc.yaml
+$ tctl get oidc/myoidc --with-secrets > oidc.yaml
 ```
 
 Edit `oidc.yaml`, adding `{{ role }}` to the
@@ -110,8 +110,8 @@ Here is an example:
 
 ```diff
   claims_to_roles:
-    - name: "groups" 
-      value: "my-group" 
+    - name: "groups"
+      value: "my-group"
       roles:
         - access
 +       - {{ role }}

--- a/docs/pages/management/export-audit-events/splunk.mdx
+++ b/docs/pages/management/export-audit-events/splunk.mdx
@@ -12,7 +12,7 @@ In this guide, we will show you how to configure the Teleport Event Handler
 plugin to send your Teleport audit logs to Splunk. In this setup, the Teleport
 Event Handler plugin forwards audit logs from Teleport to Splunk's Universal
 Forwarder, which stores them in Splunk Cloud Platform or Splunk Enterprise for
-visualization and alerting. 
+visualization and alerting.
 
 ## Prerequisites
 
@@ -101,7 +101,7 @@ $ tctl create -f teleport-event-handler-role.yaml
 
 In order for the Teleport Event Handler plugin to forward events from your
 Teleport cluster, it needs signed credentials from the cluster's certificate
-authority. 
+authority.
 
 The `teleport-event-handler` user cannot request this itself, and requires
 another user to **impersonate** this account in order to request credentials. We
@@ -139,7 +139,7 @@ $ tctl create -f teleport-event-handler-impersonator.yaml
 
 Assign this role to your Teleport user by running the following commands,
 depending on whether you authenticate as a local Teleport user or via the
-`github`, `saml`, or `oidc` authentication connectors: 
+`github`, `saml`, or `oidc` authentication connectors:
 
 <Tabs>
 <TabItem label="Local User">
@@ -169,7 +169,7 @@ $ tctl create -f myuser.yaml
 Retrieve your `github`  configuration resource:
 
 ```code
-$ tctl get github/github > github.yaml
+$ tctl get github/github --with-secrets > github.yaml
 ```
 
 Edit `github.yaml`, adding `teleport-event-handler-impersonator` to the
@@ -181,8 +181,8 @@ Here is an example:
 
 ```diff
   teams_to_roles:
-    - organization: octocats 
-      team: admins 
+    - organization: octocats
+      team: admins
       roles:
         - access
 +       - teleport-event-handler-impersonator
@@ -199,7 +199,7 @@ $ tctl create -f github.yaml
 Retrieve your `saml`  configuration resource:
 
 ```code
-$ tctl get saml/mysaml > saml.yaml
+$ tctl get saml/mysaml --with-secrets > saml.yaml
 ```
 
 Edit `saml.yaml`, adding `teleport-event-handler-impersonator` to the
@@ -212,8 +212,8 @@ Here is an example:
 
 ```diff
   attributes_to_roles:
-    - name: "groups" 
-      value: "my-group" 
+    - name: "groups"
+      value: "my-group"
       roles:
         - access
 +       - teleport-event-handler-impersonator
@@ -230,7 +230,7 @@ $ tctl create -f saml.yaml
 Retrieve your `oidc`  configuration resource:
 
 ```code
-$ tctl get oidc/myoidc > oidc.yaml
+$ tctl get oidc/myoidc --with-secrets > oidc.yaml
 ```
 
 Edit `oidc.yaml`, adding `teleport-event-handler-impersonator` to the
@@ -243,8 +243,8 @@ Here is an example:
 
 ```diff
   claims_to_roles:
-    - name: "groups" 
-      value: "my-group" 
+    - name: "groups"
+      value: "my-group"
       roles:
         - access
 +       - teleport-event-handler-impersonator
@@ -264,7 +264,7 @@ Log out of your Teleport cluster and log in again to assume the new role.
 
 Like all Teleport users, `teleport-event-handler` needs signed credentials in
 order to connect to your Teleport cluster. You will use the `tctl auth sign`
-command to request these credentials for the plugin. 
+command to request these credentials for the plugin.
 
 <ScopedBlock scope={["enterprise", "oss"]}>
 
@@ -362,7 +362,7 @@ Handler sends audit logs as HTTP POST requests with the content type
 `application/json`.
 
 We will assume that you assigned `$SPLUNK_HOME` to `/opt/splunkforwarder` when
-installing the Universal Forwarder. 
+installing the Universal Forwarder.
 
 <Details title="Finding your $SPLUNK_HOME">
 
@@ -398,7 +398,7 @@ ExecStart=/opt/splunkforwarder/bin/splunk _internal_launch_under_systemd
 Create an index for your Teleport audit logs by visiting the home page of the
 Splunk UI and navigating to **Settings** > **Indexes**. Click **New Index**.
 Name your index `teleport-audit-logs` and assign the **Index Data Type** field
-to "Events". 
+to "Events".
 
 ![Creating an Index](../../../../docs/img/enterprise/plugins/splunk/new-index.png)
 
@@ -413,7 +413,7 @@ Click **Save**
 The Universal Forwarder authenticates client traffic using a token. To generate
 a token, visit the home page of the Splunk UI. Navigate to **Settings** > **Data
 inputs** In the **Local inputs** table, find the **HTTP Event Collector** row and
-click **Add new** 
+click **Add new**
 
 Enter a name you can use to recognize the token later so you can
 manage it, e.g., `Teleport Audit Events`. Click **Next**.
@@ -461,18 +461,18 @@ On your Universal Forwarder host, create a file at
 port = 9061
 disabled = false
 serverCert = server.pem
-sslPassword = 
+sslPassword =
 requireClientCert = true
 
 [http://audit]
-token = 
+token =
 index = teleport-audit-logs
 allowQueryStringAuth = true
 ```
 
 This configuration enables the HTTP input, which will listen on port `9061` and
 receive logs from the Teleport Event Handler Plugin, assigning them to the
-`teleport-audit-logs` index. 
+`teleport-audit-logs` index.
 
 Assign `serverCert` to the path to the `server.pem` file you generated earlier.
 
@@ -597,7 +597,7 @@ url = "https://localhost:9061/services/collector/raw?token=MYTOKEN"
 
 Ensure the URL includes the scheme, host and port of your Universal Forwarder's
 HTTP input, plus the URL path that the Universal Forwarder uses for raw data
-(`/services/collector/raw`). 
+(`/services/collector/raw`).
 
 Replace `MYTOKEN` with the token you generated earlier for the Splunk Universal
 Forwarder. If you are running the Universal Forwarder and Event Handler on
@@ -654,7 +654,7 @@ $ chmod +r auth.cas auth.crt auth.key
 Start the Teleport Teleport Event Handler as a daemon. To do so, create a
 systemd service definition at the path
 `/usr/lib/systemd/system/teleport-event-handler.service` with the following
-content: 
+content:
 
 ```ini
 [Unit]


### PR DESCRIPTION
When updating Github/SAML/OIDC connectors we must update them with their original secrets. The exporter command in the plugins guide didn't export the connectors with their original secrets and the upsert replaced them.

If users follow the guide, it results in no one being able to login to Teleport using those connectors because of the missing secrets.

This PR corrects the instructions used to extract the connectors and their secrets.

It also fixes a documentation reference to incorrect resources.