### PR TITLE
Expose process ID for enterprise services.

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -527,6 +527,11 @@ func (process *TeleportProcess) WaitForConnector(identityEvent string, log logru
 	return conn, nil
 }
 
+// GetID returns the process ID.
+func (process *TeleportProcess) GetID() string {
+	return process.id
+}
+
 func (process *TeleportProcess) setClusterFeatures(features *proto.Features) {
 	process.Lock()
 	defer process.Unlock()


### PR DESCRIPTION
The process ID has been exposed for enterprise services, particularly during init processes.