### PR TITLE
Add user group read/write access to the Okta role.

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -807,6 +807,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindEvent, services.RW()),
 						types.NewRule(types.KindAccessRequest, services.RO()),
 						types.NewRule(types.KindUser, services.RO()),
+						types.NewRule(types.KindUserGroup, services.RW()),
 						types.NewRule(types.KindOktaImportRule, services.RO()),
 						types.NewRule(types.KindOktaAssignment, services.RW()),
 					},


### PR DESCRIPTION
The Okta role is able to read and write user groups, which is necessary for permissions access and syncing by the Okta service.