### PR TITLE
ALPN handshake test improvements

### DIFF
--- a/api/defaults/defaults.go
+++ b/api/defaults/defaults.go
@@ -145,4 +145,13 @@ const (
 const (
 	// TunnelPublicAddrEnvar optionally specifies the alternative reverse tunnel address.
 	TunnelPublicAddrEnvar = "TELEPORT_TUNNEL_PUBLIC_ADDR"
+
+	// TLSRoutingConnUpgradeEnvVar overwrites the test result for deciding if
+	// ALPN connection upgrade is required.
+	//
+	// Sample values:
+	// true
+	// <some.cluster.com>=yes,<another.cluster.com>=no
+	// 0,<some.cluster.com>=1
+	TLSRoutingConnUpgradeEnvVar = "TELEPORT_TLS_ROUTING_CONN_UPGRADE"
 )

--- a/api/defaults/defaults.go
+++ b/api/defaults/defaults.go
@@ -153,5 +153,7 @@ const (
 	// true
 	// <some.cluster.com>=yes,<another.cluster.com>=no
 	// 0,<some.cluster.com>=1
+	//
+	// TODO(greedy52) DELETE IN 15.0
 	TLSRoutingConnUpgradeEnvVar = "TELEPORT_TLS_ROUTING_CONN_UPGRADE"
 )

--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -85,6 +85,13 @@ type Profile struct {
 	// all proxy services are exposed on a single TLS listener (Proxy Web Listener).
 	TLSRoutingEnabled bool `yaml:"tls_routing_enabled,omitempty"`
 
+	// TLSRoutingConnUpgradeRequired indicates that ALPN connection upgrades
+	// are required for making TLS routing requests.
+	//
+	// Note that this is applicable to the Proxy's Web port regardless of
+	// whether the Proxy is in single-port or multi-port configuration.
+	TLSRoutingConnUpgradeRequired bool `yaml:"tls_routing_conn_upgrade_required,omitempty"`
+
 	// AuthConnector (like "google", "passwordless").
 	// Equivalent to the --auth tsh flag.
 	AuthConnector string `yaml:"auth_connector,omitempty"`

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -852,6 +852,9 @@ func (c *Config) DatabaseProxyHostPort(db tlsca.RouteToDatabase) (string, int) {
 }
 
 // DoesDatabaseUseWebProxyHostPort returns true if database is using web port.
+//
+// This is useful for deciding whether local proxy is required when web port is
+// behind a load balancer.
 func (c *Config) DoesDatabaseUseWebProxyHostPort(db tlsca.RouteToDatabase) bool {
 	dbHost, dbPort := c.DatabaseProxyHostPort(db)
 	webHost, webPort := c.WebProxyHostPort()

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -621,7 +621,7 @@ func (c *Config) LoadProfile(ps ProfileStore, proxyAddr string) error {
 		log.Warnf("Unable to parse dynamic port forwarding in user profile: %v.", err)
 	}
 
-	if required, ok := alpnproxy.OverwriteALPNConnUpgradeRequiredByEnv(c.WebProxyAddr); ok {
+	if required, ok := alpnproxy.OverwriteALPNConnUpgradeRequirementByEnv(c.WebProxyAddr); ok {
 		c.TLSRoutingConnUpgradeRequired = required
 	}
 	log.Infof("ALPN connection upgrade required for %q: %v.", c.WebProxyAddr, c.TLSRoutingConnUpgradeRequired)
@@ -851,8 +851,8 @@ func (c *Config) DatabaseProxyHostPort(db tlsca.RouteToDatabase) (string, int) {
 	return c.WebProxyHostPort()
 }
 
-// DoesDatabseUserWebProxyHostPort returns true if database is using web port.
-func (c *Config) DoesDatabseUserWebProxyHostPort(db tlsca.RouteToDatabase) bool {
+// DoesDatabseUseWebProxyHostPort returns true if database is using web port.
+func (c *Config) DoesDatabseUseWebProxyHostPort(db tlsca.RouteToDatabase) bool {
 	dbHost, dbPort := c.DatabaseProxyHostPort(db)
 	webHost, webPort := c.WebProxyHostPort()
 	return dbHost == webHost && dbPort == webPort

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -851,8 +851,8 @@ func (c *Config) DatabaseProxyHostPort(db tlsca.RouteToDatabase) (string, int) {
 	return c.WebProxyHostPort()
 }
 
-// DoesDatabseUseWebProxyHostPort returns true if database is using web port.
-func (c *Config) DoesDatabseUseWebProxyHostPort(db tlsca.RouteToDatabase) bool {
+// DoesDatabaseUseWebProxyHostPort returns true if database is using web port.
+func (c *Config) DoesDatabaseUseWebProxyHostPort(db tlsca.RouteToDatabase) bool {
 	dbHost, dbPort := c.DatabaseProxyHostPort(db)
 	webHost, webPort := c.WebProxyHostPort()
 	return dbHost == webHost && dbPort == webPort

--- a/lib/srv/alpnproxy/conn_upgrade.go
+++ b/lib/srv/alpnproxy/conn_upgrade.go
@@ -49,7 +49,7 @@ import (
 // Proxy Service to establish a tunnel for the originally planned traffic to
 // preserve the ALPN and SNI information.
 func IsALPNConnUpgradeRequired(addr string, insecure bool) bool {
-	if result, ok := OverwriteALPNConnUpgradeRequiredByEnv(addr); ok {
+	if result, ok := OverwriteALPNConnUpgradeRequirementByEnv(addr); ok {
 		return result
 	}
 
@@ -93,9 +93,9 @@ func isRemoteNoALPNError(err error) bool {
 	return netOpError.Op == "remote error" && strings.Contains(netOpError.Err.Error(), "tls: no application protocol")
 }
 
-// OverwriteALPNConnUpgradeRequiredByEnv overwrites ALPN connection upgrade
+// OverwriteALPNConnUpgradeRequirementByEnv overwrites ALPN connection upgrade
 // requirement by environment variable.
-func OverwriteALPNConnUpgradeRequiredByEnv(addr string) (bool, bool) {
+func OverwriteALPNConnUpgradeRequirementByEnv(addr string) (bool, bool) {
 	envValue := os.Getenv(defaults.TLSRoutingConnUpgradeEnvVar)
 	if envValue == "" {
 		return false, false

--- a/lib/srv/alpnproxy/conn_upgrade.go
+++ b/lib/srv/alpnproxy/conn_upgrade.go
@@ -83,14 +83,8 @@ func IsALPNConnUpgradeRequired(addr string, insecure bool) bool {
 }
 
 func isRemoteNoALPNError(err error) bool {
-	if err = errors.Unwrap(err); err == nil {
-		return false
-	}
-	netOpError, ok := err.(*net.OpError)
-	if !ok {
-		return false
-	}
-	return netOpError.Op == "remote error" && strings.Contains(netOpError.Err.Error(), "tls: no application protocol")
+	var opErr *net.OpError
+	return errors.As(err, &opErr) && opErr.Op == "remote error" && strings.Contains(opErr.Err.Error(), "tls: no application protocol")
 }
 
 // OverwriteALPNConnUpgradeRequirementByEnv overwrites ALPN connection upgrade

--- a/lib/srv/alpnproxy/conn_upgrade.go
+++ b/lib/srv/alpnproxy/conn_upgrade.go
@@ -89,6 +89,8 @@ func isRemoteNoALPNError(err error) bool {
 
 // OverwriteALPNConnUpgradeRequirementByEnv overwrites ALPN connection upgrade
 // requirement by environment variable.
+//
+// TODO(greedy52) DELETE in 15.0
 func OverwriteALPNConnUpgradeRequirementByEnv(addr string) (bool, bool) {
 	envValue := os.Getenv(defaults.TLSRoutingConnUpgradeEnvVar)
 	if envValue == "" {
@@ -99,6 +101,19 @@ func OverwriteALPNConnUpgradeRequirementByEnv(addr string) (bool, bool) {
 	return result, true
 }
 
+// isALPNConnUpgradeRequiredByEnv checks if ALPN connection upgrade is required
+// based on provided env value.
+//
+// The env value should contain a list of conditions separated by either ';' or
+// ','. A condition is in format of either '<addr>=<bool>' or '<bool>'. The
+// former specifies the upgrade requirement for a specific address and the
+// later specifies the upgrade requirement for all other addresses. By default,
+// upgrade is not required if target is not specified in the env value.
+//
+// Sample values:
+// true
+// <some.cluster.com>=yes,<another.cluster.com>=no
+// 0,<some.cluster.com>=1
 func isALPNConnUpgradeRequiredByEnv(addr, envValue string) bool {
 	tokens := strings.FieldsFunc(envValue, func(r rune) bool {
 		return r == ';' || r == ','

--- a/lib/srv/alpnproxy/local_proxy_config_opt.go
+++ b/lib/srv/alpnproxy/local_proxy_config_opt.go
@@ -56,10 +56,7 @@ func WithClusterCAsIfConnUpgrade(ctx context.Context, getClusterCertPool GetClus
 
 		// If ALPN connection upgrade is required, explicitly use the cluster
 		// CAs since the tunneled TLS routing connection serves the Host cert.
-		if config.RootCAs == nil && getClusterCertPool != nil {
-			return trace.Wrap(WithClusterCAs(ctx, getClusterCertPool)(config))
-		}
-		return nil
+		return trace.Wrap(WithClusterCAs(ctx, getClusterCertPool)(config))
 	}
 }
 

--- a/tool/tsh/app.go
+++ b/tool/tsh/app.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -194,7 +193,7 @@ func onAppLogin(cf *CLIConf) error {
 }
 
 func localProxyRequiredForApp(tc *client.TeleportClient) bool {
-	return alpnproxy.IsALPNConnUpgradeRequired(tc.WebProxyAddr, tc.InsecureSkipVerify)
+	return tc.TLSRoutingConnUpgradeRequired
 }
 
 // appLoginTpl is the message that gets printed to a user upon successful login

--- a/tool/tsh/app_aws.go
+++ b/tool/tsh/app_aws.go
@@ -277,7 +277,7 @@ func (a *awsApp) startLocalALPNProxy(port string) error {
 	a.localALPNProxy, err = alpnproxy.NewLocalProxy(
 		makeBasicLocalProxyConfig(a.cf, tc, listener),
 		alpnproxy.WithClientCerts(appCerts),
-		alpnproxy.WithALPNConnUpgradeTest(a.cf.Context, tc.RootClusterCACertPool),
+		alpnproxy.WithClusterCAsIfConnUpgrade(a.cf.Context, tc.RootClusterCACertPool),
 		alpnproxy.WithHTTPMiddleware(&alpnproxy.AWSAccessMiddleware{
 			AWSCredentials: cred,
 		}),

--- a/tool/tsh/app_azure.go
+++ b/tool/tsh/app_azure.go
@@ -241,7 +241,7 @@ func (a *azureApp) startLocalALPNProxy(port string) error {
 	a.localALPNProxy, err = alpnproxy.NewLocalProxy(
 		makeBasicLocalProxyConfig(a.cf, tc, listener),
 		alpnproxy.WithClientCerts(appCerts),
-		alpnproxy.WithALPNConnUpgradeTest(a.cf.Context, tc.RootClusterCACertPool),
+		alpnproxy.WithClusterCAsIfConnUpgrade(a.cf.Context, tc.RootClusterCACertPool),
 		alpnproxy.WithHTTPMiddleware(&alpnproxy.AzureMSIMiddleware{
 			Key:    wsPK,
 			Secret: a.msiSecret,

--- a/tool/tsh/app_gcp.go
+++ b/tool/tsh/app_gcp.go
@@ -325,7 +325,7 @@ func (a *gcpApp) startLocalALPNProxy(port string) error {
 	a.localALPNProxy, err = alpnproxy.NewLocalProxy(
 		makeBasicLocalProxyConfig(a.cf, tc, listener),
 		alpnproxy.WithClientCerts(appCerts),
-		alpnproxy.WithALPNConnUpgradeTest(a.cf.Context, tc.RootClusterCACertPool),
+		alpnproxy.WithClusterCAsIfConnUpgrade(a.cf.Context, tc.RootClusterCACertPool),
 		alpnproxy.WithHTTPMiddleware(&alpnproxy.AuthorizationCheckerMiddleware{
 			Secret: a.secret,
 		}),

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -661,7 +661,7 @@ func prepareLocalProxyOptions(arg *localProxyConfig) ([]alpnproxy.LocalProxyConf
 
 	opts := []alpnproxy.LocalProxyConfigOpt{
 		alpnproxy.WithDatabaseProtocol(arg.route.Protocol),
-		alpnproxy.WithALPNConnUpgradeTest(arg.cf.Context, arg.tc.RootClusterCACertPool),
+		alpnproxy.WithClusterCAsIfConnUpgrade(arg.cf.Context, arg.tc.RootClusterCACertPool),
 	}
 
 	if !arg.tunnel && arg.route.Protocol == defaults.ProtocolPostgres {
@@ -1108,6 +1108,10 @@ func getDBLocalProxyRequirement(tc *client.TeleportClient, route *tlsca.RouteToD
 	switch tc.PrivateKeyPolicy {
 	case keys.PrivateKeyPolicyHardwareKey, keys.PrivateKeyPolicyHardwareKeyTouch:
 		out.addLocalProxyWithTunnel(formatKeyPolicyReason(tc.PrivateKeyPolicy))
+	}
+
+	if tc.TLSRoutingConnUpgradeRequired && tc.DoesDatabseUserWebProxyHostPort(*route) {
+		out.addLocalProxy("Teleport Proxy is behind a load balancer.")
 	}
 
 	switch route.Protocol {

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -1110,7 +1110,7 @@ func getDBLocalProxyRequirement(tc *client.TeleportClient, route *tlsca.RouteToD
 		out.addLocalProxyWithTunnel(formatKeyPolicyReason(tc.PrivateKeyPolicy))
 	}
 
-	if tc.TLSRoutingConnUpgradeRequired && tc.DoesDatabseUseWebProxyHostPort(*route) {
+	if tc.TLSRoutingConnUpgradeRequired && tc.DoesDatabaseUseWebProxyHostPort(*route) {
 		out.addLocalProxy("Teleport Proxy is behind a load balancer")
 	}
 

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -1112,7 +1112,7 @@ func getDBLocalProxyRequirement(tc *client.TeleportClient, route *tlsca.RouteToD
 
 	// When Proxy is behind a load balancer and the database requires the web
 	// port, a local proxy must be used so the TLS routing request can be
-	// upgradded, regardless whether Proxy is in single or separate port mode.
+	// upgraded, regardless whether Proxy is in single or separate port mode.
 	if tc.TLSRoutingConnUpgradeRequired && tc.DoesDatabaseUseWebProxyHostPort(*route) {
 		out.addLocalProxy("Teleport Proxy is behind a load balancer")
 	}

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -1110,7 +1110,7 @@ func getDBLocalProxyRequirement(tc *client.TeleportClient, route *tlsca.RouteToD
 		out.addLocalProxyWithTunnel(formatKeyPolicyReason(tc.PrivateKeyPolicy))
 	}
 
-	if tc.TLSRoutingConnUpgradeRequired && tc.DoesDatabseUserWebProxyHostPort(*route) {
+	if tc.TLSRoutingConnUpgradeRequired && tc.DoesDatabseUseWebProxyHostPort(*route) {
 		out.addLocalProxy("Teleport Proxy is behind a load balancer.")
 	}
 

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -1111,7 +1111,7 @@ func getDBLocalProxyRequirement(tc *client.TeleportClient, route *tlsca.RouteToD
 	}
 
 	if tc.TLSRoutingConnUpgradeRequired && tc.DoesDatabseUseWebProxyHostPort(*route) {
-		out.addLocalProxy("Teleport Proxy is behind a load balancer.")
+		out.addLocalProxy("Teleport Proxy is behind a load balancer")
 	}
 
 	switch route.Protocol {

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -1110,6 +1110,9 @@ func getDBLocalProxyRequirement(tc *client.TeleportClient, route *tlsca.RouteToD
 		out.addLocalProxyWithTunnel(formatKeyPolicyReason(tc.PrivateKeyPolicy))
 	}
 
+	// When Proxy is behind a load balancer and the database requires the web
+	// port, a local proxy must be used so the TLS routing request can be
+	// upgradded, regardless whether Proxy is in single or separate port mode.
 	if tc.TLSRoutingConnUpgradeRequired && tc.DoesDatabaseUseWebProxyHostPort(*route) {
 		out.addLocalProxy("Teleport Proxy is behind a load balancer")
 	}

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -255,7 +255,7 @@ func TestLocalProxyRequirement(t *testing.T) {
 	tests := map[string]struct {
 		clusterAuthPref types.AuthPreference
 		route           *tlsca.RouteToDatabase
-		fakeSetup       func(*client.TeleportClient)
+		setupTC         func(*client.TeleportClient)
 		wantLocalProxy  bool
 		wantTunnel      bool
 	}{
@@ -280,7 +280,7 @@ func TestLocalProxyRequirement(t *testing.T) {
 		},
 		"local proxy not required for separate port": {
 			clusterAuthPref: defaultAuthPref,
-			fakeSetup: func(tc *client.TeleportClient) {
+			setupTC: func(tc *client.TeleportClient) {
 				tc.TLSRoutingEnabled = false
 				tc.TLSRoutingConnUpgradeRequired = true
 				tc.PostgresProxyAddr = "separate.postgres.hostport:8888"
@@ -290,7 +290,7 @@ func TestLocalProxyRequirement(t *testing.T) {
 		},
 		"local proxy required if behind lb": {
 			clusterAuthPref: defaultAuthPref,
-			fakeSetup: func(tc *client.TeleportClient) {
+			setupTC: func(tc *client.TeleportClient) {
 				tc.TLSRoutingEnabled = true
 				tc.TLSRoutingConnUpgradeRequired = true
 			},
@@ -311,8 +311,8 @@ func TestLocalProxyRequirement(t *testing.T) {
 			}
 			tc, err := makeClient(cf, false)
 			require.NoError(t, err)
-			if tt.fakeSetup != nil {
-				tt.fakeSetup(tc)
+			if tt.setupTC != nil {
+				tt.setupTC(tc)
 			}
 			route := &tlsca.RouteToDatabase{
 				ServiceName: "foo-db",

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -574,7 +574,7 @@ func onProxyCommandApp(cf *CLIConf) error {
 		makeBasicLocalProxyConfig(cf, tc, listener),
 		alpnproxy.WithALPNProtocol(alpnProtocolForApp(app)),
 		alpnproxy.WithClientCerts(appCerts),
-		alpnproxy.WithALPNConnUpgradeTest(cf.Context, tc.RootClusterCACertPool),
+		alpnproxy.WithClusterCAsIfConnUpgrade(cf.Context, tc.RootClusterCACertPool),
 	)
 	if err != nil {
 		if cerr := listener.Close(); cerr != nil {
@@ -813,10 +813,11 @@ func isLocalProxyTunnelRequested(cf *CLIConf) bool {
 
 func makeBasicLocalProxyConfig(cf *CLIConf, tc *libclient.TeleportClient, listener net.Listener) alpnproxy.LocalProxyConfig {
 	return alpnproxy.LocalProxyConfig{
-		RemoteProxyAddr:    tc.WebProxyAddr,
-		InsecureSkipVerify: cf.InsecureSkipVerify,
-		ParentContext:      cf.Context,
-		Listener:           listener,
+		RemoteProxyAddr:         tc.WebProxyAddr,
+		InsecureSkipVerify:      cf.InsecureSkipVerify,
+		ParentContext:           cf.Context,
+		Listener:                listener,
+		ALPNConnUpgradeRequired: tc.TLSRoutingConnUpgradeRequired,
 	}
 }
 


### PR DESCRIPTION
Implements #21870
rfd: #22347

This change has a collection of improvements.

- Require conn upgrade if handshake test fails when server sends `tls: no application protocol`
- Use env `TELEPORT_TLS_ROUTING_CONN_UPGRADE` to overwrite handshake test result
- Save handshake test result in tsh profile during `tsh login`
- Added a `tsh db` requirement that local proxy should be required when
  - conn upgrade is required
  - and, the db type is using web port.