### PR TITLE
Add the Okta access point for the Okta service.

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -1241,6 +1241,13 @@ func (w *OktaWrapper) DeleteOktaAssignment(ctx context.Context, name string) err
 	return w.NoCache.DeleteOktaAssignment(ctx, name)
 }
 
+// Close closes all associated resources
+func (w *OktaWrapper) Close() error {
+	err := w.NoCache.Close()
+	err2 := w.ReadOktaAccessPoint.Close()
+	return trace.NewAggregate(err, err2)
+}
+
 // NewRemoteProxyCachingAccessPoint returns new caching access point using
 // access point policy
 type NewRemoteProxyCachingAccessPoint func(clt ClientI, cacheName []string) (RemoteProxyAccessPoint, error)

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -721,6 +721,76 @@ type DiscoveryAccessPoint interface {
 	DeleteDatabase(ctx context.Context, name string) error
 }
 
+// ReadOktaAccessPoint is a read only API interface to be
+// used by an Okta component.
+//
+// NOTE: This interface must match the resources replicated in cache.ForOkta except for
+// access requests, which are expected to only be used by events.
+type ReadOktaAccessPoint interface {
+	// Closer closes all the resources
+	io.Closer
+
+	// NewWatcher returns a new event watcher.
+	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
+
+	// GetUser returns a services.User for this cluster.
+	GetUser(name string, withSecrets bool) (types.User, error)
+
+	// ListUserGroups returns a paginated list of all user group resources.
+	ListUserGroups(context.Context, int, string) ([]types.UserGroup, string, error)
+
+	// GetUserGroup returns the specified user group resources.
+	GetUserGroup(ctx context.Context, name string) (types.UserGroup, error)
+
+	// ListOktaImportRules returns a paginated list of all Okta import rule resources.
+	ListOktaImportRules(context.Context, int, string) ([]types.OktaImportRule, string, error)
+
+	// GetOktaImportRule returns the specified Okta import rule resources.
+	GetOktaImportRule(ctx context.Context, name string) (types.OktaImportRule, error)
+
+	// ListOktaAssignments returns a paginated list of all Okta assignment resources.
+	ListOktaAssignments(context.Context, int, string) ([]types.OktaAssignment, string, error)
+
+	// GetOktaAssignmen treturns the specified Okta assignment resources.
+	GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error)
+}
+
+// OktaAccessPoint is a read only cache interface used by an Okta component.
+type OktaAccessPoint interface {
+	// ReadOktaAccessPoint provides methods to read data
+	ReadOktaAccessPoint
+
+	// accessPoint provides common access point functionality
+	accessPoint
+
+	// CreateUserGroup creates a new user group resource.
+	CreateUserGroup(context.Context, types.UserGroup) error
+
+	// UpdateUserGroup updates an existing user group resource.
+	UpdateUserGroup(context.Context, types.UserGroup) error
+
+	// DeleteUserGroup removes the specified user group resource.
+	DeleteUserGroup(ctx context.Context, name string) error
+
+	// CreateOktaImportRule creates a new Okta import rule resource.
+	CreateOktaImportRule(context.Context, types.OktaImportRule) (types.OktaImportRule, error)
+
+	// UpdateOktaImportRule updates an existing Okta import rule resource.
+	UpdateOktaImportRule(context.Context, types.OktaImportRule) (types.OktaImportRule, error)
+
+	// DeleteOktaImportRule removes the specified Okta import rule resource.
+	DeleteOktaImportRule(ctx context.Context, name string) error
+
+	// CreateOktaAssignment creates a new Okta assignment resource.
+	CreateOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
+
+	// UpdateOktaAssignment updates an existing Okta assignment resource.
+	UpdateOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
+
+	// DeleteOktaAssignment removes the specified Okta assignment resource.
+	DeleteOktaAssignment(ctx context.Context, name string) error
+}
+
 // AccessCache is a subset of the interface working on the certificate authorities
 type AccessCache interface {
 	// GetCertAuthority returns cert authority by id
@@ -1110,6 +1180,65 @@ func (w *DiscoveryWrapper) Close() error {
 	err := w.NoCache.Close()
 	err2 := w.ReadDiscoveryAccessPoint.Close()
 	return trace.NewAggregate(err, err2)
+}
+
+type OktaWrapper struct {
+	ReadOktaAccessPoint
+	accessPoint
+	NoCache OktaAccessPoint
+}
+
+func NewOktaWrapper(base OktaAccessPoint, cache ReadOktaAccessPoint) OktaAccessPoint {
+	return &OktaWrapper{
+		NoCache:             base,
+		accessPoint:         base,
+		ReadOktaAccessPoint: cache,
+	}
+}
+
+// CreateUserGroup creates a new user group resource.
+func (w *OktaWrapper) CreateUserGroup(ctx context.Context, userGroup types.UserGroup) error {
+	return w.NoCache.CreateUserGroup(ctx, userGroup)
+}
+
+// UpdateUserGroup updates an existing user group resource.
+func (w *OktaWrapper) UpdateUserGroup(ctx context.Context, userGroup types.UserGroup) error {
+	return w.NoCache.UpdateUserGroup(ctx, userGroup)
+}
+
+// DeleteUserGroup removes the specified user group resource.
+func (w *OktaWrapper) DeleteUserGroup(ctx context.Context, name string) error {
+	return w.NoCache.DeleteUserGroup(ctx, name)
+}
+
+// CreateOktaImportRule creates a new Okta import rule resource.
+func (w *OktaWrapper) CreateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) (types.OktaImportRule, error) {
+	return w.NoCache.CreateOktaImportRule(ctx, importRule)
+}
+
+// UpdateOktaImportRule updates an existing Okta import rule resource.
+func (w *OktaWrapper) UpdateOktaImportRule(ctx context.Context, importRule types.OktaImportRule) (types.OktaImportRule, error) {
+	return w.NoCache.UpdateOktaImportRule(ctx, importRule)
+}
+
+// DeleteOktaImportRule removes the specified Okta import rule resource.
+func (w *OktaWrapper) DeleteOktaImportRule(ctx context.Context, name string) error {
+	return w.NoCache.DeleteOktaImportRule(ctx, name)
+}
+
+// CreateOktaAssignment creates a new Okta assignment resource.
+func (w *OktaWrapper) CreateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
+	return w.NoCache.CreateOktaAssignment(ctx, assignment)
+}
+
+// UpdateOktaAssignment updates an existing Okta assignment resource.
+func (w *OktaWrapper) UpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
+	return w.NoCache.UpdateOktaAssignment(ctx, assignment)
+}
+
+// DeleteOktaAssignment removes the specified Okta assignment resource.
+func (w *OktaWrapper) DeleteOktaAssignment(ctx context.Context, name string) error {
+	return w.NoCache.DeleteOktaAssignment(ctx, name)
 }
 
 // NewRemoteProxyCachingAccessPoint returns new caching access point using

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -724,7 +724,7 @@ type DiscoveryAccessPoint interface {
 // ReadOktaAccessPoint is a read only API interface to be
 // used by an Okta component.
 //
-// NOTE: This interface must provide read interfaces for the resources seen in cache.ForOkta
+// NOTE: This interface must provide read interfaces for the [types.WatchKind] registered in [cache.ForOkta]
 // except for access requests, which are expected to only be used by events.
 type ReadOktaAccessPoint interface {
 	// Closer closes all the resources

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -724,8 +724,8 @@ type DiscoveryAccessPoint interface {
 // ReadOktaAccessPoint is a read only API interface to be
 // used by an Okta component.
 //
-// NOTE: This interface must match the resources replicated in cache.ForOkta except for
-// access requests, which are expected to only be used by events.
+// NOTE: This interface must provide read interfaces for the resources seen in cache.ForOkta
+// except for access requests, which are expected to only be used by events.
 type ReadOktaAccessPoint interface {
 	// Closer closes all the resources
 	io.Closer
@@ -755,7 +755,7 @@ type ReadOktaAccessPoint interface {
 	GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error)
 }
 
-// OktaAccessPoint is a read only cache interface used by an Okta component.
+// OktaAccessPoint is a read caching interface used by an Okta component.
 type OktaAccessPoint interface {
 	// ReadOktaAccessPoint provides methods to read data
 	ReadOktaAccessPoint


### PR DESCRIPTION
The Okta access point has been introduced for use by the Okta service.

Note: Cache implementation is here: https://github.com/gravitational/teleport/pull/23059