### PR TITLE
Refactor `stream.Source` implementations

### DIFF
--- a/lib/proxy/peer/client.go
+++ b/lib/proxy/peer/client.go
@@ -394,6 +394,14 @@ func (s frameStream) Recv() ([]byte, error) {
 	return frame.GetData().Bytes, nil
 }
 
+func (s frameStream) Close() error {
+	if cs, ok := s.stream.(grpc.ClientStream); ok {
+		return trace.Wrap(cs.CloseSend())
+	}
+
+	return nil
+}
+
 // Shutdown gracefully shuts down all existing client connections.
 func (c *Client) Shutdown() {
 	c.Lock()


### PR DESCRIPTION
The interface smuggling within `stream.ReadWriter.Close` now checks for `io.Closer` instead of `grpc.ClientStream` to allow clients that need to perform additoinal closing logic besides sending a `CloseSend` message to do so. All existing client implementations of `stream.Source` now implement `io.Closer` so they are still cleaned up properly.

The multiplexed ssh streams are now tied together to prevent attempts to send a message at the same time. In addition, the client ssh streams have been updated to only send a single `CloseSend` on which ever protocol is terminated first.