### PR TITLE
Bump cloud version to 12.1.2

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1376,7 +1376,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "12.1.1",
+      "version": "12.1.2",
       "major_version": "12",
       "sla": {
         "monthly_percentage": "99.5%",


### PR DESCRIPTION
Teleport Cloud will be upgraded to 12.1.2 on Wednesday 3/22/23.

See: https://github.com/gravitational/cloud/issues/3838