### PR TITLE
Send signed proxy header to the kube service

### DIFF
--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -325,7 +325,8 @@ func (p *transport) start() {
 		clientDst = dst
 	}
 	var signedHeader []byte
-	if shouldSendSignedPROXYHeader(p.proxySigner, dreq.TeleportVersion, useTunnel, dreq.Address != RemoteAuthServer, clientSrc, clientDst) {
+	isKubeOrAuth := dreq.ConnType == types.KubeTunnel || dreq.Address == RemoteAuthServer
+	if shouldSendSignedPROXYHeader(p.proxySigner, dreq.TeleportVersion, useTunnel, !isKubeOrAuth, clientSrc, clientDst) {
 		signedHeader, err = p.proxySigner.SignPROXYHeader(clientSrc, clientDst)
 		if err != nil {
 			errorMessage := fmt.Sprintf("connection rejected - could not create signed PROXY header: %v", err)
@@ -354,7 +355,7 @@ func (p *transport) start() {
 
 	errorCh := make(chan error, 2)
 
-	if signedHeader != nil {
+	if len(signedHeader) > 0 {
 		_, err = conn.Write(signedHeader)
 		if err != nil {
 			p.log.Errorf("Could not write PROXY header to the connection: %v", err)


### PR DESCRIPTION
During testing IP pinning found a problem with accessing leaf cluster's kube service - because it was checking target server version (which is empty, we don't need it for kube service), signed headers were not sent, when we contacted leaf cluster's kube service. That resulted in connection being denied for users with IP pinning.
This PR fixes it and makes sure we send signed proxy header to the kube service.